### PR TITLE
Change StringView constructor to take signed length.

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1333,7 +1333,7 @@ void StringDictionaryColumnReader::readFlatVector(
                             strData,
                             strLen) ||
             hasStrideDict;
-        dataPtr[i] = StringView{strData, static_cast<uint32_t>(strLen)};
+        dataPtr[i] = StringView{strData, static_cast<int32_t>(strLen)};
       }
     }
   } else {
@@ -1349,7 +1349,7 @@ void StringDictionaryColumnReader::readFlatVector(
                           strData,
                           strLen) ||
           hasStrideDict;
-      dataPtr[i] = StringView{strData, static_cast<uint32_t>(strLen)};
+      dataPtr[i] = StringView{strData, static_cast<int32_t>(strLen)};
     }
   }
   std::vector<BufferPtr> stringBuffers = {dictionaryBlob};

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -478,7 +478,7 @@ void KeyNode<StringView>::fillKeysVector(
   auto& flatVec = static_cast<FlatVector<StringView>&>(*vector);
   buffer->fillKey(ordinal_, [&](auto data, auto size) {
     const_cast<StringView*>(flatVec.rawValues())[offset] =
-        StringView{data, size};
+        StringView{data, static_cast<int32_t>(size)};
   });
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -333,7 +333,9 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       if constexpr (std::is_same_v<T, StringView>) {
         strKey = keyNodes_[k].key.get();
         if (!strKey.isInline()) {
-          strKey = {&rawStrKeyBuffer[strKeySize], strKey.size()};
+          strKey = {
+              &rawStrKeyBuffer[strKeySize],
+              static_cast<int32_t>(strKey.size())};
           strKeySize += strKey.size();
         }
       }

--- a/velox/functions/lib/ApproxMostFrequentStreamSummary.h
+++ b/velox/functions/lib/ApproxMostFrequentStreamSummary.h
@@ -321,7 +321,7 @@ void ApproxMostFrequentStreamSummary<T, A>::mergeSerialized(const char* other) {
     auto v = values[i];
     if constexpr (std::is_same_v<T, StringView>) {
       if (!v.isInline()) {
-        v = {other, v.size()};
+        v = {other, static_cast<int32_t>(v.size())};
         other += v.size();
       }
     }

--- a/velox/type/StringView.h
+++ b/velox/type/StringView.h
@@ -55,8 +55,9 @@ struct StringView {
     memset(this, 0, sizeof(StringView));
   }
 
-  StringView(const char* data, size_t len) : size_(len) {
-    VELOX_DCHECK(data || size_ == 0);
+  StringView(const char* data, int32_t len) : size_(len) {
+    VELOX_CHECK_GE(len, 0);
+    VELOX_DCHECK(data || len == 0);
     if (isInline()) {
       // Zero the inline part.
       // this makes sure that inline strings can be compared for equality with 2

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -110,3 +110,16 @@ target_link_libraries(
   gtest_main
   gflags::gflags
   glog::glog)
+
+add_executable(velox_string_view_benchmark StringViewBenchmark.cpp)
+
+target_link_libraries(
+  velox_string_view_benchmark
+  velox_type
+  ${FOLLY}
+  ${FOLLY_BENCHMARK}
+  ${DOUBLE_CONVERSION}
+  gtest
+  gtest_main
+  gflags::gflags
+  glog::glog)

--- a/velox/type/tests/StringViewBenchmark.cpp
+++ b/velox/type/tests/StringViewBenchmark.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Random.h>
+#include <folly/init/Init.h>
+#include "folly/Benchmark.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox {
+namespace {
+
+void runStringViewCreate(uint32_t iterations, uint32_t len) {
+  folly::BenchmarkSuspender suspender;
+
+  const std::string chars =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+  if (len > chars.size()) {
+    len = chars.size();
+  }
+  size_t sum = 0;
+  suspender.dismiss();
+
+  for (auto i = 0; i < iterations; i++) {
+    StringView str(chars.data() + i % (chars.size() - len), len);
+    sum += str.data()[0];
+  }
+
+  folly::doNotOptimizeAway(sum);
+}
+
+constexpr auto INLINE_SIZE = StringView::kInlineSize;
+constexpr auto NON_INLINE_SIZE = StringView::kInlineSize + 10;
+
+// Short strings which can be inlined.
+BENCHMARK_PARAM(runStringViewCreate, INLINE_SIZE);
+
+// Larger strings which won't be inlined.
+BENCHMARK_PARAM(runStringViewCreate, NON_INLINE_SIZE);
+} // namespace
+} // namespace facebook::velox
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/type/tests/StringViewTest.cpp
+++ b/velox/type/tests/StringViewTest.cpp
@@ -151,3 +151,8 @@ TEST(StringView, implicitConstructionAndConversion) {
   };
   testOptionalConversion("literal");
 }
+
+TEST(StringView, negativeSizes) {
+  EXPECT_THROW(StringView("abc", -10), VeloxException);
+  EXPECT_NO_THROW(StringView(nullptr, 0));
+}


### PR DESCRIPTION
Currently, It is possible to pass a negative size to StringView which due to implict casting creates bad values. We change signature to ensure we dont get passed bad values. 
Fixes #4331. 

Note, that we do not add this check for the user defined literal _sv since it's guaranteed to be non negative (https://en.cppreference.com/w/cpp/language/user_literal) . 