### PR TITLE
Only upload cached projects with built_marker

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -632,12 +632,15 @@ class BuildCmd(ProjectCmdBase):
                     # set the built_marker. This allows subsequent runs of getdeps.py
                     # for the project to run with different cmake_targets to trigger
                     # cmake
+                    has_built_marker = False
                     if not (m == manifest and args.cmake_target != "install"):
                         with open(built_marker, "w") as f:
                             f.write(project_hash)
+                            has_built_marker = True
 
-                    # Only populate the cache from continuous build runs
-                    if args.schedule_type == "continuous":
+                    # Only populate the cache from continuous build runs, and
+                    # only if we have a built_marker.
+                    if args.schedule_type == "continuous" and has_built_marker:
                         cached_project.upload()
                 elif args.verbose:
                     print("found good %s" % built_marker)


### PR DESCRIPTION
Summary:
Under some circumstances, getdeps can cache a project artifact
where there is no built_marker, forcing the script to re-build the artifact
from source.  After D43260530 (https://github.com/facebookincubator/velox/commit/44c80b714fa9f00e351b74a35c3c9da334fe1021) this no longer causes a build failure, but it can
still make builds take longer than they should.

This ensures we only cache artifacts with a built_marker, so that they aren't
overwritten by artifacts without.

Differential Revision: D43405855

