### PR TITLE
Automate and simplify opaque custom type creation

### DIFF
--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+
+namespace exec {
+class CastOperator;
+}
+
+// Given a class T, create a custom type that can be used to refer to it, with
+// an underlying opaque vector type.
+// Note that name must be stored in a variable and passed and cant be inlined.
+// OpaqueCustomTypeRegister<T, "type"> wont compile.
+// but static constexpr char* type = "type", OpaqueCustomTypeRegister<T, type>
+// works.
+template <typename T, const char* name>
+class OpaqueCustomTypeRegister {
+ public:
+  static void registerType() {
+    facebook::velox::registerType(name, std::make_unique<const TypeFactory>());
+  }
+
+  // Type used in the simple function interface as CustomType<TypeT>.
+  struct TypeT {
+    using type = std::shared_ptr<T>;
+    static constexpr const char* typeName = name;
+  };
+
+  using SimpleType = CustomType<TypeT>;
+
+  class VeloxType : public OpaqueType {
+   public:
+    VeloxType() : OpaqueType(std::type_index(typeid(T))) {}
+
+    static const TypePtr& get() {
+      static const TypePtr instance{new VeloxType()};
+      return instance;
+    }
+
+    static const std::shared_ptr<const exec::CastOperator>& getCastOperator() {
+      VELOX_UNSUPPORTED();
+    }
+
+    bool equivalent(const velox::Type& other) const override {
+      // Pointer comparison works since this type is a singleton.
+      return this == &other;
+    }
+
+    std::string toString() const override {
+      return name;
+    }
+  };
+
+  static const TypePtr& singletonTypePtr() {
+    return VeloxType::get();
+  }
+
+ private:
+  class TypeFactory : public CustomTypeFactories {
+   public:
+    TypeFactory() = default;
+
+    TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+      return singletonTypePtr();
+    }
+
+    exec::CastOperatorPtr getCastOperator() const override {
+      VELOX_UNSUPPORTED();
+    }
+  };
+};
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
Given a UDT X user need to only do :
```

static constexpr char kName[] = "tuple_type";
using TypeRegistrar = OpaqueCustomTypeRegister<X, name>;
// The type used in the simple function interface.
TypeRegistrar::registerType();

// To refer to get access to the velox type ptr someone can do.
auto type = TypeRegistrar::SingletonTypePtr()
BaseVector::ensureWritable(rows, type..);

// when writing simple functions use the simple type
using TupleType = typename TypeRegistrar::SimpleType;

template <typename T>
struct FuncReduce {
  VELOX_DEFINE_FUNCTION_TYPES(T);
  void call(int64_t& result, const arg_type<TupleType>& a) {
    result = a->x + a->y;
  }
};
``

Differential Revision: D43054815

