### PR TITLE
Document Spark functions

### DIFF
--- a/velox/docs/conf.py
+++ b/velox/docs/conf.py
@@ -46,7 +46,7 @@ copyright = "TBD"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["issue", "pr"]
+extensions = ["issue", "pr", "spark"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/velox/docs/ext/spark.py
+++ b/velox/docs/ext/spark.py
@@ -1,3 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """The Spark domain."""
 
 from __future__ import annotations
@@ -39,22 +53,23 @@ logger = logging.getLogger(__name__)
 
 # REs for Spark signatures
 py_sig_re = re.compile(
-    r'''^ ([\w.]*\.)?            # class name(s)
+    r"""^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
           (?: \(\s*(.*)\s*\)     # optional: arguments
            (?:\s* -> \s* (.*))?  #           return annotation
           )? $                   # and nothing more
-          ''', re.VERBOSE)
-
+          """,
+    re.VERBOSE,
+)
 
 pairindextypes = {
-    'module':    _('module'),
-    'keyword':   _('keyword'),
-    'operator':  _('operator'),
-    'object':    _('object'),
-    'exception': _('exception'),
-    'statement': _('statement'),
-    'builtin':   _('built-in function'),
+    "module": _("module"),
+    "keyword": _("keyword"),
+    "operator": _("operator"),
+    "object": _("object"),
+    "exception": _("exception"),
+    "statement": _("statement"),
+    "builtin": _("built-in function"),
 }
 
 
@@ -73,52 +88,63 @@ class ModuleEntry(NamedTuple):
     deprecated: bool
 
 
-def parse_reftarget(reftarget: str, suppress_prefix: bool = False
-                    ) -> tuple[str, str, str, bool]:
+def parse_reftarget(
+    reftarget: str, suppress_prefix: bool = False
+) -> tuple[str, str, str, bool]:
     """Parse a type string and return (reftype, reftarget, title, refspecific flag)"""
     refspecific = False
-    if reftarget.startswith('.'):
+    if reftarget.startswith("."):
         reftarget = reftarget[1:]
         title = reftarget
         refspecific = True
-    elif reftarget.startswith('~'):
+    elif reftarget.startswith("~"):
         reftarget = reftarget[1:]
-        title = reftarget.split('.')[-1]
+        title = reftarget.split(".")[-1]
     elif suppress_prefix:
-        title = reftarget.split('.')[-1]
-    elif reftarget.startswith('typing.'):
+        title = reftarget.split(".")[-1]
+    elif reftarget.startswith("typing."):
         title = reftarget[7:]
     else:
         title = reftarget
 
-    if reftarget == 'None' or reftarget.startswith('typing.'):
+    if reftarget == "None" or reftarget.startswith("typing."):
         # typing module provides non-class types.  Obj reference is good to refer them.
-        reftype = 'obj'
+        reftype = "obj"
     else:
-        reftype = 'class'
+        reftype = "class"
 
     return reftype, reftarget, title, refspecific
 
 
-def type_to_xref(target: str, env: BuildEnvironment | None = None,
-                 suppress_prefix: bool = False) -> addnodes.pending_xref:
+def type_to_xref(
+    target: str, env: BuildEnvironment | None = None, suppress_prefix: bool = False
+) -> addnodes.pending_xref:
     """Convert a type string to a cross reference node."""
     if env:
-        kwargs = {'spark:module': env.ref_context.get('spark:module'),
-                  'spark:class': env.ref_context.get('spark:class')}
+        kwargs = {
+            "spark:module": env.ref_context.get("spark:module"),
+            "spark:class": env.ref_context.get("spark:class"),
+        }
     else:
         kwargs = {}
 
     reftype, target, title, refspecific = parse_reftarget(target, suppress_prefix)
     contnodes = [nodes.Text(title)]
 
-    return pending_xref('', *contnodes,
-                        refdomain='spark', reftype=reftype, reftarget=target,
-                        refspecific=refspecific, **kwargs)
+    return pending_xref(
+        "",
+        *contnodes,
+        refdomain="spark",
+        reftype=reftype,
+        reftarget=target,
+        refspecific=refspecific,
+        **kwargs,
+    )
 
 
 def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Node]:
     """Parse type annotation."""
+
     def unparse(node: ast.AST) -> list[Node]:
         if isinstance(node, ast.Attribute):
             return [nodes.Text(f"{unparse(node.value)[0]}.{node.attr}")]
@@ -128,18 +154,20 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
             result.extend(unparse(node.right))
             return result
         elif isinstance(node, ast.BitOr):
-            return [addnodes.desc_sig_space(),
-                    addnodes.desc_sig_punctuation('', '|'),
-                    addnodes.desc_sig_space()]
+            return [
+                addnodes.desc_sig_space(),
+                addnodes.desc_sig_punctuation("", "|"),
+                addnodes.desc_sig_space(),
+            ]
         elif isinstance(node, ast.Constant):
             if node.value is Ellipsis:
-                return [addnodes.desc_sig_punctuation('', "...")]
+                return [addnodes.desc_sig_punctuation("", "...")]
             elif isinstance(node.value, bool):
-                return [addnodes.desc_sig_keyword('', repr(node.value))]
+                return [addnodes.desc_sig_keyword("", repr(node.value))]
             elif isinstance(node.value, int):
-                return [addnodes.desc_sig_literal_number('', repr(node.value))]
+                return [addnodes.desc_sig_literal_number("", repr(node.value))]
             elif isinstance(node.value, str):
-                return [addnodes.desc_sig_literal_string('', repr(node.value))]
+                return [addnodes.desc_sig_literal_string("", repr(node.value))]
             else:
                 # handles None, which is further handled by type_to_xref later
                 # and fallback for other types that should be converted
@@ -149,38 +177,38 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
         elif isinstance(node, ast.Index):
             return unparse(node.value)
         elif isinstance(node, ast.Invert):
-            return [addnodes.desc_sig_punctuation('', '~')]
+            return [addnodes.desc_sig_punctuation("", "~")]
         elif isinstance(node, ast.List):
-            result = [addnodes.desc_sig_punctuation('', '[')]
+            result = [addnodes.desc_sig_punctuation("", "[")]
             if node.elts:
                 # check if there are elements in node.elts to only pop the
                 # last element of result if the for-loop was run at least
                 # once
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_punctuation("", ","))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
-            result.append(addnodes.desc_sig_punctuation('', ']'))
+            result.append(addnodes.desc_sig_punctuation("", "]"))
             return result
         elif isinstance(node, ast.Module):
             return sum((unparse(e) for e in node.body), [])
         elif isinstance(node, ast.Name):
             return [nodes.Text(node.id)]
         elif isinstance(node, ast.Subscript):
-            if getattr(node.value, 'id', '') in {'Optional', 'Union'}:
+            if getattr(node.value, "id", "") in {"Optional", "Union"}:
                 return _unparse_pep_604_annotation(node)
             result = unparse(node.value)
-            result.append(addnodes.desc_sig_punctuation('', '['))
+            result.append(addnodes.desc_sig_punctuation("", "]"))
             result.extend(unparse(node.slice))
-            result.append(addnodes.desc_sig_punctuation('', ']'))
+            result.append(addnodes.desc_sig_punctuation("", "]"))
 
             # Wrap the Text nodes inside brackets by literal node if the subscript is a Literal
-            if result[0] in ('Literal', 'typing.Literal'):
+            if result[0] in ("Literal", "typing.Literal"):
                 for i, subnode in enumerate(result[1:], start=1):
                     if isinstance(subnode, nodes.Text):
-                        result[i] = nodes.literal('', '', subnode)
+                        result[i] = nodes.literal("", "", subnode)
             return result
         elif isinstance(node, ast.UnaryOp):
             return unparse(node.op) + unparse(node.operand)
@@ -189,13 +217,15 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
                 result = []
                 for elem in node.elts:
                     result.extend(unparse(elem))
-                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_punctuation("", ","))
                     result.append(addnodes.desc_sig_space())
                 result.pop()
                 result.pop()
             else:
-                result = [addnodes.desc_sig_punctuation('', '('),
-                          addnodes.desc_sig_punctuation('', ')')]
+                result = [
+                    addnodes.desc_sig_punctuation("", "("),
+                    addnodes.desc_sig_punctuation("", ")"),
+                ]
 
             return result
         else:
@@ -217,9 +247,9 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
             # e.g. a Union[] inside an Optional[]
             flattened.extend(unparse(subscript))
 
-        if getattr(node.value, 'id', '') == 'Optional':
+        if getattr(node.value, "id", "") == "Optional":
             flattened.extend(unparse(ast.BitOr()))
-            flattened.append(nodes.Text('None'))
+            flattened.append(nodes.Text("None"))
 
         return flattened
 
@@ -230,8 +260,11 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
             if isinstance(node, nodes.literal):
                 result.append(node[0])
             elif isinstance(node, nodes.Text) and node.strip():
-                if (result and isinstance(result[-1], addnodes.desc_sig_punctuation) and
-                        result[-1].astext() == '~'):
+                if (
+                    result
+                    and isinstance(result[-1], addnodes.desc_sig_punctuation)
+                    and result[-1].astext() == "~"
+                ):
                     result.pop()
                     result.append(type_to_xref(str(node), env, suppress_prefix=True))
                 else:
@@ -248,55 +281,62 @@ def _parse_arglist(
 ) -> addnodes.desc_parameterlist:
     """Parse a list of arguments using AST parser"""
     params = addnodes.desc_parameterlist(arglist)
-    sig = signature_from_str('(%s)' % arglist)
+    sig = signature_from_str("(%s)" % arglist)
     last_kind = None
     for param in sig.parameters.values():
         if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
             # PEP-570: Separator for Positional Only Parameter: /
-            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
-        if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
-                                                              param.POSITIONAL_ONLY,
-                                                              None):
+            params += addnodes.desc_parameter(
+                "", "", addnodes.desc_sig_operator("", "/")
+            )
+        if param.kind == param.KEYWORD_ONLY and last_kind in (
+            param.POSITIONAL_OR_KEYWORD,
+            param.POSITIONAL_ONLY,
+            None,
+        ):
             # PEP-3102: Separator for Keyword Only Parameter: *
-            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '*'))
+            params += addnodes.desc_parameter(
+                "", "", addnodes.desc_sig_operator("", "*")
+            )
 
         node = addnodes.desc_parameter()
         if param.kind == param.VAR_POSITIONAL:
-            node += addnodes.desc_sig_operator('', '*')
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_operator("", "*")
+            node += addnodes.desc_sig_name("", param.name)
         elif param.kind == param.VAR_KEYWORD:
-            node += addnodes.desc_sig_operator('', '**')
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_operator("", "**")
+            node += addnodes.desc_sig_name("", param.name)
         else:
-            node += addnodes.desc_sig_name('', param.name)
+            node += addnodes.desc_sig_name("", param.name)
 
         if param.annotation is not param.empty:
             children = _parse_annotation(param.annotation, env)
-            node += addnodes.desc_sig_punctuation('', ':')
+            node += addnodes.desc_sig_punctuation("", ":")
             node += addnodes.desc_sig_space()
-            node += addnodes.desc_sig_name('', '', *children)  # type: ignore
+            node += addnodes.desc_sig_name("", "", *children)  # type: ignore
         if param.default is not param.empty:
             if param.annotation is not param.empty:
                 node += addnodes.desc_sig_space()
-                node += addnodes.desc_sig_operator('', '=')
+                node += addnodes.desc_sig_operator("", "=")
                 node += addnodes.desc_sig_space()
             else:
-                node += addnodes.desc_sig_operator('', '=')
-            node += nodes.inline('', param.default, classes=['default_value'],
-                                 support_smartquotes=False)
+                node += addnodes.desc_sig_operator("", "=")
+            node += nodes.inline(
+                "", param.default, classes=["default_value"], support_smartquotes=False
+            )
 
         params += node
         last_kind = param.kind
 
     if last_kind == Parameter.POSITIONAL_ONLY:
         # PEP-570: Separator for Positional Only Parameter: /
-        params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
+        params += addnodes.desc_parameter("", "", addnodes.desc_sig_operator("", "/"))
 
     return params
 
 
 def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
-    """"Parse" a list of arguments separated by commas.
+    """ "Parse" a list of arguments separated by commas.
 
     Arguments can have "optional" annotations given by enclosing them in
     brackets.  Currently, this will split at any comma, even if it's inside a
@@ -305,25 +345,26 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
     paramlist = addnodes.desc_parameterlist()
     stack: list[Element] = [paramlist]
     try:
-        for argument in arglist.split(','):
+        for argument in arglist.split(","):
             argument = argument.strip()
             ends_open = ends_close = 0
-            while argument.startswith('['):
+            while argument.startswith("["):
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
                 argument = argument[1:].strip()
-            while argument.startswith(']'):
+            while argument.startswith("]"):
                 stack.pop()
                 argument = argument[1:].strip()
-            while argument.endswith(']') and not argument.endswith('[]'):
+            while argument.endswith("]") and not argument.endswith("[]"):
                 ends_close += 1
                 argument = argument[:-1].strip()
-            while argument.endswith('['):
+            while argument.endswith("["):
                 ends_open += 1
                 argument = argument[:-1].strip()
             if argument:
                 stack[-1] += addnodes.desc_parameter(
-                    '', '', addnodes.desc_sig_name(argument, argument))
+                    "", "", addnodes.desc_sig_name(argument, argument)
+                )
             while ends_open:
                 stack.append(addnodes.desc_optional())
                 stack[-2] += stack[-1]
@@ -343,6 +384,7 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
     else:
         signode += paramlist
 
+
 class SparkObject(ObjectDescription[Tuple[str, str]]):
     """
     Description of a general Python object.
@@ -350,18 +392,23 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
     """
+
     option_spec: OptionSpec = {
-        'noindex': directives.flag,
-        'noindexentry': directives.flag,
-        'nocontentsentry': directives.flag,
-        'module': directives.unchanged,
-        'canonical': directives.unchanged,
-        'annotation': directives.unchanged,
+        "noindex": directives.flag,
+        "noindexentry": directives.flag,
+        "nocontentsentry": directives.flag,
+        "module": directives.unchanged,
+        "canonical": directives.unchanged,
+        "annotation": directives.unchanged,
     }
 
     doc_field_types = [
-        Field('returnvalue', label=_('Returns'), has_arg=False,
-              names=('returns', 'return')),
+        Field(
+            "returnvalue",
+            label=_("Returns"),
+            has_arg=False,
+            names=("returns", "return"),
+        ),
     ]
 
     allow_nesting = False
@@ -393,34 +440,33 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
         prefix, name, arglist, retann = m.groups()
 
         # determine module and class name (if applicable), as well as full name
-        modname = self.options.get('module', self.env.ref_context.get('spark:module'))
-        classname = self.env.ref_context.get('spark:class')
+        modname = self.options.get("module", self.env.ref_context.get("spark:module"))
+        classname = self.env.ref_context.get("spark:class")
         if classname:
             add_module = False
-            if prefix and (prefix == classname or
-                           prefix.startswith(classname + ".")):
+            if prefix and (prefix == classname or prefix.startswith(classname + ".")):
                 fullname = prefix + name
                 # class name is given again in the signature
-                prefix = prefix[len(classname):].lstrip('.')
+                prefix = prefix[len(classname) :].lstrip(".")
             elif prefix:
                 # class name is given in the signature, but different
                 # (shouldn't happen)
-                fullname = classname + '.' + prefix + name
+                fullname = classname + "." + prefix + name
             else:
                 # class name is not given in the signature
-                fullname = classname + '.' + name
+                fullname = classname + "." + name
         else:
             add_module = True
             if prefix:
-                classname = prefix.rstrip('.')
+                classname = prefix.rstrip(".")
                 fullname = prefix + name
             else:
-                classname = ''
+                classname = ""
                 fullname = name
 
-        signode['module'] = modname
-        signode['class'] = classname
-        signode['fullname'] = fullname
+        signode["module"] = modname
+        signode["class"] = classname
+        signode["fullname"] = fullname
 
         sig_prefix = self.get_signature_prefix(sig)
         if sig_prefix:
@@ -428,14 +474,15 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
                 raise TypeError(
                     "Python directive method get_signature_prefix()"
                     " must return a list of nodes."
-                    f" Return value was '{sig_prefix}'.")
+                    f" Return value was '{sig_prefix}'."
+                )
             else:
-                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
+                signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
 
         if prefix:
             signode += addnodes.desc_addname(prefix, prefix)
         elif modname and add_module and self.env.config.add_module_names:
-            nodetext = modname + '.'
+            nodetext = modname + "."
             signode += addnodes.desc_addname(nodetext, nodetext)
 
         signode += addnodes.desc_name(name, name)
@@ -447,8 +494,9 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
                 # it supports to represent optional arguments (ex. "func(foo [, bar])")
                 _pseudo_parse_arglist(signode, arglist)
             except NotImplementedError as exc:
-                logger.warning("could not parse arglist (%r): %s", arglist, exc,
-                               location=signode)
+                logger.warning(
+                    "could not parse arglist (%r): %s", arglist, exc, location=signode
+                )
                 _pseudo_parse_arglist(signode, arglist)
         else:
             if self.needs_arglist():
@@ -457,51 +505,55 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
 
         if retann:
             children = _parse_annotation(retann, self.env)
-            signode += addnodes.desc_returns(retann, '', *children)
+            signode += addnodes.desc_returns(retann, "", *children)
 
-        anno = self.options.get('annotation')
+        anno = self.options.get("annotation")
         if anno:
-            signode += addnodes.desc_annotation(' ' + anno, '',
-                                                addnodes.desc_sig_space(),
-                                                nodes.Text(anno))
+            signode += addnodes.desc_annotation(
+                " " + anno, "", addnodes.desc_sig_space(), nodes.Text(anno)
+            )
 
         return fullname, prefix
 
     def _object_hierarchy_parts(self, sig_node: desc_signature) -> tuple[str, ...]:
-        if 'fullname' not in sig_node:
+        if "fullname" not in sig_node:
             return ()
-        modname = sig_node.get('module')
-        fullname = sig_node['fullname']
+        modname = sig_node.get("module")
+        fullname = sig_node["fullname"]
 
         if modname:
-            return (modname, *fullname.split('.'))
+            return (modname, *fullname.split("."))
         else:
-            return tuple(fullname.split('.'))
+            return tuple(fullname.split("."))
 
     def get_index_text(self, modname: str, name: tuple[str, str]) -> str:
         """Return the text for the index entry of the object."""
-        raise NotImplementedError('must be implemented in subclasses')
+        raise NotImplementedError("must be implemented in subclasses")
 
-    def add_target_and_index(self, name_cls: tuple[str, str], sig: str,
-                             signode: desc_signature) -> None:
-        modname = self.options.get('module', self.env.ref_context.get('spark:module'))
-        fullname = (modname + '.' if modname else '') + name_cls[0]
-        node_id = make_id(self.env, self.state.document, '', fullname)
-        signode['ids'].append(node_id)
+    def add_target_and_index(
+        self, name_cls: tuple[str, str], sig: str, signode: desc_signature
+    ) -> None:
+        modname = self.options.get("module", self.env.ref_context.get("spark:module"))
+        fullname = (modname + "." if modname else "") + name_cls[0]
+        node_id = make_id(self.env, self.state.document, "", fullname)
+        signode["ids"].append(node_id)
         self.state.document.note_explicit_target(signode)
 
-        domain = cast(SparkDomain, self.env.get_domain('spark'))
+        domain = cast(SparkDomain, self.env.get_domain("spark"))
         domain.note_object(fullname, self.objtype, node_id, location=signode)
 
-        canonical_name = self.options.get('canonical')
+        canonical_name = self.options.get("canonical")
         if canonical_name:
-            domain.note_object(canonical_name, self.objtype, node_id, aliased=True,
-                               location=signode)
+            domain.note_object(
+                canonical_name, self.objtype, node_id, aliased=True, location=signode
+            )
 
-        if 'noindexentry' not in self.options:
+        if "noindexentry" not in self.options:
             indextext = self.get_index_text(modname, name_cls)
             if indextext:
-                self.indexnode['entries'].append(('single', indextext, node_id, '', None))
+                self.indexnode["entries"].append(
+                    ("single", indextext, node_id, "", None)
+                )
 
     def before_content(self) -> None:
         """Handle object nesting before content
@@ -525,16 +577,16 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
             if self.allow_nesting:
                 prefix = fullname
             elif name_prefix:
-                prefix = name_prefix.strip('.')
+                prefix = name_prefix.strip(".")
         if prefix:
-            self.env.ref_context['spark:class'] = prefix
+            self.env.ref_context["spark:class"] = prefix
             if self.allow_nesting:
-                classes = self.env.ref_context.setdefault('spark:classes', [])
+                classes = self.env.ref_context.setdefault("spark:classes", [])
                 classes.append(prefix)
-        if 'module' in self.options:
-            modules = self.env.ref_context.setdefault('spark:modules', [])
-            modules.append(self.env.ref_context.get('spark:module'))
-            self.env.ref_context['spark:module'] = self.options['module']
+        if "module" in self.options:
+            modules = self.env.ref_context.setdefault("spark:modules", [])
+            modules.append(self.env.ref_context.get("spark:module"))
+            self.env.ref_context["spark:module"] = self.options["module"]
 
     def after_content(self) -> None:
         """Handle object de-nesting after content
@@ -546,73 +598,76 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
         be altered as we didn't affect the nesting levels in
         :spark:meth:`before_content`.
         """
-        classes = self.env.ref_context.setdefault('spark:classes', [])
+        classes = self.env.ref_context.setdefault("spark:classes", [])
         if self.allow_nesting:
             try:
                 classes.pop()
             except IndexError:
                 pass
-        self.env.ref_context['spark:class'] = (classes[-1] if len(classes) > 0
-                                            else None)
-        if 'module' in self.options:
-            modules = self.env.ref_context.setdefault('spark:modules', [])
+        self.env.ref_context["spark:class"] = classes[-1] if len(classes) > 0 else None
+        if "module" in self.options:
+            modules = self.env.ref_context.setdefault("spark:modules", [])
             if modules:
-                self.env.ref_context['spark:module'] = modules.pop()
+                self.env.ref_context["spark:module"] = modules.pop()
             else:
-                self.env.ref_context.pop('spark:module')
+                self.env.ref_context.pop("spark:module")
 
     def _toc_entry_name(self, sig_node: desc_signature) -> str:
-        if not sig_node.get('_toc_parts'):
-            return ''
+        if not sig_node.get("_toc_parts"):
+            return ""
 
         config = self.env.app.config
-        objtype = sig_node.parent.get('objtype')
-        if config.add_function_parentheses and objtype in {'function', 'method'}:
-            parens = '()'
+        objtype = sig_node.parent.get("objtype")
+        if config.add_function_parentheses and objtype in {"function", "method"}:
+            parens = "()"
         else:
-            parens = ''
-        *parents, name = sig_node['_toc_parts']
-        if config.toc_object_entries_show_parents == 'domain':
-            return sig_node.get('fullname', name) + parens
-        if config.toc_object_entries_show_parents == 'hide':
+            parens = ""
+        *parents, name = sig_node["_toc_parts"]
+        if config.toc_object_entries_show_parents == "domain":
+            return sig_node.get("fullname", name) + parens
+        if config.toc_object_entries_show_parents == "hide":
             return name + parens
-        if config.toc_object_entries_show_parents == 'all':
-            return '.'.join(parents + [name + parens])
-        return ''
+        if config.toc_object_entries_show_parents == "all":
+            return ".".join(parents + [name + parens])
+        return ""
 
 
 class SparkFunction(SparkObject):
     """Description of a function."""
 
     option_spec: OptionSpec = SparkObject.option_spec.copy()
-    option_spec.update({
-        'async': directives.flag,
-    })
+    option_spec.update(
+        {
+            "async": directives.flag,
+        }
+    )
 
     def get_signature_prefix(self, sig: str) -> list[nodes.Node]:
-        if 'async' in self.options:
-            return [addnodes.desc_sig_keyword('', 'async'),
-                    addnodes.desc_sig_space()]
+        if "async" in self.options:
+            return [addnodes.desc_sig_keyword("", "async"), addnodes.desc_sig_space()]
         else:
             return []
 
     def needs_arglist(self) -> bool:
         return True
 
-    def add_target_and_index(self, name_cls: tuple[str, str], sig: str,
-                             signode: desc_signature) -> None:
+    def add_target_and_index(
+        self, name_cls: tuple[str, str], sig: str, signode: desc_signature
+    ) -> None:
         super().add_target_and_index(name_cls, sig, signode)
-        if 'noindexentry' not in self.options:
-            modname = self.options.get('module', self.env.ref_context.get('spark:module'))
-            node_id = signode['ids'][0]
+        if "noindexentry" not in self.options:
+            modname = self.options.get(
+                "module", self.env.ref_context.get("spark:module")
+            )
+            node_id = signode["ids"][0]
 
             name, cls = name_cls
             if modname:
-                text = _('%s() (in module %s)') % (name, modname)
-                self.indexnode['entries'].append(('single', text, node_id, '', None))
+                text = _("%s() (in module %s)") % (name, modname)
+                self.indexnode["entries"].append(("single", text, node_id, "", None))
             else:
                 text = f'{pairindextypes["builtin"]}; {name}()'
-                self.indexnode['entries'].append(('pair', text, node_id, '', None))
+                self.indexnode["entries"].append(("pair", text, node_id, "", None))
 
     def get_index_text(self, modname: str, name_cls: tuple[str, str]) -> str | None:
         # add index in own add_target_and_index() instead.
@@ -620,25 +675,31 @@ class SparkFunction(SparkObject):
 
 
 class SparkXRefRole(XRefRole):
-    def process_link(self, env: BuildEnvironment, refnode: Element,
-                     has_explicit_title: bool, title: str, target: str) -> tuple[str, str]:
-        refnode['spark:module'] = env.ref_context.get('spark:module')
-        refnode['spark:class'] = env.ref_context.get('spark:class')
+    def process_link(
+        self,
+        env: BuildEnvironment,
+        refnode: Element,
+        has_explicit_title: bool,
+        title: str,
+        target: str,
+    ) -> tuple[str, str]:
+        refnode["spark:module"] = env.ref_context.get("spark:module")
+        refnode["spark:class"] = env.ref_context.get("spark:class")
         if not has_explicit_title:
-            title = title.lstrip('.')    # only has a meaning for the target
-            target = target.lstrip('~')  # only has a meaning for the title
+            title = title.lstrip(".")  # only has a meaning for the target
+            target = target.lstrip("~")  # only has a meaning for the title
             # if the first character is a tilde, don't display the module/class
             # parts of the contents
-            if title[0:1] == '~':
+            if title[0:1] == "~":
                 title = title[1:]
-                dot = title.rfind('.')
+                dot = title.rfind(".")
                 if dot != -1:
-                    title = title[dot + 1:]
+                    title = title[dot + 1 :]
         # if the first character is a dot, search more specific namespaces first
         # else search builtins first
-        if target[0:1] == '.':
+        if target[0:1] == ".":
             target = target[1:]
-            refnode['refspecific'] = True
+            refnode["refspecific"] = True
         return title, target
 
 
@@ -647,21 +708,23 @@ class SparkModuleIndex(Index):
     Index subclass to provide the Python module index.
     """
 
-    name = 'modindex'
-    localname = _('Python Module Index')
-    shortname = _('modules')
+    name = "modindex"
+    localname = _("Python Module Index")
+    shortname = _("modules")
 
-    def generate(self, docnames: Iterable[str] | None = None
-                 ) -> tuple[list[tuple[str, list[IndexEntry]]], bool]:
+    def generate(
+        self, docnames: Iterable[str] | None = None
+    ) -> tuple[list[tuple[str, list[IndexEntry]]], bool]:
         content: dict[str, list[IndexEntry]] = {}
         # list of prefixes to ignore
-        ignores: list[str] = self.domain.env.config['modindex_common_prefix']
+        ignores: list[str] = self.domain.env.config["modindex_common_prefix"]
         ignores = sorted(ignores, key=len, reverse=True)
         # list of all modules, sorted by module name
-        modules = sorted(self.domain.data['modules'].items(),
-                         key=lambda x: x[0].lower())
+        modules = sorted(
+            self.domain.data["modules"].items(), key=lambda x: x[0].lower()
+        )
         # sort out collapsible modules
-        prev_modname = ''
+        prev_modname = ""
         num_toplevels = 0
         for modname, (docname, node_id, synopsis, platforms, deprecated) in modules:
             if docnames and docname not in docnames:
@@ -669,38 +732,50 @@ class SparkModuleIndex(Index):
 
             for ignore in ignores:
                 if modname.startswith(ignore):
-                    modname = modname[len(ignore):]
+                    modname = modname[len(ignore) :]
                     stripped = ignore
                     break
             else:
-                stripped = ''
+                stripped = ""
 
             # we stripped the whole module name?
             if not modname:
-                modname, stripped = stripped, ''
+                modname, stripped = stripped, ""
 
             entries = content.setdefault(modname[0].lower(), [])
 
-            package = modname.split('.')[0]
+            package = modname.split(".")[0]
             if package != modname:
                 # it's a submodule
                 if prev_modname == package:
                     # first submodule - make parent a group head
                     if entries:
                         last = entries[-1]
-                        entries[-1] = IndexEntry(last[0], 1, last[2], last[3],
-                                                 last[4], last[5], last[6])
+                        entries[-1] = IndexEntry(
+                            last[0], 1, last[2], last[3], last[4], last[5], last[6]
+                        )
                 elif not prev_modname.startswith(package):
                     # submodule without parent in list, add dummy entry
-                    entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))
+                    entries.append(
+                        IndexEntry(stripped + package, 1, "", "", "", "", "")
+                    )
                 subtype = 2
             else:
                 num_toplevels += 1
                 subtype = 0
 
-            qualifier = _('Deprecated') if deprecated else ''
-            entries.append(IndexEntry(stripped + modname, subtype, docname,
-                                      node_id, platforms, qualifier, synopsis))
+            qualifier = _("Deprecated") if deprecated else ""
+            entries.append(
+                IndexEntry(
+                    stripped + modname,
+                    subtype,
+                    docname,
+                    node_id,
+                    platforms,
+                    qualifier,
+                    synopsis,
+                )
+            )
             prev_modname = modname
 
         # apply heuristics when to collapse modindex at page load:
@@ -716,21 +791,22 @@ class SparkModuleIndex(Index):
 
 class SparkDomain(Domain):
     """Spark domain."""
-    name = 'spark'
-    label = 'Spark'
+
+    name = "spark"
+    label = "Spark"
     object_types: dict[str, ObjType] = {
-        'function':     ObjType(_('function'),      'func', 'obj'),
+        "function": ObjType(_("function"), "func", "obj"),
     }
 
     directives = {
-        'function':        SparkFunction,
+        "function": SparkFunction,
     }
     roles = {
-        'func':  SparkXRefRole(fix_parens=True),
+        "func": SparkXRefRole(fix_parens=True),
     }
     initial_data: dict[str, dict[str, tuple[Any]]] = {
-        'objects': {},  # fullname -> docname, objtype
-        'modules': {},  # modname -> docname, synopsis, platform, deprecated
+        "objects": {},  # fullname -> docname, objtype
+        "modules": {},  # modname -> docname, synopsis, platform, deprecated
     }
     indices = [
         SparkModuleIndex,
@@ -738,10 +814,16 @@ class SparkDomain(Domain):
 
     @property
     def objects(self) -> dict[str, ObjectEntry]:
-        return self.data.setdefault('objects', {})  # fullname -> ObjectEntry
+        return self.data.setdefault("objects", {})  # fullname -> ObjectEntry
 
-    def note_object(self, name: str, objtype: str, node_id: str,
-                    aliased: bool = False, location: Any = None) -> None:
+    def note_object(
+        self,
+        name: str,
+        objtype: str,
+        node_id: str,
+        aliased: bool = False,
+        location: Any = None,
+    ) -> None:
         """Note a spark object for cross reference.
 
         .. versionadded:: 2.1
@@ -756,23 +838,31 @@ class SparkDomain(Domain):
                 return
             else:
                 # duplicated
-                logger.warning(__('duplicate object description of %s, '
-                                  'other instance in %s, use :noindex: for one of them'),
-                               name, other.docname, location=location)
+                logger.warning(
+                    __(
+                        "duplicate object description of %s, "
+                        "other instance in %s, use :noindex: for one of them"
+                    ),
+                    name,
+                    other.docname,
+                    location=location,
+                )
         self.objects[name] = ObjectEntry(self.env.docname, node_id, objtype, aliased)
 
     @property
     def modules(self) -> dict[str, ModuleEntry]:
-        return self.data.setdefault('modules', {})  # modname -> ModuleEntry
+        return self.data.setdefault("modules", {})  # modname -> ModuleEntry
 
-    def note_module(self, name: str, node_id: str, synopsis: str,
-                    platform: str, deprecated: bool) -> None:
+    def note_module(
+        self, name: str, node_id: str, synopsis: str, platform: str, deprecated: bool
+    ) -> None:
         """Note a spark module for cross reference.
 
         .. versionadded:: 2.1
         """
-        self.modules[name] = ModuleEntry(self.env.docname, node_id,
-                                         synopsis, platform, deprecated)
+        self.modules[name] = ModuleEntry(
+            self.env.docname, node_id, synopsis, platform, deprecated
+        )
 
     def clear_doc(self, docname: str) -> None:
         for fullname, obj in list(self.objects.items()):
@@ -784,21 +874,27 @@ class SparkDomain(Domain):
 
     def merge_domaindata(self, docnames: list[str], otherdata: dict[str, Any]) -> None:
         # XXX check duplicates?
-        for fullname, obj in otherdata['objects'].items():
+        for fullname, obj in otherdata["objects"].items():
             if obj.docname in docnames:
                 self.objects[fullname] = obj
-        for modname, mod in otherdata['modules'].items():
+        for modname, mod in otherdata["modules"].items():
             if mod.docname in docnames:
                 self.modules[modname] = mod
 
-    def find_obj(self, env: BuildEnvironment, modname: str, classname: str,
-                 name: str, type: str | None, searchmode: int = 0
-                 ) -> list[tuple[str, ObjectEntry]]:
+    def find_obj(
+        self,
+        env: BuildEnvironment,
+        modname: str,
+        classname: str,
+        name: str,
+        type: str | None,
+        searchmode: int = 0,
+    ) -> list[tuple[str, ObjectEntry]]:
         """Find a Python object for "name", perhaps using the given module
         and/or classname.  Returns a list of (name, object entry) tuples.
         """
         # skip parens
-        if name[-2:] == '()':
+        if name[-2:] == "()":
             name = name[:-2]
 
         if not name:
@@ -814,60 +910,80 @@ class SparkDomain(Domain):
                 objtypes = self.objtypes_for_role(type)
             if objtypes is not None:
                 if modname and classname:
-                    fullname = modname + '.' + classname + '.' + name
-                    if fullname in self.objects and self.objects[fullname].objtype in objtypes:
+                    fullname = modname + "." + classname + "." + name
+                    if (
+                        fullname in self.objects
+                        and self.objects[fullname].objtype in objtypes
+                    ):
                         newname = fullname
                 if not newname:
-                    if modname and modname + '.' + name in self.objects and \
-                       self.objects[modname + '.' + name].objtype in objtypes:
-                        newname = modname + '.' + name
-                    elif name in self.objects and self.objects[name].objtype in objtypes:
+                    if (
+                        modname
+                        and modname + "." + name in self.objects
+                        and self.objects[modname + "." + name].objtype in objtypes
+                    ):
+                        newname = modname + "." + name
+                    elif (
+                        name in self.objects and self.objects[name].objtype in objtypes
+                    ):
                         newname = name
                     else:
                         # "fuzzy" searching mode
-                        searchname = '.' + name
-                        matches = [(oname, self.objects[oname]) for oname in self.objects
-                                   if oname.endswith(searchname) and
-                                   self.objects[oname].objtype in objtypes]
+                        searchname = "." + name
+                        matches = [
+                            (oname, self.objects[oname])
+                            for oname in self.objects
+                            if oname.endswith(searchname)
+                            and self.objects[oname].objtype in objtypes
+                        ]
         else:
             # NOTE: searching for exact match, object type is not considered
             if name in self.objects:
                 newname = name
-            elif type == 'mod':
+            elif type == "mod":
                 # only exact matches allowed for modules
                 return []
-            elif classname and classname + '.' + name in self.objects:
-                newname = classname + '.' + name
-            elif modname and modname + '.' + name in self.objects:
-                newname = modname + '.' + name
-            elif modname and classname and \
-                    modname + '.' + classname + '.' + name in self.objects:
-                newname = modname + '.' + classname + '.' + name
+            elif classname and classname + "." + name in self.objects:
+                newname = classname + "." + name
+            elif modname and modname + "." + name in self.objects:
+                newname = modname + "." + name
+            elif (
+                modname
+                and classname
+                and modname + "." + classname + "." + name in self.objects
+            ):
+                newname = modname + "." + classname + "." + name
         if newname is not None:
             matches.append((newname, self.objects[newname]))
         return matches
 
-    def resolve_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
-                     type: str, target: str, node: pending_xref, contnode: Element
-                     ) -> Element | None:
-        modname = node.get('spark:module')
-        clsname = node.get('spark:class')
-        searchmode = 1 if node.hasattr('refspecific') else 0
-        matches = self.find_obj(env, modname, clsname, target,
-                                type, searchmode)
+    def resolve_xref(
+        self,
+        env: BuildEnvironment,
+        fromdocname: str,
+        builder: Builder,
+        type: str,
+        target: str,
+        node: pending_xref,
+        contnode: Element,
+    ) -> Element | None:
+        modname = node.get("spark:module")
+        clsname = node.get("spark:class")
+        searchmode = 1 if node.hasattr("refspecific") else 0
+        matches = self.find_obj(env, modname, clsname, target, type, searchmode)
 
-        if not matches and type == 'attr':
+        if not matches and type == "attr":
             # fallback to meth (for property; Sphinx-2.4.x)
             # this ensures that `:attr:` role continues to refer to the old property entry
             # that defined by ``method`` directive in old reST files.
-            matches = self.find_obj(env, modname, clsname, target, 'meth', searchmode)
-        if not matches and type == 'meth':
+            matches = self.find_obj(env, modname, clsname, target, "meth", searchmode)
+        if not matches and type == "meth":
             # fallback to attr (for property)
             # this ensures that `:meth:` in the old reST files can refer to the property
             # entry that defined by ``property`` directive.
             #
             # Note: _prop is a secret role only for internal look-up.
-            matches = self.find_obj(env, modname, clsname, target, '_prop', searchmode)
+            matches = self.find_obj(env, modname, clsname, target, "_prop", searchmode)
 
         if not matches:
             return None
@@ -876,16 +992,21 @@ class SparkDomain(Domain):
             if len(canonicals) == 1:
                 matches = canonicals
             else:
-                logger.warning(__('more than one target found for cross-reference %r: %s'),
-                               target, ', '.join(match[0] for match in matches),
-                               type='ref', subtype='python', location=node)
+                logger.warning(
+                    __("more than one target found for cross-reference %r: %s"),
+                    target,
+                    ", ".join(match[0] for match in matches),
+                    type="ref",
+                    subtype="python",
+                    location=node,
+                )
         name, obj = matches[0]
 
-        if obj[2] == 'module':
+        if obj[2] == "module":
             return self._make_module_refnode(builder, fromdocname, name, contnode)
         else:
             # determine the content of the reference by conditions
-            content = find_pending_xref_condition(node, 'resolved')
+            content = find_pending_xref_condition(node, "resolved")
             if content:
                 children = content.children
             else:
@@ -894,11 +1015,17 @@ class SparkDomain(Domain):
 
             return make_refnode(builder, fromdocname, obj[0], obj[1], children, name)
 
-    def resolve_any_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
-                         target: str, node: pending_xref, contnode: Element
-                         ) -> list[tuple[str, Element]]:
-        modname = node.get('spark:module')
-        clsname = node.get('spark:class')
+    def resolve_any_xref(
+        self,
+        env: BuildEnvironment,
+        fromdocname: str,
+        builder: Builder,
+        target: str,
+        node: pending_xref,
+        contnode: Element,
+    ) -> list[tuple[str, Element]]:
+        modname = node.get("spark:module")
+        clsname = node.get("spark:class")
         results: list[tuple[str, Element]] = []
 
         # always search in "refspecific" mode with the :any: role
@@ -911,43 +1038,53 @@ class SparkDomain(Domain):
                 # Skip duplicated matches
                 continue
 
-            if obj[2] == 'module':
-                results.append(('spark:mod',
-                                self._make_module_refnode(builder, fromdocname,
-                                                          name, contnode)))
+            if obj[2] == "module":
+                results.append(
+                    (
+                        "spark:mod",
+                        self._make_module_refnode(builder, fromdocname, name, contnode),
+                    )
+                )
             else:
                 # determine the content of the reference by conditions
-                content = find_pending_xref_condition(node, 'resolved')
+                content = find_pending_xref_condition(node, "resolved")
                 if content:
                     children = content.children
                 else:
                     # if not found, use contnode
                     children = [contnode]
 
-                results.append(('spark:' + self.role_for_objtype(obj[2]),
-                                make_refnode(builder, fromdocname, obj[0], obj[1],
-                                             children, name)))
+                results.append(
+                    (
+                        "spark:" + self.role_for_objtype(obj[2]),
+                        make_refnode(
+                            builder, fromdocname, obj[0], obj[1], children, name
+                        ),
+                    )
+                )
         return results
 
-    def _make_module_refnode(self, builder: Builder, fromdocname: str, name: str,
-                             contnode: Node) -> Element:
+    def _make_module_refnode(
+        self, builder: Builder, fromdocname: str, name: str, contnode: Node
+    ) -> Element:
         # get additional info for modules
         module = self.modules[name]
         title = name
         if module.synopsis:
-            title += ': ' + module.synopsis
+            title += ": " + module.synopsis
         if module.deprecated:
-            title += _(' (deprecated)')
+            title += _(" (deprecated)")
         if module.platform:
-            title += ' (' + module.platform + ')'
-        return make_refnode(builder, fromdocname, module.docname, module.node_id,
-                            contnode, title)
+            title += " (" + module.platform + ")"
+        return make_refnode(
+            builder, fromdocname, module.docname, module.node_id, contnode, title
+        )
 
     def get_objects(self) -> Iterator[tuple[str, str, str, str, str, int]]:
         for modname, mod in self.modules.items():
-            yield (modname, modname, 'module', mod.docname, mod.node_id, 0)
+            yield (modname, modname, "module", mod.docname, mod.node_id, 0)
         for refname, obj in self.objects.items():
-            if obj.objtype != 'module':  # modules are already handled
+            if obj.objtype != "module":  # modules are already handled
                 if obj.aliased:
                     # aliased names are not full-text searchable.
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, -1)
@@ -955,22 +1092,22 @@ class SparkDomain(Domain):
                     yield (refname, refname, obj.objtype, obj.docname, obj.node_id, 1)
 
     def get_full_qualified_name(self, node: Element) -> str | None:
-        modname = node.get('spark:module')
-        clsname = node.get('spark:class')
-        target = node.get('reftarget')
+        modname = node.get("spark:module")
+        clsname = node.get("spark:class")
+        target = node.get("reftarget")
         if target is None:
             return None
         else:
-            return '.'.join(filter(None, [modname, clsname, target]))
+            return ".".join(filter(None, [modname, clsname, target]))
 
 
 def setup(app: Sphinx) -> dict[str, Any]:
-    app.setup_extension('sphinx.directives')
+    app.setup_extension("sphinx.directives")
     app.add_domain(SparkDomain)
 
     return {
-        'version': 'builtin',
-        'env_version': 3,
-        'parallel_read_safe': True,
-        'parallel_write_safe': True,
+        "version": "builtin",
+        "env_version": 3,
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
     }

--- a/velox/docs/ext/spark.py
+++ b/velox/docs/ext/spark.py
@@ -52,7 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 # REs for Spark signatures
-py_sig_re = re.compile(
+spark_sig_re = re.compile(
     r"""^ ([\w.]*\.)?            # class name(s)
           (\w+)  \s*             # thing name
           (?: \(\s*(.*)\s*\)     # optional: arguments
@@ -234,7 +234,6 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
     def _unparse_pep_604_annotation(node: ast.Subscript) -> list[Node]:
         subscript = node.slice
         if isinstance(subscript, ast.Index):
-            # py38 only
             subscript = subscript.value  # type: ignore[assignment]
 
         flattened: list[Node] = []
@@ -387,7 +386,7 @@ def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
 
 class SparkObject(ObjectDescription[Tuple[str, str]]):
     """
-    Description of a general Python object.
+    Description of a general Spark object.
 
     :cvar allow_nesting: Class is an object that allows for nested namespaces
     :vartype allow_nesting: bool
@@ -424,96 +423,6 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
         the document contains none.
         """
         return False
-
-    def handle_signature(self, sig: str, signode: desc_signature) -> tuple[str, str]:
-        """Transform a Python signature into RST nodes.
-
-        Return (fully qualified name of the thing, classname if any).
-
-        If inside a class, the current class name is handled intelligently:
-        * it is stripped from the displayed name if present
-        * it is added to the full name (return value) if not present
-        """
-        m = py_sig_re.match(sig)
-        if m is None:
-            raise ValueError
-        prefix, name, arglist, retann = m.groups()
-
-        # determine module and class name (if applicable), as well as full name
-        modname = self.options.get("module", self.env.ref_context.get("spark:module"))
-        classname = self.env.ref_context.get("spark:class")
-        if classname:
-            add_module = False
-            if prefix and (prefix == classname or prefix.startswith(classname + ".")):
-                fullname = prefix + name
-                # class name is given again in the signature
-                prefix = prefix[len(classname) :].lstrip(".")
-            elif prefix:
-                # class name is given in the signature, but different
-                # (shouldn't happen)
-                fullname = classname + "." + prefix + name
-            else:
-                # class name is not given in the signature
-                fullname = classname + "." + name
-        else:
-            add_module = True
-            if prefix:
-                classname = prefix.rstrip(".")
-                fullname = prefix + name
-            else:
-                classname = ""
-                fullname = name
-
-        signode["module"] = modname
-        signode["class"] = classname
-        signode["fullname"] = fullname
-
-        sig_prefix = self.get_signature_prefix(sig)
-        if sig_prefix:
-            if type(sig_prefix) is str:
-                raise TypeError(
-                    "Python directive method get_signature_prefix()"
-                    " must return a list of nodes."
-                    f" Return value was '{sig_prefix}'."
-                )
-            else:
-                signode += addnodes.desc_annotation(str(sig_prefix), "", *sig_prefix)
-
-        if prefix:
-            signode += addnodes.desc_addname(prefix, prefix)
-        elif modname and add_module and self.env.config.add_module_names:
-            nodetext = modname + "."
-            signode += addnodes.desc_addname(nodetext, nodetext)
-
-        signode += addnodes.desc_name(name, name)
-        if arglist:
-            try:
-                signode += _parse_arglist(arglist, self.env)
-            except SyntaxError:
-                # fallback to parse arglist original parser.
-                # it supports to represent optional arguments (ex. "func(foo [, bar])")
-                _pseudo_parse_arglist(signode, arglist)
-            except NotImplementedError as exc:
-                logger.warning(
-                    "could not parse arglist (%r): %s", arglist, exc, location=signode
-                )
-                _pseudo_parse_arglist(signode, arglist)
-        else:
-            if self.needs_arglist():
-                # for callables, add an empty parameter list
-                signode += addnodes.desc_parameterlist()
-
-        if retann:
-            children = _parse_annotation(retann, self.env)
-            signode += addnodes.desc_returns(retann, "", *children)
-
-        anno = self.options.get("annotation")
-        if anno:
-            signode += addnodes.desc_annotation(
-                " " + anno, "", addnodes.desc_sig_space(), nodes.Text(anno)
-            )
-
-        return fullname, prefix
 
     def _object_hierarchy_parts(self, sig_node: desc_signature) -> tuple[str, ...]:
         if "fullname" not in sig_node:

--- a/velox/docs/ext/spark.py
+++ b/velox/docs/ext/spark.py
@@ -467,11 +467,6 @@ class SparkObject(ObjectDescription[Tuple[str, str]]):
     def before_content(self) -> None:
         """Handle object nesting before content
 
-        :spark:class:`SparkObject` represents Python language constructs. For
-        constructs that are nestable, such as a Python classes, this method will
-        build up a stack of the nesting hierarchy so that it can be later
-        de-nested correctly, in :spark:meth:`after_content`.
-
         For constructs that aren't nestable, the stack is bypassed, and instead
         only the most recent object is tracked. This object prefix name will be
         removed with :spark:meth:`after_content`.
@@ -614,11 +609,11 @@ class SparkXRefRole(XRefRole):
 
 class SparkModuleIndex(Index):
     """
-    Index subclass to provide the Python module index.
+    Index subclass to provide the Spark module index.
     """
 
     name = "modindex"
-    localname = _("Python Module Index")
+    localname = _("Spark Module Index")
     shortname = _("modules")
 
     def generate(
@@ -799,7 +794,7 @@ class SparkDomain(Domain):
         type: str | None,
         searchmode: int = 0,
     ) -> list[tuple[str, ObjectEntry]]:
-        """Find a Python object for "name", perhaps using the given module
+        """Find a Spark object for "name", perhaps using the given module
         and/or classname.  Returns a list of (name, object entry) tuples.
         """
         # skip parens

--- a/velox/docs/ext/spark.py
+++ b/velox/docs/ext/spark.py
@@ -1,0 +1,976 @@
+"""The Spark domain."""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import inspect
+import re
+import typing
+from inspect import Parameter
+from typing import Any, Iterable, Iterator, List, NamedTuple, Tuple, cast
+
+from docutils import nodes
+from docutils.nodes import Element, Node
+from docutils.parsers.rst import directives
+from docutils.parsers.rst.states import Inliner
+
+from sphinx import addnodes
+from sphinx.addnodes import desc_signature, pending_xref
+from sphinx.application import Sphinx
+from sphinx.builders import Builder
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, Index, IndexEntry, ObjType
+from sphinx.environment import BuildEnvironment
+from sphinx.locale import _, __
+from sphinx.roles import XRefRole
+from sphinx.util import logging
+from sphinx.util.docfields import Field
+from sphinx.util.inspect import signature_from_str
+from sphinx.util.nodes import (
+    find_pending_xref_condition,
+    make_id,
+    make_refnode,
+)
+from sphinx.util.typing import OptionSpec
+
+logger = logging.getLogger(__name__)
+
+
+# REs for Spark signatures
+py_sig_re = re.compile(
+    r'''^ ([\w.]*\.)?            # class name(s)
+          (\w+)  \s*             # thing name
+          (?: \(\s*(.*)\s*\)     # optional: arguments
+           (?:\s* -> \s* (.*))?  #           return annotation
+          )? $                   # and nothing more
+          ''', re.VERBOSE)
+
+
+pairindextypes = {
+    'module':    _('module'),
+    'keyword':   _('keyword'),
+    'operator':  _('operator'),
+    'object':    _('object'),
+    'exception': _('exception'),
+    'statement': _('statement'),
+    'builtin':   _('built-in function'),
+}
+
+
+class ObjectEntry(NamedTuple):
+    docname: str
+    node_id: str
+    objtype: str
+    aliased: bool
+
+
+class ModuleEntry(NamedTuple):
+    docname: str
+    node_id: str
+    synopsis: str
+    platform: str
+    deprecated: bool
+
+
+def parse_reftarget(reftarget: str, suppress_prefix: bool = False
+                    ) -> tuple[str, str, str, bool]:
+    """Parse a type string and return (reftype, reftarget, title, refspecific flag)"""
+    refspecific = False
+    if reftarget.startswith('.'):
+        reftarget = reftarget[1:]
+        title = reftarget
+        refspecific = True
+    elif reftarget.startswith('~'):
+        reftarget = reftarget[1:]
+        title = reftarget.split('.')[-1]
+    elif suppress_prefix:
+        title = reftarget.split('.')[-1]
+    elif reftarget.startswith('typing.'):
+        title = reftarget[7:]
+    else:
+        title = reftarget
+
+    if reftarget == 'None' or reftarget.startswith('typing.'):
+        # typing module provides non-class types.  Obj reference is good to refer them.
+        reftype = 'obj'
+    else:
+        reftype = 'class'
+
+    return reftype, reftarget, title, refspecific
+
+
+def type_to_xref(target: str, env: BuildEnvironment | None = None,
+                 suppress_prefix: bool = False) -> addnodes.pending_xref:
+    """Convert a type string to a cross reference node."""
+    if env:
+        kwargs = {'spark:module': env.ref_context.get('spark:module'),
+                  'spark:class': env.ref_context.get('spark:class')}
+    else:
+        kwargs = {}
+
+    reftype, target, title, refspecific = parse_reftarget(target, suppress_prefix)
+    contnodes = [nodes.Text(title)]
+
+    return pending_xref('', *contnodes,
+                        refdomain='spark', reftype=reftype, reftarget=target,
+                        refspecific=refspecific, **kwargs)
+
+
+def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Node]:
+    """Parse type annotation."""
+    def unparse(node: ast.AST) -> list[Node]:
+        if isinstance(node, ast.Attribute):
+            return [nodes.Text(f"{unparse(node.value)[0]}.{node.attr}")]
+        elif isinstance(node, ast.BinOp):
+            result: list[Node] = unparse(node.left)
+            result.extend(unparse(node.op))
+            result.extend(unparse(node.right))
+            return result
+        elif isinstance(node, ast.BitOr):
+            return [addnodes.desc_sig_space(),
+                    addnodes.desc_sig_punctuation('', '|'),
+                    addnodes.desc_sig_space()]
+        elif isinstance(node, ast.Constant):
+            if node.value is Ellipsis:
+                return [addnodes.desc_sig_punctuation('', "...")]
+            elif isinstance(node.value, bool):
+                return [addnodes.desc_sig_keyword('', repr(node.value))]
+            elif isinstance(node.value, int):
+                return [addnodes.desc_sig_literal_number('', repr(node.value))]
+            elif isinstance(node.value, str):
+                return [addnodes.desc_sig_literal_string('', repr(node.value))]
+            else:
+                # handles None, which is further handled by type_to_xref later
+                # and fallback for other types that should be converted
+                return [nodes.Text(repr(node.value))]
+        elif isinstance(node, ast.Expr):
+            return unparse(node.value)
+        elif isinstance(node, ast.Index):
+            return unparse(node.value)
+        elif isinstance(node, ast.Invert):
+            return [addnodes.desc_sig_punctuation('', '~')]
+        elif isinstance(node, ast.List):
+            result = [addnodes.desc_sig_punctuation('', '[')]
+            if node.elts:
+                # check if there are elements in node.elts to only pop the
+                # last element of result if the for-loop was run at least
+                # once
+                for elem in node.elts:
+                    result.extend(unparse(elem))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_space())
+                result.pop()
+                result.pop()
+            result.append(addnodes.desc_sig_punctuation('', ']'))
+            return result
+        elif isinstance(node, ast.Module):
+            return sum((unparse(e) for e in node.body), [])
+        elif isinstance(node, ast.Name):
+            return [nodes.Text(node.id)]
+        elif isinstance(node, ast.Subscript):
+            if getattr(node.value, 'id', '') in {'Optional', 'Union'}:
+                return _unparse_pep_604_annotation(node)
+            result = unparse(node.value)
+            result.append(addnodes.desc_sig_punctuation('', '['))
+            result.extend(unparse(node.slice))
+            result.append(addnodes.desc_sig_punctuation('', ']'))
+
+            # Wrap the Text nodes inside brackets by literal node if the subscript is a Literal
+            if result[0] in ('Literal', 'typing.Literal'):
+                for i, subnode in enumerate(result[1:], start=1):
+                    if isinstance(subnode, nodes.Text):
+                        result[i] = nodes.literal('', '', subnode)
+            return result
+        elif isinstance(node, ast.UnaryOp):
+            return unparse(node.op) + unparse(node.operand)
+        elif isinstance(node, ast.Tuple):
+            if node.elts:
+                result = []
+                for elem in node.elts:
+                    result.extend(unparse(elem))
+                    result.append(addnodes.desc_sig_punctuation('', ','))
+                    result.append(addnodes.desc_sig_space())
+                result.pop()
+                result.pop()
+            else:
+                result = [addnodes.desc_sig_punctuation('', '('),
+                          addnodes.desc_sig_punctuation('', ')')]
+
+            return result
+        else:
+            raise SyntaxError  # unsupported syntax
+
+    def _unparse_pep_604_annotation(node: ast.Subscript) -> list[Node]:
+        subscript = node.slice
+        if isinstance(subscript, ast.Index):
+            # py38 only
+            subscript = subscript.value  # type: ignore[assignment]
+
+        flattened: list[Node] = []
+        if isinstance(subscript, ast.Tuple):
+            flattened.extend(unparse(subscript.elts[0]))
+            for elt in subscript.elts[1:]:
+                flattened.extend(unparse(ast.BitOr()))
+                flattened.extend(unparse(elt))
+        else:
+            # e.g. a Union[] inside an Optional[]
+            flattened.extend(unparse(subscript))
+
+        if getattr(node.value, 'id', '') == 'Optional':
+            flattened.extend(unparse(ast.BitOr()))
+            flattened.append(nodes.Text('None'))
+
+        return flattened
+
+    try:
+        tree = ast.parse(annotation, type_comments=True)
+        result: list[Node] = []
+        for node in unparse(tree):
+            if isinstance(node, nodes.literal):
+                result.append(node[0])
+            elif isinstance(node, nodes.Text) and node.strip():
+                if (result and isinstance(result[-1], addnodes.desc_sig_punctuation) and
+                        result[-1].astext() == '~'):
+                    result.pop()
+                    result.append(type_to_xref(str(node), env, suppress_prefix=True))
+                else:
+                    result.append(type_to_xref(str(node), env))
+            else:
+                result.append(node)
+        return result
+    except SyntaxError:
+        return [type_to_xref(annotation, env)]
+
+
+def _parse_arglist(
+    arglist: str, env: BuildEnvironment | None = None
+) -> addnodes.desc_parameterlist:
+    """Parse a list of arguments using AST parser"""
+    params = addnodes.desc_parameterlist(arglist)
+    sig = signature_from_str('(%s)' % arglist)
+    last_kind = None
+    for param in sig.parameters.values():
+        if param.kind != param.POSITIONAL_ONLY and last_kind == param.POSITIONAL_ONLY:
+            # PEP-570: Separator for Positional Only Parameter: /
+            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
+        if param.kind == param.KEYWORD_ONLY and last_kind in (param.POSITIONAL_OR_KEYWORD,
+                                                              param.POSITIONAL_ONLY,
+                                                              None):
+            # PEP-3102: Separator for Keyword Only Parameter: *
+            params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '*'))
+
+        node = addnodes.desc_parameter()
+        if param.kind == param.VAR_POSITIONAL:
+            node += addnodes.desc_sig_operator('', '*')
+            node += addnodes.desc_sig_name('', param.name)
+        elif param.kind == param.VAR_KEYWORD:
+            node += addnodes.desc_sig_operator('', '**')
+            node += addnodes.desc_sig_name('', param.name)
+        else:
+            node += addnodes.desc_sig_name('', param.name)
+
+        if param.annotation is not param.empty:
+            children = _parse_annotation(param.annotation, env)
+            node += addnodes.desc_sig_punctuation('', ':')
+            node += addnodes.desc_sig_space()
+            node += addnodes.desc_sig_name('', '', *children)  # type: ignore
+        if param.default is not param.empty:
+            if param.annotation is not param.empty:
+                node += addnodes.desc_sig_space()
+                node += addnodes.desc_sig_operator('', '=')
+                node += addnodes.desc_sig_space()
+            else:
+                node += addnodes.desc_sig_operator('', '=')
+            node += nodes.inline('', param.default, classes=['default_value'],
+                                 support_smartquotes=False)
+
+        params += node
+        last_kind = param.kind
+
+    if last_kind == Parameter.POSITIONAL_ONLY:
+        # PEP-570: Separator for Positional Only Parameter: /
+        params += addnodes.desc_parameter('', '', addnodes.desc_sig_operator('', '/'))
+
+    return params
+
+
+def _pseudo_parse_arglist(signode: desc_signature, arglist: str) -> None:
+    """"Parse" a list of arguments separated by commas.
+
+    Arguments can have "optional" annotations given by enclosing them in
+    brackets.  Currently, this will split at any comma, even if it's inside a
+    string literal (e.g. default argument value).
+    """
+    paramlist = addnodes.desc_parameterlist()
+    stack: list[Element] = [paramlist]
+    try:
+        for argument in arglist.split(','):
+            argument = argument.strip()
+            ends_open = ends_close = 0
+            while argument.startswith('['):
+                stack.append(addnodes.desc_optional())
+                stack[-2] += stack[-1]
+                argument = argument[1:].strip()
+            while argument.startswith(']'):
+                stack.pop()
+                argument = argument[1:].strip()
+            while argument.endswith(']') and not argument.endswith('[]'):
+                ends_close += 1
+                argument = argument[:-1].strip()
+            while argument.endswith('['):
+                ends_open += 1
+                argument = argument[:-1].strip()
+            if argument:
+                stack[-1] += addnodes.desc_parameter(
+                    '', '', addnodes.desc_sig_name(argument, argument))
+            while ends_open:
+                stack.append(addnodes.desc_optional())
+                stack[-2] += stack[-1]
+                ends_open -= 1
+            while ends_close:
+                stack.pop()
+                ends_close -= 1
+        if len(stack) != 1:
+            raise IndexError
+    except IndexError:
+        # if there are too few or too many elements on the stack, just give up
+        # and treat the whole argument list as one argument, discarding the
+        # already partially populated paramlist node
+        paramlist = addnodes.desc_parameterlist()
+        paramlist += addnodes.desc_parameter(arglist, arglist)
+        signode += paramlist
+    else:
+        signode += paramlist
+
+class SparkObject(ObjectDescription[Tuple[str, str]]):
+    """
+    Description of a general Python object.
+
+    :cvar allow_nesting: Class is an object that allows for nested namespaces
+    :vartype allow_nesting: bool
+    """
+    option_spec: OptionSpec = {
+        'noindex': directives.flag,
+        'noindexentry': directives.flag,
+        'nocontentsentry': directives.flag,
+        'module': directives.unchanged,
+        'canonical': directives.unchanged,
+        'annotation': directives.unchanged,
+    }
+
+    doc_field_types = [
+        Field('returnvalue', label=_('Returns'), has_arg=False,
+              names=('returns', 'return')),
+    ]
+
+    allow_nesting = False
+
+    def get_signature_prefix(self, sig: str) -> list[nodes.Node]:
+        """May return a prefix to put before the object name in the
+        signature.
+        """
+        return []
+
+    def needs_arglist(self) -> bool:
+        """May return true if an empty argument list is to be generated even if
+        the document contains none.
+        """
+        return False
+
+    def handle_signature(self, sig: str, signode: desc_signature) -> tuple[str, str]:
+        """Transform a Python signature into RST nodes.
+
+        Return (fully qualified name of the thing, classname if any).
+
+        If inside a class, the current class name is handled intelligently:
+        * it is stripped from the displayed name if present
+        * it is added to the full name (return value) if not present
+        """
+        m = py_sig_re.match(sig)
+        if m is None:
+            raise ValueError
+        prefix, name, arglist, retann = m.groups()
+
+        # determine module and class name (if applicable), as well as full name
+        modname = self.options.get('module', self.env.ref_context.get('spark:module'))
+        classname = self.env.ref_context.get('spark:class')
+        if classname:
+            add_module = False
+            if prefix and (prefix == classname or
+                           prefix.startswith(classname + ".")):
+                fullname = prefix + name
+                # class name is given again in the signature
+                prefix = prefix[len(classname):].lstrip('.')
+            elif prefix:
+                # class name is given in the signature, but different
+                # (shouldn't happen)
+                fullname = classname + '.' + prefix + name
+            else:
+                # class name is not given in the signature
+                fullname = classname + '.' + name
+        else:
+            add_module = True
+            if prefix:
+                classname = prefix.rstrip('.')
+                fullname = prefix + name
+            else:
+                classname = ''
+                fullname = name
+
+        signode['module'] = modname
+        signode['class'] = classname
+        signode['fullname'] = fullname
+
+        sig_prefix = self.get_signature_prefix(sig)
+        if sig_prefix:
+            if type(sig_prefix) is str:
+                raise TypeError(
+                    "Python directive method get_signature_prefix()"
+                    " must return a list of nodes."
+                    f" Return value was '{sig_prefix}'.")
+            else:
+                signode += addnodes.desc_annotation(str(sig_prefix), '', *sig_prefix)
+
+        if prefix:
+            signode += addnodes.desc_addname(prefix, prefix)
+        elif modname and add_module and self.env.config.add_module_names:
+            nodetext = modname + '.'
+            signode += addnodes.desc_addname(nodetext, nodetext)
+
+        signode += addnodes.desc_name(name, name)
+        if arglist:
+            try:
+                signode += _parse_arglist(arglist, self.env)
+            except SyntaxError:
+                # fallback to parse arglist original parser.
+                # it supports to represent optional arguments (ex. "func(foo [, bar])")
+                _pseudo_parse_arglist(signode, arglist)
+            except NotImplementedError as exc:
+                logger.warning("could not parse arglist (%r): %s", arglist, exc,
+                               location=signode)
+                _pseudo_parse_arglist(signode, arglist)
+        else:
+            if self.needs_arglist():
+                # for callables, add an empty parameter list
+                signode += addnodes.desc_parameterlist()
+
+        if retann:
+            children = _parse_annotation(retann, self.env)
+            signode += addnodes.desc_returns(retann, '', *children)
+
+        anno = self.options.get('annotation')
+        if anno:
+            signode += addnodes.desc_annotation(' ' + anno, '',
+                                                addnodes.desc_sig_space(),
+                                                nodes.Text(anno))
+
+        return fullname, prefix
+
+    def _object_hierarchy_parts(self, sig_node: desc_signature) -> tuple[str, ...]:
+        if 'fullname' not in sig_node:
+            return ()
+        modname = sig_node.get('module')
+        fullname = sig_node['fullname']
+
+        if modname:
+            return (modname, *fullname.split('.'))
+        else:
+            return tuple(fullname.split('.'))
+
+    def get_index_text(self, modname: str, name: tuple[str, str]) -> str:
+        """Return the text for the index entry of the object."""
+        raise NotImplementedError('must be implemented in subclasses')
+
+    def add_target_and_index(self, name_cls: tuple[str, str], sig: str,
+                             signode: desc_signature) -> None:
+        modname = self.options.get('module', self.env.ref_context.get('spark:module'))
+        fullname = (modname + '.' if modname else '') + name_cls[0]
+        node_id = make_id(self.env, self.state.document, '', fullname)
+        signode['ids'].append(node_id)
+        self.state.document.note_explicit_target(signode)
+
+        domain = cast(SparkDomain, self.env.get_domain('spark'))
+        domain.note_object(fullname, self.objtype, node_id, location=signode)
+
+        canonical_name = self.options.get('canonical')
+        if canonical_name:
+            domain.note_object(canonical_name, self.objtype, node_id, aliased=True,
+                               location=signode)
+
+        if 'noindexentry' not in self.options:
+            indextext = self.get_index_text(modname, name_cls)
+            if indextext:
+                self.indexnode['entries'].append(('single', indextext, node_id, '', None))
+
+    def before_content(self) -> None:
+        """Handle object nesting before content
+
+        :spark:class:`SparkObject` represents Python language constructs. For
+        constructs that are nestable, such as a Python classes, this method will
+        build up a stack of the nesting hierarchy so that it can be later
+        de-nested correctly, in :spark:meth:`after_content`.
+
+        For constructs that aren't nestable, the stack is bypassed, and instead
+        only the most recent object is tracked. This object prefix name will be
+        removed with :spark:meth:`after_content`.
+        """
+        prefix = None
+        if self.names:
+            # fullname and name_prefix come from the `handle_signature` method.
+            # fullname represents the full object name that is constructed using
+            # object nesting and explicit prefixes. `name_prefix` is the
+            # explicit prefix given in a signature
+            (fullname, name_prefix) = self.names[-1]
+            if self.allow_nesting:
+                prefix = fullname
+            elif name_prefix:
+                prefix = name_prefix.strip('.')
+        if prefix:
+            self.env.ref_context['spark:class'] = prefix
+            if self.allow_nesting:
+                classes = self.env.ref_context.setdefault('spark:classes', [])
+                classes.append(prefix)
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('spark:modules', [])
+            modules.append(self.env.ref_context.get('spark:module'))
+            self.env.ref_context['spark:module'] = self.options['module']
+
+    def after_content(self) -> None:
+        """Handle object de-nesting after content
+
+        If this class is a nestable object, removing the last nested class prefix
+        ends further nesting in the object.
+
+        If this class is not a nestable object, the list of classes should not
+        be altered as we didn't affect the nesting levels in
+        :spark:meth:`before_content`.
+        """
+        classes = self.env.ref_context.setdefault('spark:classes', [])
+        if self.allow_nesting:
+            try:
+                classes.pop()
+            except IndexError:
+                pass
+        self.env.ref_context['spark:class'] = (classes[-1] if len(classes) > 0
+                                            else None)
+        if 'module' in self.options:
+            modules = self.env.ref_context.setdefault('spark:modules', [])
+            if modules:
+                self.env.ref_context['spark:module'] = modules.pop()
+            else:
+                self.env.ref_context.pop('spark:module')
+
+    def _toc_entry_name(self, sig_node: desc_signature) -> str:
+        if not sig_node.get('_toc_parts'):
+            return ''
+
+        config = self.env.app.config
+        objtype = sig_node.parent.get('objtype')
+        if config.add_function_parentheses and objtype in {'function', 'method'}:
+            parens = '()'
+        else:
+            parens = ''
+        *parents, name = sig_node['_toc_parts']
+        if config.toc_object_entries_show_parents == 'domain':
+            return sig_node.get('fullname', name) + parens
+        if config.toc_object_entries_show_parents == 'hide':
+            return name + parens
+        if config.toc_object_entries_show_parents == 'all':
+            return '.'.join(parents + [name + parens])
+        return ''
+
+
+class SparkFunction(SparkObject):
+    """Description of a function."""
+
+    option_spec: OptionSpec = SparkObject.option_spec.copy()
+    option_spec.update({
+        'async': directives.flag,
+    })
+
+    def get_signature_prefix(self, sig: str) -> list[nodes.Node]:
+        if 'async' in self.options:
+            return [addnodes.desc_sig_keyword('', 'async'),
+                    addnodes.desc_sig_space()]
+        else:
+            return []
+
+    def needs_arglist(self) -> bool:
+        return True
+
+    def add_target_and_index(self, name_cls: tuple[str, str], sig: str,
+                             signode: desc_signature) -> None:
+        super().add_target_and_index(name_cls, sig, signode)
+        if 'noindexentry' not in self.options:
+            modname = self.options.get('module', self.env.ref_context.get('spark:module'))
+            node_id = signode['ids'][0]
+
+            name, cls = name_cls
+            if modname:
+                text = _('%s() (in module %s)') % (name, modname)
+                self.indexnode['entries'].append(('single', text, node_id, '', None))
+            else:
+                text = f'{pairindextypes["builtin"]}; {name}()'
+                self.indexnode['entries'].append(('pair', text, node_id, '', None))
+
+    def get_index_text(self, modname: str, name_cls: tuple[str, str]) -> str | None:
+        # add index in own add_target_and_index() instead.
+        return None
+
+
+class SparkXRefRole(XRefRole):
+    def process_link(self, env: BuildEnvironment, refnode: Element,
+                     has_explicit_title: bool, title: str, target: str) -> tuple[str, str]:
+        refnode['spark:module'] = env.ref_context.get('spark:module')
+        refnode['spark:class'] = env.ref_context.get('spark:class')
+        if not has_explicit_title:
+            title = title.lstrip('.')    # only has a meaning for the target
+            target = target.lstrip('~')  # only has a meaning for the title
+            # if the first character is a tilde, don't display the module/class
+            # parts of the contents
+            if title[0:1] == '~':
+                title = title[1:]
+                dot = title.rfind('.')
+                if dot != -1:
+                    title = title[dot + 1:]
+        # if the first character is a dot, search more specific namespaces first
+        # else search builtins first
+        if target[0:1] == '.':
+            target = target[1:]
+            refnode['refspecific'] = True
+        return title, target
+
+
+class SparkModuleIndex(Index):
+    """
+    Index subclass to provide the Python module index.
+    """
+
+    name = 'modindex'
+    localname = _('Python Module Index')
+    shortname = _('modules')
+
+    def generate(self, docnames: Iterable[str] | None = None
+                 ) -> tuple[list[tuple[str, list[IndexEntry]]], bool]:
+        content: dict[str, list[IndexEntry]] = {}
+        # list of prefixes to ignore
+        ignores: list[str] = self.domain.env.config['modindex_common_prefix']
+        ignores = sorted(ignores, key=len, reverse=True)
+        # list of all modules, sorted by module name
+        modules = sorted(self.domain.data['modules'].items(),
+                         key=lambda x: x[0].lower())
+        # sort out collapsible modules
+        prev_modname = ''
+        num_toplevels = 0
+        for modname, (docname, node_id, synopsis, platforms, deprecated) in modules:
+            if docnames and docname not in docnames:
+                continue
+
+            for ignore in ignores:
+                if modname.startswith(ignore):
+                    modname = modname[len(ignore):]
+                    stripped = ignore
+                    break
+            else:
+                stripped = ''
+
+            # we stripped the whole module name?
+            if not modname:
+                modname, stripped = stripped, ''
+
+            entries = content.setdefault(modname[0].lower(), [])
+
+            package = modname.split('.')[0]
+            if package != modname:
+                # it's a submodule
+                if prev_modname == package:
+                    # first submodule - make parent a group head
+                    if entries:
+                        last = entries[-1]
+                        entries[-1] = IndexEntry(last[0], 1, last[2], last[3],
+                                                 last[4], last[5], last[6])
+                elif not prev_modname.startswith(package):
+                    # submodule without parent in list, add dummy entry
+                    entries.append(IndexEntry(stripped + package, 1, '', '', '', '', ''))
+                subtype = 2
+            else:
+                num_toplevels += 1
+                subtype = 0
+
+            qualifier = _('Deprecated') if deprecated else ''
+            entries.append(IndexEntry(stripped + modname, subtype, docname,
+                                      node_id, platforms, qualifier, synopsis))
+            prev_modname = modname
+
+        # apply heuristics when to collapse modindex at page load:
+        # only collapse if number of toplevel modules is larger than
+        # number of submodules
+        collapse = len(modules) - num_toplevels < num_toplevels
+
+        # sort by first letter
+        sorted_content = sorted(content.items())
+
+        return sorted_content, collapse
+
+
+class SparkDomain(Domain):
+    """Spark domain."""
+    name = 'spark'
+    label = 'Spark'
+    object_types: dict[str, ObjType] = {
+        'function':     ObjType(_('function'),      'func', 'obj'),
+    }
+
+    directives = {
+        'function':        SparkFunction,
+    }
+    roles = {
+        'func':  SparkXRefRole(fix_parens=True),
+    }
+    initial_data: dict[str, dict[str, tuple[Any]]] = {
+        'objects': {},  # fullname -> docname, objtype
+        'modules': {},  # modname -> docname, synopsis, platform, deprecated
+    }
+    indices = [
+        SparkModuleIndex,
+    ]
+
+    @property
+    def objects(self) -> dict[str, ObjectEntry]:
+        return self.data.setdefault('objects', {})  # fullname -> ObjectEntry
+
+    def note_object(self, name: str, objtype: str, node_id: str,
+                    aliased: bool = False, location: Any = None) -> None:
+        """Note a spark object for cross reference.
+
+        .. versionadded:: 2.1
+        """
+        if name in self.objects:
+            other = self.objects[name]
+            if other.aliased and aliased is False:
+                # The original definition found. Override it!
+                pass
+            elif other.aliased is False and aliased:
+                # The original definition is already registered.
+                return
+            else:
+                # duplicated
+                logger.warning(__('duplicate object description of %s, '
+                                  'other instance in %s, use :noindex: for one of them'),
+                               name, other.docname, location=location)
+        self.objects[name] = ObjectEntry(self.env.docname, node_id, objtype, aliased)
+
+    @property
+    def modules(self) -> dict[str, ModuleEntry]:
+        return self.data.setdefault('modules', {})  # modname -> ModuleEntry
+
+    def note_module(self, name: str, node_id: str, synopsis: str,
+                    platform: str, deprecated: bool) -> None:
+        """Note a spark module for cross reference.
+
+        .. versionadded:: 2.1
+        """
+        self.modules[name] = ModuleEntry(self.env.docname, node_id,
+                                         synopsis, platform, deprecated)
+
+    def clear_doc(self, docname: str) -> None:
+        for fullname, obj in list(self.objects.items()):
+            if obj.docname == docname:
+                del self.objects[fullname]
+        for modname, mod in list(self.modules.items()):
+            if mod.docname == docname:
+                del self.modules[modname]
+
+    def merge_domaindata(self, docnames: list[str], otherdata: dict[str, Any]) -> None:
+        # XXX check duplicates?
+        for fullname, obj in otherdata['objects'].items():
+            if obj.docname in docnames:
+                self.objects[fullname] = obj
+        for modname, mod in otherdata['modules'].items():
+            if mod.docname in docnames:
+                self.modules[modname] = mod
+
+    def find_obj(self, env: BuildEnvironment, modname: str, classname: str,
+                 name: str, type: str | None, searchmode: int = 0
+                 ) -> list[tuple[str, ObjectEntry]]:
+        """Find a Python object for "name", perhaps using the given module
+        and/or classname.  Returns a list of (name, object entry) tuples.
+        """
+        # skip parens
+        if name[-2:] == '()':
+            name = name[:-2]
+
+        if not name:
+            return []
+
+        matches: list[tuple[str, ObjectEntry]] = []
+
+        newname = None
+        if searchmode == 1:
+            if type is None:
+                objtypes = list(self.object_types)
+            else:
+                objtypes = self.objtypes_for_role(type)
+            if objtypes is not None:
+                if modname and classname:
+                    fullname = modname + '.' + classname + '.' + name
+                    if fullname in self.objects and self.objects[fullname].objtype in objtypes:
+                        newname = fullname
+                if not newname:
+                    if modname and modname + '.' + name in self.objects and \
+                       self.objects[modname + '.' + name].objtype in objtypes:
+                        newname = modname + '.' + name
+                    elif name in self.objects and self.objects[name].objtype in objtypes:
+                        newname = name
+                    else:
+                        # "fuzzy" searching mode
+                        searchname = '.' + name
+                        matches = [(oname, self.objects[oname]) for oname in self.objects
+                                   if oname.endswith(searchname) and
+                                   self.objects[oname].objtype in objtypes]
+        else:
+            # NOTE: searching for exact match, object type is not considered
+            if name in self.objects:
+                newname = name
+            elif type == 'mod':
+                # only exact matches allowed for modules
+                return []
+            elif classname and classname + '.' + name in self.objects:
+                newname = classname + '.' + name
+            elif modname and modname + '.' + name in self.objects:
+                newname = modname + '.' + name
+            elif modname and classname and \
+                    modname + '.' + classname + '.' + name in self.objects:
+                newname = modname + '.' + classname + '.' + name
+        if newname is not None:
+            matches.append((newname, self.objects[newname]))
+        return matches
+
+    def resolve_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
+                     type: str, target: str, node: pending_xref, contnode: Element
+                     ) -> Element | None:
+        modname = node.get('spark:module')
+        clsname = node.get('spark:class')
+        searchmode = 1 if node.hasattr('refspecific') else 0
+        matches = self.find_obj(env, modname, clsname, target,
+                                type, searchmode)
+
+        if not matches and type == 'attr':
+            # fallback to meth (for property; Sphinx-2.4.x)
+            # this ensures that `:attr:` role continues to refer to the old property entry
+            # that defined by ``method`` directive in old reST files.
+            matches = self.find_obj(env, modname, clsname, target, 'meth', searchmode)
+        if not matches and type == 'meth':
+            # fallback to attr (for property)
+            # this ensures that `:meth:` in the old reST files can refer to the property
+            # entry that defined by ``property`` directive.
+            #
+            # Note: _prop is a secret role only for internal look-up.
+            matches = self.find_obj(env, modname, clsname, target, '_prop', searchmode)
+
+        if not matches:
+            return None
+        elif len(matches) > 1:
+            canonicals = [m for m in matches if not m[1].aliased]
+            if len(canonicals) == 1:
+                matches = canonicals
+            else:
+                logger.warning(__('more than one target found for cross-reference %r: %s'),
+                               target, ', '.join(match[0] for match in matches),
+                               type='ref', subtype='python', location=node)
+        name, obj = matches[0]
+
+        if obj[2] == 'module':
+            return self._make_module_refnode(builder, fromdocname, name, contnode)
+        else:
+            # determine the content of the reference by conditions
+            content = find_pending_xref_condition(node, 'resolved')
+            if content:
+                children = content.children
+            else:
+                # if not found, use contnode
+                children = [contnode]
+
+            return make_refnode(builder, fromdocname, obj[0], obj[1], children, name)
+
+    def resolve_any_xref(self, env: BuildEnvironment, fromdocname: str, builder: Builder,
+                         target: str, node: pending_xref, contnode: Element
+                         ) -> list[tuple[str, Element]]:
+        modname = node.get('spark:module')
+        clsname = node.get('spark:class')
+        results: list[tuple[str, Element]] = []
+
+        # always search in "refspecific" mode with the :any: role
+        matches = self.find_obj(env, modname, clsname, target, None, 1)
+        multiple_matches = len(matches) > 1
+
+        for name, obj in matches:
+
+            if multiple_matches and obj.aliased:
+                # Skip duplicated matches
+                continue
+
+            if obj[2] == 'module':
+                results.append(('spark:mod',
+                                self._make_module_refnode(builder, fromdocname,
+                                                          name, contnode)))
+            else:
+                # determine the content of the reference by conditions
+                content = find_pending_xref_condition(node, 'resolved')
+                if content:
+                    children = content.children
+                else:
+                    # if not found, use contnode
+                    children = [contnode]
+
+                results.append(('spark:' + self.role_for_objtype(obj[2]),
+                                make_refnode(builder, fromdocname, obj[0], obj[1],
+                                             children, name)))
+        return results
+
+    def _make_module_refnode(self, builder: Builder, fromdocname: str, name: str,
+                             contnode: Node) -> Element:
+        # get additional info for modules
+        module = self.modules[name]
+        title = name
+        if module.synopsis:
+            title += ': ' + module.synopsis
+        if module.deprecated:
+            title += _(' (deprecated)')
+        if module.platform:
+            title += ' (' + module.platform + ')'
+        return make_refnode(builder, fromdocname, module.docname, module.node_id,
+                            contnode, title)
+
+    def get_objects(self) -> Iterator[tuple[str, str, str, str, str, int]]:
+        for modname, mod in self.modules.items():
+            yield (modname, modname, 'module', mod.docname, mod.node_id, 0)
+        for refname, obj in self.objects.items():
+            if obj.objtype != 'module':  # modules are already handled
+                if obj.aliased:
+                    # aliased names are not full-text searchable.
+                    yield (refname, refname, obj.objtype, obj.docname, obj.node_id, -1)
+                else:
+                    yield (refname, refname, obj.objtype, obj.docname, obj.node_id, 1)
+
+    def get_full_qualified_name(self, node: Element) -> str | None:
+        modname = node.get('spark:module')
+        clsname = node.get('spark:class')
+        target = node.get('reftarget')
+        if target is None:
+            return None
+        else:
+            return '.'.join(filter(None, [modname, clsname, target]))
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    app.setup_extension('sphinx.directives')
+    app.add_domain(SparkDomain)
+
+    return {
+        'version': 'builtin',
+        'env_version': 3,
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -11,7 +11,7 @@ General Aggregate Functions
 
     Returns the last value of `x` for a group of rows.
 
-.. spark:function::last(x, ignoreNull) -> x
+.. spark:function:: last(x, ignoreNull) -> x
 
     Returns the last value of `x` for a group of rows. If `ignoreNull` is true, returns only non-null values.
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -1,0 +1,17 @@
+===================
+Aggregate Functions
+===================
+
+Aggregate functions operate on a set of values to compute a single result.
+
+General Aggregate Functions
+---------------------------
+
+.. spark:function:: last(x) -> x
+
+    Returns the last value of `x` for a group of rows.
+
+.. spark:function::last(x, ignoreNull) -> x
+
+    Returns the last value of `x` for a group of rows. If `ignoreNull` is true, returns only non-null values.
+

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -15,14 +15,14 @@ Array Functions
 
 .. spark:function:: in(value, array(E)) -> boolean
 
-    This function returns true if value matches at least one of the elements of the array.
+    Returns true if value matches at least one of the elements of the array.
     Supports BOOLEAN, REAL, DOUBLE, BIGINT, VARCHAR, TIMESTAMP, DATE input types.
 
 .. spark:function:: size(array(E)) -> bigint
 
-    Returns the size of the input array. The function returns null for null input
-    if legacySizeOfNull is set to false. Otherwise, the function returns -1 for null input.
-    With the default settings, the function returns -1 for null input.
+    Returns the size of the array. Returns null for null input
+    if :doc:`spark.legacy-size-of-null <../../configs>` is set to false. 
+    Otherwise, returns -1 for null input.
 
 .. spark:function:: sort_array(array(E)) -> array(E)
 
@@ -30,7 +30,7 @@ Array Functions
     be orderable. Null elements will be placed at the beginning of the returned array. ::
 
         SELECT sort_array(ARRAY [1, 2, 3]); -- [1, 2, 3]
-        SELECT sort_array(ARRAY [NULL, 2, 1]); -- [null, 1, 2]
+        SELECT sort_array(ARRAY [NULL, 2, 1]); -- [NULL, 1, 2]
 
 .. spark:function:: sort_array(array(E), ascendingOrder) -> array(E)
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -1,0 +1,44 @@
+=============================
+Array Functions
+=============================
+
+.. spark:function:: array_sort(array(E)) -> array(E)
+
+    Returns an array which has the sorted order of the input array(E). The elements of array(E) must
+    be orderable. Null elements will be placed at the end of the returned array. ::
+
+        SELECT array_sort(ARRAY [1, 2, 3]); -- [1, 2, 3]
+        SELECT array_sort(ARRAY [3, 2, 1]); -- [1, 2, 3]
+        SELECT array_sort(ARRAY [2, 1, NULL]; -- [1, 2, NULL]
+        SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
+        SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
+
+.. spark:function:: in(value, array(E)) -> boolean
+
+    This function returns true if value matches at least one of the elements of the array.
+    Supports BOOLEAN, REAL, DOUBLE, BIGINT, VARCHAR, TIMESTAMP, DATE input types.
+
+.. spark:function:: size(array(E)) -> bigint
+
+    Returns the size of the input array. The function returns null for null input
+    if legacySizeOfNull is set to false. Otherwise, the function returns -1 for null input.
+    With the default settings, the function returns -1 for null input.
+
+.. spark:function:: sort_array(array(E)) -> array(E)
+
+    Returns an array which has the sorted order of the input array. The elements of array must
+    be orderable. Null elements will be placed at the beginning of the returned array. ::
+
+        SELECT sort_array(ARRAY [1, 2, 3]); -- [1, 2, 3]
+        SELECT sort_array(ARRAY [NULL, 2, 1]); -- [null, 1, 2]
+
+.. spark:function:: sort_array(array(E), ascendingOrder) -> array(E)
+
+    Returns an array which has the sorted order of the input array. The elements of array must
+    be orderable. Null elements will be placed at the beginning of the returned array in ascending
+    order or at the end of the returned array in descending order. ::
+
+        SELECT sort_array(ARRAY [3, 2, 1], true); -- [1, 2, 3]
+        SELECT sort_array(ARRAY [2, 1, NULL, true]; -- [NULL, 1, 2]
+        SELECT sort_array(ARRAY [NULL, 1, NULL], false); -- [1, NULL, NULL]
+

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -1,0 +1,15 @@
+================
+Binary Functions
+================
+
+.. spark:function:: hash(x) -> integer
+
+    Computes the hash of x.
+
+.. spark:function:: md5(x) -> varbinary
+
+    Computes the md5 of x.
+
+.. spark:function:: xxhash64(x) -> integer
+
+    Computes the xxhash64 of x.

--- a/velox/docs/functions/spark/bitwise.rst
+++ b/velox/docs/functions/spark/bitwise.rst
@@ -1,0 +1,22 @@
+=================
+Bitwise Functions
+=================
+
+.. spark:function:: bitwise_and(x, y) -> [same as input]
+
+    Returns the bitwise AND of ``x`` and ``y`` in 2's complement representation. 
+    Corresponds to scala's operator ``&``.
+
+.. spark:function:: bitwise_or(x, y) -> [same as input]
+
+    Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
+    Corresponds to scala's operator ``^``.
+
+.. spark:function:: shiftleft(x, shift) -> [same as x]
+
+    Returns the left shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
+    Supported types for 'x' are INTEGER and BIGINT.
+
+.. spark:function:: shiftright(x, shift) -> [same as x]
+
+    Returns the logical right shifted value of ``x``. Supported types for 'x' are INTEGER and BIGINT.

--- a/velox/docs/functions/spark/bitwise.rst
+++ b/velox/docs/functions/spark/bitwise.rst
@@ -5,18 +5,17 @@ Bitwise Functions
 .. spark:function:: bitwise_and(x, y) -> [same as input]
 
     Returns the bitwise AND of ``x`` and ``y`` in 2's complement representation. 
-    Corresponds to scala's operator ``&``.
+    Corresponds to Spark's operator ``&``.
 
 .. spark:function:: bitwise_or(x, y) -> [same as input]
 
     Returns the bitwise OR of ``x`` and ``y`` in 2's complement representation.
-    Corresponds to scala's operator ``^``.
+    Corresponds to Spark's operator ``^``.
 
-.. spark:function:: shiftleft(x, shift) -> [same as x]
+.. spark:function:: shiftleft(x, n) -> [same as x]
 
-    Returns the left shift operation on ``x`` (treated as ``bits``-bit integer) shifted by ``shift``.
-    Supported types for 'x' are INTEGER and BIGINT.
+    Returns x bitwise left shifted by n bits. Supported types for 'x' are INTEGER and BIGINT.
 
-.. spark:function:: shiftright(x, shift) -> [same as x]
+.. spark:function:: shiftright(x, n) -> [same as x]
 
-    Returns the logical right shifted value of ``x``. Supported types for 'x' are INTEGER and BIGINT.
+    Returns x bitwise right shifted by n bits. Supported types for 'x' are INTEGER and BIGINT.

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -11,58 +11,57 @@ Comparison Functions
 .. spark:function:: equalnullsafe(x, y) -> boolean
 
     Returns true if x is equal to y. Supports all scalar types. The
-    types of x and y must be the same. this differs from EqualTo in that
-    it returns true (rather than NULL) if both inputs are NULL,
-    and false (rather than NULL) if one of the input is NULL.
-    Corresponds to scala's operator ``<=>``.
+    types of x and y must be the same. Unlike :spark:func:`equalto` returns true if both inputs
+    are NULL and false if one of the inputs is NULL.
+    Corresponds to Spark's operator ``<=>``.
 
 .. spark:function:: equalto(x, y) -> boolean
 
     Returns true if x is equal to y. Supports all scalar types. The
-    types of x and y must be the same. Corresponds to scala's operator ``=`` and ``==``.
+    types of x and y must be the same. Corresponds to Spark's operators ``=`` and ``==``.
 
 .. spark:function:: greaterthan(x, y) -> boolean
 
     Returns true if x is greater than y. Supports all scalar types. The
-    types of x and y must be the same. Corresponds to scala's operator ``>``.
+    types of x and y must be the same. Corresponds to Spark's operator ``>``.
 
 .. spark:function:: greaterthanorequal(x, y) -> boolean
 
     Returns true if x is greater than y or x is equal to y. Supports all scalar types. The
-    types of x and y must be the same. Corresponds to scala's operator ``>=``.
+    types of x and y must be the same. Corresponds to Spark's operator ``>=``.
 
 .. spark:function:: greatest(value1, value2, ..., valueN) -> [same as input]
 
-    Returns the largest of the provided values. skipping null values. Supports all scalar types. 
+    Returns the largest of the provided values ignoring nulls. Supports all scalar types. 
     The types of all arguments must be the same. ::
 
         SELECT greatest(10, 9, 2, 4, 3); -- 10
         SELECT greatest(10, 9, 2, 4, 3, null); -- 10
-        SELECT greatest(null ,null) - null
+        SELECT greatest(null, null) - null
 
 .. spark:function:: least(value1, value2, ..., valueN) -> [same as input]
 
-    Returns the smallest of the provided values. Skipping null values. Supports all scalar types.
+    Returns the smallest of the provided values ignoring nulls. Supports all scalar types.
     The types of all arguments must be the same. ::
 
         SELECT least(10, 9, 2, 4, 3); -- 2
         SELECT least(10, 9, 2, 4, 3, null); -- 2
-        SELECT least(null ,null) - null
+        SELECT least(null, null) - null
 
 .. spark:function:: lessthan(x, y) -> boolean
 
     Returns true if x is less than y. Supports all scalar types. The types
-    of x and y must be the same. Corresponds to scala's operator ``<``.
+    of x and y must be the same. Corresponds to Spark's operator ``<``.
 
 .. spark:function:: lessthanorequal(x, y) -> boolean
 
     Returns true if x is less than y or x is equal to y. Supports all scalar types. The
-    types of x and y must be the same. Corresponds to scala's operator ``<=``.
+    types of x and y must be the same. Corresponds to Spark's operator ``<=``.
 
 .. spark:function:: notequalto(x, y) -> boolean
 
     Returns true if x is not equal to y. Supports all scalar types. The types
-    of x and y must be the same. Corresponds to scala's operator ``!=``.
+    of x and y must be the same. Corresponds to Spark's operator ``!=``.
 
 
 

--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -1,0 +1,68 @@
+=====================================
+Comparison Functions
+=====================================
+
+.. spark:function:: between(x, min, max) -> boolean
+
+    Returns true if x is within the specified [min, max] range
+    inclusive. The types of all arguments must be the same.
+    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, DOUBLE, REAL.
+
+.. spark:function:: equalnullsafe(x, y) -> boolean
+
+    Returns true if x is equal to y. Supports all scalar types. The
+    types of x and y must be the same. this differs from EqualTo in that
+    it returns true (rather than NULL) if both inputs are NULL,
+    and false (rather than NULL) if one of the input is NULL.
+    Corresponds to scala's operator ``<=>``.
+
+.. spark:function:: equalto(x, y) -> boolean
+
+    Returns true if x is equal to y. Supports all scalar types. The
+    types of x and y must be the same. Corresponds to scala's operator ``=`` and ``==``.
+
+.. spark:function:: greaterthan(x, y) -> boolean
+
+    Returns true if x is greater than y. Supports all scalar types. The
+    types of x and y must be the same. Corresponds to scala's operator ``>``.
+
+.. spark:function:: greaterthanorequal(x, y) -> boolean
+
+    Returns true if x is greater than y or x is equal to y. Supports all scalar types. The
+    types of x and y must be the same. Corresponds to scala's operator ``>=``.
+
+.. spark:function:: greatest(value1, value2, ..., valueN) -> [same as input]
+
+    Returns the largest of the provided values. skipping null values. Supports all scalar types. 
+    The types of all arguments must be the same. ::
+
+        SELECT greatest(10, 9, 2, 4, 3); -- 10
+        SELECT greatest(10, 9, 2, 4, 3, null); -- 10
+        SELECT greatest(null ,null) - null
+
+.. spark:function:: least(value1, value2, ..., valueN) -> [same as input]
+
+    Returns the smallest of the provided values. Skipping null values. Supports all scalar types.
+    The types of all arguments must be the same. ::
+
+        SELECT least(10, 9, 2, 4, 3); -- 2
+        SELECT least(10, 9, 2, 4, 3, null); -- 2
+        SELECT least(null ,null) - null
+
+.. spark:function:: lessthan(x, y) -> boolean
+
+    Returns true if x is less than y. Supports all scalar types. The types
+    of x and y must be the same. Corresponds to scala's operator ``<``.
+
+.. spark:function:: lessthanorequal(x, y) -> boolean
+
+    Returns true if x is less than y or x is equal to y. Supports all scalar types. The
+    types of x and y must be the same. Corresponds to scala's operator ``<=``.
+
+.. spark:function:: notequalto(x, y) -> boolean
+
+    Returns true if x is not equal to y. Supports all scalar types. The types
+    of x and y must be the same. Corresponds to scala's operator ``!=``.
+
+
+

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -1,0 +1,12 @@
+=====================================
+Date and Time Functions
+=====================================
+
+Convenience Extraction Functions
+--------------------------------
+
+These functions support TIMESTAMP and DATE input types.
+
+.. spark:function:: year(x) -> integer
+
+    Returns the year from ``x``.

--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -4,6 +4,7 @@ JSON Functions
 
 JSON Format
 -----------
+
 JSON is a language-independent data format that represents data as
 human-readable text. A JSON text can represent a number, a boolean, a
 string, an array, an object, or a null, with slightly different grammar.
@@ -19,13 +20,8 @@ such as ``[1,2,3]``. More detailed grammar can be found in
 JSON Functions
 --------------
 
-.. spark:function:: get_json_object(json, json_path) -> varchar
+.. spark:function:: get_json_object(json, path) -> varchar
 
-    Evaluates the `JSONPath`_-like expression ``json_path`` (a string containing JSON)
-    on ``json`` (a string containing JSON) and returns the result as a string. The
-    value referenced by ``json_path`` must be a scalar (boolean, number
-    or string). ::
+    Extracts a json object from path::
 
-        SELECT get_json_object('{"a":"b"}', '$.a'); - b
-
-.. _JSONPath: http://goessner.net/articles/JsonPath/
+        SELECT get_json_object('{"a":"b"}', '$.a'); -- b

--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -1,0 +1,31 @@
+==============
+JSON Functions
+==============
+
+JSON Format
+-----------
+JSON is a language-independent data format that represents data as
+human-readable text. A JSON text can represent a number, a boolean, a
+string, an array, an object, or a null, with slightly different grammar.
+For instance, a JSON text representing a string must escape all characters
+and enclose the string in double quotes, such as ``"123\n"``, whereas a JSON
+text representing a number does not need to, such as ``123``. A JSON text
+representing an array must enclose the array elements in square brackets,
+such as ``[1,2,3]``. More detailed grammar can be found in
+`this JSON introduction`_.
+
+.. _this JSON introduction: https://www.json.org
+
+JSON Functions
+--------------
+
+.. spark:function:: get_json_object(json, json_path) -> varchar
+
+    Evaluates the `JSONPath`_-like expression ``json_path`` (a string containing JSON)
+    on ``json`` (a string containing JSON) and returns the result as a string. The
+    value referenced by ``json_path`` must be a scalar (boolean, number
+    or string). ::
+
+        SELECT get_json_object('{"a":"b"}', '$.a'); - b
+
+.. _JSONPath: http://goessner.net/articles/JsonPath/

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -20,5 +20,6 @@ Map Functions
 
 .. spark:function:: size(map(K,V)) -> bigint
 
-    Returns the size of the input map. The function returns null for null input
-    if spark.legacy-size-of-null is set to false. Otherwise, the function returns -1 for null input.
+    Returns the size of the input map. Returns null for null input
+    if :doc:`spark.legacy-size-of-null <../../configs>` is set to false. 
+    Otherwise, returns -1 for null input.

--- a/velox/docs/functions/spark/map.rst
+++ b/velox/docs/functions/spark/map.rst
@@ -1,0 +1,24 @@
+===========================
+Map Functions
+===========================
+
+.. spark:function:: element_at(map(K,V), key) -> V
+
+    Returns value for given ``key``, or ``NULL`` if the key is not contained in the map.
+
+.. spark:function:: map() -> map(unknown, unknown)
+
+    Returns an empty map. ::
+
+        SELECT map(); -- {}
+
+.. spark:function:: map(array(K), array(V)) -> map(K,V)
+
+    Returns a map created using the given key/value arrays. Duplicate map key will cause exception. ::
+
+        SELECT map(ARRAY[1,3], ARRAY[2,4]); -- {1 -> 2, 3 -> 4}
+
+.. spark:function:: size(map(K,V)) -> bigint
+
+    Returns the size of the input map. The function returns null for null input
+    if spark.legacy-size-of-null is set to false. Otherwise, the function returns -1 for null input.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -14,12 +14,15 @@ Mathematical Functions
 .. spark:function:: ceil(x) -> [same as x]
 
     Returns ``x`` rounded up to the nearest integer.  
-    In spark only long, double, and decimal have ceil.
+    In Spark, Supported types are: BIGINT and DOUBLE.
 
-.. spark:function:: divide(x, y) -> [same as x]
+.. spark:function:: divide(x, y) -> double
 
-    Returns the results of dividing x by y. The types of x and y must be the same.
-    It always performs floating point division. Corresponds to spark's operator ``/``.
+    Returns the results of dividing x by y. It always performs floating point division.
+    Corresponds to spark's operator ``/``. ::
+        SELECT 3 / 2; -- 1.5
+        SELECT 2L / 2L; -- 1.0
+        SELECT 3 / 0; -- NULL
 
 .. spark:function:: exp(x) -> double
 
@@ -28,7 +31,7 @@ Mathematical Functions
 .. spark:function:: floor(x) -> [same as x]
 
     Returns ``x`` rounded down to the nearest integer.
-    In spark only long, double, and decimal have floor.
+    In Spark, Supported types are: BIGINT and DOUBLE.
 
 .. spark:function:: multiply(x, y) -> [same as x]
 
@@ -37,7 +40,7 @@ Mathematical Functions
 
 .. spark:function:: pmod(n, m) -> [same as n]
 
-    Returns the positive value of ``n`` divided by ``m``.
+    Returns the positive remainder of n divided by m.
 
 .. spark:function:: power(x, p) -> double
 
@@ -49,9 +52,10 @@ Mathematical Functions
 
 .. spark:function:: round(x, d) -> [same as x]
 
-    Returns ``x`` rounded to ``d`` decimal places using HALF_UP rounding mode.
+    Returns ``x`` rounded to ``d`` decimal places using HALF_UP rounding mode. 
+    In HALF_UP rounding, the digit 5 is rounded up.
 
 .. spark:function:: subtract(x, y) -> [same as x]
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to scala's operator ``-``.
+    For integral types, overflow results in an error. Corresponds to Spark's operator ``-``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -1,0 +1,57 @@
+====================================
+Mathematical Functions
+====================================
+
+.. spark:function:: abs(x) -> [same as x]
+
+    Returns the absolute value of ``x``.
+
+.. spark:function:: add(x, y) -> [same as x]
+
+    Returns the result of adding x to y. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to sparks's operator ``+``.
+
+.. spark:function:: ceil(x) -> [same as x]
+
+    Returns ``x`` rounded up to the nearest integer.  
+    In spark only long, double, and decimal have ceil.
+
+.. spark:function:: divide(x, y) -> [same as x]
+
+    Returns the results of dividing x by y. The types of x and y must be the same.
+    It always performs floating point division. Corresponds to spark's operator ``/``.
+
+.. spark:function:: exp(x) -> double
+
+    Returns Euler's number raised to the power of ``x``.
+
+.. spark:function:: floor(x) -> [same as x]
+
+    Returns ``x`` rounded down to the nearest integer.
+    In spark only long, double, and decimal have floor.
+
+.. spark:function:: multiply(x, y) -> [same as x]
+
+    Returns the result of multiplying x by y. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to spark's operator ``*``.
+
+.. spark:function:: pmod(n, m) -> [same as n]
+
+    Returns the positive value of ``n`` divided by ``m``.
+
+.. spark:function:: power(x, p) -> double
+
+    Returns ``x`` raised to the power of ``p``.
+
+.. spark:function:: remainder(n, m) -> [same as n]
+
+    Returns the modulus (remainder) of ``n`` divided by ``m``. Corresponds to spark's operator ``%``.
+
+.. spark:function:: round(x, d) -> [same as x]
+
+    Returns ``x`` rounded to ``d`` decimal places using HALF_UP rounding mode.
+
+.. spark:function:: subtract(x, y) -> [same as x]
+
+    Returns the result of subtracting y from x. The types of x and y must be the same.
+    For integral types, overflow results in an error. Corresponds to scala's operator ``-``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -14,12 +14,12 @@ Mathematical Functions
 .. spark:function:: ceil(x) -> [same as x]
 
     Returns ``x`` rounded up to the nearest integer.  
-    In Spark, Supported types are: BIGINT and DOUBLE.
+    Supported types are: BIGINT and DOUBLE.
 
 .. spark:function:: divide(x, y) -> double
 
-    Returns the results of dividing x by y. It always performs floating point division.
-    Corresponds to spark's operator ``/``. ::
+    Returns the results of dividing x by y. Performs floating point division.
+    Corresponds to Spark's operator ``/``. ::
         SELECT 3 / 2; -- 1.5
         SELECT 2L / 2L; -- 1.0
         SELECT 3 / 0; -- NULL
@@ -31,12 +31,12 @@ Mathematical Functions
 .. spark:function:: floor(x) -> [same as x]
 
     Returns ``x`` rounded down to the nearest integer.
-    In Spark, Supported types are: BIGINT and DOUBLE.
+    Supported types are: BIGINT and DOUBLE.
 
 .. spark:function:: multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.
-    For integral types, overflow results in an error. Corresponds to spark's operator ``*``.
+    For integral types, overflow results in an error. Corresponds to Spark's operator ``*``.
 
 .. spark:function:: pmod(n, m) -> [same as n]
 
@@ -48,7 +48,7 @@ Mathematical Functions
 
 .. spark:function:: remainder(n, m) -> [same as n]
 
-    Returns the modulus (remainder) of ``n`` divided by ``m``. Corresponds to spark's operator ``%``.
+    Returns the modulus (remainder) of ``n`` divided by ``m``. Corresponds to Spark's operator ``%``.
 
 .. spark:function:: round(x, d) -> [same as x]
 

--- a/velox/docs/functions/spark/regexp.rst
+++ b/velox/docs/functions/spark/regexp.rst
@@ -1,0 +1,35 @@
+============================
+Regular Expression Functions
+============================
+
+Regular expression functions use RE2 as the regex engine. RE2 is fast, but
+supports only a subset of PCRE syntax and in particular does not support
+backtracking and associated features (e.g. back references).
+See https://github.com/google/re2/wiki/Syntax for more information.
+
+.. spark:function:: regexp_extract(string, pattern) -> varchar
+
+    Returns the first substring matched by the regular expression ``pattern``
+    in ``string``. ::
+
+        SELECT regexp_extract('1a 2b 14m', '\d+'); -- 1
+
+.. spark:function:: regexp_extract(string, pattern, group) -> varchar
+
+    Finds the first occurrence of the regular expression ``pattern`` in
+    ``string`` and returns the capturing group number ``group``. ::
+
+        SELECT regexp_extract('1a 2b 14m', '(\d+)([a-z]+)', 2); -- 'a'
+
+.. spark:function:: rlike(string, pattern) -> boolean
+
+    Evaluates the regular expression ``pattern`` and determines if it is
+    contained within ``string``.
+
+    This function is similar to the ``LIKE`` operator, except that the
+    pattern only needs to be contained within ``string``, rather than
+    needing to match all of ``string``. In other words, this performs a
+    *contains* operation rather than a *match* operation. You can match
+    the entire string by anchoring the pattern using ``^`` and ``$``. ::
+
+        SELECT rlike('1a 2b 14m', '\d+b'); -- true

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -1,0 +1,87 @@
+====================================
+String Functions
+====================================
+
+.. note::
+
+    These functions assume that the input strings contain valid UTF-8 encoded
+    Unicode code points. There are no explicit checks for valid UTF-8 and
+    the functions may return incorrect results on invalid UTF-8.
+
+    Additionally, the functions operate on Unicode code points and not user
+    visible *characters* (or *grapheme clusters*).  Some languages combine
+    multiple code points into a single user-perceived *character*, the basic
+    unit of a writing system for a language, but the functions will treat each
+    code point as a separate unit.
+
+.. spark:function:: ascii(string) -> integer
+
+    Returns the numeric value of the first character of ``string``.
+
+.. spark:function:: chr(n) -> varchar
+
+    Returns the Unicode code point ``n`` as a single character string.
+
+.. spark:function:: contains(left, right) -> boolean
+
+    Returns a boolean. The value is True if right is found inside left.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
+    Both left or right must be of STRING. ::
+
+        SELECT contains('js SQL', 'js'); -- true
+        SELECT contains('js SQL', 'js'); -- false
+        SELECT contains('js SQL', null); -- NULL
+
+.. spark:function:: endsWith(left, right) -> boolean
+
+    Returns a boolean. The value is True if left ends with right.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
+    Both left or right must be of STRING. ::
+
+        SELECT endswith('js SQL', 'SQL'); -- true
+        SELECT endswith('js SQL', 'js'); -- false
+        SELECT endswith('js SQL', null); -- NULL
+
+.. spark:function:: instr(string, substring) -> integer
+
+    Returns the starting position of the first instance of ``substring`` in
+    ``string``. Positions start with ``1``. If not found, ``0`` is returned.
+
+.. spark:function:: length(string) -> integer
+
+    Returns the length of ``string`` in characters.
+
+.. spark:function:: split(string, delimiter) -> array(string)
+
+    Splits ``string`` on ``delimiter`` and returns an array. ::
+
+        SELECT split('oneAtwoBthreeC', '[ABC]'); -- ["one","two","three",""]
+
+.. spark:function:: split(string, delimiter, limit) -> array(string)
+
+    Splits ``string`` on ``delimiter`` and returns an array of size at most ``limit``. ::
+
+        SELECT split('oneAtwoBthreeC', '[ABC]', -1); -- ["one","two","three",""]
+        SELECT split('oneAtwoBthreeC', '[ABC]', 2); -- ["one","twoBthreeC"]
+
+.. spark:function:: startsWith(left, right) -> boolean
+
+    Returns a boolean. The value is True if left starts with right.
+    Returns NULL if either input expression is NULL. Otherwise, returns False.
+    Both left or right must be of STRING. ::
+
+        SELECT startswith('js SQL', 'js'); -- true
+        SELECT startswith('js SQL', 'SQL'); -- false
+        SELECT startswith('js SQL', null); -- NULL
+
+.. spark:function:: substring(string, start) -> varchar
+
+    Returns the rest of ``string`` from the starting position ``start``.
+    Positions start with ``1``. A negative starting position is interpreted
+    as being relative to the end of the string.
+
+.. spark:function:: substring(string, start, length) -> varchar
+
+    Returns a substring from ``string`` of length ``length`` from the starting
+    position ``start``. Positions start with ``1``. A negative starting
+    position is interpreted as being relative to the end of the string.

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -2,17 +2,8 @@
 String Functions
 ====================================
 
-.. note::
-
-    These functions assume that the input strings contain valid UTF-8 encoded
-    Unicode code points. There are no explicit checks for valid UTF-8 and
-    the functions may return incorrect results on invalid UTF-8.
-
-    Additionally, the functions operate on Unicode code points and not user
-    visible *characters* (or *grapheme clusters*).  Some languages combine
-    multiple code points into a single user-perceived *character*, the basic
-    unit of a writing system for a language, but the functions will treat each
-    code point as a separate unit.
+For functions contains, endsWith, startsWith, returns NULL if either left or right is NULL. 
+Both left or right must be of STRING. 
 
 .. spark:function:: ascii(string) -> integer
 
@@ -24,28 +15,25 @@ String Functions
 
 .. spark:function:: contains(left, right) -> boolean
 
-    Returns a boolean. The value is True if right is found inside left.
-    Returns NULL if either input expression is NULL. Otherwise, returns False.
-    Both left or right must be of STRING. ::
-
-        SELECT contains('js SQL', 'js'); -- true
-        SELECT contains('js SQL', 'js'); -- false
-        SELECT contains('js SQL', null); -- NULL
+    Returns true if 'right' is found in 'left'. Otherwise, returns False. ::
+        
+        SELECT contains('Spark SQL', 'Spark'); -- true
+        SELECT contains('Spark SQL', 'SPARK'); -- false
+        SELECT contains('Spark SQL', null); -- NULL
+        SELECT contains(x'537061726b2053514c', x'537061726b'); -- true
 
 .. spark:function:: endsWith(left, right) -> boolean
 
-    Returns a boolean. The value is True if left ends with right.
-    Returns NULL if either input expression is NULL. Otherwise, returns False.
-    Both left or right must be of STRING. ::
+    Returns true if 'left' ends with 'right'. Otherwise, returns False. ::
 
         SELECT endswith('js SQL', 'SQL'); -- true
         SELECT endswith('js SQL', 'js'); -- false
-        SELECT endswith('js SQL', null); -- NULL
+        SELECT endswith('js SQL', NULL); -- NULL
 
 .. spark:function:: instr(string, substring) -> integer
 
     Returns the starting position of the first instance of ``substring`` in
-    ``string``. Positions start with ``1``. If not found, ``0`` is returned.
+    ``string``. Positions start with ``1``. Returns 0 if 'substring' is not found.
 
 .. spark:function:: length(string) -> integer
 
@@ -56,19 +44,20 @@ String Functions
     Splits ``string`` on ``delimiter`` and returns an array. ::
 
         SELECT split('oneAtwoBthreeC', '[ABC]'); -- ["one","two","three",""]
+        SELECT split('one', ''); -- ["o", "n", "e", ""]
+        SELECT split('one', '1'); -- ["one"]
 
 .. spark:function:: split(string, delimiter, limit) -> array(string)
 
     Splits ``string`` on ``delimiter`` and returns an array of size at most ``limit``. ::
 
         SELECT split('oneAtwoBthreeC', '[ABC]', -1); -- ["one","two","three",""]
+        SELECT split('oneAtwoBthreeC', '[ABC]', 0); -- ["one", "two", "three", ""]
         SELECT split('oneAtwoBthreeC', '[ABC]', 2); -- ["one","twoBthreeC"]
 
 .. spark:function:: startsWith(left, right) -> boolean
 
-    Returns a boolean. The value is True if left starts with right.
-    Returns NULL if either input expression is NULL. Otherwise, returns False.
-    Both left or right must be of STRING. ::
+    Returns true if 'left' start with 'right'. Otherwise, returns False. ::
 
         SELECT startswith('js SQL', 'js'); -- true
         SELECT startswith('js SQL', 'SQL'); -- false
@@ -78,10 +67,15 @@ String Functions
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string.
+    as being relative to the end of the string. Supported types for ``Start`` is INTEGER. 
 
 .. spark:function:: substring(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
+    Supported types for ``Start`` is INTEGER. ::
+        SELECT substring('Spark SQL', 5, 1); -- k
+        SELECT substring('Spark SQL', 5, 0); -- ""
+        SELECT substring('Spark SQL', 5, -1); -- ""
+        SELECT substring('Spark SQL', 5, 10000); -- "k SQL"

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -2,8 +2,7 @@
 String Functions
 ====================================
 
-For functions contains, endsWith, startsWith, returns NULL if either left or right is NULL. 
-Both left or right must be of STRING. 
+Unless specified otherwise, all functions return NULL if at least one of the arguments is NULL.
 
 .. spark:function:: ascii(string) -> integer
 
@@ -15,7 +14,7 @@ Both left or right must be of STRING.
 
 .. spark:function:: contains(left, right) -> boolean
 
-    Returns true if 'right' is found in 'left'. Otherwise, returns False. ::
+    Returns true if 'right' is found in 'left'. Otherwise, returns false. ::
         
         SELECT contains('Spark SQL', 'Spark'); -- true
         SELECT contains('Spark SQL', 'SPARK'); -- false
@@ -24,7 +23,7 @@ Both left or right must be of STRING.
 
 .. spark:function:: endsWith(left, right) -> boolean
 
-    Returns true if 'left' ends with 'right'. Otherwise, returns False. ::
+    Returns true if 'left' ends with 'right'. Otherwise, returns false. ::
 
         SELECT endswith('js SQL', 'SQL'); -- true
         SELECT endswith('js SQL', 'js'); -- false
@@ -57,7 +56,7 @@ Both left or right must be of STRING.
 
 .. spark:function:: startsWith(left, right) -> boolean
 
-    Returns true if 'left' start with 'right'. Otherwise, returns False. ::
+    Returns true if 'left' starts with 'right'. Otherwise, returns false. ::
 
         SELECT startswith('js SQL', 'js'); -- true
         SELECT startswith('js SQL', 'SQL'); -- false
@@ -67,14 +66,14 @@ Both left or right must be of STRING.
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string. Supported types for ``Start`` is INTEGER. 
+    as being relative to the end of the string. Type of 'start' must be an INTEGER. 
 
 .. spark:function:: substring(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
-    Supported types for ``Start`` is INTEGER. ::
+    Type of 'start' must be an INTEGER. ::
         SELECT substring('Spark SQL', 5, 1); -- k
         SELECT substring('Spark SQL', 5, 0); -- ""
         SELECT substring('Spark SQL', 5, -1); -- ""

--- a/velox/docs/index.rst
+++ b/velox/docs/index.rst
@@ -7,6 +7,7 @@ Velox Documentation
 
     velox-in-10-min
     functions
+    spark_functions
     configs
     develop
     monthly-updates

--- a/velox/docs/monthly-updates/december-2022.rst
+++ b/velox/docs/monthly-updates/december-2022.rst
@@ -17,7 +17,7 @@ Presto Functions
 Spark Functions
 ===============
 
-* Add shiftleft and shiftright scalar functions.
+* Add :spark:func:`shiftleft` and :spark:func:`shiftright` scalar functions.
 
 Hive Connector
 ==============

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -1,0 +1,20 @@
+***********************
+Spark Functions
+***********************
+
+.. toctree::
+    :maxdepth: 1
+
+    functions/spark/math
+    functions/spark/bitwise
+    functions/spark/comparison
+    functions/spark/string
+    functions/spark/datetime
+    functions/spark/array
+    functions/spark/map
+    functions/spark/regexp
+    functions/spark/binary
+    functions/spark/json
+    functions/spark/aggregate
+
+


### PR DESCRIPTION
Add documentation for all available Spark functions.

Add "spark" domain to allow tagging Spark function docs using `spark:function::`
syntax and reference these using `:spark:func:`. The implementation of the
Spark domain is in velox/docs/ext/spark.py which is a subset of [python.py](https://github.com/sphinx-doc/sphinx/blob/a13cf2c24dd16b37670ee1d359f511cbdfa4402d/sphinx/domains/python.py).
