### PR TITLE
Read type from simple function entry and not meta data during query compiliation

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -402,9 +402,8 @@ ExprPtr compileExpression(
     } else if (
         auto simpleFunctionEntry =
             SimpleFunctions().resolveFunction(call->name(), inputTypes)) {
-      const auto& metadata = simpleFunctionEntry->getMetadata();
       VELOX_USER_CHECK(
-          resultType->kindEquals(simpleFunctionEntry->type()),
+          resultType->equivalent(*simpleFunctionEntry->type().get()),
           "Found incompatible return types for '{}' ({} vs. {}) "
           "for input types ({}).",
           call->name(),

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -72,10 +72,13 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
+  opts.containerVariableLength = false;
+  opts.complexElementsMaxSize = 1000000;
+
   // Spark uses microseconds to store timestamp
   opts.timestampPrecision =
       VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
-  opts.containerLength = 65;
+  opts.containerLength = 10;
 
   auto seed = folly::Random::rand32();
   LOG(INFO) << "seed: " << seed;

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -100,6 +100,8 @@ TEST_F(UnsafeRowSerializerTest, types) {
   opts.dictionaryHasNulls = false;
   opts.stringVariableLength = true;
   opts.stringLength = 20;
+  opts.containerVariableLength = false;
+
   // Spark uses microseconds to store timestamp
   opts.timestampPrecision =
       VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -21,6 +21,7 @@
 #include <codecvt>
 #include <locale>
 
+#include "velox/common/base/Exceptions.h"
 #include "velox/type/Date.h"
 #include "velox/type/Timestamp.h"
 #include "velox/vector/FlatVector.h"
@@ -146,6 +147,13 @@ IntervalDayTime randIntervalDayTime(FuzzerGenerator& rng) {
 size_t getElementsVectorLength(
     const VectorFuzzer::Options& opts,
     vector_size_t size) {
+  if (opts.containerVariableLength == false &&
+      size * opts.containerLength > opts.complexElementsMaxSize) {
+    VELOX_USER_FAIL(
+        "Requested fixed opts.containerVariableLength can't be satisfied: "
+        "increase opts.complexElementsMaxSize, reduce opts.containerLength"
+        " or make opts.containerVariableLength=true");
+  }
   return std::min(size * opts.containerLength, opts.complexElementsMaxSize);
 }
 

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -116,7 +116,7 @@ class VectorFuzzer {
 
     /// If true, the length of array/map are randomly generated and
     /// `containerLength` is treated as maximum length.
-    bool containerVariableLength{false};
+    bool containerVariableLength{true};
 
     /// Restricts the maximum inner (elements) vector size created when
     /// generating nested vectors (arrays, maps, and rows).

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -282,6 +282,7 @@ TEST_F(VectorFuzzerTest, constantsNull) {
 
 TEST_F(VectorFuzzerTest, array) {
   VectorFuzzer::Options opts;
+  opts.containerVariableLength = false;
   VectorFuzzer fuzzer(opts, pool());
 
   // 1 elements per array.
@@ -337,6 +338,7 @@ TEST_F(VectorFuzzerTest, array) {
 
 TEST_F(VectorFuzzerTest, map) {
   VectorFuzzer::Options opts;
+  opts.containerVariableLength = false;
   VectorFuzzer fuzzer(opts, pool());
 
   // 1 elements per array.
@@ -700,6 +702,15 @@ TEST_F(VectorFuzzerTest, complexTooLarge) {
 
   vector = fuzzer.fuzzFlat(ARRAY(ARRAY(ARRAY(ARRAY(ARRAY(SMALLINT()))))));
   validateMaxSizes(vector, opts.complexElementsMaxSize);
+
+  // If opts.containerVariableLength is false,  then throw if requested size
+  // cant be satisfied.
+  opts.containerVariableLength = false;
+  fuzzer.setOptions(opts);
+
+  EXPECT_THROW(
+      fuzzer.fuzzFlat(ARRAY(ARRAY(ARRAY(ARRAY(ARRAY(SMALLINT())))))),
+      VeloxUserError);
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
title.
Note: we are going to deprecate storing and accessing the returnType in the mete data in a sequential diff.

Differential Revision: D43149540

