### PR TITLE
Clear promises in ExchangeQueue::closeLocked()

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -175,6 +175,7 @@ class ExchangeQueue {
 
   void closeLocked() {
     queue_.clear();
+    clearAllPromises();
   }
 
  private:


### PR DESCRIPTION
Summary:
Clear promises in ExchangeQueue::closeLocked().
Failure to do so can leave and leaves zombie Tasks - the tasks that
stay indefinitely in memory, because they are referenced by their
Drivers, which are waiting on the promises from the Exchange Queue.

Also adding fix for a race between Task termination and Driver going
off the thread (see the comment in the code).

Reviewed By: amitkdutta

Differential Revision: D42584959

