### PR TITLE
Add support for generating random nulls in GeneratorSpec

### DIFF
--- a/velox/vector/fuzzer/CMakeLists.txt
+++ b/velox/vector/fuzzer/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_vector_fuzzer VectorFuzzer.cpp)
+add_library(velox_vector_fuzzer VectorFuzzer.cpp GeneratorSpec.cpp Utils.cpp)
 
 target_link_libraries(velox_vector_fuzzer velox_type velox_vector)
 

--- a/velox/vector/fuzzer/GeneratorSpec.cpp
+++ b/velox/vector/fuzzer/GeneratorSpec.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/fuzzer/GeneratorSpec.h"

--- a/velox/vector/fuzzer/Utils.cpp
+++ b/velox/vector/fuzzer/Utils.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/fuzzer/Utils.h"
+
+namespace facebook::velox::generator_spec_utils {
+
+bool coinToss(FuzzerGenerator& rng, double threshold) {
+  static std::uniform_real_distribution<> dist(0.0, 1.0);
+  return dist(rng) < threshold;
+}
+
+BufferPtr generateNullsBuffer(
+    FuzzerGenerator& rng,
+    memory::MemoryPool* pool,
+    vector_size_t vectorSize,
+    double nullProbability) {
+  NullsBuilder builder{vectorSize, pool};
+  for (size_t i = 0; i < vectorSize; ++i) {
+    if (coinToss(rng, nullProbability)) {
+      builder.setNull(i);
+    }
+  }
+  return builder.build();
+}
+
+} // namespace facebook::velox::generator_spec_utils

--- a/velox/vector/fuzzer/Utils.h
+++ b/velox/vector/fuzzer/Utils.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/NullsBuilder.h"
+
+namespace facebook::velox {
+
+using FuzzerGenerator = std::mt19937;
+
+namespace generator_spec_utils {
+
+bool coinToss(FuzzerGenerator& rng, double threshold);
+
+BufferPtr generateNullsBuffer(
+    FuzzerGenerator& rng,
+    memory::MemoryPool* pool,
+    vector_size_t vectorSize,
+    double nullProbability);
+
+} // namespace generator_spec_utils
+} // namespace facebook::velox

--- a/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
@@ -32,6 +32,7 @@ int main() {
   constexpr int32_t lo = 100, hi = 1000;
   constexpr double mu = 5.0, sigma = 2.0;
   constexpr double p = 0.25;
+  constexpr double nullProbability = 0.38;
 
   auto normal = std::normal_distribution<double>(mu, sigma);
   auto uniform = std::uniform_int_distribution<int32_t>(lo, hi);
@@ -39,7 +40,8 @@ int main() {
   FuzzerGenerator rng;
   auto pool = memory::getDefaultMemoryPool();
 
-  GeneratorSpecPtr randomArray = RANDOM_ARRAY(RANDOM_DOUBLE(normal), uniform);
+  GeneratorSpecPtr randomArray =
+      RANDOM_ARRAY(RANDOM_DOUBLE(normal, nullProbability), uniform);
 
   VectorPtr vector = randomArray->generateData(rng, pool.get(), sampleSize);
   ArrayVector* arrayVector = vector->as<ArrayVector>();

--- a/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
@@ -28,10 +28,11 @@ int main() {
   // This example shows how to use our GeneratorSpec class to generate vectors
   // of scalars with user defined distributions.
 
-  const int sampleSize = 100000;
-  const int32_t lo = 0, hi = 10;
-  const double mu = 5.0, sigma = 2.0;
-  const double userLo = 0.01, userHi = 0.99;
+  constexpr int sampleSize = 100000;
+  constexpr int32_t lo = 0, hi = 10;
+  constexpr double mu = 5.0, sigma = 2.0;
+  constexpr double userLo = 0.01, userHi = 0.99;
+  constexpr double nullProbability = 0.18;
 
   auto uniform = std::uniform_int_distribution<int32_t>(lo, hi);
   auto normal = std::normal_distribution<double>(mu, sigma);
@@ -50,9 +51,12 @@ int main() {
   FuzzerGenerator rng;
   auto pool = memory::getDefaultMemoryPool();
 
-  GeneratorSpecPtr uniformIntGenerator = RANDOM_INTEGER(uniform);
-  GeneratorSpecPtr normalDoubleGenerator = RANDOM_DOUBLE(normal);
-  GeneratorSpecPtr userDefinedGenerator = RANDOM_DOUBLE(userDefined);
+  GeneratorSpecPtr uniformIntGenerator =
+      RANDOM_INTEGER(uniform, nullProbability);
+  GeneratorSpecPtr normalDoubleGenerator =
+      RANDOM_DOUBLE(normal, nullProbability);
+  GeneratorSpecPtr userDefinedGenerator =
+      RANDOM_DOUBLE(userDefined, nullProbability);
 
   VectorPtr uniformVector =
       uniformIntGenerator->generateData(rng, pool.get(), sampleSize);


### PR DESCRIPTION
Summary:
We enable GeneratorSpec to generate a nulls buffer by making nullProbability a
member of the base GeneratorSpec class.

Reviewed By: Yuhta

Differential Revision: D42751820

