### PR TITLE
Disable "lemirebmi2" benchmark on Mac M1

### DIFF
--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -17,7 +17,11 @@
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/dwio/common/BitPackDecoder.h"
+
+#ifdef __BMI2__
 #include "velox/dwio/common/tests/Lemire/bmipacking32.h"
+#endif
+
 #include "velox/external/duckdb/duckdb-fastpforlib.hpp"
 #include "velox/external/duckdb/parquet-amalgamation.hpp"
 #include "velox/vector/TypeAliases.h"
@@ -114,7 +118,11 @@ void lemirebmi2(uint8_t bitWidth, uint32_t* result) {
   const uint8_t* inputIter =
       reinterpret_cast<const uint8_t*>(bitPackedData[bitWidth].data());
 
+#ifdef __BMI2__
   bmiunpack32(inputIter, kNumValues, bitWidth, result);
+#else
+  VELOX_FAIL("bmiunpack32 is not supported on this platform.");
+#endif
 }
 
 template <typename T>

--- a/velox/dwio/common/tests/Lemire/bmipacking32.h
+++ b/velox/dwio/common/tests/Lemire/bmipacking32.h
@@ -18,6 +18,9 @@
 // https://github.com/lemire/LittleIntPacker/blob/master/src/bmipacking32.c for
 // benchmarking use only.
 
+// Only supports x86 and x64 architecture due to inclusion of
+// <immintrin.h> and <x86intrin.h>.
+
 /**
  * This is conventional bit packing using portable C
  */


### PR DESCRIPTION
Compilation of the dwio module fails on Mac M1 due to x86-specific inclusions defined in `velox/dwio/common/tests/Lemire/bmipacking32.h`: 
> This header is only meant to be used on x86 and x64 architecture

I made the inclusion of that header conditional upon `__BMI2__` similar to BitUtil.h file. With this patch, the compilation succeeds and the unsupported on M1 benchmark `lemirebmi2` would fail with the following error:
```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: bmiunpack32 is not supported on this platform.
Retriable: False
Function: lemirebmi2
```

All of the benchmarks prior `lemirebmi2` run fine.