### PR TITLE
Fix unstable sorted result

### DIFF
--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -246,7 +246,7 @@ void OrderBy::noMoreInput() {
     returningRows_.resize(numRows_);
     RowContainerIterator iter;
     data_->listRows(&iter, numRows_, returningRows_.data());
-    std::sort(
+    std::stable_sort(
         returningRows_.begin(),
         returningRows_.end(),
         [this](const char* leftRow, const char* rightRow) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -251,44 +251,44 @@ TEST_F(OrderByTest, singleKeyStableSort) {
   vector_size_t batchSize = 1000;
   std::vector<RowVectorPtr> vectors;
 
-  auto c0 = makeFlatVector<std::string>(
-      {"Accounting",
-       "Accounting",
-       "Accounting",
-       "Accounting",
-       "Accounting",
-       "Accounting",
-       "IT",
-       "IT",
-       "SCM",
-       "SCM",
-       "SCM",
-       "SCM",
-       "SCM",
-       "Sales",
-       "Sales",
-       "Sales",
-       "Sales",
-       });
-  auto c1 = makeFlatVector<std::string>(
-      {"11472",
-       "9998",
-       "8992",
-       "8870",
-       "8435",
-       "6627",
-       "8113",
-       "5186",
-       "11798",
-       "11303",
-       "10586",
-       "10449",
-       "6949",
-       "10563",
-       "9441",
-       "9181",
-       "6660",
-       });
+  auto c0 = makeFlatVector<std::string>({
+      "Accounting",
+      "Accounting",
+      "Accounting",
+      "Accounting",
+      "Accounting",
+      "Accounting",
+      "IT",
+      "IT",
+      "SCM",
+      "SCM",
+      "SCM",
+      "SCM",
+      "SCM",
+      "Sales",
+      "Sales",
+      "Sales",
+      "Sales",
+  });
+  auto c1 = makeFlatVector<std::string>({
+      "11472",
+      "9998",
+      "8992",
+      "8870",
+      "8435",
+      "6627",
+      "8113",
+      "5186",
+      "11798",
+      "11303",
+      "10586",
+      "10449",
+      "6949",
+      "10563",
+      "9441",
+      "9181",
+      "6660",
+  });
   vectors.push_back(makeRowVector({c0, c1}));
   createDuckDbTable(vectors);
 
@@ -299,7 +299,8 @@ TEST_F(OrderByTest, singleKeyStableSort) {
                   .capturePlanNodeId(orderById)
                   .planNode();
 
-  assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+  assertQueryOrdered(
+      plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
 }
 
 TEST_F(OrderByTest, multipleKeys) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -247,6 +247,61 @@ TEST_F(OrderByTest, singleKey) {
   runTest(plan, orderById, "SELECT * FROM tmp ORDER BY c0 NULLS FIRST", {0});
 }
 
+TEST_F(OrderByTest, singleKeyStableSort) {
+  vector_size_t batchSize = 1000;
+  std::vector<RowVectorPtr> vectors;
+
+  auto c0 = makeFlatVector<std::string>(
+      {"Accounting",
+       "Accounting",
+       "Accounting",
+       "Accounting",
+       "Accounting",
+       "Accounting",
+       "IT",
+       "IT",
+       "SCM",
+       "SCM",
+       "SCM",
+       "SCM",
+       "SCM",
+       "Sales",
+       "Sales",
+       "Sales",
+       "Sales",
+       });
+  auto c1 = makeFlatVector<std::string>(
+      {"11472",
+       "9998",
+       "8992",
+       "8870",
+       "8435",
+       "6627",
+       "8113",
+       "5186",
+       "11798",
+       "11303",
+       "10586",
+       "10449",
+       "6949",
+       "10563",
+       "9441",
+       "9181",
+       "6660",
+       });
+  vectors.push_back(makeRowVector({c0, c1}));
+  createDuckDbTable(vectors);
+
+  core::PlanNodeId orderById;
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .orderBy({"c0 DESC NULLS LAST"}, false)
+                  .capturePlanNodeId(orderById)
+                  .planNode();
+
+  assertQueryOrdered(plan, "SELECT * FROM tmp ORDER BY c0 DESC NULLS LAST", {0});
+}
+
 TEST_F(OrderByTest, multipleKeys) {
   vector_size_t batchSize = 1000;
   std::vector<RowVectorPtr> vectors;


### PR DESCRIPTION
Issue is exposed from https://github.com/oap-project/gluten/issues/858

**Describe the bug**
Now Velox OrderBy operator use std::sort for sorting keys. 
The order of equal elements is not guaranteed to be preserved. 
So sometimes the sorted result is not expected.

For example:
The input data:

```
+-----------------+----------+------+---------------+---------------------+
|    employee_name|department|salary| highest_salary|second_highest_salary|
+-----------------+----------+------+---------------+---------------------+
|    Gerard Bondur|Accounting| 11472|  Gerard Bondur|       Mary Patterson|
|   Mary Patterson|Accounting|  9998|  Gerard Bondur|       Mary Patterson|
|    Jeff Firrelli|Accounting|  8992|  Gerard Bondur|       Mary Patterson|
|William Patterson|Accounting|  8870|  Gerard Bondur|       Mary Patterson|
|     Diane Murphy|Accounting|  8435|  Gerard Bondur|       Mary Patterson|
|      Anthony Bow|Accounting|  6627|  Gerard Bondur|       Mary Patterson|
|  Leslie Jennings|        IT|  8113|Leslie Jennings|      Leslie Thompson|
|  Leslie Thompson|        IT|  5186|Leslie Jennings|      Leslie Thompson|
|       Larry Bott|       SCM| 11798|     Larry Bott|      Pamela Castillo|
|  Pamela Castillo|       SCM| 11303|     Larry Bott|      Pamela Castillo|
|      Barry Jones|       SCM| 10586|     Larry Bott|      Pamela Castillo|
|      Loui Bondur|       SCM| 10449|     Larry Bott|      Pamela Castillo|
| Gerard Hernandez|       SCM|  6949|     Larry Bott|      Pamela Castillo|
|    George Vanauf|     Sales| 10563|  George Vanauf|      Steve Patterson|
|  Steve Patterson|     Sales|  9441|  George Vanauf|      Steve Patterson|
|   Julie Firrelli|     Sales|  9181|  George Vanauf|      Steve Patterson|
|   Foon Yue Tseng|     Sales|  6660|  George Vanauf|      Steve Patterson|
+-----------------+----------+------+---------------+---------------------+
```

The sort key is  "department" column,
Velox will output  result as below

```
+-----------------+----------+------+---------------+---------------------+
|    employee_name|department|salary| highest_salary|second_highest_salary|
+-----------------+----------+------+---------------+---------------------+
|   Mary Patterson|Accounting|  9998|  Gerard Bondur|       Mary Patterson|
|    Jeff Firrelli|Accounting|  8992|  Gerard Bondur|       Mary Patterson|
|William Patterson|Accounting|  8870|  Gerard Bondur|       Mary Patterson|
|     Diane Murphy|Accounting|  8435|  Gerard Bondur|       Mary Patterson|
|      Anthony Bow|Accounting|  6627|  Gerard Bondur|       Mary Patterson|
|    Gerard Bondur|Accounting| 11472|  Gerard Bondur|       Mary Patterson|
|  Leslie Jennings|        IT|  8113|Leslie Jennings|      Leslie Thompson|
|  Leslie Thompson|        IT|  5186|Leslie Jennings|      Leslie Thompson|
|       Larry Bott|       SCM| 11798|     Larry Bott|      Pamela Castillo|
| Gerard Hernandez|       SCM|  6949|     Larry Bott|      Pamela Castillo|
|      Loui Bondur|       SCM| 10449|     Larry Bott|      Pamela Castillo|
|      Barry Jones|       SCM| 10586|     Larry Bott|      Pamela Castillo|
|  Pamela Castillo|       SCM| 11303|     Larry Bott|      Pamela Castillo|
|    George Vanauf|     Sales| 10563|  George Vanauf|      Steve Patterson|
|  Steve Patterson|     Sales|  9441|  George Vanauf|      Steve Patterson|
|   Julie Firrelli|     Sales|  9181|  George Vanauf|      Steve Patterson|
|   Foon Yue Tseng|     Sales|  6660|  George Vanauf|      Steve Patterson|
+-----------------+----------+------+---------------+---------------------+
```
The rows order is shuffled. And the expected result is leave the rows order unchanged.

**Solution**
A quick fix is using std::stable_sort instead of std::sort.
