### PR TITLE
Deprecate direct root pool access under velox/dwio/ and dwio/

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -351,9 +351,7 @@ class ReaderOptions {
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
   static constexpr int32_t kDefaultCoalesceDistance = 512 << 10; // 512K
 
-  ReaderOptions(
-      velox::memory::MemoryPool* pool =
-          &facebook::velox::memory::getProcessDefaultMemoryManager().getRoot())
+  ReaderOptions(velox::memory::MemoryPool* pool)
       : tailLocation(std::numeric_limits<uint64_t>::max()),
         memoryPool(pool),
         fileFormat(FileFormat::UNKNOWN),

--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -42,6 +42,10 @@ using dwio::common::InMemoryReadFile;
 using dwio::common::MemorySink;
 using velox::common::Subfield;
 
+namespace {
+auto defaultPool = velox::memory::getDefaultMemoryPool();
+}
+
 std::vector<RowVectorPtr> E2EFilterTestBase::makeDataset(
     std::function<void()> customize,
     bool forRowGroupSkip) {
@@ -89,7 +93,7 @@ void E2EFilterTestBase::readWithoutFilter(
     std::shared_ptr<ScanSpec> spec,
     const std::vector<RowVectorPtr>& batches,
     uint64_t& time) {
-  dwio::common::ReaderOptions readerOpts;
+  dwio::common::ReaderOptions readerOpts{defaultPool.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
   auto input = std::make_unique<BufferedInput>(
@@ -140,7 +144,7 @@ void E2EFilterTestBase::readWithFilter(
     uint64_t& time,
     bool useValueHook,
     bool skipCheck) {
-  dwio::common::ReaderOptions readerOpts;
+  dwio::common::ReaderOptions readerOpts{defaultPool.get()};
   dwio::common::RowReaderOptions rowReaderOpts;
   std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
   auto input = std::make_unique<BufferedInput>(
@@ -364,7 +368,7 @@ void E2EFilterTestBase::testMetadataFilterImpl(
   specB->setChannel(1);
   specC->setProjectOut(true);
   specC->setChannel(0);
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
   std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
   auto input = std::make_unique<BufferedInput>(

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -72,7 +72,7 @@ std::unique_ptr<RowReader> writeAndGetReader(
   auto readFile = std::make_shared<facebook::velox::InMemoryReadFile>(data);
   auto input = std::make_unique<BufferedInput>(readFile, pool);
 
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{&pool};
   RowReaderOptions rowReaderOpts;
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
   return reader->createRowReader(rowReaderOpts);

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -1489,7 +1489,7 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   writer.close();
 
   std::string_view data(sinkPtr->getData(), sinkPtr->size());
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{&pool};
   return std::make_unique<DwrfReader>(
       readerOpts,
       std::make_unique<BufferedInput>(

--- a/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
+++ b/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
@@ -26,6 +26,8 @@ using namespace ::testing;
 namespace facebook::velox::dwrf {
 
 namespace {
+auto defaultPool = velox::memory::getDefaultMemoryPool();
+
 folly::Function<BufferPtr(memory::MemoryPool*)> genConsecutiveRangeBuffer(
     int64_t begin,
     int64_t end) {
@@ -57,9 +59,8 @@ void verifyRange(BufferPtr bufferPtr, int64_t begin, int64_t end) {
 } // namespace
 
 TEST(TestStripeDictionaryCache, RegisterDictionary) {
-  auto& pool = memory::getProcessDefaultMemoryManager().getRoot();
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(0, 100));
     EXPECT_EQ(1, cache.intDictionaryFactories_.size());
     EXPECT_EQ(1, cache.intDictionaryFactories_.count({9, 0}));
@@ -69,7 +70,7 @@ TEST(TestStripeDictionaryCache, RegisterDictionary) {
   // StripeStream, so it won't matter. For here, we have to test that
   // the content is not changed in getDictionaryBuffer tests.
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
 
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(0, 100));
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(100, 200));
@@ -78,7 +79,7 @@ TEST(TestStripeDictionaryCache, RegisterDictionary) {
     EXPECT_EQ(1, cache.intDictionaryFactories_.count({9, 0}));
   }
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
 
     cache.registerIntDictionary({1, 0}, genConsecutiveRangeBuffer(0, 100));
     cache.registerIntDictionary({1, 1}, genConsecutiveRangeBuffer(0, 100));
@@ -92,9 +93,8 @@ TEST(TestStripeDictionaryCache, RegisterDictionary) {
 }
 
 TEST(TestStripeDictionaryCache, GetDictionaryBuffer) {
-  auto& pool = memory::getProcessDefaultMemoryManager().getRoot();
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
 
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(0, 100));
     verifyRange(cache.getIntDictionary({9, 0}), 0, 100);
@@ -105,7 +105,7 @@ TEST(TestStripeDictionaryCache, GetDictionaryBuffer) {
   // StripeStream, so it won't matter. For here, we have to test that
   // the content is not changed.
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
 
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(0, 100));
     cache.registerIntDictionary({9, 0}, genConsecutiveRangeBuffer(100, 200));
@@ -113,7 +113,7 @@ TEST(TestStripeDictionaryCache, GetDictionaryBuffer) {
     verifyRange(cache.getIntDictionary({9, 0}), 0, 100);
   }
   {
-    StripeDictionaryCache cache{&pool};
+    StripeDictionaryCache cache{defaultPool.get()};
 
     cache.registerIntDictionary({1, 0}, genConsecutiveRangeBuffer(0, 100));
     cache.registerIntDictionary({1, 1}, genConsecutiveRangeBuffer(0, 100));

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -48,9 +48,7 @@ namespace facebook::velox::dwrf {
   options.layoutPlannerFactory = layoutPlannerFactory;
 
   auto writer = std::make_unique<Writer>(
-      options,
-      std::move(sink),
-      velox::memory::getProcessDefaultMemoryManager().getRoot());
+      options, std::move(sink), velox::memory::getDefaultMemoryPool());
 
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);
@@ -93,7 +91,7 @@ namespace facebook::velox::dwrf {
       std::string_view(sinkPtr->getData(), sinkPtr->size()));
   auto input = std::make_unique<BufferedInput>(readFile, pool);
 
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{&pool};
   RowReaderOptions rowReaderOpts;
   auto reader = std::make_unique<DwrfReader>(readerOpts, std::move(input));
   EXPECT_GE(numStripesUpper, reader->getNumberOfStripes());

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
@@ -30,6 +30,9 @@ using namespace facebook::velox;
 using namespace facebook::velox::dwio::parquet;
 using namespace facebook::velox::parquet::duckdb_reader;
 
+namespace {
+auto defaultPool = memory::getDefaultMemoryPool();
+
 std::unique_ptr<ParquetReader> createFileInput(
     const std::string& path,
     const ReaderOptions& opts) {
@@ -38,6 +41,7 @@ std::unique_ptr<ParquetReader> createFileInput(
           std::make_shared<LocalReadFile>(path)),
       opts);
 }
+} // namespace
 
 class ParquetReaderTest : public ParquetReaderTestBase {
  public:
@@ -48,7 +52,7 @@ class ParquetReaderTest : public ParquetReaderTestBase {
       const RowVectorPtr& expected) {
     const auto filePath(getExampleFilePath(fileName));
 
-    ReaderOptions readerOptions;
+    ReaderOptions readerOptions{defaultPool.get()};
     auto reader = createFileInput(filePath, readerOptions);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
@@ -69,7 +73,7 @@ TEST_F(ParquetReaderTest, readSampleFull) {
   //   b: [1.0..20.0]
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
@@ -95,7 +99,7 @@ TEST_F(ParquetReaderTest, readSampleFull) {
 TEST_F(ParquetReaderTest, readSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -111,7 +115,7 @@ TEST_F(ParquetReaderTest, readSampleRange1) {
 TEST_F(ParquetReaderTest, readSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -127,7 +131,7 @@ TEST_F(ParquetReaderTest, readSampleRange2) {
 TEST_F(ParquetReaderTest, readSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -187,7 +191,7 @@ TEST_F(ParquetReaderTest, dateRead) {
   //   date: [1969-12-27 .. 1970-01-20]
   const std::string sample(getExampleFilePath("date.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
@@ -225,7 +229,7 @@ TEST_F(ParquetReaderTest, intRead) {
   //   bigint: [1000 .. 1009]
   const std::string sample(getExampleFilePath("int.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   auto reader = createFileInput(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -119,7 +119,7 @@ class ParquetReaderBenchmark {
       const ParquetReaderType& parquetReaderType,
       std::shared_ptr<ScanSpec> scanSpec,
       const RowTypePtr& rowType) {
-    dwio::common::ReaderOptions readerOpts;
+    dwio::common::ReaderOptions readerOpts{pool_.get()};
     auto input = std::make_unique<BufferedInput>(
         std::make_shared<LocalReadFile>("test.parquet"),
         readerOpts.getMemoryPool());

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -23,6 +23,10 @@ using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::dwio::parquet;
 using namespace facebook::velox::parquet;
 
+namespace {
+auto defaultPool = memory::getDefaultMemoryPool();
+}
+
 class ParquetReaderTest : public ParquetReaderTestBase {};
 
 ParquetReader createReader(const std::string& path, const ReaderOptions& opts) {
@@ -40,7 +44,7 @@ TEST_F(ParquetReaderTest, parseSample) {
   //   b: [1.0..20.0]
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   ParquetReader reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader.numberOfRows(), 20ULL);
 
@@ -59,7 +63,7 @@ TEST_F(ParquetReaderTest, parseEmpty) {
   // 0 rows.
   const std::string empty(getExampleFilePath("empty.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   ParquetReader reader = createReader(empty, readerOptions);
   EXPECT_EQ(reader.numberOfRows(), 0ULL);
 
@@ -80,7 +84,7 @@ TEST_F(ParquetReaderTest, parseDate) {
   //   date: [1969-12-27 .. 1970-01-20]
   const std::string sample(getExampleFilePath("date.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   ParquetReader reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 25ULL);
@@ -97,7 +101,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   // ARRAY(INTEGER)) c1) c)
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
-  ReaderOptions readerOptions;
+  ReaderOptions readerOptions{defaultPool.get()};
   ParquetReader reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader.numberOfRows(), 1ULL);
@@ -130,7 +134,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{defaultPool.get()};
   ParquetReader reader =
       createReader(getExampleFilePath("sample.parquet"), readerOpts);
   RowReaderOptions rowReaderOpts;

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -41,9 +41,10 @@ int main(int argc, char** argv) {
   // filesystem. We also need to register the dwrf reader factory:
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
+  auto pool = facebook::velox::memory::getDefaultMemoryPool();
 
   std::string filePath{argv[1]};
-  ReaderOptions readerOpts;
+  ReaderOptions readerOpts{pool.get()};
   // To make DwrfReader reads ORC file, setFileFormat to FileFormat::ORC
   readerOpts.setFileFormat(FileFormat::ORC);
   auto reader = DwrfReader::create(

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -80,7 +80,7 @@ void TpchQueryBuilder::initialize(const std::string& dataPath) {
         continue;
       }
       if (tableMetadata_[tableName].dataFiles.empty()) {
-        dwio::common::ReaderOptions readerOptions;
+        dwio::common::ReaderOptions readerOptions{pool_.get()};
         readerOptions.setFileFormat(format_);
         auto input = std::make_unique<dwio::common::BufferedInput>(
             std::make_shared<LocalReadFile>(dirEntry.path().string()),


### PR DESCRIPTION
Summary:
For the better accounting practices, we want to prevent call sites from directly allocating memory from the root pool in memory manager. Effectively, we will deprecate all direct accesses to MemoryManager::getRoot(). This diff does this for all XLDB paths.

The next diff will address the rest of the call sites.

Differential Revision: D42705627

