### PR TITLE
First cut of OffProcessExpressionEval operator

### DIFF
--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -59,6 +59,7 @@ add_subdirectory(connectors)
 if(${VELOX_ENABLE_EXEC})
   add_subdirectory(exec)
   add_subdirectory(codegen)
+  add_subdirectory(experimental/exec)
 endif()
 
 if(${VELOX_ENABLE_DUCKDB})

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include "velox/connectors/fuzzer/FuzzerConnector.h"
 #include <folly/init/Init.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/connectors/fuzzer/FuzzerConnector.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
 
 target_link_libraries(
   velox_exec_test_lib
+  velox_vector_test_lib
   velox_temp_path
   velox_core
   velox_exception

--- a/velox/experimental/exec/CMakeLists.txt
+++ b/velox/experimental/exec/CMakeLists.txt
@@ -11,16 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_connector Connector.cpp)
 
-target_link_libraries(velox_connector velox_config velox_vector)
+add_library(velox_experimental_exec_off_process OBJECT
+            OffProcessExpressionEval.cpp)
 
-add_subdirectory(fuzzer)
+target_link_libraries(velox_experimental_exec_off_process velox_core velox_exec
+                      velox_vector)
 
-if(${VELOX_ENABLE_HIVE_CONNECTOR})
-  add_subdirectory(hive)
-endif()
-
-if(${VELOX_ENABLE_TPCH_CONNECTOR})
-  add_subdirectory(tpch)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
 endif()

--- a/velox/experimental/exec/OffProcessExpressionEval.cpp
+++ b/velox/experimental/exec/OffProcessExpressionEval.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/exec/OffProcessExpressionEval.h"
+
+namespace facebook::velox::exec {
+
+// Maximum buffer size in bytes for stream groups before they are
+// flushed.
+constexpr int32_t kMaxStreamGroupSizeBytes{50000};
+
+void OffProcessExpressionEvalNode::addDetails(std::stringstream& stream) const {
+  stream << "expressions: ";
+  for (auto i = 0; i < expressions_.size(); i++) {
+    auto& expr = expressions_[i];
+    if (i > 0) {
+      stream << ", ";
+    }
+    stream << "(" << expr->type()->toString() << ", " << expr->toString()
+           << ")";
+  }
+}
+
+OffProcessExpressionEvalOperator::OffProcessExpressionEvalOperator(
+    int32_t operatorId,
+    exec::DriverCtx* driverCtx,
+    const std::shared_ptr<const OffProcessExpressionEvalNode>& planNode)
+    : Operator(
+          driverCtx,
+          planNode->outputType(),
+          operatorId,
+          planNode->id(),
+          "OffProcessExpressionEval"),
+      inputType_(planNode->sources().front()->outputType()),
+      expressions_{planNode->expressions()} {}
+
+void OffProcessExpressionEvalOperator::addInput(RowVectorPtr input) {
+  if (!streamGroup_) {
+    streamGroup_ = std::make_unique<VectorStreamGroup>(pool());
+    streamGroup_->createStreamTree(inputType_, 1000);
+  }
+
+  IndexRange range{0, input->size()};
+  streamGroup_->append(input, folly::Range<IndexRange*>(&range, 1));
+
+  if (streamGroup_->size() > kMaxStreamGroupSizeBytes) {
+    flushStreamGroup();
+  }
+}
+
+void OffProcessExpressionEvalOperator::flushStreamGroup() {
+  if (streamGroup_) {
+    IOBufOutputStream stream(*pool());
+    streamGroup_->flush(&stream);
+    addRuntimeStat(
+        "dataFlushes",
+        RuntimeCounter(streamGroup_->size(), RuntimeCounter::Unit::kBytes));
+
+    auto ioBuf = stream.getIOBuf();
+    streamGroup_.reset();
+
+    ioBuf_ = sendOffProcess(expressions_, std::move(ioBuf));
+  }
+}
+
+std::unique_ptr<folly::IOBuf> OffProcessExpressionEvalOperator::sendOffProcess(
+    const std::vector<core::TypedExprPtr>& /* expressions */,
+    std::unique_ptr<folly::IOBuf>&& ioBuf) {
+  // TODO: Implement a pluggable logic to send data off-process.
+  return std::move(ioBuf);
+}
+
+void OffProcessExpressionEvalOperator::noMoreInput() {
+  flushStreamGroup();
+  Operator::noMoreInput();
+}
+
+RowVectorPtr OffProcessExpressionEvalOperator::getOutput() {
+  if (!ioBuf_) {
+    return nullptr;
+  }
+
+  auto outputVector = deserializeIOBuf(*ioBuf_);
+  ioBuf_.reset();
+  return outputVector;
+}
+
+RowVectorPtr OffProcessExpressionEvalOperator::deserializeIOBuf(
+    const folly::IOBuf& ioBuf) {
+  std::vector<ByteRange> ranges;
+  ranges.reserve(4);
+
+  for (const auto& range : ioBuf) {
+    ranges.emplace_back(ByteRange{
+        const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
+  }
+  byteStream_.resetInput(std::move(ranges));
+
+  RowVectorPtr outputVector;
+  VectorStreamGroup::read(&byteStream_, pool(), outputType_, &outputVector);
+  return outputVector;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/experimental/exec/OffProcessExpressionEval.h
+++ b/velox/experimental/exec/OffProcessExpressionEval.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/io/IOBuf.h>
+#include "velox/core/PlanNode.h"
+#include "velox/exec/Operator.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::exec {
+
+/// This file contains the plan node and operators that can be used for
+/// off-process expression evaluation in a plan. The operator serializes input
+/// batches and sends them to a remote process along with the expressions
+/// specified in `expressions`.
+
+/// Off-process expression eval plan node. `expressions` control the expressions
+/// that will be remotely executed.
+class OffProcessExpressionEvalNode : public core::PlanNode {
+ public:
+  OffProcessExpressionEvalNode(
+      core::PlanNodeId id,
+      std::vector<core::TypedExprPtr> expressions,
+      core::PlanNodePtr source)
+      : PlanNode(std::move(id)),
+        expressions_{std::move(expressions)},
+        sources_{std::move(source)} {
+    VELOX_USER_CHECK_EQ(1, sources_.size());
+  }
+
+  const RowTypePtr& outputType() const override {
+    return sources_.front()->outputType();
+  }
+
+  const std::vector<core::TypedExprPtr>& expressions() const {
+    return expressions_;
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "OffProcessExpressionEval";
+  }
+
+ private:
+  void addDetails(std::stringstream& stream) const override;
+
+  const std::vector<core::TypedExprPtr> expressions_;
+  const std::vector<core::PlanNodePtr> sources_;
+};
+
+class OffProcessExpressionEvalOperator : public exec::Operator {
+ public:
+  OffProcessExpressionEvalOperator(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      const std::shared_ptr<const OffProcessExpressionEvalNode>& planNode);
+
+  void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  RowVectorPtr getOutput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* /* future */) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_;
+  }
+
+ private:
+  // Sends the current IOBuf off-process, returning the result IOBuf received
+  // from the remote process.
+  //
+  // TODO: this function will need to return a future.
+  std::unique_ptr<folly::IOBuf> sendOffProcess(
+      const std::vector<core::TypedExprPtr>& expressions,
+      std::unique_ptr<folly::IOBuf>&& ioBuf);
+
+  // Flushes the current stream group contents.
+  void flushStreamGroup();
+
+  RowVectorPtr deserializeIOBuf(const folly::IOBuf& ioBuf);
+
+  std::unique_ptr<VectorStreamGroup> streamGroup_;
+  ByteStream byteStream_;
+
+  std::unique_ptr<folly::IOBuf> ioBuf_;
+
+  RowTypePtr inputType_;
+  std::vector<core::TypedExprPtr> expressions_;
+};
+
+class OffProcessExpressionEvalTranslator
+    : public exec::Operator::PlanNodeTranslator {
+  std::unique_ptr<exec::Operator> toOperator(
+      exec::DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto offProcessNode =
+            std::dynamic_pointer_cast<const OffProcessExpressionEvalNode>(
+                node)) {
+      return std::make_unique<OffProcessExpressionEvalOperator>(
+          id, ctx, offProcessNode);
+    }
+    return nullptr;
+  }
+};
+
+} // namespace facebook::velox::exec

--- a/velox/experimental/exec/tests/CMakeLists.txt
+++ b/velox/experimental/exec/tests/CMakeLists.txt
@@ -11,16 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_connector Connector.cpp)
+add_executable(velox_experimental_exec_test OffProcessExpressionEvalTest.cpp)
 
-target_link_libraries(velox_connector velox_config velox_vector)
+add_test(velox_experimental_exec_test velox_experimental_exec_test)
 
-add_subdirectory(fuzzer)
-
-if(${VELOX_ENABLE_HIVE_CONNECTOR})
-  add_subdirectory(hive)
-endif()
-
-if(${VELOX_ENABLE_TPCH_CONNECTOR})
-  add_subdirectory(tpch)
-endif()
+target_link_libraries(
+  velox_experimental_exec_test
+  velox_experimental_exec_off_process
+  velox_fuzzer_connector
+  velox_vector_test_lib
+  velox_exec_test_lib
+  gtest
+  gtest_main)

--- a/velox/experimental/exec/tests/OffProcessExpressionEvalTest.cpp
+++ b/velox/experimental/exec/tests/OffProcessExpressionEvalTest.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/exec/OffProcessExpressionEval.h"
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+#include "velox/connectors/fuzzer/tests/FuzzerConnectorTestBase.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
+
+namespace facebook::velox::exec::test {
+
+class OffProcessExpressionEvalTest
+    : public connector::fuzzer::test::FuzzerConnectorTestBase {
+ protected:
+  OffProcessExpressionEvalTest() {
+    exec::Operator::registerOperator(
+        std::make_unique<OffProcessExpressionEvalTranslator>());
+  }
+
+  std::vector<core::TypedExprPtr> parseExpr(
+      const std::string& exprString,
+      const RowVectorPtr& rowVector) {
+    auto rowType = asRowType(rowVector->type());
+    std::vector<core::TypedExprPtr> typedExprs;
+    typedExprs.push_back(OperatorTestBase::parseExpr(
+        exprString, rowType, parse::ParseOptions{}));
+    return typedExprs;
+  }
+
+ private:
+  VectorFuzzer::Options fuzzerOptions_;
+};
+
+TEST_F(OffProcessExpressionEvalTest, singleBatch) {
+  auto rowVector = vectorMaker_.rowVector({
+      vectorMaker_.flatVector({0, 1, 2, 3, 4}),
+      vectorMaker_.flatVector({"a", "b", "c", "d", "e"}),
+  });
+
+  auto lambda = [&](std::string id, core::PlanNodePtr input) {
+    return std::make_shared<OffProcessExpressionEvalNode>(
+        id, parseExpr("1 + 2", rowVector), input);
+  };
+
+  auto plan =
+      exec::test::PlanBuilder().values({rowVector}).addNode(lambda).planNode();
+  exec::test::AssertQueryBuilder(plan).assertResults(rowVector);
+}
+
+TEST_F(OffProcessExpressionEvalTest, multipleBatches) {
+  std::vector<RowVectorPtr> inputVectors;
+
+  for (int32_t i = 0; i < 100; i++) {
+    inputVectors.push_back(vectorMaker_.rowVector({
+        vectorMaker_.flatVector({folly::Random::rand32()}),
+        vectorMaker_.flatVector({std::to_string(i)}),
+    }));
+  }
+
+  auto plan = exec::test::PlanBuilder()
+                  .values(inputVectors)
+                  .addNode([](std::string id, core::PlanNodePtr input) {
+                    return std::make_shared<OffProcessExpressionEvalNode>(
+                        id, std::vector<core::TypedExprPtr>{}, input);
+                  })
+                  .planNode();
+
+  exec::test::AssertQueryBuilder(plan).assertResults(inputVectors);
+}
+
+TEST_F(OffProcessExpressionEvalTest, fuzzer) {
+  for (size_t i = 0; i < 10; i++) {
+    auto randType = VectorFuzzer({}, pool()).randRowType();
+
+    auto plan = exec::test::PlanBuilder()
+                    .tableScan(randType, makeFuzzerTableHandle(), {})
+                    .addNode([](std::string id, core::PlanNodePtr input) {
+                      return std::make_shared<OffProcessExpressionEvalNode>(
+                          id, std::vector<core::TypedExprPtr>{}, input);
+                    })
+                    .planNode();
+
+    exec::test::AssertQueryBuilder(plan)
+        .splits(makeFuzzerSplits(50, 100))
+        .assertTypeAndNumRows(randType, 50 * 100);
+  }
+}
+
+} // namespace facebook::velox::exec::test
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Summary:
According to the description in
(https://github.com/facebookincubator/velox/discussions/4197), adds a first
version of an operator able to execute expressions off-process. For now just
adding the skeleton under velox/experimental. Will add the remaining
functionality in follow up PRs to make it easier to review, and preventing this
base PR from being way too large.

Differential Revision: D44077009

