### PR TITLE
Add large chunk memory allocations support through memory pool

### DIFF
--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -100,7 +100,8 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_P(DenseHllTest, basic) {

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -98,7 +98,8 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_F(SparseHllTest, basic) {
@@ -173,7 +174,8 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_P(SparseHllToDenseTest, toDense) {

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -401,11 +401,11 @@ inline Date ByteStream::read<Date>() {
 class IOBufOutputStream : public OutputStream {
  public:
   explicit IOBufOutputStream(
-      memory::MemoryAllocator& MemoryAllocator,
+      memory::MemoryPool& pool,
       OutputStreamListener* listener = nullptr,
       int32_t initialSize = memory::MemoryAllocator::kPageSize)
       : OutputStream(listener),
-        arena_(std::make_shared<StreamArena>(&MemoryAllocator)),
+        arena_(std::make_shared<StreamArena>(&pool)),
         out_(std::make_unique<ByteStream>(arena_.get())) {
     out_->startWrite(initialSize);
   }

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -19,18 +19,19 @@
 #include "velox/common/memory/AllocationPool.h"
 #include "velox/common/memory/ByteStream.h"
 #include "velox/common/memory/CompactDoubleList.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/common/memory/StreamArena.h"
 #include "velox/type/StringView.h"
 
 namespace facebook::velox {
 
-// Implements an arena backed by MemoryAllocator::Allocation. This is for
-// backing ByteStream or for allocating single blocks. Blocks can be
-// individually freed. Adjacent frees are coalesced and free blocks are kept in
-// a free list. Allocated blocks are prefixed with a Header. This has a size and
-// flags. kContinue means that last 8 bytes are a pointer to another Header
-// after which the contents of this allocation continue. kFree means the block
-// is free. A free block has pointers to the next and previous free block via a
+// Implements an arena backed by MappedMemory::Allocation. This is for backing
+// ByteStream or for allocating single blocks. Blocks can be individually freed.
+// Adjacent frees are coalesced and free blocks are kept in a free list.
+// Allocated blocks are prefixed with a Header. This has a size and flags.
+// kContinue means that last 8 bytes are a pointer to another Header after which
+// the contents of this allocation continue. kFree means the block is free. A
+// free block has pointers to the next and previous free block via a
 // CompactDoubleList struct immediately after the header. The last 4 bytes of a
 // free block contain its length. kPreviousFree means that the block immediately
 // below is free. In this case the uint32_t below the header has the size of the
@@ -130,8 +131,8 @@ class HashStringAllocator : public StreamArena {
     char* FOLLY_NULLABLE position;
   };
 
-  explicit HashStringAllocator(memory::MemoryAllocator* FOLLY_NONNULL allocator)
-      : StreamArena(allocator), pool_(allocator) {}
+  explicit HashStringAllocator(memory::MemoryPool* FOLLY_NONNULL pool)
+      : StreamArena(pool), pool_(pool) {}
 
   // Copies a StringView at 'offset' in 'group' to storage owned by
   // the hash table. Updates the StringView.
@@ -269,8 +270,8 @@ class HashStringAllocator : public StreamArena {
     pool_.clear();
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
-    return pool_.allocator();
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return pool_.pool();
   }
 
   uint64_t cumulativeBytes() const {

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -209,6 +209,74 @@ void MemoryPoolImpl::free(void* p, int64_t size) {
   release(alignedSize);
 }
 
+bool MemoryPoolImpl::allocateNonContiguous(
+    MachinePageCount numPages,
+    MemoryAllocator::Allocation& out,
+    MachinePageCount minSizeClass) {
+  if (!allocator_.allocateNonContiguous(
+          numPages,
+          out,
+          [this](int64_t allocBytes, bool preAllocate) {
+            if (memoryUsageTracker_ != nullptr) {
+              memoryUsageTracker_->update(
+                  preAllocate ? allocBytes : -allocBytes);
+            }
+          },
+          minSizeClass)) {
+    VELOX_CHECK(out.empty());
+    return false;
+  }
+  VELOX_CHECK(!out.empty());
+  VELOX_CHECK_NULL(out.pool());
+  out.setPool(this);
+  return true;
+}
+
+void MemoryPoolImpl::freeNonContiguous(
+    MemoryAllocator::Allocation& allocation) {
+  const int64_t freedBytes = allocator_.freeNonContiguous(allocation);
+  VELOX_CHECK(allocation.empty());
+  if (memoryUsageTracker_ != nullptr) {
+    memoryUsageTracker_->update(-freedBytes);
+  }
+}
+
+MachinePageCount MemoryPoolImpl::largestSizeClass() const {
+  return allocator_.largestSizeClass();
+}
+
+const std::vector<MachinePageCount>& MemoryPoolImpl::sizeClasses() const {
+  return allocator_.sizeClasses();
+}
+
+bool MemoryPoolImpl::allocateContiguous(
+    MachinePageCount numPages,
+    MemoryAllocator::ContiguousAllocation& out) {
+  if (!allocator_.allocateContiguous(
+          numPages, nullptr, out, [this](int64_t allocBytes, bool preAlloc) {
+            if (memoryUsageTracker_) {
+              memoryUsageTracker_->update(preAlloc ? allocBytes : -allocBytes);
+            }
+          })) {
+    VELOX_CHECK(out.empty());
+    return false;
+  }
+  VELOX_CHECK(!out.empty());
+  VELOX_CHECK_NULL(out.pool());
+  out.setPool(this);
+  return true;
+}
+
+void MemoryPoolImpl::freeContiguous(
+    MemoryAllocator::ContiguousAllocation& allocation) {
+  const int64_t bytesToFree = allocation.size();
+  allocator_.freeContiguous(allocation);
+  VELOX_CHECK(allocation.empty());
+  if (memoryUsageTracker_ != nullptr) {
+    memoryUsageTracker_->update(-bytesToFree);
+  }
+}
+
 int64_t MemoryPoolImpl::getCurrentBytes() const {
   return getAggregateBytes();
 }
@@ -249,6 +317,10 @@ int64_t MemoryPoolImpl::updateSubtreeMemoryUsage(int64_t size) {
 
 int64_t MemoryPoolImpl::cap() const {
   return cap_;
+}
+
+uint16_t MemoryPoolImpl::getAlignment() const {
+  return alignment_;
 }
 
 void MemoryPoolImpl::capMemoryAllocation() {

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -27,32 +27,32 @@ namespace facebook::velox::memory {
 
 MmapAllocator::MmapAllocator(const Options& options)
     : MemoryAllocator(),
+      useMmapArena_(options.useMmapArena),
       numAllocated_(0),
       numMapped_(0),
       capacity_(bits::roundUp(
           options.capacity / kPageSize,
-          64 * sizeClassSizes_.back())),
-      useMmapArena_(options.useMmapArena) {
-  for (int size : sizeClassSizes_) {
+          64 * sizeClassSizes_.back())) {
+  for (const auto& size : sizeClassSizes_) {
     sizeClasses_.push_back(std::make_unique<SizeClass>(capacity_ / size, size));
   }
 
   if (useMmapArena_) {
-    auto arenaSizeBytes = bits::roundUp(
+    const auto arenaSizeBytes = bits::roundUp(
         capacity_ * kPageSize / options.mmapArenaCapacityRatio, kPageSize);
     managedArenas_ = std::make_unique<ManagedMmapArenas>(
-        arenaSizeBytes < MmapArena::kMinCapacityBytes
-            ? MmapArena::kMinCapacityBytes
-            : arenaSizeBytes);
+        std::max<uint64_t>(arenaSizeBytes, MmapArena::kMinCapacityBytes));
   }
 }
 
 bool MmapAllocator::allocateNonContiguous(
     MachinePageCount numPages,
     Allocation& out,
-    std::function<void(int64_t, bool)> userAllocCB,
+    ReservationCallback reservationCB,
     MachinePageCount minSizeClass) {
-  auto numFreed = freeInternal(out);
+  VELOX_CHECK_GT(numPages, 0);
+
+  const auto numFreed = freeInternal(out);
   if (numFreed != 0) {
     numAllocated_.fetch_sub(numFreed);
   }
@@ -66,11 +66,14 @@ bool MmapAllocator::allocateNonContiguous(
   }
   ++numAllocations_;
   numAllocatedPages_ += mix.totalPages;
-  if (userAllocCB != nullptr) {
+  if (reservationCB != nullptr) {
     try {
-      userAllocCB(mix.totalPages * kPageSize, true);
+      reservationCB(mix.totalPages * kPageSize, true);
     } catch (const std::exception& e) {
       numAllocated_.fetch_sub(mix.totalPages);
+      if (numFreed != 0) {
+        reservationCB(numFreed * kPageSize, false);
+      }
       std::rethrow_exception(std::current_exception());
     }
   }
@@ -88,18 +91,19 @@ bool MmapAllocator::allocateNonContiguous(
       // NOTE: the test callback might overwrite 'success' to inject an
       // allocation failure for test purpose.
       TestValue::adjust(
-          "facebook::velox::memory::MmapAllocator::allocate", &success);
+          "facebook::velox::memory::MmapAllocator::allocateNonContiguous",
+          &success);
     }
     if (!success) {
       // This does not normally happen since any size class can accommodate
       // all the capacity. 'allocatedPages_' must be out of sync.
       LOG(WARNING) << "Failed allocation in size class " << i << " for "
                    << mix.sizeCounts[i] << " pages";
-      auto failedPages = mix.totalPages - out.numPages();
+      const auto failedPages = mix.totalPages - out.numPages();
       freeNonContiguous(out);
       numAllocated_.fetch_sub(failedPages);
-      if (userAllocCB != nullptr) {
-        userAllocCB(mix.totalPages * kPageSize, false);
+      if (reservationCB != nullptr) {
+        reservationCB((mix.totalPages + numFreed) * kPageSize, false);
       }
       return false;
     }
@@ -111,9 +115,10 @@ bool MmapAllocator::allocateNonContiguous(
     markAllMapped(out);
     return true;
   }
+
   freeNonContiguous(out);
-  if (userAllocCB != nullptr) {
-    userAllocCB(mix.totalPages * kPageSize, false);
+  if (reservationCB != nullptr) {
+    reservationCB((mix.totalPages + numFreed) * kPageSize, false);
   }
   return false;
 }
@@ -125,14 +130,15 @@ bool MmapAllocator::ensureEnoughMappedPages(int32_t newMappedNeeded) {
     injectedFailure_ = Failure::kNone;
     return false;
   }
-  int totalMaps = numMapped_.fetch_add(newMappedNeeded) + newMappedNeeded;
+  const auto totalMaps =
+      numMapped_.fetch_add(newMappedNeeded) + newMappedNeeded;
   if (totalMaps <= capacity_) {
     // We are not at capacity. No need to advise away.
     return true;
   }
   // We need to advise away a number of pages or we fail the alloc.
-  int target = totalMaps - capacity_;
-  int numAdvised = adviseAway(target);
+  const auto target = totalMaps - capacity_;
+  const auto numAdvised = adviseAway(target);
   numAdvisedPages_ += numAdvised;
   if (numAdvised >= target) {
     numMapped_.fetch_sub(numAdvised);
@@ -143,16 +149,16 @@ bool MmapAllocator::ensureEnoughMappedPages(int32_t newMappedNeeded) {
 }
 
 int64_t MmapAllocator::freeNonContiguous(Allocation& allocation) {
-  auto numFreed = freeInternal(allocation);
+  const auto numFreed = freeInternal(allocation);
   numAllocated_.fetch_sub(numFreed);
   return numFreed * kPageSize;
 }
 
 MachinePageCount MmapAllocator::freeInternal(Allocation& allocation) {
-  if (allocation.numRuns() == 0) {
-    return 0;
-  }
   MachinePageCount numFreed = 0;
+  if (allocation.empty()) {
+    return numFreed;
+  }
 
   for (auto i = 0; i < sizeClasses_.size(); ++i) {
     auto& sizeClass = sizeClasses_[i];
@@ -162,11 +168,11 @@ MachinePageCount MmapAllocator::freeInternal(Allocation& allocation) {
       ClockTimer timer(clocks);
       pages = sizeClass->free(allocation);
     }
-    if (pages && FLAGS_velox_time_allocations) {
+    if ((pages > 0) && FLAGS_velox_time_allocations) {
       // Increment the free time only if the allocation contained
       // pages in the class. Note that size class indices in the
       // allocator are not necessarily the same as in the stats.
-      auto sizeIndex = Stats::sizeIndex(sizeClassSizes_[i] * kPageSize);
+      const auto sizeIndex = Stats::sizeIndex(sizeClassSizes_[i] * kPageSize);
       stats_.sizes[sizeIndex].freeClocks += clocks;
     }
     numFreed += pages;
@@ -179,54 +185,57 @@ bool MmapAllocator::allocateContiguousImpl(
     MachinePageCount numPages,
     MmapAllocator::Allocation* FOLLY_NULLABLE collateral,
     MmapAllocator::ContiguousAllocation& allocation,
-    std::function<void(int64_t, bool)> userAllocCB) {
+    ReservationCallback reservationCB) {
   MachinePageCount numCollateralPages = 0;
-  // 'collateral' and 'allocation' get freed anyway. But the counters
-  // are not updated to reflect this. Rather, we add the delta that is
-  // needed on top of collaterals to the allocation and mapped
-  // counters. In this way another thread will not see the temporary
-  // dip in allocation and we are sure to succeed if 'collateral' and
-  // 'allocation' together cover 'numPages'. If we need more space and
-  // fail to get this, then we subtract 'collateral' and 'allocation'
-  // from the counters.
+  // 'collateral' and 'allocation' get freed anyway. But the counters are not
+  // updated to reflect this. Rather, we add the delta that is needed on top of
+  // collaterals to the allocation and mapped counters. In this way another
+  // thread will not see the temporary dip in allocation, and we are sure to
+  // succeed if 'collateral' and 'allocation' together cover 'numPages'. If we
+  // need more space and fail to get this, then we subtract 'collateral' and
+  // 'allocation' from the counters.
   //
-  // Specifically, we do not subtract anything from counters with a
-  // resource reservation semantic, i.e. 'numAllocated_' and
-  // 'numMapped_' except at the end where the outcome of the
-  // operation is clear. Otherwise we could not have the guarantee
-  // that the operation succeeds if 'collateral' and 'allocation'
-  // cover the new size, as other threads might grab the transiently
-  // free pages.
-  if (collateral) {
+  // Specifically, we do not subtract anything from counters with a resource
+  // reservation semantic, i.e. 'numAllocated_' and 'numMapped_' except at the
+  // end where the outcome of the operation is clear. Otherwise, we could not
+  // have the guarantee that the operation succeeds if 'collateral' and
+  // 'allocation' cover the new size, as other threads might grab the
+  // transiently free pages.
+  if (collateral != nullptr) {
     numCollateralPages = freeInternal(*collateral);
   }
-  int64_t numLargeCollateralPages = allocation.numPages();
-  if (numLargeCollateralPages) {
+  const auto numLargeCollateralPages = allocation.numPages();
+  if (numLargeCollateralPages > 0) {
     if (useMmapArena_) {
       std::lock_guard<std::mutex> l(arenaMutex_);
       managedArenas_->free(allocation.data(), allocation.size());
     } else {
-      if (munmap(allocation.data(), allocation.size()) < 0) {
-        LOG(ERROR) << "munmap got " << errno << "for " << allocation.data()
-                   << ", " << allocation.size();
+      if (::munmap(allocation.data(), allocation.size()) < 0) {
+        LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << " for "
+                   << allocation.toString();
       }
     }
-    allocation.reset(nullptr, nullptr, 0);
+    allocation.clear();
   }
-  auto totalCollateralPages = numCollateralPages + numLargeCollateralPages;
-  auto numCollateralUnmap = numLargeCollateralPages;
-  int64_t newPages = numPages - totalCollateralPages;
-  if (userAllocCB) {
+
+  const auto totalCollateralPages =
+      numCollateralPages + numLargeCollateralPages;
+  const auto numCollateralUnmap = numLargeCollateralPages;
+  const int64_t newPages = numPages - totalCollateralPages;
+  if (reservationCB != nullptr) {
     try {
-      userAllocCB(newPages * kPageSize, true);
+      reservationCB(newPages * kPageSize, true);
     } catch (const std::exception& e) {
       numAllocated_ -= totalCollateralPages;
-      // We failed to grow by 'newPages. So we record the freeing off
-      // the whole collaterall and the unmap of former 'allocation'.
+      // We failed to grow by 'newPages. So we record the freeing off the whole
+      // collateral and the unmap of former 'allocation'.
       try {
-        userAllocCB(
+        reservationCB(
             static_cast<int64_t>(totalCollateralPages) * kPageSize, false);
       } catch (const std::exception& inner) {
+        LOG(ERROR)
+            << "Unexpected memory reservation release failure of the freed collateral pages: "
+            << e.what();
       };
       numMapped_ -= numCollateralUnmap;
       numExternalMapped_ -= numCollateralUnmap;
@@ -234,23 +243,29 @@ bool MmapAllocator::allocateContiguousImpl(
     }
   }
 
-  // Rolls back the counters on failure. 'mappedDecrement is subtracted from
+  // Rolls back the counters on failure. 'mappedDecrement' is subtracted from
   // 'numMapped_' on top of other adjustment.
   auto rollbackAllocation = [&](int64_t mappedDecrement) {
     // The previous allocation and collateral were both freed but not counted as
     // freed.
     numAllocated_ -= numPages;
-    try {
-      userAllocCB(numPages * kPageSize, false);
-    } catch (const std::exception& e) {
-      // Ignore exception, this is run on failure return path.
+    if (reservationCB != nullptr) {
+      try {
+        reservationCB(numPages * kPageSize, false);
+      } catch (const std::exception& e) {
+        // Ignore exception, this is run on failure return path.
+        LOG(ERROR)
+            << "Unexpected memory reservation release failure of the allocation rollback: "
+            << e.what();
+      }
     }
-    // was incremented by numPages - numLargeCollateralPages. On failure,
+    // Incremented by numPages - numLargeCollateralPages. On failure,
     // numLargeCollateralPages are freed and numPages - numLargeCollateralPages
     // were never allocated.
     numExternalMapped_ -= numPages;
     numMapped_ -= numCollateralUnmap + mappedDecrement;
   };
+
   numExternalMapped_ += numPages - numCollateralUnmap;
   auto numAllocated = numAllocated_.fetch_add(newPages) + newPages;
   // Check if went over the limit. But a net decrease always succeeds even if
@@ -262,10 +277,10 @@ bool MmapAllocator::allocateContiguousImpl(
   }
   // Make sure there are free backing pages for the size minus what we just
   // unmapped.
-  int64_t numToMap = numPages - numCollateralUnmap;
+  const int64_t numToMap = numPages - numCollateralUnmap;
   if (numToMap > 0) {
     if (!ensureEnoughMappedPages(numToMap)) {
-      LOG(WARNING) << "Could not advise away  enough for " << numToMap
+      LOG(WARNING) << "Could not advise away enough for " << numToMap
                    << " pages for allocateContiguous";
       rollbackAllocation(0);
       return false;
@@ -284,7 +299,7 @@ bool MmapAllocator::allocateContiguousImpl(
       std::lock_guard<std::mutex> l(arenaMutex_);
       data = managedArenas_->allocate(numPages * kPageSize);
     } else {
-      data = mmap(
+      data = ::mmap(
           nullptr,
           numPages * kPageSize,
           PROT_READ | PROT_WRITE,
@@ -293,33 +308,34 @@ bool MmapAllocator::allocateContiguousImpl(
           0);
     }
   }
-  if (!data) {
-    // If the mmap failed, we have unmapped former 'allocation' and
-    // the extra to be mapped.
+  if (data == nullptr) {
+    // If the mmap failed, we have unmapped former 'allocation' and the extra to
+    // be mapped.
     rollbackAllocation(numToMap);
     return false;
   }
 
-  allocation.reset(this, data, numPages * kPageSize);
+  allocation.set(data, numPages * kPageSize);
   return true;
 }
 
 void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
-  if (allocation.data() && allocation.size()) {
-    if (useMmapArena_) {
-      std::lock_guard<std::mutex> l(arenaMutex_);
-      managedArenas_->free(allocation.data(), allocation.size());
-    } else {
-      if (munmap(allocation.data(), allocation.size()) < 0) {
-        LOG(ERROR) << "munmap returned " << errno << "for " << allocation.data()
-                   << ", " << allocation.size();
-      }
-    }
-    numMapped_ -= allocation.numPages();
-    numExternalMapped_ -= allocation.numPages();
-    numAllocated_ -= allocation.numPages();
-    allocation.reset(nullptr, nullptr, 0);
+  if (allocation.empty()) {
+    return;
   }
+  if (useMmapArena_) {
+    std::lock_guard<std::mutex> l(arenaMutex_);
+    managedArenas_->free(allocation.data(), allocation.size());
+  } else {
+    if (::munmap(allocation.data(), allocation.size()) < 0) {
+      LOG(ERROR) << "munmap returned " << folly::errnoStr(errno) << " for "
+                 << allocation.toString();
+    }
+  }
+  numMapped_ -= allocation.numPages();
+  numExternalMapped_ -= allocation.numPages();
+  numAllocated_ -= allocation.numPages();
+  allocation.clear();
 }
 
 void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
@@ -336,8 +352,8 @@ void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
   }
 
   if (bytes <= sizeClassSizes_.back() * kPageSize) {
-    Allocation allocation(this);
-    auto numPages = roundUpToSizeClassSize(bytes, sizeClassSizes_);
+    Allocation allocation;
+    const auto numPages = roundUpToSizeClassSize(bytes, sizeClassSizes_);
     if (!allocateNonContiguous(numPages, allocation, nullptr, numPages)) {
       return nullptr;
     }
@@ -357,7 +373,7 @@ void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
   }
 
   char* data = allocation.data<char>();
-  allocation.reset(nullptr, nullptr, 0);
+  allocation.clear();
   return data;
 }
 
@@ -368,7 +384,7 @@ void MmapAllocator::freeBytes(void* p, uint64_t bytes) noexcept {
   }
 
   if (bytes <= sizeClassSizes_.back() * kPageSize) {
-    Allocation allocation(this);
+    Allocation allocation;
     auto numPages = roundUpToSizeClassSize(bytes, sizeClassSizes_);
     allocation.append(reinterpret_cast<uint8_t*>(p), numPages);
     freeNonContiguous(allocation);
@@ -376,7 +392,7 @@ void MmapAllocator::freeBytes(void* p, uint64_t bytes) noexcept {
   }
 
   ContiguousAllocation allocation;
-  allocation.reset(this, p, bytes);
+  allocation.set(p, bytes);
   freeContiguous(allocation);
 }
 
@@ -387,9 +403,9 @@ void MmapAllocator::markAllMapped(const Allocation& allocation) {
 }
 
 MachinePageCount MmapAllocator::adviseAway(MachinePageCount target) {
-  int numAway = 0;
-  for (int i = sizeClasses_.size() - 1; i >= 0; --i) {
-    numAway += sizeClasses_[i]->adviseAway(target - numAway, this);
+  MachinePageCount numAway = 0;
+  for (int32_t i = sizeClasses_.size() - 1; i >= 0; --i) {
+    numAway += sizeClasses_[i]->adviseAway(target - numAway);
     if (numAway >= target) {
       break;
     }
@@ -406,8 +422,11 @@ MmapAllocator::SizeClass::SizeClass(size_t capacity, MachinePageCount unitSize)
       pageBitmapSize_(capacity_ / 64),
       pageAllocated_(pageBitmapSize_ + kSimdTail),
       pageMapped_(pageBitmapSize_ + kSimdTail) {
-  VELOX_CHECK(
-      capacity_ % 64 == 0, "Sizeclass must have a multiple of 64 capacity.");
+  VELOX_CHECK_EQ(
+      capacity_ % 64,
+      0,
+      "Sizeclass {} must have a multiple of 64 capacity",
+      unitSize_);
   void* ptr = mmap(
       nullptr,
       capacity_ * unitSize_ * kPageSize,
@@ -415,12 +434,12 @@ MmapAllocator::SizeClass::SizeClass(size_t capacity, MachinePageCount unitSize)
       MAP_PRIVATE | MAP_ANONYMOUS,
       -1,
       0);
-  if (ptr == MAP_FAILED || !ptr) {
-    LOG(ERROR) << "mmap failed with " << errno;
+  if (ptr == MAP_FAILED || ptr == nullptr) {
     VELOX_FAIL(
-        "Could not allocate working memory"
-        "mmap failed with {}",
-        errno);
+        "Could not allocate working memory "
+        "mmap failed with {} for sizeClass {}",
+        folly::errnoStr(errno),
+        unitSize_);
   }
   address_ = reinterpret_cast<uint8_t*>(ptr);
 }
@@ -509,27 +528,28 @@ bool MmapAllocator::SizeClass::allocateLocked(
     const ClassPageCount numPages,
     MachinePageCount* FOLLY_NULLABLE numUnmapped,
     MmapAllocator::Allocation& out) {
-  size_t numWords = pageBitmapSize_;
+  const size_t numWords = pageBitmapSize_;
   ClassPageCount considerMappedOnly = std::min(numMappedFreePages_, numPages);
-  auto numPagesToGo = numPages;
-  if (considerMappedOnly) {
-    int previousPages = out.numPages();
+  auto numPagesToAllocate = numPages;
+  if (considerMappedOnly > 0) {
+    const auto previousPages = out.numPages();
     allocateFromMappdFree(considerMappedOnly, out);
-    auto numAllocated = (out.numPages() - previousPages) / unitSize_;
-    if (numAllocated != considerMappedOnly) {
-      VELOX_FAIL("Allocated different number of pages");
-    }
+    const auto numAllocated = (out.numPages() - previousPages) / unitSize_;
+    VELOX_CHECK_EQ(
+        numAllocated,
+        considerMappedOnly,
+        "Allocated different number of pages");
     numMappedFreePages_ -= numAllocated;
-    numPagesToGo -= numAllocated;
+    numPagesToAllocate -= numAllocated;
   }
-  if (!numPagesToGo) {
+  if (numPagesToAllocate == 0) {
     return true;
   }
-  if (!numUnmapped) {
+  if (numUnmapped == nullptr) {
     return false;
   }
   uint32_t cursor = clockHand_;
-  int numWordsTried = 0;
+  int32_t numWordsTried = 0;
   for (;;) {
     auto previousCursor = cursor;
     if (++cursor >= numWords) {
@@ -540,10 +560,10 @@ bool MmapAllocator::SizeClass::allocateLocked(
     }
     uint64_t bits = pageAllocated_[cursor];
     if (bits != kAllSet) {
-      int previousToGo = numPagesToGo;
-      allocateAny(cursor, numPagesToGo, *numUnmapped, out);
-      numAllocatedUnmapped_ += previousToGo - numPagesToGo;
-      if (numPagesToGo == 0) {
+      const auto previousToAllocate = numPagesToAllocate;
+      allocateAny(cursor, numPagesToAllocate, *numUnmapped, out);
+      numAllocatedUnmapped_ += previousToAllocate - numPagesToAllocate;
+      if (numPagesToAllocate == 0) {
         clockHand_ = previousCursor;
         return true;
       }
@@ -650,19 +670,18 @@ void MmapAllocator::SizeClass::allocateFromMappdFree(
 }
 
 MachinePageCount MmapAllocator::SizeClass::adviseAway(
-    MachinePageCount numPages,
-    MmapAllocator* allocator) {
+    MachinePageCount numPages) {
   // Allocate as many mapped free pages as needed and advise them away.
   ClassPageCount target = bits::roundUp(numPages, unitSize_) / unitSize_;
-  Allocation allocation(allocator);
+  Allocation allocation;
   {
     std::lock_guard<std::mutex> l(mutex_);
-    if (!numMappedFreePages_) {
+    if (numMappedFreePages_ == 0) {
       return 0;
     }
     target = std::min(target, numMappedFreePages_);
     allocateLocked(target, nullptr, allocation);
-    VELOX_CHECK(allocation.numPages() == target * unitSize_);
+    VELOX_CHECK_EQ(allocation.numPages(), target * unitSize_);
     numAllocatedMapped_ -= target;
     numAdvisedAway_ += target;
   }
@@ -703,8 +722,8 @@ void MmapAllocator::SizeClass::adviseAway(const Allocation& allocation) {
     if (!isInRange(run.data())) {
       continue;
     }
-    if (madvise(run.data(), run.numPages() * kPageSize, MADV_DONTNEED) < 0) {
-      LOG(WARNING) << "madvise got errno " << errno;
+    if (::madvise(run.data(), run.numPages() * kPageSize, MADV_DONTNEED) < 0) {
+      LOG(ERROR) << "madvise got errno " << folly::errnoStr(errno);
     } else {
       std::lock_guard<std::mutex> l(mutex_);
       setMappedBits(run, false);
@@ -716,22 +735,22 @@ void MmapAllocator::SizeClass::setMappedBits(
     const MemoryAllocator::PageRun run,
     bool value) {
   const uint8_t* runAddress = run.data();
-  const int firstBit = (runAddress - address_) / (unitSize_ * kPageSize);
-  VELOX_CHECK(
-      (runAddress - address_) % (kPageSize * unitSize_) == 0,
+  VELOX_CHECK_EQ(
+      (runAddress - address_) % (kPageSize * unitSize_),
+      0,
       "Unaligned allocation in setting mapped bits");
-  const int numPages = run.numPages() / unitSize_;
-  for (int page = firstBit; page < firstBit + numPages; ++page) {
+  const auto firstBit = (runAddress - address_) / (unitSize_ * kPageSize);
+  const auto numPages = run.numPages() / unitSize_;
+  for (int32_t page = firstBit; page < firstBit + numPages; ++page) {
     bits::setBit(pageMapped_.data(), page, value);
   }
 }
 
 MachinePageCount MmapAllocator::SizeClass::free(
     MemoryAllocator::Allocation& allocation) {
-  MachinePageCount numFreed = 0;
-  int firstRunInClass = -1;
+  int32_t firstRunInClass = -1;
   // Check if there are any runs in 'this' outside of 'mutex_'.
-  for (int i = 0; i < allocation.numRuns(); ++i) {
+  for (int32_t i = 0; i < allocation.numRuns(); ++i) {
     PageRun run = allocation.runAt(i);
     uint8_t* runAddress = run.data();
     if (isInRange(runAddress)) {
@@ -742,6 +761,7 @@ MachinePageCount MmapAllocator::SizeClass::free(
   if (firstRunInClass == -1) {
     return 0;
   }
+  MachinePageCount numFreed = 0;
   std::lock_guard<std::mutex> l(mutex_);
   for (int i = firstRunInClass; i < allocation.numRuns(); ++i) {
     PageRun run = allocation.runAt(i);
@@ -753,6 +773,7 @@ MachinePageCount MmapAllocator::SizeClass::free(
     const int firstBit = (runAddress - address_) / (kPageSize * unitSize_);
     for (auto page = firstBit; page < firstBit + numPages; ++page) {
       if (!bits::isBitSet(pageAllocated_.data(), page)) {
+        // TODO: change this to a velox failure to catch the bug.
         LOG(ERROR) << "Double free: page = " << page
                    << " sizeclass = " << unitSize_;
         continue;
@@ -774,9 +795,9 @@ void MmapAllocator::SizeClass::allocateAny(
     MachinePageCount& numUnmapped,
     MmapAllocator::Allocation& allocation) {
   uint64_t freeBits = ~pageAllocated_[wordIndex];
-  int toAlloc = std::min(numPages, __builtin_popcountll(freeBits));
-  for (int i = 0; i < toAlloc; ++i) {
-    int bit = __builtin_ctzll(freeBits);
+  const auto toAlloc = std::min(numPages, __builtin_popcountll(freeBits));
+  for (int32_t i = 0; i < toAlloc; ++i) {
+    const int bit = __builtin_ctzll(freeBits);
     bits::setBit(&pageAllocated_[wordIndex], bit);
     if (!(pageMapped_[wordIndex] & (1UL << bit))) {
       numUnmapped += unitSize_;

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -30,8 +30,8 @@
 
 namespace facebook::velox::memory {
 
-/// Denotes a number of pages of one size class, i.e. one page consists of a
-/// size class dependent number of consecutive machine pages.
+/// Denotes a number of pages of one size class, i.e. one page consists
+/// of a size class dependent number of consecutive machine pages.
 using ClassPageCount = int32_t;
 
 /// Implementation of MemoryAllocator with mmap and madvise. Each size class is
@@ -43,7 +43,9 @@ using ClassPageCount = int32_t;
 /// up to the capacity can be allocated without fragmentation. If a size needs
 /// to be allocated that does not correspond to size classes, we advise away
 /// enough pages from other size classes to cover for it and then make a new
-/// mmap of the requested size (ContiguousAllocation).
+/// mmap of the requested size (ContiguousAllocation). Small contiguous memory
+/// allocations less than 3/4 of smallest size class are still delegated to
+/// malloc.
 class MmapAllocator : public MemoryAllocator {
  public:
   struct Options {
@@ -67,7 +69,7 @@ class MmapAllocator : public MemoryAllocator {
   bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,
-      std::function<void(int64_t, bool)> userAllocCB = nullptr,
+      ReservationCallback reservationCB = nullptr,
       MachinePageCount minSizeClass = 0) override;
 
   int64_t freeNonContiguous(Allocation& allocation) override;
@@ -76,11 +78,12 @@ class MmapAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t, bool)> userAllocCB = nullptr) override {
+      ReservationCallback reservationCB = nullptr) override {
+    VELOX_CHECK_GT(numPages, 0);
     bool result;
     stats_.recordAllocate(numPages * kPageSize, 1, [&]() {
-      result =
-          allocateContiguousImpl(numPages, collateral, allocation, userAllocCB);
+      result = allocateContiguousImpl(
+          numPages, collateral, allocation, reservationCB);
     });
     return result;
   }
@@ -95,12 +98,12 @@ class MmapAllocator : public MemoryAllocator {
 
   void freeBytes(void* p, uint64_t bytes) noexcept override;
 
-  // Checks internal consistency of allocation data structures. Returns true if
-  // OK. May return false if there are concurrent allocations and frees during
-  // the consistency check. This is a false positive but not dangerous.
-  //
-  // Checks that the totals of mapped free and mapped and allocated pages match
-  // the data in the bitmaps in the size classes.
+  /// Checks internal consistency of allocation data structures. Returns true if
+  /// OK. May return false if there are concurrent allocations and frees during
+  /// the consistency check. This is a false positive but not dangerous.
+  ///
+  /// Checks that the totals of mapped free and mapped and allocated pages match
+  /// the data in the bitmaps in the size classes.
   bool checkConsistency() const override;
 
   MachinePageCount capacity() const {
@@ -168,9 +171,7 @@ class MmapAllocator : public MemoryAllocator {
     // Advises away backing for 'numPages' worth of unallocated mapped class
     // pages. This needs to make an Allocation, for which it needs the
     // containing MmapAllocator.
-    MachinePageCount adviseAway(
-        MachinePageCount numPages,
-        MmapAllocator* FOLLY_NONNULL allocator);
+    MachinePageCount adviseAway(MachinePageCount numPages);
 
     // Sets the mapped bits for the runs in 'allocation' to 'value' for the
     // addresses that fall in the range of 'this'
@@ -187,18 +188,18 @@ class MmapAllocator : public MemoryAllocator {
 
    private:
     static constexpr int32_t kNoLastLookup = -1;
-    // Number of bits in 'mappedPages_' for one bit in
-    // 'mappedFreeLookup_'.
+    // Number of bits in 'mappedPages_' for one bit in 'mappedFreeLookup_'.
     static constexpr int32_t kPagesPerLookupBit =
         xsimd::batch<int64_t>::size * 128;
     // Number of extra 0 uint64's at te end of allocation bitmaps for SIMD
     // checks.
     static constexpr int32_t kSimdTail = 8;
 
-    // Same as allocate, except that this must be called inside 'mutex_'. If
-    // 'numUnmapped' is nullptr, the allocated pages must all be backed by
-    // memory. Otherwise, numUnmapped is updated to be the count of machine
-    // pages needing backing memory to back the allocation.
+    // Same as allocate, except that this must be called inside
+    // 'mutex_'. If 'numUnmapped' is nullptr, the allocated pages must
+    // all be backed by memory. Otherwise numUnmapped is updated to be
+    // the count of machine pages needing backing memory to back the
+    // allocation.
     bool allocateLocked(
         ClassPageCount numPages,
         MachinePageCount* FOLLY_NULLABLE numUnmapped,
@@ -267,14 +268,12 @@ class MmapAllocator : public MemoryAllocator {
     int32_t lastLookupIndex_{kNoLastLookup};
 
     // has a set bit if the corresponding 8 word range in
-    // pageAllocated_/pageMapped_ has at least one mapped free
-    // bit. Contains 1 bit for each 8 words of
-    // pageAllocated_/pageMapped_.
+    // pageAllocated_/pageMapped_ has at least one mapped free bit. Contains 1
+    // bit for each 8 words of pageAllocated_/pageMapped_.
     std::vector<uint64_t> mappedFreeLookup_;
 
-    // Number of meaningful words in
-    // 'pageAllocated_'/'pageMapped'. The arrays themselves are padded
-    // with extra zeros for SIMD access.
+    // Number of meaningful words in 'pageAllocated_'/'pageMapped'. The arrays
+    // themselves are padded with extra zeros for SIMD access.
     const int32_t pageBitmapSize_;
 
     // Has a 1 bit if the corresponding size class page is allocated.
@@ -298,7 +297,7 @@ class MmapAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      std::function<void(int64_t, bool)> userAllocCB);
+      ReservationCallback reservationCB);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 
@@ -321,11 +320,16 @@ class MmapAllocator : public MemoryAllocator {
   // advises them away. Returns the number of pages advised away.
   MachinePageCount adviseAway(MachinePageCount target);
 
+  // If set true, allocations larger than the largest size class size will be
+  // delegated to ManagedMmapArena. Otherwise, a system mmap call will be
+  // issued for each such allocation.
+  const bool useMmapArena_;
+
   // Serializes moving capacity between size classes
   std::mutex sizeClassBalanceMutex_;
 
-  // Number of allocated pages. Allocation succeeds if an atomic
-  // increment of this by the desired amount is <= 'capacity_'.
+  // Number of allocated pages. Allocation succeeds if an atomic increment of
+  // this by the desired amount is <= 'capacity_'.
   std::atomic<MachinePageCount> numAllocated_;
 
   // Number of machine pages backed by memory in the address ranges in
@@ -353,11 +357,6 @@ class MmapAllocator : public MemoryAllocator {
   // ManagedMmapArenas, to avoid calling mmap on every allocation.
   std::mutex arenaMutex_;
   std::unique_ptr<ManagedMmapArenas> managedArenas_;
-
-  // If set true, allocations larger than largest size class size will be
-  // delegated to ManagedMmapArena. Otherwise a system mmap call will be
-  // issued for each such allocation.
-  bool useMmapArena_;
 
   Failure injectedFailure_{Failure::kNone};
   Stats stats_;

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -18,11 +18,10 @@
 
 namespace facebook::velox {
 
-StreamArena::StreamArena(memory::MemoryAllocator* allocator)
-    : allocator_(allocator->shared_from_this()), allocation_(allocator) {}
+StreamArena::StreamArena(memory::MemoryPool* pool) : pool_(pool) {}
 
 void StreamArena::newRange(int32_t bytes, ByteRange* range) {
-  VELOX_CHECK(bytes > 0);
+  VELOX_CHECK_GT(bytes, 0);
   memory::MachinePageCount numPages =
       bits::roundUp(bytes, memory::MemoryAllocator::kPageSize) /
       memory::MemoryAllocator::kPageSize;
@@ -33,7 +32,7 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
           std::make_unique<memory::MemoryAllocator::Allocation>(
               std::move(allocation_)));
     }
-    if (!allocator_->allocateNonContiguous(
+    if (!pool_->allocateNonContiguous(
             std::max(allocationQuantum_, numPages), allocation_)) {
       throw std::bad_alloc();
     }

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include "velox/common/memory/MemoryAllocator.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox {
 
@@ -27,30 +27,32 @@ struct ByteRange;
 // complex types as serialized rows.
 class StreamArena {
  public:
-  explicit StreamArena(memory::MemoryAllocator* MemoryAllocator);
+  static constexpr int32_t kVectorStreamOwner = 1;
+
+  explicit StreamArena(memory::MemoryPool* FOLLY_NONNULL pool);
 
   virtual ~StreamArena() = default;
 
   // Sets range to refer  to at least one page of writable memory owned by
   // 'this'. Up to 'numPages' may be  allocated.
-  virtual void newRange(int32_t bytes, ByteRange* range);
+  virtual void newRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
 
   // sets 'range' to point to a small piece of memory owned by this. These alwys
   // come from the heap. The use case is for headers that may change length
   // based on data properties, not for bulk data.
-  virtual void newTinyRange(int32_t bytes, ByteRange* range);
+  virtual void newTinyRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
 
   // Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {
     return size_;
   }
 
-  memory::MemoryAllocator* allocator() {
-    return allocator_.get();
+  memory::MemoryPool* FOLLY_NONNULL pool() const {
+    return pool_;
   }
 
  private:
-  std::shared_ptr<memory::MemoryAllocator> allocator_;
+  memory::MemoryPool* FOLLY_NONNULL pool_;
   // All allocations.
   std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
       allocations_;

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -33,8 +33,8 @@ struct Multipart {
 class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
-    instance_ = std::make_unique<HashStringAllocator>(
-        memory::MemoryAllocator::getInstance());
+    pool_ = memory::getDefaultMemoryPool();
+    instance_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }
 
@@ -82,6 +82,7 @@ class HashStringAllocatorTest : public testing::Test {
     return result;
   }
 
+  std::shared_ptr<memory::MemoryPool> pool_;
   std::unique_ptr<HashStringAllocator> instance_;
   int32_t sequence_ = 0;
   folly::Random::DefaultGenerator rng_;

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -20,9 +20,10 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MmapAllocator.h"
-#include "velox/exec/HashBitRange.h"
+#include "velox/common/testutil/TestValue.h"
 
 using namespace ::testing;
+using namespace facebook::velox::common::testutil;
 
 constexpr int64_t KB = 1024L;
 constexpr int64_t MB = 1024L * KB;
@@ -34,6 +35,11 @@ namespace memory {
 
 class MemoryPoolTest : public testing::TestWithParam<bool> {
  protected:
+ protected:
+  static void SetUpTestCase() {
+    TestValue::enable();
+  }
+
   MemoryPoolTest() : useMmap_(GetParam()) {}
 
   void SetUp() override {
@@ -46,6 +52,10 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
     } else {
       MemoryAllocator::setDefaultInstance(nullptr);
     }
+    const auto seed =
+        std::chrono::system_clock::now().time_since_epoch().count();
+    rng_.seed(seed);
+    LOG(INFO) << "Random seed: " << seed;
   }
 
   void TearDown() override {
@@ -63,6 +73,7 @@ class MemoryPoolTest : public testing::TestWithParam<bool> {
   }
 
   const bool useMmap_;
+  folly::Random::DefaultGenerator rng_;
   std::shared_ptr<MmapAllocator> mmapAllocator_;
 };
 
@@ -170,7 +181,6 @@ TEST_P(MemoryPoolTest, dropChild) {
   grandChild2.reset();
   ASSERT_EQ(0, root.getChildCount());
 }
-//!!!!
 
 TEST(MemoryPoolTest, CapSubtree) {
   MemoryManager manager{};
@@ -377,6 +387,7 @@ TEST_P(MemoryPoolTest, AllocTest) {
   const int64_t kChunkSize{32L * MB};
 
   void* oneChunk = child->allocate(kChunkSize);
+  ASSERT_EQ(reinterpret_cast<uint64_t>(oneChunk) % child->getAlignment(), 0);
   ASSERT_EQ(kChunkSize, child->getCurrentBytes());
   ASSERT_EQ(kChunkSize, child->getMaxBytes());
 
@@ -562,7 +573,7 @@ TEST_P(MemoryPoolTest, alignmentCheck) {
   }
 }
 
-TEST(MemoryPoolTest, MemoryCapExceptions) {
+TEST_P(MemoryPoolTest, MemoryCapExceptions) {
   MemoryManager manager{{.capacity = 127L * MB}};
   auto& root = manager.getRoot();
 
@@ -626,7 +637,7 @@ TEST(MemoryPoolTest, GetAlignment) {
   }
 }
 
-TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
+TEST_P(MemoryPoolTest, MemoryManagerGlobalCap) {
   MemoryManager manager{{.capacity = 32 * MB}};
 
   auto& root = manager.getRoot();
@@ -649,7 +660,7 @@ TEST(MemoryPoolTest, MemoryManagerGlobalCap) {
 // Tests how child updates itself and its parent's memory usage
 // and what it returns for getCurrentBytes()/getMaxBytes and
 // with memoryUsageTracker.
-TEST(MemoryPoolTest, childUsageTest) {
+TEST_P(MemoryPoolTest, childUsageTest) {
   MemoryManager manager{{.capacity = 8 * GB}};
   auto& root = manager.getRoot();
 
@@ -756,7 +767,7 @@ TEST(MemoryPoolTest, childUsageTest) {
   }
 }
 
-TEST(MemoryPoolTest, getPreferredSize) {
+TEST_P(MemoryPoolTest, getPreferredSize) {
   MemoryManager manager;
   auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
 
@@ -773,7 +784,7 @@ TEST(MemoryPoolTest, getPreferredSize) {
   EXPECT_EQ(1024 * 1024 * 2, pool.getPreferredSize(1024 * 1536 + 1));
 }
 
-TEST(MemoryPoolTest, getPreferredSizeOverflow) {
+TEST_P(MemoryPoolTest, getPreferredSizeOverflow) {
   MemoryManager manager;
   auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
 
@@ -781,12 +792,273 @@ TEST(MemoryPoolTest, getPreferredSizeOverflow) {
   EXPECT_EQ(1ULL << 63, pool.getPreferredSize((1ULL << 62) - 1 + (1ULL << 62)));
 }
 
-TEST(MemoryPoolTest, allocatorOverflow) {
-  MemoryManager manager{};
+TEST_P(MemoryPoolTest, allocatorOverflow) {
+  MemoryManager manager;
   auto& pool = dynamic_cast<MemoryPoolImpl&>(manager.getRoot());
   Allocator<int64_t> alloc(pool);
   EXPECT_THROW(alloc.allocate(1ULL << 62), VeloxException);
   EXPECT_THROW(alloc.deallocate(nullptr, 1ULL << 62), VeloxException);
+}
+
+TEST_P(MemoryPoolTest, contiguousAllocate) {
+  auto manager = getMemoryManager(8 * GB);
+  auto pool = manager->getChild();
+  const auto largestSizeClass =
+      MemoryAllocator::getInstance()->largestSizeClass();
+  struct {
+    MachinePageCount numAllocPages;
+    std::string debugString() const {
+      return fmt::format("numAllocPages:{}", numAllocPages);
+    }
+  } testSettings[] = {
+      {largestSizeClass},
+      {largestSizeClass + 1},
+      {largestSizeClass / 10},
+      {1},
+      {largestSizeClass * 2},
+      {largestSizeClass * 3 + 1}};
+  std::vector<MemoryAllocator::ContiguousAllocation> allocations;
+  const char c('M');
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    MemoryAllocator::ContiguousAllocation allocation;
+    ASSERT_TRUE(allocation.empty());
+    ASSERT_TRUE(pool->allocateContiguous(testData.numAllocPages, allocation));
+    ASSERT_FALSE(allocation.empty());
+    ASSERT_EQ(allocation.pool(), pool.get());
+    ASSERT_EQ(allocation.numPages(), testData.numAllocPages);
+    ASSERT_EQ(
+        allocation.size(), testData.numAllocPages * MemoryAllocator::kPageSize);
+    for (int32_t i = 0; i < allocation.size(); ++i) {
+      allocation.data()[i] = c;
+    }
+    allocations.push_back(std::move(allocation));
+  }
+  // Verify data.
+  for (auto& allocation : allocations) {
+    for (int32_t i = 0; i < allocation.size(); ++i) {
+      ASSERT_EQ(allocation.data()[i], c);
+    }
+  }
+  allocations.clear();
+
+  // Random tests.
+  const int32_t numIterations = 100;
+  const MachinePageCount kMaxAllocationPages = 32 << 10; // Total 128MB
+  int32_t numAllocatedPages = 0;
+  for (int32_t i = 0; i < numIterations; ++i) {
+    const MachinePageCount pagesToAllocate =
+        1 + folly::Random().rand32() % kMaxAllocationPages;
+    MemoryAllocator::ContiguousAllocation allocation;
+    if (folly::Random().oneIn(2) && !allocations.empty()) {
+      const int32_t freeAllocationIdx =
+          folly::Random().rand32() % allocations.size();
+      allocation = std::move(allocations[freeAllocationIdx]);
+      numAllocatedPages -= allocation.numPages();
+      ASSERT_GE(numAllocatedPages, 0);
+      allocations.erase(allocations.begin() + freeAllocationIdx);
+    }
+    const MachinePageCount minSizeClass = folly::Random().oneIn(4)
+        ? 0
+        : std::min(
+              MemoryAllocator::getInstance()->largestSizeClass(),
+              folly::Random().rand32() % kMaxAllocationPages);
+    ASSERT_TRUE(pool->allocateContiguous(pagesToAllocate, allocation));
+    numAllocatedPages += allocation.numPages();
+    for (int32_t j = 0; j < allocation.size(); ++j) {
+      allocation.data()[j] = c;
+    }
+    allocations.push_back(std::move(allocation));
+    while (numAllocatedPages > kMaxAllocationPages) {
+      numAllocatedPages -= allocations.back().numPages();
+      ASSERT_GE(numAllocatedPages, 0);
+      allocations.pop_back();
+    }
+  }
+  // Verify data.
+  for (auto& allocation : allocations) {
+    for (int32_t i = 0; i < allocation.size(); ++i) {
+      ASSERT_EQ(allocation.data()[i], c);
+    }
+  }
+}
+
+TEST_P(MemoryPoolTest, contiguousAllocateExceedLimit) {
+  const MachinePageCount kMaxNumPages = 1 << 10;
+  const auto kMemoryCapBytes = kMaxNumPages * MemoryAllocator::kPageSize;
+  auto manager = getMemoryManager(kMemoryCapBytes);
+  auto pool = manager->getChild();
+  auto tracker = MemoryUsageTracker::create(kMemoryCapBytes);
+  pool->setMemoryUsageTracker(tracker);
+  MemoryAllocator::ContiguousAllocation allocation;
+  ASSERT_TRUE(pool->allocateContiguous(kMaxNumPages, allocation));
+  ASSERT_THROW(
+      pool->allocateContiguous(2 * kMaxNumPages, allocation),
+      VeloxRuntimeError);
+  ASSERT_TRUE(allocation.empty());
+  ASSERT_THROW(
+      pool->allocateContiguous(2 * kMaxNumPages, allocation),
+      VeloxRuntimeError);
+  ASSERT_TRUE(allocation.empty());
+}
+
+DEBUG_ONLY_TEST_P(MemoryPoolTest, contiguousAllocateError) {
+  auto manager = getMemoryManager(8 * GB);
+  auto pool = manager->getChild();
+  if (useMmap_) {
+    auto instance =
+        dynamic_cast<MmapAllocator*>(MemoryAllocator::getInstance());
+    instance->testingInjectFailure(MmapAllocator::Failure::kMmap);
+  }
+  std::atomic<bool> testingInjectFailureOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::memory::MemoryAllocatorImpl::allocateContiguousImpl",
+      std::function<void(bool*)>([&](bool* testFlag) {
+        if (!testingInjectFailureOnce.exchange(false)) {
+          return;
+        }
+        *testFlag = true;
+      }));
+  constexpr MachinePageCount kAllocSize = 8;
+  std::unique_ptr<MemoryAllocator::ContiguousAllocation> allocation(
+      new MemoryAllocator::ContiguousAllocation());
+  ASSERT_FALSE(pool->allocateContiguous(kAllocSize, *allocation));
+  ASSERT_TRUE(pool->allocateContiguous(kAllocSize, *allocation));
+  pool->freeContiguous(*allocation);
+  ASSERT_TRUE(allocation->empty());
+}
+
+TEST_P(MemoryPoolTest, nonContiguousAllocate) {
+  auto manager = getMemoryManager(8 * GB);
+  auto pool = manager->getChild();
+  const auto& sizeClasses = MemoryAllocator::getInstance()->sizeClasses();
+  for (const auto& sizeClass : sizeClasses) {
+    SCOPED_TRACE(fmt::format("sizeClass:{}", sizeClass));
+    struct {
+      MachinePageCount numAllocPages;
+      MachinePageCount minSizeClass;
+      std::string debugString() const {
+        return fmt::format(
+            "numAllocPages:{}, minSizeClass:{}", numAllocPages, minSizeClass);
+      }
+    } testSettings[] = {
+        {sizeClass, 0},
+        {sizeClass, 1},
+        {sizeClass, 10},
+        {sizeClass, sizeClass},
+        {sizeClass, sizeClass + 1},
+        {sizeClass, sizeClass * 2},
+        {sizeClass + 10, 0},
+        {sizeClass + 10, 1},
+        {sizeClass + 10, 10},
+        {sizeClass + 10, sizeClass},
+        {sizeClass + 10, sizeClass + 1},
+        {sizeClass + 10, sizeClass * 2},
+        {sizeClass * 2, 0},
+        {sizeClass * 2, 1},
+        {sizeClass * 2, 10},
+        {sizeClass * 2, sizeClass},
+        {sizeClass * 2, sizeClass + 1},
+        {sizeClass * 2, sizeClass + 10},
+        {sizeClass * 2, sizeClass * 2},
+        {sizeClass * 2, sizeClass * 2 + 1},
+        {sizeClass * 2, sizeClass * 2 * 2}};
+    std::vector<MemoryAllocator::Allocation> allocations;
+    for (const auto& testData : testSettings) {
+      SCOPED_TRACE(testData.debugString());
+      MemoryAllocator::Allocation allocation;
+      ASSERT_TRUE(allocation.empty());
+      ASSERT_TRUE(pool->allocateNonContiguous(
+          testData.numAllocPages,
+          allocation,
+          std::min(
+              testData.minSizeClass,
+              MemoryAllocator::getInstance()->largestSizeClass())));
+      ASSERT_FALSE(allocation.empty());
+      ASSERT_EQ(allocation.pool(), pool.get());
+      ASSERT_GT(allocation.numRuns(), 0);
+      ASSERT_GE(allocation.numPages(), testData.numAllocPages);
+    }
+  }
+  // Random tests.
+  const int32_t numIterations = 100;
+  const MachinePageCount kMaxAllocationPages = 32 << 10; // Total 128MB
+  int32_t numAllocatedPages = 0;
+  std::vector<MemoryAllocator::Allocation> allocations;
+  for (int32_t i = 0; i < numIterations; ++i) {
+    const MachinePageCount pagesToAllocate =
+        1 + folly::Random().rand32() % kMaxAllocationPages;
+    MemoryAllocator::Allocation allocation;
+    if (folly::Random().oneIn(2) && !allocations.empty()) {
+      const int32_t freeAllocationIdx =
+          folly::Random().rand32() % allocations.size();
+      allocation = std::move(allocations[freeAllocationIdx]);
+      numAllocatedPages -= allocation.numPages();
+      ASSERT_GE(numAllocatedPages, 0);
+      allocations.erase(allocations.begin() + freeAllocationIdx);
+    }
+    const MachinePageCount minSizeClass = folly::Random().oneIn(4)
+        ? 0
+        : std::min(
+              MemoryAllocator::getInstance()->largestSizeClass(),
+              folly::Random().rand32() % kMaxAllocationPages);
+    ASSERT_TRUE(
+        pool->allocateNonContiguous(pagesToAllocate, allocation, minSizeClass));
+    numAllocatedPages += allocation.numPages();
+    allocations.push_back(std::move(allocation));
+    while (numAllocatedPages > kMaxAllocationPages) {
+      numAllocatedPages -= allocations.back().numPages();
+      ASSERT_GE(numAllocatedPages, 0);
+      allocations.pop_back();
+    }
+  }
+}
+
+TEST_P(MemoryPoolTest, nonContiguousAllocateExceedLimit) {
+  const MachinePageCount kMaxNumPages = 1 << 10;
+  const auto kMemoryCapBytes = kMaxNumPages * MemoryAllocator::kPageSize;
+  auto manager = getMemoryManager(kMemoryCapBytes);
+  auto pool = manager->getChild();
+  auto tracker = MemoryUsageTracker::create(kMemoryCapBytes);
+  pool->setMemoryUsageTracker(tracker);
+  MemoryAllocator::Allocation allocation;
+  ASSERT_TRUE(pool->allocateNonContiguous(kMaxNumPages, allocation));
+  ASSERT_THROW(
+      pool->allocateNonContiguous(2 * kMaxNumPages, allocation),
+      VeloxRuntimeError);
+  ASSERT_TRUE(allocation.empty());
+  ASSERT_THROW(
+      pool->allocateNonContiguous(2 * kMaxNumPages, allocation),
+      VeloxRuntimeError);
+  ASSERT_TRUE(allocation.empty());
+}
+
+DEBUG_ONLY_TEST_P(MemoryPoolTest, nonContiguousAllocateError) {
+  auto manager = getMemoryManager(8 * GB);
+  auto pool = manager->getChild();
+  const std::string testValueStr = useMmap_
+      ? "facebook::velox::memory::MmapAllocator::allocateNonContiguous"
+      : "facebook::velox::memory::MemoryAllocatorImpl::allocateNonContiguous";
+  std::atomic<bool> testingInjectFailureOnce{true};
+  SCOPED_TESTVALUE_SET(
+      testValueStr, std::function<void(bool*)>([&](bool* testFlag) {
+        if (!testingInjectFailureOnce.exchange(false)) {
+          return;
+        }
+        if (useMmap_) {
+          *testFlag = false;
+        } else {
+          *testFlag = true;
+        }
+      }));
+
+  constexpr MachinePageCount kAllocSize = 8;
+  std::unique_ptr<MemoryAllocator::Allocation> allocation(
+      new MemoryAllocator::Allocation());
+  ASSERT_FALSE(pool->allocateNonContiguous(kAllocSize, *allocation));
+  ASSERT_TRUE(pool->allocateNonContiguous(kAllocSize, *allocation));
+  pool->freeNonContiguous(*allocation);
+  ASSERT_TRUE(allocation->empty());
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "velox/common/memory/Memory.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"
 
@@ -83,6 +84,39 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   void free(void* p, int64_t size) override {
     allocator_->freeBytes(p, size);
     updateLocalMemoryUsage(-size);
+  }
+
+  bool allocateNonContiguous(
+      velox::memory::MachinePageCount /*unused*/,
+      velox::memory::MemoryAllocator::Allocation& /*unused*/,
+      velox::memory::MachinePageCount /*unused*/) override {
+    VELOX_UNSUPPORTED("allocateNonContiguous unsupported");
+  }
+
+  void freeNonContiguous(
+      velox::memory::MemoryAllocator::Allocation& /*unused*/) override {
+    VELOX_UNSUPPORTED("freeNonContiguous unsupported");
+  }
+
+  velox::memory::MachinePageCount largestSizeClass() const override {
+    VELOX_UNSUPPORTED("largestSizeClass unsupported");
+  }
+
+  const std::vector<velox::memory::MachinePageCount>& sizeClasses()
+      const override {
+    VELOX_UNSUPPORTED("sizeClasses unsupported");
+  }
+
+  bool allocateContiguous(
+      velox::memory::MachinePageCount /*unused*/,
+      velox::memory::MemoryAllocator::ContiguousAllocation& /*unused*/)
+      override {
+    VELOX_UNSUPPORTED("allocateContiguous unsupported");
+  }
+
+  void freeContiguous(velox::memory::MemoryAllocator::ContiguousAllocation&
+                      /*unused*/) override {
+    VELOX_UNSUPPORTED("freeContiguous unsupported");
   }
 
   int64_t getCurrentBytes() const override {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -184,8 +184,6 @@ class GroupingSet {
 
   const bool ignoreNullKeys_;
 
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
-
   // The maximum memory usage that a final aggregation can hold before spilling.
   // If it is zero, then there is no such limit.
   const uint64_t spillMemoryThreshold_;
@@ -253,6 +251,7 @@ class GroupingSet {
 
   // Index of first in 'nonSpilledRows_' that has not been added to output.
   size_t nonSpilledIndex_ = 0;
+
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -50,7 +50,6 @@ HashBuild::HashBuild(
     : Operator(driverCtx, nullptr, operatorId, joinNode->id(), "HashBuild"),
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
-      allocator_(operatorCtx_->allocator()),
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
@@ -132,7 +131,7 @@ void HashBuild::setupTable() {
         dependentTypes,
         true, // allowDuplicates
         true, // hasProbedFlag
-        allocator_);
+        pool());
   } else {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
@@ -149,7 +148,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          allocator_);
+          pool());
     } else {
       // Ignore null keys
       table_ = HashTable<true>::createForJoin(
@@ -157,7 +156,7 @@ void HashBuild::setupTable() {
           dependentTypes,
           !dropDuplicates, // allowDuplicates
           needProbedFlag, // hasProbedFlag
-          allocator_);
+          pool());
     }
   }
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
@@ -428,7 +427,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   const auto increment =
       rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0);
 
-  auto tracker = CHECK_NOTNULL(allocator_->tracker());
+  auto tracker = pool()->getMemoryUsageTracker();
   // There must be at least 2x the increments in reservation.
   if (tracker->availableReservation() > 2 * increment) {
     return true;
@@ -765,7 +764,7 @@ void HashBuild::postHashBuildProcess() {
 
   // Release the unused memory reservation since we have finished the table
   // build.
-  operatorCtx_->allocator()->tracker()->release();
+  pool()->getMemoryUsageTracker()->release();
 
   if (!spillEnabled()) {
     setState(State::kFinish);

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -231,9 +231,6 @@ class HashBuild final : public Operator {
 
   const core::JoinType joinType_;
 
-  // Holds the areas in RowContainer of 'table_'
-  memory::MemoryAllocator* const FOLLY_NONNULL allocator_;
-
   const std::shared_ptr<HashJoinBridge> joinBridge_;
 
   const std::optional<Spiller::Config> spillConfig_;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -312,12 +312,12 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool isJoinBuild,
       bool hasProbedFlag,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory);
+      memory::MemoryPool* FOLLY_NULLABLE pool);
 
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
       const std::vector<std::unique_ptr<Aggregate>>& aggregates,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
+      memory::MemoryPool* FOLLY_NULLABLE pool) {
     return std::make_unique<HashTable>(
         std::move(hashers),
         aggregates,
@@ -325,7 +325,7 @@ class HashTable : public BaseHashTable {
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
-        memory);
+        pool);
   }
 
   static std::unique_ptr<HashTable> createForJoin(
@@ -333,7 +333,7 @@ class HashTable : public BaseHashTable {
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool hasProbedFlag,
-      memory::MemoryAllocator* FOLLY_NULLABLE memory) {
+      memory::MemoryPool* FOLLY_NULLABLE pool) {
     static const std::vector<std::unique_ptr<Aggregate>> kNoAggregates;
     return std::make_unique<HashTable>(
         std::move(hashers),
@@ -342,7 +342,7 @@ class HashTable : public BaseHashTable {
         allowDuplicates,
         true, // isJoinBuild
         hasProbedFlag,
-        memory);
+        pool);
   }
 
   virtual ~HashTable() override = default;

--- a/velox/exec/Merge.h
+++ b/velox/exec/Merge.h
@@ -50,10 +50,6 @@ class Merge : public SourceOperator {
     return outputType_;
   }
 
-  memory::MemoryAllocator* allocator() const {
-    return operatorCtx_->allocator();
-  }
-
  protected:
   virtual BlockingReason addMergeSources(ContinueFuture* future) = 0;
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -209,14 +209,6 @@ std::optional<uint32_t> Operator::maxDrivers(
   return std::nullopt;
 }
 
-memory::MemoryAllocator* OperatorCtx::allocator() const {
-  if (!allocator_) {
-    allocator_ =
-        driverCtx_->task->addOperatorMemory(pool_->getMemoryUsageTracker());
-  }
-  return allocator_;
-}
-
 const std::string& OperatorCtx::taskId() const {
   return driverCtx_->task->taskId();
 }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -197,8 +197,6 @@ class OperatorCtx {
     return operatorType_;
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const;
-
   core::ExecCtx* FOLLY_NONNULL execCtx() const;
 
   /// Makes an extract of QueryCtx for use in a connector. 'planNodeId'
@@ -220,7 +218,6 @@ class OperatorCtx {
   velox::memory::MemoryPool* const FOLLY_NONNULL pool_;
 
   // These members are created on demand.
-  mutable memory::MemoryAllocator* FOLLY_NULLABLE allocator_{nullptr};
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
   mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -36,7 +36,6 @@ OrderBy::OrderBy(
           operatorId,
           orderByNode->id(),
           "OrderBy"),
-      allocator_(operatorCtx_->allocator()),
       numSortKeys_(orderByNode->sortingKeys().size()),
       spillMemoryThreshold_(operatorCtx_->driverCtx()
                                 ->queryConfig()
@@ -84,8 +83,7 @@ OrderBy::OrderBy(
   }
 
   // Create row container.
-  data_ = std::make_unique<RowContainer>(
-      keyTypes, dependentTypes, operatorCtx_->allocator());
+  data_ = std::make_unique<RowContainer>(keyTypes, dependentTypes, pool());
   internalStoreType_ = ROW(std::move(names), std::move(types));
 #ifndef NDEBUG
   for (int i = 0; i < internalStoreType_->children().size(); ++i) {
@@ -158,7 +156,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  auto tracker = allocator_->tracker();
+  auto tracker = pool()->getMemoryUsageTracker();
   VELOX_CHECK_NOT_NULL(tracker);
   const auto currentUsage = tracker->currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
@@ -213,7 +211,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
   VELOX_CHECK_GE(targetBytes, 0);
 
   if (spiller_ == nullptr) {
-    VELOX_DCHECK(allocator_->tracker() != nullptr);
+    VELOX_DCHECK_NOT_NULL(pool()->getMemoryUsageTracker());
     const auto& spillConfig = spillConfig_.value();
     spiller_ = std::make_unique<Spiller>(
         Spiller::Type::kOrderBy,

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -78,8 +78,6 @@ class OrderBy : public Operator {
   // in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
-
   const int32_t numSortKeys_;
 
   // The maximum memory usage that an order by can hold before spilling.

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -63,7 +63,7 @@ void Destination::serialize(
     vector_size_t begin,
     vector_size_t end) {
   if (!current_) {
-    current_ = std::make_unique<VectorStreamGroup>(allocator_);
+    current_ = std::make_unique<VectorStreamGroup>(pool_);
     auto rowType = std::dynamic_pointer_cast<const RowType>(output->type());
     vector_size_t numRows = 0;
     for (vector_size_t i = begin; i < end; i++) {
@@ -84,7 +84,7 @@ BlockingReason Destination::flush(
   constexpr int32_t kMinMessageSize = 128;
   auto listener = bufferManager.newListener();
   IOBufOutputStream stream(
-      *current_->allocator(),
+      *current_->pool(),
       listener.get(),
       std::max<int64_t>(kMinMessageSize, current_->size()));
   current_->flush(&stream);
@@ -123,8 +123,7 @@ PartitionedOutput::PartitionedOutput(
       bufferManager_(PartitionedOutputBufferManager::getInstance()),
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
-                            .maxPartitionedOutputBufferSize()),
-      allocator_{operatorCtx_->allocator()} {
+                            .maxPartitionedOutputBufferSize()) {
   if (numDestinations_ == 1 || planNode->isBroadcast()) {
     VELOX_CHECK(keyChannels_.empty());
     VELOX_CHECK_NULL(partitionFunction_);
@@ -156,8 +155,7 @@ void PartitionedOutput::initializeDestinations() {
   if (destinations_.empty()) {
     auto taskId = operatorCtx_->taskId();
     for (int i = 0; i < numDestinations_; ++i) {
-      destinations_.push_back(
-          std::make_unique<Destination>(taskId, i, allocator_));
+      destinations_.push_back(std::make_unique<Destination>(taskId, i, pool()));
     }
   }
 }

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -27,8 +27,8 @@ class Destination {
   Destination(
       const std::string& taskId,
       int destination,
-      memory::MemoryAllocator* FOLLY_NONNULL allocator)
-      : taskId_(taskId), destination_(destination), allocator_(allocator) {
+      memory::MemoryPool* FOLLY_NONNULL pool)
+      : taskId_(taskId), destination_(destination), pool_(pool) {
     setTargetSizePct();
   }
 
@@ -89,7 +89,7 @@ class Destination {
 
   const std::string taskId_;
   const int destination_;
-  memory::MemoryAllocator* FOLLY_NONNULL const allocator_;
+  memory::MemoryPool* FOLLY_NONNULL const pool_;
   uint64_t bytesInCurrent_{0};
   std::vector<IndexRange> rows_;
 
@@ -190,7 +190,6 @@ class PartitionedOutput : public Operator {
   bool replicatedAny_{false};
   std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
   const int64_t maxBufferedBytes_;
-  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   RowVectorPtr output_;
 
   // Reusable memory.

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -102,7 +102,7 @@ WriteFile& SpillFileList::currentOutput() {
 void SpillFileList::flush() {
   if (batch_) {
     IOBufOutputStream out(
-        allocator_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
+        pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
     batch_->flush(&out);
     batch_.reset();
     auto iobuf = out.getIOBuf();
@@ -118,7 +118,7 @@ void SpillFileList::write(
     const RowVectorPtr& rows,
     const folly::Range<IndexRange*>& indices) {
   if (!batch_) {
-    batch_ = std::make_unique<VectorStreamGroup>(&allocator_);
+    batch_ = std::make_unique<VectorStreamGroup>(&pool_);
     batch_->createStreamTree(
         std::static_pointer_cast<const RowType>(rows->type()),
         1000,
@@ -182,8 +182,7 @@ void SpillState::appendToPartition(
         sortCompareFlags_,
         fmt::format("{}-spill-{}", path_, partition),
         targetFileSize_,
-        pool_,
-        allocator_);
+        pool_);
   }
 
   IndexRange range{0, rows->size()};

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -22,8 +22,9 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
-
-constexpr int kLogEveryN = 32;
+namespace {
+constexpr int32_t kLogEveryN = 32;
+}
 
 Spiller::Spiller(
     Type type,
@@ -103,8 +104,7 @@ Spiller::Spiller(
           numSortingKeys,
           sortCompareFlags,
           targetFileSize,
-          pool,
-          allocator()),
+          pool),
       pool_(pool),
       executor_(executor) {
   TestValue::adjust(

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -99,7 +99,7 @@ StreamingAggregation::StreamingAggregation(
       false,
       false,
       false,
-      operatorCtx_->allocator(),
+      pool(),
       ContainerRowSerde::instance());
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -214,13 +214,6 @@ velox::memory::MemoryPool* FOLLY_NONNULL Task::addOperatorPool(
   return childPools_.back().get();
 }
 
-memory::MemoryAllocator* FOLLY_NONNULL Task::addOperatorMemory(
-    const std::shared_ptr<memory::MemoryUsageTracker>& tracker) {
-  auto allocator = queryCtx_->allocator()->addChild(tracker);
-  childAllocators_.emplace_back(allocator);
-  return allocator.get();
-}
-
 bool Task::supportsSingleThreadedExecution() const {
   std::vector<std::unique_ptr<DriverFactory>> driverFactories;
 
@@ -1495,7 +1488,7 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
   auto [promise, future] = makeVeloxContinuePromiseContract(
       fmt::format("Task::stateChangeFuture {}", taskId_));
   stateChangePromises_.emplace_back(std::move(promise));
-  if (maxWaitMicros) {
+  if (maxWaitMicros > 0) {
     return std::move(future).within(std::chrono::microseconds(maxWaitMicros));
   }
   return std::move(future);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -41,9 +41,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// for a particular partition from a set of upstream tasks participating in a
   /// distributed execution. Used to initialize an ExchangeClient. Ignored if
   /// plan fragment doesn't have an ExchangeNode.
-  /// @param queryCtx Query context containing MemoryPool and MemoryAllocator
-  /// instances to use for memory allocations during execution, executor to
-  /// schedule operators on, and session properties.
+  /// @param queryCtx Query context containing MemoryPool instance to use for
+  /// memory allocations during execution, executor to schedule operators on,
+  /// and session properties.
   /// @param consumer Optional factory function to get callbacks to pass the
   /// results of the execution. In a multi-threaded execution, results from each
   /// thread are passed on to a separate consumer.
@@ -277,12 +277,6 @@ class Task : public std::enable_shared_from_this<Task> {
       const core::PlanNodeId& planNodeId,
       int pipelineId,
       const std::string& operatorType);
-
-  /// Creates new instance of MemoryAllocator, stores it in the task to ensure
-  /// lifetime and returns a raw pointer. Not thread safe, e.g. must be called
-  /// from the Operator's constructor.
-  memory::MemoryAllocator* FOLLY_NONNULL
-  addOperatorMemory(const std::shared_ptr<memory::MemoryUsageTracker>& tracker);
 
   // Removes driver from the set of drivers in 'self'. The task will be kept
   // alive by 'self'. 'self' going out of scope may cause the Task to
@@ -736,8 +730,7 @@ class Task : public std::enable_shared_from_this<Task> {
   const std::shared_ptr<core::QueryCtx> queryCtx_;
 
   // Root MemoryPool for this Task. All member variables that hold references
-  // to pool_ must be defined after pool_, childPools_, and
-  // childAllocators_
+  // to pool_ must be defined after pool_, childPools_.
   std::shared_ptr<memory::MemoryPool> pool_;
 
   // Keep driver and operator memory pools alive for the duration of the task
@@ -749,10 +742,6 @@ class Task : public std::enable_shared_from_this<Task> {
   //
   // NOTE: ''childPools_' holds the ownerships of node memory pools.
   std::unordered_map<core::PlanNodeId, memory::MemoryPool*> nodePools_;
-
-  // Keep operator MemoryAllocator instances alive for the duration of the task
-  // to allow for sharing data without copy.
-  std::vector<std::shared_ptr<memory::MemoryAllocator>> childAllocators_;
 
   // A set of IDs of leaf plan nodes that require splits. Used to check plan
   // node IDs specified in split management methods.
@@ -863,7 +852,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // running for 'this'.
   std::vector<ContinuePromise> threadFinishPromises_;
 
-  /// Base spill directory for this task.
+  // Base spill directory for this task.
   std::string spillDirectory_;
 };
 

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -29,9 +29,7 @@ TopN::TopN(
           topNNode->id(),
           "TopN"),
       count_(topNNode->count()),
-      data_(std::make_unique<RowContainer>(
-          outputType_->children(),
-          operatorCtx_->allocator())),
+      data_(std::make_unique<RowContainer>(outputType_->children(), pool())),
       comparator_(
           outputType_,
           topNNode->sortingKeys(),

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -58,9 +58,9 @@ Window::Window(
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
       data_(std::make_unique<RowContainer>(
           windowNode->sources()[0]->outputType()->children(),
-          operatorCtx_->allocator())),
+          pool())),
       decodedInputVectors_(numInputColumns_),
-      stringAllocator_(operatorCtx_->allocator()) {
+      stringAllocator_(pool()) {
   auto inputType = windowNode->sources()[0]->outputType();
   initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
   initKeyInfo(
@@ -460,8 +460,8 @@ RowVectorPtr Window::getOutput() {
 
   auto numRowsLeft = numRows_ - numProcessedRows_;
   auto numOutputRows = std::min(numRowsPerOutput_, numRowsLeft);
-  auto result = BaseVector::create<RowVector>(
-      outputType_, numOutputRows, operatorCtx_->pool());
+  auto result = std::dynamic_pointer_cast<RowVector>(
+      BaseVector::create(outputType_, numOutputRows, operatorCtx_->pool()));
 
   // Set all passthrough input columns.
   for (int i = 0; i < numInputColumns_; ++i) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -111,7 +111,6 @@ class AggregationTest : public OperatorTestBase {
   void SetUp() override {
     OperatorTestBase::SetUp();
     filesystems::registerLocalFileSystem();
-    allocator_ = memory::MemoryAllocator::getInstance();
     registerSumNonPODAggregate("sumnonpod");
   }
 
@@ -341,7 +340,7 @@ class AggregationTest : public OperatorTestBase {
         false,
         true,
         true,
-        allocator_,
+        pool_.get(),
         ContainerRowSerde::instance());
   }
 
@@ -355,7 +354,6 @@ class AggregationTest : public OperatorTestBase {
            DOUBLE(),
            VARCHAR()})};
   folly::Random::DefaultGenerator rng_;
-  memory::MemoryAllocator* allocator_;
 };
 
 template <>

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -75,7 +75,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, allocator_);
+        std::move(keyHashers), {}, true, false, pool_.get());
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -78,7 +78,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, allocator_);
+          std::move(keyHashers), dependentTypes, true, false, pool_.get());
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -153,7 +153,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     }
     static std::vector<std::unique_ptr<Aggregate>> empty;
     return HashTable<false>::createForAggregation(
-        std::move(keyHashers), empty, allocator_);
+        std::move(keyHashers), empty, pool_.get());
   }
 
   void insertGroups(
@@ -436,7 +436,6 @@ class HashTableTest : public testing::TestWithParam<bool> {
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
@@ -518,7 +517,7 @@ TEST_P(HashTableTest, clear) {
       std::vector<TypePtr>{BIGINT()},
       BIGINT()));
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), aggregates, allocator_);
+      std::move(keyHashers), aggregates, pool_.get());
   table->clear();
 }
 
@@ -665,7 +664,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, allocator_);
+        std::move(keyHashers), {}, true, false, pool_.get());
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -30,7 +30,6 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
  protected:
   void SetUp() override {
     pool_ = facebook::velox::memory::getDefaultMemoryPool();
-    allocator_ = memory::MemoryAllocator::getInstance();
     bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -72,7 +71,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
   }
 
   std::unique_ptr<SerializedPage> toSerializedPage(VectorPtr vector) {
-    auto data = std::make_unique<VectorStreamGroup>(allocator_);
+    auto data = std::make_unique<VectorStreamGroup>(pool_.get());
     auto size = vector->size();
     auto range = IndexRange{0, size};
     data->createStreamTree(
@@ -80,7 +79,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
     data->append(
         std::dynamic_pointer_cast<RowVector>(vector), folly::Range(&range, 1));
     auto listener = bufferManager_->newListener();
-    IOBufOutputStream stream(*allocator_, listener.get(), data->size());
+    IOBufOutputStream stream(*pool_, listener.get(), data->size());
     data->flush(&stream);
     return std::make_unique<SerializedPage>(stream.getIOBuf());
   }
@@ -231,7 +230,6 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
-  memory::MemoryAllocator* allocator_;
   std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
 };
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -269,7 +269,7 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     std::vector<TypePtr> types{input->type()};
 
     // Store the vector in the rowContainer.
-    auto rowContainer = std::make_unique<RowContainer>(types, allocator_);
+    auto rowContainer = std::make_unique<RowContainer>(types, pool_.get());
     auto size = input->size();
     SelectivityVector allRows(size);
     std::vector<char*> rows(size);
@@ -806,7 +806,7 @@ TEST_F(RowContainerTest, probedFlag) {
       true, // isJoinBuild
       true, // hasProbedFlag
       false, // hasNormalizedKey
-      allocator_,
+      pool_.get(),
       ContainerRowSerde::instance());
 
   auto input = makeRowVector({

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -144,13 +144,7 @@ class SpillTest : public testing::Test,
     // the batch number of the vector in the partition. When read back, both
     // partitions produce an ascending sequence of integers without gaps.
     state_ = std::make_unique<SpillState>(
-        spillPath_,
-        numPartitions,
-        1,
-        compareFlags,
-        targetFileSize,
-        *pool(),
-        *allocator_);
+        spillPath_, numPartitions, 1, compareFlags, targetFileSize, *pool());
     EXPECT_EQ(targetFileSize, state_->targetFileSize());
     EXPECT_EQ(numPartitions, state_->maxPartitions());
     EXPECT_EQ(0, state_->spilledPartitions());
@@ -357,8 +351,7 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{1, 17'123'456},
       Timestamp{-1, 17'123'456}};
 
-  SpillState state(
-      spillPath, 1, 1, emptyCompareFlags, 1024, *pool(), *allocator_);
+  SpillState state(spillPath, 1, 1, emptyCompareFlags, 1024, *pool());
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -34,7 +34,6 @@ class RowContainerTestBase : public testing::Test,
  protected:
   void SetUp() override {
     pool_ = memory::getDefaultMemoryPool();
-    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -68,11 +67,10 @@ class RowContainerTestBase : public testing::Test,
         isJoinBuild,
         true,
         true,
-        allocator_,
+        pool_.get(),
         ContainerRowSerde::instance());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  memory::MemoryAllocator* allocator_;
 };
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -314,7 +314,8 @@ TEST(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST(KllSketchTest, memoryUsage) {
-  HashStringAllocator alloc(memory::MemoryAllocator::getInstance());
+  auto pool = memory::getDefaultMemoryPool();
+  HashStringAllocator alloc(pool.get());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));
   EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -72,9 +72,9 @@ class ValueListTest : public functions::test::FunctionBaseTest {
     return allocator_.get();
   }
 
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
   std::unique_ptr<HashStringAllocator> allocator_{
-      std::make_unique<HashStringAllocator>(
-          memory::MemoryAllocator::getInstance())};
+      std::make_unique<HashStringAllocator>(pool_.get())};
 };
 
 TEST_F(ValueListTest, empty) {

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -62,7 +62,8 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return signatureStrings;
   }
 
-  HashStringAllocator allocator_{memory::MemoryAllocator::getInstance()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  HashStringAllocator allocator_{pool_.get()};
 };
 
 TEST_F(HyperLogLogFunctionsTest, cardinalitySignatures) {

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -30,7 +30,7 @@ namespace {
 class UnsafeRowVectorSerializer : public VectorSerializer {
  public:
   explicit UnsafeRowVectorSerializer(StreamArena* streamArena)
-      : allocator_{streamArena->allocator()} {}
+      : pool_{streamArena->pool()} {}
 
   void append(
       RowVectorPtr vector,
@@ -48,7 +48,7 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
       return;
     }
 
-    auto* buffer = (char*)allocator_->allocateBytes(totalSize);
+    auto* buffer = (char*)pool_->allocate(totalSize);
     buffers_.push_back(
         ByteRange{(uint8_t*)buffer, (int32_t)totalSize, (int32_t)totalSize});
 
@@ -58,7 +58,6 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
         // Write row data.
         auto rowSize = velox::row::UnsafeRowDynamicSerializer::getSizeRow(
             vector->type(), vector.get(), i);
-
         auto size =
             velox::row::UnsafeRowDynamicSerializer::serialize(
                 vector->type(), vector, buffer + offset + sizeof(size_t), i)
@@ -78,13 +77,13 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
   void flush(OutputStream* stream) override {
     for (auto& buffer : buffers_) {
       stream->write((char*)buffer.buffer, buffer.position);
-      allocator_->freeBytes(buffer.buffer, buffer.size);
+      pool_->free(buffer.buffer, buffer.size);
     }
     buffers_.clear();
   }
 
  private:
-  memory::MemoryAllocator* allocator_;
+  memory::MemoryPool* const FOLLY_NONNULL pool_;
   std::vector<ByteRange> buffers_;
 };
 } // namespace

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -60,8 +60,7 @@ class PrestoSerializerTest : public ::testing::Test {
     sanityCheckEstimateSerializedSize(
         rowVector, folly::Range(rows.data(), numRows));
 
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = asRowType(rowVector->type());
     auto serializer =
         serde_->createSerializer(rowType, numRows, arena.get(), serdeOptions);
@@ -78,8 +77,7 @@ class PrestoSerializerTest : public ::testing::Test {
       const VectorSerde::Options* serdeOptions) {
     facebook::velox::serializer::presto::PrestoOutputStreamListener listener;
     OStreamOutputStream out(output, &listener);
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     serde_->serializeConstants(rowVector, arena.get(), serdeOptions, &out);
   }
 

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -35,8 +35,7 @@ class UnsafeRowSerializerTest : public ::testing::Test {
       rows[i] = IndexRange{i, 1};
     }
 
-    auto arena =
-        std::make_unique<StreamArena>(memory::MemoryAllocator::getInstance());
+    auto arena = std::make_unique<StreamArena>(pool_.get());
     auto rowType = std::dynamic_pointer_cast<const RowType>(rowVector->type());
     auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
 

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -77,8 +77,8 @@ bool isRegisteredVectorSerde();
 
 class VectorStreamGroup : public StreamArena {
  public:
-  explicit VectorStreamGroup(memory::MemoryAllocator* MemoryAllocator)
-      : StreamArena(MemoryAllocator) {}
+  explicit VectorStreamGroup(memory::MemoryPool* FOLLY_NONNULL pool)
+      : StreamArena(pool) {}
 
   void createStreamTree(
       RowTypePtr type,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -96,7 +96,6 @@ int NonPOD::alive = 0;
 class VectorTest : public testing::Test, public test::VectorTestBase {
  protected:
   void SetUp() override {
-    allocator_ = memory::MemoryAllocator::getInstance();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();
@@ -757,10 +756,10 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     auto sourceRow = makeRowVector({"c"}, {source});
     auto sourceRowType = asRowType(sourceRow->type());
 
-    VectorStreamGroup even(allocator_);
+    VectorStreamGroup even(pool_.get());
     even.createStreamTree(sourceRowType, source->size() / 4);
 
-    VectorStreamGroup odd(allocator_);
+    VectorStreamGroup odd(pool_.get());
     odd.createStreamTree(sourceRowType, source->size() / 3);
 
     std::vector<IndexRange> evenIndices;
@@ -866,8 +865,6 @@ class VectorTest : public testing::Test, public test::VectorTestBase {
     slice->mutableSizes(slice->size());
     EXPECT_NE(slice->rawSizes(), sizes);
   }
-
-  memory::MemoryAllocator* allocator_;
 
   size_t vectorSize_{100};
   size_t numIterations_{3};


### PR DESCRIPTION
1. Provides large chunk memory allocations through memory pool.
2. Deprecate ScopedMemoryAllocator, and removed all the direct
memory allocator accesses in Velox and all the large chunk memory
allocations now go through memory pool interface.
3. Remove the allocator from Allocation and ContiguousAllocation
objects. The memory allocator doesn't own or are aware of the
ownerships of the two allocation object types. It is memory pool object
to set the pool or ownership on allocation success. For direct allocation
from memory allocator such as AsyncDataCache, then user needs to
free the allocations explicitly.