### PR TITLE
Add methods to create all-null array and map vectors to VectorTestBase

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -408,7 +408,7 @@ TEST_F(JsonCastTest, fromArray) {
       jsonArrayOfDictElementsExpected);
 
   // Tests array vector with nulls at all rows.
-  auto allNullArray = vectorMaker_.allNullArrayVector(5, BIGINT());
+  auto allNullArray = makeAllNullArrayVector(5, BIGINT());
   auto allNullExpected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       JSON());
@@ -505,7 +505,7 @@ TEST_F(JsonCastTest, fromMap) {
       jsonMapOfDictElementsExpected);
 
   // Tests map vector with nulls at all rows.
-  auto allNullMap = vectorMaker_.allNullMapVector(5, VARCHAR(), BIGINT());
+  auto allNullMap = makeAllNullMapVector(5, VARCHAR(), BIGINT());
   auto allNullExpected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       JSON());
@@ -582,7 +582,7 @@ TEST_F(JsonCastTest, fromRow) {
       jsonRowOfDictElementsExpected);
 
   // Tests row vector with nulls at all rows.
-  auto allNullChild = vectorMaker_.allNullFlatVector<int64_t>(5);
+  auto allNullChild = makeAllNullFlatVector<int64_t>(5);
   auto nulls = AlignedBuffer::allocate<bool>(5, pool());
   auto rawNulls = nulls->asMutable<uint64_t>();
   bits::fillBits(rawNulls, 0, 5, false);

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -97,39 +97,21 @@ vector_size_t VectorMaker::createOffsetsAndSizes(
 ArrayVectorPtr VectorMaker::allNullArrayVector(
     vector_size_t size,
     const std::shared_ptr<const Type>& elementType) {
-  BufferPtr nulls = AlignedBuffer::allocate<bool>(size, pool_);
-  auto* rawNulls = nulls->asMutable<uint64_t>();
-  BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(size, pool_);
-  auto* rawOffsets = offsets->asMutable<vector_size_t>();
-  BufferPtr sizes = AlignedBuffer::allocate<vector_size_t>(size, pool_);
-  auto* rawSizes = sizes->asMutable<vector_size_t>();
-
-  for (vector_size_t i = 0; i < size; i++) {
-    bits::setNull(rawNulls, i, true);
-    rawOffsets[i] = 0;
-    rawSizes[i] = 0;
-  }
+  BufferPtr nulls = allocateNulls(size, pool_, bits::kNull);
+  BufferPtr offsets = allocateOffsets(size, pool_);
+  BufferPtr sizes = allocateSizes(size, pool_);
 
   return std::make_shared<ArrayVector>(
-      pool_, ARRAY(elementType), nulls, size, offsets, sizes, nullptr, size);
+      pool_, ARRAY(elementType), nulls, size, offsets, sizes, nullptr);
 }
 
 MapVectorPtr VectorMaker::allNullMapVector(
     vector_size_t size,
     const std::shared_ptr<const Type>& keyType,
     const std::shared_ptr<const Type>& valueType) {
-  BufferPtr nulls = AlignedBuffer::allocate<bool>(size, pool_);
-  auto* rawNulls = nulls->asMutable<uint64_t>();
-  BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(size, pool_);
-  auto* rawOffsets = offsets->asMutable<vector_size_t>();
-  BufferPtr sizes = AlignedBuffer::allocate<vector_size_t>(size, pool_);
-  auto* rawSizes = sizes->asMutable<vector_size_t>();
-
-  for (vector_size_t i = 0; i < size; i++) {
-    bits::setNull(rawNulls, i, true);
-    rawOffsets[i] = 0;
-    rawSizes[i] = 0;
-  }
+  BufferPtr nulls = allocateNulls(size, pool_, bits::kNull);
+  BufferPtr offsets = allocateOffsets(size, pool_);
+  BufferPtr sizes = allocateSizes(size, pool_);
 
   return std::make_shared<MapVector>(
       pool_,
@@ -139,8 +121,7 @@ MapVectorPtr VectorMaker::allNullMapVector(
       offsets,
       sizes,
       nullptr,
-      nullptr,
-      size);
+      nullptr);
 }
 
 namespace {

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -230,6 +230,12 @@ class VectorTestBase {
     return vectorMaker_.arrayVector<T>(data);
   }
 
+  ArrayVectorPtr makeAllNullArrayVector(
+      vector_size_t size,
+      const TypePtr& elementType) {
+    return vectorMaker_.allNullArrayVector(size, elementType);
+  }
+
   // Create an ArrayVector<ROW> from nested std::vectors of variants.
   // Example:
   //   auto arrayVector = makeArrayOfRowVector(
@@ -585,6 +591,13 @@ class VectorTestBase {
       const VectorPtr& valueVector,
       const std::vector<vector_size_t>& nulls = {}) {
     return vectorMaker_.mapVector(offsets, keyVector, valueVector, nulls);
+  }
+
+  MapVectorPtr makeAllNullMapVector(
+      vector_size_t size,
+      const TypePtr& keyType,
+      const TypePtr& valueType) {
+    return vectorMaker_.allNullMapVector(size, keyType, valueType);
   }
 
   VectorPtr makeConstant(const variant& value, vector_size_t size) {


### PR DESCRIPTION
Add VectorTestBase::makeAllNullArrayVector(size, elementType) and
VectorTestBase::makeAllNullMapVector(size, keyType, valueType) methods to
streamline tests.

Also, simplify the implementation of corresponding method in the VectorMaker.