### PR TITLE
Make thread safe to access singleton memory allocators

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -95,6 +95,7 @@ void MemoryAllocator::alignmentCheck(
 
 // static
 void MemoryAllocator::testingDestroyInstance() {
+  std::lock_guard<std::mutex> l(initMutex_);
   instance_ = nullptr;
 }
 
@@ -443,14 +444,11 @@ bool MemoryAllocatorImpl::checkConsistency() const {
 
 // static
 MemoryAllocator* MemoryAllocator::getInstance() {
-  if (customInstance_) {
+  std::lock_guard<std::mutex> l(initMutex_);
+  if (customInstance_ != nullptr) {
     return customInstance_;
   }
-  if (instance_) {
-    return instance_.get();
-  }
-  std::lock_guard<std::mutex> l(initMutex_);
-  if (instance_) {
+  if (instance_ != nullptr) {
     return instance_.get();
   }
   instance_ = createDefaultInstance();
@@ -464,6 +462,7 @@ std::shared_ptr<MemoryAllocator> MemoryAllocator::createDefaultInstance() {
 
 // static
 void MemoryAllocator::setDefaultInstance(MemoryAllocator* instance) {
+  std::lock_guard<std::mutex> l(initMutex_);
   customInstance_ = instance;
 }
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -521,12 +521,14 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   static std::atomic<uint64_t> totalLargeAllocateBytes_;
 
  private:
+  static std::mutex initMutex_;
+
   // Singleton instance.
   static std::shared_ptr<MemoryAllocator> instance_;
+
   // Application-supplied custom implementation of MemoryAllocator to be
   // returned by getInstance().
   static MemoryAllocator* FOLLY_NULLABLE customInstance_;
-  static std::mutex initMutex_;
 };
 
 // Wrapper around MemoryAllocator for scoped tracking of activity. We


### PR DESCRIPTION
Summary: Add lock to protect customInstance_ and instance_ to fix tsan failure

Differential Revision: D42242963

