### PR TITLE
Adding date/date.h to get_deps (#6)

### DIFF
--- a/build/fbcode_builder/manifests/date
+++ b/build/fbcode_builder/manifests/date
@@ -1,0 +1,10 @@
+[manifest]
+name = date
+
+[download]
+url = https://github.com/HowardHinnant/date/archive/refs/tags/v3.0.1.tar.gz
+sha256 = 7a390f200f0ccd207e8cff6757e04817c1a0aec3e327b006b7eb451c57ee3538
+
+[build]
+builder = cmake
+subdir = date-3.0.1


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/crux/pull/6

X-link: https://github.com/facebook/openr/pull/144

X-link: https://github.com/facebookexperimental/edencommon/pull/7

X-link: https://github.com/facebook/wangle/pull/213

X-link: https://github.com/facebook/fboss/pull/135

X-link: https://github.com/facebook/watchman/pull/1108

X-link: https://github.com/facebook/proxygen/pull/441

Adding date/date.h github project to getdeps framework.

Reviewed By: fanzeyi

Differential Revision: D43285609

