### PR TITLE
Set memory usage tracker in concurrent allocation benchmark

### DIFF
--- a/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
+++ b/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
@@ -38,6 +38,10 @@ DEFINE_uint32(
     num_runs,
     32,
     "The number of benchmark runs and reports the average results");
+DEFINE_bool(
+    enable_memory_usage_tracker,
+    true,
+    "If true, set memory usage tracker in the memory pool to measure the memory usage track cost");
 
 using namespace facebook::velox;
 using namespace facebook::velox::memory;
@@ -55,6 +59,9 @@ class MemoryOperator {
         maxOps_(maxOps),
         pool_(memoryManager->getChild()) {
     rng_.seed(1234);
+    if (FLAGS_enable_memory_usage_tracker) {
+      pool_->setMemoryUsageTracker(MemoryUsageTracker::create());
+    }
   }
 
   ~MemoryOperator() = default;


### PR DESCRIPTION
Set memory usage tracker in concurrent allocation benchmark to measure
usage track cost. This helps analyzing the performance of the concurrency
control simplification in the memory usage tracker in followup.