### PR TITLE
Fix DuckDB parse for BOOLEAN literal

### DIFF
--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -47,6 +47,10 @@ TEST(DuckParserTest, constants) {
 
   // Nulls
   EXPECT_EQ("null", parseExpr("NULL")->toString());
+
+  // Booleans
+  EXPECT_EQ("true", parseExpr("TRUE")->toString());
+  EXPECT_EQ("false", parseExpr("FALSE")->toString());
 }
 
 TEST(DuckParserTest, arrays) {


### PR DESCRIPTION
Summary: DuckDB parser is returning cast expression (e.g. `cast('t' as BOOLEAN)`) for BOOLEAN literal.  Fix this by restoring it back to constant expression.

Differential Revision: D43194736

