### PR TITLE
Auto generate field names when creating Row type

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1699,7 +1699,15 @@ struct CppToType<Array<ELEMENT>> : public TypeTraits<TypeKind::ARRAY> {
 template <typename... T>
 struct CppToType<Row<T...>> : public TypeTraits<TypeKind::ROW> {
   static auto create() {
-    return ROW({CppToType<T>::create()...});
+    // When creating ROW type, auto generate the individual column names like
+    // c1, c2, c3 ... instead of leaving the names empty.
+    auto n = sizeof...(T);
+    std::vector<std::string> names;
+    names.reserve(n);
+    for (auto i = 1; i <= n; ++i) {
+      names.push_back(fmt::format("c{}", i));
+    }
+    return ROW(std::move(names), {CppToType<T>::create()...});
   }
 };
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -528,6 +528,12 @@ TEST(TypeTest, cpp2Type) {
   EXPECT_EQ(*CppToType<Array<int32_t>>::create(), *ARRAY(INTEGER()));
   auto type = CppToType<Map<int32_t, Map<int64_t, float>>>::create();
   EXPECT_EQ(*type, *MAP(INTEGER(), MAP(BIGINT(), REAL())));
+  // Verify auto generated column names in the Row type in the format c1, c2,
+  // c3...
+  auto rowType = CppToType<Row<int64_t, Array<int32_t>, std::string>>::create();
+  EXPECT_EQ(
+      *rowType,
+      *ROW({{"c1", BIGINT()}, {"c2", ARRAY(INTEGER())}, {"c3", VARCHAR()}}));
 }
 
 TEST(TypeTest, equivalent) {


### PR DESCRIPTION
Summary: In CppToType path for ROW, we currently create the ROW type with empty ("") names. In this change, I create column names like c1, c2 .. for each of the fields in the ROW and create the corresponding ROW type.

Differential Revision: D42768055

