### PR TITLE
Fix in_map stream column id population

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -101,7 +101,7 @@ class ValueWriter {
       : sequence_{sequence},
         keyInfo_{keyInfo},
         inMap_{createBooleanRleEncoder(context.newStream(
-            {type.id, sequence, 0, StreamKind::StreamKind_IN_MAP}))},
+            {type.id, sequence, type.column, StreamKind::StreamKind_IN_MAP}))},
         columnWriter_{BaseColumnWriter::create(
             context,
             type,


### PR DESCRIPTION
Summary:
Populate the stream identifier metadata properly so feature reordering and feature stats aggregation can pick up in_map streams.

This currently causes the prod feature reordering to be slightly worse than the theoretical ceiling because it pushes the in_map stream of the reordered keys to the front of the stripe instead of grouping with the data streams in the back. However, since the reordered in_maps are still together in chunks, the gap should be very small.

Differential Revision: D42177016

