### PR TITLE
Reject null aware right semi project joins with filter

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1234,6 +1234,12 @@ class HashJoinNode : public AbstractJoinNode {
           "Null-aware flag is supported only for semi and anti joins");
       VELOX_USER_CHECK_EQ(
           1, leftKeys_.size(), "Null-aware joins allow only one join key");
+
+      if (filter_) {
+        VELOX_USER_CHECK(
+            !isRightSemiProjectJoin(),
+            "Null-aware right semi project join doesn't support extra filter");
+      }
     }
   }
 


### PR DESCRIPTION
Proper implementation of the null-aware right semi project join with extra
filter requires holding all of probe side in memory for a cross-join with build
side row with null join keys or no matches which is not practical.