### PR TITLE
Fix compile error caused by nonexist tests dir

### DIFF
--- a/velox/codegen/CMakeLists.txt
+++ b/velox/codegen/CMakeLists.txt
@@ -19,6 +19,3 @@ else()
   target_link_libraries(velox_codegen velox_core velox_exec velox_expression
                         ${FOLLY_WITH_DEPENDENCIES})
 endif()
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()


### PR DESCRIPTION
Compile error when run ```make```:
```
CMake Error at velox/codegen/CMakeLists.txt:23 (add_subdirectory):
  add_subdirectory given source "tests" which is not an existing directory.
```

System info:
```
Velox System Info v0.0.2
Commit: https://github.com/facebookincubator/velox/commit/364df9251a46b89d508585abe79a955620a1e90f
CMake Version: 3.24.1
System: Darwin-20.6.0
Arch: x86_64
C++ Compiler: /Library/Developer/CommandLineTools/usr/bin/c++
C++ Compiler Version: 13.0.0.13000029
C Compiler: /Library/Developer/CommandLineTools/usr/bin/cc
C Compiler Version: 13.0.0.13000029
CMake Prefix Path: /Library/Developer/CommandLineTools/SDKs/MacOSX11.3.sdk/usr;/usr/local;/usr;/;/usr/local/Cellar/cmake/3.24.1;/usr/local;/usr/X11R6;/usr/pkg;/opt;/sw;/opt/local
```

That's because codegen doesn't have tests directory.