### PR TITLE
Refactor custom types managing functions

### DIFF
--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -79,13 +79,13 @@ class CastExpr : public SpecialForm {
             false /* supportsFlatNoNullsFastPath */,
             trackCpuUsage) {
     auto fromType = inputs_[0]->type();
-    castFromOperator_ = getCastOperator(fromType->toString());
+    castFromOperator_ = getCustomTypeCastOperator(fromType->toString());
     if (castFromOperator_ && !castFromOperator_->isSupportedToType(type)) {
       VELOX_FAIL(
           "Cannot cast {} to {}.", fromType->toString(), type->toString());
     }
 
-    castToOperator_ = getCastOperator(type->toString());
+    castToOperator_ = getCustomTypeCastOperator(type->toString());
     if (castToOperator_ && !castToOperator_->isSupportedFromType(fromType)) {
       VELOX_FAIL(
           "Cannot cast {} to {}.", fromType->toString(), type->toString());

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -161,7 +161,7 @@ void validateBaseTypeAndCollectTypeParams(
     }
 
     if (!isPositiveInteger(typeName) && !isCommonDecimalName(typeName) &&
-        !typeExists(typeName)) {
+        !customTypeExists(typeName)) {
       // Check to ensure base type is supported.
       mapNameToTypeKind(typeName);
     }

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -199,7 +199,7 @@ bool SignatureBinderBase::tryBind(
   // Type is not a variable.
   auto typeName = boost::algorithm::to_upper_copy(baseName);
 
-  if (auto customType = getType(baseName, {})) {
+  if (auto customType = getCustomType(baseName)) {
     VELOX_CHECK_EQ(
         typeSignature.parameters().size(),
         0,
@@ -272,7 +272,7 @@ TypePtr SignatureBinder::tryResolveType(
     children.emplace_back(type);
   }
 
-  if (auto type = getType(typeName, children)) {
+  if (auto type = getCustomType(typeName)) {
     return type;
   }
 

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -535,7 +535,7 @@ TEST(SignatureBinderTest, lambda) {
 }
 
 TEST(SignatureBinderTest, customType) {
-  registerType(
+  registerCustomType(
       "timestamp with time zone",
       std::make_unique<const TimestampWithTimeZoneTypeFactories>());
 

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -452,7 +452,7 @@ bool registerApproxDistinct(
 } // namespace
 
 void registerApproxDistinctAggregates(const std::string& prefix) {
-  registerType(
+  registerCustomType(
       prefix + "hyperloglog",
       std::make_unique<const HyperLogLogTypeFactories>());
   registerApproxDistinct(prefix + kApproxDistinct, false, false);

--- a/velox/functions/prestosql/types/HyperLogLogType.cpp
+++ b/velox/functions/prestosql/types/HyperLogLogType.cpp
@@ -18,7 +18,7 @@
 namespace facebook::velox {
 
 void registerHyperLogLogType() {
-  registerType(
+  registerCustomType(
       "hyperloglog", std::make_unique<const HyperLogLogTypeFactories>());
 }
 

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -68,7 +68,7 @@ using HyperLogLog = CustomType<HyperLogLogT>;
 
 class HyperLogLogTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+  TypePtr getType() const override {
     return HYPERLOGLOG();
   }
 

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -859,7 +859,7 @@ void JsonCastOperator::castFrom(
 }
 
 void registerJsonType() {
-  registerType("json", std::make_unique<const JsonTypeFactories>());
+  registerCustomType("json", std::make_unique<const JsonTypeFactories>());
 }
 
 } // namespace facebook::velox

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -105,7 +105,7 @@ class JsonTypeFactories : public CustomTypeFactories {
  public:
   JsonTypeFactories() = default;
 
-  TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+  TypePtr getType() const override {
     return JSON();
   }
 

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -18,7 +18,7 @@
 namespace facebook::velox {
 
 void registerTimestampWithTimeZoneType() {
-  registerType(
+  registerCustomType(
       "timestamp with time zone",
       std::make_unique<const TimestampWithTimeZoneTypeFactories>());
 }

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -72,7 +72,7 @@ using TimestampWithTimezone = CustomType<TimestampWithTimezoneT>;
 
 class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
  public:
-  TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+  TypePtr getType() const override {
     return TIMESTAMP_WITH_TIME_ZONE();
   }
 

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -34,7 +34,8 @@ template <typename T, const char* name>
 class OpaqueCustomTypeRegister {
  public:
   static void registerType() {
-    facebook::velox::registerType(name, std::make_unique<const TypeFactory>());
+    facebook::velox::registerCustomType(
+        name, std::make_unique<const TypeFactory>());
   }
 
   // Type used in the simple function interface as CustomType<TypeT>.
@@ -77,7 +78,7 @@ class OpaqueCustomTypeRegister {
    public:
     TypeFactory() = default;
 
-    TypePtr getType(std::vector<TypePtr> /*childTypes*/) const override {
+    TypePtr getType() const override {
       return singletonTypePtr();
     }
 

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -185,8 +185,8 @@ TypePtr Type::create(const folly::dynamic& obj) {
 
   // Checks if 'typeName' specifies a custom type.
   auto typeName = obj["type"].asString();
-  if (typeExists(typeName)) {
-    return getType(typeName, std::move(childTypes));
+  if (customTypeExists(typeName)) {
+    return getCustomType(typeName);
   }
 
   // 'typeName' must be a built-in type.
@@ -758,14 +758,14 @@ typeFactories() {
 
 } // namespace
 
-bool registerType(
+bool registerCustomType(
     const std::string& name,
     std::unique_ptr<const CustomTypeFactories> factories) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
   return typeFactories().emplace(uppercaseName, std::move(factories)).second;
 }
 
-bool typeExists(const std::string& name) {
+bool customTypeExists(const std::string& name) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
   return typeFactories().count(uppercaseName) > 0;
 }
@@ -778,7 +778,7 @@ std::unordered_set<std::string> getCustomTypeNames() {
   return typeNames;
 }
 
-bool unregisterType(const std::string& name) {
+bool unregisterCustomType(const std::string& name) {
   auto uppercaseName = boost::algorithm::to_upper_copy(name);
   return typeFactories().erase(uppercaseName) == 1;
 }
@@ -795,16 +795,16 @@ getTypeFactories(const std::string& name) {
   return nullptr;
 }
 
-TypePtr getType(const std::string& name, std::vector<TypePtr> childTypes) {
+TypePtr getCustomType(const std::string& name) {
   auto factories = getTypeFactories(name);
   if (factories) {
-    return factories->getType(std::move(childTypes));
+    return factories->getType();
   }
 
   return nullptr;
 }
 
-exec::CastOperatorPtr getCastOperator(const std::string& name) {
+exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name) {
   auto factories = getTypeFactories(name);
   if (factories) {
     return factories->getCastOperator();

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1811,9 +1811,8 @@ class CustomTypeFactories {
  public:
   virtual ~CustomTypeFactories() = default;
 
-  /// Returns a shared pointer to the custom type with the specified child
-  /// types.
-  virtual TypePtr getType(std::vector<TypePtr> childTypes) const = 0;
+  /// Returns a shared pointer to the custom type.
+  virtual TypePtr getType() const = 0;
 
   /// Returns a shared pointer to the custom cast operator. If a custom type
   /// should be treated as its underlying native type during type castings,
@@ -1825,28 +1824,28 @@ class CustomTypeFactories {
 /// Adds custom type to the registry if it doesn't exist already. No-op if type
 /// with specified name already exists. Returns true if type was added, false if
 /// type with the specified name already exists.
-bool registerType(
+bool registerCustomType(
     const std::string& name,
     std::unique_ptr<const CustomTypeFactories> factories);
 
-/// Return true if customer type with specified name exists.
-bool typeExists(const std::string& name);
+/// Return true if a custom type with the specified name exists.
+bool customTypeExists(const std::string& name);
 
 /// Returns a set of all registered custom type names.
 std::unordered_set<std::string> getCustomTypeNames();
 
 /// Returns an instance of a custom type with the specified name and specified
 /// child types.
-TypePtr getType(const std::string& name, std::vector<TypePtr> childTypes);
+TypePtr getCustomType(const std::string& name);
 
 /// Removes custom type from the registry if exists. Returns true if type was
 /// removed, false if type didn't exist.
-bool unregisterType(const std::string& name);
+bool unregisterCustomType(const std::string& name);
 
 /// Returns the custom cast operator for the custom type with the specified
 /// name. Returns nullptr if a type with the specified name does not exist or
 /// does not have a dedicated custom cast operator.
-exec::CastOperatorPtr getCastOperator(const std::string& name);
+exec::CastOperatorPtr getCustomTypeCastOperator(const std::string& name);
 
 // Allows us to transparently use folly::toAppend(), folly::join(), etc.
 template <class TString>


### PR DESCRIPTION
Summary:
1. Rename functions that manage custom types only
ex: getType-> getCustomType.
2. We do not have custom type with types dependent on
children types, hence removing the unused arg from the
interface.

Reviewed By: mbasmanova

Differential Revision: D44042270

