### PR TITLE
Fix numMapped_ pages counting in memory allocators

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -170,10 +170,6 @@ class MallocAllocator : public MemoryAllocator {
 
   const Kind kind_;
 
-  std::atomic<MachinePageCount> numAllocated_;
-  // When using mmap/madvise, the current of number pages backed by memory.
-  std::atomic<MachinePageCount> numMapped_;
-
   std::mutex mallocsMutex_;
   // Tracks malloc'd pointers to detect bad frees.
   std::unordered_set<void*> mallocs_;
@@ -182,8 +178,7 @@ class MallocAllocator : public MemoryAllocator {
 
 } // namespace
 
-MallocAllocator::MallocAllocator()
-    : kind_(MemoryAllocator::Kind::kMalloc), numAllocated_(0), numMapped_(0) {}
+MallocAllocator::MallocAllocator() : kind_(MemoryAllocator::Kind::kMalloc) {}
 
 bool MallocAllocator::allocateNonContiguous(
     MachinePageCount numPages,
@@ -311,7 +306,7 @@ bool MallocAllocator::allocateContiguousImpl(
     }
   }
   numAllocated_.fetch_add(numPages);
-  numMapped_.fetch_add(numNeededPages + numContiguousCollateralPages);
+  numMapped_.fetch_add(numPages);
 
   void* data = ::mmap(
       nullptr,

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -389,6 +389,10 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   const std::vector<MachinePageCount>
       sizeClassSizes_{1, 2, 4, 8, 16, 32, 64, 128, 256};
 
+  std::atomic<MachinePageCount> numAllocated_{0};
+  // Tracks the number of mapped pages.
+  std::atomic<MachinePageCount> numMapped_{0};
+
   // Indicates if the failure injection is persistent or transient.
   //
   // NOTE: this is only used for testing purpose.

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -25,8 +25,6 @@ namespace facebook::velox::memory {
 MmapAllocator::MmapAllocator(const Options& options)
     : kind_(MemoryAllocator::Kind::kMmap),
       useMmapArena_(options.useMmapArena),
-      numAllocated_(0),
-      numMapped_(0),
       capacity_(bits::roundUp(
           options.capacity / AllocationTraits::kPageSize,
           64 * sizeClassSizes_.back())) {

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -325,15 +325,6 @@ class MmapAllocator : public MemoryAllocator {
   // Serializes moving capacity between size classes
   std::mutex sizeClassBalanceMutex_;
 
-  // Number of allocated pages. Allocation succeeds if an atomic increment of
-  // this by the desired amount is <= 'capacity_'.
-  std::atomic<MachinePageCount> numAllocated_;
-
-  // Number of machine pages backed by memory in the address ranges in
-  // 'sizeClasses_'. It includes pages that are already freed. Hence it should
-  // be larger than numAllocated_
-  std::atomic<MachinePageCount> numMapped_;
-
   // Number of pages allocated and explicitly mmap'd by the
   // application via allocateContiguous, outside of
   // 'sizeClasses'. These pages are counted in 'numAllocated_' and

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -164,6 +164,10 @@ class MemoryAllocatorTest : public testing::TestWithParam<TestParam> {
   }
 
   void SetUp() override {
+    setupAllocator();
+  }
+
+  void setupAllocator() {
     MemoryAllocator::testingDestroyInstance();
     useMmap_ = GetParam().useMmap;
     if (useMmap_) {
@@ -739,6 +743,86 @@ TEST_P(MemoryAllocatorTest, externalAdvise) {
   EXPECT_TRUE(instance->checkConsistency());
   clearAllocations(allocations);
   EXPECT_TRUE(instance->checkConsistency());
+}
+
+TEST_P(MemoryAllocatorTest, allocContiguous) {
+  struct {
+    MachinePageCount nonContiguousPages;
+    MachinePageCount oldContiguousPages;
+    MachinePageCount newContiguousPages;
+
+    std::string debugString() const {
+      return fmt::format(
+          "nonContiguousPages:{} oldContiguousPages:{} newContiguousPages:{}",
+          nonContiguousPages,
+          oldContiguousPages,
+          newContiguousPages);
+    }
+  } testSettings[] = {
+      {100, 100, 200},
+      {100, 200, 200},
+      {200, 100, 200},
+      {200, 100, 400},
+      {0, 100, 100},
+      {0, 200, 100},
+      {0, 100, 200},
+      {100, 0, 100},
+      {200, 0, 100},
+      {100, 0, 200}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(fmt::format(
+        "{} useMmap{} hasTracker{}",
+        testData.debugString(),
+        useMmap_,
+        hasMemoryTracker_));
+    setupAllocator();
+    const MachinePageCount nonContiguousPages = 100;
+    Allocation allocation;
+    if (testData.nonContiguousPages != 0) {
+      instance_->allocateNonContiguous(testData.nonContiguousPages, allocation);
+    }
+    ContiguousAllocation contiguousAllocation;
+    if (testData.oldContiguousPages != 0) {
+      instance_->allocateContiguous(
+          testData.oldContiguousPages, nullptr, contiguousAllocation);
+    }
+    instance_->allocateContiguous(
+        testData.newContiguousPages, &allocation, contiguousAllocation);
+    ASSERT_EQ(instance_->numAllocated(), testData.newContiguousPages);
+
+    if (useMmap_) {
+      if (testData.nonContiguousPages > 0) {
+        // Mmap allocator doesn't free mapped pages count for the old
+        // non-contiguous allocation.
+        ASSERT_GE(
+            instance_->numMapped(),
+            testData.newContiguousPages + testData.nonContiguousPages);
+      } else {
+        ASSERT_EQ(instance_->numMapped(), testData.newContiguousPages);
+      }
+      auto mappedAllocator = dynamic_cast<MmapAllocator*>(allocator_.get());
+      ASSERT_EQ(
+          mappedAllocator->numExternalMapped(), testData.newContiguousPages);
+    } else {
+      ASSERT_EQ(instance_->numMapped(), testData.newContiguousPages);
+    }
+
+    instance_->freeContiguous(contiguousAllocation);
+
+    if (useMmap_) {
+      ASSERT_EQ(instance_->numAllocated(), 0);
+      if (testData.nonContiguousPages > 0) {
+        ASSERT_GE(instance_->numMapped(), testData.nonContiguousPages);
+      } else {
+        ASSERT_EQ(instance_->numMapped(), 0);
+      }
+      auto mappedAllocator = dynamic_cast<MmapAllocator*>(allocator_.get());
+      ASSERT_EQ(mappedAllocator->numExternalMapped(), 0);
+    } else {
+      ASSERT_EQ(instance_->numMapped(), 0);
+      ASSERT_EQ(instance_->numAllocated(), 0);
+    }
+  }
 }
 
 TEST_P(MemoryAllocatorTest, allocContiguousFail) {


### PR DESCRIPTION
numMapped_ is not updated properly in MallocAllocator for contiguous
memory allocation (reported by @waitinfuture). This PR fixes the issue and
add a unit test to verify numMapped(), numAllocated() and numExternalMapped()
counters.
Will enforce sanity checks in allocator destructor in followup.