### PR TITLE
Support resolving generic outputs in simple function

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -18,11 +18,13 @@
 #include <folly/Likely.h>
 #include <optional>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/expression/UdfTypeResolver.h"
 #include "velox/type/Type.h"
 #include "velox/vector/TypeAliases.h"

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -409,7 +409,7 @@ ExprPtr compileExpression(
           "Found incompatible return types for '{}' ({} vs. {}) "
           "for input types ({}).",
           call->name(),
-          metadata.returnType(),
+          simpleFunctionEntry->type(),
           resultType,
           folly::join(", ", inputTypes));
       auto func = simpleFunctionEntry->createFunction()->createVectorFunction(

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -101,25 +101,56 @@ class FunctionRegistry {
     return signatures;
   }
 
-  const FunctionEntry<Function, Metadata>* resolveFunction(
+  class ResolvedSimpleFunction {
+   public:
+    ResolvedSimpleFunction(
+        const FunctionEntry<Function, Metadata>& functionEntry,
+        const TypePtr& type)
+        : functionEntry_(functionEntry), type_(type) {}
+
+    auto createFunction() {
+      return functionEntry_.createFunction();
+    }
+
+    TypePtr& type() {
+      return type_;
+    }
+
+    const Metadata& getMetadata() const {
+      return functionEntry_.getMetadata();
+    }
+
+   private:
+    const FunctionEntry<Function, Metadata>& functionEntry_;
+    TypePtr type_;
+  };
+
+  std::optional<ResolvedSimpleFunction> resolveFunction(
       const std::string& name,
       const std::vector<TypePtr>& argTypes) const {
     const FunctionEntry<Function, Metadata>* selectedCandidate = nullptr;
-
+    TypePtr selectedCandidateType = nullptr;
     if (const auto* signatureMap = getSignatureMap(name)) {
       for (const auto& [candidateSignature, functionEntry] : *signatureMap) {
-        if (SignatureBinder(candidateSignature, argTypes).tryBind()) {
+        SignatureBinder binder(candidateSignature, argTypes);
+        if (binder.tryBind()) {
           auto* currentCandidate = functionEntry.get();
           if (!selectedCandidate ||
               currentCandidate->getMetadata().priority() <
                   selectedCandidate->getMetadata().priority()) {
             selectedCandidate = currentCandidate;
+            selectedCandidateType = binder.tryResolveReturnType();
           }
         }
       }
     }
 
-    return selectedCandidate;
+    VELOX_DCHECK(!selectedCandidate || selectedCandidateType);
+
+    return selectedCandidate
+        ? std::optional<ResolvedSimpleFunction>(
+              ResolvedSimpleFunction(*selectedCandidate, selectedCandidateType))
+        : std::nullopt;
   }
 
  private:

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -70,6 +70,8 @@ class MapWriter;
 
 class GenericView;
 
+class GenericWriter;
+
 namespace detail {
 template <typename T>
 struct resolver {
@@ -131,7 +133,7 @@ template <typename T>
 struct resolver<Generic<T>> {
   using in_type = GenericView;
   using null_free_in_type = in_type;
-  using out_type = void; // Not supported as output type yet.
+  using out_type = GenericWriter;
 };
 
 template <typename T>

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -120,11 +120,9 @@ std::shared_ptr<const Type> resolveCallableSpecialForm(
 std::shared_ptr<const Type> resolveSimpleFunction(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
-  auto resolvedFunction =
-      exec::SimpleFunctions().resolveFunction(functionName, argTypes);
-
-  if (resolvedFunction) {
-    return resolvedFunction->getMetadata().returnType();
+  if (auto resolvedFunction =
+          exec::SimpleFunctions().resolveFunction(functionName, argTypes)) {
+    return resolvedFunction->type();
   }
 
   return nullptr;


### PR DESCRIPTION
Summary:
To support simple function with generic outputs, the output type of a simple
function need to be resolved using the signature during functions resolution
process since its not fixed anymore.

For example  Array<Generic<T1>> -> Generic<T1>
output type depends on the input.

Differential Revision: D42650177

