### PR TITLE
Allow stat merge operations to ignore size

### DIFF
--- a/velox/dwio/dwrf/test/TestColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestColumnStatistics.cpp
@@ -38,6 +38,27 @@ std::unique_ptr<T> as(std::unique_ptr<U>&& ptr) {
   return nullptr;
 }
 
+TEST(StatisticsBuilder, size) {
+  {
+    StatisticsBuilder missingSize{options};
+    ASSERT_FALSE(missingSize.getSize().has_value());
+    StatisticsBuilder hasSize{
+        StatisticsBuilderOptions{/*stringLengthLimit=*/32, /*initialSize=*/10}};
+    ASSERT_TRUE(hasSize.getSize().has_value());
+    EXPECT_EQ(10, hasSize.getSize().value());
+
+    hasSize.merge(missingSize, /*ignoreSize=*/true);
+    EXPECT_FALSE(missingSize.getSize().has_value());
+    ASSERT_TRUE(hasSize.getSize().has_value());
+    EXPECT_EQ(10, hasSize.getSize().value());
+
+    // Coercing to missing/invalid size when not ignoring by default.
+    hasSize.merge(missingSize);
+    EXPECT_FALSE(missingSize.getSize().has_value());
+    EXPECT_FALSE(hasSize.getSize().has_value());
+  }
+}
+
 TEST(StatisticsBuilder, integer) {
   IntegerStatisticsBuilder builder{options};
   // empty builder should have all defaults

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -296,7 +296,7 @@ class IntegerColumnWriter : public BaseColumnWriter {
 
   void createIndexEntry() override {
     hasNull_ = hasNull_ || indexStatsBuilder_->hasNull().value();
-    fileStatsBuilder_->merge(*indexStatsBuilder_);
+    fileStatsBuilder_->merge(*indexStatsBuilder_, /*ignoreSize=*/true);
     // Add entry with stats for either case.
     indexBuilder_->addEntry(*indexStatsBuilder_);
     indexStatsBuilder_->reset();
@@ -890,7 +890,7 @@ class StringColumnWriter : public BaseColumnWriter {
 
   void createIndexEntry() override {
     hasNull_ = hasNull_ || indexStatsBuilder_->hasNull().value();
-    fileStatsBuilder_->merge(*indexStatsBuilder_);
+    fileStatsBuilder_->merge(*indexStatsBuilder_, /*ignoreSize=*/true);
     // Add entry with stats for either case.
     indexBuilder_->addEntry(*indexStatsBuilder_);
     indexStatsBuilder_->reset();

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -79,7 +79,9 @@ class BaseColumnWriter : public ColumnWriter {
 
   void createIndexEntry() override {
     hasNull_ = hasNull_ || indexStatsBuilder_->hasNull().value();
-    fileStatsBuilder_->merge(*indexStatsBuilder_);
+    // We cannot determine the physical size of columns/nodes until flush
+    // time, yet we need to maintain and aggregate logical stats.
+    fileStatsBuilder_->merge(*indexStatsBuilder_, /*ignoreSize=*/true);
     indexBuilder_->addEntry(*indexStatsBuilder_);
     indexStatsBuilder_->reset();
     recordPosition();

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -43,7 +43,7 @@ class ValueStatisticsBuilder {
   }
 
   void merge(const BaseColumnWriter& writer) const {
-    statisticsBuilder_->merge(*writer.indexStatsBuilder_);
+    statisticsBuilder_->merge(*writer.indexStatsBuilder_, /*ignoreSize=*/true);
     DWIO_ENSURE(
         children_.size() == writer.children_.size(),
         "Value statistics writer children mismatch");

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -124,7 +124,9 @@ class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
    * Merge stats of same type. This is used in writer to aggregate file level
    * stats.
    */
-  virtual void merge(const dwio::common::ColumnStatistics& other);
+  virtual void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false);
 
   /*
    * Reset. Used in the place where row index entry level stats in captured.
@@ -179,7 +181,9 @@ class BooleanStatisticsBuilder : public StatisticsBuilder,
     }
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -215,7 +219,9 @@ class IntegerStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck(sum_, value, count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -272,7 +278,9 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
     }
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -326,7 +334,9 @@ class StringStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck<uint64_t>(length_, value.size(), count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -364,7 +374,9 @@ class BinaryStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck(length_, length, count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -398,10 +410,12 @@ class MapStatisticsBuilder : public StatisticsBuilder,
     // Since addValues is called once per key info per stride,
     // it's ok to just construct the key struct per call.
     auto& keyStats = getKeyStats(constructKey(keyInfo));
-    keyStats.merge(stats);
+    keyStats.merge(stats, /*ignoreSize=*/true);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = false) override;
 
   void reset() override {
     StatisticsBuilder::reset();


### PR DESCRIPTION
Summary:
The optional semantics can't allow us to represent both missing and invalid (overflown) size stats at the same time, and information will be lost when merging against a nullopt size from another stats object. A direct comparison is with raw sizes that has the same semantics but are generally easily computable as we write and hence never missing.

Size information is generally not available at write time and are best populated by backfilling after flushes. This means when we want to operate with sizes, we have to force initialize all relevant size objects (including the stride indices that will never have accurate size stat) to 0, and unset them before flush accordingly.

This diff makes it so that merge operations ignore sizes by default, and can be enabled explicitly for file merge or other stats power users scenarios.

Differential Revision: D42177015

