### PR TITLE
Enhance TRY support in the Fuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -74,11 +74,6 @@ using facebook::velox::test::SignatureTemplate;
 namespace facebook::velox::exec::test {
 namespace {
 
-struct ResultOrError {
-  RowVectorPtr result;
-  std::exception_ptr exceptionPtr;
-};
-
 class AggregationFuzzer {
  public:
   AggregationFuzzer(
@@ -182,12 +177,14 @@ class AggregationFuzzer {
       const std::vector<RowVectorPtr>& input,
       const core::PlanNodePtr& plan);
 
-  ResultOrError execute(const core::PlanNodePtr& plan, bool injectSpill);
+  velox::test::ResultOrError execute(
+      const core::PlanNodePtr& plan,
+      bool injectSpill);
 
   void testPlans(
       const std::vector<core::PlanNodePtr>& plans,
       bool verifyResults,
-      const ResultOrError& expected) {
+      const velox::test::ResultOrError& expected) {
     for (auto i = 0; i < plans.size(); ++i) {
       LOG(INFO) << "Testing plan #" << i;
       testPlan(plans[i], false /*injectSpill*/, verifyResults, expected);
@@ -201,7 +198,7 @@ class AggregationFuzzer {
       const core::PlanNodePtr& plan,
       bool injectSpill,
       bool verifyResults,
-      const ResultOrError& expected);
+      const velox::test::ResultOrError& expected);
 
   const std::unordered_map<std::string, std::string> orderDependentFunctions_;
   const bool persistAndRunOnce_;
@@ -589,13 +586,13 @@ void AggregationFuzzer::go() {
   stats_.print(iteration);
 }
 
-ResultOrError AggregationFuzzer::execute(
+velox::test::ResultOrError AggregationFuzzer::execute(
     const core::PlanNodePtr& plan,
     bool injectSpill) {
   LOG(INFO) << "Executing query plan: " << std::endl
             << plan->toString(true, true);
 
-  ResultOrError resultOrError;
+  velox::test::ResultOrError resultOrError;
   try {
     std::shared_ptr<TempDirectoryPath> spillDirectory;
     AssertQueryBuilder builder(plan);
@@ -825,7 +822,7 @@ void AggregationFuzzer::testPlan(
     const core::PlanNodePtr& plan,
     bool injectSpill,
     bool verifyResults,
-    const ResultOrError& expected) {
+    const velox::test::ResultOrError& expected) {
   auto actual = execute(plan, injectSpill);
 
   // Compare results or exceptions (if any). Fail is anything is different.

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(velox_expression_test_utility ArgumentTypeFuzzer.cpp
                                           FuzzerToolkit.cpp)
 
 target_link_libraries(velox_expression_test_utility velox_type
-                      velox_expression_functions)
+                      velox_expression_functions gtest)
 
 add_executable(
   velox_expression_test

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -18,6 +18,7 @@
 
 #include "velox/core/ITypedExpr.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/expression/tests/FuzzerToolkit.h"
 #include "velox/functions/FunctionRegistry.h"
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
@@ -55,10 +56,12 @@ class ExpressionVerifier {
   // columns/children in the input row vector that should be wrapped in a lazy
   // layer before running it through the common evaluation path.
   // Returns:
-  //  - true if both paths succeeded and returned the exact same results.
-  //  - false if both failed with compatible exceptions.
+  //  - result of evaluating the expression if both paths succeeded and returned
+  //  the exact same vectors.
+  //  - exception thrown by the common path if both paths failed with compatible
+  //  exceptions.
   //  - throws otherwise (incompatible exceptions or different results).
-  bool verify(
+  ResultOrError verify(
       const core::TypedExprPtr& plan,
       const RowVectorPtr& rowVector,
       VectorPtr&& resultVector,

--- a/velox/expression/tests/FuzzerToolkit.h
+++ b/velox/expression/tests/FuzzerToolkit.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "velox/expression/FunctionSignature.h"
-#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
 
 namespace facebook::velox::test {
 
@@ -38,6 +38,11 @@ struct SignatureTemplate {
   std::string name;
   const exec::FunctionSignature* signature;
   std::unordered_set<std::string> typeVariables;
+};
+
+struct ResultOrError {
+  RowVectorPtr result;
+  std::exception_ptr exceptionPtr;
 };
 
 /// Sort callable function signatures.


### PR DESCRIPTION
Add logic to re-try the original expression without TRY for rows that didn't
generate errors when running with TRY (e.g. rows with non-NULL results of TRY
evaluation).

Fix handling of 'canThrow' parameter in ExpressionVerifier::verify.
When 'canThrow' is false, expression evaluation failure in the common path
should be propagated even if simplified path fails with a compatible exception.

Ran the fuzzer successfully for 10 minutes with the following flags and a number 
of pending fixes: #3809, #3806, #3805, #3804, #3801, #3692, #3773 + fix for 
least and greatest.

```
velox/expression/tests/velox_expression_fuzzer_test -lazy_vector_generation_ratio 0.2 --enable_variadic_signatures --velox_fuzzer_enable_complex_types --velox_fuzzer_enable_column_reuse --velox_fuzzer_enable_expression_reuse --logtostderr=1 --retry_with_try
```

