### PR TITLE
Remove MockMemoryAllocator from test

### DIFF
--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -23,7 +23,7 @@
 using namespace facebook::velox;
 using namespace facebook::velox::memory;
 
-class ByteStreamTest : public testing::TestWithParam<bool> {
+class ByteStreamTest : public testing::Test {
  protected:
   void SetUp() override {
     constexpr uint64_t kMaxMappedMemory = 64 << 20;


### PR DESCRIPTION
MemoryPoolTest has fully covered memory usage tracking on top of
memory allocators so remove MockMemoryAllocator from test which
is not necessary now.