### PR TITLE
Pass children names when creating a row vector in velox fuzzer

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -215,7 +215,10 @@ class VectorFuzzer {
 
   // Returns a RowVector based on the provided vectors, fuzzing its top-level
   // null buffer.
-  RowVectorPtr fuzzRow(std::vector<VectorPtr>&& children, vector_size_t size);
+  RowVectorPtr fuzzRow(
+      std::vector<VectorPtr>&& children,
+      std::vector<std::string> childrenNames,
+      vector_size_t size);
 
   // Same as the function above, but never return nulls for the top-level row
   // elements.

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -405,7 +405,9 @@ TEST_F(VectorFuzzerTest, row) {
 
   // Composable API.
   vector = fuzzer.fuzzRow(
-      {fuzzer.fuzzFlat(REAL(), 100), fuzzer.fuzzFlat(BIGINT(), 100)}, 100);
+      {fuzzer.fuzzFlat(REAL(), 100), fuzzer.fuzzFlat(BIGINT(), 100)},
+      std::vector<std::string>{"", ""},
+      100);
   ASSERT_TRUE(vector->type()->kindEquals(ROW({REAL(), BIGINT()})));
   ASSERT_TRUE(vector->mayHaveNulls());
 }


### PR DESCRIPTION
Summary: velox fuzzer ignores the children names supplied by the row type, this diff is fixing the issue.

Differential Revision: D43241125

