### PR TITLE
Refactor dwio test utils to accommodate integer logical types

### DIFF
--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -105,12 +105,12 @@ class E2EFilterTestBase : public testing::Test {
   template <typename T>
   void makeIntDistribution(
       const std::string& fieldName,
-      T min,
-      T max,
+      int64_t min,
+      int64_t max,
       int32_t repeats,
       int32_t rareFrequency,
-      T rareMin,
-      T rareMax,
+      int64_t rareMin,
+      int64_t rareMax,
       bool keepNulls) {
     dataSetBuilder_->withIntDistributionForField<T>(
         Subfield(fieldName),

--- a/velox/dwio/common/tests/utils/DataSetBuilder.h
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.h
@@ -78,12 +78,12 @@ class DataSetBuilder {
   template <typename T>
   DataSetBuilder& withIntDistributionForField(
       const common::Subfield& field,
-      T min,
-      T max,
+      int64_t min,
+      int64_t max,
       int32_t repeats,
       int32_t rareFrequency,
-      T rareMin,
-      T rareMax,
+      int64_t rareMin,
+      int64_t rareMax,
       bool keepNulls) {
     int counter = 0;
     auto vec = *batches_;
@@ -94,20 +94,19 @@ class DataSetBuilder {
         if (keepNulls && numbers->isNullAt(row)) {
           continue;
         }
-        T value;
         if (counter % 100 < repeats) {
-          value = T(counter % repeats);
-          numbers->set(row, value);
+          numbers->set(row, T(counter % repeats));
         } else if (counter % 100 > 90 && row > 0) {
           numbers->copy(numbers, row - 1, row, 1);
         } else {
+          int64_t value;
           if (rareFrequency && counter % rareFrequency == 0) {
-            value = rareMin +
-                (T(folly::Random::rand32(rng_)) % T(rareMax - rareMin));
+            value =
+                rareMin + (folly::Random::rand32(rng_) % (rareMax - rareMin));
           } else {
-            value = min + (T(folly::Random::rand32(rng_)) % (max - min));
+            value = min + (folly::Random::rand32(rng_) % (max - min));
           }
-          numbers->set(row, value);
+          numbers->set(row, T(value));
         }
         ++counter;
       }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -266,12 +266,12 @@ TEST_F(E2EFilterTest, shortDecimalDictionary) {
         [&]() {
           makeIntDistribution<UnscaledShortDecimal>(
               "shortdecimal_val",
-              UnscaledShortDecimal(10), // min
-              UnscaledShortDecimal(100), // max
+              10, // min
+              100, // max
               22, // repeats
               19, // rareFrequency
-              UnscaledShortDecimal(-999), // rareMin
-              UnscaledShortDecimal(30000), // rareMax
+              -999, // rareMin
+              30000, // rareMax
               true);
         },
         false,
@@ -296,12 +296,12 @@ TEST_F(E2EFilterTest, shortDecimalDirect) {
         [&]() {
           makeIntDistribution<UnscaledShortDecimal>(
               "shortdecimal_val",
-              UnscaledShortDecimal(10), // min
-              UnscaledShortDecimal(100), // max
+              10, // min
+              100, // max
               22, // repeats
               19, // rareFrequency
-              UnscaledShortDecimal(-999), // rareMin
-              UnscaledShortDecimal(30000), // rareMax
+              -999, // rareMin
+              30000, // rareMax
               true);
         },
         false,
@@ -334,12 +334,12 @@ TEST_F(E2EFilterTest, longDecimalDictionary) {
         [&]() {
           makeIntDistribution<UnscaledLongDecimal>(
               "longdecimal_val",
-              UnscaledLongDecimal(10), // min
-              UnscaledLongDecimal(100), // max
+              10, // min
+              100, // max
               22, // repeats
               19, // rareFrequency
-              UnscaledLongDecimal(-999), // rareMin
-              UnscaledLongDecimal(30000), // rareMax
+              -999, // rareMin
+              30000, // rareMax
               true);
         },
         true,
@@ -364,12 +364,12 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
         [&]() {
           makeIntDistribution<UnscaledLongDecimal>(
               "longdecimal_val",
-              UnscaledLongDecimal(10), // min
-              UnscaledLongDecimal(100), // max
+              10, // min
+              100, // max
               22, // repeats
               19, // rareFrequency
-              UnscaledLongDecimal(-999), // rareMin
-              UnscaledLongDecimal(30000), // rareMax
+              -999, // rareMin
+              30000, // rareMax
               true);
         },
         true,


### PR DESCRIPTION
Types such as Date, Decimals, etc. are wrappers over integer types.
This change makes it easy to add tests for these types.