### PR TITLE
Enable date type for LeastGreatestFunction

### DIFF
--- a/velox/functions/sparksql/LeastGreatest.cpp
+++ b/velox/functions/sparksql/LeastGreatest.cpp
@@ -108,16 +108,17 @@ std::shared_ptr<exec::VectorFunction> makeImpl(
     return std::make_shared<LeastGreatestFunction<   \
         Cmp<TypeTraits<TypeKind::kind>::NativeType>, \
         TypeKind::kind>>();
-    SCALAR_CASE(BOOLEAN);
-    SCALAR_CASE(TINYINT);
-    SCALAR_CASE(SMALLINT);
-    SCALAR_CASE(INTEGER);
-    SCALAR_CASE(BIGINT);
-    SCALAR_CASE(REAL);
-    SCALAR_CASE(DOUBLE);
-    SCALAR_CASE(VARCHAR);
-    SCALAR_CASE(VARBINARY);
-    SCALAR_CASE(TIMESTAMP);
+    SCALAR_CASE(BOOLEAN)
+    SCALAR_CASE(TINYINT)
+    SCALAR_CASE(SMALLINT)
+    SCALAR_CASE(INTEGER)
+    SCALAR_CASE(BIGINT)
+    SCALAR_CASE(REAL)
+    SCALAR_CASE(DOUBLE)
+    SCALAR_CASE(VARCHAR)
+    SCALAR_CASE(VARBINARY)
+    SCALAR_CASE(TIMESTAMP)
+    SCALAR_CASE(DATE)
 #undef SCALAR_CASE
     default:
       VELOX_NYI(

--- a/velox/functions/sparksql/tests/LeastGreatestTest.cpp
+++ b/velox/functions/sparksql/tests/LeastGreatestTest.cpp
@@ -156,6 +156,10 @@ TEST_F(LeastTest, timestamp) {
       Timestamp(581, 1651));
 }
 
+TEST_F(LeastTest, date) {
+  EXPECT_EQ(least<Date>(Date(100), Date(1000), Date(10000)), Date(100));
+}
+
 class GreatestTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
@@ -293,6 +297,10 @@ TEST_F(GreatestTest, timestamp) {
       greatest<Timestamp>(
           Timestamp(1569, 25), Timestamp(4859, 482), Timestamp(581, 1651)),
       Timestamp(4859, 482));
+}
+
+TEST_F(GreatestTest, date) {
+  EXPECT_EQ(greatest<Date>(Date(100), Date(1000), Date(10000)), Date(10000));
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Velox has already implemented `operator<` overloading for date type (see `velox/type/Date.h`), which makes greatest/least functions workable for date type. Here, we are closing the small gap.