### PR TITLE
Fix memory corruption caused by ntile

### DIFF
--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -116,7 +116,10 @@ class NtileFunction : public exec::WindowFunction {
         vector_size_t resultOffset,
         int64_t* rawResultValues) {
       int64_t i = 0;
-      for (int64_t j = partitionOffset; j < extraBucketsBoundary; i++, j++) {
+      // This loop terminates if it reaches extraBucketBoundary or numRows
+      // in the result vector are filled.
+      for (int64_t j = partitionOffset; i < numRows && j < extraBucketsBoundary;
+           i++, j++) {
         rawResultValues[resultOffset + i] = j / (rowsPerBucket + 1) + 1;
       }
       for (; i < numRows; i++) {

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -78,7 +78,7 @@ TEST_F(NtileTest, singlePartitionWithSortOrders) {
 
 TEST_F(NtileTest, multiInput) {
   NtileTest::testWindowFunction(
-      {makeSinglePartitionVector(75), makeSinglePartitionVector(50)},
+      {makeSinglePartitionVector(100), makeSinglePartitionVector(75)},
       kBasicOverClauses);
 }
 


### PR DESCRIPTION
The NtileTest.multiInput occasionally crashed.

ntile logic computes extraBucketBoundary which separates buckets with an extra
row from the remaining. The output value is computed differently before and
after this row boundary. If the first output block of the first partition had
number of rows < extraBucketBoundary, the current logic kept writing values
beyond the number of rows upto extraBucketBoundary number of rows. This
corrupted the data beyond the values_ buffer of the result FlatVector and
caused random crashes.