### PR TITLE
Add array_remove function

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -100,6 +100,10 @@ Array Functions
 
     If ``instance > 0``, returns the position of the ``instance``-th occurrence of the ``element`` in array ``x``. If ``instance < 0``, returns the position of the ``instance``-to-last occurrence of the ``element`` in array ``x``. If no matching element instance is found, 0 is returned.
 
+.. function:: array_remove(array(E), element) -> array(E)
+
+    Removes all elements that equal ``element`` from the input array.
+
 .. function:: array_sort(array(E)) -> array(E)
 
      Returns an array which has the sorted order of the input array x. The elements of x must

--- a/velox/functions/prestosql/ArrayRemove.cpp
+++ b/velox/functions/prestosql/ArrayRemove.cpp
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/LambdaFunctionUtil.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+template <TypeKind kind>
+void applyTyped(
+    const SelectivityVector& rows,
+    DecodedVector& arrayDecoded,
+    DecodedVector& elementsDecoded,
+    DecodedVector& searchDecoded,
+    vector_size_t& indicesCursor,
+    BufferPtr& newIndices,
+    BufferPtr& newElementNulls,
+    BufferPtr& newLengths,
+    BufferPtr& newOffsets) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  auto base = arrayDecoded.base()->as<ArrayVector>();
+  auto indices = arrayDecoded.indices();
+
+  // Pointers and cursors to the raw data.
+  auto rawNewIndices = newIndices->asMutable<vector_size_t>();
+  auto rawNewElementNulls = newElementNulls->asMutable<uint64_t>();
+  auto rawNewLengths = newLengths->asMutable<vector_size_t>();
+  auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
+
+  rows.applyToSelected([&](auto row) {
+    rawNewOffsets[row] = indicesCursor;
+
+    if (searchDecoded.isNullAt(row)) {
+      bits::setNull(rawNewElementNulls, indicesCursor++, true);
+    } else {
+      auto elementToRemove = searchDecoded.valueAt<T>(row);
+
+      auto size = base->sizeAt(indices[row]);
+      auto offset = base->offsetAt(indices[row]);
+
+      for (auto i = offset; i < offset + size; i++) {
+        if (elementsDecoded.isNullAt(i)) {
+          // We always keep null values from the input array,
+          // they cannot be filtered out because search base is non-null.
+          bits::setNull(rawNewElementNulls, indicesCursor++, true);
+        } else if (elementsDecoded.valueAt<T>(i) != elementToRemove) {
+          rawNewIndices[indicesCursor++] = i;
+        }
+      }
+    }
+
+    rawNewLengths[row] = indicesCursor - rawNewOffsets[row];
+  });
+}
+
+void applyComplexType(
+    const SelectivityVector& rows,
+    DecodedVector& arrayDecoded,
+    DecodedVector& elementsDecoded,
+    DecodedVector& searchDecoded,
+    vector_size_t& indicesCursor,
+    BufferPtr& newIndices,
+    BufferPtr& newElementNulls,
+    BufferPtr& newLengths,
+    BufferPtr& newOffsets) {
+  auto base = arrayDecoded.base()->as<ArrayVector>();
+  auto indices = arrayDecoded.indices();
+
+  // Pointers and cursors to the raw data.
+  auto rawNewIndices = newIndices->asMutable<vector_size_t>();
+  auto rawNewElementNulls = newElementNulls->asMutable<uint64_t>();
+  auto rawNewLengths = newLengths->asMutable<vector_size_t>();
+  auto rawNewOffsets = newOffsets->asMutable<vector_size_t>();
+
+  // We need to use base elements instead of elementsDecoded as the indices
+  // could be remapped.
+  auto elementsBase = base->elements();
+  auto searchBase = searchDecoded.base();
+  auto searchIndices = searchDecoded.indices();
+
+  rows.applyToSelected([&](auto row) {
+    rawNewOffsets[row] = indicesCursor;
+
+    auto searchIndex = searchIndices[row];
+
+    if (searchBase->isNullAt(searchIndex)) {
+      bits::setNull(rawNewElementNulls, indicesCursor++, true);
+    } else {
+      auto size = base->sizeAt(indices[row]);
+      auto offset = base->offsetAt(indices[row]);
+
+      for (auto i = offset; i < offset + size; i++) {
+        if (elementsBase->isNullAt(i)) {
+          // We always keep null values from the input array,
+          // they cannot be filtered out because search base is non-null.
+          bits::setNull(rawNewElementNulls, indicesCursor++, true);
+        } else if (!elementsBase->equalValueAt(searchBase, i, searchIndex)) {
+          rawNewIndices[indicesCursor++] = i;
+        }
+      }
+    }
+
+    rawNewLengths[row] = indicesCursor - rawNewOffsets[row];
+  });
+}
+
+template <>
+void applyTyped<TypeKind::ARRAY>(
+    const SelectivityVector& rows,
+    DecodedVector& arrayDecoded,
+    DecodedVector& elementsDecoded,
+    DecodedVector& searchDecoded,
+    vector_size_t& indicesCursor,
+    BufferPtr& newIndices,
+    BufferPtr& newElementNulls,
+    BufferPtr& newLengths,
+    BufferPtr& newOffsets) {
+  applyComplexType(
+      rows,
+      arrayDecoded,
+      elementsDecoded,
+      searchDecoded,
+      indicesCursor,
+      newIndices,
+      newElementNulls,
+      newLengths,
+      newOffsets);
+}
+
+template <>
+void applyTyped<TypeKind::MAP>(
+    const SelectivityVector& rows,
+    DecodedVector& arrayDecoded,
+    DecodedVector& elementsDecoded,
+    DecodedVector& searchDecoded,
+    vector_size_t& indicesCursor,
+    BufferPtr& newIndices,
+    BufferPtr& newElementNulls,
+    BufferPtr& newLengths,
+    BufferPtr& newOffsets) {
+  applyComplexType(
+      rows,
+      arrayDecoded,
+      elementsDecoded,
+      searchDecoded,
+      indicesCursor,
+      newIndices,
+      newElementNulls,
+      newLengths,
+      newOffsets);
+}
+
+template <>
+void applyTyped<TypeKind::ROW>(
+    const SelectivityVector& rows,
+    DecodedVector& arrayDecoded,
+    DecodedVector& elementsDecoded,
+    DecodedVector& searchDecoded,
+    vector_size_t& indicesCursor,
+    BufferPtr& newIndices,
+    BufferPtr& newElementNulls,
+    BufferPtr& newLengths,
+    BufferPtr& newOffsets) {
+  applyComplexType(
+      rows,
+      arrayDecoded,
+      elementsDecoded,
+      searchDecoded,
+      indicesCursor,
+      newIndices,
+      newElementNulls,
+      newLengths,
+      newOffsets);
+}
+
+class ArrayRemoveFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_USER_CHECK_EQ(
+        args.size(), 2, "array_remove requires exactly 2 parameters");
+
+    const auto& arrayVector = args[0];
+    const auto& searchVector = args[1];
+
+    // Both vectors must be array vectors of the same type.
+    VELOX_USER_CHECK(
+        arrayVector->type()->isArray(),
+        "array_remove requires arguments of type ARRAY");
+    VELOX_CHECK(
+        arrayVector->type()->asArray().elementType()->kindEquals(
+            searchVector->type()),
+        "array_remove requires all arguments of the same type: {} vs. {}",
+        searchVector->type(),
+        arrayVector->type()->asArray().elementType());
+
+    exec::DecodedArgs decodedArgs(rows, args, context);
+
+    DecodedVector* arrayDecoded = decodedArgs.at(0);
+    auto base = arrayDecoded->base()->as<ArrayVector>();
+
+    exec::LocalSelectivityVector nestedRows(context, base->elements()->size());
+    nestedRows->setAll();
+    exec::LocalDecodedVector elementsDecoded(
+        context, *base->elements(), *nestedRows);
+    DecodedVector* searchDecoded = decodedArgs.at(1);
+
+    vector_size_t elementsCount =
+        countElements<ArrayVector>(rows, *arrayDecoded);
+    vector_size_t rowCount = arrayDecoded->size();
+
+    // Allocate new vectors for indices, length, and offsets.
+    memory::MemoryPool* pool = context.pool();
+    BufferPtr newIndices = allocateIndices(elementsCount, pool);
+    BufferPtr newElementNulls =
+        AlignedBuffer::allocate<bool>(elementsCount, pool, bits::kNotNull);
+    BufferPtr newLengths = allocateSizes(rowCount, pool);
+    BufferPtr newOffsets = allocateOffsets(rowCount, pool);
+
+    vector_size_t indicesCursor = 0;
+
+    VELOX_DYNAMIC_TYPE_DISPATCH(
+        applyTyped,
+        searchVector->typeKind(),
+        rows,
+        *arrayDecoded,
+        *elementsDecoded,
+        *searchDecoded,
+        indicesCursor,
+        newIndices,
+        newElementNulls,
+        newLengths,
+        newOffsets);
+
+    auto newElements = BaseVector::wrapInDictionary(
+        newElementNulls, newIndices, indicesCursor, base->elements());
+
+    auto localResult = std::make_shared<ArrayVector>(
+        pool,
+        ARRAY(base->elements()->type()),
+        nullptr,
+        rowCount,
+        newOffsets,
+        newLengths,
+        newElements,
+        0);
+
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+};
+
+static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  // array(T), T -> array(T)
+  return {exec::FunctionSignatureBuilder()
+              .typeVariable("T")
+              .argumentType("array(T)")
+              .argumentType("T")
+              .returnType("array(T)")
+              .build()};
+}
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_array_remove,
+    signatures(),
+    std::make_unique<ArrayRemoveFunction>());
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   ArrayDuplicates.cpp
   ArrayIntersectExcept.cpp
   ArrayPosition.cpp
+  ArrayRemove.cpp
   ArrayShuffle.cpp
   ArraySort.cpp
   ArraySum.cpp

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -90,6 +90,7 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "zip");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_remove, prefix + "array_remove");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_shuffle, prefix + "shuffle");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, prefix + "array_sort");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");

--- a/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class ArrayRemoveTest : public FunctionBaseTest {
+ protected:
+  void testExpr(
+      const VectorPtr& expected,
+      const std::vector<VectorPtr>& input) {
+    auto result =
+        evaluate<ArrayVector>("array_remove(C0, C1)", makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(ArrayRemoveTest, integer) {
+  auto input = makeNullableArrayVector<int32_t>({
+      {}, // No values.
+      {1}, // Only one value.
+      {1, 2, std::nullopt}, // Trim left.
+      {2, std::nullopt, 1}, // Trim right.
+      {1, 1, 1, 1, 1}, // Only search elements.
+      {2, 3, 4, 5}, // No search element.
+      {2, 3, 1, 1, 4, 5}, // Search element is in the middle.
+      {1, 2, 1, 2, 1, 2}, // Alternating values.
+      {std::nullopt, std::nullopt} // Nulls.
+  });
+  auto search = makeConstant(1, input->size());
+  auto expected = makeNullableArrayVector<int32_t>(
+      {{},
+       {},
+       {2, std::nullopt},
+       {2, std::nullopt},
+       {},
+       {2, 3, 4, 5},
+       {2, 3, 4, 5},
+       {2, 2, 2},
+       {std::nullopt, std::nullopt}});
+  testExpr(expected, {input, search});
+}
+
+TEST_F(ArrayRemoveTest, boolean) {
+  auto input = makeNullableArrayVector<bool>({
+      {}, // No values.
+      {true}, // Only one value.
+      {true, false, std::nullopt}, // Trim left.
+      {false, std::nullopt, true}, // Trim right.
+      {true, true, true, true}, // Only search elements.
+      {false, false}, // No search element.
+      {false, false, true, false, false}, // Search element is in the middle.
+      {false, true, false, true}, // Alternating values.
+      {std::nullopt, std::nullopt} // Nulls.
+  });
+  auto search = makeConstant(true, input->size());
+  auto expected = makeNullableArrayVector<bool>(
+      {{},
+       {},
+       {false, std::nullopt},
+       {false, std::nullopt},
+       {},
+       {false, false},
+       {false, false, false, false},
+       {false, false},
+       {std::nullopt, std::nullopt}});
+  testExpr(expected, {input, search});
+}
+
+TEST_F(ArrayRemoveTest, varchar) {
+  using S = StringView;
+
+  auto input = makeNullableArrayVector<S>({
+      {}, // No values.
+      {S("a")}, // Only one value.
+      {S("a"), S("b"), std::nullopt}, // Trim left.
+      {S("b"), std::nullopt, S("a")}, // Trim right.
+      {S("a"), S("a"), S("a"), S("a")}, // Only search elements.
+      {S("b"), S("b"), S("b")}, // No search element.
+      {S("b"), S("c"), S("a"), S("d"), S("e")}, // Search element is in the
+                                                // middle.
+      {S("a"), S("b"), S("a"), S("b")}, // Alternating values.
+      {std::nullopt, std::nullopt} // Nulls.
+  });
+  auto search = makeConstant("a", input->size());
+  auto expected = makeNullableArrayVector<S>(
+      {{},
+       {},
+       {S("b"), std::nullopt},
+       {S("b"), std::nullopt},
+       {},
+       {S("b"), S("b"), S("b")},
+       {S("b"), S("c"), S("d"), S("e")},
+       {S("b"), S("b")},
+       {std::nullopt, std::nullopt}});
+  testExpr(expected, {input, search});
+}
+
+TEST_F(ArrayRemoveTest, array) {
+  std::vector<std::optional<int32_t>> a{1, 2, 3};
+  std::vector<std::optional<int32_t>> b{1};
+  std::vector<std::optional<int32_t>> c{2, 3};
+
+  auto input = makeNullableNestedArrayVector<int32_t>(
+      {{{{a}, {b}, {c}}},
+       {{{b}}},
+       {{{b}, {b}, {b}}},
+       {{{a}, {c}}},
+       {{}},
+       {{std::nullopt}}});
+  auto search = makeConstantArray<int32_t>(input->size(), {1});
+  auto expected = makeNullableNestedArrayVector<int32_t>({
+      {{{a}, {c}}},
+      {{}},
+      {{}},
+      {{{a}, {c}}},
+      {{}},
+      {{std::nullopt}},
+  });
+
+  testExpr(expected, {input, search});
+}
+
+TEST_F(ArrayRemoveTest, map) {
+  using P = std::pair<int32_t, std::optional<int32_t>>;
+
+  std::vector<P> a{P{1, 100}, P{2, 200}, P{3, 300}};
+  std::vector<P> b{P{1, 100}};
+  std::vector<P> c{P{2, 200}, P{3, 300}};
+  std::vector<P> d{P{4, 400}};
+
+  auto input = makeArrayOfMapVector<int32_t, int32_t>(
+      {{},
+       {{}},
+       {a, b, c},
+       {b, b, b},
+       {a, c, d},
+       {b, std::nullopt, b},
+       {std::nullopt}});
+  auto search = makeMapVector<int32_t, int32_t>({b, b, b, b, b, b, b});
+  auto expected = makeArrayOfMapVector<int32_t, int32_t>(
+      {{}, {{}}, {a, c}, {}, {a, c, d}, {std::nullopt}, {std::nullopt}});
+
+  testExpr(expected, {input, search});
+}
+
+TEST_F(ArrayRemoveTest, row) {
+  auto rowType = ROW({"col"}, {INTEGER()});
+
+  auto input = makeArrayOfRowVector(
+      rowType,
+      {{},
+       {variant(TypeKind::ROW), variant(TypeKind::ROW)},
+       {variant(TypeKind::ROW), variant::row({1})},
+       {variant::row({1}), variant::row({2}), variant::row({3})},
+       {variant::row({1}), variant::row({1})},
+       {variant::row({2})}});
+
+  auto search = makeConstantRow(rowType, variant::row({1}), input->size());
+  auto expected = makeArrayOfRowVector(
+      rowType,
+      {{},
+       {variant(TypeKind::ROW), variant(TypeKind::ROW)},
+       {variant(TypeKind::ROW)},
+       {variant::row({2}), variant::row({3})},
+       {},
+       {variant::row({2})}});
+
+  testExpr(expected, {input, search});
+}
+
+} // namespace

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(
   ArrayMinTest.cpp
   ArrayNormalizeTest.cpp
   ArrayPositionTest.cpp
+  ArrayRemoveTest.cpp
   ArraySortTest.cpp
   ArrayShuffleTest.cpp
   ArraysOverlapTest.cpp


### PR DESCRIPTION
This PR adds `array_remove` function that handles arrays of primitive as well as array of complex types.