### PR TITLE
Check return value of gmtime_r

### DIFF
--- a/velox/docs/functions/datetime.rst
+++ b/velox/docs/functions/datetime.rst
@@ -143,6 +143,11 @@ Convenience Extraction Functions
 
 These functions support TIMESTAMP, DATE, and TIMESTAMP WITH TIME ZONE input types.
 
+These functions are implemented using
+`std::gmtime <https://en.cppreference.com/w/c/chrono/gmtime>`_ which raises an
+error when input timestamp is too large (for example, > 100'000'000'000'000'000).
+This behavior is different from Presto Java that allows arbitrary large timestamps.
+
 .. function:: day(x) -> bigint
 
     Returns the day of the month from ``x``.
@@ -196,7 +201,8 @@ These functions support TIMESTAMP, DATE, and TIMESTAMP WITH TIME ZONE input type
 .. function:: week(x) -> bigint
 
     Returns the `ISO-Week`_ of the year from x. The value ranges from ``1`` to ``53``.
-    .. _ISO-Week: https://en.wikipedia.org/wiki/ISO_week_date
+
+.. _ISO-Week: https://en.wikipedia.org/wiki/ISO_week_date
 
 .. function:: week_of_year(x) -> bigint
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -92,7 +92,10 @@ FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
   std::tm dateTime;
-  gmtime_r((const time_t*)&seconds, &dateTime);
+  VELOX_USER_CHECK_NOT_NULL(
+      gmtime_r((const time_t*)&seconds, &dateTime),
+      "Timestamp is too large: {} seconds since epoch",
+      seconds);
   return dateTime;
 }
 
@@ -100,7 +103,10 @@ FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Date date) {
   int64_t seconds = date.days() * kSecondsInDay;
   std::tm dateTime;
-  gmtime_r((const time_t*)&seconds, &dateTime);
+  VELOX_USER_CHECK_NOT_NULL(
+      gmtime_r((const time_t*)&seconds, &dateTime),
+      "Date is too large: {} days",
+      date.days());
   return dateTime;
 }
 


### PR DESCRIPTION
Make sure to check the result of gmtime_r. This function doesn't throw, but
returns nullptr to indicate failure to fill in the std::tm struct. Without
checking for return value, we may return std::tm with garbage and cause
non-deterministic behavior.

Fixes #3690 caused by week() function being called on an invalid value of
Timestamp and ending up working with uninitialized std::tm struct.

This change affects functions year, quarter, month, week, day, dow, doy, 
yow, hour, minute, second and date_trunc. These function will now throw 
an exception if input timestamp is too large 
(for example, > 100'000'000'000'000'000).

Note that this change represents a divergence from Presto Java which doesn't 
fail when input timestamp is large. Velox implementation will throw an error on 
such input.

```
presto> select from_unixtime(1667889514952985088);
             _col0
-------------------------------
 +292278994-08-17 00:12:55.807
(1 row)

presto> select week(from_unixtime(1667889514952985088));
 _col0
-------
     1
(1 row)
```