### PR TITLE
Add json_parse Presto function

### DIFF
--- a/velox/docs/functions/json.rst
+++ b/velox/docs/functions/json.rst
@@ -126,10 +126,23 @@ JSON Functions
 
 .. function:: json_format(json) -> varchar
 
-    Serializes the input JSON value to JSON text conforming to RFC 7159.
-    The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, true, false or null.
+    Serializes the input JSON value to JSON text conforming to `RFC 7159`_.
+    The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, ``true``, ``false`` or ``null``::
 
-        SELECT json_format(JSON '{"a": 1, "b": 2}')
+        SELECT json_format(JSON '[1, 2, 3]'); -- '[1,2,3]'
+        SELECT json_format(JSON '"a"'); -- '"a"'
+
+    .. _RFC 7159: https://datatracker.ietf.org/doc/html/rfc7159.html
+
+.. function:: json_parse(varchar) -> json
+
+    expects a JSON text conforming to `RFC 7159`_, and returns the JSON value deserialized from the JSON text.
+    The JSON value can be a JSON object, a JSON array, a JSON string, a JSON number, ``true``, ``false`` or ``null``::
+
+        SELECT json_parse('[1, 2, 3]'); -- JSON '[1,2,3]'
+        SELECT json_parse('"abc"'); -- JSON '"abc"'
+
+    .. _RFC 7159: https://datatracker.ietf.org/doc/html/rfc7159.html
 
 .. function:: json_size(json, value) -> bigint
 

--- a/velox/functions/prestosql/JsonFunctions.cpp
+++ b/velox/functions/prestosql/JsonFunctions.cpp
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/prestosql/Comparisons.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 
 namespace facebook::velox::functions {
 
@@ -63,10 +62,69 @@ class JsonFormatFunction : public exec::VectorFunction {
   }
 };
 
+class JsonParseFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VectorPtr localResult;
+
+    // Input can be constant or flat.
+    // TODO(arpitporwal2293) Replace folly::parseJson with a lightweight
+    // validation of JSON syntax that doesn't allocate memory or copy data.
+    assert(args.size() > 0);
+    const auto& arg = args[0];
+    if (arg->isConstantEncoding()) {
+      auto value = arg->as<ConstantVector<StringView>>()->valueAt(0);
+      try {
+        folly::parseJson(value);
+      } catch (const std::exception& e) {
+        context.setErrors(rows, std::current_exception());
+        return;
+      }
+      localResult = std::make_shared<ConstantVector<StringView>>(
+          context.pool(), rows.end(), false, JSON(), std::move(value));
+    } else {
+      auto flatInput = arg->asFlatVector<StringView>();
+
+      auto stringBuffers = flatInput->stringBuffers();
+      VELOX_CHECK_LE(rows.end(), flatInput->size());
+
+      context.applyToSelectedNoThrow(
+          rows, [&](auto row) { folly::parseJson(flatInput->valueAt(row)); });
+      localResult = std::make_shared<FlatVector<StringView>>(
+          context.pool(),
+          JSON(),
+          nullptr,
+          rows.end(),
+          flatInput->values(),
+          std::move(stringBuffers));
+    }
+
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    // varchar -> json
+    return {exec::FunctionSignatureBuilder()
+                .returnType("json")
+                .argumentType("varchar")
+                .build()};
+  }
+};
+
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION(
     udf_json_format,
     JsonFormatFunction::signatures(),
     std::make_unique<JsonFormatFunction>());
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_json_parse,
+    JsonParseFunction::signatures(),
+    std::make_unique<JsonParseFunction>());
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -36,6 +36,7 @@ void registerJsonFunctions() {
       {"json_array_contains"});
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>({"json_size"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, "json_format");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, "json_parse");
 }
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Add 'json_parse' udf to prestosql.
Doc: https://prestodb.io/docs/current/functions/json.html#json_parse

Differential Revision: D42421487

