### PR TITLE
Fix error handling in array_sum Presto function

### DIFF
--- a/velox/functions/prestosql/tests/ArraySumTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySumTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <optional>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 using namespace facebook::velox;
@@ -27,27 +28,24 @@ class ArraySumTest : public FunctionBaseTest {
  protected:
   // Evaluate an expression.
   template <typename T>
-  void testExpr(
-      const VectorPtr& expected,
-      const std::string& expression,
-      const VectorPtr& input) {
-    auto result = evaluate(expression, makeRowVector({input}));
+  void testArraySum(const VectorPtr& expected, const VectorPtr& input) {
+    auto result = evaluate("array_sum(c0)", makeRowVector({input}));
     assertEqualVectors(expected, result);
 
     // Test constant input.
-    vector_size_t constantRow = 0;
+    const vector_size_t firstRow = 0;
     result = evaluate(
-        expression,
-        makeRowVector({BaseVector::wrapInConstant(10, constantRow, input)}));
+        "array_sum(c0)",
+        makeRowVector({BaseVector::wrapInConstant(10, firstRow, input)}));
     assertEqualVectors(
-        BaseVector::wrapInConstant(10, constantRow, expected), result);
+        BaseVector::wrapInConstant(10, firstRow, expected), result);
 
-    constantRow = input->size() - 1;
+    const vector_size_t lastRow = input->size() - 1;
     result = evaluate(
-        expression,
-        makeRowVector({BaseVector::wrapInConstant(10, constantRow, input)}));
+        "array_sum(c0)",
+        makeRowVector({BaseVector::wrapInConstant(10, lastRow, input)}));
     assertEqualVectors(
-        BaseVector::wrapInConstant(10, constantRow, expected), result);
+        BaseVector::wrapInConstant(10, lastRow, expected), result);
   }
 };
 
@@ -58,38 +56,57 @@ TEST_F(ArraySumTest, int64Input) {
   auto input = makeNullableArrayVector<int64_t>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<int64_t>({3, 3, 0});
-  testExpr<int64_t>(expected, "array_sum(C0)", input);
+  testArraySum<int64_t>(expected, input);
 }
 
 TEST_F(ArraySumTest, int32Input) {
   auto input = makeNullableArrayVector<int32_t>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<int64_t>({3, 3, 0});
-  testExpr<int64_t>(expected, "array_sum(C0)", input);
+  testArraySum<int64_t>(expected, input);
 }
 
 TEST_F(ArraySumTest, int16Input) {
   auto input = makeNullableArrayVector<int16_t>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<int64_t>({3, 3, 0});
-  testExpr<int64_t>(expected, "array_sum(C0)", input);
+  testArraySum<int64_t>(expected, input);
 }
 
 TEST_F(ArraySumTest, int8Input) {
   auto input = makeNullableArrayVector<int8_t>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<int64_t>({3, 3, 0});
-  testExpr<int64_t>(expected, "array_sum(C0)", input);
+  testArraySum<int64_t>(expected, input);
 }
 
-TEST_F(ArraySumTest, int64InputLimitsOverflow) {
-  auto input = makeNullableArrayVector<int64_t>(
-      {{0, std::numeric_limits<int64_t>::max(), 2}});
-  auto expected = makeNullableFlatVector<int64_t>(
-      {std::numeric_limits<int64_t>::min() + 1});
-  EXPECT_THROW(
-      testExpr<int64_t>(expected, "array_sum(C0)", input),
-      facebook::velox::VeloxUserError);
+TEST_F(ArraySumTest, overflow) {
+  // Flat input.
+  auto input = makeRowVector({
+      makeNullableArrayVector<int64_t>(
+          {{1, 2, 3}, {0, std::numeric_limits<int64_t>::max(), 2, 3}, {}}),
+  });
+  VELOX_ASSERT_THROW(
+      evaluate("array_sum(c0)", input),
+      "integer overflow: 9223372036854775807 + 2");
+
+  auto result = evaluate("try(array_sum(c0))", input);
+  assertEqualVectors(
+      makeNullableFlatVector<int64_t>({6, std::nullopt, 0}), result);
+
+  // Constant input.
+  auto emptyInput = makeRowVector(ROW({}), 3);
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "array_sum(array[9223372036854775807, 100::bigint])", emptyInput),
+      "integer overflow: 9223372036854775807 + 100");
+
+  result = evaluate(
+      "try(array_sum(array[9223372036854775807, 100::bigint]))", emptyInput);
+  assertEqualVectors(
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, std::nullopt, std::nullopt}),
+      result);
 }
 
 // Test floating point arrays
@@ -97,14 +114,14 @@ TEST_F(ArraySumTest, realInput) {
   auto input = makeNullableArrayVector<float>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<double>({3, 3, 0});
-  testExpr<double>(expected, "array_sum(C0)", input);
+  testArraySum<double>(expected, input);
 }
 
 TEST_F(ArraySumTest, doubleInput) {
   auto input = makeNullableArrayVector<double>(
       {{0, 1, 2}, {std::nullopt, 1, 2}, {std::nullopt}});
   auto expected = makeNullableFlatVector<double>({3, 3, 0});
-  testExpr<double>(expected, "array_sum(C0)", input);
+  testArraySum<double>(expected, input);
 }
 
 TEST_F(ArraySumTest, doubleInputLimits) {
@@ -118,5 +135,5 @@ TEST_F(ArraySumTest, doubleInputLimits) {
        std::numeric_limits<double>::quiet_NaN(),
        std::numeric_limits<double>::lowest(),
        std::numeric_limits<double>::max()});
-  testExpr<double>(expected, "array_sum(C0)", input);
+  testArraySum<double>(expected, input);
 }


### PR DESCRIPTION
Report errors via EvalCtx::setError instead of throwing.

Fixes #3803.