### PR TITLE
Add complex types to Parquet reader Benchmark

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -164,8 +164,6 @@ class ParquetReaderBenchmark {
       if (!hasData) {
         break;
       }
-      resultSize += result->size();
-
       if (result->size() == 0) {
         continue;
       }
@@ -173,6 +171,15 @@ class ParquetReaderBenchmark {
       auto rowVector = result->asUnchecked<RowVector>();
       for (auto i = 0; i < rowVector->childrenSize(); ++i) {
         rowVector->childAt(i)->loadedVector();
+      }
+
+      VELOX_CHECK_EQ(
+          rowVector->childrenSize(),
+          1,
+          "The benchmark is performed on single columns. So the result should only contain one column.")
+
+      for (int i = 0; i < rowVector->size(); i++) {
+        resultSize += !rowVector->childAt(0)->isNullAt(i);
       }
     }
 
@@ -197,12 +204,16 @@ class ParquetReaderBenchmark {
             .withNullsForField(Subfield(columnName), nullsRateX100)
             .build();
     writeToFile(*batches, true);
+    std::vector<FilterSpec> filterSpecs;
 
-    FilterSpec filterSpec = createFilterSpec(
-        columnName, startPct, selectPct, rowType, false, false);
+    //    Filters on List and Map are not supported currently.
+    if (type->kind() != TypeKind::ARRAY && type->kind() != TypeKind::MAP) {
+      filterSpecs.emplace_back(createFilterSpec(
+          columnName, startPct, selectPct, rowType, false, false));
+    }
 
     std::vector<uint64_t> hitRows;
-    auto scanSpec = createScanSpec(*batches, rowType, {filterSpec}, hitRows);
+    auto scanSpec = createScanSpec(*batches, rowType, filterSpecs, hitRows);
 
     suspender.dismiss();
 
@@ -241,6 +252,7 @@ class ParquetReaderBenchmark {
 
 void run(
     uint32_t,
+    const std::string& columnName,
     const TypePtr& type,
     float filterRateX100,
     uint8_t nullsRateX100,
@@ -250,7 +262,7 @@ void run(
   BIGINT()->toString();
   benchmark.readSingleColumn(
       ParquetReaderType::NATIVE,
-      type->toString(),
+      columnName,
       type,
       0,
       filterRateX100,
@@ -258,10 +270,11 @@ void run(
       nextSize);
 }
 
-#define PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, _null_) \
+#define PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, _null_) \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_5000_dict,       \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_5k_dict,         \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -269,7 +282,8 @@ void run(
       false);                                                             \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_5000_plain,      \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_5k_plain,        \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -277,7 +291,8 @@ void run(
       true);                                                              \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_10000_dict,      \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_10k_dict,        \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -285,7 +300,8 @@ void run(
       false);                                                             \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_10000_plain,     \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_10k_Plain,       \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -293,7 +309,8 @@ void run(
       true);                                                              \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_20000_dict,      \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_20k_dict,        \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -301,7 +318,8 @@ void run(
       false);                                                             \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_20000_plain,     \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_20k_plain,       \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -309,7 +327,8 @@ void run(
       true);                                                              \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_50000_dict,      \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_50k_dict,        \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -317,7 +336,8 @@ void run(
       false);                                                             \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_50000_plain,     \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_50k_plain,       \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -325,7 +345,8 @@ void run(
       true);                                                              \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_100000_dict,     \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_100k_dict,       \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -333,7 +354,8 @@ void run(
       false);                                                             \
   BENCHMARK_NAMED_PARAM(                                                  \
       run,                                                                \
-      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_100000_plain,    \
+      _name_##_Filter_##_filter_##_Nulls_##_null_##_next_100k_plain,      \
+      #_name_,                                                            \
       _type_,                                                             \
       _filter_,                                                           \
       _null_,                                                             \
@@ -342,11 +364,11 @@ void run(
   BENCHMARK_DRAW_LINE();
 
 #define PARQUET_BENCHMARKS_FILTERS(_type_, _name_, _filter_)    \
-  PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, 0)  \
-  PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, 20) \
-  PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, 50) \
-  PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, 70) \
-  PARQUET_BENCHMARKS_NULLS_FILTER(_type_, _name_, _filter_, 100)
+  PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, 0)  \
+  PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, 20) \
+  PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, 50) \
+  PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, 70) \
+  PARQUET_BENCHMARKS_FILTER_NULLS(_type_, _name_, _filter_, 100)
 
 #define PARQUET_BENCHMARKS(_type_, _name_)        \
   PARQUET_BENCHMARKS_FILTERS(_type_, _name_, 0)   \
@@ -356,8 +378,14 @@ void run(
   PARQUET_BENCHMARKS_FILTERS(_type_, _name_, 100) \
   BENCHMARK_DRAW_LINE();
 
+#define PARQUET_BENCHMARKS_NO_FILTER(_type_, _name_) \
+  PARQUET_BENCHMARKS_FILTERS(_type_, _name_, 100)    \
+  BENCHMARK_DRAW_LINE();
+
 PARQUET_BENCHMARKS(BIGINT(), BigInt);
 PARQUET_BENCHMARKS(DOUBLE(), Double);
+PARQUET_BENCHMARKS_NO_FILTER(MAP(BIGINT(), BIGINT()), Map);
+PARQUET_BENCHMARKS_NO_FILTER(ARRAY(BIGINT()), List);
 
 // TODO: Add all data types
 
@@ -373,556 +401,670 @@ Core(s) used: 24
 Memory(GB): 96
 
 ============================================================================
-run(BigInt_Filter_0_Nulls_0_next_5000_dict)                  8.07ms   123.84
-run(BigInt_Filter_0_Nulls_0_next_5000_plain)                32.87ms    30.43
-run(BigInt_Filter_0_Nulls_0_next_10000_dict)                32.32ms    30.94
-run(BigInt_Filter_0_Nulls_0_next_10000_plain)               30.28ms    33.03
-run(BigInt_Filter_0_Nulls_0_next_20000_dict)                32.60ms    30.67
-run(BigInt_Filter_0_Nulls_0_next_20000_plain)               32.96ms    30.34
-run(BigInt_Filter_0_Nulls_0_next_50000_dict)                34.50ms    28.98
-run(BigInt_Filter_0_Nulls_0_next_50000_plain)               32.24ms    31.02
-run(BigInt_Filter_0_Nulls_0_next_100000_dict)               35.24ms    28.38
-run(BigInt_Filter_0_Nulls_0_next_100000_plain)              31.55ms    31.70
+relative                                                  time/iter  iters/s
+============================================================================
+run(BigInt_Filter_0_Nulls_0_next_5k_dict)                    7.75ms   129.03
+run(BigInt_Filter_0_Nulls_0_next_5k_plain)                  41.18ms    24.28
+run(BigInt_Filter_0_Nulls_0_next_10k_dict)                  29.86ms    33.49
+run(BigInt_Filter_0_Nulls_0_next_10k_Plain)                 40.74ms    24.54
+run(BigInt_Filter_0_Nulls_0_next_20k_dict)                  62.92ms    15.89
+run(BigInt_Filter_0_Nulls_0_next_20k_plain)                 24.68ms    40.52
+run(BigInt_Filter_0_Nulls_0_next_50k_dict)                  60.66ms    16.49
+run(BigInt_Filter_0_Nulls_0_next_50k_plain)                 13.58ms    73.63
+run(BigInt_Filter_0_Nulls_0_next_100k_dict)                 42.61ms    23.47
+run(BigInt_Filter_0_Nulls_0_next_100k_plain)                31.32ms    31.93
 ----------------------------------------------------------------------------
-run(BigInt_Filter_0_Nulls_20_next_5000_dict)                27.83ms    35.93
-run(BigInt_Filter_0_Nulls_20_next_5000_plain)               25.78ms    38.79
-run(BigInt_Filter_0_Nulls_20_next_10000_dict)               26.83ms    37.27
-run(BigInt_Filter_0_Nulls_20_next_10000_plain)              25.81ms    38.75
-run(BigInt_Filter_0_Nulls_20_next_20000_dict)               28.42ms    35.19
-run(BigInt_Filter_0_Nulls_20_next_20000_plain)              25.81ms    38.75
-run(BigInt_Filter_0_Nulls_20_next_50000_dict)               29.45ms    33.95
-run(BigInt_Filter_0_Nulls_20_next_50000_plain)              73.67ms    13.57
-run(BigInt_Filter_0_Nulls_20_next_100000_dict)              26.14ms    38.26
-run(BigInt_Filter_0_Nulls_20_next_100000_plain)             26.17ms    38.21
+run(BigInt_Filter_0_Nulls_20_next_5k_dict)                  24.36ms    41.04
+run(BigInt_Filter_0_Nulls_20_next_5k_plain)                 27.84ms    35.92
+run(BigInt_Filter_0_Nulls_20_next_10k_dict)                 12.15ms    82.33
+run(BigInt_Filter_0_Nulls_20_next_10k_Plain)                30.98ms    32.28
+run(BigInt_Filter_0_Nulls_20_next_20k_dict)                 36.97ms    27.05
+run(BigInt_Filter_0_Nulls_20_next_20k_plain)                30.09ms    33.23
+run(BigInt_Filter_0_Nulls_20_next_50k_dict)                 44.06ms    22.70
+run(BigInt_Filter_0_Nulls_20_next_50k_plain)                11.44ms    87.43
+run(BigInt_Filter_0_Nulls_20_next_100k_dict)                54.49ms    18.35
+run(BigInt_Filter_0_Nulls_20_next_100k_plain)                8.10ms   123.39
 ----------------------------------------------------------------------------
-run(BigInt_Filter_0_Nulls_50_next_5000_dict)                16.00ms    62.49
-run(BigInt_Filter_0_Nulls_50_next_5000_plain)               14.59ms    68.54
-run(BigInt_Filter_0_Nulls_50_next_10000_dict)               15.13ms    66.11
-run(BigInt_Filter_0_Nulls_50_next_10000_plain)              14.54ms    68.78
-run(BigInt_Filter_0_Nulls_50_next_20000_dict)               15.41ms    64.91
-run(BigInt_Filter_0_Nulls_50_next_20000_plain)              14.79ms    67.60
-run(BigInt_Filter_0_Nulls_50_next_50000_dict)               14.72ms    67.94
-run(BigInt_Filter_0_Nulls_50_next_50000_plain)              15.12ms    66.15
-run(BigInt_Filter_0_Nulls_50_next_100000_dict)              17.34ms    57.67
-run(BigInt_Filter_0_Nulls_50_next_100000_plain)             15.67ms    63.82
+run(BigInt_Filter_0_Nulls_50_next_5k_dict)                  24.37ms    41.03
+run(BigInt_Filter_0_Nulls_50_next_5k_plain)                 30.68ms    32.60
+run(BigInt_Filter_0_Nulls_50_next_10k_dict)                  7.20ms   138.94
+run(BigInt_Filter_0_Nulls_50_next_10k_Plain)                15.61ms    64.04
+run(BigInt_Filter_0_Nulls_50_next_20k_dict)                 17.66ms    56.63
+run(BigInt_Filter_0_Nulls_50_next_20k_plain)                17.82ms    56.12
+run(BigInt_Filter_0_Nulls_50_next_50k_dict)                 19.38ms    51.59
+run(BigInt_Filter_0_Nulls_50_next_50k_plain)                11.77ms    84.97
+run(BigInt_Filter_0_Nulls_50_next_100k_dict)                14.20ms    70.44
+run(BigInt_Filter_0_Nulls_50_next_100k_plain)               14.86ms    67.31
 ----------------------------------------------------------------------------
-run(BigInt_Filter_0_Nulls_70_next_5000_dict)                12.46ms    80.24
-run(BigInt_Filter_0_Nulls_70_next_5000_plain)               10.99ms    91.01
-run(BigInt_Filter_0_Nulls_70_next_10000_dict)               12.87ms    77.71
-run(BigInt_Filter_0_Nulls_70_next_10000_plain)              10.98ms    91.08
-run(BigInt_Filter_0_Nulls_70_next_20000_dict)               11.85ms    84.37
-run(BigInt_Filter_0_Nulls_70_next_20000_plain)              10.72ms    93.29
-run(BigInt_Filter_0_Nulls_70_next_50000_dict)               12.35ms    80.95
-run(BigInt_Filter_0_Nulls_70_next_50000_plain)               8.34ms   119.97
-run(BigInt_Filter_0_Nulls_70_next_100000_dict)              10.47ms    95.51
-run(BigInt_Filter_0_Nulls_70_next_100000_plain)             10.86ms    92.12
+run(BigInt_Filter_0_Nulls_70_next_5k_dict)                  19.18ms    52.15
+run(BigInt_Filter_0_Nulls_70_next_5k_plain)                 10.37ms    96.47
+run(BigInt_Filter_0_Nulls_70_next_10k_dict)                 11.02ms    90.76
+run(BigInt_Filter_0_Nulls_70_next_10k_Plain)                11.13ms    89.89
+run(BigInt_Filter_0_Nulls_70_next_20k_dict)                 10.43ms    95.85
+run(BigInt_Filter_0_Nulls_70_next_20k_plain)                10.60ms    94.31
+run(BigInt_Filter_0_Nulls_70_next_50k_dict)                 12.00ms    83.36
+run(BigInt_Filter_0_Nulls_70_next_50k_plain)                12.04ms    83.03
+run(BigInt_Filter_0_Nulls_70_next_100k_dict)                11.81ms    84.65
+run(BigInt_Filter_0_Nulls_70_next_100k_plain)               10.59ms    94.39
 ----------------------------------------------------------------------------
-run(BigInt_Filter_0_Nulls_100_next_5000_dict)              992.50us    1.01K
-run(BigInt_Filter_0_Nulls_100_next_5000_plain)             913.45us    1.09K
-run(BigInt_Filter_0_Nulls_100_next_10000_dict)             945.19us    1.06K
-run(BigInt_Filter_0_Nulls_100_next_10000_plain)            911.22us    1.10K
-run(BigInt_Filter_0_Nulls_100_next_20000_dict)             974.65us    1.03K
-run(BigInt_Filter_0_Nulls_100_next_20000_plain)            906.66us    1.10K
-run(BigInt_Filter_0_Nulls_100_next_50000_dict)               1.00ms   996.16
-run(BigInt_Filter_0_Nulls_100_next_50000_plain)            920.88us    1.09K
-run(BigInt_Filter_0_Nulls_100_next_100000_dict)            968.53us    1.03K
-run(BigInt_Filter_0_Nulls_100_next_100000_plain            923.57us    1.08K
+run(BigInt_Filter_0_Nulls_100_next_5k_dict)                  1.07ms   938.83
+run(BigInt_Filter_0_Nulls_100_next_5k_plain)                 1.01ms   991.27
+run(BigInt_Filter_0_Nulls_100_next_10k_dict)                 1.06ms   941.26
+run(BigInt_Filter_0_Nulls_100_next_10k_Plain)                1.02ms   979.09
+run(BigInt_Filter_0_Nulls_100_next_20k_dict)                 1.06ms   945.97
+run(BigInt_Filter_0_Nulls_100_next_20k_plain)                1.02ms   978.10
+run(BigInt_Filter_0_Nulls_100_next_50k_dict)                 1.09ms   916.37
+run(BigInt_Filter_0_Nulls_100_next_50k_plain)                1.02ms   976.12
+run(BigInt_Filter_0_Nulls_100_next_100k_dict)                1.07ms   936.30
+run(BigInt_Filter_0_Nulls_100_next_100k_plain)               1.01ms   986.33
 ----------------------------------------------------------------------------
-run(BigInt_Filter_20_Nulls_0_next_5000_dict)                44.13ms    22.66
-run(BigInt_Filter_20_Nulls_0_next_5000_plain)               46.56ms    21.48
-run(BigInt_Filter_20_Nulls_0_next_10000_dict)               48.55ms    20.60
-run(BigInt_Filter_20_Nulls_0_next_10000_plain)              45.65ms    21.91
-run(BigInt_Filter_20_Nulls_0_next_20000_dict)               73.05ms    13.69
-run(BigInt_Filter_20_Nulls_0_next_20000_plain)              46.20ms    21.65
-run(BigInt_Filter_20_Nulls_0_next_50000_dict)               72.26ms    13.84
-run(BigInt_Filter_20_Nulls_0_next_50000_plain)              45.87ms    21.80
-run(BigInt_Filter_20_Nulls_0_next_100000_dict)              72.07ms    13.87
-run(BigInt_Filter_20_Nulls_0_next_100000_plain)             46.73ms    21.40
+run(BigInt_Filter_20_Nulls_0_next_5k_dict)                  50.42ms    19.83
+run(BigInt_Filter_20_Nulls_0_next_5k_plain)                 55.73ms    17.94
+run(BigInt_Filter_20_Nulls_0_next_10k_dict)                 80.05ms    12.49
+run(BigInt_Filter_20_Nulls_0_next_10k_Plain)                58.70ms    17.04
+run(BigInt_Filter_20_Nulls_0_next_20k_dict)                 70.42ms    14.20
+run(BigInt_Filter_20_Nulls_0_next_20k_plain)                59.00ms    16.95
+run(BigInt_Filter_20_Nulls_0_next_50k_dict)                 83.51ms    11.97
+run(BigInt_Filter_20_Nulls_0_next_50k_plain)                25.46ms    39.27
+run(BigInt_Filter_20_Nulls_0_next_100k_dict)                75.88ms    13.18
+run(BigInt_Filter_20_Nulls_0_next_100k_plain)               60.11ms    16.64
 ----------------------------------------------------------------------------
-run(BigInt_Filter_20_Nulls_20_next_5000_dict)               61.59ms    16.24
-run(BigInt_Filter_20_Nulls_20_next_5000_plain)              40.28ms    24.83
-run(BigInt_Filter_20_Nulls_20_next_10000_dict)              63.84ms    15.66
-run(BigInt_Filter_20_Nulls_20_next_10000_plain)             41.25ms    24.24
-run(BigInt_Filter_20_Nulls_20_next_20000_dict)              62.43ms    16.02
-run(BigInt_Filter_20_Nulls_20_next_20000_plain)             41.13ms    24.31
-run(BigInt_Filter_20_Nulls_20_next_50000_dict)              62.83ms    15.91
-run(BigInt_Filter_20_Nulls_20_next_50000_plain)             42.40ms    23.59
-run(BigInt_Filter_20_Nulls_20_next_100000_dict)             58.72ms    17.03
-run(BigInt_Filter_20_Nulls_20_next_100000_plain             41.12ms    24.32
+run(BigInt_Filter_20_Nulls_20_next_5k_dict)                 65.20ms    15.34
+run(BigInt_Filter_20_Nulls_20_next_5k_plain)                42.99ms    23.26
+run(BigInt_Filter_20_Nulls_20_next_10k_dict)                67.89ms    14.73
+run(BigInt_Filter_20_Nulls_20_next_10k_Plain)               40.18ms    24.89
+run(BigInt_Filter_20_Nulls_20_next_20k_dict)                65.53ms    15.26
+run(BigInt_Filter_20_Nulls_20_next_20k_plain)               40.92ms    24.44
+run(BigInt_Filter_20_Nulls_20_next_50k_dict)                70.80ms    14.12
+run(BigInt_Filter_20_Nulls_20_next_50k_plain)               38.04ms    26.29
+run(BigInt_Filter_20_Nulls_20_next_100k_dict)               62.03ms    16.12
+run(BigInt_Filter_20_Nulls_20_next_100k_plain)              43.54ms    22.97
 ----------------------------------------------------------------------------
-run(BigInt_Filter_20_Nulls_50_next_5000_dict)               36.35ms    27.51
-run(BigInt_Filter_20_Nulls_50_next_5000_plain)              23.48ms    42.59
-run(BigInt_Filter_20_Nulls_50_next_10000_dict)              35.09ms    28.50
-run(BigInt_Filter_20_Nulls_50_next_10000_plain)             22.62ms    44.21
-run(BigInt_Filter_20_Nulls_50_next_20000_dict)              37.59ms    26.60
-run(BigInt_Filter_20_Nulls_50_next_20000_plain)             23.73ms    42.14
-run(BigInt_Filter_20_Nulls_50_next_50000_dict)              35.82ms    27.91
-run(BigInt_Filter_20_Nulls_50_next_50000_plain)             23.69ms    42.20
-run(BigInt_Filter_20_Nulls_50_next_100000_dict)             36.77ms    27.19
-run(BigInt_Filter_20_Nulls_50_next_100000_plain             23.83ms    41.96
+run(BigInt_Filter_20_Nulls_50_next_5k_dict)                 49.09ms    20.37
+run(BigInt_Filter_20_Nulls_50_next_5k_plain)                25.91ms    38.60
+run(BigInt_Filter_20_Nulls_50_next_10k_dict)                37.13ms    26.93
+run(BigInt_Filter_20_Nulls_50_next_10k_Plain)               27.16ms    36.82
+run(BigInt_Filter_20_Nulls_50_next_20k_dict)                37.01ms    27.02
+run(BigInt_Filter_20_Nulls_50_next_20k_plain)               26.73ms    37.41
+run(BigInt_Filter_20_Nulls_50_next_50k_dict)                36.27ms    27.57
+run(BigInt_Filter_20_Nulls_50_next_50k_plain)               25.01ms    39.98
+run(BigInt_Filter_20_Nulls_50_next_100k_dict)               36.16ms    27.65
+run(BigInt_Filter_20_Nulls_50_next_100k_plain)              27.30ms    36.63
 ----------------------------------------------------------------------------
-run(BigInt_Filter_20_Nulls_70_next_5000_dict)               26.97ms    37.08
-run(BigInt_Filter_20_Nulls_70_next_5000_plain)              19.24ms    51.98
-run(BigInt_Filter_20_Nulls_70_next_10000_dict)              28.22ms    35.43
-run(BigInt_Filter_20_Nulls_70_next_10000_plain)             17.10ms    58.48
-run(BigInt_Filter_20_Nulls_70_next_20000_dict)              24.61ms    40.64
-run(BigInt_Filter_20_Nulls_70_next_20000_plain)             17.72ms    56.45
-run(BigInt_Filter_20_Nulls_70_next_50000_dict)              26.21ms    38.15
-run(BigInt_Filter_20_Nulls_70_next_50000_plain)             17.20ms    58.14
-run(BigInt_Filter_20_Nulls_70_next_100000_dict)             24.95ms    40.08
-run(BigInt_Filter_20_Nulls_70_next_100000_plain             17.39ms    57.49
+run(BigInt_Filter_20_Nulls_70_next_5k_dict)                 34.33ms    29.13
+run(BigInt_Filter_20_Nulls_70_next_5k_plain)                18.45ms    54.19
+run(BigInt_Filter_20_Nulls_70_next_10k_dict)                25.55ms    39.14
+run(BigInt_Filter_20_Nulls_70_next_10k_Plain)               20.94ms    47.75
+run(BigInt_Filter_20_Nulls_70_next_20k_dict)                29.33ms    34.10
+run(BigInt_Filter_20_Nulls_70_next_20k_plain)               19.46ms    51.38
+run(BigInt_Filter_20_Nulls_70_next_50k_dict)                28.41ms    35.20
+run(BigInt_Filter_20_Nulls_70_next_50k_plain)               18.20ms    54.93
+run(BigInt_Filter_20_Nulls_70_next_100k_dict)               25.68ms    38.94
+run(BigInt_Filter_20_Nulls_70_next_100k_plain)              18.88ms    52.97
 ----------------------------------------------------------------------------
-run(BigInt_Filter_20_Nulls_100_next_5000_dict)             998.41us    1.00K
-run(BigInt_Filter_20_Nulls_100_next_5000_plain)            944.29us    1.06K
-run(BigInt_Filter_20_Nulls_100_next_10000_dict)            985.02us    1.02K
-run(BigInt_Filter_20_Nulls_100_next_10000_plain            997.04us    1.00K
-run(BigInt_Filter_20_Nulls_100_next_20000_dict)            995.81us    1.00K
-run(BigInt_Filter_20_Nulls_100_next_20000_plain            942.19us    1.06K
-run(BigInt_Filter_20_Nulls_100_next_50000_dict)            981.40us    1.02K
-run(BigInt_Filter_20_Nulls_100_next_50000_plain            913.60us    1.09K
-run(BigInt_Filter_20_Nulls_100_next_100000_dict              1.01ms   989.97
-run(BigInt_Filter_20_Nulls_100_next_100000_plai            946.56us    1.06K
+run(BigInt_Filter_20_Nulls_100_next_5k_dict)                 1.16ms   860.57
+run(BigInt_Filter_20_Nulls_100_next_5k_plain)                1.01ms   992.49
+run(BigInt_Filter_20_Nulls_100_next_10k_dict)                1.10ms   907.85
+run(BigInt_Filter_20_Nulls_100_next_10k_Plain)             999.27us    1.00K
+run(BigInt_Filter_20_Nulls_100_next_20k_dict)                1.12ms   890.24
+run(BigInt_Filter_20_Nulls_100_next_20k_plain)               1.06ms   942.98
+run(BigInt_Filter_20_Nulls_100_next_50k_dict)                1.15ms   872.19
+run(BigInt_Filter_20_Nulls_100_next_50k_plain)               1.06ms   945.59
+run(BigInt_Filter_20_Nulls_100_next_100k_dict)               1.11ms   896.97
+run(BigInt_Filter_20_Nulls_100_next_100k_plain)              1.08ms   926.88
 ----------------------------------------------------------------------------
-run(BigInt_Filter_50_Nulls_0_next_5000_dict)                57.85ms    17.29
-run(BigInt_Filter_50_Nulls_0_next_5000_plain)               44.08ms    22.69
-run(BigInt_Filter_50_Nulls_0_next_10000_dict)               86.27ms    11.59
-run(BigInt_Filter_50_Nulls_0_next_10000_plain)              44.59ms    22.43
-run(BigInt_Filter_50_Nulls_0_next_20000_dict)               84.18ms    11.88
-run(BigInt_Filter_50_Nulls_0_next_20000_plain)              52.36ms    19.10
-run(BigInt_Filter_50_Nulls_0_next_50000_dict)               85.51ms    11.69
-run(BigInt_Filter_50_Nulls_0_next_50000_plain)              44.10ms    22.67
-run(BigInt_Filter_50_Nulls_0_next_100000_dict)              85.23ms    11.73
-run(BigInt_Filter_50_Nulls_0_next_100000_plain)             42.83ms    23.35
+run(BigInt_Filter_50_Nulls_0_next_5k_dict)                  94.90ms    10.54
+run(BigInt_Filter_50_Nulls_0_next_5k_plain)                 26.45ms    37.81
+run(BigInt_Filter_50_Nulls_0_next_10k_dict)                188.07ms     5.32
+run(BigInt_Filter_50_Nulls_0_next_10k_Plain)                83.78ms    11.94
+run(BigInt_Filter_50_Nulls_0_next_20k_dict)                 85.43ms    11.71
+run(BigInt_Filter_50_Nulls_0_next_20k_plain)                56.34ms    17.75
+run(BigInt_Filter_50_Nulls_0_next_50k_dict)                 99.34ms    10.07
+run(BigInt_Filter_50_Nulls_0_next_50k_plain)                42.77ms    23.38
+run(BigInt_Filter_50_Nulls_0_next_100k_dict)                97.26ms    10.28
+run(BigInt_Filter_50_Nulls_0_next_100k_plain)               54.87ms    18.22
 ----------------------------------------------------------------------------
-run(BigInt_Filter_50_Nulls_20_next_5000_dict)               73.92ms    13.53
-run(BigInt_Filter_50_Nulls_20_next_5000_plain)              39.10ms    25.58
-run(BigInt_Filter_50_Nulls_20_next_10000_dict)              68.55ms    14.59
-run(BigInt_Filter_50_Nulls_20_next_10000_plain)             37.97ms    26.34
-run(BigInt_Filter_50_Nulls_20_next_20000_dict)              72.31ms    13.83
-run(BigInt_Filter_50_Nulls_20_next_20000_plain)             42.14ms    23.73
-run(BigInt_Filter_50_Nulls_20_next_50000_dict)              72.10ms    13.87
-run(BigInt_Filter_50_Nulls_20_next_50000_plain)             37.66ms    26.55
-run(BigInt_Filter_50_Nulls_20_next_100000_dict)             68.95ms    14.50
-run(BigInt_Filter_50_Nulls_20_next_100000_plain             37.49ms    26.67
+run(BigInt_Filter_50_Nulls_20_next_5k_dict)                 87.86ms    11.38
+run(BigInt_Filter_50_Nulls_20_next_5k_plain)                45.31ms    22.07
+run(BigInt_Filter_50_Nulls_20_next_10k_dict)                73.18ms    13.66
+run(BigInt_Filter_50_Nulls_20_next_10k_Plain)               49.73ms    20.11
+run(BigInt_Filter_50_Nulls_20_next_20k_dict)                73.67ms    13.57
+run(BigInt_Filter_50_Nulls_20_next_20k_plain)               42.47ms    23.54
+run(BigInt_Filter_50_Nulls_20_next_50k_dict)                73.13ms    13.67
+run(BigInt_Filter_50_Nulls_20_next_50k_plain)               48.73ms    20.52
+run(BigInt_Filter_50_Nulls_20_next_100k_dict)               74.09ms    13.50
+run(BigInt_Filter_50_Nulls_20_next_100k_plain)              44.34ms    22.55
 ----------------------------------------------------------------------------
-run(BigInt_Filter_50_Nulls_50_next_5000_dict)               50.08ms    19.97
-run(BigInt_Filter_50_Nulls_50_next_5000_plain)              22.04ms    45.38
-run(BigInt_Filter_50_Nulls_50_next_10000_dict)              40.84ms    24.48
-run(BigInt_Filter_50_Nulls_50_next_10000_plain)             23.74ms    42.11
-run(BigInt_Filter_50_Nulls_50_next_20000_dict)              42.55ms    23.50
-run(BigInt_Filter_50_Nulls_50_next_20000_plain)             22.87ms    43.73
-run(BigInt_Filter_50_Nulls_50_next_50000_dict)              41.67ms    24.00
-run(BigInt_Filter_50_Nulls_50_next_50000_plain)             22.20ms    45.04
-run(BigInt_Filter_50_Nulls_50_next_100000_dict)             41.91ms    23.86
-run(BigInt_Filter_50_Nulls_50_next_100000_plain             25.25ms    39.61
+run(BigInt_Filter_50_Nulls_50_next_5k_dict)                 54.68ms    18.29
+run(BigInt_Filter_50_Nulls_50_next_5k_plain)                29.64ms    33.74
+run(BigInt_Filter_50_Nulls_50_next_10k_dict)                46.24ms    21.63
+run(BigInt_Filter_50_Nulls_50_next_10k_Plain)               25.79ms    38.78
+run(BigInt_Filter_50_Nulls_50_next_20k_dict)                44.20ms    22.62
+run(BigInt_Filter_50_Nulls_50_next_20k_plain)               24.72ms    40.45
+run(BigInt_Filter_50_Nulls_50_next_50k_dict)                45.32ms    22.06
+run(BigInt_Filter_50_Nulls_50_next_50k_plain)               46.27ms    21.61
+run(BigInt_Filter_50_Nulls_50_next_100k_dict)              101.24ms     9.88
+run(BigInt_Filter_50_Nulls_50_next_100k_plain)              27.50ms    36.36
 ----------------------------------------------------------------------------
-run(BigInt_Filter_50_Nulls_70_next_5000_dict)               29.32ms    34.11
-run(BigInt_Filter_50_Nulls_70_next_5000_plain)              16.47ms    60.71
-run(BigInt_Filter_50_Nulls_70_next_10000_dict)              28.34ms    35.29
-run(BigInt_Filter_50_Nulls_70_next_10000_plain)             17.16ms    58.28
-run(BigInt_Filter_50_Nulls_70_next_20000_dict)              26.58ms    37.62
-run(BigInt_Filter_50_Nulls_70_next_20000_plain)             15.88ms    62.96
-run(BigInt_Filter_50_Nulls_70_next_50000_dict)              28.69ms    34.86
-run(BigInt_Filter_50_Nulls_70_next_50000_plain)             17.17ms    58.25
-run(BigInt_Filter_50_Nulls_70_next_100000_dict)             28.67ms    34.88
-run(BigInt_Filter_50_Nulls_70_next_100000_plain             17.40ms    57.48
+run(BigInt_Filter_50_Nulls_70_next_5k_dict)                 39.17ms    25.53
+run(BigInt_Filter_50_Nulls_70_next_5k_plain)                19.61ms    51.00
+run(BigInt_Filter_50_Nulls_70_next_10k_dict)                32.26ms    31.00
+run(BigInt_Filter_50_Nulls_70_next_10k_Plain)               17.96ms    55.67
+run(BigInt_Filter_50_Nulls_70_next_20k_dict)                31.52ms    31.72
+run(BigInt_Filter_50_Nulls_70_next_20k_plain)               19.25ms    51.94
+run(BigInt_Filter_50_Nulls_70_next_50k_dict)                32.78ms    30.50
+run(BigInt_Filter_50_Nulls_70_next_50k_plain)               21.08ms    47.43
+run(BigInt_Filter_50_Nulls_70_next_100k_dict)               31.40ms    31.85
+run(BigInt_Filter_50_Nulls_70_next_100k_plain)              19.42ms    51.48
 ----------------------------------------------------------------------------
-run(BigInt_Filter_50_Nulls_100_next_5000_dict)               1.04ms   958.72
-run(BigInt_Filter_50_Nulls_100_next_5000_plain)            955.89us    1.05K
-run(BigInt_Filter_50_Nulls_100_next_10000_dict)              1.01ms   990.96
-run(BigInt_Filter_50_Nulls_100_next_10000_plain            981.41us    1.02K
-run(BigInt_Filter_50_Nulls_100_next_20000_dict)              1.07ms   934.00
-run(BigInt_Filter_50_Nulls_100_next_20000_plain            980.98us    1.02K
-run(BigInt_Filter_50_Nulls_100_next_50000_dict)              1.03ms   966.34
-run(BigInt_Filter_50_Nulls_100_next_50000_plain            934.60us    1.07K
-run(BigInt_Filter_50_Nulls_100_next_100000_dict            985.81us    1.01K
-run(BigInt_Filter_50_Nulls_100_next_100000_plai            941.50us    1.06K
+run(BigInt_Filter_50_Nulls_100_next_5k_dict)                 1.13ms   883.51
+run(BigInt_Filter_50_Nulls_100_next_5k_plain)                1.01ms   989.30
+run(BigInt_Filter_50_Nulls_100_next_10k_dict)                1.11ms   903.18
+run(BigInt_Filter_50_Nulls_100_next_10k_Plain)               1.06ms   945.54
+run(BigInt_Filter_50_Nulls_100_next_20k_dict)                1.17ms   853.65
+run(BigInt_Filter_50_Nulls_100_next_20k_plain)               1.04ms   961.50
+run(BigInt_Filter_50_Nulls_100_next_50k_dict)                1.10ms   905.35
+run(BigInt_Filter_50_Nulls_100_next_50k_plain)               1.07ms   935.95
+run(BigInt_Filter_50_Nulls_100_next_100k_dict)               1.14ms   876.28
+run(BigInt_Filter_50_Nulls_100_next_100k_plain)              1.08ms   922.87
 ----------------------------------------------------------------------------
-run(BigInt_Filter_70_Nulls_0_next_5000_dict)                53.86ms    18.57
-run(BigInt_Filter_70_Nulls_0_next_5000_plain)               46.05ms    21.72
-run(BigInt_Filter_70_Nulls_0_next_10000_dict)               81.67ms    12.25
-run(BigInt_Filter_70_Nulls_0_next_10000_plain)              45.02ms    22.21
-run(BigInt_Filter_70_Nulls_0_next_20000_dict)               79.90ms    12.52
-run(BigInt_Filter_70_Nulls_0_next_20000_plain)              44.76ms    22.34
-run(BigInt_Filter_70_Nulls_0_next_50000_dict)               85.65ms    11.68
-run(BigInt_Filter_70_Nulls_0_next_50000_plain)              45.36ms    22.04
-run(BigInt_Filter_70_Nulls_0_next_100000_dict)              80.33ms    12.45
-run(BigInt_Filter_70_Nulls_0_next_100000_plain)             46.46ms    21.52
+run(BigInt_Filter_70_Nulls_0_next_5k_dict)                  67.26ms    14.87
+run(BigInt_Filter_70_Nulls_0_next_5k_plain)                 50.38ms    19.85
+run(BigInt_Filter_70_Nulls_0_next_10k_dict)                 86.54ms    11.55
+run(BigInt_Filter_70_Nulls_0_next_10k_Plain)                57.47ms    17.40
+run(BigInt_Filter_70_Nulls_0_next_20k_dict)                 86.72ms    11.53
+run(BigInt_Filter_70_Nulls_0_next_20k_plain)                30.38ms    32.92
+run(BigInt_Filter_70_Nulls_0_next_50k_dict)                 86.81ms    11.52
+run(BigInt_Filter_70_Nulls_0_next_50k_plain)                58.23ms    17.17
+run(BigInt_Filter_70_Nulls_0_next_100k_dict)                91.78ms    10.90
+run(BigInt_Filter_70_Nulls_0_next_100k_plain)               61.13ms    16.36
 ----------------------------------------------------------------------------
-run(BigInt_Filter_70_Nulls_20_next_5000_dict)               82.04ms    12.19
-run(BigInt_Filter_70_Nulls_20_next_5000_plain)              39.73ms    25.17
-run(BigInt_Filter_70_Nulls_20_next_10000_dict)              68.96ms    14.50
-run(BigInt_Filter_70_Nulls_20_next_10000_plain)             39.32ms    25.43
-run(BigInt_Filter_70_Nulls_20_next_20000_dict)              66.46ms    15.05
-run(BigInt_Filter_70_Nulls_20_next_20000_plain)             39.74ms    25.16
-run(BigInt_Filter_70_Nulls_20_next_50000_dict)              65.60ms    15.24
-run(BigInt_Filter_70_Nulls_20_next_50000_plain)             38.28ms    26.12
-run(BigInt_Filter_70_Nulls_20_next_100000_dict)             68.41ms    14.62
-run(BigInt_Filter_70_Nulls_20_next_100000_plain             48.79ms    20.50
+run(BigInt_Filter_70_Nulls_20_next_5k_dict)                 75.08ms    13.32
+run(BigInt_Filter_70_Nulls_20_next_5k_plain)                50.99ms    19.61
+run(BigInt_Filter_70_Nulls_20_next_10k_dict)                74.97ms    13.34
+run(BigInt_Filter_70_Nulls_20_next_10k_Plain)               52.91ms    18.90
+run(BigInt_Filter_70_Nulls_20_next_20k_dict)                72.78ms    13.74
+run(BigInt_Filter_70_Nulls_20_next_20k_plain)               47.73ms    20.95
+run(BigInt_Filter_70_Nulls_20_next_50k_dict)                75.43ms    13.26
+run(BigInt_Filter_70_Nulls_20_next_50k_plain)               51.01ms    19.60
+run(BigInt_Filter_70_Nulls_20_next_100k_dict)               70.30ms    14.22
+run(BigInt_Filter_70_Nulls_20_next_100k_plain)              54.85ms    18.23
 ----------------------------------------------------------------------------
-run(BigInt_Filter_70_Nulls_50_next_5000_dict)               43.10ms    23.20
-run(BigInt_Filter_70_Nulls_50_next_5000_plain)              23.60ms    42.38
-run(BigInt_Filter_70_Nulls_50_next_10000_dict)              39.26ms    25.47
-run(BigInt_Filter_70_Nulls_50_next_10000_plain)             22.94ms    43.59
-run(BigInt_Filter_70_Nulls_50_next_20000_dict)              39.95ms    25.03
-run(BigInt_Filter_70_Nulls_50_next_20000_plain)             21.92ms    45.62
-run(BigInt_Filter_70_Nulls_50_next_50000_dict)              40.90ms    24.45
-run(BigInt_Filter_70_Nulls_50_next_50000_plain)             12.76ms    78.39
-run(BigInt_Filter_70_Nulls_50_next_100000_dict)             42.04ms    23.78
-run(BigInt_Filter_70_Nulls_50_next_100000_plain             23.11ms    43.26
+run(BigInt_Filter_70_Nulls_50_next_5k_dict)                 51.76ms    19.32
+run(BigInt_Filter_70_Nulls_50_next_5k_plain)                31.75ms    31.50
+run(BigInt_Filter_70_Nulls_50_next_10k_dict)                45.24ms    22.11
+run(BigInt_Filter_70_Nulls_50_next_10k_Plain)               28.94ms    34.56
+run(BigInt_Filter_70_Nulls_50_next_20k_dict)                41.10ms    24.33
+run(BigInt_Filter_70_Nulls_50_next_20k_plain)               30.63ms    32.65
+run(BigInt_Filter_70_Nulls_50_next_50k_dict)                46.30ms    21.60
+run(BigInt_Filter_70_Nulls_50_next_50k_plain)               28.34ms    35.29
+run(BigInt_Filter_70_Nulls_50_next_100k_dict)               47.60ms    21.01
+run(BigInt_Filter_70_Nulls_50_next_100k_plain)              36.24ms    27.59
 ----------------------------------------------------------------------------
-run(BigInt_Filter_70_Nulls_70_next_5000_dict)               28.48ms    35.11
-run(BigInt_Filter_70_Nulls_70_next_5000_plain)              17.27ms    57.91
-run(BigInt_Filter_70_Nulls_70_next_10000_dict)              26.54ms    37.68
-run(BigInt_Filter_70_Nulls_70_next_10000_plain)             16.52ms    60.53
-run(BigInt_Filter_70_Nulls_70_next_20000_dict)              27.72ms    36.07
-run(BigInt_Filter_70_Nulls_70_next_20000_plain)             17.30ms    57.79
-run(BigInt_Filter_70_Nulls_70_next_50000_dict)              26.29ms    38.04
-run(BigInt_Filter_70_Nulls_70_next_50000_plain)             18.12ms    55.20
-run(BigInt_Filter_70_Nulls_70_next_100000_dict)             26.30ms    38.02
-run(BigInt_Filter_70_Nulls_70_next_100000_plain             16.36ms    61.14
+run(BigInt_Filter_70_Nulls_70_next_5k_dict)                 46.48ms    21.51
+run(BigInt_Filter_70_Nulls_70_next_5k_plain)                17.26ms    57.92
+run(BigInt_Filter_70_Nulls_70_next_10k_dict)                24.55ms    40.74
+run(BigInt_Filter_70_Nulls_70_next_10k_Plain)               18.40ms    54.36
+run(BigInt_Filter_70_Nulls_70_next_20k_dict)                32.09ms    31.16
+run(BigInt_Filter_70_Nulls_70_next_20k_plain)               20.01ms    49.98
+run(BigInt_Filter_70_Nulls_70_next_50k_dict)                32.16ms    31.09
+run(BigInt_Filter_70_Nulls_70_next_50k_plain)               19.33ms    51.72
+run(BigInt_Filter_70_Nulls_70_next_100k_dict)               28.15ms    35.53
+run(BigInt_Filter_70_Nulls_70_next_100k_plain)              20.87ms    47.91
 ----------------------------------------------------------------------------
-run(BigInt_Filter_70_Nulls_100_next_5000_dict)               1.03ms   966.35
-run(BigInt_Filter_70_Nulls_100_next_5000_plain)            958.21us    1.04K
-run(BigInt_Filter_70_Nulls_100_next_10000_dict)              1.02ms   985.06
-run(BigInt_Filter_70_Nulls_100_next_10000_plain            999.83us    1.00K
-run(BigInt_Filter_70_Nulls_100_next_20000_dict)              1.02ms   981.06
-run(BigInt_Filter_70_Nulls_100_next_20000_plain            970.79us    1.03K
-run(BigInt_Filter_70_Nulls_100_next_50000_dict)              1.04ms   964.28
-run(BigInt_Filter_70_Nulls_100_next_50000_plain            955.93us    1.05K
-run(BigInt_Filter_70_Nulls_100_next_100000_dict              1.04ms   957.80
-run(BigInt_Filter_70_Nulls_100_next_100000_plai            945.12us    1.06K
+run(BigInt_Filter_70_Nulls_100_next_5k_dict)                 1.12ms   889.19
+run(BigInt_Filter_70_Nulls_100_next_5k_plain)                1.08ms   925.58
+run(BigInt_Filter_70_Nulls_100_next_10k_dict)                1.14ms   874.84
+run(BigInt_Filter_70_Nulls_100_next_10k_Plain)               1.04ms   961.56
+run(BigInt_Filter_70_Nulls_100_next_20k_dict)                1.10ms   905.32
+run(BigInt_Filter_70_Nulls_100_next_20k_plain)               1.06ms   942.57
+run(BigInt_Filter_70_Nulls_100_next_50k_dict)                1.13ms   887.46
+run(BigInt_Filter_70_Nulls_100_next_50k_plain)               1.06ms   947.04
+run(BigInt_Filter_70_Nulls_100_next_100k_dict)               1.11ms   900.77
+run(BigInt_Filter_70_Nulls_100_next_100k_plain)              1.06ms   941.01
 ----------------------------------------------------------------------------
-run(BigInt_Filter_100_Nulls_0_next_5000_dict)               36.38ms    27.49
-run(BigInt_Filter_100_Nulls_0_next_5000_plain)              41.29ms    24.22
-run(BigInt_Filter_100_Nulls_0_next_10000_dict)              69.65ms    14.36
-run(BigInt_Filter_100_Nulls_0_next_10000_plain)             40.64ms    24.61
-run(BigInt_Filter_100_Nulls_0_next_20000_dict)              65.37ms    15.30
-run(BigInt_Filter_100_Nulls_0_next_20000_plain)             41.13ms    24.31
-run(BigInt_Filter_100_Nulls_0_next_50000_dict)              63.88ms    15.65
-run(BigInt_Filter_100_Nulls_0_next_50000_plain)             41.17ms    24.29
-run(BigInt_Filter_100_Nulls_0_next_100000_dict)             68.44ms    14.61
-run(BigInt_Filter_100_Nulls_0_next_100000_plain             42.79ms    23.37
+run(BigInt_Filter_100_Nulls_0_next_5k_dict)                 46.36ms    21.57
+run(BigInt_Filter_100_Nulls_0_next_5k_plain)                59.90ms    16.69
+run(BigInt_Filter_100_Nulls_0_next_10k_dict)                78.87ms    12.68
+run(BigInt_Filter_100_Nulls_0_next_10k_Plain)               61.97ms    16.14
+run(BigInt_Filter_100_Nulls_0_next_20k_dict)                75.71ms    13.21
+run(BigInt_Filter_100_Nulls_0_next_20k_plain)               65.25ms    15.33
+run(BigInt_Filter_100_Nulls_0_next_50k_dict)               129.60ms     7.72
+run(BigInt_Filter_100_Nulls_0_next_50k_plain)              110.12ms     9.08
+run(BigInt_Filter_100_Nulls_0_next_100k_dict)               91.04ms    10.98
+run(BigInt_Filter_100_Nulls_0_next_100k_plain)              42.92ms    23.30
 ----------------------------------------------------------------------------
-run(BigInt_Filter_100_Nulls_20_next_5000_dict)              58.92ms    16.97
-run(BigInt_Filter_100_Nulls_20_next_5000_plain)             35.55ms    28.13
-run(BigInt_Filter_100_Nulls_20_next_10000_dict)             52.93ms    18.89
-run(BigInt_Filter_100_Nulls_20_next_10000_plain             43.61ms    22.93
-run(BigInt_Filter_100_Nulls_20_next_20000_dict)             56.22ms    17.79
-run(BigInt_Filter_100_Nulls_20_next_20000_plain             34.09ms    29.34
-run(BigInt_Filter_100_Nulls_20_next_50000_dict)             55.12ms    18.14
-run(BigInt_Filter_100_Nulls_20_next_50000_plain             36.60ms    27.32
-run(BigInt_Filter_100_Nulls_20_next_100000_dict             53.57ms    18.67
-run(BigInt_Filter_100_Nulls_20_next_100000_plai             38.35ms    26.08
+run(BigInt_Filter_100_Nulls_20_next_5k_dict)                77.86ms    12.84
+run(BigInt_Filter_100_Nulls_20_next_5k_plain)               44.95ms    22.25
+run(BigInt_Filter_100_Nulls_20_next_10k_dict)               72.22ms    13.85
+run(BigInt_Filter_100_Nulls_20_next_10k_Plain)              52.12ms    19.19
+run(BigInt_Filter_100_Nulls_20_next_20k_dict)               58.55ms    17.08
+run(BigInt_Filter_100_Nulls_20_next_20k_plain)              49.64ms    20.15
+run(BigInt_Filter_100_Nulls_20_next_50k_dict)               61.28ms    16.32
+run(BigInt_Filter_100_Nulls_20_next_50k_plain)              47.43ms    21.09
+run(BigInt_Filter_100_Nulls_20_next_100k_dict)              66.19ms    15.11
+run(BigInt_Filter_100_Nulls_20_next_100k_plain)             45.53ms    21.97
 ----------------------------------------------------------------------------
-run(BigInt_Filter_100_Nulls_50_next_5000_dict)              39.52ms    25.31
-run(BigInt_Filter_100_Nulls_50_next_5000_plain)             22.42ms    44.60
-run(BigInt_Filter_100_Nulls_50_next_10000_dict)             33.82ms    29.57
-run(BigInt_Filter_100_Nulls_50_next_10000_plain             21.50ms    46.50
-run(BigInt_Filter_100_Nulls_50_next_20000_dict)             35.36ms    28.28
-run(BigInt_Filter_100_Nulls_50_next_20000_plain             25.28ms    39.56
-run(BigInt_Filter_100_Nulls_50_next_50000_dict)             33.64ms    29.73
-run(BigInt_Filter_100_Nulls_50_next_50000_plain             20.10ms    49.74
-run(BigInt_Filter_100_Nulls_50_next_100000_dict             31.41ms    31.83
-run(BigInt_Filter_100_Nulls_50_next_100000_plai             19.84ms    50.41
+run(BigInt_Filter_100_Nulls_50_next_5k_dict)                44.46ms    22.49
+run(BigInt_Filter_100_Nulls_50_next_5k_plain)               26.50ms    37.73
+run(BigInt_Filter_100_Nulls_50_next_10k_dict)               39.00ms    25.64
+run(BigInt_Filter_100_Nulls_50_next_10k_Plain)              31.51ms    31.74
+run(BigInt_Filter_100_Nulls_50_next_20k_dict)               35.79ms    27.94
+run(BigInt_Filter_100_Nulls_50_next_20k_plain)              28.04ms    35.66
+run(BigInt_Filter_100_Nulls_50_next_50k_dict)               36.43ms    27.45
+run(BigInt_Filter_100_Nulls_50_next_50k_plain)              26.79ms    37.32
+run(BigInt_Filter_100_Nulls_50_next_100k_dict)              37.73ms    26.50
+run(BigInt_Filter_100_Nulls_50_next_100k_plain)             30.57ms    32.71
 ----------------------------------------------------------------------------
-run(BigInt_Filter_100_Nulls_70_next_5000_dict)              24.19ms    41.34
-run(BigInt_Filter_100_Nulls_70_next_5000_plain)             14.59ms    68.55
-run(BigInt_Filter_100_Nulls_70_next_10000_dict)             24.32ms    41.11
-run(BigInt_Filter_100_Nulls_70_next_10000_plain             16.53ms    60.49
-run(BigInt_Filter_100_Nulls_70_next_20000_dict)             23.55ms    42.46
-run(BigInt_Filter_100_Nulls_70_next_20000_plain             16.96ms    58.97
-run(BigInt_Filter_100_Nulls_70_next_50000_dict)             23.56ms    42.45
-run(BigInt_Filter_100_Nulls_70_next_50000_plain             17.21ms    58.11
-run(BigInt_Filter_100_Nulls_70_next_100000_dict             22.62ms    44.21
-run(BigInt_Filter_100_Nulls_70_next_100000_plai             16.73ms    59.76
+run(BigInt_Filter_100_Nulls_70_next_5k_dict)                31.60ms    31.64
+run(BigInt_Filter_100_Nulls_70_next_5k_plain)               18.93ms    52.84
+run(BigInt_Filter_100_Nulls_70_next_10k_dict)               25.33ms    39.48
+run(BigInt_Filter_100_Nulls_70_next_10k_Plain)              20.15ms    49.63
+run(BigInt_Filter_100_Nulls_70_next_20k_dict)               25.75ms    38.83
+run(BigInt_Filter_100_Nulls_70_next_20k_plain)              18.67ms    53.57
+run(BigInt_Filter_100_Nulls_70_next_50k_dict)               30.65ms    32.63
+run(BigInt_Filter_100_Nulls_70_next_50k_plain)              54.27ms    18.43
+run(BigInt_Filter_100_Nulls_70_next_100k_dict)              25.32ms    39.50
+run(BigInt_Filter_100_Nulls_70_next_100k_plain)             18.07ms    55.35
 ----------------------------------------------------------------------------
-run(BigInt_Filter_100_Nulls_100_next_5000_dict)              1.03ms   967.89
-run(BigInt_Filter_100_Nulls_100_next_5000_plain            971.75us    1.03K
-run(BigInt_Filter_100_Nulls_100_next_10000_dict              1.03ms   970.09
-run(BigInt_Filter_100_Nulls_100_next_10000_plai            975.05us    1.03K
-run(BigInt_Filter_100_Nulls_100_next_20000_dict              1.02ms   981.96
-run(BigInt_Filter_100_Nulls_100_next_20000_plai            979.39us    1.02K
-run(BigInt_Filter_100_Nulls_100_next_50000_dict              1.01ms   985.63
-run(BigInt_Filter_100_Nulls_100_next_50000_plai            946.22us    1.06K
-run(BigInt_Filter_100_Nulls_100_next_100000_dic              1.03ms   968.01
-run(BigInt_Filter_100_Nulls_100_next_100000_pla            973.41us    1.03K
+run(BigInt_Filter_100_Nulls_100_next_5k_dict)                1.15ms   869.44
+run(BigInt_Filter_100_Nulls_100_next_5k_plain)               1.05ms   951.19
+run(BigInt_Filter_100_Nulls_100_next_10k_dict)               1.17ms   856.61
+run(BigInt_Filter_100_Nulls_100_next_10k_Plain)              1.05ms   951.32
+run(BigInt_Filter_100_Nulls_100_next_20k_dict)               1.12ms   891.29
+run(BigInt_Filter_100_Nulls_100_next_20k_plain)              1.07ms   932.20
+run(BigInt_Filter_100_Nulls_100_next_50k_dict)               1.11ms   899.75
+run(BigInt_Filter_100_Nulls_100_next_50k_plain)              1.06ms   939.04
+run(BigInt_Filter_100_Nulls_100_next_100k_dict)              1.11ms   897.09
+run(BigInt_Filter_100_Nulls_100_next_100k_plain              1.08ms   926.95
 ----------------------------------------------------------------------------
 ----------------------------------------------------------------------------
-run(Double_Filter_0_Nulls_0_next_5000_dict)                 16.93ms    59.05
-run(Double_Filter_0_Nulls_0_next_5000_plain)                32.60ms    30.68
-run(Double_Filter_0_Nulls_0_next_10000_dict)                36.43ms    27.45
-run(Double_Filter_0_Nulls_0_next_10000_plain)               33.33ms    30.00
-run(Double_Filter_0_Nulls_0_next_20000_dict)                34.84ms    28.70
-run(Double_Filter_0_Nulls_0_next_20000_plain)               33.10ms    30.21
-run(Double_Filter_0_Nulls_0_next_50000_dict)                34.65ms    28.86
-run(Double_Filter_0_Nulls_0_next_50000_plain)               32.66ms    30.62
-run(Double_Filter_0_Nulls_0_next_100000_dict)               33.55ms    29.80
-run(Double_Filter_0_Nulls_0_next_100000_plain)              32.56ms    30.71
+run(Double_Filter_0_Nulls_0_next_5k_dict)                   46.04ms    21.72
+run(Double_Filter_0_Nulls_0_next_5k_plain)                  10.34ms    96.76
+run(Double_Filter_0_Nulls_0_next_10k_dict)                 116.04ms     8.62
+run(Double_Filter_0_Nulls_0_next_10k_Plain)                 84.38ms    11.85
+run(Double_Filter_0_Nulls_0_next_20k_dict)                  58.66ms    17.05
+run(Double_Filter_0_Nulls_0_next_20k_plain)                 22.44ms    44.57
+run(Double_Filter_0_Nulls_0_next_50k_dict)                  36.30ms    27.55
+run(Double_Filter_0_Nulls_0_next_50k_plain)                 38.86ms    25.73
+run(Double_Filter_0_Nulls_0_next_100k_dict)                 34.28ms    29.17
+run(Double_Filter_0_Nulls_0_next_100k_plain)                40.39ms    24.76
 ----------------------------------------------------------------------------
-run(Double_Filter_0_Nulls_20_next_5000_dict)                32.66ms    30.62
-run(Double_Filter_0_Nulls_20_next_5000_plain)               28.07ms    35.62
-run(Double_Filter_0_Nulls_20_next_10000_dict)               35.44ms    28.22
-run(Double_Filter_0_Nulls_20_next_10000_plain)              26.71ms    37.44
-run(Double_Filter_0_Nulls_20_next_20000_dict)               28.87ms    34.64
-run(Double_Filter_0_Nulls_20_next_20000_plain)              25.69ms    38.92
-run(Double_Filter_0_Nulls_20_next_50000_dict)               30.32ms    32.98
-run(Double_Filter_0_Nulls_20_next_50000_plain)              26.81ms    37.30
-run(Double_Filter_0_Nulls_20_next_100000_dict)              28.81ms    34.71
-run(Double_Filter_0_Nulls_20_next_100000_plain)             26.73ms    37.41
+run(Double_Filter_0_Nulls_20_next_5k_dict)                  36.77ms    27.20
+run(Double_Filter_0_Nulls_20_next_5k_plain)                 29.27ms    34.16
+run(Double_Filter_0_Nulls_20_next_10k_dict)                 28.53ms    35.05
+run(Double_Filter_0_Nulls_20_next_10k_Plain)                48.94ms    20.43
+run(Double_Filter_0_Nulls_20_next_20k_dict)                100.08ms     9.99
+run(Double_Filter_0_Nulls_20_next_20k_plain)                61.53ms    16.25
+run(Double_Filter_0_Nulls_20_next_50k_dict)                 47.61ms    21.01
+run(Double_Filter_0_Nulls_20_next_50k_plain)                11.76ms    85.05
+run(Double_Filter_0_Nulls_20_next_100k_dict)                29.92ms    33.42
+run(Double_Filter_0_Nulls_20_next_100k_plain)               27.75ms    36.03
 ----------------------------------------------------------------------------
-run(Double_Filter_0_Nulls_50_next_5000_dict)                23.98ms    41.70
-run(Double_Filter_0_Nulls_50_next_5000_plain)               16.65ms    60.07
-run(Double_Filter_0_Nulls_50_next_10000_dict)               19.28ms    51.87
-run(Double_Filter_0_Nulls_50_next_10000_plain)              19.29ms    51.84
-run(Double_Filter_0_Nulls_50_next_20000_dict)               15.83ms    63.19
-run(Double_Filter_0_Nulls_50_next_20000_plain)              14.89ms    67.16
-run(Double_Filter_0_Nulls_50_next_50000_dict)               17.78ms    56.24
-run(Double_Filter_0_Nulls_50_next_50000_plain)              14.40ms    69.46
-run(Double_Filter_0_Nulls_50_next_100000_dict)              18.38ms    54.40
-run(Double_Filter_0_Nulls_50_next_100000_plain)             14.70ms    68.04
+run(Double_Filter_0_Nulls_50_next_5k_dict)                  31.65ms    31.60
+run(Double_Filter_0_Nulls_50_next_5k_plain)                 20.92ms    47.81
+run(Double_Filter_0_Nulls_50_next_10k_dict)                 15.91ms    62.84
+run(Double_Filter_0_Nulls_50_next_10k_Plain)                20.29ms    49.28
+run(Double_Filter_0_Nulls_50_next_20k_dict)                 15.48ms    64.60
+run(Double_Filter_0_Nulls_50_next_20k_plain)                19.93ms    50.17
+run(Double_Filter_0_Nulls_50_next_50k_dict)                 23.60ms    42.37
+run(Double_Filter_0_Nulls_50_next_50k_plain)                11.11ms    90.04
+run(Double_Filter_0_Nulls_50_next_100k_dict)                18.63ms    53.69
+run(Double_Filter_0_Nulls_50_next_100k_plain)               18.58ms    53.81
 ----------------------------------------------------------------------------
-run(Double_Filter_0_Nulls_70_next_5000_dict)                13.52ms    73.96
-run(Double_Filter_0_Nulls_70_next_5000_plain)               11.04ms    90.61
-run(Double_Filter_0_Nulls_70_next_10000_dict)               12.61ms    79.28
-run(Double_Filter_0_Nulls_70_next_10000_plain)              11.00ms    90.91
-run(Double_Filter_0_Nulls_70_next_20000_dict)               12.37ms    80.87
-run(Double_Filter_0_Nulls_70_next_20000_plain)              10.65ms    93.87
-run(Double_Filter_0_Nulls_70_next_50000_dict)               12.34ms    81.01
-run(Double_Filter_0_Nulls_70_next_50000_plain)              11.31ms    88.39
-run(Double_Filter_0_Nulls_70_next_100000_dict)              12.04ms    83.04
-run(Double_Filter_0_Nulls_70_next_100000_plain)             11.30ms    88.50
+run(Double_Filter_0_Nulls_70_next_5k_dict)                  20.09ms    49.77
+run(Double_Filter_0_Nulls_70_next_5k_plain)                 11.68ms    85.62
+run(Double_Filter_0_Nulls_70_next_10k_dict)                 12.67ms    78.94
+run(Double_Filter_0_Nulls_70_next_10k_Plain)                11.80ms    84.74
+run(Double_Filter_0_Nulls_70_next_20k_dict)                 14.77ms    67.68
+run(Double_Filter_0_Nulls_70_next_20k_plain)                11.40ms    87.69
+run(Double_Filter_0_Nulls_70_next_50k_dict)                 12.71ms    78.65
+run(Double_Filter_0_Nulls_70_next_50k_plain)                11.36ms    88.01
+run(Double_Filter_0_Nulls_70_next_100k_dict)                12.45ms    80.35
+run(Double_Filter_0_Nulls_70_next_100k_plain)               12.26ms    81.60
 ----------------------------------------------------------------------------
-run(Double_Filter_0_Nulls_100_next_5000_dict)                1.03ms   971.81
-run(Double_Filter_0_Nulls_100_next_5000_plain)             950.58us    1.05K
-run(Double_Filter_0_Nulls_100_next_10000_dict)               1.04ms   964.03
-run(Double_Filter_0_Nulls_100_next_10000_plain)            967.97us    1.03K
-run(Double_Filter_0_Nulls_100_next_20000_dict)               1.04ms   965.02
-run(Double_Filter_0_Nulls_100_next_20000_plain)            946.39us    1.06K
-run(Double_Filter_0_Nulls_100_next_50000_dict)               1.03ms   968.13
-run(Double_Filter_0_Nulls_100_next_50000_plain)            952.92us    1.05K
-run(Double_Filter_0_Nulls_100_next_100000_dict)            978.88us    1.02K
-run(Double_Filter_0_Nulls_100_next_100000_plain            940.64us    1.06K
+run(Double_Filter_0_Nulls_100_next_5k_dict)                  1.15ms   871.27
+run(Double_Filter_0_Nulls_100_next_5k_plain)                 1.11ms   903.46
+run(Double_Filter_0_Nulls_100_next_10k_dict)                 1.16ms   859.44
+run(Double_Filter_0_Nulls_100_next_10k_Plain)                1.08ms   924.40
+run(Double_Filter_0_Nulls_100_next_20k_dict)                 1.13ms   886.21
+run(Double_Filter_0_Nulls_100_next_20k_plain)                1.05ms   947.89
+run(Double_Filter_0_Nulls_100_next_50k_dict)                 1.17ms   853.94
+run(Double_Filter_0_Nulls_100_next_50k_plain)                1.11ms   904.17
+run(Double_Filter_0_Nulls_100_next_100k_dict)                1.13ms   881.83
+run(Double_Filter_0_Nulls_100_next_100k_plain)               1.10ms   906.42
 ----------------------------------------------------------------------------
-run(Double_Filter_20_Nulls_0_next_5000_dict)                50.05ms    19.98
-run(Double_Filter_20_Nulls_0_next_5000_plain)               46.57ms    21.47
-run(Double_Filter_20_Nulls_0_next_10000_dict)               77.61ms    12.89
-run(Double_Filter_20_Nulls_0_next_10000_plain)              47.71ms    20.96
-run(Double_Filter_20_Nulls_0_next_20000_dict)               75.79ms    13.19
-run(Double_Filter_20_Nulls_0_next_20000_plain)              22.19ms    45.06
-run(Double_Filter_20_Nulls_0_next_50000_dict)               75.54ms    13.24
-run(Double_Filter_20_Nulls_0_next_50000_plain)              46.60ms    21.46
-run(Double_Filter_20_Nulls_0_next_100000_dict)              80.75ms    12.38
-run(Double_Filter_20_Nulls_0_next_100000_plain)             45.81ms    21.83
+run(Double_Filter_20_Nulls_0_next_5k_dict)                  70.59ms    14.17
+run(Double_Filter_20_Nulls_0_next_5k_plain)                 54.44ms    18.37
+run(Double_Filter_20_Nulls_0_next_10k_dict)                 65.36ms    15.30
+run(Double_Filter_20_Nulls_0_next_10k_Plain)                56.26ms    17.77
+run(Double_Filter_20_Nulls_0_next_20k_dict)                107.09ms     9.34
+run(Double_Filter_20_Nulls_0_next_20k_plain)                32.33ms    30.93
+run(Double_Filter_20_Nulls_0_next_50k_dict)                 82.43ms    12.13
+run(Double_Filter_20_Nulls_0_next_50k_plain)                55.24ms    18.10
+run(Double_Filter_20_Nulls_0_next_100k_dict)                90.81ms    11.01
+run(Double_Filter_20_Nulls_0_next_100k_plain)               45.57ms    21.95
 ----------------------------------------------------------------------------
-run(Double_Filter_20_Nulls_20_next_5000_dict)               69.60ms    14.37
-run(Double_Filter_20_Nulls_20_next_5000_plain)              39.80ms    25.13
-run(Double_Filter_20_Nulls_20_next_10000_dict)              63.06ms    15.86
-run(Double_Filter_20_Nulls_20_next_10000_plain)             37.63ms    26.57
-run(Double_Filter_20_Nulls_20_next_20000_dict)              61.80ms    16.18
-run(Double_Filter_20_Nulls_20_next_20000_plain)             39.14ms    25.55
-run(Double_Filter_20_Nulls_20_next_50000_dict)              60.85ms    16.43
-run(Double_Filter_20_Nulls_20_next_50000_plain)             39.29ms    25.45
-run(Double_Filter_20_Nulls_20_next_100000_dict)             61.68ms    16.21
-run(Double_Filter_20_Nulls_20_next_100000_plain             42.16ms    23.72
+run(Double_Filter_20_Nulls_20_next_5k_dict)                 68.66ms    14.56
+run(Double_Filter_20_Nulls_20_next_5k_plain)                45.86ms    21.80
+run(Double_Filter_20_Nulls_20_next_10k_dict)                85.67ms    11.67
+run(Double_Filter_20_Nulls_20_next_10k_Plain)               43.48ms    23.00
+run(Double_Filter_20_Nulls_20_next_20k_dict)                50.89ms    19.65
+run(Double_Filter_20_Nulls_20_next_20k_plain)               45.35ms    22.05
+run(Double_Filter_20_Nulls_20_next_50k_dict)                65.92ms    15.17
+run(Double_Filter_20_Nulls_20_next_50k_plain)               52.20ms    19.16
+run(Double_Filter_20_Nulls_20_next_100k_dict)               54.88ms    18.22
+run(Double_Filter_20_Nulls_20_next_100k_plain)              44.52ms    22.46
 ----------------------------------------------------------------------------
-run(Double_Filter_20_Nulls_50_next_5000_dict)               40.78ms    24.52
-run(Double_Filter_20_Nulls_50_next_5000_plain)              24.39ms    41.00
-run(Double_Filter_20_Nulls_50_next_10000_dict)              42.00ms    23.81
-run(Double_Filter_20_Nulls_50_next_10000_plain)             24.88ms    40.19
-run(Double_Filter_20_Nulls_50_next_20000_dict)              36.25ms    27.59
-run(Double_Filter_20_Nulls_50_next_20000_plain)             23.34ms    42.84
-run(Double_Filter_20_Nulls_50_next_50000_dict)              36.43ms    27.45
-run(Double_Filter_20_Nulls_50_next_50000_plain)             22.84ms    43.79
-run(Double_Filter_20_Nulls_50_next_100000_dict)             38.94ms    25.68
-run(Double_Filter_20_Nulls_50_next_100000_plain             22.77ms    43.92
+run(Double_Filter_20_Nulls_50_next_5k_dict)                 50.85ms    19.67
+run(Double_Filter_20_Nulls_50_next_5k_plain)                27.56ms    36.29
+run(Double_Filter_20_Nulls_50_next_10k_dict)                40.32ms    24.80
+run(Double_Filter_20_Nulls_50_next_10k_Plain)               25.39ms    39.38
+run(Double_Filter_20_Nulls_50_next_20k_dict)                40.65ms    24.60
+run(Double_Filter_20_Nulls_50_next_20k_plain)               31.98ms    31.27
+run(Double_Filter_20_Nulls_50_next_50k_dict)                36.55ms    27.36
+run(Double_Filter_20_Nulls_50_next_50k_plain)               39.60ms    25.25
+run(Double_Filter_20_Nulls_50_next_100k_dict)               34.30ms    29.15
+run(Double_Filter_20_Nulls_50_next_100k_plain)              24.74ms    40.43
 ----------------------------------------------------------------------------
-run(Double_Filter_20_Nulls_70_next_5000_dict)               27.03ms    37.00
-run(Double_Filter_20_Nulls_70_next_5000_plain)              18.22ms    54.87
-run(Double_Filter_20_Nulls_70_next_10000_dict)              26.79ms    37.32
-run(Double_Filter_20_Nulls_70_next_10000_plain)             17.61ms    56.78
-run(Double_Filter_20_Nulls_70_next_20000_dict)              25.92ms    38.57
-run(Double_Filter_20_Nulls_70_next_20000_plain)             18.08ms    55.30
-run(Double_Filter_20_Nulls_70_next_50000_dict)              27.18ms    36.80
-run(Double_Filter_20_Nulls_70_next_50000_plain)             17.78ms    56.24
-run(Double_Filter_20_Nulls_70_next_100000_dict)             26.95ms    37.11
-run(Double_Filter_20_Nulls_70_next_100000_plain             18.92ms    52.87
+run(Double_Filter_20_Nulls_70_next_5k_dict)                 35.97ms    27.80
+run(Double_Filter_20_Nulls_70_next_5k_plain)                18.81ms    53.17
+run(Double_Filter_20_Nulls_70_next_10k_dict)                29.70ms    33.67
+run(Double_Filter_20_Nulls_70_next_10k_Plain)               21.07ms    47.47
+run(Double_Filter_20_Nulls_70_next_20k_dict)                26.30ms    38.02
+run(Double_Filter_20_Nulls_70_next_20k_plain)               17.80ms    56.17
+run(Double_Filter_20_Nulls_70_next_50k_dict)                29.23ms    34.21
+run(Double_Filter_20_Nulls_70_next_50k_plain)               19.76ms    50.61
+run(Double_Filter_20_Nulls_70_next_100k_dict)               27.26ms    36.68
+run(Double_Filter_20_Nulls_70_next_100k_plain)              19.21ms    52.06
 ----------------------------------------------------------------------------
-run(Double_Filter_20_Nulls_100_next_5000_dict)               1.03ms   974.38
-run(Double_Filter_20_Nulls_100_next_5000_plain)            989.89us    1.01K
-run(Double_Filter_20_Nulls_100_next_10000_dict)              1.04ms   962.33
-run(Double_Filter_20_Nulls_100_next_10000_plain            969.66us    1.03K
-run(Double_Filter_20_Nulls_100_next_20000_dict)              1.02ms   978.19
-run(Double_Filter_20_Nulls_100_next_20000_plain            971.58us    1.03K
-run(Double_Filter_20_Nulls_100_next_50000_dict)              1.08ms   926.03
-run(Double_Filter_20_Nulls_100_next_50000_plain            982.96us    1.02K
-run(Double_Filter_20_Nulls_100_next_100000_dict              1.03ms   969.36
-run(Double_Filter_20_Nulls_100_next_100000_plai              1.01ms   994.29
+run(Double_Filter_20_Nulls_100_next_5k_dict)                 1.19ms   838.33
+run(Double_Filter_20_Nulls_100_next_5k_plain)                1.08ms   923.65
+run(Double_Filter_20_Nulls_100_next_10k_dict)                1.15ms   867.52
+run(Double_Filter_20_Nulls_100_next_10k_Plain)               1.09ms   917.52
+run(Double_Filter_20_Nulls_100_next_20k_dict)                1.13ms   881.77
+run(Double_Filter_20_Nulls_100_next_20k_plain)               1.08ms   922.16
+run(Double_Filter_20_Nulls_100_next_50k_dict)                1.14ms   875.53
+run(Double_Filter_20_Nulls_100_next_50k_plain)               1.09ms   914.11
+run(Double_Filter_20_Nulls_100_next_100k_dict)               1.15ms   866.91
+run(Double_Filter_20_Nulls_100_next_100k_plain)              1.12ms   888.90
 ----------------------------------------------------------------------------
-run(Double_Filter_50_Nulls_0_next_5000_dict)                60.75ms    16.46
-run(Double_Filter_50_Nulls_0_next_5000_plain)               43.76ms    22.85
-run(Double_Filter_50_Nulls_0_next_10000_dict)               89.64ms    11.16
-run(Double_Filter_50_Nulls_0_next_10000_plain)              43.14ms    23.18
-run(Double_Filter_50_Nulls_0_next_20000_dict)               89.17ms    11.22
-run(Double_Filter_50_Nulls_0_next_20000_plain)              44.32ms    22.57
-run(Double_Filter_50_Nulls_0_next_50000_dict)               94.63ms    10.57
-run(Double_Filter_50_Nulls_0_next_50000_plain)              43.73ms    22.87
-run(Double_Filter_50_Nulls_0_next_100000_dict)              90.13ms    11.10
-run(Double_Filter_50_Nulls_0_next_100000_plain)             43.07ms    23.22
+run(Double_Filter_50_Nulls_0_next_5k_dict)                  66.61ms    15.01
+run(Double_Filter_50_Nulls_0_next_5k_plain)                 87.16ms    11.47
+run(Double_Filter_50_Nulls_0_next_10k_dict)                 69.75ms    14.34
+run(Double_Filter_50_Nulls_0_next_10k_Plain)                61.24ms    16.33
+run(Double_Filter_50_Nulls_0_next_20k_dict)                 91.42ms    10.94
+run(Double_Filter_50_Nulls_0_next_20k_plain)                58.48ms    17.10
+run(Double_Filter_50_Nulls_0_next_50k_dict)                115.35ms     8.67
+run(Double_Filter_50_Nulls_0_next_50k_plain)                35.94ms    27.83
+run(Double_Filter_50_Nulls_0_next_100k_dict)               106.14ms     9.42
+run(Double_Filter_50_Nulls_0_next_100k_plain)               46.01ms    21.73
 ----------------------------------------------------------------------------
-run(Double_Filter_50_Nulls_20_next_5000_dict)               75.82ms    13.19
-run(Double_Filter_50_Nulls_20_next_5000_plain)              38.75ms    25.81
-run(Double_Filter_50_Nulls_20_next_10000_dict)              70.94ms    14.10
-run(Double_Filter_50_Nulls_20_next_10000_plain)             41.69ms    23.99
-run(Double_Filter_50_Nulls_20_next_20000_dict)              72.92ms    13.71
-run(Double_Filter_50_Nulls_20_next_20000_plain)             37.63ms    26.58
-run(Double_Filter_50_Nulls_20_next_50000_dict)              73.09ms    13.68
-run(Double_Filter_50_Nulls_20_next_50000_plain)             37.24ms    26.85
-run(Double_Filter_50_Nulls_20_next_100000_dict)             74.64ms    13.40
-run(Double_Filter_50_Nulls_20_next_100000_plain             38.66ms    25.87
+run(Double_Filter_50_Nulls_20_next_5k_dict)                 92.77ms    10.78
+run(Double_Filter_50_Nulls_20_next_5k_plain)                44.99ms    22.23
+run(Double_Filter_50_Nulls_20_next_10k_dict)               100.23ms     9.98
+run(Double_Filter_50_Nulls_20_next_10k_Plain)               23.82ms    41.99
+run(Double_Filter_50_Nulls_20_next_20k_dict)                79.26ms    12.62
+run(Double_Filter_50_Nulls_20_next_20k_plain)               42.55ms    23.50
+run(Double_Filter_50_Nulls_20_next_50k_dict)                86.56ms    11.55
+run(Double_Filter_50_Nulls_20_next_50k_plain)               33.30ms    30.03
+run(Double_Filter_50_Nulls_20_next_100k_dict)               82.79ms    12.08
+run(Double_Filter_50_Nulls_20_next_100k_plain)              40.66ms    24.60
 ----------------------------------------------------------------------------
-run(Double_Filter_50_Nulls_50_next_5000_dict)               76.24ms    13.12
-run(Double_Filter_50_Nulls_50_next_5000_plain)              26.20ms    38.16
-run(Double_Filter_50_Nulls_50_next_10000_dict)              47.02ms    21.27
-run(Double_Filter_50_Nulls_50_next_10000_plain)             23.45ms    42.65
-run(Double_Filter_50_Nulls_50_next_20000_dict)              42.83ms    23.35
-run(Double_Filter_50_Nulls_50_next_20000_plain)             21.95ms    45.55
-run(Double_Filter_50_Nulls_50_next_50000_dict)              43.95ms    22.75
-run(Double_Filter_50_Nulls_50_next_50000_plain)             24.25ms    41.23
-run(Double_Filter_50_Nulls_50_next_100000_dict)             43.21ms    23.14
-run(Double_Filter_50_Nulls_50_next_100000_plain             12.26ms    81.56
+run(Double_Filter_50_Nulls_50_next_5k_dict)                 58.81ms    17.00
+run(Double_Filter_50_Nulls_50_next_5k_plain)                23.38ms    42.76
+run(Double_Filter_50_Nulls_50_next_10k_dict)                44.38ms    22.53
+run(Double_Filter_50_Nulls_50_next_10k_Plain)               25.49ms    39.22
+run(Double_Filter_50_Nulls_50_next_20k_dict)                47.56ms    21.03
+run(Double_Filter_50_Nulls_50_next_20k_plain)               29.23ms    34.22
+run(Double_Filter_50_Nulls_50_next_50k_dict)                47.74ms    20.95
+run(Double_Filter_50_Nulls_50_next_50k_plain)               28.10ms    35.59
+run(Double_Filter_50_Nulls_50_next_100k_dict)               45.19ms    22.13
+run(Double_Filter_50_Nulls_50_next_100k_plain)              30.13ms    33.19
 ----------------------------------------------------------------------------
-run(Double_Filter_50_Nulls_70_next_5000_dict)               31.73ms    31.52
-run(Double_Filter_50_Nulls_70_next_5000_plain)              17.60ms    56.83
-run(Double_Filter_50_Nulls_70_next_10000_dict)              30.34ms    32.96
-run(Double_Filter_50_Nulls_70_next_10000_plain)             17.59ms    56.85
-run(Double_Filter_50_Nulls_70_next_20000_dict)              31.37ms    31.88
-run(Double_Filter_50_Nulls_70_next_20000_plain)             17.78ms    56.25
-run(Double_Filter_50_Nulls_70_next_50000_dict)              31.10ms    32.15
-run(Double_Filter_50_Nulls_70_next_50000_plain)             18.49ms    54.08
-run(Double_Filter_50_Nulls_70_next_100000_dict)             30.49ms    32.80
-run(Double_Filter_50_Nulls_70_next_100000_plain             17.98ms    55.61
+run(Double_Filter_50_Nulls_70_next_5k_dict)                 42.39ms    23.59
+run(Double_Filter_50_Nulls_70_next_5k_plain)                19.13ms    52.27
+run(Double_Filter_50_Nulls_70_next_10k_dict)                39.34ms    25.42
+run(Double_Filter_50_Nulls_70_next_10k_Plain)               19.04ms    52.52
+run(Double_Filter_50_Nulls_70_next_20k_dict)                31.11ms    32.15
+run(Double_Filter_50_Nulls_70_next_20k_plain)               19.06ms    52.47
+run(Double_Filter_50_Nulls_70_next_50k_dict)                32.22ms    31.03
+run(Double_Filter_50_Nulls_70_next_50k_plain)               17.79ms    56.20
+run(Double_Filter_50_Nulls_70_next_100k_dict)               29.08ms    34.39
+run(Double_Filter_50_Nulls_70_next_100k_plain)              18.06ms    55.36
 ----------------------------------------------------------------------------
-run(Double_Filter_50_Nulls_100_next_5000_dict)               1.05ms   952.20
-run(Double_Filter_50_Nulls_100_next_5000_plain)            940.88us    1.06K
-run(Double_Filter_50_Nulls_100_next_10000_dict)            997.32us    1.00K
-run(Double_Filter_50_Nulls_100_next_10000_plain            964.69us    1.04K
-run(Double_Filter_50_Nulls_100_next_20000_dict)            993.52us    1.01K
-run(Double_Filter_50_Nulls_100_next_20000_plain            927.72us    1.08K
-run(Double_Filter_50_Nulls_100_next_50000_dict)              1.06ms   943.52
-run(Double_Filter_50_Nulls_100_next_50000_plain              1.00ms   998.13
-run(Double_Filter_50_Nulls_100_next_100000_dict              1.01ms   987.37
-run(Double_Filter_50_Nulls_100_next_100000_plai            971.42us    1.03K
+run(Double_Filter_50_Nulls_100_next_5k_dict)                 1.19ms   838.37
+run(Double_Filter_50_Nulls_100_next_5k_plain)                1.11ms   900.88
+run(Double_Filter_50_Nulls_100_next_10k_dict)                1.15ms   871.34
+run(Double_Filter_50_Nulls_100_next_10k_Plain)               1.09ms   913.35
+run(Double_Filter_50_Nulls_100_next_20k_dict)                1.20ms   832.54
+run(Double_Filter_50_Nulls_100_next_20k_plain)               1.11ms   901.54
+run(Double_Filter_50_Nulls_100_next_50k_dict)                1.19ms   840.64
+run(Double_Filter_50_Nulls_100_next_50k_plain)               1.11ms   901.77
+run(Double_Filter_50_Nulls_100_next_100k_dict)               1.18ms   844.59
+run(Double_Filter_50_Nulls_100_next_100k_plain)              1.12ms   894.72
 ----------------------------------------------------------------------------
-run(Double_Filter_70_Nulls_0_next_5000_dict)                54.10ms    18.49
-run(Double_Filter_70_Nulls_0_next_5000_plain)               46.98ms    21.29
-run(Double_Filter_70_Nulls_0_next_10000_dict)               84.41ms    11.85
-run(Double_Filter_70_Nulls_0_next_10000_plain)              47.35ms    21.12
-run(Double_Filter_70_Nulls_0_next_20000_dict)               86.48ms    11.56
-run(Double_Filter_70_Nulls_0_next_20000_plain)              48.22ms    20.74
-run(Double_Filter_70_Nulls_0_next_50000_dict)               85.84ms    11.65
-run(Double_Filter_70_Nulls_0_next_50000_plain)              47.65ms    20.98
-run(Double_Filter_70_Nulls_0_next_100000_dict)              83.28ms    12.01
-run(Double_Filter_70_Nulls_0_next_100000_plain)             48.58ms    20.59
+run(Double_Filter_70_Nulls_0_next_5k_dict)                  68.68ms    14.56
+run(Double_Filter_70_Nulls_0_next_5k_plain)                 52.46ms    19.06
+run(Double_Filter_70_Nulls_0_next_10k_dict)                104.38ms     9.58
+run(Double_Filter_70_Nulls_0_next_10k_Plain)                45.86ms    21.81
+run(Double_Filter_70_Nulls_0_next_20k_dict)                 92.56ms    10.80
+run(Double_Filter_70_Nulls_0_next_20k_plain)                60.98ms    16.40
+run(Double_Filter_70_Nulls_0_next_50k_dict)                126.62ms     7.90
+run(Double_Filter_70_Nulls_0_next_50k_plain)                36.57ms    27.35
+run(Double_Filter_70_Nulls_0_next_100k_dict)               106.28ms     9.41
+run(Double_Filter_70_Nulls_0_next_100k_plain)               43.34ms    23.07
 ----------------------------------------------------------------------------
-run(Double_Filter_70_Nulls_20_next_5000_dict)               72.87ms    13.72
-run(Double_Filter_70_Nulls_20_next_5000_plain)              41.28ms    24.22
-run(Double_Filter_70_Nulls_20_next_10000_dict)              68.41ms    14.62
-run(Double_Filter_70_Nulls_20_next_10000_plain)             42.69ms    23.43
-run(Double_Filter_70_Nulls_20_next_20000_dict)              73.65ms    13.58
-run(Double_Filter_70_Nulls_20_next_20000_plain)             42.63ms    23.46
-run(Double_Filter_70_Nulls_20_next_50000_dict)              76.02ms    13.15
-run(Double_Filter_70_Nulls_20_next_50000_plain)             37.97ms    26.34
-run(Double_Filter_70_Nulls_20_next_100000_dict)             66.45ms    15.05
-run(Double_Filter_70_Nulls_20_next_100000_plain             38.81ms    25.77
+run(Double_Filter_70_Nulls_20_next_5k_dict)                 78.40ms    12.75
+run(Double_Filter_70_Nulls_20_next_5k_plain)                26.06ms    38.37
+run(Double_Filter_70_Nulls_20_next_10k_dict)                73.75ms    13.56
+run(Double_Filter_70_Nulls_20_next_10k_Plain)               49.60ms    20.16
+run(Double_Filter_70_Nulls_20_next_20k_dict)                76.06ms    13.15
+run(Double_Filter_70_Nulls_20_next_20k_plain)               50.12ms    19.95
+run(Double_Filter_70_Nulls_20_next_50k_dict)                75.28ms    13.28
+run(Double_Filter_70_Nulls_20_next_50k_plain)               72.46ms    13.80
+run(Double_Filter_70_Nulls_20_next_100k_dict)              111.26ms     8.99
+run(Double_Filter_70_Nulls_20_next_100k_plain)             112.18ms     8.91
 ----------------------------------------------------------------------------
-run(Double_Filter_70_Nulls_50_next_5000_dict)               55.83ms    17.91
-run(Double_Filter_70_Nulls_50_next_5000_plain)              27.84ms    35.92
-run(Double_Filter_70_Nulls_50_next_10000_dict)              40.23ms    24.86
-run(Double_Filter_70_Nulls_50_next_10000_plain)             22.92ms    43.63
-run(Double_Filter_70_Nulls_50_next_20000_dict)              40.95ms    24.42
-run(Double_Filter_70_Nulls_50_next_20000_plain)             23.39ms    42.76
-run(Double_Filter_70_Nulls_50_next_50000_dict)              42.80ms    23.37
-run(Double_Filter_70_Nulls_50_next_50000_plain)             21.88ms    45.71
-run(Double_Filter_70_Nulls_50_next_100000_dict)             35.93ms    27.84
-run(Double_Filter_70_Nulls_50_next_100000_plain             24.71ms    40.47
+run(Double_Filter_70_Nulls_50_next_5k_dict)                 54.95ms    18.20
+run(Double_Filter_70_Nulls_50_next_5k_plain)                32.73ms    30.56
+run(Double_Filter_70_Nulls_50_next_10k_dict)                46.12ms    21.68
+run(Double_Filter_70_Nulls_50_next_10k_Plain)               32.05ms    31.20
+run(Double_Filter_70_Nulls_50_next_20k_dict)                41.23ms    24.26
+run(Double_Filter_70_Nulls_50_next_20k_plain)               18.43ms    54.26
+run(Double_Filter_70_Nulls_50_next_50k_dict)                43.51ms    22.99
+run(Double_Filter_70_Nulls_50_next_50k_plain)               28.03ms    35.68
+run(Double_Filter_70_Nulls_50_next_100k_dict)               48.58ms    20.59
+run(Double_Filter_70_Nulls_50_next_100k_plain)              27.13ms    36.86
 ----------------------------------------------------------------------------
-run(Double_Filter_70_Nulls_70_next_5000_dict)               29.35ms    34.08
-run(Double_Filter_70_Nulls_70_next_5000_plain)              17.64ms    56.68
-run(Double_Filter_70_Nulls_70_next_10000_dict)              28.79ms    34.74
-run(Double_Filter_70_Nulls_70_next_10000_plain)             16.69ms    59.92
-run(Double_Filter_70_Nulls_70_next_20000_dict)              28.47ms    35.12
-run(Double_Filter_70_Nulls_70_next_20000_plain)             18.71ms    53.44
-run(Double_Filter_70_Nulls_70_next_50000_dict)              29.52ms    33.87
-run(Double_Filter_70_Nulls_70_next_50000_plain)             17.42ms    57.39
-run(Double_Filter_70_Nulls_70_next_100000_dict)             28.65ms    34.90
-run(Double_Filter_70_Nulls_70_next_100000_plain             18.46ms    54.18
+run(Double_Filter_70_Nulls_70_next_5k_dict)                 36.94ms    27.07
+run(Double_Filter_70_Nulls_70_next_5k_plain)                21.51ms    46.48
+run(Double_Filter_70_Nulls_70_next_10k_dict)                30.33ms    32.97
+run(Double_Filter_70_Nulls_70_next_10k_Plain)               19.03ms    52.55
+run(Double_Filter_70_Nulls_70_next_20k_dict)                29.70ms    33.68
+run(Double_Filter_70_Nulls_70_next_20k_plain)               44.39ms    22.53
+run(Double_Filter_70_Nulls_70_next_50k_dict)                29.47ms    33.93
+run(Double_Filter_70_Nulls_70_next_50k_plain)               19.93ms    50.18
+run(Double_Filter_70_Nulls_70_next_100k_dict)               30.55ms    32.73
+run(Double_Filter_70_Nulls_70_next_100k_plain)              78.45ms    12.75
 ----------------------------------------------------------------------------
-run(Double_Filter_70_Nulls_100_next_5000_dict)               1.07ms   936.64
-run(Double_Filter_70_Nulls_100_next_5000_plain)              1.03ms   971.26
-run(Double_Filter_70_Nulls_100_next_10000_dict)              1.07ms   938.79
-run(Double_Filter_70_Nulls_100_next_10000_plain              1.06ms   941.38
-run(Double_Filter_70_Nulls_100_next_20000_dict)              1.05ms   949.69
-run(Double_Filter_70_Nulls_100_next_20000_plain            971.45us    1.03K
-run(Double_Filter_70_Nulls_100_next_50000_dict)              1.06ms   939.00
-run(Double_Filter_70_Nulls_100_next_50000_plain            980.12us    1.02K
-run(Double_Filter_70_Nulls_100_next_100000_dict              1.06ms   945.02
-run(Double_Filter_70_Nulls_100_next_100000_plai            982.13us    1.02K
+run(Double_Filter_70_Nulls_100_next_5k_dict)                 1.22ms   821.69
+run(Double_Filter_70_Nulls_100_next_5k_plain)                1.08ms   922.01
+run(Double_Filter_70_Nulls_100_next_10k_dict)                1.13ms   886.77
+run(Double_Filter_70_Nulls_100_next_10k_Plain)               1.10ms   906.80
+run(Double_Filter_70_Nulls_100_next_20k_dict)                1.25ms   801.04
+run(Double_Filter_70_Nulls_100_next_20k_plain)               1.08ms   922.37
+run(Double_Filter_70_Nulls_100_next_50k_dict)                1.13ms   881.13
+run(Double_Filter_70_Nulls_100_next_50k_plain)               1.08ms   926.57
+run(Double_Filter_70_Nulls_100_next_100k_dict)               1.16ms   859.24
+run(Double_Filter_70_Nulls_100_next_100k_plain)              1.10ms   908.55
 ----------------------------------------------------------------------------
-run(Double_Filter_100_Nulls_0_next_5000_dict)               40.80ms    24.51
-run(Double_Filter_100_Nulls_0_next_5000_plain)              49.75ms    20.10
-run(Double_Filter_100_Nulls_0_next_10000_dict)              69.62ms    14.36
-run(Double_Filter_100_Nulls_0_next_10000_plain)             17.99ms    55.59
-run(Double_Filter_100_Nulls_0_next_20000_dict)              72.57ms    13.78
-run(Double_Filter_100_Nulls_0_next_20000_plain)             45.56ms    21.95
-run(Double_Filter_100_Nulls_0_next_50000_dict)              69.34ms    14.42
-run(Double_Filter_100_Nulls_0_next_50000_plain)             45.71ms    21.88
-run(Double_Filter_100_Nulls_0_next_100000_dict)             76.33ms    13.10
-run(Double_Filter_100_Nulls_0_next_100000_plain             45.27ms    22.09
+run(Double_Filter_100_Nulls_0_next_5k_dict)                 60.38ms    16.56
+run(Double_Filter_100_Nulls_0_next_5k_plain)                77.51ms    12.90
+run(Double_Filter_100_Nulls_0_next_10k_dict)                64.41ms    15.53
+run(Double_Filter_100_Nulls_0_next_10k_Plain)               48.80ms    20.49
+run(Double_Filter_100_Nulls_0_next_20k_dict)                77.02ms    12.98
+run(Double_Filter_100_Nulls_0_next_20k_plain)               62.04ms    16.12
+run(Double_Filter_100_Nulls_0_next_50k_dict)                70.91ms    14.10
+run(Double_Filter_100_Nulls_0_next_50k_plain)               60.01ms    16.66
+run(Double_Filter_100_Nulls_0_next_100k_dict)               79.32ms    12.61
+run(Double_Filter_100_Nulls_0_next_100k_plain)              57.80ms    17.30
 ----------------------------------------------------------------------------
-run(Double_Filter_100_Nulls_20_next_5000_dict)              65.50ms    15.27
-run(Double_Filter_100_Nulls_20_next_5000_plain)             33.65ms    29.72
-run(Double_Filter_100_Nulls_20_next_10000_dict)             53.99ms    18.52
-run(Double_Filter_100_Nulls_20_next_10000_plain             37.36ms    26.77
-run(Double_Filter_100_Nulls_20_next_20000_dict)             66.01ms    15.15
-run(Double_Filter_100_Nulls_20_next_20000_plain             37.29ms    26.82
-run(Double_Filter_100_Nulls_20_next_50000_dict)             56.38ms    17.74
-run(Double_Filter_100_Nulls_20_next_50000_plain             36.22ms    27.61
-run(Double_Filter_100_Nulls_20_next_100000_dict             57.45ms    17.41
-run(Double_Filter_100_Nulls_20_next_100000_plai             47.34ms    21.12
+run(Double_Filter_100_Nulls_20_next_5k_dict)                69.99ms    14.29
+run(Double_Filter_100_Nulls_20_next_5k_plain)               44.72ms    22.36
+run(Double_Filter_100_Nulls_20_next_10k_dict)               63.70ms    15.70
+run(Double_Filter_100_Nulls_20_next_10k_Plain)              45.46ms    22.00
+run(Double_Filter_100_Nulls_20_next_20k_dict)               63.55ms    15.73
+run(Double_Filter_100_Nulls_20_next_20k_plain)              44.95ms    22.25
+run(Double_Filter_100_Nulls_20_next_50k_dict)               74.41ms    13.44
+run(Double_Filter_100_Nulls_20_next_50k_plain)              33.79ms    29.60
+run(Double_Filter_100_Nulls_20_next_100k_dict)              73.03ms    13.69
+run(Double_Filter_100_Nulls_20_next_100k_plain)             36.55ms    27.36
 ----------------------------------------------------------------------------
-run(Double_Filter_100_Nulls_50_next_5000_dict)              34.34ms    29.12
-run(Double_Filter_100_Nulls_50_next_5000_plain)             21.40ms    46.72
-run(Double_Filter_100_Nulls_50_next_10000_dict)             33.00ms    30.31
-run(Double_Filter_100_Nulls_50_next_10000_plain             20.74ms    48.21
-run(Double_Filter_100_Nulls_50_next_20000_dict)             34.59ms    28.91
-run(Double_Filter_100_Nulls_50_next_20000_plain             20.42ms    48.96
-run(Double_Filter_100_Nulls_50_next_50000_dict)             33.41ms    29.93
-run(Double_Filter_100_Nulls_50_next_50000_plain             20.63ms    48.47
-run(Double_Filter_100_Nulls_50_next_100000_dict             33.38ms    29.96
-run(Double_Filter_100_Nulls_50_next_100000_plai             20.71ms    48.28
+run(Double_Filter_100_Nulls_50_next_5k_dict)                47.57ms    21.02
+run(Double_Filter_100_Nulls_50_next_5k_plain)               30.64ms    32.63
+run(Double_Filter_100_Nulls_50_next_10k_dict)               46.46ms    21.53
+run(Double_Filter_100_Nulls_50_next_10k_Plain)              28.97ms    34.52
+run(Double_Filter_100_Nulls_50_next_20k_dict)               36.57ms    27.35
+run(Double_Filter_100_Nulls_50_next_20k_plain)              30.93ms    32.33
+run(Double_Filter_100_Nulls_50_next_50k_dict)               39.82ms    25.11
+run(Double_Filter_100_Nulls_50_next_50k_plain)              26.45ms    37.81
+run(Double_Filter_100_Nulls_50_next_100k_dict)              38.63ms    25.89
+run(Double_Filter_100_Nulls_50_next_100k_plain)             26.30ms    38.03
 ----------------------------------------------------------------------------
-run(Double_Filter_100_Nulls_70_next_5000_dict)              25.27ms    39.58
-run(Double_Filter_100_Nulls_70_next_5000_plain)             17.30ms    57.80
-run(Double_Filter_100_Nulls_70_next_10000_dict)             25.28ms    39.56
-run(Double_Filter_100_Nulls_70_next_10000_plain             15.70ms    63.71
-run(Double_Filter_100_Nulls_70_next_20000_dict)             24.43ms    40.93
-run(Double_Filter_100_Nulls_70_next_20000_plain             17.23ms    58.05
-run(Double_Filter_100_Nulls_70_next_50000_dict)             24.63ms    40.60
-run(Double_Filter_100_Nulls_70_next_50000_plain             16.71ms    59.83
-run(Double_Filter_100_Nulls_70_next_100000_dict             24.18ms    41.36
-run(Double_Filter_100_Nulls_70_next_100000_plai             18.43ms    54.27
+run(Double_Filter_100_Nulls_70_next_5k_dict)                35.46ms    28.20
+run(Double_Filter_100_Nulls_70_next_5k_plain)               16.41ms    60.94
+run(Double_Filter_100_Nulls_70_next_10k_dict)               26.78ms    37.34
+run(Double_Filter_100_Nulls_70_next_10k_Plain)              23.31ms    42.90
+run(Double_Filter_100_Nulls_70_next_20k_dict)               68.08ms    14.69
+run(Double_Filter_100_Nulls_70_next_20k_plain)              19.56ms    51.12
+run(Double_Filter_100_Nulls_70_next_50k_dict)               26.04ms    38.41
+run(Double_Filter_100_Nulls_70_next_50k_plain)              19.09ms    52.37
+run(Double_Filter_100_Nulls_70_next_100k_dict)              26.38ms    37.91
+run(Double_Filter_100_Nulls_70_next_100k_plain)             19.99ms    50.03
 ----------------------------------------------------------------------------
-run(Double_Filter_100_Nulls_100_next_5000_dict)              1.04ms   957.49
-run(Double_Filter_100_Nulls_100_next_5000_plain            955.36us    1.05K
-run(Double_Filter_100_Nulls_100_next_10000_dict              1.08ms   921.74
-run(Double_Filter_100_Nulls_100_next_10000_plai              1.01ms   993.71
-run(Double_Filter_100_Nulls_100_next_20000_dict              1.05ms   953.27
-run(Double_Filter_100_Nulls_100_next_20000_plai            993.23us    1.01K
-run(Double_Filter_100_Nulls_100_next_50000_dict              1.07ms   932.16
-run(Double_Filter_100_Nulls_100_next_50000_plai            993.38us    1.01K
-run(Double_Filter_100_Nulls_100_next_100000_dic              1.01ms   991.20
-run(Double_Filter_100_Nulls_100_next_100000_pla              1.00ms   995.84
+run(Double_Filter_100_Nulls_100_next_5k_dict)                1.23ms   812.53
+run(Double_Filter_100_Nulls_100_next_5k_plain)               1.16ms   865.38
+run(Double_Filter_100_Nulls_100_next_10k_dict)               1.22ms   818.96
+run(Double_Filter_100_Nulls_100_next_10k_Plain)              1.12ms   890.70
+run(Double_Filter_100_Nulls_100_next_20k_dict)               1.18ms   850.97
+run(Double_Filter_100_Nulls_100_next_20k_plain)              1.11ms   903.99
+run(Double_Filter_100_Nulls_100_next_50k_dict)               1.17ms   852.25
+run(Double_Filter_100_Nulls_100_next_50k_plain)              1.08ms   926.62
+run(Double_Filter_100_Nulls_100_next_100k_dict)              1.21ms   823.54
+run(Double_Filter_100_Nulls_100_next_100k_plain              1.07ms   931.79
+----------------------------------------------------------------------------
+----------------------------------------------------------------------------
+run(Map_Filter_100_Nulls_0_next_5k_dict)                   512.01ms     1.95
+run(Map_Filter_100_Nulls_0_next_5k_plain)                  519.26ms     1.93
+run(Map_Filter_100_Nulls_0_next_10k_dict)                  491.47ms     2.03
+run(Map_Filter_100_Nulls_0_next_10k_Plain)                 477.31ms     2.10
+run(Map_Filter_100_Nulls_0_next_20k_dict)                  483.19ms     2.07
+run(Map_Filter_100_Nulls_0_next_20k_plain)                 492.69ms     2.03
+run(Map_Filter_100_Nulls_0_next_50k_dict)                  503.63ms     1.99
+run(Map_Filter_100_Nulls_0_next_50k_plain)                 458.13ms     2.18
+run(Map_Filter_100_Nulls_0_next_100k_dict)                 526.96ms     1.90
+run(Map_Filter_100_Nulls_0_next_100k_plain)                484.31ms     2.06
+----------------------------------------------------------------------------
+run(Map_Filter_100_Nulls_20_next_5k_dict)                  485.14ms     2.06
+run(Map_Filter_100_Nulls_20_next_5k_plain)                 523.81ms     1.91
+run(Map_Filter_100_Nulls_20_next_10k_dict)                 487.79ms     2.05
+run(Map_Filter_100_Nulls_20_next_10k_Plain)                501.78ms     1.99
+run(Map_Filter_100_Nulls_20_next_20k_dict)                 480.07ms     2.08
+run(Map_Filter_100_Nulls_20_next_20k_plain)                500.53ms     2.00
+run(Map_Filter_100_Nulls_20_next_50k_dict)                 496.29ms     2.01
+run(Map_Filter_100_Nulls_20_next_50k_plain)                449.78ms     2.22
+run(Map_Filter_100_Nulls_20_next_100k_dict)                479.64ms     2.08
+run(Map_Filter_100_Nulls_20_next_100k_plain)               451.55ms     2.21
+----------------------------------------------------------------------------
+run(Map_Filter_100_Nulls_50_next_5k_dict)                  377.07ms     2.65
+run(Map_Filter_100_Nulls_50_next_5k_plain)                 344.94ms     2.90
+run(Map_Filter_100_Nulls_50_next_10k_dict)                 380.58ms     2.63
+run(Map_Filter_100_Nulls_50_next_10k_Plain)                334.15ms     2.99
+run(Map_Filter_100_Nulls_50_next_20k_dict)                 397.08ms     2.52
+run(Map_Filter_100_Nulls_50_next_20k_plain)                318.45ms     3.14
+run(Map_Filter_100_Nulls_50_next_50k_dict)                 420.00ms     2.38
+run(Map_Filter_100_Nulls_50_next_50k_plain)                328.35ms     3.05
+run(Map_Filter_100_Nulls_50_next_100k_dict)                380.53ms     2.63
+run(Map_Filter_100_Nulls_50_next_100k_plain)               335.41ms     2.98
+----------------------------------------------------------------------------
+run(Map_Filter_100_Nulls_70_next_5k_dict)                  269.50ms     3.71
+run(Map_Filter_100_Nulls_70_next_5k_plain)                 251.71ms     3.97
+run(Map_Filter_100_Nulls_70_next_10k_dict)                 245.63ms     4.07
+run(Map_Filter_100_Nulls_70_next_10k_Plain)                237.48ms     4.21
+run(Map_Filter_100_Nulls_70_next_20k_dict)                 242.31ms     4.13
+run(Map_Filter_100_Nulls_70_next_20k_plain)                244.02ms     4.10
+run(Map_Filter_100_Nulls_70_next_50k_dict)                 262.59ms     3.81
+run(Map_Filter_100_Nulls_70_next_50k_plain)                230.39ms     4.34
+run(Map_Filter_100_Nulls_70_next_100k_dict)                257.85ms     3.88
+run(Map_Filter_100_Nulls_70_next_100k_plain)               231.06ms     4.33
+----------------------------------------------------------------------------
+run(Map_Filter_100_Nulls_100_next_5k_dict)                  52.11ms    19.19
+run(Map_Filter_100_Nulls_100_next_5k_plain)                 50.11ms    19.95
+run(Map_Filter_100_Nulls_100_next_10k_dict)                 49.96ms    20.02
+run(Map_Filter_100_Nulls_100_next_10k_Plain)                50.56ms    19.78
+run(Map_Filter_100_Nulls_100_next_20k_dict)                 50.12ms    19.95
+run(Map_Filter_100_Nulls_100_next_20k_plain)                50.14ms    19.95
+run(Map_Filter_100_Nulls_100_next_50k_dict)                 50.40ms    19.84
+run(Map_Filter_100_Nulls_100_next_50k_plain)                50.28ms    19.89
+run(Map_Filter_100_Nulls_100_next_100k_dict)                50.64ms    19.75
+run(Map_Filter_100_Nulls_100_next_100k_plain)               50.84ms    19.67
+----------------------------------------------------------------------------
+----------------------------------------------------------------------------
+run(List_Filter_100_Nulls_0_next_5k_dict)                  510.33ms     1.96
+run(List_Filter_100_Nulls_0_next_5k_plain)                 470.09ms     2.13
+run(List_Filter_100_Nulls_0_next_10k_dict)                 635.49ms     1.57
+run(List_Filter_100_Nulls_0_next_10k_Plain)                479.80ms     2.08
+run(List_Filter_100_Nulls_0_next_20k_dict)                 583.73ms     1.71
+run(List_Filter_100_Nulls_0_next_20k_plain)                494.83ms     2.02
+run(List_Filter_100_Nulls_0_next_50k_dict)                 578.41ms     1.73
+run(List_Filter_100_Nulls_0_next_50k_plain)                480.41ms     2.08
+run(List_Filter_100_Nulls_0_next_100k_dict)                515.73ms     1.94
+run(List_Filter_100_Nulls_0_next_100k_plain)               492.10ms     2.03
+----------------------------------------------------------------------------
+run(List_Filter_100_Nulls_20_next_5k_dict)                 527.48ms     1.90
+run(List_Filter_100_Nulls_20_next_5k_plain)                448.50ms     2.23
+run(List_Filter_100_Nulls_20_next_10k_dict)                527.30ms     1.90
+run(List_Filter_100_Nulls_20_next_10k_Plain)               450.71ms     2.22
+run(List_Filter_100_Nulls_20_next_20k_dict)                513.22ms     1.95
+run(List_Filter_100_Nulls_20_next_20k_plain)               475.91ms     2.10
+run(List_Filter_100_Nulls_20_next_50k_dict)                509.59ms     1.96
+run(List_Filter_100_Nulls_20_next_50k_plain)               487.91ms     2.05
+run(List_Filter_100_Nulls_20_next_100k_dict)               551.87ms     1.81
+run(List_Filter_100_Nulls_20_next_100k_plain)              444.48ms     2.25
+----------------------------------------------------------------------------
+run(List_Filter_100_Nulls_50_next_5k_dict)                 398.44ms     2.51
+run(List_Filter_100_Nulls_50_next_5k_plain)                351.05ms     2.85
+run(List_Filter_100_Nulls_50_next_10k_dict)                358.92ms     2.79
+run(List_Filter_100_Nulls_50_next_10k_Plain)               361.92ms     2.76
+run(List_Filter_100_Nulls_50_next_20k_dict)                365.71ms     2.73
+run(List_Filter_100_Nulls_50_next_20k_plain)               379.67ms     2.63
+run(List_Filter_100_Nulls_50_next_50k_dict)                386.53ms     2.59
+run(List_Filter_100_Nulls_50_next_50k_plain)               333.08ms     3.00
+run(List_Filter_100_Nulls_50_next_100k_dict)               391.00ms     2.56
+run(List_Filter_100_Nulls_50_next_100k_plain)              314.15ms     3.18
+----------------------------------------------------------------------------
+run(List_Filter_100_Nulls_70_next_5k_dict)                 269.02ms     3.72
+run(List_Filter_100_Nulls_70_next_5k_plain)                237.83ms     4.20
+run(List_Filter_100_Nulls_70_next_10k_dict)                240.33ms     4.16
+run(List_Filter_100_Nulls_70_next_10k_Plain)               242.11ms     4.13
+run(List_Filter_100_Nulls_70_next_20k_dict)                243.19ms     4.11
+run(List_Filter_100_Nulls_70_next_20k_plain)               262.23ms     3.81
+run(List_Filter_100_Nulls_70_next_50k_dict)                241.58ms     4.14
+run(List_Filter_100_Nulls_70_next_50k_plain)               237.81ms     4.21
+run(List_Filter_100_Nulls_70_next_100k_dict)               262.14ms     3.81
+run(List_Filter_100_Nulls_70_next_100k_plain)              238.90ms     4.19
+----------------------------------------------------------------------------
+run(List_Filter_100_Nulls_100_next_5k_dict)                 49.10ms    20.37
+run(List_Filter_100_Nulls_100_next_5k_plain)                49.41ms    20.24
+run(List_Filter_100_Nulls_100_next_10k_dict)                49.93ms    20.03
+run(List_Filter_100_Nulls_100_next_10k_Plain)               49.90ms    20.04
+run(List_Filter_100_Nulls_100_next_20k_dict)                49.38ms    20.25
+run(List_Filter_100_Nulls_100_next_20k_plain)               48.86ms    20.47
+run(List_Filter_100_Nulls_100_next_50k_dict)                48.91ms    20.45
+run(List_Filter_100_Nulls_100_next_50k_plain)               49.07ms    20.38
+run(List_Filter_100_Nulls_100_next_100k_dict)               49.25ms    20.31
+run(List_Filter_100_Nulls_100_next_100k_plain)              48.90ms    20.45
 ----------------------------------------------------------------------------
 ----------------------------------------------------------------------------
 */


### PR DESCRIPTION
This PR introduces List and Map to the existing Parquet Reader Benchmark. Currently, filters over complex type are not supportted. So this benchmark measures the performance of the complex types without filters