### PR TITLE
Add ReadFileInputStreamTests.cpp to CMakeLists.txt

### DIFF
--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   LocalFileSinkTest.cpp
   LoggedExceptionTest.cpp
   RangeTests.cpp
+  ReadFileInputStreamTests.cpp
   RetryTests.cpp
   TestBufferedInput.cpp
   TestColumnSelector.cpp


### PR DESCRIPTION
This test was not included in any CMakeLists file. 
