### PR TITLE
Fix decimal sum and average aggregation issue when handling groups

### DIFF
--- a/velox/functions/prestosql/aggregates/DecimalAggregate.h
+++ b/velox/functions/prestosql/aggregates/DecimalAggregate.h
@@ -190,6 +190,7 @@ class DecimalAggregate : public exec::Aggregate {
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
         rows.applyToSelected([&](vector_size_t i) {
+          clearNull(groups[i]);
           auto accumulator = decimalAccumulator(groups[i]);
           accumulator->mergeWith(serializedAccumulator);
         });
@@ -208,6 +209,7 @@ class DecimalAggregate : public exec::Aggregate {
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
+        clearNull(groups[i]);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
@@ -231,6 +233,9 @@ class DecimalAggregate : public exec::Aggregate {
         auto decodedIndex = decodedPartial_.index(0);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
+        if (rows.hasSelections()) {
+          clearNull(group);
+        }
         rows.applyToSelected([&](vector_size_t i) {
           mergeAccumulators(group, serializedAccumulator);
         });
@@ -240,12 +245,16 @@ class DecimalAggregate : public exec::Aggregate {
         if (decodedPartial_.isNullAt(i)) {
           return;
         }
+        clearNull(group);
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =
             intermediateFlatVector->valueAt(decodedIndex);
         mergeAccumulators(group, serializedAccumulator);
       });
     } else {
+      if (rows.hasSelections()) {
+        clearNull(group);
+      }
       rows.applyToSelected([&](vector_size_t i) {
         auto decodedIndex = decodedPartial_.index(i);
         auto serializedAccumulator =

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -341,6 +341,51 @@ TEST_F(AverageAggregationTest, avgDecimal) {
       {"avg(c0)"},
       {},
       {makeRowVector({makeShortDecimalFlatVector({3'000}, DECIMAL(10, 1))})});
+
+  // Decimal average aggregation with multiple groups.
+  auto inputRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeShortDecimalFlatVector({-12783, 0}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeShortDecimalFlatVector({23178, 41093}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeShortDecimalFlatVector({-10023, 5290}, DECIMAL(5, 2))}),
+  };
+
+  auto expectedResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeShortDecimalFlatVector({37949}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeShortDecimalFlatVector({12683}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeShortDecimalFlatVector({-2498}, DECIMAL(5, 2))})};
+
+  testAggregations(inputRows, {"c0"}, {"avg(c1)"}, expectedResult);
+}
+
+TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
+  auto inputRows = {
+      makeRowVector({makeShortDecimalFlatVector({100, 200}, DECIMAL(5, 2))}),
+      makeRowVector({makeShortDecimalFlatVector({300, 400}, DECIMAL(5, 2))}),
+      makeRowVector({makeShortDecimalFlatVector({500, 600}, DECIMAL(5, 2))}),
+  };
+
+  auto expectedResult = {
+      makeRowVector({makeShortDecimalFlatVector({350}, DECIMAL(5, 2))})};
+
+  testAggregations(inputRows, {}, {"avg(c0)"}, expectedResult);
 }
 
 TEST_F(AverageAggregationTest, constantVectorOverflow) {

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -265,6 +265,38 @@ TEST_F(SumTest, sumDecimal) {
   createDuckDbTable({input});
   testAggregations(
       {input}, {}, {"sum(c0)", "sum(c1)"}, "SELECT sum(c0), sum(c1) FROM tmp");
+
+  // Decimal sum aggregation with multiple groups.
+  auto inputRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeShortDecimalFlatVector({37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeShortDecimalFlatVector({10410, 9250}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeShortDecimalFlatVector({-12783, 0}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeShortDecimalFlatVector({23178, 41093}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeShortDecimalFlatVector({-10023, 5290}, DECIMAL(5, 2))}),
+  };
+
+  auto expectedResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeLongDecimalFlatVector({113848}, DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeLongDecimalFlatVector({50730}, DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeLongDecimalFlatVector({-7493}, DECIMAL(38, 2))})};
+
+  testAggregations(inputRows, {"c0"}, {"sum(c1)"}, expectedResult);
 }
 
 TEST_F(SumTest, sumDecimalOverflow) {


### PR DESCRIPTION
This is a follow-up for https://github.com/facebookincubator/velox/pull/4129. We still need to fix groups in the aggregation otherwise `null` is returned in decimal aggregation results.