### PR TITLE
Fetch source archive if cached artifact's built_marker is missing

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -688,7 +688,10 @@ class BuildCmd(ProjectCmdBase):
     ):
         reconfigure = False
         sources_changed = False
-        if not cached_project.download():
+        if cached_project.download():
+            if not os.path.exists(built_marker):
+                fetcher.update()
+        else:
             check_fetcher = True
             if os.path.exists(built_marker):
                 check_fetcher = False


### PR DESCRIPTION
Summary:
If getdeps finds a cached build artifact, it currently skips fetching the
source archive, which is done by calling `fetcher.update()`:
https://www.internalfb.com/code/fbsource/[f64171219e95f47c81929cde0a09e720e079dd31]/fbcode/opensource/fbcode_builder/getdeps.py?lines=691

But without the built_marker, the script will still create a builder for the
artifact:
https://www.internalfb.com/code/fbsource/[f64171219e95f47c81929cde0a09e720e079dd31]/fbcode/opensource/fbcode_builder/getdeps.py?lines=600

This then fails when the builder tries to extract the missing source archive.
In Boost's case:
https://www.internalfb.com/code/fbsource/[f64171219e95f47c81929cde0a09e720e079dd31]/fbcode/opensource/fbcode_builder/getdeps/builder.py?lines=1021

This logic seems to have been broken for a while, but became a problem after
watchman's Windows build started finding cached boost and ninja artifacts that
were missing the built_marker, presumably uploaded by other projects as a
result of D42996394 (https://github.com/facebookincubator/velox/commit/45f9f72206449e45d8c70c8057aa12158cfa21a6).

This change fixes the broken watchman build, but itself doesn't get us back to
using cached artifacts.

Differential Revision: D43260530

