### PR TITLE
Fix dereference expression

### DIFF
--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -87,6 +87,11 @@ void FieldReference::evalSpecialForm(
     result = useDecode ? std::move(decoded.wrap(child, *input, rows.end()))
                        : std::move(child);
   }
+
+  // Check for nulls in the input struct. Propagate these nulls to 'result'.
+  if (!inputs_.empty() && decoded.mayHaveNulls()) {
+    addNulls(rows, decoded.nulls(), context, result);
+  }
 }
 
 void FieldReference::evalSpecialFormSimplified(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2058,95 +2058,63 @@ TEST_F(ExprTest, peelLazyDictionaryOverConstant) {
 }
 
 TEST_F(ExprTest, accessNested) {
-  // Construct Row(Row(Row(int))) vector
+  // Construct row(row(row(integer))) vector.
   auto base = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
   auto level1 = makeRowVector({base});
   auto level2 = makeRowVector({level1});
   auto level3 = makeRowVector({level2});
 
-  auto level1Type = ROW({"c0"}, {base->type()});
-  auto level2Type = ROW({"c0"}, {level1Type});
-  auto level3Type = ROW({"c0"}, {level2Type});
-
-  // Access level3->level2->level1->base
+  // Access level3->level2->level1->base.
   // TODO: Expression "c0.c0.c0" currently not supported by DuckDB
   // So we wrap with parentheses to force parsing as struct extract
   // Track https://github.com/duckdb/duckdb/issues/2568
-  auto exprSet = compileExpression("(c0).c0.c0", level3Type);
-
-  auto result = evaluate(exprSet.get(), level3);
+  auto result = evaluate("(c0).c0.c0.c0", makeRowVector({level3}));
 
   assertEqualVectors(base, result);
 }
 
 TEST_F(ExprTest, accessNestedNull) {
-  // Construct Row(Row(Row(int))) vector
+  // Construct row(row(row(integer))) vector.
   auto base = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
   auto level1 = makeRowVector({base});
 
-  auto level1Type = ROW({"c0"}, {base->type()});
-  auto level2Type = ROW({"c0"}, {level1Type});
-  auto level3Type = ROW({"c0"}, {level2Type});
-
-  BufferPtr nulls =
-      AlignedBuffer::allocate<bool>(5, execCtx_->pool(), bits::kNull);
-  // Construct level 2 row with nulls
-  auto level2 = std::make_shared<RowVector>(
-      execCtx_->pool(),
-      level2Type,
-      nulls,
-      level1->size(),
-      std::vector<VectorPtr>{level1});
+  // Construct level 2 row with nulls.
+  auto level2 = makeRowVector({level1}, nullEvery(2));
   auto level3 = makeRowVector({level2});
 
-  auto exprSet = compileExpression("(c0).c0.c0", level3Type);
-
-  auto result = evaluate(exprSet.get(), level3);
-
-  auto nullVector = makeAllNullFlatVector<int32_t>(5);
-
-  assertEqualVectors(nullVector, result);
+  auto result = evaluate("(c0).c0.c0.c0", makeRowVector({level3}));
+  auto expected = makeNullableFlatVector<int32_t>(
+      {std::nullopt, 2, std::nullopt, 4, std::nullopt});
+  assertEqualVectors(expected, result);
 }
 
 TEST_F(ExprTest, accessNestedDictionaryEncoding) {
-  // Construct Row(Row(Row(int))) vector
+  // Construct row(row(row(integer))) vector.
   auto base = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
 
-  // Reverse order in dictionary encoding
-  auto indices = makeIndices(5, [](auto row) { return 4 - row; });
+  // Reverse order in dictionary encoding.
+  auto indices = makeIndicesInReverse(5);
 
   auto level1 = makeRowVector({base});
   auto level2 = makeRowVector({wrapInDictionary(indices, 5, level1)});
   auto level3 = makeRowVector({level2});
 
-  auto level1Type = ROW({"c0"}, {base->type()});
-  auto level2Type = ROW({"c0"}, {level1Type});
-  auto level3Type = ROW({"c0"}, {level2Type});
-
-  auto exprSet = compileExpression("(c0).c0.c0", level3Type);
-
-  auto result = evaluate(exprSet.get(), level3);
+  auto result = evaluate("(c0).c0.c0.c0", makeRowVector({level3}));
 
   assertEqualVectors(makeFlatVector<int32_t>({5, 4, 3, 2, 1}), result);
 }
 
 TEST_F(ExprTest, accessNestedConstantEncoding) {
-  // Construct Row(Row(Row(int))) vector
+  // Construct row(row(row(integer))) vector.
   VectorPtr base = makeFlatVector<int32_t>({1, 2, 3, 4, 5});
-  // Wrap base in constant
+  // Wrap base in constant.
   base = BaseVector::wrapInConstant(5, 2, base);
 
   auto level1 = makeRowVector({base});
   auto level2 = makeRowVector({level1});
   auto level3 = makeRowVector({level2});
 
-  auto level1Type = ROW({"c0"}, {base->type()});
-  auto level2Type = ROW({"c0"}, {level1Type});
-  auto level3Type = ROW({"c0"}, {level2Type});
-
-  auto exprSet = compileExpression("(c0).c0.c0", level3Type);
-
-  auto result = evaluate(exprSet.get(), level3);
+  auto result = evaluate("(c0).c0.c0.c0", makeRowVector({level3}));
 
   assertEqualVectors(makeConstant(3, 5), result);
 }


### PR DESCRIPTION
Summary: Dereference expression failed to account for nested null structs and returned "garbage" data.

Let's say struct "ABC" has two fields: "AB" and "C". Let's say that "AB" is also
a struct with two fields: "A" and "B". The values of "ABC" struct may look
like {{"a", "b"}, "c"} or {null, "c"}. In the latter case the "AB" struct is
NULL. Accessing fields of "AB" struct when it is NULL used to produce incorrect
results. ABC.AB.A or ABC.AB.B didn't return NULL reliably, but rather returned
whatever value happened to be found in memory occupied by vector "A" or "B".

There existed unit tests that supposed to test these cases, but the tests
themselves were written incorrecty and tested the case when the top-level ABC
struct is NULL, not nested struct AB is NULL.

This change fixes dereference expression and tests. Modified tests do fail
without the fix for dereference expression.

Differential Revision: D43693760

