### PR TITLE
Make memory usage tracker thread safe

### DIFF
--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -41,14 +41,14 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
       "op.0.0.Values: 0B in 1 instances, min 0B, max 0B",
       "node.1: 12.00KB in 1 operators, min 12.00KB, max 12.00KB",
       "op.1.0.FilterProject: 12.00KB in 1 instances, min 12.00KB, max 12.00KB",
-      "node.2: 1.77MB in 1 operators, min 1.77MB, max 1.77MB",
-      "op.2.0.Aggregation: 1.77MB in 1 instances, min 1.77MB, max 1.77MB",
+      "node.2: 3.77MB in 1 operators, min 3.77MB, max 3.77MB",
+      "op.2.0.Aggregation: 3.77MB in 1 instances, min 3.77MB, max 3.77MB",
       "node.3: 0B in 1 operators, min 0B, max 0B",
       "op.3.0.OrderBy: 0B in 1 instances, min 0B, max 0B",
       "node.N/A: 0B in 1 operators, min 0B, max 0B",
       "op.N/A.0.CallbackSink: 0B in 1 instances, min 0B, max 0B",
       "Top operator memory usages:",
-      "Failed Operator: Aggregation.2: 1.77MB"};
+      "Failed Operator: Aggregation.2: 3.77MB"};
 
   std::vector<RowVectorPtr> data;
   for (auto i = 0; i < 100; ++i) {


### PR DESCRIPTION
Make leaf memory usage tracker thread safe.
Reservation path change:
1. make reservation decision under the lock based on
grantedReservationBytes_, usedReservationBytes_ and minReservationBytes_.
2. propagate the reservation increment up to the root tracker using
atomic reservationBytes_ without lock
3. on success, update grantedReservationBytes_, usedReservationBytes_ and
minReservationBytes_ under the lock.
Add a loop to take care of the potential conflict between reserve and release as
the memory reservation and release is quantized.
The other side effect of this change is that in case of concurrent
memory reservations, we might reserve more memory bytes due to
the quantized reservation size calculation.

Release path change:
1. make release decision under the lock based on
grantedReservationBytes_, usedReservationBytes_ and minReservationBytes_.
2. propagate the reservation decrement up to the root tracker using
atomic reservationBytes_ without lock

Add more stats tracking and export a memory tracker's internal
execution stats through Stats object.
Add a concurrent test that update memory tracker from multiple
threads and do sanity check at the end of tests.