### PR TITLE
Add exchange client to custom operator creation

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -99,6 +99,14 @@ class PlanNode {
       const = 0;
 
   /// Returns true if this is a leaf plan node and corresponding operator
+  /// requires an ExchangeClient to retrieve data. For instance, TableScanNode
+  /// is a leaf node that doesn't require an ExchangeClient. But ExchangeNode is
+  /// a leaf node that requires an ExchangeClient.
+  virtual bool requiresExchangeClient() const {
+    return false;
+  }
+
+  /// Returns true if this is a leaf plan node and corresponding operator
   /// requires splits to make progress. ValueNode is a leaf node that doesn't
   /// require splits, but TableScanNode and ExchangeNode are leaf nodes that
   /// require splits.
@@ -683,6 +691,10 @@ class ExchangeNode : public PlanNode {
   }
 
   const std::vector<PlanNodePtr>& sources() const override;
+
+  bool requiresExchangeClient() const override {
+    return true;
+  }
 
   bool requiresSplits() const override {
     return true;

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -395,9 +395,9 @@ struct DriverFactory {
   /// exchange.
   std::optional<core::PlanNodeId> needsExchangeClient() const {
     VELOX_CHECK(!planNodes.empty());
-    if (auto exchangeNode = std::dynamic_pointer_cast<const core::ExchangeNode>(
-            planNodes.front())) {
-      return exchangeNode->id();
+    const auto& leafNode = planNodes.front();
+    if (leafNode->requiresExchangeClient()) {
+      return leafNode->id();
     }
     return std::nullopt;
   }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -158,9 +158,17 @@ Operator::translators() {
 std::unique_ptr<Operator> Operator::fromPlanNode(
     DriverCtx* ctx,
     int32_t id,
-    const core::PlanNodePtr& planNode) {
+    const core::PlanNodePtr& planNode,
+    std::shared_ptr<ExchangeClient> exchangeClient) {
+  VELOX_CHECK_EQ(exchangeClient != nullptr, planNode->requiresExchangeClient());
   for (auto& translator : translators()) {
-    auto op = translator->toOperator(ctx, id, planNode);
+    std::unique_ptr<Operator> op;
+    if (planNode->requiresExchangeClient()) {
+      op = translator->toOperator(ctx, id, planNode, exchangeClient);
+    } else {
+      op = translator->toOperator(ctx, id, planNode);
+    }
+
     if (op) {
       return op;
     }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -236,7 +236,19 @@ class Operator : public BaseRuntimeStatWriter {
     virtual std::unique_ptr<Operator> toOperator(
         DriverCtx* FOLLY_NONNULL ctx,
         int32_t id,
-        const core::PlanNodePtr& node) = 0;
+        const core::PlanNodePtr& node) {
+      return nullptr;
+    }
+
+    // An overloaded method that should be called when the operator needs an
+    // ExchangeClient.
+    virtual std::unique_ptr<Operator> toOperator(
+        DriverCtx* FOLLY_NONNULL ctx,
+        int32_t id,
+        const core::PlanNodePtr& node,
+        std::shared_ptr<ExchangeClient> exchangeClient) {
+      return nullptr;
+    }
 
     // Translates plan node to join bridge. Returns nullptr if the plan node
     // cannot be handled by this factory.
@@ -414,11 +426,13 @@ class Operator : public BaseRuntimeStatWriter {
 
   // Calls all the registered PlanNodeTranslators on 'planNode' and
   // returns the result of the first one that returns non-nullptr
-  // or nullptr if all return nullptr.
+  // or nullptr if all return nullptr. exchangeClient is not-null only when
+  // planNode->requiresExchangeClient() is true.
   static std::unique_ptr<Operator> fromPlanNode(
       DriverCtx* FOLLY_NONNULL ctx,
       int32_t id,
-      const core::PlanNodePtr& planNode);
+      const core::PlanNodePtr& planNode,
+      std::shared_ptr<ExchangeClient> exchangeClient = nullptr);
 
   // Calls all the registered PlanNodeTranslators on 'planNode' and
   // returns the result of the first one that returns non-nullptr


### PR DESCRIPTION
Some custom operators (e.g. ShuffleRead that extends from Exchange) may require ExchangeClient to build. This PR made changes to PlanNodeTranslator API to allow passing of ExchangeClient. In order to achieve that, an API change is made to PlanNode: 

```
  /// Returns true if this is a leaf plan node and corresponding operator
  /// requires an ExchangeClient to retrieve data. TableScanNode is a leaf node
  /// that doesn't require an ExchangeClient. But ExchangeNode is a leaf node
  /// that requires an ExchangeClient.
  virtual bool requiresExchangeClient()  const;
```
