### PR TITLE
Fix handling of empty arrays and maps in subscript operator

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -62,8 +62,6 @@ int main(int argc, char** argv) {
       "element_at",
       "width_bucket",
       "array_intersect",
-      // TODO: Remove after fixing issue #3625
-      "subscript",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(


### PR DESCRIPTION
A recent patch introduced a bug where the implementation of subscript
operator would check for an empty values vector in the input
array/map and directly return a null vector as a result. This meant
that checks for invalid indices were not performed which resulted in
divergence from the expected behavior for element_at or subscript
operators. This patch makes sure that the handling of such empty
arrays and maps is consistent with that of Presto, that is, checks
for invalid indices is done regardless of whether the array vector
has a non-empty values vector.

Fixes #3625

Test Plan:
Added unit test and consolidated related ones in the same test case.