### PR TITLE
Expose operational endpoints for HiveConnector file handle cache

### DIFF
--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -176,6 +176,18 @@ class CachedFactory {
     return cache_->maxSize();
   }
 
+  SimpleLRUCacheStats cacheStats() {
+    std::lock_guard l(cacheMu_);
+    return cache_->getStats();
+  }
+
+  // Clear the cache and return the current cache status
+  SimpleLRUCacheStats clearCache() {
+    std::lock_guard l(cacheMu_);
+    cache_->free(cache_->maxSize());
+    return cache_->getStats();
+  }
+
   // Move allowed, copy disallowed.
   CachedFactory(CachedFactory&&) = default;
   CachedFactory& operator=(CachedFactory&&) = default;

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -34,5 +34,11 @@ target_link_libraries(
 
 add_executable(cached_factory_test CachedFactoryTest.cpp)
 add_test(cached_factory_test cached_factory_test)
-target_link_libraries(cached_factory_test gtest gtest_main glog::glog
-                      gflags::gflags ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(
+  cached_factory_test
+  velox_caching
+  gtest
+  gtest_main
+  glog::glog
+  gflags::gflags
+  ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -285,6 +285,16 @@ class HiveConnector final : public Connector {
     return executor_;
   }
 
+  SimpleLRUCacheStats fileHandleCacheStats() {
+    return fileHandleFactory_.cacheStats();
+  }
+
+  // NOTE: this is to clear file handle cache which might affect performance,
+  // and is only used for operational purposes.
+  SimpleLRUCacheStats clearFileHandleCache() {
+    return fileHandleFactory_.clearCache();
+  }
+
  private:
   FileHandleFactory fileHandleFactory_;
   folly::Executor* FOLLY_NULLABLE executor_;


### PR DESCRIPTION
For operational ease, exposing file handle cache endpoints allows us to manipulate file handle cache at runtime without restarting services. Current added endpoints are "cache clearing" and "cache stats".