### PR TITLE
Fix size of Cast result of nested complex input

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -378,7 +378,7 @@ VectorPtr CastExpr::applyMap(
       context.pool(),
       MAP(toType.keyType(), toType.valueType()),
       input->nulls(),
-      rows.size(),
+      rows.end(),
       input->offsets(),
       input->sizes(),
       newMapKeys,
@@ -423,7 +423,7 @@ VectorPtr CastExpr::applyArray(
       context.pool(),
       ARRAY(toType.elementType()),
       input->nulls(),
-      rows.size(),
+      rows.end(),
       input->offsets(),
       input->sizes(),
       newElements);
@@ -507,7 +507,7 @@ VectorPtr CastExpr::applyRow(
       context.pool(),
       toType,
       input->nulls(),
-      rows.size(),
+      rows.end(),
       std::move(newChildren));
 }
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -161,7 +161,7 @@ class CastExprTest : public functions::test::CastBaseTest {
       EXPECT_THROW(
           evaluate(
               fmt::format("{}(c0 as {})", castFunction, typeString), rowVector),
-          VeloxException);
+          VeloxUserError);
       return;
     }
     // run try cast and get the result vector

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2674,7 +2674,7 @@ TEST_F(ExprTest, castExceptionContext) {
       makeFlatVector(std::vector<int8_t>{1}),
       "cast((c0) as TIMESTAMP)",
       "Same as context.",
-      "Failed to cast from TINYINT to TIMESTAMP: 1. ");
+      "Failed to cast from TINYINT to TIMESTAMP: 1. Conversion of TINYINT to Timestamp is not supported");
 }
 
 TEST_F(ExprTest, switchExceptionContext) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -34,7 +34,10 @@ struct Converter {
   // If in the future we change nullOutput in many functions we can revisit that
   // contract.
   static typename TypeTraits<KIND>::NativeType cast(T val, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to {} is not supported",
+        CppToType<T>::name,
+        TypeTraits<KIND>::name);
   }
 };
 
@@ -81,7 +84,10 @@ struct Converter<
 
   template <typename From>
   static T cast(const From& v, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to {} is not supported",
+        CppToType<From>::name,
+        TypeTraits<KIND>::name);
   }
 
   static T convertStringToInt(const folly::StringPiece& v, bool& nullOutput) {
@@ -386,7 +392,10 @@ struct Converter<TypeKind::TIMESTAMP> {
 
   template <typename From>
   static T cast(const From& /* v */, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to Timestamp is not supported",
+        CppToType<From>::name);
+    return T();
   }
 
   static T cast(folly::StringPiece v, bool& nullOutput) {
@@ -413,7 +422,9 @@ struct Converter<TypeKind::DATE, void, TRUNCATE> {
   using T = typename TypeTraits<TypeKind::DATE>::NativeType;
   template <typename From>
   static T cast(const From& /* v */, bool& nullOutput) {
-    VELOX_NYI();
+    VELOX_UNSUPPORTED(
+        "Conversion of {} to Date is not supported", CppToType<From>::name);
+    return T();
   }
 
   static T cast(folly::StringPiece v, bool& nullOutput) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -41,6 +41,7 @@
  */
 
 #include "velox/type/TimestampConversion.h"
+#include "velox/common/base/CheckedArithmetic.h"
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::util {
@@ -178,13 +179,13 @@ bool tryParseDateString(
   }
   // First parse the year.
   for (; pos < len && characterIsDigit(buf[pos]); pos++) {
-    year = (buf[pos] - '0') + year * 10;
+    year = checkedPlus((buf[pos] - '0'), checkedMultiply(year, 10));
     if (year > kMaxYear) {
       break;
     }
   }
   if (yearneg) {
-    year = -year;
+    year = checkedNegate(year);
     if (year < kMinYear) {
       return false;
     }

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -182,6 +182,12 @@ TEST(DateTimeUtilTest, fromTimestampStrInvalid) {
   EXPECT_THROW(fromTimestampString("1970-01-01 00:00:00-asd"), VeloxUserError);
   EXPECT_THROW(
       fromTimestampString("1970-01-01 00:00:00+00:00:00"), VeloxUserError);
+
+  // Integer overflow during timestamp parsing.
+  EXPECT_THROW(
+      fromTimestampString("2773581570-01-01 00:00:00-asd"), VeloxUserError);
+  EXPECT_THROW(
+      fromTimestampString("-2147483648-01-01 00:00:00-asd"), VeloxUserError);
 }
 
 TEST(DateTimeUtilTest, toGMT) {

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -29,6 +29,20 @@ BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool) {
   return indices;
 }
 
+BufferPtr makeIndices(
+    vector_size_t size,
+    std::function<vector_size_t(vector_size_t)> indexAt,
+    memory::MemoryPool* pool) {
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  for (vector_size_t i = 0; i < size; i++) {
+    rawIndices[i] = indexAt(i);
+  }
+
+  return indices;
+}
+
 VectorTestBase::~VectorTestBase() {
   // Wait for all the tasks to be deleted.
   exec::Task::testingWaitForAllTasksToBeDeleted();
@@ -64,14 +78,7 @@ BufferPtr VectorTestBase::makeEvenIndices(vector_size_t size) {
 BufferPtr VectorTestBase::makeIndices(
     vector_size_t size,
     std::function<vector_size_t(vector_size_t)> indexAt) const {
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-
-  for (vector_size_t i = 0; i < size; i++) {
-    rawIndices[i] = indexAt(i);
-  }
-
-  return indices;
+  return test::makeIndices(size, indexAt, pool());
 }
 
 BufferPtr VectorTestBase::makeIndices(

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -28,6 +28,11 @@ namespace facebook::velox::test {
 /// Returns indices buffer with sequential values going from size - 1 to 0.
 BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool);
 
+BufferPtr makeIndices(
+    vector_size_t size,
+    std::function<vector_size_t(vector_size_t)> indexAt,
+    memory::MemoryPool* pool);
+
 // TODO: enable ASSERT_EQ for vectors.
 void assertEqualVectors(const VectorPtr& expected, const VectorPtr& actual);
 


### PR DESCRIPTION
Summary:
When CastExpr create a complex-typed result vector, the lengths of the element
vector and top-level vector should match. Currently, CastExpr::applyArray(),
CastExpr::applyMap(), and CastExpr::applyRow() may produce element vector(s)
of the length rows.end() (when the input element vector is dictionary encoded),
while it creates a top-level vector of the length rows.size(). This caused an
error when I run expression fuzzer with the support for "cast" enabled.

The added unit test gives an example of casting ARRAY<ROW<BIGINT>> to 
ARRAY<ROW<VARCHAR>>. In this example, the ARRAY vector has 2 rows, each 
having 3 elements. The ARRAY vector is wrapped in a dictionary layer that only 
references its first row, hence only the first 3 out of 6 rows are evaluated for the 
ROW and BIGINT vector. The BIGINT vector is also dictionary-encoded and 
CastExpr produces a result VARCHAR vector of length 3. CastExpr::applyRow() 
then creates a ROW<VARCHAR> vector of length 6 (i.e., rows.size()) where only the 
first 3 rows have meaningful values. (However, since the ROW vector is constructed 
with input->nulls() buffer, the last 3 rows are not marked null.) Next, since the 
input ROW vector has null at index 2, CastExpr attempts to add this null to the result 
ROW vector. It calls Expr::addNull() which calls 
BaseVector::ensureWritable(SelectivityVector::empty(), ..., ..., result). 
ensureWritable creates a new vector and attempts to copy values from result 
to it at the first std::max(rows.size(), result->size()) rows (which is 
result->size() == 6). At this moment, it accesses the indices 3--5 of the 
ROW vector and hence the corresponding elements in the VARCHAR vector which do 
not exist and causes the error.

This diff fixes https://github.com/facebookincubator/velox/issues/4060.

Differential Revision: D43307970

