### PR TITLE
[WIP] Simplify nulls reading for Parquet primitive types

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -459,6 +459,10 @@ class ColumnVisitor {
     numRows_ = newRows.size();
   }
 
+  bool isDropValues() {
+    return std::is_same_v<decltype(values_), DropValues>;
+  }
+
  protected:
   TFilter& filter_;
   SelectiveColumnReader* reader_;

--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -40,8 +40,7 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
   }
 
   template <typename Reader>
-  void
-  readCommon(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
+  void readCommon(RowSet rows);
 
   void getValues(RowSet rows, VectorPtr* result) override {
     getFlatValues<TRequested, TRequested>(rows, result);
@@ -158,10 +157,7 @@ void SelectiveFloatingPointColumnReader<TData, TRequested>::processValueHook(
 template <typename TData, typename TRequested>
 template <typename Reader>
 void SelectiveFloatingPointColumnReader<TData, TRequested>::readCommon(
-    vector_size_t offset,
-    RowSet rows,
-    const uint64_t* incomingNulls) {
-  prepareRead<TRequested>(offset, rows, incomingNulls);
+    RowSet rows) {
   bool isDense = rows.back() == rows.size() - 1;
   if (scanSpec_->keepValues()) {
     if (scanSpec_->valueHook()) {

--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -124,16 +124,10 @@ void SelectiveIntegerColumnReader::processFilter(
           filter, rows, extractValues);
       break;
     case velox::common::FilterKind::kIsNull:
-      filterNulls<int64_t>(
-          rows, true, !std::is_same_v<decltype(extractValues), DropValues>);
-      break;
+      VELOX_FAIL("Filter kIsNull should have been processed", valueSize_);
     case velox::common::FilterKind::kIsNotNull:
-      if (std::is_same_v<decltype(extractValues), DropValues>) {
-        filterNulls<int64_t>(rows, false, false);
-      } else {
-        readHelper<Reader, velox::common::IsNotNull, isDense>(
-            filter, rows, extractValues);
-      }
+      readHelper<Reader, velox::common::IsNotNull, isDense>(
+          filter, rows, extractValues);
       break;
     case velox::common::FilterKind::kBigintRange:
       readHelper<Reader, velox::common::BigintRange, isDense>(

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -174,8 +174,11 @@ void SelectiveListColumnReader::read(
   // Catch up if the child is behind the length stream.
   child_->seekTo(childTargetReadOffset_, false);
   prepareRead<char>(offset, rows, incomingNulls);
-  auto activeRows = applyFilter(rows);
+  readNulls(rows, 0, incomingNulls);
+
+  RowSet activeRows = filterNulls<int32_t>(rows, false);
   makeNestedRowSet(activeRows);
+
   if (child_ && !nestedRows_.empty()) {
     child_->read(child_->readOffset(), nestedRows_, nullptr);
   }
@@ -253,8 +256,11 @@ void SelectiveMapColumnReader::read(
   }
 
   prepareRead<char>(offset, rows, incomingNulls);
-  auto activeRows = applyFilter(rows);
+  readNulls(rows, 0, incomingNulls);
+
+  auto activeRows = filterNulls<int32_t>(rows, false);
   makeNestedRowSet(activeRows);
+
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
     keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
     elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.cpp
@@ -33,6 +33,7 @@ void SelectiveByteRleColumnReader::read(
     RowSet rows,
     const uint64_t* incomingNulls) {
   prepareRead<int8_t>(offset, rows, incomingNulls);
+  readNulls(rows, 0, incomingNulls);
   bool isDense = rows.back() == rows.size() - 1;
   common::Filter* filter =
       scanSpec_->filter() ? scanSpec_->filter() : &dwio::common::alwaysTrue();

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -246,6 +246,7 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       override {
     numReads_ = scanSpec_->newRead();
     prepareRead<char>(offset, rows, incomingNulls);
+    readNulls(rows, 0, incomingNulls);
     auto* mapNulls =
         nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
     for (auto* reader : children_) {

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -48,7 +48,10 @@ class SelectiveFloatingPointColumnReader
   void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
       override {
     using T = SelectiveFloatingPointColumnReader<TData, TRequested>;
-    base::template readCommon<T>(offset, rows, incomingNulls);
+    dwio::common::SelectiveColumnReader::prepareRead<TRequested>(
+        offset, rows, incomingNulls);
+    dwio::common::SelectiveColumnReader::readNulls(rows, 0, incomingNulls);
+    base::template readCommon<T>(rows);
   }
 
   template <typename TVisitor>

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -34,6 +34,13 @@ void SelectiveIntegerDirectColumnReader::read(
       offset,
       rows,
       incomingNulls);
+  readNulls(rows, 0, incomingNulls);
+
+  if (readsNullsOnly()) {
+    filterNulls<int64_t>(rows, scanSpec_->keepValues());
+    return;
+  }
+
   readCommon<SelectiveIntegerDirectColumnReader>(rows);
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -123,6 +123,7 @@ void SelectiveTimestampColumnReader::read(
     RowSet rows,
     const uint64_t* incomingNulls) {
   prepareRead<int64_t>(offset, rows, incomingNulls);
+  readNulls(rows, 0, incomingNulls);
   VELOX_CHECK(!scanSpec_->filter());
   bool isDense = rows.back() == rows.size() - 1;
   if (isDense) {

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -48,7 +48,7 @@ class FloatingPointColumnReader
   void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
       override {
     using T = FloatingPointColumnReader<TData, TRequested>;
-    base::template readCommon<T>(offset, rows, incomingNulls);
+    base::template readCommon<T>(rows);
   }
 
   template <typename TVisitor>

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -70,7 +70,6 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   template <typename ColumnVisitor>
   void readWithVisitor(RowSet rows, ColumnVisitor visitor) {
     formatData_->as<ParquetData>().readWithVisitor(visitor);
-    readOffset_ += rows.back() + 1;
   }
 };
 

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -164,6 +164,7 @@ void ListColumnReader::setLengthsFromRepDefs(PageReader& pageReader) {
   formatData_->as<ParquetData>().setNulls(nullsInReadRange(), numLists);
   setLengths(std::move(lengths));
 }
+
 void ListColumnReader::read(
     vector_size_t offset,
     RowSet rows,

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -64,6 +64,7 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
  private:
   bool filterMatches(const thrift::RowGroup& rowGroup);
+
   dwio::common::SelectiveColumnReader* findBestLeaf();
 
   // Leaf column reader used for getting nullability information for


### PR DESCRIPTION
Nulls reading for Parquet primitive types was done in two cases: 1) In
    XXXColumnReader::prepareRead() when XXXColumnReader::readsNullsOnly()
    is true; 2) In PageReader::rowsForPage() along with reading page data
    when XXXColumnReader::readsNullsOnly() is false. This commit does the
    following:

1.    Removed the first case, and only read nulls in one location while reading the pages.
2.    Refactored PageReader::rowsForPage() so that it only handles RowSet partitioning for the current page. The nulls reading logic is moved out into PageReader::readWithVisitor().
3.    The nulls reading and concatenation are now altogether in PageReader::readWithVisitor().
4.    Removed unnecessary readNullsOnly(), skipNullsOnly() logic, and some unnecessary nulls array members from PageReader class.
5.    Removed unnecessary readNullsOnly(), skipNullsOnly() logic from ParquetData class.