### PR TITLE
Fix bug in boolean vector example in Velox vectors docs

### DIFF
--- a/velox/docs/develop/vectors.rst
+++ b/velox/docs/develop/vectors.rst
@@ -86,7 +86,7 @@ using helper methods from the “bits” namespace.
     bool active = bits::isBitSet(rawFlags, 12);
 
     // Read-write access.
-    uint64_t* rawFlags = flags->asMutable<int64_t>();
+    uint64_t* rawFlags = flags->asMutable<uint64_t>();
 
     // Set flag 15 to true/on.
     bits::setBit(rawFlags, 15);


### PR DESCRIPTION
Summary: Documentation indicates to use uint64_t for boolean flags. Example for non-mutable access uses uint64_t correctly, but example of mutable access seemingly incorrectly uses int64_t.

Reviewed By: Yuhta

Differential Revision: D42619714

