### PR TITLE
Cleanup task pause API

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -542,7 +542,7 @@ void Task::resume(std::shared_ptr<Task> self) {
   std::lock_guard<std::mutex> l(self->mutex_);
   // Setting pause requested must be atomic with the resuming so that
   // suspended sections do not go back on thread during resume.
-  self->requestPauseLocked(false);
+  self->pauseRequested_ = false;
   for (auto& driver : self->drivers_) {
     if (driver) {
       if (driver->state().isSuspended) {
@@ -1867,8 +1867,9 @@ StopReason Task::shouldStopLocked() {
   return StopReason::kNone;
 }
 
-ContinueFuture Task::requestPauseLocked(bool pause) {
-  pauseRequested_ = pause;
+ContinueFuture Task::requestPause() {
+  std::lock_guard<std::mutex> l(mutex_);
+  pauseRequested_ = true;
   return makeFinishFutureLocked("Task::requestPause");
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -471,12 +471,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Requests the Task to stop activity.  The returned future is
   /// realized when all running threads have stopped running. Activity
   /// can be resumed with resume() after the future is realized.
-  ContinueFuture requestPause(bool pause) {
-    std::lock_guard<std::mutex> l(mutex_);
-    return requestPauseLocked(pause);
-  }
-
-  ContinueFuture requestPauseLocked(bool pause);
+  ContinueFuture requestPause();
 
   /// Requests activity of 'this' to stop. The returned future will be
   /// realized when the last thread stops running for 'this'. This is used to

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -206,7 +206,7 @@ class DriverTest : public OperatorTestBase {
           cursor->task()->requestYield();
         } else if (operation == ResultOperation::kPause) {
           auto& executor = folly::QueuedImmediateExecutor::instance();
-          auto future = cursor->task()->requestPause(true).via(&executor);
+          auto future = cursor->task()->requestPause().via(&executor);
           future.wait();
           paused = true;
         }
@@ -661,7 +661,7 @@ class TestingPauser : public Operator {
             continue;
           }
           auto& executor = folly::QueuedImmediateExecutor::instance();
-          auto future = task->requestPause(true).via(&executor);
+          auto future = task->requestPause().via(&executor);
           future.wait();
           sleep(2);
           Task::resume(task);
@@ -964,8 +964,8 @@ DEBUG_ONLY_TEST_F(DriverTest, driverSuspensionRaceWithTaskPause) {
           testData.numDrivers,
           StopReason::kNone,
           StopReason::kNone,
-          [&](Task* task) { task->requestPause(true); },
-          [&](Task* task) { task->requestPause(true).wait(); },
+          [&](Task* task) { task->requestPause(); },
+          [&](Task* task) { task->requestPause().wait(); },
           [&](Task* task) {
             // Let the suspension leave thread to run first.
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -983,9 +983,9 @@ DEBUG_ONLY_TEST_F(DriverTest, driverSuspensionRaceWithTaskPause) {
           testData.numDrivers,
           StopReason::kNone,
           StopReason::kNone,
-          [&](Task* task) { task->requestPause(true); },
+          [&](Task* task) { task->requestPause(); },
           [&](Task* task) {
-            task->requestPause(true).wait();
+            task->requestPause().wait();
             Task::resume(task->shared_from_this());
           });
     } else if (
@@ -996,7 +996,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverSuspensionRaceWithTaskPause) {
           StopReason::kNone,
           StopReason::kNone,
           nullptr,
-          [&](Task* task) { task->requestPause(true).wait(); },
+          [&](Task* task) { task->requestPause().wait(); },
           [&](Task* task) {
             // Let the suspension leave thread to run first.
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -1014,7 +1014,7 @@ DEBUG_ONLY_TEST_F(DriverTest, driverSuspensionRaceWithTaskPause) {
           StopReason::kNone,
           nullptr,
           [&](Task* task) {
-            task->requestPause(true).wait();
+            task->requestPause().wait();
             Task::resume(task->shared_from_this());
           });
     }


### PR DESCRIPTION
Remove the pause flag from requestPause API so requestPause
only does pause. Task::resume does the resume. Current code
will return a future for resume case which is incorrect