### PR TITLE
Support spark-compatible year functions

### DIFF
--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <velox/type/Timestamp.h>
+#include "velox/core/QueryConfig.h"
+#include "velox/external/date/tz.h"
+#include "velox/functions/Macros.h"
+#include "velox/type/Date.h"
+
+using facebook::velox::Date;
+using facebook::velox::Timestamp;
+using facebook::velox::core::QueryConfig;
+
+namespace facebook::velox::functions {
+namespace {
+inline constexpr int64_t kSecondsInDay = 86'400;
+inline constexpr int64_t kDaysInWeek = 7;
+
+FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
+    const QueryConfig& config) {
+  if (config.adjustTimestampToTimezone()) {
+    auto sessionTzName = config.sessionTimezone();
+    if (!sessionTzName.empty()) {
+      return date::locate_zone(sessionTzName);
+    }
+  }
+  return nullptr;
+}
+
+FOLLY_ALWAYS_INLINE int64_t
+getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
+  if (timeZone != nullptr) {
+    timestamp.toTimezone(*timeZone);
+    return timestamp.getSeconds();
+  } else {
+    return timestamp.getSeconds();
+  }
+}
+} // namespace
+
+FOLLY_ALWAYS_INLINE
+std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
+  int64_t seconds = getSeconds(timestamp, timeZone);
+  std::tm dateTime;
+  VELOX_USER_CHECK_NOT_NULL(
+      gmtime_r((const time_t*)&seconds, &dateTime),
+      "Timestamp is too large: {} seconds since epoch",
+      seconds);
+  return dateTime;
+}
+
+FOLLY_ALWAYS_INLINE
+std::tm getDateTime(Date date) {
+  int64_t seconds = date.days() * kSecondsInDay;
+  std::tm dateTime;
+  VELOX_USER_CHECK_NOT_NULL(
+      gmtime_r((const time_t*)&seconds, &dateTime),
+      "Date is too large: {} days",
+      date.days());
+  return dateTime;
+}
+
+template <typename T>
+struct InitSessionTimezone {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  const date::time_zone* timeZone_{nullptr};
+
+  FOLLY_ALWAYS_INLINE void initialize(
+      const QueryConfig& config,
+      const arg_type<Timestamp>* /*timestamp*/) {
+    timeZone_ = getTimeZoneFromConfig(config);
+  }
+};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include <velox/type/Timestamp.h>
 #include <string_view>
-#include "velox/core/QueryConfig.h"
-#include "velox/external/date/tz.h"
-#include "velox/functions/Macros.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
+#include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/TimestampConversion.h"
@@ -64,63 +61,6 @@ struct FromUnixtimeFunction {
 };
 
 namespace {
-inline constexpr int64_t kSecondsInDay = 86'400;
-inline constexpr int64_t kDaysInWeek = 7;
-
-FOLLY_ALWAYS_INLINE const date::time_zone* getTimeZoneFromConfig(
-    const core::QueryConfig& config) {
-  if (config.adjustTimestampToTimezone()) {
-    auto sessionTzName = config.sessionTimezone();
-    if (!sessionTzName.empty()) {
-      return date::locate_zone(sessionTzName);
-    }
-  }
-  return nullptr;
-}
-
-FOLLY_ALWAYS_INLINE int64_t
-getSeconds(Timestamp timestamp, const date::time_zone* timeZone) {
-  if (timeZone != nullptr) {
-    timestamp.toTimezone(*timeZone);
-    return timestamp.getSeconds();
-  } else {
-    return timestamp.getSeconds();
-  }
-}
-
-FOLLY_ALWAYS_INLINE
-std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
-  int64_t seconds = getSeconds(timestamp, timeZone);
-  std::tm dateTime;
-  VELOX_USER_CHECK_NOT_NULL(
-      gmtime_r((const time_t*)&seconds, &dateTime),
-      "Timestamp is too large: {} seconds since epoch",
-      seconds);
-  return dateTime;
-}
-
-FOLLY_ALWAYS_INLINE
-std::tm getDateTime(Date date) {
-  int64_t seconds = date.days() * kSecondsInDay;
-  std::tm dateTime;
-  VELOX_USER_CHECK_NOT_NULL(
-      gmtime_r((const time_t*)&seconds, &dateTime),
-      "Date is too large: {} days",
-      date.days());
-  return dateTime;
-}
-
-template <typename T>
-struct InitSessionTimezone {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-  const date::time_zone* timeZone_{nullptr};
-
-  FOLLY_ALWAYS_INLINE void initialize(
-      const core::QueryConfig& config,
-      const arg_type<Timestamp>* /*timestamp*/) {
-    timeZone_ = getTimeZoneFromConfig(config);
-  }
-};
 
 template <typename T>
 struct TimestampWithTimezoneSupport {

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/TimeUtils.h"
+
+namespace facebook::velox::functions::sparksql {
+
+template <typename T>
+struct YearFunction : public InitSessionTimezone<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE int32_t getYear(const std::tm& time) {
+    return 1900 + time.tm_year;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      int32_t& result,
+      const arg_type<Timestamp>& timestamp) {
+    result = getYear(getDateTime(timestamp, this->timeZone_));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    result = getYear(getDateTime(date));
+  }
+};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -18,13 +18,13 @@
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
-#include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
 #include "velox/functions/sparksql/ArraySort.h"
 #include "velox/functions/sparksql/Bitwise.h"
 #include "velox/functions/sparksql/CompareFunctionsNullSafe.h"
+#include "velox/functions/sparksql/DateTimeFunctions.h"
 #include "velox/functions/sparksql/Hash.h"
 #include "velox/functions/sparksql/In.h"
 #include "velox/functions/sparksql/LeastGreatest.h"
@@ -144,6 +144,9 @@ void registerFunctions(const std::string& prefix) {
       prefix + "array_sort", arraySortSignatures(), makeArraySort);
   exec::registerStatefulVectorFunction(
       prefix + "sort_array", sortArraySignatures(), makeSortArray);
+
+  registerFunction<YearFunction, int32_t, Timestamp>({"year"});
+  registerFunction<YearFunction, int32_t, Date>({"year"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   ArraySortTest.cpp
   BitwiseTest.cpp
   CompareNullSafeTests.cpp
+  DateTimeFunctionsTest.cpp
   HashTest.cpp
   InTest.cpp
   LeastGreatestTest.cpp

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+#include "velox/type/tz/TimeZoneMap.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class DateTimeFunctionsTest : public SparkFunctionBaseTest {
+ protected:
+  void setQueryTimeZone(const std::string& timeZone) {
+    queryCtx_->setConfigOverridesUnsafe({
+        {core::QueryConfig::kSessionTimezone, timeZone},
+        {core::QueryConfig::kAdjustTimestampToTimezone, "true"},
+    });
+  }
+};
+
+TEST_F(DateTimeFunctionsTest, year) {
+  const auto year = [&](std::optional<Timestamp> date) {
+    return evaluateOnce<int32_t>("year(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, year(std::nullopt));
+  EXPECT_EQ(1970, year(Timestamp(0, 0)));
+  EXPECT_EQ(1969, year(Timestamp(-1, 9000)));
+  EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
+  EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
+  EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));
+  EXPECT_EQ(2001, year(Timestamp(998423705, 321000000)));
+
+  setQueryTimeZone("Pacific/Apia");
+
+  EXPECT_EQ(std::nullopt, year(std::nullopt));
+  EXPECT_EQ(1969, year(Timestamp(0, 0)));
+  EXPECT_EQ(1969, year(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
+  EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
+  EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));
+  EXPECT_EQ(2001, year(Timestamp(998423705, 321000000)));
+}
+
+TEST_F(DateTimeFunctionsTest, yearDate) {
+  const auto year = [&](std::optional<Date> date) {
+    return evaluateOnce<int32_t>("year(c0)", date);
+  };
+  EXPECT_EQ(std::nullopt, year(std::nullopt));
+  EXPECT_EQ(1970, year(Date(0)));
+  EXPECT_EQ(1969, year(Date(-1)));
+  EXPECT_EQ(2020, year(Date(18262)));
+  EXPECT_EQ(1920, year(Date(-18262)));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
For year function. Spark expects to use int32_t as the result type. 