### PR TITLE
Fix velox memory concurrent allocation benchmark

### DIFF
--- a/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
+++ b/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
@@ -51,17 +51,19 @@ class MemoryOperator {
  public:
   MemoryOperator(
       MemoryManager* memoryManager,
+      std::shared_ptr<MemoryUsageTracker> tracker,
       uint64_t maxMemory,
       uint64_t allocationSize,
       uint32_t maxOps)
       : maxMemory_(maxMemory),
         allocationBytes_(allocationSize),
         maxOps_(maxOps),
-        pool_(
-            memoryManager->getPool("MemoryOperator", MemoryPool::Kind::kLeaf)) {
+        pool_(memoryManager->getPool(
+            fmt::format("MemoryOperator{}", poolId_++),
+            MemoryPool::Kind::kLeaf)) {
     rng_.seed(1234);
     if (FLAGS_enable_memory_usage_tracker) {
-      pool_->setMemoryUsageTracker(MemoryUsageTracker::create());
+      pool_->setMemoryUsageTracker(tracker->addChild());
     }
   }
 
@@ -87,6 +89,8 @@ class MemoryOperator {
   void free();
 
   void cleanup();
+
+  static inline int32_t poolId_{0};
 
   const uint64_t maxMemory_;
   const size_t allocationBytes_;
@@ -158,7 +162,7 @@ class MemoryAllocationBenchMark {
   };
 
   explicit MemoryAllocationBenchMark(const Options& options)
-      : options_(options) {
+      : options_(options), tracker_(MemoryUsageTracker::create()) {
     const int64_t maxMemory = options_.maxMemory + (256 << 20);
     switch (options_.allocatorType) {
       case Type::kMmap: {
@@ -193,6 +197,7 @@ class MemoryAllocationBenchMark {
   };
 
   const Options options_;
+  const std::shared_ptr<MemoryUsageTracker> tracker_;
   std::shared_ptr<MmapAllocator> allocator_;
   std::shared_ptr<MemoryManager> manager_;
   std::vector<Result> results_;
@@ -210,6 +215,7 @@ void MemoryAllocationBenchMark::run() {
     for (int i = 0; i < options_.numThreads; ++i) {
       auto memOp = std::make_unique<MemoryOperator>(
           manager_.get(),
+          tracker_,
           options_.maxMemory / options_.numThreads,
           options_.allocationBytes,
           options_.numOpsPerThread);


### PR DESCRIPTION
Summary: Fix the memory usage tracker setup in concurrent memory allocation benchmark

Reviewed By: oerling

Differential Revision: D44230019

