### PR TITLE
Enable INSERT INTO unpartitioned tables

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -52,4 +52,9 @@ uint32_t HiveConfig::maxPartitionsPerWriters(const Config* config) {
   return config->get<uint32_t>(kMaxPartitionsPerWriters, 100);
 }
 
+// static
+bool HiveConfig::immutablePartitions(const Config* config) {
+  return config->get<bool>(kImmutablePartitions, false);
+}
+
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -35,10 +35,16 @@ class HiveConfig {
   static constexpr const char* kMaxPartitionsPerWriters =
       "max_partitions_per_writers";
 
+  /// Whether new data can be inserted into an unpartition table.
+  /// Velox currently does not support appending data to existing partitions.
+  static constexpr const char* kImmutablePartitions = "immutable_partitions";
+
   static InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const Config* config);
 
   static uint32_t maxPartitionsPerWriters(const Config* config);
+
+  static bool immutablePartitions(const Config* config);
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -291,7 +291,10 @@ HiveWriterParameters::UpdateMode HiveDataSink::getUpdateMode() const {
           VELOX_UNSUPPORTED("Unsupported insert existing partitions behavior.");
       }
     } else {
-      VELOX_USER_FAIL("Unpartitioned Hive tables are immutable.");
+      if (HiveConfig::immutablePartitions(connectorQueryCtx_->config())) {
+        VELOX_USER_FAIL("Unpartitioned Hive tables are immutable.");
+      }
+      return HiveWriterParameters::UpdateMode::kAppend;
     }
   } else {
     return HiveWriterParameters::UpdateMode::kNew;

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -99,6 +99,8 @@ class HiveWriterParameters {
   enum class UpdateMode {
     kNew, // Write files to a new directory.
     kOverwrite, // Overwrite an existing directory.
+    // Append mode is currently only supported for unpartitioned tables.
+    kAppend, // Append to an unpartitioned table.
   };
 
   /// @param updateMode Write the files to a new directory, or append to an
@@ -138,6 +140,8 @@ class HiveWriterParameters {
         return "NEW";
       case UpdateMode::kOverwrite:
         return "OVERWRITE";
+      case UpdateMode::kAppend:
+        return "APPEND";
       default:
         VELOX_UNSUPPORTED("Unsupported update mode.");
     }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -179,6 +179,16 @@ sets the update mode to indicate overwriting a partition if exists.
 ``ERROR`` sets the update mode to indicate error throwing if writing
 to an existing partition.
 
+``immutable_partitions``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``bool``
+    * **Default value:** ``false``
+
+True if appending data to an existing unpartitioned table is allowed.
+Currently this configuration does not support appending to existing partitions.
+
+
 Spark-specific configuration
 ----------------------------
 


### PR DESCRIPTION
This PR adds a new configuration option `immutable_partitions` which is the same as `hive.immutable-partitions` in Presto and UpdateMode::kAppend.

This enables insert into unpartitioned tables, e.g. 
```sql
create table ivan_test (a int, b int);
insert into ivan_test values (1, 2), (3, 4);
```

Without the fix, insert would fail with (Presto Java runner works fine):
```
VeloxUserError:  Unpartitioned Hive tables are immutable.
```
