### PR TITLE
Fix invalid-shift-exponent error in Presto bitwise_left_shift and bitwise_right_shift

### DIFF
--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -99,7 +99,7 @@ __attribute__((no_sanitize("integer")))
 #endif
 FOLLY_ALWAYS_INLINE bool
 bitwiseLeftShift(int64_t& result, T number, T shift) {
-  if ((uint32_t)shift >= MAX_SHIFT) {
+  if ((uint64_t)shift >= MAX_SHIFT) {
     result = 0;
   } else {
     result = (number << shift);
@@ -127,7 +127,7 @@ struct BitwiseLeftShiftFunction {
 namespace {
 template <typename T, typename UT, int MAX_SHIFT>
 FOLLY_ALWAYS_INLINE bool bitwiseRightShift(int64_t& result, T number, T shift) {
-  if ((uint32_t)shift >= MAX_SHIFT) {
+  if ((uint64_t)shift >= MAX_SHIFT) {
     result = 0;
   } else {
     result = ((UT)number >> shift);

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -329,6 +329,8 @@ TEST_F(BitwiseTest, leftShift) {
 
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMin64, kMax64), 0);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMax64, kMax64), 0);
+  EXPECT_EQ(
+      bitwiseLeftShift<int64_t>(5787029258914367756, 6918663727935913984), 0);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMax64, 1), kMax64 << 1);
   EXPECT_EQ(bitwiseLeftShift<int64_t>(kMin64, 1), 0);
 }
@@ -351,6 +353,8 @@ TEST_F(BitwiseTest, rightShift) {
 
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, kMax64), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, kMax64), 0);
+  EXPECT_EQ(
+      bitwiseRightShift<int64_t>(5787029258914367756, 6918663727935913984), 0);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMax64, 1), kMax64 >> 1);
   EXPECT_EQ(bitwiseRightShift<int64_t>(kMin64, 1), (kMax64 >> 1) + 1);
 }


### PR DESCRIPTION
Summary: Fix https://github.com/facebookincubator/velox/issues/3241

Differential Revision: D42548938

