### PR TITLE
Parquet PageReader wrongly skips nulls count #3648

### DIFF
--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -758,8 +758,9 @@ void PageReader::skipNullsOnly(int64_t numRows) {
     seekToPage(firstUnvisited_ + numRows);
     firstUnvisited_ += numRows;
     toSkip = firstUnvisited_ - rowOfPage_;
+  } else {
+    firstUnvisited_ += numRows;
   }
-  firstUnvisited_ += numRows;
 
   // Skip nulls
   skipNulls(toSkip);


### PR DESCRIPTION
Summary:
  numRows was added twice.