### PR TITLE
Rename Task::safeErrorMessage() to errorMessageLocked()

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1525,7 +1525,7 @@ std::string Task::toString() const {
   out << "{Task " << shortId(taskId_) << " (" << taskId_ << ")";
 
   if (exception_) {
-    out << "Error: " << safeErrorMessage() << std::endl;
+    out << "Error: " << errorMessageLocked() << std::endl;
   }
 
   if (planFragment_.planNode) {
@@ -1677,13 +1677,13 @@ void Task::setError(const std::string& message) {
   }
 }
 
-std::string Task::safeErrorMessage() const {
+std::string Task::errorMessageLocked() const {
   return errorMessageImpl(exception_);
 }
 
 std::string Task::errorMessage() const {
   std::lock_guard<std::mutex> l(mutex_);
-  return safeErrorMessage();
+  return errorMessageLocked();
 }
 
 StopReason Task::enter(ThreadState& state) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -528,7 +528,7 @@ class Task : public std::enable_shared_from_this<Task> {
 
   /// Returns task execution error message or empty string if not error
   /// occurred. This should only be called inside mutex_ protection.
-  std::string safeErrorMessage() const;
+  std::string errorMessageLocked() const;
 
   // Counts the number of created tasks which is incremented on each task
   // creation.


### PR DESCRIPTION
Summary: Rename the member function Task::safeErrorMessage() to follow naming convention.

Differential Revision: D42850893

