### PR TITLE
Fix integer overflow in TimestampConversion

### DIFF
--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -41,6 +41,7 @@
  */
 
 #include "velox/type/TimestampConversion.h"
+#include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::util {
@@ -178,13 +179,13 @@ bool tryParseDateString(
   }
   // First parse the year.
   for (; pos < len && characterIsDigit(buf[pos]); pos++) {
-    year = (buf[pos] - '0') + year * 10;
+    year = checkedPlus((buf[pos] - '0'), checkedMultiply(year, 10));
     if (year > kMaxYear) {
       break;
     }
   }
   if (yearneg) {
-    year = -year;
+    year = checkedNegate(year);
     if (year < kMinYear) {
       return false;
     }

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -182,6 +182,12 @@ TEST(DateTimeUtilTest, fromTimestampStrInvalid) {
   EXPECT_THROW(fromTimestampString("1970-01-01 00:00:00-asd"), VeloxUserError);
   EXPECT_THROW(
       fromTimestampString("1970-01-01 00:00:00+00:00:00"), VeloxUserError);
+
+  // Integer overflow during timestamp parsing.
+  EXPECT_THROW(
+      fromTimestampString("2773581570-01-01 00:00:00-asd"), VeloxUserError);
+  EXPECT_THROW(
+      fromTimestampString("-2147483648-01-01 00:00:00-asd"), VeloxUserError);
 }
 
 TEST(DateTimeUtilTest, toGMT) {


### PR DESCRIPTION
Summary:
Fuzzer caught a runtime error caused by integer overflow during the timestamp parsing
in TimestampConversion. This diff fixes this problem by using CheckedArithmetic.

This diff fixes https://github.com/facebookincubator/velox/issues/4011.

Differential Revision: D43167732

