### PR TITLE
Add 'prefix' to Presto function registration.

### DIFF
--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -88,6 +88,11 @@ class FunctionRegistry {
     return result;
   }
 
+  /// Used only in the unit tests.
+  void testingClear() {
+    registeredFunctions_.clear();
+  }
+
   std::vector<const FunctionSignature*> getFunctionSignatures(
       const std::string& name) const {
     std::vector<const FunctionSignature*> signatures;

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -450,12 +450,13 @@ bool registerApproxDistinct(
 
 } // namespace
 
-void registerApproxDistinctAggregates() {
+void registerApproxDistinctAggregates(const std::string& prefix) {
   registerType(
-      "hyperloglog", std::make_unique<const HyperLogLogTypeFactories>());
-  registerApproxDistinct(kApproxDistinct, false, false);
-  registerApproxDistinct(kApproxSet, true, false);
-  registerApproxDistinct(kMerge, true, true);
+      prefix + "hyperloglog",
+      std::make_unique<const HyperLogLogTypeFactories>());
+  registerApproxDistinct(prefix + kApproxDistinct, false, false);
+  registerApproxDistinct(prefix + kApproxSet, true, false);
+  registerApproxDistinct(prefix + kMerge, true, true);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -352,8 +352,8 @@ bool registerApproxMostFrequent(const std::string& name) {
 
 } // namespace
 
-void registerApproxMostFrequentAggregate() {
-  registerApproxMostFrequent(kApproxMostFrequent);
+void registerApproxMostFrequentAggregate(const std::string& prefix) {
+  registerApproxMostFrequent(prefix + kApproxMostFrequent);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -798,8 +798,8 @@ bool registerApproxPercentile(const std::string& name) {
 
 } // namespace
 
-void registerApproxPercentileAggregate() {
-  registerApproxPercentile(kApproxPercentile);
+void registerApproxPercentileAggregate(const std::string& prefix) {
+  registerApproxPercentile(prefix + kApproxPercentile);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -253,7 +253,7 @@ class NonNumericArbitrary : public exec::Aggregate {
   }
 };
 
-bool registerArbitraryAggregate(const std::string& name) {
+bool registerArbitrary(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -310,8 +310,8 @@ bool registerArbitraryAggregate(const std::string& name) {
 
 } // namespace
 
-void registerArbitraryAggregate() {
-  registerArbitraryAggregate(kArbitrary);
+void registerArbitraryAggregate(const std::string& prefix) {
+  registerArbitrary(prefix + kArbitrary);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -169,7 +169,7 @@ class ArrayAggAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-bool registerArrayAggregate(const std::string& name) {
+bool registerArray(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
@@ -194,8 +194,8 @@ bool registerArrayAggregate(const std::string& name) {
 
 } // namespace
 
-void registerArrayAggregate() {
-  registerArrayAggregate(kArrayAgg);
+void registerArrayAggregate(const std::string& prefix) {
+  registerArray(prefix + kArrayAgg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -321,7 +321,7 @@ class DecimalAverageAggregate : public DecimalAggregate<TUnscaledType> {
   }
 };
 
-bool registerAverageAggregate(const std::string& name) {
+bool registerAverage(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"smallint", "integer", "bigint", "double"}) {
@@ -428,8 +428,8 @@ bool registerAverageAggregate(const std::string& name) {
 
 } // namespace
 
-void registerAverageAggregate() {
-  registerAverageAggregate(kAvg);
+void registerAverageAggregate(const std::string& prefix) {
+  registerAverage(prefix + kAvg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -148,7 +148,7 @@ class BitwiseAndAggregate : public BitwiseAndOrAggregate<T> {
 };
 
 template <template <typename U> class T>
-bool registerBitwiseAggregate(const std::string& name) {
+bool registerBitwise(const std::string& name) {
   // TODO Fix the signatures to match Presto.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& inputType : {"tinyint", "smallint", "integer", "bigint"}) {
@@ -190,9 +190,9 @@ bool registerBitwiseAggregate(const std::string& name) {
 
 } // namespace
 
-void registerBitwiseAggregates() {
-  registerBitwiseAggregate<BitwiseOrAggregate>(kBitwiseOr);
-  registerBitwiseAggregate<BitwiseAndAggregate>(kBitwiseAnd);
+void registerBitwiseAggregates(const std::string& prefix) {
+  registerBitwise<BitwiseOrAggregate>(prefix + kBitwiseOr);
+  registerBitwise<BitwiseAndAggregate>(prefix + kBitwiseAnd);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -177,7 +177,7 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 };
 
 template <class T>
-bool registerBoolAggregate(const std::string& name) {
+bool registerBool(const std::string& name) {
   // TODO Fix signature to match Presto.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
@@ -209,10 +209,10 @@ bool registerBoolAggregate(const std::string& name) {
 
 } // namespace
 
-void registerBoolAggregates() {
-  registerBoolAggregate<BoolAndAggregate>(kBoolAnd);
-  registerBoolAggregate<BoolAndAggregate>(kEvery);
-  registerBoolAggregate<BoolOrAggregate>(kBoolOr);
+void registerBoolAggregates(const std::string& prefix) {
+  registerBool<BoolAndAggregate>(prefix + kBoolAnd);
+  registerBool<BoolAndAggregate>(prefix + kEvery);
+  registerBool<BoolOrAggregate>(prefix + kBoolOr);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -207,7 +207,7 @@ class ChecksumAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-bool registerChecksumAggregate(const std::string& name) {
+bool registerChecksum(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -238,8 +238,8 @@ bool registerChecksumAggregate(const std::string& name) {
 
 } // namespace
 
-void registerChecksumAggregate() {
-  registerChecksumAggregate(kChecksum);
+void registerChecksumAggregate(const std::string& prefix) {
+  registerChecksum(prefix + kChecksum);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -146,7 +146,7 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
   DecodedVector decodedIntermediate_;
 };
 
-bool registerCountAggregate(const std::string& name) {
+bool registerCount(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -177,8 +177,8 @@ bool registerCountAggregate(const std::string& name) {
 
 } // namespace
 
-void registerCountAggregate() {
-  registerCountAggregate(kCount);
+void registerCountAggregate(const std::string& prefix) {
+  registerCount(prefix + kCount);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -168,7 +168,7 @@ class CountIfAggregate : public exec::Aggregate {
   }
 };
 
-bool registerCountIfAggregate(const std::string& name) {
+bool registerCountIf(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -203,8 +203,8 @@ bool registerCountIfAggregate(const std::string& name) {
 
 } // namespace
 
-void registerCountIfAggregate() {
-  registerCountIfAggregate(kCountIf);
+void registerCountIfAggregate(const std::string& prefix) {
+  registerCountIf(prefix + kCountIf);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -447,7 +447,7 @@ template <
     typename TIntermediateInput,
     typename TIntermediateResult,
     typename TResultAccessor>
-bool registerCovarianceAggregate(const std::string& name) {
+bool registerCovariance(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       // (double, double) -> double
       exec::AggregateFunctionSignatureBuilder()
@@ -499,22 +499,22 @@ bool registerCovarianceAggregate(const std::string& name) {
 
 } // namespace
 
-void registerCovarianceAggregates() {
-  registerCovarianceAggregate<
+void registerCovarianceAggregates(const std::string& prefix) {
+  registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarPopResultAccessor>(kCovarPop);
-  registerCovarianceAggregate<
+      CovarPopResultAccessor>(prefix + kCovarPop);
+  registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarSampResultAccessor>(kCovarSamp);
-  registerCovarianceAggregate<
+      CovarSampResultAccessor>(prefix + kCovarSamp);
+  registerCovariance<
       CorrAccumulator,
       CorrIntermediateInput,
       CorrIntermediateResult,
-      CorrResultAccessor>(kCorr);
+      CorrResultAccessor>(prefix + kCorr);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -221,7 +221,7 @@ class HistogramAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-bool registerHistogramAggregate(const std::string& name) {
+bool registerHistogram(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -279,8 +279,8 @@ bool registerHistogramAggregate(const std::string& name) {
 
 } // namespace
 
-void registerHistogramAggregate() {
-  registerHistogramAggregate(kHistogram);
+void registerHistogramAggregate(const std::string& prefix) {
+  registerHistogram(prefix + kHistogram);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -68,7 +68,7 @@ class MapAggAggregate : public aggregate::MapAggregateBase {
   }
 };
 
-bool registerMapAggAggregate(const std::string& name) {
+bool registerMapAgg(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .knownTypeVariable("K")
@@ -99,8 +99,8 @@ bool registerMapAggAggregate(const std::string& name) {
 
 } // namespace
 
-void registerMapAggAggregate() {
-  registerMapAggAggregate(kMapAgg);
+void registerMapAggAggregate(const std::string& prefix) {
+  registerMapAgg(prefix + kMapAgg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -42,7 +42,7 @@ class MapUnionAggregate : public aggregate::MapAggregateBase {
   }
 };
 
-bool registerMapUnionAggregate(const std::string& name) {
+bool registerMapUnion(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .knownTypeVariable("K")
@@ -71,8 +71,8 @@ bool registerMapUnionAggregate(const std::string& name) {
 
 } // namespace
 
-void registerMapUnionAggregate() {
-  registerMapUnionAggregate(kMapUnion);
+void registerMapUnionAggregate(const std::string& prefix) {
+  registerMapUnion(prefix + kMapUnion);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -201,7 +201,7 @@ class MaxSizeForStatsAggregate
   }
 };
 
-bool registerMaxSizeForStatsAggregate(const std::string& name) {
+bool registerMaxSizeForStats(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -227,8 +227,8 @@ bool registerMaxSizeForStatsAggregate(const std::string& name) {
 
 } // namespace
 
-void registerMaxSizeForStatsAggregate() {
-  registerMaxSizeForStatsAggregate(kMaxSizeForStats);
+void registerMaxSizeForStatsAggregate(const std::string& prefix) {
+  registerMaxSizeForStats(prefix + kMaxSizeForStats);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -459,7 +459,7 @@ class NonNumericMinAggregate : public NonNumericMinMaxAggregateBase {
 };
 
 template <template <typename T> class TNumeric, typename TNonNumeric>
-bool registerMinMaxAggregate(const std::string& name) {
+bool registerMinMax(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .typeVariable("T")
@@ -515,9 +515,9 @@ bool registerMinMaxAggregate(const std::string& name) {
 
 } // namespace
 
-void registerMinMaxAggregates() {
-  registerMinMaxAggregate<MinAggregate, NonNumericMinAggregate>(kMin);
-  registerMinMaxAggregate<MaxAggregate, NonNumericMaxAggregate>(kMax);
+void registerMinMaxAggregates(const std::string& prefix) {
+  registerMinMax<MinAggregate, NonNumericMinAggregate>(prefix + kMin);
+  registerMinMax<MaxAggregate, NonNumericMaxAggregate>(prefix + kMax);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -645,7 +645,7 @@ std::unique_ptr<exec::Aggregate> create(
 }
 
 template <template <typename U, typename V> class Aggregate>
-bool registerMinMaxByAggregate(const std::string& name) {
+bool registerMinMaxBy(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& valueType :
        {"tinyint",
@@ -746,9 +746,9 @@ bool registerMinMaxByAggregate(const std::string& name) {
 
 } // namespace
 
-void registerMinMaxByAggregates() {
-  registerMinMaxByAggregate<MaxByAggregate>(kMaxBy);
-  registerMinMaxByAggregate<MinByAggregate>(kMinBy);
+void registerMinMaxByAggregates(const std::string& prefix) {
+  registerMinMaxBy<MaxByAggregate>(prefix + kMaxBy);
+  registerMinMaxBy<MinByAggregate>(prefix + kMinBy);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -17,48 +17,48 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-extern void registerApproxDistinctAggregates();
-extern void registerApproxMostFrequentAggregate();
-extern void registerApproxPercentileAggregate();
-extern void registerArbitraryAggregate();
-extern void registerArrayAggregate();
-extern void registerAverageAggregate();
-extern void registerBitwiseAggregates();
-extern void registerBoolAggregates();
-extern void registerChecksumAggregate();
-extern void registerCountAggregate();
-extern void registerCountIfAggregate();
-extern void registerCovarianceAggregates();
-extern void registerHistogramAggregate();
-extern void registerMapAggAggregate();
-extern void registerMapUnionAggregate();
-extern void registerMaxSizeForStatsAggregate();
-extern void registerMinMaxAggregates();
-extern void registerMinMaxByAggregates();
-extern void registerSumAggregate();
-extern void registerVarianceAggregates();
+extern void registerApproxDistinctAggregates(const std::string& prefix);
+extern void registerApproxMostFrequentAggregate(const std::string& prefix);
+extern void registerApproxPercentileAggregate(const std::string& prefix);
+extern void registerArbitraryAggregate(const std::string& prefix);
+extern void registerArrayAggregate(const std::string& prefix);
+extern void registerAverageAggregate(const std::string& prefix);
+extern void registerBitwiseAggregates(const std::string& prefix);
+extern void registerBoolAggregates(const std::string& prefix);
+extern void registerChecksumAggregate(const std::string& prefix);
+extern void registerCountAggregate(const std::string& prefix);
+extern void registerCountIfAggregate(const std::string& prefix);
+extern void registerCovarianceAggregates(const std::string& prefix);
+extern void registerHistogramAggregate(const std::string& prefix);
+extern void registerMapAggAggregate(const std::string& prefix);
+extern void registerMapUnionAggregate(const std::string& prefix);
+extern void registerMaxSizeForStatsAggregate(const std::string& prefix);
+extern void registerMinMaxAggregates(const std::string& prefix);
+extern void registerMinMaxByAggregates(const std::string& prefix);
+extern void registerSumAggregate(const std::string& prefix);
+extern void registerVarianceAggregates(const std::string& prefix);
 
-void registerAllAggregateFunctions() {
-  registerApproxDistinctAggregates();
-  registerApproxMostFrequentAggregate();
-  registerApproxPercentileAggregate();
-  registerArbitraryAggregate();
-  registerArrayAggregate();
-  registerAverageAggregate();
-  registerBitwiseAggregates();
-  registerBoolAggregates();
-  registerChecksumAggregate();
-  registerCountAggregate();
-  registerCountIfAggregate();
-  registerCovarianceAggregates();
-  registerHistogramAggregate();
-  registerMapAggAggregate();
-  registerMapUnionAggregate();
-  registerMaxSizeForStatsAggregate();
-  registerMinMaxAggregates();
-  registerMinMaxByAggregates();
-  registerSumAggregate();
-  registerVarianceAggregates();
+void registerAllAggregateFunctions(const std::string& prefix) {
+  registerApproxDistinctAggregates(prefix);
+  registerApproxMostFrequentAggregate(prefix);
+  registerApproxPercentileAggregate(prefix);
+  registerArbitraryAggregate(prefix);
+  registerArrayAggregate(prefix);
+  registerAverageAggregate(prefix);
+  registerBitwiseAggregates(prefix);
+  registerBoolAggregates(prefix);
+  registerChecksumAggregate(prefix);
+  registerCountAggregate(prefix);
+  registerCountIfAggregate(prefix);
+  registerCovarianceAggregates(prefix);
+  registerHistogramAggregate(prefix);
+  registerMapAggAggregate(prefix);
+  registerMapUnionAggregate(prefix);
+  registerMaxSizeForStatsAggregate(prefix);
+  registerMinMaxAggregates(prefix);
+  registerMinMaxByAggregates(prefix);
+  registerSumAggregate(prefix);
+  registerVarianceAggregates(prefix);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include <string>
+
 namespace facebook::velox::aggregate::prestosql {
-void registerAllAggregateFunctions();
+void registerAllAggregateFunctions(const std::string& prefix = "");
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -18,8 +18,8 @@
 
 namespace facebook::velox::aggregate::prestosql {
 
-void registerSumAggregate() {
-  registerSumAggregate<SumAggregate>(kSum);
+void registerSumAggregate(const std::string& prefix) {
+  registerSum<SumAggregate>(prefix + kSum);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -194,7 +194,7 @@ class DecimalSumAggregate
 };
 
 template <template <typename U, typename V, typename W> class T>
-bool registerSumAggregate(const std::string& name) {
+bool registerSum(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -460,7 +460,7 @@ void checkSumCountRowType(
 }
 
 template <template <typename TInput> class TClass>
-bool registerVarianceAggregate(const std::string& name) {
+bool registerVariance(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {
       "smallint", "integer", "bigint", "real", "double"};
@@ -512,13 +512,13 @@ bool registerVarianceAggregate(const std::string& name) {
 
 } // namespace
 
-void registerVarianceAggregates() {
-  registerVarianceAggregate<StdDevSampAggregate>(kStdDev);
-  registerVarianceAggregate<StdDevPopAggregate>(kStdDevPop);
-  registerVarianceAggregate<StdDevSampAggregate>(kStdDevSamp);
-  registerVarianceAggregate<VarSampAggregate>(kVariance);
-  registerVarianceAggregate<VarPopAggregate>(kVarPop);
-  registerVarianceAggregate<VarSampAggregate>(kVarSamp);
+void registerVarianceAggregates(const std::string& prefix) {
+  registerVariance<StdDevSampAggregate>(prefix + kStdDev);
+  registerVariance<StdDevPopAggregate>(prefix + kStdDevPop);
+  registerVariance<StdDevSampAggregate>(prefix + kStdDevSamp);
+  registerVariance<VarSampAggregate>(prefix + kVariance);
+  registerVariance<VarPopAggregate>(prefix + kVarPop);
+  registerVariance<VarSampAggregate>(prefix + kVarSamp);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AggregationFunctionRegTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+
+namespace facebook::velox::aggregate::test {
+
+class AggregationFunctionRegTest : public testing::Test {};
+
+TEST_F(AggregationFunctionRegTest, prefix) {
+  // Remove all functions and check for no entries.
+  exec::aggregateFunctions().clear();
+  EXPECT_EQ(0, exec::aggregateFunctions().size());
+
+  // Register without prefix and memorize function maps.
+  aggregate::prestosql::registerAllAggregateFunctions();
+  const auto aggrFuncMapBase = exec::aggregateFunctions();
+
+  // Remove all functions and check for no entries.
+  exec::aggregateFunctions().clear();
+  EXPECT_EQ(0, exec::aggregateFunctions().size());
+
+  // Register with prefix and check all functions have the prefix.
+  const std::string prefix{"test.abc_schema."};
+  aggregate::prestosql::registerAllAggregateFunctions(prefix);
+  auto& aggrFuncMap = exec::aggregateFunctions();
+  for (const auto& entry : aggrFuncMap) {
+    EXPECT_EQ(prefix, entry.first.substr(0, prefix.size()));
+    EXPECT_EQ(1, aggrFuncMapBase.count(entry.first.substr(prefix.size())));
+  }
+}
+
+} // namespace facebook::velox::aggregate::test

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(velox_aggregates_test_lib velox_exec_test_lib)
 
 add_executable(
   velox_aggregates_test
+  AggregationFunctionRegTest.cpp
   ApproxDistinctTest.cpp
   ApproxMostFrequentTest.cpp
   ApproxPercentileTest.cpp

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -22,83 +22,94 @@
 namespace facebook::velox::functions {
 
 namespace {
-void registerSimpleFunctions() {
-  registerBinaryFloatingPoint<PlusFunction>({"plus"});
-  registerBinaryFloatingPoint<MinusFunction>({"minus"});
-  registerBinaryFloatingPoint<MultiplyFunction>({"multiply"});
-  registerBinaryFloatingPoint<DivideFunction>({"divide"});
-  registerBinaryFloatingPoint<ModulusFunction>({"mod"});
-  registerUnaryNumeric<CeilFunction>({"ceil", "ceiling"});
-  registerUnaryNumeric<FloorFunction>({"floor"});
-  registerUnaryNumeric<AbsFunction>({"abs"});
-  registerUnaryFloatingPoint<NegateFunction>({"negate"});
-  registerFunction<RadiansFunction, double, double>({"radians"});
-  registerFunction<DegreesFunction, double, double>({"degrees"});
-  registerUnaryNumeric<RoundFunction>({"round"});
-  registerFunction<RoundFunction, int8_t, int8_t, int32_t>({"round"});
-  registerFunction<RoundFunction, int16_t, int16_t, int32_t>({"round"});
-  registerFunction<RoundFunction, int32_t, int32_t, int32_t>({"round"});
-  registerFunction<RoundFunction, int64_t, int64_t, int32_t>({"round"});
-  registerFunction<RoundFunction, double, double, int32_t>({"round"});
-  registerFunction<RoundFunction, float, float, int32_t>({"round"});
-  registerFunction<PowerFunction, double, double, double>({"power", "pow"});
-  registerFunction<PowerFunction, double, int64_t, int64_t>({"power", "pow"});
-  registerFunction<ExpFunction, double, double>({"exp"});
-  registerFunction<ClampFunction, int8_t, int8_t, int8_t, int8_t>({"clamp"});
+void registerSimpleFunctions(const std::string& prefix) {
+  registerBinaryFloatingPoint<PlusFunction>({prefix + "plus"});
+  registerBinaryFloatingPoint<MinusFunction>({prefix + "minus"});
+  registerBinaryFloatingPoint<MultiplyFunction>({prefix + "multiply"});
+  registerBinaryFloatingPoint<DivideFunction>({prefix + "divide"});
+  registerBinaryFloatingPoint<ModulusFunction>({prefix + "mod"});
+  registerUnaryNumeric<CeilFunction>({prefix + "ceil", prefix + "ceiling"});
+  registerUnaryNumeric<FloorFunction>({prefix + "floor"});
+  registerUnaryNumeric<AbsFunction>({prefix + "abs"});
+  registerUnaryFloatingPoint<NegateFunction>({prefix + "negate"});
+  registerFunction<RadiansFunction, double, double>({prefix + "radians"});
+  registerFunction<DegreesFunction, double, double>({prefix + "degrees"});
+  registerUnaryNumeric<RoundFunction>({prefix + "round"});
+  registerFunction<RoundFunction, int8_t, int8_t, int32_t>({prefix + "round"});
+  registerFunction<RoundFunction, int16_t, int16_t, int32_t>(
+      {prefix + "round"});
+  registerFunction<RoundFunction, int32_t, int32_t, int32_t>(
+      {prefix + "round"});
+  registerFunction<RoundFunction, int64_t, int64_t, int32_t>(
+      {prefix + "round"});
+  registerFunction<RoundFunction, double, double, int32_t>({prefix + "round"});
+  registerFunction<RoundFunction, float, float, int32_t>({prefix + "round"});
+  registerFunction<PowerFunction, double, double, double>(
+      {prefix + "power", prefix + "pow"});
+  registerFunction<PowerFunction, double, int64_t, int64_t>(
+      {prefix + "power", prefix + "pow"});
+  registerFunction<ExpFunction, double, double>({prefix + "exp"});
+  registerFunction<ClampFunction, int8_t, int8_t, int8_t, int8_t>(
+      {prefix + "clamp"});
   registerFunction<ClampFunction, int16_t, int16_t, int16_t, int16_t>(
-      {"clamp"});
+      {prefix + "clamp"});
   registerFunction<ClampFunction, int32_t, int32_t, int32_t, int32_t>(
-      {"clamp"});
+      {prefix + "clamp"});
   registerFunction<ClampFunction, int64_t, int64_t, int64_t, int64_t>(
-      {"clamp"});
-  registerFunction<ClampFunction, double, double, double, double>({"clamp"});
-  registerFunction<ClampFunction, float, float, float, float>({"clamp"});
-  registerFunction<LnFunction, double, double>({"ln"});
-  registerFunction<Log2Function, double, double>({"log2"});
-  registerFunction<Log10Function, double, double>({"log10"});
-  registerFunction<CosFunction, double, double>({"cos"});
-  registerFunction<CoshFunction, double, double>({"cosh"});
-  registerFunction<AcosFunction, double, double>({"acos"});
-  registerFunction<SinFunction, double, double>({"sin"});
-  registerFunction<AsinFunction, double, double>({"asin"});
-  registerFunction<TanFunction, double, double>({"tan"});
-  registerFunction<TanhFunction, double, double>({"tanh"});
-  registerFunction<AtanFunction, double, double>({"atan"});
-  registerFunction<Atan2Function, double, double, double>({"atan2"});
-  registerFunction<SqrtFunction, double, double>({"sqrt"});
-  registerFunction<CbrtFunction, double, double>({"cbrt"});
+      {prefix + "clamp"});
+  registerFunction<ClampFunction, double, double, double, double>(
+      {prefix + "clamp"});
+  registerFunction<ClampFunction, float, float, float, float>(
+      {prefix + "clamp"});
+  registerFunction<LnFunction, double, double>({prefix + "ln"});
+  registerFunction<Log2Function, double, double>({prefix + "log2"});
+  registerFunction<Log10Function, double, double>({prefix + "log10"});
+  registerFunction<CosFunction, double, double>({prefix + "cos"});
+  registerFunction<CoshFunction, double, double>({prefix + "cosh"});
+  registerFunction<AcosFunction, double, double>({prefix + "acos"});
+  registerFunction<SinFunction, double, double>({prefix + "sin"});
+  registerFunction<AsinFunction, double, double>({prefix + "asin"});
+  registerFunction<TanFunction, double, double>({prefix + "tan"});
+  registerFunction<TanhFunction, double, double>({prefix + "tanh"});
+  registerFunction<AtanFunction, double, double>({prefix + "atan"});
+  registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
+  registerFunction<SqrtFunction, double, double>({prefix + "sqrt"});
+  registerFunction<CbrtFunction, double, double>({prefix + "cbrt"});
   registerFunction<
       WidthBucketFunction,
       int64_t,
       double,
       double,
       double,
-      int64_t>({"width_bucket"});
+      int64_t>({prefix + "width_bucket"});
 
-  registerUnaryNumeric<SignFunction>({"sign"});
-  registerFunction<InfinityFunction, double>({"infinity"});
-  registerFunction<IsFiniteFunction, bool, double>({"is_finite"});
-  registerFunction<IsInfiniteFunction, bool, double>({"is_infinite"});
-  registerFunction<IsNanFunction, bool, double>({"is_nan"});
-  registerFunction<NanFunction, double>({"nan"});
-  registerFunction<RandFunction, double>({"rand", "random"});
-  registerFunction<FromBaseFunction, int64_t, Varchar, int64_t>({"from_base"});
-  registerFunction<ToBaseFunction, Varchar, int64_t, int64_t>({"to_base"});
-  registerFunction<PiFunction, double>({"pi"});
-  registerFunction<EulerConstantFunction, double>({"e"});
-  registerFunction<TruncateFunction, double, double>({"truncate"});
-  registerFunction<TruncateFunction, double, double, int32_t>({"truncate"});
+  registerUnaryNumeric<SignFunction>({prefix + "sign"});
+  registerFunction<InfinityFunction, double>({prefix + "infinity"});
+  registerFunction<IsFiniteFunction, bool, double>({prefix + "is_finite"});
+  registerFunction<IsInfiniteFunction, bool, double>({prefix + "is_infinite"});
+  registerFunction<IsNanFunction, bool, double>({prefix + "is_nan"});
+  registerFunction<NanFunction, double>({prefix + "nan"});
+  registerFunction<RandFunction, double>({prefix + "rand", prefix + "random"});
+  registerFunction<FromBaseFunction, int64_t, Varchar, int64_t>(
+      {prefix + "from_base"});
+  registerFunction<ToBaseFunction, Varchar, int64_t, int64_t>(
+      {prefix + "to_base"});
+  registerFunction<PiFunction, double>({prefix + "pi"});
+  registerFunction<EulerConstantFunction, double>({prefix + "e"});
+  registerFunction<TruncateFunction, double, double>({prefix + "truncate"});
+  registerFunction<TruncateFunction, double, double, int32_t>(
+      {prefix + "truncate"});
 }
 
 } // namespace
 
-void registerArithmeticFunctions() {
-  registerSimpleFunctions();
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_not, "not");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_add, "plus");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_sub, "minus");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, "multiply");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, "divide");
+void registerArithmeticFunctions(const std::string& prefix = "") {
+  registerSimpleFunctions(prefix);
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_not, prefix + "not");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_add, prefix + "plus");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_sub, prefix + "minus");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, prefix + "multiply");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -21,127 +21,131 @@
 
 namespace facebook::velox::functions {
 template <typename T>
-inline void registerArrayMinMaxFunctions() {
-  registerFunction<ArrayMinFunction, T, Array<T>>({"array_min"});
-  registerFunction<ArrayMaxFunction, T, Array<T>>({"array_max"});
+inline void registerArrayMinMaxFunctions(const std::string& prefix) {
+  registerFunction<ArrayMinFunction, T, Array<T>>({prefix + "array_min"});
+  registerFunction<ArrayMaxFunction, T, Array<T>>({prefix + "array_max"});
 }
 
 template <typename T>
-inline void registerArrayJoinFunctions() {
+inline void registerArrayJoinFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayJoinFunction, T>,
       Varchar,
       Array<T>,
-      Varchar>({"array_join"});
+      Varchar>({prefix + "array_join"});
 
   registerFunction<
       ParameterBinder<ArrayJoinFunction, T>,
       Varchar,
       Array<T>,
       Varchar,
-      Varchar>({"array_join"});
+      Varchar>({prefix + "array_join"});
 }
 
 template <typename T>
-inline void registerArrayCombinationsFunctions() {
+inline void registerArrayCombinationsFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<CombinationsFunction, T>,
       Array<Array<T>>,
       Array<T>,
-      int64_t>({"combinations"});
+      int64_t>({prefix + "combinations"});
 }
 
 template <typename T>
-inline void registerArrayHasDuplicatesFunctions() {
+inline void registerArrayHasDuplicatesFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayHasDuplicatesFunction, T>,
       bool,
-      Array<T>>({"array_has_duplicates"});
+      Array<T>>({prefix + "array_has_duplicates"});
 }
 
 template <typename T>
-inline void registerArrayFrequencyFunctions() {
+inline void registerArrayFrequencyFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayFrequencyFunction, T>,
       Map<T, int>,
-      Array<T>>({"array_frequency"});
+      Array<T>>({prefix + "array_frequency"});
 }
 
 template <typename T>
-inline void registerArrayNormalizeFunctions() {
+inline void registerArrayNormalizeFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayNormalizeFunction, T>,
       Array<T>,
       Array<T>,
-      T>({"array_normalize"});
+      T>({prefix + "array_normalize"});
 }
 
-void registerArrayFunctions() {
-  registerArrayConstructor("array_constructor");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, "array_distinct");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_duplicates, "array_duplicates");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_intersect, "array_intersect");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_contains, "contains");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, "array_except");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, "arrays_overlap");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_slice, "slice");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, "zip");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_zip_with, "zip_with");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, "array_position");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_shuffle, "shuffle");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, "array_sort");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, "array_sum");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, "repeat");
+void registerArrayFunctions(const std::string& prefix) {
+  registerArrayConstructor(prefix + "array_constructor");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_distinct, prefix + "array_distinct");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_array_duplicates, prefix + "array_duplicates");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_array_intersect, prefix + "array_intersect");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_contains, prefix + "contains");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_except, prefix + "array_except");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_arrays_overlap, prefix + "arrays_overlap");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_slice, prefix + "slice");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_zip, prefix + "zip");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_shuffle, prefix + "shuffle");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, prefix + "array_sort");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, prefix + "repeat");
 
   exec::registerStatefulVectorFunction(
-      "width_bucket", widthBucketArraySignature(), makeWidthBucketArray);
+      prefix + "width_bucket",
+      widthBucketArraySignature(),
+      makeWidthBucketArray);
 
-  registerArrayMinMaxFunctions<int8_t>();
-  registerArrayMinMaxFunctions<int16_t>();
-  registerArrayMinMaxFunctions<int32_t>();
-  registerArrayMinMaxFunctions<int64_t>();
-  registerArrayMinMaxFunctions<float>();
-  registerArrayMinMaxFunctions<double>();
-  registerArrayMinMaxFunctions<bool>();
-  registerArrayMinMaxFunctions<Varchar>();
-  registerArrayMinMaxFunctions<Timestamp>();
-  registerArrayMinMaxFunctions<Date>();
+  registerArrayMinMaxFunctions<int8_t>(prefix);
+  registerArrayMinMaxFunctions<int16_t>(prefix);
+  registerArrayMinMaxFunctions<int32_t>(prefix);
+  registerArrayMinMaxFunctions<int64_t>(prefix);
+  registerArrayMinMaxFunctions<float>(prefix);
+  registerArrayMinMaxFunctions<double>(prefix);
+  registerArrayMinMaxFunctions<bool>(prefix);
+  registerArrayMinMaxFunctions<Varchar>(prefix);
+  registerArrayMinMaxFunctions<Timestamp>(prefix);
+  registerArrayMinMaxFunctions<Date>(prefix);
 
-  registerArrayJoinFunctions<int8_t>();
-  registerArrayJoinFunctions<int16_t>();
-  registerArrayJoinFunctions<int32_t>();
-  registerArrayJoinFunctions<int64_t>();
-  registerArrayJoinFunctions<float>();
-  registerArrayJoinFunctions<double>();
-  registerArrayJoinFunctions<bool>();
-  registerArrayJoinFunctions<Varchar>();
-  registerArrayJoinFunctions<Timestamp>();
-  registerArrayJoinFunctions<Date>();
+  registerArrayJoinFunctions<int8_t>(prefix);
+  registerArrayJoinFunctions<int16_t>(prefix);
+  registerArrayJoinFunctions<int32_t>(prefix);
+  registerArrayJoinFunctions<int64_t>(prefix);
+  registerArrayJoinFunctions<float>(prefix);
+  registerArrayJoinFunctions<double>(prefix);
+  registerArrayJoinFunctions<bool>(prefix);
+  registerArrayJoinFunctions<Varchar>(prefix);
+  registerArrayJoinFunctions<Timestamp>(prefix);
+  registerArrayJoinFunctions<Date>(prefix);
 
   registerFunction<ArrayAverageFunction, double, Array<double>>(
-      {"array_average"});
+      {prefix + "array_average"});
 
-  registerArrayCombinationsFunctions<int8_t>();
-  registerArrayCombinationsFunctions<int16_t>();
-  registerArrayCombinationsFunctions<int32_t>();
-  registerArrayCombinationsFunctions<int64_t>();
-  registerArrayCombinationsFunctions<float>();
-  registerArrayCombinationsFunctions<double>();
-  registerArrayCombinationsFunctions<bool>();
-  registerArrayCombinationsFunctions<Varchar>();
-  registerArrayCombinationsFunctions<Timestamp>();
-  registerArrayCombinationsFunctions<Date>();
+  registerArrayCombinationsFunctions<int8_t>(prefix);
+  registerArrayCombinationsFunctions<int16_t>(prefix);
+  registerArrayCombinationsFunctions<int32_t>(prefix);
+  registerArrayCombinationsFunctions<int64_t>(prefix);
+  registerArrayCombinationsFunctions<float>(prefix);
+  registerArrayCombinationsFunctions<double>(prefix);
+  registerArrayCombinationsFunctions<bool>(prefix);
+  registerArrayCombinationsFunctions<Varchar>(prefix);
+  registerArrayCombinationsFunctions<Timestamp>(prefix);
+  registerArrayCombinationsFunctions<Date>(prefix);
 
-  registerArrayHasDuplicatesFunctions<int8_t>();
-  registerArrayHasDuplicatesFunctions<int16_t>();
-  registerArrayHasDuplicatesFunctions<int32_t>();
-  registerArrayHasDuplicatesFunctions<int64_t>();
-  registerArrayHasDuplicatesFunctions<Varchar>();
+  registerArrayHasDuplicatesFunctions<int8_t>(prefix);
+  registerArrayHasDuplicatesFunctions<int16_t>(prefix);
+  registerArrayHasDuplicatesFunctions<int32_t>(prefix);
+  registerArrayHasDuplicatesFunctions<int64_t>(prefix);
+  registerArrayHasDuplicatesFunctions<Varchar>(prefix);
 
-  registerArrayFrequencyFunctions<int64_t>();
-  registerArrayFrequencyFunctions<Varchar>();
+  registerArrayFrequencyFunctions<int64_t>(prefix);
+  registerArrayFrequencyFunctions<Varchar>(prefix);
 
-  registerArrayNormalizeFunctions<float>();
-  registerArrayNormalizeFunctions<double>();
+  registerArrayNormalizeFunctions<float>(prefix);
+  registerArrayNormalizeFunctions<double>(prefix);
 }
 }; // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
@@ -36,32 +36,32 @@ void registerBitwiseUnaryIntegral(const std::vector<std::string>& aliases) {
 }
 } // namespace
 
-void registerBitwiseFunctions() {
-  registerBitwiseBinaryIntegral<BitwiseAndFunction>({"bitwise_and"});
-  registerBitwiseUnaryIntegral<BitwiseNotFunction>({"bitwise_not"});
-  registerBitwiseBinaryIntegral<BitwiseOrFunction>({"bitwise_or"});
-  registerBitwiseBinaryIntegral<BitwiseXorFunction>({"bitwise_xor"});
-  registerBitwiseBinaryIntegral<BitCountFunction>({"bit_count"});
+void registerBitwiseFunctions(const std::string& prefix) {
+  registerBitwiseBinaryIntegral<BitwiseAndFunction>({prefix + "bitwise_and"});
+  registerBitwiseUnaryIntegral<BitwiseNotFunction>({prefix + "bitwise_not"});
+  registerBitwiseBinaryIntegral<BitwiseOrFunction>({prefix + "bitwise_or"});
+  registerBitwiseBinaryIntegral<BitwiseXorFunction>({prefix + "bitwise_xor"});
+  registerBitwiseBinaryIntegral<BitCountFunction>({prefix + "bit_count"});
   registerBitwiseBinaryIntegral<BitwiseArithmeticShiftRightFunction>(
-      {"bitwise_arithmetic_shift_right"});
+      {prefix + "bitwise_arithmetic_shift_right"});
   registerBitwiseBinaryIntegral<BitwiseLeftShiftFunction>(
-      {"bitwise_left_shift"});
+      {prefix + "bitwise_left_shift"});
   registerBitwiseBinaryIntegral<BitwiseRightShiftFunction>(
-      {"bitwise_right_shift"});
+      {prefix + "bitwise_right_shift"});
   registerBitwiseBinaryIntegral<BitwiseRightShiftArithmeticFunction>(
-      {"bitwise_right_shift_arithmetic"});
+      {prefix + "bitwise_right_shift_arithmetic"});
   registerFunction<
       BitwiseLogicalShiftRightFunction,
       int64_t,
       int64_t,
       int64_t,
-      int64_t>({"bitwise_logical_shift_right"});
+      int64_t>({prefix + "bitwise_logical_shift_right"});
   registerFunction<
       BitwiseShiftLeftFunction,
       int64_t,
       int64_t,
       int64_t,
-      int64_t>({"bitwise_shift_left"});
+      int64_t>({prefix + "bitwise_shift_left"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
+++ b/velox/functions/prestosql/registration/CheckedArithmeticRegistration.cpp
@@ -19,13 +19,13 @@
 
 namespace facebook::velox::functions {
 
-void registerCheckedArithmeticFunctions() {
-  registerBinaryIntegral<CheckedPlusFunction>({"plus"});
-  registerBinaryIntegral<CheckedMinusFunction>({"minus"});
-  registerBinaryIntegral<CheckedMultiplyFunction>({"multiply"});
-  registerBinaryIntegral<CheckedModulusFunction>({"mod"});
-  registerBinaryIntegral<CheckedDivideFunction>({"divide"});
-  registerUnaryIntegral<CheckedNegateFunction>({"negate"});
+void registerCheckedArithmeticFunctions(const std::string& prefix) {
+  registerBinaryIntegral<CheckedPlusFunction>({prefix + "plus"});
+  registerBinaryIntegral<CheckedMinusFunction>({prefix + "minus"});
+  registerBinaryIntegral<CheckedMultiplyFunction>({prefix + "multiply"});
+  registerBinaryIntegral<CheckedModulusFunction>({prefix + "mod"});
+  registerBinaryIntegral<CheckedDivideFunction>({prefix + "divide"});
+  registerUnaryIntegral<CheckedNegateFunction>({prefix + "negate"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -20,81 +20,85 @@
 
 namespace facebook::velox::functions {
 
-void registerComparisonFunctions() {
-  registerNonSimdizableScalar<EqFunction, bool>({"eq"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, "eq");
-  registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({"eq"});
+void registerComparisonFunctions(const std::string& prefix) {
+  registerNonSimdizableScalar<EqFunction, bool>({prefix + "eq"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_eq, prefix + "eq");
+  registerFunction<EqFunction, bool, Generic<T1>, Generic<T1>>({prefix + "eq"});
 
-  registerNonSimdizableScalar<NeqFunction, bool>({"neq"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_neq, "neq");
+  registerNonSimdizableScalar<NeqFunction, bool>({prefix + "neq"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_neq, prefix + "neq");
 
-  registerNonSimdizableScalar<LtFunction, bool>({"lt"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, "lt");
+  registerNonSimdizableScalar<LtFunction, bool>({prefix + "lt"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lt, prefix + "lt");
 
-  registerNonSimdizableScalar<GtFunction, bool>({"gt"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, "gt");
+  registerNonSimdizableScalar<GtFunction, bool>({prefix + "gt"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gt, prefix + "gt");
 
-  registerNonSimdizableScalar<LteFunction, bool>({"lte"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, "lte");
+  registerNonSimdizableScalar<LteFunction, bool>({prefix + "lte"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_lte, prefix + "lte");
 
-  registerNonSimdizableScalar<GteFunction, bool>({"gte"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, "gte");
+  registerNonSimdizableScalar<GteFunction, bool>({prefix + "gte"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_simd_comparison_gte, prefix + "gte");
 
-  registerBinaryScalar<DistinctFromFunction, bool>({"distinct_from"});
+  registerBinaryScalar<DistinctFromFunction, bool>({prefix + "distinct_from"});
 
-  registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>({"between"});
+  registerFunction<BetweenFunction, bool, int8_t, int8_t, int8_t>(
+      {prefix + "between"});
   registerFunction<BetweenFunction, bool, int16_t, int16_t, int16_t>(
-      {"between"});
+      {prefix + "between"});
   registerFunction<BetweenFunction, bool, int32_t, int32_t, int32_t>(
-      {"between"});
+      {prefix + "between"});
   registerFunction<BetweenFunction, bool, int64_t, int64_t, int64_t>(
-      {"between"});
-  registerFunction<BetweenFunction, bool, double, double, double>({"between"});
-  registerFunction<BetweenFunction, bool, float, float, float>({"between"});
+      {prefix + "between"});
+  registerFunction<BetweenFunction, bool, double, double, double>(
+      {prefix + "between"});
+  registerFunction<BetweenFunction, bool, float, float, float>(
+      {prefix + "between"});
   registerFunction<BetweenFunction, bool, Varchar, Varchar, Varchar>(
-      {"between"});
-  registerFunction<BetweenFunction, bool, Date, Date, Date>({"between"});
+      {prefix + "between"});
+  registerFunction<BetweenFunction, bool, Date, Date, Date>(
+      {prefix + "between"});
   registerFunction<
       BetweenFunction,
       bool,
       UnscaledShortDecimal,
       UnscaledShortDecimal,
-      UnscaledShortDecimal>({"between"});
+      UnscaledShortDecimal>({prefix + "between"});
   registerFunction<
       BetweenFunction,
       bool,
       UnscaledLongDecimal,
       UnscaledLongDecimal,
-      UnscaledLongDecimal>({"between"});
+      UnscaledLongDecimal>({prefix + "between"});
   registerFunction<
       GtFunction,
       bool,
       UnscaledShortDecimal,
-      UnscaledShortDecimal>({"gt"});
+      UnscaledShortDecimal>({prefix + "gt"});
   registerFunction<GtFunction, bool, UnscaledLongDecimal, UnscaledLongDecimal>(
-      {"gt"});
+      {prefix + "gt"});
   registerFunction<
       LtFunction,
       bool,
       UnscaledShortDecimal,
-      UnscaledShortDecimal>({"lt"});
+      UnscaledShortDecimal>({prefix + "lt"});
   registerFunction<LtFunction, bool, UnscaledLongDecimal, UnscaledLongDecimal>(
-      {"lt"});
+      {prefix + "lt"});
 
   registerFunction<
       GteFunction,
       bool,
       UnscaledShortDecimal,
-      UnscaledShortDecimal>({"gte"});
+      UnscaledShortDecimal>({prefix + "gte"});
   registerFunction<GteFunction, bool, UnscaledLongDecimal, UnscaledLongDecimal>(
-      {"gte"});
+      {prefix + "gte"});
   registerFunction<
       LteFunction,
       bool,
       UnscaledShortDecimal,
-      UnscaledShortDecimal>({"lte"});
+      UnscaledShortDecimal>({prefix + "lte"});
   registerFunction<LteFunction, bool, UnscaledLongDecimal, UnscaledLongDecimal>(
-      {"lte"});
+      {prefix + "lte"});
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -20,98 +20,116 @@
 
 namespace facebook::velox::functions {
 namespace {
-void registerSimpleFunctions() {
+void registerSimpleFunctions(const std::string& prefix) {
   // Date time functions.
-  registerFunction<ToUnixtimeFunction, double, Timestamp>({"to_unixtime"});
+  registerFunction<ToUnixtimeFunction, double, Timestamp>(
+      {prefix + "to_unixtime"});
   registerFunction<ToUnixtimeFunction, double, TimestampWithTimezone>(
-      {"to_unixtime"});
-  registerFunction<FromUnixtimeFunction, Timestamp, double>({"from_unixtime"});
+      {prefix + "to_unixtime"});
+  registerFunction<FromUnixtimeFunction, Timestamp, double>(
+      {prefix + "from_unixtime"});
 
-  registerFunction<YearFunction, int64_t, Timestamp>({"year"});
-  registerFunction<YearFunction, int64_t, Date>({"year"});
-  registerFunction<YearFunction, int64_t, TimestampWithTimezone>({"year"});
-  registerFunction<WeekFunction, int64_t, Timestamp>({"week", "week_of_year"});
-  registerFunction<WeekFunction, int64_t, Date>({"week", "week_of_year"});
+  registerFunction<YearFunction, int64_t, Timestamp>({prefix + "year"});
+  registerFunction<YearFunction, int64_t, Date>({prefix + "year"});
+  registerFunction<YearFunction, int64_t, TimestampWithTimezone>(
+      {prefix + "year"});
+  registerFunction<WeekFunction, int64_t, Timestamp>(
+      {prefix + "week", prefix + "week_of_year"});
+  registerFunction<WeekFunction, int64_t, Date>(
+      {prefix + "week", prefix + "week_of_year"});
   registerFunction<WeekFunction, int64_t, TimestampWithTimezone>(
-      {"week", "week_of_year"});
-  registerFunction<QuarterFunction, int64_t, Timestamp>({"quarter"});
-  registerFunction<QuarterFunction, int64_t, Date>({"quarter"});
+      {prefix + "week", prefix + "week_of_year"});
+  registerFunction<QuarterFunction, int64_t, Timestamp>({prefix + "quarter"});
+  registerFunction<QuarterFunction, int64_t, Date>({prefix + "quarter"});
   registerFunction<QuarterFunction, int64_t, TimestampWithTimezone>(
-      {"quarter"});
-  registerFunction<MonthFunction, int64_t, Timestamp>({"month"});
-  registerFunction<MonthFunction, int64_t, Date>({"month"});
-  registerFunction<MonthFunction, int64_t, TimestampWithTimezone>({"month"});
-  registerFunction<DayFunction, int64_t, Timestamp>({"day", "day_of_month"});
-  registerFunction<DayFunction, int64_t, Date>({"day", "day_of_month"});
+      {prefix + "quarter"});
+  registerFunction<MonthFunction, int64_t, Timestamp>({prefix + "month"});
+  registerFunction<MonthFunction, int64_t, Date>({prefix + "month"});
+  registerFunction<MonthFunction, int64_t, TimestampWithTimezone>(
+      {prefix + "month"});
+  registerFunction<DayFunction, int64_t, Timestamp>(
+      {prefix + "day", prefix + "day_of_month"});
+  registerFunction<DayFunction, int64_t, Date>(
+      {prefix + "day", prefix + "day_of_month"});
   registerFunction<DateMinusIntervalDayTime, Date, Date, IntervalDayTime>(
-      {"minus"});
+      {prefix + "minus"});
   registerFunction<DatePlusIntervalDayTime, Date, Date, IntervalDayTime>(
-      {"plus"});
+      {prefix + "plus"});
   registerFunction<DayFunction, int64_t, TimestampWithTimezone>(
-      {"day", "day_of_month"});
+      {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(
-      {"dow", "day_of_week"});
-  registerFunction<DayOfWeekFunction, int64_t, Date>({"dow", "day_of_week"});
+      {prefix + "dow", prefix + "day_of_week"});
+  registerFunction<DayOfWeekFunction, int64_t, Date>(
+      {prefix + "dow", prefix + "day_of_week"});
   registerFunction<DayOfWeekFunction, int64_t, TimestampWithTimezone>(
-      {"dow", "day_of_week"});
+      {prefix + "dow", prefix + "day_of_week"});
   registerFunction<DayOfYearFunction, int64_t, Timestamp>(
-      {"doy", "day_of_year"});
-  registerFunction<DayOfYearFunction, int64_t, Date>({"doy", "day_of_year"});
+      {prefix + "doy", prefix + "day_of_year"});
+  registerFunction<DayOfYearFunction, int64_t, Date>(
+      {prefix + "doy", prefix + "day_of_year"});
   registerFunction<DayOfYearFunction, int64_t, TimestampWithTimezone>(
-      {"doy", "day_of_year"});
+      {prefix + "doy", prefix + "day_of_year"});
   registerFunction<YearOfWeekFunction, int64_t, Timestamp>(
-      {"yow", "year_of_week"});
-  registerFunction<YearOfWeekFunction, int64_t, Date>({"yow", "year_of_week"});
+      {prefix + "yow", prefix + "year_of_week"});
+  registerFunction<YearOfWeekFunction, int64_t, Date>(
+      {prefix + "yow", prefix + "year_of_week"});
   registerFunction<YearOfWeekFunction, int64_t, TimestampWithTimezone>(
-      {"yow", "year_of_week"});
-  registerFunction<HourFunction, int64_t, Timestamp>({"hour"});
-  registerFunction<HourFunction, int64_t, Date>({"hour"});
-  registerFunction<HourFunction, int64_t, TimestampWithTimezone>({"hour"});
-  registerFunction<MinuteFunction, int64_t, Timestamp>({"minute"});
-  registerFunction<MinuteFunction, int64_t, Date>({"minute"});
-  registerFunction<MinuteFunction, int64_t, TimestampWithTimezone>({"minute"});
-  registerFunction<SecondFunction, int64_t, Timestamp>({"second"});
-  registerFunction<SecondFunction, int64_t, Date>({"second"});
-  registerFunction<SecondFunction, int64_t, TimestampWithTimezone>({"second"});
-  registerFunction<MillisecondFunction, int64_t, Timestamp>({"millisecond"});
-  registerFunction<MillisecondFunction, int64_t, Date>({"millisecond"});
+      {prefix + "yow", prefix + "year_of_week"});
+  registerFunction<HourFunction, int64_t, Timestamp>({prefix + "hour"});
+  registerFunction<HourFunction, int64_t, Date>({prefix + "hour"});
+  registerFunction<HourFunction, int64_t, TimestampWithTimezone>(
+      {prefix + "hour"});
+  registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
+  registerFunction<MinuteFunction, int64_t, Date>({prefix + "minute"});
+  registerFunction<MinuteFunction, int64_t, TimestampWithTimezone>(
+      {prefix + "minute"});
+  registerFunction<SecondFunction, int64_t, Timestamp>({prefix + "second"});
+  registerFunction<SecondFunction, int64_t, Date>({prefix + "second"});
+  registerFunction<SecondFunction, int64_t, TimestampWithTimezone>(
+      {prefix + "second"});
+  registerFunction<MillisecondFunction, int64_t, Timestamp>(
+      {prefix + "millisecond"});
+  registerFunction<MillisecondFunction, int64_t, Date>(
+      {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int64_t, TimestampWithTimezone>(
-      {"millisecond"});
+      {prefix + "millisecond"});
   registerFunction<DateTruncFunction, Timestamp, Varchar, Timestamp>(
-      {"date_trunc"});
-  registerFunction<DateTruncFunction, Date, Varchar, Date>({"date_trunc"});
+      {prefix + "date_trunc"});
+  registerFunction<DateTruncFunction, Date, Varchar, Date>(
+      {prefix + "date_trunc"});
   registerFunction<
       DateTruncFunction,
       TimestampWithTimezone,
       Varchar,
-      TimestampWithTimezone>({"date_trunc"});
-  registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>({"date_add"});
+      TimestampWithTimezone>({prefix + "date_trunc"});
+  registerFunction<DateAddFunction, Date, Varchar, int64_t, Date>(
+      {prefix + "date_add"});
   registerFunction<DateAddFunction, Timestamp, Varchar, int64_t, Timestamp>(
-      {"date_add"});
+      {prefix + "date_add"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Date, Date>(
-      {"date_diff"});
+      {prefix + "date_diff"});
   registerFunction<DateDiffFunction, int64_t, Varchar, Timestamp, Timestamp>(
-      {"date_diff"});
+      {prefix + "date_diff"});
   registerFunction<DateFormatFunction, Varchar, Timestamp, Varchar>(
-      {"date_format"});
+      {prefix + "date_format"});
   registerFunction<DateFormatFunction, Varchar, TimestampWithTimezone, Varchar>(
-      {"date_format"});
+      {prefix + "date_format"});
   registerFunction<FormatDateTimeFunction, Varchar, Timestamp, Varchar>(
-      {"format_datetime"});
+      {prefix + "format_datetime"});
   registerFunction<
       ParseDateTimeFunction,
       TimestampWithTimezone,
       Varchar,
-      Varchar>({"parse_datetime"});
+      Varchar>({prefix + "parse_datetime"});
   registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
-      {"date_parse"});
+      {prefix + "date_parse"});
 }
 } // namespace
 
-void registerDateTimeFunctions() {
+void registerDateTimeFunctions(const std::string& prefix) {
   registerTimestampWithTimeZoneType();
 
-  registerSimpleFunctions();
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_from_unixtime, "from_unixtime");
+  registerSimpleFunctions(prefix);
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_from_unixtime, prefix + "from_unixtime");
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -19,23 +19,24 @@
 
 namespace facebook::velox::functions {
 
-void registerGeneralFunctions() {
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, "element_at");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, "subscript");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, "transform");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_reduce, "reduce");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, "in");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, "filter");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "row_constructor");
+void registerGeneralFunctions(const std::string& prefix) {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, prefix + "element_at");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, prefix + "subscript");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, prefix + "transform");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_reduce, prefix + "reduce");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, prefix + "in");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, prefix + "row_constructor");
 
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_least, "least");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_greatest, "greatest");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_least, prefix + "least");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_greatest, prefix + "greatest");
 
-  registerFunction<CardinalityFunction, int64_t, Array<Any>>({"cardinality"});
+  registerFunction<CardinalityFunction, int64_t, Array<Any>>(
+      {prefix + "cardinality"});
   registerFunction<CardinalityFunction, int64_t, Map<Any, Any>>(
-      {"cardinality"});
+      {prefix + "cardinality"});
 
-  registerIsNullFunction("is_null");
+  registerIsNullFunction(prefix + "is_null");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/HyperLogFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/HyperLogFunctionsRegistration.cpp
@@ -18,13 +18,15 @@
 
 namespace facebook::velox::functions {
 
-void registerHyperLogFunctions() {
+void registerHyperLogFunctions(const std::string& prefix) {
   registerHyperLogLogType();
 
-  registerFunction<CardinalityFunction, int64_t, HyperLogLog>({"cardinality"});
+  registerFunction<CardinalityFunction, int64_t, HyperLogLog>(
+      {prefix + "cardinality"});
 
   registerFunction<EmptyApproxSetWithMaxErrorFunction, HyperLogLog, double>(
-      {"empty_approx_set"});
-  registerFunction<EmptyApproxSetFunction, HyperLogLog>({"empty_approx_set"});
+      {prefix + "empty_approx_set"});
+  registerFunction<EmptyApproxSetFunction, HyperLogLog>(
+      {prefix + "empty_approx_set"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -18,25 +18,27 @@
 #include "velox/functions/prestosql/JsonFunctions.h"
 
 namespace facebook::velox::functions {
-void registerJsonFunctions() {
+void registerJsonFunctions(const std::string& prefix) {
   registerJsonType();
 
-  registerFunction<IsJsonScalarFunction, bool, Json>({"is_json_scalar"});
+  registerFunction<IsJsonScalarFunction, bool, Json>(
+      {prefix + "is_json_scalar"});
   registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
-      {"json_extract_scalar"});
+      {prefix + "json_extract_scalar"});
   registerFunction<JsonArrayLengthFunction, int64_t, Json>(
-      {"json_array_length"});
+      {prefix + "json_array_length"});
   registerFunction<JsonArrayContainsFunction, bool, Json, bool>(
-      {"json_array_contains"});
+      {prefix + "json_array_contains"});
   registerFunction<JsonArrayContainsFunction, bool, Json, int64_t>(
-      {"json_array_contains"});
+      {prefix + "json_array_contains"});
   registerFunction<JsonArrayContainsFunction, bool, Json, double>(
-      {"json_array_contains"});
+      {prefix + "json_array_contains"});
   registerFunction<JsonArrayContainsFunction, bool, Json, Varchar>(
-      {"json_array_contains"});
-  registerFunction<JsonSizeFunction, int64_t, Json, Varchar>({"json_size"});
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, "json_format");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, "json_parse");
+      {prefix + "json_array_contains"});
+  registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
+      {prefix + "json_size"});
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, prefix + "json_parse");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -19,20 +19,23 @@
 #include "velox/functions/lib/MapConcat.h"
 
 namespace facebook::velox::functions {
-void registerMapFunctions() {
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_filter, "map_filter");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_keys, "transform_keys");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_values, "transform_values");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map, "map");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_entries, "map_entries");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, "map_keys");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, "map_values");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, "map_zip_with");
+void registerMapFunctions(const std::string& prefix) {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_filter, prefix + "map_filter");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_transform_keys, prefix + "transform_keys");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_transform_values, prefix + "transform_values");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_entries, prefix + "map_entries");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, prefix + "map_keys");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, prefix + "map_values");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, prefix + "map_zip_with");
 
-  registerMapConcatFunction("map_concat");
+  registerMapConcatFunction(prefix + "map_concat");
 }
 
-void registerMapAllowingDuplicates(const std::string& name) {
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_allow_duplicates, name);
+void registerMapAllowingDuplicates(
+    const std::string& name,
+    const std::string& prefix) {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_map_allow_duplicates, prefix + name);
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/RegistrationFunctions.cpp
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.cpp
@@ -16,88 +16,91 @@
 #include <string>
 
 namespace facebook::velox::functions {
-// TODO: move functions that are not shared with spark to prestosql and avoid
-// the indirection here.
-extern void registerArithmeticFunctions();
-extern void registerCheckedArithmeticFunctions();
-extern void registerComparisonFunctions();
-extern void registerArrayFunctions();
-extern void registerMapFunctions();
-extern void registerJsonFunctions();
-extern void registerHyperLogFunctions();
-extern void registerGeneralFunctions();
-extern void registerDateTimeFunctions();
-extern void registerURLFunctions();
-extern void registerStringFunctions();
-extern void registerBitwiseFunctions();
-extern void registerMapAllowingDuplicates(const std::string& name);
+
+extern void registerArithmeticFunctions(const std::string& prefix);
+extern void registerArrayFunctions(const std::string& prefix);
+extern void registerBitwiseFunctions(const std::string& prefix);
+extern void registerCheckedArithmeticFunctions(const std::string& prefix);
+extern void registerComparisonFunctions(const std::string& prefix);
+extern void registerDateTimeFunctions(const std::string& prefix);
+extern void registerGeneralFunctions(const std::string& prefix);
+extern void registerHyperLogFunctions(const std::string& prefix);
+extern void registerJsonFunctions(const std::string& prefix);
+extern void registerMapFunctions(const std::string& prefix);
+extern void registerStringFunctions(const std::string& prefix);
+extern void registerURLFunctions(const std::string& prefix);
+extern void registerMapAllowingDuplicates(
+    const std::string& name,
+    const std::string& prefix);
 
 namespace prestosql {
-void registerArithmeticFunctions() {
-  functions::registerArithmeticFunctions();
+void registerArithmeticFunctions(const std::string& prefix) {
+  functions::registerArithmeticFunctions(prefix);
 }
 
-void registerCheckedArithmeticFunctions() {
-  functions::registerCheckedArithmeticFunctions();
+void registerCheckedArithmeticFunctions(const std::string& prefix) {
+  functions::registerCheckedArithmeticFunctions(prefix);
 }
 
-void registerComparisonFunctions() {
-  functions::registerComparisonFunctions();
+void registerComparisonFunctions(const std::string& prefix) {
+  functions::registerComparisonFunctions(prefix);
 }
 
-void registerArrayFunctions() {
-  functions::registerArrayFunctions();
+void registerArrayFunctions(const std::string& prefix) {
+  functions::registerArrayFunctions(prefix);
 }
 
-void registerMapFunctions() {
-  functions::registerMapFunctions();
+void registerMapFunctions(const std::string& prefix) {
+  functions::registerMapFunctions(prefix);
 }
 
-void registerJsonFunctions() {
-  functions::registerJsonFunctions();
+void registerJsonFunctions(const std::string& prefix) {
+  functions::registerJsonFunctions(prefix);
 }
 
-void registerHyperLogFunctions() {
-  functions::registerHyperLogFunctions();
+void registerHyperLogFunctions(const std::string& prefix) {
+  functions::registerHyperLogFunctions(prefix);
 }
 
-void registerGeneralFunctions() {
-  functions::registerGeneralFunctions();
+void registerGeneralFunctions(const std::string& prefix) {
+  functions::registerGeneralFunctions(prefix);
 }
 
-void registerDateTimeFunctions() {
-  functions::registerDateTimeFunctions();
+void registerDateTimeFunctions(const std::string& prefix) {
+  functions::registerDateTimeFunctions(prefix);
 }
 
-void registerURLFunctions() {
-  functions::registerURLFunctions();
+void registerURLFunctions(const std::string& prefix) {
+  functions::registerURLFunctions(prefix);
 }
 
-void registerStringFunctions() {
-  functions::registerStringFunctions();
+void registerStringFunctions(const std::string& prefix) {
+  functions::registerStringFunctions(prefix);
 }
 
-void registerBitwiseFunctions() {
-  functions::registerBitwiseFunctions();
+void registerBitwiseFunctions(const std::string& prefix) {
+  functions::registerBitwiseFunctions(prefix);
 }
 
-void registerAllScalarFunctions() {
-  registerArithmeticFunctions();
-  registerCheckedArithmeticFunctions();
-  registerComparisonFunctions();
-  registerMapFunctions();
-  registerArrayFunctions();
-  registerJsonFunctions();
-  registerHyperLogFunctions();
-  registerGeneralFunctions();
-  registerDateTimeFunctions();
-  registerURLFunctions();
-  registerStringFunctions();
-  registerBitwiseFunctions();
+void registerAllScalarFunctions(const std::string& prefix) {
+  registerArithmeticFunctions(prefix);
+  registerCheckedArithmeticFunctions(prefix);
+  registerComparisonFunctions(prefix);
+  registerMapFunctions(prefix);
+  registerArrayFunctions(prefix);
+  registerJsonFunctions(prefix);
+  registerHyperLogFunctions(prefix);
+  registerGeneralFunctions(prefix);
+  registerDateTimeFunctions(prefix);
+  registerURLFunctions(prefix);
+  registerStringFunctions(prefix);
+  registerBitwiseFunctions(prefix);
 }
 
-void registerMapAllowingDuplicates(const std::string& name) {
-  functions::registerMapAllowingDuplicates(name);
+void registerMapAllowingDuplicates(
+    const std::string& name,
+    const std::string& prefix) {
+  functions::registerMapAllowingDuplicates(name, prefix);
 }
 } // namespace prestosql
 

--- a/velox/functions/prestosql/registration/RegistrationFunctions.h
+++ b/velox/functions/prestosql/registration/RegistrationFunctions.h
@@ -17,31 +17,33 @@
 #include <string>
 
 namespace facebook::velox::functions::prestosql {
-void registerArithmeticFunctions();
+void registerArithmeticFunctions(const std::string& prefix = "");
 
-void registerCheckedArithmeticFunctions();
+void registerCheckedArithmeticFunctions(const std::string& prefix = "");
 
-void registerComparisonFunctions();
+void registerComparisonFunctions(const std::string& prefix = "");
 
-void registerArrayFunctions();
+void registerArrayFunctions(const std::string& prefix = "");
 
-void registerMapFunctions();
+void registerMapFunctions(const std::string& prefix = "");
 
-void registerJsonFunctions();
+void registerJsonFunctions(const std::string& prefix = "");
 
-void registerHyperLogFunctions();
+void registerHyperLogFunctions(const std::string& prefix = "");
 
-void registerGeneralFunctions();
+void registerGeneralFunctions(const std::string& prefix = "");
 
-void registerDateTimeFunctions();
+void registerDateTimeFunctions(const std::string& prefix = "");
 
-void registerURLFunctions();
+void registerURLFunctions(const std::string& prefix = "");
 
-void registerStringFunctions();
+void registerStringFunctions(const std::string& prefix = "");
 
-void registerBitwiseFunctions();
+void registerBitwiseFunctions(const std::string& prefix = "");
 
-void registerAllScalarFunctions();
+void registerAllScalarFunctions(const std::string& prefix = "");
 
-void registerMapAllowingDuplicates(const std::string& name);
+void registerMapAllowingDuplicates(
+    const std::string& name,
+    const std::string& prefix = "");
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -29,88 +29,100 @@ std::shared_ptr<exec::VectorFunction> makeRegexExtract(
   return makeRe2Extract(name, inputArgs, /*emptyNoMatch=*/false);
 }
 
-void registerSimpleFunctions() {
+void registerSimpleFunctions(const std::string& prefix) {
   using namespace stringImpl;
 
   // Register string functions.
-  registerFunction<ChrFunction, Varchar, int64_t>({"chr"});
-  registerFunction<CodePointFunction, int32_t, Varchar>({"codepoint"});
-  registerFunction<LengthFunction, int64_t, Varchar>({"length"});
+  registerFunction<ChrFunction, Varchar, int64_t>({prefix + "chr"});
+  registerFunction<CodePointFunction, int32_t, Varchar>({prefix + "codepoint"});
+  registerFunction<LengthFunction, int64_t, Varchar>({prefix + "length"});
 
-  registerFunction<SubstrFunction, Varchar, Varchar, int64_t>({"substr"});
+  registerFunction<SubstrFunction, Varchar, Varchar, int64_t>(
+      {prefix + "substr"});
   registerFunction<SubstrFunction, Varchar, Varchar, int64_t, int64_t>(
-      {"substr"});
-  registerFunction<SubstrFunction, Varchar, Varchar, int32_t>({"substr"});
+      {prefix + "substr"});
+  registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
+      {prefix + "substr"});
   registerFunction<SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
-      {"substr"});
+      {prefix + "substr"});
 
   registerFunction<SplitPart, Varchar, Varchar, Varchar, int64_t>(
-      {"split_part"});
+      {prefix + "split_part"});
 
-  registerFunction<TrimFunction, Varchar, Varchar>({"trim"});
-  registerFunction<LTrimFunction, Varchar, Varchar>({"ltrim"});
-  registerFunction<RTrimFunction, Varchar, Varchar>({"rtrim"});
+  registerFunction<TrimFunction, Varchar, Varchar>({prefix + "trim"});
+  registerFunction<LTrimFunction, Varchar, Varchar>({prefix + "ltrim"});
+  registerFunction<RTrimFunction, Varchar, Varchar>({prefix + "rtrim"});
 
-  registerFunction<LPadFunction, Varchar, Varchar, int64_t, Varchar>({"lpad"});
-  registerFunction<RPadFunction, Varchar, Varchar, int64_t, Varchar>({"rpad"});
+  registerFunction<LPadFunction, Varchar, Varchar, int64_t, Varchar>(
+      {prefix + "lpad"});
+  registerFunction<RPadFunction, Varchar, Varchar, int64_t, Varchar>(
+      {prefix + "rpad"});
 
   // Register hash functions.
-  registerFunction<CRC32Function, int64_t, Varbinary>({"crc32"});
-  registerFunction<XxHash64Function, Varbinary, Varbinary>({"xxhash64"});
-  registerFunction<Md5Function, Varbinary, Varbinary>({"md5"});
-  registerFunction<Sha1Function, Varbinary, Varbinary>({"sha1"});
-  registerFunction<Sha256Function, Varbinary, Varbinary>({"sha256"});
-  registerFunction<Sha512Function, Varbinary, Varbinary>({"sha512"});
+  registerFunction<CRC32Function, int64_t, Varbinary>({prefix + "crc32"});
+  registerFunction<XxHash64Function, Varbinary, Varbinary>(
+      {prefix + "xxhash64"});
+  registerFunction<Md5Function, Varbinary, Varbinary>({prefix + "md5"});
+  registerFunction<Sha1Function, Varbinary, Varbinary>({prefix + "sha1"});
+  registerFunction<Sha256Function, Varbinary, Varbinary>({prefix + "sha256"});
+  registerFunction<Sha512Function, Varbinary, Varbinary>({prefix + "sha512"});
   registerFunction<HmacSha1Function, Varbinary, Varbinary, Varbinary>(
-      {"hmac_sha1"});
+      {prefix + "hmac_sha1"});
   registerFunction<HmacSha256Function, Varbinary, Varbinary, Varbinary>(
-      {"hmac_sha256"});
+      {prefix + "hmac_sha256"});
   registerFunction<HmacSha512Function, Varbinary, Varbinary, Varbinary>(
-      {"hmac_sha512"});
+      {prefix + "hmac_sha512"});
   registerFunction<SpookyHashV232Function, Varbinary, Varbinary>(
-      {"spooky_hash_v2_32"});
+      {prefix + "spooky_hash_v2_32"});
   registerFunction<SpookyHashV264Function, Varbinary, Varbinary>(
-      {"spooky_hash_v2_64"});
+      {prefix + "spooky_hash_v2_64"});
 
-  registerFunction<ToHexFunction, Varchar, Varbinary>({"to_hex"});
-  registerFunction<FromHexFunction, Varbinary, Varchar>({"from_hex"});
-  registerFunction<ToBase64Function, Varchar, Varbinary>({"to_base64"});
-  registerFunction<FromBase64Function, Varbinary, Varchar>({"from_base64"});
-  exec::registerStatefulVectorFunction("like", likeSignatures(), makeLike);
+  registerFunction<ToHexFunction, Varchar, Varbinary>({prefix + "to_hex"});
+  registerFunction<FromHexFunction, Varbinary, Varchar>({prefix + "from_hex"});
+  registerFunction<ToBase64Function, Varchar, Varbinary>(
+      {prefix + "to_base64"});
+  registerFunction<FromBase64Function, Varbinary, Varchar>(
+      {prefix + "from_base64"});
+  exec::registerStatefulVectorFunction(
+      prefix + "like", likeSignatures(), makeLike);
 
   registerFunction<SplitPart, Varchar, Varchar, Varchar, int64_t>(
-      {"split_part"});
+      {prefix + "split_part"});
   registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Varchar>(
-      {"regexp_replace"});
+      {prefix + "regexp_replace"});
   registerFunction<Re2RegexpReplacePresto, Varchar, Varchar, Varchar, Varchar>(
-      {"regexp_replace"});
+      {prefix + "regexp_replace"});
 }
 } // namespace
 
-void registerStringFunctions() {
-  registerSimpleFunctions();
+void registerStringFunctions(const std::string& prefix) {
+  registerSimpleFunctions(prefix);
 
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, "lower");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, "upper");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_split, "split");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, "concat");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, "replace");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_reverse, "reverse");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, "to_utf8");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, prefix + "upper");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_split, prefix + "split");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_reverse, prefix + "reverse");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_to_utf8, prefix + "to_utf8");
 
   // Regex functions
   exec::registerStatefulVectorFunction(
-      "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
+      prefix + "regexp_extract", re2ExtractSignatures(), makeRegexExtract);
   exec::registerStatefulVectorFunction(
-      "regexp_extract_all", re2ExtractAllSignatures(), makeRe2ExtractAll);
+      prefix + "regexp_extract_all",
+      re2ExtractAllSignatures(),
+      makeRe2ExtractAll);
   exec::registerStatefulVectorFunction(
-      "regexp_like", re2SearchSignatures(), makeRe2Search);
+      prefix + "regexp_like", re2SearchSignatures(), makeRe2Search);
 
-  registerFunction<StrLPosFunction, int64_t, Varchar, Varchar>({"strpos"});
+  registerFunction<StrLPosFunction, int64_t, Varchar, Varchar>(
+      {prefix + "strpos"});
   registerFunction<StrLPosFunction, int64_t, Varchar, Varchar, int64_t>(
-      {"strpos"});
-  registerFunction<StrRPosFunction, int64_t, Varchar, Varchar>({"strrpos"});
+      {prefix + "strpos"});
+  registerFunction<StrRPosFunction, int64_t, Varchar, Varchar>(
+      {prefix + "strrpos"});
   registerFunction<StrRPosFunction, int64_t, Varchar, Varchar, int64_t>(
-      {"strrpos"});
+      {prefix + "strrpos"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/URLFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/URLFunctionsRegistration.cpp
@@ -20,22 +20,24 @@
 
 namespace facebook::velox::functions {
 
-void registerURLFunctions() {
+void registerURLFunctions(const std::string& prefix) {
   registerFunction<UrlExtractHostFunction, Varchar, Varchar>(
-      {"url_extract_host"});
+      {prefix + "url_extract_host"});
   registerFunction<UrlExtractFragmentFunction, Varchar, Varchar>(
-      {"url_extract_fragment"});
+      {prefix + "url_extract_fragment"});
   registerFunction<UrlExtractPathFunction, Varchar, Varchar>(
-      {"url_extract_path"});
+      {prefix + "url_extract_path"});
   registerFunction<UrlExtractParameterFunction, Varchar, Varchar, Varchar>(
-      {"url_extract_parameter"});
+      {prefix + "url_extract_parameter"});
   registerFunction<UrlExtractProtocolFunction, Varchar, Varchar>(
-      {"url_extract_protocol"});
+      {prefix + "url_extract_protocol"});
   registerFunction<UrlExtractPortFunction, int64_t, Varchar>(
-      {"url_extract_port"});
+      {prefix + "url_extract_port"});
   registerFunction<UrlExtractQueryFunction, Varchar, Varchar>(
-      {"url_extract_query"});
-  registerFunction<UrlEncodeFunction, Varchar, Varchar>({"url_encode"});
-  registerFunction<UrlDecodeFunction, Varchar, Varchar>({"url_decode"});
+      {prefix + "url_extract_query"});
+  registerFunction<UrlEncodeFunction, Varchar, Varchar>(
+      {prefix + "url_encode"});
+  registerFunction<UrlDecodeFunction, Varchar, Varchar>(
+      {prefix + "url_decode"});
 }
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(
   RepeatTest.cpp
   ReverseTest.cpp
   RoundTest.cpp
+  ScalarFunctionRegTest.cpp
   SliceTest.cpp
   SplitTest.cpp
   StringFunctionsTest.cpp

--- a/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
+++ b/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/expression/SimpleFunctionRegistry.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::functions::test {
+
+class ScalarFunctionRegTest : public testing::Test {};
+
+TEST_F(ScalarFunctionRegTest, prefix) {
+  // Remove all functions and check for no entries.
+  exec::vectorFunctionFactories().wlock()->clear();
+  exec::SimpleFunctions().testingClear();
+  EXPECT_EQ(0, exec::vectorFunctionFactories().rlock()->size());
+  EXPECT_EQ(0, exec::SimpleFunctions().getFunctionNames().size());
+
+  // Register without prefix and memorize function maps.
+  prestosql::registerAllScalarFunctions();
+  const std::unordered_map<std::string, exec::VectorFunctionEntry>
+      scalarVectorFuncMapBase = *(exec::vectorFunctionFactories().rlock());
+  std::unordered_set<std::string> scalarSimpleFuncBaseNames;
+  for (const auto& funcName : exec::SimpleFunctions().getFunctionNames()) {
+    scalarSimpleFuncBaseNames.insert(funcName);
+  }
+
+  // Remove all functions and check for no entries.
+  exec::vectorFunctionFactories().wlock()->clear();
+  exec::SimpleFunctions().testingClear();
+  EXPECT_EQ(0, exec::vectorFunctionFactories().rlock()->size());
+  EXPECT_EQ(0, exec::SimpleFunctions().getFunctionNames().size());
+
+  // Register with prefix and check all functions have the prefix.
+  const std::string prefix{"test.abc_schema."};
+  prestosql::registerAllScalarFunctions(prefix);
+  std::unordered_map<std::string, exec::VectorFunctionEntry>
+      scalarVectorFuncMap = *(exec::vectorFunctionFactories().rlock());
+
+  for (const auto& entry : scalarVectorFuncMap) {
+    EXPECT_EQ(prefix, entry.first.substr(0, prefix.size()));
+    EXPECT_EQ(
+        1, scalarVectorFuncMapBase.count(entry.first.substr(prefix.size())));
+  }
+  for (const auto& funcName : exec::SimpleFunctions().getFunctionNames()) {
+    EXPECT_EQ(prefix, funcName.substr(0, prefix.size()));
+    EXPECT_EQ(
+        1, scalarSimpleFuncBaseNames.count(funcName.substr(prefix.size())));
+  }
+}
+
+} // namespace facebook::velox::functions::test

--- a/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/window/WindowFunctionsRegistration.cpp
@@ -27,14 +27,14 @@ extern void registerCumeDist(const std::string& name);
 extern void registerNtile(const std::string& name);
 extern void registerNthValue(const std::string& name);
 
-void registerAllWindowFunctions() {
-  registerRowNumber("row_number");
-  registerRank("rank");
-  registerDenseRank("dense_rank");
-  registerPercentRank("percent_rank");
-  registerCumeDist("cume_dist");
-  registerNtile("ntile");
-  registerNthValue("nth_value");
+void registerAllWindowFunctions(const std::string& prefix) {
+  registerRowNumber(prefix + "row_number");
+  registerRank(prefix + "rank");
+  registerDenseRank(prefix + "dense_rank");
+  registerPercentRank(prefix + "percent_rank");
+  registerCumeDist(prefix + "cume_dist");
+  registerNtile(prefix + "ntile");
+  registerNthValue(prefix + "nth_value");
 }
 
 } // namespace prestosql

--- a/velox/functions/prestosql/window/WindowFunctionsRegistration.h
+++ b/velox/functions/prestosql/window/WindowFunctionsRegistration.h
@@ -17,6 +17,6 @@
 
 namespace facebook::velox::window::prestosql {
 
-void registerAllWindowFunctions();
+void registerAllWindowFunctions(const std::string& prefix = "");
 
 } // namespace facebook::velox::window::prestosql

--- a/velox/functions/prestosql/window/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/window/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
   RankTest.cpp
   RowNumberTest.cpp
   SimpleAggregatesTest.cpp
+  WindowFunctionRegTest.cpp
   WindowTestBase.cpp)
 
 add_test(

--- a/velox/functions/prestosql/window/tests/WindowFunctionRegTest.cpp
+++ b/velox/functions/prestosql/window/tests/WindowFunctionRegTest.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/WindowFunction.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+
+namespace facebook::velox::window::test {
+
+class WindowFunctionRegTest : public testing::Test {};
+
+TEST_F(WindowFunctionRegTest, prefix) {
+  // Remove all functions and check for no entries.
+  exec::windowFunctions().clear();
+  EXPECT_EQ(0, exec::windowFunctions().size());
+
+  // Register without prefix and memorize function maps.
+  window::prestosql::registerAllWindowFunctions();
+  const auto windowFuncMapBase = exec::windowFunctions();
+
+  // Remove all functions and check for no entries.
+  exec::windowFunctions().clear();
+  EXPECT_EQ(0, exec::windowFunctions().size());
+
+  // Register with prefix and check all functions have the prefix.
+  const std::string prefix{"test.abc_schema."};
+  window::prestosql::registerAllWindowFunctions(prefix);
+  auto& windowFuncMap = exec::windowFunctions();
+  for (const auto& entry : windowFuncMap) {
+    EXPECT_EQ(prefix, entry.first.substr(0, prefix.size()));
+    EXPECT_EQ(1, windowFuncMapBase.count(entry.first.substr(prefix.size())));
+  }
+}
+
+} // namespace facebook::velox::window::test


### PR DESCRIPTION
Summary:
Add 'prefix' to functions registering Presto
scalar, aggregation and window functions.
By default the prefix is empty.
This will later be used to remove hardcoded prefix
'presto.default." from the Presto to Velox query plan
conversion code.

Differential Revision: D44000593

