### PR TITLE
Enable different failure behaviors in cast expression through substrait

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ option(VELOX_ENABLE_PARSE "Build parser used for unit tests." ON)
 option(VELOX_ENABLE_EXAMPLES
        "Build examples. This will enable VELOX_ENABLE_EXPRESSION automatically."
        OFF)
-option(VELOX_ENABLE_SUBSTRAIT "Buid Substrait-to-Velox converter." OFF)
+option(VELOX_ENABLE_SUBSTRAIT "Build Substrait-to-Velox converter." OFF)
 option(VELOX_ENABLE_BENCHMARKS "Enable Velox top level benchmarks." OFF)
 option(VELOX_ENABLE_BENCHMARKS_BASIC "Enable Velox basic benchmarks." OFF)
 option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -322,18 +322,22 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     const RowTypePtr& inputType) {
   auto substraitType = substraitParser_.parseType(castExpr.type());
   auto type = toVeloxType(substraitType->type);
-  auto failureBehavior =  castExpr.failure_behavior();
+  auto failureBehavior = castExpr.failure_behavior();
   bool nullOnFailure;
   switch (failureBehavior) {
-    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
-    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
       nullOnFailure = false;
       break;
-    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
       nullOnFailure = true;
       break;
     default:
-      VELOX_NYI("The given failure behavior is NOT supported: '{}'", failureBehavior);
+      VELOX_NYI(
+          "The given failure behavior is NOT supported: '{}'", failureBehavior);
   }
 
   std::vector<core::TypedExprPtr> inputs{

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -145,6 +145,24 @@ VectorPtr constructFlatVector(
   return vector;
 }
 
+/// Whether null will be returned on cast failure.
+bool isNullOnFailure(
+    ::substrait::Expression::Cast::FailureBehavior failureBehavior) {
+  switch (failureBehavior) {
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
+      return false;
+    case ::substrait::
+        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
+      return true;
+    default:
+      VELOX_NYI(
+          "The given failure behavior is NOT supported: '{}'", failureBehavior);
+  }
+}
+
 } // namespace
 
 namespace facebook::velox::substrait {
@@ -328,23 +346,6 @@ SubstraitVeloxExprConverter::toVeloxExpr(
       toVeloxExpr(castExpr.input(), inputType)};
 
   return std::make_shared<core::CastTypedExpr>(type, inputs, nullOnFailure);
-}
-
-bool SubstraitVeloxExprConverter::isNullOnFailure(
-    ::substrait::Expression::Cast::FailureBehavior failureBehavior) {
-  switch (failureBehavior) {
-    case ::substrait::
-        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
-    case ::substrait::
-        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
-      return false;
-    case ::substrait::
-        Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
-      return true;
-    default:
-      VELOX_NYI(
-          "The given failure behavior is NOT supported: '{}'", failureBehavior);
-  }
 }
 
 std::shared_ptr<const core::ITypedExpr>

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -326,16 +326,14 @@ SubstraitVeloxExprConverter::toVeloxExpr(
   bool nullOnFailure;
   switch (failureBehavior) {
     case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
       nullOnFailure = false;
       break;
     case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
       nullOnFailure = true;
       break;
-    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
-      nullOnFailure = false;
-      break;
     default:
-      VELOX_FAIL("The given failure behavior is NOT supported!");
+      VELOX_NYI("The given failure behavior is NOT supported: '{}'", failureBehavior);
   }
 
   std::vector<core::TypedExprPtr> inputs{

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -331,7 +331,7 @@ SubstraitVeloxExprConverter::toVeloxExpr(
 }
 
 bool SubstraitVeloxExprConverter::isNullOnFailure(
-  ::substrait::Expression::Cast::FailureBehavior failureBehavior) {
+    ::substrait::Expression::Cast::FailureBehavior failureBehavior) {
   switch (failureBehavior) {
     case ::substrait::
         Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -322,8 +322,21 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     const RowTypePtr& inputType) {
   auto substraitType = substraitParser_.parseType(castExpr.type());
   auto type = toVeloxType(substraitType->type);
-  // TODO add flag in substrait after. now is set false.
-  bool nullOnFailure = false;
+  auto failureBehavior =  castExpr.failure_behavior();
+  bool nullOnFailure;
+  switch (failureBehavior) {
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED:
+      nullOnFailure = false;
+      break;
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL:
+      nullOnFailure = true;
+      break;
+    case ::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION:
+      nullOnFailure = false;
+      break;
+    default:
+      VELOX_FAIL("The given failure behavior is NOT supported!");
+  }
 
   std::vector<core::TypedExprPtr> inputs{
       toVeloxExpr(castExpr.input(), inputType)};

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -63,10 +63,6 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression::IfThen& substraitIfThen,
       const RowTypePtr& inputType);
 
-  /// Whether null will be returned on cast failure.
-  bool isNullOnFailure(
-      ::substrait::Expression::Cast::FailureBehavior failureBehavior);
-
  private:
   /// Convert list literal to ArrayVector.
   ArrayVectorPtr literalsToArrayVector(

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -63,6 +63,9 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression::IfThen& substraitIfThen,
       const RowTypePtr& inputType);
 
+  /// Whether null will be returned on cast failure.
+  bool isNullOnFailure(::substrait::Expression::Cast::FailureBehavior failureBehavior);
+
  private:
   /// Convert list literal to ArrayVector.
   ArrayVectorPtr literalsToArrayVector(

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -64,7 +64,8 @@ class SubstraitVeloxExprConverter {
       const RowTypePtr& inputType);
 
   /// Whether null will be returned on cast failure.
-  bool isNullOnFailure(::substrait::Expression::Cast::FailureBehavior failureBehavior);
+  bool isNullOnFailure(
+      ::substrait::Expression::Cast::FailureBehavior failureBehavior);
 
  private:
   /// Convert list literal to ArrayVector.

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -448,7 +448,6 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
     substraitCastExpr->mutable_input()->MergeFrom(
         toSubstraitExpr(arena, arg, inputType));
   }
-  // Set failure behaviro as FAILURE_BEHAVIOR_UNSPECIFIED.
   if (castExpr->nullOnFailure()) {
     substraitCastExpr->set_failure_behavior(
         ::substrait::

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -448,6 +448,8 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
     substraitCastExpr->mutable_input()->MergeFrom(
         toSubstraitExpr(arena, arg, inputType));
   }
+  // Set failure behaviro as FAILURE_BEHAVIOR_UNSPECIFIED.
+  substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
   return *substraitCastExpr;
 }
 

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -450,10 +450,15 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
   }
   // Set failure behaviro as FAILURE_BEHAVIOR_UNSPECIFIED.
   if (castExpr->nullOnFailure()) {
-    substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);
+    substraitCastExpr->set_failure_behavior(
+        ::substrait::
+            Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);
   } else {
-    // It is equivalent to the setting with Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION.
-    substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
+    // It is equivalent to the setting with
+    // Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION.
+    substraitCastExpr->set_failure_behavior(
+        ::substrait::
+            Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
   }
   return *substraitCastExpr;
 }

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -453,11 +453,9 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
         ::substrait::
             Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);
   } else {
-    // It is equivalent to the setting with
-    // Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION.
     substraitCastExpr->set_failure_behavior(
         ::substrait::
-            Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
+            Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION);
   }
   return *substraitCastExpr;
 }

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -449,7 +449,12 @@ VeloxToSubstraitExprConvertor::toSubstraitExpr(
         toSubstraitExpr(arena, arg, inputType));
   }
   // Set failure behaviro as FAILURE_BEHAVIOR_UNSPECIFIED.
-  substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
+  if (castExpr->nullOnFailure()) {
+    substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_RETURN_NULL);
+  } else {
+    // It is equivalent to the setting with Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_THROW_EXCEPTION.
+    substraitCastExpr->set_failure_behavior(::substrait::Expression_Cast_FailureBehavior_FAILURE_BEHAVIOR_UNSPECIFIED);
+  }
   return *substraitCastExpr;
 }
 

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -83,14 +83,20 @@ class VeloxSubstraitRoundTripTest : public OperatorTestBase {
 
     // Convert Substrait Plan to the same Velox Plan.
     auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
-    auto projections = std::dynamic_pointer_cast<const core::ProjectNode>(samePlan)->projections();
-    auto projectionsOriginal = std::dynamic_pointer_cast<const core::ProjectNode>(plan)->projections();
+    auto projections =
+        std::dynamic_pointer_cast<const core::ProjectNode>(samePlan)
+            ->projections();
+    auto projectionsOriginal =
+        std::dynamic_pointer_cast<const core::ProjectNode>(plan)->projections();
     ASSERT_EQ(projections.size(), projectionsOriginal.size());
     for (int i = 0; i < projections.size(); i++) {
       auto castExpr =
           std::dynamic_pointer_cast<const core::CastTypedExpr>(projections[i]);
-      auto castExprOriginal = std::dynamic_pointer_cast<const core::CastTypedExpr>(projectionsOriginal[i]);
-      // The cast failure behavior should keep consistent after the round trip conversion.
+      auto castExprOriginal =
+          std::dynamic_pointer_cast<const core::CastTypedExpr>(
+              projectionsOriginal[i]);
+      // The cast failure behavior should keep consistent after the round trip
+      // conversion.
       ASSERT_EQ(castExpr->nullOnFailure(), castExprOriginal->nullOnFailure());
     }
 

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -84,11 +84,14 @@ class VeloxSubstraitRoundTripTest : public OperatorTestBase {
     // Convert Substrait Plan to the same Velox Plan.
     auto samePlan = substraitConverter_->toVeloxPlan(substraitPlan);
     auto projections = std::dynamic_pointer_cast<const core::ProjectNode>(samePlan)->projections();
-    for (auto& projection: projections) {
+    auto projectionsOriginal = std::dynamic_pointer_cast<const core::ProjectNode>(plan)->projections();
+    ASSERT_EQ(projections.size(), projectionsOriginal.size());
+    for (int i = 0; i < projections.size(); i++) {
       auto castExpr =
-          std::dynamic_pointer_cast<const core::CastTypedExpr>(projection);
-      // For unspecified failure behavior, we are expecting nullOnFailure is false.
-      ASSERT_FALSE(castExpr->nullOnFailure());
+          std::dynamic_pointer_cast<const core::CastTypedExpr>(projections[i]);
+      auto castExprOriginal = std::dynamic_pointer_cast<const core::CastTypedExpr>(projectionsOriginal[i]);
+      // The cast failure behavior should keep consistent after the round trip conversion.
+      ASSERT_EQ(castExpr->nullOnFailure(), castExprOriginal->nullOnFailure());
     }
 
     // Assert velox again.


### PR DESCRIPTION
Currently, it is available in substrait to specify cast failure behavior. And velox also has its own logic to handle cast failure according to a flag, i.e., `nullOnFailure`. With this patch, we can make this velox flag set through substrait to align with upper sql engine's cast failure behavior.