### PR TITLE
Fix race condition between task terminate and noMoreSplit calls

### DIFF
--- a/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
+++ b/velox/common/memory/tests/MemoryUsageTrackerTest.cpp
@@ -488,7 +488,7 @@ class MemoryUsageTrackTester {
     switch (op) {
       case 0: {
         // update increase.
-        const int64_t updateBytes = folly::Random().rand32() % maxMemory_;
+        const int64_t updateBytes = folly::Random().rand32() % maxMemory_ / 32;
         try {
           tracker_.update(updateBytes);
         } catch (VeloxException& e) {
@@ -544,9 +544,9 @@ class MemoryUsageTrackTester {
 
 TEST_F(MemoryUsageTrackerTest, concurrentUpdateToDifferentPools) {
   constexpr int64_t kMB = 1 << 20;
-  constexpr int64_t kMaxMemory = 10 * kMB;
+  constexpr int64_t kMaxMemory = 32 * kMB;
   auto parent = memory::MemoryUsageTracker::create(kMaxMemory);
-  const int32_t kNumThreads = 10;
+  const int32_t kNumThreads = 5;
   // Create one memory tracker per each thread.
   std::vector<std::shared_ptr<MemoryUsageTracker>> childTrackers;
   for (int32_t i = 0; i < kNumThreads; ++i) {
@@ -556,7 +556,7 @@ TEST_F(MemoryUsageTrackerTest, concurrentUpdateToDifferentPools) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1234);
 
-  const int32_t kNumOpsPerThread = 50'000;
+  const int32_t kNumOpsPerThread = 2'000;
   std::vector<std::thread> threads;
   threads.reserve(kNumThreads);
   for (size_t i = 0; i < kNumThreads; ++i) {
@@ -593,9 +593,9 @@ TEST_F(MemoryUsageTrackerTest, concurrentUpdatesToTheSamePool) {
   for (const bool concurrentLevel : concurrentLevels) {
     SCOPED_TRACE(fmt::format("concurrentLevel:{}", concurrentLevel));
     constexpr int64_t kMB = 1 << 20;
-    constexpr int64_t kMaxMemory = 10 * kMB;
+    constexpr int64_t kMaxMemory = 32 * kMB;
     auto parent = memory::MemoryUsageTracker::create(kMaxMemory);
-    const int32_t kNumThreads = 10;
+    const int32_t kNumThreads = 5;
     const int32_t kNumChildPools = 2;
     std::vector<std::shared_ptr<MemoryUsageTracker>> childTrackers;
     if (concurrentLevel == 1) {
@@ -607,7 +607,7 @@ TEST_F(MemoryUsageTrackerTest, concurrentUpdatesToTheSamePool) {
     folly::Random::DefaultGenerator rng;
     rng.seed(1234);
 
-    const int32_t kNumOpsPerThread = 50'000;
+    const int32_t kNumOpsPerThread = 2'000;
     std::vector<std::thread> threads;
     threads.reserve(kNumThreads);
     for (size_t i = 0; i < kNumThreads; ++i) {

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -323,8 +323,10 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     } else if (
         auto exchangeNode =
             std::dynamic_pointer_cast<const core::ExchangeNode>(planNode)) {
+      // NOTE: the exchange client can only be used by one operator in a driver.
+      VELOX_CHECK_NOT_NULL(exchangeClient);
       operators.push_back(std::make_unique<Exchange>(
-          id, ctx.get(), exchangeNode, exchangeClient));
+          id, ctx.get(), exchangeNode, std::move(exchangeClient)));
     } else if (
         auto partitionedOutputNode =
             std::dynamic_pointer_cast<const core::PartitionedOutputNode>(

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -100,7 +100,6 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
 }
 
 bool Merge::isFinished() {
-  TestValue::adjust("facebook::velox::exec::Merge::isFinished", &finished_);
   return finished_;
 }
 

--- a/velox/exec/Split.h
+++ b/velox/exec/Split.h
@@ -23,7 +23,7 @@ struct Split {
   std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit;
   int32_t groupId{-1}; // Bucketed group id (-1 means 'none').
 
-  Split() {}
+  Split() = default;
 
   explicit Split(
       std::shared_ptr<velox::connector::ConnectorSplit>&& connectorSplit,

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -649,8 +649,6 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
   // Set up the test value to generate the race condition that the output
   // pipeline finishes early and terminate the task while the input pipeline
   // driver is running on thread.
-  ContinuePromise mergePromise("mergePromise");
-  ContinueFuture mergeFuture = mergePromise.getSemiFuture();
   ContinuePromise valuePromise("mergePromise");
   ContinueFuture valueFuture = valuePromise.getSemiFuture();
   ContinuePromise driverPromise("driverPromise");
@@ -663,26 +661,8 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
         if (*outputIdx != 1) {
           return;
         }
-        mergePromise.setValue();
         std::move(valueFuture).wait();
         driverPromise.setValue();
-      })));
-
-  SCOPED_TESTVALUE_SET(
-      "facebook::velox::exec::Merge::isFinished",
-      std::function<void(const bool*)>(([&](const bool* isFinished) {
-        // Only wait for the value operator running after the merge operator is
-        // finished.
-        if (!*isFinished) {
-          return;
-        }
-
-        // There will be only one merge driver thread because of the limit node
-        // on the output pipeline so there is no race to access mergeFuture.
-        ContinueFuture future = std::move(mergeFuture);
-        if (future.valid()) {
-          future.wait();
-        }
       })));
 
   CursorParameters params;
@@ -690,9 +670,21 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
   params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
       {{core::QueryConfig::kPreferredOutputBatchSize, "1"}});
-  auto task = assertQueryOrdered(params, "VALUES (0)", {0});
-  ASSERT_TRUE(waitForTaskCompletion(task.get(), 1'000'000));
-  task.reset();
+
+  {
+    auto cursor = std::make_unique<TaskCursor>(params);
+    std::vector<RowVectorPtr> result;
+    auto* task = cursor->task().get();
+    while (cursor->moveNext()) {
+      result.push_back(cursor->current());
+    }
+    assertResults(
+        result,
+        params.planNode->outputType(),
+        "VALUES (0)",
+        duckDbQueryRunner_);
+    ASSERT_TRUE(waitForTaskStateChange(task, TaskState::kFinished, 3'000'000));
+  }
   valuePromise.setValue();
   // Wait for Values driver to complete.
   driverFuture.wait();

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -119,6 +119,24 @@ bool waitForTaskCompletion(
     exec::Task* task,
     uint64_t maxWaitMicros = 1'000'000);
 
+/// Similar to waitForTaskCompletion but wait for the task to fail.
+bool waitForTaskFailure(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
+
+/// Wait up to maxWaitMicros for 'task' state changes to 'state'. The function
+/// returns true if 'task' has changed to the expected 'state', otherwise false.
+bool waitForTaskStateChange(
+    exec::Task* task,
+    TaskState state,
+    uint64_t maxWaitMicros = 1'000'000);
+
+/// Wait up to maxWaitMicros for all the task drivers to finish. The function
+/// returns true if all the drivers have finished, otherwise false.
+///
+/// NOTE: user must call this on a finished or failed task.
+bool waitForTaskDriversToFinish(
+    exec::Task* task,
+    uint64_t maxWaitMicros = 1'000'000);
+
 std::shared_ptr<Task> assertQuery(
     const std::shared_ptr<const core::PlanNode>& plan,
     const std::string& duckDbSql,


### PR DESCRIPTION
We found the following race condition in Meta internal Prestissimo workload
shadowing that can cause segment fault:
T1: task terminate triggered by task error.
T2: task terminate collects all the pending remote splits under the task lock.
T3: task terminate release the lock to handle the pending remote splits.
T4: no more split call get invoked and erase the exchange client since the task
       is not running.
T5: task terminate processes the pending remote splits by accessing the
      associated exchange client and run into segment fault.

This PR fixes the issue by keeping exchange client in no more split call as the
exchange client must have been closed at that point . And verify the fix with unit
test. This PR also makes the exchange client access thread-safe in task.