### PR TITLE
Fix logging of stats in fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -837,11 +837,14 @@ void ExpressionFuzzer::logStats() {
   LOG(INFO)
       << "Format: functionName numTimesSelected proportionOfTimesSelected "
          "numProcessedRows";
-  for (int i = entries.size() - 1; i >= entries.size() - maxEntriesLimit; i--) {
-    LOG(INFO) << entries[i].first << " " << entries[i].second.numTimesSelected
-              << " " << std::fixed << std::setprecision(2)
-              << (entries[i].second.numTimesSelected * 100.00) / totalSelections
-              << "% " << entries[i].second.numProcessedRows;
+  for (int i = 0; i < maxEntriesLimit; i++) {
+    int idx = entries.size() - 1 - i;
+    LOG(INFO) << entries[idx].first << " "
+              << entries[idx].second.numTimesSelected << " " << std::fixed
+              << std::setprecision(2)
+              << (entries[idx].second.numTimesSelected * 100.00) /
+            totalSelections
+              << "% " << entries[idx].second.numProcessedRows;
   }
 
   // sort by numTimesSelected


### PR DESCRIPTION
Summary:
This fixes a bug in the implementation for logging stats where the
termination condition of a for loop was not evaluated correctly due
to an implicit conversion of signed to unsigned long, that is, the
following (signed) -1 >= (unsigned) 0 evaluates to true because
before the comparison is executed, the signed -1 gets casted directly
into unsigned resulting in a value of 18446744073709551615.

Fixes: #3685

Differential Revision: D42464943

