### PR TITLE
Expose Config entry config keys

### DIFF
--- a/velox/common/config/Config.h
+++ b/velox/common/config/Config.h
@@ -51,6 +51,12 @@ class ConfigBase {
             })
         : key_{key}, default_{val}, toStr_{toStr}, toT_{toT} {}
 
+   public:
+    const std::string& configKey() const {
+      return key_;
+    }
+
+   private:
     const std::string key_;
     const T default_;
     const std::function<std::string(const T&)> toStr_;


### PR DESCRIPTION
Summary: I find it silly that we can't use the config key constants from their definition and have to define separate constants elsewhere when we manipulate serde bags. This diff allows future access to these constants through the entry definitions.

Differential Revision: D43883611

