### PR TITLE
Fix rendering of Presto Functions documentation page

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -3,7 +3,7 @@ Presto Functions
 ***********************
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     functions/presto/math
     functions/presto/bitwise


### PR DESCRIPTION
Make sure to display functions in a table and not in a tree-shaped bulleted list in https://facebookincubator.github.io/velox/functions.html