### PR TITLE
Make ConstantTypedExpr safer to use

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -70,13 +70,15 @@ class InputTypedExpr : public ITypedExpr {
 
 class ConstantTypedExpr : public ITypedExpr {
  public:
+// TODO Remove this constructor after Prestissimo is updated.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   // Creates constant expression of scalar type.
   explicit ConstantTypedExpr(variant value)
       : ITypedExpr{value.inferType()}, value_{std::move(value)} {}
+#endif
 
-  // Creates constant expression for cases when type cannot be properly inferred
-  // from the variant, like variant::null(). For complex types, only
-  // variant::null() is supported.
+  // Creates constant expression. For complex types, only
+  // variant::null() value is supported.
   ConstantTypedExpr(std::shared_ptr<const Type> type, variant value)
       : ITypedExpr{std::move(type)}, value_{std::move(value)} {}
 

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -201,7 +201,8 @@ TEST_F(PlanFragmentTest, hashJoin) {
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0")};
   const std::vector<FieldAccessTypedExprPtr> probeKeys{
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "u0")};
-  TypedExprPtr filter{std::make_shared<core::ConstantTypedExpr>(true)};
+  TypedExprPtr filter{
+      std::make_shared<core::ConstantTypedExpr>(BOOLEAN(), true)};
 
   struct {
     JoinType joinType;

--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -167,7 +167,7 @@ TypePtr toVeloxType(LogicalType type) {
   }
 }
 
-variant duckValueToVariant(const Value& val, bool parseDecimalAsDouble) {
+variant duckValueToVariant(const Value& val) {
   switch (val.type().id()) {
     case LogicalTypeId::SQLNULL:
       return variant(TypeKind::UNKNOWN);
@@ -186,11 +186,7 @@ variant duckValueToVariant(const Value& val, bool parseDecimalAsDouble) {
     case LogicalTypeId::DOUBLE:
       return variant(val.GetValue<double>());
     case LogicalTypeId::DECIMAL:
-      if (parseDecimalAsDouble) {
-        return variant(val.GetValue<double>());
-      } else {
-        return decimalVariant(val);
-      }
+      return decimalVariant(val);
     case LogicalTypeId::VARCHAR:
       return variant(val.GetValue<std::string>());
     case LogicalTypeId::BLOB:

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -42,11 +42,9 @@ static Timestamp duckdbTimestampToVelox(
   return Timestamp(micros / 1000000, (micros % 1000000) * 1000);
 }
 
-// Converts a duckDB Value (class that holds an arbitraty data type) into a
-// VELOX's variant.
-variant duckValueToVariant(
-    const ::duckdb::Value& val,
-    bool parseDecimalAsDouble);
+// Converts a duckDB Value (class that holds an arbitrary data type) into
+// Velox variant.
+variant duckValueToVariant(const ::duckdb::Value& val);
 
 // value conversion routines
 template <class T>

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -27,66 +27,64 @@ using ::duckdb::Value;
 
 TEST(DuckConversionTest, duckValueToVariant) {
   // NULLs must be the same.
-  EXPECT_EQ(variant(TypeKind::UNKNOWN), duckValueToVariant(Value(), true));
+  EXPECT_EQ(variant(TypeKind::UNKNOWN), duckValueToVariant(Value()));
 
   // Booleans.
-  EXPECT_EQ(variant(false), duckValueToVariant(Value::BOOLEAN(0), true));
-  EXPECT_EQ(variant(true), duckValueToVariant(Value::BOOLEAN(1), true));
+  EXPECT_EQ(variant(false), duckValueToVariant(Value::BOOLEAN(0)));
+  EXPECT_EQ(variant(true), duckValueToVariant(Value::BOOLEAN(1)));
 
   // Integers.
   auto min8 = std::numeric_limits<int8_t>::min();
   auto max8 = std::numeric_limits<int8_t>::max();
-  EXPECT_EQ(variant(min8), duckValueToVariant(Value::TINYINT(min8), true));
-  EXPECT_EQ(variant(max8), duckValueToVariant(Value::TINYINT(max8), true));
+  EXPECT_EQ(variant(min8), duckValueToVariant(Value::TINYINT(min8)));
+  EXPECT_EQ(variant(max8), duckValueToVariant(Value::TINYINT(max8)));
 
   auto min16 = std::numeric_limits<int16_t>::min();
   auto max16 = std::numeric_limits<int16_t>::max();
-  EXPECT_EQ(variant(min16), duckValueToVariant(Value::SMALLINT(min16), true));
-  EXPECT_EQ(variant(max16), duckValueToVariant(Value::SMALLINT(max16), true));
+  EXPECT_EQ(variant(min16), duckValueToVariant(Value::SMALLINT(min16)));
+  EXPECT_EQ(variant(max16), duckValueToVariant(Value::SMALLINT(max16)));
 
   auto min32 = std::numeric_limits<int32_t>::min();
   auto max32 = std::numeric_limits<int32_t>::max();
-  EXPECT_EQ(variant(min32), duckValueToVariant(Value::INTEGER(min32), true));
-  EXPECT_EQ(variant(max32), duckValueToVariant(Value::INTEGER(max32), true));
+  EXPECT_EQ(variant(min32), duckValueToVariant(Value::INTEGER(min32)));
+  EXPECT_EQ(variant(max32), duckValueToVariant(Value::INTEGER(max32)));
 
   auto min64 = std::numeric_limits<int64_t>::min();
   auto max64 = std::numeric_limits<int64_t>::max();
-  EXPECT_EQ(variant(min64), duckValueToVariant(Value::BIGINT(min64), true));
-  EXPECT_EQ(variant(max64), duckValueToVariant(Value::BIGINT(max64), true));
+  EXPECT_EQ(variant(min64), duckValueToVariant(Value::BIGINT(min64)));
+  EXPECT_EQ(variant(max64), duckValueToVariant(Value::BIGINT(max64)));
 
   // Doubles.
   for (const auto i : {0.99L, 88.321L, -3.23L}) {
-    EXPECT_EQ(variant(double(i)), duckValueToVariant(Value::DOUBLE(i), true));
+    EXPECT_EQ(variant(double(i)), duckValueToVariant(Value::DOUBLE(i)));
 
     // Floats are harder to compare because of low-precision. Just making sure
     // they don't throw.
-    EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i), true));
+    EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i)));
   }
 
   // Strings.
   std::vector<std::string> vec = {"", "asdf", "aS$!#^*HFD"};
   for (const auto& i : vec) {
-    EXPECT_EQ(variant(i), duckValueToVariant(Value(i), true));
+    EXPECT_EQ(variant(i), duckValueToVariant(Value(i)));
   }
 
   // Decimal type inference.
   EXPECT_EQ(
       *DECIMAL(4, 2),
-      *duckValueToVariant(Value::DECIMAL(static_cast<int16_t>(10), 4, 2), false)
+      *duckValueToVariant(Value::DECIMAL(static_cast<int16_t>(10), 4, 2))
            .inferType());
   EXPECT_EQ(
       *DECIMAL(9, 2),
-      *duckValueToVariant(Value::DECIMAL(static_cast<int32_t>(10), 9, 2), false)
+      *duckValueToVariant(Value::DECIMAL(static_cast<int32_t>(10), 9, 2))
            .inferType());
   EXPECT_EQ(
       *DECIMAL(17, 2),
-      *duckValueToVariant(
-           Value::DECIMAL(static_cast<int64_t>(10), 17, 2), false)
+      *duckValueToVariant(Value::DECIMAL(static_cast<int64_t>(10), 17, 2))
            .inferType());
   EXPECT_EQ(
       *DECIMAL(20, 2),
-      *duckValueToVariant(
-           Value::DECIMAL(::duckdb::hugeint_t(100), 20, 2), false)
+      *duckValueToVariant(Value::DECIMAL(::duckdb::hugeint_t(100), 20, 2))
            .inferType());
 }
 
@@ -100,7 +98,7 @@ TEST(DuckConversionTest, duckValueToVariantUnsupported) {
           {{"a", LogicalType::INTEGER}, {"b", LogicalType::TINYINT}})};
 
   for (const auto& i : unsupported) {
-    EXPECT_THROW(duckValueToVariant(Value(i), true), std::runtime_error);
+    EXPECT_THROW(duckValueToVariant(Value(i)), std::runtime_error);
   }
 }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -58,7 +58,8 @@ class CastExprTest : public functions::test::CastBaseTest {
   }
 
   std::shared_ptr<core::ConstantTypedExpr> makeConstantNullExpr(TypeKind kind) {
-    return std::make_shared<core::ConstantTypedExpr>(variant(kind));
+    return std::make_shared<core::ConstantTypedExpr>(
+        createType(kind, {}), variant(kind));
   }
 
   std::shared_ptr<core::CastTypedExpr> makeCastExpr(

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -62,11 +62,11 @@ class ExprCompilerTest : public testing::Test,
   }
 
   core::TypedExprPtr bigint(int64_t value) {
-    return std::make_shared<core::ConstantTypedExpr>(value);
+    return std::make_shared<core::ConstantTypedExpr>(BIGINT(), value);
   }
 
   core::TypedExprPtr varchar(const std::string& value) {
-    return std::make_shared<core::ConstantTypedExpr>(variant(value));
+    return std::make_shared<core::ConstantTypedExpr>(VARCHAR(), variant(value));
   }
 
   std::function<core::TypedExprPtr(const std::string& name)> makeField(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -146,7 +146,8 @@ class ExprTest : public testing::Test, public VectorTestBase {
 
   /// Create constant expression from a variant of primitive type.
   std::shared_ptr<core::ConstantTypedExpr> makeConstantExpr(variant value) {
-    return std::make_shared<core::ConstantTypedExpr>(std::move(value));
+    auto type = value.inferType();
+    return std::make_shared<core::ConstantTypedExpr>(type, std::move(value));
   }
 
   // Create LazyVector that produces a flat vector and asserts that is is being
@@ -398,7 +399,7 @@ TEST_F(ExprTest, constantNull) {
   auto inputExpr =
       std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "c0");
   auto nullConstant = std::make_shared<core::ConstantTypedExpr>(
-      variant::null(TypeKind::INTEGER));
+      INTEGER(), variant::null(TypeKind::INTEGER));
 
   // Builds the following expression: "plus(c0, plus(c0, null))"
   auto expression = std::make_shared<core::CallTypedExpr>(
@@ -2375,7 +2376,7 @@ TEST_F(ExprTest, constantToString) {
       makeNullableArrayVector<float>({{1.2, 3.4, std::nullopt, 5.6}});
 
   exec::ExprSet exprSet(
-      {std::make_shared<core::ConstantTypedExpr>(23),
+      {std::make_shared<core::ConstantTypedExpr>(INTEGER(), 23),
        std::make_shared<core::ConstantTypedExpr>(
            DOUBLE(), variant::null(TypeKind::DOUBLE)),
        makeConstantExpr(arrayVector, 0)},

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -263,7 +263,8 @@ TypedExprPtr Expressions::inferTypes(
               pool, 1, 0, arrayVector);
       return std::make_shared<const ConstantTypedExpr>(constantVector);
     }
-    return std::make_shared<const ConstantTypedExpr>(constant->value());
+    return std::make_shared<const ConstantTypedExpr>(
+        constant->type(), constant->value());
   }
   if (auto cast = std::dynamic_pointer_cast<const CastExpr>(expr)) {
     return std::make_shared<const CastTypedExpr>(

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -193,8 +193,7 @@ TypedExprPtr toVeloxExpression(
           dynamic_cast<::duckdb::BoundConstantExpression*>(&expression);
       return std::make_shared<ConstantTypedExpr>(
           duckdb::toVeloxType(constant->return_type),
-          duckdb::duckValueToVariant(
-              constant->value, true /*parseDecimalAsDouble*/));
+          duckdb::duckValueToVariant(constant->value));
     }
     case ::duckdb::ExpressionType::COMPARE_EQUAL:
       return toVeloxComparisonExpression("eq", expression, inputType);

--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -202,30 +202,30 @@ SubstraitVeloxExprConverter::toVeloxExpr(
   switch (typeCase) {
     case ::substrait::Expression_Literal::LiteralTypeCase::kBoolean:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.boolean()));
+          BOOLEAN(), variant(substraitLit.boolean()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI8:
       // SubstraitLit.i8() will return int32, so we need this type conversion.
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(static_cast<int8_t>(substraitLit.i8())));
+          TINYINT(), variant(static_cast<int8_t>(substraitLit.i8())));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI16:
       // SubstraitLit.i16() will return int32, so we need this type conversion.
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(static_cast<int16_t>(substraitLit.i16())));
+          SMALLINT(), variant(static_cast<int16_t>(substraitLit.i16())));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI32:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.i32()));
+          INTEGER(), variant(substraitLit.i32()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kFp32:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.fp32()));
+          REAL(), variant(substraitLit.fp32()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kI64:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.i64()));
+          BIGINT(), variant(substraitLit.i64()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kFp64:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.fp64()));
+          DOUBLE(), variant(substraitLit.fp64()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kString:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.string()));
+          VARCHAR(), variant(substraitLit.string()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kNull: {
       auto veloxType =
           toVeloxType(substraitParser_.parseType(substraitLit.null())->type);
@@ -234,7 +234,7 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kVarChar:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(substraitLit.var_char().value()));
+          VARCHAR(), variant(substraitLit.var_char().value()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kList: {
       auto constantVector =
           BaseVector::wrapInConstant(1, 0, literalsToArrayVector(substraitLit));
@@ -242,7 +242,7 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kDate:
       return std::make_shared<core::ConstantTypedExpr>(
-          variant(Date(substraitLit.date())));
+          DATE(), variant(Date(substraitLit.date())));
     default:
       VELOX_NYI(
           "Substrait conversion not supported for type case '{}'", typeCase);

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -357,6 +357,17 @@ TEST_F(VeloxSubstraitRoundTripTest, topNTwoKeys) {
       "SELECT * FROM tmp WHERE c0 > 15 ORDER BY c0 NULLS FIRST, c1 DESC NULLS LAST LIMIT 10");
 }
 
+namespace {
+core::TypedExprPtr makeConstantExpr(const TypePtr& type, const variant& value) {
+  return std::make_shared<const core::ConstantTypedExpr>(type, value);
+}
+
+core::TypedExprPtr makeConstantExpr(const VectorPtr& vector) {
+  return std::make_shared<const core::ConstantTypedExpr>(
+      BaseVector::wrapInConstant(1, 0, vector));
+}
+} // namespace
+
 TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
   auto vectors = makeRowVector(ROW({}, {}), 1);
   auto plan = PlanBuilder(pool_.get())
@@ -365,14 +376,14 @@ TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
                     std::vector<std::string> projectNames = {
                         "a", "b", "c", "d", "e", "f", "g", "h"};
                     std::vector<core::TypedExprPtr> projectExpressions = {
-                        std::make_shared<core::ConstantTypedExpr>((bool)1),
-                        std::make_shared<core::ConstantTypedExpr>((int8_t)23),
-                        std::make_shared<core::ConstantTypedExpr>((int16_t)45),
-                        std::make_shared<core::ConstantTypedExpr>((int32_t)678),
-                        std::make_shared<core::ConstantTypedExpr>((int64_t)910),
-                        std::make_shared<core::ConstantTypedExpr>((float)1.23),
-                        std::make_shared<core::ConstantTypedExpr>((double)4.56),
-                        std::make_shared<core::ConstantTypedExpr>("789")};
+                        makeConstantExpr(BOOLEAN(), (bool)1),
+                        makeConstantExpr(TINYINT(), (int8_t)23),
+                        makeConstantExpr(SMALLINT(), (int16_t)45),
+                        makeConstantExpr(INTEGER(), (int32_t)678),
+                        makeConstantExpr(BIGINT(), (int64_t)910),
+                        makeConstantExpr(REAL(), (float)1.23),
+                        makeConstantExpr(DOUBLE(), (double)4.56),
+                        makeConstantExpr(VARCHAR(), "789")};
                     return std::make_shared<core::ProjectNode>(
                         id,
                         std::move(projectNames),
@@ -383,13 +394,6 @@ TEST_F(VeloxSubstraitRoundTripTest, notNullLiteral) {
   assertPlanConversion(
       plan, "SELECT true, 23, 45, 678, 910, 1.23, 4.56, '789'");
 }
-
-namespace {
-core::TypedExprPtr makeConstantExpr(const VectorPtr& vector) {
-  return std::make_shared<const core::ConstantTypedExpr>(
-      BaseVector::wrapInConstant(1, 0, vector));
-}
-} // namespace
 
 TEST_F(VeloxSubstraitRoundTripTest, arrayLiteral) {
   auto vectors = makeRowVector(ROW({}), 1);


### PR DESCRIPTION
Summary:
Remove constructor that takes only 'variant' input. Usage of velox::variant is
error prone as it cannot always accurately capture the logical type of the
data. Require local type to be specified explicitly.

Differential Revision: D43192784

