### PR TITLE
Add array_frequency to skip function list of expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
       "element_at",
       "width_bucket",
       "array_intersect",
+      "array_frequency", // https://github.com/facebookincubator/velox/issues/3906
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(


### PR DESCRIPTION
Summary:
The array_frequency() function is implemented with folly::F14FastMap that doesn't guarantee deterministic ordering of elements. This leads to mismatch of the fuzzer test results that have the same elements but with different orders. So we add array_frequency() to the skip function list for now.

This fixes https://github.com/facebookincubator/velox/issues/3906.

Differential Revision: D42944822

