### PR TITLE
Fix memory tracker init and usage issues

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -139,11 +139,13 @@ class QueryCtx : public Context {
   }
 
   void initPool(const std::string& queryId) {
-    if (!pool_) {
+    if (pool_ == nullptr) {
       pool_ = memory::getProcessDefaultMemoryManager().getRoot().addChild(
           QueryCtx::generatePoolName(queryId));
     }
-    pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
+    if (pool_->getMemoryUsageTracker() == nullptr) {
+      pool_->setMemoryUsageTracker(memory::MemoryUsageTracker::create());
+    }
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -356,8 +356,10 @@ class Operator : public BaseRuntimeStatWriter {
   virtual void close() {
     input_ = nullptr;
     results_.clear();
-    // Release the unused memory reservation on close.
-    operatorCtx_->pool()->getMemoryUsageTracker()->release();
+    if (operatorCtx_->pool()->getMemoryUsageTracker() != nullptr) {
+      // Release the unused memory reservation on close.
+      operatorCtx_->pool()->getMemoryUsageTracker()->release();
+    }
   }
 
   // Returns true if 'this' never has more output rows than input rows.


### PR DESCRIPTION
1. We shall check if a memory tracker has been set in memory pool
when release its reservation on close.
2. For use case like Presto CPP has set memory pool with a quota limit,
then we shall not override it in QueryCtx init.
