### PR TITLE
Using bash explicitly to install conda on Ubuntu

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -88,7 +88,7 @@ function install_conda {
   mkdir -p conda && cd conda
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   MINICONDA_PATH=/opt/miniconda-for-velox
-  sh Miniconda3-latest-Linux-x86_64.sh -b -p $MINICONDA_PATH
+  bash Miniconda3-latest-Linux-x86_64.sh -b -p $MINICONDA_PATH
 }
 
 function install_velox_deps {


### PR DESCRIPTION
Summary:
Looks like the conda script was recently updated and fails using sh
instead of bash.

Differential Revision: D42224837

