### PR TITLE
Consolidate Peeling functionality used during expression evaluation

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -37,7 +37,8 @@ add_library(
   SimpleFunctionRegistry.cpp
   SwitchExpr.cpp
   TryExpr.cpp
-  GenericWriter.cpp)
+  GenericWriter.cpp
+  PeeledEncoding.cpp)
 
 target_link_libraries(
   velox_expression velox_core velox_vector velox_common_base

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -18,6 +18,7 @@
 #include <exception>
 #include "velox/common/base/RawVector.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/PeeledEncoding.h"
 
 namespace facebook::velox::exec {
 
@@ -50,55 +51,6 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
   VELOX_CHECK_NOT_NULL(execCtx);
 }
 
-VectorPtr EvalCtx::applyWrapToPeeledResult(
-    const TypePtr& outputType,
-    VectorPtr peeledResult,
-    const SelectivityVector& rows) {
-  VectorPtr wrappedResult;
-  if (wrapEncoding_ == VectorEncoding::Simple::DICTIONARY) {
-    if (!peeledResult) {
-      // If all rows are null, make a constant null vector of the right type.
-      wrappedResult =
-          BaseVector::createNullConstant(outputType, rows.size(), pool());
-    } else {
-      BufferPtr nulls;
-      if (!rows.isAllSelected()) {
-        // The new base vector may be shorter than the original base vector
-        // (e.g. if positions at the end of the original vector were not
-        // selected for evaluation). In this case some original indices
-        // corresponding to non-selected rows may point past the end of the base
-        // vector. Disable these by setting corresponding positions to null.
-        nulls = AlignedBuffer::allocate<bool>(rows.size(), pool(), bits::kNull);
-        // Set the active rows to non-null.
-        rows.clearNulls(nulls);
-        if (wrapNulls_) {
-          // Add the nulls from the wrapping.
-          bits::andBits(
-              nulls->asMutable<uint64_t>(),
-              wrapNulls_->as<uint64_t>(),
-              rows.begin(),
-              rows.end());
-        }
-        // Reset nulls buffer if all positions happen to be non-null.
-        if (bits::isAllSet(
-                nulls->as<uint64_t>(), 0, rows.end(), bits::kNotNull)) {
-          nulls.reset();
-        }
-      } else {
-        nulls = wrapNulls_;
-      }
-      wrappedResult = BaseVector::wrapInDictionary(
-          std::move(nulls), wrap_, rows.end(), std::move(peeledResult));
-    }
-  } else if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
-    wrappedResult = BaseVector::wrapInConstant(
-        rows.size(), constantWrapIndex_, std::move(peeledResult));
-  } else {
-    VELOX_FAIL("Bad expression wrap encoding {}", wrapEncoding_);
-  }
-  return wrappedResult;
-}
-
 void EvalCtx::saveAndReset(
     ScopedContextSaver& saver,
     const SelectivityVector& rows) {
@@ -109,11 +61,8 @@ void EvalCtx::saveAndReset(
   saver.rows = &rows;
   saver.finalSelection = finalSelection_;
   saver.peeled = std::move(peeledFields_);
-  saver.wrap = std::move(wrap_);
-  saver.wrapNulls = std::move(wrapNulls_);
-  saver.constantWrapIndex = constantWrapIndex_;
-  saver.wrapEncoding = wrapEncoding_;
-  wrapEncoding_ = VectorEncoding::Simple::FLAT;
+  saver.peeledEncoding = std::move(peeledEncoding_);
+  peeledEncoding_.reset();
   saver.nullsPruned = nullsPruned_;
   nullsPruned_ = false;
   if (errors_) {
@@ -186,29 +135,19 @@ void EvalCtx::restore(ScopedContextSaver& saver) {
   nullsPruned_ = saver.nullsPruned;
   if (errors_) {
     int32_t errorSize = errors_->size();
-    // A constant wrap has no indices.
-    auto indices = wrap_ ? wrap_->as<vector_size_t>() : nullptr;
-    auto wrapNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
-    saver.rows->applyToSelected([&](auto row) {
-      // A known null in the outer row masks an error.
-      if (wrapNulls && bits::isBitNull(wrapNulls, row)) {
-        return;
-      }
-      vector_size_t innerRow = indices ? indices[row] : constantWrapIndex_;
-      if (innerRow < errorSize && !errors_->isNullAt(innerRow)) {
-        addError(
-            row,
-            *std::static_pointer_cast<std::exception_ptr>(
-                errors_->valueAt(innerRow)),
-            saver.errors);
-      }
-    });
+    peeledEncoding_->applyToNonNullInnerRows(
+        *saver.rows, [&](auto outerRow, auto innerRow) {
+          if (innerRow < errorSize && !errors_->isNullAt(innerRow)) {
+            addError(
+                outerRow,
+                *std::static_pointer_cast<std::exception_ptr>(
+                    errors_->valueAt(innerRow)),
+                saver.errors);
+          }
+        });
   }
   errors_ = std::move(saver.errors);
-  wrap_ = std::move(saver.wrap);
-  wrapNulls_ = std::move(saver.wrapNulls);
-  constantWrapIndex_ = saver.constantWrapIndex;
-  wrapEncoding_ = saver.wrapEncoding;
+  peeledEncoding_ = std::move(saver.peeledEncoding);
   finalSelection_ = saver.finalSelection;
 }
 
@@ -335,4 +274,8 @@ ScopedFinalSelectionSetter::~ScopedFinalSelectionSetter() {
   *evalCtx_.mutableIsFinalSelection() = oldIsFinalSelection_;
 }
 
+VectorEncoding::Simple EvalCtx::wrapEncoding() const {
+  return !peeledEncoding_ ? VectorEncoding::Simple::FLAT
+                          : peeledEncoding_->getWrapEncoding();
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -27,7 +27,10 @@ namespace facebook::velox::exec {
 
 class Expr;
 class ExprSet;
+class LocalDecodedVector;
+class LocalSelectivityVector;
 struct ScopedContextSaver;
+class PeeledEncoding;
 
 // Context for holding the base row vector, error state and various
 // flags for Expr interpreter.
@@ -73,13 +76,6 @@ class EvalCtx {
   void saveAndReset(ScopedContextSaver& saver, const SelectivityVector& rows);
 
   void restore(ScopedContextSaver& saver);
-
-  // Wraps the 'peeledResult' in the wrap produced by the last peeling in
-  // EvalEncoding() and returns the vector created as a result.
-  VectorPtr applyWrapToPeeledResult(
-      const TypePtr& outputType,
-      VectorPtr peeledResult,
-      const SelectivityVector& rows);
 
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);
 
@@ -200,23 +196,10 @@ class EvalCtx {
     return exprSet_;
   }
 
-  VectorEncoding::Simple wrapEncoding() const {
-    return wrapEncoding_;
-  }
+  VectorEncoding::Simple wrapEncoding() const;
 
-  bool hasWrap() const {
-    return wrapEncoding_ != VectorEncoding::Simple::FLAT;
-  }
-
-  void setConstantWrap(vector_size_t wrapIndex) {
-    wrapEncoding_ = VectorEncoding::Simple::CONSTANT;
-    constantWrapIndex_ = wrapIndex;
-  }
-
-  void setDictionaryWrap(BufferPtr wrap, BufferPtr wrapNulls) {
-    wrapEncoding_ = VectorEncoding::Simple::DICTIONARY;
-    wrap_ = std::move(wrap);
-    wrapNulls_ = std::move(wrapNulls);
+  void setPeeledEncoding(std::shared_ptr<PeeledEncoding>& peel) {
+    peeledEncoding_ = std::move(peel);
   }
 
   // Copy "rows" of localResult into results if "result" is partially populated
@@ -262,6 +245,9 @@ class EvalCtx {
   /// Make sure the vector is addressable up to index `size`-1. Initialize all
   /// new elements to null.
   void ensureErrorsVectorSize(ErrorVectorPtr& vector, vector_size_t size) const;
+  PeeledEncoding* getPeeledEncoding() {
+    return peeledEncoding_.get();
+  }
 
  private:
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
@@ -272,10 +258,10 @@ class EvalCtx {
   // Corresponds 1:1 to children of 'row_'. Set to an inner vector
   // after removing dictionary/sequence wrappers.
   std::vector<VectorPtr> peeledFields_;
-  BufferPtr wrap_;
-  BufferPtr wrapNulls_;
-  VectorEncoding::Simple wrapEncoding_ = VectorEncoding::Simple::FLAT;
-  vector_size_t constantWrapIndex_;
+
+  // Set if peeling was successful, that is, common encodings from inputs were
+  // peeled off.
+  std::shared_ptr<PeeledEncoding> peeledEncoding_;
 
   // True if nulls in the input vectors were pruned (removed from the current
   // selectivity vector). Only possible is all expressions have default null
@@ -305,10 +291,7 @@ struct ScopedContextSaver {
   // The context to restore. nullptr if nothing to restore.
   EvalCtx* FOLLY_NULLABLE context = nullptr;
   std::vector<VectorPtr> peeled;
-  BufferPtr wrap;
-  BufferPtr wrapNulls;
-  vector_size_t constantWrapIndex;
-  VectorEncoding::Simple wrapEncoding;
+  std::shared_ptr<PeeledEncoding> peeledEncoding;
   bool nullsPruned = false;
   // The selection of the context being saved.
   const SelectivityVector* FOLLY_NONNULL rows;

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -26,6 +26,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/ExprCompiler.h"
 #include "velox/expression/FieldReference.h"
+#include "velox/expression/PeeledEncoding.h"
 #include "velox/expression/ScopedVarSetter.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/vector/SelectivityVector.h"
@@ -688,64 +689,6 @@ void Expr::evaluateSharedSubexpr(
   context.moveOrCopyResult(sharedSubexprValues_, rows, result);
 }
 
-namespace {
-inline void setPeeled(
-    const VectorPtr& leaf,
-    int32_t fieldIndex,
-    EvalCtx& context,
-    std::vector<VectorPtr>& peeled) {
-  if (peeled.size() <= fieldIndex) {
-    peeled.resize(context.row()->childrenSize());
-  }
-  assert(peeled.size() > fieldIndex);
-  peeled[fieldIndex] = leaf;
-}
-
-/// Returns true if 'wrapper' is a dictionary vector over a flat vector.
-bool isDictionaryOverFlat(const BaseVector& wrapper) {
-  return wrapper.encoding() == VectorEncoding::Simple::DICTIONARY &&
-      wrapper.valueVector()->isFlatEncoding();
-}
-
-void setDictionaryWrapping(
-    DecodedVector& decoded,
-    const SelectivityVector& rows,
-    BaseVector& firstWrapper,
-    EvalCtx& context) {
-  if (isDictionaryOverFlat(firstWrapper)) {
-    // Re-use indices and nulls buffers.
-    context.setDictionaryWrap(firstWrapper.wrapInfo(), firstWrapper.nulls());
-    return;
-  }
-  auto wrapping = decoded.dictionaryWrapping(firstWrapper, rows.end());
-  context.setDictionaryWrap(
-      std::move(wrapping.indices), std::move(wrapping.nulls));
-}
-} // namespace
-
-SelectivityVector* translateToInnerRows(
-    const SelectivityVector& rows,
-    DecodedVector& decoded,
-    LocalSelectivityVector& newRowsHolder) {
-  auto baseSize = decoded.base()->size();
-  auto indices = decoded.indices();
-  // If the wrappers add nulls, do not enable the inner rows. The
-  // indices for places that a dictionary sets to null are not
-  // defined. Null adding dictionaries are not peeled off non
-  // null-propagating Exprs.
-  auto flatNulls = decoded.hasExtraNulls() ? decoded.nulls() : nullptr;
-
-  auto* newRows = newRowsHolder.get(baseSize, false);
-  rows.applyToSelected([&](vector_size_t row) {
-    if (!flatNulls || !bits::isBitNull(flatNulls, row)) {
-      newRows->setValid(indices[row], true);
-    }
-  });
-  newRows->updateBounds();
-
-  return newRows;
-}
-
 SelectivityVector* singleRow(
     LocalSelectivityVector& holder,
     vector_size_t row) {
@@ -765,141 +708,60 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
   if (context.wrapEncoding() == VectorEncoding::Simple::CONSTANT) {
     return Expr::PeelEncodingsResult::empty();
   }
-  std::vector<VectorPtr> peeledVectors;
-  std::vector<VectorPtr> maybePeeled;
-  std::vector<bool> constantFields;
-  int numLevels = 0;
-  bool peeled;
-  bool nonConstant = false;
-  auto numFields = context.row()->childrenSize();
-  int32_t firstPeeled = -1;
-  do {
-    peeled = true;
-    BufferPtr firstIndices;
-    BufferPtr firstLengths;
-    for (const auto& field : distinctFields_) {
-      auto fieldIndex = field->index(context);
-      assert(fieldIndex >= 0 && fieldIndex < numFields);
-      auto leaf = peeledVectors.empty() ? context.getField(fieldIndex)
-                                        : peeledVectors[fieldIndex];
-      if (!constantFields.empty() && constantFields[fieldIndex]) {
-        setPeeled(leaf, fieldIndex, context, maybePeeled);
-        continue;
-      }
-      if (numLevels == 0 && leaf->isConstantEncoding()) {
-        leaf = context.ensureFieldLoaded(fieldIndex, rows);
-        setPeeled(leaf, fieldIndex, context, maybePeeled);
-        constantFields.resize(numFields);
-        constantFields.at(fieldIndex) = true;
-        continue;
-      }
-      nonConstant = true;
-      auto encoding = leaf->encoding();
-      if (encoding == VectorEncoding::Simple::DICTIONARY) {
-        if (firstLengths) {
-          // having a mix of dictionary and sequence encoded fields
-          peeled = false;
-          break;
-        }
-        if (!propagatesNulls_ && leaf->rawNulls()) {
-          // A dictionary that adds nulls over an Expr that is not null for a
-          // null argument cannot be peeled.
-          peeled = false;
-          break;
-        }
-        BufferPtr indices = leaf->wrapInfo();
-        if (!firstIndices) {
-          firstIndices = std::move(indices);
-        } else if (indices != firstIndices) {
-          // different fields use different dictionaries
-          peeled = false;
-          break;
-        }
-        if (firstPeeled == -1) {
-          firstPeeled = fieldIndex;
-        }
-        setPeeled(leaf->valueVector(), fieldIndex, context, maybePeeled);
-      } else if (encoding == VectorEncoding::Simple::SEQUENCE) {
-        if (firstIndices) {
-          // having a mix of dictionary and sequence encoded fields
-          peeled = false;
-          break;
-        }
-        BufferPtr lengths = leaf->wrapInfo();
-        if (!firstLengths) {
-          firstLengths = std::move(lengths);
-        } else if (lengths != firstLengths) {
-          // different fields use different sequences
-          peeled = false;
-          break;
-        }
-        if (firstPeeled == -1) {
-          firstPeeled = fieldIndex;
-        }
-        setPeeled(leaf->valueVector(), fieldIndex, context, maybePeeled);
-      } else {
-        // Non-peelable encoding.
-        peeled = false;
-        break;
-      }
-    }
-    if (peeled) {
-      ++numLevels;
-      peeledVectors = std::move(maybePeeled);
-    }
-  } while (peeled && nonConstant);
 
-  if (numLevels == 0 && nonConstant) {
+  // Prepare the rows and vectors to peel.
+  const auto& rowsToPeel =
+      context.isFinalSelection() ? rows : *context.finalSelection();
+  auto numFields = context.row()->childrenSize();
+  std::vector<VectorPtr> vectorsToPeel;
+  vectorsToPeel.reserve(distinctFields_.size());
+  for (const auto& field : distinctFields_) {
+    auto fieldIndex = field->index(context);
+    assert(fieldIndex >= 0 && fieldIndex < numFields);
+    auto fieldVector = context.getField(fieldIndex);
+    if (fieldVector->isConstantEncoding()) {
+      // Make sure constant encoded fields are loaded
+      fieldVector = context.ensureFieldLoaded(fieldIndex, rows);
+    }
+    vectorsToPeel.push_back(fieldVector);
+  }
+
+  // Attempt peeling.
+  VELOX_CHECK(!vectorsToPeel.empty());
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      vectorsToPeel, rowsToPeel, localDecoded, propagatesNulls_, peeledVectors);
+
+  if (!peeledEncoding) {
     return Expr::PeelEncodingsResult::empty();
   }
 
-  // We peel off the wrappers and make a new selection.
-  SelectivityVector* newRows;
-  SelectivityVector* newFinalSelection;
-  if (firstPeeled == -1) {
-    // All the fields are constant across the rows of interest.
-    newRows = singleRow(newRowsHolder, rows.begin());
-    context.saveAndReset(saver, rows);
-    context.setConstantWrap(rows.begin());
-  } else {
-    auto decoded = localDecoded.get();
-    auto firstWrapper = context.getField(firstPeeled).get();
-    const auto& rowsToDecode =
-        context.isFinalSelection() ? rows : *context.finalSelection();
-    decoded->makeIndices(*firstWrapper, rowsToDecode, numLevels);
-
-    newRows = translateToInnerRows(rows, *decoded, newRowsHolder);
-
-    if (!context.isFinalSelection()) {
-      newFinalSelection = translateToInnerRows(
-          *context.finalSelection(), *decoded, finalRowsHolder);
-    }
-
-    context.saveAndReset(saver, rows);
-
-    if (!context.isFinalSelection()) {
-      *context.mutableFinalSelection() = newFinalSelection;
-    }
-
-    setDictionaryWrapping(*decoded, rowsToDecode, *firstWrapper, context);
+  // Translate the relevant rows.
+  SelectivityVector* newFinalSelection = nullptr;
+  if (!context.isFinalSelection()) {
+    newFinalSelection = peeledEncoding->translateToInnerRows(
+        *context.finalSelection(), finalRowsHolder);
   }
-  int numPeeled = 0;
+  auto newRows = peeledEncoding->translateToInnerRows(rows, newRowsHolder);
+
+  // Save context and set the peel, peeled fields and final selection (if
+  // applicable).
+  context.saveAndReset(saver, rows);
+  context.setPeeledEncoding(peeledEncoding);
+  if (newFinalSelection) {
+    *context.mutableFinalSelection() = newFinalSelection;
+  }
+  DCHECK_EQ(peeledVectors.size(), distinctFields_.size());
   for (int i = 0; i < peeledVectors.size(); ++i) {
-    auto& values = peeledVectors[i];
-    if (!values) {
-      continue;
-    }
-    if (values->isConstantEncoding() && values->size() < newRows->end()) {
-      values = BaseVector::wrapInConstant(newRows->end(), 0, values);
-    }
-    context.setPeeled(i, values);
-    if (constantFields.empty() || !constantFields[i]) {
-      ++numPeeled;
-    }
+    auto fieldIndex = distinctFields_[i]->index(context);
+    context.setPeeled(fieldIndex, peeledVectors[i]);
   }
+
   // If the expression depends on one dictionary, results are cacheable.
-  bool mayCache = numPeeled == 1 && constantFields.empty();
-  return {newRows, newFinalSelection, mayCache};
+  bool mayCache = distinctFields_.size() == 1 &&
+      VectorEncoding::isDictionary(context.wrapEncoding());
+
+  return {newRows, finalRowsHolder.get(), mayCache};
 }
 
 void Expr::evalEncodings(
@@ -907,15 +769,15 @@ void Expr::evalEncodings(
     EvalCtx& context,
     VectorPtr& result) {
   if (deterministic_ && !distinctFields_.empty()) {
-    bool hasNonFlat = false;
+    bool hasFlat = false;
     for (const auto& field : distinctFields_) {
-      if (!isFlat(*context.getField(field->index(context)))) {
-        hasNonFlat = true;
+      if (isFlat(*context.getField(field->index(context)))) {
+        hasFlat = true;
         break;
       }
     }
 
-    if (hasNonFlat) {
+    if (!hasFlat) {
       VectorPtr wrappedResult;
       // Attempt peeling and bound the scope of the context used for it.
       {
@@ -943,8 +805,8 @@ void Expr::evalEncodings(
               evalWithNulls(*newRows, context, peeledResult);
             }
           }
-          wrappedResult =
-              context.applyWrapToPeeledResult(this->type(), peeledResult, rows);
+          wrappedResult = context.getPeeledEncoding()->wrap(
+              this->type(), context.pool(), peeledResult, rows);
         }
       }
       if (wrappedResult != nullptr) {
@@ -1234,17 +1096,6 @@ std::optional<bool> computeIsAsciiForResult(
   return isAsciiSet ? std::optional(true) : std::nullopt;
 }
 
-inline bool isPeelable(VectorEncoding::Simple encoding) {
-  switch (encoding) {
-    case VectorEncoding::Simple::CONSTANT:
-    case VectorEncoding::Simple::DICTIONARY:
-    case VectorEncoding::Simple::SEQUENCE:
-      return true;
-    default:
-      return false;
-  }
-}
-
 /// Maintains a set of rows for evaluation and removes rows with
 /// nulls or errors as needed. Helps to avoid copying SelectivityVector in cases
 /// when evaluation doesn't encounter nulls or errors.
@@ -1347,7 +1198,8 @@ void Expr::evalAllImpl(
   inputValues_.resize(inputs_.size());
   for (int32_t i = 0; i < inputs_.size(); ++i) {
     inputs_[i]->eval(remainingRows.rows(), context, inputValues_[i]);
-    tryPeelArgs = tryPeelArgs && isPeelable(inputValues_[i]->encoding());
+    tryPeelArgs =
+        tryPeelArgs && PeeledEncoding::isPeelable(inputValues_[i]->encoding());
 
     // Do not continue evaluation for rows with errors.
     if (context.errors() && !remainingRows.deselectErrors()) {
@@ -1373,7 +1225,7 @@ void Expr::evalAllImpl(
   }
 
   if (!tryPeelArgs ||
-      !applyFunctionWithPeeling(rows, remainingRows.rows(), context, result)) {
+      !applyFunctionWithPeeling(remainingRows.rows(), context, result)) {
     applyFunction(remainingRows.rows(), context, result);
   }
 
@@ -1399,128 +1251,41 @@ void setPeeledArg(
 } // namespace
 
 bool Expr::applyFunctionWithPeeling(
-    const SelectivityVector& rows,
     const SelectivityVector& applyRows,
     EvalCtx& context,
     VectorPtr& result) {
-  int numLevels = 0;
-  bool peeled;
-  int32_t numConstant = 0;
-  auto numArgs = inputValues_.size();
-  // Holds the outermost wrapper. This may be the last reference after
-  // peeling for a temporary dictionary, hence use a shared_ptr.
-  VectorPtr firstWrapper = nullptr;
-  std::vector<bool> constantArgs;
-  do {
-    peeled = true;
-    BufferPtr firstIndices;
-    BufferPtr firstLengths;
-    std::vector<VectorPtr> maybePeeled;
-    for (auto i = 0; i < inputValues_.size(); ++i) {
-      auto leaf = inputValues_[i];
-      if (!constantArgs.empty() && constantArgs[i]) {
-        setPeeledArg(leaf, i, numArgs, maybePeeled);
-        continue;
-      }
-      if (leaf->isConstantEncoding()) {
-        setPeeledArg(leaf, i, numArgs, maybePeeled);
-        constantArgs.resize(numArgs);
-        constantArgs.at(i) = true;
-        ++numConstant;
-        continue;
-      }
-      auto encoding = leaf->encoding();
-      if (encoding == VectorEncoding::Simple::DICTIONARY) {
-        if (firstLengths) {
-          // having a mix of dictionary and sequence encoded fields
-          peeled = false;
-          break;
-        }
-        if (!vectorFunction_->isDefaultNullBehavior() && leaf->rawNulls()) {
-          // A dictionary that adds nulls over an Expr that is not null for a
-          // null argument cannot be peeled.
-          peeled = false;
-          break;
-        }
-        BufferPtr indices = leaf->wrapInfo();
-        if (!firstIndices) {
-          firstIndices = std::move(indices);
-        } else if (indices != firstIndices) {
-          // different fields use different dictionaries
-          peeled = false;
-          break;
-        }
-        if (!firstWrapper) {
-          firstWrapper = leaf;
-        }
-        setPeeledArg(leaf->valueVector(), i, numArgs, maybePeeled);
-      } else if (encoding == VectorEncoding::Simple::SEQUENCE) {
-        if (firstIndices) {
-          // having a mix of dictionary and sequence encoded fields
-          peeled = false;
-          break;
-        }
-        BufferPtr lengths = leaf->wrapInfo();
-        if (!firstLengths) {
-          firstLengths = std::move(lengths);
-        } else if (lengths != firstLengths) {
-          // different fields use different sequences
-          peeled = false;
-          break;
-        }
-        if (!firstWrapper) {
-          firstWrapper = leaf;
-        }
-        setPeeledArg(leaf->valueVector(), i, numArgs, maybePeeled);
-      } else {
-        // Non-peelable encoding.
-        peeled = false;
-        break;
-      }
-    }
-    if (peeled) {
-      ++numLevels;
-      inputValues_ = std::move(maybePeeled);
-    }
-  } while (peeled && numConstant != numArgs);
-  if (!numLevels) {
-    return false;
-  }
+  LocalDecodedVector localDecoded(context);
   LocalSelectivityVector newRowsHolder(context);
   ScopedContextSaver saver;
-  // We peel off the wrappers and make a new selection.
-  SelectivityVector* newRows;
-  LocalDecodedVector localDecoded(context);
-  if (numConstant == numArgs) {
-    // All the fields are constant across the rows of interest.
-    newRows = singleRow(newRowsHolder, rows.begin());
-
-    context.saveAndReset(saver, applyRows);
-    context.setConstantWrap(rows.begin());
-  } else {
-    auto decoded = localDecoded.get();
-    decoded->makeIndices(*firstWrapper, rows, numLevels);
-    newRows = translateToInnerRows(applyRows, *decoded, newRowsHolder);
-    context.saveAndReset(saver, applyRows);
-    setDictionaryWrapping(*decoded, rows, *firstWrapper, context);
-
-    // 'newRows' comes from the set of row numbers in the base vector. These
-    // numbers may be larger than rows.end(). Hence, we need to resize constant
-    // inputs.
-    if (newRows->end() > rows.end() && numConstant) {
-      for (int i = 0; i < constantArgs.size(); ++i) {
-        if (!constantArgs.empty() && constantArgs[i]) {
-          inputValues_[i] =
-              BaseVector::wrapInConstant(newRows->end(), 0, inputValues_[i]);
-        }
-      }
-    }
+  // Attempt peeling.
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      inputValues_,
+      applyRows,
+      localDecoded,
+      vectorFunction_->isDefaultNullBehavior(),
+      peeledVectors);
+  if (!peeledEncoding) {
+    return false;
   }
+  inputValues_ = std::move(peeledVectors);
+  peeledVectors.clear();
 
+  // Translate the relevant rows.
+  // Note: We do not need to translate final selection since at this stage those
+  // rows are not used but isFinalSelection() is only used to check whether
+  // pre-existing rows need to be preserved.
+  auto newRows = peeledEncoding->translateToInnerRows(applyRows, newRowsHolder);
+
+  // Save context and set the peel.
+  context.saveAndReset(saver, applyRows);
+  context.setPeeledEncoding(peeledEncoding);
+
+  // Apply the function.
   VectorPtr peeledResult;
   applyFunction(*newRows, context, peeledResult);
-  VectorPtr wrappedResult =
-      context.applyWrapToPeeledResult(this->type(), peeledResult, applyRows);
+  VectorPtr wrappedResult = context.getPeeledEncoding()->wrap(
+      this->type(), context.pool(), peeledResult, applyRows);
   context.moveOrCopyResult(wrappedResult, applyRows, result);
 
   // Recycle peeledResult if it's not owned by the result vector. Examples of

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -334,7 +334,6 @@ class Expr {
   // cardinality. Returns true if the function was called. Returns
   // false if no encodings could be peeled off.
   bool applyFunctionWithPeeling(
-      const SelectivityVector& rows,
       const SelectivityVector& applyRows,
       EvalCtx& context,
       VectorPtr& result);
@@ -466,13 +465,6 @@ class Expr {
   /// Runtime statistics. CPU time, wall time and number of processed rows.
   ExprStats stats_;
 };
-
-/// Translates row number of the outer vector into row number of the inner
-/// vector using DecodedVector.
-SelectivityVector* FOLLY_NONNULL translateToInnerRows(
-    const SelectivityVector& rows,
-    DecodedVector& decoded,
-    LocalSelectivityVector& newRowsHolder);
 
 /// Generate a selectivity vector of a single row.
 SelectivityVector* FOLLY_NONNULL

--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/PeeledEncoding.h"
+
+#include "velox/expression/EvalCtx.h"
+
+namespace facebook::velox::exec {
+
+std::shared_ptr<PeeledEncoding> PeeledEncoding::Peel(
+    const std::vector<VectorPtr>& vectorsToPeel,
+    const SelectivityVector& rows,
+    LocalDecodedVector& decodedVector,
+    bool canPeelsHaveNulls,
+    std::vector<VectorPtr>& peeledVectors) {
+  std::shared_ptr<PeeledEncoding> peeledEncoding(new PeeledEncoding());
+  if (peeledEncoding->peelInternal(
+          vectorsToPeel,
+          rows,
+          decodedVector,
+          canPeelsHaveNulls,
+          peeledVectors)) {
+    return peeledEncoding;
+  }
+  return nullptr;
+}
+
+SelectivityVector* PeeledEncoding::translateToInnerRows(
+    const SelectivityVector& outerRows,
+    LocalSelectivityVector& innerRowsHolder) const {
+  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  if (wrapEncoding_ == VectorEncoding::Simple::CONSTANT) {
+    auto newRows = innerRowsHolder.get(constantWrapIndex_ + 1, false);
+    newRows->setValid(constantWrapIndex_, true);
+    newRows->updateBounds();
+    return newRows;
+  }
+  auto baseSize = baseSize_;
+  auto indices = wrap_->as<vector_size_t>();
+  // If the wrappers add nulls, do not enable the inner rows. The
+  // indices for places that a dictionary sets to null are not
+  // defined. Null adding dictionaries are not peeled off non
+  // null-propagating Exprs.
+  auto flatNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
+
+  auto* newRows = innerRowsHolder.get(baseSize, false);
+  outerRows.applyToSelected([&](vector_size_t row) {
+    if (!(flatNulls && bits::isBitNull(flatNulls, row))) {
+      newRows->setValid(indices[row], true);
+    }
+  });
+  newRows->updateBounds();
+
+  return newRows;
+}
+
+namespace {
+inline void setPeeled(
+    const VectorPtr& leaf,
+    int32_t fieldIndex,
+    std::vector<VectorPtr>& peeled) {
+  VELOX_DCHECK(peeled.size() > fieldIndex);
+  peeled[fieldIndex] = leaf;
+}
+
+/// Returns true if 'wrapper' is a dictionary vector over a flat vector.
+bool isDictionaryOverFlat(const BaseVector& wrapper) {
+  return wrapper.encoding() == VectorEncoding::Simple::DICTIONARY &&
+      wrapper.valueVector()->isFlatEncoding();
+}
+} // namespace
+
+void PeeledEncoding::setDictionaryWrapping(
+    DecodedVector& decoded,
+    const SelectivityVector& rows,
+    BaseVector& firstWrapper) {
+  wrapEncoding_ = VectorEncoding::Simple::DICTIONARY;
+  baseSize_ = decoded.base()->size();
+  if (isDictionaryOverFlat(firstWrapper)) {
+    // Re-use indices and nulls buffers.
+    wrap_ = firstWrapper.wrapInfo();
+    wrapNulls_ = firstWrapper.nulls();
+    return;
+  }
+  auto wrapping = decoded.dictionaryWrapping(firstWrapper, rows.end());
+  wrap_ = std::move(wrapping.indices);
+  wrapNulls_ = std::move(wrapping.nulls);
+}
+
+bool PeeledEncoding::peelInternal(
+    const std::vector<VectorPtr>& vectorsToPeel,
+    const SelectivityVector& rows,
+    LocalDecodedVector& decodedVector,
+    bool canPeelsHaveNulls,
+    std::vector<VectorPtr>& peeledVectors) {
+  auto numFields = vectorsToPeel.size();
+  std::vector<VectorPtr> maybePeeled;
+  std::vector<bool> constantFields;
+  int numLevels = 0;
+  bool peeled;
+  bool nonConstant = false;
+  int32_t firstPeeled = -1;
+  do {
+    peeled = true;
+    BufferPtr firstIndices;
+    BufferPtr firstLengths;
+    maybePeeled.resize(numFields);
+    for (int fieldIndex = 0; fieldIndex < numFields; fieldIndex++) {
+      auto leaf = peeledVectors.empty() ? vectorsToPeel[fieldIndex]
+                                        : peeledVectors[fieldIndex];
+      if (leaf == nullptr) {
+        continue;
+      }
+      if (!constantFields.empty() && constantFields[fieldIndex]) {
+        setPeeled(leaf, fieldIndex, maybePeeled);
+        continue;
+      }
+      // TODO: consider removing check for numLevels by ensuring this will not
+      // affect CSE.
+      // Context: numLevels == 0 was done in peelEncodings but not in
+      // applyFunctionWithPeeling. This check prevents peeling if other
+      // dictionary vectors have further layers. For eg. take D1(D2(FLAT)),
+      // D1(C1), if this check is in place then peeling will stop at D1,
+      // otherwise peeling will continue and peel off D2 as well.
+      if (numLevels == 0 && leaf->isConstantEncoding()) {
+        setPeeled(leaf, fieldIndex, maybePeeled);
+        constantFields.resize(numFields);
+        constantFields.at(fieldIndex) = true;
+        continue;
+      }
+      nonConstant = true;
+      auto encoding = leaf->encoding();
+      if (encoding == VectorEncoding::Simple::DICTIONARY) {
+        if (firstLengths) {
+          // having a mix of dictionary and sequence encoded fields
+          peeled = false;
+          break;
+        }
+        if (!canPeelsHaveNulls && leaf->rawNulls()) {
+          // A dictionary that adds nulls over an Expr that is not null for a
+          // null argument cannot be peeled.
+          peeled = false;
+          break;
+        }
+        BufferPtr indices = leaf->wrapInfo();
+        if (!firstIndices) {
+          firstIndices = std::move(indices);
+        } else if (indices != firstIndices) {
+          // different fields use different dictionaries
+          peeled = false;
+          break;
+        }
+        if (firstPeeled == -1) {
+          firstPeeled = fieldIndex;
+        }
+        setPeeled(leaf->valueVector(), fieldIndex, maybePeeled);
+      } else if (encoding == VectorEncoding::Simple::SEQUENCE) {
+        if (firstIndices) {
+          // having a mix of dictionary and sequence encoded fields
+          peeled = false;
+          break;
+        }
+        BufferPtr lengths = leaf->wrapInfo();
+        if (!firstLengths) {
+          firstLengths = std::move(lengths);
+        } else if (lengths != firstLengths) {
+          // different fields use different sequences
+          peeled = false;
+          break;
+        }
+        if (firstPeeled == -1) {
+          firstPeeled = fieldIndex;
+        }
+        setPeeled(leaf->valueVector(), fieldIndex, maybePeeled);
+      } else {
+        // Non-peelable encoding.
+        peeled = false;
+        break;
+      }
+    }
+    if (peeled) {
+      ++numLevels;
+      peeledVectors = std::move(maybePeeled);
+    }
+  } while (peeled && nonConstant);
+
+  if (numLevels == 0 && nonConstant) {
+    return false;
+  }
+
+  if (firstPeeled == -1) {
+    wrapEncoding_ = VectorEncoding::Simple::CONSTANT;
+    // Check if constant encoding can be peeled off too if the input is of the
+    // form Constant(complex).
+    if (peeledVectors.size() == 1 &&
+        peeledVectors.back()->valueVector() != nullptr) {
+      auto constVector = peeledVectors.back();
+      constantWrapIndex_ = constVector->wrappedIndex(rows.begin());
+      peeledVectors[0] = constVector->valueVector();
+    } else {
+      constantWrapIndex_ = rows.begin();
+    }
+  } else {
+    auto decoded = decodedVector.get();
+    auto firstWrapper = vectorsToPeel[firstPeeled];
+    // Check if constant encoding can be peeled off too if the input is of the
+    // form Dictionary(Constant(complex)).
+    if (peeledVectors.size() == 1 &&
+        peeledVectors.back()->isConstantEncoding() &&
+        peeledVectors.back()->valueVector() != nullptr) {
+      numLevels++; // include the constant layer while decoding.
+      peeledVectors.back() = peeledVectors.back()->valueVector();
+    }
+    decoded->makeIndices(*firstWrapper, rows, numLevels);
+    if (decoded->isConstantMapping()) {
+      // This can only happen if the attempt to peel a constant encoding layer
+      // exposed a null complex constant as the base.
+      VELOX_CHECK(peeledVectors.size() == 1);
+      auto innerIdx = decoded->index(rows.begin());
+      VELOX_CHECK(peeledVectors.back()->isNullAt(innerIdx));
+      wrapEncoding_ = VectorEncoding::Simple::CONSTANT;
+      constantWrapIndex_ = innerIdx;
+    } else {
+      setDictionaryWrapping(*decoded, rows, *firstWrapper);
+      // Make sure all the constant vectors have at least the same length as the
+      // base vector after peeling. This will make sure any translated rows
+      // point to valid rows in the constant vector.
+      if (baseSize_ > rows.end() && !constantFields.empty()) {
+        for (int i = 0; i < constantFields.size(); ++i) {
+          if (constantFields[i]) {
+            peeledVectors[i] =
+                BaseVector::wrapInConstant(baseSize_, 0, peeledVectors[i]);
+          }
+        }
+      }
+    }
+  }
+  return true;
+}
+
+VectorEncoding::Simple PeeledEncoding::getWrapEncoding() const {
+  return wrapEncoding_;
+}
+
+VectorPtr PeeledEncoding::wrap(
+    const TypePtr& outputType,
+    velox::memory::MemoryPool* pool,
+    VectorPtr peeledResult,
+    const SelectivityVector& rows) const {
+  VELOX_CHECK(wrapEncoding_ != VectorEncoding::Simple::FLAT);
+  VectorPtr wrappedResult;
+  if (wrapEncoding_ == VectorEncoding::Simple::DICTIONARY) {
+    if (!peeledResult) {
+      // If all rows are null, make a constant null vector of the right type.
+      wrappedResult =
+          BaseVector::createNullConstant(outputType, rows.size(), pool);
+    } else {
+      BufferPtr nulls;
+      if (!rows.isAllSelected()) {
+        // The new base vector may be shorter than the original base vector
+        // (e.g. if positions at the end of the original vector were not
+        // selected for evaluation). In this case some original indices
+        // corresponding to non-selected rows may point past the end of the base
+        // vector. Disable these by setting corresponding positions to null.
+        nulls = AlignedBuffer::allocate<bool>(rows.size(), pool, bits::kNull);
+        // Set the active rows to non-null.
+        rows.clearNulls(nulls);
+        if (wrapNulls_) {
+          // Add the nulls from the wrapping.
+          bits::andBits(
+              nulls->asMutable<uint64_t>(),
+              wrapNulls_->as<uint64_t>(),
+              rows.begin(),
+              rows.end());
+        }
+        // Reset nulls buffer if all positions happen to be non-null.
+        if (bits::isAllSet(
+                nulls->as<uint64_t>(), 0, rows.end(), bits::kNotNull)) {
+          nulls.reset();
+        }
+      } else {
+        nulls = wrapNulls_;
+      }
+      wrappedResult = BaseVector::wrapInDictionary(
+          std::move(nulls), wrap_, rows.end(), std::move(peeledResult));
+    }
+  } else {
+    wrappedResult = BaseVector::wrapInConstant(
+        rows.size(), constantWrapIndex_, std::move(peeledResult));
+  }
+  return wrappedResult;
+}
+} // namespace facebook::velox::exec

--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox {
+class DecodedVector;
+}
+
+namespace facebook::velox::exec {
+class LocalDecodedVector;
+class LocalSelectivityVector;
+
+/// Utility class for enabling peeling functionality. It takes a list of
+/// vectors, peels off the common encodings off of them, stores the peel and
+/// returns a list of the peeled vectors. The saved peel can then be used to
+/// translate top level rows into inner rows and wrap a vector (typically
+/// generated as a result of applying an expression on the peeled vectors).
+///
+/// Typical usage pattern for peeling includes:
+/// (See Expr::applyFunctionWithPeeling() for example usage)
+/// 1. peeling a set of input vectors
+/// 2. converting relevant rows (top level rows and final selection rows)
+/// 3. Saving the current context and setting the peel
+/// 4. Applying the function or moving forward with expression eval
+/// 5. wrapping the result vector with the peel
+///
+/// Few important examples of how vectors are peeled:
+/// 1. Common dictionary layers are peeled
+///    Input Vectors: Dict1(Dict2(Flat1)), Dict1(Dict2(Const1)),
+///                   Dict1(Dict2(Dict3(Flat2)))
+///    Peeled Vectors: Flat, Const1, Dict3(Flat2)
+///    Peel: Dict1(Dict2) => collapsed into one dictionary
+///
+/// 2. Common dictionary layers are peeled
+///    Input Vectors: Dict1(Dict2(Flat1)), Dict1(Const1)),
+///                   Dict1(Dict2(Dict3(Flat2)))
+///    Peeled Vectors: Dict2(Flat), Const1, Dict2(Dict3(Flat2))
+///    Peel: Dict1
+///
+/// 3. Common dictionary layers are peeled while constant is ignored
+///    (since all valid rows translated via the common dictionary layers would
+///    point to the same constant index)
+///    Input Vectors: Dict1(Dict2(Flat1)), Const1,
+///                   Dict1(Dict2(Dict3(Flat2)))
+///    Peeled Vectors: Flat, Const1, Dict3(Flat2)
+///    Peel: Dict1(Dict2) => collapsed into one dictionary
+///
+/// 4. A single vector with constant encoding layer over a complex vector can
+///    be peeled.
+///    Input Vectors: Const1(Complex1)
+///    Peeled Vectors: Complex
+///    Peel: Const1
+///
+/// 5. A single vector with arbitrary dictionary layers over a constant
+///    encoding layer over a NULL complex vector can be peeled and the peels can
+///    be merged into a single constant layer.
+///    Input Vectors: Dict1(Const1(NullComplex))
+///    Peeled Vectors: Null Complex vector
+///    Peel: Const(generic constant index)
+///
+/// 6. All constant inputs where the peel is just a constant pointing to the
+///    first valid row. The peel itself is irrelevant but allows us to translate
+///    input rows into a single row.
+///    Input Vectors: Const1(Complex1), Const2, Const3
+///    Peeled Vectors: Const1(Complex1), Const2, Const3
+///    Peel: Const(generic constant index)
+///
+/// 7. No inputs. This is considered as constant encoding since its expected
+///    to produce the same result for all valid rows.
+///    Input Vectors: <empty>
+///    Peeled Vectors: <empty>
+///    Peel: Const(generic constant index)
+///
+/// 8. A single vector with dictionary over constant encoding layer over a
+///    complex vector can be peeled all the way to the complex vector.
+///    Input Vectors: Dict1(Const1(Complex1))
+///    Peeled Vectors: Complex
+///    Peel: Dict1(Const1) => collapsed into one dictionary
+///
+/// 9. One of the middle wraps adds nulls but 'canPeelsHaveNulls' is set to
+///    false.
+///    Input Vectors: DictNoNulls(DictWithNulls(Flat1)), Const1,
+///                   DictNoNulls(DictWithNulls((Flat2))
+///    Peeled Vectors: DictWithNulls(Flat1), Const1,
+///                    DictWithNulls(Dict3(Flat2))
+///    Peel: DictNoNulls
+class PeeledEncoding {
+ public:
+  /// Factory method for constructing a PeeledEncoding object only if peeling
+  /// was successful. Takes a set of vectors and peels all the common encoding
+  /// layers off of them. Returns the set of vectors obtained after peeling
+  /// those layers. Ensures that all peeled vectors will have valid rows for
+  /// every valid inner row (rows obtained by translating top level rows via the
+  /// peels). Returns a nullptr if peeling was unsuccessful, otherwise returns a
+  /// valid PeeledEncoding object and populates 'peeledVectors' with the peeled
+  /// vectors.
+  static std::shared_ptr<PeeledEncoding> Peel(
+      const std::vector<VectorPtr>& vectorsToPeel,
+      const SelectivityVector& rows,
+      LocalDecodedVector& decodedVector,
+      bool canPeelsHaveNulls,
+      std::vector<VectorPtr>& peeledVectors);
+
+  /// Utility method used to check whether an encoding is peel-able.
+  constexpr static bool isPeelable(VectorEncoding::Simple encoding) {
+    switch (encoding) {
+      case VectorEncoding::Simple::CONSTANT:
+      case VectorEncoding::Simple::DICTIONARY:
+      case VectorEncoding::Simple::SEQUENCE:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /// Return the encoding of the peeled wrap.
+  VectorEncoding::Simple getWrapEncoding() const;
+
+  /// Translates row numbers of the outer vector via the peel into row numbers
+  /// of the inner vector. Returns a pointer to the selectivityVector
+  /// (representing inner rows) allocated from the input "innerRowsHolder".
+  SelectivityVector* translateToInnerRows(
+      const SelectivityVector& outerRows,
+      LocalSelectivityVector& innerRowsHolder) const;
+
+  /// Wraps the given vector 'peeledResult' with the peeled encoding and
+  /// generates a vector which has valid rows as per the input 'rows'
+  /// selectivity vector.
+  VectorPtr wrap(
+      const TypePtr& outputType,
+      velox::memory::MemoryPool* FOLLY_NONNULL pool,
+      VectorPtr peeledResult,
+      const SelectivityVector& rows) const;
+
+  /// Takes a set of outer rows (rows defined over the peel) and a functor that
+  /// is executed for each outer row which does not map to a null row.
+  /// The outer and its corresponding inner row is passed to the functor.
+  void applyToNonNullInnerRows(
+      const SelectivityVector& outerRows,
+      std::function<void(vector_size_t, vector_size_t)> func) const {
+    auto indices = wrap_ ? wrap_->as<vector_size_t>() : nullptr;
+    auto wrapNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
+    outerRows.applyToSelected([&](auto outerRow) {
+      // A known null in the outer row masks an error.
+      if (wrapNulls && bits::isBitNull(wrapNulls, outerRow)) {
+        return;
+      }
+      vector_size_t innerRow = indices ? indices[outerRow] : constantWrapIndex_;
+      func(outerRow, innerRow);
+    });
+  };
+
+ private:
+  PeeledEncoding() = default;
+
+  // Contains the actual implementation of peeling. Return true is peeling was
+  // successful.
+  bool peelInternal(
+      const std::vector<VectorPtr>& vectorsToPeel,
+      const SelectivityVector& rows,
+      LocalDecodedVector& decodedVector,
+      bool canPeelsHaveNulls,
+      std::vector<VectorPtr>& peeledVectors);
+
+  void setDictionaryWrapping(
+      DecodedVector& decoded,
+      const SelectivityVector& rows,
+      BaseVector& firstWrapper);
+
+  /// The encoding of the peel. Set after getPeeledVectors() is called. Is equal
+  /// to Flat if getPeeledVectors() has not been called or peeling was not
+  /// successful.
+  VectorEncoding::Simple wrapEncoding_ = VectorEncoding::Simple::FLAT;
+
+  /// The dictionary indices. Only valid if wrapEncoding_ = DICTIONARY.
+  BufferPtr wrap_;
+
+  /// The dictionary nulls. Only valid if wrapEncoding_ = DICTIONARY.
+  BufferPtr wrapNulls_;
+
+  /// The size of one of the peeled vectors. Only valid if wrapEncoding_ =
+  /// DICTIONARY.
+  vector_size_t baseSize_ = 0;
+
+  /// The constant index. Only valid if wrapEncoding_ = CONSTANT.
+  vector_size_t constantWrapIndex_ = 0;
+};
+} // namespace facebook::velox::exec

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -52,7 +52,8 @@ add_executable(
   TryExprTest.cpp
   VariadicViewTest.cpp
   VectorReaderTest.cpp
-  GenericWriterTest.cpp)
+  GenericWriterTest.cpp
+  PeeledEncodingTest.cpp)
 
 add_test(
   NAME velox_expression_test

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -191,38 +191,6 @@ TEST_F(EvalCtxTest, addErrorsPreserveOldErrors) {
   ASSERT_TRUE(context.errors()->isNullAt(2));
 }
 
-/// Verify that constant wrapping is saved and restored correctly.
-TEST_F(EvalCtxTest, constantWrapSaver) {
-  EvalCtx context(&execCtx_);
-  SelectivityVector rows(10);
-
-  ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::FLAT);
-  {
-    ScopedContextSaver saver;
-    context.saveAndReset(saver, rows);
-
-    context.setConstantWrap(2);
-    ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::CONSTANT);
-
-    auto vector = makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5});
-    auto wrapped = context.applyWrapToPeeledResult(BIGINT(), vector, rows);
-    ASSERT_TRUE(wrapped->isConstantEncoding());
-    ASSERT_EQ(wrapped->as<ConstantVector<int64_t>>()->valueAt(0), 2);
-
-    {
-      ScopedContextSaver innerSaver;
-      context.saveAndReset(innerSaver, rows);
-      context.setConstantWrap(10);
-    }
-    ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::CONSTANT);
-
-    wrapped = context.applyWrapToPeeledResult(BIGINT(), vector, rows);
-    ASSERT_TRUE(wrapped->isConstantEncoding());
-    ASSERT_EQ(wrapped->as<ConstantVector<int64_t>>()->valueAt(0), 2);
-  }
-  ASSERT_EQ(context.wrapEncoding(), VectorEncoding::Simple::FLAT);
-}
-
 TEST_F(EvalCtxTest, localSingleRow) {
   EvalCtx context(&execCtx_);
 

--- a/velox/expression/tests/PeeledEncodingTest.cpp
+++ b/velox/expression/tests/PeeledEncodingTest.cpp
@@ -1,0 +1,490 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/PeeledEncoding.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+class PeeledEncodingTest : public testing::Test, public VectorTestBase {
+ public:
+  struct DictionaryWrap {
+    BufferPtr indices;
+    BufferPtr nulls;
+    int size;
+  };
+
+ protected:
+  static DictionaryWrap generateDictionaryWrap(
+      VectorFuzzer& fuzzer,
+      vector_size_t size) {
+    return {fuzzer.fuzzIndices(size, size), fuzzer.fuzzNulls(size), size};
+  }
+
+  // Utility function to wrap an arbitrary number of dictionary wrappings. Takes
+  // the 'base' vector to wrap and a list of references to DictionaryWrap
+  // objects. The base is then wrapped with those layers in the same order as
+  // encountered in the list.
+  VectorPtr wrapInDictionaryLayers(
+      VectorPtr base,
+      std::vector<DictionaryWrap*> layers) {
+    for (DictionaryWrap* wrap : layers) {
+      VELOX_CHECK_NOT_NULL(wrap);
+      base = BaseVector::wrapInDictionary(
+          wrap->nulls, wrap->indices, wrap->size, base);
+    }
+    return base;
+  }
+
+  // Utility function that peels a given 'wrappedVector'. Takes the number of
+  // wraps to peel and a vector which is expected to have that many number of
+  // wraps.
+  VectorPtr peelWrappings(int numWrappingsToPeel, VectorPtr wrappedVector) {
+    if (numWrappingsToPeel == 0 ||
+        !PeeledEncoding::isPeelable(wrappedVector->encoding())) {
+      return wrappedVector;
+    } else {
+      return peelWrappings(
+          numWrappingsToPeel - 1, wrappedVector->valueVector());
+    }
+  }
+
+  void SetUp() override {
+    VectorFuzzer::Options options;
+    options.nullRatio = 0.3;
+    fuzzer = std::make_shared<VectorFuzzer>(options, pool());
+
+    dictWrap1 = generateDictionaryWrap(*fuzzer, vectorSize_);
+    dictWrap2 = generateDictionaryWrap(*fuzzer, vectorSize_);
+    dictWrap3 = generateDictionaryWrap(*fuzzer, vectorSize_);
+
+    flat1 = fuzzer->fuzzFlat(INTEGER());
+    flat2 = fuzzer->fuzzFlat(INTEGER());
+    const1 = fuzzer->fuzzConstant(INTEGER());
+    const2 = fuzzer->fuzzConstant(INTEGER());
+    complexConst = fuzzer->fuzzConstant(ARRAY(INTEGER()));
+  }
+
+  static const vector_size_t vectorSize_ = 100;
+  core::ExecCtx execCtx_{pool_.get(), nullptr};
+  std::shared_ptr<VectorFuzzer> fuzzer;
+  // Common test data used by tests.
+  DictionaryWrap dictWrap1;
+  DictionaryWrap dictWrap2;
+  DictionaryWrap dictWrap3;
+  VectorPtr flat1;
+  VectorPtr flat2;
+  VectorPtr const1;
+  VectorPtr const2;
+  VectorPtr complexConst;
+};
+
+struct ParamType {
+  std::string testName;
+  SelectivityVector rows;
+};
+
+class PeeledEncodingBasicTests : public PeeledEncodingTest,
+                                 public testing::WithParamInterface<ParamType> {
+ public:
+  static std::vector<ParamType> generateTestParams() {
+    std::vector<ParamType> params;
+    // One selected.
+    SelectivityVector rows(vectorSize_, false);
+    rows.setValid(1, true);
+    rows.updateBounds();
+    params.push_back({"one_row_selected", rows});
+
+    // Trailing rows selected.
+    rows.clearAll();
+    rows.setValidRange(vectorSize_ / 3, vectorSize_, true);
+    rows.updateBounds();
+    params.push_back({"trailing_rows_selected", rows});
+
+    // Trailing rows not selected.
+    rows.clearAll();
+    rows.setValidRange(0, (2 * vectorSize_) / 3, true);
+    rows.updateBounds();
+    params.push_back({"trailing_rows_not_selected", rows});
+
+    // Rows in the middle selected.
+    rows.clearAll();
+    rows.setValidRange(vectorSize_ / 3, (2 * vectorSize_) / 3, true);
+    rows.updateBounds();
+    params.push_back({"rows_in_the_middle_selected", rows});
+
+    // Rows in the middle not selected.
+    rows.clearAll();
+    rows.setValidRange(0, vectorSize_ / 3, true);
+    rows.setValidRange((2 * vectorSize_) / 3, vectorSize_, true);
+    rows.updateBounds();
+    params.push_back({"rows_in_the_middle_not_selected", rows});
+
+    // All selected.
+    rows.setAll();
+    params.push_back({"all_rows_selected", rows});
+
+    return params;
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    PeeledEncodingTests,
+    PeeledEncodingBasicTests,
+    testing::ValuesIn(PeeledEncodingBasicTests::generateTestParams()),
+    [](const ::testing::TestParamInfo<PeeledEncodingBasicTests::ParamType>&
+           info) { return info.param.testName; });
+
+TEST_P(PeeledEncodingBasicTests, allCommonDictionaryLayers) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 1. Common dictionary layers are peeled
+  //    Input Vectors: Dict1(Dict2(Flat1)), Dict1(Dict2(Const1)),
+  //                   Dict1(Dict2(Dict3(Flat2)))
+  //    Peeled Vectors: Flat, Const1, Dict3(Flat2)
+  //    Peel: Dict1(Dict2) => collapsed into one dictionary
+
+  auto input1 = wrapInDictionaryLayers(flat1, {&dictWrap2, &dictWrap1});
+  auto input2 = wrapInDictionaryLayers(const1, {&dictWrap2, &dictWrap1});
+  auto input3 =
+      wrapInDictionaryLayers(flat2, {&dictWrap3, &dictWrap2, &dictWrap1});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 3);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+  ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
+  assertEqualVectors(
+      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, someCommonDictionaryLayers) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 2. Common dictionary layers are peeled
+  //    Input Vectors: Dict1(Dict2(Flat1)), Dict1(Const1)),
+  //                   Dict1(Dict2(Dict3(Flat2)))
+  //    Peeled Vectors: Dict2(Flat), Const1, Dict2(Dict3(Flat2))
+  //    Peel: Dict1
+
+  auto input1 = wrapInDictionaryLayers(flat1, {&dictWrap2, &dictWrap1});
+  auto input2 = wrapInDictionaryLayers(const1, {&dictWrap1});
+  auto input3 =
+      wrapInDictionaryLayers(flat2, {&dictWrap3, &dictWrap2, &dictWrap1});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 3);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+  ASSERT_EQ(peeledVectors[1].get(), peelWrappings(1, input2).get());
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
+  assertEqualVectors(
+      wrapInDictionaryLayers(flat1, {&dictWrap1}),
+      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, commonDictionaryLayersAndAConstant) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 3. Common dictionary layers are peeled while constant is ignored
+  //    (since all valid rows translated via the common dictionary layers would
+  //    point to the same constant index)
+  //    Input Vectors: Dict1(Dict2(Flat1)), Const1,
+  //                   Dict1(Dict2(Dict3(Flat2)))
+  //    Peeled Vectors: Flat, Const1, Dict3(Flat2)
+  //    Peel: Dict1(Dict2) => collapsed into one dictionary
+  auto input1 = wrapInDictionaryLayers(flat1, {&dictWrap2, &dictWrap1});
+  auto input2 = const1;
+  auto input3 =
+      wrapInDictionaryLayers(flat2, {&dictWrap3, &dictWrap2, &dictWrap1});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 3);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flat1.get());
+  if (peeledVectors[1].get() != const1.get()) {
+    // In case the constant is resized to match other peeledVector's size.
+    assertEqualVectors(peeledVectors[1], const1, rows);
+  }
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(2, input3).get());
+  assertEqualVectors(
+      input1, peeledEncoding->wrap(flat1->type(), pool(), flat1, rows), rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, singleConstantEncodedVector) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  /// 4. A single vector with constant encoding layer over a complex vector can
+  ///    be peeled.
+  ///    Input Vectors: Const1(Complex1)
+  ///    Peeled Vectors: Complex
+  ///    Peel: Const1
+  auto input1 = complexConst;
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 1);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+  ASSERT_EQ(peeledVectors[0]->encoding(), VectorEncoding::Simple::ARRAY);
+  assertEqualVectors(
+      input1,
+      peeledEncoding->wrap(
+          complexConst->type(), pool(), complexConst->valueVector(), rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, dictionaryOverConstantOverNullComplex) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 5. A single vector with arbitrary dictionary layers over a constant
+  //    encoding layer over a NULL complex vector can be peeled and the peels
+  //    can be merged into a single constant layer. Input Vectors:
+  //    Dict1(Const1(NullComplex)) Peeled Vectors: Null Complex vector Peel:
+  //    Const(generic constant index)
+  auto nullComplexConst =
+      BaseVector::createNullConstant(complexConst->type(), vectorSize_, pool());
+  auto input1 = wrapInDictionaryLayers(nullComplexConst, {&dictWrap1});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 1);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(2, input1).get());
+  ASSERT_EQ(peeledVectors[0]->encoding(), VectorEncoding::Simple::ARRAY);
+  assertEqualVectors(
+      input1,
+      peeledEncoding->wrap(
+          complexConst->type(), pool(), nullComplexConst->valueVector(), rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, dictionaryOverConstantOverComplex) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 6. A single vector with arbitrary dictionary layers over a constant
+  //    encoding layer over a Non-NULL complex vector.
+  //    Input Vectors: Dict1(Const1(NonNullComplex))
+  //    Peeled Vectors: Non-Null Complex vector
+  //    Peel: Dict1(Const) => collapsed into one dictionary
+  auto nonNullComplexConst = BaseVector::wrapInConstant(
+      vectorSize_, 0, fuzzer->fuzzNotNull(ARRAY(INTEGER()), 1));
+  auto input1 = wrapInDictionaryLayers(nonNullComplexConst, {&dictWrap1});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 1);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(2, input1).get());
+  ASSERT_EQ(peeledVectors[0]->encoding(), VectorEncoding::Simple::ARRAY);
+  assertEqualVectors(
+      input1,
+      peeledEncoding->wrap(
+          nonNullComplexConst->type(),
+          pool(),
+          nonNullComplexConst->valueVector(),
+          rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, allConstant) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 7. All constant inputs where the peel is just a constant pointing to the
+  //    first valid row. The peel itself is irrelevant but allows us to
+  //    translate input rows into a single row.
+  //    Input Vectors: Const1(Complex1), Const2, Const3
+  //    Peeled Vectors: Const1(Complex1), Const2, Const3
+  //    Peel: Const(generic constant index)
+  auto input1 = complexConst;
+  auto input2 = const1;
+  auto input3 = const2;
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2, input3}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 3);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(peeledVectors[0].get(), complexConst.get());
+  ASSERT_EQ(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledVectors[2].get(), const2.get());
+  assertEqualVectors(
+      input1,
+      peeledEncoding->wrap(complexConst->type(), pool(), complexConst, rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, emptyInputVectors) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 8. No inputs. This is considered as constant encoding since its expected
+  //    to produce the same result for all valid rows.
+  //    Input Vectors: <empty>
+  //    Peeled Vectors: <empty>
+  //    Peel: Const(generic constant index)
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding =
+      PeeledEncoding::Peel({}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 0);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::CONSTANT);
+  assertEqualVectors(
+      const1, peeledEncoding->wrap(const1->type(), pool(), const1, rows), rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, dictionaryLayersHavingNulls) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 9. One of the middle wraps adds nulls but 'canPeelsHaveNulls' is set to
+  //    false.
+  //    Input Vectors: DictNoNulls(DictWithNulls(Flat1)), Const1,
+  //                   DictNoNulls(DictWithNulls((Flat2))
+  //    Peeled Vectors: DictWithNulls(Flat1), Const1,
+  //                    DictWithNulls(Dict3(Flat2))
+  //    Peel: DictNoNulls
+  DictionaryWrap dictNoNulls{
+      .indices = dictWrap1.indices, .nulls = nullptr, .size = dictWrap3.size};
+  auto dictWithNulls = dictWrap2;
+  auto input1 = wrapInDictionaryLayers(flat1, {&dictWithNulls, &dictNoNulls});
+  auto input2 = const1;
+  auto input3 =
+      wrapInDictionaryLayers(flat2, {&dictWrap3, &dictWithNulls, &dictNoNulls});
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2, input3}, rows, localDecodedVector, false, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 3);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), peelWrappings(1, input1).get());
+  if (peeledVectors[1].get() != const1.get()) {
+    // In case the constant is resized to match other peeledVector's size.
+    assertEqualVectors(peeledVectors[1], const1, rows);
+  }
+  ASSERT_EQ(peeledVectors[2].get(), peelWrappings(1, input3).get());
+  assertEqualVectors(
+      wrapInDictionaryLayers(flat1, {&dictNoNulls}),
+      peeledEncoding->wrap(flat1->type(), pool(), flat1, rows),
+      rows);
+}
+
+TEST_P(PeeledEncodingBasicTests, constantResize) {
+  LocalDecodedVector localDecodedVector(execCtx_);
+  const SelectivityVector& rows = GetParam().rows;
+  // 10. Verify that the constant vector is resized to at least the same length
+  //    as the base vector after peeling dictionary layers.
+  //    Input Vectors: Dict1(Dict2(FlatLarge)), ConstSmallerSize,
+  //    Peeled Vectors: FlatLarge, ConstSizeSameAsFlatLarge
+  //    Peel: Dict1(Dict2) => collapsed into one dictionary
+  auto flatLarge = fuzzer->fuzzFlat(INTEGER(), 2 * vectorSize_);
+  auto input1 = wrapInDictionaryLayers(flatLarge, {&dictWrap2, &dictWrap1});
+  auto input2 = const1;
+  std::vector<VectorPtr> peeledVectors;
+  auto peeledEncoding = PeeledEncoding::Peel(
+      {input1, input2}, rows, localDecodedVector, true, peeledVectors);
+  ASSERT_EQ(peeledVectors.size(), 2);
+  ASSERT_EQ(
+      peeledEncoding->getWrapEncoding(), VectorEncoding::Simple::DICTIONARY);
+  ASSERT_EQ(peeledVectors[0].get(), flatLarge.get());
+  ASSERT_NE(peeledVectors[1].get(), const1.get());
+  ASSERT_EQ(peeledVectors[1]->encoding(), VectorEncoding::Simple::CONSTANT);
+  ASSERT_EQ(peeledVectors[1]->size(), 2 * vectorSize_);
+  assertEqualVectors(
+      input1,
+      peeledEncoding->wrap(flatLarge->type(), pool(), flatLarge, rows),
+      rows);
+}
+
+TEST_F(PeeledEncodingTest, peelingFails) {
+  VectorFuzzer::Options options;
+  options.nullRatio = 0.3;
+  VectorFuzzer fuzzer(options, pool());
+  vector_size_t size = 100;
+
+  auto dictWrap1 = generateDictionaryWrap(fuzzer, size);
+  auto dictWrap2 = generateDictionaryWrap(fuzzer, size);
+
+  auto flat1 = fuzzer.fuzzFlat(INTEGER());
+  auto flat2 = fuzzer.fuzzFlat(INTEGER());
+  auto const1 = fuzzer.fuzzConstant(INTEGER());
+
+  SelectivityVector rows(size);
+  LocalDecodedVector localDecodedVector(execCtx_);
+
+  // 1. Top level dictionary layers are different
+  //    Input Vectors: Dict1(Flat1), Dict2(Flat2)
+  {
+    auto input1 = wrapInDictionaryLayers(flat1, {&dictWrap1});
+    auto input2 = wrapInDictionaryLayers(flat2, {&dictWrap2});
+    std::vector<VectorPtr> peeledVectors;
+    auto peeledEncoding = PeeledEncoding::Peel(
+        {input1, input2}, rows, localDecodedVector, true, peeledVectors);
+    ASSERT_TRUE(peeledVectors.empty());
+    ASSERT_TRUE(!peeledEncoding);
+  }
+
+  // 2. One of the inputs does not have any wraps.
+  //    Input Vectors: Dict1(Dict2(Flat1)), Dict1(Const1)), Flat2
+  {
+    auto input1 = wrapInDictionaryLayers(flat1, {&dictWrap2, &dictWrap1});
+    auto input2 = wrapInDictionaryLayers(const1, {&dictWrap1});
+    auto input3 = flat2;
+    std::vector<VectorPtr> peeledVectors;
+    auto peeledEncoding = PeeledEncoding::Peel(
+        {input1, input2, input3},
+        rows,
+        localDecodedVector,
+        true,
+        peeledVectors);
+    ASSERT_TRUE(peeledVectors.empty());
+    ASSERT_TRUE(!peeledEncoding);
+  }
+
+  // 3. Topmost wrap adds nulls but 'canPeelsHaveNulls' is set to false.
+  //    Input Vectors: DictWithNulls(Flat1)), Const1,
+  //                   DictWithNulls(Dict2((Flat2))
+  {
+    auto dictWithNulls = dictWrap1;
+    auto input1 = wrapInDictionaryLayers(flat1, {&dictWithNulls});
+    auto input2 = const1;
+    auto input3 = wrapInDictionaryLayers(flat2, {&dictWrap2, &dictWithNulls});
+    std::vector<VectorPtr> peeledVectors;
+    auto peeledEncoding = PeeledEncoding::Peel(
+        {input1, input2, input3},
+        rows,
+        localDecodedVector,
+        false,
+        peeledVectors);
+    ASSERT_TRUE(peeledVectors.empty());
+    ASSERT_TRUE(!peeledEncoding);
+  }
+}

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -656,7 +656,7 @@ TEST_F(JsonCastTest, unsupportedTypes) {
   VELOX_ASSERT_THROW(
       evaluateCast<JsonNativeType>(
           MAP(VARCHAR(), BIGINT()), JSON(), makeRowVector({nullKeyMap})),
-      "Cannot cast map with null keys to JSON");
+      "Map keys cannot be null.");
 
   // Map keys cannot be complex type.
   auto arrayKeyVector = makeNullableArrayVector<int64_t>({{1}, {2}});

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -32,7 +32,6 @@ namespace facebook::velox {
 /// the following steps are taken:
 /// 1. It first traverses the top dictionary layers (if they exist) and
 ///    combines their indices and nulls
-
 /// 2. Next, if it encounters a constant layer, it does the following:
 ///    ** If the dictionary layers over it were adding additional nulls, then it
 ///    replaces all non-null indices with the constant index.
@@ -66,15 +65,13 @@ namespace facebook::velox {
 /// on memory allocations (see LocalDecodedVector class).
 ///
 /// NOTE:
-///
-/// If all layers are traversed, then the nulls of the base vector are also
-/// combined into the resultant nulls buffer. Therefore, if dictionaryWrapping()
-/// and wrap() are used then the nulls from the base will also propagate to the
-/// wrap which ultimately gets applied.
-///
-/// The number of layers to merge can also be controlled using makeIndices() API
-/// which takes in a ’level’ parameter for the same. Please see method comment
-/// for makeIndices() for more details.
+/// DecodedVector is only designed to read a potentially encoded vector. If the
+/// primary use-case is to peel and eventually wrap a peeled result then
+/// checkout the PeeledEncodings class. There are certain extensions of the
+/// DecodedVector API which are necessary to implement functionality in
+/// PeeledEncodings and should only be used there. Please refrain from using
+/// those APIs as their behaviour can diverge significantly from others, namely,
+/// makeIndices(), wrap(), dictionaryWrapping().
 class DecodedVector {
  public:
   /// Default constructor. The caller must call decode() or makeIndices() next.
@@ -128,24 +125,6 @@ class DecodedVector {
 
   void decode(const BaseVector& vector, bool loadLazy = true) {
     decode(vector, nullptr, loadLazy);
-  }
-
-  /// Given a dictionary vector with at least 'numLevel' levels of dictionary
-  /// wrapping, combines 'numLevel' wrappings into one.
-  /// Example usage: <InputVector> : Dictionary2(Dictionary1(Complex)) If we
-  /// call makeIndices(<Input Vector>, Level = 2), only Dictionary2 and
-  /// Dictionary1 will have indices and nulls merged and the nulls from the
-  /// Complex flat vector will not be merged. If instead Level is set to 3, then
-  /// additionally nulls from the complex base vector will also be merged.
-  void makeIndices(
-      const BaseVector& vector,
-      const SelectivityVector& rows,
-      int32_t numLevels) {
-    return makeIndices(vector, &rows, numLevels);
-  }
-
-  void makeIndices(const BaseVector& vector, int32_t numLevels) {
-    return makeIndices(vector, nullptr, numLevels);
   }
 
   /// Returns the values buffer for the base vector. Assumes the vector is of
@@ -249,6 +228,28 @@ class DecodedVector {
     return isConstantMapping_;
   }
 
+  /////////////////////////////////////////////////////////////////
+  /// BEGIN: Members that must only be used by PeeledEncoding class.
+  /// See class comment for more details.
+
+  /// Given a dictionary vector with at least 'numLevel' levels of dictionary
+  /// wrapping, combines 'numLevel' wrappings into one.
+  /// Example usage: <InputVector> : Dictionary2(Dictionary1(Complex)) If we
+  /// call makeIndices(<Input Vector>, Level = 2), only Dictionary2 and
+  /// Dictionary1 will have indices and nulls merged and the nulls from the
+  /// Complex flat vector will not be merged. If instead Level is set to 3, then
+  /// additionally nulls from the complex base vector will also be merged.
+  void makeIndices(
+      const BaseVector& vector,
+      const SelectivityVector& rows,
+      int32_t numLevels) {
+    return makeIndices(vector, &rows, numLevels);
+  }
+
+  void makeIndices(const BaseVector& vector, int32_t numLevels) {
+    return makeIndices(vector, nullptr, numLevels);
+  }
+
   /// Wraps a vector with the same wrapping as another. 'wrapper' must
   /// have been previously decoded by 'this'. This is used when 'data'
   /// is a component of the base vector of 'wrapper' and must be used
@@ -283,6 +284,9 @@ class DecodedVector {
       const SelectivityVector& rows) const {
     return dictionaryWrapping(wrapper, rows.end());
   }
+
+  /// END: Members that must only be used by PeeledEncoding
+  /////////////////////////////////////////////////////////
 
   /// Pre-allocated vector of 0, 1, 2,..
   static const std::vector<vector_size_t>& consecutiveIndices();

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -581,12 +581,7 @@ VectorPtr VectorFuzzer::fuzzDictionary(
   VELOX_CHECK(
       vectorSize > 0 || size == 0,
       "Cannot build a non-empty dictionary on an empty underlying vector");
-  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool_);
-  auto rawIndices = indices->asMutable<vector_size_t>();
-
-  for (size_t i = 0; i < size; ++i) {
-    rawIndices[i] = rand<vector_size_t>(rng_) % vectorSize;
-  }
+  BufferPtr indices = fuzzIndices(size, vectorSize);
 
   auto nulls = opts_.dictionaryHasNulls ? fuzzNulls(size) : nullptr;
   return BaseVector::wrapInDictionary(nulls, indices, size, vector);
@@ -771,6 +766,19 @@ BufferPtr VectorFuzzer::fuzzNulls(vector_size_t size) {
     }
   }
   return builder.build();
+}
+
+BufferPtr VectorFuzzer::fuzzIndices(
+    vector_size_t size,
+    vector_size_t baseVectorSize) {
+  VELOX_CHECK_GE(size, 0);
+  BufferPtr indices = AlignedBuffer::allocate<vector_size_t>(size, pool_);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  for (size_t i = 0; i < size; ++i) {
+    rawIndices[i] = rand<vector_size_t>(rng_) % baseVectorSize;
+  }
+  return indices;
 }
 
 std::pair<int8_t, int8_t> VectorFuzzer::randPrecisionScale(TypeKind kind) {

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -289,6 +289,13 @@ class VectorFuzzer {
       RowVectorPtr rowVector,
       const std::vector<column_index_t>& columnsToWrapInLazy);
 
+  // Generate a random null buffer.
+  BufferPtr fuzzNulls(vector_size_t size);
+
+  // Generate a random indices buffer of 'size' with maximum possible index
+  // pointing to (baseVectorSize-1).
+  BufferPtr fuzzIndices(vector_size_t size, vector_size_t baseVectorSize);
+
  private:
   // Generates a flat vector for primitive types.
   VectorPtr fuzzFlatPrimitive(const TypePtr& type, vector_size_t size);
@@ -303,9 +310,6 @@ class VectorFuzzer {
   // flat encodings if flatEncoding is set to false, otherwise they will all be
   // flat.
   VectorPtr fuzzComplex(const TypePtr& type, vector_size_t size);
-
-  // Generate a random null buffer.
-  BufferPtr fuzzNulls(vector_size_t size);
 
   void fuzzOffsetsAndSizes(
       BufferPtr& offsets,

--- a/velox/vector/tests/TestingDictionaryArrayElementsFunction.h
+++ b/velox/vector/tests/TestingDictionaryArrayElementsFunction.h
@@ -37,7 +37,7 @@ class TestingDictionaryArrayElementsFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     ArrayVector* array{nullptr};
-    if (args[0]->isFlatEncoding()) {
+    if (args[0]->encoding() == VectorEncoding::Simple::ARRAY) {
       array = args[0]->as<ArrayVector>();
     } else if (args[0]->isConstantEncoding()) {
       array = args[0]


### PR DESCRIPTION
This patch attempts to consolidate the peeling functionality into a
utility class and provides a simple to use API that enables peeling.
The following instances have been transitioned to using this class:

- Peeling field references
- Peeling inputs before applying a function
- Peeling inputs before casting
- Peeling input before casting to json
TODO:
- Transition peeling employed in FieldReference expression

Testing:
All current expression cast and json tests pass.
Added a test suite for PeeledEncoding class.
ExpressionFuzzer ran successfully for close to an hour.