### PR TITLE
Add `repeatTimes` option to ValuesOperator

### DIFF
--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -396,6 +396,10 @@ The values operation returns specified data.
      - Description
    * - values
      - Set of rows to return.
+   * - parallelizable
+     - If the same input should be produced by each thread (one per driver).
+   * - repeatTimes
+     - How many times each vector should be produced as input.
 
 ExchangeNode
 ~~~~~~~~~~~~

--- a/velox/exec/Values.h
+++ b/velox/exec/Values.h
@@ -49,6 +49,7 @@ class Values : public SourceOperator {
  private:
   std::vector<RowVectorPtr> values_;
   int32_t current_ = 0;
+  size_t roundsLeft_ = 1;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ add_executable(
   UnorderedStreamReaderTest.cpp
   UnnestTest.cpp
   VectorHasherTest.cpp
+  ValuesTest.cpp
   WindowFunctionRegistryTest.cpp)
 
 add_test(

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -31,6 +31,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::exec::test {
+
 class TaskTest : public HiveConnectorTestBase {
  protected:
   static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>

--- a/velox/exec/tests/ValuesTest.cpp
+++ b/velox/exec/tests/ValuesTest.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+using namespace facebook::velox;
+using exec::test::AssertQueryBuilder;
+
+namespace facebook::velox::exec::test {
+
+class ValuesTest : public OperatorTestBase {
+ protected:
+  // Sample row vectors.
+  RowVectorPtr input_{makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 2, 3, 5}),
+      makeFlatVector<StringView>({"a", "b", "c", "d", "e"}),
+      makeFlatVector<float>({0.1, 2.3, 4.5, 6.7, 8.9}),
+  })};
+
+  RowVectorPtr input2_{makeRowVector({
+      makeFlatVector<int32_t>({6, 7}),
+      makeFlatVector<StringView>({"f", "g"}),
+      makeFlatVector<float>({10.11, 12.13}),
+  })};
+};
+
+TEST_F(ValuesTest, empty) {
+  // Base case: no vectors.
+  AssertQueryBuilder(PlanBuilder().values({}).planNode())
+      .assertResults(std::vector<RowVectorPtr>{});
+
+  // Empty input vector.
+  auto emptyInput = makeRowVector({});
+  AssertQueryBuilder(PlanBuilder().values({emptyInput}).planNode())
+      .assertResults(std::vector<RowVectorPtr>{});
+
+  // Many empty vectors as input.
+  AssertQueryBuilder(
+      PlanBuilder().values({emptyInput, emptyInput, emptyInput}).planNode())
+      .assertResults(std::vector<RowVectorPtr>{});
+}
+
+TEST_F(ValuesTest, simple) {
+  // Single vector in, single vector out.
+  AssertQueryBuilder(PlanBuilder().values({input_}).planNode())
+      .assertResults({input_});
+
+  // 3 vectors in, 3 vectors out.
+  AssertQueryBuilder(PlanBuilder().values({input_, input_, input_}).planNode())
+      .assertResults({input_, input_, input_});
+
+  // Combine two different vectors.
+  AssertQueryBuilder(
+      PlanBuilder().values({input_, input2_, input2_, input_}).planNode())
+      .assertResults({input_, input2_, input2_, input_});
+}
+
+TEST_F(ValuesTest, valuesWithParallelism) {
+  // Parallelism true but single thread.
+  AssertQueryBuilder(PlanBuilder().values({input_}, true).planNode())
+      .assertResults({input_});
+
+  // 5 threads.
+  AssertQueryBuilder(PlanBuilder().values({input_}, true).planNode())
+      .maxDrivers(5)
+      .assertResults({input_, input_, input_, input_, input_});
+}
+
+TEST_F(ValuesTest, valuesWithRepeat) {
+  // Single vectors in with repeat, many vectors out.
+  AssertQueryBuilder(PlanBuilder().values({input_}, false, 2).planNode())
+      .assertResults({input_, input_});
+
+  AssertQueryBuilder(PlanBuilder().values({input_}, false, 7).planNode())
+      .assertResults({input_, input_, input_, input_, input_, input_, input_});
+
+  // Zero repeats.
+  AssertQueryBuilder(PlanBuilder().values({}, false, 0).planNode())
+      .assertResults(std::vector<RowVectorPtr>{});
+  AssertQueryBuilder(PlanBuilder().values({input_}, false, 0).planNode())
+      .assertResults(std::vector<RowVectorPtr>{});
+
+  // Try repeating with 2 different row vectors.
+  AssertQueryBuilder(
+      PlanBuilder().values({input_, input2_}, false, 3).planNode())
+      .assertResults({input_, input2_, input_, input2_, input_, input2_});
+}
+
+TEST_F(ValuesTest, valuesWithRepeatAndParallelism) {
+  // Two threads repeating twice each buffer.
+  AssertQueryBuilder(
+      PlanBuilder().values({input_, input2_}, true, 2).planNode())
+      .maxDrivers(2)
+      .assertResults(
+          {input_, input2_, input_, input2_, input_, input2_, input_, input2_});
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -163,10 +163,11 @@ PlanBuilder& PlanBuilder::tableScan(
 
 PlanBuilder& PlanBuilder::values(
     const std::vector<RowVectorPtr>& values,
-    bool parallelizable) {
+    bool parallelizable,
+    size_t repeatTimes) {
   auto valuesCopy = values;
   planNode_ = std::make_shared<core::ValuesNode>(
-      nextPlanNodeId(), std::move(valuesCopy), parallelizable);
+      nextPlanNodeId(), std::move(valuesCopy), parallelizable, repeatTimes);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -162,9 +162,15 @@ class PlanBuilder {
   /// @param parallelizable If true, ValuesNode can run multi-threaded, in which
   /// case it will produce duplicate data from each thread, e.g. each thread
   /// will return all the data in 'values'. Useful for testing.
+  /// @param repeatTimes The number of times data is produced as input. If
+  /// greater than one, each RowVector will produce data as input `repeatTimes`.
+  /// For example, in case `values` has 3 vectors {v1, v2, v3} and repeatTimes
+  /// is 2, the input produced will be {v1, v2, v3, v1, v2, v3}. Useful for
+  /// testing.
   PlanBuilder& values(
       const std::vector<RowVectorPtr>& values,
-      bool parallelizable = false);
+      bool parallelizable = false,
+      size_t repeatTimes = 1);
 
   /// Add an ExchangeNode.
   ///


### PR DESCRIPTION
Summary:
Adding an option to ValuesOperator that controls how many times the
input vectors are produced as output. This is useful, for example, to
continuously generate data for testing purposes.

Also refactoring some code and fixing failure for empty vectors.

Differential Revision: D43959501

