### PR TITLE
Remove unneeded memory capping logic

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -31,14 +31,6 @@ namespace {
       "Exceeded memory manager cap of {} MB",                       \
       (cap) / 1024 / 1024);
 
-#define VELOX_MEM_MANUAL_CAP()                                      \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Memory allocation manually capped");
-
 constexpr folly::StringPiece kRootNodeName{"__root__"};
 } // namespace
 
@@ -78,15 +70,10 @@ void MemoryPool::visitChildren(
   }
 }
 
-std::shared_ptr<MemoryPool> MemoryPool::addChild(
-    const std::string& name,
-    int64_t cap) {
+std::shared_ptr<MemoryPool> MemoryPool::addChild(const std::string& name) {
   folly::SharedMutex::WriteHolder guard{childrenMutex_};
   // Upon name collision we would throw and not modify the map.
-  auto child = genChild(shared_from_this(), name, cap);
-  if (isMemoryCapped()) {
-    child->capMemoryAllocation();
-  }
+  auto child = genChild(shared_from_this(), name);
   if (auto usageTracker = getMemoryUsageTracker()) {
     child->setMemoryUsageTracker(usageTracker->addChild());
   }
@@ -130,12 +117,9 @@ MemoryPoolImpl::MemoryPoolImpl(
     std::shared_ptr<MemoryPool> parent,
     const Options& options)
     : MemoryPool{name, parent, options},
-      cap_{options.capacity},
       memoryManager_{memoryManager},
       localMemoryUsage_{},
-      allocator_{memoryManager_.getAllocator()} {
-  VELOX_USER_CHECK_GT(cap_, 0);
-}
+      allocator_{memoryManager_.getAllocator()} {}
 
 MemoryPoolImpl::~MemoryPoolImpl() {
   if (const auto& tracker = getMemoryUsageTracker()) {
@@ -159,18 +143,12 @@ int64_t MemoryPoolImpl::sizeAlign(int64_t size) {
 }
 
 void* MemoryPoolImpl::allocate(int64_t size) {
-  if (this->isMemoryCapped()) {
-    VELOX_MEM_MANUAL_CAP();
-  }
   const auto alignedSize = sizeAlign(size);
   reserve(alignedSize);
   return allocator_.allocateBytes(alignedSize, alignment_);
 }
 
 void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
-  if (this->isMemoryCapped()) {
-    VELOX_MEM_MANUAL_CAP();
-  }
   const auto alignedSize = sizeAlign(sizeEach * numEntries);
   reserve(alignedSize);
   return allocator_.allocateZeroFilled(alignedSize);
@@ -196,7 +174,9 @@ void* MemoryPoolImpl::reallocate(
     free(p, alignedSize);
     auto errorMessage = fmt::format(
         MEM_CAP_EXCEEDED_ERROR_FORMAT,
-        succinctBytes(cap_),
+        // This is not accurate either way. We'll make it the proper memory
+        // quota when we migrate all of capping and tracking to memory tracker.
+        succinctBytes(getMemoryUsageTracker()->maxMemory()),
         succinctBytes(difference));
     VELOX_MEM_CAP_EXCEEDED(errorMessage);
   }
@@ -300,12 +280,6 @@ MemoryPoolImpl::getMemoryUsageTracker() const {
   return memoryUsageTracker_;
 }
 
-void MemoryPoolImpl::setSubtreeMemoryUsage(int64_t size) {
-  updateSubtreeMemoryUsage([size](MemoryUsage& subtreeUsage) {
-    subtreeUsage.setCurrentBytes(size);
-  });
-}
-
 int64_t MemoryPoolImpl::updateSubtreeMemoryUsage(int64_t size) {
   int64_t aggregateBytes;
   updateSubtreeMemoryUsage([&aggregateBytes, size](MemoryUsage& subtreeUsage) {
@@ -315,46 +289,15 @@ int64_t MemoryPoolImpl::updateSubtreeMemoryUsage(int64_t size) {
   return aggregateBytes;
 }
 
-int64_t MemoryPoolImpl::cap() const {
-  return cap_;
-}
-
 uint16_t MemoryPoolImpl::getAlignment() const {
   return alignment_;
 }
 
-void MemoryPoolImpl::capMemoryAllocation() {
-  capped_.store(true);
-  for (const auto& child : children_) {
-    child->capMemoryAllocation();
-  }
-}
-
-void MemoryPoolImpl::uncapMemoryAllocation() {
-  // This means if we try to post-order traverse the tree like we do
-  // in MemoryManager, only parent has the right to lift the cap.
-  // This suffices because parent will then recursively lift the cap on the
-  // entire tree.
-  if (getAggregateBytes() > cap()) {
-    return;
-  }
-  if (parent_ != nullptr && parent_->isMemoryCapped()) {
-    return;
-  }
-  capped_.store(false);
-  visitChildren([](MemoryPool* child) { child->uncapMemoryAllocation(); });
-}
-
-bool MemoryPoolImpl::isMemoryCapped() const {
-  return capped_.load();
-}
-
 std::shared_ptr<MemoryPool> MemoryPoolImpl::genChild(
     std::shared_ptr<MemoryPool> parent,
-    const std::string& name,
-    int64_t cap) {
+    const std::string& name) {
   return std::make_shared<MemoryPoolImpl>(
-      memoryManager_, name, parent, Options{alignment_, cap});
+      memoryManager_, name, parent, Options{.alignment = alignment_});
 }
 
 const MemoryUsage& MemoryPoolImpl::getLocalMemoryUsage() const {
@@ -396,25 +339,13 @@ void MemoryPoolImpl::reserve(int64_t size) {
   localMemoryUsage_.incrementCurrentBytes(size);
 
   bool success = memoryManager_.reserve(size);
-  bool manualCap = isMemoryCapped();
-  int64_t aggregateBytes = getAggregateBytes();
-  if (UNLIKELY(!success || manualCap || aggregateBytes > cap_)) {
+  if (UNLIKELY(!success)) {
     // NOTE: If we can make the reserve and release a single transaction we
     // would have more accurate aggregates in intermediate states. However, this
     // is low-pri because we can only have inflated aggregates, and be on the
     // more conservative side.
     release(size);
-    if (!success) {
-      VELOX_MEM_MANAGER_CAP_EXCEEDED(memoryManager_.getMemoryQuota());
-    }
-    if (manualCap) {
-      VELOX_MEM_MANUAL_CAP();
-    }
-    auto errorMessage = fmt::format(
-        MEM_CAP_EXCEEDED_ERROR_FORMAT,
-        succinctBytes(cap_),
-        succinctBytes(size));
-    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+    VELOX_MEM_MANAGER_CAP_EXCEEDED(memoryManager_.getMemoryQuota());
   }
 }
 
@@ -460,11 +391,9 @@ MemoryPool& MemoryManager::getRoot() const {
 }
 
 std::shared_ptr<MemoryPool> MemoryManager::getChild(int64_t cap) {
-  return root_->addChild(
-      fmt::format(
-          "default_usage_node_{}",
-          folly::to<std::string>(folly::Random::rand64())),
-      cap);
+  return root_->addChild(fmt::format(
+      "default_usage_node_{}",
+      folly::to<std::string>(folly::Random::rand64())));
 }
 
 int64_t MemoryManager::getTotalBytes() const {

--- a/velox/common/memory/tests/MemoryHeaderTest.cpp
+++ b/velox/common/memory/tests/MemoryHeaderTest.cpp
@@ -41,9 +41,8 @@ TEST(MemoryHeaderTest, getDefaultMemoryPool) {
   ASSERT_EQ(0, manager.getRoot().getChildCount());
   {
     auto poolA = getDefaultMemoryPool();
-    auto poolB = getDefaultMemoryPool(42);
+    auto poolB = getDefaultMemoryPool();
     EXPECT_EQ(2, manager.getRoot().getChildCount());
-    EXPECT_EQ(42, poolB->cap());
     {
       auto poolC = getDefaultMemoryPool();
       EXPECT_EQ(3, manager.getRoot().getChildCount());

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -30,7 +30,6 @@ TEST(MemoryManagerTest, Ctor) {
     MemoryManager manager{};
     const auto& root = manager.getRoot();
 
-    ASSERT_EQ(std::numeric_limits<int64_t>::max(), root.cap());
     ASSERT_EQ(0, root.getChildCount());
     ASSERT_EQ(0, root.getCurrentBytes());
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), manager.getMemoryQuota());
@@ -41,7 +40,6 @@ TEST(MemoryManagerTest, Ctor) {
     MemoryManager manager{{.capacity = 8L * 1024 * 1024}};
     const auto& root = manager.getRoot();
 
-    ASSERT_EQ(8L * 1024 * 1024, root.cap());
     ASSERT_EQ(0, root.getChildCount());
     ASSERT_EQ(0, root.getCurrentBytes());
     ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
@@ -52,7 +50,8 @@ TEST(MemoryManagerTest, Ctor) {
     const auto& root = manager.getRoot();
 
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
-    ASSERT_EQ(8L * 1024 * 1024, root.cap());
+    // TODO: replace with root pool memory tracker quota check.
+    // ASSERT_EQ(8L * 1024 * 1024, root.cap());
     ASSERT_EQ(0, root.getChildCount());
     ASSERT_EQ(0, root.getCurrentBytes());
     ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
@@ -69,7 +68,7 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
   auto& managerII = MemoryManager::getInstance();
 
   auto& root = manager.getRoot();
-  auto child = root.addChild("some_child", 42);
+  auto child = root.addChild("some_child");
   ASSERT_EQ(1, root.getChildCount());
 
   auto& rootII = managerII.getRoot();
@@ -80,7 +79,6 @@ TEST(MemoryManagerTest, GlobalMemoryManager) {
   ASSERT_EQ(1, pools.size());
   auto& pool = *pools.back();
   ASSERT_EQ("some_child", pool.name());
-  ASSERT_EQ(42, pool.cap());
 }
 
 TEST(MemoryManagerTest, Reserve) {

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -80,21 +80,6 @@ BENCHMARK(SingleNodeAlloc, iters) {
     pool->free(p, dataSize);
   }
 }
-// Should be the same.
-BENCHMARK(SingleNodeAllocWithCap, iters) {
-  folly::BenchmarkSuspender suspender;
-  MemoryManager manager{};
-  auto pool = manager.getRoot().addChild(
-      "pride_of_higara", iters * kMemoryFootprintIncrement);
-
-  for (size_t i = 0; i < iters; ++i) {
-    auto dataSize = (i + 1) * kMemoryFootprintIncrement;
-    suspender.dismiss();
-    auto p = pool->allocate(dataSize);
-    suspender.rehire();
-    pool->free(p, dataSize);
-  }
-}
 
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
@@ -141,25 +126,6 @@ BENCHMARK(SingleNodeAlignedAlloc, iters) {
   }
 }
 
-BENCHMARK(SingleNodeAlignedAllocWithCap, iters) {
-  folly::BenchmarkSuspender suspender;
-  MemoryManager manager{};
-  auto unalignedTotal = iters * kMemoryFootprintIncrement;
-  auto alignedCap = unalignedTotal % MemoryAllocator::kMaxAlignment == 0
-      ? unalignedTotal
-      : (unalignedTotal / MemoryAllocator::kMaxAlignment + 1) *
-          MemoryAllocator::kMaxAlignment;
-  auto pool = manager.getRoot().addChild("pride_of_higara", alignedCap);
-
-  for (size_t i = 0; i < iters; ++i) {
-    auto dataSize = (i + 1) * kMemoryFootprintIncrement;
-    suspender.dismiss();
-    auto p = pool->allocate(dataSize);
-    suspender.rehire();
-    pool->free(p, dataSize);
-  }
-}
-
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
@@ -178,12 +144,9 @@ BENCHMARK(SingleNodeAlignedRealloc, iters) {
 }
 
 namespace {
-void addNLeaves(
-    MemoryPool& pool,
-    size_t n,
-    int64_t cap = std::numeric_limits<int64_t>::max()) {
+void addNLeaves(MemoryPool& pool, size_t n) {
   for (size_t i = 0; i < n; ++i) {
-    pool.addChild(pool.name() + ".leaf_" + folly::to<std::string>(i), cap);
+    pool.addChild(pool.name() + ".leaf_" + folly::to<std::string>(i));
   }
 }
 } // namespace

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -172,11 +172,9 @@ class Writer : public WriterBase {
       : Writer{
             options,
             std::move(sink),
-            parentPool.addChild(
-                fmt::format(
-                    "writer_node_{}",
-                    folly::to<std::string>(folly::Random::rand64())),
-                std::min(options.memoryBudget, parentPool.cap()))} {}
+            parentPool.addChild(fmt::format(
+                "writer_node_{}",
+                folly::to<std::string>(folly::Random::rand64())))} {}
 
   ~Writer() override = default;
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <limits>
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/dwio/dwrf/common/Compression.h"
@@ -245,7 +246,9 @@ class WriterContext : public CompressionBufferPool {
   }
 
   int64_t getMemoryBudget() const {
-    return pool_->cap();
+    auto memoryUsageTracker = pool_->getMemoryUsageTracker();
+    return memoryUsageTracker ? memoryUsageTracker->maxMemory()
+                              : std::numeric_limits<int64_t>::max();
   }
 
   const encryption::EncryptionHandler& getEncryptionHandler() const {

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -65,8 +65,7 @@ void HiveConnectorTestBase::writeToFile(
   options.schema = vectors[0]->type();
   auto sink =
       std::make_unique<facebook::velox::dwio::common::LocalFileSink>(filePath);
-  auto childPool =
-      pool_->addChild(kWriter, std::numeric_limits<int64_t>::max());
+  auto childPool = pool_->addChild(kWriter);
   facebook::velox::dwrf::Writer writer{options, std::move(sink), *childPool};
   for (size_t i = 0; i < vectors.size(); ++i) {
     writer.write(vectors[i]);


### PR DESCRIPTION
Summary:
When the memory stack was first introduced, the plan was to do accounting in the memory pool and use periodic aggregation to mitigate the potential lock contention on the memory hierarchy.

The design has been changed, and we will fully use memory tracker to delegate the accounting and memory capping logic. We also won't allow custom memory caps for intermediate nodes and only at top level pools instead.

This diff gets rid of the unneeded logic and changes call sites for removal of memory cap concept when adding child.

Differential Revision: D42256726

