### PR TITLE
Unify exception kinds of unsupported cast operations

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -161,7 +161,7 @@ class CastExprTest : public functions::test::CastBaseTest {
       EXPECT_THROW(
           evaluate(
               fmt::format("{}(c0 as {})", castFunction, typeString), rowVector),
-          VeloxException);
+          VeloxUserError);
       return;
     }
     // run try cast and get the result vector

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2674,7 +2674,7 @@ TEST_F(ExprTest, castExceptionContext) {
       makeFlatVector(std::vector<int8_t>{1}),
       "cast((c0) as TIMESTAMP)",
       "Same as context.",
-      "Failed to cast from TINYINT to TIMESTAMP: 1. ");
+      "Failed to cast from TINYINT to TIMESTAMP: 1. Conversion of TINYINT to Timestamp is not supported");
 }
 
 TEST_F(ExprTest, switchExceptionContext) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -34,7 +34,10 @@ struct Converter {
   // If in the future we change nullOutput in many functions we can revisit that
   // contract.
   static typename TypeTraits<KIND>::NativeType cast(T val, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to {} is not supported",
+        CppToType<T>::name,
+        TypeTraits<KIND>::name);
   }
 };
 
@@ -81,7 +84,10 @@ struct Converter<
 
   template <typename From>
   static T cast(const From& v, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to {} is not supported",
+        CppToType<From>::name,
+        TypeTraits<KIND>::name);
   }
 
   static T convertStringToInt(const folly::StringPiece& v, bool& nullOutput) {
@@ -386,7 +392,10 @@ struct Converter<TypeKind::TIMESTAMP> {
 
   template <typename From>
   static T cast(const From& /* v */, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to Timestamp is not supported",
+        CppToType<From>::name);
+    return T();
   }
 
   static T cast(folly::StringPiece v, bool& nullOutput) {
@@ -413,7 +422,9 @@ struct Converter<TypeKind::DATE, void, TRUNCATE> {
   using T = typename TypeTraits<TypeKind::DATE>::NativeType;
   template <typename From>
   static T cast(const From& /* v */, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to Date is not supported", CppToType<From>::name);
+    return T();
   }
 
   static T cast(folly::StringPiece v, bool& nullOutput) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -41,6 +41,7 @@
  */
 
 #include "velox/type/TimestampConversion.h"
+#include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::util {
@@ -178,13 +179,13 @@ bool tryParseDateString(
   }
   // First parse the year.
   for (; pos < len && characterIsDigit(buf[pos]); pos++) {
-    year = (buf[pos] - '0') + year * 10;
+    year = checkedPlus((buf[pos] - '0'), checkedMultiply(year, 10));
     if (year > kMaxYear) {
       break;
     }
   }
   if (yearneg) {
-    year = -year;
+    year = checkedNegate(year);
     if (year < kMinYear) {
       return false;
     }

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -182,6 +182,12 @@ TEST(DateTimeUtilTest, fromTimestampStrInvalid) {
   EXPECT_THROW(fromTimestampString("1970-01-01 00:00:00-asd"), VeloxUserError);
   EXPECT_THROW(
       fromTimestampString("1970-01-01 00:00:00+00:00:00"), VeloxUserError);
+
+  // Integer overflow during timestamp parsing.
+  EXPECT_THROW(
+      fromTimestampString("2773581570-01-01 00:00:00-asd"), VeloxUserError);
+  EXPECT_THROW(
+      fromTimestampString("-2147483648-01-01 00:00:00-asd"), VeloxUserError);
 }
 
 TEST(DateTimeUtilTest, toGMT) {


### PR DESCRIPTION
Summary:
Some unsupported Cast operations throw VeloxUserError and some throw
VeloxRuntimeError. This causes failures of fuzzer test with Cast enabled
 when there are unsupported castings. This diff makes all unsupported Cast
operations throw VeloxUserError.

Reviewed By: xiaoxmeng

Differential Revision: D43289020

