### PR TITLE
Fix floating-point precision errors in variance aggregation functions

### DIFF
--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -66,9 +66,8 @@ struct VarianceAccumulator {
       return;
     }
     int64_t newCount = countOther + count();
-    double newMean =
-        ((countOther * meanOther) + (count() * mean())) / (double)newCount;
     double delta = meanOther - mean();
+    double newMean = mean() + delta / newCount * countOther;
     m2_ += m2Other + delta * delta * countOther * count() / (double)newCount;
     count_ = newCount;
     mean_ = newMean;


### PR DESCRIPTION
The PR addresses floating-point precision errors which could return an incorrect result when running variance on large int64 values. 

Example of such difference, the added test reproduces the issue and passes with the fix:
```
Expected 5, got 5
1 extra rows, 1 missing rows
1 of extra rows:
	-5 | 256

1 of missing rows:
	-5 | "0"
```

A more detailed explanation is provided in https://github.com/facebookincubator/velox/issues/4225.