### PR TITLE
Fix error handling in regex_* functions

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -196,8 +196,14 @@ class Re2MatchConstantPattern final : public VectorFunction {
     VELOX_CHECK_EQ(args.size(), 2);
     FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
-    checkForBadPattern(re_);
-    rows.applyToSelected([&](vector_size_t i) {
+    try {
+      checkForBadPattern(re_);
+    } catch (const std::exception& e) {
+      context.setErrors(rows, std::current_exception());
+      return;
+    }
+
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
       result.set(i, Fn(toSearch->valueAt<StringView>(i), re_));
     });
   }
@@ -225,7 +231,7 @@ class Re2Match final : public VectorFunction {
     FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
     exec::LocalDecodedVector pattern(context, *args[1], rows);
-    rows.applyToSelected([&](vector_size_t row) {
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
       RE2 re(toStringPiece(pattern->valueAt<StringView>(row)), RE2::Quiet);
       checkForBadPattern(re);
       result.set(row, Fn(toSearch->valueAt<StringView>(row), re));
@@ -259,7 +265,12 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
         ensureWritableStringView(rows, context, resultRef);
 
     // apply() will not be invoked if the selection is empty.
-    checkForBadPattern(re_);
+    try {
+      checkForBadPattern(re_);
+    } catch (const std::exception& e) {
+      context.setErrors(rows, std::current_exception());
+      return;
+    }
 
     exec::LocalDecodedVector toSearch(context, *args[0], rows);
     bool mustRefSourceStrings = false;
@@ -267,7 +278,7 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
     // Common case: constant group id.
     if (args.size() == 2) {
       groups.resize(1);
-      rows.applyToSelected([&](vector_size_t i) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         mustRefSourceStrings |=
             re2Extract(result, i, re_, toSearch, groups, 0, emptyNoMatch_);
       });
@@ -278,9 +289,15 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
     }
 
     if (const auto groupId = getIfConstant<T>(*args[2])) {
-      checkForBadGroupId(*groupId, re_);
+      try {
+        checkForBadGroupId(*groupId, re_);
+      } catch (const std::exception& e) {
+        context.setErrors(rows, std::current_exception());
+        return;
+      }
+
       groups.resize(*groupId + 1);
-      rows.applyToSelected([&](vector_size_t i) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         mustRefSourceStrings |= re2Extract(
             result, i, re_, toSearch, groups, *groupId, emptyNoMatch_);
       });
@@ -291,18 +308,13 @@ class Re2SearchAndExtractConstantPattern final : public VectorFunction {
     }
 
     // Less common case: variable group id. Resize the groups vector to
-    // accommodate the largest group id referenced.
+    // number of capturing groups + 1.
     exec::LocalDecodedVector groupIds(context, *args[2], rows);
-    T maxGroupId = 0, minGroupId = 0;
-    rows.applyToSelected([&](vector_size_t i) {
-      maxGroupId = std::max(groupIds->valueAt<T>(i), maxGroupId);
-      minGroupId = std::min(groupIds->valueAt<T>(i), minGroupId);
-    });
-    checkForBadGroupId(maxGroupId, re_);
-    checkForBadGroupId(minGroupId, re_);
-    groups.resize(maxGroupId + 1);
-    rows.applyToSelected([&](vector_size_t i) {
+
+    groups.resize(re_.NumberOfCapturingGroups() + 1);
+    context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
       T group = groupIds->valueAt<T>(i);
+      checkForBadGroupId(group, re_);
       mustRefSourceStrings |=
           re2Extract(result, i, re_, toSearch, groups, group, emptyNoMatch_);
     });
@@ -347,7 +359,7 @@ class Re2SearchAndExtract final : public VectorFunction {
     FOLLY_DECLARE_REUSED(groups, std::vector<re2::StringPiece>);
     if (args.size() == 2) {
       groups.resize(1);
-      rows.applyToSelected([&](vector_size_t i) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         RE2 re(toStringPiece(pattern->valueAt<StringView>(i)), RE2::Quiet);
         checkForBadPattern(re);
         mustRefSourceStrings |=
@@ -355,7 +367,7 @@ class Re2SearchAndExtract final : public VectorFunction {
       });
     } else {
       exec::LocalDecodedVector groupIds(context, *args[2], rows);
-      rows.applyToSelected([&](vector_size_t i) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         const auto groupId = groupIds->valueAt<T>(i);
         RE2 re(toStringPiece(pattern->valueAt<StringView>(i)), RE2::Quiet);
         checkForBadPattern(re);
@@ -440,15 +452,15 @@ class OptimizedLikeWithMemcmp final : public VectorFunction {
 
     if (toSearch->isIdentityMapping()) {
       auto input = toSearch->data<StringView>();
-      rows.applyToSelected(
-          [&](vector_size_t i) { result.set(i, match(input[i])); });
+      context.applyToSelectedNoThrow(
+          rows, [&](vector_size_t i) { result.set(i, match(input[i])); });
       return;
     }
     if (toSearch->isConstantMapping()) {
       auto input = toSearch->valueAt<StringView>(0);
       bool matchResult = match(input);
-      rows.applyToSelected(
-          [&](vector_size_t i) { result.set(i, matchResult); });
+      context.applyToSelectedNoThrow(
+          rows, [&](vector_size_t i) { result.set(i, matchResult); });
       return;
     }
 
@@ -489,14 +501,20 @@ class LikeWithRe2 final : public VectorFunction {
     }
 
     // apply() will not be invoked if the selection is empty.
-    checkForBadPattern(*re_);
+    try {
+      checkForBadPattern(*re_);
+    } catch (const std::exception& e) {
+      context.setErrors(rows, std::current_exception());
+      return;
+    }
+
     FlatVector<bool>& result = ensureWritableBool(rows, context, resultRef);
 
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto toSearch = decodedArgs.at(0);
     if (toSearch->isIdentityMapping()) {
       auto rawStrings = toSearch->data<StringView>();
-      rows.applyToSelected([&](vector_size_t i) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t i) {
         result.set(i, re2FullMatch(rawStrings[i], *re_));
       });
       return;
@@ -504,7 +522,8 @@ class LikeWithRe2 final : public VectorFunction {
 
     if (toSearch->isConstantMapping()) {
       bool match = re2FullMatch(toSearch->valueAt<StringView>(0), *re_);
-      rows.applyToSelected([&](vector_size_t i) { result.set(i, match); });
+      context.applyToSelectedNoThrow(
+          rows, [&](vector_size_t i) { result.set(i, match); });
       return;
     }
 
@@ -559,7 +578,12 @@ class Re2ExtractAllConstantPattern final : public VectorFunction {
       EvalCtx& context,
       VectorPtr& resultRef) const final {
     VELOX_CHECK(args.size() == 2 || args.size() == 3);
-    checkForBadPattern(re_);
+    try {
+      checkForBadPattern(re_);
+    } catch (const std::exception& e) {
+      context.setErrors(rows, std::current_exception());
+      return;
+    }
 
     ArrayBuilder<Varchar> builder(
         rows.size(), rows.countSelected() * 3, context.pool());
@@ -576,24 +600,23 @@ class Re2ExtractAllConstantPattern final : public VectorFunction {
     } else if (const auto _groupId = getIfConstant<T>(*args[2])) {
       // Case 2: Constant groupId
       //
-      checkForBadGroupId(*_groupId, re_);
+      try {
+        checkForBadGroupId(*_groupId, re_);
+      } catch (const std::exception& e) {
+        context.setErrors(rows, std::current_exception());
+        return;
+      }
+
       groups.resize(*_groupId + 1);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
         re2ExtractAll(builder, re_, inputStrs, row, groups, *_groupId);
       });
     } else {
       // Case 3: Variable groupId, so resize the groups vector to accommodate
-      // the largest group id referenced.
-      //
+      // number of capturing groups + 1.
       exec::LocalDecodedVector groupIds(context, *args[2], rows);
-      T maxGroupId = 0, minGroupId = 0;
-      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
-        maxGroupId = std::max(groupIds->valueAt<T>(row), maxGroupId);
-        minGroupId = std::min(groupIds->valueAt<T>(row), minGroupId);
-      });
-      checkForBadGroupId(maxGroupId, re_);
-      checkForBadGroupId(minGroupId, re_);
-      groups.resize(maxGroupId + 1);
+
+      groups.resize(re_.NumberOfCapturingGroups() + 1);
       context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
         const T groupId = groupIds->valueAt<T>(row);
         checkForBadGroupId(groupId, re_);


### PR DESCRIPTION
Fixes #3681

Make sure to report errors via EvalCtx::setError instead of throwing exceptions.
