### PR TITLE
Handle empty ranges in setValidRange

### DIFF
--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -102,11 +102,15 @@ class SelectivityVector {
   }
 
   /**
-   * Set a range of values to valid from [start, end). updateBounds() need to be
-   * called explicitly after setValidRange() call, it can be called only once
-   * after multiple setValidRange() calls in a row.
+   * If range is not empty, set a range of values to valid from [start, end).
+   * updateBounds() need to be called explicitly after setValidRange() call, it
+   * can be called only once after multiple setValidRange() calls in a row.
    */
   void setValidRange(vector_size_t begin, vector_size_t end, bool valid) {
+    VELOX_DCHECK_GE(end, begin);
+    if (begin == end) {
+      return;
+    }
     VELOX_DCHECK_LE(end, bits_.size() * sizeof(bits_[0]) * 8);
     bits::fillBits(bits_.data(), begin, end, valid);
     allSelected_.reset();

--- a/velox/vector/tests/SelectivityVectorTest.cpp
+++ b/velox/vector/tests/SelectivityVectorTest.cpp
@@ -216,6 +216,10 @@ TEST(SelectivityVectorTest, setValidRange) {
 
   ASSERT_NO_FATAL_FAILURE(setRangeAndAssert(0, vectorSize, false))
       << "all to false";
+
+  // Test empty ranges.
+  ASSERT_NO_FATAL_FAILURE(setRangeAndAssert(50000, 50000, false));
+  ASSERT_NO_FATAL_FAILURE(setRangeAndAssert(0, 0, false));
 }
 
 TEST(SelectivityVectorTest, clearAll) {


### PR DESCRIPTION
Summary:
setValidRange is called in several places with empty ranges, usually
while traversing array elements. sometimes it receives empty ranges
in that case when the check
```
    VELOX_DCHECK_LE(end, bits_.size() * sizeof(bits_[0]) * 8);
```
is performed then it will throws, because end and begin could be outside
 the bits range, but since its an empty range. we can simply return.

this fix the fuzzer issue:
https://app.circleci.com/pipelines/github/facebookincubator/velox/21301/workflows/8d307c8d-dd67-4c91-b604-a4f48e1c6cc3/jobs/134003

Reviewed By: kgpai

Differential Revision: D44139153

