### PR TITLE
Break early from the inner loop in MmapAllocator::SizeClass::allocateFromMappdFree

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -623,7 +623,8 @@ void MmapAllocator::SizeClass::allocateFromMappdFree(
     }
     bool anyFound = false;
     bool groupEmpty = false;
-    for (auto index = group; index <= group + kWidth && !groupEmpty; index += kWidth) {
+    for (auto index = group; index <= group + kWidth && !groupEmpty;
+         index += kWidth) {
       auto bits = mappedFreeBits(index);
       uint16_t mask = simd::allSetBitMask<int64_t>() ^
           simd::toBitMask(bits == xsimd::broadcast<uint64_t>(0));


### PR DESCRIPTION
At the end of each iteration in the inner loop in MmapAllocator::SizeClass::allocateFromMappdFree, if allUsed is true for the current iteration, it will look ahead and check next iteration, as follows:
```
      if (allUsed) {
        if (index == group + kWidth ||
            isAllZero(mappedFreeBits(index + kWidth))) {
          bits::setBit(mappedFreeLookup_.data(), group / kWordsPerGroup, false);
        }
      }
```

Consider the case when ```index == group + kWidth``` is false and ```isAllZero(mappedFreeBits(index + kWidth))``` is true, we can break the inner loop after setBit to avoid step into next iteration and do duplicated mappedFreeBits().

fix #3895 

cc @mbasmanova