### PR TITLE
Fix restoreSelectivityVector

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -819,10 +819,13 @@ void saveSelectivityVector(const SelectivityVector& rows, std::ostream& out) {
 SelectivityVector restoreSelectivityVector(std::istream& in) {
   auto size = read<int32_t>(in);
 
+  const auto numBytes = bits::nbytes(size);
+
   // SelectivityVector::setFromBits reads whole words (8 bytes). Make sure it is
   // safe to access the "last" partially-populated word.
-  std::vector<char> bits(bits::roundUp(bits::nbytes(size), 8));
-  in.read(bits.data(), bits.size());
+  std::vector<char> bits(bits::roundUp(numBytes, 8));
+
+  in.read(bits.data(), numBytes);
 
   SelectivityVector rows(size);
   rows.setFromBits(reinterpret_cast<uint64_t*>(bits.data()), size);


### PR DESCRIPTION
restoreSelectivityVector used to read too much, more bytes than
saveSelectivityVector wrote. This caused failures when restoring vectors from a
binary that has multiple vectors written back-to-back.