### PR TITLE
Add comments for const problem while compiling with gcc12.1

### DIFF
--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -162,6 +162,9 @@ std::unique_ptr<SimpleVector<uint64_t>> DictionaryVector<T>::hashAll() const {
     }
   }
   return std::make_unique<FlatVector<uint64_t>>(
+      // This would occur const problem while trying to compile with gcc12.1.
+      // Please upgrade gcc12.1 to 12.2 or just change BaseVector::pool_ to
+      // DictionaryVector::pool_.
       BaseVector::pool_,
       BufferPtr(nullptr),
       BaseVector::length_,

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -108,6 +108,9 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
     }
   }
   return std::make_unique<FlatVector<uint64_t>>(
+      // This would occur const problem while trying to compile with gcc12.1.
+      // Please upgrade gcc12.1 to 12.2 or just change BaseVector::pool_ to
+      // FlatVector::pool_.
       BaseVector::pool_,
       BufferPtr(nullptr),
       BaseVector::length_,


### PR DESCRIPTION
As described in #4067 , the const problem occurs when trying to compile with gcc12.1. It is a bug([Wrong overload selected in base class](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105637)) of gcc12.1, , and it has been fixed in 12.2. Users who encounter this problem need to upgrade gcc12.1 to 12.2 or make the changes in comments.