### PR TITLE
Fix lastRangeEnd_ set in resetInput of ByteStream

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -26,7 +26,7 @@ struct ByteRange {
   // Start of buffer. Not owned.
   uint8_t* buffer;
 
-  // Number of bytes or bits  starting at 'buffer'.
+  // Number of bytes or bits starting at 'buffer'.
   int32_t size;
 
   // Index of next byte/bit to be read/written in 'buffer'.
@@ -112,6 +112,7 @@ class ByteStream {
   void resetInput(std::vector<ByteRange>&& ranges) {
     ranges_ = std::move(ranges);
     current_ = &ranges_[0];
+    lastRangeEnd_ = ranges_.back().size;
   }
 
   void setRange(ByteRange range) {

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -92,3 +92,21 @@ TEST_F(ByteStreamTest, outputStream) {
   // We expect dropping the stream and the iobuf frees the backing memory.
   EXPECT_EQ(0, mmapAllocator_->numAllocated());
 }
+
+TEST_F(ByteStreamTest, resetInput) {
+  uint8_t* const kFakeBuffer = reinterpret_cast<uint8_t*>(this);
+  std::vector<ByteRange> byteRanges;
+  size_t totalBytes{0};
+  size_t lastRangeEnd;
+  for (int32_t i = 0; i < 32; ++i) {
+    byteRanges.push_back(ByteRange{kFakeBuffer, 4096 + i, 0});
+    totalBytes += 4096 + i;
+  }
+  lastRangeEnd = byteRanges.back().size;
+  ByteStream byteStream;
+  ASSERT_EQ(byteStream.size(), 0);
+  ASSERT_EQ(byteStream.lastRangeEnd(), 0);
+  byteStream.resetInput(std::move(byteRanges));
+  ASSERT_EQ(byteStream.size(), totalBytes);
+  ASSERT_EQ(byteStream.lastRangeEnd(), lastRangeEnd);
+}


### PR DESCRIPTION
lastRangeEnd_ is not set in ByteStream which cause lastRangeEnd()
and size() reports wrong value.