### PR TITLE
Fix Incorrect Page Header Size Check for Parquet Page V1

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -76,7 +76,7 @@ void ReaderBase::loadFileMetaData() {
   }
 
   auto thriftTransport = std::make_shared<thrift::ThriftBufferedTransport>(
-      copy.data() + footerOffsetInBuffer, footerLength);
+      copy.data() + footerOffsetInBuffer, footerLength, true);
   auto thriftProtocol =
       std::make_unique<apache::thrift::protocol::TCompactProtocolT<
           thrift::ThriftBufferedTransport>>(thriftTransport);

--- a/velox/dwio/parquet/thrift/ThriftTransport.h
+++ b/velox/dwio/parquet/thrift/ThriftTransport.h
@@ -25,13 +25,17 @@ class ThriftBufferedTransport
     : public apache::thrift::transport::TVirtualTransport<
           ThriftBufferedTransport> {
  public:
-  ThriftBufferedTransport(const void* inputBuf, uint64_t len)
+  ThriftBufferedTransport(
+      const void* inputBuf,
+      uint64_t len,
+      bool ensureThriftSize = true)
       : inputBuf_(reinterpret_cast<const uint8_t*>(inputBuf)),
         size_(len),
-        offset_(0) {}
+        offset_(0),
+        ensureThriftSize_(ensureThriftSize) {}
 
   uint32_t read(uint8_t* outputBuf, uint32_t len) {
-    DWIO_ENSURE(offset_ + len <= size_);
+    DWIO_ENSURE(!ensureThriftSize_ || (offset_ + len <= size_));
     memcpy(outputBuf, inputBuf_ + offset_, len);
     offset_ += len;
     return len;
@@ -41,6 +45,7 @@ class ThriftBufferedTransport
   const uint8_t* inputBuf_;
   const uint64_t size_;
   uint64_t offset_;
+  bool ensureThriftSize_;
 };
 
 } // namespace facebook::velox::parquet::thrift


### PR DESCRIPTION
In Parquet Page V1 design, the size of the thrift page header message is unknown until the entire message is parsed. So we cannot enforce the header size check when parsing the Thrift Page Header. This PR is to add another flag `ensureThriftSize_` to prevent the incorrect Page Header Size Check. And this flag can be turned on when ensuring Thrift Parquet Footer size or for the future V2 development.  