### PR TITLE
Introduce ConstantTypedExpr::toConstantVector

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -121,6 +121,16 @@ class ConstantTypedExpr : public ITypedExpr {
     return valueVector_;
   }
 
+  VectorPtr toConstantVector(memory::MemoryPool* pool) const {
+    if (valueVector_) {
+      return valueVector_;
+    }
+    if (value_.isNull()) {
+      return BaseVector::createNullConstant(type(), 1, pool);
+    }
+    return BaseVector::createConstant(type(), value_, 1, pool);
+  }
+
   const std::vector<TypedExprPtr>& inputs() const {
     static const std::vector<TypedExprPtr> kEmpty{};
     return kEmpty;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -90,13 +90,7 @@ HashAggregation::HashAggregation(
       channels.push_back(exprToChannel(arg.get(), inputType));
       if (channels.back() == kConstantChannel) {
         auto constant = dynamic_cast<const core::ConstantTypedExpr*>(arg.get());
-        if (constant->hasValueVector()) {
-          constants.push_back(
-              BaseVector::wrapInConstant(1, 0, constant->valueVector()));
-        } else {
-          constants.push_back(BaseVector::createConstant(
-              constant->type(), constant->value(), 1, operatorCtx_->pool()));
-        }
+        constants.push_back(constant->toConstantVector(pool()));
       } else {
         constants.push_back(nullptr);
       }

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -470,17 +470,7 @@ ExprPtr compileExpression(
   } else if (
       auto constant =
           dynamic_cast<const core::ConstantTypedExpr*>(expr.get())) {
-    if (constant->hasValueVector()) {
-      result = std::make_shared<ConstantExpr>(constant->valueVector());
-    } else {
-      if (constant->value().isNull()) {
-        result = std::make_shared<ConstantExpr>(
-            BaseVector::createNullConstant(constant->type(), 1, pool));
-      } else {
-        result = std::make_shared<ConstantExpr>(BaseVector::createConstant(
-            constant->type(), constant->value(), 1, pool));
-      }
-    }
+    result = std::make_shared<ConstantExpr>(constant->toConstantVector(pool));
   } else if (
       auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(expr.get())) {
     result = compileLambda(

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -145,13 +145,7 @@ void AggregationTestBase::validateStreamingInTestAggregations(
       auto channel = exec::exprToChannel(arg.get(), input->type());
       if (channel == kConstantChannel) {
         auto constant = dynamic_cast<const core::ConstantTypedExpr*>(arg.get());
-        if (constant->hasValueVector()) {
-          column = BaseVector::wrapInConstant(
-              input->size(), 0, constant->valueVector());
-        } else {
-          column = BaseVector::createConstant(
-              constant->type(), constant->value(), input->size(), pool());
-        }
+        column = constant->toConstantVector(pool());
       } else {
         column = input->childAt(channel);
       }


### PR DESCRIPTION
We used to convert ConstantTypedExpr to ConstantVector in multiple places
(HashAggregation and Window operators, ExprCompiler). All these places
duplicate the same logic. This change adds ConstantTypedExpr::toConstantVector() 
method to implement that logic once and reuse. 