### PR TITLE
Feature physical size stat

### DIFF
--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -461,6 +461,21 @@ target_link_libraries(
   ${ZLIB_LIBRARIES}
   ${TEST_LINK_LIBS})
 
+add_executable(physical_size_aggregator_test PhysicalSizeAggregatorTest.cpp)
+add_test(physical_size_aggregator_test physical_size_aggregator_test)
+
+target_link_libraries(
+  physical_size_aggregator_test
+  velox_dwrf_test_utils
+  ${VELOX_LINK_LIBS}
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${FMT}
+  ${LZ4}
+  ${LZO}
+  ${ZSTD}
+  ${ZLIB_LIBRARIES}
+  ${TEST_LINK_LIBS})
+
 add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
 target_link_libraries(
   velox_dwrf_int_encoder_benchmark velox_dwio_dwrf_common velox_memory

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -17,6 +17,8 @@
 #include <folly/Random.h>
 #include <random>
 #include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Statistics.h"
+#include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/common/encryption/TestProvider.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/common/tests/utils/MapBuilder.h"
@@ -503,7 +505,7 @@ void testFlatMapConfig(
   bool preload = true;
   std::unordered_set<uint32_t> actualNodeIds;
   for (int32_t i = 0; i < reader->getNumberOfStripes(); ++i) {
-    dwrfRowReader->loadStripe(0, preload);
+    dwrfRowReader->loadStripe(i, preload);
     auto& footer = dwrfRowReader->getStripeFooter();
     for (int32_t j = 0; j < footer.encoding_size(); ++j) {
       auto encoding = footer.encoding(j);

--- a/velox/dwio/dwrf/test/PhysicalSizeAggregatorTest.cpp
+++ b/velox/dwio/dwrf/test/PhysicalSizeAggregatorTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/dwio/dwrf/writer/PhysicalSizeAggregator.h"
+
+using namespace ::testing;
+
+namespace facebook::velox::dwrf {
+TEST(PhysicalSizeAggregatorTest, UpdateLeaf) {
+  auto leafOne = std::make_unique<PhysicalSizeAggregator>(nullptr);
+  auto leafTwo = std::make_unique<PhysicalSizeAggregator>(nullptr);
+  ASSERT_EQ(0, leafOne->getResult());
+  ASSERT_EQ(0, leafTwo->getResult());
+
+  leafOne->recordSize(
+      DwrfStreamIdentifier{0, 0, 0, StreamKind::StreamKind_DATA}, 1);
+  EXPECT_EQ(1, leafOne->getResult());
+  EXPECT_EQ(0, leafTwo->getResult());
+
+  leafTwo->recordSize(
+      DwrfStreamIdentifier{1, 0, 0, StreamKind::StreamKind_DATA}, 2);
+  EXPECT_EQ(1, leafOne->getResult());
+  EXPECT_EQ(2, leafTwo->getResult());
+
+  leafOne->recordSize(
+      DwrfStreamIdentifier{2, 0, 0, StreamKind::StreamKind_DATA}, 4);
+  EXPECT_EQ(5, leafOne->getResult());
+  EXPECT_EQ(2, leafTwo->getResult());
+}
+
+TEST(PhysicalSizeAggregatorTest, UpdateParent) {
+  auto parent = std::make_unique<PhysicalSizeAggregator>(nullptr);
+  auto childOne = std::make_unique<PhysicalSizeAggregator>(parent.get());
+  auto childTwo = std::make_unique<PhysicalSizeAggregator>(parent.get());
+  ASSERT_EQ(0, parent->getResult());
+  ASSERT_EQ(0, childOne->getResult());
+  ASSERT_EQ(0, childTwo->getResult());
+
+  parent->recordSize(
+      DwrfStreamIdentifier{0, 0, 0, StreamKind::StreamKind_DATA}, 1);
+  ASSERT_EQ(1, parent->getResult());
+  ASSERT_EQ(0, childOne->getResult());
+  ASSERT_EQ(0, childTwo->getResult());
+
+  childOne->recordSize(
+      DwrfStreamIdentifier{1, 0, 0, StreamKind::StreamKind_DATA}, 2);
+  EXPECT_EQ(3, parent->getResult());
+  EXPECT_EQ(2, childOne->getResult());
+  EXPECT_EQ(0, childTwo->getResult());
+
+  childTwo->recordSize(
+      DwrfStreamIdentifier{2, 0, 0, StreamKind::StreamKind_DATA}, 4);
+  EXPECT_EQ(7, parent->getResult());
+  EXPECT_EQ(2, childOne->getResult());
+  EXPECT_EQ(4, childTwo->getResult());
+}
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/ColumnWriter.h
+++ b/velox/dwio/dwrf/writer/ColumnWriter.h
@@ -123,9 +123,9 @@ class BaseColumnWriter : public ColumnWriter {
                               statsFactory) const override {
     auto& stats = statsFactory(id_);
     fileStatsBuilder_->toProto(stats);
-    uint64_t size = context_.getNodeSize(id_);
+    uint64_t size = context_.getPhysicalSizeAggregator(id_).getResult();
     for (auto& child : children_) {
-      size += child->writeFileStats(statsFactory);
+      child->writeFileStats(statsFactory);
     }
     stats.set_size(size);
     return size;

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -56,9 +56,9 @@ class ValueStatisticsBuilder {
       std::function<proto::ColumnStatistics&(uint32_t)> statsFactory) const {
     auto& stats = statsFactory(id_);
     statisticsBuilder_->toProto(stats);
-    uint64_t size = context_.getNodeSize(id_);
+    uint64_t size = context_.getPhysicalSizeAggregator(id_).getResult();
     for (int32_t i = 0; i < children_.size(); ++i) {
-      size += children_[i]->writeFileStats(statsFactory);
+      children_[i]->writeFileStats(statsFactory);
     }
     stats.set_size(size);
     return size;

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.h
@@ -168,6 +168,10 @@ class ValueWriter {
     return sequence_;
   }
 
+  const proto::KeyInfo& getKeyInfo() const {
+    return keyInfo_;
+  }
+
   void createIndexEntry(
       const ValueStatisticsBuilder& valueStatsBuilder,
       MapStatisticsBuilder& mapStatsBuilder) {
@@ -300,6 +304,7 @@ class FlatMapColumnWriter : public BaseColumnWriter {
 
   // Stores column keys if writing with RowVector input
   std::vector<KeyType> structKeys_;
+  const bool collectMapStats_;
 };
 
 template <>

--- a/velox/dwio/dwrf/writer/PhysicalSizeAggregator.h
+++ b/velox/dwio/dwrf/writer/PhysicalSizeAggregator.h
@@ -53,6 +53,13 @@ class MapPhysicalSizeAggregator : public PhysicalSizeAggregator {
   void recordSize(const DwrfStreamIdentifier& id, uint64_t streamSize)
       override {
     PhysicalSizeAggregator::recordSize(id, streamSize);
+    if (!mapStatsBuilder_) {
+      return;
+    }
+    if (id.encodingKey().sequence != 0) {
+      mapStatsBuilder_->incrementSize(
+          sequenceToKey_.at(id.encodingKey().sequence), streamSize);
+    }
   }
 
   void prepare(

--- a/velox/dwio/dwrf/writer/PhysicalSizeAggregator.h
+++ b/velox/dwio/dwrf/writer/PhysicalSizeAggregator.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/dwio/dwrf/writer/StatisticsBuilder.h"
+
+namespace facebook::velox::dwrf {
+
+class PhysicalSizeAggregator {
+ public:
+  explicit PhysicalSizeAggregator(PhysicalSizeAggregator* parent = nullptr)
+      : parent_{parent} {}
+
+  virtual ~PhysicalSizeAggregator() = default;
+
+  virtual void recordSize(const DwrfStreamIdentifier& id, uint64_t streamSize) {
+    result_ += streamSize;
+    if (parent_) {
+      parent_->recordSize(id, streamSize);
+    }
+  }
+
+  uint64_t getResult() {
+    return result_;
+  }
+
+ private:
+  uint64_t result_{0};
+  PhysicalSizeAggregator* parent_;
+};
+
+class MapPhysicalSizeAggregator : public PhysicalSizeAggregator {
+ public:
+  explicit MapPhysicalSizeAggregator(PhysicalSizeAggregator* parent = nullptr)
+      : PhysicalSizeAggregator{parent} {}
+
+  virtual ~MapPhysicalSizeAggregator() = default;
+
+  void recordSize(const DwrfStreamIdentifier& id, uint64_t streamSize)
+      override {
+    PhysicalSizeAggregator::recordSize(id, streamSize);
+  }
+
+  void prepare(
+      folly::F14FastMap<uint32_t, const proto::KeyInfo&> sequenceToKey,
+      MapStatisticsBuilder* mapStatsBuilder) {
+    sequenceToKey_ = std::move(sequenceToKey);
+    mapStatsBuilder_ = mapStatsBuilder;
+  }
+
+ private:
+  folly::F14FastMap<uint32_t, const proto::KeyInfo&> sequenceToKey_;
+  MapStatisticsBuilder* mapStatsBuilder_{nullptr};
+};
+
+} // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.h
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.h
@@ -120,6 +120,18 @@ class StatisticsBuilder : public virtual dwio::common::ColumnStatistics {
     rawSize_.reset();
   }
 
+  void ensureSize() {
+    if (!size_.has_value()) {
+      size_ = 0;
+    }
+  }
+
+  void incrementSize(uint64_t size) {
+    if (LIKELY(size_.has_value())) {
+      addWithOverflowCheck(size_, size, /*count=*/1);
+    }
+  }
+
   /*
    * Merge stats of same type. This is used in writer to aggregate file level
    * stats.
@@ -411,6 +423,14 @@ class MapStatisticsBuilder : public StatisticsBuilder,
     // it's ok to just construct the key struct per call.
     auto& keyStats = getKeyStats(constructKey(keyInfo));
     keyStats.merge(stats, /*ignoreSize=*/true);
+  }
+
+  void incrementSize(const dwrf::proto::KeyInfo& keyInfo, uint64_t size) {
+    // Since incrementSize is called once per key info per stripe,
+    // it's ok to just construct the key struct per call.
+    auto& keyStats = getKeyStats(constructKey(keyInfo));
+    keyStats.ensureSize();
+    keyStats.incrementSize(size);
   }
 
   void merge(

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -429,7 +429,7 @@ void Writer::flushStripe(bool close) {
     s->set_usevints(context.getConfig(Config::USE_VINTS));
     offset += out.size();
 
-    context.incrementNodeSize(nodeId, out.size());
+    context.recordPhysicalSize(stream, out.size());
   };
 
   // TODO: T45025996 Discard all empty streams at flush time.

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -142,8 +142,9 @@ class Writer : public WriterBase {
                                       options.encrypterFactory.get())
                                 : nullptr);
     initContext(options.config, std::move(pool), std::move(handler));
+    auto& context = getContext();
+    context.buildPhysicalSizeAggregators(*schema_);
     if (!options.flushPolicyFactory) {
-      auto& context = getContext();
       flushPolicy_ = std::make_unique<DefaultFlushPolicy>(
           context.stripeSizeFlushThreshold,
           context.dictionarySizeFlushThreshold);

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -19,10 +19,12 @@
 #include <limits>
 #include "velox/common/base/GTestMacros.h"
 #include "velox/common/time/CpuWallTimer.h"
+#include "velox/dwio/dwrf/common/Common.h"
 #include "velox/dwio/dwrf/common/Compression.h"
 #include "velox/dwio/dwrf/common/EncoderUtil.h"
 #include "velox/dwio/dwrf/writer/IndexBuilder.h"
 #include "velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h"
+#include "velox/dwio/dwrf/writer/PhysicalSizeAggregator.h"
 #include "velox/dwio/dwrf/writer/RatioTracker.h"
 #include "velox/vector/DecodedVector.h"
 
@@ -392,6 +394,74 @@ class WriterContext : public CompressionBufferPool {
     return lowMemoryMode_;
   }
 
+  PhysicalSizeAggregator& getPhysicalSizeAggregator(uint32_t node) {
+    return *physicalSizeAggregators_.at(node);
+  }
+
+  void recordPhysicalSize(const DwrfStreamIdentifier& streamId, uint64_t size) {
+    auto& agg = getPhysicalSizeAggregator(streamId.encodingKey().node);
+    agg.recordSize(streamId, size);
+  }
+
+  void buildPhysicalSizeAggregators(
+      const velox::dwio::common::TypeWithId& type,
+      PhysicalSizeAggregator* parent = nullptr) {
+    switch (type.type->kind()) {
+      case TypeKind::ROW: {
+        physicalSizeAggregators_.emplace(
+            type.id, std::make_unique<PhysicalSizeAggregator>(parent));
+        auto current = physicalSizeAggregators_.at(type.id).get();
+        for (auto& child : type.getChildren()) {
+          buildPhysicalSizeAggregators(*child, current);
+        }
+        break;
+      }
+      case TypeKind::MAP: {
+        // MapPhysicalSizeAggregator is only required for flatmaps, but it will
+        // behave just fine as a regular PhysicalSizeAggregator.
+        physicalSizeAggregators_.emplace(
+            type.id, std::make_unique<MapPhysicalSizeAggregator>(parent));
+        auto current = physicalSizeAggregators_.at(type.id).get();
+        buildPhysicalSizeAggregators(*type.childAt(0), current);
+        buildPhysicalSizeAggregators(*type.childAt(1), current);
+        break;
+      }
+      case TypeKind::ARRAY: {
+        physicalSizeAggregators_.emplace(
+            type.id, std::make_unique<PhysicalSizeAggregator>(parent));
+        auto current = physicalSizeAggregators_.at(type.id).get();
+        buildPhysicalSizeAggregators(*type.childAt(0), current);
+        break;
+      }
+      case TypeKind::BOOLEAN:
+      case TypeKind::TINYINT:
+      case TypeKind::SMALLINT:
+      case TypeKind::INTEGER:
+      case TypeKind::BIGINT:
+      case TypeKind::REAL:
+      case TypeKind::DOUBLE:
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+      case TypeKind::TIMESTAMP:
+      case TypeKind::DATE:
+      case TypeKind::INTERVAL_DAY_TIME:
+      case TypeKind::SHORT_DECIMAL:
+      case TypeKind::LONG_DECIMAL:
+        physicalSizeAggregators_.emplace(
+            type.id, std::make_unique<PhysicalSizeAggregator>(parent));
+        break;
+      case TypeKind::UNKNOWN:
+      case TypeKind::FUNCTION:
+      case TypeKind::OPAQUE:
+      case TypeKind::INVALID:
+        VELOX_FAIL(fmt::format(
+            "Unexpected type kind {} encountered when building "
+            "physical size aggregator for node {}.",
+            type.type->toString(),
+            type.id));
+    }
+  }
+
   class LocalDecodedVector {
    public:
     explicit LocalDecodedVector(WriterContext& context)
@@ -458,6 +528,8 @@ class WriterContext : public CompressionBufferPool {
       DataBufferHolder,
       dwio::common::StreamIdentifierHash>
       streams_;
+  folly::F14NodeMap<uint32_t, std::unique_ptr<PhysicalSizeAggregator>>
+      physicalSizeAggregators_;
   folly::F14FastMap<
       EncodingKey,
       std::unique_ptr<AbstractIntegerDictionaryEncoder>,


### PR DESCRIPTION
Summary:
Feature physical sizes cannot be incrementally aggregated as we write batches in the writer. Instead, it has to be aggregated after every flush.
This diff contains the logic to use the previously introduced map physical stats aggregator to update data stream sizes and taking care of the nullable size semantics upon merge with the new api introduced in D42177015 (https://github.com/facebookincubator/velox/commit/3abfd44a793e9d0b16c7298fb7e48232ada97748).

Differential Revision: D42687435

