### PR TITLE
Combine the root memoryPool for Velox and Koski.

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -390,6 +390,10 @@ MemoryPool& MemoryManager::getRoot() const {
   return *root_;
 }
 
+std::shared_ptr<MemoryPool> MemoryManager::getRootAsSharedPtr() const {
+  return root_;
+}
+
 std::shared_ptr<MemoryPool> MemoryManager::getChild(int64_t cap) {
   return root_->addChild(fmt::format(
       "default_usage_node_{}",

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -437,6 +437,8 @@ class MemoryManager final : public IMemoryManager {
 
   MemoryPool& getRoot() const final;
 
+  std::shared_ptr<MemoryPool> getRootAsSharedPtr() const;
+
   std::shared_ptr<MemoryPool> getChild(int64_t cap = kMaxMemory) final;
 
   int64_t getTotalBytes() const final;

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -54,9 +54,7 @@ class QueryCtx : public Context {
         queryId_(queryId),
         spillExecutor_(std::move(spillExecutor)) {
     setConfigOverrides(config);
-    if (!pool_) {
-      initPool(queryId);
-    }
+    initPool(queryId);
   }
 
   // Constructor to block the destruction of executor while this
@@ -80,9 +78,7 @@ class QueryCtx : public Context {
         queryConfig_{this},
         queryId_(queryId) {
     setConfigOverrides(config);
-    if (!pool_) {
-      initPool(queryId);
-    }
+    initPool(queryId);
   }
 
   static std::string generatePoolName(const std::string& queryId) {
@@ -143,8 +139,10 @@ class QueryCtx : public Context {
   }
 
   void initPool(const std::string& queryId) {
-    pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
-        QueryCtx::generatePoolName(queryId));
+    if (!pool_) {
+      pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
+          QueryCtx::generatePoolName(queryId));
+    }
     pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
   }
 


### PR DESCRIPTION
Summary:
Currently, in the veloski path, koski will create a MemoryManager in its QueryCtx. During the creation of the new MemoryManager, a new instance of MemoryPool would be created. Also, the MemoryPool created in Koski are reused in DwioConfig.

https://www.internalfb.com/code/fbsource/[06fd515cb6974e86da937b8afb9cb29d22bfa2ca]/fbcode/koski/connect/dw/dwio/DwioScan.cpp?lines=224

However, the memoryPool is not passed to the velox for reuse. Thus, Velox will use the default ManagerManager for its own, thus a new instance of MemoryPool would be created subsequently.

Abovementioned logic leads to the multiple destruction of MemoryManager as shown in this log P597271381.

This separation of the MemoryPool usage causes the lifecircle discrepency in the Veloski path, where the DwioScan relied on the MemoryPool koski created, whereas, the Velox are dependend on the Velox default MemoryPool.

Differential Revision: D42590521

