### PR TITLE
Fix signed-integer-overflow in Spark's remainder function

### DIFF
--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -51,7 +51,11 @@ struct RemainderFunction {
     if (UNLIKELY(n == 0)) {
       return false;
     }
-    result = a % n;
+    if (UNLIKELY(n == 1 || n == -1)) {
+      result = 0;
+    } else {
+      result = a % n;
+    }
     return true;
   }
 };

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -102,6 +102,8 @@ TEST_F(RemainderTest, int32) {
   EXPECT_EQ(-11, remainder<int32_t>(-15181535, -12));
   EXPECT_EQ(INT32_MAX, remainder<int32_t>(INT32_MAX, INT32_MIN));
   EXPECT_EQ(-1, remainder<int32_t>(INT32_MIN, INT32_MAX));
+  EXPECT_EQ(0, remainder<int32_t>(-15181535, -1));
+  EXPECT_EQ(0, remainder<int32_t>(INT32_MIN, -1));
 }
 
 TEST_F(RemainderTest, int64) {


### PR DESCRIPTION
For signed integer, the absolute value of MIN is larger than that of MAX. Therefore, `MIN % -1` causes an overflow of positive integer when calculating `MIN / -1`. This PR fixed this issue by specially handling the case of divisor being 1.

Fixes https://github.com/facebookincubator/velox/issues/3951.