### PR TITLE
Allow reverse conversion from Config to serde bag

### DIFF
--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -31,6 +31,7 @@ class ConfigBase {
  public:
   template <typename T>
   class Entry {
+   private:
     Entry(
         const std::string& key,
         const T& val,
@@ -81,6 +82,10 @@ class ConfigBase {
     auto iter = configs_.find(entry.key_);
     return iter != configs_.end() ? entry.toT_(entry.key_, iter->second)
                                   : entry.default_;
+  }
+
+  std::map<std::string, std::string> toSerdeParams() {
+    return std::map{configs_.cbegin(), configs_.cend()};
   }
 
  protected:


### PR DESCRIPTION
Summary: Reverse conversion from config to serde bag allows easier manipulation of configs and conversion to configs of other types across file formats. This is good for both format migrations and experimentation.

Differential Revision: D42407231

