### PR TITLE
Remove duplicate TIMESTAMP(), DATE() and INTERVAL_DAY_TIME() functions

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1088,12 +1088,6 @@ std::shared_ptr<const MapType> MAP(
     std::shared_ptr<const Type> keyType,
     std::shared_ptr<const Type> valType);
 
-std::shared_ptr<const TimestampType> TIMESTAMP();
-
-std::shared_ptr<const DateType> DATE();
-
-std::shared_ptr<const IntervalDayTimeType> INTERVAL_DAY_TIME();
-
 std::shared_ptr<const ShortDecimalType> SHORT_DECIMAL(
     uint8_t precision,
     uint8_t scale);


### PR DESCRIPTION
These are covered by the VELOX_SCALAR_ACCESSOR macro, so there is no need to
declare them separately.