### PR TITLE
Remove macos-intel builds due to CCI brew issue.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ workflows:
       - macos-build:
           matrix:
             parameters:
-              os: [macos-intel, macos-m1]
+              os: [macos-m1]
       - format-check
       - header-check
 


### PR DESCRIPTION
We have raised a support issue : https://support.circleci.com/hc/en-us/requests/129830?page=1 . 
As soon as we have a resolution we will turn this on. 