### PR TITLE
Build dependencies in release mode in setup-ubuntu.sh

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -26,6 +26,7 @@ export COMPILER_FLAGS
 FB_OS_VERSION=v2022.11.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
+export CMAKE_BUILD_TYPE=Release
 
 # Install all velox and folly dependencies.
 sudo --preserve-env apt update && apt install -y \


### PR DESCRIPTION
As discovered in https://github.com/facebookincubator/velox/pull/3830#issuecomment-1407192706 folly is build in debug mode when the ubuntu docker container is built, this causes issues with the benchmarks and does not match folly when built as a bundled dependency.

I have tested that it works here: https://github.com/facebookincubator/velox/actions/runs/4029446621/jobs/6927345123#step:11:20