### PR TITLE
Choose merge-base from upstream

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -82,7 +82,7 @@ jobs:
           git fetch upstream
           git status
           merge_base=$(git merge-base 'upstream/${{ github.base_ref }}' 'origin/${{ github.head_ref }}') || \
-            { echo ""::error::Failed to find merge base"; exit 1; }
+            { echo "::error::Failed to find merge base"; exit 1; }
           echo "Merge Base: $merge_base"
           git checkout $merge_base
           echo $(git log -n 1)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -81,7 +81,8 @@ jobs:
           git remote add upstream https://github.com/facebookincubator/velox
           git fetch upstream
           git status
-          merge_base=$(git merge-base 'upstream/${{ github.base_ref }}' 'origin/${{ github.head_ref }}')
+          merge_base=$(git merge-base 'upstream/${{ github.base_ref }}' 'origin/${{ github.head_ref }}') || \
+            { echo ""::error::Failed to find merge base"; exit 1; }
           echo "Merge Base: $merge_base"
           git checkout $merge_base
           echo $(git log -n 1)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -75,9 +75,13 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: velox
         run: |
+          # Choose merge base from upstream main to avoid issues with
+          # outdated fork branches
           git fetch origin
+          git remote add upstream https://github.com/facebookincubator/velox
+          git fetch upstream
           git status
-          merge_base=$(git merge-base 'origin/${{ github.base_ref }}' 'origin/${{ github.head_ref }}')
+          merge_base=$(git merge-base 'upstream/${{ github.base_ref }}' 'origin/${{ github.head_ref }}')
           echo "Merge Base: $merge_base"
           git checkout $merge_base
           echo $(git log -n 1)


### PR DESCRIPTION
Previously we required the fork main to be in-sync with the upstream main, this assumption is not valid. This PR chooses the merge-base based on the upstream main which fixes the issue of an outdated merge base. I also added an error message to make it clear when finding the merge base failed. 