### PR TITLE
Fix compilation error on gcc 8.x

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -580,26 +580,28 @@ class SimpleFunctionAdapter : public VectorFunction {
         // once per batch instead of once per row shows a significant
         // performance improvement when there are no nulls.
         if (applyContext.mayHaveNullsRecursive) {
-          applyContext.applyToSelectedNoThrow([&, this](auto row) INLINE_LAMBDA {
-            typename return_type_traits::NativeType out{};
-            auto containsNull = (readers.containsNull(row) || ...);
-            bool notNull;
-            if (containsNull) {
-              // Result is NULL because the input contains NULL.
-              notNull = false;
-            } else {
-              notNull = doApplyNullFree<0>(row, out, readers...);
-            }
+          applyContext.applyToSelectedNoThrow(
+              [&, this](auto row) INLINE_LAMBDA {
+                typename return_type_traits::NativeType out{};
+                auto containsNull = (readers.containsNull(row) || ...);
+                bool notNull;
+                if (containsNull) {
+                  // Result is NULL because the input contains NULL.
+                  notNull = false;
+                } else {
+                  notNull = doApplyNullFree<0>(row, out, readers...);
+                }
 
-            writeResult(row, notNull, out);
-          });
+                writeResult(row, notNull, out);
+              });
         } else {
-          applyContext.applyToSelectedNoThrow([&, this](auto row) INLINE_LAMBDA {
-            typename return_type_traits::NativeType out{};
-            bool notNull = doApplyNullFree<0>(row, out, readers...);
+          applyContext.applyToSelectedNoThrow(
+              [&, this](auto row) INLINE_LAMBDA {
+                typename return_type_traits::NativeType out{};
+                bool notNull = doApplyNullFree<0>(row, out, readers...);
 
-            writeResult(row, notNull, out);
-          });
+                writeResult(row, notNull, out);
+              });
         }
       } else if (allNotNull) {
         applyContext.applyToSelectedNoThrow([&, this](auto row) INLINE_LAMBDA {


### PR DESCRIPTION
Compiling Velox on GCC 8.x (e.g. Debian 10 used in Google's Dataproc) results in an Internal Compiler Error:
```
/home/user/gluten/ep/build-velox/build/velox_ep/./velox/expression/SimpleFunctionAdapter.h:591:23: internal compiler error: trying to capture ‘this’ in instantiation of generic lambda
               notNull = doApplyNullFree<0>(row, out, readers...);
               ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This PR modifies the relevant file to avoid this error.
