### PR TITLE
Skip call to fmt in _VELOX_THROW_IMPL when no formatting is required

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -142,6 +142,10 @@ inline const char* errorMessage(const char* s) {
   return s;
 }
 
+inline std::string errorMessage(const std::string& str) {
+  return str;
+}
+
 template <typename... Args>
 std::string errorMessage(fmt::string_view fmt, const Args&... args) {
   return fmt::vformat(fmt, fmt::make_format_args(args...));


### PR DESCRIPTION
This adds an overloaded function that allows the complier to skip call
to fmt::vformat in the expansion of _VELOX_THROW_IMPL macro when no
formatting is required, that is, only the error string is passed to
it.

Test Plan:
Added a unit test.