### PR TITLE
Fix array_except/intersect for VARBINARY inputs

### DIFF
--- a/velox/functions/prestosql/ArrayIntersectExcept.cpp
+++ b/velox/functions/prestosql/ArrayIntersectExcept.cpp
@@ -123,7 +123,7 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
-      const TypePtr& /* outputType */,
+      const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     memory::MemoryPool* pool = context.pool();
@@ -249,13 +249,12 @@ class ArrayIntersectExceptFunction : public exec::VectorFunction {
         newElementNulls, newIndices, indicesCursor, baseLeftArray->elements());
     auto resultArray = std::make_shared<ArrayVector>(
         pool,
-        ARRAY(CppToType<T>::create()),
-        BufferPtr(nullptr),
+        outputType,
+        nullptr,
         rowCount,
         newOffsets,
         newLengths,
-        newElements,
-        0);
+        newElements);
     context.moveOrCopyResult(resultArray, rows, result);
   }
 

--- a/velox/functions/prestosql/tests/ArrayExceptTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayExceptTest.cpp
@@ -251,6 +251,25 @@ TEST_F(ArrayExceptTest, longStrArrays) {
   testExpr(expected, "array_except(C1, C0)", {array1, array2});
 }
 
+TEST_F(ArrayExceptTest, varbinary) {
+  auto left = makeNullableArrayVector<StringView>(
+      {{"a"_sv, "b"_sv, "c"_sv}}, ARRAY(VARBINARY()));
+  auto right = makeNullableArrayVector<StringView>(
+      {{"b"_sv, "d"_sv}}, ARRAY(VARBINARY()));
+
+  auto expected = makeNullableArrayVector<StringView>({{}}, ARRAY(VARBINARY()));
+  testExpr(expected, "array_except(c0, c1)", {left, left});
+  testExpr(expected, "array_except(c0, c1)", {right, right});
+
+  expected = makeNullableArrayVector<StringView>(
+      {{"a"_sv, "c"_sv}}, ARRAY(VARBINARY()));
+  testExpr(expected, "array_except(c0, c1)", {left, right});
+
+  expected =
+      makeNullableArrayVector<StringView>({{"d"_sv}}, ARRAY(VARBINARY()));
+  testExpr(expected, "array_except(c0, c1)", {right, left});
+}
+
 // When one of the arrays is constant.
 TEST_F(ArrayExceptTest, constant) {
   auto array1 = makeNullableArrayVector<int32_t>({

--- a/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayIntersectTest.cpp
@@ -233,6 +233,21 @@ TEST_F(ArrayIntersectTest, longStrArrays) {
   testExpr(expected, "array_intersect(C1, C0)", {array1, array2});
 }
 
+TEST_F(ArrayIntersectTest, varbinary) {
+  auto left = makeNullableArrayVector<StringView>(
+      {{"a"_sv, "b"_sv, "c"_sv}}, ARRAY(VARBINARY()));
+  auto right = makeNullableArrayVector<StringView>(
+      {{"b"_sv, "d"_sv}}, ARRAY(VARBINARY()));
+
+  testExpr(left, "array_intersect(c0, c1)", {left, left});
+  testExpr(right, "array_intersect(c0, c1)", {right, right});
+
+  auto expected =
+      makeNullableArrayVector<StringView>({{"b"_sv}}, ARRAY(VARBINARY()));
+  testExpr(expected, "array_intersect(c0, c1)", {left, right});
+  testExpr(expected, "array_intersect(c0, c1)", {right, left});
+}
+
 // When one of the arrays is constant.
 TEST_F(ArrayIntersectTest, constant) {
   auto array1 = makeNullableArrayVector<int32_t>({

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -431,7 +431,6 @@ TEST_F(VectorMakerTest, nullableArrayVector) {
   auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
 
   EXPECT_TRUE(elementsVector->mayHaveNulls());
-  EXPECT_EQ(3, elementsVector->getNullCount().value());
 
   vector_size_t idx = 0;
   for (const auto& item : data) {
@@ -475,7 +474,6 @@ TEST_F(VectorMakerTest, nullableFixedSizeArrayVector) {
   auto elementsVector = arrayVector->elements()->asFlatVector<int64_t>();
 
   EXPECT_TRUE(elementsVector->mayHaveNulls());
-  EXPECT_EQ(4, elementsVector->getNullCount().value());
 
   vector_size_t idx = 0;
   for (const auto& item : data) {


### PR DESCRIPTION
Presto functions array_except and array_intersect didn't handle properly inputs
of type ARRAY(VARBINARY). They were trying to create a result vector of type
ARRAY(VARCHAR) with elements vector of type VARBINARY.

Fixes #3802.