### PR TITLE
Support Map type in Parquet Reader

### DIFF
--- a/velox/dwio/common/tests/utils/BatchMaker.cpp
+++ b/velox/dwio/common/tests/utils/BatchMaker.cpp
@@ -665,7 +665,8 @@ void setNullRecursive(BaseVector& vector, vector_size_t i) {
     case TypeKind::MAP: {
       auto map = vector.asUnchecked<MapVector>();
       for (auto j = 0; j < map->sizeAt(i); ++j) {
-        setNullRecursive(*map->mapKeys(), map->offsetAt(i) + j);
+        //        We only set nulls recursively to Values. This is because nulls
+        //        are not expected in Parquet Map Keys.
         setNullRecursive(*map->mapValues(), map->offsetAt(i) + j);
       }
     } break;

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -66,10 +66,12 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::ARRAY:
       return std::make_unique<ListColumnReader>(dataType, params, scanSpec);
 
-    case TypeKind::BOOLEAN:
     case TypeKind::MAP:
+      return std::make_unique<MapColumnReader>(dataType, params, scanSpec);
 
+    case TypeKind::BOOLEAN:
       VELOX_UNSUPPORTED("Type is not supported: ", dataType->type->kind());
+
     default:
       VELOX_FAIL(
           "buildReader unhandled type: " +

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -44,7 +44,8 @@ StructColumnReader::StructColumnReader(
     auto child = childForRepDefs_;
     for (;;) {
       assert(child);
-      if (child->type()->kind() == TypeKind::ARRAY) {
+      if (child->type()->kind() == TypeKind::ARRAY ||
+          child->type()->kind() == TypeKind::MAP) {
         levelMode_ = LevelMode::kStructOverLists;
         break;
       }
@@ -99,6 +100,8 @@ void StructColumnReader::enqueueRowGroup(
       structChild->enqueueRowGroup(index, input);
     } else if (auto listChild = dynamic_cast<ListColumnReader*>(child)) {
       listChild->enqueueRowGroup(index, input);
+    } else if (auto mapChild = dynamic_cast<MapColumnReader*>(child)) {
+      mapChild->enqueueRowGroup(index, input);
     } else {
       child->formatData().as<ParquetData>().enqueueRowGroup(index, input);
     }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -480,6 +480,23 @@ TEST_F(E2EFilterTest, metadataFilter) {
   testMetadataFilter();
 }
 
+TEST_F(E2EFilterTest, map) {
+  // Break up the leaf data in small pages to cover coalescing repdefs.
+  writerProperties_ =
+      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  batchCount_ = 2;
+  batchSize_ = 12000;
+  testWithTypes(
+      "long_val:bigint,"
+      "map_val:map<int, int>,"
+      "nested_map:map<int, map<int, bigint>>,"
+      "struct_map: struct<m: map<int, struct<k:int, v:int, vm: map<bigint, smallint>>>>",
+      nullptr,
+      false,
+      {"long_val"},
+      10);
+}
+
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
This PR introduces the Map type to Parquet Reader, based on the existing List reading implementation.