### PR TITLE
Remove selectiviy vector re-construction from comparison_conjunct benchmark.

### DIFF
--- a/velox/benchmarks/basic/ComparisonConjunct.cpp
+++ b/velox/benchmarks/basic/ComparisonConjunct.cpp
@@ -99,10 +99,12 @@ class ComparisonBenchmark : public functions::test::FunctionBenchmarkBase {
     folly::BenchmarkSuspender suspender;
     auto exprSet = compileExpression(expression, inputType_);
     suspender.dismiss();
-
+    // For functions like eq, the construction if the selectivity vector is
+    // effect the total runtime, hence we pulled out of the evaluation loop.
+    SelectivityVector rows(rowVector_->size());
     size_t count = 0;
     for (auto i = 0; i < times; i++) {
-      count += evaluate(exprSet, rowVector_)->size();
+      count += evaluate(exprSet, rowVector_, rows)->size();
     }
     return count;
   }

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -38,12 +38,19 @@ class FunctionBenchmarkBase {
     return exec::ExprSet({typed}, &execCtx_);
   }
 
-  VectorPtr evaluate(exec::ExprSet& exprSet, const RowVectorPtr& data) {
-    SelectivityVector rows(data->size());
+  VectorPtr evaluate(
+      exec::ExprSet& exprSet,
+      const RowVectorPtr& data,
+      const SelectivityVector& rows) {
     exec::EvalCtx evalCtx(&execCtx_, &exprSet, data.get());
     std::vector<VectorPtr> results(1);
     exprSet.eval(rows, evalCtx, results);
     return results[0];
+  }
+
+  VectorPtr evaluate(exec::ExprSet& exprSet, const RowVectorPtr& data) {
+    SelectivityVector rows(data->size());
+    return evaluate(exprSet, data, rows);
   }
 
   VectorPtr evaluate(const std::string& expression, const RowVectorPtr& data) {


### PR DESCRIPTION
Summary: title.

Differential Revision: D42889179

