### PR TITLE
std::-qualify `move` & `forward` in 5 files starting w/ velox/external/duckdb/duckdb.hpp

### DIFF
--- a/velox/external/duckdb/duckdb.hpp
+++ b/velox/external/duckdb/duckdb.hpp
@@ -24052,7 +24052,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateCollationInfo>(name, function, combinable, not_required_for_equality);
 		CopyProperties(*result);
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24140,7 +24140,7 @@ public:
 		for (auto &expr : expressions) {
 			result->expressions.push_back(expr->Copy());
 		}
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24224,7 +24224,7 @@ public:
 		result->function = function->Copy();
 		result->name = name;
 		CopyProperties(*result);
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24247,11 +24247,11 @@ namespace duckdb {
 struct CreatePragmaFunctionInfo : public CreateFunctionInfo {
 	explicit CreatePragmaFunctionInfo(PragmaFunction function)
 	    : CreateFunctionInfo(CatalogType::PRAGMA_FUNCTION_ENTRY) {
-		functions.push_back(move(function));
+		functions.push_back(std::move(function));
 		this->name = function.name;
 	}
 	CreatePragmaFunctionInfo(string name, vector<PragmaFunction> functions_)
-	    : CreateFunctionInfo(CatalogType::PRAGMA_FUNCTION_ENTRY), functions(move(functions_)) {
+	    : CreateFunctionInfo(CatalogType::PRAGMA_FUNCTION_ENTRY), functions(std::move(functions_)) {
 		this->name = name;
 		for (auto &function : functions) {
 			function.name = name;
@@ -24264,7 +24264,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreatePragmaFunctionInfo>(functions[0].name, functions);
 		CopyProperties(*result);
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24291,7 +24291,7 @@ public:
 	unique_ptr<CreateInfo> Copy() const override {
 		auto result = make_unique<CreateSchemaInfo>();
 		CopyProperties(*result);
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24329,7 +24329,7 @@ public:
 		CopyProperties(*result);
 		result->name = name;
 		result->type = type;
-		return move(result);
+		return std::move(result);
 	}
 };
 
@@ -24372,7 +24372,7 @@ public:
 		result->aliases = aliases;
 		result->types = types;
 		result->query = unique_ptr_cast<SQLStatement, SelectStatement>(query->Copy());
-		return move(result);
+		return std::move(result);
 	}
 };
 

--- a/velox/external/duckdb/parquet-amalgamation.hpp
+++ b/velox/external/duckdb/parquet-amalgamation.hpp
@@ -7748,19 +7748,19 @@ public:
 	ParquetReader(Allocator &allocator, unique_ptr<FileHandle> file_handle_p,
 	              const vector<LogicalType> &expected_types_p, const string &initial_filename_p = string());
 	ParquetReader(Allocator &allocator, unique_ptr<FileHandle> file_handle_p)
-	    : ParquetReader(allocator, move(file_handle_p), vector<LogicalType>(), string()) {
+	    : ParquetReader(allocator, std::move(file_handle_p), vector<LogicalType>(), string()) {
 	}
 
 	ParquetReader(ClientContext &context, string file_name, const vector<string> &names,
 	              const vector<LogicalType> &expected_types_p, const vector<column_t> &column_ids,
 	              ParquetOptions parquet_options, const string &initial_filename = string());
 	ParquetReader(ClientContext &context, string file_name, ParquetOptions parquet_options)
-	    : ParquetReader(context, move(file_name), vector<string>(), vector<LogicalType>(), vector<column_t>(),
+	    : ParquetReader(context, std::move(file_name), vector<string>(), vector<LogicalType>(), vector<column_t>(),
 	                    parquet_options, string()) {
 	}
 	ParquetReader(ClientContext &context, string file_name, const vector<LogicalType> &expected_types_p,
 	              ParquetOptions parquet_options)
-	    : ParquetReader(context, move(file_name), vector<string>(), expected_types_p, vector<column_t>(),
+	    : ParquetReader(context, std::move(file_name), vector<string>(), expected_types_p, vector<column_t>(),
 	                    parquet_options, string()) {
 	}
 	~ParquetReader();

--- a/velox/external/duckdb/tpch/dbgen/dbgen.cpp
+++ b/velox/external/duckdb/tpch/dbgen/dbgen.cpp
@@ -423,7 +423,7 @@ static void CreateTPCHTable(ClientContext &context, string schema, string suffix
 		info->constraints.push_back(make_unique<NotNullConstraint>(i));
 	}
 	auto &catalog = Catalog::GetCatalog(context);
-	catalog.CreateTable(context, move(info));
+	catalog.CreateTable(context, std::move(info));
 }
 
 void DBGenWrapper::CreateTPCHSchema(ClientContext &context, string schema, string suffix) {

--- a/velox/external/duckdb/tpch/tpch-extension.cpp
+++ b/velox/external/duckdb/tpch/tpch-extension.cpp
@@ -43,7 +43,7 @@ static unique_ptr<FunctionData> DbgenBind(ClientContext &context, TableFunctionB
 	}
 	return_types.emplace_back(LogicalType::BOOLEAN);
 	names.emplace_back("Success");
-	return move(result);
+	return std::move(result);
 }
 
 static void DbgenFunction(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
@@ -65,7 +65,7 @@ struct TPCHData : public GlobalTableFunctionState {
 
 unique_ptr<GlobalTableFunctionState> TPCHInit(ClientContext &context, TableFunctionInitInput &input) {
 	auto result = make_unique<TPCHData>();
-	return move(result);
+	return std::move(result);
 }
 
 static unique_ptr<FunctionData> TPCHQueryBind(ClientContext &context, TableFunctionBindInput &input,


### PR DESCRIPTION
Summary:
With LLVM-15, we require that `move` be qualified as `std::move` (and same with `forward`). This fixes that in this file.

The use of an unqualified `move`/`forward` often means that a `using namespace std` is present in a file. Bitter experience has shown that `using namespace std` causes severe problems in header (`.h`) files and even in implementation files (`.cpp`) and therefore is a kind of tech debt. This diff removes such debt.

Our "use after move" linter also only inspects `std::move`/`std::forward`. Therefore, adding appropriate qualifications makes our code safer by allowing the linter to detect problematic instances.

**If you see a use-after-move bug please add the `use-after-move-bug` tag to the diff.**

Please see T140686815 for FAQ.

 - If you approve of this diff, please use the "Accept & Ship" button :-)

Differential Revision: D42304588

