### PR TITLE
Fix memory reservation leak in HashBuild when task fails

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -204,6 +204,8 @@ void MemoryUsageTracker::sanityCheckLocked() const {
 }
 
 bool MemoryUsageTracker::maybeReserve(uint64_t increment) {
+  TestValue::adjust(
+      "facebook::velox::memory::MemoryUsageTracker::maybeReserve", this);
   constexpr int32_t kGrowthQuantum = 8 << 20;
   const auto reservationToAdd = bits::roundUp(increment, kGrowthQuantum);
   try {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -77,8 +77,6 @@ class HashBuild final : public Operator {
 
   bool isFinished() override;
 
-  void close() override {}
-
  private:
   void setState(State state);
   void checkStateTransition(State state);

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -112,15 +112,24 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     std::function<void(exec::Task*)> addSplits);
 
 /// The Task can return results before the Driver is finished executing.
-/// Wait upto maxWaitMicros for the Task to finish before returning to ensure
-/// it's stable e.g. the Driver isn't updating it anymore.
+/// Wait upto maxWaitMicros for the Task to finish as 'expectedState' before
+/// returning to ensure it's stable e.g. the Driver isn't updating it anymore.
 /// Returns true if the task is completed before maxWaitMicros expires.
+bool waitForTaskFinish(
+    exec::Task* task,
+    TaskState expectedState,
+    uint64_t maxWaitMicros = 1'000'000);
+
+/// Similar to waitForTaskFinish but wait for the task to succeed.
 bool waitForTaskCompletion(
     exec::Task* task,
     uint64_t maxWaitMicros = 1'000'000);
 
-/// Similar to waitForTaskCompletion but wait for the task to fail.
+/// Similar to waitForTaskFinish but wait for the task to fail.
 bool waitForTaskFailure(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
+
+/// Similar to waitForTaskFinish but wait for the task to abort.
+bool waitForTaskAborted(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
 
 /// Wait up to maxWaitMicros for 'task' state changes to 'state'. The function
 /// returns true if 'task' has changed to the expected 'state', otherwise false.


### PR DESCRIPTION
HashBuild operator overrides the Operator::close method but does nothing. The
default Operator::close releases the reserved memory. Having HashBuild::close
not releasing memory causes memory reservation leak when spilling is enabled
and the task fails in the middle of hash build execution. Note: if the hash
build runs to completion, then hash build post processing releases the memory
reservation.

Add unit test to reproduce and verify the issue. @spershin has helped verify the
fix in Meta's test cluster.