### PR TITLE
Fix numAllocated_ counting issue for reallocate

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -202,12 +202,6 @@ void* MemoryPoolImpl::reallocate(
   auto alignedSize = sizeAlign(size);
   auto alignedNewSize = sizeAlign(newSize);
   const int64_t difference = alignedNewSize - alignedSize;
-  if (FOLLY_UNLIKELY(difference <= 0)) {
-    // Track and pretend the shrink took place for accounting purposes.
-    release(-difference);
-    return p;
-  }
-
   reserve(difference);
   void* newP =
       allocator_.reallocateBytes(p, alignedSize, alignedNewSize, alignment_);

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -305,7 +305,7 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     return Stats();
   }
 
-  virtual std::string toString() const;
+  virtual std::string toString() const = 0;
 
   /// Invoked to check if 'alignmentBytes' is valid and 'allocateBytes' is
   /// multiple of 'alignmentBytes'.

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -64,6 +64,8 @@ class MmapAllocator : public MemoryAllocator {
 
   explicit MmapAllocator(const Options& options);
 
+  ~MmapAllocator();
+
   Kind kind() const override {
     return kind_;
   }


### PR DESCRIPTION
Memory pool shortcut reallocate() if the new size is smaller than the
old size. This is incorrect and can also cause numAllocated_ counting
issue in memory allocator. Also adds sanity checks in memory allocator
destructor.

This PR also improves the test coverage in memory allocator.