### PR TITLE
Fix VectorTestBase::makeConstant for custom types

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1594,7 +1594,7 @@ TEST_F(ExprTest, ifWithConstant) {
   vector_size_t size = 4;
 
   auto a = makeFlatVector<int32_t>({-1, -2, -3, -4});
-  auto b = makeConstant(variant(TypeKind::INTEGER), size); // 4 nulls
+  auto b = makeNullConstant(TypeKind::INTEGER, size); // 4 nulls
   auto result = evaluate("is_null(if(c0 > 0, c0, c1))", makeRowVector({a, b}));
   EXPECT_EQ(VectorEncoding::Simple::CONSTANT, result->encoding());
   EXPECT_EQ(true, result->as<ConstantVector<bool>>()->valueAt(0));

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -157,7 +157,7 @@ TEST_F(ArbitraryTest, varcharConstAndNulls) {
   auto vectors = {makeRowVector({
       makeFlatVector<int32_t>(100, [](auto row) { return row % 7; }),
       makeConstant("apple", 100),
-      makeConstant(TypeKind::VARCHAR, 100),
+      makeNullConstant(TypeKind::VARCHAR, 100),
   })};
 
   createDuckDbTable(vectors);

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -157,7 +157,7 @@ TEST_F(MinMaxTest, constVarchar) {
            makeNullConstant(TypeKind::VARCHAR, 1'000)}),
       makeRowVector({
           makeConstant("banana", 1'000),
-          makeConstant(TypeKind::VARCHAR, 1'000),
+          makeNullConstant(TypeKind::VARCHAR, 1'000),
       })};
 
   testAggregations(

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -587,22 +587,24 @@ class VectorTestBase {
     return vectorMaker_.mapVector(offsets, keyVector, valueVector, nulls);
   }
 
-  template <typename T>
-  VectorPtr
-  makeConstant(T value, vector_size_t size, const TypePtr& type = {}) {
-    variant v;
-    if constexpr (std::is_same_v<T, UnscaledShortDecimal>) {
-      v = variant::shortDecimal(value.unscaledValue(), type);
-    } else if constexpr (std::is_same_v<T, UnscaledLongDecimal>) {
-      v = variant::longDecimal(value.unscaledValue(), type);
-    } else {
-      v = value;
-    }
-    return BaseVector::createConstant(v, size, pool());
+  VectorPtr makeConstant(const variant& value, vector_size_t size) {
+    return BaseVector::createConstant(value, size, pool());
   }
 
   template <typename T>
-  VectorPtr makeConstant(const std::optional<T>& value, vector_size_t size) {
+  VectorPtr makeConstant(
+      T value,
+      vector_size_t size,
+      const TypePtr& type = CppToType<EvalType<T>>::create()) {
+    return std::make_shared<ConstantVector<EvalType<T>>>(
+        pool(), size, false, type, std::move(value));
+  }
+
+  template <typename T>
+  VectorPtr makeConstant(
+      const std::optional<T>& value,
+      vector_size_t size,
+      const TypePtr& type = CppToType<EvalType<T>>::create()) {
     return std::make_shared<ConstantVector<EvalType<T>>>(
         pool(),
         size,


### PR DESCRIPTION
`makeConstant(T value, vector_size_t size, const TypePtr& type = {})` method
didn't respect the 'type' parameter passed by the caller. When asked to create
a JSON constant, it returned a constant of type VARCHAR.