### PR TITLE
Enable installSigPipeHandler option in S3FileSystem

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -236,6 +236,8 @@ class S3FileSystem::Impl {
       // In some situations, curl triggers a SIGPIPE signal causing the entire
       // process to be terminated without any notification.
       // This behavior is seen via Prestissimo on AmazonLinux2 on AWS EC2.
+      // Relevant documentation in AWS SDK C++
+      // https://github.com/aws/aws-sdk-cpp/blob/276ee83080fcc521d41d456dbbe61d49392ddf77/src/aws-cpp-sdk-core/include/aws/core/Aws.h#L96
       // This option allows the AWS SDK C++ to catch the SIGPIPE signal and
       // log a message.
       awsOptions.httpOptions.installSigPipeHandler = true;

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -233,6 +233,7 @@ class S3FileSystem::Impl {
     if (origCount == 0) {
       Aws::SDKOptions awsOptions;
       awsOptions.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Fatal;
+      awsOptions.httpOptions.installSigPipeHandler = true;
       Aws::InitAPI(awsOptions);
     }
   }

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -233,6 +233,11 @@ class S3FileSystem::Impl {
     if (origCount == 0) {
       Aws::SDKOptions awsOptions;
       awsOptions.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Fatal;
+      // In some situations, curl triggers a SIGPIPE signal causing the entire
+      // process to be terminated without any notification.
+      // This behavior is seen via Prestissimo on AmazonLinux2 on AWS EC2.
+      // This option allows the AWS SDK C++ to catch the SIGPIPE signal and
+      // log a message.
       awsOptions.httpOptions.installSigPipeHandler = true;
       Aws::InitAPI(awsOptions);
     }


### PR DESCRIPTION
AWS SDK C++ uses libcurl on Linux.
In some situations, curl triggers a SIGPIPE signal causing the entire process to be terminated
without any notification. This behavior is seen via Prestissimo on AmazonLinux2. 
The backtrace is provided at https://github.com/facebookincubator/velox/issues/3828.
The `httpOptions.installSigPipeHandler` option allows the AWS SDK C++ to catch the 
SIGPIPE signal and log a message.

Relevant documentation in AWS SDK C++
https://github.com/aws/aws-sdk-cpp/blob/276ee83080fcc521d41d456dbbe61d49392ddf77/src/aws-cpp-sdk-core/include/aws/core/Aws.h#L96

Verifying the fix
Build and run Prestissimo on AWS EC2 cluster with the default AmazonLinux2 OS.
Without the fix, when querying data on AWS S3, the Prestissimo process will exit without any
core dump or log message.
This behavior is also described in https://github.com/facebookincubator/velox/issues/3800

Resolves https://github.com/facebookincubator/velox/issues/3828