### PR TITLE
Fix Json custom type mapping

### DIFF
--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -95,7 +95,7 @@ FOLLY_ALWAYS_INLINE std::shared_ptr<const JsonType> JSON() {
 
 // Type used for function registration.
 struct JsonT {
-  using type = StringView;
+  using type = Varchar;
   static constexpr const char* typeName = "json";
 };
 


### PR DESCRIPTION
Summary: type should refer to a simple type, strings uses Varchar.

Differential Revision: D44061421

