### PR TITLE
Check numRuns in HashStringAllocator::checkConsistency

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -419,8 +419,7 @@ void HashStringAllocator::checkConsistency() const {
         VELOX_CHECK(!header->isContinued());
         if (header->next()) {
           VELOX_CHECK_EQ(
-              header->size(),
-              *(reinterpret_cast<int32_t*>(header->end()) - 1));
+              header->size(), *(reinterpret_cast<int32_t*>(header->end()) - 1));
         }
         ++numFree;
         freeBytes += sizeof(Header) + header->size();

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -409,9 +409,13 @@ void HashStringAllocator::checkConsistency() const {
     auto end = reinterpret_cast<Header*>(run.data<char>() + size);
     auto header = run.data<Header>();
     while (header != end) {
-      VELOX_CHECK(header >= run.data<Header>());
-      VELOX_CHECK(header < end);
-      VELOX_CHECK(header->end() <= reinterpret_cast<char*>(end));
+      VELOX_CHECK_GE(
+          reinterpret_cast<char*>(header),
+          reinterpret_cast<char*>(run.data<Header>()));
+      VELOX_CHECK_LT(
+          reinterpret_cast<char*>(header), reinterpret_cast<char*>(end));
+      VELOX_CHECK_LE(
+          reinterpret_cast<char*>(header->end()), reinterpret_cast<char*>(end));
       VELOX_CHECK_EQ(header->isPreviousFree(), previousFree);
 
       if (header->isFree()) {
@@ -433,16 +437,16 @@ void HashStringAllocator::checkConsistency() const {
       header = reinterpret_cast<Header*>(header->end());
     }
   }
-  VELOX_CHECK(numFree == numFree_);
-  VELOX_CHECK(freeBytes == freeBytes_);
+  VELOX_CHECK_EQ(numFree, numFree_);
+  VELOX_CHECK_EQ(freeBytes, freeBytes_);
   uint64_t numInFreeList = 0;
   uint64_t bytesInFreeList = 0;
   for (auto free = free_.next(); free != &free_; free = free->next()) {
     ++numInFreeList;
     bytesInFreeList += headerOf(free)->size() + sizeof(Header);
   }
-  VELOX_CHECK(numInFreeList == numFree_);
-  VELOX_CHECK(bytesInFreeList == freeBytes_);
+  VELOX_CHECK_EQ(numInFreeList, numFree_);
+  VELOX_CHECK_EQ(bytesInFreeList, freeBytes_);
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -402,37 +402,36 @@ void HashStringAllocator::checkConsistency() const {
   VELOX_CHECK_EQ(pool_.numLargeAllocations(), 0);
   for (auto i = 0; i < pool_.numSmallAllocations(); ++i) {
     auto allocation = pool_.allocationAt(i);
-    for (auto runIndex = 0; runIndex < allocation->numRuns(); ++runIndex) {
-      auto run = allocation->runAt(runIndex);
-      auto size = run.numBytes() - sizeof(Header);
-      bool previousFree = false;
-      auto end = reinterpret_cast<Header*>(run.data<char>() + size);
-      auto header = run.data<Header>();
-      while (header != end) {
-        VELOX_CHECK(header >= run.data<Header>());
-        VELOX_CHECK(header < end);
-        VELOX_CHECK(header->end() <= reinterpret_cast<char*>(end));
-        VELOX_CHECK_EQ(header->isPreviousFree(), previousFree);
+    VELOX_CHECK_EQ(allocation->numRuns(), 1);
+    auto run = allocation->runAt(0);
+    auto size = run.numBytes() - sizeof(Header);
+    bool previousFree = false;
+    auto end = reinterpret_cast<Header*>(run.data<char>() + size);
+    auto header = run.data<Header>();
+    while (header != end) {
+      VELOX_CHECK(header >= run.data<Header>());
+      VELOX_CHECK(header < end);
+      VELOX_CHECK(header->end() <= reinterpret_cast<char*>(end));
+      VELOX_CHECK_EQ(header->isPreviousFree(), previousFree);
 
-        if (header->isFree()) {
-          VELOX_CHECK(!previousFree);
-          VELOX_CHECK(!header->isContinued());
-          if (header->next()) {
-            VELOX_CHECK_EQ(
-                header->size(),
-                *(reinterpret_cast<int32_t*>(header->end()) - 1));
-          }
-          ++numFree;
-          freeBytes += sizeof(Header) + header->size();
-        } else if (header->isContinued()) {
-          // If the content of the header is continued, check the
-          // continue header is readable and not free.
-          auto continued = getNextContinued(header);
-          VELOX_CHECK(!continued->isFree());
+      if (header->isFree()) {
+        VELOX_CHECK(!previousFree);
+        VELOX_CHECK(!header->isContinued());
+        if (header->next()) {
+          VELOX_CHECK_EQ(
+              header->size(),
+              *(reinterpret_cast<int32_t*>(header->end()) - 1));
         }
-        previousFree = header->isFree();
-        header = reinterpret_cast<Header*>(header->end());
+        ++numFree;
+        freeBytes += sizeof(Header) + header->size();
+      } else if (header->isContinued()) {
+        // If the content of the header is continued, check the
+        // continue header is readable and not free.
+        auto continued = getNextContinued(header);
+        VELOX_CHECK(!continued->isFree());
       }
+      previousFree = header->isFree();
+      header = reinterpret_cast<Header*>(header->end());
     }
   }
   VELOX_CHECK(numFree == numFree_);


### PR DESCRIPTION
Since AllocationPool directly passes the needed pages as minimal size class
(refer the commit message of
https://github.com/facebookincubator/velox/pull/1906), the
```allocation->numRuns()``` should always be 1 in HashStringAllocator's pool_.
Add the check in ```HashStringAllocator::checkConsistency()```.

If ```allocation->numRuns()``` is more than 1, ```AllocationPool::newRunImpl```
can just return the next run, which might not satisfy required ```numPages```.