### PR TITLE
Remove the Task's spill folder instead of each spill file.

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -152,6 +152,18 @@ class LocalFileSystem : public FileSystem {
         ec.message());
   }
 
+  void rmdir(std::string_view path) override {
+    std::error_code ec;
+    std::filesystem::remove_all(path, ec);
+    VELOX_CHECK_EQ(
+        0,
+        ec.value(),
+        "Rmdir {} failed: {}, message: {}",
+        path,
+        ec,
+        ec.message());
+  }
+
   static std::function<bool(std::string_view)> schemeMatcher() {
     // Note: presto behavior is to prefix local paths with 'file:'.
     // Check for that prefix and prune to absolute regular paths as needed.

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -70,6 +70,10 @@ class FileSystem {
   // Create a directory (recursively). Throws velox exception on failure.
   virtual void mkdir(std::string_view path) = 0;
 
+  // Remove a directory (all the files and sub-directories underneath
+  // recursively). Throws velox exception on failure.
+  virtual void rmdir(std::string_view path) = 0;
+
  protected:
   std::shared_ptr<const Config> config_;
 };

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -241,3 +241,37 @@ TEST(LocalFile, mkdir) {
   }
   EXPECT_TRUE(localFs->exists(path));
 }
+
+TEST(LocalFile, rmdir) {
+  filesystems::registerLocalFileSystem();
+  auto tempFolder = ::exec::test::TempDirectoryPath::create();
+
+  std::string path = tempFolder->path;
+  auto localFs = filesystems::getFileSystem(path, nullptr);
+
+  // Create 3 levels of directories and ensure they exist.
+  path += "/level1/level2/level3";
+  EXPECT_NO_THROW(localFs->mkdir(path));
+  EXPECT_TRUE(localFs->exists(path));
+
+  // Write a file to our directory to double check it exist.
+  path += "/a.txt";
+  const std::string data("aaaaa");
+  {
+    auto writeFile = localFs->openFileForWrite(path);
+    writeFile->append(data);
+    writeFile->close();
+  }
+  EXPECT_TRUE(localFs->exists(path));
+
+  // Now delete the whole temp folder and ensure it is gone.
+  EXPECT_NO_THROW(localFs->rmdir(tempFolder->path));
+  EXPECT_FALSE(localFs->exists(tempFolder->path));
+
+  // Delete a non-existing directory.
+  path += "/does_not_exist/subdir";
+  EXPECT_FALSE(localFs->exists(path));
+  // The function does not throw, but will return zero files and folders
+  // deleted, which is not an error.
+  EXPECT_NO_THROW(localFs->rmdir(tempFolder->path));
+}

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -62,6 +62,10 @@ class HdfsFileSystem : public FileSystem {
     VELOX_UNSUPPORTED("mkdir for HDFS not implemented");
   }
 
+  void rmdir(std::string_view path) override {
+    VELOX_UNSUPPORTED("rmdir for HDFS not implemented");
+  }
+
   static bool isHdfsFile(std::string_view filename);
 
  protected:

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -60,6 +60,10 @@ class S3FileSystem : public FileSystem {
     VELOX_UNSUPPORTED("mkdir for S3 not implemented");
   }
 
+  void rmdir(std::string_view path) override {
+    VELOX_UNSUPPORTED("rmdir for S3 not implemented");
+  }
+
  protected:
   class Impl;
   std::shared_ptr<Impl> impl_;

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -45,15 +45,6 @@ void SpillMergeStream::pop() {
   }
 }
 
-SpillFile::~SpillFile() {
-  try {
-    auto fs = filesystems::getFileSystem(path_, nullptr);
-    fs->remove(path_);
-  } catch (const std::exception& e) {
-    LOG(ERROR) << "Error deleting spill file " << path_ << " : " << e.what();
-  }
-}
-
 WriteFile& SpillFile::output() {
   if (!output_) {
     auto fs = filesystems::getFileSystem(path_, nullptr);

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -56,6 +56,11 @@ class SpillInput : public ByteStream {
 /// Represents a spill file that is first in write mode and then
 /// turns into a source of spilled RowVectors. Owns a file system file that
 /// contains the spilled data and is live for the duration of 'this'.
+
+/// NOTE: The class will not delete spill file upon destruction, so the user
+/// needs to remove the unused spill files at some point later. For example, a
+/// query Task deletes all the generated spill files in one operation using
+/// rmdir() call.
 class SpillFile {
  public:
   SpillFile(
@@ -76,8 +81,6 @@ class SpillFile {
         sortCompareFlags_.empty() ||
         sortCompareFlags_.size() == numSortingKeys_);
   }
-
-  ~SpillFile();
 
   int32_t numSortingKeys() const {
     return numSortingKeys_;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -533,6 +533,10 @@ class Task : public std::enable_shared_from_this<Task> {
   static void testingWaitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
 
  private:
+  // Remove the spill directory, if the Task was creating it for potential
+  // spilling.
+  void removeSpillDirectoryIfExists();
+
   // Creates new instance of MemoryPool for a plan node, stores it in the task
   // to ensure lifetime and returns a raw pointer.
   memory::MemoryPool* FOLLY_NONNULL

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -878,6 +878,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
 
     auto stats = task->taskStats().pipelineStats;
     ASSERT_EQ(testData.expectSpill, stats[0].operatorStats[1].spilledBytes > 0);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 }
 
@@ -992,6 +993,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
     // Check spilled bytes.
     EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
     EXPECT_GE(kNumPartitions - 1, stats[0].operatorStats[1].spilledPartitions);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 }
 
@@ -1101,6 +1103,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   // Check spilled bytes.
   EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
   EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 
 /// Verify number of memory allocations in the HashAggregation operator.
@@ -1341,6 +1344,7 @@ TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
     ASSERT_EQ(
         folly::divCeil(opStats.outputPositions, outputBufferSize),
         opStats.outputVectors);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 }
 
@@ -1362,6 +1366,7 @@ TEST_F(AggregationTest, distinctWithSpilling) {
                   .assertResults("SELECT distinct c0 FROM tmp");
   // Verify that spilling is not triggered.
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 
 TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
@@ -1399,6 +1404,7 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
   auto stats = task->taskStats().pipelineStats;
   // Verify that spilling is not triggered.
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 
 } // namespace

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -629,6 +629,8 @@ class HashJoinBuilder {
     if (testVerifier_ != nullptr) {
       testVerifier_(task, injectSpill);
     }
+
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 
   VectorFuzzer::Options fuzzerOpts_;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -186,6 +186,7 @@ class OrderByTest : public OperatorTestBase {
       } else {
         EXPECT_EQ(0, spilledStats(*task).spilledBytes);
       }
+      OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
     }
   }
 };
@@ -448,6 +449,7 @@ TEST_F(OrderByTest, spill) {
   EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
   EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
   EXPECT_EQ(2, stats[0].operatorStats[1].spilledFiles);
+  OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
 
 TEST_F(OrderByTest, spillWithMemoryLimit) {
@@ -506,5 +508,6 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
 
     auto stats = task->taskStats().pipelineStats;
     ASSERT_EQ(testData.expectSpill, stats[0].operatorStats[1].spilledBytes > 0);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -299,10 +299,9 @@ class SpillTest : public testing::Test,
     // Both spilled bytes and files stats are cleared after merge read.
     EXPECT_EQ(0, state_->spilledBytes());
     EXPECT_EQ(0, state_->spilledFiles());
-    // Verify the spilled file has been removed from file system after spill
-    // state destruction.
-    for (const auto& spilledFile : spilledFiles) {
-      EXPECT_ANY_THROW(fs->openFileForRead(spilledFile));
+    // Verify the spilled files are still there after spill state destruction.
+    for (const auto& spilledFile : spilledFileSet) {
+      EXPECT_NO_THROW(fs->exists(spilledFile));
     }
     // Verify stats.
     ASSERT_EQ(stats_["spillFileSize"].count, spilledFiles.size());

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -219,10 +219,9 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     verifySortedSpillData(outputBatchSize);
 
     spiller_.reset();
-    // Verify the spilled file has been removed from file system after spiller
-    // destruction.
-    for (auto spilledFile : spilledFileSet) {
-      EXPECT_ANY_THROW(fs_->openFileForRead(spilledFile));
+    // Verify the spilled files are still there after spiller destruction.
+    for (const auto& spilledFile : spilledFileSet) {
+      EXPECT_NO_THROW(fs_->exists(spilledFile));
     }
   }
 

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -133,6 +133,10 @@ class OperatorTestBase : public testing::Test,
       RowTypePtr rowType,
       const parse::ParseOptions& options = {});
 
+ public:
+  static void deleteTaskAndCheckSpillDirectory(std::shared_ptr<Task>& task);
+
+ protected:
   DuckDbQueryRunner duckDbQueryRunner_;
 
   // Used as default MappedMemory. Created on first use.


### PR DESCRIPTION
Summary:
We have found that removing each spill file can overload the
FS backend and cause driver threads to get stuck for a considerable
amount of time.
This change also adds FileSystem::rmdir() member.

Differential Revision: D43202630

