### PR TITLE
Add error message to vector creation with null type

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -41,7 +41,7 @@ BaseVector::BaseVector(
     std::optional<ByteCount> representedByteCount,
     std::optional<ByteCount> storageByteCount)
     : type_(std::move(type)),
-      typeKind_(type_->kind()),
+      typeKind_(type_ ? type_->kind() : TypeKind::INVALID),
       encoding_(encoding),
       nulls_(std::move(nulls)),
       rawNulls_(nulls_.get() ? nulls_->as<uint64_t>() : nullptr),
@@ -51,6 +51,8 @@ BaseVector::BaseVector(
       distinctValueCount_(distinctValueCount),
       representedByteCount_(representedByteCount),
       storageByteCount_(storageByteCount) {
+  VELOX_CHECK_NOT_NULL(type_, "Vector creation requires a non-null type.");
+
   if (nulls_) {
     int32_t bytes = byteSize<bool>(length_);
     VELOX_CHECK(nulls_->capacity() >= bytes);
@@ -261,6 +263,7 @@ VectorPtr BaseVector::createInternal(
     const TypePtr& type,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(type, "Vector creation requires a non-null type.");
   auto kind = type->kind();
   switch (kind) {
     case TypeKind::ROW: {
@@ -675,6 +678,7 @@ std::shared_ptr<BaseVector> BaseVector::createNullConstant(
     const TypePtr& type,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(type, "Vector creation requires a non-null type.");
   if (!type->isPrimitiveType()) {
     return std::make_shared<ConstantVector<ComplexType>>(
         pool, size, true, type, ComplexType());

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -63,6 +63,7 @@ std::string stringifyTruncatedElementList(
 std::shared_ptr<RowVector> RowVector::createEmpty(
     std::shared_ptr<const Type> type,
     velox::memory::MemoryPool* pool) {
+  VELOX_CHECK_NOT_NULL(type, "Vector creation requires a non-null type.");
   VELOX_CHECK(type->isRow());
   return std::static_pointer_cast<RowVector>(BaseVector::create(type, 0, pool));
 }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2173,3 +2173,40 @@ TEST_F(VectorTest, ensureNullsCapacity) {
   auto nulls = vec->mutableNulls(2);
   ASSERT_GE(nulls->size(), bits::nbytes(size));
 }
+
+TEST_F(VectorTest, createVectorWithNullType) {
+  std::string kErrorMessage = "Vector creation requires a non-null type.";
+
+  VELOX_ASSERT_THROW(BaseVector::create(nullptr, 100, pool()), kErrorMessage);
+  VELOX_ASSERT_THROW(
+      BaseVector::createNullConstant(nullptr, 100, pool()), kErrorMessage);
+  VELOX_ASSERT_THROW(
+      BaseVector::getOrCreateEmpty(nullptr, nullptr, pool()), kErrorMessage);
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ConstantVector<int64_t>>(pool(), 100, false, nullptr, 0),
+      kErrorMessage);
+
+  std::vector<BufferPtr> stringBuffers;
+  VELOX_ASSERT_THROW(
+      std::make_shared<FlatVector<int64_t>>(
+          pool(), nullptr, nullptr, 100, nullptr, std::move(stringBuffers)),
+      kErrorMessage);
+
+  std::vector<VectorPtr> children;
+  VELOX_ASSERT_THROW(
+      std::make_shared<RowVector>(pool(), nullptr, nullptr, 100, children),
+      kErrorMessage);
+
+  VELOX_ASSERT_THROW(RowVector::createEmpty(nullptr, pool()), kErrorMessage);
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<ArrayVector>(
+          pool(), nullptr, nullptr, 100, nullptr, nullptr, nullptr),
+      kErrorMessage);
+
+  VELOX_ASSERT_THROW(
+      std::make_shared<MapVector>(
+          pool(), nullptr, nullptr, 100, nullptr, nullptr, nullptr, nullptr),
+      kErrorMessage);
+}


### PR DESCRIPTION
Summary:
Vector creation with null type should fail, but right now it crashes directly without
error messages which makes it hard to debug. This diff add runtime checks of the
type when creating a vector and throw with a descriptive error message in case of
type being null.

Reviewed By: mbasmanova

Differential Revision: D42728113

