### PR TITLE
Add option to cap max vector size generated by VectorFuzzer

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -121,6 +121,10 @@ class VectorFuzzer {
     /// `containerLength` is treated as maximum length.
     bool containerVariableLength{false};
 
+    /// Restricts the maximum inner (elements) vector size created when
+    /// generating nested vectors (arrays, maps, and rows).
+    size_t complexElementsMaxSize{10000};
+
     /// If true, generated map keys are normalized (unique and not-null).
     bool normalizeMapKeys{true};
 

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -74,6 +74,8 @@ class VectorFuzzerTest : public testing::Test {
     }
   }
 
+  void validateMaxSizes(VectorPtr vector, size_t maxSize);
+
  private:
   std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
 };
@@ -573,6 +575,52 @@ TEST_F(VectorFuzzerTest, lazyOverDictionary) {
       ASSERT_EQ(dict->wrappedIndex(row), lazy->wrappedIndex(row));
     }
   });
+}
+
+void VectorFuzzerTest::validateMaxSizes(VectorPtr vector, size_t maxSize) {
+  if (vector->typeKind() == TypeKind::ARRAY) {
+    validateMaxSizes(vector->template as<ArrayVector>()->elements(), maxSize);
+  } else if (vector->typeKind() == TypeKind::MAP) {
+    auto mapVector = vector->as<MapVector>();
+    validateMaxSizes(mapVector->mapKeys(), maxSize);
+    validateMaxSizes(mapVector->mapValues(), maxSize);
+  } else if (vector->typeKind() == TypeKind::ROW) {
+    auto rowVector = vector->as<RowVector>();
+    for (const auto& child : rowVector->children()) {
+      validateMaxSizes(child, maxSize);
+    }
+  }
+  EXPECT_LE(vector->size(), maxSize);
+}
+
+// Ensures we don't generate inner vectors exceeding `complexElementsMaxSize`.
+TEST_F(VectorFuzzerTest, complexTooLarge) {
+  VectorFuzzer::Options opts;
+  VectorFuzzer fuzzer(opts, pool());
+  VectorPtr vector;
+
+  vector = fuzzer.fuzzFlat(ARRAY(ARRAY(ARRAY(ARRAY(ARRAY(SMALLINT()))))));
+  validateMaxSizes(vector, opts.complexElementsMaxSize);
+
+  vector = fuzzer.fuzzFlat(MAP(
+      BIGINT(), MAP(SMALLINT(), MAP(INTEGER(), MAP(SMALLINT(), DOUBLE())))));
+  validateMaxSizes(vector, opts.complexElementsMaxSize);
+
+  vector = fuzzer.fuzzFlat(
+      ROW({BIGINT(), ROW({SMALLINT(), ROW({INTEGER()})}), DOUBLE()}));
+  validateMaxSizes(vector, opts.complexElementsMaxSize);
+
+  // Mix and match.
+  vector = fuzzer.fuzzFlat(
+      ROW({ARRAY(ROW({SMALLINT(), ROW({MAP(INTEGER(), DOUBLE())})}))}));
+  validateMaxSizes(vector, opts.complexElementsMaxSize);
+
+  // Try a more restrictive max size.
+  opts.complexElementsMaxSize = 100;
+  fuzzer.setOptions(opts);
+
+  vector = fuzzer.fuzzFlat(ARRAY(ARRAY(ARRAY(ARRAY(ARRAY(SMALLINT()))))));
+  validateMaxSizes(vector, opts.complexElementsMaxSize);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Adding maxVectorSize option to VectorFuzzer to restrict the maximum
size of inner vectors generated for nested complex types. We saw in fuzzer runs
some very large vectors being generated (10M strings) and hanging the fuzzer.

Differential Revision: D42909808

