### PR TITLE
Require type in ConstantVector constructor

### DIFF
--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -106,7 +106,7 @@ RowVectorPtr GroupId::getOutput() {
   // Add groupId column.
   outputColumns[outputType_->size() - 1] =
       std::make_shared<ConstantVector<int64_t>>(
-          pool(), numInput, false, groupingSetIndex_);
+          pool(), numInput, false, BIGINT(), groupingSetIndex_);
 
   ++groupingSetIndex_;
   if (groupingSetIndex_ == groupingKeyMappings_.size()) {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -643,7 +643,7 @@ void HashProbe::prepareOutput(vector_size_t size) {
 namespace {
 VectorPtr createConstantFalse(vector_size_t size, memory::MemoryPool* pool) {
   return std::make_shared<ConstantVector<bool>>(
-      pool, size, false /*isNull*/, false /*value*/);
+      pool, size, false /*isNull*/, BOOLEAN(), false /*value*/);
 }
 } // namespace
 

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -106,7 +106,7 @@ RowVectorPtr TableWriter::getOutput() {
         nullptr,
         1,
         std::vector<VectorPtr>{std::make_shared<ConstantVector<int64_t>>(
-            pool, 1, false /*isNull*/, numWrittenRows_)});
+            pool, 1, false /*isNull*/, BIGINT(), numWrittenRows_)});
   }
 
   std::vector<std::string> fragments = dataSink_->finish();

--- a/velox/functions/prestosql/ArraySum.cpp
+++ b/velox/functions/prestosql/ArraySum.cpp
@@ -152,7 +152,11 @@ class ArraySumFunction : public exec::VectorFunction {
 
       context.moveOrCopyResult(
           std::make_shared<ConstantVector<TOutput>>(
-              context.pool(), rows.end(), false /*isNull*/, std::move(sum)),
+              context.pool(),
+              rows.end(),
+              false /*isNull*/,
+              outputType,
+              std::move(sum)),
           rows,
           result);
       return;

--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -54,7 +54,7 @@ class FromUnixtimeFunction : public exec::VectorFunction {
       int16_t timezoneId = util::getTimeZoneID(
           std::string_view(timezoneName.data(), timezoneName.size()));
       timezones = std::make_shared<ConstantVector<int16_t>>(
-          pool, size, false /*isNull*/, std::move(timezoneId));
+          pool, size, false /*isNull*/, SMALLINT(), std::move(timezoneId));
 
       rows.applyToSelected([&](auto row) {
         rawTimestamps[row] = toMillis(unixtimes->valueAt<double>(row));

--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -227,13 +227,13 @@ class InPredicate : public exec::VectorFunction {
       vector_size_t size,
       exec::EvalCtx& context) {
     return std::make_shared<ConstantVector<bool>>(
-        context.pool(), size, true /*isNull*/, false);
+        context.pool(), size, true /*isNull*/, BOOLEAN(), false);
   }
 
   static VectorPtr
   createBoolConstant(bool value, vector_size_t size, exec::EvalCtx& context) {
     return std::make_shared<ConstantVector<bool>>(
-        context.pool(), size, false /*isNull*/, std::move(value));
+        context.pool(), size, false /*isNull*/, BOOLEAN(), std::move(value));
   }
 
   template <typename T, typename F>

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -134,9 +134,9 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
     auto rowVec = (*result)->as<RowVector>();
     VELOX_CHECK(rowVec);
     rowVec->childAt(0) = std::make_shared<ConstantVector<int64_t>>(
-        rowVec->pool(), numGroups, false, int64_t(buckets_));
+        rowVec->pool(), numGroups, false, BIGINT(), int64_t(buckets_));
     rowVec->childAt(1) = std::make_shared<ConstantVector<int64_t>>(
-        rowVec->pool(), numGroups, false, int64_t(capacity_));
+        rowVec->pool(), numGroups, false, BIGINT(), int64_t(capacity_));
     auto values = rowVec->childAt(2)->as<ArrayVector>();
     auto counts = rowVec->childAt(3)->as<ArrayVector>();
     rowVec->resize(numGroups);

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -236,26 +236,19 @@ class ApproxPercentileAggregate : public exec::Aggregate {
           BaseVector::wrapInConstant(numGroups, 0, std::move(array));
       rowResult->childAt(kPercentilesIsArray) =
           std::make_shared<ConstantVector<bool>>(
-              pool, numGroups, false, bool(percentiles_->isArray));
+              pool, numGroups, false, BOOLEAN(), bool(percentiles_->isArray));
     } else {
-      rowResult->childAt(kPercentiles) = BaseVector::wrapInConstant(
-          numGroups,
-          0,
-          std::make_shared<ArrayVector>(
-              pool,
-              ARRAY(DOUBLE()),
-              AlignedBuffer::allocate<bool>(1, pool, bits::kNull),
-              1,
-              AlignedBuffer::allocate<vector_size_t>(1, pool, 0),
-              AlignedBuffer::allocate<vector_size_t>(1, pool, 0),
-              nullptr));
+      rowResult->childAt(kPercentiles) =
+          BaseVector::createNullConstant(ARRAY(DOUBLE()), numGroups, pool);
       rowResult->childAt(kPercentilesIsArray) =
-          std::make_shared<ConstantVector<bool>>(pool, numGroups, true, false);
+          std::make_shared<ConstantVector<bool>>(
+              pool, numGroups, true, BOOLEAN(), false);
     }
     rowResult->childAt(kAccuracy) = std::make_shared<ConstantVector<double>>(
         pool,
         numGroups,
         accuracy_ == kMissingNormalizedValue,
+        DOUBLE(),
         double(accuracy_));
     auto k = rowResult->childAt(kK)->asFlatVector<int32_t>();
     auto n = rowResult->childAt(kN)->asFlatVector<int64_t>();

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -338,10 +338,9 @@ TEST_F(ApproxPercentileTest, invalidWeight) {
   constexpr int64_t kMaxWeight = (1ll << 60) - 1;
   auto makePlan = [&](int64_t weight, bool grouped) {
     auto rows = makeRowVector({
-        std::make_shared<ConstantVector<int32_t>>(pool(), 1, false, 0),
-        std::make_shared<ConstantVector<int64_t>>(
-            pool(), 1, false, int64_t(weight)),
-        std::make_shared<ConstantVector<int32_t>>(pool(), 1, false, 1),
+        makeConstant<int32_t>(0, 1),
+        makeConstant<int64_t>(weight, 1),
+        makeConstant<int32_t>(1, 1),
     });
     std::vector<std::string> groupingKeys;
     if (grouped) {

--- a/velox/vector/BiasVector-inl.h
+++ b/velox/vector/BiasVector-inl.h
@@ -46,6 +46,7 @@ BiasVector<T>::BiasVector(
     std::optional<ByteCount> storageByteCount)
     : SimpleVector<T>(
           pool,
+          CppToType<T>::create(),
           VectorEncoding::Simple::BIASED,
           nulls,
           length,

--- a/velox/vector/ConstantVector-inl.h
+++ b/velox/vector/ConstantVector-inl.h
@@ -23,6 +23,7 @@ std::unique_ptr<SimpleVector<uint64_t>> ConstantVector<T>::hashAll() const {
       BaseVector::pool_,
       BaseVector::length_,
       false /* isNull */,
+      BIGINT(),
       this->hashValueAt(0),
       SimpleVectorStats<uint64_t>{}, /* stats */
       sizeof(uint64_t) * BaseVector::length_ /* representedBytes */);

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -44,25 +44,7 @@ class ConstantVector final : public SimpleVector<T> {
       velox::memory::MemoryPool* pool,
       size_t length,
       bool isNull,
-      T&& val,
-      const SimpleVectorStats<T>& stats = {},
-      std::optional<ByteCount> representedBytes = std::nullopt,
-      std::optional<ByteCount> storageByteCount = std::nullopt)
-      : ConstantVector(
-            pool,
-            length,
-            isNull,
-            CppToType<T>::create(),
-            std::move(val),
-            stats,
-            representedBytes,
-            storageByteCount) {}
-
-  ConstantVector(
-      velox::memory::MemoryPool* pool,
-      size_t length,
-      bool isNull,
-      std::shared_ptr<const Type> type,
+      TypePtr type,
       T&& val,
       const SimpleVectorStats<T>& stats = {},
       std::optional<ByteCount> representedBytes = std::nullopt,

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -59,7 +59,7 @@ class SimpleVector : public BaseVector {
  public:
   SimpleVector(
       velox::memory::MemoryPool* pool,
-      std::shared_ptr<const Type> type,
+      TypePtr type,
       VectorEncoding::Simple encoding,
       BufferPtr nulls,
       size_t length,
@@ -82,31 +82,6 @@ class SimpleVector : public BaseVector {
         isSorted_(isSorted),
         elementSize_(sizeof(T)),
         stats_(stats) {}
-
-  // Constructs SimpleVector inferring the type from T.
-  SimpleVector(
-      velox::memory::MemoryPool* pool,
-      VectorEncoding::Simple encoding,
-      BufferPtr nulls,
-      size_t length,
-      const SimpleVectorStats<T>& stats,
-      std::optional<vector_size_t> distinctValueCount,
-      std::optional<vector_size_t> nullCount,
-      std::optional<bool> isSorted,
-      std::optional<ByteCount> representedByteCount,
-      std::optional<ByteCount> storageByteCount = std::nullopt)
-      : SimpleVector(
-            pool,
-            CppToType<T>::create(),
-            encoding,
-            std::move(nulls),
-            length,
-            stats,
-            distinctValueCount,
-            nullCount,
-            isSorted,
-            representedByteCount,
-            storageByteCount) {}
 
   virtual ~SimpleVector() override {}
 

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -333,7 +333,7 @@ void writeConstantVector(const BaseVector& vector, std::ostream& out) {
 
 template <TypeKind kind>
 VectorPtr readConstant(
-    const TypePtr& /* type */,
+    const TypePtr& type,
     vector_size_t size,
     velox::memory::MemoryPool* pool,
     std::istream& in) {
@@ -348,12 +348,16 @@ VectorPtr readConstant(
       in.read(stringBuffer->template asMutable<char>(), stringSize);
 
       return std::make_shared<ConstantVector<T>>(
-          pool, size, false, StringView(stringBuffer->as<char>(), stringSize));
+          pool,
+          size,
+          false,
+          type,
+          StringView(stringBuffer->as<char>(), stringSize));
     }
   }
 
   return std::make_shared<ConstantVector<T>>(
-      pool, size, false, std::move(value));
+      pool, size, false, type, std::move(value));
 }
 
 VectorPtr readConstantVector(

--- a/velox/vector/tests/utils/VectorMaker-inl.h
+++ b/velox/vector/tests/utils/VectorMaker-inl.h
@@ -163,6 +163,7 @@ ConstantVectorPtr<VectorMaker::EvalType<T>> VectorMaker::constantVector(
       pool_,
       data.size(),
       nullCount > 0,
+      CppToType<TEvalType>::create(),
       (nullCount > 0) ? TEvalType() : folly::copy(*data.front()),
       stats.asSimpleVectorStats());
 }


### PR DESCRIPTION
Inferring logical type from physical type is error prone. This change removing
such logic from ConstantVector and SimpleVector constructors and requires the
caller to specify logical type explicitly.

A similar change is needed for the FlatVector constructor.

See https://github.com/facebookincubator/velox/discussions/4069