### PR TITLE
Add drilldown to minimal failing expr to expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -1102,19 +1102,22 @@ void ExpressionFuzzer::go() {
     }
 
     auto columnsToWrapInLazy = generateLazyColumnIds(rowVector, vectorFuzzer_);
+    ResultOrError result;
+    try {
+      result = verifier_.verify(
+          plan,
+          rowVector,
+          resultVector ? BaseVector::copy(*resultVector) : nullptr,
+          true, // canThrow
+          columnsToWrapInLazy);
+    } catch (const std::exception& e) {
+      drilldown(plan, rowVector, columnsToWrapInLazy);
+    }
 
     // If both paths threw compatible exceptions, we add a try() function to
     // the expression's root and execute it again. This time the expression
     // cannot throw.
-    if (verifier_
-            .verify(
-                plan,
-                rowVector,
-                resultVector ? BaseVector::copy(*resultVector) : nullptr,
-                true, // canThrow
-                columnsToWrapInLazy)
-            .exceptionPtr &&
-        FLAGS_retry_with_try) {
+    if (result.exceptionPtr && FLAGS_retry_with_try) {
       LOG(INFO)
           << "Both paths failed with compatible exceptions. Retrying expression using try().";
 
@@ -1157,6 +1160,91 @@ void ExpressionFuzzer::go() {
     ++i;
   }
   logStats();
+}
+
+void ExpressionFuzzer::errorExit(const std::string& text) {
+  VELOX_FAIL(text);
+}
+
+void ExpressionFuzzer::drilldown(
+    core::TypedExprPtr plan,
+    const RowVectorPtr& rowVector,
+    const std::vector<column_index_t>& columnsToWrapInLazy) {
+  if (tryExpr(plan, rowVector, columnsToWrapInLazy)) {
+    errorExit("Retry should have failed");
+  }
+  bool minimalFound = false;
+  drilldownRecursive(plan, rowVector, columnsToWrapInLazy, minimalFound);
+  if (minimalFound) {
+    errorExit("Found minimal failing expression");
+  } else {
+    errorExit("Only the top level expression failed");
+  }
+}
+
+void ExpressionFuzzer::drilldownRecursive(
+    core::TypedExprPtr plan,
+    const RowVectorPtr& rowVector,
+    const std::vector<column_index_t>& columnsToWrapInLazy,
+    bool& minimalFound) {
+  bool anyFailed = false;
+  for (auto& input : plan->inputs()) {
+    if (!tryExpr(input, rowVector, columnsToWrapInLazy)) {
+      anyFailed = true;
+      drilldownRecursive(input, rowVector, columnsToWrapInLazy, minimalFound);
+      if (minimalFound) {
+        return;
+      }
+    }
+  }
+  if (!anyFailed) {
+    minimalFound = true;
+    LOG(INFO) << "Failed with all children succeeding: " << plan->toString();
+    // Re-running the minimum failed. Put breakpoint here to debug.
+    tryExpr(plan, rowVector, columnsToWrapInLazy);
+    if (!columnsToWrapInLazy.empty()) {
+      LOG(INFO) << "Trying without lazy:";
+      if (tryExpr(plan, rowVector, {})) {
+        LOG(INFO) << "Minimal failure succeeded without lazy vectors";
+      }
+    }
+  }
+}
+
+bool ExpressionFuzzer::tryExpr(
+    core::TypedExprPtr plan,
+    const RowVectorPtr& rowVector,
+    const std::vector<column_index_t>& columnsToWrapInLazy) {
+  VectorPtr result;
+  bool emptyResult =
+      tryWithResult(plan, rowVector, columnsToWrapInLazy, result);
+  result = vectorFuzzer_.fuzzFlat(plan->type());
+  bool filledResult =
+      tryWithResult(plan, rowVector, columnsToWrapInLazy, result);
+  if (emptyResult != filledResult) {
+    LOG(ERROR) << fmt::format(
+        "empty result = {} filledResult = {}", emptyResult, filledResult);
+  }
+  return filledResult && emptyResult;
+}
+
+bool ExpressionFuzzer::tryWithResult(
+    core::TypedExprPtr plan,
+    const RowVectorPtr& rowVector,
+    const std::vector<column_index_t>& columnsToWrapInLazy,
+    VectorPtr resultVector) {
+  ResultOrError result;
+  try {
+    result = verifier_.verify(
+        plan,
+        rowVector,
+        resultVector ? BaseVector::copy(*resultVector) : nullptr,
+        true, // canThrow
+        columnsToWrapInLazy);
+  } catch (const std::exception& e) {
+    return false;
+  }
+  return true;
 }
 
 void expressionFuzzer(FunctionSignatureMap signatureMap, size_t seed) {

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -138,6 +138,37 @@ class ExpressionFuzzer {
     std::unordered_map<std::string, ExprUsageStats>& exprNameToStats_;
   };
 
+  // Central point for failure exit.
+  void errorExit(const std::string& message);
+
+  // Tries subexpressions of [plan until finding the minimal failing subtree.
+  void drilldown(
+      core::TypedExprPtr plan,
+      const RowVectorPtr& rowVector,
+      const std::vector<column_index_t>& columnsToWrapInLazy);
+
+  // Verifies children of 'plan'. If all succeed, sets minimalFound to
+  // true and reruns 'plan' wth and without lazy vectors. Set
+  // breakpoint inside this to debug failures.
+  void drilldownRecursive(
+      core::TypedExprPtr plan,
+      const RowVectorPtr& rowVector,
+      const std::vector<column_index_t>& columnsToWrapInLazy,
+      bool& minimalFound);
+  // Tries 'plan' against 'rowVector' with and without pre-existing contents in
+  // result vector.
+  bool tryExpr(
+      core::TypedExprPtr plan,
+      const RowVectorPtr& rowVector,
+      const std::vector<column_index_t>& columnsToWrapInLazy);
+
+  // Tries 'plan' against 'rowVector' with results set to 'results'.
+  bool tryWithResult(
+      core::TypedExprPtr plan,
+      const RowVectorPtr& rowVector,
+      const std::vector<column_index_t>& columnsToWrapInLazy,
+      VectorPtr result);
+
   const std::string kTypeParameterName = "T";
 
   enum ArgumentKind { kArgConstant = 0, kArgColumn = 1, kArgExpression = 2 };


### PR DESCRIPTION
When ExpressionFuzzer finds a failing expression, runs verification for subexpressions until finding a failing expression where all child expressions succeed. Tries variants with existing results as well as results allocated by expression in drilldown. Also tries evaluation with no lazy vectors for the minimal filaing expression.