### PR TITLE
Fix ConstantTypedExpr::operator== for null custom type constants

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -136,7 +136,7 @@ class ConstantTypedExpr : public ITypedExpr {
       return false;
     }
 
-    if (!this->type()->kindEquals(casted->type())) {
+    if (!this->type()->equivalent(*casted->type())) {
       return false;
     }
 

--- a/velox/core/tests/ConstantTypedExprTest.cpp
+++ b/velox/core/tests/ConstantTypedExprTest.cpp
@@ -16,6 +16,9 @@
 #include <gtest/gtest.h>
 
 #include "velox/core/Expressions.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::core::test {
 
@@ -31,10 +34,33 @@ TEST(ConstantTypedExprTest, null) {
       *makeNull(MAP(BIGINT(), INTEGER())) ==
       *makeNull(MAP(BIGINT(), DOUBLE())));
 
+  EXPECT_FALSE(*makeNull(JSON()) == *makeNull(VARCHAR()));
+  EXPECT_FALSE(*makeNull(VARCHAR()) == *makeNull(JSON()));
+
+  EXPECT_FALSE(*makeNull(ARRAY(JSON())) == *makeNull(ARRAY(VARCHAR())));
+  EXPECT_FALSE(*makeNull(ARRAY(VARCHAR())) == *makeNull(ARRAY(JSON())));
+  EXPECT_FALSE(
+      *makeNull(MAP(BIGINT(), JSON())) == *makeNull(MAP(BIGINT(), VARCHAR())));
+  EXPECT_FALSE(
+      *makeNull(MAP(BIGINT(), VARCHAR())) == *makeNull(MAP(BIGINT(), JSON())));
+
+  EXPECT_FALSE(*makeNull(HYPERLOGLOG()) == *makeNull(VARBINARY()));
+  EXPECT_FALSE(*makeNull(VARBINARY()) == *makeNull(HYPERLOGLOG()));
+
+  EXPECT_FALSE(
+      *makeNull(TIMESTAMP_WITH_TIME_ZONE()) ==
+      *makeNull(ROW({BIGINT(), SMALLINT()})));
+  EXPECT_FALSE(
+      *makeNull(ROW({BIGINT(), SMALLINT()})) ==
+      *makeNull(TIMESTAMP_WITH_TIME_ZONE()));
+
   EXPECT_TRUE(*makeNull(DOUBLE()) == *makeNull(DOUBLE()));
   EXPECT_TRUE(*makeNull(ARRAY(DOUBLE())) == *makeNull(ARRAY(DOUBLE())));
   EXPECT_TRUE(
       *makeNull(ROW({"a", "b"}, {INTEGER(), REAL()})) ==
       *makeNull(ROW({"x", "y"}, {INTEGER(), REAL()})));
+  EXPECT_TRUE(*makeNull(JSON()) == *makeNull(JSON()));
+  EXPECT_TRUE(
+      *makeNull(MAP(VARCHAR(), JSON())) == *makeNull(MAP(VARCHAR(), JSON())));
 }
 } // namespace facebook::velox::core::test

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -444,7 +444,8 @@ ExprPtr compileExpression(
             folly::join(", ", inputTypes));
       } else {
         VELOX_FAIL(
-            "Scalar function {} not registered with arguments: ({}).  Found function registered with the following signatures:\n{}",
+            "Scalar function {} not registered with arguments: ({}). "
+            "Found function registered with the following signatures:\n{}",
             call->name(),
             folly::join(", ", inputTypes),
             folly::join("\n", signatures));

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -190,7 +190,8 @@ TEST_F(ExprCompilerTest, functionNameNotRegistered) {
 
   VELOX_ASSERT_THROW(
       compile(expression),
-      "Scalar function name not registered: not_registered_function, called with arguments: (VARCHAR, VARCHAR).");
+      "Scalar function name not registered: not_registered_function, "
+      "called with arguments: (VARCHAR, VARCHAR).");
 }
 
 TEST_F(ExprCompilerTest, functionSignatureNotRegistered) {
@@ -199,6 +200,8 @@ TEST_F(ExprCompilerTest, functionSignatureNotRegistered) {
 
   VELOX_ASSERT_THROW(
       compile(expression),
-      "Scalar function concat not registered with arguments: (BIGINT, BIGINT).  Found function registered with the following signatures:\n((varchar,varchar...) -> varchar)");
+      "Scalar function concat not registered with arguments: (BIGINT, BIGINT). "
+      "Found function registered with the following signatures:\n"
+      "((varchar,varchar...) -> varchar)");
 }
 } // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -23,6 +23,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
 
@@ -398,7 +399,7 @@ bool registerApproxDistinct(
   if (hllAsRawInput) {
     signatures.push_back(
         exec::AggregateFunctionSignatureBuilder()
-            .returnType(hllAsFinalResult ? "varbinary" : "bigint")
+            .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
             .intermediateType("varbinary")
             .argumentType("varbinary")
             .build());
@@ -416,14 +417,14 @@ bool registerApproxDistinct(
           "date"}) {
       signatures.push_back(
           exec::AggregateFunctionSignatureBuilder()
-              .returnType(hllAsFinalResult ? "varbinary" : "bigint")
+              .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
               .intermediateType("varbinary")
               .argumentType(inputType)
               .build());
 
       signatures.push_back(
           exec::AggregateFunctionSignatureBuilder()
-              .returnType(hllAsFinalResult ? "varbinary" : "bigint")
+              .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
               .intermediateType("varbinary")
               .argumentType(inputType)
               .argumentType("double")
@@ -452,6 +453,8 @@ bool registerApproxDistinct(
 } // namespace
 
 void registerApproxDistinctAggregates() {
+  registerType(
+      "hyperloglog", std::make_unique<const HyperLogLogTypeFactories>());
   registerApproxDistinct(kApproxDistinct, false, false);
   registerApproxDistinct(kApproxSet, true, false);
   registerApproxDistinct(kMerge, true, true);

--- a/velox/functions/prestosql/tests/CastBaseTest.h
+++ b/velox/functions/prestosql/tests/CastBaseTest.h
@@ -137,25 +137,37 @@ class CastBaseTest : public FunctionBaseTest {
       const TypePtr& toType,
       const VectorPtr& input,
       const VectorPtr& expected) {
+    SCOPED_TRACE(fmt::format(
+        "Cast from {} to {}", fromType->toString(), toType->toString()));
     // Test with flat encoding.
-    evaluateAndVerify<TTo>(fromType, toType, makeRowVector({input}), expected);
-    evaluateAndVerify<TTo>(
-        fromType, toType, makeRowVector({input}), expected, true);
+    {
+      SCOPED_TRACE("Flat encoding");
+      evaluateAndVerify<TTo>(
+          fromType, toType, makeRowVector({input}), expected);
+      evaluateAndVerify<TTo>(
+          fromType, toType, makeRowVector({input}), expected, true);
+    }
 
     // Test with constant encoding that repeats the first element five times.
-    auto constInput = BaseVector::wrapInConstant(5, 0, input);
-    auto constExpected = BaseVector::wrapInConstant(5, 0, expected);
+    {
+      SCOPED_TRACE("Constant encoding");
+      auto constInput = BaseVector::wrapInConstant(5, 0, input);
+      auto constExpected = BaseVector::wrapInConstant(5, 0, expected);
 
-    evaluateAndVerify<TTo>(
-        fromType, toType, makeRowVector({constInput}), constExpected);
-    evaluateAndVerify<TTo>(
-        fromType, toType, makeRowVector({constInput}), constExpected, true);
+      evaluateAndVerify<TTo>(
+          fromType, toType, makeRowVector({constInput}), constExpected);
+      evaluateAndVerify<TTo>(
+          fromType, toType, makeRowVector({constInput}), constExpected, true);
+    }
 
     // Test with dictionary encoding that reverses the indices.
-    evaluateAndVerifyDictEncoding<TTo>(
-        fromType, toType, makeRowVector({input}), expected);
-    evaluateAndVerifyDictEncoding<TTo>(
-        fromType, toType, makeRowVector({input}), expected, true);
+    {
+      SCOPED_TRACE("Dictionary encoding");
+      evaluateAndVerifyDictEncoding<TTo>(
+          fromType, toType, makeRowVector({input}), expected);
+      evaluateAndVerifyDictEncoding<TTo>(
+          fromType, toType, makeRowVector({input}), expected, true);
+    }
   }
 
   template <typename TFrom, typename TTo>

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -23,33 +23,48 @@ namespace facebook::velox::functions::prestosql {
 namespace {
 
 class JsonFunctionsTest : public functions::test::FunctionBaseTest {
- public:
-  std::optional<bool> is_json_scalar(std::optional<std::string> json) {
-    return evaluateOnce<bool>("is_json_scalar(c0)", json);
+ protected:
+  VectorPtr makeJsonVector(std::optional<std::string> json) {
+    std::optional<StringView> s = json.has_value()
+        ? std::make_optional(StringView(json.value()))
+        : std::nullopt;
+    return makeNullableFlatVector<StringView>({s}, JSON());
   }
 
-  std::optional<int64_t> json_array_length(std::optional<std::string> json) {
-    return evaluateOnce<int64_t>("json_array_length(c0)", json);
+  std::optional<bool> jsJsonScalar(std::optional<std::string> json) {
+    return evaluateOnce<bool>(
+        "is_json_scalar(c0)", makeRowVector({makeJsonVector(json)}));
+  }
+
+  std::optional<int64_t> jsonArrayLength(std::optional<std::string> json) {
+    return evaluateOnce<int64_t>(
+        "json_array_length(c0)", makeRowVector({makeJsonVector(json)}));
   }
 
   template <typename T>
-  std::optional<bool> json_array_contains(
+  std::optional<bool> jsonArrayContains(
       std::optional<std::string> json,
       std::optional<T> value) {
-    return evaluateOnce<bool>("json_array_contains(c0, c1)", json, value);
+    return evaluateOnce<bool>(
+        "json_array_contains(c0, c1)",
+        makeRowVector(
+            {makeJsonVector(json), makeNullableFlatVector<T>({value})}));
   }
 
-  std::optional<int64_t> json_size(
+  std::optional<int64_t> jsonSize(
       std::optional<std::string> json,
-      std::optional<std::string> path) {
-    return evaluateOnce<int64_t>("json_size(c0, c1)", json, path);
+      const std::string& path) {
+    return evaluateOnce<int64_t>(
+        "json_size(c0, c1)",
+        makeRowVector(
+            {makeJsonVector(json), makeFlatVector<std::string>({path})}));
   }
 };
 
 TEST_F(JsonFunctionsTest, jsonFormat) {
   const auto jsonFormat = [&](std::optional<std::string> value) {
-    return evaluateOnce<std::string, std::string>(
-        "json_format(c0)", {value}, {JSON()});
+    return evaluateOnce<std::string>(
+        "json_format(c0)", makeRowVector({makeJsonVector(value)}));
   };
 
   EXPECT_EQ(jsonFormat(std::nullopt), std::nullopt);
@@ -61,31 +76,32 @@ TEST_F(JsonFunctionsTest, jsonFormat) {
   EXPECT_EQ(jsonFormat(R"({"k1":"v1"})"), R"({"k1":"v1"})");
 
   auto data = makeRowVector({makeFlatVector<StringView>(
-      {"This is a long sentence", "This is some other sentence"})});
+      {"This is a long sentence", "This is some other sentence"}, JSON())});
 
   auto result = evaluate("json_format(c0)", data);
   auto expected = makeFlatVector<StringView>(
       {"This is a long sentence", "This is some other sentence"});
-  facebook::velox::test::assertEqualVectors(expected, result);
+  velox::test::assertEqualVectors(expected, result);
 
-  data = makeRowVector({makeConstant("apple", 2)});
+  data = makeRowVector({makeConstant("apple", 2, JSON())});
   result = evaluate("json_format(c0)", data);
   expected = makeFlatVector<StringView>({{"apple", "apple"}});
 
-  facebook::velox::test::assertEqualVectors(expected, result);
+  velox::test::assertEqualVectors(expected, result);
 
   data = makeRowVector(
       {makeFlatVector<bool>({true, false}),
        makeFlatVector<StringView>(
-           {"This is a long sentence", "This is some other sentence"})});
+           {"This is a long sentence", "This is some other sentence"},
+           JSON())});
 
   result = evaluate("if(c0, 'foo', json_format(c1))", data);
   expected = makeFlatVector<StringView>({"foo", "This is some other sentence"});
-  facebook::velox::test::assertEqualVectors(expected, result);
+  velox::test::assertEqualVectors(expected, result);
 
   result = evaluate("if(c0, json_format(c1), 'bar')", data);
   expected = makeFlatVector<StringView>({"This is a long sentence", "bar"});
-  facebook::velox::test::assertEqualVectors(expected, result);
+  velox::test::assertEqualVectors(expected, result);
 }
 
 TEST_F(JsonFunctionsTest, jsonParse) {
@@ -107,7 +123,8 @@ TEST_F(JsonFunctionsTest, jsonParse) {
   EXPECT_EQ(jsonParse(R"(["k1", "v1"])"), R"(["k1", "v1"])");
 
   VELOX_ASSERT_THROW(jsonParse(R"({"k1":})"), "expected json value");
-  VELOX_ASSERT_THROW(jsonParse(R"({:"k1"})"), "expected json value");
+  VELOX_ASSERT_THROW(
+      jsonParse(R"({:"k1"})"), "json parse error on line 0 near `:\"k1\"}");
   VELOX_ASSERT_THROW(jsonParse(R"(not_json)"), "expected json value");
 
   EXPECT_EQ(jsonParseWithTry(R"(not_json)"), std::nullopt);
@@ -120,13 +137,13 @@ TEST_F(JsonFunctionsTest, jsonParse) {
       evaluate("try(json_parse(c0))", makeRowVector({elementVector}));
 
   auto expectedVector = makeNullableFlatVector<StringView>(
-      {R"("abc")", "42", R"({"k1":"v1"})", std::nullopt, std::nullopt});
-  facebook::velox::test::assertEqualVectors(expectedVector, resultVector);
+      {R"("abc")", "42", R"({"k1":"v1"})", std::nullopt, std::nullopt}, JSON());
+  velox::test::assertEqualVectors(expectedVector, resultVector);
 
   auto data = makeRowVector({makeConstant(R"("k1":)", 2)});
   expectedVector =
-      makeNullableFlatVector<StringView>({std::nullopt, std::nullopt});
-  facebook::velox::test::assertEqualVectors(
+      makeNullableFlatVector<StringView>({std::nullopt, std::nullopt}, JSON());
+  velox::test::assertEqualVectors(
       expectedVector, evaluate("try(json_parse(c0))", data));
 
   VELOX_ASSERT_THROW(
@@ -138,14 +155,15 @@ TEST_F(JsonFunctionsTest, jsonParse) {
 
   auto result = evaluate("json_parse(c0)", data);
   auto expected = makeFlatVector<StringView>(
-      {R"("This is a long sentence")", R"("This is some other sentence")"});
-  facebook::velox::test::assertEqualVectors(expected, result);
+      {R"("This is a long sentence")", R"("This is some other sentence")"},
+      JSON());
+  velox::test::assertEqualVectors(expected, result);
 
   data = makeRowVector({makeConstant(R"("apple")", 2)});
   result = evaluate("json_parse(c0)", data);
-  expected = makeFlatVector<StringView>({{R"("apple")", R"("apple")"}});
+  expected = makeFlatVector<StringView>({{R"("apple")", R"("apple")"}}, JSON());
 
-  facebook::velox::test::assertEqualVectors(expected, result);
+  velox::test::assertEqualVectors(expected, result);
 
   data = makeRowVector(
       {makeFlatVector<bool>({true, false}),
@@ -155,8 +173,9 @@ TEST_F(JsonFunctionsTest, jsonParse) {
 
   result = evaluate("if(c0, json_parse(c1), json_parse(c1))", data);
   expected = makeFlatVector<StringView>(
-      {R"("This is a long sentence")", R"("This is some other sentence")"});
-  facebook::velox::test::assertEqualVectors(expected, result);
+      {R"("This is a long sentence")", R"("This is some other sentence")"},
+      JSON());
+  velox::test::assertEqualVectors(expected, result);
 }
 
 TEST_F(JsonFunctionsTest, isJsonScalarSignatures) {
@@ -199,71 +218,69 @@ TEST_F(JsonFunctionsTest, jsonSizeSignatures) {
 
 TEST_F(JsonFunctionsTest, isJsonScalar) {
   // Scalars.
-  EXPECT_EQ(is_json_scalar(R"(1)"), true);
-  EXPECT_EQ(is_json_scalar(R"(123456)"), true);
-  EXPECT_EQ(is_json_scalar(R"("hello")"), true);
-  EXPECT_EQ(is_json_scalar(R"("thefoxjumpedoverthefence")"), true);
-  EXPECT_EQ(is_json_scalar(R"(1.1)"), true);
-  EXPECT_EQ(is_json_scalar(R"("")"), true);
-  EXPECT_EQ(is_json_scalar(R"(true)"), true);
+  EXPECT_EQ(jsJsonScalar(R"(1)"), true);
+  EXPECT_EQ(jsJsonScalar(R"(123456)"), true);
+  EXPECT_EQ(jsJsonScalar(R"("hello")"), true);
+  EXPECT_EQ(jsJsonScalar(R"("thefoxjumpedoverthefence")"), true);
+  EXPECT_EQ(jsJsonScalar(R"(1.1)"), true);
+  EXPECT_EQ(jsJsonScalar(R"("")"), true);
+  EXPECT_EQ(jsJsonScalar(R"(true)"), true);
 
   // Lists and maps
-  EXPECT_EQ(is_json_scalar(R"([1,2])"), false);
-  EXPECT_EQ(is_json_scalar(R"({"k1":"v1"})"), false);
-  EXPECT_EQ(is_json_scalar(R"({"k1":[0,1,2]})"), false);
-  EXPECT_EQ(is_json_scalar(R"({"k1":""})"), false);
+  EXPECT_EQ(jsJsonScalar(R"([1,2])"), false);
+  EXPECT_EQ(jsJsonScalar(R"({"k1":"v1"})"), false);
+  EXPECT_EQ(jsJsonScalar(R"({"k1":[0,1,2]})"), false);
+  EXPECT_EQ(jsJsonScalar(R"({"k1":""})"), false);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayLength) {
-  EXPECT_EQ(json_array_length(R"([])"), 0);
-  EXPECT_EQ(json_array_length(R"([1])"), 1);
-  EXPECT_EQ(json_array_length(R"([1, 2, 3])"), 3);
+  EXPECT_EQ(jsonArrayLength(R"([])"), 0);
+  EXPECT_EQ(jsonArrayLength(R"([1])"), 1);
+  EXPECT_EQ(jsonArrayLength(R"([1, 2, 3])"), 3);
   EXPECT_EQ(
-      json_array_length(
+      jsonArrayLength(
           R"([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])"),
       20);
 
-  EXPECT_EQ(json_array_length(R"(1)"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"("hello")"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"("")"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"(true)"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"({"k1":"v1"})"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"({"k1":[0,1,2]})"), std::nullopt);
-  EXPECT_EQ(json_array_length(R"({"k1":[0,1,2], "k2":"v1"})"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"(1)"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"("hello")"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"("")"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"(true)"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"({"k1":"v1"})"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"({"k1":[0,1,2]})"), std::nullopt);
+  EXPECT_EQ(jsonArrayLength(R"({"k1":[0,1,2], "k2":"v1"})"), std::nullopt);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsBool) {
-  EXPECT_EQ(json_array_contains<bool>(R"([])", true), false);
-  EXPECT_EQ(json_array_contains<bool>(R"([1, 2, 3])", false), false);
-  EXPECT_EQ(json_array_contains<bool>(R"([1.2, 2.3, 3.4])", true), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([])", true), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([1, 2, 3])", false), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([1.2, 2.3, 3.4])", true), false);
   EXPECT_EQ(
-      json_array_contains<bool>(R"(["hello", "presto", "world"])", false),
-      false);
-  EXPECT_EQ(json_array_contains<bool>(R"(1)", true), std::nullopt);
+      jsonArrayContains<bool>(R"(["hello", "presto", "world"])", false), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"(1)", true), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<bool>(R"("thefoxjumpedoverthefence")", false),
+      jsonArrayContains<bool>(R"("thefoxjumpedoverthefence")", false),
       std::nullopt);
-  EXPECT_EQ(json_array_contains<bool>(R"("")", false), std::nullopt);
-  EXPECT_EQ(json_array_contains<bool>(R"(true)", true), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<bool>(R"("")", false), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<bool>(R"(true)", true), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<bool>(R"({"k1":[0,1,2], "k2":"v1"})", true),
+      jsonArrayContains<bool>(R"({"k1":[0,1,2], "k2":"v1"})", true),
       std::nullopt);
 
-  EXPECT_EQ(json_array_contains<bool>(R"([true, false])", true), true);
-  EXPECT_EQ(json_array_contains<bool>(R"([true, true])", false), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([true, false])", true), true);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([true, true])", false), false);
   EXPECT_EQ(
-      json_array_contains<bool>(R"([123, 123.456, true, "abc"])", true), true);
+      jsonArrayContains<bool>(R"([123, 123.456, true, "abc"])", true), true);
   EXPECT_EQ(
-      json_array_contains<bool>(R"([123, 123.456, true, "abc"])", false),
-      false);
+      jsonArrayContains<bool>(R"([123, 123.456, true, "abc"])", false), false);
   EXPECT_EQ(
-      json_array_contains<bool>(
+      jsonArrayContains<bool>(
           R"([false, false, false, false, false, false, false,
 false, false, false, false, false, false, true, false, false, false, false])",
           true),
       true);
   EXPECT_EQ(
-      json_array_contains<bool>(
+      jsonArrayContains<bool>(
           R"([true, true, true, true, true, true, true,
 true, true, true, true, true, true, true, true, true, true, true])",
           false),
@@ -271,167 +288,160 @@ true, true, true, true, true, true, true, true, true, true, true])",
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsInt) {
-  EXPECT_EQ(json_array_contains<int64_t>(R"([])", 0), false);
-  EXPECT_EQ(json_array_contains<int64_t>(R"([1.2, 2.3, 3.4])", 2), false);
-  EXPECT_EQ(json_array_contains<int64_t>(R"([1.2, 2.0, 3.4])", 2), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([])", 0), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1.2, 2.3, 3.4])", 2), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1.2, 2.0, 3.4])", 2), false);
   EXPECT_EQ(
-      json_array_contains<int64_t>(R"(["hello", "presto", "world"])", 2),
-      false);
+      jsonArrayContains<int64_t>(R"(["hello", "presto", "world"])", 2), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([false, false, false])", 17), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"(1)", 1), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<int64_t>(R"([false, false, false])", 17), false);
-  EXPECT_EQ(json_array_contains<int64_t>(R"(1)", 1), std::nullopt);
-  EXPECT_EQ(
-      json_array_contains<int64_t>(R"("thefoxjumpedoverthefence")", 1),
+      jsonArrayContains<int64_t>(R"("thefoxjumpedoverthefence")", 1),
       std::nullopt);
-  EXPECT_EQ(json_array_contains<int64_t>(R"("")", 1), std::nullopt);
-  EXPECT_EQ(json_array_contains<int64_t>(R"(true)", 1), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"("")", 1), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"(true)", 1), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<int64_t>(R"({"k1":[0,1,2], "k2":"v1"})", 1),
+      jsonArrayContains<int64_t>(R"({"k1":[0,1,2], "k2":"v1"})", 1),
       std::nullopt);
 
-  EXPECT_EQ(json_array_contains<int64_t>(R"([1, 2, 3])", 1), true);
-  EXPECT_EQ(json_array_contains<int64_t>(R"([1, 2, 3])", 4), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3])", 1), true);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([1, 2, 3])", 4), false);
   EXPECT_EQ(
-      json_array_contains<int64_t>(R"([123, 123.456, true, "abc"])", 123),
-      true);
+      jsonArrayContains<int64_t>(R"([123, 123.456, true, "abc"])", 123), true);
   EXPECT_EQ(
-      json_array_contains<int64_t>(R"([123, 123.456, true, "abc"])", 456),
-      false);
+      jsonArrayContains<int64_t>(R"([123, 123.456, true, "abc"])", 456), false);
   EXPECT_EQ(
-      json_array_contains<int64_t>(
+      jsonArrayContains<int64_t>(
           R"([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])",
           17),
       true);
   EXPECT_EQ(
-      json_array_contains<int64_t>(
+      jsonArrayContains<int64_t>(
           R"([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20])",
           23),
       false);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsDouble) {
-  EXPECT_EQ(json_array_contains<double>(R"([])", 2.3), false);
-  EXPECT_EQ(json_array_contains<double>(R"([1, 2, 3])", 2.3), false);
-  EXPECT_EQ(json_array_contains<double>(R"([1, 2, 3])", 2.0), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([])", 2.3), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1, 2, 3])", 2.3), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1, 2, 3])", 2.0), false);
   EXPECT_EQ(
-      json_array_contains<double>(R"(["hello", "presto", "world"])", 2.3),
-      false);
+      jsonArrayContains<double>(R"(["hello", "presto", "world"])", 2.3), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([false, false, false])", 2.3), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"(1)", 2.3), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<double>(R"([false, false, false])", 2.3), false);
-  EXPECT_EQ(json_array_contains<double>(R"(1)", 2.3), std::nullopt);
-  EXPECT_EQ(
-      json_array_contains<double>(R"("thefoxjumpedoverthefence")", 2.3),
+      jsonArrayContains<double>(R"("thefoxjumpedoverthefence")", 2.3),
       std::nullopt);
-  EXPECT_EQ(json_array_contains<double>(R"("")", 2.3), std::nullopt);
-  EXPECT_EQ(json_array_contains<double>(R"(true)", 2.3), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<double>(R"("")", 2.3), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<double>(R"(true)", 2.3), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<double>(R"({"k1":[0,1,2], "k2":"v1"})", 2.3),
+      jsonArrayContains<double>(R"({"k1":[0,1,2], "k2":"v1"})", 2.3),
       std::nullopt);
 
-  EXPECT_EQ(json_array_contains<double>(R"([1.2, 2.3, 3.4])", 2.3), true);
-  EXPECT_EQ(json_array_contains<double>(R"([1.2, 2.3, 3.4])", 2.4), false);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.2, 2.3, 3.4])", 2.3), true);
+  EXPECT_EQ(jsonArrayContains<double>(R"([1.2, 2.3, 3.4])", 2.4), false);
   EXPECT_EQ(
-      json_array_contains<double>(R"([123, 123.456, true, "abc"])", 123.456),
+      jsonArrayContains<double>(R"([123, 123.456, true, "abc"])", 123.456),
       true);
   EXPECT_EQ(
-      json_array_contains<double>(R"([123, 123.456, true, "abc"])", 456.789),
+      jsonArrayContains<double>(R"([123, 123.456, true, "abc"])", 456.789),
       false);
   EXPECT_EQ(
-      json_array_contains<double>(
+      jsonArrayContains<double>(
           R"([1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5])",
           4.5),
       true);
   EXPECT_EQ(
-      json_array_contains<double>(
+      jsonArrayContains<double>(
           R"([1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5])",
           4.3),
       false);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsString) {
-  EXPECT_EQ(json_array_contains<std::string>(R"([])", ""), false);
-  EXPECT_EQ(json_array_contains<std::string>(R"([1, 2, 3])", "1"), false);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"([])", ""), false);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"([1, 2, 3])", "1"), false);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"([1.2, 2.3, 3.4])", "2.3"), false);
   EXPECT_EQ(
-      json_array_contains<std::string>(R"([1.2, 2.3, 3.4])", "2.3"), false);
+      jsonArrayContains<std::string>(R"([true, false])", R"("true")"), false);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"(1)", "1"), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<std::string>(R"([true, false])", R"("true")"), false);
-  EXPECT_EQ(json_array_contains<std::string>(R"(1)", "1"), std::nullopt);
-  EXPECT_EQ(
-      json_array_contains<std::string>(R"("thefoxjumpedoverthefence")", "1"),
+      jsonArrayContains<std::string>(R"("thefoxjumpedoverthefence")", "1"),
       std::nullopt);
-  EXPECT_EQ(json_array_contains<std::string>(R"("")", "1"), std::nullopt);
-  EXPECT_EQ(json_array_contains<std::string>(R"(true)", "1"), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"("")", "1"), std::nullopt);
+  EXPECT_EQ(jsonArrayContains<std::string>(R"(true)", "1"), std::nullopt);
   EXPECT_EQ(
-      json_array_contains<std::string>(R"({"k1":[0,1,2], "k2":"v1"})", "1"),
+      jsonArrayContains<std::string>(R"({"k1":[0,1,2], "k2":"v1"})", "1"),
       std::nullopt);
 
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["hello", "presto", "world"])", "presto"),
       true);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["hello", "presto", "world"])", "nation"),
       false);
   EXPECT_EQ(
-      json_array_contains<std::string>(R"([123, 123.456, true, "abc"])", "abc"),
+      jsonArrayContains<std::string>(R"([123, 123.456, true, "abc"])", "abc"),
       true);
   EXPECT_EQ(
-      json_array_contains<std::string>(R"([123, 123.456, true, "abc"])", "def"),
+      jsonArrayContains<std::string>(R"([123, 123.456, true, "abc"])", "def"),
       false);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["hello", "presto", "world", "hello", "presto", "world", "hello", "presto", "world", "hello",
 "presto", "world", "hello", "presto", "world", "hello", "presto", "world"])",
           "hello"),
       true);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["hello", "presto", "world", "hello", "presto", "world", "hello", "presto", "world", "hello",
 "presto", "world", "hello", "presto", "world", "hello", "presto", "world"])",
           "hola"),
       false);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["hello", "presto", "world", 1, 2, 3, true, false, 1.2, 2.3, {"k1":[0,1,2], "k2":"v1"}])",
           "world"),
       true);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["the fox jumped over the fence", "hello presto world"])",
           "hello velox world"),
       false);
   EXPECT_EQ(
-      json_array_contains<std::string>(
+      jsonArrayContains<std::string>(
           R"(["the fox jumped over the fence", "hello presto world"])",
           "the fox jumped over the fence"),
       true);
 }
 
 TEST_F(JsonFunctionsTest, jsonSize) {
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": 1})", "$.k1.k2"), 0);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": 1})", "$.k1"), 1);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": 1})", "$"), 2);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": 1})", "$.k3"), 0);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": [1, 2, 3, 4]})", "$.k3"), 4);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": 1})", "$.k4"), std::nullopt);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3"})", "$.k4"), std::nullopt);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": true})", "$.k3"), 0);
-  EXPECT_EQ(json_size(R"({"k1":{"k2": 999}, "k3": null})", "$.k3"), 0);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": 1})", "$.k1.k2"), 0);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": 1})", "$.k1"), 1);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": 1})", "$"), 2);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": 1})", "$.k3"), 0);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": [1, 2, 3, 4]})", "$.k3"), 4);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": 1})", "$.k4"), std::nullopt);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3"})", "$.k4"), std::nullopt);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": true})", "$.k3"), 0);
+  EXPECT_EQ(jsonSize(R"({"k1":{"k2": 999}, "k3": null})", "$.k3"), 0);
   EXPECT_EQ(
-      json_size(
+      jsonSize(
           R"({"k1":{"k2": 999, "k3": [{"k4": [1, 2, 3]}]}})", "$.k1.k3[0].k4"),
       3);
 }
 
 TEST_F(JsonFunctionsTest, invalidPath) {
-  EXPECT_THROW(json_size(R"([0,1,2])", ""), VeloxUserError);
-  EXPECT_THROW(json_size(R"([0,1,2])", "$[]"), VeloxUserError);
-  EXPECT_THROW(json_size(R"([0,1,2])", "$[-1]"), VeloxUserError);
-  EXPECT_THROW(json_size(R"({"k1":"v1"})", "$k1"), VeloxUserError);
-  EXPECT_THROW(json_size(R"({"k1":"v1"})", "$.k1."), VeloxUserError);
-  EXPECT_THROW(json_size(R"({"k1":"v1"})", "$.k1]"), VeloxUserError);
-  EXPECT_THROW(json_size(R"({"k1":"v1)", "$.k1]"), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"([0,1,2])", ""), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"([0,1,2])", "$[]"), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"([0,1,2])", "$[-1]"), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$k1"), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1."), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1]"), VeloxUserError);
+  EXPECT_THROW(jsonSize(R"({"k1":"v1)", "$.k1]"), VeloxUserError);
 }
 
 } // namespace

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -31,6 +31,11 @@ class HyperLogLogType : public VarbinaryType {
     return instance;
   }
 
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
   std::string toString() const override {
     return "HYPERLOGLOG";
   }

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -69,6 +69,11 @@ class JsonType : public VarcharType {
     return JsonCastOperator::get();
   }
 
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
   std::string toString() const override {
     return "JSON";
   }

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -35,6 +35,11 @@ class TimestampWithTimeZoneType : public RowType {
     return instance;
   }
 
+  bool equivalent(const Type& other) const override {
+    // Pointer comparison works since this type is a singleton.
+    return this == &other;
+  }
+
   std::string toString() const override {
     return "TIMESTAMP WITH TIME ZONE";
   }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -228,7 +228,7 @@ bool ArrayType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!other.isArray()) {
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
   auto& otherArray = other.asArray();
@@ -259,13 +259,19 @@ std::string FixedSizeArrayType::toString() const {
 }
 
 bool FixedSizeArrayType::equivalent(const Type& other) const {
-  if (!ArrayType::equivalent(other)) {
+  if (&other == this) {
+    return true;
+  }
+
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
+
   auto otherFixedSizeArray = dynamic_cast<const FixedSizeArrayType*>(&other);
-  if (!otherFixedSizeArray) {
+  if (!child_->equivalent(*otherFixedSizeArray->child_)) {
     return false;
   }
+
   if (fixedElementsWidth() != otherFixedSizeArray->fixedElementsWidth()) {
     return false;
   }
@@ -375,7 +381,7 @@ bool RowType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::ROW) {
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
   auto& otherTyped = other.asRow();
@@ -467,7 +473,7 @@ bool MapType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!other.isMap()) {
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
   auto& otherMap = other.asMap();
@@ -479,7 +485,7 @@ bool FunctionType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::FUNCTION) {
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
   auto& otherTyped = *reinterpret_cast<const FunctionType*>(&other);
@@ -507,7 +513,7 @@ bool OpaqueType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::OPAQUE) {
+  if (!Type::hasSameTypeId(other)) {
     return false;
   }
   return true;

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -281,8 +281,6 @@ class VectorFuzzer {
       BufferPtr& offsets,
       BufferPtr& sizes);
 
-  variant randVariant(const TypePtr& arg);
-
   VectorFuzzer::Options opts_;
 
   memory::MemoryPool* pool_;

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -609,7 +609,7 @@ class VectorTestBase {
         pool(),
         size,
         /*isNull=*/!value.has_value(),
-        CppToType<T>::create(),
+        type,
         value ? EvalType<T>(*value) : EvalType<T>(),
         SimpleVectorStats<EvalType<T>>{},
         sizeof(EvalType<T>));


### PR DESCRIPTION
- Override Type::equivalent for all custom types (Json, HyperLogLog and TimestampWithTimeZone).
- Use Type::equivalent (instead of Type::kindEquals) in ConstantTypedExpr::operator==.

Fixes #3817.