### PR TITLE
Don't rely on workflow API for pr number

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -123,7 +123,17 @@ jobs:
             make benchmarks-basic-run \
                 EXTRA_BENCHMARK_FLAGS="--binary_path ${BINARY_DIR}/baseline/ --output_path ${BASELINE_OUTPUT_PATH}"
 
-      - uses: actions/upload-artifact@v3
+      - name: "Save PR number"
+        run: echo "${{ github.event.pull_request.number }}" > pr_number.txt
+
+      - name: "Upload PR number"
+        uses: actions/upload-artifact@v3
+        with:
+          path: "pr_number.txt"
+          name: "pr_number"
+      
+      - name: "Upload result artifact"
+        uses: actions/upload-artifact@v3
         with:
           path: "benchmark-results"
           name: "benchmark-results"

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -46,38 +46,46 @@ jobs:
             repo: context.repo.repo,
             run_id: run_id,
           });
-
-          let run_data = benchmark_run.data;
-          let pr = run_data.pull_requests[0];
-          let pr_number = pr == undefined || run_data.event === 'push' ? '' : pr.number;
-            
-          core.setOutput('contender_sha', run_data.head_sha);
-          core.setOutput('pr_number', pr_number);
-
-
+          
           let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
             owner: context.repo.owner,
             repo: context.repo.repo,
             run_id: run_id,
           });
 
-          var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+          let result_artifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "benchmark-results"
           })[0];
+          
+          let pr_artifact = artifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "pr_number"
+          })[0];
 
-          var download = await github.rest.actions.downloadArtifact({
+          let result_download = await github.rest.actions.downloadArtifact({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            artifact_id: matchArtifact.id,
+            artifact_id: result_artifact.id,
+            archive_format: 'zip',
+          });
+          
+          let pr_download = await github.rest.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: pr_artifact.id,
             archive_format: 'zip',
           });
           
           var fs = require('fs');
-          fs.writeFileSync('${{github.workspace}}/benchmark-results.zip', Buffer.from(download.data));
-    
-    - name: Extract artifact
-      run: unzip benchmark-results.zip -d benchmark-results
-
+          fs.writeFileSync('${{github.workspace}}/benchmark-results.zip', Buffer.from(result_download.data));
+          fs.writeFileSync('${{github.workspace}}/pr_number.zip', Buffer.from(pr_download.data));
+            
+          core.setOutput('contender_sha', benchmark_run.data.head_sha);
+    - name: Extract artifact 
+      id: extract
+      run: |
+        unzip benchmark-results.zip -d benchmark-results
+        unzip pr_number.zip
+        echo "pr_number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
     - uses: actions/checkout@v3
       with:
         path: velox
@@ -99,6 +107,6 @@ jobs:
       run: |
         ./velox/scripts/benchmark-runner.py upload \
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
-          --pr_number "${{ steps.download.outputs.pr_number }}" \
+          --pr_number "${{ steps.extract.outputs.pr_number }}" \
           --sha "${{ steps.download.outputs.contender_sha }}" \
           --output_dir "${{ github.workspace }}/benchmark-results/contender/"

--- a/.github/workflows/conbench_upload.yml
+++ b/.github/workflows/conbench_upload.yml
@@ -102,9 +102,15 @@ jobs:
       env:
         CONBENCH_URL: "https://velox-conbench.voltrondata.run/"
         CONBENCH_MACHINE_INFO_NAME: "GitHub-runner-8-core"
-        CONBENCH_EMAIL: ${{ secrets.CONBENCH_EMAIL }}
-        CONBENCH_PASSWORD: ${{ secrets.CONBENCH_PASSWORD }}
+        CONBENCH_EMAIL: "${{ secrets.CONBENCH_EMAIL }}"
+        CONBENCH_PASSWORD: "${{ secrets.CONBENCH_PASSWORD }}"
+        CONBENCH_PROJECT_REPOSITORY: "${{ github.repository }}"
+        CONBENCH_PROJECT_COMMIT: "${{ steps.download.outputs.contender_sha }}"
       run: |
+        if [ "${{ steps.extract.outputs.pr_number }}" -gt 0]; then
+          export CONBENCH_PROJECT_PR_NUMBER="${{ steps.extract.outputs.pr_number }}"
+        fi
+        
         ./velox/scripts/benchmark-runner.py upload \
           --run_id "GHA-${{ github.run_id }}-${{ github.run_attempt }}" \
           --pr_number "${{ steps.extract.outputs.pr_number }}" \


### PR DESCRIPTION
Previously I was using the workflow API and the `pull_requests` key to get the pr number. It  seems that this key is not always populated (empty for fork prs?).

This pr adds a workaround by exporting the pr number as a file.

Tested on my [PR](https://github.com/assignUser/velox/actions/runs/4055757952/jobs/6979324722).