### PR TITLE
Consolidate memory allocators

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -114,7 +114,7 @@ class TpchBenchmark {
       auto allocator = std::make_shared<memory::MmapAllocator>(options);
       allocator_ = std::make_shared<cache::AsyncDataCache>(
           allocator, memoryBytes, nullptr);
-      memory::MappedMemory::setDefaultInstance(allocator_.get());
+      memory::MemoryAllocator::setDefaultInstance(allocator_.get());
     }
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();
@@ -175,7 +175,7 @@ class TpchBenchmark {
   }
 
   std::unique_ptr<folly::IOThreadPoolExecutor> ioExecutor_;
-  std::shared_ptr<memory::MappedMemory> allocator_;
+  std::shared_ptr<memory::MemoryAllocator> allocator_;
 };
 
 TpchBenchmark benchmark;

--- a/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
+++ b/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
@@ -51,12 +51,10 @@ class MemoryPoolAllocationBenchMark {
       : type_(type), minSize_(minSize), maxSize_(maxSize) {
     switch (type_) {
       case Type::kMmap:
-        manager_ =
-            std::make_shared<MemoryManager<MmapMemoryAllocator, ALIGNMENT>>();
+        manager_ = std::make_shared<MemoryManager<ALIGNMENT>>();
         break;
       case Type::kStd:
-        manager_ =
-            std::make_shared<MemoryManager<MemoryAllocator, ALIGNMENT>>();
+        manager_ = std::make_shared<MemoryManager<ALIGNMENT>>();
         break;
       default:
         VELOX_USER_FAIL("Unknown allocator type: {}", static_cast<int>(type_));
@@ -193,13 +191,13 @@ size_t MemoryPoolAllocationBenchMark<ALIGNMENT>::runReallocate() {
 
 // allocateBytes API.
 BENCHMARK_MULTI(StdAllocateSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 3072);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 3072);
   return benchmark.runAllocate();
 }
@@ -215,13 +213,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateSmall64) {
 }
 
 BENCHMARK_MULTI(StdAllocateMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runAllocate();
 }
@@ -237,13 +235,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateMid64) {
 }
 
 BENCHMARK_MULTI(StdAllocateLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runAllocate();
 }
@@ -259,13 +257,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateLarge64) {
 }
 
 BENCHMARK_MULTI(StdAllocateMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
@@ -282,13 +280,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateMix64) {
 
 // allocateZeroFilled API.
 BENCHMARK_MULTI(StdAllocateZeroFilledSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 3072);
   return benchmark.runAllocateZeroFilled();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 3072);
   return benchmark.runAllocateZeroFilled();
 }
@@ -304,13 +302,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledSmall64) {
 }
 
 BENCHMARK_MULTI(StdAllocateZeroFilledMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runAllocateZeroFilled();
 }
@@ -326,13 +324,13 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMid64) {
 }
 
 BENCHMARK_MULTI(StdAllocateZeroFilledLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runAllocateZeroFilled();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runAllocateZeroFilled();
 }
@@ -348,37 +346,37 @@ BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledLarge64) {
 }
 
 BENCHMARK_MULTI(StdAllocateZeroFilledMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_MULTI(StdAllocateZeroFilledMix64) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapAllocateZeroFilledMix64) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 32 << 20);
   return benchmark.runAllocate();
 }
 
 BENCHMARK_MULTI(StdReallocateSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 3072);
   return benchmark.runReallocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapReallocateSmallNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 3072);
   return benchmark.runReallocate();
 }
@@ -394,13 +392,13 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateSmall64) {
 }
 
 BENCHMARK_MULTI(StdReallocateMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 4 << 10, 1 << 20);
   return benchmark.runReallocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapReallocateMidNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 4 << 10, 1 << 20);
   return benchmark.runReallocate();
 }
@@ -416,13 +414,13 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateMid64) {
 }
 
 BENCHMARK_MULTI(StdReallocateLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 1 << 20, 32 << 20);
   return benchmark.runReallocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapReallocateLargeNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 1 << 20, 32 << 20);
   return benchmark.runReallocate();
 }
@@ -438,13 +436,13 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateLarge64) {
 }
 
 BENCHMARK_MULTI(StdReallocateMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kStd, 128, 32 << 20);
   return benchmark.runReallocate();
 }
 
 BENCHMARK_RELATIVE_MULTI(MmapReallocateMixNoAlignment) {
-  MemoryPoolAllocationBenchMark<MappedMemory::kMinAlignment> benchmark(
+  MemoryPoolAllocationBenchMark<MemoryAllocator::kMinAlignment> benchmark(
       Type::kMmap, 128, 32 << 20);
   return benchmark.runReallocate();
 }

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -44,8 +44,7 @@ class BufferTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
-      memoryManager_;
+  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -29,7 +29,7 @@
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/caching/StringIdMap.h"
 #include "velox/common/file/File.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox::cache {
 
@@ -147,11 +147,11 @@ class AsyncDataCacheEntry {
   //  hold no memory when calling this.
   void initialize(FileCacheKey key);
 
-  memory::MappedMemory::Allocation& data() {
+  memory::MemoryAllocator::Allocation& data() {
     return data_;
   }
 
-  const memory::MappedMemory::Allocation& data() const {
+  const memory::MemoryAllocator::Allocation& data() const {
     return data_;
   }
 
@@ -267,10 +267,10 @@ class AsyncDataCacheEntry {
   CacheShard* const shard_;
 
   // The data being cached.
-  memory::MappedMemory::Allocation data_;
+  memory::MemoryAllocator::Allocation data_;
 
-  // Contains the cached data if this is much smaller than a MappedMemory page
-  // (kTinyDataSize).
+  // Contains the cached data if this is much smaller than a MemoryAllocator
+  // page (kTinyDataSize).
   std::string tinyData_;
 
   std::unique_ptr<folly::SharedPromise<bool>> promise_;
@@ -591,15 +591,15 @@ class CacheShard {
   // Sum of evict scores. This divided by 'numEvict_' correlates to
   // time data stays in cache.
   uint64_t sumEvictScore_{};
-  // Tracker of time spent in allocating/freeing MappedMemory space
+  // Tracker of time spent in allocating/freeing MemoryAllocator space
   // for backing cached data.
   std::atomic<uint64_t> allocClocks_;
 };
 
-class AsyncDataCache : public memory::MappedMemory {
+class AsyncDataCache : public memory::MemoryAllocator {
  public:
   AsyncDataCache(
-      const std::shared_ptr<memory::MappedMemory>& mappedMemory,
+      const std::shared_ptr<memory::MemoryAllocator>& MemoryAllocator,
       uint64_t maxBytes,
       std::unique_ptr<SsdCache> ssdCache = nullptr);
 
@@ -629,7 +629,7 @@ class AsyncDataCache : public memory::MappedMemory {
       memory::MachinePageCount minSizeClass = 0) override;
 
   int64_t freeNonContiguous(Allocation& allocation) override {
-    return mappedMemory_->freeNonContiguous(allocation);
+    return MemoryAllocator_->freeNonContiguous(allocation);
   }
 
   bool allocateContiguous(
@@ -639,29 +639,29 @@ class AsyncDataCache : public memory::MappedMemory {
       std::function<void(int64_t, bool)> beforeAllocCB = nullptr) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override {
-    mappedMemory_->freeContiguous(allocation);
+    MemoryAllocator_->freeContiguous(allocation);
   }
 
   void* allocateBytes(uint64_t bytes, uint16_t alignment) override;
 
   void freeBytes(void* p, uint64_t size) noexcept override {
-    mappedMemory_->freeBytes(p, size);
+    MemoryAllocator_->freeBytes(p, size);
   }
 
   bool checkConsistency() const override {
-    return mappedMemory_->checkConsistency();
+    return MemoryAllocator_->checkConsistency();
   }
 
   const std::vector<memory::MachinePageCount>& sizeClasses() const override {
-    return mappedMemory_->sizeClasses();
+    return MemoryAllocator_->sizeClasses();
   }
 
   memory::MachinePageCount numAllocated() const override {
-    return mappedMemory_->numAllocated();
+    return MemoryAllocator_->numAllocated();
   }
 
   memory::MachinePageCount numMapped() const override {
-    return mappedMemory_->numMapped();
+    return MemoryAllocator_->numMapped();
   }
 
   CacheStats refreshStats() const;
@@ -737,7 +737,7 @@ class AsyncDataCache : public memory::MappedMemory {
   }
 
   memory::Stats stats() const override {
-    return mappedMemory_->stats();
+    return MemoryAllocator_->stats();
   }
 
  private:
@@ -758,7 +758,7 @@ class AsyncDataCache : public memory::MappedMemory {
       memory::MachinePageCount numPages,
       std::function<bool()> allocate);
 
-  std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  std::shared_ptr<memory::MemoryAllocator> MemoryAllocator_;
   std::unique_ptr<SsdCache> ssdCache_;
   std::vector<std::unique_ptr<CacheShard>> shards_;
   std::atomic<int32_t> shardCounter_{0};

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -31,7 +31,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::cache;
 
-using facebook::velox::memory::MappedMemory;
+using facebook::velox::memory::MemoryAllocator;
 
 // Represents a planned load from a file. Many of these constitute a load plan.
 struct Request {
@@ -137,13 +137,13 @@ class AsyncDataCacheTest : public testing::Test {
   // Deterministically fills 'allocation'  based on 'sequence'
   static void initializeContents(
       int64_t sequence,
-      MappedMemory::Allocation& alloc) {
+      MemoryAllocator::Allocation& alloc) {
     bool first = true;
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           ptr[offset] = sequence;
@@ -165,10 +165,10 @@ class AsyncDataCacheTest : public testing::Test {
     int64_t sequence;
     int32_t bytesChecked = sizeof(int64_t);
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           sequence = ptr[offset];
@@ -539,16 +539,16 @@ TEST_F(AsyncDataCacheTest, replace) {
   auto stats = cache_->refreshStats();
   EXPECT_LT(0, stats.numEvict);
   EXPECT_GE(
-      kMaxBytes / memory::MappedMemory::kPageSize,
+      kMaxBytes / memory::MemoryAllocator::kPageSize,
       cache_->incrementCachedPages(0));
 }
 
 TEST_F(AsyncDataCacheTest, outOfCapacity) {
   constexpr int64_t kMaxBytes = 16 << 20;
   constexpr int32_t kSize = 16 << 10;
-  constexpr int32_t kSizeInPages = kSize / MappedMemory::kPageSize;
+  constexpr int32_t kSizeInPages = kSize / MemoryAllocator::kPageSize;
   std::deque<CachePin> pins;
-  std::deque<MappedMemory::Allocation> allocations;
+  std::deque<MemoryAllocator::Allocation> allocations;
   initializeCache(kMaxBytes);
   // We pin 2 16K entries and unpin 1. Eventually the whole capacity
   // is pinned and we fail making a ew entry.
@@ -562,7 +562,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
     }
     pins.pop_front();
   }
-  MappedMemory::Allocation allocation(cache_.get());
+  MemoryAllocator::Allocation allocation(cache_.get());
   EXPECT_FALSE(cache_->allocateNonContiguous(kSizeInPages, allocation));
   // One 4 page entry below the max size of 4K 4 page entries in 16MB of
   // capacity.
@@ -572,7 +572,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
 
   // We allocate the full capacity and expect the cache entries to go.
   for (;;) {
-    MappedMemory::Allocation(cache_.get());
+    MemoryAllocator::Allocation(cache_.get());
     if (!cache_->allocateNonContiguous(kSizeInPages, allocation)) {
       break;
     }

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -25,7 +25,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::cache;
 
-using facebook::velox::memory::MappedMemory;
+using facebook::velox::memory::MemoryAllocator;
 
 // Represents an entry written to SSD.
 struct TestEntry {
@@ -51,7 +51,7 @@ class SsdFileTest : public testing::Test {
     // tmpfs does not support O_DIRECT, so turn this off for testing.
     FLAGS_ssd_odirect = false;
     cache_ = std::make_shared<AsyncDataCache>(
-        MappedMemory::createDefaultInstance(), maxBytes);
+        MemoryAllocator::createDefaultInstance(), maxBytes);
 
     fileName_ = StringIdLease(fileIds(), "fileInStorage");
 
@@ -64,13 +64,13 @@ class SsdFileTest : public testing::Test {
 
   static void initializeContents(
       int64_t sequence,
-      MappedMemory::Allocation& alloc) {
+      MemoryAllocator::Allocation& alloc) {
     bool first = true;
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           ptr[offset] = sequence;
@@ -85,16 +85,16 @@ class SsdFileTest : public testing::Test {
   // Checks that the contents are consistent with what is set in
   // initializeContents.
   static void checkContents(
-      const MappedMemory::Allocation& alloc,
+      const MemoryAllocator::Allocation& alloc,
       int32_t numBytes) {
     bool first = true;
     int64_t sequence;
     int32_t bytesChecked = sizeof(int64_t);
     for (int32_t i = 0; i < alloc.numRuns(); ++i) {
-      MappedMemory::PageRun run = alloc.runAt(i);
+      MemoryAllocator::PageRun run = alloc.runAt(i);
       int64_t* ptr = reinterpret_cast<int64_t*>(run.data());
       int32_t numWords =
-          run.numPages() * MappedMemory::kPageSize / sizeof(void*);
+          run.numPages() * MemoryAllocator::kPageSize / sizeof(void*);
       for (int32_t offset = 0; offset < numWords; offset++) {
         if (first) {
           sequence = ptr[offset];

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -100,7 +100,7 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_P(DenseHllTest, basic) {

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -98,7 +98,7 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_F(SparseHllTest, basic) {
@@ -173,7 +173,7 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_P(SparseHllToDenseTest, toDense) {

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/common/memory/AllocationPool.h"
 #include <velox/common/base/Exceptions.h>
-#include <velox/common/memory/MappedMemory.h>
+#include <velox/common/memory/MemoryAllocator.h>
 #include "velox/common/base/BitUtil.h"
 
 namespace facebook::velox {
@@ -31,15 +31,15 @@ void AllocationPool::clear() {
 char* AllocationPool::allocateFixed(uint64_t bytes) {
   VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
 
-  auto numPages = bits::roundUp(bytes, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
+  auto numPages = bits::roundUp(bytes, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
 
   // Use contiguous allocations from mapped memory if allocation size is large
-  if (numPages > mappedMemory_->largestSizeClass()) {
+  if (numPages > allocator_->largestSizeClass()) {
     auto largeAlloc =
-        std::make_unique<memory::MappedMemory::ContiguousAllocation>();
-    largeAlloc->reset(mappedMemory_, nullptr, 0);
-    if (!mappedMemory_->allocateContiguous(numPages, nullptr, *largeAlloc)) {
+        std::make_unique<memory::MemoryAllocator::ContiguousAllocation>();
+    largeAlloc->reset(allocator_, nullptr, 0);
+    if (!allocator_->allocateContiguous(numPages, nullptr, *largeAlloc)) {
       throw std::bad_alloc();
     }
     largeAllocations_.emplace_back(std::move(largeAlloc));
@@ -63,10 +63,11 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
   ++currentRun_;
   if (currentRun_ >= allocation_.numRuns()) {
     if (allocation_.numRuns()) {
-      allocations_.push_back(std::make_unique<memory::MappedMemory::Allocation>(
-          std::move(allocation_)));
+      allocations_.push_back(
+          std::make_unique<memory::MemoryAllocator::Allocation>(
+              std::move(allocation_)));
     }
-    if (!mappedMemory_->allocateNonContiguous(
+    if (!allocator_->allocateNonContiguous(
             std::max<int32_t>(kMinPages, numPages),
             allocation_,
             nullptr,
@@ -80,8 +81,8 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
 
 void AllocationPool::newRun(int32_t preferredSize) {
   auto numPages =
-      bits::roundUp(preferredSize, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
+      bits::roundUp(preferredSize, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
   newRunImpl(numPages);
 }
 

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -328,7 +328,7 @@ class ByteStream {
       if (offset == bytes) {
         return;
       }
-      extend(bits::roundUp(bytes - offset, memory::MappedMemory::kPageSize));
+      extend(bits::roundUp(bytes - offset, memory::MemoryAllocator::kPageSize));
     }
   }
 
@@ -350,7 +350,7 @@ class ByteStream {
   }
 
  private:
-  void extend(int32_t bytes = memory::MappedMemory::kPageSize);
+  void extend(int32_t bytes = memory::MemoryAllocator::kPageSize);
 
   void updateEnd() {
     if (!ranges_.empty() && current_ == &ranges_.back() &&
@@ -401,11 +401,11 @@ inline Date ByteStream::read<Date>() {
 class IOBufOutputStream : public OutputStream {
  public:
   explicit IOBufOutputStream(
-      memory::MappedMemory& mappedMemory,
+      memory::MemoryAllocator& MemoryAllocator,
       OutputStreamListener* listener = nullptr,
-      int32_t initialSize = memory::MappedMemory::kPageSize)
+      int32_t initialSize = memory::MemoryAllocator::kPageSize)
       : OutputStream(listener),
-        arena_(std::make_shared<StreamArena>(&mappedMemory)),
+        arena_(std::make_shared<StreamArena>(&MemoryAllocator)),
         out_(std::make_unique<ByteStream>(arena_.get())) {
     out_->startWrite(initialSize);
   }

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -21,8 +21,8 @@ add_library(
   ByteStream.cpp
   HashStringAllocator.cpp
   Memory.cpp
+  MemoryAllocator.cpp
   MemoryUsage.cpp
-  MappedMemory.cpp
   MmapAllocator.cpp
   MmapArena.cpp
   MemoryUsageTracker.cpp

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -148,7 +148,8 @@ HashStringAllocator::Position HashStringAllocator::finishWrite(
 
 void HashStringAllocator::newSlab(int32_t size) {
   int32_t needed = std::max<int32_t>(
-      bits::roundUp(size + 2 * sizeof(Header), memory::MappedMemory::kPageSize),
+      bits::roundUp(
+          size + 2 * sizeof(Header), memory::MemoryAllocator::kPageSize),
       kUnitSize);
   pool_.newRun(needed);
   auto run = pool_.firstFreeInRun();

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -36,7 +36,7 @@
 #include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/base/SuccinctPrinter.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
@@ -265,76 +265,20 @@ static inline MemoryPool& getCheckedReference(std::weak_ptr<MemoryPool> ptr) {
 };
 } // namespace detail
 
-// A standard allocator interface for the actual allocator of the memory
-// node tree.
-class MemoryAllocator {
- public:
-  static std::shared_ptr<MemoryAllocator> createDefaultAllocator();
-
-  virtual ~MemoryAllocator() {}
-
-  virtual void* FOLLY_NULLABLE alloc(int64_t size);
-  virtual void* FOLLY_NULLABLE
-  allocZeroFilled(int64_t numMembers, int64_t sizeEach);
-  // TODO: might be able to collapse this with templated class
-  virtual void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size);
-  virtual void* FOLLY_NULLABLE
-  realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize);
-  virtual void* FOLLY_NULLABLE reallocAligned(
-      void* FOLLY_NULLABLE p,
-      uint16_t alignment,
-      int64_t size,
-      int64_t newSize);
-  virtual void free(void* FOLLY_NULLABLE p, int64_t size);
-};
-
-// An allocator that uses memory::MappedMemory to allocate memory. We leverage
-// MappedMemory for relatively small allocations. Allocations less than 3/4 of
-// smallest size class and larger than largest size class are delegated to
-// malloc still.
-class MmapMemoryAllocator : public MemoryAllocator {
- public:
-  static std::shared_ptr<MmapMemoryAllocator> createDefaultAllocator();
-
-  MmapMemoryAllocator() : mappedMemory_(MappedMemory::getInstance()) {}
-  void* FOLLY_NULLABLE alloc(int64_t size) override;
-  void* FOLLY_NULLABLE
-  allocZeroFilled(int64_t numMembers, int64_t sizeEach) override;
-  void* FOLLY_NULLABLE allocAligned(uint16_t alignment, int64_t size) override;
-  void* FOLLY_NULLABLE
-  realloc(void* FOLLY_NULLABLE p, int64_t size, int64_t newSize) override;
-  void* FOLLY_NULLABLE reallocAligned(
-      void* FOLLY_NULLABLE p,
-      uint16_t alignment,
-      int64_t size,
-      int64_t newSize) override;
-  void free(void* FOLLY_NULLABLE p, int64_t size) override;
-
-  MappedMemory* FOLLY_NONNULL mappedMemory() {
-    return mappedMemory_;
-  }
-
- private:
-  MappedMemory* FOLLY_NONNULL mappedMemory_;
-};
-
-template <typename Allocator, uint16_t ALIGNMENT>
+template <uint16_t ALIGNMENT>
 class MemoryManager;
-template <typename Allocator, uint16_t ALIGNMENT>
+template <uint16_t ALIGNMENT>
 class MemoryPoolImpl;
 
-/// The implementation of MemoryPool interface with customized memory
-/// 'Allocator' and memory allocation size 'ALIGNMENT' through template
-/// parameters.
-template <
-    typename Allocator = MemoryAllocator,
-    uint16_t ALIGNMENT = kNoAlignment>
+/// The implementation of MemoryPool interface with customized memory allocation
+/// size 'ALIGNMENT' through template parameters.
+template <uint16_t ALIGNMENT = kNoAlignment>
 class MemoryPoolImpl : public MemoryPool {
  public:
   // Should perhaps make this method private so that we only create node through
   // parent.
   MemoryPoolImpl(
-      MemoryManager<Allocator, ALIGNMENT>& memoryManager,
+      MemoryManager<ALIGNMENT>& memoryManager,
       const std::string& name,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = kMaxMemory);
@@ -443,13 +387,13 @@ class MemoryPoolImpl : public MemoryPool {
 
   template <uint16_t A, typename = std::enable_if_t<A != kNoAlignment>>
   void* FOLLY_NULLABLE allocAligned(ALIGNER<A> /* unused */, int64_t size) {
-    return allocator_.allocAligned(A, size);
+    return allocator_.allocateBytes(size, A);
   }
 
   template <uint16_t A>
   void* FOLLY_NULLABLE
   allocAligned(ALIGNER<kNoAlignment> /* unused */, int64_t size) {
-    return allocator_.alloc(size);
+    return allocator_.allocateBytes(size, A);
   }
 
   template <uint16_t A, typename = std::enable_if_t<A != kNoAlignment>>
@@ -458,7 +402,7 @@ class MemoryPoolImpl : public MemoryPool {
       void* FOLLY_NULLABLE p,
       int64_t size,
       int64_t newSize) {
-    return allocator_.reallocAligned(p, A, size, newSize);
+    return allocator_.reallocateBytes(p, size, newSize, A);
   }
 
   template <uint16_t A>
@@ -467,14 +411,14 @@ class MemoryPoolImpl : public MemoryPool {
       void* FOLLY_NULLABLE p,
       int64_t size,
       int64_t newSize) {
-    return allocator_.realloc(p, size, newSize);
+    return allocator_.reallocateBytes(p, size, newSize);
   }
 
   void accessSubtreeMemoryUsage(
       std::function<void(const MemoryUsage&)> visitor) const;
   void updateSubtreeMemoryUsage(std::function<void(MemoryUsage&)> visitor);
 
-  MemoryManager<Allocator, ALIGNMENT>& memoryManager_;
+  MemoryManager<ALIGNMENT>& memoryManager_;
 
   // Memory allocated attributed to the memory node.
   MemoryUsage localMemoryUsage_;
@@ -484,7 +428,7 @@ class MemoryPoolImpl : public MemoryPool {
   int64_t cap_;
   std::atomic_bool capped_{false};
 
-  Allocator& allocator_;
+  MemoryAllocator& allocator_;
 };
 
 constexpr folly::StringPiece kRootNodeName{"__root__"};
@@ -522,19 +466,15 @@ class IMemoryManager {
 // For now, users wanting multiple different allocators would need to
 // instantiate different MemoryManager classes and manage them across
 // static boundaries.
-template <
-    typename Allocator = MemoryAllocator,
-    uint16_t ALIGNMENT = kNoAlignment>
+template <uint16_t ALIGNMENT = kNoAlignment>
 class MemoryManager final : public IMemoryManager {
  public:
   // Tries to get the process singleton manager. If not previously initialized,
   // the process singleton manager will be initialized with the given quota.
-  FOLLY_EXPORT static MemoryManager<Allocator, ALIGNMENT>&
-  getProcessDefaultManager(
+  FOLLY_EXPORT static MemoryManager<ALIGNMENT>& getProcessDefaultManager(
       int64_t quota = kMaxMemory,
       bool ensureQuota = false) {
-    static MemoryManager<Allocator, ALIGNMENT> manager{
-        Allocator::createDefaultAllocator(), quota};
+    static MemoryManager<ALIGNMENT> manager{quota};
     auto actualQuota = manager.getMemoryQuota();
     VELOX_USER_CHECK(
         !ensureQuota || actualQuota == quota,
@@ -545,23 +485,25 @@ class MemoryManager final : public IMemoryManager {
     return manager;
   }
 
-  explicit MemoryManager(int64_t memoryQuota = kMaxMemory);
-
   explicit MemoryManager(
-      std::shared_ptr<Allocator> allocator,
-      int64_t memoryQuota = kMaxMemory);
+      int64_t memoryQuota = kMaxMemory,
+      MemoryAllocator* FOLLY_NONNULL allocator =
+          MemoryAllocator::getInstance());
   ~MemoryManager();
 
   int64_t getMemoryQuota() const final;
+
   MemoryPool& getRoot() const final;
 
   std::shared_ptr<MemoryPool> getChild(int64_t cap = kMaxMemory) final;
 
   int64_t getTotalBytes() const final;
+
   bool reserve(int64_t size) final;
+
   void release(int64_t size) final;
 
-  Allocator& getAllocator();
+  MemoryAllocator& getAllocator();
 
   std::string toString() final {
     return fmt::format(
@@ -576,16 +518,17 @@ class MemoryManager final : public IMemoryManager {
   VELOX_FRIEND_TEST(MultiThreadingUncappingTest, Flat);
   VELOX_FRIEND_TEST(MultiThreadingUncappingTest, SimpleTree);
 
-  std::shared_ptr<Allocator> allocator_;
+  const std::shared_ptr<MemoryAllocator> allocator_;
   const int64_t memoryQuota_;
+
   std::shared_ptr<MemoryPool> root_;
   mutable folly::SharedMutex mutex_;
   std::atomic_long totalBytes_{0};
 };
 
-template <typename Allocator, uint16_t ALIGNMENT>
-MemoryPoolImpl<Allocator, ALIGNMENT>::MemoryPoolImpl(
-    MemoryManager<Allocator, ALIGNMENT>& memoryManager,
+template <uint16_t ALIGNMENT>
+MemoryPoolImpl<ALIGNMENT>::MemoryPoolImpl(
+    MemoryManager<ALIGNMENT>& memoryManager,
     const std::string& name,
     std::shared_ptr<MemoryPool> parent,
     int64_t cap)
@@ -597,9 +540,8 @@ MemoryPoolImpl<Allocator, ALIGNMENT>::MemoryPoolImpl(
   VELOX_USER_CHECK_GT(cap, 0);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void* FOLLY_NULLABLE
-MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
+template <uint16_t ALIGNMENT>
+void* FOLLY_NULLABLE MemoryPoolImpl<ALIGNMENT>::allocate(int64_t size) {
   if (this->isMemoryCapped()) {
     VELOX_MEM_MANUAL_CAP();
   }
@@ -608,8 +550,8 @@ MemoryPoolImpl<Allocator, ALIGNMENT>::allocate(int64_t size) {
   return allocAligned<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, alignedSize);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
+template <uint16_t ALIGNMENT>
+void* FOLLY_NULLABLE MemoryPoolImpl<ALIGNMENT>::allocateZeroFilled(
     int64_t numMembers,
     int64_t sizeEach) {
   auto alignedSize =
@@ -618,11 +560,11 @@ void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::allocateZeroFilled(
     VELOX_MEM_MANUAL_CAP();
   }
   reserve(alignedSize);
-  return allocator_.allocZeroFilled(1, alignedSize);
+  return allocator_.allocateZeroFilled(alignedSize);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
+template <uint16_t ALIGNMENT>
+void* FOLLY_NULLABLE MemoryPoolImpl<ALIGNMENT>::reallocate(
     void* FOLLY_NULLABLE p,
     int64_t size,
     int64_t newSize) {
@@ -650,27 +592,25 @@ void* FOLLY_NULLABLE MemoryPoolImpl<Allocator, ALIGNMENT>::reallocate(
   return newP;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::free(
-    void* FOLLY_NULLABLE p,
-    int64_t size) {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::free(void* FOLLY_NULLABLE p, int64_t size) {
   auto alignedSize = sizeAlign<ALIGNMENT>(ALIGNER<ALIGNMENT>{}, size);
-  allocator_.free(p, alignedSize);
+  allocator_.freeBytes(p, alignedSize);
   release(alignedSize);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getCurrentBytes() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::getCurrentBytes() const {
   return getAggregateBytes();
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getMaxBytes() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::getMaxBytes() const {
   return std::max(getSubtreeMaxBytes(), localMemoryUsage_.getMaxBytes());
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::setMemoryUsageTracker(
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::setMemoryUsageTracker(
     const std::shared_ptr<MemoryUsageTracker>& tracker) {
   const auto currentBytes = getCurrentBytes();
   if (memoryUsageTracker_) {
@@ -680,22 +620,21 @@ void MemoryPoolImpl<Allocator, ALIGNMENT>::setMemoryUsageTracker(
   memoryUsageTracker_->update(currentBytes);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
+template <uint16_t ALIGNMENT>
 const std::shared_ptr<MemoryUsageTracker>&
-MemoryPoolImpl<Allocator, ALIGNMENT>::getMemoryUsageTracker() const {
+MemoryPoolImpl<ALIGNMENT>::getMemoryUsageTracker() const {
   return memoryUsageTracker_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::setSubtreeMemoryUsage(int64_t size) {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::setSubtreeMemoryUsage(int64_t size) {
   updateSubtreeMemoryUsage([size](MemoryUsage& subtreeUsage) {
     subtreeUsage.setCurrentBytes(size);
   });
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::updateSubtreeMemoryUsage(
-    int64_t size) {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::updateSubtreeMemoryUsage(int64_t size) {
   int64_t aggregateBytes;
   updateSubtreeMemoryUsage([&aggregateBytes, size](MemoryUsage& subtreeUsage) {
     aggregateBytes = subtreeUsage.getCurrentBytes() + size;
@@ -704,26 +643,26 @@ int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::updateSubtreeMemoryUsage(
   return aggregateBytes;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::cap() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::cap() const {
   return cap_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-uint16_t MemoryPoolImpl<Allocator, ALIGNMENT>::getAlignment() const {
+template <uint16_t ALIGNMENT>
+uint16_t MemoryPoolImpl<ALIGNMENT>::getAlignment() const {
   return ALIGNMENT;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::capMemoryAllocation() {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::capMemoryAllocation() {
   capped_.store(true);
   for (const auto& child : children_) {
     child->capMemoryAllocation();
   }
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::uncapMemoryAllocation() {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::uncapMemoryAllocation() {
   // This means if we try to post-order traverse the tree like we do
   // in MemoryManager, only parent has the right to lift the cap.
   // This suffices because parent will then recursively lift the cap on the
@@ -738,28 +677,27 @@ void MemoryPoolImpl<Allocator, ALIGNMENT>::uncapMemoryAllocation() {
   visitChildren([](MemoryPool* child) { child->uncapMemoryAllocation(); });
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-bool MemoryPoolImpl<Allocator, ALIGNMENT>::isMemoryCapped() const {
+template <uint16_t ALIGNMENT>
+bool MemoryPoolImpl<ALIGNMENT>::isMemoryCapped() const {
   return capped_.load();
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-std::shared_ptr<MemoryPool> MemoryPoolImpl<Allocator, ALIGNMENT>::genChild(
+template <uint16_t ALIGNMENT>
+std::shared_ptr<MemoryPool> MemoryPoolImpl<ALIGNMENT>::genChild(
     std::shared_ptr<MemoryPool> parent,
     const std::string& name,
     int64_t cap) {
-  return std::make_shared<MemoryPoolImpl<Allocator, ALIGNMENT>>(
+  return std::make_shared<MemoryPoolImpl<ALIGNMENT>>(
       memoryManager_, name, parent, cap);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-const MemoryUsage& MemoryPoolImpl<Allocator, ALIGNMENT>::getLocalMemoryUsage()
-    const {
+template <uint16_t ALIGNMENT>
+const MemoryUsage& MemoryPoolImpl<ALIGNMENT>::getLocalMemoryUsage() const {
   return localMemoryUsage_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getAggregateBytes() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::getAggregateBytes() const {
   int64_t aggregateBytes = localMemoryUsage_.getCurrentBytes();
   accessSubtreeMemoryUsage([&aggregateBytes](const MemoryUsage& subtreeUsage) {
     aggregateBytes += subtreeUsage.getCurrentBytes();
@@ -767,8 +705,8 @@ int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getAggregateBytes() const {
   return aggregateBytes;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getSubtreeMaxBytes() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryPoolImpl<ALIGNMENT>::getSubtreeMaxBytes() const {
   int64_t maxBytes;
   accessSubtreeMemoryUsage([&maxBytes](const MemoryUsage& subtreeUsage) {
     maxBytes = subtreeUsage.getMaxBytes();
@@ -776,22 +714,22 @@ int64_t MemoryPoolImpl<Allocator, ALIGNMENT>::getSubtreeMaxBytes() const {
   return maxBytes;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::accessSubtreeMemoryUsage(
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::accessSubtreeMemoryUsage(
     std::function<void(const MemoryUsage&)> visitor) const {
   folly::SharedMutex::ReadHolder readLock{subtreeUsageMutex_};
   visitor(subtreeMemoryUsage_);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::updateSubtreeMemoryUsage(
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::updateSubtreeMemoryUsage(
     std::function<void(MemoryUsage&)> visitor) {
   folly::SharedMutex::WriteHolder writeLock{subtreeUsageMutex_};
   visitor(subtreeMemoryUsage_);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::reserve(int64_t size) {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::reserve(int64_t size) {
   if (memoryUsageTracker_) {
     memoryUsageTracker_->update(size);
   }
@@ -820,8 +758,8 @@ void MemoryPoolImpl<Allocator, ALIGNMENT>::reserve(int64_t size) {
   }
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryPoolImpl<Allocator, ALIGNMENT>::release(int64_t size) {
+template <uint16_t ALIGNMENT>
+void MemoryPoolImpl<ALIGNMENT>::release(int64_t size) {
   memoryManager_.release(size);
   localMemoryUsage_.incrementCurrentBytes(-size);
   if (memoryUsageTracker_) {
@@ -837,45 +775,42 @@ static inline int64_t getTimeInUsec() {
 }
 } // namespace detail
 
-template <typename Allocator, uint16_t ALIGNMENT>
-MemoryManager<Allocator, ALIGNMENT>::MemoryManager(int64_t memoryQuota)
-    : MemoryManager(Allocator::createDefaultAllocator(), memoryQuota) {}
-
-template <typename Allocator, uint16_t ALIGNMENT>
-MemoryManager<Allocator, ALIGNMENT>::MemoryManager(
-    std::shared_ptr<Allocator> allocator,
-    int64_t memoryQuota)
-    : allocator_{std::move(allocator)},
+template <uint16_t ALIGNMENT>
+MemoryManager<ALIGNMENT>::MemoryManager(
+    int64_t memoryQuota,
+    MemoryAllocator* FOLLY_NONNULL allocator)
+    : allocator_{allocator->shared_from_this()},
       memoryQuota_{memoryQuota},
-      root_{std::make_shared<MemoryPoolImpl<Allocator, ALIGNMENT>>(
+      root_{std::make_shared<MemoryPoolImpl<ALIGNMENT>>(
           *this,
           kRootNodeName.str(),
           nullptr,
           memoryQuota)} {
+  static_assert(ALIGNMENT >= MemoryAllocator::kMinAlignment);
+  static_assert(ALIGNMENT <= MemoryAllocator::kMaxAlignment);
   VELOX_USER_CHECK_GE(memoryQuota_, 0);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-MemoryManager<Allocator, ALIGNMENT>::~MemoryManager() {
-  auto currentBytes = getTotalBytes();
-  if (currentBytes) {
-    LOG(INFO) << "Leaked total memory of " << currentBytes << " bytes.";
+template <uint16_t ALIGNMENT>
+MemoryManager<ALIGNMENT>::~MemoryManager() {
+  const auto currentBytes = getTotalBytes();
+  if (currentBytes > 0) {
+    LOG(WARNING) << "Leaked total memory of " << currentBytes << " bytes";
   }
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryManager<Allocator, ALIGNMENT>::getMemoryQuota() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryManager<ALIGNMENT>::getMemoryQuota() const {
   return memoryQuota_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-MemoryPool& MemoryManager<Allocator, ALIGNMENT>::getRoot() const {
+template <uint16_t ALIGNMENT>
+MemoryPool& MemoryManager<ALIGNMENT>::getRoot() const {
   return *root_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-std::shared_ptr<MemoryPool> MemoryManager<Allocator, ALIGNMENT>::getChild(
-    int64_t cap) {
+template <uint16_t ALIGNMENT>
+std::shared_ptr<MemoryPool> MemoryManager<ALIGNMENT>::getChild(int64_t cap) {
   return root_->addChild(
       fmt::format(
           "default_usage_node_{}",
@@ -883,24 +818,24 @@ std::shared_ptr<MemoryPool> MemoryManager<Allocator, ALIGNMENT>::getChild(
       cap);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-int64_t MemoryManager<Allocator, ALIGNMENT>::getTotalBytes() const {
+template <uint16_t ALIGNMENT>
+int64_t MemoryManager<ALIGNMENT>::getTotalBytes() const {
   return totalBytes_.load(std::memory_order_relaxed);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-bool MemoryManager<Allocator, ALIGNMENT>::reserve(int64_t size) {
+template <uint16_t ALIGNMENT>
+bool MemoryManager<ALIGNMENT>::reserve(int64_t size) {
   return totalBytes_.fetch_add(size, std::memory_order_relaxed) + size <=
       memoryQuota_;
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-void MemoryManager<Allocator, ALIGNMENT>::release(int64_t size) {
+template <uint16_t ALIGNMENT>
+void MemoryManager<ALIGNMENT>::release(int64_t size) {
   totalBytes_.fetch_sub(size, std::memory_order_relaxed);
 }
 
-template <typename Allocator, uint16_t ALIGNMENT>
-Allocator& MemoryManager<Allocator, ALIGNMENT>::getAllocator() {
+template <uint16_t ALIGNMENT>
+MemoryAllocator& MemoryManager<ALIGNMENT>::getAllocator() {
   return *allocator_;
 }
 

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -26,7 +26,7 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::memory {
 
 MmapAllocator::MmapAllocator(const Options& options)
-    : MappedMemory(),
+    : MemoryAllocator(),
       numAllocated_(0),
       numMapped_(0),
       capacity_(bits::roundUp(
@@ -491,7 +491,7 @@ std::string MmapAllocator::SizeClass::toString() const {
     mappedFreeCount +=
         __builtin_popcountll(~pageAllocated_[i] & pageMapped_[i]);
   }
-  auto mb = (count * MappedMemory::kPageSize * unitSize_) >> 20;
+  auto mb = (count * MemoryAllocator::kPageSize * unitSize_) >> 20;
   out << "[size " << unitSize_ << ": " << count << "(" << mb << "MB) allocated "
       << mappedCount << " mapped";
   if (mappedFreeCount != numMappedFreePages_) {
@@ -720,7 +720,7 @@ void MmapAllocator::SizeClass::adviseAway(const Allocation& allocation) {
 }
 
 void MmapAllocator::SizeClass::setMappedBits(
-    const MappedMemory::PageRun run,
+    const MemoryAllocator::PageRun run,
     bool value) {
   const uint8_t* runAddress = run.data();
   const int firstBit = (runAddress - address_) / (unitSize_ * kPageSize);
@@ -734,7 +734,7 @@ void MmapAllocator::SizeClass::setMappedBits(
 }
 
 MachinePageCount MmapAllocator::SizeClass::free(
-    MappedMemory::Allocation& allocation) {
+    MemoryAllocator::Allocation& allocation) {
   MachinePageCount numFreed = 0;
   int firstRunInClass = -1;
   // Check if there are any runs in 'this' outside of 'mutex_'.

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -25,7 +25,7 @@
 #include <unordered_set>
 
 #include "velox/common/base/SimdUtil.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MmapArena.h"
 
 namespace facebook::velox::memory {
@@ -34,7 +34,7 @@ namespace facebook::velox::memory {
 /// size class dependent number of consecutive machine pages.
 using ClassPageCount = int32_t;
 
-/// Implementation of MappedMemory with mmap and madvise. Each size class is
+/// Implementation of MemoryAllocator with mmap and madvise. Each size class is
 /// mmapped for the whole capacity. Each size class has a bitmap of allocated
 /// entries and entries that are backed by memory. If a size class does not have
 /// an entry that is free and backed by memory, we allocate an entry that is
@@ -44,7 +44,7 @@ using ClassPageCount = int32_t;
 /// to be allocated that does not correspond to size classes, we advise away
 /// enough pages from other size classes to cover for it and then make a new
 /// mmap of the requested size (ContiguousAllocation).
-class MmapAllocator : public MappedMemory {
+class MmapAllocator : public MemoryAllocator {
  public:
   struct Options {
     ///  Capacity in bytes, default 512MB
@@ -154,7 +154,7 @@ class MmapAllocator : public MappedMemory {
     bool allocate(
         ClassPageCount numPages,
         MachinePageCount& numUnmapped,
-        MappedMemory::Allocation& out);
+        MemoryAllocator::Allocation& out);
 
     // Frees all pages of 'allocation' that fall in this size
     // class. Erases the corresponding runs from 'allocation'.
@@ -177,7 +177,7 @@ class MmapAllocator : public MappedMemory {
     void setAllMapped(const Allocation& allocation, bool value);
 
     // Sets the mapped flag for the class pages in 'run' to 'value'
-    void setMappedBits(const MappedMemory::PageRun run, bool value);
+    void setMappedBits(const MemoryAllocator::PageRun run, bool value);
 
     // True if 'ptr' is in the address range of 'this'. Checks that ptr is at a
     // size class page boundary.
@@ -202,7 +202,7 @@ class MmapAllocator : public MappedMemory {
     bool allocateLocked(
         ClassPageCount numPages,
         MachinePageCount* FOLLY_NULLABLE numUnmapped,
-        MappedMemory::Allocation& out);
+        MemoryAllocator::Allocation& out);
 
     // Returns the bit offset of the first bit of a 512 bit group in
     // 'pageAllocated_'/'pageMapped_'  that contains at least one mapped free

--- a/velox/common/memory/MmapArena.h
+++ b/velox/common/memory/MmapArena.h
@@ -21,7 +21,8 @@
 #include <map>
 #include <memory>
 #include <unordered_set>
-#include "velox/common/memory/MappedMemory.h"
+
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox::memory {
 

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox {
 
@@ -27,7 +27,7 @@ struct ByteRange;
 // complex types as serialized rows.
 class StreamArena {
  public:
-  explicit StreamArena(memory::MappedMemory* mappedMemory);
+  explicit StreamArena(memory::MemoryAllocator* MemoryAllocator);
 
   virtual ~StreamArena() = default;
 
@@ -45,17 +45,18 @@ class StreamArena {
     return size_;
   }
 
-  memory::MappedMemory* mappedMemory() {
-    return mappedMemory_.get();
+  memory::MemoryAllocator* allocator() {
+    return allocator_.get();
   }
 
  private:
-  std::shared_ptr<memory::MappedMemory> mappedMemory_;
+  std::shared_ptr<memory::MemoryAllocator> allocator_;
   // All allocations.
-  std::vector<std::unique_ptr<memory::MappedMemory::Allocation>> allocations_;
+  std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
+      allocations_;
   // The allocation from which pages are given out. Moved to 'allocations_' when
   // used up.
-  memory::MappedMemory::Allocation allocation_;
+  memory::MemoryAllocator::Allocation allocation_;
   int32_t currentRun_ = 0;
   int32_t currentPage_ = 0;
   memory::MachinePageCount allocationQuantum_ = 2;

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/memory/ByteStream.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/MmapAllocator.h"
 
 #include <gflags/gflags.h>
@@ -26,16 +26,16 @@ using namespace facebook::velox::memory;
 class ByteStreamTest : public testing::TestWithParam<bool> {
  protected:
   void SetUp() override {
-    constexpr uint64_t kMaxMappedMemory = 64 << 20;
+    constexpr uint64_t kMaxMemoryAllocator = 64 << 20;
     MmapAllocator::Options options;
-    options.capacity = kMaxMappedMemory;
+    options.capacity = kMaxMemoryAllocator;
     mmapAllocator_ = std::make_shared<MmapAllocator>(options);
-    MappedMemory::setDefaultInstance(mmapAllocator_.get());
+    MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
   }
 
   void TearDown() override {
-    MappedMemory::testingDestroyInstance();
-    MappedMemory::setDefaultInstance(nullptr);
+    MemoryAllocator::testingDestroyInstance();
+    MemoryAllocator::setDefaultInstance(nullptr);
   }
 
   std::shared_ptr<MmapAllocator> mmapAllocator_;

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -17,12 +17,12 @@ add_executable(
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp
+  MemoryAllocatorTest.cpp
   MemoryHeaderTest.cpp
   MemoryManagerTest.cpp
   MemoryPoolTest.cpp
   MemoryUsageTest.cpp
-  MemoryUsageTrackerTest.cpp
-  MappedMemoryTest.cpp)
+  MemoryUsageTrackerTest.cpp)
 
 target_link_libraries(
   velox_memory_test

--- a/velox/common/memory/tests/FragmentationBenchmark.cpp
+++ b/velox/common/memory/tests/FragmentationBenchmark.cpp
@@ -42,7 +42,7 @@ struct Block {
 
   size_t size = 0;
   char* data = nullptr;
-  std::shared_ptr<MappedMemory::Allocation> allocation;
+  std::shared_ptr<MemoryAllocator::Allocation> allocation;
   MmapAllocator::ContiguousAllocation contiguous;
 };
 
@@ -89,7 +89,7 @@ class FragmentationTest {
     if (memory_) {
       if (size <= 8 << 20) {
         block->allocation =
-            std::make_shared<MappedMemory::Allocation>(memory_.get());
+            std::make_shared<MemoryAllocator::Allocation>(memory_.get());
         if (!memory_->allocateNonContiguous(size / 4096, *block->allocation)) {
           VELOX_FAIL("allocate() faild");
         }

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -34,7 +34,7 @@ class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
     instance_ = std::make_unique<HashStringAllocator>(
-        memory::MappedMemory::getInstance());
+        memory::MemoryAllocator::getInstance());
     rng_.seed(1);
   }
 

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -27,7 +27,7 @@ namespace memory {
 
 TEST(MemoryManagerTest, Ctor) {
   {
-    MemoryManager<MemoryAllocator> manager{};
+    MemoryManager<> manager{};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
@@ -37,7 +37,7 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager<MemoryAllocator> manager{8L * 1024 * 1024};
+    MemoryManager<> manager{8L * 1024 * 1024};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(8L * 1024 * 1024, root.cap());
@@ -46,7 +46,7 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
-  { ASSERT_ANY_THROW(MemoryManager<MemoryAllocator> manager{-1}); }
+  { ASSERT_ANY_THROW(MemoryManager<> manager{-1}); }
 }
 
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
@@ -73,7 +73,7 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
 
 TEST(MemoryManagerTest, Reserve) {
   {
-    MemoryManager<MemoryAllocator> manager{};
+    MemoryManager<> manager{};
     ASSERT_TRUE(manager.reserve(0));
     ASSERT_EQ(0, manager.getTotalBytes());
     manager.release(0);
@@ -86,7 +86,7 @@ TEST(MemoryManagerTest, Reserve) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager<MemoryAllocator> manager{42};
+    MemoryManager<> manager{42};
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(2));

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -30,7 +30,7 @@ namespace facebook::velox::memory {
 
 class BenchmarkHelper {
  public:
-  BenchmarkHelper(MemoryManager<MemoryAllocator, kNoAlignment>& manager)
+  BenchmarkHelper(MemoryManager<kNoAlignment>& manager)
       : manager_{manager}, leaves_{findLeaves()} {}
 
   std::vector<MemoryPool*> findLeaves() {
@@ -62,14 +62,14 @@ class BenchmarkHelper {
 
  private:
   // TODO: move semantic is better
-  MemoryManager<MemoryAllocator, kNoAlignment>& manager_;
+  MemoryManager<kNoAlignment>& manager_;
   std::vector<MemoryPool*> leaves_;
 };
 } // namespace facebook::velox::memory
 
 BENCHMARK(SingleNodeAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -83,7 +83,7 @@ BENCHMARK(SingleNodeAlloc, iters) {
 // Should be the same.
 BENCHMARK(SingleNodeAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild(
       "pride_of_higara", iters * kMemoryFootprintIncrement);
 
@@ -98,7 +98,7 @@ BENCHMARK(SingleNodeAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -112,7 +112,7 @@ BENCHMARK(SingleNodeFree, iters) {
 
 BENCHMARK(SingleNodeRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -129,7 +129,7 @@ BENCHMARK(SingleNodeRealloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAlloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
@@ -143,7 +143,7 @@ BENCHMARK(SingleNodeAlignedAlloc, iters) {
 
 BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto unalignedTotal = iters * kMemoryFootprintIncrement;
   auto alignedCap = unalignedTotal % kDefaultAlignment == 0
       ? unalignedTotal
@@ -161,7 +161,7 @@ BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
 
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kDefaultAlignment> manager{};
+  MemoryManager<kDefaultAlignment> manager{};
   auto pool = manager.getRoot().addChild("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
@@ -191,7 +191,7 @@ void addNLeaves(
 // with single leaf runs.
 BENCHMARK(FlatTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   addNLeaves(manager.getRoot(), 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
@@ -211,7 +211,7 @@ BENCHMARK(FlatTree, iters) {
 // with single leaf runs.
 BENCHMARK(DeeperTree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   for (size_t i = 0; i < 10; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));
@@ -233,7 +233,7 @@ BENCHMARK(DeeperTree, iters) {
 
 BENCHMARK(FlatSubtree, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   auto child = manager.getRoot().addChild("query_fragment_1");
   addNLeaves(*child, 10 * 20);
   BenchmarkHelper helper{manager};
@@ -252,7 +252,7 @@ BENCHMARK(FlatSubtree, iters) {
 
 BENCHMARK(FlatSticks, iters) {
   folly::BenchmarkSuspender suspender;
-  MemoryManager<MemoryAllocator, kNoAlignment> manager{};
+  MemoryManager<kNoAlignment> manager{};
   for (size_t i = 0; i < 10 * 20; ++i) {
     auto child = manager.getRoot().addChild(
         "query_fragment_" + folly::to<std::string>(i));

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -34,16 +34,17 @@ namespace memory {
 
 class MemoryPoolTest : public testing::TestWithParam<bool> {
  protected:
+  MemoryPoolTest() : useMmap_(GetParam()) {}
+
   void SetUp() override {
-    useMmap_ = GetParam();
     // For duration of the test, make a local MmapAllocator that will not be
     // seen by any other test.
     if (useMmap_) {
       MmapAllocator::Options opts{8UL << 30};
-      mmapAllocator_ = std::make_unique<MmapAllocator>(opts);
-      MappedMemory::setDefaultInstance(mmapAllocator_.get());
+      mmapAllocator_ = std::make_shared<MmapAllocator>(opts);
+      MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
     } else {
-      MappedMemory::setDefaultInstance(nullptr);
+      MemoryAllocator::setDefaultInstance(nullptr);
     }
   }
 
@@ -52,28 +53,25 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<IMemoryManager> getMemoryManager(int64_t quota) {
-    if (useMmap_) {
-      return std::make_shared<MemoryManager<MmapMemoryAllocator>>(quota);
-    }
-    return std::make_shared<MemoryManager<MemoryAllocator>>(quota);
+    return std::make_shared<MemoryManager<>>(quota);
   }
 
-  bool useMmap_;
-  std::unique_ptr<MmapAllocator> mmapAllocator_;
+  const bool useMmap_;
+  std::shared_ptr<MmapAllocator> mmapAllocator_;
 };
 
 TEST(MemoryPoolTest, Ctor) {
-  MemoryManager<MemoryAllocator, 64> manager{8 * GB};
-  // While not recomended, the root allocator should be valid.
-  auto& root =
-      dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(manager.getRoot());
+  constexpr uint16_t kAlignment = 64;
+  MemoryManager<kAlignment> manager{8 * GB};
+  // While not recommended, the root allocator should be valid.
+  auto& root = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
 
   ASSERT_EQ(8 * GB, root.cap_);
   ASSERT_EQ(0, root.getCurrentBytes());
   ASSERT_EQ(root.parent(), nullptr);
 
   {
-    auto fakeRoot = std::make_shared<MemoryPoolImpl<MemoryAllocator, 64>>(
+    auto fakeRoot = std::make_shared<MemoryPoolImpl<64>>(
         manager, "fake_root", nullptr, 4 * GB);
     ASSERT_EQ("fake_root", fakeRoot->name());
     ASSERT_EQ(4 * GB, fakeRoot->cap_);
@@ -84,8 +82,7 @@ TEST(MemoryPoolTest, Ctor) {
   {
     auto child = root.addChild("favorite_child");
     ASSERT_EQ(child->parent(), &root);
-    auto& favoriteChild =
-        dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(*child);
+    auto& favoriteChild = dynamic_cast<MemoryPoolImpl<kAlignment>&>(*child);
     ASSERT_EQ("favorite_child", favoriteChild.name());
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), favoriteChild.cap_);
     ASSERT_EQ(&root.allocator_, &favoriteChild.allocator_);
@@ -94,8 +91,7 @@ TEST(MemoryPoolTest, Ctor) {
   {
     auto child = root.addChild("naughty_child", 3 * GB);
     ASSERT_EQ(child->parent(), &root);
-    auto& naughtyChild =
-        dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(*child);
+    auto& naughtyChild = dynamic_cast<MemoryPoolImpl<kAlignment>&>(*child);
     ASSERT_EQ("naughty_child", naughtyChild.name());
     ASSERT_EQ(3 * GB, naughtyChild.cap_);
     ASSERT_EQ(&root.allocator_, &naughtyChild.allocator_);
@@ -104,7 +100,7 @@ TEST(MemoryPoolTest, Ctor) {
 }
 
 TEST(MemoryPoolTest, AddChild) {
-  MemoryManager<MemoryAllocator> manager{};
+  MemoryManager<> manager{};
   auto& root = manager.getRoot();
 
   ASSERT_EQ(0, root.getChildCount());
@@ -129,7 +125,7 @@ TEST(MemoryPoolTest, AddChild) {
 }
 
 TEST_P(MemoryPoolTest, dropChild) {
-  MemoryManager<MemoryAllocator> manager{};
+  MemoryManager<> manager{};
   auto& root = manager.getRoot();
   ASSERT_EQ(root.parent(), nullptr);
 
@@ -170,7 +166,7 @@ TEST_P(MemoryPoolTest, dropChild) {
 }
 
 TEST(MemoryPoolTest, CapSubtree) {
-  MemoryManager<MemoryAllocator> manager{};
+  MemoryManager<> manager{};
   auto& root = manager.getRoot();
 
   // left subtree.
@@ -212,7 +208,7 @@ TEST(MemoryPoolTest, CapSubtree) {
 }
 
 TEST(MemoryPoolTest, UncapMemory) {
-  MemoryManager<MemoryAllocator> manager{};
+  MemoryManager<> manager{};
   auto& root = manager.getRoot();
 
   auto node_a = root.addChild("node_a");
@@ -263,7 +259,7 @@ TEST(MemoryPoolTest, UncapMemory) {
 
 // Mainly tests how it tracks externally allocated memory.
 TEST(MemoryPoolTest, ReserveTest) {
-  MemoryManager<MemoryAllocator> manager{8 * GB};
+  MemoryManager<> manager{8 * GB};
   auto& root = manager.getRoot();
 
   auto child = root.addChild("elastic_quota");
@@ -284,9 +280,9 @@ TEST(MemoryPoolTest, ReserveTest) {
 }
 
 MachinePageCount numPagesNeeded(
-    const MappedMemory* mappedMemory,
+    const MmapAllocator* mmapAllocator,
     MachinePageCount numPages) {
-  auto& sizeClasses = mappedMemory->sizeClasses();
+  auto& sizeClasses = mmapAllocator->sizeClasses();
   if (numPages > sizeClasses.back()) {
     return numPages;
   }
@@ -302,7 +298,7 @@ void testMmapMemoryAllocation(
     const MmapAllocator* mmapAllocator,
     MachinePageCount allocPages,
     size_t allocCount) {
-  MemoryManager<MmapMemoryAllocator> manager(8 * GB);
+  MemoryManager<> manager(8 * GB);
   const auto kPageSize = 4 * KB;
 
   auto& root = manager.getRoot();
@@ -348,16 +344,17 @@ void testMmapMemoryAllocation(
 TEST(MemoryPoolTest, SmallMmapMemoryAllocation) {
   MmapAllocator::Options options;
   options.capacity = 8 * GB;
-  auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
-  MappedMemory::setDefaultInstance(mmapAllocator.get());
+  auto mmapAllocator = std::make_shared<memory::MmapAllocator>(options);
+  MemoryAllocator::setDefaultInstance(mmapAllocator.get());
   testMmapMemoryAllocation(mmapAllocator.get(), 6, 100);
+  MemoryAllocator::setDefaultInstance(nullptr);
 }
 
 TEST(MemoryPoolTest, BigMmapMemoryAllocation) {
   MmapAllocator::Options options;
   options.capacity = 8 * GB;
-  auto mmapAllocator = std::make_unique<memory::MmapAllocator>(options);
-  MappedMemory::setDefaultInstance(mmapAllocator.get());
+  auto mmapAllocator = std::make_shared<memory::MmapAllocator>(options);
+  MemoryAllocator::setDefaultInstance(mmapAllocator.get());
   testMmapMemoryAllocation(
       mmapAllocator.get(), mmapAllocator->sizeClasses().back() + 56, 20);
 }
@@ -514,7 +511,7 @@ TEST_P(MemoryPoolTest, allocateZeroFilled) {
 }
 
 TEST(MemoryPoolTest, MemoryCapExceptions) {
-  MemoryManager<MemoryAllocator> manager{127L * MB};
+  MemoryManager<> manager{127L * MB};
   auto& root = manager.getRoot();
 
   auto pool = root.addChild("static_quota", 63L * MB);
@@ -567,18 +564,16 @@ TEST(MemoryPoolTest, MemoryCapExceptions) {
 
 TEST(MemoryPoolTest, GetAlignment) {
   {
-    EXPECT_EQ(
-        kNoAlignment,
-        MemoryManager<MemoryAllocator>{32 * MB}.getRoot().getAlignment());
+    EXPECT_EQ(kNoAlignment, MemoryManager<>{32 * MB}.getRoot().getAlignment());
   }
   {
-    MemoryManager<MemoryAllocator, 64> manager{32 * MB};
+    MemoryManager<64> manager{32 * MB};
     EXPECT_EQ(64, manager.getRoot().getAlignment());
   }
 }
 
 TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
-  MemoryManager<MemoryAllocator> manager{32 * MB};
+  MemoryManager<> manager{32 * MB};
 
   auto& root = manager.getRoot();
   auto pool = root.addChild("unbounded");
@@ -601,7 +596,7 @@ TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
 // and what it returns for getCurrentBytes()/getMaxBytes and
 // with memoryUsageTracker.
 TEST(MemoryPoolTest, childUsageTest) {
-  MemoryManager<MemoryAllocator> manager{8 * GB};
+  MemoryManager<> manager{8 * GB};
   auto& root = manager.getRoot();
 
   auto pool = root.addChild("main_pool");
@@ -708,9 +703,8 @@ TEST(MemoryPoolTest, childUsageTest) {
 }
 
 TEST(MemoryPoolTest, getPreferredSize) {
-  MemoryManager<MemoryAllocator, 64> manager{};
-  auto& pool =
-      dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(manager.getRoot());
+  MemoryManager<64> manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
 
   // size < 8
   EXPECT_EQ(8, pool.getPreferredSize(1));
@@ -726,18 +720,16 @@ TEST(MemoryPoolTest, getPreferredSize) {
 }
 
 TEST(MemoryPoolTest, getPreferredSizeOverflow) {
-  MemoryManager<MemoryAllocator, 64> manager{};
-  auto& pool =
-      dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(manager.getRoot());
+  MemoryManager<64> manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
 
   EXPECT_EQ(1ULL << 32, pool.getPreferredSize((1ULL << 32) - 1));
   EXPECT_EQ(1ULL << 63, pool.getPreferredSize((1ULL << 62) - 1 + (1ULL << 62)));
 }
 
 TEST(MemoryPoolTest, allocatorOverflow) {
-  MemoryManager<MemoryAllocator, 64> manager{};
-  auto& pool =
-      dynamic_cast<MemoryPoolImpl<MemoryAllocator, 64>&>(manager.getRoot());
+  MemoryManager<64> manager{};
+  auto& pool = dynamic_cast<MemoryPoolImpl<64>&>(manager.getRoot());
   Allocator<int64_t> alloc(pool);
   EXPECT_THROW(alloc.allocate(1ULL << 62), VeloxException);
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), VeloxException);

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -179,14 +179,14 @@ class ConnectorQueryCtx {
       memory::MemoryPool* FOLLY_NONNULL pool,
       const Config* FOLLY_NONNULL connectorConfig,
       ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const std::string& taskId,
       const std::string& planNodeId,
       int driverId)
       : pool_(pool),
         config_(connectorConfig),
         expressionEvaluator_(expressionEvaluator),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         scanId_(fmt::format("{}.{}", taskId, planNodeId)),
         taskId_(taskId),
         driverId_(driverId) {}
@@ -203,10 +203,10 @@ class ConnectorQueryCtx {
     return expressionEvaluator_;
   }
 
-  // MappedMemory for large allocations. Used for caching with
+  // MemoryAllocator for large allocations. Used for caching with
   // CachedBufferedImput if this implements cache::AsyncDataCache.
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
   // This is a combination of task id and the scan's PlanNodeId. This is an id
@@ -229,7 +229,7 @@ class ConnectorQueryCtx {
   memory::MemoryPool* FOLLY_NONNULL pool_;
   const Config* FOLLY_NONNULL config_;
   ExpressionEvaluator* FOLLY_NULLABLE expressionEvaluator_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   const std::string scanId_;
   const std::string taskId_;
   const int driverId_;

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -172,7 +172,7 @@ HiveDataSource::HiveDataSource(
     FileHandleFactory* fileHandleFactory,
     velox::memory::MemoryPool* pool,
     ExpressionEvaluator* expressionEvaluator,
-    memory::MappedMemory* mappedMemory,
+    memory::MemoryAllocator* allocator,
     const std::string& scanId,
     folly::Executor* executor)
     : outputType_(outputType),
@@ -180,7 +180,7 @@ HiveDataSource::HiveDataSource(
       pool_(pool),
       readerOpts_(pool),
       expressionEvaluator_(expressionEvaluator),
-      mappedMemory_(mappedMemory),
+      allocator_(allocator),
       scanId_(scanId),
       executor_(executor) {
   // Column handled keyed on the column alias, the name used in the query.
@@ -337,7 +337,7 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   fileHandle_ = fileHandleFactory_->generate(split_->filePath);
   std::unique_ptr<dwio::common::BufferedInput> input;
-  if (auto* asyncCache = dynamic_cast<cache::AsyncDataCache*>(mappedMemory_)) {
+  if (auto* asyncCache = dynamic_cast<cache::AsyncDataCache*>(allocator_)) {
     input = std::make_unique<dwio::common::CachedBufferedInput>(
         fileHandle_->file,
         readerOpts_.getMemoryPool(),

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -114,7 +114,7 @@ class HiveDataSource : public DataSource {
       FileHandleFactory* FOLLY_NONNULL fileHandleFactory,
       velox::memory::MemoryPool* FOLLY_NONNULL pool,
       ExpressionEvaluator* FOLLY_NONNULL expressionEvaluator,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const std::string& scanId,
       folly::Executor* FOLLY_NULLABLE executor);
 
@@ -193,7 +193,7 @@ class HiveDataSource : public DataSource {
   SelectivityVector filterRows_;
   exec::FilterEvalCtx filterEvalCtx_;
 
-  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
   const std::string& scanId_;
   folly::Executor* FOLLY_NULLABLE executor_;
 };
@@ -236,7 +236,7 @@ class HiveConnector final : public Connector {
         &fileHandleFactory_,
         connectorQueryCtx->memoryPool(),
         connectorQueryCtx->expressionEvaluator(),
-        connectorQueryCtx->mappedMemory(),
+        connectorQueryCtx->allocator(),
         connectorQueryCtx->scanId(),
         executor_);
   }

--- a/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
+++ b/velox/connectors/hive/tests/HiveWriteProtocolTest.cpp
@@ -34,7 +34,7 @@ TEST(HiveWriteProtocolTest, writerParameters) {
       queryCtx->pool(),
       queryCtx->getConnectorConfig(HiveConnectorFactory::kHiveConnectorName),
       nullptr,
-      queryCtx->mappedMemory(),
+      queryCtx->allocator(),
       "test_task_id",
       "test_plan_node_id",
       0);

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -17,8 +17,8 @@
 
 #include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
-#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/core/Context.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/vector/DecodedVector.h"
@@ -40,14 +40,14 @@ class QueryCtx : public Context {
       std::shared_ptr<Config> config = std::make_shared<MemConfig>(),
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory =
-          memory::MappedMemory::getInstance(),
+      memory::MemoryAllocator* FOLLY_NONNULL allocator =
+          memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       std::shared_ptr<folly::Executor> spillExecutor = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
         pool_(std::move(pool)),
-        mappedMemory_(mappedMemory),
+        allocator_(allocator),
         connectorConfigs_(connectorConfigs),
         executor_(executor),
         queryConfig_{this},
@@ -68,13 +68,13 @@ class QueryCtx : public Context {
       std::shared_ptr<Config> config = std::make_shared<MemConfig>(),
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory =
-          memory::MappedMemory::getInstance(),
+      memory::MemoryAllocator* FOLLY_NONNULL MemoryAllocator =
+          memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       const std::string& queryId = "")
       : Context{ContextScope::QUERY},
         pool_(std::move(pool)),
-        mappedMemory_(mappedMemory),
+        allocator_(MemoryAllocator),
         connectorConfigs_(connectorConfigs),
         executorKeepalive_(std::move(executorKeepalive)),
         queryConfig_{this},
@@ -93,8 +93,8 @@ class QueryCtx : public Context {
     return pool_.get();
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return allocator_;
   }
 
   folly::Executor* FOLLY_NONNULL executor() const {
@@ -149,7 +149,7 @@ class QueryCtx : public Context {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
   folly::Executor* FOLLY_NULLABLE executor_;
   folly::Executor::KeepAlive<> executorKeepalive_;

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -25,7 +25,7 @@ namespace facebook::velox::dwio::common {
 
 using velox::cache::ScanTracker;
 using velox::cache::TrackingId;
-using velox::memory::MappedMemory;
+using velox::memory::MemoryAllocator;
 
 CacheInputStream::CacheInputStream(
     CachedBufferedInput* bufferedInput,
@@ -149,7 +149,7 @@ std::vector<folly::Range<char*>> makeRanges(
     uint64_t offsetInRuns = 0;
     for (int i = 0; i < allocation.numRuns(); ++i) {
       auto run = allocation.runAt(i);
-      uint64_t bytes = run.numPages() * MappedMemory::kPageSize;
+      uint64_t bytes = run.numPages() * MemoryAllocator::kPageSize;
       uint64_t readSize = std::min(bytes, length - offsetInRuns);
       buffers.push_back(folly::Range<char*>(run.data<char>(), readSize));
       offsetInRuns += readSize;
@@ -320,7 +320,7 @@ void CacheInputStream::loadPosition() {
       offsetOfRun_ = offsetInEntry - offsetInRun_;
       auto run = entry->data().runAt(runIndex_);
       run_ = run.data();
-      runSize_ = run.numPages() * MappedMemory::kPageSize;
+      runSize_ = run.numPages() * MemoryAllocator::kPageSize;
       if (offsetOfRun_ + runSize_ > entry->size()) {
         runSize_ = entry->size() - offsetOfRun_;
       }

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -32,7 +32,7 @@ using cache::ScanTracker;
 using cache::SsdFile;
 using cache::SsdPin;
 using cache::TrackingId;
-using memory::MappedMemory;
+using memory::MemoryAllocator;
 
 std::unique_ptr<SeekableInputStream> CachedBufferedInput::enqueue(
     Region region,
@@ -80,11 +80,11 @@ bool CachedBufferedInput::shouldPreload(int32_t numPages) {
   for (auto& request : requests_) {
     numPages += bits::roundUp(
                     std::min<int32_t>(request.size, loadQuantum_),
-                    MappedMemory::kPageSize) /
-        MappedMemory::kPageSize;
+                    MemoryAllocator::kPageSize) /
+        MemoryAllocator::kPageSize;
   }
   auto cachePages = cache_->incrementCachedPages(0);
-  auto maxPages = cache_->maxBytes() / MappedMemory::kPageSize;
+  auto maxPages = cache_->maxBytes() / MemoryAllocator::kPageSize;
   auto allocatedPages = cache_->numAllocated();
   if (numPages < maxPages - allocatedPages) {
     // There is free space for the read-ahead.
@@ -494,8 +494,8 @@ std::unique_ptr<SeekableInputStream> CachedBufferedInput::read(
 
 bool CachedBufferedInput::prefetch(Region region) {
   int32_t numPages =
-      bits::roundUp(region.length, memory::MappedMemory::kPageSize) /
-      memory::MappedMemory::kPageSize;
+      bits::roundUp(region.length, memory::MemoryAllocator::kPageSize) /
+      memory::MemoryAllocator::kPageSize;
   if (!shouldPreload(numPages)) {
     return false;
   }

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::cache;
 
-using memory::MappedMemory;
+using memory::MemoryAllocator;
 using IoStatisticsPtr = std::shared_ptr<IoStatistics>;
 
 // Testing stream producing deterministic data. The byte at offset is
@@ -473,7 +473,8 @@ TEST_F(CacheTest, window) {
   auto stream = input->read(begin, end - begin, LogType::TEST);
   auto cacheInput = dynamic_cast<CacheInputStream*>(stream.get());
   EXPECT_TRUE(cacheInput != nullptr);
-  auto maxSize = cache_->sizeClasses().back() * memory::MappedMemory::kPageSize;
+  auto maxSize =
+      cache_->sizeClasses().back() * memory::MemoryAllocator::kPageSize;
   const void* buffer;
   int32_t size;
   int32_t numRead = 0;

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -60,11 +60,11 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   void* allocate(int64_t size) override {
     updateLocalMemoryUsage(size);
-    return allocator_.alloc(size);
+    return allocator_->allocateBytes(size);
   }
   void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
     updateLocalMemoryUsage(numMembers * sizeEach);
-    return allocator_.allocZeroFilled(numMembers, sizeEach);
+    return allocator_->allocateZeroFilled(numMembers * sizeEach);
   }
 
   // No-op for attempts to shrink buffer.
@@ -76,10 +76,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     if (UNLIKELY(difference <= 0)) {
       return p;
     }
-    return allocator_.realloc(p, size, newSize);
+    return allocator_->reallocateBytes(p, size, newSize);
   }
   void free(void* p, int64_t size) override {
-    allocator_.free(p, size);
+    allocator_->freeBytes(p, size);
     updateLocalMemoryUsage(-size);
   }
 
@@ -126,7 +126,8 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   MOCK_CONST_METHOD0(getAlignment, uint16_t());
 
  private:
-  velox::memory::MemoryAllocator allocator_{};
+  velox::memory::MemoryAllocator* const FOLLY_NONNULL allocator_{
+      velox::memory::MemoryAllocator::getInstance()};
   int64_t localMemoryUsage_{0};
   int64_t subtreeMemoryUsage_{0};
   int64_t cap_;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -15,8 +15,8 @@
  */
 #pragma once
 
-#include <velox/common/memory/MappedMemory.h>
 #include <velox/common/memory/Memory.h>
+#include <velox/common/memory/MemoryAllocator.h>
 #include <memory>
 #include "velox/common/memory/ByteStream.h"
 #include "velox/exec/Operator.h"

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -184,7 +184,7 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   // The maximum memory usage that a final aggregation can hold before spilling.
   // If it is zero, then there is no such limit.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -50,7 +50,7 @@ HashBuild::HashBuild(
     : Operator(driverCtx, nullptr, operatorId, joinNode->id(), "HashBuild"),
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
-      mappedMemory_(operatorCtx_->mappedMemory()),
+      allocator_(operatorCtx_->allocator()),
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
@@ -132,7 +132,7 @@ void HashBuild::setupTable() {
         dependentTypes,
         true, // allowDuplicates
         true, // hasProbedFlag
-        mappedMemory_);
+        allocator_);
   } else {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
@@ -149,7 +149,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          mappedMemory_);
+          allocator_);
     } else {
       // Ignore null keys
       table_ = HashTable<true>::createForJoin(
@@ -157,7 +157,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          mappedMemory_);
+          allocator_);
     }
   }
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
@@ -428,7 +428,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   const auto increment =
       rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0);
 
-  auto tracker = CHECK_NOTNULL(mappedMemory_->tracker());
+  auto tracker = CHECK_NOTNULL(allocator_->tracker());
   // There must be at least 2x the increments in reservation.
   if (tracker->availableReservation() > 2 * increment) {
     return true;
@@ -765,7 +765,7 @@ void HashBuild::postHashBuildProcess() {
 
   // Release the unused memory reservation since we have finished the table
   // build.
-  operatorCtx_->mappedMemory()->tracker()->release();
+  operatorCtx_->allocator()->tracker()->release();
 
   if (!spillEnabled()) {
     setState(State::kFinish);

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -232,7 +232,7 @@ class HashBuild final : public Operator {
   const core::JoinType joinType_;
 
   // Holds the areas in RowContainer of 'table_'
-  memory::MappedMemory* const FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
 
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -53,7 +53,7 @@ HashTable<ignoreNullKeys>::HashTable(
     bool allowDuplicates,
     bool isJoinBuild,
     bool hasProbedFlag,
-    memory::MappedMemory* mappedMemory)
+    memory::MemoryAllocator* allocator)
     : BaseHashTable(std::move(hashers)), isJoinBuild_(isJoinBuild) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
@@ -71,7 +71,7 @@ HashTable<ignoreNullKeys>::HashTable(
       isJoinBuild,
       hasProbedFlag,
       hashMode_ != HashMode::kHash,
-      mappedMemory,
+      allocator,
       ContainerRowSerde::instance());
   nextOffset_ = rows_->nextOffset();
 }
@@ -608,11 +608,11 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
   numTombstones_ = 0;
   sizeMask_ = capacity_ - 1;
   sizeBits_ = __builtin_popcountll(sizeMask_);
-  constexpr auto kPageSize = memory::MappedMemory::kPageSize;
+  constexpr auto kPageSize = memory::MemoryAllocator::kPageSize;
   // The total size is 9 bytes per slot, 8 in the pointers table and 1 in the
   // tags table.
   auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
-  if (!rows_->mappedMemory()->allocateContiguous(
+  if (!rows_->allocator()->allocateContiguous(
           numPages, nullptr, tableAllocation_)) {
     VELOX_FAIL("Could not allocate join/group by hash table");
   }
@@ -1119,9 +1119,9 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
   VELOX_CHECK_NE(hashMode_, HashMode::kHash);
   if (mode == HashMode::kArray) {
     auto bytes = capacity_ * sizeof(char*);
-    constexpr auto kPageSize = memory::MappedMemory::kPageSize;
+    constexpr auto kPageSize = memory::MemoryAllocator::kPageSize;
     auto numPages = bits::roundUp(bytes, kPageSize) / kPageSize;
-    if (!rows_->mappedMemory()->allocateContiguous(
+    if (!rows_->allocator()->allocateContiguous(
             numPages, nullptr, tableAllocation_)) {
       VELOX_FAIL(
           "Could not allocate array with {} bytes/{} pages "

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -15,7 +15,7 @@
  */
 #pragma once
 
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
@@ -312,12 +312,12 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool isJoinBuild,
       bool hasProbedFlag,
-      memory::MappedMemory* FOLLY_NULLABLE memory);
+      memory::MemoryAllocator* FOLLY_NULLABLE memory);
 
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       const std::vector<std::unique_ptr<Aggregate>>& aggregates,
-      memory::MappedMemory* FOLLY_NULLABLE memory) {
+      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         aggregates,
@@ -333,7 +333,7 @@ class HashTable : public BaseHashTable {
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool hasProbedFlag,
-      memory::MappedMemory* FOLLY_NULLABLE memory) {
+      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
     static const std::vector<std::unique_ptr<Aggregate>> kNoAggregates;
     return std::make_unique<HashTable>(
         std::move(hashers),
@@ -379,7 +379,7 @@ class HashTable : public BaseHashTable {
 
   int64_t allocatedBytes() const override {
     // for each row: 1 byte per tag + sizeof(Entry) per table entry + memory
-    // allocated with MappedMemory for fixed-width rows and strings.
+    // allocated with MemoryAllocator for fixed-width rows and strings.
     return (1 + sizeof(char*)) * capacity_ + rows_->allocatedBytes();
   }
 
@@ -655,7 +655,7 @@ class HashTable : public BaseHashTable {
   int32_t nextOffset_;
   uint8_t* FOLLY_NULLABLE tags_ = nullptr;
   char* FOLLY_NULLABLE* FOLLY_NULLABLE table_ = nullptr;
-  memory::MappedMemory::ContiguousAllocation tableAllocation_;
+  memory::MemoryAllocator::ContiguousAllocation tableAllocation_;
   int64_t capacity_{0};
   int64_t sizeMask_{0};
   int64_t numDistinct_{0};

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -50,8 +50,8 @@ class Merge : public SourceOperator {
     return outputType_;
   }
 
-  memory::MappedMemory* mappedMemory() const {
-    return operatorCtx_->mappedMemory();
+  memory::MemoryAllocator* allocator() const {
+    return operatorCtx_->allocator();
   }
 
  protected:

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -84,7 +84,7 @@ OperatorCtx::createConnectorQueryCtx(
       pool_,
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       expressionEvaluator_.get(),
-      driverCtx_->task->queryCtx()->mappedMemory(),
+      driverCtx_->task->queryCtx()->allocator(),
       taskId(),
       planNodeId,
       driverCtx_->driverId);
@@ -209,12 +209,12 @@ std::optional<uint32_t> Operator::maxDrivers(
   return std::nullopt;
 }
 
-memory::MappedMemory* OperatorCtx::mappedMemory() const {
-  if (!mappedMemory_) {
-    mappedMemory_ =
+memory::MemoryAllocator* OperatorCtx::allocator() const {
+  if (!allocator_) {
+    allocator_ =
         driverCtx_->task->addOperatorMemory(pool_->getMemoryUsageTracker());
   }
-  return mappedMemory_;
+  return allocator_;
 }
 
 const std::string& OperatorCtx::taskId() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -197,7 +197,7 @@ class OperatorCtx {
     return operatorType_;
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const;
 
   core::ExecCtx* FOLLY_NONNULL execCtx() const;
 
@@ -220,7 +220,7 @@ class OperatorCtx {
   velox::memory::MemoryPool* const FOLLY_NONNULL pool_;
 
   // These members are created on demand.
-  mutable memory::MappedMemory* FOLLY_NULLABLE mappedMemory_{nullptr};
+  mutable memory::MemoryAllocator* FOLLY_NULLABLE allocator_{nullptr};
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
   mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -36,7 +36,7 @@ OrderBy::OrderBy(
           operatorId,
           orderByNode->id(),
           "OrderBy"),
-      mappedMemory_(operatorCtx_->mappedMemory()),
+      allocator_(operatorCtx_->allocator()),
       numSortKeys_(orderByNode->sortingKeys().size()),
       spillMemoryThreshold_(operatorCtx_->driverCtx()
                                 ->queryConfig()
@@ -85,7 +85,7 @@ OrderBy::OrderBy(
 
   // Create row container.
   data_ = std::make_unique<RowContainer>(
-      keyTypes, dependentTypes, operatorCtx_->mappedMemory());
+      keyTypes, dependentTypes, operatorCtx_->allocator());
   internalStoreType_ = ROW(std::move(names), std::move(types));
 #ifndef NDEBUG
   for (int i = 0; i < internalStoreType_->children().size(); ++i) {
@@ -158,7 +158,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  auto tracker = mappedMemory_->tracker();
+  auto tracker = allocator_->tracker();
   VELOX_CHECK_NOT_NULL(tracker);
   const auto currentUsage = tracker->currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
@@ -213,7 +213,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
   VELOX_CHECK_GE(targetBytes, 0);
 
   if (spiller_ == nullptr) {
-    VELOX_DCHECK(mappedMemory_->tracker() != nullptr);
+    VELOX_DCHECK(allocator_->tracker() != nullptr);
     const auto& spillConfig = spillConfig_.value();
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kOrderBy,

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -78,7 +78,7 @@ class OrderBy : public Operator {
   // in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
-  memory::MappedMemory* FOLLY_NONNULL const mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
 
   const int32_t numSortKeys_;
 

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -63,7 +63,7 @@ void Destination::serialize(
     vector_size_t begin,
     vector_size_t end) {
   if (!current_) {
-    current_ = std::make_unique<VectorStreamGroup>(memory_);
+    current_ = std::make_unique<VectorStreamGroup>(allocator_);
     auto rowType = std::dynamic_pointer_cast<const RowType>(output->type());
     vector_size_t numRows = 0;
     for (vector_size_t i = begin; i < end; i++) {
@@ -84,7 +84,7 @@ BlockingReason Destination::flush(
   constexpr int32_t kMinMessageSize = 128;
   auto listener = bufferManager.newListener();
   IOBufOutputStream stream(
-      *current_->mappedMemory(),
+      *current_->allocator(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
   current_->flush(&stream);
@@ -124,7 +124,7 @@ PartitionedOutput::PartitionedOutput(
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
                             .maxPartitionedOutputBufferSize()),
-      mappedMemory_{operatorCtx_->mappedMemory()} {
+      allocator_{operatorCtx_->allocator()} {
   if (numDestinations_ == 1 || planNode->isBroadcast()) {
     VELOX_CHECK(keyChannels_.empty());
     VELOX_CHECK_NULL(partitionFunction_);
@@ -157,7 +157,7 @@ void PartitionedOutput::initializeDestinations() {
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
       destinations_.push_back(
-          std::make_unique<Destination>(taskId, i, mappedMemory_));
+          std::make_unique<Destination>(taskId, i, allocator_));
     }
   }
 }

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -27,8 +27,8 @@ class Destination {
   Destination(
       const std::string& taskId,
       int destination,
-      memory::MappedMemory* FOLLY_NONNULL memory)
-      : taskId_(taskId), destination_(destination), memory_(memory) {
+      memory::MemoryAllocator* FOLLY_NONNULL allocator)
+      : taskId_(taskId), destination_(destination), allocator_(allocator) {
     setTargetSizePct();
   }
 
@@ -89,7 +89,7 @@ class Destination {
 
   const std::string taskId_;
   const int destination_;
-  memory::MappedMemory* FOLLY_NONNULL const memory_;
+  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
   uint64_t bytesInCurrent_{0};
   std::vector<IndexRange> rows_;
 
@@ -190,7 +190,7 @@ class PartitionedOutput : public Operator {
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
   const int64_t maxBufferedBytes_;
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory_;
+  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   RowVectorPtr output_;
 
   // Reusable memory.

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/common/memory/MappedMemory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
 #include "velox/exec/Spill.h"
@@ -65,7 +65,7 @@ struct RowContainerIterator {
 class RowPartitions {
  public:
   /// Initializes this to hold up to 'numRows'.
-  RowPartitions(int32_t numRows, memory::MappedMemory& mappedMemory);
+  RowPartitions(int32_t numRows, memory::MemoryAllocator& MemoryAllocator);
 
   /// Appends 'partitions' to the end of 'this'. Throws if adding more than the
   /// capacity given at construction.
@@ -86,7 +86,7 @@ class RowPartitions {
   int32_t size_{0};
 
   // Partition numbers. 1 byte each.
-  memory::MappedMemory::Allocation allocation_;
+  memory::MemoryAllocator::Allocation allocation_;
 };
 
 // Packed representation of offset, null byte offset and null mask for
@@ -131,17 +131,17 @@ class RowContainer {
   static constexpr uint64_t kUnlimited = std::numeric_limits<uint64_t>::max();
   using Eraser = std::function<void(folly::Range<char**> rows)>;
 
-  // 'keyTypes' gives the type of row and use 'mappedMemory' for bulk
+  // 'keyTypes' gives the type of row and use 'MemoryAllocator' for bulk
   // allocation.
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory)
-      : RowContainer(keyTypes, std::vector<TypePtr>{}, mappedMemory) {}
+      memory::MemoryAllocator* FOLLY_NONNULL MemoryAllocator)
+      : RowContainer(keyTypes, std::vector<TypePtr>{}, MemoryAllocator) {}
 
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory)
+      memory::MemoryAllocator* FOLLY_NONNULL MemoryAllocator)
       : RowContainer(
             keyTypes,
             true, // nullableKeys
@@ -151,7 +151,7 @@ class RowContainer {
             false, // isJoinBuild
             false, // hasProbedFlag
             false, // hasNormalizedKey
-            mappedMemory,
+            MemoryAllocator,
             ContainerRowSerde::instance()) {}
 
   // 'keyTypes' gives the type of the key of each row. For a group by,
@@ -168,7 +168,7 @@ class RowContainer {
   // join. 'hasNormalizedKey' specifies that an extra word is left
   // below each row for a normalized key that collapses all parts
   // into one word for faster comparison. The bulk allocation is done
-  // from 'mappedMemory'.  'serde_' is used for serializing complex
+  // from 'MemoryAllocator'.  'serde_' is used for serializing complex
   // type values into the container.
   RowContainer(
       const std::vector<TypePtr>& keyTypes,
@@ -179,7 +179,7 @@ class RowContainer {
       bool isJoinBuild,
       bool hasProbedFlag,
       bool hasNormalizedKey,
-      memory::MappedMemory* FOLLY_NONNULL mappedMemory,
+      memory::MemoryAllocator* FOLLY_NONNULL MemoryAllocator,
       const RowSerde& serde);
 
   // Allocates a new row and initializes possible aggregates to null.
@@ -354,13 +354,13 @@ class RowContainer {
       auto allocation = rows_.allocationAt(i);
       auto numRuns = allocation->numRuns();
       for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
-        memory::MappedMemory::PageRun run = allocation->runAt(runIndex);
+        memory::MemoryAllocator::PageRun run = allocation->runAt(runIndex);
         auto data = run.data<char>();
         int64_t limit;
         if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
           limit = rows_.currentOffset();
         } else {
-          limit = run.numPages() * memory::MappedMemory::kPageSize;
+          limit = run.numPages() * memory::MemoryAllocator::kPageSize;
         }
         auto row = iter->rowOffset;
         while (row + rowSize <= limit) {
@@ -569,8 +569,8 @@ class RowContainer {
     }
   }
 
-  memory::MappedMemory* FOLLY_NONNULL mappedMemory() const {
-    return stringAllocator_.mappedMemory();
+  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+    return stringAllocator_.allocator();
   }
 
   // Returns the types of all non-aggregate columns of 'this', keys first.

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -102,7 +102,7 @@ WriteFile& SpillFileList::currentOutput() {
 void SpillFileList::flush() {
   if (batch_) {
     IOBufOutputStream out(
-        mappedMemory_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+        allocator_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
     batch_->flush(&out);
     batch_.reset();
     auto iobuf = out.getIOBuf();
@@ -118,7 +118,7 @@ void SpillFileList::write(
     const RowVectorPtr& rows,
     const folly::Range<IndexRange*>& indices) {
   if (!batch_) {
-    batch_ = std::make_unique<VectorStreamGroup>(&mappedMemory_);
+    batch_ = std::make_unique<VectorStreamGroup>(&allocator_);
     batch_->createStreamTree(
         std::static_pointer_cast<const RowType>(rows->type()),
         1000,
@@ -183,7 +183,7 @@ void SpillState::appendToPartition(
         fmt::format("{}-spill-{}", path_, partition),
         targetFileSize_,
         pool_,
-        mappedMemory_);
+        allocator_);
   }
 
   IndexRange range{0, rows->size()};

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -159,7 +159,7 @@ class SpillFileList {
   /// content. 'numSortingKeys' is the number of leading columns on which the
   /// data is sorted. 'path' is a file path prefix. ' 'targetFileSize' is the
   /// target byte size of a single file in the file set. 'pool' and
-  /// 'mappedMemory' are used for buffering and constructing the result data
+  /// 'MemoryAllocator' are used for buffering and constructing the result data
   /// read from 'this'.
   ///
   /// When writing sorted spill runs, the caller is responsible for buffering
@@ -171,14 +171,14 @@ class SpillFileList {
       const std::string& path,
       uint64_t targetFileSize,
       memory::MemoryPool& pool,
-      memory::MappedMemory& mappedMemory)
+      memory::MemoryAllocator& allocator)
       : type_(type),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         path_(path),
         targetFileSize_(targetFileSize),
         pool_(pool),
-        mappedMemory_(mappedMemory) {
+        allocator_(allocator) {
     // NOTE: if the associated spilling operator has specified the sort
     // comparison flags, then it must match the number of sorting keys.
     VELOX_CHECK(
@@ -230,7 +230,7 @@ class SpillFileList {
   const std::string path_;
   const uint64_t targetFileSize_;
   memory::MemoryPool& pool_;
-  memory::MappedMemory& mappedMemory_;
+  memory::MemoryAllocator& allocator_;
   std::unique_ptr<VectorStreamGroup> batch_;
   SpillFiles files_;
 };
@@ -550,7 +550,7 @@ class SpillState {
   // number of partitions. 'numSortingKeys' is the number of leading columns
   // on which the data is sorted, 0 if only hash partitioning is used.
   // 'targetFileSize' is the target size of a single
-  // file.  'pool' and 'mappedMemory' own
+  // file.  'pool' and 'MemoryAllocator' own
   // the memory for state and results.
   SpillState(
       const std::string& path,
@@ -559,14 +559,14 @@ class SpillState {
       const std::vector<CompareFlags>& sortCompareFlags,
       uint64_t targetFileSize,
       memory::MemoryPool& pool,
-      memory::MappedMemory& mappedMemory)
+      memory::MemoryAllocator& MemoryAllocator)
       : path_(path),
         maxPartitions_(maxPartitions),
         numSortingKeys_(numSortingKeys),
         sortCompareFlags_(sortCompareFlags),
         targetFileSize_(targetFileSize),
         pool_(pool),
-        mappedMemory_(mappedMemory),
+        allocator_(MemoryAllocator),
         files_(maxPartitions_) {}
 
   /// Indicates if a given 'partition' has been spilled or not.
@@ -652,7 +652,7 @@ class SpillState {
   const uint64_t targetFileSize_;
 
   memory::MemoryPool& pool_;
-  memory::MappedMemory& mappedMemory_;
+  memory::MemoryAllocator& allocator_;
 
   // A set of spilled partition numbers.
   SpillPartitionNumSet spilledPartitionSet_;

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -104,7 +104,7 @@ Spiller::Spiller(
           sortCompareFlags,
           targetFileSize,
           pool,
-          spillMappedMemory()),
+          allocator()),
       pool_(pool),
       executor_(executor) {
   TestValue::adjust(
@@ -115,7 +115,7 @@ Spiller::Spiller(
   VELOX_CHECK((type_ != Type::kOrderBy) || (state_.maxPartitions() == 1));
   spillRuns_.reserve(state_.maxPartitions());
   for (int i = 0; i < state_.maxPartitions(); ++i) {
-    spillRuns_.emplace_back(spillMappedMemory());
+    spillRuns_.emplace_back(allocator());
   }
 }
 
@@ -497,7 +497,7 @@ Spiller::SpillRows Spiller::finishSpill() {
   spillFinalized_ = true;
 
   SpillRows rowsFromNonSpillingPartitions(
-      0, memory::StlMappedMemoryAllocator<char*>(&spillMappedMemory()));
+      0, memory::StlMemoryAllocator<char*>(&allocator()));
   if (type_ != Spiller::Type::kHashJoinProbe) {
     fillSpillRuns(&rowsFromNonSpillingPartitions);
   }
@@ -650,12 +650,12 @@ void Spiller::fillSpillRuns(std::vector<SpillableStats>& statsList) {
 }
 
 // static
-memory::MappedMemory& Spiller::spillMappedMemory() {
+memory::MemoryAllocator& Spiller::allocator() {
   // Return the top level instance. Since this too may be full,
   // another possibility is to return an emergency instance that
   // delegates to the process wide one and makes a file-backed mmap
   // if the allocation fails.
-  return *memory::MappedMemory::getInstance();
+  return *memory::MemoryAllocator::getInstance();
 }
 
 // static

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -106,7 +106,7 @@ class Spiller {
     int32_t testSpillPct;
   };
 
-  using SpillRows = std::vector<char*, memory::StlMappedMemoryAllocator<char*>>;
+  using SpillRows = std::vector<char*, memory::StlMemoryAllocator<char*>>;
 
   // The constructor without specifying hash bits which will only use one
   // partition by default. It is only used by kOrderBy spiller type as for now.
@@ -296,10 +296,10 @@ class Spiller {
     return state_.spilledFiles();
   }
 
-  // Returns the MappedMemory to use for intermediate storage for
+  // Returns the MemoryAllocator to use for intermediate storage for
   // spilling. This is not directly the RowContainer's memory because
   // this is usually at limit when starting spilling.
-  static memory::MappedMemory& spillMappedMemory();
+  static memory::MemoryAllocator& allocator();
 
   // Global memory pool for spill intermediates. ~1MB per spill executor thread
   // is the expected peak utilization.
@@ -326,8 +326,8 @@ class Spiller {
   // goes empty this is refilled from the RowContainer for the next
   // spill run from the same partition.
   struct SpillRun {
-    explicit SpillRun(memory::MappedMemory& mappedMemory)
-        : rows(0, memory::StlMappedMemoryAllocator<char*>(&mappedMemory)) {}
+    explicit SpillRun(memory::MemoryAllocator& MemoryAllocator)
+        : rows(0, memory::StlMemoryAllocator<char*>(&MemoryAllocator)) {}
     // Spillable rows from the RowContainer.
     SpillRows rows;
     // The total byte size of rows referenced from 'rows'.

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -99,7 +99,7 @@ StreamingAggregation::StreamingAggregation(
       false,
       false,
       false,
-      operatorCtx_->mappedMemory(),
+      operatorCtx_->allocator(),
       ContainerRowSerde::instance());
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -214,11 +214,11 @@ velox::memory::MemoryPool* FOLLY_NONNULL Task::addOperatorPool(
   return childPools_.back().get();
 }
 
-memory::MappedMemory* FOLLY_NONNULL Task::addOperatorMemory(
+memory::MemoryAllocator* FOLLY_NONNULL Task::addOperatorMemory(
     const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-  auto mappedMemory = queryCtx_->mappedMemory()->addChild(tracker);
-  childMappedMemories_.emplace_back(mappedMemory);
-  return mappedMemory.get();
+  auto allocator = queryCtx_->allocator()->addChild(tracker);
+  childAllocators_.emplace_back(allocator);
+  return allocator.get();
 }
 
 bool Task::supportsSingleThreadedExecution() const {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -41,7 +41,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// for a particular partition from a set of upstream tasks participating in a
   /// distributed execution. Used to initialize an ExchangeClient. Ignored if
   /// plan fragment doesn't have an ExchangeNode.
-  /// @param queryCtx Query context containing MemoryPool and MappedMemory
+  /// @param queryCtx Query context containing MemoryPool and MemoryAllocator
   /// instances to use for memory allocations during execution, executor to
   /// schedule operators on, and session properties.
   /// @param consumer Optional factory function to get callbacks to pass the
@@ -278,10 +278,10 @@ class Task : public std::enable_shared_from_this<Task> {
       int pipelineId,
       const std::string& operatorType);
 
-  /// Creates new instance of MappedMemory, stores it in the task to ensure
+  /// Creates new instance of MemoryAllocator, stores it in the task to ensure
   /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
   /// from the Operator's constructor.
-  memory::MappedMemory* FOLLY_NONNULL
+  memory::MemoryAllocator* FOLLY_NONNULL
   addOperatorMemory(const std::shared_ptr<memory::MemoryUsageTracker>& tracker);
 
   // Removes driver from the set of drivers in 'self'. The task will be kept
@@ -737,7 +737,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Root MemoryPool for this Task. All member variables that hold references
   // to pool_ must be defined after pool_, childPools_, and
-  // childMappedMemories_
+  // childAllocators_
   std::shared_ptr<memory::MemoryPool> pool_;
 
   // Keep driver and operator memory pools alive for the duration of the task
@@ -750,9 +750,9 @@ class Task : public std::enable_shared_from_this<Task> {
   // NOTE: ''childPools_' holds the ownerships of node memory pools.
   std::unordered_map<core::PlanNodeId, memory::MemoryPool*> nodePools_;
 
-  // Keep operator MappedMemory instances alive for the duration of the task to
-  // allow for sharing data without copy.
-  std::vector<std::shared_ptr<memory::MappedMemory>> childMappedMemories_;
+  // Keep operator MemoryAllocator instances alive for the duration of the task
+  // to allow for sharing data without copy.
+  std::vector<std::shared_ptr<memory::MemoryAllocator>> childAllocators_;
 
   // A set of IDs of leaf plan nodes that require splits. Used to check plan
   // node IDs specified in split management methods.

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -31,7 +31,7 @@ TopN::TopN(
       count_(topNNode->count()),
       data_(std::make_unique<RowContainer>(
           outputType_->children(),
-          operatorCtx_->mappedMemory())),
+          operatorCtx_->allocator())),
       comparator_(
           outputType_,
           topNNode->sortingKeys(),

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -58,9 +58,9 @@ Window::Window(
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
       data_(std::make_unique<RowContainer>(
           windowNode->sources()[0]->outputType()->children(),
-          operatorCtx_->mappedMemory())),
+          operatorCtx_->allocator())),
       decodedInputVectors_(numInputColumns_),
-      stringAllocator_(operatorCtx_->mappedMemory()) {
+      stringAllocator_(operatorCtx_->allocator()) {
   auto inputType = windowNode->sources()[0]->outputType();
   initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
   initKeyInfo(

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -111,7 +111,7 @@ class AggregationTest : public OperatorTestBase {
   void SetUp() override {
     OperatorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     registerSumNonPODAggregate("sumnonpod");
   }
 
@@ -341,7 +341,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         true,
         true,
-        mappedMemory_,
+        allocator_,
         ContainerRowSerde::instance());
   }
 
@@ -355,7 +355,7 @@ class AggregationTest : public OperatorTestBase {
            DOUBLE(),
            VARCHAR()})};
   folly::Random::DefaultGenerator rng_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 };
 
 template <>

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -75,7 +75,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, mappedMemory_);
+        std::move(keyHashers), {}, true, false, allocator_);
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {
@@ -137,7 +137,7 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t numSpillFilesPerPartition_{20};
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
+  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 
   std::mutex mutex_;

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -78,7 +78,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, mappedMemory_);
+          std::move(keyHashers), dependentTypes, true, false, allocator_);
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -153,7 +153,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     }
     static std::vector<std::unique_ptr<Aggregate>> empty;
     return HashTable<false>::createForAggregation(
-        std::move(keyHashers), empty, mappedMemory_);
+        std::move(keyHashers), empty, allocator_);
   }
 
   void insertGroups(
@@ -436,7 +436,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MappedMemory* mappedMemory_{memory::MappedMemory::getInstance()};
+  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
@@ -518,7 +518,7 @@ TEST_P(HashTableTest, clear) {
       std::vector<TypePtr>{BIGINT()},
       BIGINT()));
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), aggregates, mappedMemory_);
+      std::move(keyHashers), aggregates, allocator_);
   table->clear();
 }
 
@@ -665,7 +665,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, mappedMemory_);
+        std::move(keyHashers), {}, true, false, allocator_);
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include <gtest/gtest.h>
-#include <velox/common/memory/MappedMemory.h>
+#include <velox/common/memory/MemoryAllocator.h>
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -30,7 +30,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
  protected:
   void SetUp() override {
     pool_ = facebook::velox::memory::getDefaultMemoryPool();
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -72,7 +72,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
   }
 
   std::unique_ptr<SerializedPage> toSerializedPage(VectorPtr vector) {
-    auto data = std::make_unique<VectorStreamGroup>(mappedMemory_);
+    auto data = std::make_unique<VectorStreamGroup>(allocator_);
     auto size = vector->size();
     auto range = IndexRange{0, size};
     data->createStreamTree(
@@ -80,7 +80,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
     data->append(
         std::dynamic_pointer_cast<RowVector>(vector), folly::Range(&range, 1));
     auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*mappedMemory_, listener.get(), data->size());
+    IOBufOutputStream stream(*allocator_, listener.get(), data->size());
     data->flush(&stream);
     return std::make_unique<SerializedPage>(stream.getIOBuf());
   }
@@ -231,7 +231,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
   std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
 };
 
@@ -399,25 +399,23 @@ TEST_F(PartitionedOutputBufferManagerTest, serializedPage) {
 
   // External managed memory case
   {
-    auto mappedMemory = memory::MappedMemory::getInstance();
-    void* buffer = mappedMemory->allocateBytes(kBufferSize);
+    auto allocator = memory::MemoryAllocator::getInstance();
+    void* buffer = allocator->allocateBytes(kBufferSize);
     auto iobuf = folly::IOBuf::wrapBuffer(buffer, kBufferSize);
     std::string payload = "abcdefghijklmnopq";
     std::memcpy(iobuf->writableData(), payload.data(), payload.size());
 
     EXPECT_EQ(0, pool_->getCurrentBytes());
-    EXPECT_EQ(mappedMemory->allocateBytesStats().totalSmall, kBufferSize);
+    EXPECT_EQ(allocator->allocateBytesStats().totalSmall, kBufferSize);
     {
       auto serializedPage = std::make_shared<SerializedPage>(
-          std::move(iobuf),
-          pool_.get(),
-          [mappedMemory, kBufferSize](auto& iobuf) {
-            mappedMemory->freeBytes(iobuf.writableData(), kBufferSize);
+          std::move(iobuf), pool_.get(), [allocator, kBufferSize](auto& iobuf) {
+            allocator->freeBytes(iobuf.writableData(), kBufferSize);
           });
       EXPECT_EQ(kBufferSize, pool_->getCurrentBytes());
     }
     EXPECT_EQ(0, pool_->getCurrentBytes());
-    EXPECT_EQ(mappedMemory->allocateBytesStats().totalSmall, 0);
+    EXPECT_EQ(allocator->allocateBytesStats().totalSmall, 0);
   }
 }
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -269,7 +269,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     std::vector<TypePtr> types{input->type()};
 
     // Store the vector in the rowContainer.
-    auto rowContainer = std::make_unique<RowContainer>(types, mappedMemory_);
+    auto rowContainer = std::make_unique<RowContainer>(types, allocator_);
     auto size = input->size();
     SelectivityVector allRows(size);
     std::vector<char*> rows(size);
@@ -806,7 +806,7 @@ TEST_F(RowContainerTest, probedFlag) {
       true, // isJoinBuild
       true, // hasProbedFlag
       false, // hasNormalizedKey
-      mappedMemory_,
+      allocator_,
       ContainerRowSerde::instance());
 
   auto input = makeRowVector({

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -63,7 +63,7 @@ class SpillTest : public testing::Test,
 
  protected:
   void SetUp() override {
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     tempDir_ = exec::test::TempDirectoryPath::create();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -150,7 +150,7 @@ class SpillTest : public testing::Test,
         compareFlags,
         targetFileSize,
         *pool(),
-        *mappedMemory_);
+        *allocator_);
     EXPECT_EQ(targetFileSize, state_->targetFileSize());
     EXPECT_EQ(numPartitions, state_->maxPartitions());
     EXPECT_EQ(0, state_->spilledPartitions());
@@ -316,7 +316,7 @@ class SpillTest : public testing::Test,
 
   folly::Random::DefaultGenerator rng_;
   std::shared_ptr<TempDirectoryPath> tempDir_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
   std::vector<std::optional<int64_t>> values_;
   std::vector<std::vector<RowVectorPtr>> batchesByPartition_;
   std::string spillPath_;
@@ -358,7 +358,7 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{-1, 17'123'456}};
 
   SpillState state(
-      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *mappedMemory_);
+      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *allocator_);
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2198,8 +2198,8 @@ TEST_F(TableScanTest, addSplitsToFailedTask) {
 }
 
 TEST_F(TableScanTest, errorInLoadLazy) {
-  auto cache =
-      dynamic_cast<cache::AsyncDataCache*>(memory::MappedMemory::getInstance());
+  auto cache = dynamic_cast<cache::AsyncDataCache*>(
+      memory::MemoryAllocator::getInstance());
   VELOX_CHECK_NOT_NULL(cache);
   auto vectors = makeVectors(10, 1'000);
   auto filePath = TempFilePath::create();

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -139,8 +139,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
     return assignments;
   }
 
-  memory::MappedMemory* mappedMemory() {
-    return memory::MappedMemory::getInstance();
+  memory::MemoryAllocator* allocator() {
+    return memory::MemoryAllocator::getInstance();
   }
 };
 

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -36,7 +36,7 @@ namespace facebook::velox::exec::test {
 std::shared_ptr<cache::AsyncDataCache> OperatorTestBase::asyncDataCache_;
 
 OperatorTestBase::OperatorTestBase() {
-  using memory::MappedMemory;
+  using memory::MemoryAllocator;
   facebook::velox::exec::ExchangeSource::registerFactory();
   parse::registerTypeResolver();
 }
@@ -46,8 +46,8 @@ void OperatorTestBase::registerVectorSerde() {
 }
 
 OperatorTestBase::~OperatorTestBase() {
-  // Revert to default process-wide MappedMemory.
-  memory::MappedMemory::setDefaultInstance(nullptr);
+  // Revert to default process-wide MemoryAllocator.
+  memory::MemoryAllocator::setDefaultInstance(nullptr);
 }
 
 void OperatorTestBase::TearDownTestCase() {
@@ -55,13 +55,13 @@ void OperatorTestBase::TearDownTestCase() {
 }
 
 void OperatorTestBase::SetUp() {
-  // Sets the process default MappedMemory to an async cache of up
-  // to 4GB backed by a default MappedMemory
+  // Sets the process default MemoryAllocator to an async cache of up
+  // to 4GB backed by a default MemoryAllocator
   if (!asyncDataCache_) {
     asyncDataCache_ = std::make_shared<cache::AsyncDataCache>(
-        memory::MappedMemory::createDefaultInstance(), 4UL << 30);
+        memory::MemoryAllocator::createDefaultInstance(), 4UL << 30);
   }
-  memory::MappedMemory::setDefaultInstance(asyncDataCache_.get());
+  memory::MemoryAllocator::setDefaultInstance(asyncDataCache_.get());
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
   }

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -34,7 +34,7 @@ class RowContainerTestBase : public testing::Test,
  protected:
   void SetUp() override {
     pool_ = memory::getDefaultMemoryPool();
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -68,11 +68,11 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         true,
         true,
-        mappedMemory_,
+        allocator_,
         ContainerRowSerde::instance());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -314,7 +314,7 @@ TEST(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST(KllSketchTest, memoryUsage) {
-  HashStringAllocator alloc(memory::MappedMemory::getInstance());
+  HashStringAllocator alloc(memory::MemoryAllocator::getInstance());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));
   EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);
@@ -327,7 +327,7 @@ TEST(KllSketchTest, memoryUsage) {
   for (int i = 1024; i < 8192; ++i) {
     kll.insert(i);
   }
-  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 28000);
+  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 32840);
 }
 
 } // namespace

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -74,7 +74,7 @@ class ValueListTest : public functions::test::FunctionBaseTest {
 
   std::unique_ptr<HashStringAllocator> allocator_{
       std::make_unique<HashStringAllocator>(
-          memory::MappedMemory::getInstance())};
+          memory::MemoryAllocator::getInstance())};
 };
 
 TEST_F(ValueListTest, empty) {

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -62,7 +62,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return signatureStrings;
   }
 
-  HashStringAllocator allocator_{memory::MappedMemory::getInstance()};
+  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
 };
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -30,7 +30,7 @@ namespace {
 class UnsafeRowVectorSerializer : public VectorSerializer {
  public:
   explicit UnsafeRowVectorSerializer(StreamArena* streamArena)
-      : mappedMemory_{streamArena->mappedMemory()} {}
+      : allocator_{streamArena->allocator()} {}
 
   void append(
       RowVectorPtr vector,
@@ -48,7 +48,7 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
       return;
     }
 
-    auto* buffer = (char*)mappedMemory_->allocateBytes(totalSize);
+    auto* buffer = (char*)allocator_->allocateBytes(totalSize);
     buffers_.push_back(
         ByteRange{(uint8_t*)buffer, (int32_t)totalSize, (int32_t)totalSize});
 
@@ -78,13 +78,13 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
   void flush(OutputStream* stream) override {
     for (auto& buffer : buffers_) {
       stream->write((char*)buffer.buffer, buffer.position);
-      mappedMemory_->freeBytes(buffer.buffer, buffer.size);
+      allocator_->freeBytes(buffer.buffer, buffer.size);
     }
     buffers_.clear();
   }
 
  private:
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
   std::vector<ByteRange> buffers_;
 };
 } // namespace

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -61,7 +61,7 @@ class PrestoSerializerTest : public ::testing::Test {
         rowVector, folly::Range(rows.data(), numRows));
 
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     auto rowType = asRowType(rowVector->type());
     auto serializer =
         serde_->createSerializer(rowType, numRows, arena.get(), serdeOptions);
@@ -79,7 +79,7 @@ class PrestoSerializerTest : public ::testing::Test {
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(output, &listener);
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     serde_->serializeConstants(rowVector, arena.get(), serdeOptions, &out);
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -36,7 +36,7 @@ class UnsafeRowSerializerTest : public ::testing::Test {
     }
 
     auto arena =
-        std::make_unique<StreamArena>(memory::MappedMemory::getInstance());
+        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
     auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
     auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -17,8 +17,8 @@
 
 #include "velox/buffer/Buffer.h"
 #include "velox/common/memory/ByteStream.h"
-#include "velox/common/memory/MappedMemory.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryAllocator.h"
 #include "velox/common/memory/StreamArena.h"
 #include "velox/vector/ComplexVector.h"
 
@@ -77,8 +77,8 @@ bool isRegisteredVectorSerde();
 
 class VectorStreamGroup : public StreamArena {
  public:
-  explicit VectorStreamGroup(memory::MappedMemory* mappedMemory)
-      : StreamArena(mappedMemory) {}
+  explicit VectorStreamGroup(memory::MemoryAllocator* MemoryAllocator)
+      : StreamArena(MemoryAllocator) {}
 
   void createStreamTree(
       RowTypePtr type,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -96,7 +96,7 @@ int NonPOD::alive = 0;
 class VectorTest : public testing::Test, public test::VectorTestBase {
  protected:
   void SetUp() override {
-    mappedMemory_ = memory::MappedMemory::getInstance();
+    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -757,10 +757,10 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto sourceRow = makeRowVector({"c"}, {source});
     auto sourceRowType = asRowType(sourceRow->type());
 
-    VectorStreamGroup even(mappedMemory_);
+    VectorStreamGroup even(allocator_);
     even.createStreamTree(sourceRowType, source->size() / 4);
 
-    VectorStreamGroup odd(mappedMemory_);
+    VectorStreamGroup odd(allocator_);
     odd.createStreamTree(sourceRowType, source->size() / 3);
 
     std::vector<IndexRange> evenIndices;
@@ -867,7 +867,7 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     EXPECT_NE(slice->rawSizes(), sizes);
   }
 
-  memory::MappedMemory* mappedMemory_;
+  memory::MemoryAllocator* allocator_;
 
   size_t vectorSize_{100};
   size_t numIterations_{3};

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -61,8 +61,7 @@ class VectorUtilTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<memory::MemoryAllocator, AlignedBuffer::kAlignment>
-      memoryManager_;
+  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 


### PR DESCRIPTION
1. Remove the existing memory allocator objects: MemoryAllocator
    and MmapMemoryAllocator. Both are interfacing wrappers for
    memory allocations from MemoryPool. MemoryAllocator delegates
    all the memory allocations to std::malloc directly. MmapMemoryAllocator
    delegates the memory allocations to MappedMemory which has three
    implementations: MappedMemoryImpl, MmapAllocator and AsyncDataCache.
    The AsyncDataCache is a simple wrapper on top of either
    MappedMemoryImpl or MmapAllocator to integrate
    with file cache. MappedMemoryImpl delegates most memory allocation to
    std::malloc except large contiguous memory allocation which use mmap.
    MmapAllocator manages the memory through madvice only small memory
    allocation goes to std::malloc. There is ScopedMappedMemory which is
    a simple wrapper on either one of the above three to provide memory tracking
    capabilities;
2. Simplify the memory manager by removing the allocator template after remove
    MemoryAllocator and MmapMemoryAllocator. The memory manager constructor
    either take default singleton MemoryAllocator instance or passed it by the caller.

Next steps is to (1) remove the alignment template from MemoryManager and
MemoryPool and pass options; (2) extend memory pool to support large chunk
memory allocations (both contiguous and non-contiguous) and then deprecate
ScopedMemoryAllocator and all the memory allocations go through memory pool
but not through MemoryAllocator interface directly.