### PR TITLE
std::-qualify `move` & `forward` in 5 files starting w/ ti/edgeray/pipeline/UDPPipelineAcceptor.cpp

### DIFF
--- a/velox/duckdb/conversion/DuckWrapper.cpp
+++ b/velox/duckdb/conversion/DuckWrapper.cpp
@@ -70,7 +70,7 @@ DuckDBWrapper::~DuckDBWrapper() {}
 
 std::unique_ptr<DuckResult> DuckDBWrapper::execute(const std::string& query) {
   auto duckResult = connection_->Query(query);
-  return std::make_unique<DuckResult>(context_, move(duckResult));
+  return std::make_unique<DuckResult>(context_, std::move(duckResult));
 }
 
 void DuckDBWrapper::print(const std::string& query) {
@@ -92,7 +92,7 @@ DuckResult::DuckResult(
     types.push_back(getType(i));
     names.push_back(getName(i));
   }
-  type_ = std::make_shared<RowType>(move(names), move(types));
+  type_ = std::make_shared<RowType>(std::move(names), std::move(types));
 }
 
 DuckResult::~DuckResult() {}

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -58,7 +58,8 @@ class BaseDuckWrapperTest : public testing::Test {
       const std::string& query,
       const std::vector<T>& expectedOutput) {
     std::vector<bool> nulls(expectedOutput.size(), false);
-    verifyUnaryResult<T>(move(query), move(expectedOutput), move(nulls));
+    verifyUnaryResult<T>(
+        std::move(query), std::move(expectedOutput), std::move(nulls));
   }
 
   template <class T>

--- a/velox/duckdb/functions/DuckFunctions.cpp
+++ b/velox/duckdb/functions/DuckFunctions.cpp
@@ -428,7 +428,8 @@ struct DuckDBFunctionData {
 
 class DuckDBFunction : public exec::VectorFunction {
  public:
-  explicit DuckDBFunction(std::vector<ScalarFunction> set) : set_(move(set)) {
+  explicit DuckDBFunction(std::vector<ScalarFunction> set)
+      : set_(std::move(set)) {
     assert(set_.size() > 0);
   }
 
@@ -449,7 +450,7 @@ class DuckDBFunction : public exec::VectorFunction {
     }
 
     duckdb::VeloxPoolAllocator duckDBAllocator(*context.pool());
-    auto state = initializeState(move(inputTypes), duckDBAllocator);
+    auto state = initializeState(std::move(inputTypes), duckDBAllocator);
     assert(state->functionIndex < set_.size());
     auto& function = set_[state->functionIndex];
     idx_t nrow = rows.size();
@@ -601,7 +602,7 @@ class DuckDBFunction : public exec::VectorFunction {
       duckdb::VeloxPoolAllocator& duckDBAllocator) const {
     assert(set_.size() > 0);
     auto result = std::make_unique<DuckDBFunctionData>();
-    result->inputTypes = move(inputTypes);
+    result->inputTypes = std::move(inputTypes);
     std::string error;
     bool castParameters;
     result->functionIndex = ::duckdb::Function::BindFunction(
@@ -740,7 +741,7 @@ void registerDuckDBFunction(CatalogEntry* entry, const std::string& prefix) {
   exec::registerVectorFunction(
       prefix + name,
       signatures,
-      std::make_unique<DuckDBFunction>(move(functions)));
+      std::make_unique<DuckDBFunction>(std::move(functions)));
 }
 
 void registerDuckdbFunctions(const std::string& prefix) {


### PR DESCRIPTION
Summary:
With LLVM-15, we require that `move` be qualified as `std::move` (and same with `forward`). This fixes that in this file.

The use of an unqualified `move`/`forward` often means that a `using namespace std` is present in a file. Bitter experience has shown that `using namespace std` causes severe problems in header (`.h`) files and even in implementation files (`.cpp`) and therefore is a kind of tech debt. This diff removes such debt.

Our "use after move" linter also only inspects `std::move`/`std::forward`. Therefore, adding appropriate qualifications makes our code safer by allowing the linter to detect problematic instances.

**If you see a use-after-move bug please add the `use-after-move-bug` tag to the diff.**

Please see T140686815 for FAQ.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Reviewed By: xiaoxmeng

Differential Revision: D42304596

