### PR TITLE
Move benchmark job to GHA

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,6 @@ name: "Linux Benchmark"
 
 on:
   pull_request:
-  # only running on changes to source files would be possible
   push:
     branches: [main]
 
@@ -26,13 +25,14 @@ permissions:
 defaults:
   run:
     shell: bash
-
+#TODO  concurrency groups?
 jobs:
   benchmark:
     runs-on: ubuntu-22.04
     container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      CCACHE_BASEDIR: "${{ github.workspace }}"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
       CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
       CONBENCH_HOST: "GitHub-runner"
@@ -41,69 +41,56 @@ jobs:
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
       TARGET_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/target/"
     steps:
-      - run: |
+      - name: "Setup ccache and python"
+        run: |
             # Set up ccache configs .
             mkdir -p .ccache
             ccache -sz -M 5Gi
+            
+            # We can not use setup-python as we are running in a container
+            apt update
+            apt install -y lsb-release python3 pip
+
       - uses: actions/cache/restore@v3
         id: restore-cache
         with:
           path: ".ccache"
-          key: ccache-benchmark-${{ github.run_id }}
+          key: ccache-benchmark-${{ github.sha }}
           restore-keys: |
             ccache-benchmark-
 
       - name: "Checkout Base"
         uses: actions/checkout@v3
         with:
-          repository: "facebookincubator/velox"
-          ref: "e1fe3ce469d47a2ad1355afa952646b1f098e3a3"
-          path: 'base'
+          path: 'velox'
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           submodules: 'recursive'
 
-      - name: "Checkout Head"
-        uses: actions/checkout@v3
-        with:
-          path: 'head'
-          submodules: 'recursive'
-      
-      - run: |
-          apt update
-          apt install -y lsb-release python3 pip
-
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: '3.8'
-      #     cache: 'pip'
-      #     cache-dependency-path: 'head/scripts/*'
-      
-      # - name: "Setup Ubuntu"
-      #   run: |
-      #     # install libunwind explicitly to avoid dependecy hell
-      #     # https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919
-      #     sudo apt install -y libunwind-dev
-
-      #     # Run the setup script from HEAD so changes from PRs are reflected.
-      #     sudo ./head/scripts/setup-ubuntu.sh
-
-      - name: build-benchmarks
+      - name: Build Base Benchmarks
+        working-directory: velox
         run: |
-          build_benchmarks() {
-            echo "::group::Build $2 Benchmarks"
-            pushd $1
             n_cores=$(nproc)
-            # make ccache agnostic to the build directory
-            export CCACHE_BASEDIR=$(pwd)
             make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$((n_cores/2)) MAX_LINK_JOBS=$n_cores
             ccache -s
-            mkdir -p $3
-            cp -r --verbose _build/release/velox/benchmarks/basic/* $3
-            echo "::endgroup::"
-            popd
-          }
+            mkdir -p ${BINARY_DIR}/baseline/
+            cp -r --verbose _build/release/velox/benchmarks/basic/* ${BINARY_DIR}/baseline/
 
-          build_benchmarks base Baseline ${BINARY_DIR}/baseline/
-          build_benchmarks head Target ${BINARY_DIR}/target/
+      - name: "Checkout Head"
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3
+        with:
+          path: 'velox'
+          submodules: 'recursive'
+
+      - name: Build Target Benchmarks
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: velox
+        run: |
+            n_cores=$(nproc)
+            make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$n_cores MAX_LINK_JOBS=$n_cores
+            ccache -s
+            mkdir -p  ${BINARY_DIR}/target/
+            cp -r --verbose _build/release/velox/benchmarks/basic/*  ${BINARY_DIR}/target/
 
       - uses: actions/cache/save@v3
         if: ${{ github.event_name == 'push' && success() }}
@@ -112,26 +99,38 @@ jobs:
           path: ".ccache"
           key: ccache-benchmark-${{ github.sha }}
 
+      - name: Remove Unchanged Benchmarks
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+            cd ${BINARY_DIR}/baseline/
+            # list all executable files in the directory
+            for file in $(find . -type f -executable); do
+              # compare the files byte bye byte and remove them if they are the same
+              if cmp -s "$file" "../target/$file"; then
+                echo "Removing unchanged benchmark: $file"
+                rm "$file"
+                rm "../target/$file"
+              fi
+            done
+
       - name: "Install benchmark dependencies"
         run: |
-          cd head
+          cd velox
           python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Run Benchmarks - Full Round"
-        working-directory: 'head'
+        working-directory: 'velox'
         run: |
-            # TODO: For now we just compare the target binary with itself, until we
-            # stabilize benchmark runs. We should eventually have two different
-            # set of binaries.
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
-            make benchmarks-basic-run \
-                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
 
-      - name: "Save PR info"
-        run: |
-          echo "${{ github.event.pull_request.number }}" > pr_number.txt
-          echo "${{ github.sha }}" > sha.txt
+            if [ "${{ github.event_name }}" == "pull_request" ]; then
+             make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
+            else
+              echo "Copying baseline results to target for upload."
+              cp -r ${BASELINE_OUTPUT_PATH}/* ${TARGET_OUTPUT_PATH}
+            fi 
 
       - uses: actions/upload-artifact@v3
         if: always()
@@ -139,9 +138,3 @@ jobs:
           path: "benchmark-results"
           name: "benchmark-results"
 
-      - uses: actions/upload-artifact@v3
-        with:
-          path: |
-            pr_number.txt
-            sha.txt
-          name: "info"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,6 +52,7 @@ jobs:
             ccache -sz -M 5Gi
             
             # We can not use setup-python as we are running in a container
+            # TODO add to docker image and remove here
             apt update
             apt install -y lsb-release python3 pip
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,6 @@ jobs:
             cp -r --verbose _build/release/velox/benchmarks/basic/*  ${BINARY_DIR}/target/
 
       - uses: actions/cache/save@v3
-        if: ${{ github.event_name == 'push' && success() }}
         id: cache
         with:
           path: ".ccache"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Linux Benchmark
+name: "Linux Benchmark"
 
 on:
   pull_request:
@@ -141,7 +141,7 @@ jobs:
 
       - uses: actions/upload-artifact@v3
         with:
-          path: 
-            - "pr_number.txt"
-            - "sha.txt"
+          path: |
+            pr_number.txt
+            sha.txt
           name: "info"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,6 +16,10 @@ name: "Linux Benchmark"
 
 on:
   pull_request:
+    paths:
+      - 'velox/**'
+      - 'third_party/**'
+      - '.github/workflows/benchmark.yml'
   push:
     branches: [main]
 
@@ -99,25 +103,34 @@ jobs:
           key: ccache-benchmark-${{ github.sha }}
 
       - name: Remove Unchanged Benchmarks
+        id: delete
         if: ${{ github.event_name == 'pull_request' }}
         run: |
-            cd ${BINARY_DIR}/baseline/
-            # list all executable files in the directory
-            for file in $(find . -type f -executable); do
-              # compare the files byte bye byte and remove them if they are the same
-              if cmp -s "$file" "../target/$file"; then
-                echo "Removing unchanged benchmark: $file"
-                rm "$file"
-                rm "../target/$file"
-              fi
-            done
+          pushd ${BINARY_DIR}/baseline/
+          # list all executable files in the directory
+          for file in $(find . -type f -executable); do
+            # compare the files byte bye byte and remove them if they are the same
+            if cmp -s "$file" "../target/$file"; then
+              echo "Removing unchanged benchmark: $file"
+              rm "$file"
+              rm "../target/$file"
+            fi
+          done
 
+          popd
+          
+          if [ !$(ls -A) ]; then
+            echo "set-output name=empty::true"
+            mkdir -p ${BASELINE_OUTPUT_PATH}
+            mkdir -p ${TARGET_OUTPUT_PATH}
+          fi
       - name: "Install benchmark dependencies"
         run: |
           cd velox
           python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Run Benchmarks - Full Round"
+        if: ${{ steps.delete.outputs.empty != 'true' }}
         working-directory: 'velox'
         run: |
             make benchmarks-basic-run \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -129,6 +129,7 @@ jobs:
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
             else
               echo "Copying baseline results to target for upload."
+              mkdir -p ${TARGET_OUTPUT_PATH}
               cp -r ${BASELINE_OUTPUT_PATH}/* ${TARGET_OUTPUT_PATH}
             fi 
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,147 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Linux Benchmark
+
+on:
+  pull_request:
+  # only running on changes to source files would be possible
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-22.04
+    container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
+    env:
+      CCACHE_DIR: "${{ github.workspace }}/.ccache/"
+      BINARY_DIR: "${{ github.workspace }}/benchmarks/"
+      CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
+      CONBENCH_HOST: "GitHub-runner"
+      LINUX_DISTRO: "ubuntu"
+      RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
+      BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
+      TARGET_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/target/"
+    steps:
+      - run: |
+            # Set up ccache configs .
+            mkdir -p .ccache
+            ccache -sz -M 5Gi
+      - uses: actions/cache/restore@v3
+        id: restore-cache
+        with:
+          path: ".ccache"
+          key: ccache-benchmark-${{ github.run_id }}
+          restore-keys: |
+            ccache-benchmark-
+
+      - name: "Checkout Base"
+        uses: actions/checkout@v3
+        with:
+          repository: "facebookincubator/velox"
+          ref: "e1fe3ce469d47a2ad1355afa952646b1f098e3a3"
+          path: 'base'
+          submodules: 'recursive'
+
+      - name: "Checkout Head"
+        uses: actions/checkout@v3
+        with:
+          path: 'head'
+          submodules: 'recursive'
+      
+      - run: |
+          apt update
+          apt install -y lsb-release python3 pip
+
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.8'
+      #     cache: 'pip'
+      #     cache-dependency-path: 'head/scripts/*'
+      
+      # - name: "Setup Ubuntu"
+      #   run: |
+      #     # install libunwind explicitly to avoid dependecy hell
+      #     # https://bugs.launchpad.net/ubuntu/+source/google-glog/+bug/1991919
+      #     sudo apt install -y libunwind-dev
+
+      #     # Run the setup script from HEAD so changes from PRs are reflected.
+      #     sudo ./head/scripts/setup-ubuntu.sh
+
+      - name: build-benchmarks
+        run: |
+          build_benchmarks() {
+            echo "::group::Build $2 Benchmarks"
+            pushd $1
+            n_cores=$(nproc)
+            # make ccache agnostic to the build directory
+            export CCACHE_BASEDIR=$(pwd)
+            make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$((n_cores/2)) MAX_LINK_JOBS=$n_cores
+            ccache -s
+            mkdir -p $3
+            cp -r --verbose _build/release/velox/benchmarks/basic/* $3
+            echo "::endgroup::"
+            popd
+          }
+
+          build_benchmarks base Baseline ${BINARY_DIR}/baseline/
+          build_benchmarks head Target ${BINARY_DIR}/target/
+
+      - uses: actions/cache/save@v3
+        if: ${{ github.event_name == 'push' && success() }}
+        id: cache
+        with:
+          path: ".ccache"
+          key: ccache-benchmark-${{ github.sha }}
+
+      - name: "Install benchmark dependencies"
+        run: |
+          cd head
+          python3 -m pip install -r scripts/benchmark-requirements.txt
+
+      - name: "Run Benchmarks - Full Round"
+        working-directory: 'head'
+        run: |
+            # TODO: For now we just compare the target binary with itself, until we
+            # stabilize benchmark runs. We should eventually have two different
+            # set of binaries.
+            make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
+            make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
+
+      - name: "Save PR info"
+        run: |
+          echo "${{ github.event.pull_request.number }}" > pr_number.txt
+          echo "${{ github.sha }}" > sha.txt
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          path: "benchmark-results"
+          name: "benchmark-results"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: 
+            - "pr_number.txt"
+            - "sha.txt"
+          name: "info"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,7 +39,6 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
-      folly_SOURCE: BUNDLED
       LINUX_DISTRO: "ubuntu"
       RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -100,17 +100,11 @@ jobs:
             cp -r --verbose _build/release/velox/benchmarks/basic/* ${BINARY_DIR}/baseline/
 
       - name: "Save ccache"
-        if: ${{ github.event_name == 'push' }}
         uses: actions/cache/save@v3
         id: cache
         with:
           path: ".ccache"
           key: ccache-benchmark-${{ github.sha }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ${{ env.BINARY_DIR }}
-          name: "benchmark-binaries"
 
       - name: "Install benchmark dependencies"
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -118,10 +118,8 @@ jobs:
             fi
           done
 
-          popd
-          
           if ! find . -type f -executable | grep -q .; then
-            echo "set-output name=empty::true"
+            echo "empty=true" >> $GITHUB_OUTPUT
             mkdir -p ${BASELINE_OUTPUT_PATH}
             mkdir -p ${TARGET_OUTPUT_PATH}
           fi

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
       LINUX_DISTRO: "ubuntu"
       RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
-      TARGET_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/target/"
+      CONTENDER_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/contender/"
     steps:
       - name: "Setup ccache and python"
         run: |
@@ -94,8 +94,8 @@ jobs:
             n_cores=$(nproc)
             make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$n_cores MAX_LINK_JOBS=$n_cores
             ccache -s
-            mkdir -p  ${BINARY_DIR}/target/
-            cp -r --verbose _build/release/velox/benchmarks/basic/*  ${BINARY_DIR}/target/
+            mkdir -p  ${BINARY_DIR}/contender/
+            cp -r --verbose _build/release/velox/benchmarks/basic/*  ${BINARY_DIR}/contender/
 
       - uses: actions/cache/save@v3
         id: cache
@@ -121,11 +121,11 @@ jobs:
 
             if [ "${{ github.event_name }}" == "pull_request" ]; then
              make benchmarks-basic-run \
-                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/target/ --output_path ${TARGET_OUTPUT_PATH}"
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/contender/ --output_path ${CONTENDER_OUTPUT_PATH}"
             else
-              echo "Copying baseline results to target for upload."
-              mkdir -p ${TARGET_OUTPUT_PATH}
-              cp -r ${BASELINE_OUTPUT_PATH}/* ${TARGET_OUTPUT_PATH}
+              echo "Copying baseline results to contender for upload."
+              mkdir -p ${CONTENDER_OUTPUT_PATH}
+              cp -r ${BASELINE_OUTPUT_PATH}/* ${CONTENDER_OUTPUT_PATH}
             fi 
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,6 +38,7 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
+      folly_SOURCE: BUNDLED
       LINUX_DISTRO: "ubuntu"
       RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -56,7 +56,8 @@ jobs:
             apt update
             apt install -y lsb-release python3 pip
 
-      - uses: actions/cache/restore@v3
+      - name: "Restore ccache"
+        uses: actions/cache/restore@v3
         id: restore-cache
         with:
           path: ".ccache"
@@ -64,32 +65,13 @@ jobs:
           restore-keys: |
             ccache-benchmark-
 
-      - name: "Checkout Base"
+      - name: "Checkout Contender"
         uses: actions/checkout@v3
         with:
           path: 'velox'
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
           submodules: 'recursive'
 
-      - name: Build Base Benchmarks
-        working-directory: velox
-        run: |
-            n_cores=$(nproc)
-            make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$((n_cores/2)) MAX_LINK_JOBS=$n_cores
-            ccache -s
-            mkdir -p ${BINARY_DIR}/baseline/
-            cp -r --verbose _build/release/velox/benchmarks/basic/* ${BINARY_DIR}/baseline/
-
-      - name: "Checkout Head"
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/checkout@v3
-        with:
-          clean: false
-          path: 'velox'
-          submodules: 'recursive'
-
-      - name: Build Target Benchmarks
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: Build Contender Benchmarks
         working-directory: velox
         run: |
             n_cores=$(nproc)
@@ -98,7 +80,28 @@ jobs:
             mkdir -p  ${BINARY_DIR}/contender/
             cp -r --verbose _build/release/velox/benchmarks/basic/*  ${BINARY_DIR}/contender/
 
-      - uses: actions/cache/save@v3
+      - name: "Checkout Baseline"
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/checkout@v3
+        with:
+          clean: false
+          path: 'velox'
+          ref: ${{ github.event.pull_request.base.sha }}
+          submodules: 'recursive'
+
+      - name: Build Baseline Benchmarks
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: velox
+        run: |
+            n_cores=$(nproc)
+            make benchmarks-basic-build NUM_THREADS=$n_cores MAX_HIGH_MEM_JOBS=$n_cores MAX_LINK_JOBS=$n_cores
+            ccache -s
+            mkdir -p ${BINARY_DIR}/baseline/
+            cp -r --verbose _build/release/velox/benchmarks/basic/* ${BINARY_DIR}/baseline/
+
+      - name: "Save ccache"
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/cache/save@v3
         id: cache
         with:
           path: ".ccache"
@@ -114,20 +117,18 @@ jobs:
           cd velox
           python3 -m pip install -r scripts/benchmark-requirements.txt
 
-      - name: "Run Benchmarks - Full Round"
+      - name: "Run Benchmarks - Contender"
+        working-directory: 'velox'
+        run: |
+            make benchmarks-basic-run \
+                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/contender/ --output_path ${CONTENDER_OUTPUT_PATH}"
+
+      - name: "Run Benchmarks - Baseline"
+        if: ${{ github.event_name == 'pull_request' }}
         working-directory: 'velox'
         run: |
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
-
-            if [ "${{ github.event_name }}" == "pull_request" ]; then
-             make benchmarks-basic-run \
-                EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/contender/ --output_path ${CONTENDER_OUTPUT_PATH}"
-            else
-              echo "Copying baseline results to contender for upload."
-              mkdir -p ${CONTENDER_OUTPUT_PATH}
-              cp -r ${BASELINE_OUTPUT_PATH}/* ${CONTENDER_OUTPUT_PATH}
-            fi 
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -120,7 +120,7 @@ jobs:
 
           popd
           
-          if [ !$(ls -A) ]; then
+          if ! find . -type f -executable | grep -q .; then
             echo "set-output name=empty::true"
             mkdir -p ${BASELINE_OUTPUT_PATH}
             mkdir -p ${TARGET_OUTPUT_PATH}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -103,6 +103,11 @@ jobs:
           path: ".ccache"
           key: ccache-benchmark-${{ github.sha }}
 
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ${{ env.BINARY_DIR }}
+          name: "benchmark-binaries"
+
       - name: Remove Unchanged Benchmarks
         id: delete
         if: false # deactivated for now ${{ github.event_name == 'pull_request' }}
@@ -145,7 +150,6 @@ jobs:
             fi 
 
       - uses: actions/upload-artifact@v3
-        if: always()
         with:
           path: "benchmark-results"
           name: "benchmark-results"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,8 +38,6 @@ jobs:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
       BINARY_DIR: "${{ github.workspace }}/benchmarks/"
-      CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
-      CONBENCH_HOST: "GitHub-runner"
       LINUX_DISTRO: "ubuntu"
       RESULTS_ROOT: "${{ github.workspace }}/benchmark-results"
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ defaults:
 #TODO  concurrency groups?
 jobs:
   benchmark:
-    runs-on: ubuntu-22.04
+    runs-on: 8-core
     container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ on:
     paths:
       - 'velox/**'
       - 'third_party/**'
-      - 'pyvellox/**'
+      - 'pyvelox/**'
       - '.github/workflows/benchmark.yml'
   push:
     branches: [main]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -106,33 +106,12 @@ jobs:
           path: ${{ env.BINARY_DIR }}
           name: "benchmark-binaries"
 
-      - name: Remove Unchanged Benchmarks
-        id: delete
-        if: false # deactivated for now ${{ github.event_name == 'pull_request' }}
-        run: |
-          pushd ${BINARY_DIR}/baseline/
-          # list all executable files in the directory
-          for file in $(find . -type f -executable); do
-            # compare the files byte bye byte and remove them if they are the same
-            if cmp -s "$file" "../target/$file"; then
-              echo "Removing unchanged benchmark: $file"
-              rm "$file"
-              rm "../target/$file"
-            fi
-          done
-
-          if ! find . -type f -executable | grep -q .; then
-            echo "empty=true" >> $GITHUB_OUTPUT
-            mkdir -p ${BASELINE_OUTPUT_PATH}
-            mkdir -p ${TARGET_OUTPUT_PATH}
-          fi
       - name: "Install benchmark dependencies"
         run: |
           cd velox
           python3 -m pip install -r scripts/benchmark-requirements.txt
 
       - name: "Run Benchmarks - Full Round"
-        if: ${{ steps.delete.outputs.empty != 'true' }}
         working-directory: 'velox'
         run: |
             make benchmarks-basic-run \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,6 +82,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3
         with:
+          clean: false
           path: 'velox'
           submodules: 'recursive'
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: actions/checkout@v3
         with:
-          clean: false
+          clean: true # make sure benchmarks are rebuilt
           path: 'velox'
           ref: ${{ github.event.pull_request.base.sha }}
           submodules: 'recursive'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -105,7 +105,7 @@ jobs:
 
       - name: Remove Unchanged Benchmarks
         id: delete
-        if: ${{ github.event_name == 'pull_request' }}
+        if: false # deactivated for now ${{ github.event_name == 'pull_request' }}
         run: |
           pushd ${BINARY_DIR}/baseline/
           # list all executable files in the directory

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ defaults:
 jobs:
   benchmark:
     runs-on: 8-core
-    container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
+    container: ghcr.io/assignuser/velox-dev:ubuntu-benchmark 
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,7 +34,7 @@ defaults:
 jobs:
   benchmark:
     runs-on: 8-core
-    container: ghcr.io/assignuser/velox-dev:ubuntu-benchmark 
+    container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,7 @@ on:
     paths:
       - 'velox/**'
       - 'third_party/**'
+      - 'pyvellox/**'
       - '.github/workflows/benchmark.yml'
   push:
     branches: [main]

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: "Linux Benchmark"
+name: "Ubuntu Benchmark"
 
 on:
   pull_request:

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -1,0 +1,69 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  workflow_run:
+    workflows: ["Linux Benchmark"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  #TODO comment results to PR
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+
+    - uses: actions/download-artifact@v3
+      with:
+        path: "benchmark-results"
+        name: "benchmark-results"
+    
+    - uses: actions/download-artifact@v3
+      with:
+        path: "info"
+        name: "info"
+
+    - uses: actions/checkout@v3
+      with:
+        path: velox
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+        cache: 'pip'
+    
+    - name: "Install dependencies"
+      run: python -m pip install -r velox/scripts/benchmark-requirements.txt
+
+    - name: "Extract PR info"
+      id: info
+      run: |
+        echo "::set-output name=pr_number::$(cat info/pr_number.txt)"
+        echo "::set-output name=sha::$(cat info/sha.txt)"
+    
+    - name: "Upload results"
+      env:
+        CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
+        CONBENCH_HOST: "GitHub-runner"
+        CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
+        CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASSWORD }}
+      run: |
+        ./velox/scripts/benchmark-runner.py upload \
+          --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
+          --pr_number "${{ steps.info.outputs.pr_number }} \
+          --sha "${{ steps.info.outputs.sha }}" \
+          --results_root "${{ github.workspace }}/benchmark-results/target/"

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+name: Upload Benchmark Results
 on:
   workflow_dispatch:
     inputs:
@@ -40,19 +41,19 @@ jobs:
       with:
         script: |
           const run_id = "${{ github.event.workflow_run.id || inputs.run_id }}";
-          let benchmark_run = await github.actions.getWorkflowRun({
+          let benchmark_run = await github.rest.actions.getWorkflowRun({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: run_id,
           });
-
-          let pr_number = benchmark_run.data.pull_requests[0].number || '';
+          let pr = benchmark_run.data.pull_requests[0];
+          let pr_number = pr == undefined ? '' : pr.number;
             
           core.setOutput('target_sha', benchmark_run.data.head_sha);
           core.setOutput('pr_number', pr_number);
 
 
-          let artifacts = await github.actions.listWorkflowRunArtifacts({
+          let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: run_id,
@@ -62,7 +63,7 @@ jobs:
             return artifact.name == "benchmark-results"
           })[0];
 
-          var download = await github.actions.downloadArtifact({
+          var download = await github.rest.actions.downloadArtifact({
             owner: context.repo.owner,
             repo: context.repo.repo,
             artifact_id: matchArtifact.id,
@@ -72,8 +73,8 @@ jobs:
           var fs = require('fs');
           fs.writeFileSync('${{github.workspace}}/benchmark-results.zip', Buffer.from(download.data));
     
-    - uname: Extract artifact
-      run: unzip benchmark-results.zip
+    - name: Extract artifact
+      run: unzip benchmark-results.zip -d benchmark-results
 
     - uses: actions/checkout@v3
       with:
@@ -82,6 +83,7 @@ jobs:
       with:
         python-version: '3.8'
         cache: 'pip'
+        cache-dependency-path: "velox/scripts/*"
     
     - name: "Install dependencies"
       run: python -m pip install -r velox/scripts/benchmark-requirements.txt
@@ -97,4 +99,4 @@ jobs:
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
           --pr_number "${{ steps.download.outputs.pr_number }}" \
           --sha "${{ steps.download.outputs.target_sha }}" \
-          --results_root "${{ github.workspace }}/benchmark-results/target/"
+          --output_dir "${{ github.workspace }}/benchmark-results/target/"

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'workflow run id to use the artifacts from'
+        required: true
   workflow_run:
     workflows: ["Linux Benchmark"]
     types:
@@ -20,23 +25,55 @@ on:
 
 permissions:
   contents: read
+  actions: read
   #TODO comment results to PR
 
 jobs:
   upload:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
 
-    - uses: actions/download-artifact@v3
+    - name: 'Download artifacts'
+      id: 'download'
+      uses: actions/github-script@v5
       with:
-        path: "benchmark-results"
-        name: "benchmark-results"
+        script: |
+          const run_id = "${{ github.event.workflow_run.id || inputs.run_id }}";
+          let benchmark_run = await github.actions.getWorkflowRun({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: run_id,
+          });
+
+          let pr_number = benchmark_run.data.pull_requests[0].number || '';
+            
+          core.setOutput('target_sha', benchmark_run.data.head_sha);
+          core.setOutput('pr_number', pr_number);
+
+
+          let artifacts = await github.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: run_id,
+          });
+
+          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "benchmark-results"
+          })[0];
+
+          var download = await github.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: matchArtifact.id,
+            archive_format: 'zip',
+          });
+          
+          var fs = require('fs');
+          fs.writeFileSync('${{github.workspace}}/benchmark-results.zip', Buffer.from(download.data));
     
-    - uses: actions/download-artifact@v3
-      with:
-        path: "info"
-        name: "info"
+    - uname: Extract artifact
+      run: unzip benchmark-results.zip
 
     - uses: actions/checkout@v3
       with:
@@ -48,12 +85,6 @@ jobs:
     
     - name: "Install dependencies"
       run: python -m pip install -r velox/scripts/benchmark-requirements.txt
-
-    - name: "Extract PR info"
-      id: info
-      run: |
-        echo "::set-output name=pr_number::$(cat info/pr_number.txt)"
-        echo "::set-output name=sha::$(cat info/sha.txt)"
     
     - name: "Upload results"
       env:
@@ -64,6 +95,6 @@ jobs:
       run: |
         ./velox/scripts/benchmark-runner.py upload \
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
-          --pr_number "${{ steps.info.outputs.pr_number }} \
-          --sha "${{ steps.info.outputs.sha }}" \
+          --pr_number "${{ steps.download.outputs.pr_number }}" \
+          --sha "${{ steps.download.outputs.target_sha }}" \
           --results_root "${{ github.workspace }}/benchmark-results/target/"

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -46,10 +46,12 @@ jobs:
             repo: context.repo.repo,
             run_id: run_id,
           });
-          let pr = benchmark_run.data.pull_requests[0];
-          let pr_number = pr == undefined ? '' : pr.number;
+
+          let run_data = benchmark_run.data;
+          let pr = run_data.pull_requests[0];
+          let pr_number = pr == undefined || run_data.event === 'push' ? '' : pr.number;
             
-          core.setOutput('target_sha', benchmark_run.data.head_sha);
+          core.setOutput('target_sha', run_data.head_sha);
           core.setOutput('pr_number', pr_number);
 
 

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: 'Download artifacts'
       id: 'download'
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         script: |
           const run_id = "${{ github.event.workflow_run.id || inputs.run_id }}";

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -93,7 +93,7 @@ jobs:
     - name: "Upload results"
       env:
         CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
-        CONBENCH_HOST: "GitHub-runner"
+        CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-8-core"
         CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
         CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASSWORD }}
       run: |

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -20,7 +20,7 @@ on:
         description: 'workflow run id to use the artifacts from'
         required: true
   workflow_run:
-    workflows: ["Linux Benchmark"]
+    workflows: ["Ubuntu Benchmark"]
     types:
       - completed
 

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -51,7 +51,7 @@ jobs:
           let pr = run_data.pull_requests[0];
           let pr_number = pr == undefined || run_data.event === 'push' ? '' : pr.number;
             
-          core.setOutput('target_sha', run_data.head_sha);
+          core.setOutput('contender_sha', run_data.head_sha);
           core.setOutput('pr_number', pr_number);
 
 
@@ -100,5 +100,5 @@ jobs:
         ./velox/scripts/benchmark-runner.py upload \
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
           --pr_number "${{ steps.download.outputs.pr_number }}" \
-          --sha "${{ steps.download.outputs.target_sha }}" \
-          --output_dir "${{ github.workspace }}/benchmark-results/target/"
+          --sha "${{ steps.download.outputs.contender_sha }}" \
+          --output_dir "${{ github.workspace }}/benchmark-results/contender/"

--- a/scripts/benchmark-requirements.txt
+++ b/scripts/benchmark-requirements.txt
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-benchadapt@git+https://github.com/conbench/conbench.git@a791fe6#subdirectory=benchadapt/python
+benchadapt@git+https://github.com/conbench/conbench.git@07061a7#subdirectory=benchadapt/python
 benchalerts@git+https://github.com/conbench/benchalerts.git@0.4.0

--- a/scripts/benchmark-runner.py
+++ b/scripts/benchmark-runner.py
@@ -326,7 +326,7 @@ def run_all_benchmarks(
             raise e
 
 
-def upload_results(output_dir, run_id):
+def upload_results(output_dir, run_id, sha, pr_number):
     print(f"Uploading results from {output_dir=} to Conbench with {run_id=}")
 
     # Check there's actually results first
@@ -351,14 +351,9 @@ def upload_results(output_dir, run_id):
         )
         return
 
-    # This should work, though it would be much better to get the sha from velox
-    # directly so we know we're using the right one (see TODO below)
-    commit = os.environ["CIRCLE_SHA1"]
-
-    pr_number_env = os.getenv("CIRCLE_PR_NUMBER", "")
-    pr_number = int(pr_number_env) if pr_number_env else None
+    pr_number = int(pr_number) if pr_number else None
     run_reason = "pull request" if pr_number else "commit"
-    run_name = f"{run_reason}: {commit}"
+    run_name = f"{run_reason}: {sha}"
 
     conbench_upload_callable = FollyAdapter(
         # Since benchmarks have already run, this run command is a no-op
@@ -371,7 +366,7 @@ def upload_results(output_dir, run_id):
             "github": {
                 "repository": "https://github.com/facebookincubator/velox",
                 "pr_number": pr_number,
-                "commit": commit,
+                "commit": sha,
             },
         },
         result_fields_append={
@@ -387,6 +382,19 @@ def upload_results(output_dir, run_id):
     )
 
     conbench_upload_callable()
+
+
+def upload(args):
+    try:
+        upload_results(
+            output_dir=args.output_dir,
+            run_id=args.run_id,
+            sha=args.sha,
+            pr_number=args.pr_number,
+        )
+    except Exception:
+        print("ERROR caught during uploading results:")
+        print(traceback.format_exc())
 
 
 def run(args):
@@ -421,13 +429,6 @@ def run(args):
     else:
         run_all_benchmarks(**kwargs)
 
-    if args.conbench_upload_run_id:
-        try:
-            upload_results(output_dir=output_dir, run_id=args.conbench_upload_run_id)
-        except Exception:
-            print("ERROR caught during uploading results:")
-            print(traceback.format_exc())
-
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Velox Benchmark Runner Utility.")
@@ -437,6 +438,7 @@ def parse_args():
 
     # Arguments for the "run" subparser.
     parser_run = subparsers.add_parser("run", help="Run benchmarks and dump results.")
+    parser_run.set_defaults(func=run)
     parser_run.add_argument(
         "--binary_path",
         default=None,
@@ -486,15 +488,6 @@ def parse_args():
         "be run. This file needs to be generated using the "
         "--rerun_json_output flag.",
     )
-    parser_run.add_argument(
-        "--conbench_upload_run_id",
-        default=None,
-        help="A Conbench run ID unique to this build. If given, the run script will "
-        "upload results to Conbench upon completion. Requires the `benchadapt` package "
-        "installed and the following env vars set: CIRCLE_SHA1, CIRCLE_PR_NUMBER, "
-        "CONBENCH_URL, CONBENCH_EMAIL, CONBENCH_PASSWORD",
-    )
-    parser_run.set_defaults(func=run)
 
     # Arguments for the "compare" subparser.
     parser_compare = subparsers.add_parser(
@@ -540,6 +533,35 @@ def parse_args():
         action="store_true",
         help="Do not return failure code if comparisons fail.",
     )
+
+    parser_upload = subparsers.add_parser(
+        "upload",
+        help="Upload benchmark results to conbench. Requires the `benchadapt` package "
+        "installed and the following env vars set: "
+        "CONBENCH_URL, CONBENCH_EMAIL, CONBENCH_PASSWORD",
+    )
+    parser_upload.set_defaults(func=upload)
+    parser_upload.add_argument(
+        "--output_dir",
+        default=None,
+        help="Location of the benchmark results.",
+    )
+    parser_upload.add_argument(
+        "--run_id",
+        default=None,
+        help="A Conbench run ID unique to this build.",
+    )
+    parser_upload.add_argument(
+        "--sha",
+        default=None,
+        help="HEAD sha for the result upload to conbench.",
+    )
+    parser_upload.add_argument(
+        "--pr_number",
+        default=None,
+        help="PR number for the result upload to conbench.",
+    )
+
     return parser.parse_args()
 
 


### PR DESCRIPTION
This PR adds a new workflow for benchmarking. Due to security reasons the process of uploading (requires secrets) the results is in a separate workflow that does not execute user controlled code. 

This workflow has to be on the default branch to run so it is not possible to test it here but I have tested it on my fork. The results are visible here: https://velox-conbench.voltrondata.run/

I have added a step to remove any benchmark binaries which are identical between baseline and target to avoid running the same benchmark twice, 

For the same reasons I have reduced the workflow on merge to main to only run baseline, previously it was building and running the same benchmarks twice. It will run all benchmarks on push to main.

This is functional but leaves out the comparison of results and re-runs, getting the data collection back online was my main priority for now.