### PR TITLE
FIX: applyFunctionWithPeeling should flatten single arg functions input always.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1286,9 +1286,6 @@ bool Expr::applyFunctionWithPeeling(
     const SelectivityVector& applyRows,
     EvalCtx& context,
     VectorPtr& result) {
-  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
-    return false;
-  }
   int numLevels = 0;
   bool peeled;
   int32_t numConstant = 0;

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -681,5 +681,12 @@ TEST_F(ArithmeticTest, truncate) {
   EXPECT_DOUBLE_EQ(truncate(123456789012345678901.23, -21).value(), 0.0);
 }
 
+TEST_F(ArithmeticTest, fuzzRepro) {
+  const auto truncate = [&](std::optional<double> a,
+                            std::optional<int32_t> n = 0) {
+    return evaluateOnce<double>("truncate(c0,c1)", a, n);
+  };
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
+++ b/velox/functions/prestosql/tests/WidthBucketArrayTest.cpp
@@ -144,4 +144,14 @@ TEST_F(WidthBucketArrayTest, failureForConstant) {
       2, "ARRAY[1.0, 0.0]", "Bin values are not sorted in ascending order");
 }
 
+TEST_F(WidthBucketArrayTest, makeWidthBucketArrayNoThrow) {
+  auto test = [&](const std::string& sql) {
+    auto typed = makeTypedExpr(sql, ROW({DOUBLE(), ARRAY(BIGINT())}));
+    ASSERT_NO_THROW(ExprSet exprSet({typed}, &execCtx_));
+  };
+
+  test("width_bucket(0.0, array_constructor(null::BIGINT))");
+  test("width_bucket(0.0, array_constructor()::BIGINT[])");
+  test("width_bucket(0.0, array_constructor(1,0))");
+}
 } // namespace


### PR DESCRIPTION
Summary:
if we have f1(f3(f2(c0,1)))
if c0 is constant encoding, then since all inputs are constant we peel all inputs initially into constant vectors.

then lets say f2 generates a dictionary vector.
right now f3 should peel the input and flatten it based on the vector function contract(single arg functions always receive flat), but we are not doing that
based on a heuristic decision that if the most recent peeling resulted in constant wrapping it's better not to peel again.
This diff changes the code to make an exception for that assumption when peeling is mandatory.

Differential Revision: D42565341

