### PR TITLE
Add assertEmptyResults() syntactic sugar to AssertQueryBuilder

### DIFF
--- a/velox/exec/tests/ValuesTest.cpp
+++ b/velox/exec/tests/ValuesTest.cpp
@@ -41,18 +41,17 @@ class ValuesTest : public OperatorTestBase {
 
 TEST_F(ValuesTest, empty) {
   // Base case: no vectors.
-  AssertQueryBuilder(PlanBuilder().values({}).planNode())
-      .assertResults(std::vector<RowVectorPtr>{});
+  AssertQueryBuilder(PlanBuilder().values({}).planNode()).assertEmptyResults();
 
   // Empty input vector.
   auto emptyInput = makeRowVector({});
   AssertQueryBuilder(PlanBuilder().values({emptyInput}).planNode())
-      .assertResults(std::vector<RowVectorPtr>{});
+      .assertEmptyResults();
 
   // Many empty vectors as input.
   AssertQueryBuilder(
       PlanBuilder().values({emptyInput, emptyInput, emptyInput}).planNode())
-      .assertResults(std::vector<RowVectorPtr>{});
+      .assertEmptyResults();
 }
 
 TEST_F(ValuesTest, simple) {
@@ -91,9 +90,9 @@ TEST_F(ValuesTest, valuesWithRepeat) {
 
   // Zero repeats.
   AssertQueryBuilder(PlanBuilder().values({}, false, 0).planNode())
-      .assertResults(std::vector<RowVectorPtr>{});
+      .assertEmptyResults();
   AssertQueryBuilder(PlanBuilder().values({input_}, false, 0).planNode())
-      .assertResults(std::vector<RowVectorPtr>{});
+      .assertEmptyResults();
 
   // Try repeating with 2 different row vectors.
   AssertQueryBuilder(

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -164,6 +164,12 @@ std::shared_ptr<Task> AssertQueryBuilder::assertResults(
   return cursor->task();
 }
 
+std::shared_ptr<Task> AssertQueryBuilder::assertEmptyResults() {
+  auto [cursor, results] = readCursor();
+  test::assertEmptyResults(results);
+  return cursor->task();
+}
+
 std::shared_ptr<Task> AssertQueryBuilder::assertTypeAndNumRows(
     const TypePtr& expectedType,
     vector_size_t expectedNumRows) {

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -114,6 +114,9 @@ class AssertQueryBuilder {
   std::shared_ptr<Task> assertResults(
       const std::vector<RowVectorPtr>& expected);
 
+  /// Run the query and test that it returns no results (empty result set).
+  std::shared_ptr<Task> assertEmptyResults();
+
   /// Run the query and ensure it returns batches of `expectedType`, and exactly
   /// `numRows`.
   std::shared_ptr<Task> assertTypeAndNumRows(

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -150,6 +150,8 @@ std::shared_ptr<Task> assertQuery(
 std::shared_ptr<Task> assertQueryReturnsEmptyResult(
     const std::shared_ptr<const core::PlanNode>& plan);
 
+void assertEmptyResults(const std::vector<RowVectorPtr>& results);
+
 void assertResults(
     const std::vector<RowVectorPtr>& results,
     const std::shared_ptr<const RowType>& resultType,


### PR DESCRIPTION
Summary:
Add assertEmptyResults() syntactic sugar to AssertQueryBuilder. Use
ADD_FAILURE() to improve error message.

Differential Revision: D44006966

