### PR TITLE
Fix approx_distinct to allow addRawInput after addIntermediateResults

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -94,7 +94,9 @@ class Aggregate {
     rowSizeOffset_ = rowSizeOffset;
   }
 
-  // Initializes null flags and accumulators for newly encountered groups.
+  // Initializes null flags and accumulators for newly encountered groups.  This
+  // function should be called only once for each group.
+  //
   // @param groups Pointers to the start of the new group rows.
   // @param indices Indices into 'groups' of the new entries.
   virtual void initializeNewGroups(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -319,7 +319,8 @@ column_index_t exprToChannel(
   if (dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
     return kConstantChannel;
   }
-  VELOX_CHECK(false, "Expression must be field access or constant");
+  VELOX_FAIL(
+      "Expression must be field access or constant, got: {}", expr->toString());
   return 0; // not reached.
 }
 

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -209,9 +209,8 @@ class ApproxDistinctAggregate : public exec::Aggregate {
         auto group = groups[row];
         auto tracker = trackRowSize(group);
         auto accumulator = value<HllAccumulator>(group);
-        if (clearNull(group)) {
-          accumulator->setIndexBitLength(indexBitLength_);
-        }
+        clearNull(group);
+        accumulator->setIndexBitLength(indexBitLength_);
 
         auto hash = hashOne(decodedValue_.valueAt<T>(row));
         accumulator->append(hash);
@@ -259,9 +258,8 @@ class ApproxDistinctAggregate : public exec::Aggregate {
         }
 
         auto accumulator = value<HllAccumulator>(group);
-        if (clearNull(group)) {
-          accumulator->setIndexBitLength(indexBitLength_);
-        }
+        clearNull(group);
+        accumulator->setIndexBitLength(indexBitLength_);
 
         auto hash = hashOne(decodedValue_.valueAt<T>(row));
         accumulator->append(hash);

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -96,6 +96,9 @@ class ArbitraryAggregate : public SimpleNumericAggregate<T, T, T> {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
+    if (!exec::Aggregate::isNull(group)) {
+      return;
+    }
     DecodedVector decoded(*args[0], rows);
 
     if (decoded.isConstantMapping()) {

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.h
@@ -111,6 +111,16 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& postAggregationProjections,
       const std::vector<RowVectorPtr>& expectedResult);
 
+  /// Ensure the function is working in streaming use case.  Create a first
+  /// aggregation function, add the rawInput1, then extract the accumulator,
+  /// read the accumulator to second function, and continue to add rawInput2 to
+  /// second function.
+  VectorPtr testStreaming(
+      const std::string& functionName,
+      bool testGlobal,
+      const std::vector<VectorPtr>& rawInput1,
+      const std::vector<VectorPtr>& rawInput2);
+
   /// Specifies that aggregate functions used in this test are not sensitive
   /// to the order of inputs.
   void allowInputShuffle() {
@@ -122,7 +132,22 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
     allowInputShuffle_ = false;
   }
 
+  /// Whether testStreaming should be called in testAggregations.
+  bool testStreaming_{true};
+
  private:
+  void validateStreamingInTestAggregations(
+      const std::function<void(exec::test::PlanBuilder&)>& makeSource,
+      const std::vector<std::string>& aggregates);
+
+  VectorPtr testStreaming(
+      const std::string& functionName,
+      bool testGlobal,
+      const std::vector<VectorPtr>& rawInput1,
+      vector_size_t rawInput1Size,
+      const std::vector<VectorPtr>& rawInput2,
+      vector_size_t rawInput2Size);
+
   bool allowInputShuffle_{false};
 };
 

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -245,5 +245,17 @@ TEST_F(ApproxDistinctTest, globalAggAllNulls) {
   EXPECT_TRUE(readSingleValue(op).isNull());
 }
 
+TEST_F(ApproxDistinctTest, streaming) {
+  auto rawInput1 = makeFlatVector<int64_t>({1, 2, 3});
+  auto rawInput2 = makeFlatVector<int64_t>(1000, folly::identity);
+  auto result =
+      testStreaming("approx_distinct", true, {rawInput1}, {rawInput2});
+  ASSERT_EQ(result->size(), 1);
+  ASSERT_EQ(result->asFlatVector<int64_t>()->valueAt(0), 1008);
+  result = testStreaming("approx_distinct", false, {rawInput1}, {rawInput2});
+  ASSERT_EQ(result->size(), 1);
+  ASSERT_EQ(result->asFlatVector<int64_t>()->valueAt(0), 1008);
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -69,18 +69,16 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
   void testGlobalAggregation() {
     auto vectors = {makeRowVector({
         makeNullableFlatVector<T>({std::nullopt, 1, 2, std::nullopt}),
-        makeConstant<bool>(true, 4),
-        makeConstant<bool>(false, 4),
     })};
 
     // Verify when ignoreNull is true.
     auto expectedTrue = {makeRowVector({makeNullableFlatVector<T>({2})})};
-    testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+    testAggregations(vectors, {}, {"last(c0, TRUE)"}, expectedTrue);
 
     // Verify when ignoreNull is false.
     auto expectedFalse = {
         makeRowVector({makeNullableFlatVector<T>({std::nullopt})})};
-    testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+    testAggregations(vectors, {}, {"last(c0, FALSE)"}, expectedFalse);
 
     // Verify when ignoreNull is not provided. Defaults to false.
     testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
@@ -192,19 +190,17 @@ TEST_F(LastAggregateTest, varcharGlobal) {
   auto vectors = {makeRowVector({
       makeNullableFlatVector<std::string>(
           {std::nullopt, "a", "b", std::nullopt}),
-      makeConstant<bool>(true, 4),
-      makeConstant<bool>(false, 4),
   })};
 
   // Verify when ignoreNull is true.
   auto expectedTrue = {
       makeRowVector({makeNullableFlatVector<std::string>({"b"})})};
-  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+  testAggregations(vectors, {}, {"last(c0, TRUE)"}, expectedTrue);
 
   // Verify when ignoreNull is false.
   auto expectedFalse = {
       makeRowVector({makeNullableFlatVector<std::string>({std::nullopt})})};
-  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+  testAggregations(vectors, {}, {"last(c0, FALSE)"}, expectedFalse);
 
   // Verify when ignoreNull is not provided. Defaults to false.
   testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
@@ -264,8 +260,6 @@ TEST_F(LastAggregateTest, arrayGlobal) {
   auto vectors = {makeRowVector({
       makeNullableArrayVector<int64_t>(
           {std::nullopt, {{1, 2}}, {{3, 4}}, std::nullopt}),
-      makeConstant<bool>(true, 4),
-      makeConstant<bool>(false, 4),
   })};
 
   auto expectedTrue = {makeRowVector({
@@ -273,13 +267,13 @@ TEST_F(LastAggregateTest, arrayGlobal) {
   })};
 
   // Verify when ignoreNull is true.
-  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+  testAggregations(vectors, {}, {"last(c0, TRUE)"}, expectedTrue);
 
   // Verify when ignoreNull is false.
   auto expectedFalse = {makeRowVector({
       makeNullableArrayVector<int64_t>({std::nullopt}),
   })};
-  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+  testAggregations(vectors, {}, {"last(c0, FALSE)"}, expectedFalse);
 
   // Verify when ignoreNull is not provided. Defaults to false.
   testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);
@@ -317,8 +311,6 @@ TEST_F(LastAggregateTest, mapGlobal) {
   auto vectors = {makeRowVector({
       makeNullableMapVector<int64_t, float>(
           {std::nullopt, O({{1, 2.0}}), O({{2, 4.0}}), std::nullopt}),
-      makeConstant<bool>(true, 4),
-      makeConstant<bool>(false, 4),
   })};
 
   auto expectedTrue = {makeRowVector({
@@ -326,13 +318,13 @@ TEST_F(LastAggregateTest, mapGlobal) {
   })};
 
   // Verify when ignoreNull is true.
-  testAggregations(vectors, {}, {"last(c0, c1)"}, expectedTrue);
+  testAggregations(vectors, {}, {"last(c0, TRUE)"}, expectedTrue);
 
   // Verify when ignoreNull is false.
   auto expectedFalse = {makeRowVector({
       makeNullableMapVector<int64_t, float>({std::nullopt}),
   })};
-  testAggregations(vectors, {}, {"last(c0, c2)"}, expectedFalse);
+  testAggregations(vectors, {}, {"last(c0, FALSE)"}, expectedFalse);
 
   // Verify when ignoreFalse is not provided. Defaults to false.
   testAggregations(vectors, {}, {"last(c0)"}, expectedFalse);


### PR DESCRIPTION
Summary:
We have some use case for the same aggregate function to accept raw
inputs and intermediate results at same time.  This change makes sure
`approx_distinct` is able to do this without problem.

Differential Revision: D43089610

