### PR TITLE
Add serialization for expressions

### DIFF
--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,7 +18,8 @@ endif()
 add_library(velox_config Context.cpp)
 target_link_libraries(velox_config ${FOLLY_WITH_DEPENDENCIES})
 
-add_library(velox_core PlanFragment.cpp PlanNode.cpp SimpleFunctionMetadata.cpp)
+add_library(velox_core Expressions.cpp PlanFragment.cpp PlanNode.cpp
+                       SimpleFunctionMetadata.cpp)
 
 target_link_libraries(
   velox_core

--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+#include "velox/common/encode/Base64.h"
+#include "velox/vector/VectorSaver.h"
+
+namespace facebook::velox::core {
+
+namespace {
+TypePtr deserializeType(const folly::dynamic& obj, void* context) {
+  return ISerializable::deserialize<Type>(obj["type"]);
+}
+
+std::vector<TypedExprPtr> deserializeInputs(
+    const folly::dynamic& obj,
+    void* context) {
+  if (obj.count("inputs")) {
+    return ISerializable::deserialize<std::vector<ITypedExpr>>(
+        obj["inputs"], context);
+  }
+
+  return {};
+}
+} // namespace
+
+folly::dynamic ITypedExpr::serializeBase(std::string_view name) const {
+  folly::dynamic obj = folly::dynamic::object;
+  obj["name"] = name;
+  obj["type"] = type_->serialize();
+
+  if (!inputs_.empty()) {
+    folly::dynamic serializedInputs = folly::dynamic::array;
+    for (const auto& input : inputs_) {
+      serializedInputs.push_back(input->serialize());
+    }
+
+    obj["inputs"] = serializedInputs;
+  }
+
+  return obj;
+}
+
+// static
+void ITypedExpr::registerSerDe() {
+  auto& registry = DeserializationWithContextRegistryForSharedPtr();
+
+  registry.Register("CallTypedExpr", core::CallTypedExpr::create);
+  registry.Register("CastTypedExpr", core::CastTypedExpr::create);
+  registry.Register("ConcatTypedExpr", core::ConcatTypedExpr::create);
+  registry.Register("ConstantTypedExpr", core::ConstantTypedExpr::create);
+  registry.Register("FieldAccessTypedExpr", core::FieldAccessTypedExpr::create);
+  registry.Register("InputTypedExpr", core::InputTypedExpr::create);
+  registry.Register("LambdaTypedExpr", core::LambdaTypedExpr::create);
+}
+
+folly::dynamic InputTypedExpr::serialize() const {
+  return ITypedExpr::serializeBase("InputTypedExpr");
+}
+
+// static
+TypedExprPtr InputTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto type = core::deserializeType(obj, context);
+
+  return std::make_shared<InputTypedExpr>(std::move(type));
+}
+
+folly::dynamic ConstantTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("ConstantTypedExpr");
+  if (valueVector_) {
+    std::ostringstream out;
+    saveVector(*valueVector_, out);
+    auto serializedValue = out.str();
+    obj["valueVector"] = encoding::Base64::encode(
+        serializedValue.data(), serializedValue.size());
+  } else {
+    obj["value"] = value_.serialize();
+  }
+
+  return obj;
+}
+
+// static
+TypedExprPtr ConstantTypedExpr::create(
+    const folly::dynamic& obj,
+    void* context) {
+  auto type = core::deserializeType(obj, context);
+
+  if (obj.count("value")) {
+    auto value = variant::create(obj["value"]);
+    return std::make_shared<ConstantTypedExpr>(std::move(type), value);
+  }
+
+  auto encodedData = obj["valueVector"].asString();
+  auto serializedData = encoding::Base64::decode(encodedData);
+  std::istringstream dataStream(serializedData);
+
+  auto* pool = static_cast<memory::MemoryPool*>(context);
+
+  return std::make_shared<ConstantTypedExpr>(restoreVector(dataStream, pool));
+}
+
+folly::dynamic CallTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("CallTypedExpr");
+  obj["functionName"] = name_;
+  return obj;
+}
+
+// static
+TypedExprPtr CallTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+
+  return std::make_shared<CallTypedExpr>(
+      std::move(type), std::move(inputs), obj["functionName"].asString());
+}
+
+folly::dynamic FieldAccessTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("FieldAccessTypedExpr");
+  obj["fieldName"] = name_;
+  return obj;
+}
+
+// static
+TypedExprPtr FieldAccessTypedExpr::create(
+    const folly::dynamic& obj,
+    void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+  VELOX_CHECK_LE(inputs.size(), 1);
+
+  auto name = obj["fieldName"].asString();
+
+  if (inputs.empty()) {
+    return std::make_shared<FieldAccessTypedExpr>(std::move(type), name);
+  } else {
+    return std::make_shared<FieldAccessTypedExpr>(
+        std::move(type), std::move(inputs[0]), name);
+  }
+}
+
+folly::dynamic ConcatTypedExpr::serialize() const {
+  return ITypedExpr::serializeBase("ConcatTypedExpr");
+}
+
+// static
+TypedExprPtr ConcatTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+
+  return std::make_shared<ConcatTypedExpr>(
+      type->asRow().names(), std::move(inputs));
+}
+
+folly::dynamic LambdaTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("LambdaTypedExpr");
+  obj["signature"] = signature_->serialize();
+  obj["body"] = body_->serialize();
+  return obj;
+}
+
+// static
+TypedExprPtr LambdaTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto signature = ISerializable::deserialize<Type>(obj["signature"]);
+  auto body = ISerializable::deserialize<ITypedExpr>(obj["body"]);
+
+  return std::make_shared<LambdaTypedExpr>(
+      asRowType(signature), std::move(body));
+}
+
+folly::dynamic CastTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("CastTypedExpr");
+  obj["nullOnFailure"] = nullOnFailure_;
+  return obj;
+}
+
+// static
+TypedExprPtr CastTypedExpr::create(const folly::dynamic& obj, void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+
+  return std::make_shared<CastTypedExpr>(
+      std::move(type), std::move(inputs), obj["nullOnFailure"].asBool());
+}
+
+} // namespace facebook::velox::core

--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -66,6 +66,10 @@ class InputTypedExpr : public ITypedExpr {
 
     return std::make_shared<InputTypedExpr>(type());
   }
+
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
 };
 
 class ConstantTypedExpr : public ITypedExpr {
@@ -168,7 +172,9 @@ class ConstantTypedExpr : public ITypedExpr {
     return this->equals(other);
   }
 
-  VELOX_DEFINE_CLASS_NAME(ConstantTypedExpr)
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
   const variant value_;
@@ -230,6 +236,10 @@ class CallTypedExpr : public ITypedExpr {
         casted->inputs().end(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
+
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
   const std::string name_;
@@ -311,6 +321,10 @@ class FieldAccessTypedExpr : public ITypedExpr {
     return isInputColumn_;
   }
 
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
+
  private:
   const std::string name_;
   const bool isInputColumn_;
@@ -325,8 +339,8 @@ class ConcatTypedExpr : public ITypedExpr {
  public:
   ConcatTypedExpr(
       const std::vector<std::string>& names,
-      const std::vector<TypedExprPtr>& expressions)
-      : ITypedExpr{toType(names, expressions), expressions} {}
+      const std::vector<TypedExprPtr>& inputs)
+      : ITypedExpr{toType(names, inputs), inputs} {}
 
   TypedExprPtr rewriteInputNames(
       const std::unordered_map<std::string, std::string>& mapping)
@@ -355,7 +369,7 @@ class ConcatTypedExpr : public ITypedExpr {
   }
 
   bool operator==(const ITypedExpr& other) const override {
-    const auto* casted = dynamic_cast<const FieldAccessTypedExpr*>(&other);
+    const auto* casted = dynamic_cast<const ConcatTypedExpr*>(&other);
     if (!casted) {
       return false;
     }
@@ -366,6 +380,10 @@ class ConcatTypedExpr : public ITypedExpr {
         casted->inputs().end(),
         [](const auto& p1, const auto& p2) { return *p1 == *p2; });
   }
+
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
   static std::shared_ptr<const Type> toType(
@@ -423,6 +441,10 @@ class LambdaTypedExpr : public ITypedExpr {
     return *signature_ == *casted->signature_ && *body_ == *casted->body_;
   }
 
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
+
  private:
   const RowTypePtr signature_;
   const TypedExprPtr body_;
@@ -475,6 +497,10 @@ class CastTypedExpr : public ITypedExpr {
   bool nullOnFailure() const {
     return nullOnFailure_;
   }
+
+  folly::dynamic serialize() const override;
+
+  static TypedExprPtr create(const folly::dynamic& obj, void* context);
 
  private:
   // This flag prevents throws and instead returns

--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -21,7 +21,7 @@
 namespace facebook::velox::core {
 
 /* a strongly-typed expression, such as literal, function call, etc... */
-class ITypedExpr {
+class ITypedExpr : public ISerializable {
  public:
   explicit ITypedExpr(std::shared_ptr<const Type> type)
       : type_{std::move(type)}, inputs_{} {}
@@ -81,7 +81,11 @@ class ITypedExpr {
 
   virtual bool operator==(const ITypedExpr& other) const = 0;
 
+  static void registerSerDe();
+
  protected:
+  folly::dynamic serializeBase(std::string_view name) const;
+
   std::vector<std::shared_ptr<const ITypedExpr>> rewriteInputsRecursive(
       const std::unordered_map<std::string, std::string>& mapping) const {
     std::vector<std::shared_ptr<const ITypedExpr>> newInputs;

--- a/velox/core/tests/CMakeLists.txt
+++ b/velox/core/tests/CMakeLists.txt
@@ -14,9 +14,15 @@
 
 add_executable(
   velox_core_test
-  ConstantTypedExprTest.cpp PlanFragmentTest.cpp PlanNodeTest.cpp
-  QueryConfigTest.cpp StringTest.cpp TypeAnalysisTest.cpp)
+  ConstantTypedExprTest.cpp
+  PlanFragmentTest.cpp
+  PlanNodeTest.cpp
+  QueryConfigTest.cpp
+  StringTest.cpp
+  TypeAnalysisTest.cpp
+  TypedExprSerdeTest.cpp)
 
 add_test(velox_core_test velox_core_test)
 
-target_link_libraries(velox_core_test velox_core gtest gtest_main)
+target_link_libraries(velox_core_test velox_core velox_vector_test_lib gtest
+                      gtest_main)

--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/core/Expressions.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook::velox::core::test {
+
+class TypedExprSerDeTest : public testing::Test,
+                           public velox::test::VectorTestBase {
+ protected:
+  TypedExprSerDeTest() {
+    Type::registerSerDe();
+
+    ITypedExpr::registerSerDe();
+  }
+
+  void testSerde(const TypedExprPtr& expression) {
+    auto serialized = expression->serialize();
+
+    auto copy =
+        velox::ISerializable::deserialize<ITypedExpr>(serialized, pool());
+
+    ASSERT_EQ(expression->toString(), copy->toString());
+    ASSERT_EQ(*expression->type(), *copy->type());
+    ASSERT_EQ(*expression, *copy);
+  }
+
+  std::vector<RowVectorPtr> data_;
+};
+
+TEST_F(TypedExprSerDeTest, input) {
+  auto expression = std::make_shared<InputTypedExpr>(
+      ROW({"a", "b", "c"}, {BIGINT(), BOOLEAN(), VARCHAR()}));
+
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, fieldAccess) {
+  auto expression = std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a");
+  testSerde(expression);
+
+  expression = std::make_shared<FieldAccessTypedExpr>(
+      VARCHAR(),
+      std::make_shared<FieldAccessTypedExpr>(
+          ROW({"a", "b"}, {VARCHAR(), BOOLEAN()}), "ab"),
+      "a");
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, constant) {
+  auto expression = std::make_shared<ConstantTypedExpr>(BIGINT(), 127);
+  testSerde(expression);
+
+  expression =
+      std::make_shared<ConstantTypedExpr>(makeFlatVector<int32_t>({123, 234}));
+  testSerde(expression);
+
+  expression = std::make_shared<ConstantTypedExpr>(makeArrayVector<int64_t>({
+      {1, 2, 3, 4, 5},
+  }));
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, call) {
+  // a + b
+  auto expression = std::make_shared<CallTypedExpr>(
+      BIGINT(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b"),
+      },
+      "plus");
+
+  testSerde(expression);
+
+  // f(g(h(a, b), c))
+  expression = std::make_shared<CallTypedExpr>(
+      VARCHAR(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<CallTypedExpr>(
+              DOUBLE(),
+              std::vector<TypedExprPtr>{
+                  std::make_shared<CallTypedExpr>(
+                      BIGINT(),
+                      std::vector<TypedExprPtr>{
+                          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+                          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "b"),
+                      },
+                      "h"),
+                  std::make_shared<FieldAccessTypedExpr>(BIGINT(), "c"),
+              },
+              "g"),
+      },
+      "f");
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, cast) {
+  auto expression = std::make_shared<CastTypedExpr>(
+      BIGINT(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(VARCHAR(), "a"),
+      },
+      false);
+  testSerde(expression);
+
+  expression = std::make_shared<CastTypedExpr>(
+      VARCHAR(),
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+      },
+      true);
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, concat) {
+  auto expression = std::make_shared<ConcatTypedExpr>(
+      std::vector<std::string>{"x", "y", "z"},
+      std::vector<TypedExprPtr>{
+          std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a"),
+          std::make_shared<FieldAccessTypedExpr>(DOUBLE(), "b"),
+          std::make_shared<FieldAccessTypedExpr>(VARBINARY(), "c"),
+      });
+  testSerde(expression);
+}
+
+TEST_F(TypedExprSerDeTest, lambda) {
+  // x -> (x > 10)
+  auto expression = std::make_shared<LambdaTypedExpr>(
+      ROW({"x"}, {BIGINT()}),
+      std::make_shared<CallTypedExpr>(
+          BOOLEAN(),
+          std::vector<TypedExprPtr>{
+              std::make_shared<FieldAccessTypedExpr>(BIGINT(), "x"),
+              std::make_shared<ConstantTypedExpr>(BIGINT(), 10),
+          },
+          "gt"));
+  testSerde(expression);
+}
+
+} // namespace facebook::velox::core::test


### PR DESCRIPTION
Allow serializing expressions into JSON using ISerializable framework. Use
VectorSaver to serialize constant vectors found in ConstantTypedExpr.

To serialize: `expression->serialize()`.

To deserialize:

```
ITypedExpr::registerSerDe();

auto expression = velox::ISerializable::deserialize<ITypedExpr>(serialized, pool());
```

Depends on #4307 

Part of #4303