### PR TITLE
Disable split prefetch in table scan and turn it on later with fix

### DIFF
--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -18,7 +18,7 @@
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
 
-DEFINE_int32(split_preload_per_driver, 2, "Prefetch split metadata");
+DEFINE_int32(split_preload_per_driver, 0, "Prefetch split metadata");
 
 namespace facebook::velox::exec {
 


### PR DESCRIPTION
The recent added split prefetch feature has caused crashes in meta
internal staging clusters. Disable it temporarily and re-enable it after
RCA anf fix.