### PR TITLE
Include XSIMD header in BitPackDecoder.

### DIFF
--- a/velox/dwio/common/BitPackDecoder.h
+++ b/velox/dwio/common/BitPackDecoder.h
@@ -21,6 +21,7 @@
 #include "velox/vector/TypeAliases.h"
 
 #include <folly/Range.h>
+#include <xsimd/config/xsimd_config.hpp>
 
 namespace facebook::velox::dwio::common {
 


### PR DESCRIPTION
None of the included headers include `xsimd/config/xsimd_config.hpp`, so `XSIMD_WITH_AVX2` is never defined. This means that the AVX2-specialized code is never run in the BiPackDecoder. The `xsimd_config.hpp` header defines this macro.