### PR TITLE
Introduce FuzzerConnector

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -27,12 +27,15 @@
 namespace facebook::velox::common {
 class Filter;
 }
+
 namespace facebook::velox::core {
 class ITypedExpr;
 } // namespace facebook::velox::core
+
 namespace facebook::velox::exec {
 class ExprSet;
 }
+
 namespace facebook::velox::connector {
 
 class DataSource;

--- a/velox/connectors/fuzzer/CMakeLists.txt
+++ b/velox/connectors/fuzzer/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_fuzzer_connector OBJECT FuzzerConnector.cpp)
+
+target_link_libraries(velox_fuzzer_connector velox_connector
+                      velox_vector_fuzzer)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/connectors/fuzzer/FuzzerConnector.cpp
+++ b/velox/connectors/fuzzer/FuzzerConnector.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/fuzzer/FuzzerConnector.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::connector::fuzzer {
+
+FuzzerDataSource::FuzzerDataSource(
+    const std::shared_ptr<const RowType>& outputType,
+    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+    velox::memory::MemoryPool* FOLLY_NONNULL pool)
+    : outputType_(outputType), pool_(pool) {
+  auto fuzzerTableHandle =
+      std::dynamic_pointer_cast<FuzzerTableHandle>(tableHandle);
+  VELOX_CHECK_NOT_NULL(
+      fuzzerTableHandle,
+      "TableHandle must be an instance of FuzzerTableHandle");
+
+  vectorFuzzer_ = std::make_unique<VectorFuzzer>(
+      fuzzerTableHandle->fuzzerOptions, pool_, fuzzerTableHandle->fuzzerSeed);
+}
+
+void FuzzerDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  VELOX_CHECK_EQ(
+      currentSplit_,
+      nullptr,
+      "Previous split has not been processed yet. Call next() to process the split.");
+  currentSplit_ = std::dynamic_pointer_cast<FuzzerConnectorSplit>(split);
+  VELOX_CHECK(currentSplit_, "Wrong type of split for FuzzerDataSource.");
+
+  splitOffset_ = 0;
+  splitEnd_ = currentSplit_->numRows;
+}
+
+std::optional<RowVectorPtr> FuzzerDataSource::next(
+    uint64_t size,
+    velox::ContinueFuture& /*future*/) {
+  VELOX_CHECK_NOT_NULL(
+      currentSplit_, "No split to process. Call addSplit() first.");
+
+  // Split exhausted.
+  if (splitOffset_ >= splitEnd_) {
+    currentSplit_ = nullptr;
+    splitOffset_ = 0;
+    splitEnd_ = 0;
+    return nullptr;
+  }
+
+  const size_t outputRows = std::min(size, (splitEnd_ - splitOffset_));
+  splitOffset_ += outputRows;
+
+  auto outputVector = vectorFuzzer_->fuzzRow(outputType_, outputRows);
+  completedRows_ += outputVector->size();
+  completedBytes_ += outputVector->retainedSize();
+  return outputVector;
+}
+
+VELOX_REGISTER_CONNECTOR_FACTORY(std::make_shared<FuzzerConnectorFactory>())
+
+} // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+#include "velox/connectors/fuzzer/FuzzerConnectorSplit.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox::connector::fuzzer {
+
+/// `FuzzerConnector` is a connector that generates data on-the-fly using
+/// VectorFuzzer, based on the expected outputType defined by the client.
+///
+/// FuzzerConnector doesn't have the concept of table names, but using
+/// `FuzzerTableHandle` clients can specify VectorFuzzer options and seed, which
+/// are used when instantiating VectorFuzzer.
+///
+/// FuzzerConnectorSplit lets clients specify how many rows are expected to be
+/// generated.
+
+class FuzzerTableHandle : public ConnectorTableHandle {
+ public:
+  explicit FuzzerTableHandle(
+      std::string connectorId,
+      VectorFuzzer::Options options,
+      size_t fuzzerSeed = 0)
+      : ConnectorTableHandle(std::move(connectorId)),
+        fuzzerOptions(options),
+        fuzzerSeed(fuzzerSeed) {}
+
+  ~FuzzerTableHandle() override {}
+
+  std::string toString() const override {
+    return "fuzzer-mock-table";
+  }
+
+  const VectorFuzzer::Options fuzzerOptions;
+  size_t fuzzerSeed;
+};
+
+class FuzzerDataSource : public DataSource {
+ public:
+  FuzzerDataSource(
+      const std::shared_ptr<const RowType>& outputType,
+      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool);
+
+  void addSplit(std::shared_ptr<ConnectorSplit> split) override;
+
+  void addDynamicFilter(
+      column_index_t /*outputChannel*/,
+      const std::shared_ptr<common::Filter>& /*filter*/) override {
+    VELOX_NYI("Dynamic filters not supported by FuzzerConnector.");
+  }
+
+  std::optional<RowVectorPtr> next(uint64_t size, velox::ContinueFuture& future)
+      override;
+
+  uint64_t getCompletedRows() override {
+    return completedRows_;
+  }
+
+  uint64_t getCompletedBytes() override {
+    return completedBytes_;
+  }
+
+  std::unordered_map<std::string, RuntimeCounter> runtimeStats() override {
+    // TODO: Which stats do we want to expose here?
+    return {};
+  }
+
+ private:
+  const RowTypePtr outputType_;
+  std::unique_ptr<VectorFuzzer> vectorFuzzer_;
+
+  // The current split being processed.
+  std::shared_ptr<FuzzerConnectorSplit> currentSplit_;
+
+  // How many rows were generated for this split.
+  uint64_t splitOffset_{0};
+  uint64_t splitEnd_{0};
+
+  size_t completedRows_{0};
+  size_t completedBytes_{0};
+
+  memory::MemoryPool* FOLLY_NONNULL pool_;
+};
+
+class FuzzerConnector final : public Connector {
+ public:
+  FuzzerConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> properties,
+      folly::Executor* FOLLY_NULLABLE /*executor*/)
+      : Connector(id, properties) {}
+
+  std::shared_ptr<DataSource> createDataSource(
+      const std::shared_ptr<const RowType>& outputType,
+      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>& /*columnHandles*/,
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
+    return std::make_shared<FuzzerDataSource>(
+        outputType, tableHandle, connectorQueryCtx->memoryPool());
+  }
+
+  std::shared_ptr<DataSink> createDataSink(
+      RowTypePtr /*inputType*/,
+      std::shared_ptr<
+          ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
+      ConnectorQueryCtx* /*connectorQueryCtx*/,
+      CommitStrategy /*commitStrategy*/) override final {
+    VELOX_NYI("FuzzerConnector does not support data sink.");
+  }
+};
+
+class FuzzerConnectorFactory : public ConnectorFactory {
+ public:
+  static constexpr const char* FOLLY_NONNULL kFuzzerConnectorName{"fuzzer"};
+
+  FuzzerConnectorFactory() : ConnectorFactory(kFuzzerConnectorName) {}
+
+  explicit FuzzerConnectorFactory(const char* FOLLY_NONNULL connectorName)
+      : ConnectorFactory(connectorName) {}
+
+  std::shared_ptr<Connector> newConnector(
+      const std::string& id,
+      std::shared_ptr<const Config> properties,
+      folly::Executor* FOLLY_NULLABLE executor = nullptr) override {
+    return std::make_shared<FuzzerConnector>(id, properties, executor);
+  }
+};
+
+} // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/FuzzerConnectorSplit.h
+++ b/velox/connectors/fuzzer/FuzzerConnectorSplit.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/Connector.h"
+
+namespace facebook::velox::connector::fuzzer {
+
+struct FuzzerConnectorSplit : public connector::ConnectorSplit {
+  explicit FuzzerConnectorSplit(const std::string& connectorId, size_t numRows)
+      : ConnectorSplit(connectorId), numRows(numRows) {}
+
+  // Row many rows to generate.
+  size_t numRows;
+};
+
+} // namespace facebook::velox::connector::fuzzer

--- a/velox/connectors/fuzzer/tests/CMakeLists.txt
+++ b/velox/connectors/fuzzer/tests/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+add_executable(velox_fuzzer_connector_test FuzzerConnectorTest.cpp)
+
+add_test(velox_fuzzer_connector_test velox_fuzzer_connector_test)
+
+target_link_libraries(
+  velox_fuzzer_connector_test
+  velox_fuzzer_connector
+  velox_vector_test_lib
+  velox_exec_test_lib
+  velox_aggregates
+  gtest
+  gtest_main)

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/fuzzer/FuzzerConnector.h"
+#include <folly/init/Init.h>
+#include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace {
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::fuzzer;
+
+using facebook::velox::exec::test::PlanBuilder;
+
+class FuzzerConnectorTest : public exec::test::OperatorTestBase {
+ public:
+  const std::string kFuzzerConnectorId = "test-fuzzer";
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+    auto fuzzerConnector =
+        connector::getConnectorFactory(
+            connector::fuzzer::FuzzerConnectorFactory::kFuzzerConnectorName)
+            ->newConnector(kFuzzerConnectorId, nullptr);
+    connector::registerConnector(fuzzerConnector);
+  }
+
+  void TearDown() override {
+    connector::unregisterConnector(kFuzzerConnectorId);
+    OperatorTestBase::TearDown();
+  }
+
+  exec::Split makeFuzzerSplit(size_t numRows) const {
+    return exec::Split(
+        std::make_shared<FuzzerConnectorSplit>(kFuzzerConnectorId, numRows));
+  }
+
+  std::vector<exec::Split> makeFuzzerSplits(
+      size_t rowsPerSplit,
+      size_t numSplits) const {
+    std::vector<exec::Split> splits;
+    splits.reserve(numSplits);
+
+    for (size_t i = 0; i < numSplits; ++i) {
+      splits.emplace_back(makeFuzzerSplit(rowsPerSplit));
+    }
+    return splits;
+  }
+
+  std::shared_ptr<FuzzerTableHandle> makeFuzzerTableHandle(
+      size_t fuzzerSeed = 0) const {
+    return std::make_shared<FuzzerTableHandle>(
+        kFuzzerConnectorId, fuzzerOptions_, fuzzerSeed);
+  }
+
+ private:
+  VectorFuzzer::Options fuzzerOptions_;
+};
+
+TEST_F(FuzzerConnectorTest, singleSplit) {
+  const size_t numRows = 100;
+  auto type = ROW({BIGINT(), DOUBLE(), VARCHAR()});
+
+  auto plan =
+      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .split(makeFuzzerSplit(numRows))
+      .assertTypeAndNumRows(type, numRows);
+}
+
+TEST_F(FuzzerConnectorTest, floatingPoints) {
+  const size_t numRows = 1000;
+  auto type = ROW({REAL(), DOUBLE()});
+
+  auto plan =
+      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .split(makeFuzzerSplit(numRows))
+      .assertTypeAndNumRows(type, numRows);
+}
+
+TEST_F(FuzzerConnectorTest, complexTypes) {
+  const size_t numRows = 100;
+  auto type = ROW({
+      ARRAY(BIGINT()),
+      ROW({VARCHAR(), MAP(INTEGER(), ARRAY(DOUBLE())), VARBINARY()}),
+      REAL(),
+  });
+
+  auto plan =
+      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .split(makeFuzzerSplit(numRows))
+      .assertTypeAndNumRows(type, numRows);
+}
+
+TEST_F(FuzzerConnectorTest, multipleSplits) {
+  const size_t rowsPerSplit = 100;
+  const size_t numSplits = 10;
+  auto type = ROW({BIGINT(), DOUBLE(), VARCHAR()});
+
+  auto plan =
+      PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+
+  exec::test::AssertQueryBuilder(plan)
+      .splits(makeFuzzerSplits(rowsPerSplit, numSplits))
+      .assertTypeAndNumRows(type, rowsPerSplit * numSplits);
+}
+
+TEST_F(FuzzerConnectorTest, randomTypes) {
+  const size_t rowsPerSplit = 100;
+  const size_t numSplits = 10;
+
+  const size_t iterations = 20;
+
+  for (size_t i = 0; i < iterations; ++i) {
+    auto type = VectorFuzzer({}, pool()).randRowType();
+
+    auto plan =
+        PlanBuilder().tableScan(type, makeFuzzerTableHandle(), {}).planNode();
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeFuzzerSplits(rowsPerSplit, numSplits))
+        .assertTypeAndNumRows(type, rowsPerSplit * numSplits);
+  }
+}
+
+TEST_F(FuzzerConnectorTest, reproducible) {
+  const size_t numRows = 100;
+  auto type = ROW({BIGINT(), ARRAY(INTEGER()), VARCHAR()});
+
+  auto plan1 =
+      PlanBuilder()
+          .tableScan(type, makeFuzzerTableHandle(/*fuzerSeed=*/1234), {})
+          .planNode();
+  auto plan2 =
+      PlanBuilder()
+          .tableScan(type, makeFuzzerTableHandle(/*fuzerSeed=*/1234), {})
+          .planNode();
+
+  auto results1 = exec::test::AssertQueryBuilder(plan1)
+                      .split(makeFuzzerSplit(numRows))
+                      .copyResults(pool());
+  auto results2 = exec::test::AssertQueryBuilder(plan2)
+                      .split(makeFuzzerSplit(numRows))
+                      .copyResults(pool());
+
+  exec::test::assertEqualResults({results1}, {results2});
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -164,6 +164,15 @@ std::shared_ptr<Task> AssertQueryBuilder::assertResults(
   return cursor->task();
 }
 
+std::shared_ptr<Task> AssertQueryBuilder::assertTypeAndNumRows(
+    const TypePtr& expectedType,
+    vector_size_t expectedNumRows) {
+  auto [cursor, results] = readCursor();
+
+  assertEqualTypeAndNumRows(expectedType, expectedNumRows, results);
+  return cursor->task();
+}
+
 RowVectorPtr AssertQueryBuilder::copyResults(memory::MemoryPool* pool) {
   auto [cursor, results] = readCursor();
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -114,6 +114,12 @@ class AssertQueryBuilder {
   std::shared_ptr<Task> assertResults(
       const std::vector<RowVectorPtr>& expected);
 
+  /// Run the query and ensure it returns batches of `expectedType`, and exactly
+  /// `numRows`.
+  std::shared_ptr<Task> assertTypeAndNumRows(
+      const TypePtr& expectedType,
+      vector_size_t expectedNumRows);
+
   /// Run the query and collect all results into a single vector. Throws if
   /// query returns empty result.
   RowVectorPtr copyResults(memory::MemoryPool* FOLLY_NONNULL pool);
@@ -132,4 +138,5 @@ class AssertQueryBuilder {
       connectorConfigs_;
   std::unordered_map<core::PlanNodeId, std::vector<Split>> splits_;
 };
+
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -977,6 +977,18 @@ bool assertEqualResults(
   return assertEqualResults(expectedRows, actual);
 }
 
+void assertEqualTypeAndNumRows(
+    const TypePtr& expectedType,
+    vector_size_t expectedNumRows,
+    const std::vector<RowVectorPtr>& actual) {
+  size_t actualNumRows = 0;
+  for (const auto& result : actual) {
+    EXPECT_EQ(*expectedType, *result->type());
+    actualNumRows += result->size();
+  }
+  EXPECT_EQ(expectedNumRows, actualNumRows);
+}
+
 /// Returns the number of floating-point columns and a list of columns indices
 /// with floating-point columns placed at the end.
 std::tuple<uint32_t, std::vector<velox::column_index_t>>

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -202,6 +202,12 @@ bool assertEqualResults(
     const MaterializedRowMultiset& expected,
     const std::vector<RowVectorPtr>& actual);
 
+/// Ensure both datasets have the same type and number of rows.
+void assertEqualTypeAndNumRows(
+    const TypePtr& expectedType,
+    vector_size_t expectedNumRows,
+    const std::vector<RowVectorPtr>& actual);
+
 void printResults(const RowVectorPtr& result, std::ostream& out);
 
 } // namespace facebook::velox::exec::test

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -46,14 +46,12 @@ enum UTF8CharList {
 /// The `fuzz(type)` method provides the highest degree of entropy. It randomly
 /// generates different types of (possibly nested) encodings given the input
 /// type, including constants, dictionaries, sliced vectors, and more. It
-/// accepts any primitive, complex, or nested types. Additionally,
-/// 'opt.allowLazyVector' can be set to true to enable a chance of generating a
-/// lazy vector:
+/// accepts any primitive, complex, or nested types:
 ///
-///   auto vector1 = fuzzer.fuzz(INTEGER(), true);
+///   auto vector1 = fuzzer.fuzz(INTEGER());
 ///   auto vector2 =
-///       fuzzer.fuzz(MAP(ARRAY(INTEGER()), ROW({REAL(), BIGINT()})), false);
-///   auto vector3 = fuzzer.fuzz(ROW({SMALLINT(), DOUBLE()}), true);
+///       fuzzer.fuzz(MAP(ARRAY(INTEGER()), ROW({REAL(), BIGINT()})));
+///   auto vector3 = fuzzer.fuzz(ROW({SMALLINT(), DOUBLE()}));
 ///
 /// #2.
 ///
@@ -212,6 +210,7 @@ class VectorFuzzer {
 
   // Returns a "fuzzed" row vector with randomized data and nulls.
   RowVectorPtr fuzzRow(const RowTypePtr& rowType);
+  RowVectorPtr fuzzRow(const RowTypePtr& rowType, vector_size_t size);
 
   // Returns a RowVector based on the provided vectors, fuzzing its top-level
   // null buffer.
@@ -294,8 +293,6 @@ class VectorFuzzer {
   // flat encodings if flatEncoding is set to false, otherwise they will all be
   // flat.
   VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
-
-  RowVectorPtr fuzzRow(const RowTypePtr& rowType, vector_size_t size);
 
   // Generate a random null buffer.
   BufferPtr fuzzNulls(vector_size_t size);


### PR DESCRIPTION
Summary:
FuzzerConnector makes it convenient to use data generated by
VetorFuzzer in query plans. The new connectors takes a VectorFuzzer::Options
and seed as part of the table handle, and generates data according to the
outputType specific by the client.
.
FuzzerConnectorSplits only control the number of rows to be generated.
.
Also, adding assertNumRows() to `AssertQueryBuilder` which only checks t
hat the results have the expected type and number of rows (not their actual
content).

Differential Revision: D43428261

