### PR TITLE
Fix BaseVector::createNullConstant for custom types

### DIFF
--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -240,4 +240,23 @@ TEST_F(CustomTypeTest, getCustomTypeNames) {
 
   ASSERT_TRUE(unregisterType("fancy_int"));
 }
+
+TEST_F(CustomTypeTest, nullConstant) {
+  ASSERT_TRUE(
+      registerType("fancy_int", std::make_unique<FancyIntTypeFactories>()));
+
+  auto names = getCustomTypeNames();
+  for (const auto& name : names) {
+    auto type = getType(name, {});
+    auto null = BaseVector::createNullConstant(type, 10, pool());
+    EXPECT_TRUE(null->isConstantEncoding());
+    EXPECT_TRUE(type->equivalent(*null->type()));
+    EXPECT_EQ(type->toString(), null->type()->toString());
+    for (auto i = 0; i < 10; ++i) {
+      EXPECT_TRUE(null->isNullAt(i));
+    }
+  }
+
+  ASSERT_TRUE(unregisterType("fancy_int"));
+}
 } // namespace facebook::velox::test

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1542,6 +1542,7 @@ class VectorCreateConstantTest : public VectorTest {
     ASSERT_TRUE(simpleVector != nullptr);
 
     ASSERT_EQ(KIND, simpleVector->typeKind());
+    ASSERT_TRUE(type->equivalent(*simpleVector->type()));
     ASSERT_EQ(size_, simpleVector->size());
     ASSERT_EQ(simpleVector->isScalar(), TypeTraits<KIND>::isPrimitiveType);
 


### PR DESCRIPTION
Before this change BaseVector::createNullConstant for JSON() type return a constant vector of VARCHAR type.