### PR TITLE
Add support for custom types to VectorSaver

### DIFF
--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(
   velox_serialization
   velox_memory
   velox_presto_serializer
+  velox_presto_types
   velox_temp_path
   velox_vector_fuzzer
   ${Boost_ATOMIC_LIBRARIES}


### PR DESCRIPTION
VectorSaver wasn't able to correctly serialize custom types and used to
serialize JSON type as VARCHAR. This change is to serialize the type using
Type::serialize.