### PR TITLE
Add support to serialize and deserialize long decimals

### DIFF
--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -161,6 +161,22 @@ struct UnscaledLongDecimal {
     return *this;
   }
 
+  static FOLLY_ALWAYS_INLINE void serialize(
+      const UnscaledLongDecimal& longDecimal,
+      char* serializedData) {
+    *reinterpret_cast<uint64_t*>(serializedData) =
+        (uint64_t)longDecimal.unscaledValue();
+    *reinterpret_cast<uint64_t*>(serializedData + sizeof(uint64_t)) =
+        ((uint64_t)(longDecimal.unscaledValue() >> 64));
+  }
+
+  static FOLLY_ALWAYS_INLINE UnscaledLongDecimal
+  deserialize(const char* serializedData) {
+    auto lower = reinterpret_cast<const uint64_t*>(serializedData);
+    auto upper = lower + 1;
+    return UnscaledLongDecimal(buildInt128(*upper, *lower));
+  }
+
  private:
   static constexpr int128_t kMin =
       -(1'000'000'000'000'000'000 * (int128_t)1'000'000'000'000'000'000 *

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -138,5 +138,26 @@ TEST(DecimalTest, addUnsignedValues) {
   ASSERT_EQ(UPPER(sum), 0x1673df52e37f2410);
   ASSERT_EQ(LOWER(sum), 0x11d0ffffff0bdc0);
 }
+
+TEST(DecimalTest, longDecimalSerDe) {
+  char data[100];
+  UnscaledLongDecimal::serialize(UnscaledLongDecimal::min(), data);
+  auto deserializedData = UnscaledLongDecimal::deserialize(data);
+  ASSERT_EQ(deserializedData, UnscaledLongDecimal::min());
+
+  UnscaledLongDecimal::serialize(UnscaledLongDecimal::max(), data);
+  deserializedData = UnscaledLongDecimal::deserialize(data);
+  ASSERT_EQ(deserializedData, UnscaledLongDecimal::max());
+
+  auto longData = UnscaledLongDecimal(-1);
+  UnscaledLongDecimal::serialize(longData, data);
+  deserializedData = UnscaledLongDecimal::deserialize(data);
+  ASSERT_EQ(deserializedData, longData);
+
+  longData = UnscaledLongDecimal(10);
+  UnscaledLongDecimal::serialize(longData, data);
+  deserializedData = UnscaledLongDecimal::deserialize(data);
+  ASSERT_EQ(deserializedData, longData);
+}
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Some operations like Aggregate functions, use reinterpret_cast on a char buffer to retrieve values. But, `reinterpret_cast` from `char*` to `UnscaledLongDecimal` type leads to  Segmentation fault on linux systems.

This change adds static functions to serialize UnscaledLongDecimal into a char buffer and deserialize into UnscaledLongDecimal.

Testing:
Added unit tests.