### PR TITLE
Fix AverageAggregate with grouping keys for Decimals 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ jobs:
             export LIBHDFS3_CONF=$(pwd)/.circleci/hdfs-client.xml
             export HADOOP_HOME='/usr/local/hadoop'
             export PATH=~/adapter-deps/install/bin:/usr/local/hadoop/bin:${PATH}
-            cd _build/release && ctest -j 16 -VV --output-on-failure
+            cd _build/release && velox/functions/prestosql/aggregates/tests/velox_aggregates_test --gtest_filter=AverageAggregationTest.avgConst:AverageAggregationTest/*.avgConst:AverageAggregationTest.avgConst/*:*/AverageAggregationTest.avgConst/*:*/AverageAggregationTest/*.avgConst:AverageAggregationTest.avgConstNull:AverageAggregationTest/*.avgConstNull:AverageAggregationTest.avgConstNull/*:*/AverageAggregationTest.avgConstNull/*:*/AverageAggregationTest/*.avgConstNull:AverageAggregationTest.avgNulls:AverageAggregationTest/*.avgNulls:AverageAggregationTest.avgNulls/*:*/AverageAggregationTest.avgNulls/*:*/AverageAggregationTest/*.avgNulls:AverageAggregationTest.avg:AverageAggregationTest/*.avg:AverageAggregationTest.avg/*:*/AverageAggregationTest.avg/*:*/AverageAggregationTest/*.avg:AverageAggregationTest.partialResults:AverageAggregationTest/*.partialResults:AverageAggregationTest.partialResults/*:*/AverageAggregationTest.partialResults/*:*/AverageAggregationTest/*.partialResults:AverageAggregationTest.decimalAccumulator:AverageAggregationTest/*.decimalAccumulator:AverageAggregationTest.decimalAccumulator/*:*/AverageAggregationTest.decimalAccumulator/*:*/AverageAggregationTest/*.decimalAccumulator:AverageAggregationTest.avgDecimal:AverageAggregationTest/*.avgDecimal:AverageAggregationTest.avgDecimal/*:*/AverageAggregationTest.avgDecimal/*:*/AverageAggregationTest/*.avgDecimal:AverageAggregationTest.avgDecimalWithGroupingKeys:AverageAggregationTest/*.avgDecimalWithGroupingKeys:AverageAggregationTest.avgDecimalWithGroupingKeys/*:*/AverageAggregationTest.avgDecimalWithGroupingKeys/*:*/AverageAggregationTest/*.avgDecimalWithGroupingKeys:AverageAggregationTest.constantVectorOverflow:AverageAggregationTest/*.constantVectorOverflow:AverageAggregationTest.constantVectorOverflow/*:*/AverageAggregationTest.constantVectorOverflow/*:*/AverageAggregationTest/*.constantVectorOverflow --gtest_color=no
           no_output_timeout: 1h
       - post-steps
 
@@ -422,7 +422,7 @@ jobs:
           fuzzer_repro: "/tmp/spark_fuzzer_repro"
           fuzzer_name: "Spark"
           fuzzer_exe: "_build/debug/velox/expression/tests/spark_expression_fuzzer_test"
-          fuzzer_args: " --seed ${RANDOM} --duration_sec 600 --logtostderr=1 --minloglevel=0 \ 
+          fuzzer_args: " --seed ${RANDOM} --duration_sec 600 --logtostderr=1 --minloglevel=0 \
           --repro_persist_path=/tmp/spark_fuzzer_repro"
 
 
@@ -436,7 +436,7 @@ jobs:
           fuzzer_repro: "/tmp/aggregate_fuzzer_repro"
           fuzzer_name: "Aggregate"
           fuzzer_exe: "_build/debug/velox/exec/tests/velox_aggregation_fuzzer_test"
-          fuzzer_args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \ 
+          fuzzer_args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \
           --repro_persist_path=/tmp/aggregate_fuzzer_repro"
 
   linux-join-fuzzer-run:
@@ -500,7 +500,7 @@ jobs:
             source ~/.bashrc
             conda create -y --name docgenenv python=3.7
             conda activate docgenenv
-            pip install sphinx sphinx-tabs breathe sphinx_rtd_theme 
+            pip install sphinx sphinx-tabs breathe sphinx_rtd_theme
             make -C velox/docs html
             git checkout gh-pages
             cp -R velox/docs/_build/html/* docs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,7 +248,7 @@ jobs:
       - run:
           name: "Build"
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=OFF"
             ccache -s
           no_output_timeout: 1h
       - run:
@@ -378,7 +378,7 @@ jobs:
       - run:
           name: Build including all Benchmarks
           command: |
-            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_BENCHMARKS=ON -DVELOX_ENABLE_ARROW=ON -DVELOX_ENABLE_PARQUET=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON -DVELOX_ENABLE_SUBSTRAIT=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_BENCHMARKS=OFF -DVELOX_ENABLE_ARROW=OFF -DVELOX_ENABLE_PARQUET=OFF -DVELOX_ENABLE_HDFS=OFF -DVELOX_ENABLE_S3=OFF -DVELOX_ENABLE_SUBSTRAIT=OFF" AWSSDK_ROOT_DIR=~/adapter-deps/install NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
             ccache -s
           no_output_timeout: 1h
       - run:

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <iostream>
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 
 namespace facebook::velox::exec::test {
@@ -158,9 +159,12 @@ std::shared_ptr<Task> AssertQueryBuilder::assertResults(
 
 std::shared_ptr<Task> AssertQueryBuilder::assertResults(
     const std::vector<RowVectorPtr>& expected) {
+  std::cout << "assertResults begin" << std::endl;
   auto [cursor, results] = readCursor();
+  std::cout << "assertResults finished reading cursor" << std::endl;
 
   assertEqualResults(expected, results);
+  std::cout << "assertEqualResults finished" << std::endl;
   return cursor->task();
 }
 

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -479,6 +479,12 @@ velox::variant rowVariantAt(const VectorPtr& vector, vector_size_t row) {
 variant variantAt(const VectorPtr& vector, vector_size_t row) {
   auto typeKind = vector->typeKind();
   if (vector->isNullAt(row)) {
+    if (typeKind == TypeKind::SHORT_DECIMAL) {
+      return variant::shortDecimal(std::nullopt, vector->type());
+    }
+    if (typeKind == TypeKind::LONG_DECIMAL) {
+      return variant::longDecimal(std::nullopt, vector->type());
+    }
     return variant(typeKind);
   }
 

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -973,13 +973,17 @@ bool assertEqualResults(
     const std::vector<RowVectorPtr>& actual) {
   MaterializedRowMultiset expectedRows;
   for (auto vector : expected) {
+    std::cout << "assertEqualResults Expected " << vector->toString(true) << std::endl;
     auto rows = materialize(vector);
+    std::cout << "assertEqualResults materialize " << std::endl;
     std::copy(
         rows.begin(),
         rows.end(),
         std::inserter(expectedRows, expectedRows.end()));
+    std::cout << "assertEqualResults finished copy " << std::endl;
   }
 
+  std::cout << "assertEqualResults comparison" << std::endl;
   return assertEqualResults(expectedRows, actual);
 }
 
@@ -1020,9 +1024,12 @@ bool assertEqualResults(
     const MaterializedRowMultiset& expectedRows,
     const MaterializedRowMultiset& actualRows,
     const std::string& message) {
+  std::cout << "assertEqualResults start comparison 2" << std::endl;
   if (expectedRows.empty() != actualRows.empty()) {
+    std::cout << "assertEqualResults start comparison 2 compare" << std::endl;
     EXPECT_TRUE(false) << generateUserFriendlyDiff(expectedRows, actualRows)
                        << message;
+    std::cout << "assertEqualResults start comparison 2 friendly message" << std::endl;
     return false;
   }
 
@@ -1031,6 +1038,7 @@ bool assertEqualResults(
   }
 
   if (!equalTypeKinds(*expectedRows.begin(), *actualRows.begin())) {
+    std::cout << "assertEqualResults start comparison 2 type does not match" << std::endl;
     EXPECT_TRUE(false) << "Types of expected and actual results do not match";
     return false;
   }
@@ -1038,6 +1046,7 @@ bool assertEqualResults(
   auto [numFloatingPointColumns, columns] =
       findFloatingPointColumns(*expectedRows.begin());
   if (numFloatingPointColumns) {
+    std::cout << "assertEqualResults start comparison 2 numFloatingPointColumns" << std::endl;
     MaterializedRowEpsilonComparator comparator{
         numFloatingPointColumns, columns};
     if (auto result = comparator.areEqual(expectedRows, actualRows)) {
@@ -1066,6 +1075,7 @@ bool assertEqualResults(
 bool assertEqualResults(
     const MaterializedRowMultiset& expectedRows,
     const std::vector<RowVectorPtr>& actual) {
+  std::cout << "assertEqualResults start comparison" << std::endl;
   MaterializedRowMultiset actualRows;
   for (auto vector : actual) {
     auto rows = materialize(vector);

--- a/velox/functions/prestosql/aggregates/DecimalAggregate.h
+++ b/velox/functions/prestosql/aggregates/DecimalAggregate.h
@@ -208,6 +208,7 @@ class DecimalAggregate : public exec::Aggregate {
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
+        clearNull(groups[i]);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);

--- a/velox/functions/prestosql/aggregates/DecimalAggregate.h
+++ b/velox/functions/prestosql/aggregates/DecimalAggregate.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <iostream>
 #include "velox/common/base/IOUtils.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/vector/FlatVector.h"
@@ -208,7 +209,7 @@ class DecimalAggregate : public exec::Aggregate {
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
-//        clearNull(groups[i]);
+        clearNull(groups[i]);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
@@ -241,6 +242,7 @@ class DecimalAggregate : public exec::Aggregate {
         if (decodedPartial_.isNullAt(i)) {
           return;
         }
+        clearNull(group);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
@@ -248,6 +250,7 @@ class DecimalAggregate : public exec::Aggregate {
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
+        clearNull(group);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);

--- a/velox/functions/prestosql/aggregates/DecimalAggregate.h
+++ b/velox/functions/prestosql/aggregates/DecimalAggregate.h
@@ -208,7 +208,7 @@ class DecimalAggregate : public exec::Aggregate {
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
-        clearNull(groups[i]);
+//        clearNull(groups[i]);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);

--- a/velox/functions/prestosql/aggregates/DecimalAggregate.h
+++ b/velox/functions/prestosql/aggregates/DecimalAggregate.h
@@ -270,6 +270,7 @@ class DecimalAggregate : public exec::Aggregate {
       if (isNull(groups[i])) {
         stringViewVector->setNull(i, true);
       } else {
+        std::cout << "extractAccumulators, group: " << i << " clearNull" << std::endl;
         clearNull(rawNulls, i);
         auto size = accumulator->serializedSize();
         Buffer* buffer = stringViewVector->getBufferWithSpace(size);
@@ -295,8 +296,10 @@ class DecimalAggregate : public exec::Aggregate {
     for (int32_t i = 0; i < numGroups; ++i) {
       char* group = groups[i];
       if (isNull(group)) {
+        std::cout << "extractValues, group: " << i << " is null" << std::endl;
         vector->setNull(i, true);
       } else {
+        std::cout << "extractValues, group: " << i << " is not null" << std::endl;
         clearNull(rawNulls, i);
         auto accumulator = decimalAccumulator(group);
         rawValues[i] = computeFinalValue(accumulator);

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -90,7 +90,12 @@ void AggregationTestBase::testAggregations(
       groupingKeys,
       aggregates,
       postAggregationProjections,
-      [&](auto& builder) { return builder.assertResults(expectedResult); });
+      [&](auto& builder) {
+        std::cout << "testAggregation.builder.assertResults begin" << std::endl;
+        auto res = builder.assertResults(expectedResult);
+        std::cout << "testAggregation.builder.assertResults end" << std::endl;
+        return res;
+      });
 }
 
 void AggregationTestBase::testAggregations(

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -172,14 +172,19 @@ void AggregationTestBase::testAggregations(
         assertResults) {
   {
     SCOPED_TRACE("Run partial + final");
+    std::cout << "Run partial + final" << std::endl;
     PlanBuilder builder(pool());
+    std::cout << "makeSource" << std::endl;
     makeSource(builder);
+    std::cout << "builder.partialAggregation" << std::endl;
     builder.partialAggregation(groupingKeys, aggregates).finalAggregation();
     if (!postAggregationProjections.empty()) {
       builder.project(postAggregationProjections);
     }
 
+    std::cout << "AssertQueryBuilder queryBuilder" << std::endl;
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    std::cout << "assertResults" << std::endl;
     assertResults(queryBuilder);
   }
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -346,14 +346,16 @@ TEST_F(AverageAggregationTest, avgDecimal) {
 TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
   std::cout << "Step 1 begin" << std::endl;
 
-  auto input = {
-      makeRowVector(
-          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
-      makeRowVector(
-          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
-  };
+//  auto input = {
+//      makeRowVector(
+//          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
+//           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+//      makeRowVector(
+//          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
+//           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+//  };
+
+  auto input = {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})};
 
   std::cout << "Step 1 end" << std::endl;
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -344,6 +344,7 @@ TEST_F(AverageAggregationTest, avgDecimal) {
 }
 
 TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
+  std::cout << "Started the test" << std::endl;
   auto input = {
       makeRowVector(
           {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
@@ -353,11 +354,15 @@ TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
            makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
   };
 
+  std::cout << "Running the test" << std::endl;
+
   auto result = {makeRowVector(
       {makeFlatVector<StringView>({StringView{"1"}}),
        makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
 
   testAggregations(input, {"c0"}, {"avg(c1)"}, {}, result);
+
+  std::cout << "Finished the test" << std::endl;
 }
 
 TEST_F(AverageAggregationTest, constantVectorOverflow) {

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -346,24 +346,24 @@ TEST_F(AverageAggregationTest, avgDecimal) {
 TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
   std::cout << "Step 1 begin" << std::endl;
 
-//  auto input = {
-//      makeRowVector(
-//          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-//           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
-//      makeRowVector(
-//          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-//           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
-//  };
-
-  auto input = {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})};
+  auto input = {
+      makeRowVector(
+          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
+           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
+           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+  };
 
   std::cout << "Step 1 end" << std::endl;
 
   std::cout << "Step 2 begin" << std::endl;
 
-  auto result = {makeRowVector(
-      {makeFlatVector<StringView>({StringView{"1"}}),
-       makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
+//  auto result = {makeRowVector(
+//      {makeFlatVector<StringView>({StringView{"1"}}),
+//       makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
+  
+  auto result = {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})};
 
   std::cout << "Step 2 end" << std::endl;
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -362,7 +362,7 @@ TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
 //  auto result = {makeRowVector(
 //      {makeFlatVector<StringView>({StringView{"1"}}),
 //       makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
-  
+
   auto result = {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})};
 
   std::cout << "Step 2 end" << std::endl;

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -343,6 +343,22 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})});
 }
 
+TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
+  auto input = {
+      makeRowVector(
+          {makeFlatVector<int32_t>({1, 1}),
+           makeNullableShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeFlatVector<int32_t>({1, 1}),
+           makeNullableShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+  };
+
+  auto result = {makeRowVector(
+      {makeNullableShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
+
+  testAggregations(input, {"c0"}, {"avg(c1)"}, {"a0"}, result);
+}
+
 TEST_F(AverageAggregationTest, constantVectorOverflow) {
   auto rows = makeRowVector({makeConstant<int32_t>(1073741824, 100)});
   auto plan = PlanBuilder()

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -344,7 +344,8 @@ TEST_F(AverageAggregationTest, avgDecimal) {
 }
 
 TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
-  std::cout << "Started the test" << std::endl;
+  std::cout << "Step 1 begin" << std::endl;
+
   auto input = {
       makeRowVector(
           {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
@@ -354,15 +355,21 @@ TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
            makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
   };
 
-  std::cout << "Running the test" << std::endl;
+  std::cout << "Step 1 end" << std::endl;
+
+  std::cout << "Step 2 begin" << std::endl;
 
   auto result = {makeRowVector(
       {makeFlatVector<StringView>({StringView{"1"}}),
        makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
 
+  std::cout << "Step 2 end" << std::endl;
+
+  std::cout << "Step 3 begin" << std::endl;
+
   testAggregations(input, {"c0"}, {"avg(c1)"}, {}, result);
 
-  std::cout << "Finished the test" << std::endl;
+  std::cout << "Step 3 end" << std::endl;
 }
 
 TEST_F(AverageAggregationTest, constantVectorOverflow) {

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -347,15 +347,15 @@ TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
   auto input = {
       makeRowVector(
           {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-           makeNullableShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
       makeRowVector(
           {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
-           makeNullableShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
   };
 
   auto result = {makeRowVector(
       {makeFlatVector<StringView>({StringView{"1"}}),
-       makeNullableShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
+       makeShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
 
   testAggregations(input, {"c0"}, {"avg(c1)"}, {}, result);
 }

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -346,17 +346,18 @@ TEST_F(AverageAggregationTest, avgDecimal) {
 TEST_F(AverageAggregationTest, avgDecimalWithGroupingKeys) {
   auto input = {
       makeRowVector(
-          {makeFlatVector<int32_t>({1, 1}),
+          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
            makeNullableShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
       makeRowVector(
-          {makeFlatVector<int32_t>({1, 1}),
+          {makeFlatVector<StringView>({StringView{"1"}, StringView{"1"}}),
            makeNullableShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
   };
 
   auto result = {makeRowVector(
-      {makeNullableShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
+      {makeFlatVector<StringView>({StringView{"1"}}),
+       makeNullableShortDecimalFlatVector({27583}, DECIMAL(5, 2))})};
 
-  testAggregations(input, {"c0"}, {"avg(c1)"}, {"a0"}, result);
+  testAggregations(input, {"c0"}, {"avg(c1)"}, {}, result);
 }
 
 TEST_F(AverageAggregationTest, constantVectorOverflow) {


### PR DESCRIPTION
The PR fixes a correctness issue when the query `select a, avg(b) from table group by a` would return `null` instead of a correct aggregated value.