### PR TITLE
Remove InputStream factory

### DIFF
--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -275,43 +275,4 @@ void ReferenceableInputStream::setPrefetching(bool pf) {
   prefetching_ = pf;
 }
 
-static std::vector<InputStream::Factory>& factories() {
-  static std::vector<InputStream::Factory> factories;
-  return factories;
-}
-
-bool InputStream::registerFactory(InputStream::Factory factory) {
-  factories().push_back(factory);
-  return true;
-}
-
-std::unique_ptr<InputStream> InputStream::create(
-    const std::string& path,
-    const MetricsLogPtr& metricsLog,
-    IoStatistics* stats) {
-  DWIO_ENSURE_NOT_NULL(metricsLog.get());
-  for (auto& factory : factories()) {
-    auto result = factory(path, metricsLog, stats);
-    if (result) {
-      return result;
-    }
-  }
-  return std::make_unique<FileInputStream>(path, metricsLog, stats);
-}
-
-static std::unique_ptr<InputStream> fileInputStreamFactory(
-    const std::string& filename,
-    const MetricsLogPtr& metricsLog,
-    IoStatistics* stats = nullptr) {
-  if (strncmp(filename.c_str(), "file:", 5) == 0) {
-    return std::make_unique<FileInputStream>(
-        filename.substr(5), metricsLog, stats);
-  }
-  return nullptr;
-}
-
-VELOX_REGISTER_INPUT_STREAM_METHOD_DEFINITION(
-    FileInputStream,
-    fileInputStreamFactory)
-
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -142,18 +142,6 @@ class InputStream {
 
   virtual void logRead(uint64_t offset, uint64_t length, LogType purpose);
 
-  using Factory = std::function<std::unique_ptr<InputStream>(
-      const std::string&,
-      const MetricsLogPtr&,
-      IoStatistics* FOLLY_NULLABLE stats)>;
-
-  static std::unique_ptr<InputStream> create(
-      const std::string&,
-      const MetricsLogPtr& = MetricsLog::voidLog(),
-      IoStatistics* FOLLY_NULLABLE stats = nullptr);
-
-  static bool registerFactory(Factory factory);
-
  protected:
   std::string path_;
   MetricsLogPtr metricsLog_;
@@ -251,14 +239,3 @@ class ReferenceableInputStream : public InputStream {
   readReferenceOnly(uint64_t length, uint64_t offset, LogType) = 0;
 };
 } // namespace facebook::velox::dwio::common
-
-#define VELOX_STATIC_REGISTER_INPUT_STREAM(function)                           \
-  namespace {                                                                  \
-  static bool FB_ANONYMOUS_VARIABLE(g_InputStreamFunction) =                   \
-      facebook::velox::dwio::common::InputStream::registerFactory((function)); \
-  }
-
-#define VELOX_REGISTER_INPUT_STREAM_METHOD_DEFINITION(class, function)       \
-  void class ::registerFactory() {                                           \
-    facebook::velox::dwio::common::InputStream::registerFactory((function)); \
-  }


### PR DESCRIPTION
Summary: We're not using this approach since we need to pass specific options to the readers we create. Let's remove this code.

Differential Revision: D44189085

