### PR TITLE
Fix null filter pushdown for ARRAY and MAP

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -54,7 +54,7 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
       const uint64_t* FOLLY_NULLABLE nulls) = 0;
 
   // Create row set for child columns based on the row set of parent column.
-  void makeNestedRowSet(RowSet rows);
+  void makeNestedRowSet(RowSet rows, int32_t maxRow);
 
   // Compact the output rows (along with the offsets and lengths) based on the
   // current filtered rows passed in.
@@ -93,6 +93,10 @@ class SelectiveListColumnReader : public SelectiveRepeatedColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec);
+
+  void resetFilterCaches() override {
+    child_->resetFilterCaches();
+  }
 
   uint64_t skip(uint64_t numValues) override;
 

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -486,6 +486,12 @@ SubfieldFilters FilterGenerator::makeSubfieldFilters(
       case TypeKind::ROW:
         stats = makeStats<TypeKind::ROW>(vector->type(), rowType_);
         break;
+      case TypeKind::ARRAY:
+        stats = makeStats<TypeKind::ARRAY>(vector->type(), rowType_);
+        break;
+      case TypeKind::MAP:
+        stats = makeStats<TypeKind::MAP>(vector->type(), rowType_);
+        break;
       // TODO:
       // Add support for TypeKind::TIMESTAMP.
       case TypeKind::SHORT_DECIMAL:

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -448,6 +448,20 @@ inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ROW>(
   return std::make_unique<ComplexColumnStats>(type, rootType);
 }
 
+template <>
+inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::ARRAY>(
+    TypePtr type,
+    RowTypePtr rootType) {
+  return std::make_unique<ComplexColumnStats>(type, rootType);
+}
+
+template <>
+inline std::unique_ptr<AbstractColumnStats> makeStats<TypeKind::MAP>(
+    TypePtr type,
+    RowTypePtr rootType) {
+  return std::make_unique<ComplexColumnStats>(type, rootType);
+}
+
 class FilterGenerator {
  public:
   static std::string specsToString(const std::vector<FilterSpec>& specs);

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -293,7 +293,7 @@ TEST_F(E2EFilterTest, listAndMap) {
       "map_val:map<bigint,struct<nested_map: map<int, int>>>",
       [&]() {},
       true,
-      {"long_val", "long_val_2", "int_val"},
+      {"long_val", "long_val_2", "int_val", "array_val", "map_val"},
       numCombinations);
 }
 

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -201,6 +201,14 @@ void MapColumnReader::read(
   elementReader_->seekTo(childTargetReadOffset_, false);
 }
 
+void MapColumnReader::filterRowGroups(
+    uint64_t rowGroupSize,
+    const dwio::common::StatsContext& context,
+    dwio::common::FormatData::FilterRowGroupsResult& result) const {
+  keyReader_->filterRowGroups(rowGroupSize, context, result);
+  elementReader_->filterRowGroups(rowGroupSize, context, result);
+}
+
 ListColumnReader::ListColumnReader(
     std::shared_ptr<const dwio::common::TypeWithId> requestedType,
     ParquetParams& params,
@@ -286,6 +294,13 @@ void ListColumnReader::read(
   // repdefs will be scanned and new lengths provided, overwriting the
   // previous ones before the next read().
   child_->seekTo(childTargetReadOffset_, false);
+}
+
+void ListColumnReader::filterRowGroups(
+    uint64_t rowGroupSize,
+    const dwio::common::StatsContext& context,
+    dwio::common::FormatData::FilterRowGroupsResult& result) const {
+  child_->filterRowGroups(rowGroupSize, context, result);
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -96,6 +96,11 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
   /// supplied before receiving new lengths.
   void skipUnreadLengths();
 
+  void filterRowGroups(
+      uint64_t rowGroupSize,
+      const dwio::common::StatsContext&,
+      dwio::common::FormatData::FilterRowGroupsResult&) const override;
+
  private:
   RepeatedLengths lengths_;
   RepeatedLengths keyLengths_;
@@ -145,6 +150,11 @@ class ListColumnReader : public dwio::common::SelectiveListColumnReader {
   /// end at different positions. Repeated children must use all lengths
   /// supplied before receiving new lengths.
   void skipUnreadLengths();
+
+  void filterRowGroups(
+      uint64_t rowGroupSize,
+      const dwio::common::StatsContext&,
+      dwio::common::FormatData::FilterRowGroupsResult&) const override;
 
  private:
   RepeatedLengths lengths_;

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -472,7 +472,7 @@ TEST_F(E2EFilterTest, list) {
       "struct_array: struct<a: array<struct<k:int, v:int, va: array<smallint>>>>",
       nullptr,
       false,
-      {"long_val"},
+      {"long_val", "array_val"},
       10);
 }
 
@@ -493,7 +493,7 @@ TEST_F(E2EFilterTest, map) {
       "struct_map: struct<m: map<int, struct<k:int, v:int, vm: map<bigint, smallint>>>>",
       nullptr,
       false,
-      {"long_val"},
+      {"long_val", "map_val"},
       10);
 }
 


### PR DESCRIPTION
Summary: We are not generating null filters in E2E filter tests for ARRAY and MAP columns.  Add them to increase coverage, and fix a small bug discovered by the new tests.

Differential Revision: D42504031

