### PR TITLE
Enable Constant Folding on Simplified Eval

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -558,7 +558,7 @@ class ExprSetSimplified : public ExprSet {
   ExprSetSimplified(
       const std::vector<core::TypedExprPtr>& source,
       core::ExecCtx* FOLLY_NONNULL execCtx)
-      : ExprSet(source, execCtx, /*enableConstantFolding*/ false) {}
+      : ExprSet(source, execCtx, /*enableConstantFolding*/ true) {}
 
   virtual ~ExprSetSimplified() override {}
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -329,6 +329,9 @@ ExprPtr tryFoldIfConstant(const ExprPtr& expr, Scope* scope) {
     // instance, if other arguments are all null in a function with default null
     // behavior), the query won't fail.
     catch (const std::exception&) {
+      // Clear left-behind values. Simplified path will error out if
+      // not cleared.
+      expr->inputValues().clear();
     }
   }
   return expr;


### PR DESCRIPTION
Enables constant folding for simplified eval path in fuzzer. The simplified path expects constant exprs never to write into an existing result vector. A failed constant folding attempt must therefore clear any intermediate results from the Expr so that the simplified path does not pass these to constant exprs.