### PR TITLE
Fix crash when deserializing small KLL sketch

### DIFF
--- a/velox/functions/lib/KllSketch-inl.h
+++ b/velox/functions/lib/KllSketch-inl.h
@@ -733,7 +733,9 @@ KllSketch<T, A, C> KllSketch<T, A, C>::fromView(
   ans.items_.assign(view.items.begin(), view.items.end());
   ans.levels_.assign(view.levels.begin(), view.levels.end());
   ans.isLevelZeroSorted_ = std::is_sorted(
-      &ans.items_[ans.levels_[0]], &ans.items_[ans.levels_[1]], C());
+      ans.items_.data() + ans.levels_[0],
+      ans.items_.data() + ans.levels_[1],
+      C());
   return ans;
 }
 

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -266,6 +266,20 @@ TEST(KllSketchTest, deserialize) {
   }
 }
 
+TEST(KllSketchTest, deserializeSmall) {
+  constexpr int N = 128;
+  KllSketch<double> kll(kDefaultK, {}, 0);
+  insertRandomData(0, N, kll, nullptr);
+  kll.compact();
+  std::vector<char> data(kll.serializedByteSize());
+  kll.serialize(data.data());
+  auto kll2 = KllSketch<double>::deserialize(data.data());
+  auto q = linspace(N);
+  auto v = kll.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  auto v2 = kll2.estimateQuantiles(folly::Range(q.begin(), q.end()));
+  EXPECT_EQ(v, v2);
+}
+
 TEST(KllSketchTest, compact) {
   constexpr int N = 1e5;
   KllSketch<double> kll(kFromEpsilon(0.001));


### PR DESCRIPTION
Summary:
When level 0 is the only level, the boundary of `levels_[1]` is
pointing to the address after last element in `items_`.  The address is valid
but we cannot dereference the address.  Change to avoid the dereferencing.

Differential Revision: D42439261

