### PR TITLE
Fix: Zip function signature.

### DIFF
--- a/velox/functions/prestosql/Zip.cpp
+++ b/velox/functions/prestosql/Zip.cpp
@@ -22,17 +22,6 @@
 namespace facebook::velox::functions {
 
 namespace {
-void validateInputTypes(const std::vector<VectorPtr>& inputArgs) {
-  VELOX_USER_CHECK_GT(
-      inputArgs.size(), 1, "zip requires at least two parameters");
-
-  for (auto& arg : inputArgs) {
-    VELOX_USER_CHECK_EQ(
-        arg->type()->kind(),
-        TypeKind::ARRAY,
-        "zip requires arguments of type ARRAY");
-  }
-}
 
 class ZipFunction : public exec::VectorFunction {
   static const auto kMinArity = 2;
@@ -67,7 +56,6 @@ class ZipFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
-    validateInputTypes(args);
     const vector_size_t numInputArrays = args.size();
 
     exec::DecodedArgs decodedArgs(rows, args, context);
@@ -253,7 +241,7 @@ class ZipFunction : public exec::VectorFunction {
     }
 
     // Build all signatures from kMinArity to kMaxArity.
-    for (int i = 0; i < kAritySize; i++) {
+    for (int i = 1; i < kAritySize; i++) {
       auto builder = exec::FunctionSignatureBuilder();
       std::vector<std::string> allTypeVars;
       allTypeVars.reserve(i + 1);

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -416,4 +416,19 @@ TEST_F(ZipTest, flatArraysWithGapInElements) {
 
   assertEqualVectors(expected, result);
 }
+
+// Single arg not supported.
+TEST_F(ZipTest, singleArgument) {
+  auto vector = makeNullableArrayVector<int64_t>(
+      {{1, 2, 3, 4}, {3, 4, 5}, {std::nullopt}});
+  assertUserInvalidArgument(
+      [&]() { evaluate<ArrayVector>("zip(c0)", makeRowVector({vector})); },
+      "Scalar function signature is not supported: zip(ARRAY<BIGINT>). Supported signatures: "
+      "(array(E00),array(E01)) -> array(row(E00,E01)), (array(E00),array(E01),array(E02)) -> "
+      "array(row(E00,E01,E02)), (array(E00),array(E01),array(E02),array(E03)) -> array(row(E0"
+      "0,E01,E02,E03)), (array(E00),array(E01),array(E02),array(E03),array(E04)) -> array(row"
+      "(E00,E01,E02,E03,E04)), (array(E00),array(E01),array(E02),array(E03),array(E04),array("
+      "E05)) -> array(row(E00,E01,E02,E03,E04,E05))");
+}
+
 } // namespace


### PR DESCRIPTION
Summary:
- Zip not support single arg.
- Remove exception throws from the zip function that does not go throw context.setError

Reviewed By: kgpai

Differential Revision: D43244335

