### PR TITLE
LastRangeEnd is not set correctly in ByteStream

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -112,6 +112,7 @@ class ByteStream {
   void resetInput(std::vector<ByteRange>&& ranges) {
     ranges_ = std::move(ranges);
     current_ = &ranges_[0];
+    lastRangeEnd_ = ranges_.back().size;
   }
 
   void setRange(ByteRange range) {


### PR DESCRIPTION
Summary: Encountered the issue when using the `resetInput` API to initialize the ByteStream where the lastRangeEnd is not correctly set. That caused issues to the places where rely on the lastRangeEnd to do the calculation (for example `size()`).

Differential Revision: D42390950

