### PR TITLE
Optimize generic writer cast cost

### DIFF
--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <optional>
 #include "velox/expression/VectorReaders.h"
 #include "velox/expression/VectorWriters.h"
 #include "velox/functions/Udf.h"
@@ -475,7 +476,7 @@ TEST_F(GenericWriterTest, dynamicRow) {
 
   writer2.setOffset(0);
   auto& current2 = writer2.current();
-  ASSERT_THROW(current2.castTo<DynamicRow>(), VeloxUserError);
+  ASSERT_EQ(current2.tryCastTo<DynamicRow>(), nullptr);
 }
 
 TEST_F(GenericWriterTest, nested) {


### PR DESCRIPTION
Summary:
1. introduce castToUnsafe which does not check type compatibility
(assumes user did check that). I feel like castTo semantics should be be
that we can also just do that.
2. use dynamic_cast instead of dynamic_pointer_cast.

Differential Revision: D42878306

