### PR TITLE
Make ConstantTypedExpr easier to use

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -83,7 +83,11 @@ class ConstantTypedExpr : public ITypedExpr {
   // Creates constant expression of scalar or complex type. The value comes from
   // index zero.
   explicit ConstantTypedExpr(const VectorPtr& value)
-      : ITypedExpr{value->type()}, valueVector_{value} {}
+      : ITypedExpr{value->type()},
+        valueVector_{
+            value->isConstantEncoding()
+                ? value
+                : BaseVector::wrapInConstant(1, 0, value)} {}
 
   std::string toString() const override {
     if (hasValueVector()) {
@@ -109,8 +113,8 @@ class ConstantTypedExpr : public ITypedExpr {
     return value_;
   }
 
-  // Returns value vector if hasValueVector() is true. Vector can be of scalar
-  // or complex type. The value is at index zero.
+  /// Return constant value vector if hasValueVector() is true. Returns null
+  /// otherwise.
   const VectorPtr& valueVector() const {
     return valueVector_;
   }

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -204,4 +204,14 @@ TEST_F(ExprCompilerTest, functionSignatureNotRegistered) {
       "Found function registered with the following signatures:\n"
       "((varchar,varchar...) -> varchar)");
 }
+
+TEST_F(ExprCompilerTest, constantFromFlatVector) {
+  auto expression = std::make_shared<core::ConstantTypedExpr>(
+      makeFlatVector<int64_t>({137, 23, -10}));
+
+  ASSERT_TRUE(expression->valueVector()->isConstantEncoding());
+
+  auto exprSet = compile(expression);
+  ASSERT_EQ("137:BIGINT", compile(expression)->toString());
+}
 } // namespace facebook::velox::exec::test

--- a/velox/substrait/VeloxToSubstraitExpr.cpp
+++ b/velox/substrait/VeloxToSubstraitExpr.cpp
@@ -378,7 +378,7 @@ void convertVectorValue(
 
   using T = typename TypeTraits<kind>::NativeType;
 
-  auto childToFlatVec = vectorValue->asFlatVector<T>();
+  auto childToFlatVec = vectorValue->as<SimpleVector<T>>();
 
   //  Get the batchSize and convert each value in it.
   vector_size_t flatVecSize = childToFlatVec->size();

--- a/velox/substrait/VeloxToSubstraitExpr.h
+++ b/velox/substrait/VeloxToSubstraitExpr.h
@@ -61,6 +61,12 @@ class VeloxToSubstraitExprConvertor {
       const std::shared_ptr<const core::FieldAccessTypedExpr>& fieldExpr,
       const RowTypePtr& inputType);
 
+  /// Convert Velox vector to Substrait literal.
+  const ::substrait::Expression_Literal& toSubstraitLiteral(
+      google::protobuf::Arena& arena,
+      const velox::VectorPtr& vectorValue,
+      ::substrait::Expression_Literal_Struct* litValue);
+
  private:
   /// Convert Velox Cast Expression to Substrait Cast Expression.
   const ::substrait::Expression_Cast& toSubstraitExpr(
@@ -73,12 +79,6 @@ class VeloxToSubstraitExprConvertor {
       google::protobuf::Arena& arena,
       const std::shared_ptr<const core::CallTypedExpr>& callTypeExpr,
       const RowTypePtr& inputType);
-
-  /// Convert Velox vector to Substrait literal.
-  const ::substrait::Expression_Literal& toSubstraitLiteral(
-      google::protobuf::Arena& arena,
-      const velox::VectorPtr& vectorValue,
-      ::substrait::Expression_Literal_Struct* litValue);
 
   /// Convert Velox variant to Substrait Literal Expression.
   const ::substrait::Expression_Literal& toSubstraitLiteral(


### PR DESCRIPTION
ConstantTypedExpr's constructor says that it accepts any vector and uses value
at index 0. However, creating ConstantTypedExpr using non-constant vector
results in a compilation error, because ConstantExpr doesn't accept
non-constant vectors.

This PR changes ConstantTypedExpr's constructor to wrap input vector in a
constant to ensure that valueVector() getter always returns a constant vector.
