### PR TITLE
Rename legacySizeOfNull config to spark.legacy-size-of-null

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -190,3 +190,14 @@ the update mode field of the table writer operator output. ``OVERWRITE``
 sets the update mode to indicate overwriting a partition if exists.
 ``ERROR`` sets the update mode to indicate error throwing if writing
 to an existing partition.
+
+Spark-specific configuration
+----------------------------
+
+``spark.legacy-size-of-null``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``bool``
+    * **Default value:** ``true``
+
+If false, the function returns null for null input.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -200,4 +200,4 @@ Spark-specific configuration
     * **Type:** ``bool``
     * **Default value:** ``true``
 
-If false, the function returns null for null input.
+If false, size function returns null for null input.

--- a/velox/functions/sparksql/Size.cpp
+++ b/velox/functions/sparksql/Size.cpp
@@ -31,7 +31,7 @@ struct Size {
   FOLLY_ALWAYS_INLINE void initialize(
       const core::QueryConfig& config,
       const TInput* input /*input*/) {
-    legacySizeOfNull_ = config.get<bool>("legacySizeOfNull", true);
+    legacySizeOfNull_ = config.get<bool>("spark.legacy-size-of-null", true);
   }
 
   template <typename TInput>

--- a/velox/functions/sparksql/tests/SizeTest.cpp
+++ b/velox/functions/sparksql/tests/SizeTest.cpp
@@ -75,11 +75,11 @@ TEST_F(SizeTest, sizetest) {
   testSize(mapVector, numRows);
 }
 
-// Ensure that out if set to -1 if `legacySizeOfNull`
+// Ensure that out if set to -1 if `spark.legacy-size-of-null`
 // is specified.
 TEST_F(SizeTest, legacySizeOfNull) {
   vector_size_t numRows = 100;
-  setConfig("legacySizeOfNull", false);
+  setConfig("spark.legacy-size-of-null", false);
   auto arrayVector =
       makeArrayVector<int64_t>(numRows, sizeAt, valueAt, nullEvery(1));
   testSizeLegacyNull(arrayVector, numRows);


### PR DESCRIPTION
legacySizeOfNull configuration property affects only Spark function 'size'. The new
name, spark.legacy-size-of-null, makes that clear.