### PR TITLE
Add uuid Presto function

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -19,6 +19,7 @@ Presto Functions
     functions/aggregate
     functions/window
     functions/hyperloglog
+    functions/uuid
 
 Here is a list of all scalar and aggregate Presto functions available in Velox.
 Function names link to function descriptions. Check out coverage maps

--- a/velox/docs/functions/uuid.rst
+++ b/velox/docs/functions/uuid.rst
@@ -1,0 +1,7 @@
+=============================
+UUID Functions
+=============================
+
+.. function:: uuid() -> uuid
+
+    Returns a pseudo randomly generated UUID as a single character string

--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -15,27 +15,13 @@
  */
 
 #include "velox/expression/VectorFunction.h"
-#include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 namespace facebook::velox::test {
 
-class CustomTypeTest : public functions::test::FunctionBaseTest {
- protected:
-  static std::unordered_set<std::string> getSignatureStrings(
-      const std::string& functionName) {
-    auto allSignatures = getFunctionSignatures();
-    const auto& signatures = allSignatures.at(functionName);
-
-    std::unordered_set<std::string> signatureStrings;
-    for (const auto& signature : signatures) {
-      signatureStrings.insert(signature->toString());
-    }
-    return signatureStrings;
-  }
-};
+class CustomTypeTest : public functions::test::FunctionBaseTest {};
 
 namespace {
 struct FancyInt {

--- a/velox/functions/prestosql/Uuid.h
+++ b/velox/functions/prestosql/Uuid.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/lexical_cast.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include "velox/functions/Macros.h"
+#include "velox/functions/prestosql/types/UuidType.h"
+
+namespace facebook::velox::functions {
+
+template <typename T>
+struct UuidFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  static constexpr bool is_deterministic = false;
+
+  FOLLY_ALWAYS_INLINE void call(out_type<Uuid>& result) {
+    auto uuidString =
+        boost::lexical_cast<std::string>(boost::uuids::random_generator()());
+    result = StringView(uuidString);
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/prestosql/Cardinality.h"
+#include "velox/functions/prestosql/Uuid.h"
 
 namespace facebook::velox::functions {
 
@@ -36,6 +37,9 @@ void registerGeneralFunctions() {
       {"cardinality"});
 
   registerIsNullFunction("is_null");
+
+  registerType("uuid", std::make_unique<const UuidTypeFactories>());
+  registerFunction<UuidFunction, Uuid>({"uuid"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -67,7 +67,8 @@ add_executable(
   WidthBucketArrayTest.cpp
   GreatestLeastTest.cpp
   ZipTest.cpp
-  ZipWithTest.cpp)
+  ZipWithTest.cpp
+  UuidTest.cpp)
 
 add_test(velox_functions_test velox_functions_test)
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -17,7 +17,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/type/Date.h"
@@ -210,18 +209,6 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
             makeNullableFlatVector<int64_t>({timestamp}),
             makeNullableFlatVector<int16_t>({tzid}),
         })}));
-  }
-
-  static std::unordered_set<std::string> getSignatureStrings(
-      const std::string& functionName) {
-    auto allSignatures = getFunctionSignatures();
-    const auto& signatures = allSignatures.at(functionName);
-
-    std::unordered_set<std::string> signatureStrings;
-    for (const auto& signature : signatures) {
-      signatureStrings.insert(signature->toString());
-    }
-    return signatureStrings;
   }
 
   Date parseDate(const std::string& dateStr) {

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/common/hyperloglog/SparseHll.h"
-#include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/HyperLogLogType.h"
 #define XXH_INLINE_ALL
@@ -47,19 +46,6 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     serialized.resize(denseHll.serializedSize());
     denseHll.serialize(serialized.data());
     return serialized;
-  }
-
-  static std::unordered_set<std::string> getSignatureStrings(
-      const std::string& functionName) {
-    auto allSignatures = getFunctionSignatures();
-    const auto& signatures = allSignatures.at(functionName);
-
-    std::unordered_set<std::string> signatureStrings;
-    for (const auto& signature : signatures) {
-      signatureStrings.insert(signature->toString());
-      LOG(ERROR) << signature->toString();
-    }
-    return signatureStrings;
   }
 
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "velox/functions/FunctionRegistry.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 
@@ -43,18 +42,6 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
       std::optional<std::string> json,
       std::optional<std::string> path) {
     return evaluateOnce<int64_t>("json_size(c0, c1)", json, path);
-  }
-
-  static std::unordered_set<std::string> getSignatureStrings(
-      const std::string& functionName) {
-    auto allSignatures = getFunctionSignatures();
-    const auto& signatures = allSignatures.at(functionName);
-
-    std::unordered_set<std::string> signatureStrings;
-    for (const auto& signature : signatures) {
-      signatureStrings.insert(signature->toString());
-    }
-    return signatureStrings;
   }
 };
 

--- a/velox/functions/prestosql/tests/UuidTest.cpp
+++ b/velox/functions/prestosql/tests/UuidTest.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+
+class UuidTest : public functions::test::FunctionBaseTest {};
+
+TEST_F(UuidTest, uuidSignatures) {
+  auto signatures = getSignatureStrings("uuid");
+  ASSERT_EQ(1, signatures.size());
+  ASSERT_EQ(1, signatures.count("() -> uuid"));
+}
+
+TEST_F(UuidTest, uuid) {
+  const auto uuid = [&]() {
+    return evaluateOnce<std::string>("uuid()", makeRowVector(ROW({}), 1));
+  };
+
+  EXPECT_EQ(36, uuid()->length());
+}

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.h
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/expression/Expr.h"
+#include "velox/functions/FunctionRegistry.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Type.h"
@@ -70,6 +71,18 @@ class FunctionBaseTest : public testing::Test,
       const std::string& name2,
       const TypePtr& type2) {
     return ROW({name, name2}, {type, type2});
+  }
+
+  static std::unordered_set<std::string> getSignatureStrings(
+      const std::string& functionName) {
+    auto allSignatures = getFunctionSignatures();
+    const auto& signatures = allSignatures.at(functionName);
+
+    std::unordered_set<std::string> signatureStrings;
+    for (const auto& signature : signatures) {
+      signatureStrings.insert(signature->toString());
+    }
+    return signatureStrings;
   }
 
   core::TypedExprPtr makeTypedExpr(

--- a/velox/functions/prestosql/types/UuidType.h
+++ b/velox/functions/prestosql/types/UuidType.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+class UuidType : public VarcharType {
+ public:
+  UuidType() = default;
+
+  static const std::shared_ptr<const UuidType>& get() {
+    static const std::shared_ptr<const UuidType> kInstance{
+        std::make_shared<const UuidType>()};
+    return kInstance;
+  }
+
+  std::string toString() const override {
+    static const auto typeName = "UUID";
+    return typeName;
+  }
+};
+
+FOLLY_ALWAYS_INLINE bool isUuidType(const TypePtr& type) {
+  // Pointer comparison works since this type is a singleton.
+  return UuidType::get() == type;
+}
+
+FOLLY_ALWAYS_INLINE std::shared_ptr<const UuidType> UUID() {
+  return UuidType::get();
+}
+
+struct UuidT {
+  using type = StringView;
+  static constexpr const char* typeName = "uuid";
+};
+
+using Uuid = CustomType<UuidT>;
+
+class UuidTypeFactories : public CustomTypeFactories {
+ public:
+  TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+    return UUID();
+  }
+
+  exec::CastOperatorPtr getCastOperator() const override {
+    return nullptr;
+  }
+};
+
+} // namespace facebook::velox


### PR DESCRIPTION
This PR contains three changes:

- Add uuid() function for presto 
- Add a new UUID type
- Move getSignatureStrings() function to FunctionBaseTest for reuse
