### PR TITLE
Update comment and add unit test for signature binding of FixedSizeArray

### DIFF
--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -314,6 +314,7 @@ TEST(SignatureBinderTest, generics) {
         signature,
         {ARRAY(FIXED_SIZE_ARRAY(20, BIGINT())),
          FIXED_SIZE_ARRAY(10, BIGINT())});
+    assertCannotResolve(signature, {FIXED_SIZE_ARRAY(10, BIGINT()), BIGINT()});
   }
 
   // array(array(T)), array(T) -> boolean
@@ -588,4 +589,31 @@ TEST(SignatureBinderTest, customType) {
           .argumentType("fancy_type")
           .build(),
       "not found : FANCY_TYPE");
+}
+
+TEST(SignatureBinderTest, fixedSizeArray) {
+  auto signature = exec::FunctionSignatureBuilder()
+                       .returnType("boolean")
+                       .argumentType("fixed_size_array(bigint)")
+                       .argumentType("bigint")
+                       .build();
+
+  testSignatureBinder(
+      signature, {FIXED_SIZE_ARRAY(10, BIGINT()), BIGINT()}, BOOLEAN());
+  testSignatureBinder(
+      signature, {FIXED_SIZE_ARRAY(20, BIGINT()), BIGINT()}, BOOLEAN());
+  assertCannotResolve(signature, {ARRAY(BIGINT()), BIGINT()});
+
+  signature = exec::FunctionSignatureBuilder()
+                  .typeVariable("T")
+                  .returnType("boolean")
+                  .argumentType("fixed_size_array(T)")
+                  .argumentType("T")
+                  .build();
+
+  testSignatureBinder(
+      signature, {FIXED_SIZE_ARRAY(10, BIGINT()), BIGINT()}, BOOLEAN());
+  testSignatureBinder(
+      signature, {FIXED_SIZE_ARRAY(20, DOUBLE()), DOUBLE()}, BOOLEAN());
+  assertCannotResolve(signature, {ARRAY(BIGINT()), BIGINT()});
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -754,7 +754,9 @@ class ArrayType : public TypeBase<TypeKind::ARRAY> {
 /// as Presto/Spark do not have a notion of fixed size array.
 ///
 /// Anywhere an ArrayType can be used, a FixedSizeArrayType can be
-/// used.
+/// used, except that the parameter type in the signature of a function that
+/// receives FixedSizeArray should be "fixed_size_array(T)" where T is the
+/// element type.
 class FixedSizeArrayType : public ArrayType {
  public:
   explicit FixedSizeArrayType(size_type len, std::shared_ptr<const Type> child);


### PR DESCRIPTION
Summary:
FixedSizeArray-typed argument cannot bind to array-typed parameter in function
signatures and vice versa. This diff updates the comments and adds a unit test to
clarify this difference.

Differential Revision: D43173726

