### PR TITLE
Add parseIntegerAsBigint option to DuckParser

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -132,7 +132,7 @@ std::shared_ptr<const core::IExpr> parseConstantExpr(
   // parser. By default literal integer constants in DuckDB parser are INTEGER,
   // while in Koski parser they were BIGINT.
   if (value.type().id() == LogicalTypeId::INTEGER &&
-      options.castIntegerToBigint) {
+      options.parseIntegerAsBigint) {
     value = Value::BIGINT(value.GetValue<int32_t>());
   }
 

--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -131,7 +131,8 @@ std::shared_ptr<const core::IExpr> parseConstantExpr(
   // This is a hack to make DuckDB more compatible with the old Koski-based
   // parser. By default literal integer constants in DuckDB parser are INTEGER,
   // while in Koski parser they were BIGINT.
-  if (value.type().id() == LogicalTypeId::INTEGER) {
+  if (value.type().id() == LogicalTypeId::INTEGER &&
+      options.castIntegerToBigint) {
     value = Value::BIGINT(value.GetValue<int32_t>());
   }
 

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -29,6 +29,7 @@ namespace facebook::velox::duckdb {
 struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
+  bool castIntegerToBigint = true;
 };
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -29,7 +29,7 @@ namespace facebook::velox::duckdb {
 struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
-  bool castIntegerToBigint = true;
+  bool parseIntegerAsBigint = true;
 };
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -529,6 +529,18 @@ TEST(DuckParserTest, parseDecimalConstant) {
   }
 }
 
+TEST(DuckParserTest, parseInteger) {
+  ParseOptions options;
+  options.parseIntegerAsBigint = false;
+  auto expr = parseExpr("1234", options);
+  if (auto constant =
+          std::dynamic_pointer_cast<const core::ConstantExpr>(expr)) {
+    ASSERT_EQ(*constant->type(), *INTEGER());
+  } else {
+    FAIL() << expr->toString() << " is not a constant";
+  }
+}
+
 TEST(DuckParserTest, lambda) {
   // There is a bug in DuckDB in parsing lambda expressions that use
   // comparisons. This doesn't work: filter(a, x -> x = 10). This does:

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -592,20 +592,6 @@ TEST_F(PlanNodeToStringTest, decimalConstant) {
       plan->toString(true));
 }
 
-TEST_F(PlanNodeToStringTest, integer) {
-  parse::ParseOptions options;
-  options.castIntegerToBigint = false;
-
-  auto plan = PlanBuilder()
-                  .setParseOptions(options)
-                  .tableScan(ROW({"a"}, {VARCHAR()}))
-                  .project({"a", "1"})
-                  .planNode();
-  ASSERT_EQ(
-      "-- Project[expressions: (a:VARCHAR, ROW[\"a\"]), (p1:INTEGER, 1)] -> a:VARCHAR, p1:INTEGER\n",
-      plan->toString(true));
-}
-
 TEST_F(PlanNodeToStringTest, window) {
   std::vector<exec::FunctionSignaturePtr> signatures{
       exec::FunctionSignatureBuilder()

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -592,6 +592,20 @@ TEST_F(PlanNodeToStringTest, decimalConstant) {
       plan->toString(true));
 }
 
+TEST_F(PlanNodeToStringTest, integer) {
+  parse::ParseOptions options;
+  options.castIntegerToBigint = false;
+
+  auto plan = PlanBuilder()
+                  .setParseOptions(options)
+                  .tableScan(ROW({"a"}, {VARCHAR()}))
+                  .project({"a", "1"})
+                  .planNode();
+  ASSERT_EQ(
+      "-- Project[expressions: (a:VARCHAR, ROW[\"a\"]), (p1:INTEGER, 1)] -> a:VARCHAR, p1:INTEGER\n",
+      plan->toString(true));
+}
+
 TEST_F(PlanNodeToStringTest, window) {
   std::vector<exec::FunctionSignaturePtr> signatures{
       exec::FunctionSignatureBuilder()

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -23,7 +23,7 @@ std::shared_ptr<const core::IExpr> parseExpr(
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
-  duckConversionOptions.castIntegerToBigint = options.castIntegerToBigint;
+  duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
 
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
@@ -33,7 +33,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
-  duckConversionOptions.castIntegerToBigint = options.castIntegerToBigint;
+  duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
   return facebook::velox::duckdb::parseMultipleExpressions(
       expr, duckConversionOptions);
 }

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -23,6 +23,8 @@ std::shared_ptr<const core::IExpr> parseExpr(
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
+  duckConversionOptions.castIntegerToBigint = options.castIntegerToBigint;
+
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
@@ -31,6 +33,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
     const ParseOptions& options) {
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
+  duckConversionOptions.castIntegerToBigint = options.castIntegerToBigint;
   return facebook::velox::duckdb::parseMultipleExpressions(
       expr, duckConversionOptions);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -26,6 +26,7 @@ namespace facebook::velox::parse {
 struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
+  bool castIntegerToBigint = true;
 };
 
 std::shared_ptr<const core::IExpr> parseExpr(

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -26,7 +26,7 @@ namespace facebook::velox::parse {
 struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
-  bool castIntegerToBigint = true;
+  bool parseIntegerAsBigint = true;
 };
 
 std::shared_ptr<const core::IExpr> parseExpr(


### PR DESCRIPTION
Introduce an parseIntegerAsBigint option for DuckParser to choose parsing an integer constant as INTEGER or BIGINT.