### PR TITLE
Run document generation job on larger machines. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -182,9 +182,6 @@ executors:
   check:
     docker:
       - image : ghcr.io/facebookincubator/velox-dev:check-avx
-  doc-gen:
-    docker:
-      - image : ghcr.io/facebookincubator/velox-dev:circleci-avx
   macos-intel:
     macos:
       xcode: "12.5.1"
@@ -499,7 +496,7 @@ jobs:
             fi
 
   doc-gen-job:
-    executor: doc-gen
+    executor: build
     steps:
       - checkout
       - update-submodules


### PR DESCRIPTION
Currently doc-gen job seems to die when compiling : https://app.circleci.com/pipelines/github/facebookincubator/velox/21054/workflows/39748de5-fcdc-4c40-a015-cc10f3512c0e/jobs/132313 . 