### PR TITLE
Add PlanFragment::groupedExecutionLeafNodeIds.

### DIFF
--- a/velox/core/PlanFragment.h
+++ b/velox/core/PlanFragment.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 #include <memory>
+#include <unordered_set>
 #include <vector>
 #include "velox/core/PlanNode.h"
 
@@ -42,8 +43,21 @@ struct PlanFragment {
   ExecutionStrategy executionStrategy{ExecutionStrategy::kUngrouped};
   int numSplitGroups{0};
 
+  /// Contains leaf plan nodes that need to be executed in the grouped mode.
+  std::unordered_set<PlanNodeId> groupedExecutionLeafNodeIds;
+
+  /// Returns true if the fragment uses grouped execution strategy meaning that
+  /// at least one pipeline has a leaf node that should run grouped execution.
+  /// Note that it does not mean that all pipelines run grouped execution -
+  /// some leaf nodes might still run ungrouped execution.
   inline bool isGroupedExecution() const {
     return executionStrategy == ExecutionStrategy::kGrouped;
+  }
+
+  /// Returns true for leaf nodes that use grouped execution, false otherwise.
+  inline bool leafNodeRunsGroupedExecution(const PlanNodeId& planNodeId) const {
+    return groupedExecutionLeafNodeIds.find(planNodeId) !=
+        groupedExecutionLeafNodeIds.end();
   }
 
   PlanFragment() = default;


### PR DESCRIPTION
The new member (unordered_set) contains leaf plan nodes that
need to be executed in the grouped mode.

It is required, since some leaf nodes might still run ungrouped execution
in a fragment that runs with grouped execution strategy.

In this case we have for mixed grouped and ungrouped execution (e.g. broadcast
hash join for a large bucketed-on-join-keys probe-side table).

Example plan:
```
SELECT FROM
  SELECT FROM deltoid3.usr_mdf_source_node_fast_rid -- grouped execution
  INNER JOIN
  VALUES -- broadcast
GROUP BY
ORDER BY

```
Differential Revision: D43370236

**NOTE**: We don't use PlanFragment::groupedExecutionLeafNodeIds yet, as it
would break Presto Native. After updating Presto Native we would roll out the
next change where the new member would be used.