### PR TITLE
Update PyVelox wheels compatibility tag 

### DIFF
--- a/.github/workflows/build_pyvelox.yml
+++ b/.github/workflows/build_pyvelox.yml
@@ -147,6 +147,13 @@ jobs:
           path: ".ccache"
           key: ccache-wheels-${{ matrix.os }}-${{ github.sha }}
 
+      - name: "Rename wheel compatibility tag"
+        if: matrix.os == 'macos-11'
+        run: |
+          brew install rename
+          cd wheelhouse
+          rename 's/11_0/10_15/g' *.whl
+
       - uses: actions/upload-artifact@v3
         with:
           name: wheels


### PR DESCRIPTION
Closes #4141 

As the tags are upwards compatible it is not necessary to copy the files and have both 11_0 and 10_15 version.