### PR TITLE
Add serialization for PlanNode classes

### DIFF
--- a/velox/common/serialization/Serializable.h
+++ b/velox/common/serialization/Serializable.h
@@ -88,7 +88,8 @@ class ISerializable {
   template <
       typename T,
       typename = std::enable_if_t<std::is_base_of_v<ISerializable, T>>>
-  static folly::dynamic serialize(std::shared_ptr<const T> serializable) {
+  static folly::dynamic serialize(
+      const std::shared_ptr<const T>& serializable) {
     return serializable->serialize();
   }
 
@@ -103,11 +104,15 @@ class ISerializable {
       typename T,
       typename = std::enable_if_t<
           is_any_of<T, int64_t, double, std::string, bool>::value>>
-  static folly::dynamic serialize(T val) {
+  static folly::dynamic serialize(const T& val) {
     return val;
   }
 
   static folly::dynamic serialize(int32_t val) {
+    return folly::dynamic{(int64_t)val};
+  }
+
+  static folly::dynamic serialize(uint32_t val) {
     return folly::dynamic{(int64_t)val};
   }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -76,6 +76,10 @@ class SortOrder {
         (nullsFirst_ ? "FIRST" : "LAST"));
   }
 
+  folly::dynamic serialize() const;
+
+  static SortOrder deserialize(const folly::dynamic& obj);
+
  private:
   bool ascending_;
   bool nullsFirst_;
@@ -86,7 +90,7 @@ extern const SortOrder kAscNullsLast;
 extern const SortOrder kDescNullsFirst;
 extern const SortOrder kDescNullsLast;
 
-class PlanNode {
+class PlanNode : public ISerializable {
  public:
   explicit PlanNode(const PlanNodeId& id) : id_{id} {}
 
@@ -95,6 +99,10 @@ class PlanNode {
   const PlanNodeId& id() const {
     return id_;
   }
+
+  folly::dynamic serialize() const override;
+
+  static void registerSerDe();
 
   virtual const RowTypePtr& outputType() const = 0;
 
@@ -239,6 +247,10 @@ class ValuesNode : public PlanNode {
     return "Values";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -274,6 +286,10 @@ class ArrowStreamNode : public PlanNode {
     return "ArrowStream";
   }
 
+  folly::dynamic serialize() const override {
+    VELOX_UNSUPPORTED("ArrowStream plan node is not serializable");
+  }
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -306,6 +322,10 @@ class FilterNode : public PlanNode {
   std::string_view name() const override {
     return "Filter";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override {
@@ -361,6 +381,10 @@ class ProjectNode : public PlanNode {
   virtual std::string_view name() const override {
     return "Project";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -420,6 +444,10 @@ class TableScanNode : public PlanNode {
   std::string_view name() const override {
     return "TableScan";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -486,6 +514,10 @@ class TableWriteNode : public PlanNode {
     return "TableWrite";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -510,19 +542,9 @@ class AggregationNode : public PlanNode {
     kSingle
   };
 
-  static const char* stepName(Step step) {
-    switch (step) {
-      case Step::kPartial:
-        return "PARTIAL";
-      case Step::kFinal:
-        return "FINAL";
-      case Step::kIntermediate:
-        return "INTERMEDIATE";
-      case Step::kSingle:
-        return "SINGLE";
-    }
-    VELOX_UNREACHABLE();
-  }
+  static const char* stepName(Step step);
+
+  static Step stepFromName(const std::string& name);
 
   /**
    * @param preGroupedKeys A subset of the 'groupingKeys' on which the input is
@@ -600,6 +622,10 @@ class AggregationNode : public PlanNode {
   bool isSingle() const {
     return step_ == Step::kSingle;
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -705,6 +731,10 @@ class GroupIdNode : public PlanNode {
     return "GroupId";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -739,6 +769,10 @@ class ExchangeNode : public PlanNode {
     return "Exchange";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -767,6 +801,10 @@ class MergeExchangeNode : public ExchangeNode {
   std::string_view name() const override {
     return "MergeExchange";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -807,6 +845,10 @@ class LocalMergeNode : public PlanNode {
     return "LocalMerge";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -842,6 +884,10 @@ class LocalPartitionNode : public PlanNode {
     // N-to-M shuffle.
     kRepartition,
   };
+
+  static const char* typeName(Type type);
+
+  static Type typeFromName(const std::string& name);
 
   LocalPartitionNode(
       const PlanNodeId& id,
@@ -897,6 +943,10 @@ class LocalPartitionNode : public PlanNode {
   std::string_view name() const override {
     return "LocalPartition";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -1013,6 +1063,10 @@ class PartitionedOutputNode : public PlanNode {
     return "PartitionedOutput";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1089,29 +1143,9 @@ enum class JoinType {
   kAnti,
 };
 
-inline const char* joinTypeName(JoinType joinType) {
-  switch (joinType) {
-    case JoinType::kInner:
-      return "INNER";
-    case JoinType::kLeft:
-      return "LEFT";
-    case JoinType::kRight:
-      return "RIGHT";
-    case JoinType::kFull:
-      return "FULL";
-    case JoinType::kLeftSemiFilter:
-      return "LEFT SEMI (FILTER)";
-    case JoinType::kRightSemiFilter:
-      return "RIGHT SEMI (FILTER)";
-    case JoinType::kLeftSemiProject:
-      return "LEFT SEMI (PROJECT)";
-    case JoinType::kRightSemiProject:
-      return "RIGHT SEMI (PROJECT)";
-    case JoinType::kAnti:
-      return "ANTI";
-  }
-  VELOX_UNREACHABLE();
-}
+const char* joinTypeName(JoinType joinType);
+
+JoinType joinTypeFromName(const std::string& name);
 
 inline bool isInnerJoin(JoinType joinType) {
   return joinType == JoinType::kInner;
@@ -1232,6 +1266,8 @@ class AbstractJoinNode : public PlanNode {
  protected:
   void addDetails(std::stringstream& stream) const override;
 
+  folly::dynamic serializeBase() const;
+
   const JoinType joinType_;
   const std::vector<FieldAccessTypedExprPtr> leftKeys_;
   const std::vector<FieldAccessTypedExprPtr> rightKeys_;
@@ -1305,6 +1341,10 @@ class HashJoinNode : public AbstractJoinNode {
     return nullAware_;
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1340,6 +1380,10 @@ class MergeJoinNode : public AbstractJoinNode {
   std::string_view name() const override {
     return "MergeJoin";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 };
 
 // Cross join.
@@ -1362,6 +1406,10 @@ class CrossJoinNode : public PlanNode {
   std::string_view name() const override {
     return "CrossJoin";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -1421,6 +1469,10 @@ class OrderByNode : public PlanNode {
   std::string_view name() const override {
     return "OrderBy";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -1483,6 +1535,10 @@ class TopNNode : public PlanNode {
     return "TopN";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1537,6 +1593,10 @@ class LimitNode : public PlanNode {
   std::string_view name() const override {
     return "Limit";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -1598,6 +1658,10 @@ class UnnestNode : public PlanNode {
     return "Unnest";
   }
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1629,6 +1693,10 @@ class EnforceSingleRowNode : public PlanNode {
   std::string_view name() const override {
     return "EnforceSingleRow";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;
@@ -1674,6 +1742,10 @@ class AssignUniqueIdNode : public PlanNode {
     return uniqueIdCounter_;
   };
 
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
+
  private:
   void addDetails(std::stringstream& stream) const override;
 
@@ -1702,6 +1774,10 @@ class WindowNode : public PlanNode {
  public:
   enum class WindowType { kRange, kRows };
 
+  static const char* windowTypeName(WindowType type);
+
+  static WindowType windowTypeFromName(const std::string& name);
+
   enum class BoundType {
     kUnboundedPreceding,
     kPreceding,
@@ -1710,18 +1786,30 @@ class WindowNode : public PlanNode {
     kUnboundedFollowing
   };
 
+  static const char* boundTypeName(BoundType type);
+
+  static BoundType boundTypeFromName(const std::string& name);
+
   struct Frame {
     WindowType type;
     BoundType startType;
     TypedExprPtr startValue;
     BoundType endType;
     TypedExprPtr endValue;
+
+    folly::dynamic serialize() const;
+
+    static Frame deserialize(const folly::dynamic& obj);
   };
 
   struct Function {
     CallTypedExprPtr functionCall;
     Frame frame;
     bool ignoreNulls;
+
+    folly::dynamic serialize() const;
+
+    static Function deserialize(const folly::dynamic& obj);
   };
 
   /// @param windowColumnNames specifies the output column
@@ -1765,6 +1853,10 @@ class WindowNode : public PlanNode {
   std::string_view name() const override {
     return "Window";
   }
+
+  folly::dynamic serialize() const override;
+
+  static PlanNodePtr create(const folly::dynamic& obj, void* context);
 
  private:
   void addDetails(std::stringstream& stream) const override;

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -43,6 +43,7 @@ add_executable(
   ParseTypeSignatureTest.cpp
   PartitionedOutputBufferManagerTest.cpp
   PlanBuilderTest.cpp
+  PlanNodeSerdeTest.cpp
   PlanNodeToStringTest.cpp
   PrintPlanWithStatsTest.cpp
   RoundRobinPartitionFunctionTest.cpp

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/WindowFunction.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::exec::test {
+
+class PlanNodeSerdeTest : public testing::Test,
+                          public velox::test::VectorTestBase {
+ protected:
+  PlanNodeSerdeTest() {
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    parse::registerTypeResolver();
+
+    Type::registerSerDe();
+    core::PlanNode::registerSerDe();
+    core::ITypedExpr::registerSerDe();
+
+    data_ = {makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3}),
+        makeFlatVector<int32_t>({10, 20, 30}),
+        makeConstant(true, 3),
+    })};
+  }
+
+  void testSerde(const core::PlanNodePtr& plan) {
+    auto serialized = plan->serialize();
+
+    auto copy =
+        velox::ISerializable::deserialize<core::PlanNode>(serialized, pool());
+
+    ASSERT_EQ(plan->toString(true, true), copy->toString(true, true));
+  }
+
+  std::vector<RowVectorPtr> data_;
+};
+
+TEST_F(PlanNodeSerdeTest, aggregation) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .partialAggregation({"c0"}, {"count(1)", "sum(c1)"})
+                  .finalAggregation()
+                  .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, assignUniqueId) {
+  auto plan = PlanBuilder().values({data_}).assignUniqueId().planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, enforceSingleRow) {
+  auto plan = PlanBuilder().values({data_}).enforceSingleRow().planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, filter) {
+  auto plan = PlanBuilder().values({data_}).filter("c0 > 100").planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, limit) {
+  auto plan = PlanBuilder().values({data_}).limit(0, 10, true).planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder().values({data_}).limit(0, 10, false).planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder().values({data_}).limit(12, 10, false).planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, localMerge) {
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .localMerge(
+              {"c0"},
+              {
+                  PlanBuilder(planNodeIdGenerator).values({data_}).planNode(),
+                  PlanBuilder(planNodeIdGenerator).values({data_}).planNode(),
+              })
+          .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, mergeJoin) {
+  auto probe = makeRowVector(
+      {"t0", "t1", "t2"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, true, false}),
+      });
+
+  auto build = makeRowVector(
+      {"u0", "u1", "u2"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, true, false}),
+      });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probe})
+          .mergeJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+              "t1 > u1",
+              {"t0", "t1", "u2", "t2"},
+              core::JoinType::kInner)
+          .planNode();
+
+  testSerde(plan);
+
+  plan = PlanBuilder(planNodeIdGenerator)
+             .values({probe})
+             .mergeJoin(
+                 {"t0"},
+                 {"u0"},
+                 PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+                 "", // no filter
+                 {"t0", "t1", "u2", "t2"},
+                 core::JoinType::kLeft)
+             .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, orderBy) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .orderBy({"c0", "c1 DESC NULLS FIRST"}, true)
+                  .planNode();
+
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .orderBy({"c0", "c1 DESC NULLS FIRST"}, false)
+             .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, project) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .project({"c0 * 10", "c0 + c1", "c1 > 0"})
+                  .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, hashJoin) {
+  auto probe = makeRowVector(
+      {"t0", "t1", "t2"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, true, false}),
+      });
+
+  auto build = makeRowVector(
+      {"u0", "u1", "u2"},
+      {
+          makeFlatVector<int32_t>({1, 2, 3}),
+          makeFlatVector<int64_t>({10, 20, 30}),
+          makeFlatVector<bool>({true, true, false}),
+      });
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({probe})
+          .hashJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+              "t1 > u1",
+              {"t0", "t1", "u2", "t2"},
+              core::JoinType::kInner)
+          .planNode();
+
+  testSerde(plan);
+
+  plan = PlanBuilder(planNodeIdGenerator)
+             .values({probe})
+             .hashJoin(
+                 {"t0"},
+                 {"u0"},
+                 PlanBuilder(planNodeIdGenerator).values({build}).planNode(),
+                 "", // no filter
+                 {"t0", "t1", "u2", "t2"},
+                 core::JoinType::kLeft)
+             .planNode();
+
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, topN) {
+  auto plan = PlanBuilder().values({data_}).topN({"c0"}, 10, true).planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder().values({data_}).topN({"c0 DESC"}, 10, false).planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .topN({"c0", "c1 DESC NULLS FIRST"}, 10, true)
+             .planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, unnest) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3}),
+      makeArrayVector<int32_t>({
+          {1, 2},
+          {3, 4, 5},
+          {},
+      }),
+      makeMapVector<int64_t, int32_t>(
+          {{{1, 10}, {2, 20}}, {{3, 30}, {4, 40}, {5, 50}}, {}}),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .unnest({"c0"}, {"c1", "c2"}, std::nullopt)
+                  .planNode();
+  testSerde(plan);
+
+  plan =
+      PlanBuilder().values({data}).unnest({"c0"}, {"c1"}, "ordinal").planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, values) {
+  auto plan = PlanBuilder().values({data_}).planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_}, true /*parallelizable*/, 5 /*repeatTimes*/)
+             .planNode();
+  testSerde(plan);
+}
+
+TEST_F(PlanNodeSerdeTest, window) {
+  auto plan =
+      PlanBuilder()
+          .values({data_})
+          .window(
+              {"sum(c0) over (partition by c1 order by c2 rows between 10 preceding and 5 following)"})
+          .planNode();
+
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .window({"sum(c0) over (partition by c1 order by c2)"})
+             .planNode();
+
+  testSerde(plan);
+}
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Allow serializing query plans into JSON using ISerializable framework. Use
VectorSaver to serialize vectors found in ValuesNodes.

To serialize: `plan->serialize()`.

To deserialize:

```
PlanNode::registerSerDe();

auto plan = velox::ISerializable::deserialize<PlanNode>(serialized, pool());
```

The following plan nodes support serialization:

- Aggregation
- AssignUniqueId
- EnforceSingleRow
- Filter
- HashJoin and MergeJoin
- Limit
- LocalMerge
- Project
- OrderBy
- TopN
- UnnestNode
- Values
- Window

Follow-up PRs will add serialization support to the rest of the plan nodes:

- CrossJoinNode
- ExchangeNode
- GroupIdNode
- LocalPartitionNode
- MergeExchangeNode
- PartitionedOutputNode
- TableScanNode
- TableWriteNode

Part of #4303