### PR TITLE
Fix peeling of constant vector smaller than selected inner rows size

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -868,6 +868,9 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
     if (!values) {
       continue;
     }
+    if (values->isConstantEncoding() && values->size() < newRows->end()) {
+      values = BaseVector::wrapInConstant(newRows->end(), 0, values);
+    }
     context.setPeeled(i, values);
     if (constantFields.empty() || !constantFields[i]) {
       ++numPeeled;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3483,3 +3483,22 @@ TEST_F(ExprTest, smallerWrappedBaseVector) {
            std::nullopt}),
       result[0]);
 }
+
+TEST_F(ExprTest, peelingWithSmallerConstantInput) {
+  // This test ensures that when a dictionary-encoded vector is peeled together
+  // with a constant vector whose size is smaller than the corresponding
+  // selected rows of the dictionary base vector, the subsequent evaluation on
+  // the constant vector doesn't access values beyond its size.
+  auto data = makeRowVector({makeFlatVector<int64_t>({1, 2})});
+  auto c0 = makeRowVector(
+      {makeFlatVector<int64_t>({1, 3, 5, 7, 9})}, nullEvery(1, 2));
+  auto indices = makeIndices({2, 3, 4});
+  auto d0 = wrapInDictionary(indices, c0);
+  auto c1 = BaseVector::wrapInConstant(3, 1, data);
+
+  // After evaluating d0, Coalesce copies values from c1 to an existing result
+  // vector. c1 should be large enough so that this copy step does not access
+  // values out of bound.
+  auto result = evaluate("coalesce(c0, c1)", makeRowVector({d0, c1}));
+  assertEqualVectors(c1, result);
+}


### PR DESCRIPTION
Summary:
Fuzzer found a bug where two input vectors of an expression are a dictionary vector and a
constant vector whose size is smaller than the size of selected base rows of the dictionary
one. The current code peels off common encodings (i.e., the dictionary layer) and save the
dictionary base vector together with the original constant vector to EvalCtx for later access.
The subsequent evaluation is performed on the selected inner rows of the dictionary vector,
which is larger than the constant vector size and hence causes out-of-bound access.

This diff fixes this issue by resizing the constant vector to the size of the selected inner rows
after peeling if the constant vector size is smaller. This resizing happens before the constant
vector is saved to EvalCtx.

This diff fixes https://github.com/facebookincubator/velox/issues/4262.

Differential Revision: D44059058

