### PR TITLE
Build PyVelox Wheels for Linux and MacOS (x86_64)

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -23,6 +23,11 @@ on:
       ref:
         description: 'git ref to build'
         required: false
+      publish:
+        description: 'publish to PyPI'
+        required: false
+        type: boolean
+        default: false
   schedule:
     - cron: '15 0 * * *'
   pull_request:
@@ -114,11 +119,17 @@ jobs:
           BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         with:
           output-dir: wheelhouse
+
+      - name: "Create sdist"
+        run: |
+          python setup.py sdist --dist-dir wheelhouse
+
       - name: "Move .ccache to workspace"
         if: matrix.os != 'macos-11'
         run: |
           mkdir -p .ccache
           cp -R ./wheelhouse/.ccache/* .ccache
+
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: cache
@@ -129,4 +140,29 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./wheelhouse/*.whl
+          path: |
+            ./wheelhouse/*.whl
+            ./wheelhouse/*.tar.gz
+
+  publish_wheels:
+    name: Publish Wheels to PyPI
+    if: ${{ github.event_name == 'schedule' || inputs.publish }}
+    needs: build_wheels
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse
+      
+      - run: ls wheelhouse
+      
+      - uses: actions/setupo-python@v3
+        with:
+          python-version: 3.10
+
+      - name: Publish a Python distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.6.4
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages_dir: wheelhouse 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -53,7 +53,9 @@ jobs:
           CIBW_BUILD: "cp39-* cp310-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
-          CIBW_BEFORE_ALL_MACOS: "bash {package}/scripts/setup-macos.sh"
+          CIBW_BEFORE_ALL_MACOS: >
+            bash {package}/scripts/setup-macos.sh && 
+            bash {package}/scripts/setup-macos.sh install_folly
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -78,12 +78,12 @@ jobs:
           LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0 || echo $INITIAL_COMMIT)
           COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
 
-          if [ $LAST_TAG = $INITIAL_COMMIT ]; then
+          if [ "$LAST_TAG" = "$INITIAL_COMMIT" ]; then
             VERSION=$BASE_VERSION
           else
             VERSION=$(echo $LAST_TAG | sed '/pyvelox-v//')
           fi
-          NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF=$NF++ ; print}')
+          NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF++ ; print}')
           echo "build_version=${NEXT_VERSION}.dev${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
           
       - run: mkdir -p .ccache
@@ -102,6 +102,8 @@ jobs:
 
       - name: "Create sdist"
         if: matrix.os == 'ubuntu-22.04'
+        env:
+          BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         run: |
           python setup.py sdist --dist-dir wheelhouse
                   

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -106,7 +106,6 @@ jobs:
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output &&
             cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
-            ccache -o cache_dir="/output/.ccache" &&
             ccache -s
           CIBW_ENVIRONMENT_PASS_LINUX: CCACHE_DIR BUILD_VERSION
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -73,8 +73,10 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
-            mkdir -p /output &&
-            cp -R /host/${{ github.workspace }}/.ccache /output/.ccache
+            mkdir -p /output/.ccache &&
+            cp -Rv /host${{ github.workspace }}/.ccache/* /output/.ccache &&
+            ls /output/.ccache &&
+            ccache -s
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"
           CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/.ccache"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -78,7 +78,7 @@ jobs:
           LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0 || echo $INITIAL_COMMIT)
           COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
 
-          if [ $LAST_TAG == $INITIAL_COMMIT ]; then
+          if [ $LAST_TAG = $INITIAL_COMMIT ]; then
             VERSION=$BASE_VERSION
           else
             VERSION=$(echo $LAST_TAG | sed '/pyvelox-v//')

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -60,12 +60,12 @@ jobs:
             github_checkout facebook/folly "v2022.11.14.00" &&
             BINARY_DIR=_build &&
             mkdir -p "${BINARY_DIR}" &&
-            cmake -Wno-dev -B"${BINARY_DIR}" \
-              -GNinja \
-              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-              -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" \
-              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)"" \
+            cmake -Wno-dev -B"${BINARY_DIR}" 
+              -GNinja 
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
+              -DCMAKE_CXX_STANDARD=17 
+              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" 
+              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)"" 
               -DBUILD_TESTING=OFF &&
             ninja -C "${BINARY_DIR}" install
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -57,6 +57,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
           submodules: recursive
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -80,12 +80,16 @@ jobs:
           CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse
-
+      - name: "Move .ccache to workspace"
+        if: matrix.os != 'macos-11'
+        run: |
+          mkdir -p .ccache
+          cp -R /output/.ccache/* .ccache
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: cache
         with:
-          path: "${{ matrix.os != 'macos-11' && 'wheelhouse/' || '' }}.ccache"
+          path: ".ccache"
           key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -14,16 +14,10 @@
 
 name: Build Pyvelox Wheels
 
-on: 
-  push:
-    branches:
-      - main
-    paths:
-      - 'velox/**'
-      - '!velox/docs/**'
-      - 'third_party/**'
-      - 'pyvelox/**'
-      - '.github/workflows/build_pyvelox.yml'
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '15 0 * * *'
   pull_request:
     paths:
       - 'velox/**'

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -56,9 +56,9 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
-            export COMPILER_FLAGS=$(get_cxx_flags "SSE") &&
+            export COMPILER_FLAGS=$(get_cxx_flags "sse") &&
             github_checkout facebook/folly "v2022.11.14.00" &&
-            cmake_install -DBUILD_TESTS=OFF
+            cmake_install -DBUILD_TESTS=OFF DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -74,6 +74,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output/.ccache &&
+            ls -l /host &&
             cp -Rv /host${{ github.workspace }}/.ccache/* /output/.ccache &&
             ls /output/.ccache &&
             ccache -s

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -74,7 +74,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output &&
-            ls -la /host${{ github.workspace }} &&
+            echo $CCACHE_DIR &&
             cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
             ls /output/.ccache &&
             ccache -s

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -57,7 +57,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
             echo "Installing folly from source..." &&
-            export COMPILER_FLAGS=$(get_cxx_flags) &&
+            export COMPILER_FLAGS=$(CPU_TARGET="" get_cxx_flags) &&
             github_checkout facebook/folly "v2022.11.14.00" &&
             cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+
       - uses: actions/setup-python@v4
         with:
           python-version: '3.10'
@@ -98,7 +99,12 @@ jobs:
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV
-        
+
+      - name: "Create sdist"
+        if: matrix.os == 'ubuntu-22.04'
+        run: |
+          python setup.py sdist --dist-dir wheelhouse
+                  
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0
         env:
@@ -123,11 +129,6 @@ jobs:
           BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         with:
           output-dir: wheelhouse
-
-      - name: "Create sdist"
-        if: matrix.os == 'ubuntu-22.04'
-        run: |
-          python setup.py sdist --dist-dir wheelhouse
 
       - name: "Move .ccache to workspace"
         if: matrix.os != 'macos-11'

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -50,7 +50,7 @@ jobs:
           # required for preadv/pwritev
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: "x86_64"
-          CIBW_BUILD: "cp39-* cp310-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
           CIBW_BEFORE_ALL_MACOS: >

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -84,7 +84,7 @@ jobs:
         if: matrix.os != 'macos-11'
         run: |
           mkdir -p .ccache
-          cp -R /output/.ccache/* .ccache
+          cp -R ./wheelhouse/.ccache/* .ccache
       - name: "Save ccache"
         uses: actions/cache/save@v3
         id: cache

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -57,6 +57,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
+          CIBW_TEST_COMMAND: "cd {project} && python -m unittest -v"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -59,9 +59,9 @@ jobs:
           # required for preadv/pwritev
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: "x86_64"
-          # On PRs only build for Python 3.9
-          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp39-*' || 'cp39-* cp310-* cp311-*' }}
-          CIBW_SKIP: "*musllinux*"
+          # On PRs only build for Python 3.7
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp37-*' || 'cp3*' }}
+          CIBW_SKIP: "*musllinux* cp36-*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh && 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -18,19 +18,7 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'velox/**'
-      - '!velox/docs/**'
-      - 'third_party/**'
-      - 'pyvelox/**'
-      - '.github/workflows/build_pyvelox.yml'
   pull_request:
-    paths:
-      - 'velox/**'
-      - '!velox/docs/**'
-      - 'third_party/**'
-      - 'pyvelox/**'
-      - '.github/workflows/build_pyvelox.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -56,9 +56,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
-            CPU_TARGET="avx" &&
-            COMPILER_FLAGS=$(get_cxx_flags "$CPU_TARGET") &&
-            export COMPILER_FLAGS &&
+            export COMPILER_FLAGS=$(get_cxx_flags "SSE") &&
             github_checkout facebook/folly "v2022.11.14.00" &&
             cmake_install -DBUILD_TESTS=OFF
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -75,7 +75,7 @@ jobs:
           INITIAL_COMMIT=5d4db2569b7c249644bf36a543ba1bd8f12bf77c
           BASE_VERSION=0.0.0
 
-          LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0) || $INITIAL_COMMIT
+          LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0 || echo $INITIAL_COMMIT)
           COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
 
           if [ $LAST_TAG == $INITIAL_COMMIT ]; then

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -60,7 +60,7 @@ jobs:
           key: ccache-wheels-${{ github.sha }}
           restore-keys: |
             ccache-wheels-
-            
+
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV
@@ -79,6 +79,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
+          CIBW_TEST_SKIP: "*macos*"
           CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/host/' || '' }}${{ github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -23,6 +23,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -66,7 +66,7 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
-          CIBW_TEST_COMMAND: "cd {project} && python -m unittest -v"
+          CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CCACHE_DIR: "${{ matrix.os == 'macos-11' && '' || '/host/' }}${{ github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-
+      - run: mkdir -p .ccache
       - name: "Restore ccache"
         uses: actions/cache/restore@v3
         id: restore-cache

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -58,6 +58,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+    
       - name: "Determine Version"
         if: ${{ !inputs.version && github.event_name != 'pull_request' }}
         id: version
@@ -121,6 +125,7 @@ jobs:
           output-dir: wheelhouse
 
       - name: "Create sdist"
+        if: matrix.os == 'ubuntu-22.04'
         run: |
           python setup.py sdist --dist-dir wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -67,6 +67,7 @@ jobs:
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV
+          sysctl -a
         
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -56,7 +56,8 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
-            export COMPILER_FLAGS=$(get_cxx_flags "sse") &&
+            export CPU_TARGET=sse &&
+            export COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET) &&
             github_checkout facebook/folly "v2022.11.14.00" &&
             cmake_install -DBUILD_TESTS=OFF DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -18,7 +18,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'velox/**'
+      - '!velox/docs/**'
+      - 'third_party/**'
+      - 'pyvelox/**'
+      - '.github/workflows/build_pyvelox.yml'
   pull_request:
+    paths:
+      - 'velox/**'
+      - '!velox/docs/**'
+      - 'third_party/**'
+      - 'pyvelox/**'
+      - '.github/workflows/build_pyvelox.yml'
 
 permissions:
   contents: read
@@ -48,7 +60,10 @@ jobs:
           key: ccache-wheels-${{ github.sha }}
           restore-keys: |
             ccache-wheels-
-
+      - name: Debug
+        run: |
+          source ./scripts/setup-helper-functions.sh
+          get_cxx_flags
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -110,7 +110,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output &&
-            cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
+            cp -R /host${{ github.workspace }}/.ccache /output/.ccache &&
             ccache -s
           CIBW_ENVIRONMENT_PASS_LINUX: CCACHE_DIR BUILD_VERSION
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
@@ -156,7 +156,7 @@ jobs:
           path: ./wheelhouse
       
       - run: ls wheelhouse
-      
+
       - uses: actions/setupo-python@v3
         with:
           python-version: 3.10

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -49,7 +49,14 @@ jobs:
           CIBW_BUILD: "cp39-* cp310-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
-          CIBW_BEFORE_ALL_MACOS: "bash {package}/scripts/setup-macos.sh"
+          CIBW_BEFORE_ALL_MACOS: >
+            bash {package}/scripts/setup-macos.sh &&
+            source {package}/scripts/setup-helper-functions.sh &&
+            CPU_TARGET="avx" &&
+            COMPILER_FLAGS=$(get_cxx_flags "$CPU_TARGET") &&
+            export COMPILER_FLAGS &&
+            github_checkout facebook/folly "v2022.11.14.00" &&
+            cmake_install -DBUILD_TESTS=OFF
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -60,12 +60,12 @@ jobs:
             github_checkout facebook/folly "v2022.11.14.00" &&
             BINARY_DIR=_build &&
             mkdir -p "${BINARY_DIR}" &&
-            cmake -Wno-dev -B"${BINARY_DIR}" 
-              -GNinja 
-              -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
-              -DCMAKE_CXX_STANDARD=17 
-              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" 
-              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)" 
+            cmake -Wno-dev -B"${BINARY_DIR}" \
+              -GNinja \
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" \
+              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)" \
               -DBUILD_TESTING=OFF &&
             ninja -C "${BINARY_DIR}" install
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -168,7 +168,7 @@ jobs:
 
       - uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@v1.6.4

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -82,7 +82,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
-          CCACHE_DIR: "${{ matrix.os == 'macos-11' && '' || '/host/' }}${{ github.workspace }}/.ccache"
+          CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/host/' || '' }}${{ github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -56,10 +56,10 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
-            export CPU_TARGET=sse &&
-            export COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET) &&
+            echo "Installing folly from source..." &&
+            export COMPILER_FLAGS=$(get_cxx_flags) &&
             github_checkout facebook/folly "v2022.11.14.00" &&
-            cmake_install -DBUILD_TESTS=OFF DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
+            cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -74,7 +74,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output/.ccache &&
-            ls -l /host &&
+            ls -la /host${{ github.workspace }} &&
             cp -Rv /host${{ github.workspace }}/.ccache/* /output/.ccache &&
             ls /output/.ccache &&
             ccache -s

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -28,8 +28,8 @@ on:
         required: false
         type: boolean
         default: false
-  schedule:
-    - cron: '15 0 * * *'
+  # schedule:
+  #   - cron: '15 0 * * *'
   pull_request:
     paths:
       - 'velox/**'
@@ -71,10 +71,11 @@ jobs:
           # count number of commits since last tag matching a regex
           # and use that to determine the version number
           # e.g. if the last tag is 0.0.1, and there have been 5 commits since then
-          # the version will be 0.0.2.dev5
+          # the version will be 0.0.1a5
           git fetch --tags
           INITIAL_COMMIT=5d4db2569b7c249644bf36a543ba1bd8f12bf77c
-          BASE_VERSION=0.0.0
+          # Can't use PCRE for portability
+          BASE_VERSION=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' version.txt)
 
           LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0 || echo $INITIAL_COMMIT)
           COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
@@ -84,8 +85,8 @@ jobs:
           else
             VERSION=$(echo $LAST_TAG | sed '/pyvelox-v//')
           fi
-          NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF++ ; print}')
-          echo "build_version=${NEXT_VERSION}.dev${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
+          # NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF++ ; print}')
+          echo "build_version=${VERSION}a${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
           
       - run: mkdir -p .ccache
       - name: "Restore ccache"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -58,7 +58,6 @@ jobs:
             source {package}/scripts/setup-helper-functions.sh &&
             echo "Installing folly from source..." &&
             github_checkout facebook/folly "v2022.11.14.00" &&
-            cmake_install -DBUILD_TESTS=OFF
             BINARY_DIR=_build &&
             mkdir -p "${BINARY_DIR}" &&
             cmake -Wno-dev -B"${BINARY_DIR}" \

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -67,7 +67,6 @@ jobs:
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV
-          sysctl -a
         
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.0

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -74,9 +74,8 @@ jobs:
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
             mkdir -p /output &&
-            echo $CCACHE_DIR &&
             cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
-            ls /output/.ccache &&
+            ccache -o cache_dir="/output/.ccache" &&
             ccache -s
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -18,7 +18,19 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'velox/**'
+      - '!velox/docs/**'
+      - 'third_party/**'
+      - 'pyvelox/**'
+      - '.github/workflows/build_pyvelox.yml'
   pull_request:
+    paths:
+      - 'velox/**'
+      - '!velox/docs/**'
+      - 'third_party/**'
+      - 'pyvelox/**'
+      - '.github/workflows/build_pyvelox.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -50,7 +50,8 @@ jobs:
           # required for preadv/pwritev
           MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_ARCHS: "x86_64"
-          CIBW_BUILD: "cp39-* cp310-* cp311-*"
+          # On PRs only build for Python 3.9
+          CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp39-*' || 'cp39-* cp310-* cp311-*' }}
           CIBW_SKIP: "*musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
           CIBW_BEFORE_ALL_MACOS: >

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -57,9 +57,18 @@ jobs:
             bash {package}/scripts/setup-macos.sh &&
             source {package}/scripts/setup-helper-functions.sh &&
             echo "Installing folly from source..." &&
-            export COMPILER_FLAGS=$(CPU_TARGET="" get_cxx_flags) &&
             github_checkout facebook/folly "v2022.11.14.00" &&
-            cmake_install -DBUILD_TESTS=OFF -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)"
+            cmake_install -DBUILD_TESTS=OFF
+            BINARY_DIR=_build &&
+            mkdir -p "${BINARY_DIR}" &&
+            cmake -Wno-dev -B"${BINARY_DIR}" \
+              -GNinja \
+              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" \
+              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)"" \
+              -DBUILD_TESTING=OFF &&
+            ninja -C "${BINARY_DIR}" install
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -51,9 +51,9 @@ jobs:
         id: restore-cache
         with:
           path: ".ccache"
-          key: ccache-wheels-${{ github.sha }}
+          key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
           restore-keys: |
-            ccache-wheels-
+            ccache-wheels-${{ matrix.os }}-
 
       - if: matrix.os == 'macos-11'
         run: |
@@ -72,9 +72,11 @@ jobs:
           CIBW_BEFORE_ALL_MACOS: >
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
+          CIBW_BEFORE_ALL_LINUX: >
+            cp -R /host/${{ github.workspace }}/.ccache /output/.ccache
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"
-          CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/host/' || '' }}${{ github.workspace }}/.ccache"
+          CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse
 
@@ -82,8 +84,8 @@ jobs:
         uses: actions/cache/save@v3
         id: cache
         with:
-          path: ".ccache"
-          key: ccache-wheels-${{ github.sha }}
+          path: "${{ matrix.os != 'macos-11' && 'wheelhouse/' || '' }}.ccache"
+          key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -40,6 +40,15 @@ jobs:
         with:
           submodules: recursive
 
+      - name: "Restore ccache"
+        uses: actions/cache/restore@v3
+        id: restore-cache
+        with:
+          path: ".ccache"
+          key: ccache-wheels-${{ github.sha }}
+          restore-keys: |
+            ccache-wheels-
+
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV
@@ -58,9 +67,18 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_TEST_COMMAND: "cd {project} && python -m unittest -v"
+          CCACHE_DIR: "${{ matrix.os == 'macos-11' && '' || '/host/' }}${{ github.workspace }}/.ccache"
         with:
           output-dir: wheelhouse
 
+      - name: "Save ccache"
+        uses: actions/cache/save@v3
+        id: cache
+        with:
+          path: ".ccache"
+          key: ccache-wheels-${{ github.sha }}
+
       - uses: actions/upload-artifact@v3
         with:
+          name: wheels
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -65,7 +65,7 @@ jobs:
               -DCMAKE_POSITION_INDEPENDENT_CODE=ON 
               -DCMAKE_CXX_STANDARD=17 
               -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" 
-              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)"" 
+              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)" 
               -DBUILD_TESTING=OFF &&
             ninja -C "${BINARY_DIR}" install
         with:

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -73,6 +73,7 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
+            mkdir -p /output &&
             cp -R /host/${{ github.workspace }}/.ccache /output/.ccache
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -166,7 +166,7 @@ jobs:
       
       - run: ls wheelhouse
 
-      - uses: actions/setupo-python@v3
+      - uses: actions/setup-python@v3
         with:
           python-version: 3.10
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -53,21 +53,7 @@ jobs:
           CIBW_BUILD: "cp39-* cp310-*"
           CIBW_SKIP: "*musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: "ghcr.io/facebookincubator/velox-dev:torcharrow-avx"
-          CIBW_BEFORE_ALL_MACOS: >
-            bash {package}/scripts/setup-macos.sh &&
-            source {package}/scripts/setup-helper-functions.sh &&
-            echo "Installing folly from source..." &&
-            github_checkout facebook/folly "v2022.11.14.00" &&
-            BINARY_DIR=_build &&
-            mkdir -p "${BINARY_DIR}" &&
-            cmake -Wno-dev -B"${BINARY_DIR}" \
-              -GNinja \
-              -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-              -DCMAKE_CXX_STANDARD=17 \
-              -DCMAKE_PREFIX_PATH="$(brew --prefix openssl@1.1)" \
-              -DCMAKE_CXX_FLAGS="$(get_cxx_flags)" \
-              -DBUILD_TESTING=OFF &&
-            ninja -C "${BINARY_DIR}" install
+          CIBW_BEFORE_ALL_MACOS: "bash {package}/scripts/setup-macos.sh"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -73,9 +73,9 @@ jobs:
             bash {package}/scripts/setup-macos.sh && 
             bash {package}/scripts/setup-macos.sh install_folly
           CIBW_BEFORE_ALL_LINUX: >
-            mkdir -p /output/.ccache &&
+            mkdir -p /output &&
             ls -la /host${{ github.workspace }} &&
-            cp -Rv /host${{ github.workspace }}/.ccache/* /output/.ccache &&
+            cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
             ls /output/.ccache &&
             ccache -s
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -60,10 +60,7 @@ jobs:
           key: ccache-wheels-${{ github.sha }}
           restore-keys: |
             ccache-wheels-
-      - name: Debug
-        run: |
-          source ./scripts/setup-helper-functions.sh
-          get_cxx_flags
+            
       - if: matrix.os == 'macos-11'
         run: |
           echo "OPENSSL_ROOT_DIR=/usr/local/opt/openssl@1.1/" >> $GITHUB_ENV

--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -16,6 +16,13 @@ name: Build Pyvelox Wheels
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'pyvelox version'
+        required: false
+      ref:
+        description: 'git ref to build'
+        required: false
   schedule:
     - cron: '15 0 * * *'
   pull_request:
@@ -44,7 +51,31 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.ref || github.ref }}
           submodules: recursive
+      - name: "Determine Version"
+        if: ${{ !inputs.version && github.event_name != 'pull_request' }}
+        id: version
+        run: |
+          # count number of commits since last tag matching a regex
+          # and use that to determine the version number
+          # e.g. if the last tag is 0.0.1, and there have been 5 commits since then
+          # the version will be 0.0.2.dev5
+          git fetch --tags
+          INITIAL_COMMIT=5d4db2569b7c249644bf36a543ba1bd8f12bf77c
+          BASE_VERSION=0.0.0
+
+          LAST_TAG=$(git describe --tags --match "pyvelox-v[0-9]*" --abbrev=0) || $INITIAL_COMMIT
+          COMMITS_SINCE_TAG=$(git rev-list --count ${LAST_TAG}..HEAD)
+
+          if [ $LAST_TAG == $INITIAL_COMMIT ]; then
+            VERSION=$BASE_VERSION
+          else
+            VERSION=$(echo $LAST_TAG | sed '/pyvelox-v//')
+          fi
+          NEXT_VERSION=$(echo $VERSION | awk -F. -v OFS=. '{$NF=$NF++ ; print}')
+          echo "build_version=${NEXT_VERSION}.dev${COMMITS_SINCE_TAG}" >> $GITHUB_OUTPUT
+          
       - run: mkdir -p .ccache
       - name: "Restore ccache"
         uses: actions/cache/restore@v3
@@ -77,9 +108,11 @@ jobs:
             cp -Rv /host${{ github.workspace }}/.ccache /output/.ccache &&
             ccache -o cache_dir="/output/.ccache" &&
             ccache -s
+          CIBW_ENVIRONMENT_PASS_LINUX: CCACHE_DIR BUILD_VERSION
           CIBW_TEST_COMMAND: "cd {project}/pyvelox && python -m unittest -v"
           CIBW_TEST_SKIP: "*macos*"
           CCACHE_DIR: "${{ matrix.os != 'macos-11' && '/output' || github.workspace }}/.ccache"
+          BUILD_VERSION: "${{ inputs.version || steps.version.outputs.build_version }}"
         with:
           output-dir: wheelhouse
       - name: "Move .ccache to workspace"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)
 option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
 option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
+option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 
 option(VELOX_BUILD_TEST_UTILS "Builds Velox test utilities" OFF)
 option(VELOX_BUILD_PYTHON_PACKAGE "Builds Velox Python bindings" OFF)
@@ -141,6 +142,21 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
   set(VELOX_ENABLE_SUBSTRAIT OFF)
   set(VELOX_CODEGEN_SUPPORT OFF)
   set(VELOX_ENABLE_BENCHMARKS_BASIC OFF)
+endif()
+
+if(VELOX_ENABLE_CCACHE
+   AND NOT CMAKE_C_COMPILER_LAUNCHER
+   AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
+
+  find_program(CCACHE_FOUND ccache)
+
+  if(CCACHE_FOUND)
+    message(STATUS "Using ccache: ${CCACHE_FOUND}")
+    set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_FOUND})
+    set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_FOUND})
+    # keep comments as they might matter to the compiler
+    set(ENV{CCACHE_COMMENTS} "1")
+  endif()
 endif()
 
 if(VELOX_ENABLE_S3)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ find_package(gflags COMPONENTS shared)
 find_package(glog REQUIRED)
 
 set_source(fmt)
-resolve_dependency(fmt 8.0.1)
+resolve_dependency(fmt)
 
 find_library(EVENT event)
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+inculde CMakeLists.txt
+include *.cmake
+graft CMake
+graft third_party
+graft velox
+prune velox/docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
-inculde CMakeLists.txt
+inculde *.txt
 include *.cmake
 graft CMake
 graft third_party
 graft velox
+graft pyvelox
+graft scripts
 prune velox/docs

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -81,9 +81,7 @@ macro(build_folly)
     # Avoid possible errors for known warnings
     target_compile_options(folly PUBLIC ${EXTRA_CXX_FLAGS})
     add_library(Folly::folly ALIAS folly)
-    target_include_directories(
-      folly INTERFACE $<BUILD_INTERFACE:${folly_SOURCE_DIR}/folly>
-                      $<INSTALL_INTERFACE:include/folly>)
+    target_include_directories(folly INTERFACE ${folly_SOURCE_DIR}/folly)
   endif()
   set(FOLLY_BENCHMARK_STATIC_LIB
       ${folly_BINARY_DIR}/folly/libfollybenchmark${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -81,7 +81,9 @@ macro(build_folly)
     # Avoid possible errors for known warnings
     target_compile_options(folly PUBLIC ${EXTRA_CXX_FLAGS})
     add_library(Folly::folly ALIAS folly)
-    target_include_directories(folly INTERFACE ${folly_SOURCE_DIR}/folly)
+    target_include_directories(
+      folly INTERFACE $<BUILD_INTERFACE:${folly_SOURCE_DIR}/folly>
+                      $<INSTALL_INTERFACE:include/folly>)
   endif()
   set(FOLLY_BENCHMARK_STATIC_LIB
       ${folly_BINARY_DIR}/folly/libfollybenchmark${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/ThirdpartyToolchain.cmake
+++ b/ThirdpartyToolchain.cmake
@@ -81,7 +81,6 @@ macro(build_folly)
     # Avoid possible errors for known warnings
     target_compile_options(folly PUBLIC ${EXTRA_CXX_FLAGS})
     add_library(Folly::folly ALIAS folly)
-    target_include_directories(folly INTERFACE ${folly_SOURCE_DIR}/folly)
   endif()
   set(FOLLY_BENCHMARK_STATIC_LIB
       ${folly_BINARY_DIR}/folly/libfollybenchmark${CMAKE_STATIC_LIBRARY_SUFFIX})

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,7 +127,7 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  CPU_TARGET="${CPU_TARGET-avx}"
+  CPU_TARGET="${CPU_TARGET:-avx}"
   COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,7 +127,7 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  CPU_TARGET="${CPU_TARGET:-avx}"
+  CPU_TARGET="${CPU_TARGET-avx}"
   COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -114,7 +114,6 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_double_conversion
   run_and_time install_re2
-  run_and_time install_folly
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -85,6 +85,12 @@ function install_fmt {
   cmake_install -DFMT_TEST=OFF
 }
 
+function install_folly {
+  github_checkout facebook/folly "v2022.11.14.00"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+    cmake_install -DBUILD_TESTS=OFF
+}
+
 function install_double_conversion {
   github_checkout google/double-conversion v3.1.5
   cmake_install -DBUILD_TESTING=OFF
@@ -108,6 +114,7 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_double_conversion
   run_and_time install_re2
+  run_and_time install_folly
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = Path(__file__).parent.resolve()
 
-with open('README.md') as f:
+with open("README.md") as f:
     readme = f.read()
 
 # Override build directory
@@ -161,7 +161,7 @@ setup(
     version=VERSION,
     description="Python bindings and extensions for Velox",
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url="https://github.com/facebookincubator/velox",
     author="Meta",
     author_email="velox@fb.com",
@@ -176,7 +176,7 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
-        'License :: OSI Approved :: Apache Software License',
+        "License :: OSI Approved :: Apache Software License",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ ROOT_DIR = Path(__file__).parent.resolve()
 with open("README.md") as f:
     readme = f.read()
 
+
 # Override build directory
 class BuildCommand(distutils.command.build.build):
     def initialize_options(self):

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(
     url="https://github.com/facebookincubator/velox",
     author="Meta",
     author_email="velox@fb.com",
-    license="BSD",
+    license="Apache License 2.0",
     install_requires=[
         "cffi",
         "typing",
@@ -176,7 +176,7 @@ setup(
     classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
+        'License :: OSI Approved :: Apache Software License',
         "Operating System :: POSIX :: Linux",
         "Programming Language :: C++",
         "Programming Language :: Python :: 3.7",

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,8 @@ from setuptools.command.build_ext import build_ext
 
 ROOT_DIR = Path(__file__).parent.resolve()
 
+with open('README.md') as f:
+    readme = f.read()
 
 # Override build directory
 class BuildCommand(distutils.command.build.build):
@@ -158,6 +160,8 @@ setup(
     name="pyvelox",
     version=VERSION,
     description="Python bindings and extensions for Velox",
+    long_description=readme,
+    long_description_content_type='text/markdown',
     url="https://github.com/facebookincubator/velox",
     author="Meta",
     author_email="velox@fb.com",


### PR DESCRIPTION
This PR sets up a CI Job to build pyvelox wheels for x86_64 MacOS and Linux for python 3.9 - 3.11. The wheels are uploaded as artifacts. We can easily add a job to publish them to pypi regularly. 