### PR TITLE
memory and task code cleanup

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -497,8 +497,7 @@ AsyncDataCache::AsyncDataCache(
     const std::shared_ptr<MemoryAllocator>& allocator,
     uint64_t maxBytes,
     std::unique_ptr<SsdCache> ssdCache)
-    : memory::MemoryAllocator(memory::MemoryAllocator::Kind::kCache),
-      allocator_(allocator),
+    : allocator_(allocator),
       ssdCache_(std::move(ssdCache)),
       cachedPages_(0),
       maxBytes_(maxBytes) {

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -626,6 +626,10 @@ class AsyncDataCache : public memory::MemoryAllocator {
   // Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+  Kind kind() const override {
+    return allocator_->kind();
+  }
+
   bool allocateNonContiguous(
       memory::MachinePageCount numPages,
       Allocation& out,

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -108,8 +108,8 @@ class AsyncDataCacheTest : public testing::Test {
         filenames_.push_back(StringIdLease(fileIds(), name));
       }
     }
-    ASSERT_EQ(cache_->kind(), MemoryAllocator::Kind::kCache);
-    ASSERT_EQ(MemoryAllocator::kindString(cache_->kind()), "CACHE");
+    ASSERT_EQ(cache_->kind(), MemoryAllocator::Kind::kMmap);
+    ASSERT_EQ(MemoryAllocator::kindString(cache_->kind()), "MMAP");
   }
 
   // Finds one entry from RAM, SSD or storage. Throws if the data

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -93,9 +93,7 @@ std::string MemoryAllocator::Allocation::toString() const {
 MemoryAllocator::ContiguousAllocation::~ContiguousAllocation() {
   if (pool_ != nullptr) {
     pool_->freeContiguous(*this);
-    data_ = nullptr;
     pool_ = nullptr;
-    size_ = 0;
   }
   VELOX_CHECK_NULL(data_);
   VELOX_CHECK_EQ(size_, 0);
@@ -126,14 +124,10 @@ std::string MemoryAllocator::ContiguousAllocation::toString() const {
 
 std::string MemoryAllocator::kindString(Kind kind) {
   switch (kind) {
-    case Kind::kStd:
-      return "STD";
+    case Kind::kMalloc:
+      return "MALLOC";
     case Kind::kMmap:
       return "MMAP";
-    case Kind::kCache:
-      return "CACHE";
-    case Kind::kTest:
-      return "TEST";
     default:
       return fmt::format("UNKNOWN: {}", static_cast<int>(kind));
   }
@@ -192,6 +186,10 @@ class MemoryAllocatorImpl : public MemoryAllocator {
  public:
   MemoryAllocatorImpl();
 
+  Kind kind() const override {
+    return kind_;
+  }
+
   bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,
@@ -205,7 +203,7 @@ class MemoryAllocatorImpl : public MemoryAllocator {
       Allocation* collateral,
       ContiguousAllocation& allocation,
       ReservationCallback reservationCB = nullptr) override {
-    // VELOX_CHECK_GT(numPages, 0);
+    VELOX_CHECK_GT(numPages, 0);
     bool result;
     stats_.recordAllocate(numPages * kPageSize, 1, [&]() {
       result = allocateContiguousImpl(
@@ -254,6 +252,8 @@ class MemoryAllocatorImpl : public MemoryAllocator {
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 
+  const Kind kind_;
+
   std::atomic<MachinePageCount> numAllocated_;
   // When using mmap/madvise, the current of number pages backed by memory.
   std::atomic<MachinePageCount> numMapped_;
@@ -267,9 +267,7 @@ class MemoryAllocatorImpl : public MemoryAllocator {
 } // namespace
 
 MemoryAllocatorImpl::MemoryAllocatorImpl()
-    : MemoryAllocator(MemoryAllocator::Kind::kStd),
-      numAllocated_(0),
-      numMapped_(0) {}
+    : kind_(MemoryAllocator::Kind::kMalloc), numAllocated_(0), numMapped_(0) {}
 
 bool MemoryAllocatorImpl::allocateNonContiguous(
     MachinePageCount numPages,
@@ -292,6 +290,10 @@ bool MemoryAllocatorImpl::allocateNonContiguous(
     try {
       reservationCB(bytesToAllocate, true);
     } catch (std::exception& e) {
+      LOG(WARNING) << "Failed to reserve " << bytesToAllocate
+                   << " bytes for non-contiguous allocation of " << numPages
+                   << " pages, then release " << freedBytes
+                   << " bytes from the old allocation";
       // If the new memory reservation fails, we need to release the memory
       // reservation of the freed memory of previously allocation.
       reservationCB(freedBytes, false);
@@ -339,6 +341,10 @@ bool MemoryAllocatorImpl::allocateNonContiguous(
     }
     out.clear();
     if (reservationCB != nullptr) {
+      LOG(WARNING)
+          << "Failed to allocate memory for non-contiguous allocation of "
+          << numPages << " pages, then release " << bytesToAllocate + freedBytes
+          << " bytes of memory reservation including the old gallocation";
       reservationCB(bytesToAllocate + freedBytes, false);
     }
     return false;
@@ -381,6 +387,12 @@ bool MemoryAllocatorImpl::allocateContiguousImpl(
     } catch (std::exception& e) {
       // If the new memory reservation fails, we need to release the memory
       // reservation of the freed contiguous and non-contiguous memory.
+      LOG(WARNING) << "Failed to reserve " << numNeededPages * kPageSize
+                   << " bytes for contiguous allocation of " << numPages
+                   << " pages, then release "
+                   << (numCollateralPages + numContiguousCollateralPages) *
+              kPageSize
+                   << " bytes from the old allocations";
       reservationCB(
           (numCollateralPages + numContiguousCollateralPages) * kPageSize,
           false);

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -164,35 +164,24 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   enum class Kind {
     /// The default memory allocator kind which is implemented by
     /// MemoryAllocatorImpl. It delegates the memory allocations to std::malloc.
-    kStd,
+    kMalloc,
     /// The memory allocator kind which is implemented by MmapAllocator. It
     /// manages the large chunk of memory allocations on its own by leveraging
     /// mmap and madvice, to optimize the memory fragmentation in the long
     /// running service such as Prestissimo.
     kMmap,
-    /// The memory allocator kind which is implemented by AsyncDataCache to
-    /// integrate with the file cache management. It is a wrapper on top of an
-    /// actual memory allocator. It delegates the memory allocation to the
-    /// associated memory allocator and might evict file cache to make space for
-    /// the memory allocations and retries on allocation failures.
-    kCache,
-    /// The memory allocator kind which is implemented by MockMemoryAllocator
-    /// and used for test only. It is a wrapper on top of an actual memory
-    /// allocator. It uses MemoryUsageTracker to count the memory usage and
-    /// delegates the memory allocations to the associated memory allocator.
-    kTest,
   };
 
   static std::string kindString(Kind kind);
 
   /// Returns the process-wide default instance or an application-supplied
   /// custom instance set via setDefaultInstance().
-  static MemoryAllocator* FOLLY_NONNULL getInstance();
+  static MemoryAllocator* getInstance();
 
   /// Overrides the process-wide default instance. The caller keeps ownership
   /// and must not destroy the instance until it is empty. Calling this with
   /// nullptr restores the initial process-wide default instance.
-  static void setDefaultInstance(MemoryAllocator* FOLLY_NULLABLE instance);
+  static void setDefaultInstance(MemoryAllocator* instance);
 
   /// Creates a default MemoryAllocator instance but does not set this to
   /// process default.
@@ -217,7 +206,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     static constexpr uint32_t kMaxPagesInRun =
         (1UL << (64U - kPointerSignificantBits)) - 1;
 
-    PageRun(void* FOLLY_NONNULL address, MachinePageCount numPages) {
+    PageRun(void* address, MachinePageCount numPages) {
       auto word = reinterpret_cast<uint64_t>(address); // NOLINT
       if (!FLAGS_velox_use_malloc) {
         VELOX_CHECK_EQ(
@@ -233,7 +222,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     }
 
     template <typename T = uint8_t>
-    T* FOLLY_NONNULL data() const {
+    T* data() const {
       return reinterpret_cast<T*>(data_ & kPointerMask); // NOLINT
     }
 
@@ -261,9 +250,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       pool_ = other.pool_;
       runs_ = std::move(other.runs_);
       numPages_ = other.numPages_;
-      other.numPages_ = 0;
-      other.runs_.clear();
-      other.pool_ = nullptr;
+      other.clear();
       sanityCheck();
     }
 
@@ -273,8 +260,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       pool_ = other.pool_;
       runs_ = std::move(other.runs_);
       numPages_ = other.numPages_;
-      other.numPages_ = 0;
-      other.pool_ = nullptr;
+      other.clear();
     }
 
     MachinePageCount numPages() const {
@@ -293,15 +279,20 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       return numPages_ * kPageSize;
     }
 
-    void append(uint8_t* FOLLY_NONNULL address, int32_t numPages);
+    void append(uint8_t* address, int32_t numPages);
 
-    void setPool(MemoryPool* FOLLY_NONNULL pool) {
+    /// Invoked by memory pool to set the ownership on allocation success. All
+    /// the external non-contiguous memory allocations go through memory pool.
+    ///
+    /// NOTE: we can't set the memory pool on object constructor as the memory
+    /// allocator also uses it for temporal allocation internally.
+    void setPool(MemoryPool* pool) {
       VELOX_CHECK_NOT_NULL(pool);
       VELOX_CHECK_NULL(pool_);
       pool_ = pool;
     }
 
-    MemoryPool* FOLLY_NULLABLE pool() const {
+    MemoryPool* pool() const {
       return pool_;
     }
 
@@ -313,10 +304,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
 
     /// Returns the run number in 'runs_' and the position within the run
     /// corresponding to 'offset' from the start of 'this'.
-    void findRun(
-        uint64_t offset,
-        int32_t* FOLLY_NONNULL index,
-        int32_t* FOLLY_NONNULL offsetInRun) const;
+    void findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun) const;
 
     /// Returns if this allocation is empty.
     bool empty() const {
@@ -332,7 +320,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       VELOX_CHECK(numPages_ != 0 || pool_ == nullptr);
     }
 
-    MemoryPool* FOLLY_NULLABLE pool_{nullptr};
+    MemoryPool* pool_{nullptr};
     std::vector<PageRun> runs_;
     int32_t numPages_ = 0;
   };
@@ -349,9 +337,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       pool_ = other.pool_;
       data_ = other.data_;
       size_ = other.size_;
-      other.pool_ = nullptr;
-      other.data_ = nullptr;
-      other.size_ = 0;
+      other.clear();
       sanityCheck();
       return *this;
     }
@@ -360,16 +346,14 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       pool_ = other.pool_;
       data_ = other.data_;
       size_ = other.size_;
-      other.pool_ = nullptr;
-      other.data_ = nullptr;
-      other.size_ = 0;
+      other.clear();
       sanityCheck();
     }
 
     MachinePageCount numPages() const;
 
     template <typename T = uint8_t>
-    T* FOLLY_NULLABLE data() const {
+    T* data() const {
       return reinterpret_cast<T*>(data_);
     }
 
@@ -378,12 +362,18 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       return size_;
     }
 
-    void setPool(MemoryPool* FOLLY_NONNULL pool) {
+    /// Invoked by memory pool to set the ownership on allocation success. All
+    /// the external contiguous memory allocations go through memory pool.
+    ///
+    /// NOTE: we can't set the memory pool on object constructor as the memory
+    /// allocator also uses it for temporal allocation internally.
+    void setPool(MemoryPool* pool) {
       VELOX_CHECK_NOT_NULL(pool);
       VELOX_CHECK_NULL(pool_);
       pool_ = pool;
     }
-    MemoryPool* FOLLY_NULLABLE pool() const {
+
+    MemoryPool* pool() const {
       return pool_;
     }
 
@@ -392,7 +382,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       return size_ == 0;
     }
 
-    void set(void* FOLLY_NULLABLE data, uint64_t size);
+    void set(void* data, uint64_t size);
     void clear();
 
     std::string toString() const;
@@ -403,16 +393,16 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       VELOX_CHECK(size_ != 0 || pool_ == nullptr);
     }
 
-    MemoryPool* FOLLY_NULLABLE pool_{nullptr};
-    void* FOLLY_NULLABLE data_{nullptr};
+    MemoryPool* pool_{nullptr};
+    void* data_{nullptr};
     uint64_t size_{0};
   };
 
-  using ReservationCallback = std::function<void(int64_t, bool)>;
+  /// Returns the kind of this memory allocator. For AsyncDataCache, it returns
+  /// the kind of the delegated memory allocator underneath.
+  virtual Kind kind() const = 0;
 
-  Kind kind() const {
-    return kind_;
-  }
+  using ReservationCallback = std::function<void(int64_t, bool)>;
 
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
@@ -456,7 +446,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// 'freeContiguous' on the same memory allocator object.
   virtual bool allocateContiguous(
       MachinePageCount numPages,
-      Allocation* FOLLY_NULLABLE collateral,
+      Allocation* collateral,
       ContiguousAllocation& allocation,
       ReservationCallback reservationCB = nullptr) = 0;
 
@@ -476,11 +466,12 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   ///
   /// NOTE: 'alignment' must be power of two and in range of [kMinAlignment,
   /// kMaxAlignment].
-  virtual void* FOLLY_NULLABLE
-  allocateBytes(uint64_t bytes, uint16_t alignment = kMinAlignment) = 0;
+  virtual void* allocateBytes(
+      uint64_t bytes,
+      uint16_t alignment = kMinAlignment) = 0;
 
   /// Allocates a zero-filled contiguous bytes.
-  virtual void* FOLLY_NULLABLE allocateZeroFilled(uint64_t bytes);
+  virtual void* allocateZeroFilled(uint64_t bytes);
 
   /// Allocates 'newSize' contiguous bytes. If 'p' is not null, this function
   /// copies std::min(size, newSize) bytes from 'p' to the newly allocated
@@ -489,15 +480,15 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   ///
   /// NOTE: 'alignment' must be power of two and in range of [kMinAlignment,
   /// kMaxAlignment].
-  virtual void* FOLLY_NULLABLE reallocateBytes(
-      void* FOLLY_NONNULL p,
+  virtual void* reallocateBytes(
+      void* p,
       int64_t size,
       int64_t newSize,
       uint16_t alignment = kMinAlignment);
 
   /// Frees contiguous memory allocated by allocateBytes, allocateZeroFilled,
   /// reallocateBytes.
-  virtual void freeBytes(void* FOLLY_NONNULL p, uint64_t size) noexcept = 0;
+  virtual void freeBytes(void* p, uint64_t size) noexcept = 0;
 
   /// Checks internal consistency of allocation data structures. Returns true if
   /// OK.
@@ -527,7 +518,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   static void alignmentCheck(uint64_t allocateBytes, uint16_t alignmentBytes);
 
  protected:
-  explicit MemoryAllocator(Kind kind) : kind_(kind) {}
+  MemoryAllocator() = default;
 
   // Returns the size class size that corresponds to 'bytes'.
   static MachinePageCount roundUpToSizeClassSize(
@@ -560,15 +551,13 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   const std::vector<MachinePageCount>
       sizeClassSizes_{1, 2, 4, 8, 16, 32, 64, 128, 256};
 
-  const Kind kind_;
-
  private:
   static std::mutex initMutex_;
   // Singleton instance.
   static std::shared_ptr<MemoryAllocator> instance_;
   // Application-supplied custom implementation of MemoryAllocator to be
   // returned by getInstance().
-  static MemoryAllocator* FOLLY_NULLABLE customInstance_;
+  static MemoryAllocator* customInstance_;
 };
 
 std::ostream& operator<<(std::ostream& out, const MemoryAllocator::Kind& kind);

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -19,14 +19,11 @@
 #include <sys/mman.h>
 
 #include "velox/common/base/Portability.h"
-#include "velox/common/testutil/TestValue.h"
-
-using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
 
 MmapAllocator::MmapAllocator(const Options& options)
-    : MemoryAllocator(MemoryAllocator::Kind::kMmap),
+    : kind_(MemoryAllocator::Kind::kMmap),
       useMmapArena_(options.useMmapArena),
       numAllocated_(0),
       numMapped_(0),

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -62,9 +62,11 @@ class MmapAllocator : public MemoryAllocator {
     int32_t mmapArenaCapacityRatio = 10;
   };
 
-  enum class Failure { kNone, kMadvise, kMmap, kAllocate };
-
   explicit MmapAllocator(const Options& options);
+
+  Kind kind() const override {
+    return kind_;
+  }
 
   bool allocateNonContiguous(
       MachinePageCount numPages,
@@ -122,6 +124,7 @@ class MmapAllocator : public MemoryAllocator {
   /// function for validating otherwise unreachable error paths. If 'persistent'
   /// is false, then we only inject failure once in the next call. Otherwise, we
   /// keep injecting failures until next 'testingClearFailureInjection' call.
+  enum class Failure { kNone, kMadvise, kMmap, kAllocate };
   void testingSetFailureInjection(Failure failure, bool persistent = false) {
     injectedFailure_ = failure;
     isPersistentFailureInjection_ = persistent;
@@ -327,6 +330,8 @@ class MmapAllocator : public MemoryAllocator {
   // Finds at least  'target' unallocated pages in different size classes and
   // advises them away. Returns the number of pages advised away.
   MachinePageCount adviseAway(MachinePageCount target);
+
+  const Kind kind_;
 
   // If set true, allocations larger than the largest size class size will be
   // delegated to ManagedMmapArena. Otherwise, a system mmap call will be

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -27,32 +27,30 @@ struct ByteRange;
 // complex types as serialized rows.
 class StreamArena {
  public:
-  static constexpr int32_t kVectorStreamOwner = 1;
-
-  explicit StreamArena(memory::MemoryPool* FOLLY_NONNULL pool);
+  explicit StreamArena(memory::MemoryPool* pool);
 
   virtual ~StreamArena() = default;
 
   // Sets range to refer  to at least one page of writable memory owned by
   // 'this'. Up to 'numPages' may be  allocated.
-  virtual void newRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
+  virtual void newRange(int32_t bytes, ByteRange* range);
 
   // sets 'range' to point to a small piece of memory owned by this. These alwys
   // come from the heap. The use case is for headers that may change length
   // based on data properties, not for bulk data.
-  virtual void newTinyRange(int32_t bytes, ByteRange* FOLLY_NONNULL range);
+  virtual void newTinyRange(int32_t bytes, ByteRange* range);
 
   // Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {
     return size_;
   }
 
-  memory::MemoryPool* FOLLY_NONNULL pool() const {
+  memory::MemoryPool* pool() const {
     return pool_;
   }
 
  private:
-  memory::MemoryPool* FOLLY_NONNULL pool_;
+  memory::MemoryPool* const pool_;
   // All allocations.
   std::vector<std::unique_ptr<memory::MemoryAllocator::Allocation>>
       allocations_;


### PR DESCRIPTION
Remove CACHE and TEST kinds and use the kind of the delegated
memory allocator instead. In debugging, it is more meaningful log
out the actual kind of the delegated memory allocator.

Rename STD to MALLOC and will do the class name cleanup in followup.