### PR TITLE
Loop in findMappedFreeGroup should use step-length of kWidth instead …

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -593,7 +593,7 @@ int32_t MmapAllocator::SizeClass::findMappedFreeGroup() {
     index = 0;
   }
   auto lookupSize = mappedFreeLookup_.size() + kSimdTail;
-  for (auto counter = 0; counter <= lookupSize; ++counter) {
+  for (auto counter = 0; counter <= lookupSize; counter += kWidth) {
     auto candidates = xsimd::load_unaligned(mappedFreeLookup_.data() + index);
     auto bits = simd::allSetBitMask<int64_t>() ^
         simd::toBitMask(candidates == xsimd::broadcast<uint64_t>(0LL));


### PR DESCRIPTION
…of one

fix https://github.com/facebookincubator/velox/issues/3888