### PR TITLE
Fix processing empty and skipped splits with dynamic filters

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -526,22 +526,12 @@ void HiveDataSource::setFromDataSource(
   emptySplit_ = source->emptySplit_;
   split_ = std::move(source->split_);
   if (emptySplit_) {
-    // Leave old readers in place so tat their adaptation can be moved to a new
-    // reader.
     return;
   }
-  if (rowReader_) {
-    if (!source->rowReader_->moveAdaptationFrom(*rowReader_)) {
-      // The source had a reader that did not have state that could be
-      // advanced. Keep the old readers so that you can transfer the
-      // adaptation to the next non-empty one.
-      emptySplit_ = true;
-      return;
-    }
-  }
+  source->scanSpec_->moveAdaptationFrom(*scanSpec_);
+  scanSpec_ = std::move(source->scanSpec_);
   reader_ = std::move(source->reader_);
   rowReader_ = std::move(source->rowReader_);
-  scanSpec_ = std::move(source->scanSpec_);
   // New io will be accounted on the stats of 'source'. Add the existing
   // balance to that.
   source->ioStats_->merge(*ioStats_);

--- a/velox/dwio/common/Reader.h
+++ b/velox/dwio/common/Reader.h
@@ -63,13 +63,6 @@ class RowReader {
    */
   virtual void resetFilterCaches() = 0;
 
-  // Moves the adaptively acquired filters/filter order from 'other'
-  // to 'this'. Returns true if 'this' is ready to read, false if
-  // 'this' is known to be empty.
-  virtual bool moveAdaptationFrom(RowReader& /*other*/) {
-    return true;
-  }
-
   /**
    * Get an estimated row size basing on available statistics. Can
    * differ from the actual row size due to variable-length values.

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -359,11 +359,6 @@ class SelectiveColumnReader {
     initTimeClocks_ = 0;
   }
 
-  /// Moves the adaptation encoded in ScanSpec from 'other' to 'this'.
-  virtual void moveScanSpec(SelectiveColumnReader& /*other*/) {
-    VELOX_NYI();
-  }
-
   virtual void filterRowGroups(
       uint64_t rowGroupSize,
       const dwio::common::StatsContext& context,

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -94,11 +94,6 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
     inputRows_ = outputRows_;
   }
 
-  void moveScanSpec(SelectiveColumnReader& other) override {
-    auto otherStruct = dynamic_cast<SelectiveStructColumnReaderBase*>(&other);
-    scanSpec_->moveAdaptationFrom(*otherStruct->scanSpec_);
-  }
-
   const std::string& debugString() const {
     return debugString_;
   }

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -464,22 +464,6 @@ std::optional<size_t> DwrfRowReader::estimatedRowSize() const {
   return std::nullopt;
 }
 
-bool DwrfRowReader::moveAdaptationFrom(RowReader& other) {
-  auto otherReader = dynamic_cast<DwrfRowReader*>(&other);
-  if (!selectiveColumnReader_) {
-    VLOG(1) << "PRESPL: Moving adaptation to reader with no reader tree. Can "
-            << "happen if split contains no stripe begin.";
-    return false;
-  }
-  if (!otherReader->selectiveColumnReader_) {
-    VLOG(1) << "PRESPL: Moving adaptation from reader with no tree. "
-            << "No adaptation moved but continuing.";
-    return true;
-  }
-  selectiveColumnReader_->moveScanSpec(*otherReader->selectiveColumnReader_);
-  return true;
-}
-
 DwrfReader::DwrfReader(
     const ReaderOptions& options,
     std::unique_ptr<dwio::common::BufferedInput> input)

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -91,8 +91,6 @@ class DwrfRowReader : public StrideIndexProvider,
 
   void resetFilterCaches() override;
 
-  bool moveAdaptationFrom(RowReader& other) override;
-
   bool allPrefetchIssued() const override {
     return true;
   }

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -137,15 +137,6 @@ class ParquetRowReader : public dwio::common::RowReader {
     return options_;
   }
 
-  bool moveAdaptationFrom(RowReader& other) override {
-    auto otherReader = dynamic_cast<ParquetRowReader*>(&other);
-    if (!columnReader_ || !otherReader->columnReader_) {
-      return false;
-    }
-    columnReader_->moveScanSpec(*otherReader->columnReader_);
-    return true;
-  }
-
   bool allPrefetchIssued() const override {
     //  Allow opening the next split while this is reading.
     return true;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -4056,6 +4056,225 @@ TEST_F(HashJoinTest, dynamicFilters) {
   }
 }
 
+TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
+  const int32_t numSplits = 20;
+  const int32_t numNonSkippedSplits = 10;
+  const int32_t numRowsProbe = 333;
+  const int32_t numRowsBuild = 100;
+
+  std::vector<RowVectorPtr> probeVectors;
+  probeVectors.reserve(numSplits);
+
+  std::vector<std::shared_ptr<TempFilePath>> tempFiles;
+  std::vector<exec::Split> probeSplits;
+  // Each split has a column containing
+  // the split number. This is used to filter out whole splits based
+  // on metadata. We test how using metadata for dropping splits
+  // interactts with dynamic filters. In specific, if the first split
+  // is discarded based on metadata, the dynamic filters must not be
+  // lost even if there is no actual reader for the split.
+  for (int32_t i = 0; i < numSplits; ++i) {
+    auto rowVector = makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsProbe, [&](auto row) { return row - i * 10; }),
+        makeFlatVector<int64_t>(numRowsProbe, [](auto row) { return row; }),
+        makeFlatVector<int64_t>(
+            numRowsProbe, [&](auto /*row*/) { return i % 2 == 0 ? 0 : i; }),
+    });
+    probeVectors.push_back(rowVector);
+    tempFiles.push_back(TempFilePath::create());
+    writeToFile(tempFiles.back()->path, rowVector);
+    probeSplits.push_back(
+        exec::Split(makeHiveConnectorSplit(tempFiles.back()->path)));
+  }
+
+  // We add splits that have no rows.
+  auto makeEmpty = [&]() {
+    return exec::Split(HiveConnectorSplitBuilder(tempFiles.back()->path)
+                           .start(10000000)
+                           .length(1)
+                           .build());
+  };
+  std::vector<exec::Split> emptyFront = {makeEmpty(), makeEmpty()};
+  std::vector<exec::Split> emptyMiddle = {makeEmpty(), makeEmpty()};
+  probeSplits.insert(probeSplits.begin(), emptyFront.begin(), emptyFront.end());
+  probeSplits.insert(
+      probeSplits.begin() + 13, emptyMiddle.begin(), emptyMiddle.end());
+  // 100 key values in [35, 233] range.
+  std::vector<RowVectorPtr> buildVectors;
+  for (int i = 0; i < 5; ++i) {
+    buildVectors.push_back(makeRowVector({
+        makeFlatVector<int32_t>(
+            numRowsBuild / 5,
+            [i](auto row) { return 35 + 2 * (row + i * numRowsBuild / 5); }),
+        makeFlatVector<int64_t>(numRowsBuild / 5, [](auto row) { return row; }),
+    }));
+  }
+  std::vector<RowVectorPtr> keyOnlyBuildVectors;
+  for (int i = 0; i < 5; ++i) {
+    keyOnlyBuildVectors.push_back(
+        makeRowVector({makeFlatVector<int32_t>(numRowsBuild / 5, [i](auto row) {
+          return 35 + 2 * (row + i * numRowsBuild / 5);
+        })}));
+  }
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto probeType = ROW({"c0", "c1", "c2"}, {INTEGER(), BIGINT(), BIGINT()});
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+
+  auto buildSide = PlanBuilder(planNodeIdGenerator)
+                       .values(buildVectors)
+                       .project({"c0 AS u_c0", "c1 AS u_c1"})
+                       .planNode();
+  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator)
+                              .values(keyOnlyBuildVectors)
+                              .project({"c0 AS u_c0"})
+                              .planNode();
+
+  // Basic push-down.
+  {
+    // Inner join.
+    core::PlanNodeId probeScanId;
+    auto op = PlanBuilder(planNodeIdGenerator)
+                  .tableScan(probeType, {"c2 > 0"})
+                  .capturePlanNodeId(probeScanId)
+                  .hashJoin(
+                      {"c0"},
+                      {"u_c0"},
+                      buildSide,
+                      "",
+                      {"c0", "c1", "u_c1"},
+                      core::JoinType::kInner)
+                  .project({"c0", "c1 + 1", "c1 + u_c1"})
+                  .planNode();
+    {
+      SplitInput splits;
+      splits.emplace(probeScanId, probeSplits);
+
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .planNode(std::move(op))
+          .numDrivers(1)
+          .inputSplits(splits)
+          .referenceQuery(
+              "SELECT t.c0, t.c1 + 1, t.c1 + u.c1 FROM t, u WHERE t.c0 = u.c0 AND t.c2 > 0")
+          .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+            SCOPED_TRACE(fmt::format("hasSpill:{}", hasSpill));
+            if (hasSpill) {
+              // Dynamic filtering should be disabled with spilling triggered.
+              ASSERT_EQ(0, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(0, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            } else {
+              ASSERT_EQ(1, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(1, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+              ASSERT_LT(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            }
+          })
+          .run();
+    }
+
+    // Left semi join.
+    op = PlanBuilder(planNodeIdGenerator)
+             .tableScan(probeType, {"c2 > 0"})
+             .capturePlanNodeId(probeScanId)
+             .hashJoin(
+                 {"c0"},
+                 {"u_c0"},
+                 buildSide,
+                 "",
+                 {"c0", "c1"},
+                 core::JoinType::kLeftSemiFilter)
+             .project({"c0", "c1 + 1"})
+             .planNode();
+
+    {
+      SplitInput splits;
+      splits.emplace(probeScanId, probeSplits);
+
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .planNode(std::move(op))
+          .numDrivers(1)
+          .inputSplits(splits)
+          .referenceQuery(
+              "SELECT t.c0, t.c1 + 1 FROM t WHERE t.c0 IN (SELECT c0 FROM u) AND t.c2 > 0")
+          .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+            SCOPED_TRACE(fmt::format("hasSpill:{}", hasSpill));
+            if (hasSpill) {
+              // Dynamic filtering should be disabled with spilling triggered.
+              ASSERT_EQ(0, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(0, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(0, getReplacedWithFilterRows(task, 1).sum);
+              ASSERT_EQ(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            } else {
+              ASSERT_EQ(1, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(1, getFiltersAccepted(task, 0).sum);
+              ASSERT_GT(getReplacedWithFilterRows(task, 1).sum, 0);
+              ASSERT_LT(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            }
+          })
+          .run();
+    }
+
+    // Right semi join.
+    op = PlanBuilder(planNodeIdGenerator)
+             .tableScan(probeType, {"c2 > 0"})
+             .capturePlanNodeId(probeScanId)
+             .hashJoin(
+                 {"c0"},
+                 {"u_c0"},
+                 buildSide,
+                 "",
+                 {"u_c0", "u_c1"},
+                 core::JoinType::kRightSemiFilter)
+             .project({"u_c0", "u_c1 + 1"})
+             .planNode();
+
+    {
+      SplitInput splits;
+      splits.emplace(probeScanId, probeSplits);
+
+      HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+          .planNode(std::move(op))
+          .numDrivers(1)
+          .inputSplits(splits)
+          .referenceQuery(
+              "SELECT u.c0, u.c1 + 1 FROM u WHERE u.c0 IN (SELECT c0 FROM t WHERE t.c2 > 0)")
+          .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+            SCOPED_TRACE(fmt::format("hasSpill:{}", hasSpill));
+            if (hasSpill) {
+              // Dynamic filtering should be disabled with spilling triggered.
+              ASSERT_EQ(0, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(0, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(getReplacedWithFilterRows(task, 1).sum, 0);
+              ASSERT_EQ(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            } else {
+              ASSERT_EQ(1, getFiltersProduced(task, 1).sum);
+              ASSERT_EQ(1, getFiltersAccepted(task, 0).sum);
+              ASSERT_EQ(getReplacedWithFilterRows(task, 1).sum, 0);
+              ASSERT_LT(
+                  getInputPositions(task, 1),
+                  numRowsProbe * numNonSkippedSplits);
+            }
+          })
+          .run();
+    }
+  }
+}
+
 // Verify the size of the join output vectors when projecting build-side
 // variable-width column.
 TEST_F(HashJoinTest, memoryUsage) {


### PR DESCRIPTION
It could happen that a split had a reader with no
SelectiveColumnReader. This would get adaptation transferred to it but the ransfer would not take place. It coud could also happen that the first split of a scan was empty and then would accept the ScanSpec of the next split without transferring the adaptation. The adaptation consists of dynamic filters and filter order.

We therefore remove methods for transferring adaptation between RowReaders. Instead we always transfer adaptation from the pre-existing ScanSpec to the new one.

Transfer of adaptation is needed when DataSources are asynchronously prepared. The tableScan always has one primary DataSource. However, reader trees are prepared asynchronously in auxiliary DataSources. These are moved over the primary one with setFromDataSource.

We note that dynamic filters rely on the ScanSpec in the DataSource being physically the same ScanSpec as referenced from the reader tree. Therefore the ScanSpec is passed from the asynchronously prepared to the primary but the adaptation is first passed from the primary to the new one.