### PR TITLE
Support rowNumberRange for SideTableSplitReader.

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -102,6 +102,7 @@ class RowReaderOptions {
   std::shared_ptr<folly::Executor> decodingExecutor_;
   std::shared_ptr<folly::Executor> ioExecutor_;
   bool appendRowNumberColumn_ = false;
+  bool fillRowNumberRange_ = false;
 
  public:
   RowReaderOptions(const RowReaderOptions& other) {
@@ -116,6 +117,7 @@ class RowReaderOptions {
     returnFlatVector_ = other.returnFlatVector_;
     flatmapNodeIdAsStruct_ = other.flatmapNodeIdAsStruct_;
     appendRowNumberColumn_ = other.appendRowNumberColumn_;
+    fillRowNumberRange_ = other.fillRowNumberRange_;
   }
 
   RowReaderOptions() noexcept
@@ -285,8 +287,20 @@ class RowReaderOptions {
     appendRowNumberColumn_ = value;
   }
 
+  /*
+   * Set to true, if you want to fill in the start/end rowNumber in the
+   * Batch::RowNumRange.
+   */
+  void setFillRowNumberRange(bool value) {
+    fillRowNumberRange_ = value;
+  }
+
   bool getAppendRowNumberColumn() const {
     return appendRowNumberColumn_;
+  }
+
+  bool getFillRowNumberRange() const {
+    return fillRowNumberRange_;
   }
 
   const std::shared_ptr<folly::Executor>& getDecodingExecutor() const {


### PR DESCRIPTION
Summary:
## Background
This is the first diff for support the side table sampling task.

To support side table sampling in Koski, we need the rowNumberRange in the SideTableSplitReader in order to do the merge.

## Solution
In this diff, we add a member variable in Batch called `rowNumberRange`, and fill in the rowNumber information during the DwrfReader. Besides, in order for the SideTableSplitReader to gain that information, several changes in the QueryBuilder and DwioConfig have been made in this diff to pass the enabling flag to the DwrfReader. Also, `Fill` transformer is used in SideTableSplitReader in order to combine different batch together to gain a batch with specified `batchSize`. A rowCounter is added to the `Fill` operator to combine/split the DwrfReader batch to correctly filling in the rowNumberRange information.

Differential Revision: D43104839

