### PR TITLE
Fix ConstantTypedExpr::operator== for null constants

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -136,14 +136,19 @@ class ConstantTypedExpr : public ITypedExpr {
       return false;
     }
 
-    if (this->hasValueVector()) {
-      return casted->hasValueVector() &&
-          this->valueVector_->type()->kindEquals(
-              casted->valueVector_->type()) &&
-          this->valueVector_->equalValueAt(casted->valueVector_.get(), 0, 0);
+    if (!this->type()->kindEquals(casted->type())) {
+      return false;
     }
 
-    return !casted->hasValueVector() && this->value_ == casted->value_;
+    if (this->hasValueVector() != casted->hasValueVector()) {
+      return false;
+    }
+
+    if (this->hasValueVector()) {
+      return this->valueVector_->equalValueAt(casted->valueVector_.get(), 0, 0);
+    }
+
+    return this->value_ == casted->value_;
   }
 
   VELOX_DEFINE_CLASS_NAME(ConstantTypedExpr)

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 add_executable(
-  velox_core_test PlanFragmentTest.cpp PlanNodeTest.cpp QueryConfigTest.cpp
-                  StringTest.cpp TypeAnalysisTest.cpp)
+  velox_core_test
+  ConstantTypedExprTest.cpp PlanFragmentTest.cpp PlanNodeTest.cpp
+  QueryConfigTest.cpp StringTest.cpp TypeAnalysisTest.cpp)
 
 add_test(velox_core_test velox_core_test)
 

--- a/velox/core/tests/ConstantTypedExprTest.cpp
+++ b/velox/core/tests/ConstantTypedExprTest.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::core::test {
+
+TEST(ConstantTypedExprTest, null) {
+  auto makeNull = [](const TypePtr& type) {
+    return std::make_shared<ConstantTypedExpr>(
+        type, variant::null(type->kind()));
+  };
+
+  EXPECT_FALSE(*makeNull(BIGINT()) == *makeNull(DOUBLE()));
+  EXPECT_FALSE(*makeNull(ARRAY(BIGINT())) == *makeNull(ARRAY(DOUBLE())));
+  EXPECT_FALSE(
+      *makeNull(MAP(BIGINT(), INTEGER())) ==
+      *makeNull(MAP(BIGINT(), DOUBLE())));
+
+  EXPECT_TRUE(*makeNull(DOUBLE()) == *makeNull(DOUBLE()));
+  EXPECT_TRUE(*makeNull(ARRAY(DOUBLE())) == *makeNull(ARRAY(DOUBLE())));
+  EXPECT_TRUE(
+      *makeNull(ROW({"a", "b"}, {INTEGER(), REAL()})) ==
+      *makeNull(ROW({"x", "y"}, {INTEGER(), REAL()})));
+}
+} // namespace facebook::velox::core::test


### PR DESCRIPTION
ConstantTypedExpr::operator== failed to check the types of constants causing
null constants of different complex types to be reported "equal".

There is still a problem where constants of complex types may be
reported "equal" to similar constants of built in types. A follow-up PR will
fix that.

Partially addresses #3817.