### PR TITLE
Fix decimal sum and average aggregation issues due to int128_t handling in the accumulator

### DIFF
--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -316,7 +316,7 @@ class DecimalAverageAggregate : public DecimalAggregate<TUnscaledType> {
     // Handles round-up of fraction results.
     int128_t average{0};
     DecimalUtil::computeAverage(
-        average, accumulator->sum, accumulator->count, accumulator->overflow);
+        average, accumulator->sum(), accumulator->count, accumulator->overflow);
     return TUnscaledType(average);
   }
 };

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -178,12 +178,12 @@ class DecimalSumAggregate
   virtual UnscaledLongDecimal computeFinalValue(
       LongDecimalWithOverflowState* accumulator) final {
     // Value is valid if the conditions below are true.
-    int128_t sum = accumulator->sum;
-    if ((accumulator->overflow == 1 && accumulator->sum < 0) ||
-        (accumulator->overflow == -1 && accumulator->sum > 0)) {
+    int128_t sum = accumulator->sum();
+    if ((accumulator->overflow == 1 && sum < 0) ||
+        (accumulator->overflow == -1 && sum > 0)) {
       sum = static_cast<int128_t>(
-          DecimalUtil::kOverflowMultiplier * accumulator->overflow +
-          accumulator->sum);
+          DecimalUtil::kOverflowMultiplier * accumulator->overflow + sum);
+      accumulator->setSum(sum);
     } else {
       VELOX_CHECK(accumulator->overflow == 0, "Decimal overflow");
     }

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -265,6 +265,38 @@ TEST_F(SumTest, sumDecimal) {
   createDuckDbTable({input});
   testAggregations(
       {input}, {}, {"sum(c0)", "sum(c1)"}, "SELECT sum(c0), sum(c1) FROM tmp");
+
+  // Decimal sum aggregation with multiple groups.
+  auto inputRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeShortDecimalFlatVector({-12783, 0}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeShortDecimalFlatVector({23178, 41093}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeShortDecimalFlatVector({-10023, 5290}, DECIMAL(5, 2))}),
+  };
+
+  auto expectedResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeLongDecimalFlatVector({113848}, DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeLongDecimalFlatVector({50730}, DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeLongDecimalFlatVector({-7493}, DECIMAL(38, 2))})};
+
+  testAggregations(inputRows, {"c0"}, {"sum(c1)"}, expectedResult);
 }
 
 TEST_F(SumTest, sumDecimalOverflow) {


### PR DESCRIPTION
The PR fixes two issues:
- int128_t field handling on different platforms that could result in segfault due to issues with struct alignment. I split the sum into two int64_t fields instead.
- Decimal average and sum returning null result instead of the correct value when running something like `select a, avg(b) from table`.

The issues are interleaved (one's test verifies the other's fix) so I could not open two separate PRs because of this.

Without the fix, the tests would crash on following setup:
```
Velox System Info v0.0.2
Commit: b1f3c2bbd22bb732dfcaada09a8d968b2d09e050
CMake Version: 3.17.5
System: Linux-4.18.0-408.el8.x86_64
Arch: x86_64
C++ Compiler: /opt/rh/gcc-toolset-9/root/usr/bin/c++
C++ Compiler Version: 9.2.1
C Compiler: /opt/rh/gcc-toolset-9/root/usr/bin/cc
C Compiler Version: 9.2.1
```

```
Linux ip-172-31-22-108.ec2.internal 4.18.0-408.el8.x86_64 #1 SMP Mon Jul 18 17:42:52 UTC 2022 x86_64 x86_64 x86_64 GNU/Linux
```