### PR TITLE
Add support for decimal types to VectorFuzzer

### DIFF
--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -989,7 +989,8 @@ VectorFuzzer::Options fuzzerOptions() {
       .dictionaryHasNulls = false,
       .stringVariableLength = true,
       .containerVariableLength = true,
-      .useMicrosecondPrecisionTimestamp = true};
+      .useMicrosecondPrecisionTimestamp = true,
+  };
 }
 
 TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
@@ -999,26 +1000,10 @@ TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
   }
   std::string buffer(100 << 20, '\0'); // Up to 100MB.
   VectorFuzzer fuzzer(fuzzerOptions(), this->pool_.get(), 0);
-  /// @TODO Add support for decimals in UnsafeRow SerDe.
-  /// Refer https://github.com/facebookincubator/velox/issues/3784
-  static std::vector<TypeKind> kSupportedScalarTypes{
-      TypeKind::BOOLEAN,
-      TypeKind::TINYINT,
-      TypeKind::SMALLINT,
-      TypeKind::INTEGER,
-      TypeKind::BIGINT,
-      TypeKind::REAL,
-      TypeKind::DOUBLE,
-      TypeKind::VARCHAR,
-      TypeKind::VARBINARY,
-      TypeKind::TIMESTAMP,
-      TypeKind::DATE,
-  };
-
-  for (int i = 0; i < 1; ++i) {
+  for (int i = 0; i < 100; ++i) {
     auto seed = i; // TODO: Switch to folly::Random::rand32().
     fuzzer.reSeed(seed);
-    const auto type = fuzzer.randRowType(5, kSupportedScalarTypes);
+    const auto type = fuzzer.randRowType();
     LOG(INFO) << "i=" << i << " seed=" << seed << " type=" << type->toString();
     const VectorPtr input = fuzzer.fuzzRow(type);
     std::vector<std::string_view> rowData;

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -989,8 +989,7 @@ VectorFuzzer::Options fuzzerOptions() {
       .dictionaryHasNulls = false,
       .stringVariableLength = true,
       .containerVariableLength = true,
-      .useMicrosecondPrecisionTimestamp = true,
-  };
+      .useMicrosecondPrecisionTimestamp = true};
 }
 
 TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
@@ -1000,10 +999,26 @@ TYPED_TEST(UnsafeRowComplexDeserializerTests, Fuzzer) {
   }
   std::string buffer(100 << 20, '\0'); // Up to 100MB.
   VectorFuzzer fuzzer(fuzzerOptions(), this->pool_.get(), 0);
-  for (int i = 0; i < 100; ++i) {
+  /// @TODO Add support for decimals in UnsafeRow SerDe.
+  /// Refer https://github.com/facebookincubator/velox/issues/3784
+  static std::vector<TypeKind> kSupportedScalarTypes{
+      TypeKind::BOOLEAN,
+      TypeKind::TINYINT,
+      TypeKind::SMALLINT,
+      TypeKind::INTEGER,
+      TypeKind::BIGINT,
+      TypeKind::REAL,
+      TypeKind::DOUBLE,
+      TypeKind::VARCHAR,
+      TypeKind::VARBINARY,
+      TypeKind::TIMESTAMP,
+      TypeKind::DATE,
+  };
+
+  for (int i = 0; i < 1; ++i) {
     auto seed = i; // TODO: Switch to folly::Random::rand32().
     fuzzer.reSeed(seed);
-    const auto type = fuzzer.randRowType();
+    const auto type = fuzzer.randRowType(5, kSupportedScalarTypes);
     LOG(INFO) << "i=" << i << " seed=" << seed << " type=" << type->toString();
     const VectorPtr input = fuzzer.fuzzRow(type);
     std::vector<std::string_view> rowData;

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -107,6 +107,16 @@ uint32_t rand(FuzzerGenerator& rng) {
   return boost::random::uniform_int_distribution<uint32_t>()(rng);
 }
 
+template <>
+uint64_t rand(FuzzerGenerator& rng) {
+  return boost::random::uniform_int_distribution<uint64_t>()(rng);
+}
+
+template <>
+int128_t rand(FuzzerGenerator& rng) {
+  return buildInt128(rand<int64_t>(rng), rand<uint64_t>(rng));
+}
+
 Timestamp randTimestamp(
     FuzzerGenerator& rng,
     bool useMicrosecondPrecisionTimestamp = false) {
@@ -127,6 +137,20 @@ size_t getElementsVectorLength(
     const VectorFuzzer::Options& opts,
     vector_size_t size) {
   return std::min(size * opts.containerLength, opts.complexElementsMaxSize);
+}
+
+UnscaledShortDecimal randShortDecimal(
+    const TypePtr& type,
+    FuzzerGenerator& rng) {
+  auto precision = type->asShortDecimal().precision();
+  auto randVal = rand<int64_t>(rng) % DecimalUtil::kPowersOfTen[precision];
+  return UnscaledShortDecimal(randVal);
+}
+
+UnscaledLongDecimal randLongDecimal(const TypePtr& type, FuzzerGenerator& rng) {
+  auto precision = type->asLongDecimal().precision();
+  auto randVal = rand<int128_t>(rng) % DecimalUtil::kPowersOfTen[precision];
+  return UnscaledLongDecimal(randVal);
 }
 
 /// Unicode character ranges. Ensure the vector indexes match the UTF8CharList
@@ -234,6 +258,12 @@ VectorPtr fuzzConstantPrimitiveImpl(
   } else if constexpr (std::is_same_v<TCpp, IntervalDayTime>) {
     return std::make_shared<ConstantVector<TCpp>>(
         pool, size, false, type, randIntervalDayTime(rng));
+  } else if constexpr (std::is_same_v<TCpp, UnscaledShortDecimal>) {
+    return std::make_shared<ConstantVector<TCpp>>(
+        pool, size, false, type, randShortDecimal(type, rng));
+  } else if constexpr (std::is_same_v<TCpp, UnscaledLongDecimal>) {
+    return std::make_shared<ConstantVector<TCpp>>(
+        pool, size, false, type, randLongDecimal(type, rng));
   } else {
     return std::make_shared<ConstantVector<TCpp>>(
         pool, size, false, type, rand<TCpp>(rng));
@@ -262,6 +292,10 @@ void fuzzFlatPrimitiveImpl(
       flatVector->set(i, randDate(rng));
     } else if constexpr (std::is_same_v<TCpp, IntervalDayTime>) {
       flatVector->set(i, randIntervalDayTime(rng));
+    } else if constexpr (std::is_same_v<TCpp, UnscaledShortDecimal>) {
+      flatVector->set(i, randShortDecimal(vector->type(), rng));
+    } else if constexpr (std::is_same_v<TCpp, UnscaledLongDecimal>) {
+      flatVector->set(i, randLongDecimal(vector->type(), rng));
     } else {
       flatVector->set(i, rand<TCpp>(rng));
     }
@@ -375,7 +409,7 @@ VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type, vector_size_t size) {
     if (type->isUnKnown()) {
       return BaseVector::createNullConstant(type, size, pool_);
     } else {
-      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
           fuzzConstantPrimitiveImpl,
           type->kind(),
           pool_,
@@ -471,7 +505,7 @@ VectorPtr VectorFuzzer::fuzzFlatPrimitive(
     // First, fill it with random values.
     // TODO: We should bias towards edge cases (min, max, Nan, etc).
     auto kind = vector->typeKind();
-    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
         fuzzFlatPrimitiveImpl, kind, vector, rng_, opts_);
 
     // Second, generate a random null vector.
@@ -702,25 +736,47 @@ BufferPtr VectorFuzzer::fuzzNulls(vector_size_t size) {
   return builder.build();
 }
 
-TypePtr VectorFuzzer::randType(int maxDepth) {
-  static TypePtr kScalarTypes[]{
-      BOOLEAN(),
-      TINYINT(),
-      SMALLINT(),
-      INTEGER(),
-      BIGINT(),
-      REAL(),
-      DOUBLE(),
-      VARCHAR(),
-      VARBINARY(),
-      TIMESTAMP(),
-      DATE(),
-  };
-  static constexpr int kNumScalarTypes =
-      sizeof(kScalarTypes) / sizeof(kScalarTypes[0]);
+std::pair<int8_t, int8_t> VectorFuzzer::randPrecisionScale(TypeKind kind) {
+  VELOX_DCHECK(isDecimalKind(kind));
+  // Generate precision in range [1, Decimal type max precision]
+  auto precision = 1 +
+      rand<int8_t>(rng_) %
+          (kind == TypeKind::SHORT_DECIMAL ? ShortDecimalType::kMaxPrecision
+                                           : LongDecimalType::kMaxPrecision);
+  // Generate scale in range [0, precision]
+  auto scale = rand<int8_t>(rng_) % (precision + 1);
+  return {precision, scale};
+}
+
+TypePtr VectorFuzzer::randType(
+    int maxDepth,
+    const std::vector<TypeKind>& supportedScalarTypes) {
+  static std::vector<TypeKind> kScalarTypes = {
+      TypeKind::BOOLEAN,
+      TypeKind::TINYINT,
+      TypeKind::SMALLINT,
+      TypeKind::INTEGER,
+      TypeKind::BIGINT,
+      TypeKind::REAL,
+      TypeKind::DOUBLE,
+      TypeKind::VARCHAR,
+      TypeKind::VARBINARY,
+      TypeKind::TIMESTAMP,
+      TypeKind::DATE,
+      TypeKind::SHORT_DECIMAL,
+      TypeKind::LONG_DECIMAL};
+  auto scalarTypes =
+      supportedScalarTypes.size() == 0 ? kScalarTypes : supportedScalarTypes;
+  auto numScalarTypes = scalarTypes.size();
   // Should we generate a scalar type?
   if (maxDepth <= 1 || rand<bool>(rng_)) {
-    return kScalarTypes[rand<uint32_t>(rng_) % kNumScalarTypes];
+    auto randTypeKind = scalarTypes[rand<uint32_t>(rng_) % numScalarTypes];
+    if (isDecimalKind(randTypeKind)) {
+      // Generate precision in range [1, Decimal type max precision]
+      const auto& [precision, scale] = randPrecisionScale(randTypeKind);
+      return DECIMAL(precision, scale);
+    }
+    return fromKindToScalerType(randTypeKind);
   }
   switch (rand<uint32_t>(rng_) % 3) {
     case 0:
@@ -732,13 +788,15 @@ TypePtr VectorFuzzer::randType(int maxDepth) {
   }
 }
 
-RowTypePtr VectorFuzzer::randRowType(int maxDepth) {
+RowTypePtr VectorFuzzer::randRowType(
+    int maxDepth,
+    const std::vector<TypeKind>& scalarTypes) {
   int numFields = 1 + rand<uint32_t>(rng_) % 7;
   std::vector<std::string> names;
   std::vector<TypePtr> fields;
   for (int i = 0; i < numFields; ++i) {
     names.push_back(fmt::format("f{}", i));
-    fields.push_back(randType(maxDepth));
+    fields.push_back(randType(maxDepth, scalarTypes));
   }
   return ROW(std::move(names), std::move(fields));
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -222,10 +222,26 @@ class VectorFuzzer {
   // limits the maximum level of nesting for complex types. maxDepth <= 1 means
   // no complex types are allowed.
   //
-  // There are no options to control type generation yet; these may be added in
-  // the future.
-  TypePtr randType(int maxDepth = 5);
-  RowTypePtr randRowType(int maxDepth = 5);
+  // @param maxDepth Depth of a complex type.
+  // @param scalarTypes List of scalar types to be
+  // used to generate the random scalar and complex types. If not specified
+  // uses the default list, which includes all scalar types.
+  TypePtr randType(
+      int maxDepth = 5,
+      const std::vector<TypeKind>& scalarTypes = {});
+  RowTypePtr randRowType(
+      int maxDepth = 5,
+      const std::vector<TypeKind>& scalarTypes = {});
+
+  // Generates short decimal TypePtr with random precision and scale.
+  inline TypePtr randShortDecimalType() {
+    return randType(1, {TypeKind::SHORT_DECIMAL});
+  }
+
+  // Generates long decimal TypePtr with random precision and scale.
+  inline TypePtr randLongDecimalType() {
+    return randType(1, {TypeKind::LONG_DECIMAL});
+  }
 
   void reSeed(size_t seed) {
     rng_.seed(seed);
@@ -257,6 +273,11 @@ class VectorFuzzer {
  private:
   // Generates a flat vector for primitive types.
   VectorPtr fuzzFlatPrimitive(const TypePtr& type, vector_size_t size);
+
+  /// Generates random precision in range [1, max precision for decimal
+  /// TypeKind] and scale in range [0, random precision generated].
+  /// @param kind must be a decimal type kind.
+  std::pair<int8_t, int8_t> randPrecisionScale(TypeKind kind);
 
   // Returns a complex vector with randomized data and nulls.  The children and
   // all other descendant vectors will randomly use constant, dictionary, or

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -222,25 +222,21 @@ class VectorFuzzer {
   // limits the maximum level of nesting for complex types. maxDepth <= 1 means
   // no complex types are allowed.
   //
-  // @param maxDepth Depth of a complex type.
-  // @param scalarTypes List of scalar types to be
-  // used to generate the random scalar and complex types. If not specified
-  // uses the default list, which includes all scalar types.
-  TypePtr randType(
-      int maxDepth = 5,
-      const std::vector<TypeKind>& scalarTypes = {});
-  RowTypePtr randRowType(
-      int maxDepth = 5,
-      const std::vector<TypeKind>& scalarTypes = {});
+  // There are no options to control type generation yet; these may be added in
+  // the future.
+  TypePtr randType(int maxDepth = 5);
+  RowTypePtr randRowType(int maxDepth = 5);
 
   // Generates short decimal TypePtr with random precision and scale.
   inline TypePtr randShortDecimalType() {
-    return randType(1, {TypeKind::SHORT_DECIMAL});
+    auto [precision, scale] = randPrecisionScale(TypeKind::SHORT_DECIMAL);
+    return SHORT_DECIMAL(precision, scale);
   }
 
   // Generates long decimal TypePtr with random precision and scale.
   inline TypePtr randLongDecimalType() {
-    return randType(1, {TypeKind::LONG_DECIMAL});
+    auto [precision, scale] = randPrecisionScale(TypeKind::LONG_DECIMAL);
+    return LONG_DECIMAL(precision, scale);
   }
 
   void reSeed(size_t seed) {

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -99,7 +99,8 @@ TEST_F(VectorFuzzerTest, flatPrimitive) {
       TIMESTAMP(),
       INTERVAL_DAY_TIME(),
       UNKNOWN(),
-  };
+      fuzzer.randShortDecimalType(),
+      fuzzer.randLongDecimalType()};
 
   for (const auto& type : types) {
     vector = fuzzer.fuzzFlat(type);
@@ -223,6 +224,18 @@ TEST_F(VectorFuzzerTest, constants) {
 
   vector = fuzzer.fuzzConstant(VARCHAR());
   ASSERT_TRUE(vector->type()->kindEquals(VARCHAR()));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_FALSE(vector->mayHaveNulls());
+
+  auto shortDecimalType = fuzzer.randShortDecimalType();
+  vector = fuzzer.fuzzConstant(shortDecimalType);
+  ASSERT_TRUE(vector->type()->kindEquals(shortDecimalType));
+  ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
+  ASSERT_FALSE(vector->mayHaveNulls());
+
+  auto longDecimalType = fuzzer.randLongDecimalType();
+  vector = fuzzer.fuzzConstant(longDecimalType);
+  ASSERT_TRUE(vector->type()->kindEquals(longDecimalType));
   ASSERT_EQ(VectorEncoding::Simple::CONSTANT, vector->encoding());
   ASSERT_FALSE(vector->mayHaveNulls());
 


### PR DESCRIPTION
Add methods to generate random `UnscaledShortDecimal` and `UnscaledLongDecimal`
values. The values are capped within the range of precision provided. 