### PR TITLE
Remove BaseVector::isConstant(rows) method

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -756,7 +756,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
         setPeeled(leaf, fieldIndex, context, maybePeeled);
         continue;
       }
-      if (numLevels == 0 && leaf->isConstant(rows)) {
+      if (numLevels == 0 && leaf->isConstantEncoding()) {
         leaf = context.ensureFieldLoaded(fieldIndex, rows);
         setPeeled(leaf, fieldIndex, context, maybePeeled);
         constantFields.resize(numFields);
@@ -859,11 +859,8 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
     if (!values) {
       continue;
     }
-    if (!constantFields.empty() && constantFields[i]) {
-      context.setPeeled(
-          i, BaseVector::wrapInConstant(rows.size(), rows.begin(), values));
-    } else {
-      context.setPeeled(i, values);
+    context.setPeeled(i, values);
+    if (constantFields.empty() || !constantFields[i]) {
       ++numPeeled;
     }
   }
@@ -1372,17 +1369,8 @@ bool Expr::applyFunctionWithPeeling(
         setPeeledArg(leaf, i, numArgs, maybePeeled);
         continue;
       }
-      if ((numLevels == 0 && leaf->isConstant(rows)) ||
-          leaf->isConstantEncoding()) {
-        if (leaf->isConstantEncoding()) {
-          setPeeledArg(leaf, i, numArgs, maybePeeled);
-        } else {
-          setPeeledArg(
-              BaseVector::wrapInConstant(leaf->size(), rows.begin(), leaf),
-              i,
-              numArgs,
-              maybePeeled);
-        }
+      if (leaf->isConstantEncoding()) {
+        setPeeledArg(leaf, i, numArgs, maybePeeled);
         constantArgs.resize(numArgs);
         constantArgs.at(i) = true;
         ++numConstant;

--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -253,7 +253,7 @@ class InPredicate : public exec::VectorFunction {
     // Indicates whether result can be true or null only, e.g. no false results.
     const bool passOrNull = filter_->testNull();
 
-    if (arg->isConstant(rows)) {
+    if (arg->isConstantEncoding()) {
       auto simpleArg = arg->asUnchecked<SimpleVector<T>>();
       VectorPtr localResult;
       if (simpleArg->isNullAt(rows.begin())) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -292,11 +292,6 @@ class BaseVector {
    */
   virtual std::unique_ptr<SimpleVector<uint64_t>> hashAll() const = 0;
 
-  // Returns true if all values in the specified rows are the same.
-  virtual bool isConstant(const SelectivityVector& rows) const {
-    return false;
-  }
-
   /// Returns true if this vector is encoded as flat (FlatVector).
   bool isFlatEncoding() const {
     return encoding_ == VectorEncoding::Simple::FLAT;

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -231,11 +231,6 @@ class ConstantVector final : public SimpleVector<T> {
     return const_cast<ConstantVector<T>*>(this)->loadedVector();
   }
 
-  // Fast Check to optimize for constant vectors
-  bool isConstant(const SelectivityVector& rows) const override {
-    return true;
-  }
-
   bool isScalar() const override {
     return valueVector_ ? valueVector_->isScalar()
                         : (this->typeKind() != TypeKind::UNKNOWN);

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -130,17 +130,6 @@ class DictionaryVector : public SimpleVector<T> {
         indices_->capacity();
   }
 
-  bool isConstant(const SelectivityVector& rows) const override {
-    VELOX_CHECK(rows.hasSelections(), "No selected rows in isConstant()");
-    auto firstIdx = getDictionaryIndex(rows.begin());
-    auto firstNull = BaseVector::isNullAt(rows.begin());
-    return rows.testSelected([&](auto row) {
-      bool isNull = BaseVector::isNullAt(row);
-      return (firstNull && isNull) ||
-          (firstIdx == getDictionaryIndex(row) && !firstNull && !isNull);
-    });
-  }
-
   bool isScalar() const override {
     return dictionaryValues_->isScalar();
   }

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -167,14 +167,6 @@ class FunctionVector : public BaseVector {
     return index;
   }
 
-  // Fast shortcut for determining constancy. The vector will nearly
-  // always have a single function. If the non-function argument of a
-  // lambda-accepting function is wrapped in a dictionary, the
-  // dictionary can be peeled off if the function is constant.
-  bool isConstant(const SelectivityVector& /*rows*/) const override {
-    return functions_.size() == 1;
-  }
-
   Iterator iterator(const SelectivityVector* rows) const {
     return Iterator(this, rows);
   }

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -135,10 +135,6 @@ class SequenceVector : public SimpleVector<T> {
     return sequenceValues_->retainedSize() + sequenceLengths_->capacity();
   }
 
-  bool isConstant(const SelectivityVector& rows) const override {
-    return offsetOfIndex(rows.begin()) == offsetOfIndex(rows.end() - 1);
-  }
-
   bool isScalar() const override {
     return sequenceValues_->isScalar();
   }

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1698,62 +1698,6 @@ TEST_F(VectorTest, byteSize) {
   EXPECT_EQ(BaseVector::byteSize<int64_t>(count), expected);
 }
 
-TEST_F(VectorTest, constantDictionary) {
-  auto vectorMaker = std::make_unique<test::VectorMaker>(pool_.get());
-  auto flatVector = vectorMaker->flatVector<int32_t>({1, 2, 3, 4});
-
-  // Repeat each row twice: 1, 1, 2, 2, 3, 3, 4, 4.
-  auto dictionarySize = flatVector->size() * 2;
-  auto indices = allocateIndices(dictionarySize, pool_.get());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  for (auto i = 0; i < dictionarySize; i++) {
-    rawIndices[i] = i / 2;
-  }
-  auto dictionaryVector = BaseVector::wrapInDictionary(
-      nullptr, indices, dictionarySize, flatVector);
-
-  {
-    SelectivityVector rows(dictionarySize);
-    ASSERT_FALSE(dictionaryVector->isConstant(rows));
-  }
-
-  // First two rows are the same.
-  {
-    SelectivityVector rows(2);
-    ASSERT_TRUE(dictionaryVector->isConstant(rows));
-  }
-
-  // Single row is always constant.
-  {
-    SelectivityVector rows(dictionarySize, false);
-    rows.setValid(3, true);
-    rows.updateBounds();
-    ASSERT_TRUE(dictionaryVector->isConstant(rows));
-  }
-
-  // Test nulls added by DictionaryVector.
-  auto dictNulls = AlignedBuffer::allocate<bool>(
-      dictionarySize, pool_.get(), bits::kNotNull);
-  auto rawNulls = dictNulls->asMutable<uint64_t>();
-  bits::setNull(rawNulls, 0);
-  bits::setNull(rawNulls, 2);
-  dictionaryVector = BaseVector::wrapInDictionary(
-      dictNulls, indices, dictionarySize, flatVector);
-  // Elements 0 and 1 are not equal because the dictionary adds a null at 0.
-  {
-    SelectivityVector rows(2);
-    ASSERT_FALSE(dictionaryVector->isConstant(rows));
-  }
-  // The vector is constant for 0, 2 because both add a null.
-  {
-    SelectivityVector rows(dictionarySize, false);
-    rows.setValid(0, true);
-    rows.setValid(2, true);
-    rows.updateBounds();
-    ASSERT_TRUE(dictionaryVector->isConstant(rows));
-  }
-}
-
 TEST_F(VectorTest, clearNulls) {
   auto vectorSize = 100;
   auto vector = BaseVector::create(INTEGER(), vectorSize, pool_.get());


### PR DESCRIPTION
BaseVector::isConstant(rows) method returned true if it is guaranteed that all
values in the specified rows are the same. This method had default
implementation that returned 'false' unconditionally.
ConstantVector::isConstant returned 'true' unconditionally and
DictionaryVector::isConstant returned 'true' if all rows were null or had the
same index.

This method was primarily used in peeling of encodings in expression evaluation.
It made this logic non-intuitive as peeling results for the same input vectors
would be different for different sets of rows.

In particular, this behavior makes it difficult to enable CSE optimization for encoded 
inputs. See #3920.

This change removes BaseVector::isConstant(rows) and corresponding logic 
from the expression evaluation.