### PR TITLE
Make Task::toString() thread safe

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1520,11 +1520,12 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
 }
 
 std::string Task::toString() const {
+  std::lock_guard<std::mutex> l(mutex_);
   std::stringstream out;
   out << "{Task " << shortId(taskId_) << " (" << taskId_ << ")";
 
   if (exception_) {
-    out << "Error: " << errorMessage() << std::endl;
+    out << "Error: " << safeErrorMessage() << std::endl;
   }
 
   if (planFragment_.planNode) {
@@ -1676,9 +1677,13 @@ void Task::setError(const std::string& message) {
   }
 }
 
+std::string Task::safeErrorMessage() const {
+  return errorMessageImpl(exception_);
+}
+
 std::string Task::errorMessage() const {
   std::lock_guard<std::mutex> l(mutex_);
-  return errorMessageImpl(exception_);
+  return safeErrorMessage();
 }
 
 StopReason Task::enter(ThreadState& state) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -526,6 +526,10 @@ class Task : public std::enable_shared_from_this<Task> {
       const core::PlanNodeId& planNodeId,
       uint32_t pipelineId);
 
+  /// Returns task execution error message or empty string if not error
+  /// occurred. This should only be called inside mutex_ protection.
+  std::string safeErrorMessage() const;
+
   // Counts the number of created tasks which is incremented on each task
   // creation.
   static std::atomic<uint64_t> numCreatedTasks_;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1964,7 +1964,7 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, leftJoin) {
-  // Left side keys are [0, 1, 2,..10].
+  // Left side keys are [0, 1, 2,..20].
   // Use 3-rd column as row number to allow for asserting the order of results.
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
@@ -1974,7 +1974,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoin) {
                 {"c0", "c1", "row_number"},
                 {
                     makeFlatVector<int32_t>(
-                        77, [](auto row) { return row % 11; }, nullEvery(13)),
+                        77, [](auto row) { return row % 21; }, nullEvery(13)),
                     makeFlatVector<int32_t>(77, [](auto row) { return row; }),
                     makeFlatVector<int32_t>(77, [](auto row) { return row; }),
                 });
@@ -1987,7 +1987,7 @@ TEST_P(MultiThreadedHashJoinTest, leftJoin) {
                 {
                     makeFlatVector<int32_t>(
                         97,
-                        [](auto row) { return (row + 3) % 11; },
+                        [](auto row) { return (row + 3) % 21; },
                         nullEvery(13)),
                     makeFlatVector<int32_t>(97, [](auto row) { return row; }),
                     makeFlatVector<int32_t>(
@@ -2323,14 +2323,14 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNullableFilter) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, rightJoin) {
-  // Left side keys are [0, 1, 2,..10].
+  // Left side keys are [0, 1, 2,..20].
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
           [&](int32_t /*unused*/) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
-                    137, [](auto row) { return row % 11; }, nullEvery(13)),
+                    137, [](auto row) { return row % 21; }, nullEvery(13)),
                 makeFlatVector<int32_t>(137, [](auto row) { return row; }),
             });
           }),
@@ -2340,7 +2340,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoin) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
                     234,
-                    [](auto row) { return (row + 3) % 11; },
+                    [](auto row) { return (row + 3) % 21; },
                     nullEvery(13)),
                 makeFlatVector<int32_t>(234, [](auto row) { return row; }),
             });
@@ -2424,14 +2424,14 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithEmptyBuild) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, rightJoinWithAllMatch) {
-  // Left side keys are [0, 1, 2,..10].
+  // Left side keys are [0, 1, 2,..20].
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
           [&](int32_t /*unused*/) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
-                    137, [](auto row) { return row % 11; }, nullEvery(13)),
+                    137, [](auto row) { return row % 21; }, nullEvery(13)),
                 makeFlatVector<int32_t>(137, [](auto row) { return row; }),
             });
           }),
@@ -2441,7 +2441,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithAllMatch) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
                     234,
-                    [](auto row) { return (row + 3) % 11; },
+                    [](auto row) { return (row + 3) % 21; },
                     nullEvery(13)),
                 makeFlatVector<int32_t>(234, [](auto row) { return row; }),
             });
@@ -2475,14 +2475,14 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithAllMatch) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
-  // Left side keys are [0, 1, 2,..10].
+  // Left side keys are [0, 1, 2,..20].
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
           [&](int32_t /*unused*/) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
-                    137, [](auto row) { return row % 11; }, nullEvery(13)),
+                    137, [](auto row) { return row % 21; }, nullEvery(13)),
                 makeFlatVector<int32_t>(137, [](auto row) { return row; }),
             });
           }),
@@ -2492,7 +2492,7 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
                     234,
-                    [](auto row) { return (row + 3) % 11; },
+                    [](auto row) { return (row + 3) % 21; },
                     nullEvery(13)),
                 makeFlatVector<int32_t>(234, [](auto row) { return row; }),
             });
@@ -2550,14 +2550,14 @@ TEST_P(MultiThreadedHashJoinTest, rightJoinWithFilter) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, fullJoin) {
-  // Left side keys are [0, 1, 2,..10].
+  // Left side keys are [0, 1, 2,..20].
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
           [&](int32_t /*unused*/) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
-                    213, [](auto row) { return row % 11; }, nullEvery(13)),
+                    213, [](auto row) { return row % 21; }, nullEvery(13)),
                 makeFlatVector<int32_t>(213, [](auto row) { return row; }),
             });
           }),
@@ -2567,7 +2567,7 @@ TEST_P(MultiThreadedHashJoinTest, fullJoin) {
             return makeRowVector({
                 makeFlatVector<int32_t>(
                     137,
-                    [](auto row) { return (row + 3) % 11; },
+                    [](auto row) { return (row + 3) % 21; },
                     nullEvery(13)),
                 makeFlatVector<int32_t>(137, [](auto row) { return row; }),
             });


### PR DESCRIPTION
Summary:
Task::toString() iterates over all drivers to log their status. The tsan build of DriverTest.slow caught a data race where Task::toString() was called before the task completion, while a driver was finishing and being removed on another thread at the same time. This diff avoids this race condition by making Task::toString acquire a lock that Task::removeDriver acquires too.

This diff fixes https://github.com/facebookincubator/velox/issues/3836.

Differential Revision: D42757318

