### PR TITLE
Ensure child memory pool name unique and use weak ptr to track

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -82,7 +82,10 @@ class QueryCtx : public Context {
   }
 
   static std::string generatePoolName(const std::string& queryId) {
-    return fmt::format("query.{}", queryId.c_str());
+    // We attach a monotonically increasing sequence number to ensure the pool
+    // name is unique.
+    static std::atomic<int64_t> seqNum{0};
+    return fmt::format("query.{}.{}", queryId.c_str(), seqNum++);
   }
 
   memory::MemoryPool* FOLLY_NONNULL pool() const {

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -36,7 +36,6 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
   // why).
   std::array<std::string, 14> expectedTexts = {
       "Exceeded memory cap of 5.00MB when requesting 2.00MB.",
-      "query.: total: 5.00MB",
       "node.0: 0B in 1 operators, min 0B, max 0B",
       "op.0.0.0.Values: 0B in 1 instances, min 0B, max 0B",
       "node.1: 12.00KB in 1 operators, min 12.00KB, max 12.00KB",

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -67,7 +67,8 @@ class SpillOperatorGroupTest : public testing::Test {
               driverCtx,
               nullptr,
               operatorId,
-              "SpillNode",
+              // Ensure the spill plan node id is unique.
+              fmt::format("SpillNode{}", operatorId),
               "SpillOperator"),
           spillGroup_(spillGroup),
           spillFuture_(ContinueFuture::makeEmpty()) {


### PR DESCRIPTION
- Ensure child memory pool name unique
- Use weak ptr instead of raw pointer to track child pool
- Add concurrent memory pool structure access test