### PR TITLE
Memory pool always return valid buffer otherwise throw

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -89,6 +89,9 @@ inline constexpr auto kNotImplemented = "NOT_IMPLEMENTED"_fs;
 // An error raised when memory exceeded limits.
 inline constexpr auto kMemCapExceeded = "MEM_CAP_EXCEEDED"_fs;
 
+// Error caused by memory allocation failure.
+inline constexpr auto kMemAllocError = "MEM_ALLOC_ERROR"_fs;
+
 // Error caused by failing to allocate cache buffer space for IO.
 inline constexpr auto kNoCacheSpace = "NO_CACHE_SPACE"_fs;
 

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -38,9 +38,7 @@ char* AllocationPool::allocateFixed(uint64_t bytes) {
   // Use contiguous allocations from mapped memory if allocation size is large
   if (numPages > pool_->largestSizeClass()) {
     auto largeAlloc = std::make_unique<memory::ContiguousAllocation>();
-    if (!pool_->allocateContiguous(numPages, *largeAlloc)) {
-      throw std::bad_alloc();
-    }
+    pool_->allocateContiguous(numPages, *largeAlloc);
     largeAllocations_.emplace_back(std::move(largeAlloc));
     auto res = largeAllocations_.back()->data<char>();
     VELOX_CHECK_NOT_NULL(
@@ -65,10 +63,8 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
       allocations_.push_back(
           std::make_unique<memory::Allocation>(std::move(allocation_)));
     }
-    if (!pool_->allocateNonContiguous(
-            std::max<int32_t>(kMinPages, numPages), allocation_, numPages)) {
-      throw std::bad_alloc();
-    }
+    pool_->allocateNonContiguous(
+        std::max<int32_t>(kMinPages, numPages), allocation_, numPages);
     currentRun_ = 0;
   }
   currentOffset_ = 0;

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -333,9 +333,9 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     int32_t totalPages{0};
   };
 
-  /// Returns a mix of standard sizes and allocation counts for covering
-  /// 'numPages' worth of memory. 'minSizeClass' is the size of the smallest
-  /// usable size class.
+  // Returns a mix of standard sizes and allocation counts for covering
+  // 'numPages' worth of memory. 'minSizeClass' is the size of the
+  // smallest usable size class.
   SizeMix allocationSize(
       MachinePageCount numPages,
       MachinePageCount minSizeClass) const;

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -124,7 +124,7 @@ class MmapAllocator : public MemoryAllocator {
   /// function for validating otherwise unreachable error paths. If 'persistent'
   /// is false, then we only inject failure once in the next call. Otherwise, we
   /// keep injecting failures until next 'testingClearFailureInjection' call.
-  enum class Failure { kNone, kMadvise, kMmap, kAllocate };
+  enum class Failure { kNone, kMadvise, kMmap, kAllocate, kCap };
   void testingSetFailureInjection(Failure failure, bool persistent = false) {
     injectedFailure_ = failure;
     isPersistentFailureInjection_ = persistent;

--- a/velox/common/memory/StreamArena.cpp
+++ b/velox/common/memory/StreamArena.cpp
@@ -31,10 +31,8 @@ void StreamArena::newRange(int32_t bytes, ByteRange* range) {
       allocations_.push_back(
           std::make_unique<memory::Allocation>(std::move(allocation_)));
     }
-    if (!pool_->allocateNonContiguous(
-            std::max(allocationQuantum_, numPages), allocation_)) {
-      throw std::bad_alloc();
-    }
+    pool_->allocateNonContiguous(
+        std::max(allocationQuantum_, numPages), allocation_);
     currentRun_ = 0;
     currentPage_ = 0;
     size_ += allocation_.byteSize();

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -85,7 +85,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     updateLocalMemoryUsage(-size);
   }
 
-  bool allocateNonContiguous(
+  void allocateNonContiguous(
       velox::memory::MachinePageCount /*unused*/,
       velox::memory::Allocation& /*unused*/,
       velox::memory::MachinePageCount /*unused*/) override {
@@ -105,7 +105,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_UNSUPPORTED("sizeClasses unsupported");
   }
 
-  bool allocateContiguous(
+  void allocateContiguous(
       velox::memory::MachinePageCount /*unused*/,
       velox::memory::ContiguousAllocation& /*unused*/) override {
     VELOX_UNSUPPORTED("allocateContiguous unsupported");
@@ -139,13 +139,16 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   }
 
   MOCK_CONST_METHOD0(getMaxBytes, int64_t());
-  // MOCK_METHOD1(
-  //     setMemoryUsageTracker,
-  //     void(const std::shared_ptr<velox::memory::MemoryUsageTracker>&));
 
   MOCK_METHOD1(updateSubtreeMemoryUsage, int64_t(int64_t));
 
   MOCK_CONST_METHOD0(getAlignment, uint16_t());
+
+  std::string toString() const override {
+    return fmt::format(
+        "Mock Memory Pool[{}]",
+        velox::memory::MemoryAllocator::kindString(allocator_->kind()));
+  }
 
  private:
   velox::memory::MemoryAllocator* const FOLLY_NONNULL allocator_{

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -618,9 +618,7 @@ void HashTable<ignoreNullKeys>::allocateTables(uint64_t size) {
   // The total size is 9 bytes per slot, 8 in the pointers table and 1 in the
   // tags table.
   auto numPages = bits::roundUp(size * 9, kPageSize) / kPageSize;
-  if (!rows_->pool()->allocateContiguous(numPages, tableAllocation_)) {
-    VELOX_FAIL("Could not allocate join/group by hash table");
-  }
+  rows_->pool()->allocateContiguous(numPages, tableAllocation_);
   table_ = tableAllocation_.data<char*>();
   tags_ = reinterpret_cast<uint8_t*>(table_ + size);
   memset(tags_, 0, capacity_);
@@ -1122,13 +1120,7 @@ void HashTable<ignoreNullKeys>::setHashMode(HashMode mode, int32_t numNew) {
     auto bytes = capacity_ * sizeof(char*);
     constexpr auto kPageSize = memory::AllocationTraits::kPageSize;
     auto numPages = bits::roundUp(bytes, kPageSize) / kPageSize;
-    if (!rows_->pool()->allocateContiguous(numPages, tableAllocation_)) {
-      VELOX_FAIL(
-          "Could not allocate array with {} bytes/{} pages "
-          "for array mode hash table",
-          bytes,
-          numPages);
-    }
+    rows_->pool()->allocateContiguous(numPages, tableAllocation_);
     table_ = tableAllocation_.data<char*>();
     memset(table_, 0, bytes);
     hashMode_ = HashMode::kArray;

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -711,10 +711,7 @@ RowPartitions::RowPartitions(int32_t numRows, memory::MemoryPool& pool)
   auto numPages =
       bits::roundUp(capacity_, memory::AllocationTraits::kPageSize) /
       memory::AllocationTraits::kPageSize;
-  if (!pool.allocateNonContiguous(numPages, allocation_)) {
-    VELOX_FAIL(
-        "Failed to allocate RowContainer partitions: {} pages", numPages);
-  }
+  pool.allocateNonContiguous(numPages, allocation_);
 }
 
 void RowPartitions::appendPartitions(folly::Range<const uint8_t*> partitions) {


### PR DESCRIPTION
1. Change all MemoryPool allocation APIs to return a valid buffer on success
    and throw on error instead. A memory allocator specific error code is added
    in Velox runtime exception This simplifies the user code error handling for
    large chunk of memory allocations. It also ease segment fault debugging in
    prod as such kind of errors might be mixed with real code bugs.
2. Fix a memory reservation counting issue when memory allocator fails the
    allocation. The current code doesn't rollback the reservation in memory pool
3. Improve the error handling when allocate too many pages in non-contiguous
    memory allocation by throw exception in MemoryAllocator::allocationSize
    when a PageRun exceeds 2^16 limit.
4. A couple of tests are added including a concurrent memory pool test.
