### PR TITLE
Add ReturnRowNumbers flag to RowReaderOptions

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -101,6 +101,7 @@ class RowReaderOptions {
   // operations.
   std::shared_ptr<folly::Executor> decodingExecutor_;
   std::shared_ptr<folly::Executor> ioExecutor_;
+  bool appendRowNumberColumn_ = false;
 
  public:
   RowReaderOptions(const RowReaderOptions& other) {
@@ -114,6 +115,7 @@ class RowReaderOptions {
     metadataFilter_ = other.metadataFilter_;
     returnFlatVector_ = other.returnFlatVector_;
     flatmapNodeIdAsStruct_ = other.flatmapNodeIdAsStruct_;
+    appendRowNumberColumn_ = other.appendRowNumberColumn_;
   }
 
   RowReaderOptions() noexcept
@@ -273,6 +275,18 @@ class RowReaderOptions {
 
   void setIOExecutor(std::shared_ptr<folly::Executor> executor) {
     ioExecutor_ = executor;
+  }
+
+  /*
+   * Set to true, if you want to add a new column to the results containing the
+   * row numbers.
+   */
+  void setAppendRowNumberColumn(bool value) {
+    appendRowNumberColumn_ = value;
+  }
+
+  bool getAppendRowNumberColumn() const {
+    return appendRowNumberColumn_;
   }
 
   const std::shared_ptr<folly::Executor>& getDecodingExecutor() const {

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+#include "velox/dwio/common/Options.h"
+
+using namespace ::testing;
+using namespace facebook::velox::dwio::common;
+
+TEST(OptionsTests, defaultAppendRowNumberColumnTest) {
+  // appendRowNumberColumn flag should be false by default
+  RowReaderOptions rowReaderOptions;
+  ASSERT_EQ(false, rowReaderOptions.getAppendRowNumberColumn());
+}
+
+TEST(OptionsTests, setAppendRowNumberColumnToTrueTest) {
+  RowReaderOptions rowReaderOptions;
+  rowReaderOptions.setAppendRowNumberColumn(true);
+  ASSERT_EQ(true, rowReaderOptions.getAppendRowNumberColumn());
+}
+
+TEST(OptionsTests, testAppendRowNumberColumnInCopy) {
+  RowReaderOptions rowReaderOptions;
+  RowReaderOptions rowReaderOptionsCopy{rowReaderOptions};
+  ASSERT_EQ(false, rowReaderOptionsCopy.getAppendRowNumberColumn());
+
+  rowReaderOptions.setAppendRowNumberColumn(true);
+  RowReaderOptions rowReaderOptionsSecondCopy{rowReaderOptions};
+  ASSERT_EQ(true, rowReaderOptionsSecondCopy.getAppendRowNumberColumn());
+}


### PR DESCRIPTION
Summary: Add a new flag in RowReaderOptions. Readers can use this flag and append a vector with row numbers to the resuts.

Differential Revision: D42682830

