### PR TITLE
Fix the driver suspension handling issues

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -142,6 +142,33 @@ class CancelGuard {
 };
 } // namespace
 
+std::string stopReasonString(StopReason reason) {
+  switch (reason) {
+    case StopReason::kNone:
+      return "NONE";
+    case StopReason::kBlock:
+      return "BLOCK";
+    case StopReason::kTerminate:
+      return "TERMINATE";
+    case StopReason::kAlreadyTerminated:
+      return "ALREADY_TERMINATED";
+    case StopReason::kYield:
+      return "YIELD";
+    case StopReason::kPause:
+      return "PAUSE";
+    case StopReason::kAlreadyOnThread:
+      return "ALREADY_ON_THREAD";
+    case StopReason::kAtEnd:
+      return "AT_END";
+    default:
+      return fmt::format("UNKNOWN_REASON {}", static_cast<int>(reason));
+  }
+}
+
+std::ostream& operator<<(std::ostream& out, const StopReason& reason) {
+  return out << stopReasonString(reason);
+}
+
 // static
 void Driver::enqueue(std::shared_ptr<Driver> driver) {
   // This is expected to be called inside the Driver's Tasks's mutex.

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -53,6 +53,10 @@ enum class StopReason {
   kAlreadyOnThread
 };
 
+std::string stopReasonString(StopReason reason);
+
+std::ostream& operator<<(std::ostream& out, const StopReason& reason);
+
 // Represents a Driver's state. This is used for cancellation, forcing
 // release of and for waiting for memory. The fields are serialized on
 // the mutex of the Driver's Task.

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -450,6 +450,12 @@ class Operator : public BaseRuntimeStatWriter {
   // the first one that is not std::nullopt or std::nullopt otherwise.
   static std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& planNode);
 
+  /// Returns the operator context of this operator. This method is only used
+  /// for test.
+  const OperatorCtx* testingOperatorCtx() const {
+    return operatorCtx_.get();
+  }
+
  protected:
   static std::vector<std::unique_ptr<PlanNodeTranslator>>& translators();
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -537,6 +537,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// during this wait call. This is for testing purpose for now.
   static void testingWaitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
 
+  /// Invoked to run provided 'callback' on each alive driver of the task.
+  void testingVisitDrivers(const std::function<void(Driver*)>& callback);
+
  private:
   // Returns reference to the SplitsState structure for the specified plan node
   // id. Throws if not found, meaning that plan node does not expect splits.

--- a/velox/exec/Values.cpp
+++ b/velox/exec/Values.cpp
@@ -41,7 +41,7 @@ Values::Values(
 }
 
 RowVectorPtr Values::getOutput() {
-  TestValue::adjust("facebook::velox::exec::Values::getOutput", &current_);
+  TestValue::adjust("facebook::velox::exec::Values::getOutput", this);
   if (current_ >= values_.size()) {
     return nullptr;
   }

--- a/velox/exec/Values.h
+++ b/velox/exec/Values.h
@@ -40,6 +40,12 @@ class Values : public SourceOperator {
 
   void close() override;
 
+  /// Returns the current processing vector index in 'values_'. This method is
+  /// only used for test.
+  int32_t testingCurrent() const {
+    return current_;
+  }
+
  private:
   std::vector<RowVectorPtr> values_;
   int32_t current_ = 0;

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -21,7 +21,6 @@
 #include "velox/dwio/common/DataSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/PartitionedOutput.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"


### PR DESCRIPTION
- Fix Task::enterSuspended to return kTerminate stop reason instead of
   kNone to indicate the suspension failure. The caller such as SuspendedSection
   shall quit the driver thread execution such as throw exception. Otherwise the
   task pause call might be busy waiting there forever.
- Add similar sanity checks in Task::leaveSuspended: the driver has no blocking
   future and must be on driver thread.
- Add the following unit tests to cover the driver suspension behaviors:
   - driverSuspensionRaceWithTaskPause to cover the various races between
      driver suspension and task pause
   - driverSuspensionRaceWithTaskTerminate to cover the race between driver
      suspension and task terminate
   - driverSuspensionCalledFromOffThread to verify we must only enter and leave
      driver suspension from a driver thread

Note: this code logic hasn't been used in production and will be used
by memory arbitration.