### PR TITLE
Add test in bigintValuesUsingHashTableSimd for corner case

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -239,7 +239,7 @@ xsimd::batch_bool<int64_t> BigintValuesUsingHashTable::testValues(
   constexpr int kArraySize = xsimd::batch<int64_t>::size;
   alignas(kAlign) int64_t indicesArray[kArraySize];
   alignas(kAlign) int64_t valuesArray[kArraySize];
-  (indices + 1).store_aligned(indicesArray);
+  ((indices + 1) & sizeMask_).store_aligned(indicesArray);
   x.store_aligned(valuesArray);
   while (unresolved) {
     auto lane = bits::getAndClearLastSetBit(unresolved);

--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -239,7 +239,7 @@ xsimd::batch_bool<int64_t> BigintValuesUsingHashTable::testValues(
   constexpr int kArraySize = xsimd::batch<int64_t>::size;
   alignas(kAlign) int64_t indicesArray[kArraySize];
   alignas(kAlign) int64_t valuesArray[kArraySize];
-  ((indices + 1) & sizeMask_).store_aligned(indicesArray);
+  (indices + 1).store_aligned(indicesArray);
   x.store_aligned(valuesArray);
   while (unresolved) {
     auto lane = bits::getAndClearLastSetBit(unresolved);

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -382,6 +382,18 @@ TEST(FilterTest, bigintValuesUsingHashTableSimd) {
   }
 
   applySimdTestToVector(numbers32, *filter, verify);
+
+  // Make a filter with sizeMask_'s slot filled and the kPaddingElements'
+  // slots tested
+  // numbers has 4 elements, so the sizeMask_ is 15 (1 << log2(4*5) - 1 = 15)
+  // The 15'th slot is filled by 19 (19 * 0xc6a4a7935bd1e995L & 15L = 15L)
+  // The test value 3 will also be hashed to 15'th slot
+  // (3 * 0xc6a4a7935bd1e995L & 15L = 15L), and 3 is within [min, max]
+  numbers = {0, 1, 19, 10'000};
+  filter = createBigintValues(numbers, false);
+  ASSERT_TRUE(dynamic_cast<BigintValuesUsingHashTable*>(filter.get()));
+  int64_t values[] = {3};
+  checkSimd(filter.get(), values, verify);
 }
 
 TEST(FilterTest, negatedBigintValuesUsingHashTableSimd) {


### PR DESCRIPTION
In BigintValuesUsingHashTable::testValues, the indices are incremented by 1 before checking the unresolved values:
```
(indices + 1).store_aligned(indicesArray);
```
There can be cases that after incrementing, the indices are exceeding sizeMask_. The padding elements are to solve the cases:
```
  // Replicate the last element of hashTable kPaddingEntries times at 'size_' so
  // that one can load a full vector of elements past the last used index.
  for (auto i = 0; i < kPaddingElements; ++i) {
    hashTable_[sizeMask_ + 1 + i] = hashTable_[sizeMask_];
  }
```
So there will be redundant check for the padding elements. The following case can trigger such case:
```
  // Make a filter with sizeMask_'s slot filled and the kPaddingElements'
  // slots tested
  // numbers has 4 elements, so the sizeMask_ is 15 (1 << log2(4*5) - 1 = 15)
  // The 15'th slot is filled by 19 (19 * 0xc6a4a7935bd1e995L & 15L = 15L)
  // The test value 3 will also be hashed to 15'th slot
  // (3 * 0xc6a4a7935bd1e995L & 15L = 15L), and 3 is within [min, max]
  numbers = {0, 1, 19, 10'000};
  filter = createBigintValues(numbers, false);
  ASSERT_TRUE(dynamic_cast<BigintValuesUsingHashTable*>(filter.get()));
  int64_t values[] = {3};
  checkSimd(filter.get(), values, verify);
```
But if we add modulo operation, it will add cost for common cases. So this PR just adds a test for the corner case.