### PR TITLE
Enable CAST in expression fuzzer test

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -36,7 +36,7 @@ DEFINE_string(
 
 DEFINE_string(
     special_forms,
-    "and,or",
+    "and,or,cast",
     "Comma-separated list of special forms to use in generated expression. "
     "Supported special forms: and, or, coalesce, if, switch, cast.");
 


### PR DESCRIPTION
Summary: Enable expression fuzzer to generate expression with Cast. This diff is for https://github.com/facebookincubator/velox/issues/3499.

Differential Revision: D43372563

