### PR TITLE
Add support for fuzzing vectors with customized generator specs in VectorFuzzer

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -359,6 +359,10 @@ VectorPtr VectorFuzzer::fuzz(const TypePtr& type, vector_size_t size) {
   return vector;
 }
 
+VectorPtr VectorFuzzer::fuzz(const GeneratorSpec& generatorSpec) {
+  return generatorSpec.generateData(rng_, pool_, opts_.vectorSize);
+}
+
 VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type) {
   return fuzzConstant(type, opts_.vectorSize);
 }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -22,10 +22,9 @@
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/ComplexVector.h"
+#include "velox/vector/fuzzer/GeneratorSpec.h"
 
 namespace facebook::velox {
-
-using FuzzerGenerator = std::mt19937;
 
 enum UTF8CharList {
   ASCII = 0, // Ascii character set.
@@ -158,6 +157,10 @@ class VectorFuzzer {
   // `size` elements.
   VectorPtr fuzz(const TypePtr& type);
   VectorPtr fuzz(const TypePtr& type, vector_size_t size);
+
+  // Returns a "fuzzed" vector containing randomized data customized according
+  // to generatorSpec.
+  VectorPtr fuzz(const GeneratorSpec& generatorSpec);
 
   // Same as above, but returns a vector without nulls (regardless of the value
   // of opts.nullRatio).


### PR DESCRIPTION
Summary:
We integrate GeneratorSpec into the VectorFuzzer to support more flexible
customization of the random data generated.

Reviewed By: Yuhta

Differential Revision: D42743865

