### PR TITLE
Add back deterministic machine name in Conbench

### DIFF
--- a/scripts/benchmark-runner.py
+++ b/scripts/benchmark-runner.py
@@ -383,6 +383,7 @@ def upload_results(output_dir, run_id):
                 "velox_compiler_version": None,
             },
             "context": {"velox_compiler_flags": None},
+            "machine_info": {"name": "CircleCI-runner-dedicated"},
         },
     )
 


### PR DESCRIPTION
In #3452 I accidentally stopped giving the machine a deterministic name when reporting to Conbench, so the "Hardware" column looks like this:

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/16600275/209208591-f3a212a5-c965-46a8-baa0-32d40d5257fe.png">

This also makes benchmark runs incomparable with each other for history plots and baselines. This PR fixes all that.