### PR TITLE
Add support for nullAware flag in semi join project w/o filter

### DIFF
--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -231,6 +231,8 @@ class HashBuild final : public Operator {
 
   const core::JoinType joinType_;
 
+  const bool nullAware_;
+
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 
   const std::optional<Spiller::Config> spillConfig_;

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -119,6 +119,9 @@ class HashProbe : public Operator {
   // Populate output columns.
   void fillOutput(vector_size_t size);
 
+  // Populate 'match' output column for the left semi join project,
+  void fillLeftSemiProjectMatchColumn(vector_size_t size);
+
   // Clears the columns of 'output_' that are projected from
   // 'input_'. This should be done when preparing to produce a next
   // batch of output to drop any lingering references to row
@@ -252,6 +255,8 @@ class HashProbe : public Operator {
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
   const core::JoinType joinType_;
+
+  const bool nullAware_;
 
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -307,14 +307,15 @@ class RowContainer {
 
   /// Copies the 'probed' flags for the specified rows into 'result'.
   /// The 'result' is expected to be flat vector of type boolean.
-  /// Sets null in 'result' for rows with null keys.
-  /// If 'replaceFalseWithNull' is true, replaces the false probed
-  /// flag with null in 'result' for rows with no null keys. This is used for
-  /// right semi project join type when probe side has nulls in the join keys.
+  /// For rows with null keys, sets null in 'result' if 'setNullForNullKeysRow'
+  /// is true and false otherwise. For rows with 'false' probed flag, sets null
+  /// in 'result' if 'setNullForNonProbedRow' is true and false otherwise. This
+  /// is used for null aware and regular right semi project join types.
   void extractProbedFlags(
       const char* FOLLY_NONNULL const* FOLLY_NONNULL rows,
       int32_t numRows,
-      bool replaceFalseWithNull,
+      bool setNullForNullKeysRow,
+      bool setNullForNonProbedRow,
       const VectorPtr& result);
 
   static inline int32_t nullByte(int32_t nullOffset) {


### PR DESCRIPTION
Existing semi join project implementation has IN (null aware) semantic. This
change adds EXISTS (regular) semantic for the case when there is no filter.
Follow-up will implement EXISTS semantic for the case when there is a filter.

See #3555 for more details.

<img width="1396" alt="Screenshot 2022-12-22 at 2 56 03 PM" src="https://user-images.githubusercontent.com/27965151/209215891-783df2f7-1bfc-459e-a269-915aa743cd02.png">
