### PR TITLE
Use applyRow in Expr::applyFunctionWithPeeling()

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -334,7 +334,6 @@ class Expr {
   // cardinality. Returns true if the function was called. Returns
   // false if no encodings could be peeled off.
   bool applyFunctionWithPeeling(
-      const SelectivityVector& rows,
       const SelectivityVector& applyRows,
       EvalCtx& context,
       VectorPtr& result);

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -237,6 +237,9 @@ class ExpressionFuzzer {
   /// Should be called whenever a function is selected by the fuzzer.
   void markSelected(const std::string& funcName) {
     exprNameToStats_[funcName].numTimesSelected++;
+    if (funcName == "coalesce") {
+      hasCoalesce = true;
+    }
   }
 
   /// Called at the end of a successful fuzzer run. It logs the top and bottom
@@ -313,6 +316,10 @@ class ExpressionFuzzer {
 
   std::shared_ptr<ExprStatsListener> statListener_;
   std::unordered_map<std::string, ExprUsageStats> exprNameToStats_;
+
+  /// The randomly-generated expression of the current iteration has Colesce in
+  /// it.
+  bool hasCoalesce{false};
 };
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Fuzzer found a bug in Expr::applyFunctionWithPeeling() when evaluating the subscript()
function. The exception throws when creating indices of size `rows.end() == 100`
with an argument vector of size 99. The argument vector was evaluated with non-null
rows (i.e., `applyRows`) up to row 99, so we should make indices with non-null rows
instead of all rows as well. In general, inputs to applyFunctionWithPeeling() is evaluated
with applyRows, so code inside this function should not process rows outside of this
range.

This diff fixes this bug by making applyFunctionWithPeeling() use applyRows instead of
rows. It fixes https://github.com/facebookincubator/velox/issues/4340.

Differential Revision: D44192368

