### PR TITLE
Increase CLANG warning level

### DIFF
--- a/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/StringDictionaryEncoder.h
@@ -209,7 +209,7 @@ class StringDictionaryEncoder {
   // key index -> cached hash
   dwio::common::DataBuffer<uint32_t> hash_;
 
-  friend class DictStringIdHash;
+  friend struct DictStringIdHash;
 };
 
 FOLLY_ALWAYS_INLINE bool DictStringIdEquality::operator()(


### PR DESCRIPTION
Summary:
Fixing some dependent warning issues for mismatched -tags

Example in Velox:
```
error: class 'DictStringIdHash' was previously declared as a struct; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Werror,-Wmismatched-tags]
```

Differential Revision: D42566869

