### PR TITLE
Fix document generation job.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,6 +496,11 @@ jobs:
             git config --global user.email "velox@users.noreply.github.com"
             git config --global user.name "velox"
             git checkout main
+            conda init bash
+            source ~/.bashrc
+            conda create -y --name docgenenv python=3.7
+            conda activate docgenenv
+            pip install sphinx sphinx-tabs breathe sphinx_rtd_theme 
             make -C velox/docs html
             git checkout gh-pages
             cp -R velox/docs/_build/html/* docs

--- a/velox/docs/ext/spark.py
+++ b/velox/docs/ext/spark.py
@@ -17,18 +17,11 @@
 from __future__ import annotations
 
 import ast
-import builtins
-import inspect
 import re
-import typing
-from inspect import Parameter
-from typing import Any, Iterable, Iterator, List, NamedTuple, Tuple, cast
-
 from docutils import nodes
 from docutils.nodes import Element, Node
 from docutils.parsers.rst import directives
-from docutils.parsers.rst.states import Inliner
-
+from inspect import Parameter
 from sphinx import addnodes
 from sphinx.addnodes import desc_signature, pending_xref
 from sphinx.application import Sphinx
@@ -47,6 +40,7 @@ from sphinx.util.nodes import (
     make_refnode,
 )
 from sphinx.util.typing import OptionSpec
+from typing import Any, Iterable, Iterator, NamedTuple, Tuple, cast
 
 logger = logging.getLogger(__name__)
 
@@ -253,7 +247,7 @@ def _parse_annotation(annotation: str, env: BuildEnvironment | None) -> list[Nod
         return flattened
 
     try:
-        tree = ast.parse(annotation, type_comments=True)
+        tree = ast.parse(annotation)
         result: list[Node] = []
         for node in unparse(tree):
             if isinstance(node, nodes.literal):


### PR DESCRIPTION
Fixes #3928 .
The document generation job is broken because the container used to run it , has only a bare bones Python. Since Conda is part of the docker image, I am using conda to have a more fully fledged python, plus also install requisite sphinx libraries.  This also required a small fix to the spark document generation as some api's have changed. 
I have validated this change locally.  