### PR TITLE
Remove SimpleVector::invalidateIsAscii() API

### DIFF
--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -67,7 +67,8 @@ class CodegenBenchmark : public CodegenTestCore {
       for (auto& rowVector : inputVector) {
         for (auto& columns : rowVector->children()) {
           if (auto stringVector = columns->asFlatVector<StringView>()) {
-            stringVector->invalidateIsAscii();
+            // Clear asciiness flags via ensureWritable.
+            stringVector->ensureWritable(SelectivityVector(1));
           }
         }
       }

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1946,10 +1946,10 @@ class InputModifyingFunction : public MultiStringFunction {
       VectorPtr& result) const override {
     MultiStringFunction::apply(rows, args, outputType, context, result);
 
-    // Modify args and remove its asciness
+    // Clear data-dependent flags of args including their asciiness.
     for (auto& arg : args) {
       auto input = arg->as<SimpleVector<StringView>>();
-      input->invalidateIsAscii();
+      input->ensureWritable(rows);
     }
   }
 };

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -544,6 +544,7 @@ void BaseVector::ensureWritable(const SelectivityVector& rows) {
   }
 
   this->resize(newSize);
+  this->clearDataDependentFlags();
 }
 
 void BaseVector::ensureWritable(
@@ -769,6 +770,7 @@ void BaseVector::prepareForReuse() {
       rawNulls_ = nullptr;
     }
   }
+  this->clearDataDependentFlags();
 }
 
 namespace {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -472,7 +472,7 @@ class BaseVector {
   // overwritten.
   //
   // After invoking this function, the 'result' is guaranteed to be a flat
-  // uniquely-referenced vector.
+  // uniquely-referenced vector with all data-dependent flags cleared.
   //
   // Use SelectivityVector::empty() to make the 'result' writable and preserve
   // all current values.
@@ -640,14 +640,16 @@ class BaseVector {
   /// To safely reuse a vector one needs to (1) ensure that the vector as well
   /// as all its buffers and child vectors are singly-referenced and mutable
   /// (for buffers); (2) clear append-only string buffers and child vectors
-  /// (elements of arrays, keys and values of maps, fields of structs).
+  /// (elements of arrays, keys and values of maps, fields of structs); (3)
+  /// clear all data-dependent flags.
   ///
   /// This method takes a non-const reference to a 'vector' and updates it to
   /// possibly a new flat vector of the specified size that is safe to reuse.
   /// If input 'vector' is not singly-referenced or not flat, replaces 'vector'
   /// with a new vector of the same type and specified size. If some of the
   /// buffers cannot be reused, these buffers are reset. Child vectors are
-  /// updated by calling this method recursively with size zero.
+  /// updated by calling this method recursively with size zero. Data-dependent
+  /// flags are cleared after this call.
   static void prepareForReuse(
       std::shared_ptr<BaseVector>& vector,
       vector_size_t size);
@@ -788,6 +790,18 @@ class BaseVector {
 
   BufferPtr sliceNulls(vector_size_t offset, vector_size_t length) const {
     return sliceBuffer(*BOOLEAN(), nulls_, offset, length, pool_);
+  }
+
+  // Reset data-dependent flags to the "unknown" status. This is needed whenever
+  // a vector is mutated because the modification may invalidate these flags.
+  // Currently, we call this function in BaseVector::ensureWritable() and
+  // BaseVector::prepareForReuse() that are expected to be called before any
+  // vector mutation.
+  virtual void clearDataDependentFlags() {
+    nullCount_ = std::nullopt;
+    distinctValueCount_ = std::nullopt;
+    representedByteCount_ = std::nullopt;
+    storageByteCount_ = std::nullopt;
   }
 
   const TypePtr type_;

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1006,8 +1006,6 @@ uint64_t MapVector::estimateFlatSize() const {
 void MapVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
-  sortedKeys_ = false;
-
   if (!(offsets_->unique() && offsets_->isMutable())) {
     offsets_ = nullptr;
   } else {

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -563,6 +563,12 @@ class MapVector : public ArrayVectorBase {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+ protected:
+  virtual void clearDataDependentFlags() override {
+    BaseVector::clearDataDependentFlags();
+    sortedKeys_ = false;
+  }
+
  private:
   // Returns true if the keys for map at 'index' are sorted from first
   // to last in the type's collation order.

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -319,6 +319,14 @@ class SimpleVector : public BaseVector {
     return left < right ? -1 : left == right ? 0 : 1;
   }
 
+  virtual void clearDataDependentFlags() override {
+    BaseVector::clearDataDependentFlags();
+    isSorted_ = std::nullopt;
+    stats_ = SimpleVectorStats<T>{};
+    asciiSetRows_.clearAll();
+    isAllAscii_ = false;
+  }
+
   std::optional<bool> isSorted_ = std::nullopt;
 
   // Allows checking that access is with the same width of T as

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -238,14 +238,6 @@ class SimpleVector : public BaseVector {
     return isAllAscii_;
   }
 
-  /// Clears asciiness state.
-  template <typename U = T>
-  typename std::enable_if_t<std::is_same_v<U, StringView>, void>
-  invalidateIsAscii() {
-    asciiSetRows_.clearAll();
-    isAllAscii_ = false;
-  }
-
   /// Explicitly set asciness.
   template <typename U = T>
   typename std::enable_if_t<std::is_same_v<U, StringView>, void> setIsAscii(

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -30,7 +30,8 @@ add_executable(
   IsWritableVectorTest.cpp
   LazyVectorTest.cpp
   MayHaveNullsRecursiveTest.cpp
-  VariantToVectorTest.cpp)
+  VariantToVectorTest.cpp
+  VectorTestUtils.cpp)
 
 add_test(velox_vector_test velox_vector_test)
 

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -220,7 +220,7 @@ TEST_F(SimpleVectorNonParameterizedTest, computeAscii) {
     asciiSubset.setValid(0, false);
     asciiSubset.updateBounds();
 
-    vector->invalidateIsAscii();
+    vector = maker_.encodedVector(encoding, stringData_);
     vector->computeAndSetIsAscii(asciiSubset);
 
     ASSERT_TRUE(vector->isAscii(asciiSubset).has_value());
@@ -239,9 +239,9 @@ TEST_F(SimpleVectorNonParameterizedTest, isAscii) {
     bool ascii = vector->isAscii(all).value();
     ASSERT_FALSE(ascii);
 
-    // Clear asciiness and compute asciiness only for 2nd row
-    // Then ask for asciiness for some other row.
-    vector->invalidateIsAscii();
+    // Compute asciiness only for 2nd row Then ask for asciiness for some other
+    // row.
+    vector = maker_.encodedVector(encoding, stringData_);
     SelectivityVector first(stringData_.size(), false);
     first.setValid(1, true);
     first.updateBounds();
@@ -255,7 +255,7 @@ TEST_F(SimpleVectorNonParameterizedTest, isAscii) {
     ASSERT_TRUE(vector->isAscii(first).value());
 
     // Give it a selectivity vector with larger bounds than supported.
-    vector->invalidateIsAscii();
+    vector = maker_.encodedVector(encoding, stringData_);
     vector->computeAndSetIsAscii(all);
 
     SelectivityVector larger(stringData_.size() + 1, false);
@@ -310,25 +310,10 @@ TEST_F(SimpleVectorNonParameterizedTest, isAsciiSourceRows) {
     SelectivityVector some(all.size(), false);
     some.setValid(0, true);
     some.updateBounds();
-    vector->invalidateIsAscii();
+    vector = maker_.encodedVector(encoding, stringData_);
     vector->setIsAscii(true, some);
     ascii = vector->isAscii(all, sourceMappings);
     ASSERT_FALSE(ascii.has_value());
-  }
-}
-
-TEST_F(SimpleVectorNonParameterizedTest, invalidateIsAscii) {
-  for (auto encoding : kAsciiEncodings) {
-    LOG(INFO) << "Running:" << encoding;
-
-    auto vector = maker_.encodedVector(encoding, stringData_);
-    SelectivityVector all(stringData_.size());
-    vector->computeAndSetIsAscii(all);
-
-    assertIsAscii(vector, all, false);
-
-    vector->invalidateIsAscii();
-    ASSERT_FALSE(vector->isAscii(all).has_value());
   }
 }
 
@@ -341,7 +326,7 @@ TEST_F(SimpleVectorNonParameterizedTest, setAscii) {
     vector->computeAndSetIsAscii(all);
     assertIsAscii(vector, all, false);
 
-    vector->invalidateIsAscii();
+    vector = maker_.encodedVector(encoding, stringData_);
     vector->setIsAscii(true, all);
     assertIsAscii(vector, all, true);
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1353,7 +1353,7 @@ TEST_F(VectorTest, copyAscii) {
   ASSERT_FALSE(ascii.has_value());
 
   // Copy over asciness from a vector without asciiness set.
-  source->invalidateIsAscii();
+  source = makeFlatVector(stringData);
   other->ensureWritable(all);
   other->copy(source.get(), all, nullptr);
   // Ensure isAscii returns nullopt

--- a/velox/vector/tests/VectorTestUtils.cpp
+++ b/velox/vector/tests/VectorTestUtils.cpp
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/tests/VectorTestUtils.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+void checkBaseVectorFlagsSet(const BaseVector& vector) {
+  EXPECT_TRUE(vector.getNullCount().has_value());
+  EXPECT_TRUE(vector.getDistinctValueCount().has_value());
+  EXPECT_TRUE(vector.representedBytes().has_value());
+  EXPECT_TRUE(vector.storageBytes().has_value());
+}
+
+void checkBaseVectorFlagsCleared(const BaseVector& vector) {
+  EXPECT_FALSE(vector.getNullCount().has_value());
+  EXPECT_FALSE(vector.getDistinctValueCount().has_value());
+  EXPECT_FALSE(vector.representedBytes().has_value());
+  EXPECT_FALSE(vector.storageBytes().has_value());
+}
+
+void checkVectorFlagsSet(const MapVector& vector) {
+  EXPECT_TRUE(vector.hasSortedKeys());
+}
+
+void checkVectorFlagsCleared(const MapVector& vector) {
+  EXPECT_FALSE(vector.hasSortedKeys());
+}
+
+FlatVectorPtr<StringView> makeFlatVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool) {
+  auto values = AlignedBuffer::allocate<StringView>(kSize, pool, "a"_sv);
+  auto vector = std::make_shared<FlatVector<StringView>>(
+      pool,
+      VARCHAR(),
+      nulls,
+      kSize,
+      std::move(values),
+      std::vector<BufferPtr>(),
+      /*stats*/ SimpleVectorStats<StringView>{"a"_sv, "a"_sv},
+      /*distinctValueCount*/ 1,
+      /*nullCount*/ 1,
+      /*isSorted*/ true,
+      /*representedBytes*/ 0,
+      /*storageByteCount*/ 0);
+  vector->computeAndSetIsAscii(SelectivityVector(kSize - 1));
+  checkVectorFlagsSet(*vector);
+  return vector;
+}
+
+ConstantVectorPtr<StringView> makeConstantVectorWithFlags(
+    vector_size_t kSize,
+    memory::MemoryPool* pool) {
+  auto vector = std::make_shared<ConstantVector<StringView>>(
+      pool,
+      kSize,
+      false,
+      VARCHAR(),
+      "a"_sv,
+      /*stats*/ SimpleVectorStats<StringView>{"a"_sv, "a"_sv},
+      /*representedBytes*/ 0,
+      /*storageByteCount*/ 0);
+  vector->computeAndSetIsAscii(SelectivityVector(kSize));
+  checkVectorFlagsSet(*vector);
+  return vector;
+}
+
+DictionaryVectorPtr<StringView> makeDictionaryVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool) {
+  auto base = BaseVector::createConstant(VARCHAR(), "a", kSize, pool);
+  auto vector = std::make_shared<DictionaryVector<StringView>>(
+      pool,
+      nulls,
+      kSize,
+      base,
+      test::makeIndices(
+          kSize, [](auto row) { return row; }, pool),
+      /*stats*/ SimpleVectorStats<StringView>{"a"_sv, "a"_sv},
+      /*distinctValueCount*/ 1,
+      /*nullCount*/ 1,
+      /*isSorted*/ true,
+      /*representedBytes*/ 0,
+      /*storageByteCount*/ 0);
+  vector->computeAndSetIsAscii(SelectivityVector(kSize - 1));
+  checkVectorFlagsSet(*vector);
+  return vector;
+}
+
+MapVectorPtr makeMapVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool) {
+  auto keys = BaseVector::createConstant(VARCHAR(), "a", kSize, pool);
+  auto values = BaseVector::createConstant(VARCHAR(), "b", kSize, pool);
+
+  auto offsets = allocateOffsets(kSize, pool);
+  auto* rawOffsets = offsets->asMutable<vector_size_t>();
+  auto sizes = allocateSizes(kSize, pool);
+  auto* rawSizes = sizes->asMutable<vector_size_t>();
+  for (auto i = 0; i < kSize; ++i) {
+    rawOffsets[i] = i;
+    rawSizes[i] = 1;
+  }
+
+  auto vector = std::make_shared<MapVector>(
+      pool,
+      MAP(VARCHAR(), VARCHAR()),
+      nulls,
+      kSize,
+      offsets,
+      sizes,
+      keys,
+      values,
+      /*nullCount*/ 1,
+      /*sortedKeys*/ true);
+  checkVectorFlagsSet(*vector);
+  return vector;
+}
+
+} // namespace facebook::velox::test

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <gtest/gtest.h>
 #include "velox/vector/tests/VectorValueGenerator.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 #include "velox/vector/tests/utils/VectorMakerStats.h"
@@ -275,6 +276,96 @@ SimpleVectorPtr<T> createAndAssert(
   auto vector = maker.encodedVector(encoding, expected);
   assertVectorAndProperties(expected, vector);
   return vector;
+}
+
+// Check that data-dependent flags of `vector` are set or cleared.
+void checkBaseVectorFlagsSet(const BaseVector& vector);
+
+void checkBaseVectorFlagsCleared(const BaseVector& vector);
+
+void checkVectorFlagsSet(const MapVector& vector);
+
+void checkVectorFlagsCleared(const MapVector& vector);
+
+template <typename T>
+void checkVectorFlagsSet(const SimpleVector<T>& vector) {
+  checkBaseVectorFlagsSet(vector);
+  EXPECT_TRUE(vector.getStats().min.has_value());
+  EXPECT_TRUE(vector.getStats().max.has_value());
+  EXPECT_TRUE(vector.isSorted().has_value());
+  EXPECT_TRUE(vector.isAscii(0).has_value());
+};
+
+template <typename T>
+void checkVectorFlagsCleared(const SimpleVector<T>& vector) {
+  checkBaseVectorFlagsCleared(vector);
+  EXPECT_FALSE(vector.getStats().min.has_value());
+  EXPECT_FALSE(vector.getStats().max.has_value());
+  EXPECT_FALSE(vector.isSorted().has_value());
+  EXPECT_FALSE(vector.isAscii(0).has_value());
+}
+
+// Create a flat vector of StringView with data-dependent flags being set.
+FlatVectorPtr<StringView> makeFlatVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool);
+
+// Create a constant vector of StringView with data-dependent flags being set.
+ConstantVectorPtr<StringView> makeConstantVectorWithFlags(
+    vector_size_t kSize,
+    memory::MemoryPool* pool);
+
+// Create a dictionary vector of StringView with data-dependent flags being set.
+DictionaryVectorPtr<StringView> makeDictionaryVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool);
+
+// Create a flat map(varchar, varchar) vector with data-dependent flags being
+// set.
+MapVectorPtr makeMapVectorWithFlags(
+    vector_size_t kSize,
+    const BufferPtr& nulls,
+    memory::MemoryPool* pool);
+
+// Create a vector through createVector and verify that data-dependent flags
+// are set. Then call ensureWritable() or prepareForReuse through makeMutable
+// and verify that data-dependent flags are cleared after the call.
+template <typename T>
+void checkVectorFlagsReset(
+    memory::MemoryPool* pool,
+    const std::function<std::shared_ptr<
+        T>(vector_size_t, const BufferPtr&, memory::MemoryPool* pool)>&
+        createVector,
+    const std::function<BaseVector*(std::shared_ptr<T>&, VectorPtr&)>&
+        makeMutable) {
+  using V = std::conditional_t<
+      std::is_same_v<T, MapVector>,
+      MapVector,
+      FlatVector<StringView>>;
+  auto kSize = 10;
+  auto nulls = allocateNulls(kSize, pool);
+  auto* rawNulls = nulls->asMutable<uint64_t>();
+  bits::setNull(rawNulls, kSize - 1, true);
+
+  VectorPtr resultHolder;
+
+  auto vector = createVector(kSize, nulls, pool);
+  auto another = vector;
+  auto* result = makeMutable(vector, resultHolder);
+  checkVectorFlagsCleared(*result->template as<V>());
+
+  if constexpr (std::is_same_v<T, FlatVector<StringView>>) {
+    vector = createVector(kSize, nulls, pool);
+    auto values = vector->values();
+    result = makeMutable(vector, resultHolder);
+    checkVectorFlagsCleared(*result->template as<V>());
+  }
+
+  vector = createVector(kSize, nulls, pool);
+  result = makeMutable(vector, resultHolder);
+  checkVectorFlagsCleared(*result->template as<V>());
 }
 
 } // namespace facebook::velox::test

--- a/velox/vector/tests/VectorValueGenerator.h
+++ b/velox/vector/tests/VectorValueGenerator.h
@@ -23,7 +23,9 @@
 
 #include "velox/buffer/StringViewBufferHolder.h"
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/DecimalUtil.h"
 #include "velox/type/StringView.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::test {
 


### PR DESCRIPTION
Summary: A previous change (https://github.com/facebookincubator/velox/pull/4200) makes BaseVector::ensureWritable() and BaseVector::prepareForReuse() clear all data-dependent flags of a vector, including the flags about its asciiness. So SimpleVector::invalidateIsAscii() is no longer needed. This diff removes this API.

Differential Revision: D43915997

