### PR TITLE
Fix compilation of constant expressions

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -150,6 +150,7 @@ class HiveDataSource : public DataSource {
 
   void setConstantValue(
       common::ScanSpec* FOLLY_NONNULL spec,
+      const TypePtr& type,
       const velox::variant& value) const;
 
   void setNullConstantValue(

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -227,7 +227,10 @@ int main(int argc, char** argv) {
 
   // Create vector #2. Just a constant to the shared_ptr we created above.
   auto vector2 = BaseVector::createConstant(
-      variant::opaque(opaqueObj), vectorSize, execCtx.pool());
+      OPAQUE<UserDefinedMap>(),
+      variant::opaque(opaqueObj),
+      vectorSize,
+      execCtx.pool());
 
   // Create vector #3. The monotinically increasing flatVector<bigint>.
   auto vector3 = BaseVector::create<FlatVector<int64_t>>(

--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -105,7 +105,8 @@ RowVectorPtr GroupId::getOutput() {
 
   // Add groupId column.
   outputColumns[outputType_->size() - 1] =
-      BaseVector::createConstant((int64_t)groupingSetIndex_, numInput, pool());
+      std::make_shared<ConstantVector<int64_t>>(
+          pool(), numInput, false, groupingSetIndex_);
 
   ++groupingSetIndex_;
   if (groupingSetIndex_ == groupingKeyMappings_.size()) {

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -95,7 +95,7 @@ HashAggregation::HashAggregation(
               BaseVector::wrapInConstant(1, 0, constant->valueVector()));
         } else {
           constants.push_back(BaseVector::createConstant(
-              constant->value(), 1, operatorCtx_->pool()));
+              constant->type(), constant->value(), 1, operatorCtx_->pool()));
         }
       } else {
         constants.push_back(nullptr);

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -64,7 +64,7 @@ StreamingAggregation::StreamingAggregation(
       if (channels.back() == kConstantChannel) {
         auto constant = static_cast<const core::ConstantTypedExpr*>(arg.get());
         constants.push_back(BaseVector::createConstant(
-            constant->value(), 1, operatorCtx_->pool()));
+            constant->type(), constant->value(), 1, operatorCtx_->pool()));
       } else {
         constants.push_back(nullptr);
       }

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -105,8 +105,8 @@ RowVectorPtr TableWriter::getOutput() {
         outputType_,
         nullptr,
         1,
-        std::vector<VectorPtr>{
-            BaseVector::createConstant((int64_t)numWrittenRows_, 1, pool)});
+        std::vector<VectorPtr>{std::make_shared<ConstantVector<int64_t>>(
+            pool, 1, false /*isNull*/, numWrittenRows_)});
   }
 
   std::vector<std::string> fragments = dataSink_->finish();
@@ -139,8 +139,13 @@ RowVectorPtr TableWriter::getOutput() {
            ("pageSinkCommitStrategy", commitStrategyToString(commitStrategy_))
            ("lastPage", true));
   // clang-format on
-  VectorPtr commitContextVector = BaseVector::createConstant(
-      variant::binary(commitContextJson), numOutputRows, pool);
+
+  auto commitContextVector = std::make_shared<ConstantVector<StringView>>(
+      pool,
+      numOutputRows,
+      false /*isNull*/,
+      VARBINARY(),
+      StringView(commitContextJson));
 
   std::vector<VectorPtr> columns = {
       writtenRowsVector, fragmentsVector, commitContextVector};

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -50,7 +50,8 @@ VectorPtr const toConstantVector(
   if (constantExpr->value().isNull()) {
     return BaseVector::createNullConstant(constantExpr->type(), 1, pool);
   }
-  return BaseVector::createConstant(constantExpr->value(), 1, pool);
+  return BaseVector::createConstant(
+      constantExpr->type(), constantExpr->value(), 1, pool);
 }
 
 }; // namespace

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -459,17 +459,12 @@ TEST_F(AggregationTest, multiKeyDistinct) {
 }
 
 TEST_F(AggregationTest, aggregateOfNulls) {
-  auto rowType = ROW({"c0", "c1"}, {BIGINT(), SMALLINT()});
-
-  auto children = {
+  auto rowVector = makeRowVector({
       BatchMaker::createVector<TypeKind::BIGINT>(
           rowType_->childAt(0), 100, *pool_),
-      BaseVector::createConstant(
-          facebook::velox::variant(TypeKind::SMALLINT), 100, pool_.get()),
-  };
+      makeNullConstant(TypeKind::SMALLINT, 100),
+  });
 
-  auto rowVector = std::make_shared<RowVector>(
-      pool_.get(), rowType, BufferPtr(nullptr), 100, children);
   auto vectors = {rowVector};
   createDuckDbTable(vectors);
 

--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -253,27 +253,16 @@ TEST_F(FilterProjectTest, dereference) {
 }
 
 TEST_F(FilterProjectTest, allFailedOrPassed) {
-  auto rowType = ROW({"c0", "c1"}, {INTEGER(), INTEGER()});
   std::vector<RowVectorPtr> vectors;
   for (int32_t i = 0; i < 10; ++i) {
     // We alternate between a batch where all pass and a batch where
     // no row passes. c0 is flat vector. c1 is constant vector.
-    int32_t value = i % 2 == 0 ? 0 : 1;
+    const int32_t value = i % 2 == 0 ? 0 : 1;
 
-    auto c0 =
-        BaseVector::create<FlatVector<int32_t>>(INTEGER(), 100, pool_.get());
-    for (auto row = 0; row < c0->size(); ++row) {
-      c0->set(row, value);
-    }
-
-    auto c1 = BaseVector::createConstant(value, 100, pool_.get());
-
-    vectors.push_back(std::make_shared<RowVector>(
-        pool_.get(),
-        rowType,
-        BufferPtr(nullptr),
-        2,
-        std::vector<VectorPtr>{c0, c1}));
+    vectors.push_back(makeRowVector({
+        makeFlatVector<int32_t>(100, [&](auto row) { return value; }),
+        makeConstant(value, 100),
+    }));
   }
   createDuckDbTable(vectors);
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -1025,12 +1025,12 @@ TEST_P(MultiThreadedHashJoinTest, arrayBasedLookup) {
       }),
       // Join key vector is constant. There is a match in the build side.
       makeRowVector({
-          BaseVector::createConstant(4, 2'000, pool_.get()),
+          makeConstant(4, 2'000),
           makeFlatVector<int64_t>(2'000, [](auto row) { return row; }),
       }),
       // Join key vector is constant. There is no match.
       makeRowVector({
-          BaseVector::createConstant(5, 2'000, pool_.get()),
+          makeConstant(5, 2'000),
           makeFlatVector<int64_t>(2'000, [](auto row) { return row; }),
       }),
       // Join key vector is a dictionary.

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -110,7 +110,7 @@ class OperatorUtilsTest
 };
 
 TEST_F(OperatorUtilsTest, wrapChildConstant) {
-  auto constant = BaseVector::createConstant(11, 1'000, pool_.get());
+  auto constant = makeConstant(11, 1'000);
 
   BufferPtr mapping = allocateIndices(1'234, pool_.get());
   auto rawMapping = mapping->asMutable<vector_size_t>();
@@ -175,10 +175,10 @@ TEST_F(OperatorUtilsTest, gatherCopy) {
 
   // Test with UNKNOWN type.
   int kNumRows = 100;
-  auto sourceVector = makeRowVector(
-      {makeFlatVector<int64_t>(kNumRows, [](auto row) { return row % 7; }),
-       BaseVector::createConstant(
-           variant(TypeKind::UNKNOWN), kNumRows, pool_.get())});
+  auto sourceVector = makeRowVector({
+      makeFlatVector<int64_t>(kNumRows, [](auto row) { return row % 7; }),
+      BaseVector::createNullConstant(UNKNOWN(), kNumRows, pool()),
+  });
   std::vector<const RowVector*> sourceVectors(kNumRows);
   std::vector<vector_size_t> sourceIndices(kNumRows);
   for (int i = 0; i < kNumRows; ++i) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -331,10 +331,10 @@ TEST_F(OrderByTest, varfields) {
 
 TEST_F(OrderByTest, unknown) {
   vector_size_t size = 1'000;
-  auto vector = makeRowVector(
-      {makeFlatVector<int64_t>(size, [](auto row) { return row % 7; }),
-       BaseVector::createConstant(
-           variant(TypeKind::UNKNOWN), size, pool_.get())});
+  auto vector = makeRowVector({
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 7; }),
+      BaseVector::createNullConstant(UNKNOWN(), size, pool()),
+  });
 
   // Exclude "UNKNOWN" column as DuckDB doesn't understand UNKNOWN type
   createDuckDbTable(

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -38,10 +38,6 @@ class TableWriteTest : public HiveConnectorTestBase {
     HiveConnectorTestBase::SetUp();
   }
 
-  VectorPtr createConstant(variant value, vector_size_t size) const {
-    return BaseVector::createConstant(value, size, pool_.get());
-  }
-
   std::vector<std::shared_ptr<connector::ConnectorSplit>>
   makeHiveConnectorSplits(
       const std::shared_ptr<TempDirectoryPath>& directoryPath) {
@@ -290,19 +286,19 @@ TEST_F(TableWriteTest, constantVectors) {
   // Make constant vectors of various types with null and non-null values.
   std::string somewhatLongString = "Somewhat long string";
   auto vector = makeRowVector({
-      createConstant((int64_t)123'456, size),
-      createConstant(variant(TypeKind::BIGINT), size),
-      createConstant((int32_t)12'345, size),
-      createConstant(variant(TypeKind::INTEGER), size),
-      createConstant((int16_t)1'234, size),
-      createConstant(variant(TypeKind::SMALLINT), size),
-      createConstant((int8_t)123, size),
-      createConstant(variant(TypeKind::TINYINT), size),
-      createConstant(true, size),
-      createConstant(false, size),
-      createConstant(variant(TypeKind::BOOLEAN), size),
-      createConstant(somewhatLongString.c_str(), size),
-      createConstant(variant(TypeKind::VARCHAR), size),
+      makeConstant((int64_t)123'456, size),
+      makeConstant(variant(TypeKind::BIGINT), size),
+      makeConstant((int32_t)12'345, size),
+      makeConstant(variant(TypeKind::INTEGER), size),
+      makeConstant((int16_t)1'234, size),
+      makeConstant(variant(TypeKind::SMALLINT), size),
+      makeConstant((int8_t)123, size),
+      makeConstant(variant(TypeKind::TINYINT), size),
+      makeConstant(true, size),
+      makeConstant(false, size),
+      makeConstant(variant(TypeKind::BOOLEAN), size),
+      makeConstant(somewhatLongString.c_str(), size),
+      makeConstant(variant(TypeKind::VARCHAR), size),
   });
   auto rowType = std::dynamic_pointer_cast<const RowType>(vector->type());
 
@@ -494,7 +490,7 @@ TEST_F(TableWriteTest, singlePartition) {
         {makeFlatVector<StringView>(
              1'000,
              [&](auto row) { return StringView(fmt::format("str_{}", row)); }),
-         createConstant((int64_t)365, 1'000)});
+         makeConstant((int64_t)365, 1'000)});
   });
   createDuckDbTable(vectors);
 

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -225,7 +225,7 @@ TEST_F(VectorHasherTest, flat) {
 
 TEST_F(VectorHasherTest, nonNullConstant) {
   auto hasher = exec::VectorHasher::create(INTEGER(), 1);
-  auto vector = BaseVector::createConstant(123, 100, pool_.get());
+  auto vector = BaseVector::createConstant(INTEGER(), 123, 100, pool_.get());
 
   auto hash = folly::hasher<int32_t>()(123);
 
@@ -246,8 +246,7 @@ TEST_F(VectorHasherTest, nonNullConstant) {
 
 TEST_F(VectorHasherTest, nullConstant) {
   auto hasher = exec::VectorHasher::create(INTEGER(), 1);
-  auto vector =
-      BaseVector::createConstant(variant(TypeKind::INTEGER), 100, pool_.get());
+  auto vector = BaseVector::createNullConstant(INTEGER(), 100, pool_.get());
 
   raw_vector<uint64_t> hashes(100);
   std::fill(hashes.begin(), hashes.end(), 0);

--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -21,11 +21,6 @@ void ConstantExpr::evalSpecialForm(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
-  if (!sharedSubexprValues_) {
-    sharedSubexprValues_ =
-        BaseVector::createConstant(value_, 1, context.execCtx()->pool());
-  }
-
   if (needToSetIsAscii_) {
     auto* vector =
         sharedSubexprValues_->asUnchecked<SimpleVector<StringView>>();
@@ -61,20 +56,12 @@ void ConstantExpr::evalSpecialFormSimplified(
   // pre-allocated.
   VELOX_CHECK_NULL(result);
 
-  if (sharedSubexprValues_ == nullptr) {
-    result = BaseVector::createConstant(value_, rows.end(), context.pool());
-  } else {
-    result = BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_);
-  }
+  result = BaseVector::wrapInConstant(rows.end(), 0, sharedSubexprValues_);
 }
 
 std::string ConstantExpr::toString(bool /*recursive*/) const {
-  if (sharedSubexprValues_ == nullptr) {
-    return fmt::format("{}:{}", value_.toJson(), type()->toString());
-  } else {
-    return fmt::format(
-        "{}:{}", sharedSubexprValues_->toString(0), type()->toString());
-  }
+  return fmt::format(
+      "{}:{}", sharedSubexprValues_->toString(0), type()->toString());
 }
 
 namespace {

--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -20,16 +20,6 @@
 namespace facebook::velox::exec {
 class ConstantExpr : public SpecialForm {
  public:
-  ConstantExpr(TypePtr type, variant value)
-      : SpecialForm(
-            std::move(type),
-            std::vector<ExprPtr>(),
-            "literal",
-            !value.isNull() /* supportsFlatNoNullsFastPath */,
-            false /* trackCpuUsage */),
-        value_(std::move(value)),
-        needToSetIsAscii_{type->isVarchar()} {}
-
   explicit ConstantExpr(VectorPtr value)
       : SpecialForm(
             value->type(),
@@ -65,7 +55,6 @@ class ConstantExpr : public SpecialForm {
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
  private:
-  const variant value_;
   bool needToSetIsAscii_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -474,8 +474,8 @@ ExprPtr compileExpression(
         result = std::make_shared<ConstantExpr>(
             BaseVector::createNullConstant(constant->type(), 1, pool));
       } else {
-        result = std::make_shared<ConstantExpr>(
-            BaseVector::createConstant(constant->value(), 1, pool));
+        result = std::make_shared<ConstantExpr>(BaseVector::createConstant(
+            constant->type(), constant->value(), 1, pool));
       }
     }
   } else if (

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -214,4 +215,13 @@ TEST_F(ExprCompilerTest, constantFromFlatVector) {
   auto exprSet = compile(expression);
   ASSERT_EQ("137:BIGINT", compile(expression)->toString());
 }
+
+TEST_F(ExprCompilerTest, customTypeConstant) {
+  auto expression =
+      std::make_shared<core::ConstantTypedExpr>(JSON(), "[1, 2, 3]");
+
+  auto exprSet = compile(expression);
+  ASSERT_EQ("[1, 2, 3]:JSON", compile(expression)->toString());
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -219,7 +219,8 @@ class CreateConstantAndThrow : public exec::VectorFunction {
       const TypePtr& /* outputType */,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
-    result = BaseVector::createConstant((int64_t)1, rows.end(), context.pool());
+    result = BaseVector::createConstant(
+        BIGINT(), (int64_t)1, rows.end(), context.pool());
 
     rows.applyToSelected([&](int row) {
       context.setError(

--- a/velox/functions/lib/IsNull.cpp
+++ b/velox/functions/lib/IsNull.cpp
@@ -38,7 +38,7 @@ class IsNullFunction : public exec::VectorFunction {
     if (arg->isConstantEncoding()) {
       bool isNull = arg->isNullAt(rows.begin());
       auto localResult = BaseVector::createConstant(
-          IsNotNULL ? !isNull : isNull, rows.size(), pool);
+          BOOLEAN(), IsNotNULL ? !isNull : isNull, rows.size(), pool);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }
@@ -46,7 +46,7 @@ class IsNullFunction : public exec::VectorFunction {
     if (!arg->mayHaveNulls()) {
       // No nulls.
       auto localResult = BaseVector::createConstant(
-          IsNotNULL ? true : false, rows.size(), pool);
+          BOOLEAN(), IsNotNULL ? true : false, rows.size(), pool);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }

--- a/velox/functions/prestosql/ArraySum.cpp
+++ b/velox/functions/prestosql/ArraySum.cpp
@@ -151,7 +151,8 @@ class ArraySumFunction : public exec::VectorFunction {
       }
 
       context.moveOrCopyResult(
-          BaseVector::createConstant(sum, rows.end(), context.pool()),
+          std::make_shared<ConstantVector<TOutput>>(
+              context.pool(), rows.end(), false /*isNull*/, std::move(sum)),
           rows,
           result);
       return;

--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -53,7 +53,8 @@ class FromUnixtimeFunction : public exec::VectorFunction {
 
       int16_t timezoneId = util::getTimeZoneID(
           std::string_view(timezoneName.data(), timezoneName.size()));
-      timezones = BaseVector::createConstant(timezoneId, size, pool);
+      timezones = std::make_shared<ConstantVector<int16_t>>(
+          pool, size, false /*isNull*/, std::move(timezoneId));
 
       rows.applyToSelected([&](auto row) {
         rawTimestamps[row] = toMillis(unixtimes->valueAt<double>(row));

--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -226,13 +226,14 @@ class InPredicate : public exec::VectorFunction {
   static VectorPtr createBoolConstantNull(
       vector_size_t size,
       exec::EvalCtx& context) {
-    return BaseVector::createConstant(
-        variant(TypeKind::BOOLEAN), size, context.pool());
+    return std::make_shared<ConstantVector<bool>>(
+        context.pool(), size, true /*isNull*/, false);
   }
 
   static VectorPtr
   createBoolConstant(bool value, vector_size_t size, exec::EvalCtx& context) {
-    return BaseVector::createConstant(value, size, context.pool());
+    return std::make_shared<ConstantVector<bool>>(
+        context.pool(), size, false /*isNull*/, std::move(value));
   }
 
   template <typename T, typename F>
@@ -243,8 +244,7 @@ class InPredicate : public exec::VectorFunction {
       VectorPtr& result,
       F&& testFunction) const {
     if (alwaysNull_) {
-      auto localResult = BaseVector::createNullConstant(
-          BOOLEAN(), rows.size(), context.pool());
+      auto localResult = createBoolConstantNull(rows.size(), context);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -150,7 +150,7 @@ void AggregationTestBase::validateStreamingInTestAggregations(
               input->size(), 0, constant->valueVector());
         } else {
           column = BaseVector::createConstant(
-              constant->value(), input->size(), pool());
+              constant->type(), constant->value(), input->size(), pool());
         }
       } else {
         column = input->childAt(channel);

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -84,7 +84,8 @@ class ArrayContainsBenchmark : public functions::test::FunctionBenchmarkBase {
         [](auto row) { return row % 5; },
         [](auto row) { return row % 23; });
 
-    auto elementVector = BaseVector::createConstant(7, size, execCtx_.pool());
+    auto elementVector =
+        BaseVector::createConstant(INTEGER(), 7, size, execCtx_.pool());
 
     auto rowVector = vectorMaker_.rowVector({arrayVector, elementVector});
     auto exprSet = compileExpression(
@@ -113,8 +114,8 @@ class ArrayContainsBenchmark : public functions::test::FunctionBenchmarkBase {
         [](auto row) { return row % 5; },
         [&](auto row) { return StringView(colors[row % colors.size()]); });
 
-    auto elementVector =
-        BaseVector::createConstant("crimson red", size, execCtx_.pool());
+    auto elementVector = BaseVector::createConstant(
+        VARCHAR(), "crimson red", size, execCtx_.pool());
 
     auto rowVector = vectorMaker_.rowVector({arrayVector, elementVector});
     auto exprSet = compileExpression(

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
@@ -144,14 +144,14 @@ class ArrayPositionBenchmark : public functions::test::FunctionBenchmarkBase {
         [](auto row) { return row % 5; },
         [](auto row) { return row % 23; });
 
-    auto searchVector =
-        BaseVector::createConstant(int32_t{7}, size, execCtx_.pool());
+    auto searchVector = BaseVector::createConstant(
+        INTEGER(), int32_t{7}, size, execCtx_.pool());
 
     if (vectorCount == 2) {
       return vectorMaker_.rowVector({arrayVector, searchVector});
     } else {
-      auto instanceVector =
-          BaseVector::createConstant(int64_t{5}, size, execCtx_.pool());
+      auto instanceVector = BaseVector::createConstant(
+          BIGINT(), int64_t{5}, size, execCtx_.pool());
       return vectorMaker_.rowVector(
           {arrayVector, searchVector, instanceVector});
     }

--- a/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
@@ -72,8 +72,8 @@ class StringAsciiUTFFunctionBenchmark
     VectorFuzzer fuzzer(opts, execCtx_.pool());
     auto vector = fuzzer.fuzzFlat(VARCHAR());
 
-    auto positionVector =
-        BaseVector::createConstant(25, opts.vectorSize, execCtx_.pool());
+    auto positionVector = BaseVector::createConstant(
+        INTEGER(), 25, opts.vectorSize, execCtx_.pool());
 
     auto rowVector = vectorMaker_.rowVector({vector, positionVector});
 
@@ -101,8 +101,8 @@ class StringAsciiUTFFunctionBenchmark
     auto stringVector = fuzzer.fuzzFlat(VARCHAR());
     auto padStringVector = fuzzer.fuzzFlat(VARCHAR());
 
-    auto sizeVector =
-        BaseVector::createConstant(55, opts.vectorSize, execCtx_.pool());
+    auto sizeVector = BaseVector::createConstant(
+        INTEGER(), 55, opts.vectorSize, execCtx_.pool());
 
     auto rowVector =
         vectorMaker_.rowVector({stringVector, sizeVector, padStringVector});

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -201,7 +201,8 @@ class UrlBenchmark : public functions::test::FunctionBenchmarkBase {
               row % 3));
         },
         nullptr);
-    auto constVector = BaseVector::createConstant("k1", size, pool());
+    auto constVector =
+        BaseVector::createConstant(VARCHAR(), "k1", size, pool());
     auto rowVector = isParameter
         ? vectorMaker_.rowVector({vectorUrls, constVector})
         : vectorMaker_.rowVector({vectorUrls});

--- a/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
@@ -78,7 +78,7 @@ class WidthBucketBenchmark : public functions::test::FunctionBenchmarkBase {
     auto bound2Vector =
         vectorMaker_.flatVector<double>(size, [](auto row) { return row + 4; });
     auto bucketCountVector =
-        BaseVector::createConstant(3, size, execCtx_.pool());
+        BaseVector::createConstant(INTEGER(), 3, size, execCtx_.pool());
 
     auto rowVector = vectorMaker_.rowVector(
         {operandVector, bound1Vector, bound2Vector, bucketCountVector});

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -31,7 +31,7 @@ class JsonFunctionsTest : public functions::test::FunctionBaseTest {
     return makeNullableFlatVector<StringView>({s}, JSON());
   }
 
-  std::optional<bool> jsJsonScalar(std::optional<std::string> json) {
+  std::optional<bool> isJsonScalar(std::optional<std::string> json) {
     return evaluateOnce<bool>(
         "is_json_scalar(c0)", makeRowVector({makeJsonVector(json)}));
   }
@@ -218,19 +218,19 @@ TEST_F(JsonFunctionsTest, jsonSizeSignatures) {
 
 TEST_F(JsonFunctionsTest, isJsonScalar) {
   // Scalars.
-  EXPECT_EQ(jsJsonScalar(R"(1)"), true);
-  EXPECT_EQ(jsJsonScalar(R"(123456)"), true);
-  EXPECT_EQ(jsJsonScalar(R"("hello")"), true);
-  EXPECT_EQ(jsJsonScalar(R"("thefoxjumpedoverthefence")"), true);
-  EXPECT_EQ(jsJsonScalar(R"(1.1)"), true);
-  EXPECT_EQ(jsJsonScalar(R"("")"), true);
-  EXPECT_EQ(jsJsonScalar(R"(true)"), true);
+  EXPECT_EQ(isJsonScalar(R"(1)"), true);
+  EXPECT_EQ(isJsonScalar(R"(123456)"), true);
+  EXPECT_EQ(isJsonScalar(R"("hello")"), true);
+  EXPECT_EQ(isJsonScalar(R"("thefoxjumpedoverthefence")"), true);
+  EXPECT_EQ(isJsonScalar(R"(1.1)"), true);
+  EXPECT_EQ(isJsonScalar(R"("")"), true);
+  EXPECT_EQ(isJsonScalar(R"(true)"), true);
 
   // Lists and maps
-  EXPECT_EQ(jsJsonScalar(R"([1,2])"), false);
-  EXPECT_EQ(jsJsonScalar(R"({"k1":"v1"})"), false);
-  EXPECT_EQ(jsJsonScalar(R"({"k1":[0,1,2]})"), false);
-  EXPECT_EQ(jsJsonScalar(R"({"k1":""})"), false);
+  EXPECT_EQ(isJsonScalar(R"([1,2])"), false);
+  EXPECT_EQ(isJsonScalar(R"({"k1":"v1"})"), false);
+  EXPECT_EQ(isJsonScalar(R"({"k1":[0,1,2]})"), false);
+  EXPECT_EQ(isJsonScalar(R"({"k1":""})"), false);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayLength) {
@@ -435,13 +435,13 @@ TEST_F(JsonFunctionsTest, jsonSize) {
 }
 
 TEST_F(JsonFunctionsTest, invalidPath) {
-  EXPECT_THROW(jsonSize(R"([0,1,2])", ""), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"([0,1,2])", "$[]"), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"([0,1,2])", "$[-1]"), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$k1"), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1."), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1]"), VeloxUserError);
-  EXPECT_THROW(jsonSize(R"({"k1":"v1)", "$.k1]"), VeloxUserError);
+  VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", ""), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$[]"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"([0,1,2])", "$[-1]"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$k1"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1."), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1"})", "$.k1]"), "Invalid JSON path");
+  VELOX_ASSERT_THROW(jsonSize(R"({"k1":"v1)", "$.k1]"), "Invalid JSON path");
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/SplitTest.cpp
+++ b/velox/functions/prestosql/tests/SplitTest.cpp
@@ -78,8 +78,7 @@ class SplitTest : public FunctionBaseTest {
           numRows,
           std::make_unique<SimpleVectorLoader>(funcCreateFlatStrings));
     } else if (isDictionary(encodingStrings)) {
-      strings = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
+      strings = wrapInDictionary(
           makeIndices(numRows, funcReverseIndices),
           numRows,
           funcCreateFlatStrings({}));
@@ -89,8 +88,7 @@ class SplitTest : public FunctionBaseTest {
     if (isFlat(encodingDelims)) {
       delims = funcCreateFlatDelims({});
     } else if (isConstant(encodingDelims)) {
-      delims =
-          BaseVector::createConstant(delim.c_str(), numRows, execCtx_.pool());
+      delims = makeConstant(delim.c_str(), numRows);
     } else if (isLazy(encodingDelims)) {
       delims = std::make_shared<LazyVector>(
           execCtx_.pool(),
@@ -98,8 +96,7 @@ class SplitTest : public FunctionBaseTest {
           numRows,
           std::make_unique<SimpleVectorLoader>(funcCreateFlatDelims));
     } else if (isDictionary(encodingDelims)) {
-      delims = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
+      delims = wrapInDictionary(
           makeIndices(numRows, funcReverseIndices),
           numRows,
           funcCreateFlatDelims({}));
@@ -109,7 +106,7 @@ class SplitTest : public FunctionBaseTest {
     if (isFlat(encodingLimit)) {
       limits = funcCreateFlatLimits({});
     } else if (isConstant(encodingLimit)) {
-      limits = BaseVector::createConstant(limit, numRows, execCtx_.pool());
+      limits = makeConstant(limit, numRows);
     } else if (isLazy(encodingLimit)) {
       limits = std::make_shared<LazyVector>(
           execCtx_.pool(),
@@ -117,8 +114,7 @@ class SplitTest : public FunctionBaseTest {
           numRows,
           std::make_unique<SimpleVectorLoader>(funcCreateFlatLimits));
     } else if (isDictionary(encodingLimit)) {
-      limits = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
+      limits = wrapInDictionary(
           makeIndices(numRows, funcReverseIndices),
           numRows,
           funcCreateFlatLimits({}));
@@ -154,8 +150,7 @@ class SplitTest : public FunctionBaseTest {
         return arrayVector->size() - 1 - row;
       };
 
-      auto dictVector = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
+      auto dictVector = wrapInDictionary(
           makeIndices(arrayVector->size(), funcReverseIndices),
           arrayVector->size(),
           arrayVector);

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -243,7 +243,7 @@ TEST_F(PrestoSerializerTest, intervalDayTime) {
 TEST_F(PrestoSerializerTest, unknown) {
   const vector_size_t size = 123;
   auto constantVector =
-      BaseVector::createConstant(variant(TypeKind::UNKNOWN), 123, pool_.get());
+      BaseVector::createNullConstant(UNKNOWN(), 123, pool_.get());
   testRoundTrip(constantVector);
 
   auto flatVector = BaseVector::create(UNKNOWN(), size, pool_.get());
@@ -341,11 +341,12 @@ TEST_F(PrestoSerializerTest, unscaledLongDecimal) {
 
 TEST_F(PrestoSerializerTest, rle) {
   // Test RLE vectors with non-null value.
-  testRleRoundTrip(BaseVector::createConstant(true, 12, pool_.get()));
-  testRleRoundTrip(BaseVector::createConstant(779, 12, pool_.get()));
-  testRleRoundTrip(BaseVector::createConstant(1.23, 12, pool_.get()));
   testRleRoundTrip(
-      BaseVector::createConstant("Hello, world!", 12, pool_.get()));
+      BaseVector::createConstant(BOOLEAN(), true, 12, pool_.get()));
+  testRleRoundTrip(BaseVector::createConstant(INTEGER(), 779, 12, pool_.get()));
+  testRleRoundTrip(BaseVector::createConstant(DOUBLE(), 1.23, 12, pool_.get()));
+  testRleRoundTrip(
+      BaseVector::createConstant(VARCHAR(), "Hello, world!", 12, pool_.get()));
   testRleRoundTrip(BaseVector::wrapInConstant(
       12, 0, vectorMaker_->arrayVector<int64_t>({{1, 2, 3}})));
   testRleRoundTrip(BaseVector::wrapInConstant(

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -610,67 +610,52 @@ void BaseVector::ensureWritable(
 
 template <TypeKind kind>
 VectorPtr newConstant(
+    const TypePtr& type,
     variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
   using T = typename KindToFlatVector<kind>::WrapperType;
-  T copy = T();
-  TypePtr type;
+
+  if (value.isNull()) {
+    return std::make_shared<ConstantVector<T>>(pool, size, true, type, T());
+  }
+
+  T copy;
   if constexpr (std::is_same_v<T, StringView>) {
-    type = Type::create<kind>();
-    if (!value.isNull()) {
-      copy = StringView(value.value<kind>());
-    }
+    copy = StringView(value.value<kind>());
   } else if constexpr (
       std::is_same_v<T, UnscaledShortDecimal> ||
       std::is_same_v<T, UnscaledLongDecimal>) {
-    const auto& decimal = value.value<kind>();
-    type = DECIMAL(decimal.precision, decimal.scale);
-    if (!value.isNull()) {
-      copy = decimal.value();
-    }
+    copy = value.value<kind>().value();
   } else {
-    type = Type::create<kind>();
-    if (!value.isNull()) {
-      copy = value.value<T>();
-    }
+    copy = value.value<T>();
   }
 
   return std::make_shared<ConstantVector<T>>(
-      pool,
-      size,
-      value.isNull(),
-      type,
-      std::move(copy),
-      SimpleVectorStats<T>{},
-      sizeof(T) /*representedByteCount*/);
+      pool, size, false, type, std::move(copy));
 }
 
 template <>
 VectorPtr newConstant<TypeKind::OPAQUE>(
+    const TypePtr& type,
     variant& value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
-  VELOX_CHECK(!value.isNull(), "Can't infer type from null opaque object");
   const auto& capsule = value.value<TypeKind::OPAQUE>();
 
   return std::make_shared<ConstantVector<std::shared_ptr<void>>>(
-      pool,
-      size,
-      value.isNull(),
-      capsule.type,
-      std::shared_ptr<void>(capsule.obj),
-      SimpleVectorStats<std::shared_ptr<void>>{},
-      sizeof(std::shared_ptr<void>) /*representedByteCount*/);
+      pool, size, value.isNull(), type, std::shared_ptr<void>(capsule.obj));
 }
 
 // static
 VectorPtr BaseVector::createConstant(
+    const TypePtr& type,
     variant value,
     vector_size_t size,
     velox::memory::MemoryPool* pool) {
+  VELOX_CHECK_EQ(type->kind(), value.kind());
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
-      newConstant, value.kind(), value, size, pool);
+      newConstant, value.kind(), type, value, size, pool);
 }
 
 namespace {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -434,6 +434,7 @@ class BaseVector {
       std::shared_ptr<BaseVector>&& source);
 
   static std::shared_ptr<BaseVector> createConstant(
+      const TypePtr& type,
       variant value,
       vector_size_t size,
       velox::memory::MemoryPool* pool);

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -661,7 +661,7 @@ TEST_F(ArrowBridgeArrayExportTest, unsupported) {
   EXPECT_THROW(exportToArrow(vector, arrowArray, pool_.get()), VeloxException);
 
   // Constant encoding.
-  vector = BaseVector::createConstant(variant(10), 10, pool_.get());
+  vector = BaseVector::createConstant(INTEGER(), variant(10), 10, pool_.get());
   EXPECT_THROW(exportToArrow(vector, arrowArray, pool_.get()), VeloxException);
 }
 

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -412,7 +412,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
   {
     const vector_size_t size = 100;
     auto constant = BaseVector::createConstant(
-        variant::create<TypeKind::BIGINT>(123), size, pool_.get());
+        BIGINT(), variant::create<TypeKind::BIGINT>(123), size, pool_.get());
     BaseVector::ensureWritable(
         SelectivityVector::empty(), BIGINT(), pool_.get(), constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
@@ -424,7 +424,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
   {
     const vector_size_t selectivityVectorSize = 100;
     auto constant = BaseVector::createConstant(
-        variant::create<TypeKind::BIGINT>(123), 1, pool_.get());
+        BIGINT(), variant::create<TypeKind::BIGINT>(123), 1, pool_.get());
     BaseVector::ensureWritable(
         SelectivityVector::empty(selectivityVectorSize),
         BIGINT(),
@@ -440,6 +440,7 @@ TEST_F(EnsureWritableVectorTest, constant) {
     const vector_size_t selectivityVectorSize = 100;
     const vector_size_t constantVectorSize = 200;
     auto constant = BaseVector::createConstant(
+        BIGINT(),
         variant::create<TypeKind::BIGINT>(123),
         constantVectorSize,
         pool_.get());

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1075,8 +1075,8 @@ TEST_F(VectorTest, map) {
 
 TEST_F(VectorTest, unknown) {
   // Creates a const UNKNOWN vector.
-  auto constUnknownVector =
-      BaseVector::createConstant(variant(TypeKind::UNKNOWN), 123, pool_.get());
+  auto constUnknownVector = BaseVector::createConstant(
+      UNKNOWN(), variant(TypeKind::UNKNOWN), 123, pool_.get());
   ASSERT_FALSE(constUnknownVector->isScalar());
   ASSERT_EQ(TypeKind::UNKNOWN, constUnknownVector->typeKind());
   ASSERT_EQ(123, constUnknownVector->size());
@@ -1273,7 +1273,10 @@ TEST_F(VectorTest, wrapConstantInDictionary) {
   // Wrap Constant in Dictionary with no extra nulls. Expect Constant.
   auto indices = makeIndices(10, [](auto row) { return row % 2; });
   auto vector = BaseVector::wrapInDictionary(
-      nullptr, indices, 10, BaseVector::createConstant(7, 100, pool_.get()));
+      nullptr,
+      indices,
+      10,
+      BaseVector::createConstant(INTEGER(), 7, 100, pool_.get()));
   ASSERT_EQ(vector->encoding(), VectorEncoding::Simple::CONSTANT);
   auto constantVector =
       std::dynamic_pointer_cast<ConstantVector<int32_t>>(vector);
@@ -1285,7 +1288,10 @@ TEST_F(VectorTest, wrapConstantInDictionary) {
   // Wrap Constant in Dictionary with extra nulls. Expect Dictionary.
   auto nulls = makeNulls(10, [](auto row) { return row % 3 == 0; });
   vector = BaseVector::wrapInDictionary(
-      nulls, indices, 10, BaseVector::createConstant(11, 100, pool_.get()));
+      nulls,
+      indices,
+      10,
+      BaseVector::createConstant(INTEGER(), 11, 100, pool_.get()));
   ASSERT_EQ(vector->encoding(), VectorEncoding::Simple::DICTIONARY);
   auto dictVector = std::dynamic_pointer_cast<SimpleVector<int32_t>>(vector);
   for (auto i = 0; i < 10; ++i) {
@@ -1477,7 +1483,7 @@ class VectorCreateConstantTest : public VectorTest {
       var = variant::create<KIND>(val);
     }
 
-    auto baseVector = BaseVector::createConstant(var, size_, pool_.get());
+    auto baseVector = BaseVector::createConstant(type, var, size_, pool_.get());
     auto simpleVector = baseVector->template as<SimpleVector<TCpp>>();
     ASSERT_TRUE(simpleVector != nullptr);
 

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -601,7 +601,7 @@ class VectorTestBase {
   }
 
   VectorPtr makeConstant(const variant& value, vector_size_t size) {
-    return BaseVector::createConstant(value, size, pool());
+    return BaseVector::createConstant(value.inferType(), value, size, pool());
   }
 
   template <typename T>
@@ -644,7 +644,8 @@ class VectorTestBase {
   }
 
   VectorPtr makeNullConstant(TypeKind typeKind, vector_size_t size) {
-    return BaseVector::createConstant(variant(typeKind), size, pool());
+    return BaseVector::createNullConstant(
+        createType(typeKind, {}), size, pool());
   }
 
   BufferPtr makeIndices(


### PR DESCRIPTION
Usage of velox::variant is error prone because variant cannot always capture the
logical type accurately. This PR removes usage of variant from ConstantExpr and
updates BaseVector::createConstant method to add type parameter.

This fixes compilation of constant expressions that use values of custom type,
e.g. JSON. Before this change, JSON typed constant expression compiled into
VARCHAR typed expression causing type mismatch errors during evaluation.

Update BaseVector::createConstant call sites to pass additional type parameter
or use ConstantVector's constructor directly. BaseVector::createConstant is
more expensive then constructing ConstantVector's directly since it needs to
switch on type.

Fixes #4004