### PR TITLE
Do not allow createType() for SHORT_ and LONG_DECIMAL

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -707,6 +707,20 @@ std::shared_ptr<const Type> createType(
 }
 
 template <>
+std::shared_ptr<const Type> createType<TypeKind::SHORT_DECIMAL>(
+    std::vector<std::shared_ptr<const Type>>&& /*children*/) {
+  std::string name{TypeTraits<TypeKind::SHORT_DECIMAL>::name};
+  VELOX_USER_FAIL("Not supported for kind: {}", name);
+}
+
+template <>
+std::shared_ptr<const Type> createType<TypeKind::LONG_DECIMAL>(
+    std::vector<std::shared_ptr<const Type>>&& /*children*/) {
+  std::string name{TypeTraits<TypeKind::LONG_DECIMAL>::name};
+  VELOX_USER_FAIL("Not supported for kind: {}", name);
+}
+
+template <>
 std::shared_ptr<const Type> createType<TypeKind::ROW>(
     std::vector<std::shared_ptr<const Type>>&& /*children*/) {
   std::string name{TypeTraits<TypeKind::ROW>::name};

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -627,8 +627,15 @@ class DecimalType : public ScalarType<KIND> {
 
   DecimalType(const uint8_t precision = 18, const uint8_t scale = 0)
       : precision_(precision), scale_(scale) {
-    VELOX_CHECK_LE(scale, precision);
-    VELOX_CHECK_LE(precision, kMaxPrecision);
+    VELOX_CHECK_LE(
+        scale,
+        precision,
+        "Scale of decimal type must not exceed its precision");
+    VELOX_CHECK_LE(
+        precision,
+        kMaxPrecision,
+        "Precision of decimal type must not exceed {}",
+        kMaxPrecision);
   }
 
   inline bool equivalent(const Type& otherDecimal) const override {
@@ -1456,8 +1463,17 @@ std::shared_ptr<const Type> createType(
 }
 
 template <>
+std::shared_ptr<const Type> createType<TypeKind::SHORT_DECIMAL>(
+    std::vector<std::shared_ptr<const Type>>&& children);
+
+template <>
+std::shared_ptr<const Type> createType<TypeKind::LONG_DECIMAL>(
+    std::vector<std::shared_ptr<const Type>>&& children);
+
+template <>
 std::shared_ptr<const Type> createType<TypeKind::ROW>(
-    std::vector<std::shared_ptr<const Type>>&& /*children*/);
+    std::vector<std::shared_ptr<const Type>>&& children);
+
 template <>
 std::shared_ptr<const Type> createType<TypeKind::ARRAY>(
     std::vector<std::shared_ptr<const Type>>&& children);
@@ -1465,6 +1481,7 @@ std::shared_ptr<const Type> createType<TypeKind::ARRAY>(
 template <>
 std::shared_ptr<const Type> createType<TypeKind::MAP>(
     std::vector<std::shared_ptr<const Type>>&& children);
+
 template <>
 std::shared_ptr<const Type> createType<TypeKind::OPAQUE>(
     std::vector<std::shared_ptr<const Type>>&& children);

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -143,12 +143,16 @@ TEST(TypeTest, shortDecimal) {
   EXPECT_EQ(*SHORT_DECIMAL(10, 5), *shortDecimal);
   EXPECT_NE(*SHORT_DECIMAL(9, 5), *shortDecimal);
   EXPECT_NE(*SHORT_DECIMAL(10, 4), *shortDecimal);
-  try {
-    shortDecimal = SHORT_DECIMAL(19, 5);
-    FAIL() << "Function should throw.";
-  } catch (const VeloxRuntimeError& e) {
-    EXPECT_EQ("(19 vs. 18)", e.message());
-  }
+  VELOX_ASSERT_THROW(
+      SHORT_DECIMAL(19, 5), "Precision of decimal type must not exceed 18");
+  VELOX_ASSERT_THROW(
+      SHORT_DECIMAL(5, 6),
+      "Scale of decimal type must not exceed its precision");
+  VELOX_ASSERT_THROW(
+      createScalarType(TypeKind::SHORT_DECIMAL), "not a scalar type");
+  VELOX_ASSERT_THROW(
+      createType(TypeKind::SHORT_DECIMAL, {}),
+      "Not supported for kind: SHORT_DECIMAL");
 }
 
 TEST(TypeTest, longDecimal) {
@@ -162,12 +166,16 @@ TEST(TypeTest, longDecimal) {
   EXPECT_EQ(*LONG_DECIMAL(30, 5), *longDecimal);
   EXPECT_NE(*LONG_DECIMAL(9, 5), *longDecimal);
   EXPECT_NE(*LONG_DECIMAL(30, 3), *longDecimal);
-  try {
-    longDecimal = LONG_DECIMAL(39, 5);
-    FAIL() << "Function should throw.";
-  } catch (const VeloxRuntimeError& e) {
-    EXPECT_EQ("(39 vs. 38)", e.message());
-  }
+  VELOX_ASSERT_THROW(
+      LONG_DECIMAL(39, 5), "Precision of decimal type must not exceed 38");
+  VELOX_ASSERT_THROW(
+      LONG_DECIMAL(5, 6),
+      "Scale of decimal type must not exceed its precision");
+  VELOX_ASSERT_THROW(
+      createScalarType(TypeKind::LONG_DECIMAL), "not a scalar type");
+  VELOX_ASSERT_THROW(
+      createType(TypeKind::LONG_DECIMAL, {}),
+      "Not supported for kind: LONG_DECIMAL");
 }
 
 TEST(TypeTest, dateToString) {
@@ -339,6 +347,10 @@ TEST(TypeTest, row) {
   auto row2 = ROW({{"", INTEGER()}});
   EXPECT_EQ(row2->toString(), "ROW<\"\":INTEGER>");
   EXPECT_EQ(row2->nameOf(0), "");
+
+  VELOX_ASSERT_THROW(createScalarType(TypeKind::ROW), "not a scalar type");
+  VELOX_ASSERT_THROW(
+      createType(TypeKind::ROW, {}), "Not supported for kind: ROW");
 }
 
 class Foo {};


### PR DESCRIPTION
createType(SHORT_DECIMAL) used to return an instance of
ScalarType<SHORT_DECIMAL> which is not a correct representation of the decimal
type. It should be DecimalType<SHORT_DECIMAL>. After this change createType
will throw if input is SHORT_ or LONG_DECIMAL.

Also, improve error messages when creating decimal types with incorrect precision 
or scale.