### PR TITLE
Fix compareMaterializedRows to check all rows in two sets are equal

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -719,6 +719,15 @@ static bool compareMaterializedRows(
     }
   }
 
+  // In case left has duplicate values and there are values in right but not in
+  // left, check the other way around. E.g., left = {1, 1, 2}, right = {1, 2,
+  // 3}.
+  for (auto& it : right) {
+    if (left.count(it) == 0) {
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
Summary: There is a bug in compareMaterializedRows(left, right) that compares two result sets left and right. It currently only check that all rows in left can be found in right, but not the other way around. Hence it would miss the cases like left = {1, 1, 2} and right = {1, 2, 3}. This diff fixes this bug by adding the check the other way around.

This fix discovered an error in the MultiFragmentTest.limit unit test (https://github.com/facebookincubator/velox/issues/3726) where the input vector contains nulls every 7 indices, whereas the expected result given in the test that contains null only at index 0 is incorrect. This diff also fixes this bug in the test.

Differential Revision: D42551023

