### PR TITLE
Add "hashless" partial aggregation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -88,6 +88,10 @@ class QueryConfig {
   static constexpr const char* kMaxExtendedPartialAggregationMemory =
       "max_extended_partial_aggregation_memory";
 
+  /// Skip hashtable grouping in partial aggregation step
+  static constexpr const char* kAllowSkipPartialAggregationGrouping =
+      "skip_partial_aggregation_grouping";
+
   /// Output volume as percentage of input volume below which we will not seek
   /// to increase reduction by using more memory. the data volume is measured as
   /// the number of rows.
@@ -185,6 +189,11 @@ class QueryConfig {
   uint64_t aggregationSpillMemoryThreshold() const {
     static constexpr uint64_t kDefault = 0;
     return get<uint64_t>(kAggregationSpillMemoryThreshold, kDefault);
+  }
+
+  bool allowSkipPartialAggregationGrouping() const {
+    static constexpr bool kDefault = false;
+    return get<bool>(kAllowSkipPartialAggregationGrouping, kDefault);
   }
 
   double partialAggregationGoodPct() const {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -367,8 +367,8 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
           return RowContainer::normalizedKey(group) ==
               lookup.normalizedKeys[row];
         },
-        [&](int32_t index, int32_t row) {
-          return isJoin ? nullptr : insertEntry(lookup, row, index);
+        [&](int32_t row, int32_t index) {
+          return isJoin ? nullptr : insertEntry(lookup, index, row);
         },
         numTombstones_,
         !isJoin && extraCheck);
@@ -381,8 +381,8 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::fullProbe(
       sizeMask_,
       0,
       [&](char* group, int32_t row) { return compareKeys(group, lookup, row); },
-      [&](int32_t index, int32_t row) {
-        return isJoin ? nullptr : insertEntry(lookup, row, index);
+      [&](int32_t row, int32_t index) {
+        return isJoin ? nullptr : insertEntry(lookup, index, row);
       },
       numTombstones_,
       !isJoin && extraCheck);

--- a/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationTestBase.cpp
@@ -183,6 +183,34 @@ void AggregationTestBase::testAggregations(
     assertResults(queryBuilder);
   }
 
+  {
+    SCOPED_TRACE("Run partial + final with partial agg no grouping");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+    builder.partialAggregation(groupingKeys, aggregates).finalAggregation();
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.config(
+        core::QueryConfig::kAllowSkipPartialAggregationGrouping, "true");
+    assertResults(queryBuilder);
+  }
+
+  {
+    SCOPED_TRACE("Run single");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+    builder.singleAggregation(groupingKeys, aggregates);
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    assertResults(queryBuilder);
+  }
+
   if (!groupingKeys.empty() && allowInputShuffle_) {
     SCOPED_TRACE("Run partial + final with spilling");
     PlanBuilder builder(pool());

--- a/velox/functions/sparksql/aggregates/LastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/LastAggregate.cpp
@@ -468,7 +468,7 @@ class LastAggregateNonNumeric : public exec::Aggregate {
       clearNull(rawNulls, i);
       ignoreNullVector->set(i, ignoreNull_.value());
       if (isNull(group)) {
-        (*result)->setNull(i, true);
+        baseVector->setNull(i, true);
       } else {
         (*result)->setNull(i, false);
         auto accumulator = value<aggregate::SingleValueAccumulator>(group);


### PR DESCRIPTION
Add "hashless" partial aggregation

    Add logic to detect cardinality changes in input vectors to HashAggregation.
    When cardinality is high, disable groupingSet's "hashing" behavior and have it store
    each input row individually.

    A note on cardinality checking logic:
    We periodically sample input cardinality (by running GroupingSet::AddInput's full hashing logic) and when high
    cardinality is detected, we put GroupingSet in "hashless mode" for the next N inputs, after which
    we will sample again (on N+1 vector) and check cardinality.

    N is a variable adjusted in exponential manner as powers of 2 [2^0.. 2^10].
    Repeated high cardinality samples will push N to 1024, effectively disabling hash grouping in GroupingSet.
    Repeated low cardinality samples will reduce N to 0, effectively making GroupingSet::AddInput always hash rows.

    If cardinality fluctuates, N will dynamically adapt in an exponential manner.

    Cardinality high/low is determined by partial_aggregation_reduction_ratio_threshold.
    To enable this "hashless" behavior, set skip_partial_aggregation_grouping to true.

    Benchmark testing on TPCH Q15 and other Bytedance internal high cardinality use cases show visible improvements.