### PR TITLE
Disable parallel join build with disk spilling is triggered

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -735,10 +735,14 @@ bool HashBuild::finishHashBuild() {
         }
       }
 
-      const bool hasOthers = !otherTables.empty();
+      // TODO: re-enable parallel join build with spilling triggered after
+      // https://github.com/facebookincubator/velox/issues/3567 is fixed.
+      const bool allowPrallelJoinBuild =
+          !otherTables.empty() && spillPartitions.empty();
       table_->prepareJoinTable(
           std::move(otherTables),
-          hasOthers ? operatorCtx_->task()->queryCtx()->executor() : nullptr);
+          allowPrallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
+                                : nullptr);
 
       addRuntimeStats();
       if (joinBridge_->setHashTable(


### PR DESCRIPTION
Parallel join build build has issue when spilling is triggered,
see issue for more details: https://github.com/facebookincubator/velox/issues/3567
Temporarily disable the parallel join when spilling is triggered
and re-enable it after the fix.