### PR TITLE
Add startup flag to specify functions that should be favorably selected by fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <boost/algorithm/string.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 #include <folly/ScopeGuard.h>
 #include <glog/logging.h>
@@ -117,6 +118,21 @@ DEFINE_bool(
     false,
     "Enable re-use already generated expression. Currently it only re-uses "
     "expressions that do not have nested expressions.");
+
+DEFINE_string(
+    assign_function_tickets,
+    "",
+    "Comma separated list of function names and their tickets in the format "
+    "<function_name>=<tickets>. Every ticket represents an opportunity for "
+    "a function to be chosen from a pool of candidates. By default, "
+    "every function has one ticket, and the likelihood of a function "
+    "being picked can be increased by allotting it more tickets. Note "
+    "that in practice, increasing the number of tickets does not "
+    "proportionally increase the likelihood of selection, as the selection "
+    "process involves filtering the pool of candidates by a required "
+    "return type so not all functions may compete against the same number "
+    "of functions at every instance. Number of tickets must be a positive "
+    "integer. Example: eq=3,floor=5");
 
 namespace facebook::velox::test {
 
@@ -311,6 +327,48 @@ RowVectorPtr wrapChildren(
       rowVector->pool(), rowVector->type(), nullptr, size, newInputs);
 }
 
+// Parse --assign_function_tickets startup flag into a map that maps function
+// name to its number of tickets.
+std::unordered_map<std::string, int> getTicketsForFunctions() {
+  std::unordered_map<std::string, int> functionToTickets;
+  if (FLAGS_assign_function_tickets.empty()) {
+    return functionToTickets;
+  }
+  std::vector<std::string> results;
+  boost::algorithm::split(
+      results, FLAGS_assign_function_tickets, boost::is_any_of(","));
+
+  for (auto& entry : results) {
+    std::vector<std::string> separated;
+    boost::algorithm::split(separated, entry, boost::is_any_of("="));
+    if (separated.size() != 2) {
+      LOG(FATAL)
+          << "Invalid format. Expected a function name and its number of "
+             "tickets separated by '=', instead found: "
+          << entry;
+    }
+    int tickets = 0;
+    try {
+      tickets = stoi(separated[1]);
+    } catch (std::exception& e) {
+      LOG(FATAL)
+          << "Invalid number of tickets. Expected a function name and its "
+             "number of tickets separated by '=', instead found: "
+          << entry << " Error encountered: " << e.what();
+    }
+
+    if (tickets < 1) {
+      LOG(FATAL)
+          << "Number of tickets should be a positive integer. Expected a "
+             "function name and its number of tickets separated by '=',"
+             " instead found: "
+          << entry;
+    }
+    functionToTickets.insert({separated[0], tickets});
+  }
+  return functionToTickets;
+}
+
 } // namespace
 
 ExpressionFuzzer::ExpressionFuzzer(
@@ -435,6 +493,15 @@ ExpressionFuzzer::ExpressionFuzzer(
       unsupportedFunctionSignatures,
       (double)unsupportedFunctionSignatures / totalFunctionSignatures * 100);
 
+  auto functionsToTickets = getTicketsForFunctions();
+  auto getTickets = [&functionsToTickets](const std::string& funcName) {
+    auto itr = functionsToTickets.find(funcName);
+    int tickets = 1;
+    if (itr != functionsToTickets.end()) {
+      tickets = itr->second;
+    }
+    return tickets;
+  };
   // We sort the available signatures before inserting them into
   // typeToExpressionList_ and expressionToSignature_. The purpose of this step
   // is to ensure the vector of function signatures associated with each key in
@@ -447,10 +514,14 @@ ExpressionFuzzer::ExpressionFuzzer(
     auto returnType = typeToBaseName(it.returnType);
     if (typeToExpressionList_[returnType].empty() ||
         typeToExpressionList_[returnType].back() != it.name) {
-      // Ensure only one entry for a function name is added. This
+      // Ensure entries for a function name are added only once. This
       // gives all others a fair chance to be selected. Since signatures
       // are sorted on the function name this check will always work.
-      typeToExpressionList_[returnType].push_back(it.name);
+      int tickets = getTickets(it.name);
+      // Add multiple entries to increase likelihood of its selection.
+      for (int i = 0; i < tickets; i++) {
+        typeToExpressionList_[returnType].push_back(it.name);
+      }
     }
     expressionToSignature_[it.name][returnType].push_back(&it);
   }
@@ -467,7 +538,10 @@ ExpressionFuzzer::ExpressionFuzzer(
     }
     if (typeToExpressionList_[*returnTypeKey].empty() ||
         typeToExpressionList_[*returnTypeKey].back() != it.name) {
-      typeToExpressionList_[*returnTypeKey].push_back(it.name);
+      int tickets = getTickets(it.name);
+      for (int i = 0; i < tickets; i++) {
+        typeToExpressionList_[*returnTypeKey].push_back(it.name);
+      }
     }
     expressionToTemplatedSignature_[it.name][*returnTypeKey].push_back(&it);
   }


### PR DESCRIPTION
This adds a startup flag "assign_function_tickets" to the fuzzer that takes
a comma separated list of function names and their tickets in the format
<function_name>=<tickets>. Every ticket represents an opportunity for
a function to be chosen from a pool of candidates. By default, every
function has one ticket, and the likelihood of a function being picked
can be increased by allotting it more tickets. Note that in practice,
increasing the number of tickets does not proportionally increase the
likelihood of selection, as the selection process involves filtering
the pool of candidates by a required return type so not all functions
may compete against the same number of functions at every instance.
Number of tickets must be a positive integer.
Example:
--assign_function_tickets "eq=3,floor=5"

Test Plan:

Ran fuzzer for 60 secs with:

Case 1:
--assign_function_tickets "reverse=1"

functionName numTimesSelected proportionOfTimesSelected numProcessedRows
subscript 4698 6.24% 50935
array_min 3039 4.04% 31115
array_max 3027 4.02% 34004
least 1830 2.43% 10932
greatest 1749 2.32% 9115
clamp 1492 1.98% 13815
floor 1416 1.88% 20626
divide 1404 1.87% 18279
negate 1399 1.86% 19363
sign 1367 1.82% 16842
multiply 1362 1.81% 19842
ceil 1346 1.79% 16744
minus 1341 1.78% 17084
mod 1335 1.77% 18587
abs 1324 1.76% 17189
round 1315 1.75% 17258
ceiling 1310 1.74% 19120
plus 1299 1.73% 18900
reverse 1100 1.46% 11350

Case 2:
--assign_function_tickets "reverse=6"

subscript 4914 6.17% 56986
reverse 3209 4.03% 35340
array_max 3180 3.99% 38363
array_min 3171 3.98% 35746
greatest 1787 2.24% 9678
least 1763 2.21% 10213
multiply 1533 1.93% 24829
ceil 1518 1.91% 21930
round 1517 1.91% 19357
abs 1499 1.88% 20086
plus 1489 1.87% 19672
mod 1487 1.87% 19735
minus 1466 1.84% 19829
ceiling 1443 1.81% 22217
negate 1438 1.81% 21344
clamp 1433 1.80% 14652
sign 1432 1.80% 20460
floor 1423 1.79% 18669
divide 1408 1.77% 19904
date_add 1062 1.33% 4755
date_trunc 1021 1.28% 8358
slice 777 0.98% 7429