### PR TITLE
Skip non-deterministic parameterized function signatures

### DIFF
--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -127,12 +127,13 @@ TypePtr ArgumentTypeFuzzer::fuzzReturnType() {
 
   determineUnboundedTypeVariables();
   if (signature_.returnType().baseName() == "any") {
-    return randomType(rng_);
+    returnType_ = randomType(rng_);
+    return returnType_;
   } else {
-    auto actualType = exec::SignatureBinder::tryResolveType(
+    returnType_ = exec::SignatureBinder::tryResolveType(
         signature_.returnType(), variables(), bindings_);
-    VELOX_CHECK_NE(actualType, nullptr);
-    return actualType;
+    VELOX_CHECK_NE(returnType_, nullptr);
+    return returnType_;
   }
 }
 

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -55,7 +55,8 @@ class ArgumentTypeFuzzer {
   }
 
   /// Return a random type that can bind to the function signature's return
-  /// type. This is only allowed when returnType_ is not initialized.
+  /// type and set returnType_ to this type. This function can only be called
+  /// when returnType_ is uninitialized.
   TypePtr fuzzReturnType();
 
  private:
@@ -69,7 +70,7 @@ class ArgumentTypeFuzzer {
 
   const exec::FunctionSignature& signature_;
 
-  const TypePtr returnType_;
+  TypePtr returnType_;
 
   std::vector<TypePtr> argumentTypes_;
 


### PR DESCRIPTION
Summary:
Non-deterministic function signatures should be skipped during expression fuzzer
tests. The previous code only skip non-deterministic ones among regular function
signatures. This diff fix the logic to skip non-deterministic ones among parameterized
function signatures too. (https://github.com/facebookincubator/velox/issues/3603)

Differential Revision: D42335248

