### PR TITLE
Improve flatmap too many keys exception message

### DIFF
--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -199,7 +199,11 @@ ValueWriter& FlatMapColumnWriter<K>::getValueWriter(
   }
 
   if (valueWriters_.size() >= maxKeyCount_) {
-    DWIO_RAISE("Too many map keys requested. Allowed: ", maxKeyCount_);
+    DWIO_RAISE(fmt::format(
+        "Too many map keys requested in (node {}, column {}). Allowed: {}",
+        id_,
+        type_.column,
+        maxKeyCount_));
   }
 
   auto keyInfo = getKeyInfo(key);


### PR DESCRIPTION
Summary: Column id and node id allows customers to quickly identify the offending column and subcolumns and verify if they truly want to bump the max key config on their table serde.

Differential Revision: D44146901

