### PR TITLE
[BUILD] Support loading dependencies from non-system directories

### DIFF
--- a/CMake/FindThrift.cmake
+++ b/CMake/FindThrift.cmake
@@ -1,0 +1,162 @@
+# Copyright 2012 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# - Find Thrift (a cross platform RPC lib/tool)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  Thrift_ROOT - When set, this path is inspected instead of standard library
+#                locations as the root of the Thrift installation.
+#                The environment variable THRIFT_HOME overrides this variable.
+#
+# This module defines
+#  Thrift_FOUND, whether Thrift is found or not
+#  Thrift_COMPILER_FOUND, whether Thrift compiler is found or not
+#
+#  thrift::thrift, a library target to use Thrift
+#  thrift::compiler, a executable target to use Thrift compiler
+
+if(Thrift_FOUND)
+    return()
+endif()
+
+function(EXTRACT_THRIFT_VERSION)
+    if(THRIFT_INCLUDE_DIR)
+        file(READ "${THRIFT_INCLUDE_DIR}/thrift/config.h" THRIFT_CONFIG_H_CONTENT)
+        string(REGEX MATCH "#define PACKAGE_VERSION \"[0-9.]+\"" THRIFT_VERSION_DEFINITION
+                "${THRIFT_CONFIG_H_CONTENT}")
+        string(REGEX MATCH "[0-9.]+" Thrift_VERSION "${THRIFT_VERSION_DEFINITION}")
+        set(Thrift_VERSION
+                "${Thrift_VERSION}"
+                PARENT_SCOPE)
+    else()
+        set(Thrift_VERSION
+                ""
+                PARENT_SCOPE)
+    endif()
+endfunction(EXTRACT_THRIFT_VERSION)
+
+if(MSVC_TOOLCHAIN AND NOT DEFINED THRIFT_MSVC_LIB_SUFFIX)
+    if(NOT ARROW_THRIFT_USE_SHARED)
+        if(ARROW_USE_STATIC_CRT)
+            if("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+                set(THRIFT_MSVC_LIB_SUFFIX "mtd")
+            else()
+                set(THRIFT_MSVC_LIB_SUFFIX "mt")
+            endif()
+        else()
+            if("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+                set(THRIFT_MSVC_LIB_SUFFIX "mdd")
+            else()
+                set(THRIFT_MSVC_LIB_SUFFIX "md")
+            endif()
+        endif()
+    endif()
+endif()
+set(THRIFT_LIB_NAME_BASE "thrift${THRIFT_MSVC_LIB_SUFFIX}")
+
+if(ARROW_THRIFT_USE_SHARED)
+    set(THRIFT_LIB_NAMES thrift)
+    if(CMAKE_IMPORT_LIBRARY_SUFFIX)
+        list(APPEND
+                THRIFT_LIB_NAMES
+                "${CMAKE_IMPORT_LIBRARY_PREFIX}${THRIFT_LIB_NAME_BASE}${CMAKE_IMPORT_LIBRARY_SUFFIX}"
+                )
+    endif()
+    list(APPEND
+            THRIFT_LIB_NAMES
+            "${CMAKE_SHARED_LIBRARY_PREFIX}${THRIFT_LIB_NAME_BASE}${CMAKE_SHARED_LIBRARY_SUFFIX}"
+            )
+else()
+    set(THRIFT_LIB_NAMES
+            "${CMAKE_STATIC_LIBRARY_PREFIX}${THRIFT_LIB_NAME_BASE}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+            )
+endif()
+
+if(Thrift_ROOT)
+    find_library(THRIFT_LIB
+            NAMES ${THRIFT_LIB_NAMES}
+            PATHS ${Thrift_ROOT}
+            PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib")
+    find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h
+            PATHS ${Thrift_ROOT}
+            PATH_SUFFIXES "include")
+    find_program(THRIFT_COMPILER thrift
+            PATHS ${Thrift_ROOT}
+            PATH_SUFFIXES "bin")
+    extract_thrift_version()
+else()
+    # THRIFT-4760: The pkgconfig files are currently only installed when using autotools.
+    # Starting with 0.13, they are also installed for the CMake-based installations of Thrift.
+    find_package(PkgConfig QUIET)
+    pkg_check_modules(THRIFT_PC thrift)
+    if(THRIFT_PC_FOUND)
+        set(THRIFT_INCLUDE_DIR "${THRIFT_PC_INCLUDEDIR}")
+
+        list(APPEND THRIFT_PC_LIBRARY_DIRS "${THRIFT_PC_LIBDIR}")
+
+        find_library(THRIFT_LIB
+                NAMES ${THRIFT_LIB_NAMES}
+                PATHS ${THRIFT_PC_LIBRARY_DIRS}
+                NO_DEFAULT_PATH)
+        find_program(THRIFT_COMPILER thrift
+                HINTS ${THRIFT_PC_PREFIX}
+                NO_DEFAULT_PATH
+                PATH_SUFFIXES "bin")
+        set(Thrift_VERSION ${THRIFT_PC_VERSION})
+    else()
+        find_library(THRIFT_LIB
+                NAMES ${THRIFT_LIB_NAMES}
+                PATH_SUFFIXES "lib/${CMAKE_LIBRARY_ARCHITECTURE}" "lib")
+        find_path(THRIFT_INCLUDE_DIR thrift/Thrift.h PATH_SUFFIXES "include")
+        find_program(THRIFT_COMPILER thrift PATH_SUFFIXES "bin")
+        extract_thrift_version()
+    endif()
+endif()
+
+if(THRIFT_COMPILER)
+    set(Thrift_COMPILER_FOUND TRUE)
+else()
+    set(Thrift_COMPILER_FOUND FALSE)
+endif()
+
+find_package_handle_standard_args(
+        Thrift
+        REQUIRED_VARS THRIFT_LIB THRIFT_INCLUDE_DIR
+        VERSION_VAR Thrift_VERSION
+        HANDLE_COMPONENTS)
+
+if(Thrift_FOUND)
+    if(ARROW_THRIFT_USE_SHARED)
+        add_library(thrift::thrift SHARED IMPORTED)
+    else()
+        add_library(thrift::thrift STATIC IMPORTED)
+    endif()
+    set_target_properties(thrift::thrift
+            PROPERTIES IMPORTED_LOCATION "${THRIFT_LIB}"
+            INTERFACE_INCLUDE_DIRECTORIES "${THRIFT_INCLUDE_DIR}")
+    if(WIN32 AND NOT MSVC_TOOLCHAIN)
+        # We don't need this for Visual C++ because Thrift uses
+        # "#pragma comment(lib, "Ws2_32.lib")" in
+        # thrift/windows/config.h for Visual C++.
+        set_target_properties(thrift::thrift PROPERTIES INTERFACE_LINK_LIBRARIES "ws2_32")
+    endif()
+
+    if(Thrift_COMPILER_FOUND)
+        add_executable(thrift::compiler IMPORTED)
+        set_target_properties(thrift::compiler PROPERTIES IMPORTED_LOCATION
+                "${THRIFT_COMPILER}")
+    endif()
+endif()

--- a/CMake/Findfmt.cmake
+++ b/CMake/Findfmt.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+find_path(LIBFMT_INCLUDE_DIR fmt/core.h)
+mark_as_advanced(LIBFMT_INCLUDE_DIR)
+
+find_library(LIBFMT_LIBRARY NAMES fmt fmtd)
+mark_as_advanced(LIBFMT_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+        fmt
+        DEFAULT_MSG
+        LIBFMT_LIBRARY LIBFMT_INCLUDE_DIR)
+
+if(fmt_FOUND)
+    set(LIBFMT_LIBRARIES ${LIBFMT_LIBRARY})
+    set(LIBFMT_INCLUDE_DIRS ${LIBFMT_INCLUDE_DIR})
+    message(STATUS "Found fmt: ${LIBFMT_LIBRARY}")
+    add_library(fmt::fmt UNKNOWN IMPORTED)
+    set_target_properties(
+            fmt::fmt PROPERTIES
+            INTERFACE_INCLUDE_DIRECTORIES "${LIBFMT_INCLUDE_DIR}"
+    )
+    set_target_properties(
+            fmt::fmt PROPERTIES
+            IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+            IMPORTED_LOCATION "${LIBFMT_LIBRARY}"
+    )
+endif()

--- a/CMake/Findfolly.cmake
+++ b/CMake/Findfolly.cmake
@@ -1,0 +1,50 @@
+# - Try to find google test headers and libraries.
+#
+# Usage of this module as follows:
+#
+#     find_package(folly)
+#
+# Variables used by this module, they can change the default behaviour and need
+# to be set before calling find_package:
+#
+#  FOLLY_ROOT_DIR Set this variable to the root installation of
+#                    folly if the module has problems finding
+#                    the proper installation path.
+#
+# Variables defined by this module:
+#
+#  FOLLY_FOUND             System has folly libs/headers
+#  FOLLY_LIBRARIES         The folly library/libraries
+#  FOLLY_INCLUDE_DIR       The location of folly headers
+
+find_path(FOLLY_ROOT_DIR
+        NAMES include/folly/folly-config.h)
+
+find_library(FOLLY_LIBRARIES
+        NAMES folly
+        HINTS ${FOLLY_ROOT_DIR}/lib)
+
+find_library(FOLLY_BENCHMARK_LIBRARIES
+        NAMES follybenchmark
+        HINTS ${FOLLY_ROOT_DIR}/lib)
+
+find_path(FOLLY_INCLUDE_DIR
+        NAMES folly/folly-config.h
+        HINTS ${FOLLY_ROOT_DIR}/include)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(folly DEFAULT_MSG
+        FOLLY_LIBRARIES
+        FOLLY_INCLUDE_DIR)
+
+
+if(folly_FOUND)
+    message(STATUS "Found folly: ${FOLLY_LIBRARIES}")
+    add_library(Folly::folly UNKNOWN IMPORTED)
+    mark_as_advanced(
+            FOLLY_ROOT_DIR
+            FOLLY_LIBRARIES
+            FOLLY_BENCHMARK_LIBRARIES
+            FOLLY_INCLUDE_DIR
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ if(VELOX_ENABLE_HDFS)
     LIBHDFS3
     NAMES libhdfs3.so libhdfs3.dylib
     HINTS "${CMAKE_SOURCE_DIR}/hawq/depends/libhdfs3/_build/src/" REQUIRED)
+  include_directories(${LIBHDFS3_INCLUDE_DIR})
   add_definitions(-DVELOX_ENABLE_HDFS3)
 endif()
 
@@ -310,31 +311,43 @@ set(BOOST_INCLUDE_LIBRARIES
     thread)
 
 resolve_dependency(Boost 1.66.0 COMPONENTS ${BOOST_INCLUDE_LIBRARIES})
+include_directories(${Boost_INCLUDE_DIRS})
 
 # Range-v3 will be enable when the codegen code actually lands keeping it here
 # for reference. find_package(range-v3)
 
 find_package(gflags COMPONENTS shared)
+include_directories(${LIBGFLAGS_INCLUDE_DIR})
 find_package(glog REQUIRED)
+include_directories(${GLOG_INCLUDE_DIRS})
 
 set_source(fmt)
 resolve_dependency(fmt 8.0.1)
+include_directories(${LIBFMT_INCLUDE_DIRS})
 
 find_library(EVENT event)
+include_directories(${LIBEVENT_INCLUDE_DIR})
 
 find_library(DOUBLE_CONVERSION double-conversion)
+include_directories(${DOUBLE_CONVERSION_INCLUDE_DIR})
 
 # Required for boost.
 find_package(ZLIB)
+include_directories(${ZLIB_INCLUDE_DIRS})
 
 if(NOT ${VELOX_BUILD_MINIMAL})
   find_library(LZ4 lz4)
+  include_directories(${LZ4_INCLUDE_DIR})
   find_library(LZO lzo2)
+  include_directories(${LZO_INCLUDE_DIR})
   find_library(ZSTD zstd)
+  include_directories(${ZSTD_INCLUDE_DIR})
   find_library(SNAPPY snappy)
+  include_directories(${SNAPPY_INCLUDE_DIR})
 endif()
 
 find_library(RE2 re2 REQUIRED)
+include_directories(${RE2_INCLUDE_DIR})
 
 if(${VELOX_BUILD_PYTHON_PACKAGE})
   set(pybind11_SOURCE AUTO)
@@ -345,6 +358,7 @@ endif()
 # Locate or build folly.
 set_source(folly)
 resolve_dependency(folly)
+include_directories(SYSTEM ${FOLLY_INCLUDE_DIR})
 
 # If we use BUNDLED boost we need to set this manually AFTER folly is configured
 if(NOT DEFINED Boost_LIBRARIES)
@@ -371,10 +385,9 @@ if(NOT ${VELOX_BUILD_MINIMAL})
   find_package(BZip2 MODULE)
   if(BZIP2_FOUND)
     list(APPEND FOLLY_WITH_DEPENDENCIES ${BZIP2_LIBRARIES})
+    include_directories(${BZIP2_INCLUDE_DIRS})
   endif()
 endif()
-
-include_directories(SYSTEM ${FOLLY_INCLUDE_DIRS})
 
 if(NOT ${VELOX_BUILD_MINIMAL})
   # Locate or build protobuf.
@@ -437,6 +450,8 @@ if(CMAKE_HOST_SYSTEM_NAME MATCHES "Darwin")
 endif()
 find_package(BISON 3.0.4 REQUIRED)
 find_package(FLEX 2.5.13 REQUIRED)
+include_directories(${FLEX_INCLUDE_DIRS})
+include_directories(${LIBDWARF_INCLUDE_DIR})
 
 include_directories(SYSTEM velox)
 include_directories(SYSTEM velox/external)


### PR DESCRIPTION
Recently, we are trying to compile velox with components installed in the user directory by non-root users, which causes failed to find errors for these components. So this PR tries to resolve this problem and support to find components from other directories.