### PR TITLE
Fix reader crash when reading into lazy vector

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -553,8 +553,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
     velox::ContinueFuture& /*future*/) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
   if (emptySplit_) {
-    split_.reset();
-    // Keep readers around to hold adaptation.
+    resetSplit();
     return nullptr;
   }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2143,6 +2143,46 @@ TEST_F(TableScanTest, structLazy) {
   assertQuery(op, {filePath}, "select c0 % 3 from tmp");
 }
 
+TEST_F(TableScanTest, interleaveLazyEager) {
+  constexpr int kSize = 1000;
+  auto column = makeRowVector(
+      {makeFlatVector<int64_t>(kSize, folly::identity),
+       makeRowVector({makeFlatVector<int64_t>(kSize, folly::identity)})});
+  auto rows = makeRowVector({column});
+  auto rowType = asRowType(rows->type());
+  auto lazyFile = TempFilePath::create();
+  writeToFile(lazyFile->path, {rows});
+  auto rowsWithNulls = makeVectors(1, kSize, rowType);
+  int numNonNull = 0;
+  for (int i = 0; i < kSize; ++i) {
+    auto* c0 = rowsWithNulls[0]->childAt(0)->asUnchecked<RowVector>();
+    if (c0->isNullAt(i)) {
+      continue;
+    }
+    auto& c0c0 = c0->asUnchecked<RowVector>()->childAt(0);
+    numNonNull += !c0c0->isNullAt(i);
+  }
+  auto eagerFile = TempFilePath::create();
+  writeToFile(eagerFile->path, rowsWithNulls);
+  auto tableHandle = makeTableHandle(
+      SubfieldFiltersBuilder().add("c0.c0", isNotNull()).build());
+  ColumnHandleMap assignments = {{"c0", regularColumn("c0", column->type())}};
+  CursorParameters params;
+  params.planNode =
+      PlanBuilder().tableScan(rowType, tableHandle, assignments).planNode();
+  TaskCursor cursor(params);
+  cursor.task()->addSplit("0", makeHiveSplit(lazyFile->path));
+  cursor.task()->addSplit("0", makeHiveSplit(eagerFile->path));
+  cursor.task()->addSplit("0", makeHiveSplit(lazyFile->path));
+  cursor.task()->noMoreSplits("0");
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_TRUE(cursor.moveNext());
+    auto result = cursor.current();
+    ASSERT_EQ(result->size(), i % 2 == 0 ? kSize : numNonNull);
+  }
+  ASSERT_FALSE(cursor.moveNext());
+}
+
 TEST_F(TableScanTest, lazyVectorAccessTwiceWithDifferentRows) {
   auto data = makeRowVector({
       makeNullableFlatVector<int64_t>({1, 1, 1, std::nullopt}),

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1339,6 +1339,9 @@ void serializeColumn(
     case VectorEncoding::Simple::MAP:
       serializeMapVector(vector, ranges, stream);
       break;
+    case VectorEncoding::Simple::LAZY:
+      serializeColumn(vector->loadedVector(), ranges, stream);
+      break;
     default:
       serializeWrapped(vector, ranges, stream);
   }
@@ -1600,6 +1603,9 @@ void estimateSerializedSizeInt(
           arrayVector->elements().get(), childRanges, childSizes.data());
       break;
     }
+    case VectorEncoding::Simple::LAZY:
+      estimateSerializedSizeInt(vector->loadedVector(), ranges, sizes);
+      break;
     default:
       VELOX_CHECK(false, "Unsupported vector encoding {}", vector->encoding());
   }
@@ -1622,7 +1628,7 @@ class PrestoVectorSerializer : public VectorSerializer {
   }
 
   void append(
-      RowVectorPtr vector,
+      const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges) override {
     auto newRows = rangesTotalSize(ranges);
     if (newRows > 0) {

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -33,7 +33,7 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
       : pool_{streamArena->pool()} {}
 
   void append(
-      RowVectorPtr vector,
+      const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges) override {
     size_t totalSize = 0;
     for (auto& range : ranges) {

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -367,3 +367,14 @@ TEST_F(PrestoSerializerTest, rle) {
   testRleRoundTrip(BaseVector::createNullConstant(
       MAP(VARCHAR(), INTEGER()), 17, pool_.get()));
 }
+
+TEST_F(PrestoSerializerTest, lazy) {
+  constexpr int kSize = 1000;
+  auto rowVector = makeTestVector(kSize);
+  auto lazyVector = std::make_shared<LazyVector>(
+      pool_.get(),
+      rowVector->type(),
+      kSize,
+      std::make_unique<SimpleVectorLoader>([&](auto) { return rowVector; }));
+  testRoundTrip(lazyVector);
+}

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -378,6 +378,9 @@ class BaseVector {
       const vector_size_t* toSourceRow) {
     rows.applyToSelected([&](vector_size_t row) {
       auto sourceRow = toSourceRow ? toSourceRow[row] : row;
+      if (sourceRow >= source->size()) {
+        return;
+      }
       if (source->isNullAt(sourceRow)) {
         setNull(row, true);
       } else {

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -175,8 +175,10 @@ void FlatVector<T>::copyValuesAndNulls(
         }
       });
     } else {
-      VELOX_CHECK_GE(source->size(), rows.end());
       rows.applyToSelected([&](vector_size_t row) {
+        if (row >= source->size()) {
+          return;
+        }
         if (sourceValues) {
           rawValues_[row] = sourceValues[row];
         }

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -36,7 +36,7 @@ class VectorSerializer {
   virtual ~VectorSerializer() = default;
 
   virtual void append(
-      RowVectorPtr vector,
+      const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges) = 0;
 
   // Writes the contents to 'stream' in wire format


### PR DESCRIPTION
Summary: When we reading the struct column, sometimes we read them as lazy vector to facilitate late materialization.  In some cases we read them as lazy first, then in a subsequent stripe, the lazy condition is no longer satisfied and we need to read them eagerly.  In such cases the code did not check whether the result vector we write into is lazy or not, and caused crash because of this.  We takes care of such cases in the reader in this change.

Differential Revision: D43983549

