### PR TITLE
Fix propagation of evaluated results from common subexpression

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -662,11 +662,14 @@ void Expr::evaluateSharedSubexpr(
 
   eval(*missingRows, context, sharedSubexprValues_);
 
+  // recycling missingRowsHolder.
+  auto rowsToCopy = missingRows;
+  *rowsToCopy = rows;
   // Clear the rows which failed to compute.
-  context.deselectErrors(*missingRows);
+  context.deselectErrors(*rowsToCopy);
 
-  sharedSubexprRows_->select(*missingRows);
-  context.moveOrCopyResult(sharedSubexprValues_, *missingRows, result);
+  sharedSubexprRows_->select(*rowsToCopy);
+  context.moveOrCopyResult(sharedSubexprValues_, *rowsToCopy, result);
 }
 
 namespace {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -898,8 +898,12 @@ TEST_F(ExprTest, csePartialEvaluation) {
   auto a = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
   auto b = makeFlatVector<std::string>({"a", "b", "c", "d", "e"});
 
+  // The second expression also uses an 'if' expression to make sure a result
+  // vector exists and values need to be copied over from the vector holding
+  // shared values.
   auto results = evaluateMultiple(
-      {"if (c0 >= 3, add_suffix(c1), 'n/a')", "add_suffix(c1)"},
+      {"if (c0 >= 3, add_suffix(c1), 'n/a')",
+       "if (c0 < 2, 'n/a', add_suffix(c1))"},
       makeRowVector({a, b}));
 
   auto expected =
@@ -907,7 +911,7 @@ TEST_F(ExprTest, csePartialEvaluation) {
   assertEqualVectors(expected, results[0]);
 
   expected =
-      makeFlatVector<std::string>({"a_xx", "b_xx", "c_xx", "d_xx", "e_xx"});
+      makeFlatVector<std::string>({"n/a", "b_xx", "c_xx", "d_xx", "e_xx"});
   assertEqualVectors(expected, results[1]);
 }
 


### PR DESCRIPTION
This fixes a bug in the common sub expression implementation where
if the set of already evaluated shared rows is a subset of the
newly requested rows, then only the intersection of these sets gets
copied over. As a concrete example, if the shared set consists of
{1,2,3} rows and the newly requested rows are {2,3,4} then only {4}
is copied over to the result.

Test Plan:
Modifies an existing test case to ensure this code path is exercised.
The existing test did not catch this bug because it went through a
shortcut in moveOrCopyResult() where to avoid copying, if the result
is a nullptr then the result vector is pointed directly to the full
set of shared rows which already had all the computed values.