### PR TITLE
Fix initPool method in QueryCtx.h

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -139,11 +139,11 @@ class QueryCtx : public Context {
   }
 
   void initPool(const std::string& queryId) {
-    if (!pool_) {
+    if (pool_ == nullptr) {
       pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
           QueryCtx::generatePoolName(queryId));
+      pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
     }
-    pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;


### PR DESCRIPTION
This is a follow-up of https://github.com/facebookincubator/velox/pull/3754. Unblocks https://github.com/prestodb/presto/pull/18966.

The `initPool` method is not idempotent and would attach a memory usage tracker every time the function is invoked which is a change in behaviour compared to the previous code.

This PR fixes the issue by only attaching a memory usage tracker for uninitialised pool only. I manually imported the commit in Presto to verify the change.