### PR TITLE
Introduce LocalSingleRow helper class

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -29,8 +29,8 @@ void ConstantExpr::evalSpecialForm(
   if (needToSetIsAscii_) {
     auto* vector =
         sharedSubexprValues_->asUnchecked<SimpleVector<StringView>>();
-    LocalSelectivityVector singleRow(context);
-    bool isAscii = vector->computeAndSetIsAscii(*singleRow.get(1, true));
+    LocalSingleRow singleRow(context, 0);
+    bool isAscii = vector->computeAndSetIsAscii(*singleRow);
     vector->setAllIsAscii(isAscii);
     needToSetIsAscii_ = false;
   }

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -222,3 +222,34 @@ TEST_F(EvalCtxTest, constantWrapSaver) {
   }
   ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::FLAT);
 }
+
+TEST_F(EvalCtxTest, localSingleRow) {
+  EvalCtx context(&execCtx_);
+
+  {
+    LocalSingleRow singleRow(context, 0);
+    ASSERT_EQ(1, singleRow->size());
+    ASSERT_EQ(1, singleRow->countSelected());
+    ASSERT_TRUE(singleRow->isValid(0));
+  }
+
+  {
+    LocalSingleRow singleRow(context, 10);
+    ASSERT_EQ(11, singleRow->size());
+    ASSERT_EQ(1, singleRow->countSelected());
+    ASSERT_TRUE(singleRow->isValid(10));
+    for (auto i = 0; i < 10; ++i) {
+      ASSERT_FALSE(singleRow->isValid(i));
+    }
+  }
+
+  {
+    LocalSingleRow singleRow(context, 100);
+    ASSERT_EQ(101, singleRow->size());
+    ASSERT_EQ(1, singleRow->countSelected());
+    ASSERT_TRUE(singleRow->isValid(100));
+    for (auto i = 0; i < 100; ++i) {
+      ASSERT_FALSE(singleRow->isValid(i));
+    }
+  }
+}

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -59,11 +59,8 @@ class ArrayDistinctFunction : public exec::VectorFunction {
       const auto& flatArray = constantArray->valueVector();
       const auto flatIndex = constantArray->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyFlat(singleRow, flatArray, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -60,11 +60,8 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
       const auto& flatArray = constantArray->valueVector();
       const auto flatIndex = constantArray->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyFlat(singleRow, flatArray, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -185,11 +185,8 @@ class ArraySortFunction : public exec::VectorFunction {
       const auto& flatArray = constantArray->valueVector();
       const auto flatIndex = constantArray->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyFlat(singleRow, flatArray, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/prestosql/MapEntries.cpp
+++ b/velox/functions/prestosql/MapEntries.cpp
@@ -38,11 +38,8 @@ class MapEntriesFunction : public exec::VectorFunction {
       const auto& flatMap = constantMap->valueVector();
       const auto flatIndex = constantMap->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyFlat(singleRow, flatMap, outputType, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyFlat(*singleRow, flatMap, outputType, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -37,11 +37,8 @@ class MapKeyValueFunction : public exec::VectorFunction {
       const auto& flatMap = constantMap->valueVector();
       const auto flatIndex = constantMap->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyFlat(singleRow, flatMap, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyFlat(*singleRow, flatMap, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/prestosql/Reverse.cpp
+++ b/velox/functions/prestosql/Reverse.cpp
@@ -126,11 +126,8 @@ class ReverseFunction : public exec::VectorFunction {
       const auto& flatArray = constantArray->valueVector();
       const auto flatIndex = constantArray->index();
 
-      SelectivityVector singleRow(flatIndex + 1, false);
-      singleRow.setValid(flatIndex, true);
-      singleRow.updateBounds();
-
-      localResult = applyArrayFlat(singleRow, flatArray, context);
+      exec::LocalSingleRow singleRow(context, flatIndex);
+      localResult = applyArrayFlat(*singleRow, flatArray, context);
       localResult =
           BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
     } else {

--- a/velox/functions/sparksql/ArraySort.cpp
+++ b/velox/functions/sparksql/ArraySort.cpp
@@ -173,11 +173,8 @@ void ArraySort::apply(
     const auto& flatArray = constantArray->valueVector();
     const auto flatIndex = constantArray->index();
 
-    SelectivityVector singleRow(flatIndex + 1, false);
-    singleRow.setValid(flatIndex, true);
-    singleRow.updateBounds();
-
-    localResult = applyFlat(singleRow, flatArray, context);
+    exec::LocalSingleRow singleRow(context, flatIndex);
+    localResult = applyFlat(*singleRow, flatArray, context);
     localResult =
         BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
   } else {


### PR DESCRIPTION
There is a common use case of creating SelectivityVector with a single row
selected. Doing so requires at least 3 lines of code and more if reusing a
vector from the pool. It is also easy to forget to clear all rows when fetching
vector from the pool.

The new LocalSingleRow helper class produces a SelectivityVector with a 
single row selected using a pool of SelectivityVectors managed by the ExecCtx 
in a single line of code:

```
exec::LocalSingleRow singleRow(context, flatIndex);
```

vs. 

```
LocalSelectivityVector singleRow(context, flatIndex + 1);
singleRow->clearAll();
singleRow->setValid(flatIndex, true);
singleRow->updateBounds();
```