### PR TITLE
Clear data-dependent flags of vectors in ensureWritable() and prepareForReuse() APIs

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -500,6 +500,7 @@ void BaseVector::ensureWritable(const SelectivityVector& rows) {
   }
 
   this->resize(newSize);
+  this->resetDataDependentFlags(&rows);
 }
 
 void BaseVector::ensureWritable(
@@ -725,6 +726,7 @@ void BaseVector::prepareForReuse() {
       rawNulls_ = nullptr;
     }
   }
+  this->resetDataDependentFlags(nullptr);
 }
 
 namespace {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -475,7 +475,7 @@ class BaseVector {
   // overwritten.
   //
   // After invoking this function, the 'result' is guaranteed to be a flat
-  // uniquely-referenced vector.
+  // uniquely-referenced vector with all data-dependent flags reset.
   //
   // Use SelectivityVector::empty() to make the 'result' writable and preserve
   // all current values.
@@ -643,14 +643,16 @@ class BaseVector {
   /// To safely reuse a vector one needs to (1) ensure that the vector as well
   /// as all its buffers and child vectors are singly-referenced and mutable
   /// (for buffers); (2) clear append-only string buffers and child vectors
-  /// (elements of arrays, keys and values of maps, fields of structs).
+  /// (elements of arrays, keys and values of maps, fields of structs); (3)
+  /// reset all data-dependent flags.
   ///
   /// This method takes a non-const reference to a 'vector' and updates it to
   /// possibly a new flat vector of the specified size that is safe to reuse.
   /// If input 'vector' is not singly-referenced or not flat, replaces 'vector'
   /// with a new vector of the same type and specified size. If some of the
   /// buffers cannot be reused, these buffers are reset. Child vectors are
-  /// updated by calling this method recursively with size zero.
+  /// updated by calling this method recursively with size zero. Data-dependent
+  /// flags are reset after this call.
   static void prepareForReuse(
       std::shared_ptr<BaseVector>& vector,
       vector_size_t size);
@@ -791,6 +793,22 @@ class BaseVector {
 
   BufferPtr sliceNulls(vector_size_t offset, vector_size_t length) const {
     return sliceBuffer(*BOOLEAN(), nulls_, offset, length, pool_);
+  }
+
+  // Reset data-dependent flags to the "unknown" status. This is needed whenever
+  // a vector is mutated because the modification may invalidate these flags.
+  // Currently, we call this function in BaseVector::ensureWritable() and
+  // BaseVector::prepareForReuse() that are expected to be called before any
+  // vector mutation.
+  //
+  // Per-vector flags are reset to default values. Per-row flags are reset only
+  // at the selected rows. If rows is a nullptr, per-row flags are reset at all
+  // rows.
+  virtual void resetDataDependentFlags(const SelectivityVector* /*rows*/) {
+    nullCount_ = std::nullopt;
+    distinctValueCount_ = std::nullopt;
+    representedByteCount_ = std::nullopt;
+    storageByteCount_ = std::nullopt;
   }
 
   const TypePtr type_;

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1006,8 +1006,6 @@ uint64_t MapVector::estimateFlatSize() const {
 void MapVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
-  sortedKeys_ = false;
-
   if (!(offsets_->unique() && offsets_->isMutable())) {
     offsets_ = nullptr;
   } else {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -563,6 +563,12 @@ class MapVector : public ArrayVectorBase {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+ protected:
+  virtual void resetDataDependentFlags(const SelectivityVector* rows) override {
+    BaseVector::resetDataDependentFlags(rows);
+    sortedKeys_ = false;
+  }
+
  private:
   // Returns true if the keys for map at 'index' are sorted from first
   // to last in the type's collation order.

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -245,9 +245,6 @@ void FlatVector<StringView>::prepareForReuse() {
       rawValues_[i] = StringView();
     }
   }
-
-  // Clear ASCII-ness.
-  SimpleVector<StringView>::invalidateIsAscii();
 }
 
 template <>

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -319,6 +319,18 @@ class SimpleVector : public BaseVector {
     return left < right ? -1 : left == right ? 0 : 1;
   }
 
+  virtual void resetDataDependentFlags(const SelectivityVector* rows) override {
+    BaseVector::resetDataDependentFlags(rows);
+    isSorted_ = std::nullopt;
+    stats_ = SimpleVectorStats<T>{};
+    if (rows) {
+      asciiSetRows_.deselect(*rows);
+    } else {
+      asciiSetRows_.clearAll();
+      isAllAscii_ = false;
+    }
+  }
+
   std::optional<bool> isSorted_ = std::nullopt;
 
   // Allows checking that access is with the same width of T as

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable(
   IsWritableVectorTest.cpp
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp
-  VariantToVectorTest.cpp)
+  VariantToVectorTest.cpp
+  VectorTestUtils.cpp)
 
 add_test(velox_vector_test velox_vector_test)
 

--- a/velox/vector/tests/VectorTestUtils.cpp
+++ b/velox/vector/tests/VectorTestUtils.cpp
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/tests/VectorTestUtils.h"
+
+namespace facebook::velox::test {
+namespace {
+
+void checkBaseVectorFlagsSet(const BaseVector& vector) {
+  EXPECT_TRUE(vector.getNullCount().has_value());
+  EXPECT_TRUE(vector.getDistinctValueCount().has_value());
+  EXPECT_TRUE(vector.representedBytes().has_value());
+  EXPECT_TRUE(vector.storageBytes().has_value());
+}
+
+void checkBaseVectorFlagsCleared(const BaseVector& vector) {
+  EXPECT_FALSE(vector.getNullCount().has_value());
+  EXPECT_FALSE(vector.getDistinctValueCount().has_value());
+  EXPECT_FALSE(vector.representedBytes().has_value());
+  EXPECT_FALSE(vector.storageBytes().has_value());
+}
+
+// Forward declaration.
+void checkVectorFlagsCleared(
+    const BaseVector& vector,
+    const SelectivityVector& asciiClearedRows,
+    const SelectivityVector& asciiRemainRows);
+
+void checkVectorFlagsSet(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows);
+
+template <TypeKind kind>
+void checkVectorFlagsClearedTyped(
+    const BaseVector& vector,
+    const SelectivityVector& asciiClearedRows,
+    const SelectivityVector& asciiRemainRows) {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto* simpleVector = vector.as<SimpleVector<T>>();
+
+  checkBaseVectorFlagsCleared(vector);
+  EXPECT_FALSE(simpleVector->getStats().min.has_value());
+  EXPECT_FALSE(simpleVector->getStats().max.has_value());
+  EXPECT_FALSE(simpleVector->isSorted().has_value());
+  if constexpr (std::is_same_v<T, StringView>) {
+    asciiClearedRows.applyToSelected([&](auto row) {
+      EXPECT_FALSE(simpleVector->isAscii(row).has_value());
+    });
+    asciiRemainRows.applyToSelected([&](auto row) {
+      EXPECT_TRUE(
+          simpleVector->isNullAt(row) ||
+          simpleVector->isAscii(row).has_value());
+    });
+  }
+}
+
+template <>
+void checkVectorFlagsClearedTyped<TypeKind::MAP>(
+    const BaseVector& vector,
+    const SelectivityVector& /*asciiClearedRows*/,
+    const SelectivityVector& /*asciiRemainRows*/) {
+  auto* mapVector = vector.as<MapVector>();
+  checkBaseVectorFlagsCleared(vector);
+  EXPECT_FALSE(mapVector->hasSortedKeys());
+
+  // MapVector is not expected to clear asciiness of children vector at existing
+  // rows.
+  checkVectorFlagsCleared(*mapVector->mapKeys(), {}, {});
+  checkVectorFlagsCleared(*mapVector->mapValues(), {}, {});
+}
+
+template <>
+void checkVectorFlagsClearedTyped<TypeKind::ARRAY>(
+    const BaseVector& vector,
+    const SelectivityVector& /*asciiClearedRows*/,
+    const SelectivityVector& /*asciiRemainRows*/) {
+  checkBaseVectorFlagsCleared(vector);
+
+  // ArrayVector is not expected to clear asciiness of children vector at
+  // existing rows.
+  checkVectorFlagsCleared(*vector.as<ArrayVector>()->elements(), {}, {});
+}
+
+template <>
+void checkVectorFlagsClearedTyped<TypeKind::ROW>(
+    const BaseVector& vector,
+    const SelectivityVector& asciiClearedRows,
+    const SelectivityVector& asciiRemainRows) {
+  checkBaseVectorFlagsCleared(vector);
+
+  auto* rowVector = vector.as<RowVector>();
+  for (const auto& child : rowVector->children()) {
+    checkVectorFlagsCleared(*child, asciiClearedRows, asciiRemainRows);
+  }
+}
+
+// Check that data-dependent flags have been reset. If the asciiness flag
+// applies, check that the asciiness information is cleared at asciiClearedRows
+// and remains at asciiRemainRows.
+void checkVectorFlagsCleared(
+    const BaseVector& vector,
+    const SelectivityVector& asciiClearedRows,
+    const SelectivityVector& asciiRemainRows) {
+  VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      checkVectorFlagsClearedTyped,
+      vector.typeKind(),
+      vector,
+      asciiClearedRows,
+      asciiRemainRows);
+}
+
+template <TypeKind kind>
+void checkVectorFlagsSetTyped(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows) {
+  using T = typename TypeTraits<kind>::NativeType;
+  auto* simpleVector = vector.as<SimpleVector<T>>();
+
+  checkBaseVectorFlagsSet(vector);
+  EXPECT_TRUE(simpleVector->getStats().min.has_value());
+  EXPECT_TRUE(simpleVector->getStats().max.has_value());
+  EXPECT_TRUE(simpleVector->isSorted().has_value());
+  if constexpr (std::is_same_v<T, StringView>) {
+    asciiSetRows.applyToSelected([&](auto row) {
+      EXPECT_TRUE(
+          simpleVector->isNullAt(row) ||
+          simpleVector->isAscii(row).has_value());
+    });
+  }
+}
+
+template <>
+void checkVectorFlagsSetTyped<TypeKind::MAP>(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows) {
+  EXPECT_TRUE(vector.getNullCount().has_value());
+  auto* mapVector = vector.as<MapVector>();
+  EXPECT_TRUE(mapVector->hasSortedKeys());
+
+  checkVectorFlagsSet(*mapVector->mapKeys(), asciiSetRows);
+  checkVectorFlagsSet(*mapVector->mapValues(), asciiSetRows);
+}
+
+template <>
+void checkVectorFlagsSetTyped<TypeKind::ARRAY>(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows) {
+  EXPECT_TRUE(vector.getNullCount().has_value());
+
+  checkVectorFlagsSet(*vector.as<ArrayVector>()->elements(), asciiSetRows);
+}
+
+template <>
+void checkVectorFlagsSetTyped<TypeKind::ROW>(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows) {
+  EXPECT_TRUE(vector.getNullCount().has_value());
+
+  auto* rowVector = vector.as<RowVector>();
+  for (const auto& child : rowVector->children()) {
+    checkVectorFlagsSet(*child, asciiSetRows);
+  }
+}
+
+// Check that data-dependent flags have been set and the asciiness flag has been
+// set for asciiSetRows.
+void checkVectorFlagsSet(
+    const BaseVector& vector,
+    const SelectivityVector& asciiSetRows) {
+  VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      checkVectorFlagsSetTyped, vector.typeKind(), vector, asciiSetRows);
+}
+
+// Return an all-selected selectivity vector of the same size as a scalar or row
+// vector, or of the same size as the element vectors of an array or map vector.
+SelectivityVector createAllSelectedAsciiRows(const VectorPtr& vector) {
+  auto size = vector->size();
+  if (vector->type()->isArray()) {
+    size = vector->as<ArrayVector>()->elements()->size();
+  } else if (vector->type()->isMap()) {
+    size = vector->as<MapVector>()->mapKeys()->size();
+  }
+  return SelectivityVector{size};
+}
+
+// Return a new selectivity vector of rows in oldRows but not in mutatedRows.
+SelectivityVector getUpdatedAsciiRows(
+    const SelectivityVector& oldRows,
+    const SelectivityVector& mutatedRows) {
+  auto newRows = oldRows;
+  newRows.deselect(mutatedRows);
+  return newRows;
+}
+
+// Return true if vector is not dictionary- or constant-encoded.
+bool isFlat(const VectorPtr& vector) {
+  return vector->encoding() != VectorEncoding::Simple::DICTIONARY &&
+      vector->encoding() != VectorEncoding::Simple::CONSTANT;
+}
+
+} // namespace
+
+BufferPtr makeNulls(
+    vector_size_t size,
+    memory::MemoryPool* pool,
+    std::function<bool(vector_size_t /*row*/)> isNullAt) {
+  auto nulls = allocateNulls(size, pool);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  for (vector_size_t i = 0; i < size; i++) {
+    if (isNullAt(i)) {
+      bits::setNull(rawNulls, i, true);
+    }
+  }
+  return nulls;
+}
+
+void checkVectorFlagsReset(
+    const std::function<VectorPtr()>& createVector,
+    const std::function<void(VectorPtr&)>& makeMutable,
+    const SelectivityVector& mutatedRows) {
+  // Vector is multiply-referenced.
+  auto vector = createVector();
+  auto asciiRows = createAllSelectedAsciiRows(vector);
+  // Mutation of dictionary or constant vectors is expected to create a new
+  // vector that doesn't keep the asciiness information.
+  auto updatedAsciiRows = isFlat(vector)
+      ? getUpdatedAsciiRows(asciiRows, mutatedRows)
+      : SelectivityVector{};
+  checkVectorFlagsSet(*vector, asciiRows);
+  auto another = vector;
+  makeMutable(vector);
+  // When vector is multiply-referenced, mutation will create a new vector and
+  // hence not expected to keep the asciiness information.
+  checkVectorFlagsCleared(*vector, mutatedRows, {});
+
+  // nulls buffer is multiply-referenced.
+  vector = createVector();
+  checkVectorFlagsSet(*vector, asciiRows);
+  auto nulls = vector->nulls();
+  makeMutable(vector);
+  checkVectorFlagsCleared(*vector, mutatedRows, updatedAsciiRows);
+
+  // values buffer is multiply-referenced.
+  vector = createVector();
+  if (vector->isFlatEncoding()) {
+    checkVectorFlagsSet(*vector, asciiRows);
+    auto values = vector->values();
+    makeMutable(vector);
+    checkVectorFlagsCleared(*vector, mutatedRows, updatedAsciiRows);
+  }
+
+  vector = createVector();
+  checkVectorFlagsSet(*vector, asciiRows);
+  makeMutable(vector);
+  checkVectorFlagsCleared(*vector, mutatedRows, updatedAsciiRows);
+}
+
+} // namespace facebook::velox::test

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -23,7 +23,9 @@
 
 #include "velox/buffer/StringViewBufferHolder.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/StringView.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::test {
 


### PR DESCRIPTION
Summary:
Data-dependent flags of a vector need to be reset when this vector is modified. These flags
include
* BaseVector::nullCount_: per-vector property
* BaseVector::distinctValueCount_: per-vector property
* BaseVector::representedByteCount_: per-vector property
* BaseVector::storageByteCount_: per-vector property
* SimpleVector::asciiSetRows_: per-row property
* SimpleVector::isSorted_: per-vector property
* SimpleVector::stats_: per-vector property
* MapVector::sortedKeys_: per-vector property

Among the data dependent flags, SimpleVector::asciiSetRows_ is a SelectivityVector representing
a per-row property, i.e., which rows have known ascii-ness information, while the rest are all per-
vector properties meaning that we know something about the entire vector. Therefore, we should
reset all per-vector properties to default values when a vector is mutated, while clearing only the
mutated rows of the per-row property asciiSetRows_.

This diff adds a function BaseVector::clearDataDependentFlags() that is called in
BaseVector::ensureWritable() and BaseVector::prepareForReuse().

This diff fixes https://github.com/facebookincubator/velox/issues/4114 and https://github.com/facebookincubator/velox/issues/4116.

Differential Revision: D43846793

