### PR TITLE
Clear the page queue on ExchangeQueue error

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -121,7 +121,7 @@ class ExchangeQueue {
 
   // If data is permanently not available, e.g. the source cannot be
   // contacted, this registers an error message and causes the reading
-  // Exchanges to throw with the message
+  // Exchanges to throw with the message.
   void setError(const std::string& error) {
     std::vector<ContinuePromise> promises;
     {
@@ -131,6 +131,9 @@ class ExchangeQueue {
       }
       error_ = error;
       atEnd_ = true;
+      // NOTE: clear the serialized page queue as we won't consume from an
+      // errored queue.
+      queue_.clear();
       promises = clearAllPromisesLocked();
     }
     clearPromises(promises);

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -378,6 +378,36 @@ TEST_F(PartitionedOutputBufferManagerTest, errorInQueue) {
       auto page = queue->dequeueLocked(&atEnd, &future), std::runtime_error);
 }
 
+TEST_F(PartitionedOutputBufferManagerTest, setQueueErrorWithPendingPages) {
+  const uint64_t kBufferSize = 128;
+  auto iobuf = folly::IOBuf::create(kBufferSize);
+  const std::string payload("setQueueErrorWithPendingPages");
+  size_t payloadSize = payload.size();
+  std::memcpy(iobuf->writableData(), payload.data(), payloadSize);
+  iobuf->append(payloadSize);
+
+  auto pool = memory::getDefaultMemoryPool();
+  auto page = std::make_unique<SerializedPage>(std::move(iobuf), pool.get());
+  ASSERT_EQ(payloadSize, pool->getCurrentBytes());
+
+  auto queue = std::make_shared<ExchangeQueue>(1 << 20);
+  std::vector<ContinuePromise> promises;
+  {
+    std::lock_guard<std::mutex> l(queue->mutex());
+    queue->enqueueLocked(std::move(page), promises);
+  }
+
+  queue->setError("error");
+
+  pool.reset();
+
+  // Expect a throw on dequeue after the queue has been set error.
+  ContinueFuture future;
+  bool atEnd = false;
+  ASSERT_THROW(
+      auto page = queue->dequeueLocked(&atEnd, &future), std::runtime_error);
+}
+
 TEST_F(PartitionedOutputBufferManagerTest, serializedPage) {
   const uint64_t kBufferSize = 128;
   // IOBuf managed memory case


### PR DESCRIPTION
Clear the remaining pages from ExchangeQueue on error. Otherwise, in
some edge case as exposed by Prestissimo staging cluster test, the
remaining pages from a failed ExchangeQueue will be freed after the
associated task has been deleted:

T1:  the ExchangeQueue has been set error for some reason and there are
       remaining pages left on the queue and will never be consumed;
T2: the associated PrestoExchangeSource sends aborts to the source tasks
       which holds a local shared reference on the failed queue while sending
       the request.
T3: the presto worker is in some chaos state and sending abort takes a long
       time and the associated task has been terminated and clean up.
T4: the sending aborts finishes and drops the last local reference on the
      exchange queue to trigger its destruction which in turns destroy the
      pending pages left on the queue. The page destructor tries to free buffer
      to the memory pool which has already gone by the task destruction in T3.

This PR fixes by clearing the pages in T1 when we set queue error