### PR TITLE
remove const qualifier from FlatVector::valueAtFast

### DIFF
--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -57,7 +57,7 @@ const T* FlatVector<T>::rawValues() const {
 }
 
 template <typename T>
-const T FlatVector<T>::valueAtFast(vector_size_t idx) const {
+T FlatVector<T>::valueAtFast(vector_size_t idx) const {
   return rawValues_[idx];
 }
 

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -27,7 +27,7 @@ const bool* FlatVector<bool>::rawValues() const {
 }
 
 template <>
-const bool FlatVector<bool>::valueAtFast(vector_size_t idx) const {
+bool FlatVector<bool>::valueAtFast(vector_size_t idx) const {
   return bits::isBitSet(reinterpret_cast<const uint64_t*>(rawValues_), idx);
 }
 

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -108,7 +108,7 @@ class FlatVector final : public SimpleVector<T> {
 
   virtual ~FlatVector() override = default;
 
-  const T valueAtFast(vector_size_t idx) const;
+  T valueAtFast(vector_size_t idx) const;
 
   const T valueAt(vector_size_t idx) const override {
     return valueAtFast(idx);
@@ -450,7 +450,7 @@ class FlatVector final : public SimpleVector<T> {
 };
 
 template <>
-const bool FlatVector<bool>::valueAtFast(vector_size_t idx) const;
+bool FlatVector<bool>::valueAtFast(vector_size_t idx) const;
 
 template <>
 const bool* FlatVector<bool>::rawValues() const;

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -402,7 +402,7 @@ void exportStrings(
   rows.apply([&](vector_size_t i) {
     auto newOffset = *rawOffsets;
     if (!vec.isNullAt(i)) {
-      auto& sv = vec.valueAtFast(i);
+      auto sv = vec.valueAtFast(i);
       memcpy(rawBuffer, sv.data(), sv.size());
       rawBuffer += sv.size();
       newOffset += sv.size();


### PR DESCRIPTION
Summary:
In a recent diff (D43709886), compiler reports build error
buck-out/v2/gen/fbcode/5697cef6ea8bc955/velox/vector/__velox_vector__/buck-headers/velox/vector/FlatVector.h:453:1: error: 'const' type qualifier on return type has no effect [-Werror,-Wignored-qualifiers]
const bool FlatVector<bool>::valueAtFast(vector_size_t idx) const;

It should be safe to remove const qualifier.

Differential Revision: D43887693

