### PR TITLE
Backfill data stream sizes for feature stats

### DIFF
--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -4455,5 +4455,4 @@ TEST(ColumnWriterTests, mapDictionary) {
       MAP(INTEGER(), MAP(VARCHAR(), MAP(VARCHAR(), TINYINT()))),
       randomNulls(3));
 }
-
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -17,6 +17,8 @@
 #include <folly/Random.h>
 #include <random>
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/common/tests/utils/MapBuilder.h"
@@ -503,7 +505,7 @@ void testFlatMapConfig(
   bool preload = true;
   std::unordered_set<uint32_t> actualNodeIds;
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
-    dwrfRowReader->loadStripe(0, preload);
+    dwrfRowReader->loadStripe(i, preload);
     auto& footer = dwrfRowReader->getStripeFooter();
     for (int32_t j = 0; j < footer.encoding_size(); ++j) {
       auto encoding = footer.encoding(j);
@@ -575,6 +577,155 @@ TEST(E2EWriterTests, FlatMapConfigNotMapColumn) {
 
   EXPECT_THROW(
       { testFlatMapConfig(type, {0}, {}); }, exception::LoggedException);
+}
+
+void testFlatMapFileStats(
+    std::shared_ptr<const Type> type,
+    const std::vector<uint32_t>& mapColumnIds,
+    const uint32_t strideSize = 10000,
+    const uint32_t rowCount = 2000) {
+  auto pool = memory::getDefaultMemoryPool();
+  size_t stripes = 3;
+
+  // write file to memory
+  auto config = std::make_shared<Config>();
+  // Ensure we cross stride boundary
+  config->set(Config::ROW_INDEX_STRIDE, strideSize);
+  config->set(Config::FLATTEN_MAP, true);
+  config->set<const std::vector<uint32_t>>(Config::MAP_FLAT_COLS, mapColumnIds);
+  config->set(Config::MAP_STATISTICS, true);
+
+  auto sink = std::make_unique<MemorySink>(*pool, 400 * 1024 * 1024);
+  auto sinkPtr = sink.get();
+
+  WriterOptions options;
+  options.config = config;
+  options.schema = type;
+  Writer writer{options, std::move(sink), *pool};
+
+  const size_t seed = std::time(nullptr);
+  LOG(INFO) << "seed: " << seed;
+  std::mt19937 gen{};
+  gen.seed(seed);
+  for (size_t i = 0; i < stripes; ++i) {
+    // The logic really does not depend on data shape. Hence, we can
+    // ignore the nulls.
+    writer.write(BatchMaker::createBatch(type, rowCount, *pool, gen, nullptr));
+    writer.flush();
+  }
+
+  writer.close();
+
+  ReaderOptions readerOpts;
+  RowReaderOptions rowReaderOpts;
+  auto reader = createReader(*sinkPtr, readerOpts);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+
+  auto dwrfRowReader = dynamic_cast<DwrfRowReader*>(rowReader.get());
+  bool preload = true;
+
+  auto typeWithId = TypeWithId::create(type);
+  for (auto mapColumn : mapColumnIds) {
+    folly::F14FastMap<KeyInfo, uint64_t, folly::transparent<KeyInfoHash>>
+        featureStreamSizes;
+    auto mapTypeId = typeWithId->childAt(mapColumn)->id;
+    auto valueTypeId = mapTypeId + 2;
+    for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
+      auto currentStripeInfo = dwrfRowReader->loadStripe(i, preload);
+      StripeStreamsImpl stripeStreams(
+          *dwrfRowReader,
+          dwrfRowReader->getColumnSelector(),
+          rowReaderOpts,
+          currentStripeInfo.offset(),
+          *dwrfRowReader,
+          i);
+
+      folly::F14FastMap<int64_t, dwio::common::KeyInfo> sequenceToKey;
+
+      stripeStreams.visitStreamsOfNode(
+          valueTypeId, [&](const StreamInformation& stream) {
+            auto sequence = stream.getSequence();
+            // No need to load shared dictionary stream here.
+            if (sequence == 0) {
+              return;
+            }
+
+            EncodingKey seqEk(valueTypeId, sequence);
+            const auto& keyInfo = stripeStreams.getEncoding(seqEk).key();
+            auto key = constructKey(keyInfo);
+            sequenceToKey.emplace(sequence, key);
+          });
+
+      auto allStreams = stripeStreams.getStreamIdentifiers();
+      for (const auto& streamIdPerNode : allStreams) {
+        for (const auto& streamId : streamIdPerNode.second) {
+          if (streamId.encodingKey().sequence != 0 &&
+              streamId.column() == mapColumn) {
+            // Update the aggregate.
+            const auto& keyInfo =
+                sequenceToKey.at(streamId.encodingKey().sequence);
+            auto streamLength = stripeStreams.getStreamLength(streamId);
+            auto it = featureStreamSizes.find(keyInfo);
+            if (it == featureStreamSizes.end()) {
+              featureStreamSizes.emplace(keyInfo, streamLength);
+            } else {
+              it->second += streamLength;
+            }
+          }
+        }
+      }
+    }
+    auto stats = reader->getFooter().statistics(mapTypeId);
+    ASSERT_TRUE(stats.has_mapstatistics());
+    ASSERT_EQ(featureStreamSizes.size(), stats.mapstatistics().stats_size());
+    for (size_t i = 0; i != stats.mapstatistics().stats_size(); ++i) {
+      const auto& entry = stats.mapstatistics().stats(i);
+      ASSERT_TRUE(entry.stats().has_size());
+      EXPECT_EQ(
+          featureStreamSizes.at(constructKey(entry.key())),
+          entry.stats().size());
+    }
+  }
+}
+
+TEST(E2EWriterTests, mapStatsSingleStride) {
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "map_val:map<bigint,int>,"
+      "map_val:map<bigint,double>,"
+      "map_val:map<bigint,map<bigint,bigint>>,"
+      "map_val:map<bigint,map<bigint,double>>,"
+      "map_val:map<bigint,array<bigint>>,"
+      "map_val:map<bigint,map<string,float>>,"
+      ">");
+
+  // Single column
+  testFlatMapFileStats(type, {0});
+  // All non-nested columns
+  testFlatMapFileStats(type, {0, 1});
+  // All columns
+  testFlatMapFileStats(type, {0, 1, 2, 3, 4, 5});
+}
+
+TEST(E2EWriterTests, mapStatsMultiStrides) {
+  HiveTypeParser parser;
+  auto type = parser.parse(
+      "struct<"
+      "map_val:map<bigint,int>,"
+      "map_val:map<bigint,double>,"
+      "map_val:map<bigint,map<bigint,bigint>>,"
+      "map_val:map<bigint,map<bigint,double>>,"
+      "map_val:map<bigint,array<bigint>>,"
+      "map_val:map<bigint,map<string,float>>,"
+      ">");
+
+  // Single column
+  testFlatMapFileStats(type, {0}, /*strideSize=*/1000);
+  // All non-nested columns
+  testFlatMapFileStats(type, {0, 1}, /*strideSize=*/1000);
+  // All columns
+  testFlatMapFileStats(type, {0, 1, 2, 3, 4, 5}, /*strideSize=*/1000);
 }
 
 TEST(E2EWriterTests, PartialStride) {

--- a/velox/dwio/dwrf/test/TestColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestColumnStatistics.cpp
@@ -38,6 +38,28 @@ std::unique_ptr<T> as(std::unique_ptr<U>&& ptr) {
   return nullptr;
 }
 
+TEST(StatisticsBuilder, size) {
+  {
+    StatisticsBuilder missingSize{options};
+    ASSERT_FALSE(missingSize.getSize().has_value());
+    StatisticsBuilder hasSize{
+        StatisticsBuilderOptions{/*stringLengthLimit=*/32, /*initialSize=*/10}};
+    ASSERT_TRUE(hasSize.getSize().has_value());
+    EXPECT_EQ(10, hasSize.getSize().value());
+
+    // Ignore size when merging by default.
+    hasSize.merge(missingSize);
+    EXPECT_FALSE(missingSize.getSize().has_value());
+    ASSERT_TRUE(hasSize.getSize().has_value());
+    EXPECT_EQ(10, hasSize.getSize().value());
+
+    // Coercing to missing/invalid size when not ignoring by default.
+    hasSize.merge(missingSize, /*ignoreSize=*/false);
+    EXPECT_FALSE(missingSize.getSize().has_value());
+    EXPECT_FALSE(hasSize.getSize().has_value());
+  }
+}
+
 TEST(StatisticsBuilder, integer) {
   IntegerStatisticsBuilder builder{options};
   // empty builder should have all defaults

--- a/velox/dwio/dwrf/test/TestColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestColumnStatistics.cpp
@@ -58,6 +58,28 @@ TEST(StatisticsBuilder, size) {
     EXPECT_FALSE(missingSize.getSize().has_value());
     EXPECT_FALSE(hasSize.getSize().has_value());
   }
+  {
+    StatisticsBuilder from{options};
+    ASSERT_FALSE(from.getSize().has_value());
+
+    StatisticsBuilder to{options};
+    ASSERT_FALSE(to.getSize().has_value());
+    to.incrementSize(64);
+    ASSERT_FALSE(to.getSize().has_value());
+
+    to.ensureSize();
+    ASSERT_EQ(0, to.getSize().value());
+    to.incrementSize(64);
+    EXPECT_EQ(64, to.getSize().value());
+
+    to.merge(from);
+    EXPECT_FALSE(from.getSize().has_value());
+    EXPECT_EQ(64, to.getSize().value());
+
+    to.merge(from, /*ignoreSize=*/false);
+    EXPECT_FALSE(from.getSize().has_value());
+    EXPECT_FALSE(to.getSize().has_value());
+  }
 }
 
 TEST(StatisticsBuilder, integer) {
@@ -1017,4 +1039,74 @@ TEST(MapStatisticsBuilderTest, innerStatsType) {
     EXPECT_EQ(2, intStats.getMaximum());
     EXPECT_EQ(3, intStats.getSum());
   }
+}
+
+TEST(MapStatisticsBuilderTest, incrementSize) {
+  auto type = HiveTypeParser{}.parse("map<int, float>");
+  MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+  DoubleStatisticsBuilder statsBuilder1{options};
+  statsBuilder1.addValues(0.1);
+  statsBuilder1.addValues(1.0);
+  ASSERT_FALSE(statsBuilder1.getSize().has_value());
+  mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder1);
+  EXPECT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{1})
+                   ->getSize()
+                   .has_value());
+
+  DoubleStatisticsBuilder statsBuilder2{options};
+  statsBuilder2.addValues(0.3);
+  statsBuilder2.addValues(3.0);
+  ASSERT_FALSE(statsBuilder2.getSize().has_value());
+  mapStatsBuilder.addValues(createKeyInfo(2), statsBuilder2);
+  EXPECT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{2})
+                   ->getSize()
+                   .has_value());
+
+  mapStatsBuilder.incrementSize(createKeyInfo(1), 4);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      4,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{2})
+                   ->getSize()
+                   .has_value());
+
+  mapStatsBuilder.incrementSize(createKeyInfo(2), 8);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      4,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{2})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      8,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{2})->getSize().value());
+
+  mapStatsBuilder.incrementSize(createKeyInfo(1), 8);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      12,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{2})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      8,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{2})->getSize().value());
 }

--- a/velox/dwio/dwrf/test/WriterTests.cpp
+++ b/velox/dwio/dwrf/test/WriterTests.cpp
@@ -337,5 +337,4 @@ TEST(WriterBaseTest, FlushWriterSinkUponClose) {
     writer->close();
   }
 }
-
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -168,6 +168,10 @@ class ValueWriter {
     return sequence_;
   }
 
+  const proto::KeyInfo& getKeyInfo() const {
+    return keyInfo_;
+  }
+
   void createIndexEntry(
       const ValueStatisticsBuilder& valueStatsBuilder,
       MapStatisticsBuilder& mapStatsBuilder) {
@@ -300,6 +304,7 @@ class FlatMapColumnWriter : public BaseColumnWriter {
 
   // Stores column keys if writing with RowVector input
   std::vector<KeyType> structKeys_;
+  bool collectMapStats_;
 };
 
 template <>

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -124,7 +124,9 @@ class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
    * Merge stats of same type. This is used in writer to aggregate file level
    * stats.
    */
-  virtual void merge(const dwio::common::ColumnStatistics& other);
+  virtual void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true);
 
   /*
    * Reset. Used in the place where row index entry level stats in captured.
@@ -179,7 +181,9 @@ class BooleanStatisticsBuilder : public StatisticsBuilder,
     }
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -215,7 +219,9 @@ class IntegerStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck(sum_, value, count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -272,7 +278,9 @@ class DoubleStatisticsBuilder : public StatisticsBuilder,
     }
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -326,7 +334,9 @@ class StringStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck<uint64_t>(length_, value.size(), count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -364,7 +374,9 @@ class BinaryStatisticsBuilder : public StatisticsBuilder,
     addWithOverflowCheck(length_, length, count);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();
@@ -401,7 +413,9 @@ class MapStatisticsBuilder : public StatisticsBuilder,
     keyStats.merge(stats);
   }
 
-  void merge(const dwio::common::ColumnStatistics& other) override;
+  void merge(
+      const dwio::common::ColumnStatistics& other,
+      bool ignoreSize = true) override;
 
   void reset() override {
     StatisticsBuilder::reset();


### PR DESCRIPTION
Summary:
Feature physical sizes cannot be incrementally aggregated as we write batches in the writer. Instead, it has to be aggregated after every flush.

This diff contains the logic to update data stream sizes and taking care of the nullable size semantics with the new api introduced in the previous diff.

Differential Revision: D42132616

