### PR TITLE
Remove boost/algorithm/string.hpp from SimpleFunctionMetadata.h

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,7 +18,7 @@ endif()
 add_library(velox_config Context.cpp)
 target_link_libraries(velox_config ${FOLLY_WITH_DEPENDENCIES})
 
-add_library(velox_core PlanFragment.cpp PlanNode.cpp)
+add_library(velox_core PlanFragment.cpp PlanNode.cpp SimpleFunctionMetadata.cpp)
 
 target_link_libraries(
   velox_core

--- a/velox/core/SimpleFunctionMetadata.cpp
+++ b/velox/core/SimpleFunctionMetadata.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/SimpleFunctionMetadata.h"
+#include <boost/algorithm/string/case_conv.hpp>
+
+namespace facebook::velox::core::detail {
+
+std::string strToLowerCopy(const std::string& str) {
+  return boost::algorithm::to_lower_copy(str);
+}
+
+} // namespace facebook::velox::core::detail


### PR DESCRIPTION
Summary:
This should improve compilation time for many dependent cpp files.

`boost/algorithm/string.hpp` is just a convenience header for everything in
`boost/algorithm/string` folder. Instead we can include case_conv.hpp

But even better way is to hide the usage of boost into cpp, which I implemented here.
Would need a careful review to make sure no extra copies with the new extra wrapper.

Differential Revision: D42663194

