### PR TITLE
Handle nullptr column vectors in PrestoSerializer

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1322,6 +1322,10 @@ void serializeColumn(
     const BaseVector* vector,
     const folly::Range<const IndexRange*>& ranges,
     VectorStream* stream) {
+  if (!vector) {
+    return;
+  }
+
   switch (vector->encoding()) {
     case VectorEncoding::Simple::FLAT:
       VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(

--- a/velox/vector/tests/utils/VectorMaker.cpp
+++ b/velox/vector/tests/utils/VectorMaker.cpp
@@ -42,7 +42,12 @@ RowVectorPtr VectorMaker::rowVector(
   std::vector<std::shared_ptr<const Type>> childTypes;
   childTypes.resize(children.size());
   for (int i = 0; i < children.size(); i++) {
-    childTypes[i] = children[i]->type();
+    if (children[i]) {
+      childTypes[i] = children[i]->type();
+    } else {
+      // If child vector is nullptr, just default to any type.
+      childTypes[i] = SMALLINT();
+    }
   }
   auto rowType = ROW(std::move(childNames), std::move(childTypes));
   const size_t vectorSize = children.empty() ? 0 : children.front()->size();


### PR DESCRIPTION
Non-projected columns can be returned as nullptr. PrestoSerializer currently fails with Vectors containing nullptr columns. 
This change excludes nullptr vectors from serialization. With deserialization, we'll get an empty vector of the same type. 

Test Plan: 
- Added some new tests to verify all columns remain after deserialization, and values are unaffected.
- Validate existing tests pass.