### PR TITLE
Fix Allocation::append() pageRun merge issue which might cause memory free leak

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -32,24 +32,10 @@ Allocation::~Allocation() {
 
 void Allocation::append(uint8_t* address, int32_t numPages) {
   numPages_ += numPages;
-  if (runs_.empty()) {
-    runs_.emplace_back(address, numPages);
-    return;
-  }
-
-  PageRun last = runs_.back();
-  VELOX_CHECK_NE(
-      address, last.data(), "Appending a duplicate address into a PageRun");
-
-  // Increment page count if new data starts at end of the last run
-  // and the combined page count is within limits.
-  if ((address ==
-       last.data() + last.numPages() * AllocationTraits::kPageSize) &&
-      (last.numPages() + numPages <= PageRun::kMaxPagesInRun)) {
-    runs_.back() = PageRun(last.data(), last.numPages() + numPages);
-  } else {
-    runs_.emplace_back(address, numPages);
-  }
+  VELOX_CHECK(
+      runs_.empty() || address != runs_.back().data(),
+      "Appending a duplicate address into a PageRun");
+  runs_.emplace_back(address, numPages);
 }
 
 void Allocation::findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun)

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/Memory.h"
+
+using namespace ::testing;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::exec::test {
+
+class AllocationTest : public testing::Test {};
+
+// This test is to verify that Allocation doesn't merge different append buffers
+// into the same PageRun even if two buffers are contiguous in memory space.
+TEST_F(AllocationTest, append) {
+  Allocation allocation;
+  const uint64_t startBufAddrValue = 4096;
+  uint8_t* const firstBufAddr = reinterpret_cast<uint8_t*>(startBufAddrValue);
+  const int32_t kNumPages = 10;
+  allocation.append(firstBufAddr, kNumPages);
+  ASSERT_EQ(allocation.numPages(), kNumPages);
+  ASSERT_EQ(allocation.numRuns(), 1);
+  uint8_t* const secondBufAddr = reinterpret_cast<uint8_t*>(
+      startBufAddrValue + kNumPages * AllocationTraits::kPageSize);
+  allocation.append(secondBufAddr, kNumPages - 1);
+  ASSERT_EQ(allocation.numPages(), kNumPages * 2 - 1);
+  ASSERT_EQ(allocation.numRuns(), 2);
+  uint8_t* const thirdBufAddr = reinterpret_cast<uint8_t*>(
+      firstBufAddr + 4 * kNumPages * AllocationTraits::kPageSize);
+  allocation.append(thirdBufAddr, kNumPages * 2);
+  ASSERT_EQ(allocation.numPages(), kNumPages * 4 - 1);
+  ASSERT_EQ(allocation.numRuns(), 3);
+  VELOX_ASSERT_THROW(allocation.append(thirdBufAddr, kNumPages), "");
+  allocation.clear();
+}
+} // namespace facebook::velox::exec::test

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 include(GoogleTest)
 add_executable(
   velox_memory_test
+  AllocationTest.cpp
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp


### PR DESCRIPTION
Current Allocation::append() has an optimization to extend the last 
page run if the new append buffer is contiguous to the last page run's
buffer so that we can merge the two buffers into one larger buffer.
However, this might cause memory free leaking if the mapped memory
spaces of two size classes are contiguous. The allocation path might
merge the buffers from two different size classes into one page run.
On the free path, we might skip freeing the second part of the merged
page run if it belongs to a smaller size class. This might cause some
other error symptom if we merge a large size class buffer into a page
run from a smaller size class.

For example, here is mapped space distribution of size classes collected
from a failed linux-build-release run from circle ci:
```
I0206 21:53:17.955401 74442 MmapAllocator.cpp:492] unitSize_ 1 @ 140702774214656 byte size 268435456
I0206 21:53:17.955425 74442 MmapAllocator.cpp:492] unitSize_ 2 @ 140702505779200 byte size 268435456
I0206 21:53:17.955430 74442 MmapAllocator.cpp:492] unitSize_ 4 @ 140702237343744 byte size 268435456
I0206 21:53:17.955435 74442 MmapAllocator.cpp:492] unitSize_ 8 @ 140701968908288 byte size 268435456
I0206 21:53:17.955439 74442 MmapAllocator.cpp:492] unitSize_ 16 @ 140701700472832 byte size 268435456
I0206 21:53:17.955443 74442 MmapAllocator.cpp:492] unitSize_ 32 @ 140701432037376 byte size 268435456
I0206 21:53:17.955447 74442 MmapAllocator.cpp:492] unitSize_ 64 @ 140701163601920 byte size 268435456
I0206 21:53:17.955451 74442 MmapAllocator.cpp:492] unitSize_ 128 @ 140700895166464 byte size 268435456
I0206 21:53:17.955454 74442 MmapAllocator.cpp:492] unitSize_ 256 @ 140700626731008 byte size 268435456
```
We can see that the end of size class 256 (each class unit has 256 4KB
pages) is contiguous to the start of size class 128. For an allocation of 384
pages, MmapAllocator::SizeClass::allocateFromMappedFree can choose to
allocate the last unit from size class of 256 and the first one from size class of
128 to form 384 pages allocation. Allocation::append can merge the two
into one page run (merge the unit of size class 128 into page run created by
size class 256) as the two buffers are contiguous. On the free path,
MmapAllocator::SizeClass::free will only free the first 256 pages from the merged
page run and cause 128 pages allocation leaking.

The fix is to remove buggy optimization in Allocation::append so each append
will create a new page run.

Has verified the fix on linux-release-build with 1000 times run. Also note that
Allocation::append is mainly used by allocator internally with one call from
different size classes so it won't cause any performance regression.

We can consider to optimize the size class free path for non-contiguous allocation
since each PageRun only contains pages from one size class and we could store
the size class id in the PageRun for that purpose.