### PR TITLE
Remove check for null map keys in cast-json-to-map function

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -927,6 +927,18 @@ TEST_F(JsonCastTest, toMap) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 
   testCast<ComplexType>(JSON(), MAP(VARCHAR(), BIGINT()), data, expected);
+
+  // Null keys or non-string keys in JSON maps are not allowed.
+  testThrow<JsonNativeType, ComplexType>(
+      JSON(),
+      MAP(VARCHAR(), DOUBLE()),
+      {R"({"red":1.1,"blue":2.2})"_sv, R"({null:3.3,"yellow":4.4})"_sv},
+      "Not a JSON input");
+  testThrow<JsonNativeType, ComplexType>(
+      JSON(),
+      MAP(BIGINT(), DOUBLE()),
+      {"{1:1.1,2:2.2}"_sv},
+      "Not a JSON input");
 }
 
 TEST_F(JsonCastTest, toRow) {
@@ -1060,14 +1072,6 @@ TEST_F(JsonCastTest, toInvalid) {
       JSON(), TIMESTAMP(), {"null"_sv}, "Cannot cast JSON to TIMESTAMP");
   testThrow<JsonNativeType, Date>(
       JSON(), DATE(), {"null"_sv}, "Cannot cast JSON to DATE");
-
-  // TODO Fix this test case. The input JSON is invalid as it is not possible to
-  // use NULL key. Map keys cannot be NULL.
-  testThrow<JsonNativeType, ComplexType>(
-      JSON(),
-      MAP(VARCHAR(), DOUBLE()),
-      {R"({"red":1.1,"blue":2.2})"_sv, R"({null:3.3,"yellow":4.4})"_sv},
-      "Not a JSON input");
 
   // Casting JSON arrays to ROW type with different number of fields or
   // unmatched field order is not allowed.

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -621,8 +621,6 @@ FOLLY_ALWAYS_INLINE void castFromJsonTyped<TypeKind::MAP>(
   auto& writerTyped = writer.castTo<Map<Any, Any>>();
 
   for (const auto& pair : object.items()) {
-    VELOX_USER_CHECK(!pair.first.isNull(), "Map keys cannot be NULL.");
-
     // If casting to map of JSON values, nulls in map values should become the
     // JSON text "null".
     if (!isJsonType(writer.type()->childAt(1)) && pair.second.isNull()) {


### PR DESCRIPTION
Summary:
The check for map keys not being null is unnecessary for the cast-json-to-map
function because an input Json-map that contains non-string keys (e.g., "{null:1}"
or "{1:2}") are rejected by folly::parseJson() directly before reaching the casting
code. This diff removes the unnecessary check and move the corresponding test
cases to JsonCastTest.toMap.

Differential Revision: D43680360

