### PR TITLE
Improve Velox memory logging

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -153,7 +153,8 @@ MemoryPoolImpl::~MemoryPoolImpl() {
     VELOX_CHECK_EQ(
         0,
         remainingBytes,
-        "Memory pool should be destroyed only after all allocated memory has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
+        "Memory pool {} should be destroyed only after all allocated memory has been freed. Remaining bytes allocated: {}, cumulative bytes allocated: {}, number of allocations: {}",
+        name(),
         remainingBytes,
         tracker->cumulativeBytes(),
         tracker->numAllocs());
@@ -423,7 +424,8 @@ MemoryManager::MemoryManager(const Options& options)
 MemoryManager::~MemoryManager() {
   auto currentBytes = getTotalBytes();
   if (currentBytes > 0) {
-    LOG(WARNING) << "Leaked total memory of " << currentBytes << " bytes.";
+    VELOX_MEM_LOG(WARNING) << "Leaked total memory of " << currentBytes
+                           << " bytes.";
   }
 }
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -30,6 +30,7 @@
 
 #include <velox/common/base/Exceptions.h>
 #include "folly/CPortability.h"
+#include "folly/GLog.h"
 #include "folly/Likely.h"
 #include "folly/Random.h"
 #include "folly/SharedMutex.h"
@@ -46,6 +47,11 @@ DECLARE_int32(memory_usage_aggregation_interval_millis);
 namespace facebook {
 namespace velox {
 namespace memory {
+#define VELOX_MEM_LOG_PREFIX "[MEM] "
+#define VELOX_MEM_LOG(severity) LOG(severity) << VELOX_MEM_LOG_PREFIX
+#define VELOX_MEM_LOG_EVERY_MS(severity, ms) \
+  FB_LOG_EVERY_MS(severity, ms) << VELOX_MEM_LOG_PREFIX
+
 #define VELOX_MEM_ALLOC_ERROR(errorMessage)                         \
   _VELOX_THROW(                                                     \
       ::facebook::velox::VeloxRuntimeError,                         \

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -15,16 +15,14 @@
  */
 
 #include "velox/common/memory/MemoryUsageTracker.h"
+
 #include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/memory/Memory.h"
 #include "velox/common/testutil/TestValue.h"
 
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
-namespace {
-constexpr int32_t kLogEveryN = 32;
-}
-
 std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
     const std::shared_ptr<MemoryUsageTracker>& parent,
     int64_t maxMemory) {
@@ -35,8 +33,7 @@ std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
 MemoryUsageTracker::~MemoryUsageTracker() {
   VELOX_DCHECK_EQ(usedReservationBytes_, 0);
   if (usedReservationBytes_ != 0) {
-    LOG_EVERY_N(ERROR, kLogEveryN)
-        << "used reservation is not zero " << toString();
+    VELOX_MEM_LOG(ERROR) << "used reservation is not zero " << toString();
   }
   VELOX_CHECK(
       (reservationBytes_ == 0) && (grantedReservationBytes_ == 0) &&
@@ -198,7 +195,7 @@ void MemoryUsageTracker::sanityCheckLocked() const {
       toString());
   VELOX_DCHECK_GE(usedReservationBytes_, 0);
   if (usedReservationBytes_ < 0) {
-    LOG_EVERY_N(ERROR, kLogEveryN)
+    VELOX_MEM_LOG_EVERY_MS(ERROR, 1000)
         << "used reservation is negative " << toString();
   }
 }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -19,9 +19,9 @@
 #include <sys/mman.h>
 
 #include "velox/common/base/Portability.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
-
 MmapAllocator::MmapAllocator(const Options& options)
     : kind_(MemoryAllocator::Kind::kMmap),
       useMmapArena_(options.useMmapArena),
@@ -56,21 +56,27 @@ bool MmapAllocator::allocateNonContiguous(
   }
 
   if (testingHasInjectedFailure(InjectedFailure::kCap)) {
-    if (reservationCB != nullptr) {
+    if ((numFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(AllocationTraits::pageBytes(numFreed), false);
     }
     return false;
   }
 
   if (numAllocated_ + mix.totalPages > capacity_) {
-    if (reservationCB != nullptr) {
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
+        << "Exceeding memory allocator limit when allocate " << mix.totalPages
+        << " pages with capacity of " << capacity_;
+    if ((numFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(AllocationTraits::pageBytes(numFreed), false);
     }
     return false;
   }
   if (numAllocated_.fetch_add(mix.totalPages) + mix.totalPages > capacity_) {
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
+        << "Exceeded memory allocator limit when allocate " << mix.totalPages
+        << " pages with capacity of " << capacity_;
     numAllocated_.fetch_sub(mix.totalPages);
-    if (reservationCB != nullptr) {
+    if ((numFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(AllocationTraits::pageBytes(numFreed), false);
     }
     return false;
@@ -83,6 +89,9 @@ bool MmapAllocator::allocateNonContiguous(
     try {
       reservationCB(AllocationTraits::pageBytes(numNeededPages), true);
     } catch (const std::exception& e) {
+      VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
+          << "Exceeded memory reservation limit when reserve " << numNeededPages
+          << " new pages when allocate " << mix.totalPages << " pages";
       numAllocated_.fetch_sub(mix.totalPages);
       reservationCB(AllocationTraits::pageBytes(numFreed), false);
       std::rethrow_exception(std::current_exception());
@@ -104,8 +113,8 @@ bool MmapAllocator::allocateNonContiguous(
     if (!success) {
       // This does not normally happen since any size class can accommodate
       // all the capacity. 'allocatedPages_' must be out of sync.
-      LOG(WARNING) << "Failed allocation in size class " << i << " for "
-                   << mix.sizeCounts[i] << " pages";
+      VELOX_MEM_LOG(WARNING) << "Failed allocation in size class " << i
+                             << " for " << mix.sizeCounts[i] << " pages";
       const auto failedPages = mix.totalPages - out.numPages();
       freeNonContiguous(out);
       numAllocated_.fetch_sub(failedPages);
@@ -123,6 +132,9 @@ bool MmapAllocator::allocateNonContiguous(
     return true;
   }
 
+  VELOX_MEM_LOG(WARNING) << "Could not advise away enough for " << newMapsNeeded
+                         << " pages with total allocation of << "
+                         << mix.totalPages << " pages";
   freeNonContiguous(out);
   if (reservationCB != nullptr) {
     reservationCB(AllocationTraits::pageBytes(mix.totalPages), false);
@@ -217,8 +229,8 @@ bool MmapAllocator::allocateContiguousImpl(
       managedArenas_->free(allocation.data(), allocation.size());
     } else {
       if (::munmap(allocation.data(), allocation.size()) < 0) {
-        LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << " for "
-                   << allocation.toString();
+        VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno)
+                             << " for " << allocation.toString();
       }
     }
     allocation.clear();
@@ -232,6 +244,9 @@ bool MmapAllocator::allocateContiguousImpl(
     try {
       reservationCB(AllocationTraits::pageBytes(newPages), true);
     } catch (const std::exception& e) {
+      VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
+          << "Exceeded memory reservation limit when reserve " << newPages
+          << " new pages when allocate " << numPages << " pages";
       numAllocated_ -= totalCollateralPages;
       numMapped_ -= numCollateralUnmap;
       numExternalMapped_ -= numCollateralUnmap;
@@ -268,6 +283,10 @@ bool MmapAllocator::allocateContiguousImpl(
   if (newPages > 0 &&
       (numAllocated > capacity_ ||
        testingHasInjectedFailure(InjectedFailure::kCap))) {
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
+        << "Exceeded memory allocator limit when allocate " << newPages
+        << " new pages for total allocation of " << numPages
+        << " pages, the memory allocator capacity is " << capacity_;
     rollbackAllocation(0);
     return false;
   }
@@ -276,8 +295,9 @@ bool MmapAllocator::allocateContiguousImpl(
   const int64_t numToMap = numPages - numCollateralUnmap;
   if (numToMap > 0) {
     if (!ensureEnoughMappedPages(numToMap)) {
-      LOG(WARNING) << "Could not advise away enough for " << numToMap
-                   << " pages for allocateContiguous";
+      VELOX_MEM_LOG(WARNING)
+          << "Could not advise away enough for " << numToMap
+          << " pages for total allocation of " << numPages << " pages";
       rollbackAllocation(0);
       return false;
     }
@@ -305,6 +325,9 @@ bool MmapAllocator::allocateContiguousImpl(
   }
   // TODO: add handling of MAP_FAILED.
   if (data == nullptr) {
+    VELOX_MEM_LOG(ERROR) << "Mmap failed with " << numPages
+                         << " pages, use MmapArena "
+                         << (useMmapArena_ ? "true" : "false");
     // If the mmap failed, we have unmapped former 'allocation' and the extra to
     // be mapped.
     rollbackAllocation(numToMap);
@@ -323,8 +346,8 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
     managedArenas_->free(allocation.data(), allocation.size());
   } else {
     if (::munmap(allocation.data(), allocation.size()) < 0) {
-      LOG(ERROR) << "munmap returned " << folly::errnoStr(errno) << " for "
-                 << allocation.toString();
+      VELOX_MEM_LOG(ERROR) << "munmap returned " << folly::errnoStr(errno)
+                           << " for " << allocation.toString();
     }
   }
   numMapped_ -= allocation.numPages();
@@ -340,8 +363,8 @@ void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
     auto* result = alignment > kMinAlignment ? ::aligned_alloc(alignment, bytes)
                                              : ::malloc(bytes);
     if (FOLLY_UNLIKELY(result == nullptr)) {
-      LOG(ERROR) << "Failed to allocateBytes " << bytes << " bytes with "
-                 << alignment << " alignment";
+      VELOX_MEM_LOG(ERROR) << "Failed to allocateBytes " << bytes
+                           << " bytes with " << alignment << " alignment";
     }
     return result;
   }
@@ -468,21 +491,22 @@ ClassPageCount MmapAllocator::SizeClass::checkConsistency(
       }
       if (bits::isBitSet(mappedFreeLookup_.data(), i / kWordsPerLookupBit)) {
         if (!mappedFreeInGroup) {
-          LOG(WARNING) << "Extra mapped free bit for group at " << i;
+          VELOX_MEM_LOG(WARNING) << "Extra mapped free bit for group at " << i;
           ++numErrors;
         }
       } else if (mappedFreeInGroup) {
         ++numErrors;
-        LOG(WARNING) << "Missing lookup bit for group at " << i;
+        VELOX_MEM_LOG(WARNING) << "Missing lookup bit for group at " << i;
       }
     }
   }
   if (mappedFreeCount != numMappedFreePages_) {
     ++numErrors;
-    LOG(WARNING) << "Mismatched count of mapped free pages in size class "
-                 << unitSize_ << ". Actual= " << mappedFreeCount
-                 << " vs recorded= " << numMappedFreePages_
-                 << ". Total mapped=" << mappedCount;
+    VELOX_MEM_LOG(WARNING)
+        << "Mismatched count of mapped free pages in size class " << unitSize_
+        << ". Actual= " << mappedFreeCount
+        << " vs recorded= " << numMappedFreePages_
+        << ". Total mapped=" << mappedCount;
   }
   numMapped = mappedCount;
   return count;
@@ -599,7 +623,7 @@ uint32_t MmapAllocator::SizeClass::findMappedFreeGroup() {
   }
   ClassPageCount ignore = 0;
   checkConsistency(ignore, ignore);
-  LOG(FATAL) << "MMAPL: Inconsistent mapped free lookup class " << unitSize_;
+  VELOX_MEM_LOG(FATAL) << "Inconsistent mapped free lookup class " << unitSize_;
 }
 
 xsimd::batch<uint64_t> MmapAllocator::SizeClass::mappedFreeBits(int32_t index) {
@@ -663,8 +687,8 @@ void MmapAllocator::SizeClass::allocateFromMappedFree(
 
     bits::setBit(mappedFreeLookup_.data(), group, false);
     if (!anyFound) {
-      LOG(ERROR) << "MMAPL: Lookup bit set but no free mapped pages class "
-                 << unitSize_;
+      VELOX_MEM_LOG(ERROR) << "Lookup bit set but no free mapped pages class "
+                           << unitSize_;
       return;
     }
   }
@@ -727,7 +751,7 @@ void MmapAllocator::SizeClass::adviseAway(const Allocation& allocation) {
             run.data(),
             AllocationTraits::pageBytes(run.numPages()),
             MADV_DONTNEED) < 0) {
-      LOG(ERROR) << "madvise got errno " << folly::errnoStr(errno);
+      VELOX_MEM_LOG(ERROR) << "madvise got errno " << folly::errnoStr(errno);
     } else {
       std::lock_guard<std::mutex> l(mutex_);
       setMappedBits(run, false);
@@ -779,8 +803,8 @@ MachinePageCount MmapAllocator::SizeClass::free(Allocation& allocation) {
     for (auto page = firstBit; page < firstBit + numPages; ++page) {
       if (!bits::isBitSet(pageAllocated_.data(), page)) {
         // TODO: change this to a velox failure to catch the bug.
-        LOG(ERROR) << "Double free: page = " << page
-                   << " sizeclass = " << unitSize_;
+        VELOX_MEM_LOG(ERROR)
+            << "Double free: page = " << page << " sizeclass = " << unitSize_;
         continue;
       }
       if (bits::isBitSet(pageMapped_.data(), page)) {
@@ -830,18 +854,19 @@ bool MmapAllocator::checkConsistency() const {
   }
   if (count != numAllocated_ - numExternalMapped_) {
     ++numErrors;
-    LOG(WARNING) << "Allocated count out of sync. Actual= " << count
-                 << " recorded= " << numAllocated_ - numExternalMapped_;
+    VELOX_MEM_LOG(WARNING) << "Allocated count out of sync. Actual= " << count
+                           << " recorded= "
+                           << numAllocated_ - numExternalMapped_;
   }
   if (mappedCount != numMapped_ - numExternalMapped_) {
     ++numErrors;
-    LOG(WARNING) << "Mapped count out of sync. Actual= "
-                 << mappedCount + numExternalMapped_
-                 << " recorded= " << numMapped_;
+    VELOX_MEM_LOG(WARNING) << "Mapped count out of sync. Actual= "
+                           << mappedCount + numExternalMapped_
+                           << " recorded= " << numMapped_;
   }
   if (numErrors) {
-    LOG(ERROR) << "MmapAllocator::checkConsistency(): " << numErrors
-               << " errors";
+    VELOX_MEM_LOG(ERROR) << "MmapAllocator::checkConsistency(): " << numErrors
+                         << " errors";
   }
   return numErrors == 0;
 }

--- a/velox/common/memory/MmapArena.cpp
+++ b/velox/common/memory/MmapArena.cpp
@@ -15,14 +15,12 @@
  */
 
 #include "velox/common/memory/MmapArena.h"
+
 #include <sys/mman.h>
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
-namespace {
-constexpr int32_t kLogEveryN = 32;
-}
-
 uint64_t MmapArena::roundBytes(uint64_t bytes) {
   return bits::nextPowerOfTwo(bytes);
 }
@@ -65,7 +63,7 @@ void* MmapArena::allocate(uint64_t bytes) {
   // First match in the list that can give this many bytes
   auto lookupItr = freeLookup_.lower_bound(bytes);
   if (lookupItr == freeLookup_.end()) {
-    LOG_EVERY_N(WARNING, kLogEveryN)
+    VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
         << "Cannot find a free block that is large enough to allocate " << bytes
         << " bytes. Current arena freeBytes " << freeBytes_ << " & lookup table"
         << freeLookupStr();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2108,7 +2108,7 @@ TEST_F(VectorTest, lifetime) {
         childPool.reset();
         v.reset();
       },
-      "Memory pool should be destroyed only after all allocated memory has been freed.");
+      "Memory pool test should be destroyed only after all allocated memory has been freed.");
 }
 
 TEST_F(VectorTest, ensureNullsCapacity) {


### PR DESCRIPTION
- Add VELOX_MEM_LOG/VELOX_MEM_LOG_EVERY_MS for memory
   subsystem logging which includes [MEM] prefix which helps to quickly
   figure out if there is any memory related failures in production log
   For VELOX_MEM_LOG_EVERY_MS, we use FB_LOG_EVERY_MS for
   logging.
- Add log in error paths in memory allocator
- Add pool name in MemoryPoolImpl destructor to log the actual pool name
   to help debugging.