### PR TITLE
Consolidate common sub-expression evaluation logic

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -211,6 +211,10 @@ class EvalCtx {
     return wrapEncoding_;
   }
 
+  bool hasWrap() const {
+    return wrapEncoding_ != VectorEncoding::Simple::FLAT;
+  }
+
   void setConstantWrap(vector_size_t wrapIndex) {
     wrapEncoding_ = VectorEncoding::Simple::CONSTANT;
     constantWrapIndex_ = wrapIndex;

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -341,18 +341,12 @@ class Expr {
       EvalCtx& context,
       LocalSelectivityVector& nullHolder);
 
-  // If this is a common subexpression, checks if there is a previously
-  // calculated result and populates the 'result'.
-  bool checkGetSharedSubexprValues(
+  // Evaluate common sub-expression. Check if sharedSubexprValues_ already has
+  // values for all 'rows'. If not, compute missing values.
+  void evaluateSharedSubexpr(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result);
-
-  // If this is a common subexpression, stores the newly calculated result.
-  void checkUpdateSharedSubexprValues(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      const VectorPtr& result);
 
   void evalSimplifiedImpl(
       const SelectivityVector& rows,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -532,6 +532,13 @@ class ExprSet {
   /// Otherwise, prints a tree of expressions one node per line.
   std::string toString(bool compact = true) const;
 
+  /// Returns evaluation statistics as a map keyed on function or special form
+  /// name. If a function or a special form occurs in the expression
+  /// multiple times, the statistics will be aggregated across all calls.
+  /// Statistics will be missing for functions and special forms that didn't get
+  /// evaluated.
+  std::unordered_map<std::string, exec::ExprStats> stats() const;
+
  protected:
   void clearSharedSubexprs();
 

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -38,4 +38,20 @@ std::unordered_set<std::string> FunctionBaseTest::getSignatureStrings(
   return signatureStrings;
 }
 
+std::pair<VectorPtr, std::unordered_map<std::string, exec::ExprStats>>
+FunctionBaseTest::evaluateWithStats(
+    const std::string& expression,
+    const RowVectorPtr& data) {
+  auto typedExpr = makeTypedExpr(expression, asRowType(data->type()));
+
+  SelectivityVector rows(data->size());
+  std::vector<VectorPtr> results(1);
+
+  exec::ExprSet exprSet({typedExpr}, &execCtx_);
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
+  exprSet.eval(rows, evalCtx, results);
+
+  return {results[0], exprSet.stats()};
+}
+
 } // namespace facebook::velox::functions::test


### PR DESCRIPTION
CSE evaluation logic in Expr.cpp was split between
checkUpdateSharedSubexprValues and checkGetSharedSubexprValues method an
interleaved with regular evaluation making it hard to following. This change
consolidates the logic in a single evaluateSharedSubexpr method. 

More refactoring is needed to make this logic easier to read and test. This 
is a first step.

Depends on #3900