### PR TITLE
Fix the reproducibility of expression fuzzer test via seed

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -293,6 +293,12 @@ ExpressionFuzzer::ExpressionFuzzer(
   size_t totalFunctionSignatures = 0;
   std::vector<std::string> supportedFunctions;
   size_t supportedFunctionSignatures = 0;
+  // A local random number generator to be used just in ExpressionFuzzer
+  // constructor. We do not use rng_ in this function because code in this
+  // function may change rng_ and cause it to mismatch with the seed printed in
+  // the log.
+  FuzzerGenerator localRng{
+      static_cast<FuzzerGenerator::result_type>(initialSeed)};
   // Process each available signature for every function.
   for (const auto& function : signatureMap) {
     ++totalFunctions;
@@ -332,7 +338,7 @@ ExpressionFuzzer::ExpressionFuzzer(
           argTypes.push_back(resolvedType);
         }
       } else {
-        ArgumentTypeFuzzer typeFuzzer{*signature, rng_};
+        ArgumentTypeFuzzer typeFuzzer{*signature, localRng};
         typeFuzzer.fuzzReturnType();
         VELOX_CHECK_EQ(
             typeFuzzer.fuzzArgumentTypes(FLAGS_max_num_varargs), true);


### PR DESCRIPTION
Summary:
ExpressionFuzzer currently uses the data member `rng_` in its constructor to generate random argument types, which changes rng_ and makes it different from the seed in the log when being used during expression and vector generation. As the result, one cannot reproduce the exact same errors via seed numbers from the logs. This diff fixes this problem by using a local random number generator instead of rng_ in ExpressionFuzzer constructor.

This diff fixes https://github.com/facebookincubator/velox/issues/3743.

Differential Revision: D42586034

