### PR TITLE
Add cast to the list of special forms in expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -70,8 +70,6 @@ DEFINE_bool(
     false,
     "Enable testing of function signatures with variadic arguments.");
 
-DEFINE_bool(enable_cast, false, "Enable testing with cast expression.");
-
 DEFINE_string(
     repro_persist_path,
     "",
@@ -679,11 +677,15 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
       chosenFunctionName = templateList[chosenExprIndex];
     }
 
-    expression = generateExpressionFromConcreteSignatures(
-        returnType, chosenFunctionName);
-    if (!expression && FLAGS_velox_fuzzer_enable_complex_types) {
-      expression = generateExpressionFromSignatureTemplate(
+    if (chosenFunctionName == "cast") {
+      expression = generateCastExpression(returnType);
+    } else {
+      expression = generateExpressionFromConcreteSignatures(
           returnType, chosenFunctionName);
+      if (!expression && FLAGS_velox_fuzzer_enable_complex_types) {
+        expression = generateExpressionFromSignatureTemplate(
+            returnType, chosenFunctionName);
+      }
     }
   }
   if (!expression) {

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -38,7 +38,7 @@ DEFINE_string(
     special_forms,
     "and,or",
     "Comma-separated list of special forms to use in generated expression. "
-    "Supported special forms: and, or, coalesce, if.");
+    "Supported special forms: and, or, coalesce, if, switch, cast.");
 
 int main(int argc, char** argv) {
   facebook::velox::functions::prestosql::registerAllScalarFunctions();

--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -217,4 +217,17 @@ const std::unordered_map<
                     .returnType("T")
                     .build()},
         },
+        {
+            "cast",
+            std::vector<facebook::velox::exec::FunctionSignaturePtr>{
+                // Signature: cast () -> output:
+                // Special handling is added during expression generation to
+                // choose the appropriate input type param based on the return
+                // type.
+                facebook::velox::exec::FunctionSignatureBuilder()
+                    .typeVariable("T")
+                    .argumentType("T")
+                    .returnType("T")
+                    .build()},
+        },
 };

--- a/velox/expression/tests/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/SparkExpressionFuzzerTest.cpp
@@ -41,7 +41,7 @@ DEFINE_string(
     special_forms,
     "and,or",
     "Comma-separated list of special forms to use in generated expression. "
-    "Supported special forms: and, or, coalesce, if.");
+    "Supported special forms: and, or, coalesce, if, switch, cast.");
 
 int main(int argc, char** argv) {
   facebook::velox::functions::sparksql::registerFunctions("");


### PR DESCRIPTION
This change adds cast as a special form which can be enabled via
the special_form startup flag.

Test Plan:
Verified manually that fuzzer generates expression with cast