### PR TITLE
Remove alignment template and options to config

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -44,7 +44,7 @@ class BufferTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
+  memory::MemoryManager memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -21,10 +21,34 @@
 namespace facebook {
 namespace velox {
 namespace memory {
+namespace {
+#define VELOX_MEM_MANAGER_CAP_EXCEEDED(cap)                         \
+  _VELOX_THROW(                                                     \
+      ::facebook::velox::VeloxRuntimeError,                         \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
+      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
+      /* isRetriable */ true,                                       \
+      "Exceeded memory manager cap of {} MB",                       \
+      (cap) / 1024 / 1024);
+
+#define VELOX_MEM_MANUAL_CAP()                                      \
+  _VELOX_THROW(                                                     \
+      ::facebook::velox::VeloxRuntimeError,                         \
+      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
+      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
+      /* isRetriable */ true,                                       \
+      "Memory allocation manually capped");
+
+constexpr folly::StringPiece kRootNodeName{"__root__"};
+} // namespace
+
 MemoryPool::MemoryPool(
     const std::string& name,
-    std::shared_ptr<MemoryPool> parent)
-    : name_(name), parent_(std::move(parent)) {}
+    std::shared_ptr<MemoryPool> parent,
+    const Options& options)
+    : name_(name), alignment_{options.alignment}, parent_(std::move(parent)) {
+  MemoryAllocator::alignmentCheck(0, alignment_);
+}
 
 MemoryPool::~MemoryPool() {
   VELOX_CHECK(children_.empty());
@@ -100,14 +124,303 @@ size_t MemoryPool::getPreferredSize(size_t size) {
   return lower * 2;
 }
 
+MemoryPoolImpl::MemoryPoolImpl(
+    MemoryManager& memoryManager,
+    const std::string& name,
+    std::shared_ptr<MemoryPool> parent,
+    const Options& options)
+    : MemoryPool{name, parent, options},
+      cap_{options.capacity},
+      memoryManager_{memoryManager},
+      localMemoryUsage_{},
+      allocator_{memoryManager_.getAllocator()} {
+  VELOX_USER_CHECK_GT(cap_, 0);
+}
+
+MemoryPoolImpl::~MemoryPoolImpl() {
+  if (const auto& tracker = getMemoryUsageTracker()) {
+    // TODO: change to check reserved bytes which including the unused
+    // reservation.
+    auto remainingBytes = tracker->currentBytes();
+    VELOX_CHECK_EQ(
+        0,
+        remainingBytes,
+        "Memory pool should be destroyed only after all allocated memory has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
+        remainingBytes,
+        tracker->cumulativeBytes(),
+        tracker->numAllocs());
+  }
+}
+
+/* static */
+int64_t MemoryPoolImpl::sizeAlign(int64_t size) {
+  const auto remainder = size % alignment_;
+  return (remainder == 0) ? size : (size + alignment_ - remainder);
+}
+
+void* MemoryPoolImpl::allocate(int64_t size) {
+  if (this->isMemoryCapped()) {
+    VELOX_MEM_MANUAL_CAP();
+  }
+  const auto alignedSize = sizeAlign(size);
+  reserve(alignedSize);
+  return allocator_.allocateBytes(alignedSize, alignment_);
+}
+
+void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
+  if (this->isMemoryCapped()) {
+    VELOX_MEM_MANUAL_CAP();
+  }
+  const auto alignedSize = sizeAlign(sizeEach * numEntries);
+  reserve(alignedSize);
+  return allocator_.allocateZeroFilled(alignedSize);
+}
+
+void* MemoryPoolImpl::reallocate(
+    void* FOLLY_NULLABLE p,
+    int64_t size,
+    int64_t newSize) {
+  auto alignedSize = sizeAlign(size);
+  auto alignedNewSize = sizeAlign(newSize);
+  const int64_t difference = alignedNewSize - alignedSize;
+  if (FOLLY_UNLIKELY(difference <= 0)) {
+    // Track and pretend the shrink took place for accounting purposes.
+    release(-difference);
+    return p;
+  }
+
+  reserve(difference);
+  void* newP =
+      allocator_.reallocateBytes(p, alignedSize, alignedNewSize, alignment_);
+  if (FOLLY_UNLIKELY(newP == nullptr)) {
+    free(p, alignedSize);
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(difference));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+  }
+  return newP;
+}
+
+void MemoryPoolImpl::free(void* p, int64_t size) {
+  const auto alignedSize = sizeAlign(size);
+  allocator_.freeBytes(p, alignedSize);
+  release(alignedSize);
+}
+
+int64_t MemoryPoolImpl::getCurrentBytes() const {
+  return getAggregateBytes();
+}
+
+int64_t MemoryPoolImpl::getMaxBytes() const {
+  return std::max(getSubtreeMaxBytes(), localMemoryUsage_.getMaxBytes());
+}
+
+void MemoryPoolImpl::setMemoryUsageTracker(
+    const std::shared_ptr<MemoryUsageTracker>& tracker) {
+  const auto currentBytes = getCurrentBytes();
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(-currentBytes);
+  }
+  memoryUsageTracker_ = tracker;
+  memoryUsageTracker_->update(currentBytes);
+}
+
+const std::shared_ptr<MemoryUsageTracker>&
+MemoryPoolImpl::getMemoryUsageTracker() const {
+  return memoryUsageTracker_;
+}
+
+void MemoryPoolImpl::setSubtreeMemoryUsage(int64_t size) {
+  updateSubtreeMemoryUsage([size](MemoryUsage& subtreeUsage) {
+    subtreeUsage.setCurrentBytes(size);
+  });
+}
+
+int64_t MemoryPoolImpl::updateSubtreeMemoryUsage(int64_t size) {
+  int64_t aggregateBytes;
+  updateSubtreeMemoryUsage([&aggregateBytes, size](MemoryUsage& subtreeUsage) {
+    aggregateBytes = subtreeUsage.getCurrentBytes() + size;
+    subtreeUsage.setCurrentBytes(aggregateBytes);
+  });
+  return aggregateBytes;
+}
+
+int64_t MemoryPoolImpl::cap() const {
+  return cap_;
+}
+
+void MemoryPoolImpl::capMemoryAllocation() {
+  capped_.store(true);
+  for (const auto& child : children_) {
+    child->capMemoryAllocation();
+  }
+}
+
+void MemoryPoolImpl::uncapMemoryAllocation() {
+  // This means if we try to post-order traverse the tree like we do
+  // in MemoryManager, only parent has the right to lift the cap.
+  // This suffices because parent will then recursively lift the cap on the
+  // entire tree.
+  if (getAggregateBytes() > cap()) {
+    return;
+  }
+  if (parent_ != nullptr && parent_->isMemoryCapped()) {
+    return;
+  }
+  capped_.store(false);
+  visitChildren([](MemoryPool* child) { child->uncapMemoryAllocation(); });
+}
+
+bool MemoryPoolImpl::isMemoryCapped() const {
+  return capped_.load();
+}
+
+std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
+    std::shared_ptr<MemoryPool> parent,
+    const std::string& name,
+    int64_t cap) {
+  return std::make_shared<MemoryPoolImpl>(
+      memoryManager_, name, parent, Options{alignment_, cap});
+}
+
+const MemoryUsage& MemoryPoolImpl::getLocalMemoryUsage() const {
+  return localMemoryUsage_;
+}
+
+int64_t MemoryPoolImpl::getAggregateBytes() const {
+  int64_t aggregateBytes = localMemoryUsage_.getCurrentBytes();
+  accessSubtreeMemoryUsage([&aggregateBytes](const MemoryUsage& subtreeUsage) {
+    aggregateBytes += subtreeUsage.getCurrentBytes();
+  });
+  return aggregateBytes;
+}
+
+int64_t MemoryPoolImpl::getSubtreeMaxBytes() const {
+  int64_t maxBytes;
+  accessSubtreeMemoryUsage([&maxBytes](const MemoryUsage& subtreeUsage) {
+    maxBytes = subtreeUsage.getMaxBytes();
+  });
+  return maxBytes;
+}
+
+void MemoryPoolImpl::accessSubtreeMemoryUsage(
+    std::function<void(const MemoryUsage&)> visitor) const {
+  folly::SharedMutex::ReadHolder readLock{subtreeUsageMutex_};
+  visitor(subtreeMemoryUsage_);
+}
+
+void MemoryPoolImpl::updateSubtreeMemoryUsage(
+    std::function<void(MemoryUsage&)> visitor) {
+  folly::SharedMutex::WriteHolder writeLock{subtreeUsageMutex_};
+  visitor(subtreeMemoryUsage_);
+}
+
+void MemoryPoolImpl::reserve(int64_t size) {
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(size);
+  }
+  localMemoryUsage_.incrementCurrentBytes(size);
+
+  bool success = memoryManager_.reserve(size);
+  bool manualCap = isMemoryCapped();
+  int64_t aggregateBytes = getAggregateBytes();
+  if (UNLIKELY(!success || manualCap || aggregateBytes > cap_)) {
+    // NOTE: If we can make the reserve and release a single transaction we
+    // would have more accurate aggregates in intermediate states. However, this
+    // is low-pri because we can only have inflated aggregates, and be on the
+    // more conservative side.
+    release(size);
+    if (!success) {
+      VELOX_MEM_MANAGER_CAP_EXCEEDED(memoryManager_.getMemoryQuota());
+    }
+    if (manualCap) {
+      VELOX_MEM_MANUAL_CAP();
+    }
+    auto errorMessage = fmt::format(
+        MEM_CAP_EXCEEDED_ERROR_FORMAT,
+        succinctBytes(cap_),
+        succinctBytes(size));
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+  }
+}
+
+void MemoryPoolImpl::release(int64_t size) {
+  memoryManager_.release(size);
+  localMemoryUsage_.incrementCurrentBytes(-size);
+  if (memoryUsageTracker_) {
+    memoryUsageTracker_->update(-size);
+  }
+}
+
+MemoryManager::MemoryManager(const Options& options)
+    : allocator_{options.allocator->shared_from_this()},
+      memoryQuota_{options.capacity},
+      alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
+      root_{std::make_shared<MemoryPoolImpl>(
+          *this,
+          kRootNodeName.str(),
+          nullptr,
+          MemoryPool::Options{alignment_, memoryQuota_})} {
+  VELOX_CHECK_NOT_NULL(allocator_);
+  VELOX_USER_CHECK_GE(memoryQuota_, 0);
+  MemoryAllocator::alignmentCheck(0, alignment_);
+}
+
+MemoryManager::~MemoryManager() {
+  auto currentBytes = getTotalBytes();
+  if (currentBytes > 0) {
+    LOG(WARNING) << "Leaked total memory of " << currentBytes << " bytes.";
+  }
+}
+
+int64_t MemoryManager::getMemoryQuota() const {
+  return memoryQuota_;
+}
+
+uint16_t MemoryManager::alignment() const {
+  return alignment_;
+}
+
+MemoryPool& MemoryManager::getRoot() const {
+  return *root_;
+}
+
+std::shared_ptr<MemoryPool> MemoryManager::getChild(int64_t cap) {
+  return root_->addChild(
+      fmt::format(
+          "default_usage_node_{}",
+          folly::to<std::string>(folly::Random::rand64())),
+      cap);
+}
+
+int64_t MemoryManager::getTotalBytes() const {
+  return totalBytes_.load(std::memory_order_relaxed);
+}
+
+bool MemoryManager::reserve(int64_t size) {
+  return totalBytes_.fetch_add(size, std::memory_order_relaxed) + size <=
+      memoryQuota_;
+}
+
+void MemoryManager::release(int64_t size) {
+  totalBytes_.fetch_sub(size, std::memory_order_relaxed);
+}
+
+MemoryAllocator& MemoryManager::getAllocator() {
+  return *allocator_;
+}
+
 IMemoryManager& getProcessDefaultMemoryManager() {
-  return MemoryManager<>::getProcessDefaultManager();
+  return MemoryManager::getInstance();
 }
 
 std::shared_ptr<MemoryPool> getDefaultMemoryPool(int64_t cap) {
   auto& memoryManager = getProcessDefaultMemoryManager();
   return memoryManager.getChild(cap);
 }
+
 } // namespace memory
 } // namespace velox
 } // namespace facebook

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -460,11 +460,11 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
 
   virtual std::string toString() const;
 
- protected:
-  // Invoked to check if 'alignmentBytes' is valid and 'allocateBytes' is
-  // multiple of 'alignmentBytes'.
+  /// Invoked to check if 'alignmentBytes' is valid and 'allocateBytes' is
+  /// multiple of 'alignmentBytes'.
   static void alignmentCheck(uint64_t allocateBytes, uint16_t alignmentBytes);
 
+ protected:
   // Returns the size class size that corresponds to 'bytes'.
   static MachinePageCount roundUpToSizeClassSize(
       size_t bytes,

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -27,7 +27,7 @@ namespace memory {
 
 TEST(MemoryManagerTest, Ctor) {
   {
-    MemoryManager<> manager{};
+    MemoryManager manager{};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
@@ -35,9 +35,10 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(0, root.getCurrentBytes());
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.getMemoryQuota());
     ASSERT_EQ(0, manager.getTotalBytes());
+    ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
   }
   {
-    MemoryManager<> manager{8L * 1024 * 1024};
+    MemoryManager manager{{.capacity = 8L * 1024 * 1024}};
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(8L * 1024 * 1024, root.cap());
@@ -46,15 +47,26 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
-  { ASSERT_ANY_THROW(MemoryManager<> manager{-1}); }
+  {
+    MemoryManager manager{{.alignment = 0, .capacity = 8L * 1024 * 1024}};
+    const auto& root = manager.getRoot();
+
+    ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
+    ASSERT_EQ(8L * 1024 * 1024, root.cap());
+    ASSERT_EQ(0, root.getChildCount());
+    ASSERT_EQ(0, root.getCurrentBytes());
+    ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
+    ASSERT_EQ(0, manager.getTotalBytes());
+  }
+  { ASSERT_ANY_THROW(MemoryManager manager{{.capacity = -1}}); }
 }
 
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
 // effects for other tests using process singleton memory manager. Might need to
 // use folly::Singleton for isolation by tag.
 TEST(MemoryManagerTest, GlobalMemoryManager) {
-  auto& manager = MemoryManager<>::getProcessDefaultManager();
-  auto& managerII = MemoryManager<>::getProcessDefaultManager();
+  auto& manager = MemoryManager::getInstance();
+  auto& managerII = MemoryManager::getInstance();
 
   auto& root = manager.getRoot();
   auto child = root.addChild("some_child", 42);
@@ -73,7 +85,7 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
 
 TEST(MemoryManagerTest, Reserve) {
   {
-    MemoryManager<> manager{};
+    MemoryManager manager{};
     ASSERT_TRUE(manager.reserve(0));
     ASSERT_EQ(0, manager.getTotalBytes());
     manager.release(0);
@@ -86,7 +98,7 @@ TEST(MemoryManagerTest, Reserve) {
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   {
-    MemoryManager<> manager{42};
+    MemoryManager manager{{.capacity = 42}};
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(1));
     ASSERT_TRUE(manager.reserve(2));
@@ -107,13 +119,50 @@ TEST(MemoryManagerTest, Reserve) {
 }
 
 TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
-  auto& manager = MemoryManager<>::getProcessDefaultManager();
+  auto& manager = MemoryManager::getInstance();
   ASSERT_THROW(
-      MemoryManager<>::getProcessDefaultManager(42, true),
+      MemoryManager::getInstance({.capacity = 42}, true),
       velox::VeloxUserError);
 
-  auto& coercedManager = MemoryManager<>::getProcessDefaultManager(42);
+  auto& coercedManager = MemoryManager::getInstance({.capacity = 42});
   ASSERT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
+}
+
+TEST(MemoryManagerTest, alignmentOptionCheck) {
+  struct {
+    uint16_t alignment;
+    bool expectedSuccess;
+
+    std::string debugString() const {
+      return fmt::format(
+          "alignment:{}, expectedSuccess:{}", alignment, expectedSuccess);
+    }
+  } testSettings[] = {
+      {0, true},
+      {MemoryAllocator::kMinAlignment - 1, true},
+      {MemoryAllocator::kMinAlignment, true},
+      {MemoryAllocator::kMinAlignment * 2, true},
+      {MemoryAllocator::kMinAlignment + 1, false},
+      {MemoryAllocator::kMaxAlignment - 1, false},
+      {MemoryAllocator::kMaxAlignment, true},
+      {MemoryAllocator::kMaxAlignment + 1, false},
+      {MemoryAllocator::kMaxAlignment * 2, false}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    IMemoryManager::Options options;
+    options.alignment = testData.alignment;
+    if (!testData.expectedSuccess) {
+      ASSERT_THROW(MemoryManager{options}, VeloxRuntimeError);
+      continue;
+    }
+    MemoryManager manager{options};
+    ASSERT_EQ(
+        manager.alignment(),
+        std::max(testData.alignment, MemoryAllocator::kMinAlignment));
+    ASSERT_EQ(
+        manager.getRoot().getAlignment(),
+        std::max(testData.alignment, MemoryAllocator::kMinAlignment));
+  }
 }
 } // namespace memory
 } // namespace velox

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -37,7 +37,8 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       const std::string& name,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, parent}, cap_{cap} {}
+      : MemoryPool{name, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
+        cap_{cap} {}
 
   // Methods not usually exposed by MemoryPool interface to
   // allow for manipulation.
@@ -62,9 +63,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     updateLocalMemoryUsage(size);
     return allocator_->allocateBytes(size);
   }
-  void* allocateZeroFilled(int64_t numMembers, int64_t sizeEach) override {
-    updateLocalMemoryUsage(numMembers * sizeEach);
-    return allocator_->allocateZeroFilled(numMembers * sizeEach);
+
+  void* allocateZeroFilled(int64_t numEntries, int64_t sizeEach) override {
+    updateLocalMemoryUsage(numEntries * sizeEach);
+    return allocator_->allocateZeroFilled(numEntries * sizeEach);
   }
 
   // No-op for attempts to shrink buffer.

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -61,7 +61,7 @@ class VectorUtilTest : public testing::Test {
     pool_ = memoryManager_.getChild();
   }
 
-  memory::MemoryManager<AlignedBuffer::kAlignment> memoryManager_;
+  memory::MemoryManager memoryManager_;
   std::shared_ptr<memory::MemoryPool> pool_;
 };
 


### PR DESCRIPTION
Remove ALIGNMENT template parameters from memory manager and pool
and add Options for both MemoryManager and MemoryPool to configure the
memory cap as well as alignment. The default alignment is changed from
no alignment to alignment as well.