### PR TITLE
Only enforce memory limit check at root tracker

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -134,7 +134,7 @@ void MemoryUsageTracker::incrementUsage(int64_t size) {
   const auto newUsage =
       currentBytes_.fetch_add(size, std::memory_order_relaxed) + size;
   // Enforce the limit.
-  if (newUsage > maxMemory_) {
+  if (parent_ == nullptr && newUsage > maxMemory_) {
     if ((growCallback_ == nullptr) || !growCallback_(size, *this)) {
       // Exceeded the limit.  revert the change to current usage.
       decrementUsage(size);


### PR DESCRIPTION
There is no use case to enforce memory limit check on the
non-root level. Also disallow to set memory grow callback for
non-root level.