### PR TITLE
Enable CSE optimization in flat-no-nulls fast path

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -125,6 +125,12 @@ class Expr {
       VectorPtr& result,
       bool topLevel = false);
 
+  void evalFlatNoNullsImpl(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result,
+      bool topLevel);
+
   // Simplified path for expression evaluation (flattens all vectors).
   void evalSimplified(
       const SelectivityVector& rows,
@@ -343,10 +349,12 @@ class Expr {
 
   // Evaluate common sub-expression. Check if sharedSubexprValues_ already has
   // values for all 'rows'. If not, compute missing values.
+  template <typename TEval>
   void evaluateSharedSubexpr(
       const SelectivityVector& rows,
       EvalCtx& context,
-      VectorPtr& result);
+      VectorPtr& result,
+      TEval eval);
 
   void evalSimplifiedImpl(
       const SelectivityVector& rows,

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -91,6 +91,19 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return evaluateMultiple({text}, input)[0];
   }
 
+  std::pair<VectorPtr, std::unordered_map<std::string, exec::ExprStats>>
+  evaluateWithStats(const std::string& expression, const RowVectorPtr& input) {
+    auto exprSet = compileExpression(expression, asRowType(input->type()));
+
+    SelectivityVector rows(input->size());
+    std::vector<VectorPtr> results(1);
+
+    exec::EvalCtx context(execCtx_.get(), exprSet.get(), input.get());
+    exprSet->eval(rows, context, results);
+
+    return {results[0], exprSet->stats()};
+  }
+
   template <
       typename T = exec::ExprSet,
       typename = std::enable_if_t<
@@ -3226,4 +3239,27 @@ TEST_F(ExprTest, conjunctUnderTry) {
   auto expected =
       BaseVector::createNullConstant(ARRAY(BOOLEAN()), input->size(), pool());
   assertEqualVectors(expected, result);
+}
+
+TEST_F(ExprTest, flatNoNullsFastPathWithCse) {
+  // Test CSE with flat-no-nulls fast path.
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<int64_t>({8, 9, 10, 11, 12}),
+  });
+
+  // Make sure CSE "c0 + c1" is evaluated only once for each row.
+  auto [result, stats] = evaluateWithStats(
+      "if((c0 + c1) > 100::bigint, 100::bigint, c0 + c1)", input);
+
+  auto expected = makeFlatVector<int64_t>({9, 11, 13, 15, 17});
+  assertEqualVectors(expected, result);
+  EXPECT_EQ(5, stats.at("plus").numProcessedRows);
+
+  std::tie(result, stats) = evaluateWithStats(
+      "if((c0 + c1) >= 15::bigint, 100::bigint, c0 + c1)", input);
+
+  expected = makeFlatVector<int64_t>({9, 11, 13, 100, 100});
+  assertEqualVectors(expected, result);
+  EXPECT_EQ(5, stats.at("plus").numProcessedRows);
 }


### PR DESCRIPTION
Flat-no-nulls fast path didn't consider common sub-expressions and ended up
evaluating these multiple times unnecessarily.

Depends on #3908.

Fixes #3903