### PR TITLE
Fix a clangtidy error about addVariable being implemented in a header file

### DIFF
--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -191,7 +191,7 @@ class AggregateFunctionSignature : public FunctionSignature {
 
 namespace {
 
-void addVariable(
+inline void addVariable(
     std::unordered_map<std::string, SignatureVariable>& variables,
     const SignatureVariable& variable) {
   VELOX_USER_CHECK(


### PR DESCRIPTION
Summary: As title. Inlining the function stops clangtidy from erroring out. Given the function is only used in the same file where it's defined, this shouldn't cause any further breakages.

Reviewed By: ng420

Differential Revision: D42018557

