### PR TITLE
Handle empty frames in window functions

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -215,6 +215,7 @@ void Window::createPeerAndFrameBuffers() {
   auto numFuncs = windowFunctions_.size();
   frameStartBuffers_.reserve(numFuncs);
   frameEndBuffers_.reserve(numFuncs);
+  validFrames_.reserve(numFuncs);
 
   for (auto i = 0; i < numFuncs; i++) {
     BufferPtr frameStartBuffer = AlignedBuffer::allocate<vector_size_t>(
@@ -223,6 +224,7 @@ void Window::createPeerAndFrameBuffers() {
         numRowsPerOutput_, operatorCtx_->pool());
     frameStartBuffers_.push_back(frameStartBuffer);
     frameEndBuffers_.push_back(frameEndBuffer);
+    validFrames_.push_back(SelectivityVector(numRowsPerOutput_));
   }
 }
 
@@ -400,26 +402,36 @@ void Window::updateFrameBounds(
 }
 
 namespace {
-void adjustKRowsFrameBounds(
+// Frame end points are always expected to go from frameStart to frameEnd
+// rows in increasing row numbers in the partition. k rows/range frames could
+// potentially violate this.
+// This function identifies the rows that violate the framing requirements
+// and sets bits in the validFrames SelectivityVector for usage in the
+// WindowFunction subsequently.
+void computeValidFrames(
     vector_size_t lastRow,
     vector_size_t numRows,
     vector_size_t* rawFrameStarts,
-    vector_size_t* rawFrameEnds) {
+    vector_size_t* rawFrameEnds,
+    SelectivityVector& validFrames) {
   auto frameStart = 0;
   auto frameEnd = 0;
 
   for (auto i = 0; i < numRows; i++) {
     frameStart = rawFrameStarts[i];
     frameEnd = rawFrameEnds[i];
-    // Clamp frameStart and frameEnd to the first and last row of the partition
-    // if required.
-    if (frameStart <= frameEnd) {
+    // All valid frames require frameStart <= frameEnd to define the frame rows.
+    // Also, frameEnd >= 0, so that the frameEnd doesn't fall before the
+    // partition. And frameStart <= lastRow so that the frameStart doesn't fall
+    // after the partition rows.
+    if (frameStart <= frameEnd && frameEnd >= 0 && frameStart <= lastRow) {
       rawFrameStarts[i] = std::max(frameStart, 0);
       rawFrameEnds[i] = std::min(frameEnd, lastRow);
     } else {
-      VELOX_NYI("Empty frames are currently not supported");
+      validFrames.setValid(i, false);
     }
   }
+  validFrames.updateBounds();
 }
 
 }; // namespace
@@ -493,7 +505,9 @@ void Window::callApplyForPartitionRows(
 
   for (auto i = 0; i < numFuncs; i++) {
     const auto& windowFrame = windowFrames_[i];
-
+    // Default all rows to have validFrames. The invalidity of frames is only
+    // computed for k rows/range frames at a later point.
+    validFrames_[i].resizeFill(numRows, true);
     updateFrameBounds(
         windowFrame,
         true,
@@ -511,14 +525,18 @@ void Window::callApplyForPartitionRows(
         rawPeerEnds,
         rawFrameEnds[i]);
     if (windowFrames_[i].start || windowFrames_[i].end) {
-      // k preceding and k following bounds in ROWS mode can go over the
-      // partition limits. Hence, they are bound to the first and last partition
-      // rows.
-      adjustKRowsFrameBounds(
+      // k preceding and k following bounds can be problematic. They can
+      // go over the partition limits or result in empty frames. Fix the
+      // frame boundaries and compute the validFrames SelectivityVector
+      // for these cases. Not all functions care about validFrames viz.
+      // Ranking functions do not care about frames. So the function decides
+      // further what to do with empty frames.
+      computeValidFrames(
           lastPartitionRow - firstPartitionRow,
           numRows,
           rawFrameStarts[i],
-          rawFrameEnds[i]);
+          rawFrameEnds[i],
+          validFrames_[i]);
     }
   }
 
@@ -529,6 +547,7 @@ void Window::callApplyForPartitionRows(
         peerEndBuffer_,
         frameStartBuffers_[w],
         frameEndBuffers_[w],
+        validFrames_[w],
         resultOffset,
         result[w]);
   }

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -234,6 +234,16 @@ class Window : public Operator {
   std::vector<BufferPtr> frameStartBuffers_;
   std::vector<BufferPtr> frameEndBuffers_;
 
+  // Frame types for kPreceding or kFollowing could result in empty
+  // frames if the frameStart > frameEnds, or frameEnds < firstPartitionRow
+  // or frameStarts > lastPartitionRow. Such frames usually evaluate to NULL
+  // in the window function.
+  // This SelectivityVector captures the valid (non-empty) frames in the
+  // buffer being worked on. The window function can use this to compute
+  // output values.
+  // There is one SelectivityVector per window function.
+  std::vector<SelectivityVector> validFrames_;
+
   // Number of rows output from the WindowOperator so far. The rows
   // are output in the same order of the pointers in sortedRows. This
   // value is updated as the WindowFunction::apply() function is

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -73,6 +73,10 @@ class WindowFunction {
   /// frame for the current row starts.
   /// @param frameEnds  A buffer of the indexes of rows at which the frame
   /// for the current row ends.
+  /// @param validRows A SelectivityVector whose bits are turned on for
+  /// valid (and off for empty) window frames in this batch of rows.
+  /// Empty window frames have boundaries that violate the condition that
+  /// the frameStart <= frameEnd for that row.
   /// @param resultOffset  This function is invoked multiple times for a
   /// partition as output buffers are available for it. resultOffset
   /// is the offset in the result buffer corresponding to the current
@@ -88,6 +92,7 @@ class WindowFunction {
       const BufferPtr& peerGroupEnds,
       const BufferPtr& frameStarts,
       const BufferPtr& frameEnds,
+      const SelectivityVector& validRows,
       vector_size_t resultOffset,
       const VectorPtr& result) = 0;
 

--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -38,6 +38,7 @@ class CumeDistFunction : public exec::WindowFunction {
       const BufferPtr& peerGroupEnds,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
+      const SelectivityVector& /*validRows*/,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -67,6 +67,7 @@ class NtileFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
+      const SelectivityVector& /*validRows*/,
       vector_size_t resultOffset,
       const VectorPtr& result) {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -69,7 +69,7 @@ class NtileFunction : public exec::WindowFunction {
       const BufferPtr& /*frameEnds*/,
       const SelectivityVector& /*validRows*/,
       vector_size_t resultOffset,
-      const VectorPtr& result) {
+      const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);
 
     if (bucketColumn_.has_value()) {

--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -48,6 +48,7 @@ class RankFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
+      const SelectivityVector& /*validRows*/,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);

--- a/velox/functions/prestosql/window/RowNumber.cpp
+++ b/velox/functions/prestosql/window/RowNumber.cpp
@@ -36,6 +36,7 @@ class RowNumberFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
+      const SelectivityVector& /*validRows*/,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);

--- a/velox/functions/prestosql/window/tests/WindowTestBase.h
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.h
@@ -92,6 +92,14 @@ static std::vector<std::string> kFrameClauses = {
     "rows between c2 preceding and c2 following",
     "rows between c1 preceding and c2 following",
     "rows between c2 preceding and c1 following",
+
+    // Frame clauses with invalid frames.
+    "rows between unbounded preceding and 1 preceding",
+    "rows between 1 preceding and 4 preceding",
+    "rows between 4 preceding and 1 preceding",
+    "rows between 1 following and unbounded following",
+    "rows between 1 following and 4 following",
+    "rows between 4 following and 1 following",
 };
 
 class WindowTestBase : public exec::test::OperatorTestBase {


### PR DESCRIPTION
Frame types for k Preceding or k Following could result in empty frames or
partial frames if they go over partition boundaries or violate frameStart <
frameEnds row limits for frames. Most window functions evaluate empty frames 
as NULL (row_number, rank are exceptions).

This PR modifies the Window operator to detect such frames and pass them along
to the window function to apply in its logic.

More details in https://docs.google.com/document/d/13jWLYu4PDSb3WPiSCI3D5eefHdXXdQd-kMIzRcG4jLI/edit#