### PR TITLE
Relax schema compatibility check

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(
   SelectiveRepeatedColumnReader.cpp
   SelectiveStructColumnReader.cpp
   SeekableInputStream.cpp
+  TypeUtils.cpp
   TypeWithId.cpp)
 
 target_link_libraries(

--- a/velox/dwio/common/ColumnSelector.cpp
+++ b/velox/dwio/common/ColumnSelector.cpp
@@ -23,7 +23,6 @@
 
 namespace facebook::velox::dwio::common {
 
-using common::typeutils::CompatChecker;
 using velox::RowType;
 using velox::Type;
 using velox::TypeKind;
@@ -77,7 +76,7 @@ FilterTypePtr ColumnSelector::buildNode(
   // make sure content type is compatible to reading request type
   // when content type is present (it may be absent due to schema mismatch)
   if (contentType != nullptr) {
-    CompatChecker::check(*contentType, *type);
+    typeutils::checkTypeCompatibility(*contentType, *type);
   }
 
   // the process will cover supported schema evolution:
@@ -143,7 +142,7 @@ void ColumnSelector::copy(
     }
 
     // ensure disk type can be converted to request type
-    CompatChecker::check(*diskType, *node->getRequestType());
+    typeutils::checkTypeCompatibility(*diskType, *node->getRequestType());
 
     // update data type during the visit as well as other data fields
     node->setDataType(diskType);
@@ -222,8 +221,7 @@ void ColumnSelector::setRead(const common::FilterTypePtr& node, bool only) {
 // TODO (cao) - SelectedTypeBuilder is uncessary to exist, can be killed
 std::shared_ptr<const TypeWithId> ColumnSelector::buildSelected() const {
   auto selector = [this](size_t index) { return shouldReadNode(index); };
-  return typeutils::SelectedTypeBuilder::build(
-      TypeWithId::create(schema_), selector);
+  return typeutils::buildSelectedType(TypeWithId::create(schema_), selector);
 }
 
 std::shared_ptr<const RowType> ColumnSelector::buildSelectedReordered() const {

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -19,7 +19,6 @@
 namespace facebook::velox::dwio::common {
 
 using dwio::common::TypeWithId;
-using dwio::common::typeutils::CompatChecker;
 
 velox::common::AlwaysTrue& alwaysTrue() {
   static velox::common::AlwaysTrue alwaysTrue;

--- a/velox/dwio/common/TypeUtils.cpp
+++ b/velox/dwio/common/TypeUtils.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/TypeUtils.h"
+#include "velox/dwio/common/exception/Exception.h"
+
+#include <unordered_set>
+
+namespace facebook::velox::dwio::common::typeutils {
+namespace {
+
+void checkChildrenSelected(
+    const std::shared_ptr<const TypeWithId>& type,
+    const std::function<bool(size_t)>& selector) {
+  for (size_t i = 0; i < type->size(); ++i) {
+    VELOX_USER_CHECK(
+        selector(type->childAt(i)->id),
+        folly::to<std::string>(
+            "invalid type selection: parent ",
+            type->type->toString(),
+            " is selected, but child (index: ",
+            i,
+            ", id: ",
+            std::to_string(type->id),
+            ") is not"));
+  }
+}
+
+std::shared_ptr<const TypeWithId> visit(
+    const std::shared_ptr<const TypeWithId>& typeWithId,
+    const std::function<bool(size_t)>& selector) {
+  if (typeWithId->type->isPrimitiveType()) {
+    return typeWithId;
+  }
+  if (typeWithId->type->isRow()) {
+    std::vector<std::string> names;
+    std::vector<std::shared_ptr<const TypeWithId>> typesWithId;
+    std::vector<std::shared_ptr<const Type>> types;
+    auto& row = typeWithId->type->asRow();
+    for (auto i = 0; i < typeWithId->size(); ++i) {
+      auto& child = typeWithId->childAt(i);
+      if (selector(child->id)) {
+        names.push_back(row.nameOf(i));
+        std::shared_ptr<const TypeWithId> twid;
+        twid = visit(child, selector);
+        typesWithId.push_back(twid);
+        types.push_back(twid->type);
+      }
+    }
+    VELOX_USER_CHECK(
+        !types.empty(), "selected nothing from row: " + row.toString());
+    return std::make_shared<TypeWithId>(
+        ROW(std::move(names), std::move(types)),
+        std::move(typesWithId),
+        typeWithId->id,
+        typeWithId->maxId,
+        typeWithId->column);
+  } else {
+    checkChildrenSelected(typeWithId, selector);
+    std::vector<std::shared_ptr<const TypeWithId>> typesWithId;
+    std::vector<std::shared_ptr<const Type>> types;
+    for (auto i = 0; i < typeWithId->size(); ++i) {
+      auto& child = typeWithId->childAt(i);
+      std::shared_ptr<const TypeWithId> twid = visit(child, selector);
+      typesWithId.push_back(twid);
+      types.push_back(twid->type);
+    }
+    auto type = createType(typeWithId->type->kind(), std::move(types));
+    return std::make_shared<TypeWithId>(
+        type,
+        std::move(typesWithId),
+        typeWithId->id,
+        typeWithId->maxId,
+        typeWithId->column);
+  }
+}
+
+uint32_t getKey(TypeKind from, TypeKind to) {
+  auto fromVal = static_cast<uint32_t>(from);
+  auto toVal = static_cast<uint32_t>(to);
+  auto limit = std::numeric_limits<uint16_t>::max();
+  DWIO_ENSURE(fromVal < limit && toVal < limit, "invalid range of type kind");
+  return (fromVal << 16) | toVal;
+}
+
+std::unordered_set<uint32_t> makeCompatibilityMap() {
+  std::unordered_set<uint32_t> compat;
+  compat.insert(getKey(TypeKind::BOOLEAN, TypeKind::TINYINT));
+  compat.insert(getKey(TypeKind::BOOLEAN, TypeKind::SMALLINT));
+  compat.insert(getKey(TypeKind::BOOLEAN, TypeKind::INTEGER));
+  compat.insert(getKey(TypeKind::BOOLEAN, TypeKind::BIGINT));
+  compat.insert(getKey(TypeKind::TINYINT, TypeKind::SMALLINT));
+  compat.insert(getKey(TypeKind::TINYINT, TypeKind::INTEGER));
+  compat.insert(getKey(TypeKind::TINYINT, TypeKind::BIGINT));
+  compat.insert(getKey(TypeKind::SMALLINT, TypeKind::INTEGER));
+  compat.insert(getKey(TypeKind::SMALLINT, TypeKind::BIGINT));
+  compat.insert(getKey(TypeKind::INTEGER, TypeKind::BIGINT));
+  compat.insert(getKey(TypeKind::REAL, TypeKind::DOUBLE));
+  return compat;
+}
+
+bool isCompatible(TypeKind from, TypeKind to) {
+  static auto compat = makeCompatibilityMap();
+  return from == to || compat.find(getKey(from, to)) != compat.end();
+}
+
+template <typename T, typename FKind, typename FShouldRead>
+void checkTypeCompatibility(
+    const Type& from,
+    const T& to,
+    bool recurse,
+    const FKind& kind,
+    const FShouldRead& shouldRead,
+    const std::function<std::string()>& exceptionMessageCreator) {
+  if (shouldRead(to) && !isCompatible(from.kind(), kind(to))) {
+    VELOX_SCHEMA_MISMATCH_ERROR(fmt::format(
+        "{}, From Kind: {}, To Kind: {}",
+        exceptionMessageCreator ? exceptionMessageCreator() : "Schema mismatch",
+        mapTypeKindToName(from.kind()),
+        mapTypeKindToName(kind(to))));
+  }
+
+  if (recurse) {
+    uint64_t childCount = std::min(from.size(), to.size());
+    for (uint64_t i = 0; i < childCount; ++i) {
+      checkTypeCompatibility(
+          *from.childAt(i),
+          *to.childAt(i),
+          true,
+          kind,
+          shouldRead,
+          exceptionMessageCreator);
+    }
+  }
+}
+
+} // namespace
+
+std::shared_ptr<const TypeWithId> buildSelectedType(
+    const std::shared_ptr<const TypeWithId>& typeWithId,
+    const std::function<bool(size_t)>& selector) {
+  return visit(typeWithId, selector);
+}
+
+void checkTypeCompatibility(
+    const Type& from,
+    const Type& to,
+    bool recurse,
+    const std::function<std::string()>& exceptionMessageCreator) {
+  return checkTypeCompatibility(
+      from,
+      to,
+      recurse,
+      [](const auto& t) { return t.kind(); },
+      [](const auto& /* ignored */) { return true; },
+      exceptionMessageCreator);
+}
+
+void checkTypeCompatibility(
+    const Type& from,
+    const ColumnSelector& selector,
+    const std::function<std::string()>& exceptionMessageCreator) {
+  return checkTypeCompatibility(
+      from,
+      *selector.getSchemaWithId(),
+      /*recurse=*/true,
+      [](const auto& t) { return t.type->kind(); },
+      [&selector](const auto& node) {
+        return selector.shouldReadNode(node.id);
+      },
+      exceptionMessageCreator);
+}
+
+} // namespace facebook::velox::dwio::common::typeutils

--- a/velox/dwio/common/TypeUtils.h
+++ b/velox/dwio/common/TypeUtils.h
@@ -16,182 +16,27 @@
 
 #pragma once
 
+#include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
-#include "velox/dwio/common/exception/Exception.h"
-
-#include <unordered_set>
 
 namespace facebook::velox::dwio::common::typeutils {
-class SelectedTypeBuilder {
- public:
-  static std::shared_ptr<const TypeWithId> build(
-      const std::shared_ptr<const TypeWithId>& typeWithId,
-      const std::function<bool(size_t)>& selector) {
-    return visit(typeWithId, selector);
-  }
 
- private:
-  static void checkChildrenSelected(
-      const std::shared_ptr<const TypeWithId>& type,
-      const std::function<bool(size_t)>& selector) {
-    for (size_t i = 0; i < type->size(); ++i) {
-      auto& child = type->childAt(i);
-      if (!selector(child->id)) {
-        std::string s{};
-        s += "invalid type selection: parent ";
-        s += type->type->toString();
-        s += " is selected, but child (index: ";
-        s += i;
-        s += ", id: ";
-        s += std::to_string(type->id);
-        s += ") is not";
-        throw std::invalid_argument{s};
-      }
-    }
-  }
+// Build selected type based on input schema and selection
+std::shared_ptr<const TypeWithId> buildSelectedType(
+    const std::shared_ptr<const TypeWithId>& typeWithId,
+    const std::function<bool(size_t)>& selector);
 
-  static std::shared_ptr<const TypeWithId> visit(
-      const std::shared_ptr<const TypeWithId>& typeWithId,
-      const std::function<bool(size_t)>& selector) {
-    if (typeWithId->type->isPrimitiveType()) {
-      return typeWithId;
-    }
-    if (typeWithId->type->isRow()) {
-      std::vector<std::string> names;
-      std::vector<std::shared_ptr<const TypeWithId>> typesWithIds;
-      std::vector<std::shared_ptr<const velox::Type>> types;
-      auto& row = typeWithId->type->asRow();
-      for (auto i = 0; i < typeWithId->size(); ++i) {
-        auto& child = typeWithId->childAt(i);
-        if (selector(child->id)) {
-          names.push_back(row.nameOf(i));
-          std::shared_ptr<const TypeWithId> twid;
-          twid = visit(child, selector);
-          typesWithIds.push_back(twid);
-          types.push_back(twid->type);
-        }
-      }
-      if (types.empty()) {
-        throw std::invalid_argument{
-            "selected nothing from row: " + row.toString()};
-      }
-      return std::make_shared<TypeWithId>(
-          velox::ROW(std::move(names), std::move(types)),
-          std::move(typesWithIds),
-          typeWithId->id,
-          typeWithId->maxId,
-          typeWithId->column);
-    } else {
-      checkChildrenSelected(typeWithId, selector);
-      std::vector<std::shared_ptr<const TypeWithId>> typesWithIds;
-      std::vector<std::shared_ptr<const velox::Type>> types;
-      for (auto i = 0; i < typeWithId->size(); ++i) {
-        auto& child = typeWithId->childAt(i);
-        std::shared_ptr<const TypeWithId> twid = visit(child, selector);
-        typesWithIds.push_back(twid);
-        types.push_back(twid->type);
-      }
-      auto type = velox::createType(typeWithId->type->kind(), std::move(types));
-      return std::make_shared<TypeWithId>(
-          type,
-          std::move(typesWithIds),
-          typeWithId->id,
-          typeWithId->maxId,
-          typeWithId->column);
-    }
-  }
-};
+// Check type compatibility with full schema
+void checkTypeCompatibility(
+    const Type& from,
+    const Type& to,
+    bool recurse = false,
+    const std::function<std::string()>& exceptionMessageCreator = nullptr);
 
-class CompatChecker {
- public:
-  static void check(
-      const velox::Type& from,
-      const velox::Type& to,
-      bool recurse = false,
-      const std::function<std::string()>& exceptionMessageCreator = []() {
-        return "";
-      }) {
-    static CompatChecker checker;
-    checker.checkImpl(from, to, recurse, exceptionMessageCreator);
-  }
-
- private:
-  void checkImpl(
-      const velox::Type& from,
-      const velox::Type& to,
-      bool recurse,
-      const std::function<std::string()>& exceptionMessageCreator) const {
-    if (!compat(from.kind(), to.kind())) {
-      VELOX_SCHEMA_MISMATCH_ERROR(fmt::format(
-          "{}, From Kind: {}, To Kind: {}",
-          exceptionMessageCreator ? exceptionMessageCreator() : "",
-          velox::mapTypeKindToName(from.kind()),
-          velox::mapTypeKindToName(to.kind())));
-    }
-
-    if (recurse) {
-      switch (from.kind()) {
-        case velox::TypeKind::ROW: {
-          uint64_t childCount = std::min(from.size(), to.size());
-          for (uint64_t i = 0; i < childCount; ++i) {
-            checkImpl(
-                *from.childAt(i),
-                *to.childAt(i),
-                true,
-                exceptionMessageCreator);
-          }
-          break;
-        }
-        case velox::TypeKind::ARRAY:
-          checkImpl(
-              *from.childAt(0), *to.childAt(0), true, exceptionMessageCreator);
-          break;
-        case velox::TypeKind::MAP: {
-          checkImpl(
-              *from.childAt(0), *to.childAt(0), true, exceptionMessageCreator);
-          checkImpl(
-              *from.childAt(1), *to.childAt(1), true, exceptionMessageCreator);
-          break;
-        }
-        default:
-          break;
-      }
-    }
-  }
-
-  static int32_t getKey(velox::TypeKind from, velox::TypeKind to) {
-    auto fromVal = static_cast<uint32_t>(from);
-    auto toVal = static_cast<uint32_t>(to);
-    auto limit = std::numeric_limits<uint16_t>::max();
-    DWIO_ENSURE(fromVal < limit && toVal < limit, "invalid range of type kind");
-    return (fromVal << 16) | toVal;
-  }
-
-  bool compat(velox::TypeKind from, velox::TypeKind to) const {
-    return from == to || compat_.find(getKey(from, to)) != compat_.end();
-  }
-
-  void setCompat(velox::TypeKind from, velox::TypeKind to) {
-    compat_.insert(getKey(from, to));
-  }
-
-  CompatChecker() {
-    setCompat(velox::TypeKind::BOOLEAN, velox::TypeKind::TINYINT);
-    setCompat(velox::TypeKind::BOOLEAN, velox::TypeKind::SMALLINT);
-    setCompat(velox::TypeKind::BOOLEAN, velox::TypeKind::INTEGER);
-    setCompat(velox::TypeKind::BOOLEAN, velox::TypeKind::BIGINT);
-    setCompat(velox::TypeKind::TINYINT, velox::TypeKind::SMALLINT);
-    setCompat(velox::TypeKind::TINYINT, velox::TypeKind::INTEGER);
-    setCompat(velox::TypeKind::TINYINT, velox::TypeKind::BIGINT);
-    setCompat(velox::TypeKind::SMALLINT, velox::TypeKind::INTEGER);
-    setCompat(velox::TypeKind::SMALLINT, velox::TypeKind::BIGINT);
-    setCompat(velox::TypeKind::INTEGER, velox::TypeKind::BIGINT);
-    setCompat(velox::TypeKind::REAL, velox::TypeKind::DOUBLE);
-  }
-
-  ~CompatChecker() = default;
-
-  std::unordered_set<uint32_t> compat_;
-};
+// Check type compatibility based on selection
+void checkTypeCompatibility(
+    const Type& from,
+    const ColumnSelector& selector,
+    const std::function<std::string()>& exceptionMessageCreator = nullptr);
 
 } // namespace facebook::velox::dwio::common::typeutils

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -25,8 +25,6 @@ using dwio::common::FileFormat;
 using dwio::common::InputStream;
 using dwio::common::ReaderOptions;
 using dwio::common::RowReaderOptions;
-using dwio::common::TypeWithId;
-using dwio::common::typeutils::CompatChecker;
 
 DwrfRowReader::DwrfRowReader(
     const std::shared_ptr<ReaderBase>& reader,
@@ -82,8 +80,8 @@ DwrfRowReader::DwrfRowReader(
     return exceptionMessageContext;
   };
 
-  CompatChecker::check(
-      *getReader().getSchema(), *getType(), true, createExceptionContext);
+  dwio::common::typeutils::checkTypeCompatibility(
+      *getReader().getSchema(), *columnSelector_, createExceptionContext);
 }
 
 uint64_t DwrfRowReader::seekToRow(uint64_t rowNumber) {

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     DwrfParams& params,
     common::ScanSpec& scanSpec) {
-  dwio::common::typeutils::CompatChecker::check(
+  dwio::common::typeutils::checkTypeCompatibility(
       *dataType->type, *requestedType->type);
   EncodingKey ek{dataType->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();


### PR DESCRIPTION
Summary: There is really no side-effect if we let unprojected incompatible fields pass the compatibility check. They don't touch the output vector anyway. So relax the compatibility check by also taking into consideration the projection.

Differential Revision: D42517100

