### PR TITLE
Fix simplified eval for field reference

### DIFF
--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -103,9 +103,29 @@ void FieldReference::evalSpecialFormSimplified(
          return static_cast<Expr*>(expr)->toString();
        },
        this});
-
-  auto row = context.row();
-  result = row->childAt(index(context));
-  BaseVector::flattenVector(result, rows.end());
+  VectorPtr input;
+  const RowVector* row;
+  if (inputs_.empty()) {
+    row = context.row();
+  } else {
+    VELOX_CHECK_EQ(inputs_.size(), 1);
+    inputs_[0]->evalSimplified(rows, context, input);
+    BaseVector::flattenVector(input, rows.end());
+    row = input->as<RowVector>();
+    VELOX_CHECK(row);
+  }
+  auto index = row->type()->asRow().getChildIdx(field_);
+  if (index_ == -1) {
+    index_ = index;
+  } else {
+    VELOX_CHECK_EQ(index_, index);
+  }
+  auto& child = row->childAt(index_);
+  context.ensureWritable(rows, type_, result);
+  result->copy(child.get(), rows, nullptr);
+  if (row->mayHaveNulls()) {
+    addNulls(rows, row->rawNulls(), context, result);
+  }
 }
+
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
`FieldReference::evalSpecialFormSimplified` is not handling nested fields correctly.

Fix https://github.com/facebookincubator/velox/issues/4319

Differential Revision: D44219319

