### PR TITLE
`noexcept` class name

### DIFF
--- a/velox/common/base/ClassName.h
+++ b/velox/common/base/ClassName.h
@@ -15,8 +15,8 @@
  */
 
 #pragma once
-#define VELOX_DEFINE_CLASS_NAME(name) \
- public:                              \
-  static const char* getClassName() { \
-    return #name;                     \
+#define VELOX_DEFINE_CLASS_NAME(name)          \
+ public:                                       \
+  static const char* getClassName() noexcept { \
+    return #name;                              \
   }


### PR DESCRIPTION
Summary:
# Rationale

**`noexcept` is good**

The function cannot throw an exception. Let's make it `noexcept` to make it clear.

Differential Revision: D44205803

