### PR TITLE
Add open graph image to website

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,6 +56,7 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      image: 'img/velox_blog_pic.png',
       navbar: {
         title: 'Velox',
         logo: {


### PR DESCRIPTION
LinkedIn has a non-standard scraper for post previews that just pics an image it comes across when there is no open graph image set (As visible [here](https://www.linkedin.com/post-inspector/inspect/velox-lib.io%2Fblog%2Fvelox-build-experience))

I have added one of the existing images as an og image in the config which is picked up by [LI correctly](https://www.linkedin.com/post-inspector/inspect/https:%2F%2Fdeploy-preview-4322--meta-velox.netlify.app%2Fblog%2Fvelox-build-experience) 

(This change will of course also affect all other post and links to `velox-lib.io` as well as other places that use the og image like twitter, mastodon ... which previously did not display anything. Preview [here](https://www.opengraph.xyz/url/https%3A%2F%2Fdeploy-preview-4322--meta-velox.netlify.app%2F))