### PR TITLE
Fix Type::equivalence method to be symmetric

### DIFF
--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -124,6 +124,14 @@ std::shared_ptr<const Type> resolveSimpleFunction(
       exec::SimpleFunctions().resolveFunction(functionName, argTypes);
 
   if (resolvedFunction) {
+    if (auto customType = getType(
+            resolvedFunction->getMetadata()
+                .signature()
+                ->returnType()
+                .toString(),
+            {})) {
+      return customType;
+    }
     return resolvedFunction->getMetadata().returnType();
   }
 

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -124,14 +124,6 @@ std::shared_ptr<const Type> resolveSimpleFunction(
       exec::SimpleFunctions().resolveFunction(functionName, argTypes);
 
   if (resolvedFunction) {
-    if (auto customType = getType(
-            resolvedFunction->getMetadata()
-                .signature()
-                ->returnType()
-                .toString(),
-            {})) {
-      return customType;
-    }
     return resolvedFunction->getMetadata().returnType();
   }
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -166,7 +166,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     if (!timestamp.has_value() || !timeZoneName.has_value()) {
       return evaluateOnce<T>(
           expression,
-          makeRowVector({makeRowVector(
+          makeRowVector({makeTimestampWTZVector(
               {
                   makeNullableFlatVector<int64_t>({std::nullopt}),
                   makeNullableFlatVector<int16_t>({std::nullopt}),
@@ -289,7 +289,7 @@ TEST_F(DateTimeFunctionsTest, toUnixtime) {
     const int64_t tzid = util::getTimeZoneID(tz);
     return evaluateOnce<double>(
         "to_unixtime(c0)",
-        makeRowVector({makeRowVector({
+        makeRowVector({makeTimestampWTZVector({
             makeNullableFlatVector<int64_t>({timestamp}),
             makeNullableFlatVector<int16_t>({tzid}),
         })}));
@@ -348,7 +348,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
         "from_unixtime(c0, '+01:00')", makeRowVector({unixtimes}));
     ASSERT_TRUE(isTimestampWithTimeZoneType(result->type()));
 
-    auto expected = makeRowVector({
+    auto expected = makeTimestampWTZVector({
         makeFlatVector<int64_t>(
             size, [&](auto row) { return unixtimeAt(row) * 1'000; }),
         makeConstant((int16_t)900, size),
@@ -360,7 +360,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
         "from_unixtime(c0, '+01:00')",
         makeRowVector({makeFlatVector<double>({kNan, kNan})}));
     ASSERT_TRUE(isTimestampWithTimeZoneType(result->type()));
-    expected = makeRowVector({
+    expected = makeTimestampWTZVector({
         makeFlatVector<int64_t>({0, 0}),
         makeFlatVector<int16_t>({900, 900}),
     });
@@ -380,7 +380,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
         "from_unixtime(c0, c1)", makeRowVector({unixtimes, timezones}));
     ASSERT_TRUE(isTimestampWithTimeZoneType(result->type()));
 
-    auto expected = makeRowVector({
+    auto expected = makeTimestampWTZVector({
         makeFlatVector<int64_t>(
             size, [&](auto row) { return unixtimeAt(row) * 1'000; }),
         makeFlatVector<int16_t>(
@@ -396,7 +396,7 @@ TEST_F(DateTimeFunctionsTest, fromUnixtimeWithTimeZone) {
             makeNullableFlatVector<StringView>({"+01:00", "+02:00"}),
         }));
     ASSERT_TRUE(isTimestampWithTimeZoneType(result->type()));
-    expected = makeRowVector({
+    expected = makeTimestampWTZVector({
         makeFlatVector<int64_t>({0, 0}),
         makeFlatVector<int16_t>({900, 960}),
     });

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -178,7 +178,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         util::getTimeZoneID(timeZoneName.value());
     return evaluateOnce<T>(
         expression,
-        makeRowVector({makeRowVector({
+        makeRowVector({makeTimestampWTZVector({
             makeNullableFlatVector<int64_t>({timestamp}),
             makeNullableFlatVector<int16_t>({tzid}),
         })}));
@@ -191,7 +191,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
     if (!timestamp.has_value() || !timeZoneName.has_value()) {
       return evaluate(
           expression,
-          makeRowVector({makeRowVector(
+          makeRowVector({makeTimestampWTZVector(
               {
                   makeNullableFlatVector<int64_t>({std::nullopt}),
                   makeNullableFlatVector<int16_t>({std::nullopt}),
@@ -203,7 +203,7 @@ class DateTimeFunctionsTest : public functions::test::FunctionBaseTest {
         util::getTimeZoneID(timeZoneName.value());
     return evaluate(
         expression,
-        makeRowVector({makeRowVector({
+        makeRowVector({makeTimestampWTZVector({
             makeNullableFlatVector<int64_t>({timestamp}),
             makeNullableFlatVector<int16_t>({tzid}),
         })}));
@@ -1397,7 +1397,7 @@ TEST_F(DateTimeFunctionsTest, dateTruncTimestampWithTimezone) {
                                      const std::string& timeZone,
                                      int64_t expectedTimestamp) {
     assertEqualVectors(
-        makeRowVector(
+        makeTimestampWTZVector(
             {makeNullableFlatVector<int64_t>({expectedTimestamp}),
              makeNullableFlatVector<int16_t>({util::getTimeZoneID(timeZone)})}),
         evaluateWithTimestampWithTimezone(

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -26,7 +26,8 @@ class JsonExtractScalarTest : public functions::test::FunctionBaseTest {
   std::optional<std::string> json_extract_scalar(
       std::optional<std::string> json,
       std::optional<std::string> path) {
-    return evaluateOnce<std::string>("json_extract_scalar(c0, c1)", json, path);
+    return evaluateOnce<std::string, std::string>(
+        "json_extract_scalar(c0, c1)", {json, path}, {JSON(), VARCHAR()});
   }
 
   void evaluateWithJsonType(

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -228,9 +228,11 @@ bool ArrayType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!other.isArray()) {
+
+  if (!hasSameTypeId(other)) {
     return false;
   }
+
   auto& otherArray = other.asArray();
   return child_->equivalent(*otherArray.child_);
 }
@@ -375,7 +377,7 @@ bool RowType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::ROW) {
+  if (!hasSameTypeId(other)) {
     return false;
   }
   auto& otherTyped = other.asRow();
@@ -467,7 +469,7 @@ bool MapType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!other.isMap()) {
+  if (!hasSameTypeId(other)) {
     return false;
   }
   auto& otherMap = other.asMap();
@@ -479,7 +481,7 @@ bool FunctionType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::FUNCTION) {
+  if (!hasSameTypeId(other)) {
     return false;
   }
   auto& otherTyped = *reinterpret_cast<const FunctionType*>(&other);
@@ -507,7 +509,7 @@ bool OpaqueType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (other.kind() != TypeKind::OPAQUE) {
+  if (!hasSameTypeId(other)) {
     return false;
   }
   return true;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -509,14 +509,7 @@ bool OpaqueType::equivalent(const Type& other) const {
   if (&other == this) {
     return true;
   }
-  if (!hasSameTypeId(other)) {
-    return false;
-  }
-  return true;
-}
-
-bool OpaqueType::operator==(const Type& other) const {
-  if (!this->equivalent(other)) {
+  if (other.kind() != TypeKind::OPAQUE) {
     return false;
   }
   auto& otherTyped = *reinterpret_cast<const OpaqueType*>(&other);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1733,13 +1733,6 @@ struct CppToType<UnscaledLongDecimal>
 template <>
 struct CppToType<UnknownValue> : public CppToTypeBase<TypeKind::UNKNOWN> {};
 
-template <typename T>
-struct CppToType<CustomType<T>> : public CppToType<typename T::type> {
-  static auto create() {
-    return CppToType<typename T::type>::create();
-  }
-};
-
 // todo: remaining cpp2type
 
 template <TypeKind KIND>
@@ -1864,6 +1857,16 @@ bool unregisterType(const std::string& name);
 /// name. Returns nullptr if a type with the specified name does not exist or
 /// does not have a dedicated custom cast operator.
 exec::CastOperatorPtr getCastOperator(const std::string& name);
+
+template <typename T>
+struct CppToType<CustomType<T>> : public CppToType<typename T::type> {
+  static TypePtr create() {
+    if (auto customType = getType(T::typeName, {})) {
+      return customType;
+    }
+    return CppToType<typename T::type>::create();
+  }
+};
 
 // Allows us to transparently use folly::toAppend(), folly::join(), etc.
 template <class TString>

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -472,6 +472,10 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 
   virtual std::string toString() const = 0;
 
+  inline bool hasSameTypeId(const Type& other) const {
+    return (std::type_index(typeid(*this)) == std::type_index(typeid(other)));
+  }
+
   /// Types are weakly matched.
   /// Examples: Two RowTypes are equivalent if the children types are
   /// equivalent, but the children names could be different. Two OpaqueTypes are
@@ -595,7 +599,7 @@ class ScalarType : public TypeBase<KIND> {
   FOLLY_NOINLINE static const std::shared_ptr<const ScalarType<KIND>> create();
 
   bool equivalent(const Type& other) const override {
-    return KIND == other.kind();
+    return this->hasSameTypeId(other);
   }
 
   // TODO: velox implementation is in cpp
@@ -632,7 +636,7 @@ class DecimalType : public ScalarType<KIND> {
   }
 
   inline bool equivalent(const Type& otherDecimal) const override {
-    if (this->kind() != otherDecimal.kind()) {
+    if (!this->hasSameTypeId(otherDecimal)) {
       return false;
     }
     auto decimalType = static_cast<const DecimalType<KIND>&>(otherDecimal);
@@ -701,7 +705,7 @@ class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
   }
 
   bool equivalent(const Type& other) const override {
-    return TypeKind::UNKNOWN == other.kind();
+    return hasSameTypeId(other);
   }
 
   folly::dynamic serialize() const override {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -473,7 +473,7 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
   virtual std::string toString() const = 0;
 
   inline bool hasSameTypeId(const Type& other) const {
-    return (std::type_index(typeid(*this)) == std::type_index(typeid(other)));
+    return typeid(*this) == typeid(other);
   }
 
   /// Types are weakly matched.

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -919,8 +919,6 @@ class OpaqueType : public TypeBase<TypeKind::OPAQUE> {
 
   bool equivalent(const Type& other) const override;
 
-  bool operator==(const Type& other) const override;
-
   const std::type_index& typeIndex() const {
     return typeIndex_;
   }

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -539,6 +539,7 @@ TEST(TypeTest, equivalent) {
   EXPECT_TRUE(ARRAY(BIGINT())->equivalent(*ARRAY(BIGINT())));
   EXPECT_FALSE(ARRAY(BIGINT())->equivalent(*ARRAY(INTEGER())));
   EXPECT_FALSE(ARRAY(BIGINT())->equivalent(*ROW({{"a", BIGINT()}})));
+  EXPECT_FALSE(ARRAY(BIGINT())->equivalent(*FIXED_SIZE_ARRAY(10, BIGINT())));
   EXPECT_FALSE(FIXED_SIZE_ARRAY(10, BIGINT())->equivalent(*ARRAY(BIGINT())));
   EXPECT_FALSE(FIXED_SIZE_ARRAY(10, BIGINT())
                    ->equivalent(*FIXED_SIZE_ARRAY(9, BIGINT())));

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/vector/BaseVector.h"
+#include "velox/functions/prestosql/types/HyperLogLogType.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/type/StringView.h"
 #include "velox/type/Type.h"
 #include "velox/type/Variant.h"
@@ -692,6 +694,17 @@ std::shared_ptr<BaseVector> BaseVector::createNullConstant(
   if (type->kind() == TypeKind::LONG_DECIMAL) {
     return std::make_shared<ConstantVector<UnscaledLongDecimal>>(
         pool, size, true, type, UnscaledLongDecimal());
+  }
+
+  if (type == HYPERLOGLOG() || type == JSON()) {
+    return std::make_shared<ConstantVector<StringView>>(
+        pool,
+        size,
+        true,
+        type,
+        StringView(),
+        SimpleVectorStats<StringView>{},
+        sizeof(StringView));
   }
 
   return BaseVector::createConstant(variant(type->kind()), size, pool);

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
 namespace facebook::velox::test {
@@ -44,11 +45,18 @@ RowVectorPtr VectorMaker::rowVector(
   for (int i = 0; i < children.size(); i++) {
     childTypes[i] = children[i]->type();
   }
+
   auto rowType = ROW(std::move(childNames), std::move(childTypes));
   const size_t vectorSize = children.empty() ? 0 : children.front()->size();
 
   return std::make_shared<RowVector>(
       pool_, rowType, BufferPtr(nullptr), vectorSize, children);
+}
+
+RowVectorPtr VectorMaker::timestampWTZVector(const std::vector<VectorPtr>& children) {
+  const size_t vectorSize = children.empty() ? 0 : children.front()->size();
+  return std::make_shared<RowVector>(
+          pool_, TimestampWithTimeZoneType::get(), BufferPtr(nullptr), vectorSize, children);
 }
 
 RowVectorPtr VectorMaker::rowVector(

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 namespace facebook::velox::test {
 
@@ -53,10 +53,15 @@ RowVectorPtr VectorMaker::rowVector(
       pool_, rowType, BufferPtr(nullptr), vectorSize, children);
 }
 
-RowVectorPtr VectorMaker::timestampWTZVector(const std::vector<VectorPtr>& children) {
+RowVectorPtr VectorMaker::timestampWTZVector(
+    const std::vector<VectorPtr>& children) {
   const size_t vectorSize = children.empty() ? 0 : children.front()->size();
   return std::make_shared<RowVector>(
-          pool_, TimestampWithTimeZoneType::get(), BufferPtr(nullptr), vectorSize, children);
+      pool_,
+      TIMESTAMP_WITH_TIME_ZONE(),
+      BufferPtr(nullptr),
+      vectorSize,
+      children);
 }
 
 RowVectorPtr VectorMaker::rowVector(

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -64,6 +64,8 @@ class VectorMaker {
       const std::shared_ptr<const RowType>& rowType,
       vector_size_t size);
 
+    RowVectorPtr timestampWTZVector(const std::vector<VectorPtr>& children);
+
   template <typename T>
   using EvalType = typename CppToType<T>::NativeType;
 

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -64,7 +64,7 @@ class VectorMaker {
       const std::shared_ptr<const RowType>& rowType,
       vector_size_t size);
 
-    RowVectorPtr timestampWTZVector(const std::vector<VectorPtr>& children);
+  RowVectorPtr timestampWTZVector(const std::vector<VectorPtr>& children);
 
   template <typename T>
   using EvalType = typename CppToType<T>::NativeType;

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -121,6 +121,16 @@ class VectorTestBase {
     return rowVector;
   }
 
+    RowVectorPtr makeTimestampWTZVector(
+            const std::vector<VectorPtr>& children,
+            std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
+      auto rowVector = vectorMaker_.timestampWTZVector(children);
+      if (isNullAt) {
+        setNulls(rowVector, isNullAt);
+      }
+      return rowVector;
+    }
+
   RowVectorPtr makeRowVector(
       const std::shared_ptr<const RowType>& rowType,
       vector_size_t size) {

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -121,15 +121,15 @@ class VectorTestBase {
     return rowVector;
   }
 
-    RowVectorPtr makeTimestampWTZVector(
-            const std::vector<VectorPtr>& children,
-            std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
-      auto rowVector = vectorMaker_.timestampWTZVector(children);
-      if (isNullAt) {
-        setNulls(rowVector, isNullAt);
-      }
-      return rowVector;
+  RowVectorPtr makeTimestampWTZVector(
+      const std::vector<VectorPtr>& children,
+      std::function<bool(vector_size_t /*row*/)> isNullAt = nullptr) {
+    auto rowVector = vectorMaker_.timestampWTZVector(children);
+    if (isNullAt) {
+      setNulls(rowVector, isNullAt);
     }
+    return rowVector;
+  }
 
   RowVectorPtr makeRowVector(
       const std::shared_ptr<const RowType>& rowType,
@@ -612,12 +612,15 @@ class VectorTestBase {
   }
 
   template <typename T>
-  VectorPtr makeConstant(const std::optional<T>& value, vector_size_t size) {
+  VectorPtr makeConstant(
+      const std::optional<T>& value,
+      vector_size_t size,
+      const TypePtr& type = CppToType<T>::create()) {
     return std::make_shared<ConstantVector<EvalType<T>>>(
         pool(),
         size,
         /*isNull=*/!value.has_value(),
-        CppToType<T>::create(),
+        type,
         value ? EvalType<T>(*value) : EvalType<T>(),
         SimpleVectorStats<EvalType<T>>{},
         sizeof(EvalType<T>));


### PR DESCRIPTION
Use typeid to make Type::equivalence symmetric.

Resolves https://github.com/facebookincubator/velox/issues/3853