### PR TITLE
Add subfield pruning in reader and HiveConnector

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -56,9 +56,9 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   // Create row set for child columns based on the row set of parent column.
   void makeNestedRowSet(RowSet rows, int32_t maxRow);
 
-  // Compact the output rows (along with the offsets and lengths) based on the
-  // current filtered rows passed in.
-  void compactOffsets(RowSet rows);
+  // Compute the offsets and lengths based on the current filtered rows passed
+  // in.
+  void makeOffsetsAndSizes(RowSet rows);
 
   // Creates a struct if '*result' is empty and 'type' is a row.
   void prepareStructResult(
@@ -74,7 +74,8 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   RowSet applyFilter(RowSet rows);
 
   std::vector<int32_t> allLengths_;
-  raw_vector<vector_size_t> nestedRows_;
+  RowSet nestedRows_;
+  raw_vector<vector_size_t> nestedRowsHolder_;
   BufferPtr offsets_;
   BufferPtr sizes_;
   // The position in the child readers that corresponds to the

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(
   velox_e2e_filter_test_base
   velox_functions_prestosql
   velox_parse_parser
+  velox_vector_test_lib
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -270,6 +270,8 @@ class E2EFilterTestBase : public testing::Test {
  protected:
   void testMetadataFilter();
 
+  void testSubfieldsPruning();
+
   // Allows testing reading with different batch sizes.
   void resetReadBatchSizes() {
     nextReadSizeIndex_ = 0;

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -502,12 +502,6 @@ class FilterGenerator {
   }
 
  private:
-  static void makeFieldSpecs(
-      const std::string& pathPrefix,
-      int32_t level,
-      const std::shared_ptr<const Type>& type,
-      ScanSpec* spec);
-
   static void collectFilterableSubFields(
       const RowType* rowType,
       std::vector<std::string>& subFields);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -58,7 +58,8 @@ SelectiveListColumnReader::SelectiveListColumnReader(
       cs.shouldReadNode(childType->id),
       "SelectiveListColumnReader must select the values stream");
   if (scanSpec_->children().empty()) {
-    scanSpec.getOrCreateChild(common::Subfield("elements"));
+    scanSpec.getOrCreateChild(
+        common::Subfield(common::ScanSpec::kArrayElementsFieldName));
   }
   scanSpec_->children()[0]->setProjectOut(true);
   scanSpec_->children()[0]->setExtractValues(true);
@@ -85,8 +86,10 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if (scanSpec_->children().empty()) {
-    scanSpec_->getOrCreateChild(common::Subfield("keys"));
-    scanSpec_->getOrCreateChild(common::Subfield("elements"));
+    scanSpec_->getOrCreateChild(
+        common::Subfield(common::ScanSpec::kMapKeysFieldName));
+    scanSpec_->getOrCreateChild(
+        common::Subfield(common::ScanSpec::kMapValuesFieldName));
   }
   scanSpec_->children()[0]->setProjectOut(true);
   scanSpec_->children()[0]->setExtractValues(true);

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -393,6 +393,10 @@ TEST_F(E2EFilterTest, metadataFilter) {
   testMetadataFilter();
 }
 
+TEST_F(E2EFilterTest, subfieldsPruning) {
+  testSubfieldsPruning();
+}
+
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -132,6 +132,7 @@ class ColumnReaderTestBase {
     if (useSelectiveReader()) {
       if (!scanSpec) {
         scanSpec_ = std::make_unique<common::ScanSpec>("root");
+        scanSpec_->addAllChildFields(*dataTypeWithId->type);
         scanSpec = scanSpec_.get();
       }
       makeFieldSpecs("", 0, rowType, scanSpec);

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -115,14 +115,7 @@ class ParquetReaderTestBase : public testing::Test {
   std::shared_ptr<velox::common::ScanSpec> makeScanSpec(
       const RowTypePtr& rowType) {
     auto scanSpec = std::make_shared<velox::common::ScanSpec>("");
-
-    for (auto i = 0; i < rowType->size(); ++i) {
-      auto child = scanSpec->getOrCreateChild(
-          velox::common::Subfield(rowType->nameOf(i)));
-      child->setProjectOut(true);
-      child->setChannel(i);
-    }
-
+    scanSpec->addAllChildFields(*rowType);
     return scanSpec;
   }
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -490,6 +490,10 @@ TEST_F(E2EFilterTest, metadataFilter) {
   testMetadataFilter();
 }
 
+TEST_F(E2EFilterTest, subfieldsPruning) {
+  testSubfieldsPruning();
+}
+
 TEST_F(E2EFilterTest, map) {
   // Break up the leaf data in small pages to cover coalescing repdefs.
   writerProperties_ =


### PR DESCRIPTION
Summary:
Implement subfield pruning to columns of complex types: arrays, maps and structs.  When a query uses only some of the subfields, the engine provides the complete list of required subfields and the connector is free to prune the rest.

* Pruning a struct means populating some of the members with null values.  This is to ensure the result vector matching the output type even some fields are pruned.  If the field is not in output type at all, we just remove that field instead of populating it with nulls.
* Pruning a map means dropping keys not listed in the required subfields.
* Pruning an array means dropping values with indices larger than maximum required index.

Only one level of subfield is supported for pruning.

Differential Revision: D42984144

