### PR TITLE
make velox compile at GCC 11.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,7 +264,8 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-unused-result \
          -Wno-format-overflow \
          -Wno-strict-aliasing \
-         -Wno-type-limits")
+         -Wno-type-limits \
+         -Wno-stringop-overflow")
   endif()
 
   set(KNOWN_WARNINGS


### PR DESCRIPTION
Fix issue when compile velox on gcc 11.3. https://github.com/facebookincubator/velox/issues/3713 