### PR TITLE
Add trim/ltrim/rtrim SparkSQL function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -44,12 +44,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT lower('SparkSql'); -- sparksql
 
-.. spark:function:: replace(string, search, replace) -> string
-
-    Replaces all occurrences of `search` with `replace`. ::
-
-        SELECT replace('ABCabc', 'abc', 'DEF'); -- ABCDEF
-
 .. spark:function:: ltrim(string) -> varchar
 
     Removes leading 0x20(space) characters from ``string``. ::
@@ -63,6 +57,12 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
         SELECT ltrim('ps', 'spark'); -- "ark"
+
+.. spark:function:: replace(string, search, replace) -> string
+
+    Replaces all occurrences of `search` with `replace`. ::
+
+        SELECT replace('ABCabc', 'abc', 'DEF'); -- ABCDEF
 
 .. spark:function:: rtrim(string) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -120,15 +120,6 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT substring('Spark SQL', 5, -1); -- ""
         SELECT substring('Spark SQL', 5, 10000); -- "k SQL"
 
-.. spark:function:: upper(string) -> string
-
-    Returns string with all characters changed to uppercase. ::
-
-        SELECT upper('SparkSql'); -- SPARKSQL
-
-
-
-
 .. spark:function:: trim(string) -> varchar
 
     Removes leading and trailing 0x20(space) characters from ``string``. ::
@@ -142,3 +133,9 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
     SELECT trim('sprk', 'spark'); -- "a"
+
+.. spark:function:: upper(string) -> string
+
+    Returns string with all characters changed to uppercase. ::
+
+        SELECT upper('SparkSql'); -- SPARKSQL

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -50,6 +50,34 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT replace('ABCabc', 'abc', 'DEF'); -- ABCDEF
 
+.. spark:function:: ltrim(string) -> varchar
+
+    Removes leading 0x20(space) characters from ``string``. ::
+
+        SELECT ltrim('  data  '); -- "data  "
+
+.. spark:function:: ltrim(trimCharacters, string) -> varchar
+
+    Removes specified leading characters from ``string``. The specified character
+    is any character contained in ``trimCharacters``.
+    ``trimCharacters`` can be empty and may contain duplicate characters. ::
+
+    SELECT ltrim('ps', 'spark'); -- "ark"
+
+.. spark:function:: rtrim(string) -> varchar
+
+    Removes trailing 0x20(space) characters from ``string``. ::
+
+        SELECT rtrim('  data  '); -- "  data"
+
+.. spark:function:: rtrim(trimCharacters, string) -> varchar
+
+    Removes specified trailing characters from ``string``. The specified character
+    is any character contained in ``trimCharacters``.
+    ``trimCharacters`` can be empty and may contain duplicate characters. ::
+
+    SELECT rtrim('kr', 'spark'); -- "spa"
+
 .. spark:function:: split(string, delimiter) -> array(string)
 
     Splits ``string`` on ``delimiter`` and returns an array. ::
@@ -98,4 +126,19 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT upper('SparkSql'); -- SPARKSQL
 
- 
+
+
+
+.. spark:function:: trim(string) -> varchar
+
+    Removes leading and trailing 0x20(space) characters from ``string``. ::
+
+        SELECT trim('  data  '); -- "data"
+
+.. spark:function:: trim(trimCharacters, string) -> varchar
+
+    Removes specified leading and trailing characters from ``string``.
+    The specified character is any character contained in ``trimCharacters``.
+    ``trimCharacters`` can be empty and may contain duplicate characters. ::
+
+    SELECT trim('sprk', 'spark'); -- "a"

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -62,7 +62,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     is any character contained in ``trimCharacters``.
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
-    SELECT ltrim('ps', 'spark'); -- "ark"
+        SELECT ltrim('ps', 'spark'); -- "ark"
 
 .. spark:function:: rtrim(string) -> varchar
 
@@ -76,7 +76,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     is any character contained in ``trimCharacters``.
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
-    SELECT rtrim('kr', 'spark'); -- "spa"
+        SELECT rtrim('kr', 'spark'); -- "spa"
 
 .. spark:function:: split(string, delimiter) -> array(string)
 
@@ -132,7 +132,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     The specified character is any character contained in ``trimCharacters``.
     ``trimCharacters`` can be empty and may contain duplicate characters. ::
 
-    SELECT trim('sprk', 'spark'); -- "a"
+        SELECT trim('sprk', 'spark'); -- "a"
 
 .. spark:function:: upper(string) -> string
 

--- a/velox/external/utf8proc/utf8procImpl.h
+++ b/velox/external/utf8proc/utf8procImpl.h
@@ -978,6 +978,15 @@ UTF8PROC_DLLEXPORT int utf8proc_char_length(const char* u_input) {
   return -1;
 }
 
+/// This function is not part of the original utf8proc.
+/// A utf-8 character may be 1 to 4 bytes long. The function will determine if
+/// the input is pointing to the first byte.
+UTF8PROC_DLLEXPORT bool utf8proc_char_first_byte(const char* u_input) {
+  auto u = (const unsigned char*)u_input;
+  unsigned char u0 = u[0];
+  return u0 <= 127 || u0 >= 192;
+}
+
 /// Return the size in bytes for the char represented by the input code point.
 /// The output is not undefined if uc is invalid. Its implemented to match
 /// the space writen by utf8proc_encode_char for invalid inputs case.

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -597,7 +597,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
   auto start = curPos;
   curPos = input.end() - 1;
   if constexpr (rightTrim) {
-    while (curPos >= start && isAsciiWhiteSpace(*curPos)) {
+    while (curPos >= start && shouldTrim(*curPos)) {
       curPos--;
     }
   }

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -571,6 +571,39 @@ template <
     bool rightTrim,
     typename TOutString,
     typename TInString>
+FOLLY_ALWAYS_INLINE void trimAsciiSpace(
+    TOutString& output,
+    const TInString& input) {
+  if (input.empty()) {
+    output.setEmpty();
+    return;
+  }
+
+  auto curPos = input.begin();
+  if constexpr (leftTrim) {
+    while (curPos < input.end() && 0x20 == *curPos) {
+      curPos++;
+    }
+  }
+  if (curPos >= input.end()) {
+    output.setEmpty();
+    return;
+  }
+  auto start = curPos;
+  curPos = input.end() - 1;
+  if constexpr (rightTrim) {
+    while (curPos >= start && 0x20 == *curPos) {
+      curPos--;
+    }
+  }
+  output.setNoCopy(StringView(start, curPos - start + 1));
+}
+
+template <
+    bool leftTrim,
+    bool rightTrim,
+    typename TOutString,
+    typename TInString>
 FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
     TOutString& output,
     const TInString& input) {

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -502,6 +502,10 @@ FOLLY_ALWAYS_INLINE bool isAsciiWhiteSpace(char ch) {
   return ch == '\t' || ch == '\n' || ch == '\r' || ch == ' ';
 }
 
+FOLLY_ALWAYS_INLINE bool isAsciiSpace(char ch) {
+  return ch == ' ';
+}
+
 // Returns -1 if 'data' does not end with a white space, otherwise returns the
 // size of the white space character at the end of 'data'. 'size' is the size of
 // 'data' in bytes.
@@ -569,39 +573,7 @@ FOLLY_ALWAYS_INLINE bool splitPart(
 template <
     bool leftTrim,
     bool rightTrim,
-    typename TOutString,
-    typename TInString>
-FOLLY_ALWAYS_INLINE void trimAsciiSpace(
-    TOutString& output,
-    const TInString& input) {
-  if (input.empty()) {
-    output.setEmpty();
-    return;
-  }
-
-  auto curPos = input.begin();
-  if constexpr (leftTrim) {
-    while (curPos < input.end() && 0x20 == *curPos) {
-      curPos++;
-    }
-  }
-  if (curPos >= input.end()) {
-    output.setEmpty();
-    return;
-  }
-  auto start = curPos;
-  curPos = input.end() - 1;
-  if constexpr (rightTrim) {
-    while (curPos >= start && 0x20 == *curPos) {
-      curPos--;
-    }
-  }
-  output.setNoCopy(StringView(start, curPos - start + 1));
-}
-
-template <
-    bool leftTrim,
-    bool rightTrim,
+    bool(shouldTrim)(char) = isAsciiWhiteSpace,
     typename TOutString,
     typename TInString>
 FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
@@ -614,7 +586,7 @@ FOLLY_ALWAYS_INLINE void trimAsciiWhiteSpace(
 
   auto curPos = input.begin();
   if constexpr (leftTrim) {
-    while (curPos < input.end() && isAsciiWhiteSpace(*curPos)) {
+    while (curPos < input.end() && shouldTrim(*curPos)) {
       curPos++;
     }
   }

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -137,11 +137,11 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<ContainsFunction, bool, Varchar, Varchar>(
       {prefix + "contains"});
 
-  registerFunction<TrimFunction, Varchar, Varchar>({"trim"});
+  registerFunction<TrimSpaceFunction, Varchar, Varchar>({"trim"});
   registerFunction<TrimFunction, Varchar, Varchar, Varchar>({"trim"});
-  registerFunction<LTrimFunction, Varchar, Varchar>({"ltrim"});
+  registerFunction<LTrimSpaceFunction, Varchar, Varchar>({"ltrim"});
   registerFunction<LTrimFunction, Varchar, Varchar, Varchar>({"ltrim"});
-  registerFunction<RTrimFunction, Varchar, Varchar>({"rtrim"});
+  registerFunction<RTrimSpaceFunction, Varchar, Varchar>({"rtrim"});
   registerFunction<RTrimFunction, Varchar, Varchar, Varchar>({"rtrim"});
 
   // Register array sort functions.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -137,6 +137,13 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<ContainsFunction, bool, Varchar, Varchar>(
       {prefix + "contains"});
 
+  registerFunction<TrimFunction, Varchar, Varchar>({"trim"});
+  registerFunction<TrimFunction, Varchar, Varchar, Varchar>({"trim"});
+  registerFunction<LTrimFunction, Varchar, Varchar>({"ltrim"});
+  registerFunction<LTrimFunction, Varchar, Varchar, Varchar>({"ltrim"});
+  registerFunction<RTrimFunction, Varchar, Varchar>({"rtrim"});
+  registerFunction<RTrimFunction, Varchar, Varchar, Varchar>({"rtrim"});
+
   // Register array sort functions.
   exec::registerStatefulVectorFunction(
       prefix + "array_sort", arraySortSignatures(), makeArraySort);

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -137,12 +137,14 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<ContainsFunction, bool, Varchar, Varchar>(
       {prefix + "contains"});
 
-  registerFunction<TrimSpaceFunction, Varchar, Varchar>({"trim"});
-  registerFunction<TrimFunction, Varchar, Varchar, Varchar>({"trim"});
-  registerFunction<LTrimSpaceFunction, Varchar, Varchar>({"ltrim"});
-  registerFunction<LTrimFunction, Varchar, Varchar, Varchar>({"ltrim"});
-  registerFunction<RTrimSpaceFunction, Varchar, Varchar>({"rtrim"});
-  registerFunction<RTrimFunction, Varchar, Varchar, Varchar>({"rtrim"});
+  registerFunction<TrimSpaceFunction, Varchar, Varchar>({prefix + "trim"});
+  registerFunction<TrimFunction, Varchar, Varchar, Varchar>({prefix + "trim"});
+  registerFunction<LTrimSpaceFunction, Varchar, Varchar>({prefix + "ltrim"});
+  registerFunction<LTrimFunction, Varchar, Varchar, Varchar>(
+      {prefix + "ltrim"});
+  registerFunction<RTrimSpaceFunction, Varchar, Varchar>({prefix + "rtrim"});
+  registerFunction<RTrimFunction, Varchar, Varchar, Varchar>(
+      {prefix + "rtrim"});
 
   // Register array sort functions.
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -345,13 +345,17 @@ struct TrimFunctionSpaceBase {
   FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& srcStr) {
-    stringImpl::trimAsciiSpace<leftTrim, rightTrim>(result, srcStr);
+    stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
+        result, srcStr);
   }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& srcStr) {
-    stringImpl::trimAsciiSpace<leftTrim, rightTrim>(result, srcStr);
+    // Because utf-8 and Ascii have the same space character code, both are
+    // char=32. So trimAsciiSpace can be reused here.
+    stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
+        result, srcStr);
   }
 };
 

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -321,7 +321,7 @@ struct TrimFunctionBase {
 /// trim(srcStr) -> varchar
 ///     Remove leading and trailing 0x20(space) characters from srcStr.
 template <typename T, bool leftTrim, bool rightTrim>
-struct TrimFunctionSpaceBase {
+struct TrimSpaceFunctionBase {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Results refer to strings in the first argument.

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -239,7 +239,7 @@ struct TrimFunctionBase {
       return;
     }
     if (trimStr.empty()) {
-      result.setNoCopy(StringView(srcStr.data(), srcStr.size()));
+      result.setNoCopy(srcStr);
       return;
     }
 
@@ -278,7 +278,7 @@ struct TrimFunctionBase {
       return;
     }
     if (trimStr.empty()) {
-      result.setNoCopy(StringView(srcStr.data(), srcStr.size()));
+      result.setNoCopy(srcStr);
       return;
     }
 
@@ -329,14 +329,6 @@ struct TrimSpaceFunctionBase {
 
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
-
-  FOLLY_ALWAYS_INLINE void callAscii(
-      out_type<Varchar>& result,
-      const arg_type<Varchar>& srcStr) {
-    stringImpl::
-        trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
-            result, srcStr);
-  }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -211,19 +211,12 @@ struct EndsWithFunction {
   }
 };
 
-/// trim functions
-/// ltrim(srcStr) -> varchar
-///     Removes leading 0x20(space) characters from srcStr.
 /// ltrim(trimStr, srcStr) -> varchar
 ///     Remove leading specified characters from srcStr. The specified character
 ///     is any character contained in trimStr.
-/// rtrim(srcStr) -> varchar
-///     Removes trailing 0x20(space) characters from srcStr.
 /// rtrim(trimStr, srcStr) -> varchar
 ///     Remove trailing specified characters from srcStr. The specified
 ///     character is any character contained in trimStr.
-/// trim(srcStr) -> varchar
-///     Remove leading and trailing 0x20(space) characters from srcStr.
 /// trim(trimStr, srcStr) -> varchar
 ///     Remove leading and trailing specified characters from srcStr. The
 ///     specified character is any character contained in trimStr.
@@ -232,7 +225,7 @@ struct TrimFunctionBase {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   // Results refer to strings in the first argument.
-  static constexpr int32_t reuse_strings_from_arg = 0;
+  static constexpr int32_t reuse_strings_from_arg = 1;
 
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
@@ -331,6 +324,23 @@ struct TrimFunctionBase {
     }
     result.setNoCopy(StringView(srcStr.data() + resultStartIndex, resultSize));
   }
+};
+
+/// ltrim(srcStr) -> varchar
+///     Removes leading 0x20(space) characters from srcStr.
+/// rtrim(srcStr) -> varchar
+///     Removes trailing 0x20(space) characters from srcStr.
+/// trim(srcStr) -> varchar
+///     Remove leading and trailing 0x20(space) characters from srcStr.
+template <typename T, bool leftTrim, bool rightTrim>
+struct TrimFunctionSpaceBase {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
 
   FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
@@ -353,5 +363,14 @@ struct LTrimFunction : public TrimFunctionBase<T, true, false> {};
 
 template <typename T>
 struct RTrimFunction : public TrimFunctionBase<T, false, true> {};
+
+template <typename T>
+struct TrimSpaceFunction : public TrimSpaceFunctionBase<T, true, true> {};
+
+template <typename T>
+struct LTrimSpaceFunction : public TrimSpaceFunctionBase<T, true, false> {};
+
+template <typename T>
+struct RTrimSpaceFunction : public TrimSpaceFunctionBase<T, false, true> {};
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -333,8 +333,9 @@ struct TrimSpaceFunctionBase {
   FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& srcStr) {
-    stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
-        result, srcStr);
+    stringImpl::
+        trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
+            result, srcStr);
   }
 
   FOLLY_ALWAYS_INLINE void call(
@@ -342,8 +343,9 @@ struct TrimSpaceFunctionBase {
       const arg_type<Varchar>& srcStr) {
     // Because utf-8 and Ascii have the same space character code, both are
     // char=32. So trimAsciiSpace can be reused here.
-    stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
-        result, srcStr);
+    stringImpl::
+        trimAsciiWhiteSpace<leftTrim, rightTrim, stringImpl::isAsciiSpace>(
+            result, srcStr);
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -50,6 +50,31 @@ class StringTest : public SparkFunctionBaseTest {
         "length(c0)", {arg}, {VARBINARY()});
   }
 
+  std::optional<std::string> trim(std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("trim(c0)", srcStr);
+  }
+  std::optional<std::string> trim(
+      std::optional<std::string> trimStr,
+      std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("trim(c0, c1)", trimStr, srcStr);
+  }
+  std::optional<std::string> ltrim(std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("ltrim(c0)", srcStr);
+  }
+  std::optional<std::string> ltrim(
+      std::optional<std::string> trimStr,
+      std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("ltrim(c0, c1)", trimStr, srcStr);
+  }
+  std::optional<std::string> rtrim(std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("rtrim(c0)", srcStr);
+  }
+  std::optional<std::string> rtrim(
+      std::optional<std::string> trimStr,
+      std::optional<std::string> srcStr) {
+    return evaluateOnce<std::string>("rtrim(c0, c1)", trimStr, srcStr);
+  }
+
   std::optional<std::string> md5(std::optional<std::string> arg) {
     return evaluateOnce<std::string, std::string>(
         "md5(c0)", {arg}, {VARBINARY()});
@@ -252,6 +277,91 @@ TEST_F(StringTest, endsWith) {
   EXPECT_EQ(endsWith("-- hello there!", "hello there"), false);
   EXPECT_EQ(endsWith("-- hello there!", std::nullopt), std::nullopt);
   EXPECT_EQ(endsWith(std::nullopt, "abc"), std::nullopt);
+}
+
+TEST_F(StringTest, trim) {
+  EXPECT_EQ(trim(""), "");
+  EXPECT_EQ(trim("  data\t "), "data\t");
+  EXPECT_EQ(trim("  data\t"), "data\t");
+  EXPECT_EQ(trim("data\t "), "data\t");
+  EXPECT_EQ(trim("data\t"), "data\t");
+  EXPECT_EQ(trim("  \u6570\u636E\t "), "\u6570\u636E\t");
+  EXPECT_EQ(trim("  \u6570\u636E\t"), "\u6570\u636E\t");
+  EXPECT_EQ(trim("\u6570\u636E\t "), "\u6570\u636E\t");
+  EXPECT_EQ(trim("\u6570\u636E\t"), "\u6570\u636E\t");
+
+  EXPECT_EQ(trim("", ""), "");
+  EXPECT_EQ(trim("", "srcStr"), "srcStr");
+  EXPECT_EQ(trim("trimStr", ""), "");
+  EXPECT_EQ(trim("data!egr< >int", "integer data!"), "");
+  EXPECT_EQ(trim("int", "integer data!"), "eger data!");
+  EXPECT_EQ(trim("!!at", "integer data!"), "integer d");
+  EXPECT_EQ(trim("a", "integer data!"), "integer data!");
+  EXPECT_EQ(
+      trim("\u6570\u6574!\u6570 \u636E!", "\u6574\u6570 \u6570\u636E!"), "");
+  EXPECT_EQ(trim(" \u6574\u6570 ", "\u6574\u6570 \u6570\u636E!"), "\u636E!");
+  EXPECT_EQ(trim("! \u6570\u636E!", "\u6574\u6570 \u6570\u636E!"), "\u6574");
+  EXPECT_EQ(
+      trim("\u6570", "\u6574\u6570 \u6570\u636E!"),
+      "\u6574\u6570 \u6570\u636E!");
+}
+
+TEST_F(StringTest, ltrim) {
+  EXPECT_EQ(ltrim(""), "");
+  EXPECT_EQ(ltrim("  data\t "), "data\t ");
+  EXPECT_EQ(ltrim("  data\t"), "data\t");
+  EXPECT_EQ(ltrim("data\t "), "data\t ");
+  EXPECT_EQ(ltrim("data\t"), "data\t");
+  EXPECT_EQ(ltrim("  \u6570\u636E\t "), "\u6570\u636E\t ");
+  EXPECT_EQ(ltrim("  \u6570\u636E\t"), "\u6570\u636E\t");
+  EXPECT_EQ(ltrim("\u6570\u636E\t "), "\u6570\u636E\t ");
+  EXPECT_EQ(ltrim("\u6570\u636E\t"), "\u6570\u636E\t");
+
+  EXPECT_EQ(ltrim("", ""), "");
+  EXPECT_EQ(ltrim("", "srcStr"), "srcStr");
+  EXPECT_EQ(ltrim("trimStr", ""), "");
+  EXPECT_EQ(ltrim("data!egr< >int", "integer data!"), "");
+  EXPECT_EQ(ltrim("int", "integer data!"), "eger data!");
+  EXPECT_EQ(ltrim("!!at", "integer data!"), "integer data!");
+  EXPECT_EQ(ltrim("a", "integer data!"), "integer data!");
+  EXPECT_EQ(
+      ltrim("\u6570\u6574!\u6570 \u636E!", "\u6574\u6570 \u6570\u636E!"), "");
+  EXPECT_EQ(ltrim(" \u6574\u6570 ", "\u6574\u6570 \u6570\u636E!"), "\u636E!");
+  EXPECT_EQ(
+      ltrim("! \u6570\u636E!", "\u6574\u6570 \u6570\u636E!"),
+      "\u6574\u6570 \u6570\u636E!");
+  EXPECT_EQ(
+      ltrim("\u6570", "\u6574\u6570 \u6570\u636E!"),
+      "\u6574\u6570 \u6570\u636E!");
+}
+
+TEST_F(StringTest, rtrim) {
+  EXPECT_EQ(rtrim(""), "");
+  EXPECT_EQ(rtrim("  data\t "), "  data\t");
+  EXPECT_EQ(rtrim("  data\t"), "  data\t");
+  EXPECT_EQ(rtrim("data\t "), "data\t");
+  EXPECT_EQ(rtrim("data\t"), "data\t");
+  EXPECT_EQ(rtrim("  \u6570\u636E\t "), "  \u6570\u636E\t");
+  EXPECT_EQ(rtrim("  \u6570\u636E\t"), "  \u6570\u636E\t");
+  EXPECT_EQ(rtrim("\u6570\u636E\t "), "\u6570\u636E\t");
+  EXPECT_EQ(rtrim("\u6570\u636E\t"), "\u6570\u636E\t");
+
+  EXPECT_EQ(rtrim("", ""), "");
+  EXPECT_EQ(rtrim("", "srcStr"), "srcStr");
+  EXPECT_EQ(rtrim("trimStr", ""), "");
+  EXPECT_EQ(rtrim("data!egr< >int", "integer data!"), "");
+  EXPECT_EQ(rtrim("int", "integer data!"), "integer data!");
+  EXPECT_EQ(rtrim("!!at", "integer data!"), "integer d");
+  EXPECT_EQ(rtrim("a", "integer data!"), "integer data!");
+  EXPECT_EQ(
+      rtrim("\u6570\u6574!\u6570 \u636E!", "\u6574\u6570 \u6570\u636E!"), "");
+  EXPECT_EQ(
+      rtrim(" \u6574\u6570 ", "\u6574\u6570 \u6570\u636E!"),
+      "\u6574\u6570 \u6570\u636E!");
+  EXPECT_EQ(rtrim("! \u6570\u636E!", "\u6574\u6570 \u6570\u636E!"), "\u6574");
+  EXPECT_EQ(
+      rtrim("\u6570", "\u6574\u6570 \u6570\u636E!"),
+      "\u6574\u6570 \u6570\u636E!");
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -53,22 +53,27 @@ class StringTest : public SparkFunctionBaseTest {
   std::optional<std::string> trim(std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("trim(c0)", srcStr);
   }
+
   std::optional<std::string> trim(
       std::optional<std::string> trimStr,
       std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("trim(c0, c1)", trimStr, srcStr);
   }
+
   std::optional<std::string> ltrim(std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("ltrim(c0)", srcStr);
   }
+
   std::optional<std::string> ltrim(
       std::optional<std::string> trimStr,
       std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("ltrim(c0, c1)", trimStr, srcStr);
   }
+
   std::optional<std::string> rtrim(std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("rtrim(c0)", srcStr);
   }
+  
   std::optional<std::string> rtrim(
       std::optional<std::string> trimStr,
       std::optional<std::string> srcStr) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -73,7 +73,7 @@ class StringTest : public SparkFunctionBaseTest {
   std::optional<std::string> rtrim(std::optional<std::string> srcStr) {
     return evaluateOnce<std::string>("rtrim(c0)", srcStr);
   }
-  
+
   std::optional<std::string> rtrim(
       std::optional<std::string> trimStr,
       std::optional<std::string> srcStr) {


### PR DESCRIPTION
These functions differ from PrestoSQL functions:

trim(string) 

- Presto trims multiple whitespace characters: 9 -> \t, 10 -> \n, 13 -> \r, 32 -> ' ', 8232 -> \u2028.
- Spark trims only one: 32 -> ' '.

trim(trimCharacters, string)

- Not supported in Presto.
- Spark trims all characters found in 'trimCharacters'.

