### PR TITLE
Delete getRootAsSharedPtr api from MemoryManager.

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -387,10 +387,6 @@ MemoryPool& MemoryManager::getRoot() const {
   return *root_;
 }
 
-std::shared_ptr<MemoryPool> MemoryManager::getRootAsSharedPtr() const {
-  return root_;
-}
-
 std::shared_ptr<MemoryPool> MemoryManager::getChild(int64_t cap) {
   return root_->addChild(fmt::format(
       "default_usage_node_{}",

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -436,8 +436,6 @@ class MemoryManager final : public IMemoryManager {
 
   MemoryPool& getRoot() const final;
 
-  std::shared_ptr<MemoryPool> getRootAsSharedPtr() const;
-
   std::shared_ptr<MemoryPool> getChild(int64_t cap = kMaxMemory) final;
 
   int64_t getTotalBytes() const final;


### PR DESCRIPTION
Summary: In this diff, we get rid of the getSharedPtr api in MemoryManager pass the root memoryChild from Koski to Velox queryCtx.

Differential Revision: D42749923

