### PR TITLE
Fix fieldReference supportsFlatNoNullsFastPath field

### DIFF
--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -23,13 +23,13 @@ class FieldReference : public SpecialForm {
  public:
   FieldReference(
       TypePtr type,
-      std::vector<ExprPtr>&& inputs,
+      const std::vector<ExprPtr>& inputs,
       const std::string& field)
       : SpecialForm(
             std::move(type),
-            std::move(inputs),
+            inputs,
             field,
-            true /* supportsFlatNoNullsFastPath */,
+            inputs.empty() ? true : false,
             false /* trackCpuUsage */),
         field_(field) {}
 

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2811,6 +2811,15 @@ TEST_F(ExprTest, flatNoNullsFastPath) {
   ASSERT_EQ(1, exprSet->exprs().size());
   ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath())
       << exprSet->toString();
+
+  // Field dereference.
+  exprSet = compileExpression("a", rowType);
+  ASSERT_EQ(1, exprSet->exprs().size());
+  ASSERT_TRUE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath());
+
+  exprSet = compileExpression("a.c0", ROW({"a"}, {ROW({"c0"}, {INTEGER()})}));
+  ASSERT_EQ(1, exprSet->exprs().size());
+  ASSERT_FALSE(exprSet->exprs()[0]->supportsFlatNoNullsFastPath());
 }
 
 TEST_F(ExprTest, commonSubExpressionWithEncodedInput) {


### PR DESCRIPTION
Summary:
When a fieldReference is referencing a functions output, (and not a context input vector)
then we shall set supportsFlatNoNullsFastPath to false.

this fix the fuzzer issue:
https://github.com/facebookincubator/velox/issues/4321

Differential Revision: D44179835

