### PR TITLE
Remove comparision of exceptions in fuzzer

### DIFF
--- a/velox/expression/tests/FuzzerToolkit.cpp
+++ b/velox/expression/tests/FuzzerToolkit.cpp
@@ -85,44 +85,6 @@ void sortSignatureTemplates(std::vector<SignatureTemplate>& signatures) {
       });
 }
 
-namespace {
-
-bool isInvalidArgumentOrUnsupported(const VeloxException& ex) {
-  return ex.errorCode() == "INVALID_ARGUMENT" ||
-      ex.errorCode() == "UNSUPPORTED";
-}
-
-void compareExceptions(
-    const VeloxException& left,
-    const VeloxException& right) {
-  // Error messages sometimes differ; check at least error codes.
-  // Since the common path may peel the input encoding off, whereas the
-  // simplified path flatten input vectors, the common and the simplified
-  // paths may evaluate the input rows in different orders and hence throw
-  // different exceptions depending on which bad input they come across
-  // first. We have seen this happen for the format_datetime Presto function
-  // that leads to unmatched error codes UNSUPPORTED vs. INVALID_ARGUMENT.
-  // Therefore, we intentionally relax the comparision here.
-  if (left.errorCode() == right.errorCode() ||
-      (isInvalidArgumentOrUnsupported(left) &&
-       isInvalidArgumentOrUnsupported(right))) {
-    VELOX_CHECK_EQ(left.errorSource(), right.errorSource());
-    VELOX_CHECK_EQ(left.exceptionName(), right.exceptionName());
-    if (left.message() != right.message()) {
-      LOG(WARNING) << "Two different VeloxExceptions were thrown:\n\t"
-                   << left.message() << "\nand\n\t" << right.message();
-    }
-  } else {
-    LOG(ERROR) << left.what();
-    LOG(ERROR) << right.what();
-    VELOX_FAIL(
-        "Two different VeloxExceptions were thrown: {} vs. {}",
-        left.message(),
-        right.message());
-  }
-}
-} // namespace
-
 void compareExceptions(
     std::exception_ptr commonPtr,
     std::exception_ptr simplifiedPtr) {
@@ -136,32 +98,6 @@ void compareExceptions(
       std::rethrow_exception(simplifiedPtr);
     }
   }
-
-  // Otherwise, make sure the exceptions are the same.
-  try {
-    std::rethrow_exception(commonPtr);
-  } catch (const VeloxException& ve1) {
-    try {
-      std::rethrow_exception(simplifiedPtr);
-    } catch (const VeloxException& ve2) {
-      compareExceptions(ve1, ve2);
-      return;
-    } catch (const std::exception& e2) {
-      LOG(WARNING) << "Two different exceptions were thrown:\n\t"
-                   << ve1.message() << "\nand\n\t" << e2.what();
-    }
-  } catch (const std::exception& e1) {
-    try {
-      std::rethrow_exception(simplifiedPtr);
-    } catch (const std::exception& e2) {
-      if (e1.what() != e2.what()) {
-        LOG(WARNING) << "Two different std::exceptions were thrown:\n\t"
-                     << e1.what() << "\nand\n\t" << e2.what();
-      }
-      return;
-    }
-  }
-  VELOX_FAIL("Got two incompatible exceptions.");
 }
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Expression fuzzer currently verifies that the error codes of exceptions from both the common and simplifed evaluation paths are the same. This is hard to guarantee because the common path performs peeling while the simplified path flattens vectors, which leads to different orders of values they process and hence different errors they come across first. Given that expression fuzzer now only allows VeloxUserErrors, it's reasonable to consider all VeloxUserErrors compatible and hence not comparing their error codes. This diff removes the comparison of error codes between exceptions in fuzzer.

This diff fixes https://github.com/facebookincubator/velox/issues/3969.

Differential Revision: D44101295

