### PR TITLE
Remove SelectivityVector::setActiveRange API

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -130,14 +130,6 @@ class SelectivityVector {
     return MutableRange<bool>(bits_.data(), begin_, end_);
   }
 
-  void setActiveRange(vector_size_t begin, vector_size_t end) {
-    VELOX_DCHECK_LE(begin, end, "Setting begin after end");
-    VELOX_DCHECK_LE(end, size_, "Range end out of range");
-    begin_ = begin;
-    end_ = end;
-    allSelected_.reset();
-  }
-
   vector_size_t begin() const {
     return begin_;
   }

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -218,15 +218,6 @@ TEST(SelectivityVectorTest, setValidRange) {
       << "all to false";
 }
 
-TEST(SelectivityVectorTest, setStartEndIdx) {
-  SelectivityVector vector(1000 /*vectorSize*/);
-
-  vector.setActiveRange(55, 100);
-
-  EXPECT_EQ(55, vector.begin());
-  EXPECT_EQ(100, vector.end());
-}
-
 TEST(SelectivityVectorTest, clearAll) {
   auto size = 3;
   // Explicitly set all bits to false.
@@ -285,18 +276,6 @@ TEST(SelectivityVectorTest, operatorEquals_dataNotEqual) {
       false /*expectEqual*/, [](auto& vector) { vector.setValid(10, false); });
 }
 
-TEST(SelectivityVectorTest, operatorEquals_startIdxNotEqual) {
-  testEquals(false /*expectEqual*/, [](auto& vector) {
-    vector.setActiveRange(10, vector.end());
-  });
-}
-
-TEST(SelectivityVectorTest, operatorEquals_endIdxNotEqual) {
-  testEquals(false /*expectEqual*/, [](auto& vector) {
-    vector.setActiveRange(vector.begin(), 10);
-  });
-}
-
 TEST(SelectivityVectorTest, emptyIterator) {
   SelectivityVector vector(2011);
   vector.clearAll();
@@ -349,7 +328,7 @@ TEST(SelectivityVectorTest, iterator) {
   bits::fillBits(&contiguous[0], 240, 540, true);
   SelectivityVector fromBits;
   fromBits.setFromBits(&contiguous[0], 64 * contiguous.size());
-  fromBits.setActiveRange(fromBits.begin(), 227);
+  fromBits.resize(227);
   EXPECT_EQ(fromBits.begin(), 67);
   EXPECT_EQ(fromBits.end(), 227);
   EXPECT_FALSE(fromBits.isAllSelected());
@@ -360,7 +339,6 @@ TEST(SelectivityVectorTest, iterator) {
     return true;
   });
   EXPECT_EQ(count, bits::countBits(&contiguous[0], 0, 240));
-  fromBits.setActiveRange(64, 227);
   EXPECT_FALSE(fromBits.isAllSelected());
   count = 0;
   fromBits.applyToSelected([&count](int32_t row) {


### PR DESCRIPTION
Summary:
SelectivityVector::setActiveRange() method is problematic because it doesn't
work well with updateBounds(). setActiveRange blindly sets begin_ and end_
without ensuring that bits before begin_ and after end_ are not set.
updateBounds() sets begin_ and end_ to the start and end of the range of set
bits.

Fixes https://github.com/facebookincubator/velox/issues/4138

Differential Revision: D43654674

