### PR TITLE
Update ssh key for circle-ci doc-gen-job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -489,7 +489,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "59:91:a0:91:69:c4:08:aa:73:f4:1f:dd:13:e2:04:ef"
+            - "7b:24:f3:1a:b1:15:97:c6:fe:06:46:27:3e:b7:6b:96"
       - run:
           name: "Build docs and update gh-pages"
           command: |


### PR DESCRIPTION
Summary:
Update ssh key for circle-ci doc-gen-job

Test Plan:
Move doc-gen-job temporarily as a regular run to see if it works there.
https://app.circleci.com/pipelines/github/facebookincubator/velox/19183/workflows/ca8ed41e-6ddc-45c3-94ec-f110adaf86b0/jobs/121361

Reviewers:

Subscribers:

Tasks:
T143462563

Tags: