### PR TITLE
Add initial GPU decoders

### DIFF
--- a/velox/experimental/gpu/Common.h
+++ b/velox/experimental/gpu/Common.h
@@ -16,9 +16,8 @@
 
 #pragma once
 
+#include <cuda_runtime.h>
 #include <cstdio>
-#include <cuda/atomic>
-#include <cuda/semaphore>
 #include <memory>
 #include <type_traits>
 

--- a/velox/experimental/gpu/tests/DoubleBufferProcessTest.cu
+++ b/velox/experimental/gpu/tests/DoubleBufferProcessTest.cu
@@ -18,6 +18,7 @@
 #include <gflags/gflags.h>
 #include <cub/cub.cuh> // @manual
 #include <numeric>
+#include <thread>
 #include "velox/experimental/gpu/Common.h"
 
 DEFINE_int64(buffer_size, 32 << 20, "");


### PR DESCRIPTION
Summary:
`GpuDecode` objects are the building blocks for GPU reader.  Each object takes care of one decoding step using one CUDA thread block.  Later we will add logic to generate and schedule these objects based on metadata to actually read the file.

Add GPU decoding operators for:
1. Dictionary + Bitunpack (also can handle baseline shift and scattering)
2. Trivial
3. SparseBool
4. MainlyConstant
5. RLE (also SumInt32 for calculating the total length)
6. Varint
7. MakeScatterIndices

Differential Revision: D43611947

