### PR TITLE
Add MarkDistinct operator

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1246,6 +1246,49 @@ PlanNodePtr WindowNode::create(const folly::dynamic& obj, void* context) {
       source);
 }
 
+RowTypePtr getMarkDistinctOutputType(
+    const RowTypePtr& inputType,
+    const std::string& markerName) {
+  std::vector<std::string> names = inputType->names();
+  std::vector<TypePtr> types = inputType->children();
+
+  names.emplace_back(markerName);
+  types.emplace_back(BOOLEAN());
+  return ROW(std::move(names), std::move(types));
+}
+
+MarkDistinctNode::MarkDistinctNode(
+    PlanNodeId id,
+    std::string markerName,
+    std::vector<FieldAccessTypedExprPtr> distinctKeys,
+    PlanNodePtr source)
+    : PlanNode(std::move(id)),
+      markerName_(std::move(markerName)),
+      distinctKeys_(std::move(distinctKeys)),
+      sources_{std::move(source)},
+      outputType_(
+          getMarkDistinctOutputType(sources_[0]->outputType(), markerName_)) {
+  VELOX_USER_CHECK_GT(markerName_.size(), 0)
+  VELOX_USER_CHECK_GT(distinctKeys_.size(), 0);
+}
+
+folly::dynamic MarkDistinctNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["distinctKeys"] = ISerializable::serialize(this->distinctKeys_);
+  obj["markerName"] = this->markerName_;
+  return obj;
+}
+
+// static
+PlanNodePtr MarkDistinctNode::create(const folly::dynamic& obj, void* context) {
+  auto source = deserializeSingleSource(obj, context);
+  auto distinctKeys = deserializeFields(obj["distinctKeys"], context);
+  auto markerName = obj["markerName"].asString();
+
+  return std::make_shared<MarkDistinctNode>(
+      deserializePlanNodeId(obj), markerName, distinctKeys, source);
+}
+
 namespace {
 RowTypePtr getRowNumberOutputType(
     const RowTypePtr& inputType,
@@ -1675,6 +1718,10 @@ PlanNodePtr OrderByNode::create(const folly::dynamic& obj, void* context) {
       std::move(source));
 }
 
+void MarkDistinctNode::addDetails(std::stringstream& stream) const {
+  addFields(stream, distinctKeys_);
+}
+
 void PlanNode::toString(
     std::stringstream& stream,
     bool detailed,
@@ -1760,6 +1807,7 @@ void PlanNode::registerSerDe() {
   registry.Register("UnnestNode", UnnestNode::create);
   registry.Register("ValuesNode", ValuesNode::create);
   registry.Register("WindowNode", WindowNode::create);
+  registry.Register("MarkDistinctNode", MarkDistinctNode::create);
   registry.Register(
       "GatherPartitionFunctionSpec", GatherPartitionFunctionSpec::deserialize);
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1990,6 +1990,56 @@ class RowNumberNode : public PlanNode {
   const RowTypePtr outputType_;
 };
 
+/// The MarkDistinct operator marks unique rows based on distinctKeys.
+/// The result is put in a new markerName column alongside the original input.
+/// @param markerName Name of the output mask channel.
+/// @param distinctKeys Names of grouping keys.
+/// column.
+class MarkDistinctNode : public PlanNode {
+ public:
+  MarkDistinctNode(
+      PlanNodeId id,
+      std::string markerName,
+      std::vector<FieldAccessTypedExprPtr> distinctKeys,
+      PlanNodePtr source);
+
+  const std::vector<PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  /// The outputType is the concatenation of the input columns and mask column.
+  const RowTypePtr& outputType() const override {
+    return outputType_;
+  }
+
+  std::string_view name() const override {
+    return "MarkDistinct";
+  }
+
+  const std::string& markerName() const {
+    return markerName_;
+  }
+
+  const std::vector<FieldAccessTypedExprPtr>& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  const std::string markerName_;
+
+  const std::vector<FieldAccessTypedExprPtr> distinctKeys_;
+
+  const std::vector<PlanNodePtr> sources_;
+
+  const RowTypePtr outputType_;
+};
+
 /// Optimized version of a WindowNode for a single row_number function with a
 /// limit over sorted partitions.
 /// The output of this node contains all input columns followed by an optional

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -38,6 +38,7 @@ FilterNode                  FilterProject
 ProjectNode                 FilterProject
 AggregationNode             HashAggregation or StreamingAggregation
 GroupIdNode                 GroupId
+MarkDistinctNode            MarkDistinct
 HashJoinNode                HashProbe and HashBuild
 MergeJoinNode               MergeJoin
 NestedLoopJoinNode          NestedLoopJoinProbe and NestedLoopJoinBuild
@@ -547,6 +548,24 @@ If no sorting columns are specified then the order of the results is unspecified
     - Output column names for each window function invocation in windowFunctions list below.
   * - windowFunctions
     - Window function calls with the frame clause. e.g row_number(), first_value(name) between range 10 preceding and current row. The default frame is between range unbounded preceding and current row.
+
+MarkDistinctNode
+~~~~~~~~~~~~~~~~
+
+The MarkDistinct operator is used to produce aggregate mask columns for aggregations over distinct values, e.g. agg(DISTINCT a).
+Mask is a boolean column set to true for a subset of input rows that collectively represent a set of unique values of 'distinctKeys'.
+
+.. list-table::
+  :widths: 10 30
+  :align: left
+  :header-rows: 1
+
+  * - Property
+    - Description
+  * - markerName
+    - Name of the output mask column.
+  * - distinctKeys
+    - Names of grouping keys.
 
 Examples
 --------

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   Limit.cpp
   LocalPartition.cpp
   LocalPlanner.cpp
+  MarkDistinct.cpp
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -96,6 +96,26 @@ GroupingSet::~GroupingSet() {
   }
 }
 
+std::unique_ptr<GroupingSet> GroupingSet::createForMarkDistinct(
+    std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+    OperatorCtx* FOLLY_NONNULL operatorCtx) {
+  tsan_atomic<bool> nonReclaimableSection{false};
+  return std::make_unique<GroupingSet>(
+      std::move(hashers),
+      /*preGroupedKeys*/ std::vector<column_index_t>{},
+      /*aggregates*/ std::vector<std::unique_ptr<Aggregate>>{},
+      /*aggrMaskChannels*/ std::vector<std::optional<column_index_t>>{},
+      /*channelLists*/ std::vector<std::vector<column_index_t>>{},
+      /*constantLists*/ std::vector<std::vector<VectorPtr>>{},
+      /*intermediateTypes*/ std::vector<TypePtr>{},
+      /*ignoreNullKeys*/ true,
+      /*isPartial*/ false,
+      /*isRawInput*/ false,
+      /*spillConfig*/ nullptr,
+      &nonReclaimableSection,
+      operatorCtx);
+};
+
 namespace {
 bool equalKeys(
     const std::vector<column_index_t>& keys,

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -44,6 +44,11 @@ class GroupingSet {
 
   ~GroupingSet();
 
+  // Used by MarkDistinct operator to identify rows with unique values.
+  static std::unique_ptr<GroupingSet> createForMarkDistinct(
+      std::vector<std::unique_ptr<VectorHasher>>&& hashers,
+      OperatorCtx* operatorCtx);
+
   void addInput(const RowVectorPtr& input, bool mayPushdown);
 
   void noMoreInput();

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -44,6 +44,7 @@ struct HashLookup {
   // Hit for each row of input. nullptr if no hit. Points to the
   // corresponding group row.
   raw_vector<char*> hits;
+  // Indices of newly inserted rows (not found during probe).
   std::vector<vector_size_t> newGroups;
 };
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -26,6 +26,7 @@
 #include "velox/exec/HashBuild.h"
 #include "velox/exec/HashProbe.h"
 #include "velox/exec/Limit.h"
+#include "velox/exec/MarkDistinct.h"
 #include "velox/exec/Merge.h"
 #include "velox/exec/MergeJoin.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
@@ -483,6 +484,11 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
             std::dynamic_pointer_cast<const core::RowNumberNode>(planNode)) {
       operators.push_back(
           std::make_unique<RowNumber>(id, ctx.get(), rowNumberNode));
+    } else if (
+        auto markDistinctNode =
+            std::dynamic_pointer_cast<const core::MarkDistinctNode>(planNode)) {
+      operators.push_back(
+          std::make_unique<MarkDistinct>(id, ctx.get(), markDistinctNode));
     } else if (
         auto localMerge =
             std::dynamic_pointer_cast<const core::LocalMergeNode>(planNode)) {

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MarkDistinct.h"
+#include "velox/common/base/Range.h"
+#include "velox/vector/FlatVector.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace facebook::velox::exec {
+
+MarkDistinct::MarkDistinct(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::MarkDistinctNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "MarkDistinct") {
+  const auto& inputType = planNode->sources()[0]->outputType();
+
+  // Set all input columns as identity projection.
+  for (auto i = 0; i < inputType->size(); ++i) {
+    identityProjections_.emplace_back(i, i);
+  }
+
+  // We will use result[0] for distinct mask output.
+  resultProjections_.emplace_back(0, inputType->size());
+
+  // Initialize groupingset
+  auto numHashers = planNode->distinctKeys().size();
+  std::vector<std::unique_ptr<VectorHasher>> hashers;
+  hashers.reserve(numHashers);
+
+  for (const auto& distinctVariable : planNode.get()->distinctKeys()) {
+    auto channel = exprToChannel(distinctVariable.get(), inputType);
+    VELOX_CHECK_NE(channel, kConstantChannel);
+    hashers.push_back(VectorHasher::create(distinctVariable->type(), channel));
+  }
+
+  groupingSet_ = GroupingSet::createForMarkDistinct(
+      std::move(hashers), operatorCtx_.get());
+
+  results_.resize(1);
+}
+
+void MarkDistinct::addInput(RowVectorPtr input) {
+  groupingSet_->addInput(input, false /*mayPushdown*/);
+
+  input_ = std::move(input);
+}
+
+RowVectorPtr MarkDistinct::getOutput() {
+  if (isFinished() || !input_) {
+    return nullptr;
+  }
+
+  auto outputSize = input_->size();
+  // Re-use memory for the ID vector if possible.
+  VectorPtr& result = results_[0];
+  if (result && result.unique()) {
+    BaseVector::prepareForReuse(result, outputSize);
+  } else {
+    result = BaseVector::create(BOOLEAN(), outputSize, operatorCtx_->pool());
+  }
+
+  // newGroups contains the indices of distinct rows.
+  // For each index in newGroups, we mark the index'th bit true in the result
+  // vector.
+  auto resultBits =
+      results_[0]->as<FlatVector<bool>>()->mutableRawValues<uint64_t>();
+
+  bits::fillBits(resultBits, 0, outputSize, false);
+  for (const auto i : groupingSet_->hashLookup().newGroups) {
+    bits::setBit(resultBits, i, true);
+  }
+  auto output = fillOutput(outputSize, nullptr);
+
+  // Drop reference to input_ to make it singly-referenced at the producer and
+  // allow for memory reuse.
+  input_ = nullptr;
+
+  return output;
+}
+
+bool MarkDistinct::isFinished() {
+  return noMoreInput_ && !input_;
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/MarkDistinct.h
+++ b/velox/exec/MarkDistinct.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/GroupingSet.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class MarkDistinct : public Operator {
+ public:
+  MarkDistinct(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::MarkDistinctNode>& planNode);
+
+  bool preservesOrder() const override {
+    return true;
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override;
+
+ private:
+  // TODO: Document spilling configuration in spilling.rst.
+  std::unique_ptr<GroupingSet> groupingSet_;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
   RoundRobinPartitionFunctionTest.cpp
   RowContainerTest.cpp
   RowNumberTest.cpp
+  MarkDistinctTest.cpp
   SpillTest.cpp
   SpillOperatorGroupTest.cpp
   SpillerTest.cpp

--- a/velox/exec/tests/MarkDistinctTest.cpp
+++ b/velox/exec/tests/MarkDistinctTest.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec::test;
+
+class MarkDistinctTest : public OperatorTestBase {
+ public:
+  void runBasicMarkDistinctTest(const VectorPtr& base) {
+    std::vector<RowVectorPtr> vectors;
+
+    const vector_size_t baseSize = base->size();
+    const vector_size_t size = baseSize * 2;
+    auto indices = makeIndices(size, [&](auto row) { return row % baseSize; });
+    auto baseEncoded = wrapInDictionary(indices, size, base);
+
+    vectors.push_back(makeRowVector({baseEncoded}));
+
+    auto distinctCol =
+        makeFlatVector<bool>(size, [&](auto row) { return row < baseSize; });
+
+    auto expectedResults = makeRowVector({baseEncoded, distinctCol});
+
+    auto op = PlanBuilder()
+                  .values(vectors)
+                  .markDistinct("c0$Distinct", {"c0"})
+                  .planNode();
+
+    auto results = AssertQueryBuilder(op).copyResults(pool());
+    assertEqualVectors(results, expectedResults);
+  }
+};
+
+template <typename T>
+class MarkDistinctPODTest : public MarkDistinctTest {};
+
+using MyTypes =
+    ::testing::Types<int8_t, int16_t, int32_t, int64_t, float, double, bool>;
+TYPED_TEST_SUITE(MarkDistinctPODTest, MyTypes);
+
+TYPED_TEST(MarkDistinctPODTest, basic) {
+  auto data = VectorTestBase::makeFlatVector<TypeParam>(
+      2, [&](auto row) { return row % 2; });
+
+  MarkDistinctTest::runBasicMarkDistinctTest(data);
+}
+
+TEST_F(MarkDistinctTest, array) {
+  auto base = makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 5},
+      {1, 2, 3},
+  });
+  runBasicMarkDistinctTest(base);
+}
+
+TEST_F(MarkDistinctTest, map) {
+  auto base = makeMapVector<int8_t, int32_t>(
+      {{{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}}, {{1, 1}, {1, 1}, {1, 1}}});
+  runBasicMarkDistinctTest(base);
+}
+
+TEST_F(MarkDistinctTest, varchar) {
+  auto base = makeFlatVector<StringView>({
+      "{1, 2, 3, 4, 5}",
+      "{1, 2, 3}",
+  });
+  runBasicMarkDistinctTest(base);
+}
+
+TEST_F(MarkDistinctTest, row) {
+  auto base = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3, 4, 5},
+          {1, 2, 3},
+      }),
+      makeMapVector<int8_t, int32_t>({
+          {{1, 1}, {1, 1}, {1, 1}, {1, 1}, {1, 1}},
+          {{1, 1}, {1, 1}, {1, 1}},
+      }),
+  });
+  runBasicMarkDistinctTest(base);
+}
+
+// This test verifies this query:
+// WITH sample AS ( SELECT * FROM (VALUES (1,1,1), (1,1,2), (1,1,1), (2,1,2),
+// (2,2,1), (2,3,2)) AS account (c1, c2, c3) ) SELECT c1,sum(distinct
+// c2),sum(distinct c3) from sample group by c1;
+TEST_F(MarkDistinctTest, distinctAggregationTest) {
+  std::vector<RowVectorPtr> vectors;
+  // Simulate the input over 3 splits.
+  vectors.push_back(makeRowVector(
+      {makeFlatVector<int32_t>({1, 1}),
+       makeFlatVector<int32_t>({1, 1}),
+       makeFlatVector<int32_t>({1, 2})}));
+  vectors.push_back(makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}),
+       makeFlatVector<int32_t>({1, 1}),
+       makeFlatVector<int32_t>({1, 2})}));
+  vectors.push_back(makeRowVector(
+      {makeFlatVector<int32_t>({2, 2}),
+       makeFlatVector<int32_t>({2, 3}),
+       makeFlatVector<int32_t>({1, 2})}));
+
+  auto op =
+      PlanBuilder()
+          .values(vectors)
+          .markDistinct("c1$Distinct", {"c0", "c1"})
+          .markDistinct("c2$Distinct", {"c0", "c2"})
+          .singleAggregation(
+              {"c0"}, {"sum(c1)", "sum(c2)"}, {"c1$Distinct", "c2$Distinct"})
+          .orderBy({"c0"}, false)
+          .planNode();
+
+  auto expected = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}),
+       makeFlatVector<int64_t>({1, 6}),
+       makeFlatVector<int64_t>({3, 3})});
+
+  auto results = AssertQueryBuilder(op).copyResults(pool());
+  assertEqualVectors(results, expected);
+}

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -73,6 +73,14 @@ TEST_F(PlanNodeSerdeTest, assignUniqueId) {
   testSerde(plan);
 }
 
+TEST_F(PlanNodeSerdeTest, markDistinct) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .markDistinct("marker", {"c0", "c1", "c2"})
+                  .planNode();
+  testSerde(plan);
+}
+
 TEST_F(PlanNodeSerdeTest, nestedLoopJoin) {
   auto left = makeRowVector(
       {"t0", "t1", "t2"},

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -742,3 +742,15 @@ TEST_F(PlanNodeToStringTest, topNRowNumber) {
       "-- TopNRowNumber[partition by (a) order by (b ASC NULLS LAST) limit 10] -> a:BIGINT, b:VARCHAR\n",
       plan->toString(true, false));
 }
+
+TEST_F(PlanNodeToStringTest, markDistinct) {
+  auto op =
+      PlanBuilder()
+          .tableScan(ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), BIGINT()}))
+          .markDistinct("marker", {"a", "b"})
+          .planNode();
+  ASSERT_EQ("-- MarkDistinct\n", op->toString());
+  ASSERT_EQ(
+      "-- MarkDistinct[a, b] -> a:VARCHAR, b:BIGINT, c:BIGINT, marker:BOOLEAN\n",
+      op->toString(true, false));
+}

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1338,6 +1338,18 @@ PlanBuilder& PlanBuilder::topNRowNumber(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::markDistinct(
+    std::string markerKey,
+    const std::vector<std::string>& distinctKeys) {
+  planNode_ = std::make_shared<core::MarkDistinctNode>(
+      nextPlanNodeId(),
+      std::move(markerKey),
+      fields(planNode_->outputType(), distinctKeys),
+
+      planNode_);
+  return *this;
+}
+
 core::PlanNodeId PlanBuilder::nextPlanNodeId() {
   return planNodeIdGenerator_->next();
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -707,6 +707,13 @@ class PlanBuilder {
       int32_t limit,
       bool generateRowNumber);
 
+  /// Add a MarkDistinctNode to compute aggregate mask channel
+  /// @param markerKey Name of output mask channel
+  /// @param distinctKeys List of columns to be marked distinct.
+  PlanBuilder& markDistinct(
+      std::string markerKey,
+      const std::vector<std::string>& distinctKeys);
+
   /// Stores the latest plan node ID into the specified variable. Useful for
   /// capturing IDs of the leaf plan nodes (table scans, exchanges, etc.) to use
   /// when adding splits at runtime.


### PR DESCRIPTION
The MarkDistinct operator produces an aggregate mask column for distinct
aggregations. The mask is a boolean vector set to true for a subset of input
rows that contain unique combinations of the grouping keys.

This operator is used to implement queries like

```
SELECT a, count(distinct c), count(distinct d) FROM t GROUP BY 1
```

Fixes #3140