### PR TITLE
Skip trying to copy invalid child vectors in RowVector::copy

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -185,8 +185,10 @@ void RowVector::copy(
 
     auto rowSource = source->loadedVector()->as<RowVector>();
     for (auto i = 0; i < childrenSize_; ++i) {
-      children_[i]->copy(
-          rowSource->childAt(i)->loadedVector(), nonNullRows, toSourceRow);
+      if (rowSource->childAt(i)) {
+        children_[i]->copy(
+            rowSource->childAt(i)->loadedVector(), nonNullRows, toSourceRow);
+      }
     }
   } else {
     auto nulls = decodedSource.nulls();


### PR DESCRIPTION
Summary:
Copying a RowVector with a nullptr in child vectors will crash with the following error. This diff makes sure copying a nullptr child in source vector will be skipped.

  *** Signal 11 (SIGSEGV) (0x0) received by PID 3887451 (pthread TID 0x7ffff37227c0) (linux TID 3887451) (code: address not mapped to object), stack trace: ***
    @ 00000000004497b3 (unknown)
    @ 0000000000448c6d (unknown)
    @ 000000000004459f (unknown)
    @ 000000000037d9bf facebook::velox::RowVector::copy(facebook::velox::BaseVector const*, facebook::velox::SelectivityVector const&, int const*)
                       ./velox/vector/ComplexVector.cpp:190

Differential Revision: D43016348

