### PR TITLE
Fix copy exception when wrappedVector.size < rows.size .

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1497,7 +1497,7 @@ bool Expr::applyFunctionWithPeeling(
   applyFunction(*newRows, context, peeledResult);
   VectorPtr wrappedResult =
       context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
-  context.moveOrCopyResult(wrappedResult, rows, result);
+  context.moveOrCopyResult(wrappedResult, applyRows, result);
 
   // Recycle peeledResult if it's not owned by the result vector. Examples of
   // when this can happen is when the result is a primitive constant vector, or


### PR DESCRIPTION
Currently we will fault when the wrappedResult from the application of a function has a smaller size than the size of the rows vector which causes it to throw an exception when copying to a results vector. This situation typically happens when the peeledResult has a lot of trailing nulls and thus applyRows ends up lesser in size than rows. In most such cases its unlikely resultVector is present and is flat which is probably why this bug wasnt caught sooner. 
This fix ensures we only copy for applyRows , since we ensure that we add trailing nulls in evalAllImpl. 

Fixes #4077 . 