### PR TITLE
Remove unused Type::fixedElementsWidth

### DIFF
--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -498,11 +498,6 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 
   virtual bool isFixedWidth() const = 0;
 
-  /// Used in FixedSizeArrayType to return the width constraint of the type.
-  virtual size_type fixedElementsWidth() const {
-    throw std::invalid_argument{"unimplemented"};
-  }
-
   static std::shared_ptr<const Type> create(const folly::dynamic& obj);
 
   /// Recursive kind hashing (uses only TypeKind).

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -274,58 +274,25 @@ VectorPtr BaseVector::createInternal(
         children.back()->resize(0);
       }
       return std::make_shared<RowVector>(
-          pool,
-          type,
-          BufferPtr(nullptr),
-          size,
-          std::move(children),
-          0 /*nullCount*/);
+          pool, type, nullptr, size, std::move(children));
     }
     case TypeKind::ARRAY: {
-      BufferPtr sizes = AlignedBuffer::allocate<vector_size_t>(size, pool, 0);
-      BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(size, pool, 0);
-      // When constructing FixedSizeArray types we validate the
-      // provided lengths are of the expected size. But
-      // BaseVector::create constructs the array with the
-      // sizes/offsets all set to zero -- presumably because the
-      // caller will fill them in later by directly manipulating
-      // rawSizes/rawOffsets. This makes the sanity check in the
-      // FixedSizeArray constructor less powerful than it would be if
-      // we knew the sizes / offsets were going to populate them with
-      // in advance and they were immutable after constructing the
-      // array.
-      //
-      // For now to support the current code structure of "create then
-      // populate" for BaseVector::create(), in the case of
-      // FixedSizeArrays we pre-initialize the sizes / offsets here
-      // with what we expect them to be so the constructor validation
-      // passes. The code that subsequently manipulates the
-      // sizes/offsets directly should also validate they are
-      // continuing to upload the fixedSize constraint.
-      if (type->isFixedWidth()) {
-        auto rawOffsets = offsets->asMutable<vector_size_t>();
-        auto rawSizes = sizes->asMutable<vector_size_t>();
-        const auto width = type->fixedElementsWidth();
-        for (vector_size_t i = 0; i < size; ++i) {
-          *rawSizes++ = width;
-          *rawOffsets++ = width * i;
-        }
-      }
+      BufferPtr sizes = allocateSizes(size, pool);
+      BufferPtr offsets = allocateOffsets(size, pool);
       auto elementType = type->as<TypeKind::ARRAY>().elementType();
       auto elements = create(elementType, 0, pool);
       return std::make_shared<ArrayVector>(
           pool,
           type,
-          BufferPtr(nullptr),
+          nullptr,
           size,
           std::move(offsets),
           std::move(sizes),
-          std::move(elements),
-          0 /*nullCount*/);
+          std::move(elements));
     }
     case TypeKind::MAP: {
-      BufferPtr sizes = AlignedBuffer::allocate<vector_size_t>(size, pool, 0);
-      BufferPtr offsets = AlignedBuffer::allocate<vector_size_t>(size, pool, 0);
+      BufferPtr sizes = allocateSizes(size, pool);
+      BufferPtr offsets = allocateOffsets(size, pool);
       auto keyType = type->as<TypeKind::MAP>().keyType();
       auto valueType = type->as<TypeKind::MAP>().valueType();
       auto keys = create(keyType, 0, pool);
@@ -333,28 +300,17 @@ VectorPtr BaseVector::createInternal(
       return std::make_shared<MapVector>(
           pool,
           type,
-          BufferPtr(nullptr),
+          nullptr,
           size,
           std::move(offsets),
           std::move(sizes),
           std::move(keys),
-          std::move(values),
-          0 /*nullCount*/);
+          std::move(values));
     }
     case TypeKind::UNKNOWN: {
-      BufferPtr nulls = AlignedBuffer::allocate<bool>(size, pool, bits::kNull);
+      BufferPtr nulls = allocateNulls(size, pool, bits::kNull);
       return std::make_shared<FlatVector<UnknownValue>>(
-          pool,
-          UNKNOWN(),
-          nulls,
-          size,
-          BufferPtr(nullptr),
-          std::vector<BufferPtr>(),
-          SimpleVectorStats<UnknownValue>{},
-          1 /*distinctValueCount*/,
-          size /*nullCount*/,
-          true /*isSorted*/,
-          0 /*representedBytes*/);
+          pool, UNKNOWN(), nulls, size, nullptr, std::vector<BufferPtr>());
     }
     default:
       return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1075,7 +1075,6 @@ TEST_F(VectorTest, unknown) {
   auto unknownVector = BaseVector::create(UNKNOWN(), 10, pool_.get());
   ASSERT_EQ(VectorEncoding::Simple::FLAT, unknownVector->encoding());
   ASSERT_FALSE(unknownVector->isScalar());
-  ASSERT_EQ(unknownVector->getNullCount().value(), 10);
   for (int i = 0; i < unknownVector->size(); ++i) {
     ASSERT_TRUE(unknownVector->isNullAt(i)) << i;
   }
@@ -1095,7 +1094,6 @@ TEST_F(VectorTest, unknown) {
 
   // It is okay to copy to a non-constant UNKNOWN vector.
   unknownVector->copy(constUnknownVector.get(), rows, nullptr);
-  ASSERT_EQ(unknownVector->getNullCount().value(), 10);
   for (int i = 0; i < unknownVector->size(); ++i) {
     ASSERT_TRUE(unknownVector->isNullAt(i)) << i;
   }


### PR DESCRIPTION
This method was used by FixedSizeArrayType, but that type was removed in #4168.