### PR TITLE
Update fmt version to 8.0.1 in setup scripts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,6 @@ jobs:
             ccache -sz -M 5Gi
 
             # We can not use setup-python as we are running in a container
-            # TODO remove after #3904 is merged
             apt update
             apt install -y lsb-release python3 pip
       - name: "Restore ccache"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -50,6 +50,10 @@ jobs:
             mkdir -p .ccache
             ccache -sz -M 5Gi
 
+            # We can not use setup-python as we are running in a container
+            # TODO remove after #3904 is merged
+            apt update
+            apt install -y lsb-release python3 pip
       - name: "Restore ccache"
         uses: actions/cache/restore@v3
         id: restore-cache

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,11 +49,6 @@ jobs:
             # Set up ccache configs .
             mkdir -p .ccache
             ccache -sz -M 5Gi
-            
-            # We can not use setup-python as we are running in a container
-            # TODO add to docker image and remove here
-            apt update
-            apt install -y lsb-release python3 pip
 
       - name: "Restore ccache"
         uses: actions/cache/restore@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,7 @@ find_package(gflags COMPONENTS shared)
 find_package(glog REQUIRED)
 
 set_source(fmt)
-resolve_dependency(fmt)
+resolve_dependency(fmt 8.0.1)
 
 find_library(EVENT event)
 

--- a/scripts/setup-centos8.sh
+++ b/scripts/setup-centos8.sh
@@ -65,7 +65,7 @@ wget_and_untar https://github.com/google/glog/archive/v0.4.0.tar.gz glog &
 wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz lzo &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
-wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
+wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz fmt &
 
 wait  # For cmake and source downloads to complete.
 

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -70,7 +70,7 @@ wget_and_untar https://github.com/google/glog/archive/v0.4.0.tar.gz glog &
 wget_and_untar http://www.oberhumer.com/opensource/lzo/download/lzo-2.10.tar.gz lzo &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.72.0/source/boost_1_72_0.tar.gz boost &
 wget_and_untar https://github.com/google/snappy/archive/1.1.8.tar.gz snappy &
-wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.0.tar.gz fmt &
+wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz fmt &
 wget_and_untar https://github.com/facebook/folly/archive/v2022.11.14.00.tar.gz folly &
 #  wget_and_untar https://github.com/ericniebler/range-v3/archive/0.11.0.tar.gz ranges-v3 &
 wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -81,7 +81,7 @@ function install_build_prerequisites {
 }
 
 function install_fmt {
-  github_checkout fmtlib/fmt 8.0.0
+  github_checkout fmtlib/fmt 8.0.1
   cmake_install -DFMT_TEST=OFF
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -76,7 +76,7 @@ function prompt {
 }
 
 function install_fmt {
-  github_checkout fmtlib/fmt 8.0.0
+  github_checkout fmtlib/fmt 8.0.1
   cmake_install -DFMT_TEST=OFF
 }
 

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -39,7 +39,6 @@ yum -y install snappy-devel
 yum -y install lzo-devel
 yum -y install wget
 yum -y install python3-devel.x86_64
-yum -y install fmt-devel
 yum -y install perl-core
 yum -y install pcre-devel
 yum -y install zlib-devel

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -24,26 +24,26 @@ CPU_TARGET="${CPU_TARGET:-avx}"
 export CFLAGS=$(get_cxx_flags $CPU_TARGET)
 export CXXFLAGS=$CFLAGS  # Used by boost.
 
-yum -y install ccache
-yum -y install ninja-build
-yum -y install git
-yum -y install double-conversion-devel
-yum -y install glog-devel
-yum -y install bzip2-devel
-yum -y install gflags-devel
-yum -y install libevent-devel
-yum -y install lz4-devel
-yum -y install libzstd-devel
-yum -y install re2-devel
-yum -y install snappy-devel
-yum -y install lzo-devel
-yum -y install wget
-yum -y install python3-devel.x86_64
-yum -y install perl-core
-yum -y install pcre-devel
-yum -y install zlib-devel
-yum -y install flex
-yum -y install libicu-devel
+yum -y install bzip2-devel \
+  ccache \
+  double-conversion-devel \
+  flex \
+  gflags-devel \
+  git \
+  glog-devel \
+  libevent-devel \
+  libicu-devel \
+  libzstd-devel \
+  lz4-devel \
+  lzo-devel \
+  ninja-build \
+  pcre-devel \
+  perl-core \
+  python3-devel.x86_64 \
+  re2-devel \
+  snappy-devel \
+  wget \
+  zlib-devel
 
 #Install conda
 rpm --import https://repo.anaconda.com/pkgs/misc/gpgkeys/anaconda.asc

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -77,6 +77,7 @@ wget_and_untar https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz 
 wget_and_untar https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz openssl &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz boost &
 wget_and_untar https://github.com/facebook/folly/archive/v2022.11.14.00.tar.gz folly &
+wget_and_untar https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.tar.gz fmt &
 
 wait
 
@@ -94,4 +95,5 @@ wait
 )
 
 cmake_install gflags -DBUILD_SHARED_LIBS=ON
+cmake_install fmt -DFMT_TEST=OFF
 cmake_install folly

--- a/scripts/ubuntu-22.04-cpp.dockerfile
+++ b/scripts/ubuntu-22.04-cpp.dockerfile
@@ -20,7 +20,11 @@ FROM ${base}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt update && \
-      apt install -y sudo
+      apt install -y sudo \
+            lsb-release \
+            pip \
+            python3
+            
 
 ADD scripts /velox/scripts/
 

--- a/scripts/velox-torcharrow-container.dockfile
+++ b/scripts/velox-torcharrow-container.dockfile
@@ -14,7 +14,7 @@
 
 # Build container to be used for TorchArrow.
 
-FROM quay.io/pypa/manylinux2014_x86_64:2022-02-13-594988e
+FROM quay.io/pypa/manylinux2014_x86_64
 ARG cpu_target
 COPY setup-velox-torcharrow.sh /
 COPY setup-helper-functions.sh /


### PR DESCRIPTION
8.0.1 bumps the internal version `fmt::v7` to `fmt::v8`. folly uses 8.0.1 and velox is also compatible.

This PR updates the setup scripts and by extension the docker containers.