### PR TITLE
Fix recursive locking issue in child memory pool visit

### DIFF
--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -1775,7 +1775,7 @@ TEST_P(MemoryPoolTest, concurrentUpdatesToTheSamePool) {
   }
 }
 
-TEST_P(MemoryPoolTest, DISABLED_concurrentPoolStructureAccess) {
+TEST_P(MemoryPoolTest, concurrentPoolStructureAccess) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1234);
   constexpr int64_t kMaxMemory = 8 * GB;
@@ -1803,11 +1803,11 @@ TEST_P(MemoryPoolTest, DISABLED_concurrentPoolStructureAccess) {
             continue;
           }
           const auto idx = folly::Random().rand32() % pools.size();
-          pool = pools[idx];
           if (folly::Random().oneIn(3)) {
             pools.erase(pools.begin() + idx);
             continue;
           }
+          pool = pools[idx];
         }
         VELOX_CHECK_NOT_NULL(pool);
 


### PR DESCRIPTION
concurrentPoolStructureAccess discovered a recursive locking issue
in visitChildren method. Here is the race condition that expose this:
Suppose parent memory pool A has one child pool B
T1: thread-1 call memory pool A's visitChildren which grabs the
      pool A's mutex lock, and successfully get the shared reference
      on child memory pool B through its weak pointer;
T2: thread-2 release the last external shared reference on child
       pool B and now visitChildren method holds the last temporal
       shared reference on memory pool B
T3: after the visit func call finishes on child memory pool B.
       visitChildren drops the last reference on memory pool B to trigger
       its destruction under the parent memory pool A's mutex lock.
T4: child memory pool B's destructor tries to remove itself (weak
       pointer reference) from the parent memory pool A which tries to
       grab memory pool A's mutex lock again.

This causes the recursive locking.

This PR fixes the issue by storing all the child memory pool's shared
reference in a temporal vector in visitChildren, and call the visit
function out of the parent pool's mutex lock. This also prevents the
potential deadlock caused by the visit function in the future.

This PR also re-enable concurrentPoolStructureAccess test