### PR TITLE
Add scoped lock with deferred callback to execute out of lock

### DIFF
--- a/velox/common/base/ScopedLock.h
+++ b/velox/common/base/ScopedLock.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <mutex>
+#include <vector>
+
+namespace facebook::velox {
+
+/// This template class is a lock wrapper which is similar to std::lock_guard
+/// and additionally, it allows user to add deferred callbacks to invoke right
+/// after the lock release. 'LockType' class needs to provides lock()/unlock()
+/// methods to acquire and release lock. Note that the class always calls
+/// unlock() in object destructor even if lock() calls throws in constructor.
+///
+/// The following is the code snippets to show how to
+/// use it:
+///    std::mutex mu;
+///    {
+///       ScopedLock sl(&mu);
+///       sl.addCallback([&]() {
+///          std::lock_guard l(mu);
+///          printf("acquired lock again"); });
+///    }
+template <typename LockType>
+class ScopedLock {
+ public:
+  ScopedLock(LockType* lock) : lock_(lock) {
+    lock_->lock();
+  }
+
+  ~ScopedLock() {
+    lock_->unlock();
+    for (auto cb : callbacks_) {
+      cb();
+    }
+  }
+
+  using Callback = std::function<void()>;
+
+  /// Invoked to add 'cb' to run after release the lock on object destruction.
+  void addCallback(Callback&& cb) {
+    callbacks_.push_back(std::move(cb));
+  }
+
+ private:
+  LockType* const lock_;
+  std::vector<Callback> callbacks_;
+};
+
+} // namespace facebook::velox

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   FsTest.cpp
   RangeTest.cpp
   RawVectorTest.cpp
+  ScopedLockTest.cpp
   SemaphoreTest.cpp
   SimdUtilTest.cpp
   StatsReporterTest.cpp

--- a/velox/common/base/tests/ScopedLockTest.cpp
+++ b/velox/common/base/tests/ScopedLockTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/ScopedLock.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox {
+
+TEST(ScopedLockTest, basic) {
+  int count = 0;
+  std::mutex mu;
+  {
+    ScopedLock sl(&mu);
+    sl.addCallback([&]() {
+      std::lock_guard<std::mutex> l(mu);
+      ++count;
+    });
+    ++count;
+  }
+  ASSERT_EQ(count, 2);
+}
+
+TEST(ScopedLockTest, multiCallbacks) {
+  int count = 0;
+  const int numCallbacks = 10;
+  std::mutex mu;
+  {
+    ScopedLock sl(&mu);
+    for (int i = 0; i < numCallbacks; ++i) {
+      sl.addCallback([&]() {
+        std::lock_guard<std::mutex> l(mu);
+        ++count;
+      });
+    }
+    ++count;
+  }
+  ASSERT_EQ(count, 1 + numCallbacks);
+}
+
+} // namespace facebook::velox

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -18,7 +18,7 @@
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"
 
-DEFINE_int32(split_preload_per_driver, 0, "Prefetch split metadata");
+DEFINE_int32(split_preload_per_driver, 2, "Prefetch split metadata");
 
 namespace facebook::velox::exec {
 


### PR DESCRIPTION
Add a template lock wrapper class which is similar to std::lock_guard
and additionally, it allows user to add deferred callbacks to invoke right
after the lock release. The following is the code snippets to show how to
use it:
```
  std::mutex mu;
  {
     ScopedLock sl(&mu);
     sl.add([&]() {
       std::lock_guard l(mu);
       printf("acquired lock again"); });
     }
 }
```
This eases the handling of the use cases such as collect the promises to
set under the lock but actually set the promises out of the lock