### PR TITLE
Set memory usage tracker on constructor

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -216,14 +216,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Returns the peak memory usage of this memory pool.
   virtual int64_t getMaxBytes() const = 0;
 
-  /// Tracks memory usage from leaf nodes to root and updates immediately
-  /// with atomic operations.
-  /// Unlike pool's getCurrentBytes(), getMaxBytes(), trace's API's returns
-  /// the aggregated usage of subtree. See 'ScopedChildUsageTest' for
-  /// difference in their behavior.
-  virtual void setMemoryUsageTracker(
-      const std::shared_ptr<MemoryUsageTracker>& tracker) = 0;
-
   /// Returns the memory usage tracker associated with this memory pool.
   virtual const std::shared_ptr<MemoryUsageTracker>& getMemoryUsageTracker()
       const = 0;
@@ -340,9 +332,6 @@ class MemoryPoolImpl : public MemoryPool {
 
   int64_t getMaxBytes() const override;
 
-  void setMemoryUsageTracker(
-      const std::shared_ptr<MemoryUsageTracker>& tracker) override;
-
   const std::shared_ptr<MemoryUsageTracker>& getMemoryUsageTracker()
       const override;
   int64_t updateSubtreeMemoryUsage(int64_t size) override;
@@ -382,13 +371,13 @@ class MemoryPoolImpl : public MemoryPool {
       std::function<void(const MemoryUsage&)> visitor) const;
   void updateSubtreeMemoryUsage(std::function<void(MemoryUsage&)> visitor);
 
+  const std::shared_ptr<MemoryUsageTracker> memoryUsageTracker_;
   MemoryManager* const memoryManager_;
   MemoryAllocator* const allocator_;
   const DestructionCallback destructionCb_;
 
   // Memory allocated attributed to the memory node.
   MemoryUsage localMemoryUsage_;
-  std::shared_ptr<MemoryUsageTracker> memoryUsageTracker_;
   mutable folly::SharedMutex subtreeUsageMutex_;
   MemoryUsage subtreeMemoryUsage_;
 };

--- a/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
+++ b/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
@@ -38,10 +38,6 @@ DEFINE_uint32(
     num_runs,
     32,
     "The number of benchmark runs and reports the average results");
-DEFINE_bool(
-    enable_memory_usage_tracker,
-    true,
-    "If true, set memory usage tracker in the memory pool to measure the memory usage track cost");
 
 using namespace facebook::velox;
 using namespace facebook::velox::memory;
@@ -62,9 +58,6 @@ class MemoryOperator {
             fmt::format("MemoryOperator{}", poolId_++),
             MemoryPool::Kind::kLeaf)) {
     rng_.seed(1234);
-    if (FLAGS_enable_memory_usage_tracker) {
-      pool_->setMemoryUsageTracker(tracker->addChild());
-    }
   }
 
   ~MemoryOperator() = default;

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -143,6 +143,10 @@ class QueryCtx : public Context {
     return queryId_;
   }
 
+  void testingOverrideMemoryPool(std::shared_ptr<memory::MemoryPool> pool) {
+    pool_ = std::move(pool);
+  }
+
  private:
   static Config* FOLLY_NONNULL getEmptyConfig() {
     static const std::unique_ptr<Config> kEmptyConfig =
@@ -154,9 +158,6 @@ class QueryCtx : public Context {
     if (pool_ == nullptr) {
       pool_ = memory::getProcessDefaultMemoryManager().getPool(
           QueryCtx::generatePoolName(queryId));
-    }
-    if (pool_->getMemoryUsageTracker() == nullptr) {
-      pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
     }
   }
 

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -130,12 +130,6 @@ class MockMemoryPool : public velox::memory::MemoryPool {
         name, kind, parent, memoryUsageTracker_->maxMemory());
   }
 
-  void setMemoryUsageTracker(
-      const std::shared_ptr<velox::memory::MemoryUsageTracker>& tracker)
-      override {
-    memoryUsageTracker_ = tracker;
-  }
-
   const std::shared_ptr<velox::memory::MemoryUsageTracker>&
   getMemoryUsageTracker() const override {
     return memoryUsageTracker_;

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -194,20 +194,6 @@ class Writer : public WriterBase {
       const WriterContext& context,
       size_t nextWriteSize) const;
 
-  // TODO: Remove this api next.
-  void setMemoryUsageTracker(
-      const std::shared_ptr<velox::memory::MemoryUsageTracker>& tracker) {
-    getContext()
-        .getMemoryPool(velox::dwrf::MemoryUsageCategory::DICTIONARY)
-        .setMemoryUsageTracker(tracker->addChild());
-    getContext()
-        .getMemoryPool(velox::dwrf::MemoryUsageCategory::GENERAL)
-        .setMemoryUsageTracker(tracker->addChild());
-    getContext()
-        .getMemoryPool(velox::dwrf::MemoryUsageCategory::OUTPUT_STREAM)
-        .setMemoryUsageTracker(tracker->addChild());
-  }
-
   // protected:
   bool overMemoryBudget(const WriterContext& context, size_t writeLength) const;
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -72,11 +72,6 @@ class WriterContext : public CompressionBufferPool {
     }
     validateConfigs();
     VLOG(1) << fmt::format("Compression config: {}", compression);
-    if (auto tracker = pool_->getMemoryUsageTracker()) {
-      dictionaryPool_->setMemoryUsageTracker(tracker->addChild());
-      outputStreamPool_->setMemoryUsageTracker(tracker->addChild());
-      generalPool_->setMemoryUsageTracker(tracker->addChild());
-    }
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         *generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -150,8 +150,11 @@ class ExchangeBenchmark : public VectorTestBase {
       int64_t maxMemory = kMaxMemory) {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), std::make_shared<core::MemConfig>(configSettings_));
-    queryCtx->pool()->setMemoryUsageTracker(
-        memory::MemoryUsageTracker::create(maxMemory));
+    queryCtx->testingOverrideMemoryPool(
+        memory::getProcessDefaultMemoryManager().getPool(
+            queryCtx->queryId(),
+            memory::MemoryPool::Kind::kAggregate,
+            maxMemory));
     core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
         taskId,

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -848,8 +848,11 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->pool()->setMemoryUsageTracker(
-        velox::memory::MemoryUsageTracker::create(kMaxBytes));
+    queryCtx->testingOverrideMemoryPool(
+        memory::getProcessDefaultMemoryManager().getPool(
+            queryCtx->queryId(),
+            memory::MemoryPool::Kind::kAggregate,
+            kMaxBytes));
     auto results = AssertQueryBuilder(
                        PlanBuilder()
                            .values(batches)
@@ -954,8 +957,11 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    queryCtx->pool()->setMemoryUsageTracker(
-        velox::memory::MemoryUsageTracker::create(kMaxBytes));
+    queryCtx->testingOverrideMemoryPool(
+        memory::getProcessDefaultMemoryManager().getPool(
+            queryCtx->queryId(),
+            memory::MemoryPool::Kind::kAggregate,
+            kMaxBytes));
 
     SCOPED_TESTVALUE_SET(
         "facebook::velox::exec::Spiller",
@@ -1075,8 +1081,11 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes));
+  queryCtx->testingOverrideMemoryPool(
+      memory::getProcessDefaultMemoryManager().getPool(
+          queryCtx->queryId(),
+          memory::MemoryPool::Kind::kAggregate,
+          kMaxBytes));
 
   auto task =
       AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -67,8 +67,11 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .orderBy({"c0"}, false)
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes));
+  queryCtx->testingOverrideMemoryPool(
+      memory::getProcessDefaultMemoryManager().getPool(
+          queryCtx->queryId(),
+          memory::MemoryPool::Kind::kAggregate,
+          kMaxBytes));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -111,8 +114,11 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .singleAggregation({"c0"}, {"sum(c1)"})
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  queryCtx->pool()->setMemoryUsageTracker(
-      velox::memory::MemoryUsageTracker::create(kMaxBytes));
+  queryCtx->testingOverrideMemoryPool(
+      memory::getProcessDefaultMemoryManager().getPool(
+          queryCtx->queryId(),
+          memory::MemoryPool::Kind::kAggregate,
+          kMaxBytes));
 
   const int32_t numDrivers = 10;
   CursorParameters params;

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -50,8 +50,11 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       int64_t maxMemory = kMaxMemory) {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), std::make_shared<core::MemConfig>(configSettings_));
-    queryCtx->pool()->setMemoryUsageTracker(
-        MemoryUsageTracker::create(maxMemory));
+    queryCtx->testingOverrideMemoryPool(
+        memory::getProcessDefaultMemoryManager().getPool(
+            queryCtx->queryId(),
+            memory::MemoryPool::Kind::kAggregate,
+            maxMemory));
     core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
         taskId,

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -32,9 +32,6 @@ class ExprStatsTest : public functions::test::FunctionBaseTest {
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();
-
-    pool_->setMemoryUsageTracker(tracker_->addChild());
-
     // Enable CPU usage tracking.
     queryCtx_->setConfigOverridesUnsafe({
         {core::QueryConfig::kExprTrackCpuUsage, "true"},

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -891,7 +891,6 @@ TEST_F(SimpleFunctionTest, cseDisabledFuncWithInput) {
 
 TEST_F(SimpleFunctionTest, reuseArgVector) {
   std::mt19937 rng;
-  pool_->setMemoryUsageTracker(tracker_->addChild());
 
   vector_size_t size = 256;
   auto data = makeRowVector({

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -88,3 +88,10 @@ DEFINE_string(
     "expression evaluation. Specifies the directory to use for storing the "
     "vectors and expression SQL strings. This flag is ignored if "
     "velox_save_input_on_expression_any_failure_path is set.");
+
+// TODO: deprecate this once all the memory leak issues have been fixed in
+// existing meta internal use cases.
+DEFINE_bool(
+    velox_memory_leak_check_enabled,
+    true,
+    "If true, check fails on any memory leaks in memory pool and memory manager");

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -48,10 +48,7 @@ void assertCopyableVector(const VectorPtr& vector);
 
 class VectorTestBase {
  protected:
-  VectorTestBase() {
-    pool_->parent()->setMemoryUsageTracker(tracker_);
-    pool_->setMemoryUsageTracker(tracker_->addChild());
-  }
+  VectorTestBase() = default;
 
   ~VectorTestBase();
 
@@ -739,12 +736,10 @@ class VectorTestBase {
     return pool_.get();
   }
 
-  std::shared_ptr<memory::MemoryUsageTracker> tracker_{
-      memory::MemoryUsageTracker::create()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
-  velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<memory::MemoryPool> rootPool_{
       memory::getProcessDefaultMemoryManager().getPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addChild("leaf")};
+  velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};


### PR DESCRIPTION
Set memory usage tracker in memory pool constructor and deprecate
set memory usage tracker API to enforce setting the memory usage tracker.
This paves way for the followup merge the memory usage tracker into the
memory pool. Also set the default memory pool with unlimited quota as it is
used for critical system purpose such as disk spilling. Note the physical OOM
prevention is enforced by the memory manager which has tracked all the
memory allocations go through the memory pools.