### PR TITLE
Remove deadcode of nullOnFailure_ from CastExpr

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -383,7 +383,7 @@ ExprPtr compileExpression(
   } else if (auto cast = dynamic_cast<const core::CastTypedExpr*>(expr.get())) {
     VELOX_CHECK(!compiledInputs.empty());
     auto castExpr = std::make_shared<CastExpr>(
-        resultType, std::move(compiledInputs[0]), trackCpuUsage, false);
+        resultType, std::move(compiledInputs[0]), trackCpuUsage);
     if (cast->nullOnFailure()) {
       result = getSpecialForm("try", resultType, {castExpr}, trackCpuUsage);
     } else {

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -833,7 +833,6 @@ void JsonCastOperator::castTo(
     const BaseVector& input,
     exec::EvalCtx& context,
     const SelectivityVector& rows,
-    bool /*nullOnFailure*/,
     const TypePtr& resultType,
     VectorPtr& result) const {
   context.ensureWritable(rows, resultType, result);
@@ -850,7 +849,6 @@ void JsonCastOperator::castFrom(
     const BaseVector& input,
     exec::EvalCtx& context,
     const SelectivityVector& rows,
-    bool /*nullOnFailure*/,
     const TypePtr& resultType,
     VectorPtr& result) const {
   context.ensureWritable(rows, resultType, result);

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -38,7 +38,6 @@ class JsonCastOperator : public exec::CastOperator {
       const BaseVector& input,
       exec::EvalCtx& context,
       const SelectivityVector& rows,
-      bool nullOnFailure,
       const TypePtr& resultType,
       VectorPtr& result) const override;
 
@@ -46,7 +45,6 @@ class JsonCastOperator : public exec::CastOperator {
       const BaseVector& input,
       exec::EvalCtx& context,
       const SelectivityVector& rows,
-      bool nullOnFailure,
       const TypePtr& resultType,
       VectorPtr& result) const override;
 

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -43,8 +43,7 @@ class DecimalUtil {
       const int fromPrecision,
       const int fromScale,
       const int toPrecision,
-      const int toScale,
-      const bool nullOnFailure) {
+      const int toScale) {
     int128_t rescaledValue = inputValue.unscaledValue();
     auto scaleDifference = toScale - fromScale;
     bool isOverflow = false;
@@ -67,9 +66,6 @@ class DecimalUtil {
     // Check overflow.
     if (rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
         rescaledValue > DecimalUtil::kPowersOfTen[toPrecision] || isOverflow) {
-      if (nullOnFailure) {
-        return std::nullopt;
-      }
       VELOX_USER_FAIL(
           "Cannot cast DECIMAL '{}' to DECIMAL({},{})",
           DecimalUtil::toString<TInput>(
@@ -88,8 +84,7 @@ class DecimalUtil {
   inline static std::optional<TOutput> rescaleBigint(
       const int128_t inputValue,
       const int toPrecision,
-      const int toScale,
-      const bool nullOnFailure) {
+      const int toScale) {
     static_assert(
         std::is_same_v<TOutput, UnscaledShortDecimal> ||
         std::is_same_v<TOutput, UnscaledLongDecimal>);
@@ -99,9 +94,6 @@ class DecimalUtil {
     // Check overflow.
     if (rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
         rescaledValue > DecimalUtil::kPowersOfTen[toPrecision] || isOverflow) {
-      if (nullOnFailure) {
-        return std::nullopt;
-      }
       VELOX_USER_FAIL(
           "Cannot cast BIGINT '{}' to DECIMAL({},{})",
           inputValue,


### PR DESCRIPTION
Summary:
A recent change translates `try_cast(...)` to `try(cast(...))`
to unify their behavior (https://github.com/facebookincubator/velox/pull/4081).
After this change, CastExpr::nullOnFailure_ that used to control the behavior of
try_cast() is always false and hence unnecessary. This diff removes the deadcode
of nullOnFailure_ from CastExpr.

Differential Revision: D43719776

