### PR TITLE
Enhance Type serialization

### DIFF
--- a/velox/functions/prestosql/types/tests/TypeTestBase.cpp
+++ b/velox/functions/prestosql/types/tests/TypeTestBase.cpp
@@ -18,10 +18,7 @@
 namespace facebook::velox::test {
 
 TypeTestBase::TypeTestBase() {
-  velox::DeserializationRegistryForSharedPtr().Register(
-      Type::getClassName(),
-      static_cast<std::shared_ptr<const Type> (*)(const folly::dynamic&)>(
-          Type::create));
+  Type::registerSerDe();
 }
 
 void TypeTestBase::testTypeSerde(const TypePtr& type) {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -500,6 +500,8 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
 
   static std::shared_ptr<const Type> create(const folly::dynamic& obj);
 
+  static void registerSerDe();
+
   /// Recursive kind hashing (uses only TypeKind).
   size_t hashKind() const;
 

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -22,10 +22,7 @@ using namespace facebook::velox;
 
 namespace {
 void testTypeSerde(const TypePtr& type) {
-  velox::DeserializationRegistryForSharedPtr().Register(
-      Type::getClassName(),
-      static_cast<std::shared_ptr<const Type> (*)(const folly::dynamic&)>(
-          Type::create));
+  Type::registerSerDe();
 
   auto copy = velox::ISerializable::deserialize<Type>(
       velox::ISerializable::serialize(type));
@@ -378,6 +375,11 @@ TEST(TypeTest, row) {
   testTypeSerde(rowInner);
 }
 
+TEST(TypeTest, emptyRow) {
+  auto row = ROW({});
+  testTypeSerde(row);
+}
+
 class Foo {};
 class Bar {};
 
@@ -660,6 +662,8 @@ TEST(TypeTest, function) {
   ASSERT_EQ(BIGINT(), type->childAt(0));
   ASSERT_EQ(VARCHAR(), type->childAt(1));
   ASSERT_EQ(BOOLEAN(), type->childAt(2));
+
+  testTypeSerde(type);
 }
 
 TEST(TypeTest, follySformat) {


### PR DESCRIPTION
- Introduce static method Type::registerSerDe() to register deserializer for Type objects.
- Allow deserializing empty RowType.
- Allow serializing FunctionType.

Part of #4303.