### PR TITLE
Add total scan time stats for ReadFileInputStream

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -550,7 +550,10 @@ std::unordered_map<std::string, RuntimeCounter> HiveDataSource::runtimeStats() {
        {"numRamRead", RuntimeCounter(ioStats_->ramHit().count())},
        {"ramReadBytes",
         RuntimeCounter(
-            ioStats_->ramHit().bytes(), RuntimeCounter::Unit::kBytes)}});
+            ioStats_->ramHit().bytes(), RuntimeCounter::Unit::kBytes)},
+       {"totalScanTime",
+        RuntimeCounter(
+            ioStats_->totalScanTime(), RuntimeCounter::Unit::kNanos)}});
   return res;
 }
 

--- a/velox/docs/develop/debugging/print-plan-with-stats.rst
+++ b/velox/docs/develop/debugging/print-plan-with-stats.rst
@@ -132,6 +132,7 @@ Here is the output for the join query from above.
               skippedSplits             sum: 0, count: 1, min: 0, max: 0
               skippedStrides            sum: 0, count: 1, min: 0, max: 0
               storageReadBytes          sum: 150.25KB, count: 1, min: 150.25KB, max: 150.25KB
+              totalScanTime             sum: 0ns, count: 1, min: 0ns, max: 0ns
         -> Project[expressions: (u_c0:INTEGER, ROW["c0"]), (u_c1:BIGINT, ROW["c1"])]
            Output: 100 rows (1.31KB), Cpu time: 21.50us, Blocked wall time: 0ns, Peak memory: 0B, Threads: 1
           -> Values[100 rows in 1 vectors]
@@ -171,6 +172,7 @@ And this is the output for the aggregation query from above.
             skippedSplits              sum: 0, count: 1, min: 0, max: 0
             skippedStrides             sum: 0, count: 1, min: 0, max: 0
             storageReadBytes           sum: 61.53KB, count: 1, min: 61.53KB, max: 61.53KB
+            totalScanTime              sum: 0ns, count: 1, min: 0ns, max: 0ns
 
 Common operator statistics
 --------------------------
@@ -242,6 +244,7 @@ groups were skipped via stats-based pruning.
            skippedSplits             sum: 0, count: 1, min: 0, max: 0
            skippedStrides            sum: 0, count: 1, min: 0, max: 0
            storageReadBytes          sum: 150.25KB, count: 1, min: 150.25KB, max: 150.25KB
+           totalScanTime             sum: 0ns, count: 1, min: 0ns, max: 0ns
 
 HashBuild operator reports range and number of distinct values for the join keys.
 

--- a/velox/dwio/common/IoStatistics.cpp
+++ b/velox/dwio/common/IoStatistics.cpp
@@ -42,6 +42,10 @@ uint64_t IoStatistics::outputBatchSize() const {
   return outputBatchSize_.load(std::memory_order_relaxed);
 }
 
+uint64_t IoStatistics::totalScanTime() const {
+  return totalScanTime_.load(std::memory_order_relaxed);
+}
+
 uint64_t IoStatistics::incRawBytesRead(int64_t v) {
   return rawBytesRead_.fetch_add(v, std::memory_order_relaxed);
 }
@@ -60,6 +64,10 @@ uint64_t IoStatistics::incOutputBatchSize(int64_t v) {
 
 uint64_t IoStatistics::incRawOverreadBytes(int64_t v) {
   return rawOverreadBytes_.fetch_add(v, std::memory_order_relaxed);
+}
+
+uint64_t IoStatistics::incTotalScanTime(int64_t v) {
+  return totalScanTime_.fetch_add(v, std::memory_order_relaxed);
 }
 
 void IoStatistics::incOperationCounters(
@@ -89,6 +97,7 @@ IoStatistics::operationStats() const {
 void IoStatistics::merge(const IoStatistics& other) {
   rawBytesRead_ += other.rawBytesRead_;
   rawBytesWritten_ += other.rawBytesWritten_;
+  totalScanTime_ += other.totalScanTime_;
 
   rawOverreadBytes_ += other.rawOverreadBytes_;
   prefetch_.merge(other.prefetch_);

--- a/velox/dwio/common/IoStatistics.h
+++ b/velox/dwio/common/IoStatistics.h
@@ -70,12 +70,14 @@ class IoStatistics {
   uint64_t rawBytesWritten() const;
   uint64_t inputBatchSize() const;
   uint64_t outputBatchSize() const;
+  uint64_t totalScanTime() const;
 
   uint64_t incRawBytesRead(int64_t);
   uint64_t incRawOverreadBytes(int64_t);
   uint64_t incRawBytesWritten(int64_t);
   uint64_t incInputBatchSize(int64_t);
   uint64_t incOutputBatchSize(int64_t);
+  uint64_t incTotalScanTime(int64_t);
 
   IoCounter& prefetch() {
     return prefetch_;
@@ -118,6 +120,7 @@ class IoStatistics {
   std::atomic<uint64_t> inputBatchSize_{0};
   std::atomic<uint64_t> outputBatchSize_{0};
   std::atomic<uint64_t> rawOverreadBytes_{0};
+  std::atomic<uint64_t> totalScanTime_{0};
 
   // Planned read from storage or SSD.
   IoCounter prefetch_;

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -189,6 +189,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          skippedSplits       [ ]* sum: 0, count: 1, min: 0, max: 0"},
        {"          skippedStrides      [ ]* sum: 0, count: 1, min: 0, max: 0"},
        {"          storageReadBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"          totalScanTime       [ ]* sum: .+, count: .+, min: .+, max: .+"},
        {"    -- Project\\[expressions: \\(u_c0:INTEGER, ROW\\[\"c0\"\\]\\), \\(u_c1:BIGINT, ROW\\[\"c1\"\\]\\)\\] -> u_c0:INTEGER, u_c1:BIGINT"},
        {"       Output: 100 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: 0B, Memory allocations: .+, Threads: 1"},
        {"      -- Values\\[100 rows in 1 vectors\\] -> c0:INTEGER, c1:BIGINT"},
@@ -258,6 +259,7 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        skippedSplitBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
          {"        skippedSplits    [ ]* sum: 0, count: 1, min: 0, max: 0"},
          {"        skippedStrides   [ ]* sum: 0, count: 1, min: 0, max: 0"},
-         {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"}});
+         {"        storageReadBytes [ ]* sum: .+, count: 1, min: .+, max: .+"},
+         {"        totalScanTime    [ ]* sum: .+, count: .+, min: .+, max: .+"}});
   }
 }


### PR DESCRIPTION
Summary:
Add totalScanTime_ stats for ReadFileInputStream when read from external system, reflect different ReadFile performance, similar to rawBytesRead_.

Partially fixed #4018 