### PR TITLE
Fix boundary check in MmapAllocator::SizeClass::isInRange

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -694,7 +694,7 @@ MachinePageCount MmapAllocator::SizeClass::adviseAway(
 bool MmapAllocator::SizeClass::isInRange(uint8_t* ptr) const {
   if (ptr >= address_ && ptr < address_ + byteSize_) {
     // See that ptr falls on a page boundary.
-    if ((ptr - address_) % unitSize_ != 0) {
+    if ((ptr - address_) % AllocationTraits::pageBytes(unitSize_) != 0) {
       VELOX_FAIL("Pointer is in a SizeClass but not at page boundary");
     }
     return true;


### PR DESCRIPTION
MmapAllocator::SizeClass::isInRange checks that a given pointer falls on a page boundary.

```
    if ((ptr - address_) % unitSize_ != 0) {
      VELOX_FAIL("Pointer is in a SizeClass but not at page boundary");
    }
```

Here, ptr - address_ is the number of bytes while unitSize_ is the number of
pages. Hence, the check is incorrect as it needs to convert number of pages to
number of bytes before computing the mod.

fix #3892 