### PR TITLE
Skip re-evaluation of non-error rows in fuzzer when the expression contains Coalesce

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -237,6 +237,9 @@ class ExpressionFuzzer {
   /// Should be called whenever a function is selected by the fuzzer.
   void markSelected(const std::string& funcName) {
     exprNameToStats_[funcName].numTimesSelected++;
+    if (funcName == "coalesce") {
+      hasCoalesce = true;
+    }
   }
 
   /// Called at the end of a successful fuzzer run. It logs the top and bottom
@@ -313,6 +316,10 @@ class ExpressionFuzzer {
 
   std::shared_ptr<ExprStatsListener> statListener_;
   std::unordered_map<std::string, ExprUsageStats> exprNameToStats_;
+
+  /// The randomly-generated expression of the current iteration has Colesce in
+  /// it.
+  bool hasCoalesce{false};
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Expression fuzzer evaluates an expression multiple time. First, it evaluates the original
expression through the common and simplified paths. Next, it wraps the expression in
try() and evaluates it through the common and simplified paths again. Finally, if the
result of the try-wrapped expression has NULLs, fuzzer removes these null-rows and
evaluates the original expression with the common path again. During the last evaluation,
fuzzer asserts there is no exception.

However, this logic doesn't work when exceptions throw inside a Coalesce expression.
Non-null rows in the result doesn't guarantee there were no exceptions because Coalesce
may populate non-null values at those rows from subsequent arguments. E.g., coalesce(always_throw(c0), 123).

This diff fixes https://github.com/facebookincubator/velox/issues/4337.

Differential Revision: D44189896

