### PR TITLE
Add bloom_filter_agg Spark aggregate function

### DIFF
--- a/velox/common/base/BloomFilter.h
+++ b/velox/common/base/BloomFilter.h
@@ -81,13 +81,13 @@ class BloomFilter {
     bits::orBits(bits_.data(), bitsdata, 0, 64 * size);
   }
 
-  uint32_t serializedSize() {
+  uint32_t serializedSize() const {
     return 1 /* version */
         + 4 /* number of bits */
         + bits_.size() * 8;
   }
 
-  void serialize(char* output) {
+  void serialize(char* output) const {
     common::OutputByteStream stream(output);
     stream.appendOne(kBloomFilterV1);
     stream.appendOne((int32_t)bits_.size());

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -11,33 +11,34 @@ General Aggregate Functions
 
     Returns the bitwise XOR of all non-null input values, or null if none.
 
-.. spark:function:: bloom_filter_agg(x, estimatedNumItems, numBits) -> varbinary
+.. spark:function:: bloom_filter_agg(hash, estimatedNumItems, numBits) -> varbinary
 
-    Creates bloom filter from values of hashed value 'x' and returns it serialized into VARBINARY.
-    ``estimatedNumItems`` and ``numBits`` decides the number of hash functions and bloom filter capacity in Spark.
-    Current bloom filter implementation is different with Spark, if specified ``numBits``, ``estimatedNumItems``
-    will not be used.
+    Creates bloom filter from input hashes and returns it serialized into VARBINARY.
+    The caller is expected to apply xxhash64 function to input data before calling bloom_filter_agg.
+    For example, 
+        bloom_filter_agg(xxhash64(x), 100, 1024)   
+    In Spark implementation, ``estimatedNumItems`` and ``numBits`` are used to decide the number of hash functions and bloom filter capacity.
+    In Velox implementation, ``estimatedNumItems`` is not used.
 
-    ``x`` should be xxhash64(``y``).
-    ``estimatedNumItems`` provides an estimate of the number of values of ``y``, which takes no effect here.
+    ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
-    Value of numBits in Spark is capped at 67,108,864, actually is capped at 716,800 in case of class memory limit .
+    In Spark,  the value of``numBits`` is automatically capped at 67,108,864.
+    In Velxo, the value of``numBits`` is automatically capped at 716,800.
 
-    ``x``, ``estimatedNumItems`` and ``numBits`` must be ``bigint``.
+    ``x``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
-.. spark:function:: bloom_filter_agg(x, estimatedNumItems) -> varbinary
+.. spark:function:: bloom_filter_agg(hash, estimatedNumItems) -> varbinary
 
     As ``bloom_filter_agg``.
-
-    ``x`` should be xxhash64(``y``).
+    ``hash`` cannot be null.
     ``estimatedNumItems`` provides an estimate of the number of values of ``y``.
     Value of estimatedNumItems is capped at 4,000,000.
     Default numBits = estimatedNumItems * 8. 
 
-.. spark:function:: bloom_filter_agg(x) -> varbinary
+.. spark:function:: bloom_filter_agg(hash) -> varbinary
     
     As ``bloom_filter_agg``.
-    ``x`` should be xxhash64(``y``).
+    ``hash`` cannot be null.
     Default estimatedNumItems = 1,000,000.
     Default numBits in spark is estimatedNumItems * 8 = 8,000,000, here is max value 716,800.
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -15,32 +15,32 @@ General Aggregate Functions
 
     Creates bloom filter from input hashes and returns it serialized into VARBINARY.
     The caller is expected to apply xxhash64 function to input data before calling bloom_filter_agg.
+
     For example, 
-        bloom_filter_agg(xxhash64(x), 100, 1024)   
+        bloom_filter_agg(xxhash64(x), 100, 1024)
     In Spark implementation, ``estimatedNumItems`` and ``numBits`` are used to decide the number of hash functions and bloom filter capacity.
     In Velox implementation, ``estimatedNumItems`` is not used.
 
     ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
-    In Spark,  the value of``numBits`` is automatically capped at 67,108,864.
-    In Velxo, the value of``numBits`` is automatically capped at 716,800.
+    In Spark, the value of ``numBits`` is automatically capped at 67,108,864.
+    In Velox, the value of ``numBits`` is automatically capped at 4,194,304.
 
-    ``x``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
+    ``hash``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
 .. spark:function:: bloom_filter_agg(hash, estimatedNumItems) -> varbinary
 
-    As ``bloom_filter_agg``.
+    A version of ``bloom_filter_agg`` that uses ``numBits`` computed as ``estimatedNumItems`` * 8.
+
     ``hash`` cannot be null.
-    ``estimatedNumItems`` provides an estimate of the number of values of ``y``.
-    Value of estimatedNumItems is capped at 4,000,000.
-    Default numBits = estimatedNumItems * 8. 
+    ``estimatedNumItems`` provides an estimate of the number of values of ``x`` under the assuption of ``hash`` is xxhash64(x),.
+    Value of ``estimatedNumItems`` is capped at 4,000,000 like to match Spark's implementation.
 
 .. spark:function:: bloom_filter_agg(hash) -> varbinary
     
-    As ``bloom_filter_agg``.
+    A version of ``bloom_filter_agg`` that use 4,194,304 as ``numBits``.
+
     ``hash`` cannot be null.
-    Default estimatedNumItems = 1,000,000.
-    Default numBits in spark is estimatedNumItems * 8 = 8,000,000, here is max value 716,800.
 
 .. spark:function:: first(x) -> x
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -23,8 +23,8 @@ General Aggregate Functions
 
     ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
-    In Spark, the value of ``numBits`` is automatically capped at 67,108,864.
-    In Velox, the value of ``numBits`` is automatically capped at 4,194,304.
+    In Spark, the value of ``numBits`` is automatically capped at config value 67,108,864.
+    In Velox, the value of ``numBits`` is automatically capped at fixed value 4,194,304.
 
     ``hash``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
@@ -33,8 +33,9 @@ General Aggregate Functions
     A version of ``bloom_filter_agg`` that uses ``numBits`` computed as ``estimatedNumItems`` * 8.
 
     ``hash`` cannot be null.
-    ``estimatedNumItems`` provides an estimate of the number of values of ``x`` under the assuption of ``hash`` is xxhash64(x),.
+    ``estimatedNumItems`` provides an estimate of the number of values of ``x`` under the fact of ``hash`` is xxhash64(x).
     Value of ``estimatedNumItems`` is capped at 4,000,000 like to match Spark's implementation.
+    But Spark allows for changing the defaults while Velox does not.
 
 .. spark:function:: bloom_filter_agg(hash) -> varbinary
     

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -11,6 +11,36 @@ General Aggregate Functions
 
     Returns the bitwise XOR of all non-null input values, or null if none.
 
+.. spark:function:: bloom_filter_agg(x, estimatedNumItems, numBits) -> varbinary
+
+    Creates bloom filter from values of hashed value 'x' and returns it serialized into VARBINARY.
+    ``estimatedNumItems`` and ``numBits`` decides the number of hash functions and bloom filter capacity in Spark.
+    Current bloom filter implementation is different with Spark, if specified ``numBits``, ``estimatedNumItems``
+    will not be used.
+
+    ``x`` should be xxhash64(``y``).
+    ``estimatedNumItems`` provides an estimate of the number of values of ``y``, which takes no effect here.
+    ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
+    Value of numBits in Spark is capped at 67,108,864, actually is capped at 716,800 in case of class memory limit .
+
+    ``x``, ``estimatedNumItems`` and ``numBits`` must be ``bigint``.
+
+.. spark:function:: bloom_filter_agg(x, estimatedNumItems) -> varbinary
+
+    As ``bloom_filter_agg``.
+
+    ``x`` should be xxhash64(``y``).
+    ``estimatedNumItems`` provides an estimate of the number of values of ``y``.
+    Value of estimatedNumItems is capped at 4,000,000.
+    Default numBits = estimatedNumItems * 8. 
+
+.. spark:function:: bloom_filter_agg(x) -> varbinary
+    
+    As ``bloom_filter_agg``.
+    ``x`` should be xxhash64(``y``).
+    Default estimatedNumItems = 1,000,000.
+    Default numBits in spark is estimatedNumItems * 8 = 8,000,000, here is max value 716,800.
+
 .. spark:function:: first(x) -> x
 
     Returns the first value of `x`.

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -47,8 +47,9 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
 
   // TODO: List of the functions that at some point crash or fail and need to
-  // be fixed before we can enable.
-  std::unordered_set<std::string> skipFunctions = {};
+  // be fixed before we can enable. Constant argument of bloom_filter_agg cause
+  // fuzzer test fail.
+  std::unordered_set<std::string> skipFunctions = {"bloom_filter_agg"};
 
   // The results of the following functions depend on the order of input
   // rows. For some functions, the result can be transformed to a value that

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -86,7 +86,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       const std::vector<VectorPtr>& args,
       bool /*mayPushdown*/) override {
     decodeArguments(rows, args);
-
     rows.applyToSelected([&](vector_size_t row) {
       VELOX_USER_CHECK(
           !decodedRaw_.isNullAt(row),
@@ -180,7 +179,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       }
 
       auto size = accumulator->serializedSize();
-      VELOX_DCHECK_GT(size, StringView::kInlineSize);
+      VELOX_DCHECK(!StringView::isInline(size));
       accumulator->serialize(bufferPtr);
       StringView serialized = StringView(bufferPtr, size);
       bufferPtr += size;
@@ -240,7 +239,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       }
 
       auto size = accumulator->serializedSize();
-      VELOX_DCHECK_GT(size, StringView::kInlineSize);
+      VELOX_DCHECK(!StringView::isInline(size));
       totalSize += size;
     }
     return totalSize;

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -206,14 +206,14 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     if (args.size() > 1) {
       DecodedVector decodedEstimatedNumItems(*args[1], rows);
       setConstantArgument(
-          "originalEstimatedNumItems",
+          "estimatedNumItems",
           originalEstimatedNumItems_,
           decodedEstimatedNumItems);
       if (args.size() > 2) {
         VELOX_CHECK_EQ(args.size(), 3);
         DecodedVector decodedNumBits(*args[2], rows);
         setConstantArgument(
-            "originalNumBits", originalNumBits_, decodedNumBits);
+            "numBits", originalNumBits_, decodedNumBits);
       } else {
         originalNumBits_ = originalEstimatedNumItems_ * 8;
       }

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
+
+#include "velox/common/base/BloomFilter.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+namespace {
+
+struct BloomFilterAccumulator {
+  explicit BloomFilterAccumulator(HashStringAllocator* allocator)
+      : bloomFilter{StlAllocator<uint64_t>(allocator)} {}
+
+  int32_t serializedSize() const {
+    return bloomFilter.serializedSize();
+  }
+
+  void serialize(char* output) const {
+    return bloomFilter.serialize(output);
+  }
+
+  void mergeWith(StringView& serialized) {
+    bloomFilter.merge(serialized.data());
+  }
+
+  bool initialized() {
+    return bloomFilter.isSet();
+  }
+
+  void init(int32_t capacity) {
+    if (!bloomFilter.isSet()) {
+      bloomFilter.reset(capacity);
+    }
+  }
+
+  void insert(int64_t value) {
+    bloomFilter.insert(folly::hasher<int64_t>()(value));
+  }
+
+  BloomFilter<StlAllocator<uint64_t>> bloomFilter;
+}; // namespace
+
+class BloomFilterAggAggregate : public exec::Aggregate {
+ public:
+  explicit BloomFilterAggAggregate(const TypePtr& resultType)
+      : Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(BloomFilterAccumulator);
+  }
+
+  bool isFixedSize() const override {
+    return false;
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) BloomFilterAccumulator(allocator_);
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodeArguments(rows, args);
+    VELOX_USER_CHECK(
+        !decodedRaw_.mayHaveNulls(), "First argument value should not be null");
+    rows.applyToSelected([&](vector_size_t row) {
+      auto group = groups[row];
+      auto tracker = trackRowSize(group);
+      auto accumulator = value<BloomFilterAccumulator>(group);
+      accumulator->init(capacity_);
+      accumulator->insert(decodedRaw_.valueAt<int64_t>(row));
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    decodedIntermediate_.decode(*args[0], rows);
+    rows.applyToSelected([&](auto row) {
+      if (UNLIKELY(decodedIntermediate_.isNullAt(row))) {
+        return;
+      }
+      auto group = groups[row];
+      auto tracker = trackRowSize(group);
+      auto serialized = decodedIntermediate_.valueAt<StringView>(row);
+      auto accumulator = value<BloomFilterAccumulator>(group);
+      accumulator->mergeWith(serialized);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    decodeArguments(rows, args);
+    auto tracker = trackRowSize(group);
+    auto accumulator = value<BloomFilterAccumulator>(group);
+    VELOX_USER_CHECK(
+        !decodedRaw_.mayHaveNulls(), "First argument value should not be null");
+    accumulator->init(capacity_);
+    if (decodedRaw_.isConstantMapping()) {
+      // All values are same, just do for the first.
+      accumulator->insert(decodedRaw_.valueAt<int64_t>(0));
+      return;
+    }
+    rows.applyToSelected([&](vector_size_t row) {
+      accumulator->insert(decodedRaw_.valueAt<int64_t>(row));
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    decodedIntermediate_.decode(*args[0], rows);
+    auto tracker = trackRowSize(group);
+    auto accumulator = value<BloomFilterAccumulator>(group);
+    rows.applyToSelected([&](auto row) {
+      if (UNLIKELY(decodedIntermediate_.isNullAt(row))) {
+        return;
+      }
+      auto serialized = decodedIntermediate_.valueAt<StringView>(row);
+      accumulator->mergeWith(serialized);
+    });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK(result);
+    auto flatResult = (*result)->asUnchecked<FlatVector<StringView>>();
+    flatResult->resize(numGroups);
+    int32_t totalSize = getTotalSize(groups, numGroups);
+    Buffer* buffer = flatResult->getBufferWithSpace(totalSize);
+    for (vector_size_t i = 0; i < numGroups; ++i) {
+      auto group = groups[i];
+      auto accumulator = value<BloomFilterAccumulator>(group);
+      if (UNLIKELY(!accumulator->initialized())) {
+        flatResult->setNull(i, true);
+        continue;
+      }
+
+      auto size = accumulator->serializedSize();
+      StringView serialized;
+      if (StringView::isInline(size)) {
+        std::string buffer(size, '\0');
+        accumulator->serialize(buffer.data());
+        serialized = StringView::makeInline(buffer);
+      } else {
+        char* ptr = buffer->asMutable<char>() + buffer->size();
+        accumulator->serialize(ptr);
+        buffer->setSize(buffer->size() + size);
+        serialized = StringView(ptr, size);
+      }
+      flatResult->setNoCopy(i, serialized);
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    extractValues(groups, numGroups, result);
+  }
+
+ private:
+  const int64_t kDefaultExpectedNumItems = 1'000'000;
+  const int64_t kMaxNumItems = 4'000'000;
+  // Spark kMaxNumBits is 67108864, but velox has memory limit sizeClassSizes
+  // 256, so decrease it to not over memory limit.
+  const int64_t kMaxNumBits = 700 * 1024;
+
+  void decodeArguments(
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
+    VELOX_USER_CHECK(args.size() > 0);
+    decodedRaw_.decode(*args[0], rows);
+    if (args.size() > 1) {
+      DecodedVector decodedEstimatedNumItems(*args[1], rows);
+      setConstantArgument(
+          "originalEstimatedNumItems",
+          originalEstimatedNumItems_,
+          decodedEstimatedNumItems);
+      if (args.size() > 2) {
+        VELOX_CHECK_EQ(args.size(), 3);
+        DecodedVector decodedNumBits(*args[2], rows);
+        setConstantArgument(
+            "originalNumBits", originalNumBits_, decodedNumBits);
+      } else {
+        originalNumBits_ = originalEstimatedNumItems_ * 8;
+      }
+    } else {
+      originalEstimatedNumItems_ = kDefaultExpectedNumItems;
+      originalNumBits_ = originalEstimatedNumItems_ * 8;
+    }
+
+    estimatedNumItems_ = std::min(originalEstimatedNumItems_, kMaxNumItems);
+    numBits_ = std::min(originalNumBits_, kMaxNumBits);
+    capacity_ = numBits_ / 16;
+  }
+
+  int32_t getTotalSize(char** groups, int32_t numGroups) const {
+    int32_t totalSize = 0;
+    for (vector_size_t i = 0; i < numGroups; ++i) {
+      auto group = groups[i];
+      auto accumulator = value<BloomFilterAccumulator>(group);
+      if (UNLIKELY(!accumulator->initialized())) {
+        continue;
+      }
+
+      auto size = accumulator->serializedSize();
+      if (StringView::isInline(size)) {
+        continue;
+      }
+      totalSize += size;
+    }
+    return totalSize;
+  }
+
+  static void setConstantArgument(
+      const char* name,
+      int64_t& currentValue,
+      const DecodedVector& vec) {
+    VELOX_CHECK(
+        vec.isConstantMapping(),
+        "{} argument must be constant for all input rows",
+        name);
+    int64_t newValue = vec.valueAt<int64_t>(0);
+    VELOX_USER_CHECK_GT(newValue, 0, "{} must be positive", name);
+    if (currentValue == kMissingArgument) {
+      currentValue = newValue;
+    } else {
+      VELOX_USER_CHECK_EQ(
+          newValue,
+          currentValue,
+          "{} argument must be constant for all input rows",
+          name);
+    }
+  }
+
+  static constexpr int64_t kMissingArgument = -1;
+  // Reusable instance of DecodedVector for decoding input vectors.
+  DecodedVector decodedRaw_;
+  DecodedVector decodedIntermediate_;
+  int64_t originalEstimatedNumItems_ = kMissingArgument;
+  int64_t originalNumBits_ = kMissingArgument;
+  int64_t estimatedNumItems_ = kMissingArgument;
+  int64_t numBits_ = kMissingArgument;
+  int32_t capacity_ = kMissingArgument;
+};
+
+} // namespace
+
+bool registerBloomFilterAggAggregate(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .argumentType("bigint")
+          .constantArgumentType("bigint")
+          .constantArgumentType("bigint")
+          .intermediateType("varbinary")
+          .returnType("varbinary")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .argumentType("bigint")
+          .constantArgumentType("bigint")
+          .intermediateType("varbinary")
+          .returnType("varbinary")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .argumentType("bigint")
+          .intermediateType("varbinary")
+          .returnType("varbinary")
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<BloomFilterAggAggregate>(resultType);
+      });
+}
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -221,7 +221,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
   void computeCapacity() {
     if (capacity_ == kMissingArgument) {
-      int64_t estimatedNumItems = std::min(estimatedNumItems_, kMaxNumItems);
+      // For further use
+      // int64_t estimatedNumItems = std::min(estimatedNumItems_, kMaxNumItems);
       int64_t numBits = std::min(numBits_, kMaxNumBits);
       capacity_ = numBits / 16;
     }
@@ -229,7 +230,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
   int32_t getTotalSize(char** groups, int32_t numGroups) const {
     int32_t totalSize = 0;
-    int32_t inlineSize = 0;
     for (vector_size_t i = 0; i < numGroups; ++i) {
       auto group = groups[i];
       auto accumulator = value<BloomFilterAccumulator>(group);
@@ -301,8 +301,8 @@ bool registerBloomFilterAggAggregate(const std::string& name) {
       name,
       std::move(signatures),
       [name](
-          core::AggregationNode::Step step,
-          const std::vector<TypePtr>& argTypes,
+          core::AggregationNode::Step /* step */,
+          const std::vector<TypePtr>& /* argTypes */,
           const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<BloomFilterAggAggregate>(resultType);
       });

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -221,7 +221,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
   void computeCapacity() {
     if (capacity_ == kMissingArgument) {
-      int64_t estimatedNumItems_ = std::min(estimatedNumItems_, kMaxNumItems);
+      int64_t estimatedNumItems = std::min(estimatedNumItems_, kMaxNumItems);
       int64_t numBits = std::min(numBits_, kMaxNumBits);
       capacity_ = numBits / 16;
     }

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -221,7 +221,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
   void computeCapacity() {
     if (capacity_ == kMissingArgument) {
-      // For further use
+      // For further use, used after spark BloomFilter implementation.
       // int64_t estimatedNumItems = std::min(estimatedNumItems_, kMaxNumItems);
       int64_t numBits = std::min(numBits_, kMaxNumBits);
       capacity_ = numBits / 16;
@@ -276,7 +276,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
 } // namespace
 
-bool registerBloomFilterAggAggregate(const std::string& name) {
+exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
+    const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .argumentType("bigint")

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -22,4 +22,4 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 bool registerBloomFilterAggAggregate(const std::string& name);
 
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -18,8 +18,11 @@
 
 #include <string>
 
+#include "velox/exec/AggregateUtil.h"
+
 namespace facebook::velox::functions::aggregate::sparksql {
 
-bool registerBloomFilterAggAggregate(const std::string& name);
+exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
+    const std::string& name);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -14,18 +14,12 @@
  * limitations under the License.
  */
 
-#include "velox/functions/sparksql/aggregates/Register.h"
+#pragma once
 
-#include "velox/functions/sparksql/aggregates/BitwiseXorAggregate.h"
-#include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
+#include <string>
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-extern void registerFirstLastAggregates(const std::string& prefix);
+bool registerBloomFilterAggAggregate(const std::string& name);
 
-void registerAggregateFunctions(const std::string& prefix) {
-  registerFirstLastAggregates(prefix);
-  registerBitwiseXorAggregate(prefix);
-  registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
-}
-} // namespace facebook::velox::functions::aggregate::sparksql
+} // namespace facebook::velox::functions::sparksql::aggregates

--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -11,8 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_functions_spark_aggregates
-            BitwiseXorAggregate.cpp FirstLastAggregate.cpp Register.cpp)
+add_library(
+  velox_functions_spark_aggregates
+  BitwiseXorAggregate.cpp BloomFilterAggAggregate.cpp FirstLastAggregate.cpp
+  Register.cpp)
 
 target_link_libraries(velox_functions_spark_aggregates fmt::fmt velox_exec
                       velox_expression_functions velox_aggregates velox_vector)

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -63,8 +63,8 @@ TEST_F(BloomFilterAggAggregateTest, bloomFilterAggArgument) {
   auto expected1 = {
       makeRowVector({makeConstant<StringView>(StringView(bloomFilter1), 1)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 6)"}, expected1);
-
-  auto bloomFilter2 = getSerializedBloomFilter(44800);
+  // This capacity is kMaxNumBits / 16.
+  auto bloomFilter2 = getSerializedBloomFilter(262144);
   auto expected2 = {
       makeRowVector({makeConstant<StringView>(StringView(bloomFilter2), 1)})};
   testAggregations(vectors, {}, {"bloom_filter_agg(c0)"}, expected2);

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -84,6 +84,6 @@ TEST_F(BloomFilterAggAggregateTest, nullBloomFilter) {
   VELOX_ASSERT_THROW(
       testAggregations(
           vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expectedFake),
-      "First argument value should not be null");
+      "First argument of bloom_filter_agg cannot be null");
 }
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/BloomFilter.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+namespace {
+class BloomFilterAggAggregateTest
+    : public aggregate::test::AggregationTestBase {
+ public:
+  BloomFilterAggAggregateTest() {
+    AggregationTestBase::SetUp();
+    registerAggregateFunctions("");
+    allowInputShuffle();
+  }
+
+  std::string getSerializedBloomFilter(int32_t capacity) {
+    BloomFilter bloomFilter;
+    bloomFilter.reset(capacity);
+    for (auto i = 0; i < 9; ++i) {
+      bloomFilter.insert(folly::hasher<int64_t>()(i));
+    }
+    std::string data;
+    data.resize(bloomFilter.serializedSize());
+    bloomFilter.serialize(data.data());
+    return data;
+  }
+};
+} // namespace
+
+TEST_F(BloomFilterAggAggregateTest, basic) {
+  auto vectors = {makeRowVector({makeFlatVector<int64_t>(
+      100, [](vector_size_t row) { return row % 9; })})};
+  auto bloomFilter = getSerializedBloomFilter(4);
+  auto expected = {makeRowVector({makeFlatVector<StringView>(
+      1, [&](vector_size_t row) { return StringView(bloomFilter); })})};
+
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
+}
+
+TEST_F(BloomFilterAggAggregateTest, bloomFilterAggArgument) {
+  auto vectors = {makeRowVector({makeFlatVector<int64_t>(
+      100, [](vector_size_t row) { return row % 9; })})};
+
+  auto bloomFilter1 = getSerializedBloomFilter(3);
+  auto expected1 = {
+      makeRowVector({makeConstant<StringView>(StringView(bloomFilter1), 1)})};
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0, 6)"}, expected1);
+
+  auto bloomFilter2 = getSerializedBloomFilter(44800);
+  auto expected2 = {
+      makeRowVector({makeConstant<StringView>(StringView(bloomFilter2), 1)})};
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0)"}, expected2);
+}
+
+TEST_F(BloomFilterAggAggregateTest, emptyInput) {
+  auto vectors = {makeRowVector({makeFlatVector<int64_t>({})})};
+  auto expected = {makeRowVector(
+      {makeNullableFlatVector<StringView>({std::nullopt}, VARBINARY())})};
+  testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
+}
+
+TEST_F(BloomFilterAggAggregateTest, nullBloomFilter) {
+  auto vectors = {makeRowVector({makeAllNullFlatVector<int64_t>(2)})};
+  auto expectedFake = {makeRowVector(
+      {makeNullableFlatVector<StringView>({std::nullopt}, VARBINARY())})};
+  VELOX_ASSERT_THROW(
+      testAggregations(
+          vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expectedFake),
+      "First argument value should not be null");
+}
+} // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -49,8 +49,8 @@ TEST_F(BloomFilterAggAggregateTest, basic) {
   auto vectors = {makeRowVector({makeFlatVector<int64_t>(
       100, [](vector_size_t row) { return row % 9; })})};
   auto bloomFilter = getSerializedBloomFilter(4);
-  auto expected = {makeRowVector({makeFlatVector<StringView>(
-      1, [&](vector_size_t row) { return StringView(bloomFilter); })})};
+  auto expected = {
+      makeRowVector({makeConstant<StringView>(StringView(bloomFilter), 1)})};
 
   testAggregations(vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expected);
 }

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -14,8 +14,8 @@
 
 add_executable(
   velox_functions_spark_aggregates_test
-  BitwiseXorAggregationTest.cpp FirstAggregateTest.cpp LastAggregateTest.cpp
-  Main.cpp)
+  BitwiseXorAggregationTest.cpp BloomFilterAggAggregateTest.cpp
+  FirstAggregateTest.cpp LastAggregateTest.cpp Main.cpp)
 
 add_test(velox_functions_spark_aggregates_test
          velox_functions_spark_aggregates_test)


### PR DESCRIPTION
This function is used in Spark Runtime Filters: https://github.com/apache/spark/pull/35789

https://docs.google.com/document/d/16IEuyLeQlubQkH8YuVuXWKo2-grVIoDJqQpHZrE7q04/edit#heading=h.4v65wq7vzy4q

BloomFilter implementation in Velox is different from Spark, hence, serialized BloomFilter is different.

Velox has memory limit for contiguous memory buffer, hence BloomFilter capacity is less than in Spark when numBits is large. See https://github.com/facebookincubator/velox/pull/4713#issuecomment-1521247959

Spark allows for changing the defaults while Velox does not.

See also #3342

Fixes #3694