### PR TITLE
Generalize acquireSharedStringBuffers logic

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -359,7 +359,6 @@ class SimpleFunctionAdapter : public VectorFunction {
     auto reuseStringsFromArg = reuseStringsFromArgValue();
     if (reuseStringsFromArg >= 0) {
       VELOX_CHECK_LT(reuseStringsFromArg, args.size());
-      VELOX_CHECK_EQ(args[reuseStringsFromArg]->typeKind(), TypeKind::VARCHAR);
       if (decoded.size() == 0 || !decoded.at(reuseStringsFromArg).has_value()) {
         // If we're here, we're guaranteed the argument is either a Flat
         // or Constant vector so no decoding is necessary.
@@ -380,7 +379,7 @@ class SimpleFunctionAdapter : public VectorFunction {
   void tryAcquireStringBuffer(BaseVector* vector, const BaseVector* source)
       const {
     if (auto* flatVector = vector->asFlatVector<StringView>()) {
-      flatVector->acquireSharedStringBuffers(source);
+      flatVector->acquireSharedStringBuffersRecursive(source);
     } else if (auto* arrayVector = vector->as<ArrayVector>()) {
       tryAcquireStringBuffer(arrayVector->elements().get(), source);
     } else if (auto* mapVector = vector->as<MapVector>()) {

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/vector/FlatVector.h"
+#include "velox/vector/ComplexVector.h"
 #include "velox/vector/ConstantVector.h"
 #include "velox/vector/TypeAliases.h"
 
@@ -286,22 +287,25 @@ void FlatVector<StringView>::setNoCopy(
 template <>
 void FlatVector<StringView>::acquireSharedStringBuffers(
     const BaseVector* source) {
-  auto leaf = source->wrappedVector();
-  if (leaf->typeKind() == TypeKind::UNKNOWN) {
-    // If the source is all nulls, it can be of unknown type.
+  if (!source) {
     return;
   }
-  switch (leaf->encoding()) {
+  if (source->typeKind() != TypeKind::VARBINARY &&
+      source->typeKind() != TypeKind::VARCHAR) {
+    return;
+  }
+  source = source->wrappedVector();
+  switch (source->encoding()) {
     case VectorEncoding::Simple::FLAT: {
-      auto* flat = leaf->asUnchecked<FlatVector<StringView>>();
+      auto* flat = source->asUnchecked<FlatVector<StringView>>();
       for (auto& buffer : flat->stringBuffers_) {
         addStringBuffer(buffer);
       }
       break;
     }
     case VectorEncoding::Simple::CONSTANT: {
-      if (!leaf->isNullAt(0)) {
-        auto* constant = leaf->asUnchecked<ConstantVector<StringView>>();
+      if (!source->isNullAt(0)) {
+        auto* constant = source->asUnchecked<ConstantVector<StringView>>();
         auto buffer = constant->getStringBuffer();
         if (buffer != nullptr) {
           addStringBuffer(buffer);
@@ -311,9 +315,83 @@ void FlatVector<StringView>::acquireSharedStringBuffers(
     }
 
     default:
-      VELOX_CHECK(
-          false,
-          "Assigning a non-flat, non-constant vector to a string vector");
+      VELOX_UNREACHABLE(
+          "unexpected encoding inside acquireSharedStringBuffers: {}",
+          source->toString());
+  }
+}
+
+template <>
+void FlatVector<StringView>::acquireSharedStringBuffersRecursive(
+    const BaseVector* source) {
+  if (!source) {
+    return;
+  }
+  source = source->wrappedVector();
+
+  switch (source->encoding()) {
+    case VectorEncoding::Simple::FLAT: {
+      if (source->typeKind() != TypeKind::VARCHAR &&
+          source->typeKind() != TypeKind::VARBINARY) {
+        // Nothing to acquire.
+        return;
+      }
+      auto* flat = source->asUnchecked<FlatVector<StringView>>();
+      for (auto& buffer : flat->stringBuffers_) {
+        addStringBuffer(buffer);
+      }
+      return;
+    }
+
+    case VectorEncoding::Simple::ARRAY: {
+      acquireSharedStringBuffersRecursive(
+          source->asUnchecked<ArrayVector>()->elements().get());
+      return;
+    }
+
+    case VectorEncoding::Simple::MAP: {
+      acquireSharedStringBuffersRecursive(
+          source->asUnchecked<MapVector>()->mapKeys().get());
+      acquireSharedStringBuffersRecursive(
+          source->asUnchecked<MapVector>()->mapValues().get());
+      return;
+    }
+
+    case VectorEncoding::Simple::ROW: {
+      for (auto& child : source->asUnchecked<RowVector>()->children()) {
+        acquireSharedStringBuffersRecursive(child.get());
+      }
+      return;
+    }
+
+    case VectorEncoding::Simple::CONSTANT: {
+      // wrappedVector can be constant vector only if the underlying type is
+      // primitive.
+      if (source->typeKind() != TypeKind::VARCHAR &&
+          source->typeKind() != TypeKind::VARBINARY) {
+        // Nothing to acquire.
+        return;
+      }
+      auto* constantVector = source->asUnchecked<ConstantVector<StringView>>();
+      if (constantVector->isNullAt(0)) {
+        return;
+      }
+      auto* constant = source->asUnchecked<ConstantVector<StringView>>();
+      auto buffer = constant->getStringBuffer();
+      if (buffer != nullptr) {
+        addStringBuffer(buffer);
+      }
+      return;
+    }
+
+    case VectorEncoding::Simple::LAZY:
+    case VectorEncoding::Simple::DICTIONARY:
+    case VectorEncoding::Simple::SEQUENCE:
+    case VectorEncoding::Simple::BIASED:
+    case VectorEncoding::Simple::FUNCTION:
+      VELOX_UNREACHABLE(
+          "unexpected encoding inside acquireSharedStringBuffersRecursive: {}",
+          source->toString());
   }
 }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -394,7 +394,14 @@ class FlatVector final : public SimpleVector<T> {
     return true;
   }
 
+  // Acquire ownership for any string buffer that appears in source, the
+  // function does nothing if the vector type is not Varchar or Varbinary.
+  // The function throws if input encoding is lazy.
   void acquireSharedStringBuffers(const BaseVector* source);
+
+  // Acquire ownership for any string buffer that appears in source or any
+  // of its children recursively. The function throws if input encoding is lazy.
+  void acquireSharedStringBuffersRecursive(const BaseVector* source);
 
   Buffer* getBufferWithSpace(vector_size_t /* unused */) {
     return nullptr;


### PR DESCRIPTION
Summary:
In the simple function interface we cant avoid copying strings from an a
string argument if its nested in complex structure.

For example: subscript for type Array<Varchar>
or an function that filters an array<Varchar> have to copy the strings.

Extending acquireSharedStringBuffers allow us to mitigate that.
The new logic is that
  acquireSharedStringBuffers(const BaseVector* source);
acquires ownership for any string buffer that appears in BaseVector.

Differential Revision: D42890518

