### PR TITLE
Make GCC and flags configurable

### DIFF
--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -18,7 +18,7 @@ set -efx -o pipefail
 # so that some low level types are the same size. Also, disable warnings.
 SCRIPTDIR=$(dirname "${BASH_SOURCE[0]}")
 CPU_TARGET="${CPU_TARGET:-avx}"
-CUSTOM_CXX_FLAGS="${CUSTOM_CXX_FLAGS:-''}"
+CUSTOM_CXX_FLAGS="${CUSTOM_CXX_FLAGS:-}"
 GCC_TOOLSET_PKG="${GCC_TOOLSET_PKG:-'gcc-toolset-9'}"
 NPROC="${NPROC:-$(getconf _NPROCESSORS_ONLN)}"
 


### PR DESCRIPTION
Make GCC and flags configurable by introducing `NPROC`, `GCC_TOOLSET_PKG` and `CUSTOM_CXX_FLAGS` env variables.

`GCC_TOOLSET_PKG` defaults to `gcc-toolset-9`

`NPROC` defaults to settings read from environment

`CUSTOM_CXX_FLAGS` defaults to empty string

This way user can use newer toolset and build for latest cpu architectures as well as use optimizations.