### PR TITLE
Fix max aggregation for floating point inputs

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -31,8 +31,9 @@ struct MinMaxTrait : public std::numeric_limits<T> {};
 
 template <>
 struct MinMaxTrait<Timestamp> {
-  static constexpr Timestamp min() {
-    return Timestamp(MinMaxTrait<int64_t>::min(), MinMaxTrait<uint64_t>::min());
+  static constexpr Timestamp lowest() {
+    return Timestamp(
+        MinMaxTrait<int64_t>::lowest(), MinMaxTrait<uint64_t>::lowest());
   }
 
   static constexpr Timestamp max() {
@@ -42,8 +43,8 @@ struct MinMaxTrait<Timestamp> {
 
 template <>
 struct MinMaxTrait<Date> {
-  static constexpr Date min() {
-    return Date(std::numeric_limits<int32_t>::min());
+  static constexpr Date lowest() {
+    return Date(std::numeric_limits<int32_t>::lowest());
   }
 
   static constexpr Date max() {
@@ -53,8 +54,8 @@ struct MinMaxTrait<Date> {
 
 template <>
 struct MinMaxTrait<IntervalDayTime> {
-  static constexpr IntervalDayTime min() {
-    return IntervalDayTime(std::numeric_limits<int64_t>::min());
+  static constexpr IntervalDayTime lowest() {
+    return IntervalDayTime(std::numeric_limits<int64_t>::lowest());
   }
 
   static constexpr IntervalDayTime max() {
@@ -177,7 +178,7 @@ class MaxAggregate : public MinMaxAggregate<T> {
   }
 
  private:
-  static constexpr T kInitialValue_{MinMaxTrait<T>::min()};
+  static constexpr T kInitialValue_{MinMaxTrait<T>::lowest()};
 };
 
 template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -107,6 +107,14 @@ TEST_F(MinMaxTest, maxBigint) {
   doTest(max, BIGINT());
 }
 
+TEST_F(MinMaxTest, maxReal) {
+  doTest(max, REAL());
+}
+
+TEST_F(MinMaxTest, maxDouble) {
+  doTest(max, DOUBLE());
+}
+
 TEST_F(MinMaxTest, maxVarchar) {
   doTest(max, VARCHAR());
 }
@@ -133,6 +141,14 @@ TEST_F(MinMaxTest, minInteger) {
 
 TEST_F(MinMaxTest, minBigint) {
   doTest(min, BIGINT());
+}
+
+TEST_F(MinMaxTest, minReal) {
+  doTest(min, REAL());
+}
+
+TEST_F(MinMaxTest, minDouble) {
+  doTest(min, DOUBLE());
 }
 
 TEST_F(MinMaxTest, minInterval) {
@@ -221,19 +237,17 @@ TEST_F(MinMaxTest, minMaxDate) {
 TEST_F(MinMaxTest, initialValue) {
   // Ensures that no groups are default initialized (to 0) in
   // aggregate::SimpleNumericAggregate.
-  auto rowType = ROW({"c0", "c1"}, {TINYINT(), TINYINT()});
-  auto arrayVectorC0 = makeFlatVector<int8_t>({1, 1, 1, 1});
-  auto arrayVectorC1 = makeFlatVector<int8_t>({-1, -1, -1, -1});
-
-  std::vector<VectorPtr> vec = {arrayVectorC0, arrayVectorC1};
-  auto row = std::make_shared<RowVector>(
-      pool_.get(), rowType, nullptr, vec.front()->size(), vec, 0);
-
-  // Test min of {1, 1, ...} and max {-1, -1, ..}.
-  // Make sure they are not zero.
-  testAggregations({row}, {}, {"min(c0)"}, "SELECT 1");
-
-  testAggregations({row}, {}, {"max(c1)"}, "SELECT -1");
+  auto row = makeRowVector({
+      makeFlatVector<int8_t>({1, 1, 1, 1}),
+      makeFlatVector<int8_t>({-1, -1, -1, -1}),
+      makeFlatVector<double>({1, 2, 3, 4}),
+      makeFlatVector<double>({-1, -2, -3, -4}),
+  });
+  testAggregations(
+      {row},
+      {},
+      {"min(c0)", "max(c1)", "min(c2)", "max(c3)"},
+      "SELECT 1, -1, 1, -1");
 }
 
 } // namespace


### PR DESCRIPTION
Summary: Currently if all inputs to `max` is negative floating point numbers, the result is incorrect, because the result is initialized to 0.

Differential Revision: D43875022

