### PR TITLE
use F1HashSet instead of std::unordeed_set in array intersect.

### DIFF
--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -31,7 +31,7 @@ struct SetWithNull {
     hasNull = false;
   }
 
-  std::unordered_set<T> set;
+  folly::F14FastSet<T> set;
   bool hasNull{false};
   static constexpr vector_size_t kInitialSetSize{128};
 };


### PR DESCRIPTION
Summary: This makes the function 2x-4x faster.

Differential Revision: D42220124

