### PR TITLE
Fix thread safety in prepare of ConnectorQueryCtx

### DIFF
--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -219,7 +219,6 @@ class OperatorCtx {
 
   // These members are created on demand.
   mutable std::unique_ptr<core::ExecCtx> execCtx_;
-  mutable std::unique_ptr<connector::ExpressionEvaluator> expressionEvaluator_;
 };
 
 // Query operator

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -198,7 +198,8 @@ void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
        table = tableHandle_,
        columns = columnHandles_,
        connector = connector_,
-       ctx = connectorQueryCtx_,
+       ctx = operatorCtx_->createConnectorQueryCtx(
+           split->connectorId, planNodeId()),
        task = operatorCtx_->task(),
        split]() -> std::unique_ptr<DataSourcePtr> {
         if (task->isCancelled()) {

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -18,6 +18,8 @@
 #include "velox/core/PlanNode.h"
 #include "velox/exec/Operator.h"
 
+DECLARE_int32(split_preload_per_driver);
+
 namespace facebook::velox::exec {
 
 class TableScan : public SourceOperator {


### PR DESCRIPTION
DataSources may be prepared asynchronously for one TableScan on multiple threads. This may entail preparing a remaining filter ExprSet. This is done with a ConnectorExpressionEvaluator. This in turn uses a single ExecCtx for expression preparation, which is not thread safe. Furthermore, the DataSources being asynchronously prepared are in a queue shared between Drivers. The DataSource could end up with a Driver other than the one that created it.

At read time, each async prepared DataSource is merged into the DataSource f the TableScan doing the reading.

The remaining expression is prepared for each DataSource. This is needed in order to know what columns it requires. Also, metadata level pruning could use expressions.

Therefore, we document that ConnectorQueryCtx and its component ConnectorExpressionEvaluator are not thread safe. We create a ConnectorQueryCtx for each async prepare of a DataSource. We make ConnectorQueryCtx independent of the creating OperatorCtx. In specific, it does not share its ExecCtx, which is strictly single-threaded. It does use the pool of the creating OperatorCtx, which is safe since the Pools are destructed only on task destruction. The expression evaluator is further owned by the ConnectorQueryCtx to make the whole decoupled from the creating context.