### PR TITLE
remove argTypes and returnType from simple functions metadata

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -404,7 +404,7 @@ ExprPtr compileExpression(
             SimpleFunctions().resolveFunction(call->name(), inputTypes)) {
       const auto& metadata = simpleFunctionEntry->getMetadata();
       VELOX_USER_CHECK(
-          resultType->kindEquals(metadata.returnType()),
+          resultType->kindEquals(simpleFunctionEntry->type()),
           "Found incompatible return types for '{}' ({} vs. {}) "
           "for input types ({}).",
           call->name(),

--- a/velox/expression/FunctionRegistry.h
+++ b/velox/expression/FunctionRegistry.h
@@ -22,9 +22,8 @@ namespace facebook::velox::exec {
 class FunctionSignature;
 
 template <typename T>
-const std::shared_ptr<const T>& GetSingletonUdfMetadata(
-    std::shared_ptr<const Type> returnType) {
-  static auto instance = std::make_shared<const T>(std::move(returnType));
+const std::shared_ptr<const T>& GetSingletonUdfMetadata() {
+  static auto instance = std::make_shared<const T>();
   return instance;
 }
 
@@ -59,14 +58,9 @@ class FunctionRegistry {
 
  public:
   template <typename UDF>
-  void registerFunction(
-      const std::vector<std::string>& aliases = {},
-      std::shared_ptr<const Type> returnType = nullptr) {
-    const auto& metadata =
-        GetSingletonUdfMetadata<typename UDF::Metadata>(std::move(returnType));
-    const auto factory = [metadata]() {
-      return CreateUdf<UDF>(metadata->returnType());
-    };
+  void registerFunction(const std::vector<std::string>& aliases = {}) {
+    const auto& metadata = GetSingletonUdfMetadata<typename UDF::Metadata>();
+    const auto factory = [metadata]() { return CreateUdf<UDF>(); };
 
     if (aliases.empty()) {
       registerFunctionInternal(metadata->getName(), metadata, factory);
@@ -160,8 +154,8 @@ class FunctionRegistry {
 
  private:
   template <typename T>
-  static std::unique_ptr<T> CreateUdf(std::shared_ptr<const Type> returnType) {
-    return std::make_unique<T>(std::move(returnType));
+  static std::unique_ptr<T> CreateUdf() {
+    return std::make_unique<T>();
   }
 
   void registerFunctionInternal(

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -224,9 +224,8 @@ class SimpleFunctionAdapter : public VectorFunction {
  public:
   explicit SimpleFunctionAdapter(
       const core::QueryConfig& config,
-      const std::vector<VectorPtr>& constantInputs,
-      std::shared_ptr<const Type> returnType)
-      : fn_{std::make_unique<FUNC>(std::move(returnType))} {
+      const std::vector<VectorPtr>& constantInputs)
+      : fn_{std::make_unique<FUNC>()} {
     if constexpr (FUNC::udf_has_initialize) {
       try {
         unpackInitialize<0>(config, constantInputs);
@@ -272,7 +271,7 @@ class SimpleFunctionAdapter : public VectorFunction {
   template <
       int32_t POSITION,
       typename std::enable_if_t<POSITION == FUNC::num_args, int32_t> = 0>
-  VectorPtr* findReusableArg(std::vector<VectorPtr>& args) const {
+  VectorPtr* findReusableArg(std::vector<VectorPtr>&) const {
     // Base case: we didn't find an input vector to reuse.
     return nullptr;
   }
@@ -865,19 +864,14 @@ class SimpleFunctionAdapterFactoryImpl : public SimpleFunctionAdapterFactory {
   // Exposed for use in FunctionRegistry
   using Metadata = typename UDFHolder::Metadata;
 
-  explicit SimpleFunctionAdapterFactoryImpl(
-      std::shared_ptr<const Type> returnType)
-      : returnType_(std::move(returnType)) {}
+  explicit SimpleFunctionAdapterFactoryImpl() {}
 
   std::unique_ptr<VectorFunction> createVectorFunction(
       const core::QueryConfig& config,
       const std::vector<VectorPtr>& constantInputs) const override {
     return std::make_unique<SimpleFunctionAdapter<UDFHolder>>(
-        config, constantInputs, returnType_);
+        config, constantInputs);
   }
-
- private:
-  const std::shared_ptr<const Type> returnType_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/SimpleFunctionRegistry.h
+++ b/velox/expression/SimpleFunctionRegistry.h
@@ -32,12 +32,9 @@ SimpleFunctionRegistry& SimpleFunctions();
 
 // This function should be called once and alone.
 template <typename UDFHolder>
-void registerSimpleFunction(
-    const std::vector<std::string>& names,
-    std::shared_ptr<const Type> returnType) {
+void registerSimpleFunction(const std::vector<std::string>& names) {
   SimpleFunctions()
-      .registerFunction<SimpleFunctionAdapterFactoryImpl<UDFHolder>>(
-          names, returnType);
+      .registerFunction<SimpleFunctionAdapterFactoryImpl<UDFHolder>>(names);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -107,7 +107,7 @@ struct ArrayWriterFunction {
 
 TEST_F(SimpleFunctionTest, arrayWriter) {
   registerFunction<ArrayWriterFunction, Array<int64_t>, int64_t>(
-      {"array_writer_func"}, ARRAY(BIGINT()));
+      {"array_writer_func"});
 
   const size_t rows = arrayData.size();
   auto flatVector = makeFlatVector<int64_t>(rows, [](auto row) { return row; });
@@ -144,7 +144,7 @@ struct ArrayOfStringsWriterFunction {
 
 TEST_F(SimpleFunctionTest, arrayOfStringsWriter) {
   registerFunction<ArrayOfStringsWriterFunction, Array<Varchar>, int64_t>(
-      {"array_of_strings_writer_func"}, ARRAY(VARCHAR()));
+      {"array_of_strings_writer_func"});
 
   const size_t rows = stringArrayData.size();
   auto flatVector = makeFlatVector<int64_t>(rows, [](auto row) { return row; });
@@ -250,7 +250,7 @@ struct RowWriterFunction {
 
 TEST_F(SimpleFunctionTest, rowWriter) {
   registerFunction<RowWriterFunction, Row<int64_t, double>, int64_t>(
-      {"row_writer_func"}, ROW({BIGINT(), DOUBLE()}));
+      {"row_writer_func"});
 
   const size_t rows = rowVectorCol1.size();
   auto flatVector = makeFlatVector<int64_t>(rows, [](auto row) { return row; });
@@ -352,7 +352,7 @@ TEST_F(SimpleFunctionTest, arrayRowWriter) {
   registerFunction<
       ArrayRowWriterFunction,
       Array<Row<int64_t, double>>,
-      int32_t>({"array_row_writer_func"}, ARRAY(ROW({BIGINT(), DOUBLE()})));
+      int32_t>({"array_row_writer_func"});
 
   const size_t rows = rowVectorCol1.size();
   auto flatVector = makeFlatVector<int32_t>(rows, [](auto row) { return row; });

--- a/velox/expression/tests/TryExprTest.cpp
+++ b/velox/expression/tests/TryExprTest.cpp
@@ -61,8 +61,7 @@ struct CountCallsFunction {
 };
 
 TEST_F(TryExprTest, skipExecution) {
-  registerFunction<CountCallsFunction, int64_t, int64_t>(
-      {"count_calls"}, BIGINT());
+  registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   std::vector<std::optional<int64_t>> expected{
       0, std::nullopt, 1, std::nullopt, 2};
@@ -132,8 +131,7 @@ TEST_F(TryExprTest, nestedTryParentErrors) {
 }
 
 TEST_F(TryExprTest, skipExecutionEvalSimplified) {
-  registerFunction<CountCallsFunction, int64_t, int64_t>(
-      {"count_calls"}, BIGINT());
+  registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   // Test that when a subset of the inputs to a function wrapped in a TRY throw
   // exceptions, that function is only evaluated on the inputs that did not
@@ -148,8 +146,7 @@ TEST_F(TryExprTest, skipExecutionEvalSimplified) {
 }
 
 TEST_F(TryExprTest, skipExecutionWholeBatchEvalSimplified) {
-  registerFunction<CountCallsFunction, int64_t, int64_t>(
-      {"count_calls"}, BIGINT());
+  registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   // Test that when all the inputs to a function wrapped in a TRY throw
   // exceptions, that function isn't evaluated and a NULL constant is returned
@@ -292,8 +289,7 @@ TEST_F(TryExprTest, constant) {
 }
 
 TEST_F(TryExprTest, evalSimplified) {
-  registerFunction<CountCallsFunction, int64_t, int64_t>(
-      {"count_calls"}, BIGINT());
+  registerFunction<CountCallsFunction, int64_t, int64_t>({"count_calls"});
 
   std::vector<std::optional<int64_t>> expected{0, 1, 2, 3};
   auto constant = makeConstant<int64_t>(0, 4);

--- a/velox/functions/Macros.h
+++ b/velox/functions/Macros.h
@@ -20,6 +20,7 @@
 
 #define VELOX_UDF_BEGIN(Name)                                                \
   struct udf_##Name {                                                        \
+    static constexpr auto name = #Name;                                      \
     template <typename __Velox_ExecParams>                                   \
     struct udf {                                                             \
       template <typename __Velox_TArg>                                       \

--- a/velox/functions/Registerer.h
+++ b/velox/functions/Registerer.h
@@ -35,13 +35,11 @@ template <template <class...> typename T, typename... TArgs>
 using ParameterBinder = TempWrapper<T<exec::VectorExec, TArgs...>>;
 
 template <typename Func, typename TReturn, typename... TArgs>
-void registerFunction(
-    const std::vector<std::string>& aliases = {},
-    std::shared_ptr<const Type> returnType = nullptr) {
+void registerFunction(const std::vector<std::string>& aliases = {}) {
   using funcClass = typename Func::template udf<exec::VectorExec>;
   using holderClass =
       core::UDFHolder<funcClass, exec::VectorExec, TReturn, TArgs...>;
-  exec::registerSimpleFunction<holderClass>(aliases, std::move(returnType));
+  exec::registerSimpleFunction<holderClass>(aliases);
 }
 
 // New registration function; mostly a copy from the function above, but taking
@@ -49,13 +47,11 @@ void registerFunction(
 // a while to maintain backwards compatibility, but the idea is to remove the
 // one above eventually.
 template <template <class> typename Func, typename TReturn, typename... TArgs>
-void registerFunction(
-    const std::vector<std::string>& aliases = {},
-    std::shared_ptr<const Type> returnType = nullptr) {
+void registerFunction(const std::vector<std::string>& aliases = {}) {
   using funcClass = Func<exec::VectorExec>;
   using holderClass =
       core::UDFHolder<funcClass, exec::VectorExec, TReturn, TArgs...>;
-  exec::registerSimpleFunction<holderClass>(aliases, std::move(returnType));
+  exec::registerSimpleFunction<holderClass>(aliases);
 }
 
 } // namespace facebook::velox

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -523,6 +523,9 @@ bool OpaqueType::equivalent(const Type& other) const {
 }
 
 bool OpaqueType::operator==(const Type& other) const {
+  if (&other == this) {
+    return true;
+  }
   if (!this->equivalent(other)) {
     return false;
   }


### PR DESCRIPTION
Summary:
metadata for simple  used to expose the return
type and the arg types, however those are not always fixed; For example,
when there are variables in the signature, or when there is variadic.

The metadata now have the signature instead which
can be used to extract such information.

This diff removes returnType and argTypes from the metadata, for some
users that depends on reading the return type from the metadata the diff
add tryResolveReturnType, that may return null if the output is not fixed.

Differential Revision: D44045196

