### PR TITLE
Report blocked wall time of individual blocked reasons for drivers

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -79,7 +79,8 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
 
         std::lock_guard<std::mutex> l(task->mutex());
         if (!driver->state().isTerminated) {
-          state->operator_->recordBlockingTime(state->sinceMicros_);
+          state->operator_->recordBlockingTime(
+              state->sinceMicros_, state->reason_);
         }
         VELOX_CHECK(!driver->state().isSuspended);
         VELOX_CHECK(driver->state().hasBlockingFuture);

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -286,12 +286,17 @@ OperatorStats Operator::stats(bool clear) {
   return ret;
 }
 
-void Operator::recordBlockingTime(uint64_t start) {
+void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
   uint64_t now =
       std::chrono::duration_cast<std::chrono::microseconds>(
           std::chrono::high_resolution_clock::now().time_since_epoch())
           .count();
-  stats_.wlock()->blockedWallNanos += (now - start) * 1000;
+  auto wallNanos = (now - start) * 1000;
+  stats_.wlock()->blockedWallNanos += wallNanos;
+  auto statName = fmt::format(
+      "blocked{}WallNanos", blockingReasonToString(reason).substr(1));
+  addRuntimeStat(
+      statName, RuntimeCounter(wallNanos, RuntimeCounter::Unit::kNanos));
 }
 
 std::string Operator::toString() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -399,7 +399,7 @@ class Operator : public BaseRuntimeStatWriter {
     return stats_;
   }
 
-  void recordBlockingTime(uint64_t start);
+  void recordBlockingTime(uint64_t start, BlockingReason reason);
 
   virtual std::string toString() const;
 

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -165,6 +165,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"        queuedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        rangeKey0\\s+sum: 200, count: 1, min: 200, max: 200"},
        {"     HashProbe: Input: 2000 rows \\(.+\\), Output: 2000 rows \\(.+\\), Cpu time: .+, Blocked wall time: .+, Peak memory: 1\\.00MB, Memory allocations: .+, Threads: 1"},
+       {"        blockedWaitForJoinBuildWallNanos\\s+sum: .+, count: 1, min: .+, max: .+"},
        {"        dynamicFiltersProduced\\s+sum: 1, count: 1, min: 1, max: 1"},
        {"        queuedWallNanos\\s+sum: .+, count: 1, min: .+, max: .+",
         true}, // This line may or may not appear depending on how the threads


### PR DESCRIPTION
Track and report as runtime stats the wall time of drivers
being blocked for individual blocked reasons.