### PR TITLE
Do not use prefix for special form functions.

### DIFF
--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -19,14 +19,19 @@
 
 namespace facebook::velox::functions {
 
+// Special form functions don't have any prefix.
+void registerAllSpecialFormGeneralFunctions() {
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, "in");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "row_constructor");
+  registerIsNullFunction("is_null");
+}
+
 void registerGeneralFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, prefix + "element_at");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, prefix + "subscript");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, prefix + "transform");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reduce, prefix + "reduce");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_in, prefix + "in");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, prefix + "row_constructor");
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_least, prefix + "least");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_greatest, prefix + "greatest");
@@ -36,7 +41,7 @@ void registerGeneralFunctions(const std::string& prefix) {
   registerFunction<CardinalityFunction, int64_t, Map<Any, Any>>(
       {prefix + "cardinality"});
 
-  registerIsNullFunction(prefix + "is_null");
+  registerAllSpecialFormGeneralFunctions();
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
+++ b/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
@@ -52,6 +52,11 @@ TEST_F(ScalarFunctionRegTest, prefix) {
   std::unordered_map<std::string, exec::VectorFunctionEntry>
       scalarVectorFuncMap = *(exec::vectorFunctionFactories().rlock());
 
+  // Remove special form functions - they don't have any prefix.
+  scalarVectorFuncMap.erase("in");
+  scalarVectorFuncMap.erase("row_constructor");
+  scalarVectorFuncMap.erase("is_null");
+
   for (const auto& entry : scalarVectorFuncMap) {
     EXPECT_EQ(prefix, entry.first.substr(0, prefix.size()));
     EXPECT_EQ(


### PR DESCRIPTION
Summary:
When registering functions, do not use prefix for
special form functions "in", "row_constructor" and "is_null".

Differential Revision: D44079902

