### PR TITLE
Allow only user errors in constant folding

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -59,7 +59,7 @@ void ConstantExpr::evalSpecialFormSimplified(
 
   // Simplified path should never ask us to write to a vector that was already
   // pre-allocated.
-  VELOX_CHECK(result == nullptr);
+  VELOX_CHECK_NULL(result);
 
   if (sharedSubexprValues_ == nullptr) {
     result = BaseVector::createConstant(value_, rows.end(), context.pool());

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -328,7 +328,7 @@ ExprPtr tryFoldIfConstant(const ExprPtr& expr, Scope* scope) {
     // If not, in case this expression is never hit at execution time (for
     // instance, if other arguments are all null in a function with default null
     // behavior), the query won't fail.
-    catch (const std::exception&) {
+    catch (const VeloxUserError&) {
     }
   }
   return expr;


### PR DESCRIPTION
Constant folding should suppress only user exceptions. System errors indicate
bugs in the engine and should be propagated.