### PR TITLE
Fix error handling in LIKE Presto function

### DIFF
--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -127,6 +127,29 @@ class VectorFunction {
   }
 };
 
+/// Vector function that generates the specified error for every row. Use this
+/// to hold an error generated while processing inputs for a stateful vector
+/// function. Such errors should not be reported until VectorFunction::apply is
+/// called to avoid signaling errors for expressions which end up not needing to
+/// evaluate the function.
+class AlwaysFailingVectorFunction final : public VectorFunction {
+ public:
+  explicit AlwaysFailingVectorFunction(std::exception_ptr exceptionPtr)
+      : exceptionPtr_{std::move(exceptionPtr)} {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& /*args*/,
+      const TypePtr& /* outputType */,
+      EvalCtx& context,
+      VectorPtr& /*resultRef*/) const final {
+    context.setErrors(rows, exceptionPtr_);
+  }
+
+ private:
+  std::exception_ptr exceptionPtr_;
+};
+
 // Factory for functions which are template generated from simple functions.
 class SimpleFunctionAdapterFactory {
  public:

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -495,7 +495,7 @@ class LikeWithRe2 final : public VectorFunction {
 
     if (!validPattern_) {
       auto error = std::make_exception_ptr(std::invalid_argument(
-          "Escape character must be followed by '%%', '_' or the escape character itself\""));
+          "Escape character must be followed by '%', '_' or the escape character itself"));
       context.setErrors(rows, error);
       return;
     }
@@ -938,8 +938,15 @@ std::shared_ptr<exec::VectorFunction> makeLike(
 
     auto constantEscape = escape->as<ConstantVector<StringView>>();
 
-    // Escape char should be a single char value
-    VELOX_USER_CHECK_EQ(constantEscape->valueAt(0).size(), 1);
+    try {
+      VELOX_USER_CHECK_EQ(
+          constantEscape->valueAt(0).size(),
+          1,
+          "Escape string must be a single character");
+    } catch (...) {
+      return std::make_shared<exec::AlwaysFailingVectorFunction>(
+          std::current_exception());
+    }
     escapeChar = constantEscape->valueAt(0).data()[0];
   }
 

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -914,8 +914,19 @@ TEST_F(Re2FunctionsTest, tryException) {
 
   // Ensure like works well with Try.
   {
-    auto result = evaluate<SimpleVector<bool>>(
-        "try(c0  like '%_*Do[^e]%' escape 'o')", makeRowVector({stringVector}));
+    auto input = makeRowVector({stringVector});
+    VELOX_ASSERT_THROW(
+        evaluate("c0 like 'test_o' escape 'o'", input),
+        "Escape character must be followed by '%', '_' or the escape character itself");
+
+    auto result = evaluate("try(c0 like 'test_o' escape 'o')", input);
+    assertEqualVectors(makeNullConstant(TypeKind::BOOLEAN, 3), result);
+
+    VELOX_ASSERT_THROW(
+        evaluate("c0 like 'test' escape 'oops'", input),
+        "Escape string must be a single character");
+
+    result = evaluate("try(c0 like 'test' escape 'oops')", input);
     assertEqualVectors(makeNullConstant(TypeKind::BOOLEAN, 3), result);
   }
 


### PR DESCRIPTION
- Generate a nice error message when escape string is not a single-character.
- Delay raising the error until VectorFunction::apply is called. Report the
  error using EvalCtx::setError. Do not throw.
- Introduce AlwaysFailingVectorFunction to hold errors generated while
  initializing stateful vector functions. 

Fixes #3808.