### PR TITLE
Allow Exchange to have pluggable serde

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -372,7 +372,7 @@ RowVectorPtr Exchange::getOutput() {
     currentPage_->prepareStreamForDeserialize(inputStream_.get());
   }
 
-  VectorStreamGroup::read(
+  getSerde()->deserialize(
       inputStream_.get(), operatorCtx_->pool(), outputType_, &result_);
 
   {
@@ -388,6 +388,10 @@ RowVectorPtr Exchange::getOutput() {
   }
 
   return result_;
+}
+
+VectorSerde* Exchange::getSerde() {
+  return getVectorSerde();
 }
 
 VELOX_REGISTER_EXCHANGE_SOURCE_METHOD_DEFINITION(

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -352,13 +352,14 @@ class Exchange : public SourceOperator {
       int32_t operatorId,
       DriverCtx* FOLLY_NONNULL ctx,
       const std::shared_ptr<const core::ExchangeNode>& exchangeNode,
-      std::shared_ptr<ExchangeClient> exchangeClient)
+      std::shared_ptr<ExchangeClient> exchangeClient,
+      const std::string& operatorType = "Exchange")
       : SourceOperator(
             ctx,
             exchangeNode->outputType(),
             operatorId,
             exchangeNode->id(),
-            "Exchange"),
+            operatorType),
         planNodeId_(exchangeNode->id()),
         exchangeClient_(std::move(exchangeClient)) {
     if (operatorCtx_->driverCtx()->driverId == 0) {
@@ -387,6 +388,9 @@ class Exchange : public SourceOperator {
   BlockingReason isBlocked(ContinueFuture* FOLLY_NONNULL future) override;
 
   bool isFinished() override;
+
+ protected:
+  virtual VectorSerde* getSerde();
 
  private:
   /// Fetches splits from the task until there are no more splits or task

--- a/velox/serializers/UnsafeRowSerializer.h
+++ b/velox/serializers/UnsafeRowSerializer.h
@@ -21,6 +21,7 @@ namespace facebook::velox::serializer::spark {
 
 class UnsafeRowVectorSerde : public VectorSerde {
  public:
+  UnsafeRowVectorSerde() = default;
   // We do not implement this method since it is not used in production code.
   void estimateSerializedSize(
       VectorPtr vector,

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -71,9 +71,11 @@ class VectorSerde {
       const Options* options = nullptr) = 0;
 };
 
-bool registerVectorSerde(std::unique_ptr<VectorSerde> serde);
+void registerVectorSerde(std::unique_ptr<VectorSerde> serdeToRegister);
 
 bool isRegisteredVectorSerde();
+
+VectorSerde* getVectorSerde();
 
 class VectorStreamGroup : public StreamArena {
  public:


### PR DESCRIPTION
To support ShuffleRead operator extending from Exchange operator and being able to provide custom serde, we change Exchange operator to be serde pluggable.