### PR TITLE
FIX DateTime formatter error reporting bug.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1286,9 +1286,6 @@ bool Expr::applyFunctionWithPeeling(
     const SelectivityVector& applyRows,
     EvalCtx& context,
     VectorPtr& result) {
-  if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
-    return false;
-  }
   int numLevels = 0;
   bool peeled;
   int32_t numConstant = 0;

--- a/velox/functions/lib/DateTimeFormatter.cpp
+++ b/velox/functions/lib/DateTimeFormatter.cpp
@@ -303,6 +303,7 @@ void parseFail(
     const std::string_view& input,
     const char* cur,
     const char* end) {
+  VELOX_DCHECK(cur <= end);
   VELOX_USER_FAIL(
       "Invalid format: \"{}\" is malformed at \"{}\"",
       input,
@@ -727,7 +728,13 @@ void parseFromPattern(
       } else if (type == DateTimeFormatterType::MYSQL) {
         // In MySQL format, year read in must have exactly two digits, otherwise
         // throw an error
-        parseFail(input, cur - count + 2, end);
+        if (count > 2) {
+          // Larger than expected, print suffix.
+          parseFail(input, cur - count + 2, end);
+        } else {
+          // Smaller than expected, print prefix.
+          parseFail(input, cur - count, end);
+        }
       }
     } else {
       while (cur < end && cur < startPos + maxDigitConsume &&

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -2818,4 +2818,14 @@ TEST_F(DateTimeFunctionsTest, dateParse) {
   // 05:30:00.000 UTC.
   EXPECT_EQ(
       Timestamp(-66600, 0), dateParse("1969-12-31+11:00", "%Y-%m-%d+%H:%i"));
+
+  assertUserInvalidArgument(
+      [&] { dateParse("", "%y+"); },
+      "Invalid format: \"\" is malformed at \"\"");
+  assertUserInvalidArgument(
+      [&] { dateParse("1", "%y+"); },
+      "Invalid format: \"1\" is malformed at \"1\"");
+  assertUserInvalidArgument(
+      [&] { dateParse("116", "%y+"); },
+      "Invalid format: \"116\" is malformed at \"6\"");
 }


### PR DESCRIPTION
Summary: Code used to access string out of its bound.

Differential Revision: D42615670

