### PR TITLE
velox: avoid C++20 ambiguous overloaded operator

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -139,7 +139,7 @@ class ConstantTypedExpr : public ITypedExpr {
     }
   }
 
-  bool operator==(const ITypedExpr& other) const final {
+  bool equals(const ITypedExpr& other) const {
     const auto* casted = dynamic_cast<const ConstantTypedExpr*>(&other);
     if (!casted) {
       return false;
@@ -158,6 +158,14 @@ class ConstantTypedExpr : public ITypedExpr {
     }
 
     return this->value_ == casted->value_;
+  }
+
+  bool operator==(const ITypedExpr& other) const final {
+    return this->equals(other);
+  }
+
+  bool operator==(const ConstantTypedExpr& other) const {
+    return this->equals(other);
   }
 
   VELOX_DEFINE_CLASS_NAME(ConstantTypedExpr)

--- a/velox/external/duckdb/duckdb.hpp
+++ b/velox/external/duckdb/duckdb.hpp
@@ -6254,7 +6254,7 @@ public:
 		}
 		return left->Equals(right);
 	}
-	bool operator==(const BaseExpression &rhs) {
+	bool operator==(const BaseExpression &rhs) const {
 		return this->Equals(&rhs);
 	}
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -380,7 +380,7 @@ bool RowType::equivalent(const Type& other) const {
   return true;
 }
 
-bool RowType::operator==(const Type& other) const {
+bool RowType::equals(const Type& other) const {
   if (!this->equivalent(other)) {
     return false;
   }
@@ -392,6 +392,14 @@ bool RowType::operator==(const Type& other) const {
     }
   }
   return true;
+}
+
+bool RowType::operator==(const Type& other) const {
+  return this->equals(other);
+}
+
+bool RowType::operator==(const RowType& other) const {
+  return this->equals(other);
 }
 
 void RowType::printChildren(std::stringstream& ss, std::string_view delimiter)

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -803,7 +803,9 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   bool equivalent(const Type& other) const override;
 
+  bool equals(const Type& other) const;
   bool operator==(const Type& other) const override;
+  bool operator==(const RowType& other) const;
 
   std::string toString() const override;
 


### PR DESCRIPTION
Summary:
Resolves errors from overloaded ambiguous operators:
```
velox/core/Expressions.h:422:24: error: ISO C++20 considers use of overloaded operator '==' (with operand types 'std::__shared_ptr_access<const facebook::velox::RowType, __gnu_cxx::_S_atomic, false, false>::element_type' (aka 'const facebook::velox::RowType') and 'std::__shared_ptr_access<const facebook::velox::RowType, __gnu_cxx::_S_atomic, false, false>::element_type') to be ambiguous despite there being a unique best viable function [-Werror,-Wambiguous-reversed-operator]
```

Reviewed By: meyering

Differential Revision: D43868143

