### PR TITLE
Include <string> in BitUtil.h

### DIFF
--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -20,6 +20,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <string>
 
 #ifdef __BMI2__
 #include <x86intrin.h>


### PR DESCRIPTION
The `toString` function introduced in #3464 returns `std::string`, which breaks the pyVelox build for me due to it not knowing what `std::string` is. This changes makes it so that it compiles for me. 