### PR TITLE
Do not throw in PartitionedOutputBufferManager::updateBroadcastOutputBuffers()

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -570,11 +570,16 @@ void PartitionedOutputBufferManager::initializeTask(
   });
 }
 
-void PartitionedOutputBufferManager::updateBroadcastOutputBuffers(
+bool PartitionedOutputBufferManager::updateBroadcastOutputBuffers(
     const std::string& taskId,
     int numBuffers,
     bool noMoreBuffers) {
-  getBuffer(taskId)->updateBroadcastOutputBuffers(numBuffers, noMoreBuffers);
+  auto buffer = getBufferIfExists(taskId);
+  if (buffer) {
+    buffer->updateBroadcastOutputBuffers(numBuffers, noMoreBuffers);
+    return true;
+  }
+  return false;
 }
 
 void PartitionedOutputBufferManager::updateNumDrivers(

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -574,8 +574,7 @@ bool PartitionedOutputBufferManager::updateBroadcastOutputBuffers(
     const std::string& taskId,
     int numBuffers,
     bool noMoreBuffers) {
-  auto buffer = getBufferIfExists(taskId);
-  if (buffer) {
+  if (auto buffer = getBufferIfExists(taskId)) {
     buffer->updateBroadcastOutputBuffers(numBuffers, noMoreBuffers);
     return true;
   }

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -193,7 +193,9 @@ class PartitionedOutputBufferManager {
       int numDestinations,
       int numDrivers);
 
-  void updateBroadcastOutputBuffers(
+  /// Updates the number of buffers to broadcast. Return true if the buffer
+  /// exists for a given taskId, else returns false.
+  bool updateBroadcastOutputBuffers(
       const std::string& taskId,
       int numBuffers,
       bool noMoreBuffers);

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1028,9 +1028,7 @@ bool Task::isFinishedLocked() const {
   return (state_ == TaskState::kFinished);
 }
 
-UpdateBroadcastStatus Task::updateBroadcastOutputBuffers(
-    int numBuffers,
-    bool noMoreBuffers) {
+bool Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
       bufferManager,
@@ -1040,17 +1038,14 @@ UpdateBroadcastStatus Task::updateBroadcastOutputBuffers(
     std::lock_guard<std::mutex> l(mutex_);
     if (noMoreBroadcastBuffers_) {
       // Ignore messages received after no-more-buffers message.
-      return kNoOp;
+      return false;
     }
     if (noMoreBuffers) {
       noMoreBroadcastBuffers_ = true;
     }
   }
-  if (bufferManager->updateBroadcastOutputBuffers(
-          taskId_, numBuffers, noMoreBuffers)) {
-    return kSuccess;
-  }
-  return kBuffersNotFound;
+  return bufferManager->updateBroadcastOutputBuffers(
+      taskId_, numBuffers, noMoreBuffers);
 }
 
 int Task::getOutputPipelineId() const {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1040,7 +1040,7 @@ UpdateBroadcastStatus Task::updateBroadcastOutputBuffers(
     std::lock_guard<std::mutex> l(mutex_);
     if (noMoreBroadcastBuffers_) {
       // Ignore messages received after no-more-buffers message.
-      return NO_OP;
+      return kNoOp;
     }
     if (noMoreBuffers) {
       noMoreBroadcastBuffers_ = true;
@@ -1048,9 +1048,9 @@ UpdateBroadcastStatus Task::updateBroadcastOutputBuffers(
   }
   if (bufferManager->updateBroadcastOutputBuffers(
           taskId_, numBuffers, noMoreBuffers)) {
-    return SUCCESS;
+    return kSuccess;
   }
-  return BUFFERS_NOT_FOUND;
+  return kBuffersNotFound;
 }
 
 int Task::getOutputPipelineId() const {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1511,7 +1511,7 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
   auto [promise, future] = makeVeloxContinuePromiseContract(
       fmt::format("Task::stateChangeFuture {}", taskId_));
   stateChangePromises_.emplace_back(std::move(promise));
-  if (maxWaitMicros) {
+  if (maxWaitMicros > 0) {
     return std::move(future).within(std::chrono::microseconds(maxWaitMicros));
   }
   return std::move(future);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -30,7 +30,7 @@ class PartitionedOutputBufferManager;
 
 class HashJoinBridge;
 class CrossJoinBridge;
-enum UpdateBroadcastStatus { SUCCESS, NO_OP, BUFFERS_NOT_FOUND };
+enum UpdateBroadcastStatus { kSuccess, kNoOp, kBuffersNotFound };
 class Task : public std::enable_shared_from_this<Task> {
  public:
   /// Creates a task to execute a plan fragment, but doesn't start execution
@@ -194,9 +194,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// of buffers. No more calls are expected after the call with noMoreBuffers
   /// == true, but occasionally the caller might resend it, so calls
   /// received after a call with noMoreBuffers == true are ignored.
-  /// @return SUCCESS if update was successful.
-  ///         NO_OP if noMoreBuffers was previously set to true.
-  ///         BUFFERS_NOT_FOUND if buffer was not found for a given task.
+  /// @return kSuccess if update was successful.
+  ///         kNoOp if noMoreBuffers was previously set to true.
+  ///         kBuffersNotFound if buffer was not found for a given task.
   UpdateBroadcastStatus updateBroadcastOutputBuffers(
       int numBuffers,
       bool noMoreBuffers);

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -41,9 +41,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// for a particular partition from a set of upstream tasks participating in a
   /// distributed execution. Used to initialize an ExchangeClient. Ignored if
   /// plan fragment doesn't have an ExchangeNode.
-  /// @param queryCtx Query context containing MemoryPool instance to use for
-  /// memory allocations during execution, executor to schedule operators on,
-  /// and session properties.
+  /// @param queryCtx Query context containing MemoryPool and MemoryAllocator
+  /// instances to use for memory allocations during execution, executor to
+  /// schedule operators on, and session properties.
   /// @param consumer Optional factory function to get callbacks to pass the
   /// results of the execution. In a multi-threaded execution, results from each
   /// thread are passed on to a separate consumer.
@@ -194,7 +194,8 @@ class Task : public std::enable_shared_from_this<Task> {
   /// of buffers. No more calls are expected after the call with noMoreBuffers
   /// == true, but occasionally the caller might resend it, so calls
   /// received after a call with noMoreBuffers == true are ignored.
-  void updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
+  /// @return bool Return true if the update was successful, else false.
+  bool updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
   /// Returns true if state is 'running'.
   bool isRunning() const;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -30,7 +30,6 @@ class PartitionedOutputBufferManager;
 
 class HashJoinBridge;
 class CrossJoinBridge;
-enum UpdateBroadcastStatus { kSuccess, kNoOp, kBuffersNotFound };
 class Task : public std::enable_shared_from_this<Task> {
  public:
   /// Creates a task to execute a plan fragment, but doesn't start execution
@@ -194,12 +193,10 @@ class Task : public std::enable_shared_from_this<Task> {
   /// of buffers. No more calls are expected after the call with noMoreBuffers
   /// == true, but occasionally the caller might resend it, so calls
   /// received after a call with noMoreBuffers == true are ignored.
-  /// @return kSuccess if update was successful.
-  ///         kNoOp if noMoreBuffers was previously set to true.
-  ///         kBuffersNotFound if buffer was not found for a given task.
-  UpdateBroadcastStatus updateBroadcastOutputBuffers(
-      int numBuffers,
-      bool noMoreBuffers);
+  /// @return true if update was successful.
+  ///         false if noMoreBuffers was previously set to true.
+  ///         false if buffer was not found for a given task.
+  bool updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
   /// Returns true if state is 'running'.
   bool isRunning() const;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -194,7 +194,8 @@ class Task : public std::enable_shared_from_this<Task> {
   /// of buffers. No more calls are expected after the call with noMoreBuffers
   /// == true, but occasionally the caller might resend it, so calls
   /// received after a call with noMoreBuffers == true are ignored.
-  /// @return bool Return true if the update was successful, else false.
+  /// @return bool Return true if the update was successful, else false. Also,
+  /// returns true if noMoreBroadcastBuffers_.
   bool updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
   /// Returns true if state is 'running'.

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -30,7 +30,7 @@ class PartitionedOutputBufferManager;
 
 class HashJoinBridge;
 class CrossJoinBridge;
-
+enum UpdateBroadcastStatus { SUCCESS, NO_OP, BUFFERS_NOT_FOUND };
 class Task : public std::enable_shared_from_this<Task> {
  public:
   /// Creates a task to execute a plan fragment, but doesn't start execution
@@ -194,9 +194,12 @@ class Task : public std::enable_shared_from_this<Task> {
   /// of buffers. No more calls are expected after the call with noMoreBuffers
   /// == true, but occasionally the caller might resend it, so calls
   /// received after a call with noMoreBuffers == true are ignored.
-  /// @return bool Return true if the update was successful, else false. Also,
-  /// returns true if noMoreBroadcastBuffers_.
-  bool updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
+  /// @return SUCCESS if update was successful.
+  ///         NO_OP if noMoreBuffers was previously set to true.
+  ///         BUFFERS_NOT_FOUND if buffer was not found for a given task.
+  UpdateBroadcastStatus updateBroadcastOutputBuffers(
+      int numBuffers,
+      bool noMoreBuffers);
 
   /// Returns true if state is 'running'.
   bool isRunning() const;

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -428,3 +428,12 @@ TEST_F(PartitionedOutputBufferManagerTest, getDataOnFailedTask) {
         VELOX_UNREACHABLE();
       }));
 }
+
+TEST_F(PartitionedOutputBufferManagerTest, updateBrodcastBufferOnFailedTask) {
+  // Updating broadcast buffer count in the buffer manager for a given unknown
+  // task must not throw exception, instead must return FALSE.
+  ASSERT_FALSE(bufferManager_->updateBroadcastOutputBuffers(
+      "test.0.1", /* unknown task */
+      10,
+      false));
+}

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -649,11 +649,11 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
     }
     ASSERT_EQ(
         task->updateBroadcastOutputBuffers(10, true /*noMoreBuffers*/),
-        UpdateBroadcastStatus::SUCCESS);
+        UpdateBroadcastStatus::kSuccess);
     // Returns NO_OP as the previous call set noMoreBuffers to true.
     ASSERT_EQ(
         task->updateBroadcastOutputBuffers(11, false),
-        UpdateBroadcastStatus::NO_OP);
+        UpdateBroadcastStatus::kNoOp);
     // Task needs to be cleaned up, the test cleanup waits for it.
     // Refer VectorTestBase::~VectorTestBase().
     task->requestAbort();
@@ -678,7 +678,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
     // Try update after task was cancelled and buffer for that task was removed.
     ASSERT_EQ(
         taskCancelled->updateBroadcastOutputBuffers(10, true),
-        UpdateBroadcastStatus::BUFFERS_NOT_FOUND);
+        UpdateBroadcastStatus::kBuffersNotFound);
   }
 }
 


### PR DESCRIPTION
Replace getBuffer() with getBufferIfExists() in
PartitionedOutputBufferManager::updateBroadcastOutputBuffers() to avoid
throwing an exception if the buffer associated with the given task has been
deleted already.

See #3593 for more details.