### PR TITLE
More flexible timestamp generation in VectorFuzzer

### DIFF
--- a/velox/functions/prestosql/window/tests/WindowTestBase.cpp
+++ b/velox/functions/prestosql/window/tests/WindowTestBase.cpp
@@ -87,7 +87,8 @@ std::vector<RowVectorPtr> WindowTestBase::makeFuzzVectors(
   VectorFuzzer::Options options;
   options.vectorSize = size;
   options.nullRatio = nullRatio;
-  options.useMicrosecondPrecisionTimestamp = true;
+  options.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   VectorFuzzer fuzzer(options, pool_.get(), 0);
   for (int32_t i = 0; i < numVectors; ++i) {
     auto vector = std::dynamic_pointer_cast<RowVector>(fuzzer.fuzzRow(rowType));
@@ -103,7 +104,8 @@ VectorPtr WindowTestBase::makeFlatFuzzVector(
   VectorFuzzer::Options options;
   options.vectorSize = size;
   options.nullRatio = nullRatio;
-  options.useMicrosecondPrecisionTimestamp = true;
+  options.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   VectorFuzzer fuzzer(options, pool_.get(), 0);
 
   return fuzzer.fuzzFlat(type);

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -96,7 +96,8 @@ class BenchmarkHelper {
     opts.stringVariableLength = true;
     opts.stringLength = 20;
     // Spark uses microseconds to store timestamp
-    opts.useMicrosecondPrecisionTimestamp = true;
+    opts.timestampPrecision =
+        VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
 
     auto seed = folly::Random::rand32();
     VectorFuzzer fuzzer(opts, pool_.get(), seed);

--- a/velox/row/tests/UnsafeRowDeserializerTest.cpp
+++ b/velox/row/tests/UnsafeRowDeserializerTest.cpp
@@ -988,7 +988,8 @@ VectorFuzzer::Options fuzzerOptions() {
       .dictionaryHasNulls = false,
       .stringVariableLength = true,
       .containerVariableLength = true,
-      .useMicrosecondPrecisionTimestamp = true,
+      .timestampPrecision =
+          VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
   };
 }
 

--- a/velox/row/tests/UnsafeRowFuzzTests.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTests.cpp
@@ -73,7 +73,8 @@ TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
   opts.stringVariableLength = true;
   opts.stringLength = 20;
   // Spark uses microseconds to store timestamp
-  opts.useMicrosecondPrecisionTimestamp = true;
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
   opts.containerLength = 65;
 
   auto seed = folly::Random::rand32();

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -101,7 +101,8 @@ TEST_F(UnsafeRowSerializerTest, types) {
   opts.stringVariableLength = true;
   opts.stringLength = 20;
   // Spark uses microseconds to store timestamp
-  opts.useMicrosecondPrecisionTimestamp = true;
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
   opts.containerLength = 10;
 
   auto seed = folly::Random::rand32();

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -125,8 +125,18 @@ class VectorFuzzer {
     /// If true, generated map keys are normalized (unique and not-null).
     bool normalizeMapKeys{true};
 
-    /// If true, the random generated timestamp value will only be in
-    /// microsecond precision (default is nanosecond).
+    /// Control the precision of timestamps generated. By default generate using
+    /// nanoseconds precision.
+    enum class TimestampPrecision : int8_t {
+      kNanoSeconds = 0,
+      kMicroSeconds = 1,
+      kMilliSeconds = 2,
+      kSeconds = 3,
+    };
+    TimestampPrecision timestampPrecision{TimestampPrecision::kNanoSeconds};
+
+    /// TODO: keeping the deprecated option for backwards compatibility. Will be
+    /// removed soon. For new code the option above.
     bool useMicrosecondPrecisionTimestamp{false};
 
     /// If true, fuzz() will randomly generate lazy vectors and fuzzInputRow()


### PR DESCRIPTION
Summary:
Making timestamp generating in VectorFuzzer more flexible to allow
users to generate second and millisecond granularity. This is important as data
in PrestoPage seem to be sserialized in millisecond level.

Differential Revision: D44205346

