### PR TITLE
Fix the set of rows passed to context.saveAndReset in Expr::applyFunctionWithPeeling

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -312,6 +312,20 @@ void Expr::evalSimplifiedImpl(
     }
   }
 
+  // If any errors occurred evaluating the arguments, its possible that the
+  // values for those arguments were not defined which can lead to undefined
+  // behavior if we try and evauate current function on them. The value for this
+  // subexpression should be NULL for these rows and thus can be safely skipped.
+  if (context.errors()) {
+    context.deselectErrors(remainingRows);
+    if (!remainingRows.hasSelections()) {
+      releaseInputValues(context);
+      result =
+          BaseVector::createNullConstant(type(), rows.size(), context.pool());
+      return;
+    }
+  }
+
   // Apply the actual function.
   try {
     vectorFunction_->apply(

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -130,6 +130,37 @@ TEST_F(TryExprTest, nestedTryParentErrors) {
       result);
 }
 
+TEST_F(TryExprTest, skipExecutionEvalSimplified) {
+  registerFunction<CountCallsFunction, int64_t, int64_t>(
+      {"count_calls"}, BIGINT());
+
+  // Test that when a subset of the inputs to a function wrapped in a TRY throw
+  // exceptions, that function is only evaluated on the inputs that did not
+  // throw exceptions.
+  std::vector<std::optional<int64_t>> expected{
+      0, std::nullopt, 1, std::nullopt, 2};
+  auto flatVector = makeFlatVector<StringView>({"1", "a", "1", "a", "1"});
+  auto result = evaluateSimplified<FlatVector<int64_t>>(
+      "try(count_calls(cast(c0 as integer)))", makeRowVector({flatVector}));
+
+  assertEqualVectors(makeNullableFlatVector(expected), result);
+}
+
+TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
+  registerFunction<CountCallsFunction, int64_t, int64_t>(
+      {"count_calls"}, BIGINT());
+
+  // Test that when all the inputs to a function wrapped in a TRY throw
+  // exceptions, that function isn't evaluated and a NULL constant is returned
+  // directly.
+  std::vector<std::optional<int64_t>> expected(3, std::nullopt);
+  auto flatVector = makeFlatVector<StringView>({"a", "b", "c"});
+  auto result = evaluateSimplified<ConstantVector<int64_t>>(
+      "try(count_calls(cast(c0 as integer)))", makeRowVector({flatVector}));
+
+  assertEqualVectors(makeNullableFlatVector(expected), result);
+}
+
 namespace {
 // A function that sets result to be a ConstantVector and then throws an
 // exception.

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -98,6 +98,15 @@ BufferPtr VectorTestBase::makeNulls(
   return nulls;
 }
 
+BufferPtr VectorTestBase::makeNulls(const std::vector<bool>& values) {
+  auto nulls = allocateNulls(values.size(), pool());
+  auto rawNulls = nulls->asMutable<uint64_t>();
+  for (auto i = 0; i < values.size(); i++) {
+    bits::setNull(rawNulls, i, values[i]);
+  }
+  return nulls;
+}
+
 void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual) {
   ASSERT_EQ(expected->size(), actual->size());
   ASSERT_TRUE(expected->type()->equivalent(*actual->type()))

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -648,6 +648,9 @@ class VectorTestBase {
       vector_size_t size,
       std::function<bool(vector_size_t /*row*/)> isNullAt);
 
+  /// Creates a null buffer from a vector of booleans.
+  BufferPtr makeNulls(const std::vector<bool>& values);
+
   static VectorPtr
   wrapInDictionary(BufferPtr indices, vector_size_t size, VectorPtr vector);
 


### PR DESCRIPTION

Consider an expression like below:
 ```
 Expr:   try(is_null(cast(c0 as integer)))
 where c0 => [DICTIONARY VARCHAR: 10 elements, 3 nulls], [CONSTANT VARCHAR: 10 elements, abc]
 ```
Here `cast` will throw when attempting to cast a string to a number and is_null should return true for every null row _without_ an exception. 

In this case then we expect that the expression should return a vector of 10 elements with 3 trues corresponding to the nulls. However in the common path we find that it returns an all null vector. 

This is because , after peeling we only evaluate the constant vector once , which throws an exception, but when we save state in ScopedContextSaver, instead of only saving the rows on which we need to apply the function (i.e all non-null rows), we save _all_ rows. The error context then presumes that all rows threw an exception , which is wrong. 
We fix this by ensuring that VectorSaver only saves the applied rows. 
Fixes : #3682
