### PR TITLE
Fix null handling of decimal values in QueryAssertions

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(
   RoundRobinPartitionFunctionTest.cpp
   RowContainerTest.cpp
   MemoryCapExceededTest.cpp
+  QueryAssertionsTest.cpp
   SpillTest.cpp
   SpillOperatorGroupTest.cpp
   SpillerTest.cpp

--- a/velox/exec/tests/QueryAssertionsTest.cpp
+++ b/velox/exec/tests/QueryAssertionsTest.cpp
@@ -343,4 +343,22 @@ TEST_F(QueryAssertionsTest, multiFloatColumnWithNonUniqueKeys) {
       "971 extra rows, 971 missing rows");
 }
 
+TEST_F(QueryAssertionsTest, nullDecimalValue) {
+  auto shortDecimal = makeRowVector({
+      makeNullableShortDecimalFlatVector(
+          {std::nullopt},
+          SHORT_DECIMAL(5, 2))});
+  EXPECT_TRUE(assertEqualResults({shortDecimal}, {shortDecimal}));
+
+  auto longDecimal = makeRowVector({
+      makeNullableLongDecimalFlatVector(
+          {std::nullopt},
+          LONG_DECIMAL(20, 2))});
+  EXPECT_TRUE(assertEqualResults({longDecimal}, {longDecimal}));
+
+  EXPECT_NONFATAL_FAILURE(
+      assertEqualResults({shortDecimal}, {longDecimal}),
+      "Types of expected and actual results do not match");
+}
+
 } // namespace facebook::velox::test

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -479,6 +479,12 @@ velox::variant rowVariantAt(const VectorPtr& vector, vector_size_t row) {
 variant variantAt(const VectorPtr& vector, vector_size_t row) {
   auto typeKind = vector->typeKind();
   if (vector->isNullAt(row)) {
+    if (typeKind == TypeKind::SHORT_DECIMAL) {
+      return variant::shortDecimal(std::nullopt, vector->type());
+    }
+    if (typeKind == TypeKind::LONG_DECIMAL) {
+      return variant::longDecimal(std::nullopt, vector->type());
+    }
     return variant(typeKind);
   }
 


### PR DESCRIPTION
This PR fixes the issue of handling LongDecimal and ShortDecimal null values when comparing results in QueryAssertions.cpp. Without the fix, such comparison would fail with
```
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Use smallDecimal() or longDecimal() for DECIMAL values.
```

I also fixed QueryAssertionsTest.cpp - it was not included in any CMakeLists.txt file so it was not running at all.