### PR TITLE
Do not call Expr::eval on rows with errors

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -532,6 +532,13 @@ class ExprSet {
   /// Otherwise, prints a tree of expressions one node per line.
   std::string toString(bool compact = true) const;
 
+  /// Returns evaluation statistics as a map keyed on function or special form
+  /// name. If a function or a special form occurs in the expression
+  /// multiple times, the statistics will be aggregated across all calls.
+  /// Statistics will be missing for functions and special forms that didn't get
+  /// evaluated.
+  std::unordered_map<std::string, exec::ExprStats> stats() const;
+
  protected:
   void clearSharedSubexprs();
 

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -38,4 +38,20 @@ std::unordered_set<std::string> FunctionBaseTest::getSignatureStrings(
   return signatureStrings;
 }
 
+std::pair<VectorPtr, std::unordered_map<std::string, exec::ExprStats>>
+FunctionBaseTest::evaluateWithStats(
+    const std::string& expression,
+    const RowVectorPtr& data) {
+  auto typedExpr = makeTypedExpr(expression, asRowType(data->type()));
+
+  SelectivityVector rows(data->size());
+  std::vector<VectorPtr> results(1);
+
+  exec::ExprSet exprSet({typedExpr}, &execCtx_);
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
+  exprSet.eval(rows, evalCtx, results);
+
+  return {results[0], exprSet.stats()};
+}
+
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
When evaluating inputs for an expression, keep track of rows that have errors
from evaluating previous inputs and avoid further computation for these rows.
Expr::eval and Expr::evalSpecialForm expect that all specified 'rows' need to be
processed and may clear errors for some of these rows. For example,
ConjunctExpr (AND/OR) clears errors if one of the conjuncts decides the result,
e.g. returns false (AND) or true (OR).

Add ExprSet::stats to expose evaluation statistics to use in tests. 

Add FunctionBaseTest::evaluateWithStats method to return both result of the 
evaluating and evaluation statistics.

Depends on #3898 and #3894.

Fixes #3886