### PR TITLE
Velox memory management related api cleanup

### DIFF
--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -66,7 +66,7 @@ struct PyVeloxContext {
 
  private:
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_ =
-      facebook::velox::memory::getDefaultMemoryPool();
+      facebook::velox::memory::addDefaultLeafMemoryPool();
   std::shared_ptr<facebook::velox::core::QueryCtx> queryCtx_ =
       std::make_shared<facebook::velox::core::QueryCtx>();
   std::unique_ptr<facebook::velox::core::ExecCtx> execCtx_ =

--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -173,7 +173,7 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
  private:
   static constexpr const char* kWildcardCharacterSet = "%_";
   static constexpr const char* kAnyWildcardCharacter = "%";
-  std::shared_ptr<MemoryPool> pool_{getDefaultMemoryPool()};
+  std::shared_ptr<MemoryPool> pool_{addDefaultLeafMemoryPool()};
   VectorPtr inputFuzzer_;
 };
 

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -28,7 +28,7 @@ namespace {
 
 using namespace facebook::velox;
 
-std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
 
 VectorFuzzer::Options getOpts(size_t n, double nullRatio = 0) {
   VectorFuzzer::Options opts;

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -37,7 +37,7 @@ constexpr int kVectorSize = 16 << 10;
 
 struct BenchmarkData {
   BenchmarkData()
-      : pool_(memory::getDefaultMemoryPool(
+      : pool_(memory::addDefaultLeafMemoryPool(
             "BenchmarkData",
             FLAGS_use_thread_safe_memory_usage_track)) {
     VectorFuzzer::Options opts;
@@ -110,7 +110,6 @@ DEFINE_BENCHMARKS(row)
 } // namespace facebook::velox
 
 int main(int argc, char* argv[]) {
-  FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
   folly::init(&argc, &argv);
   using namespace facebook::velox;
   gflags::ParseCommandLineFlags(&argc, &argv, true);

--- a/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
+++ b/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
@@ -66,8 +66,7 @@ class MemoryPoolAllocationBenchMark {
         break;
     }
     rng_.seed(FLAGS_allocation_size_seed);
-    pool_ = manager_->getPool(
-        "MemoryPoolAllocationBenchMark", memory::MemoryPool::Kind::kLeaf);
+    pool_ = manager_->addLeafPool("MemoryPoolAllocationBenchMark");
   }
 
   ~MemoryPoolAllocationBenchMark() {

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -41,8 +41,7 @@ static_assert(!Buffer::is_pod_like_v<std::shared_ptr<int>>, "");
 class BufferTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ =
-        memoryManager_.getPool("BufferTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memoryManager_.addLeafPool("BufferTest");
   }
 
   memory::MemoryManager memoryManager_;

--- a/velox/buffer/tests/StringViewBufferHolderTest.cpp
+++ b/velox/buffer/tests/StringViewBufferHolderTest.cpp
@@ -39,7 +39,7 @@ class StringViewBufferHolderTest : public testing::Test {
     return StringViewBufferHolder(pool_.get());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 
 TEST_F(StringViewBufferHolderTest, inlinedStringViewDoesNotCopyToBuffer) {

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -100,7 +100,7 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -98,7 +98,7 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 
@@ -174,7 +174,7 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -172,11 +172,21 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual void visitChildren(
       const std::function<bool(MemoryPool*)>& visitor) const;
 
+  /// TODO Remove once Prestissimo is updated.
   /// Creates named child memory pool from this with specified 'kind'.
   virtual std::shared_ptr<MemoryPool> addChild(
       const std::string& name,
-      Kind kind = MemoryPool::Kind::kLeaf,
+      Kind kind = MemoryPool::Kind::kLeaf);
+
+  /// Invoked to create a named leaf child memory pool.
+  virtual std::shared_ptr<MemoryPool> addLeafChild(
+      const std::string& name,
       bool threadSafe = true,
+      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr);
+
+  /// Invoked to create a named aggregate child memory pool.
+  virtual std::shared_ptr<MemoryPool> addAggregateChild(
+      const std::string& name,
       std::shared_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Allocates a buffer with specified 'size'.
@@ -197,9 +207,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
   /// <= the size of the largest size class. The new memory is returned in 'out'
-  /// and any memory formerly referenced by 'out' is freed. The function returns
-  /// true if the allocation succeeded. If returning false, 'out' references no
-  /// memory and any partially allocated memory is freed.
+  /// on success and any memory formerly referenced by 'out' is freed. The
+  /// function throws if allocation fails and 'out' references no memory and any
+  /// partially allocated memory is freed.
   virtual void allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,

--- a/velox/common/memory/tests/ByteStreamTest.cpp
+++ b/velox/common/memory/tests/ByteStreamTest.cpp
@@ -33,7 +33,7 @@ class ByteStreamTest : public testing::Test {
     MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
     memoryManager_ = std::make_unique<MemoryManager>(IMemoryManager::Options{
         .capacity = kMaxMemory, .allocator = MemoryAllocator::getInstance()});
-    pool_ = memoryManager_->getPool("ByteStreamTest", MemoryPool::Kind::kLeaf);
+    pool_ = memoryManager_->addLeafPool("ByteStreamTest");
   }
 
   void TearDown() override {

--- a/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
+++ b/velox/common/memory/tests/ConcurrentAllocationBenchmark.cpp
@@ -54,9 +54,8 @@ class MemoryOperator {
       : maxMemory_(maxMemory),
         allocationBytes_(allocationSize),
         maxOps_(maxOps),
-        pool_(memoryManager->getPool(
-            fmt::format("MemoryOperator{}", poolId_++),
-            MemoryPool::Kind::kLeaf)) {
+        pool_(memoryManager->addLeafPool(
+            fmt::format("MemoryOperator{}", poolId_++))) {
     rng_.seed(1234);
   }
 

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -33,7 +33,7 @@ struct Multipart {
 class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     instance_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -74,7 +74,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     instance_ = MemoryAllocator::getInstance();
     memoryManager_ = std::make_unique<MemoryManager>(IMemoryManager::Options{
         .capacity = kMaxMemory, .allocator = instance_});
-    pool_ = memoryManager_->getPool("allocatorTest", MemoryPool::Kind::kLeaf);
+    pool_ = memoryManager_->addLeafPool("allocatorTest");
     if (useMmap_) {
       ASSERT_EQ(instance_->kind(), MemoryAllocator::Kind::kMmap);
     } else {

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -72,7 +72,7 @@ class BenchmarkHelper {
 BENCHMARK(SingleNodeAlloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto pool = manager.getPool("pride_of_higara");
+  auto pool = manager.addRootPool("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
@@ -86,7 +86,7 @@ BENCHMARK(SingleNodeAlloc, iters) {
 BENCHMARK(SingleNodeFree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto pool = manager.getPool("pride_of_higara");
+  auto pool = manager.addRootPool("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
@@ -100,7 +100,7 @@ BENCHMARK(SingleNodeFree, iters) {
 BENCHMARK(SingleNodeRealloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto pool = manager.getPool("pride_of_higara");
+  auto pool = manager.addRootPool("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
   for (size_t i = 0; i < iters; ++i) {
@@ -117,7 +117,7 @@ BENCHMARK(SingleNodeRealloc, iters) {
 BENCHMARK(SingleNodeAlignedAlloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto pool = manager.getPool("pride_of_higara");
+  auto pool = manager.addRootPool("pride_of_higara");
 
   for (size_t i = 0; i < iters; ++i) {
     auto dataSize = (i + 1) * kMemoryFootprintIncrement;
@@ -131,7 +131,7 @@ BENCHMARK(SingleNodeAlignedAlloc, iters) {
 BENCHMARK(SingleNodeAlignedRealloc, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto pool = manager.getPool("pride_of_higara");
+  auto pool = manager.addRootPool("pride_of_higara");
 
   void* p = pool->allocate(kMemoryFootprintIncrement);
   for (size_t i = 0; i < iters; ++i) {
@@ -148,7 +148,7 @@ BENCHMARK(SingleNodeAlignedRealloc, iters) {
 namespace {
 void addNLeaves(MemoryPool& pool, size_t n) {
   for (size_t i = 0; i < n; ++i) {
-    pool.addChild(pool.name() + ".leaf_" + folly::to<std::string>(i));
+    pool.addLeafChild(pool.name() + ".leaf_" + folly::to<std::string>(i));
   }
 }
 } // namespace
@@ -179,7 +179,8 @@ BENCHMARK(DeeperTree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
   for (size_t i = 0; i < 10; ++i) {
-    auto child = manager.getPool("query_fragment_" + folly::to<std::string>(i));
+    auto child =
+        manager.addRootPool("query_fragment_" + folly::to<std::string>(i));
     addNLeaves(*child, 20);
   }
   BenchmarkHelper helper{manager};
@@ -199,7 +200,7 @@ BENCHMARK(DeeperTree, iters) {
 BENCHMARK(FlatSubtree, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
-  auto child = manager.getPool("query_fragment_1");
+  auto child = manager.addRootPool("query_fragment_1");
   addNLeaves(*child, 10 * 20);
   BenchmarkHelper helper{manager};
   suspender.dismiss();
@@ -219,7 +220,8 @@ BENCHMARK(FlatSticks, iters) {
   folly::BenchmarkSuspender suspender;
   MemoryManager manager{};
   for (size_t i = 0; i < 10 * 20; ++i) {
-    auto child = manager.getPool("query_fragment_" + folly::to<std::string>(i));
+    auto child =
+        manager.addRootPool("query_fragment_" + folly::to<std::string>(i));
     addNLeaves(*child, 1);
   }
   BenchmarkHelper helper{manager};

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -213,36 +213,34 @@ class ExpressionEvaluator {
 class ConnectorQueryCtx {
  public:
   ConnectorQueryCtx(
-      memory::MemoryPool* leafPool,
-      memory::MemoryPool* aggregatePool,
+      memory::MemoryPool* operatorPool,
+      memory::MemoryPool* connectorPool,
       const Config* connectorConfig,
       std::unique_ptr<ExpressionEvaluator> expressionEvaluator,
       memory::MemoryAllocator* FOLLY_NONNULL allocator,
       const std::string& taskId,
       const std::string& planNodeId,
       int driverId)
-      : leafPool_(leafPool),
-        aggregatePool_(aggregatePool),
+      : operatorPool_(operatorPool),
+        connectorPool_(connectorPool),
         config_(connectorConfig),
         expressionEvaluator_(std::move(expressionEvaluator)),
         allocator_(allocator),
         scanId_(fmt::format("{}.{}", taskId, planNodeId)),
         taskId_(taskId),
-        driverId_(driverId) {
-    VELOX_CHECK_NOT_NULL(leafPool_);
-  }
+        driverId_(driverId) {}
 
-  /// Returns the memory pool for memory allocation.
+  /// Returns the associated operator's memory pool which is a leaf kind of
+  /// memory pool, used for direct memory allocation use.
   memory::MemoryPool* memoryPool() const {
-    return leafPool_;
+    return operatorPool_;
   }
 
-  /// Returns the aggregate memory pool for the data sink that needs the
-  /// hierarchical memory pool management, such as HiveDataSink. This is set to
-  /// null for table scan.
-  memory::MemoryPool* aggregatePool() const {
-    VELOX_CHECK_NOT_NULL(aggregatePool_);
-    return aggregatePool_;
+  /// Returns the connector's memory pool which is an aggregate kind of memory
+  /// pool, used for the data sink for table write that needs the hierarchical
+  /// memory pool management, such as HiveDataSink.
+  memory::MemoryPool* connectorMemoryPool() const {
+    return connectorPool_;
   }
 
   const Config* FOLLY_NONNULL config() const {
@@ -276,8 +274,8 @@ class ConnectorQueryCtx {
   }
 
  private:
-  memory::MemoryPool* leafPool_;
-  memory::MemoryPool* aggregatePool_;
+  memory::MemoryPool* operatorPool_;
+  memory::MemoryPool* connectorPool_;
   const Config* FOLLY_NONNULL config_;
   std::unique_ptr<ExpressionEvaluator> expressionEvaluator_;
   memory::MemoryAllocator* FOLLY_NONNULL allocator_;

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -202,7 +202,7 @@ void HiveDataSink::appendWriter(
 
   auto sink = dwio::common::DataSink::create(writePath);
   writers_.push_back(std::make_unique<Writer>(
-      options, std::move(sink), *connectorQueryCtx_->aggregatePool()));
+      options, std::move(sink), *connectorQueryCtx_->connectorMemoryPool()));
   writerInfo_.push_back(std::make_shared<HiveWriterInfo>(*writerParameters));
 }
 

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -24,7 +24,8 @@ using namespace facebook::velox::common;
 
 class HiveConnectorTest : public testing::Test {
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 HiveColumnHandle makeColumnHandle(

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -156,7 +156,7 @@ class QueryCtx : public Context {
 
   void initPool(const std::string& queryId) {
     if (pool_ == nullptr) {
-      pool_ = memory::getProcessDefaultMemoryManager().getPool(
+      pool_ = memory::defaultMemoryManager().addRootPool(
           QueryCtx::generatePoolName(queryId));
     }
   }

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -76,7 +76,7 @@ class PlanFragmentTest : public testing::Test {
   RowTypePtr probeTypeWithProjection_;
   std::vector<RowVectorPtr> emptyProbeVectors_;
   std::shared_ptr<PlanNode> probeValueNode_;
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 }; // namespace
 

--- a/velox/docs/programming-guide/chapter01.rst
+++ b/velox/docs/programming-guide/chapter01.rst
@@ -15,7 +15,7 @@ Let’s start by getting access to a MemoryPool:
 
     #include "velox/common/memory/Memory.h"
 
-    auto pool = memory::getDefaultMemoryPool();
+    auto pool = memory::addDefaultLeafMemoryPool();
 
 `pool` is a std::shared_ptr<velox::memory::MemoryPool>. We can use it to
 allocate buffers.

--- a/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckWrapperTest.cpp
@@ -92,7 +92,7 @@ class BaseDuckWrapperTest : public testing::Test {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
   std::unique_ptr<DuckDBWrapper> db_{

--- a/velox/duckdb/memory/Allocator.cpp
+++ b/velox/duckdb/memory/Allocator.cpp
@@ -49,8 +49,7 @@ void veloxPoolFree(
 
 VeloxPoolAllocator& getDefaultAllocator() {
   static std::shared_ptr<memory::MemoryPool> pool =
-      memory::getProcessDefaultMemoryManager().getPool(
-          "VeloxPoolAllocator", memory::MemoryPool::Kind::kLeaf);
+      memory::addDefaultLeafMemoryPool("VeloxPoolAllocator");
   static VeloxPoolAllocator allocator{*pool};
   return allocator;
 }

--- a/velox/dwio/common/tests/BitConcatenationTest.cpp
+++ b/velox/dwio/common/tests/BitConcatenationTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
 TEST(BitConcatenationTests, basic) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   BitConcatenation bits(*pool);
   BufferPtr result;
 

--- a/velox/dwio/common/tests/ChainedBufferTests.cpp
+++ b/velox/dwio/common/tests/ChainedBufferTests.cpp
@@ -26,7 +26,7 @@ namespace dwio {
 namespace common {
 
 TEST(ChainedBufferTests, testCreate) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int32_t> buf{*pool, 128, 1024};
   ASSERT_EQ(buf.capacity(), 128);
   ASSERT_EQ(buf.pages_.size(), 1);
@@ -42,7 +42,7 @@ TEST(ChainedBufferTests, testCreate) {
 }
 
 TEST(ChainedBufferTests, testReserve) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int32_t> buf{*pool, 16, 1024};
   buf.reserve(16);
   buf.reserve(17);
@@ -60,7 +60,7 @@ TEST(ChainedBufferTests, testReserve) {
 }
 
 TEST(ChainedBufferTests, testAppend) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int32_t> buf{*pool, 16, 64};
   for (size_t i = 0; i < 16; ++i) {
     buf.unsafeAppend(i);
@@ -85,7 +85,7 @@ TEST(ChainedBufferTests, testAppend) {
 }
 
 TEST(ChainedBufferTests, testClear) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int32_t> buf{*pool, 128, 1024};
   buf.clear();
   ASSERT_EQ(buf.capacity(), 128);
@@ -100,7 +100,7 @@ TEST(ChainedBufferTests, testClear) {
 }
 
 TEST(ChainedBufferTests, testApplyRange) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   std::vector<std::tuple<uint64_t, uint64_t, int32_t>> result;
   auto fn = [&](auto ptr, auto begin, auto end) {
     result.push_back({begin, end, *ptr});
@@ -154,7 +154,7 @@ TEST(ChainedBufferTests, testApplyRange) {
 }
 
 TEST(ChainedBufferTests, testGetPage) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int32_t> buf{*pool, 1024, 1024};
   ASSERT_EQ(
       std::addressof(buf.getPageUnsafe(0)), std::addressof(buf.pages_.at(0)));
@@ -181,7 +181,7 @@ TEST(ChainedBufferTests, testGetPage) {
 }
 
 TEST(ChainedBufferTests, testGetPageIndex) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int8_t> buf{*pool, 1024, 1024};
   ASSERT_EQ(buf.getPageIndex(0), 0);
   ASSERT_EQ(buf.getPageIndex(256), 0);
@@ -199,7 +199,7 @@ TEST(ChainedBufferTests, testGetPageIndex) {
 }
 
 TEST(ChainedBufferTests, testGetPageOffset) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   ChainedBuffer<int8_t> buf{*pool, 1024, 1024};
   ASSERT_EQ(buf.getPageOffset(0), 0);
   ASSERT_EQ(buf.getPageOffset(256), 256);

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 
 BENCHMARK(DataBufferOps, iters) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     DataBuffer<int32_t> buf{*pool};
@@ -39,7 +39,7 @@ BENCHMARK(DataBufferOps, iters) {
 }
 
 BENCHMARK(ChainedBufferOps, iters) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     ChainedBuffer<int32_t> buf{*pool, size, size * 4};

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -30,7 +30,7 @@ using MemoryPool = facebook::velox::memory::MemoryPool;
 
 TEST(DataBuffer, ZeroOut) {
   const uint8_t VALUE = 13;
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   DataBuffer<uint8_t> buffer(*pool, 16);
   for (auto i = 0; i < buffer.size(); i++) {
     auto data = buffer.data();
@@ -58,7 +58,7 @@ TEST(DataBuffer, ZeroOut) {
 }
 
 TEST(DataBuffer, At) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   DataBuffer<uint8_t> buffer{*pool};
   for (auto i = 0; i != 15; ++i) {
@@ -80,7 +80,7 @@ TEST(DataBuffer, At) {
 }
 
 TEST(DataBuffer, Reset) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   DataBuffer<uint8_t> buffer{*pool};
   buffer.reserve(16);
@@ -136,7 +136,7 @@ TEST(DataBuffer, Reset) {
 }
 
 TEST(DataBuffer, Wrap) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   auto size = 26;
   auto buffer = velox::AlignedBuffer::allocate<char>(size, pool.get());
   auto raw = buffer->asMutable<char>();
@@ -153,7 +153,7 @@ TEST(DataBuffer, Wrap) {
 }
 
 TEST(DataBuffer, Move) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   {
     DataBuffer<uint8_t> buffer{*pool};
     buffer.reserve(16);

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -79,9 +79,8 @@ class E2EFilterTestBase : public testing::Test {
   static constexpr int32_t kRowsInGroup = 10'000;
 
   void SetUp() override {
-    rootPool_ =
-        memory::getProcessDefaultMemoryManager().getPool("E2EFilterTestBase");
-    leafPool_ = rootPool_->addChild("E2EFilterTestBase");
+    rootPool_ = memory::defaultMemoryManager().addRootPool("E2EFilterTestBase");
+    leafPool_ = rootPool_->addLeafChild("E2EFilterTestBase");
   }
 
   static bool typeKindSupportsValueHook(TypeKind kind) {

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox::dwio::common;
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
       std::make_shared<facebook::velox::InMemoryReadFile>(std::string());
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   BufferedInput input(readFile, *pool);
   auto ret = input.enqueue({0, 0});
   EXPECT_NE(ret, nullptr);

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -427,7 +427,7 @@ class CacheTest : public testing::Test {
   std::shared_ptr<AsyncDataCache> cache_;
   std::shared_ptr<IoStatistics> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 
   // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
   std::vector<std::unique_ptr<dwrf::DwrfStreamIdentifier>> streamIds_;

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTests.cpp
@@ -273,7 +273,7 @@ class WriterEncodingIndexTest2 {
  public:
   WriterEncodingIndexTest2()
       : config_{std::make_shared<Config>()},
-        pool_{facebook::velox::memory::getDefaultMemoryPool()} {}
+        pool_{facebook::velox::memory::addDefaultLeafMemoryPool()} {}
 
   virtual ~WriterEncodingIndexTest2() = default;
 
@@ -302,7 +302,7 @@ class WriterEncodingIndexTest2 {
     ASSERT_EQ(recordPositionCount.size(), backfillPositionCount.size());
     WriterContext context{
         config_,
-        velox::memory::getProcessDefaultMemoryManager().getPool(
+        velox::memory::defaultMemoryManager().addRootPool(
             "WriterEncodingIndexTest2")};
     std::vector<StrictMock<MockIndexBuilder>*> mocks;
     for (auto i = 0; i < recordPositionCount.size(); ++i) {
@@ -663,7 +663,7 @@ TYPED_TEST(FloatColumnWriterEncodingIndexTest, TestIndex) {
 class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit IntegerColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : pool_{memory::getDefaultMemoryPool()},
+      : pool_{memory::addDefaultLeafMemoryPool()},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(
@@ -704,7 +704,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
       std::function<bool(size_t, size_t)> callAbandonDict) {
     WriterContext context{
         config_,
-        velox::memory::getProcessDefaultMemoryManager().getPool(
+        velox::memory::defaultMemoryManager().addRootPool(
             "IntegerColumnWriterDirectEncodingIndexTest")};
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
     auto mockIndexBuilderPtr = mockIndexBuilder.get();
@@ -869,9 +869,9 @@ TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
 class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDictionaryEncodingIndexTest()
-      : rootPool_{memory::getProcessDefaultMemoryManager().getPool(
+      : rootPool_{memory::defaultMemoryManager().addRootPool(
             "StringColumnWriterDictionaryEncodingIndexTest")},
-        leafPool_{rootPool_->addChild(
+        leafPool_{rootPool_->addLeafChild(
             "StringColumnWriterDictionaryEncodingIndexTest")},
         config_{std::make_shared<Config>()} {
     config_->set(
@@ -973,10 +973,10 @@ TEST_F(StringColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
 class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : rootPool_{memory::getProcessDefaultMemoryManager().getPool(
+      : rootPool_{memory::defaultMemoryManager().addRootPool(
             "StringColumnWriterDirectEncodingIndexTest")},
-        leafPool_{
-            rootPool_->addChild("StringColumnWriterDirectEncodingIndexTest")},
+        leafPool_{rootPool_->addLeafChild(
+            "StringColumnWriterDirectEncodingIndexTest")},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -141,9 +141,8 @@ using PopulateBatch =
 class ColumnWriterStatsTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    rootPool_ =
-        getProcessDefaultMemoryManager().getPool("ColumnWriterStatsTest");
-    leafPool_ = rootPool_->addChild("ColumnWriterStatsTest");
+    rootPool_ = defaultMemoryManager().addRootPool("ColumnWriterStatsTest");
+    leafPool_ = rootPool_->addLeafChild("ColumnWriterStatsTest");
   }
 
   std::unique_ptr<RowReader> writeAndGetReader(

--- a/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
+++ b/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox::dwrf;
 using namespace facebook::velox::memory;
 
 TEST(DataBufferHolderTests, InputCheck) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   ASSERT_THROW((DataBufferHolder{*pool, 0}), exception::LoggedException);
   ASSERT_THROW(
       (DataBufferHolder{*pool, 1024, 2048}), exception::LoggedException);
@@ -35,7 +35,7 @@ TEST(DataBufferHolderTests, InputCheck) {
 }
 
 TEST(DataBufferHolderTests, TakeAndGetBuffer) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink sink{*pool, 1024};
   DataBufferHolder holder{*pool, 1024, 0, 2.0f, &sink};
   DataBuffer<char> buffer{*pool, 512};
@@ -58,7 +58,7 @@ TEST(DataBufferHolderTests, TakeAndGetBuffer) {
 }
 
 TEST(DataBufferHolderTests, TruncateBufferHolder) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, 1024};
   constexpr size_t BUF_SIZE = 10;
   DataBuffer<char> buffer{*pool, BUF_SIZE};
@@ -83,7 +83,7 @@ TEST(DataBufferHolderTests, TruncateBufferHolder) {
 }
 
 TEST(DataBufferHolderTests, TakeAndGetBufferNoOutput) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, 1024};
   DataBuffer<char> buffer{*pool, 512};
   std::memset(buffer.data(), 'a', 512);
@@ -113,7 +113,7 @@ TEST(DataBufferHolderTests, TakeAndGetBufferNoOutput) {
 }
 
 TEST(DataBufferHolderTests, Reset) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, 1024};
   DataBuffer<char> buffer{*pool, 512};
   std::memset(buffer.data(), 'a', 512);
@@ -127,7 +127,7 @@ TEST(DataBufferHolderTests, Reset) {
 }
 
 TEST(DataBufferHolderTests, TryResize) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, 1024, 128};
 
   auto runTest = [&pool, &holder](
@@ -242,7 +242,7 @@ TEST(DataBufferHolderTests, TryResize) {
 }
 
 TEST(DataBufferHolderTests, TestGrowRatio) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, 1024, 16, 4.0f};
   DataBuffer<char> buffer{*pool, 16};
   ASSERT_TRUE(holder.tryResize(buffer, 0, 1));

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -46,15 +46,14 @@ using folly::Random;
 constexpr uint64_t kSizeMB = 1024UL * 1024UL;
 
 namespace {
-auto defaultPool = memory::getDefaultMemoryPool();
+auto defaultPool = memory::addDefaultLeafMemoryPool();
 }
 
 class E2EWriterTests : public Test {
  protected:
   E2EWriterTests() {
-    rootPool_ =
-        memory::getProcessDefaultMemoryManager().getPool("E2EWriterTests");
-    leafPool_ = rootPool_->addChild("leaf");
+    rootPool_ = memory::defaultMemoryManager().addRootPool("E2EWriterTests");
+    leafPool_ = rootPool_->addLeafChild("leaf");
   }
 
   std::unique_ptr<DwrfReader> createReader(
@@ -339,7 +338,7 @@ TEST_F(E2EWriterTests, FlatMapDictionaryEncoding) {
   // Start with a size larger than stride to cover splitting into
   // strides. Continue with smaller size for faster test.
   size_t size = 1100;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -379,7 +378,7 @@ TEST_F(E2EWriterTests, MaxFlatMapKeys) {
   const uint32_t keyLimit = 2000;
   const auto randomStart = Random::rand32(100);
 
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   b::row row;
   for (int32_t i = 0; i < keyLimit; ++i) {
     row.push_back(b::pair{randomStart + i, Random::rand64()});
@@ -405,7 +404,7 @@ TEST_F(E2EWriterTests, PresentStreamIsSuppressedOnFlatMap) {
 
   const auto randomStart = Random::rand32(100);
 
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   b::row row;
   row.push_back(b::pair{randomStart, Random::rand64()});
 
@@ -452,7 +451,7 @@ TEST_F(E2EWriterTests, TooManyFlatMapKeys) {
   const uint32_t keyLimit = 2000;
   const auto randomStart = Random::rand32(100);
 
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   b::row row;
   for (int32_t i = 0; i < (keyLimit + 1); ++i) {
     row.push_back(b::pair{randomStart + i, Random::rand64()});
@@ -474,7 +473,7 @@ TEST_F(E2EWriterTests, TooManyFlatMapKeys) {
 }
 
 TEST_F(E2EWriterTests, FlatMapBackfill) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -537,7 +536,7 @@ void testFlatMapWithNulls(
     bool firstRowNotNull,
     bool enableFlatmapDictionaryEncoding = false,
     bool shareDictionary = false) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -604,7 +603,7 @@ TEST_F(E2EWriterTests, FlatMapWithNullsSharedDict) {
 }
 
 TEST_F(E2EWriterTests, FlatMapEmpty) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   using keyType = int32_t;
   using valueType = int32_t;
@@ -800,7 +799,7 @@ TEST_F(E2EWriterTests, PartialStride) {
 }
 
 TEST_F(E2EWriterTests, OversizeRows) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -838,7 +837,7 @@ TEST_F(E2EWriterTests, OversizeRows) {
 }
 
 TEST_F(E2EWriterTests, OversizeBatches) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -886,7 +885,7 @@ TEST_F(E2EWriterTests, OversizeBatches) {
 }
 
 TEST_F(E2EWriterTests, OverflowLengthIncrements) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -1294,7 +1293,7 @@ VectorPtr createKeys(
 } // namespace
 
 TEST_F(E2EWriterTests, fuzzSimple) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto type = ROW({
       {"bool_val", BOOLEAN()},
       {"byte_val", TINYINT()},
@@ -1343,7 +1342,7 @@ TEST_F(E2EWriterTests, fuzzSimple) {
 }
 
 TEST_F(E2EWriterTests, fuzzComplex) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto type = ROW({
       {"array", ARRAY(REAL())},
       {"map", MAP(INTEGER(), DOUBLE())},
@@ -1398,7 +1397,7 @@ TEST_F(E2EWriterTests, fuzzComplex) {
 }
 
 TEST_F(E2EWriterTests, fuzzFlatmap) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto type = ROW({
       {"flatmap1", MAP(INTEGER(), REAL())},
       {"flatmap2", MAP(VARCHAR(), ARRAY(REAL()))},

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -42,7 +42,7 @@ void runBenchmark(int nullEvery) {
 
   auto type = CppToType<float>::create();
   auto typeWithId = TypeWithId::create(type, 1);
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   VectorPtr vector;
   // Prepare input
   BufferPtr values = AlignedBuffer::allocate<float>(kVectorSize, pool.get());
@@ -78,7 +78,7 @@ void runBenchmark(int nullEvery) {
     auto config = std::make_shared<Config>();
     WriterContext context{
         config,
-        memory::getProcessDefaultMemoryManager().getPool(
+        memory::defaultMemoryManager().addRootPool(
             "FloatColumnWriterBenchmark")};
     auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
     writer->write(vector, common::Ranges::of(0, kVectorSize));

--- a/velox/dwio/dwrf/test/FlushPolicyTest.cpp
+++ b/velox/dwio/dwrf/test/FlushPolicyTest.cpp
@@ -139,8 +139,7 @@ TEST(RowsPerStripeFlushPolicyTest, InvalidCases) {
 TEST(RowsPerSTripeFlushPolicyTest, DictionaryCriteriaTest) {
   auto config = std::make_shared<Config>();
   WriterContext context{
-      config,
-      getProcessDefaultMemoryManager().getPool("DictionaryCriteriaTest")};
+      config, defaultMemoryManager().addRootPool("DictionaryCriteriaTest")};
 
   RowsPerStripeFlushPolicy policy({42});
   EXPECT_EQ(

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::memory;
 
 static size_t generateAutoId(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
@@ -44,7 +44,7 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
 
 static size_t generateAutoId2(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -25,7 +25,7 @@ TEST(LayoutPlannerTests, Basic) {
       Config::COMPRESSION, dwio::common::CompressionKind::CompressionKind_NONE);
   WriterContext context{
       config,
-      facebook::velox::memory::getProcessDefaultMemoryManager().getPool(
+      facebook::velox::memory::defaultMemoryManager().addRootPool(
           "LayoutPlannerTests")};
   // fake streams
   std::vector<DwrfStreamIdentifier> streams;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -39,7 +39,7 @@ inline std::string getExampleFilePath(const std::string& fileName) {
 
 class MockStripeStreams : public StripeStreams {
  public:
-  MockStripeStreams() : pool_{memory::getDefaultMemoryPool()} {};
+  MockStripeStreams() : pool_{memory::addDefaultLeafMemoryPool()} {};
   ~MockStripeStreams() = default;
 
   std::unique_ptr<dwio::common::SeekableInputStream> getStream(
@@ -231,8 +231,7 @@ class ProtoWriter : public WriterBase {
       memory::MemoryPool& sinkPool)
       : WriterBase{std::make_unique<dwio::common::MemorySink>(sinkPool, 1024)} {
     initContext(
-        std::make_shared<Config>(),
-        pool->addChild("proto_writer", MemoryPool::Kind::kAggregate));
+        std::make_shared<Config>(), pool->addAggregateChild("proto_writer"));
   }
 
   template <typename T>

--- a/velox/dwio/dwrf/test/ReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/ReaderBaseTests.cpp
@@ -49,8 +49,8 @@ void addStats(
 class EncryptedStatsTest : public Test {
  protected:
   void SetUp() override {
-    pool_ = getProcessDefaultMemoryManager().getPool("EncryptedStatsTest");
-    sinkPool_ = pool_->addChild("sink");
+    pool_ = defaultMemoryManager().addRootPool("EncryptedStatsTest");
+    sinkPool_ = pool_->addLeafChild("sink");
     ProtoWriter writer{pool_, *sinkPool_};
     auto& context = const_cast<const ProtoWriter&>(writer).getContext();
 
@@ -96,7 +96,7 @@ class EncryptedStatsTest : public Test {
 
     auto readFile =
         std::make_shared<facebook::velox::InMemoryReadFile>(std::string());
-    readerPool_ = pool_->addChild("reader");
+    readerPool_ = pool_->addLeafChild("reader");
     reader_ = std::make_unique<ReaderBase>(
         *readerPool_,
         std::make_unique<BufferedInput>(readFile, *readerPool_),
@@ -172,7 +172,7 @@ TEST_F(EncryptedStatsTest, getColumnStatisticsKeyNotLoaded) {
 std::unique_ptr<ReaderBase> createCorruptedFileReader(
     uint64_t footerLen,
     uint32_t cacheLen) {
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   MemorySink sink{*pool, 1024};
   DataBufferHolder holder{*pool, 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   BufferedOutputStream output{holder};

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -63,7 +63,7 @@ class StripeLoadKeysTest : public Test {
 
     TestDecrypterFactory factory;
     auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
-    pool_ = getDefaultMemoryPool();
+    pool_ = addDefaultLeafMemoryPool();
 
     reader_ = std::make_unique<ReaderBase>(
         *pool_,

--- a/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
+++ b/velox/dwio/dwrf/test/TestBufferedOutputStream.cpp
@@ -25,7 +25,7 @@ using namespace facebook::velox::memory;
 using namespace facebook::velox::dwrf;
 
 TEST(BufferedOutputStream, blockAligned) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
@@ -49,7 +49,7 @@ TEST(BufferedOutputStream, blockAligned) {
 }
 
 TEST(BufferedOutputStream, blockNotAligned) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
@@ -94,7 +94,7 @@ TEST(BufferedOutputStream, blockNotAligned) {
 }
 
 TEST(BufferedOutputStream, protoBufSerialization) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
 
   uint64_t block = 10;
@@ -119,7 +119,7 @@ TEST(BufferedOutputStream, protoBufSerialization) {
 }
 
 TEST(BufferedOutputStream, increaseSize) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
 
   uint64_t max = 512;
@@ -174,7 +174,7 @@ TEST(BufferedOutputStream, increaseSize) {
 }
 
 TEST(BufferedOutputStream, recordPosition) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
   uint64_t block = 256;
   uint64_t initial = 128;
@@ -234,7 +234,7 @@ TEST(BufferedOutputStream, recordPosition) {
 }
 
 TEST(AppendOnlyBufferedStream, Basic) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, 1024);
   uint64_t block = 10;
   DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};

--- a/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
@@ -111,7 +111,7 @@ void decodeAndVerifyBoolean(
 }
 
 TEST(ByteRleEncoder, random_chars) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -131,7 +131,7 @@ TEST(ByteRleEncoder, random_chars) {
 }
 
 TEST(ByteRleEncoder, random_chars_with_null) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -153,7 +153,7 @@ TEST(ByteRleEncoder, random_chars_with_null) {
 }
 
 TEST(BooleanRleEncoder, random_bits_not_aligned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -173,7 +173,7 @@ TEST(BooleanRleEncoder, random_bits_not_aligned) {
 }
 
 TEST(BooleanRleEncoder, random_bits_aligned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -193,7 +193,7 @@ TEST(BooleanRleEncoder, random_bits_aligned) {
 }
 
 TEST(BooleanRleEncoder, random_bits_aligned_with_null) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;

--- a/velox/dwio/dwrf/test/TestCompression.cpp
+++ b/velox/dwio/dwrf/test/TestCompression.cpp
@@ -160,7 +160,7 @@ class CompressionTest : public TestWithParam<TestParams> {
 };
 
 TEST_P(CompressionTest, compressOriginalString) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 128;
@@ -174,7 +174,7 @@ TEST_P(CompressionTest, compressOriginalString) {
 }
 
 TEST_P(CompressionTest, compressSimpleRepeatedString) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   constexpr uint64_t block = 128;
@@ -188,7 +188,7 @@ TEST_P(CompressionTest, compressSimpleRepeatedString) {
 }
 
 TEST_P(CompressionTest, compressTwoBlocks) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 128;
@@ -202,7 +202,7 @@ TEST_P(CompressionTest, compressTwoBlocks) {
 }
 
 TEST_P(CompressionTest, compressRandomLetters) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -218,7 +218,7 @@ TEST_P(CompressionTest, compressRandomLetters) {
 }
 
 TEST_P(CompressionTest, compressRandomBytes) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -255,7 +255,7 @@ void verifyProto(
 }
 
 TEST_P(CompressionTest, compressProtoBuf) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 256;
@@ -305,7 +305,7 @@ class RecordPositionTest : public TestWithParam<TestParams2> {
 };
 
 TEST_P(RecordPositionTest, testRecordPosition) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
   uint64_t block = 256;
   uint64_t initial = 128;

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -35,7 +35,7 @@ using namespace folly::io;
 
 const std::string simpleFile(getExampleFilePath("simple-file.binary"));
 
-std::shared_ptr<MemoryPool> pool = getDefaultMemoryPool();
+std::shared_ptr<MemoryPool> pool = addDefaultLeafMemoryPool();
 
 TEST(TestDecompression, testPrintBufferEmpty) {
   std::ostringstream str;
@@ -805,7 +805,7 @@ class TestSeek : public ::testing::Test {
     size_t offset1;
     size_t offset2;
     prepareTestData(codec, input1, input2, inputSize, output, offset1, offset2);
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
 
     std::unique_ptr<SeekableInputStream> stream = createDecompressor(
         kind,

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -91,7 +91,7 @@ TEST(TestDictionaryEncodingUtils, StringGetSortedIndexLookupTable) {
           {0, 1, 2, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -296,7 +296,7 @@ TEST(TestDictionaryEncodingUtils, StringStrideDictOptimization) {
   };
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     size_t rowCount = 0;
     for (const auto& key : testCase.addKeySequence) {

--- a/velox/dwio/dwrf/test/TestEncodingSelector.cpp
+++ b/velox/dwio/dwrf/test/TestEncodingSelector.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox::memory;
 namespace facebook::velox::dwrf {
 
 TEST(TestEntropyEncodingSelector, Ctor) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
   EXPECT_ANY_THROW(
@@ -70,7 +70,7 @@ class EntropyEncodingSelectorTest {
         decision_{decision} {}
 
   void runTest() const {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     dwio::common::DataBuffer<uint32_t> rows{*pool};
     rows.reserve(size_);

--- a/velox/dwio/dwrf/test/TestIntDirect.cpp
+++ b/velox/dwio/dwrf/test/TestIntDirect.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::dwrf;
 
 template <typename T, bool isSigned, bool vInt>
 void testInts(std::function<T()> generator) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   constexpr size_t count = 10240;
   DataBuffer<T> buffer{*pool, count};
   std::array<uint64_t, count / 64> nulls;

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -41,7 +41,7 @@ TEST(TestIntegerDictionaryEncoder, AddKey) {
       TestCase{{-2, 2, 2, -2, 2}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -74,7 +74,7 @@ TEST(TestIntegerDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -106,7 +106,7 @@ TEST(TestIntegerDictionaryEncoder, GetTotalCount) {
       TestCase{{-2, 1, 2, 0, -1, 1, 0, 2, 0, -2, -1, -2, 1}, 13}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -117,7 +117,7 @@ TEST(TestIntegerDictionaryEncoder, GetTotalCount) {
 }
 
 TEST(TestIntegerDictionaryEncoder, Clear) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   {
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     EXPECT_EQ(1, intDictEncoder.refCount_);
@@ -200,7 +200,7 @@ TEST(TestIntegerDictionaryEncoder, Clear) {
 }
 
 TEST(TestIntegerDictionaryEncoder, RepeatedFlush) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
   std::vector<int> keys{0, 1, 4, 9, 16, 25, 9, 1};
   for (const auto& key : keys) {
@@ -226,7 +226,7 @@ TEST(TestIntegerDictionaryEncoder, RepeatedFlush) {
 }
 
 TEST(TestIntegerDictionaryEncoder, Limit) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   for (size_t iter = 0; iter < 2; ++iter) {
     int16_t val = std::numeric_limits<int16_t>::min();
@@ -263,7 +263,7 @@ void testGetSortedIndexLookupTable() {
       TestCase{{-1, 0, -2, 2, 1}, false, {0, 1, 2, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -330,7 +330,7 @@ TEST(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
     values.emplace_back(static_cast<int16_t>(i));
   }
 
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   dwio::common::DataBuffer<bool> inDict{*pool};
   dwio::common::DataBuffer<int16_t> lookupTable{*pool};
@@ -443,7 +443,7 @@ void testInfrequentKeyOptimization() {
           24}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -89,7 +89,7 @@ void decodeAndVerify(
 class RleEncoderV1Test : public testing::Test {};
 
 TEST(RleEncoderV1Test, encodeMinAndMax) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -110,7 +110,7 @@ TEST(RleEncoderV1Test, encodeMinAndMax) {
 }
 
 TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -132,7 +132,7 @@ TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
 }
 
 TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -151,7 +151,7 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
 }
 
 TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -172,7 +172,7 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -191,7 +191,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -210,7 +210,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
 }
 
 TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -231,7 +231,7 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
 }
 
 TEST(RleEncoderV1Test, randomSequanceSigned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -250,7 +250,7 @@ TEST(RleEncoderV1Test, randomSequanceSigned) {
 }
 
 TEST(RleEncoderV1Test, allNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -271,7 +271,7 @@ TEST(RleEncoderV1Test, allNull) {
 }
 
 TEST(RleEncoderV1Test, recordPosition) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;
@@ -293,7 +293,7 @@ TEST(RleEncoderV1Test, recordPosition) {
 }
 
 TEST(RleEncoderV1Test, backfillPosition) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink memSink(*pool, DEFAULT_MEM_STREAM_SIZE);
 
   uint64_t block = 1024;

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -44,7 +44,7 @@ using namespace facebook::velox::test;
 
 namespace {
 const std::string structFile(getExampleFilePath("struct.orc"));
-auto defaultPool = memory::getDefaultMemoryPool();
+auto defaultPool = memory::addDefaultLeafMemoryPool();
 } // namespace
 
 TEST(TestReader, testWriterVersions) {
@@ -1120,7 +1120,7 @@ TEST(TestReader, testUpcastFloat) {
 }
 
 TEST(TestReader, testEmptyFile) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   MemorySink sink{*pool, 1024};
   DataBufferHolder holder{*pool, 1024, 0, DEFAULT_PAGE_GROW_RATIO, &sink};
   BufferedOutputStream output{holder};
@@ -1232,7 +1232,7 @@ void testBufferLifeCycle(
     std::mt19937& rng,
     size_t batchSize,
     bool hasNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {
@@ -1289,7 +1289,7 @@ void testFlatmapAsMapFieldLifeCycle(
     std::mt19937& rng,
     size_t batchSize,
     bool hasNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   std::vector<VectorPtr> batches;
   std::function<bool(vector_size_t)> isNullAt = nullptr;
   if (hasNull) {

--- a/velox/dwio/dwrf/test/TestRle.cpp
+++ b/velox/dwio/dwrf/test/TestRle.cpp
@@ -31,7 +31,7 @@ std::vector<int64_t> decodeRLEv2(
     size_t n,
     size_t count,
     const uint64_t* nulls = nullptr) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::make_unique<dwio::common::SeekableArrayInputStream>(bytes, l),
       RleVersion_2,
@@ -174,7 +174,7 @@ TEST(RLEv2, basicDelta4) {
 };
 
 TEST(RLEv2, delta0Width) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {
       0x4e, 0x2, 0x0, 0x1, 0x2, 0xc0, 0x2, 0x42, 0x0};
   std::unique_ptr<dwio::common::IntDecoder<false>> decoder =
@@ -268,7 +268,7 @@ TEST(RLEv2, multiByteShortRepeats) {
 };
 
 TEST(RLEv2, 0to2Repeat1Direct) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0x46, 0x02, 0x02, 0x40};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
@@ -366,7 +366,7 @@ TEST(RLEv2, multipleRunsDirect) {
 };
 
 TEST(RLEv2, largeNegativesDirect) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {
       0x7e, 0x04, 0xcf, 0xca, 0xcc, 0x91, 0xba, 0x38, 0x93, 0xab, 0x00,
       0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -549,7 +549,7 @@ TEST(RLEv2, mixedPatchedAndShortRepeats) {
 };
 
 TEST(RLEv2, basicDirectSeek) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   // 0,1 repeated 10 times (signed ints) followed by
   // 0,2 repeated 10 times (signed ints)
   const unsigned char bytes[] = {
@@ -601,7 +601,7 @@ TEST(RLEv2, basicDirectSeek) {
 };
 
 TEST(RLEv2, bitsLeftByPreviousStream) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   // test for #109
   // 118 DIRECT values, followed by PATHCED values
   const unsigned char bytes[] = {
@@ -667,7 +667,7 @@ TEST(RLEv2, bitsLeftByPreviousStream) {
 };
 
 TEST(RLEv1, simpleTest) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {
       0x61, 0xff, 0x64, 0xfb, 0x02, 0x03, 0x5, 0x7, 0xb};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
@@ -693,7 +693,7 @@ TEST(RLEv1, simpleTest) {
 };
 
 TEST(RLEv1, signedNullLiteralTest) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0xf8, 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7};
   std::unique_ptr<dwio::common::IntDecoder<true>> rle = createRleDecoder<true>(
       std::unique_ptr<dwio::common::SeekableInputStream>(
@@ -713,7 +713,7 @@ TEST(RLEv1, signedNullLiteralTest) {
 }
 
 TEST(RLEv1, splitHeader) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0x0, 0x00, 0xdc, 0xba, 0x98, 0x76};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(
@@ -733,7 +733,7 @@ TEST(RLEv1, splitHeader) {
 }
 
 TEST(RLEv1, splitRuns) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {
       0x7d, 0x01, 0xff, 0x01, 0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   dwio::common::SeekableInputStream* const stream =
@@ -767,7 +767,7 @@ TEST(RLEv1, splitRuns) {
 }
 
 TEST(RLEv1, testSigned) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0x7f, 0xff, 0x20};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -791,7 +791,7 @@ TEST(RLEv1, testSigned) {
 }
 
 TEST(RLEv1, testNull) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0x75, 0x02, 0x00};
   dwio::common::SeekableInputStream* const stream =
       new dwio::common::SeekableArrayInputStream(
@@ -823,7 +823,7 @@ TEST(RLEv1, testNull) {
 }
 
 TEST(RLEv1, testAllNulls) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0xf0, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05,
                                   0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c,
                                   0x0d, 0x0e, 0x0f, 0x3d, 0x00, 0x12};
@@ -863,7 +863,7 @@ TEST(RLEv1, testAllNulls) {
 }
 
 TEST(RLEv1, skipTest) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   // Create the RLE stream from Java's TestRunLengthIntegerEncoding.testSkips
   // for (size_t i = 0; i < 1024; ++i)
   //   out.write(i);
@@ -1105,7 +1105,7 @@ TEST(RLEv1, skipTest) {
 }
 
 TEST(RLEv1, seekTest) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   // Create the RLE stream from Java's
   // TestRunLengthIntegerEncoding.testUncompressedSeek
   // for (size_t i = 0; i < 1024; ++i)
@@ -3015,7 +3015,7 @@ TEST(RLEv1, seekTest) {
 }
 
 TEST(RLEv1, testLeadingNulls) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const unsigned char buffer[] = {0xfb, 0x01, 0x02, 0x03, 0x04, 0x05};
   std::unique_ptr<dwio::common::IntDecoder<false>> rle =
       createRleDecoder<false>(

--- a/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
+++ b/velox/dwio/dwrf/test/TestStatisticsBuilderUtils.cpp
@@ -56,7 +56,7 @@ TEST(TestStatisticsBuilderUtils, addIntegerValues) {
   IntegerStatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<int32_t>(size, pool.get());
@@ -101,7 +101,7 @@ TEST(TestStatisticsBuilderUtils, addDoubleValues) {
   DoubleStatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<float>(size, pool.get());
@@ -146,7 +146,7 @@ TEST(TestStatisticsBuilderUtils, addStringValues) {
   StringStatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<StringView>(10, pool.get());
@@ -191,7 +191,7 @@ TEST(TestStatisticsBuilderUtils, addBooleanValues) {
   BooleanStatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<bool>(size, pool.get());
@@ -234,7 +234,7 @@ TEST(TestStatisticsBuilderUtils, addValues) {
   StatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<bool>(size, pool.get());
@@ -268,7 +268,7 @@ TEST(TestStatisticsBuilderUtils, addBinaryValues) {
   BinaryStatisticsBuilder builder{options};
 
   // add values non null
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   size_t size = 10;
 
   auto values = AlignedBuffer::allocate<StringView>(size, pool.get());

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -40,7 +40,7 @@ TEST(TestStringDictionaryEncoder, AddKey) {
       TestCase{{"doe", "sow", "sow", "doe", "sow"}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -84,7 +84,7 @@ TEST(TestStringDictionaryEncoder, GetIndex) {
           {0, 3, 4, 2, 1, 3, 2, 4, 2, 0, 1, 0, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -133,7 +133,7 @@ TEST(TestStringDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -187,7 +187,7 @@ TEST(TestStringDictionaryEncoder, GetStride) {
           {1, 1, 6, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = getDefaultMemoryPool();
+    auto pool = addDefaultLeafMemoryPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& kv : testCase.addKeySequence) {
       stringDictEncoder.addKey(kv.first, kv.second);
@@ -210,7 +210,7 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
 }
 
 TEST(TestStringDictionaryEncoder, Clear) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 2500; ++i) {
@@ -232,7 +232,7 @@ TEST(TestStringDictionaryEncoder, Clear) {
 }
 
 TEST(TestStringDictionaryEncoder, MemBenchmark) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 10000; ++i) {
@@ -243,7 +243,7 @@ TEST(TestStringDictionaryEncoder, MemBenchmark) {
 }
 
 TEST(TestStringDictionaryEncoder, Limit) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   StringDictionaryEncoder encoder{*pool, *pool};
   encoder.addKey(folly::StringPiece{"abc"}, 0);
   dwio::common::DataBuffer<char> buf{*pool};

--- a/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
+++ b/velox/dwio/dwrf/test/TestStripeDictionaryCache.cpp
@@ -26,7 +26,7 @@ using namespace ::testing;
 namespace facebook::velox::dwrf {
 
 namespace {
-auto defaultPool = velox::memory::getDefaultMemoryPool();
+auto defaultPool = velox::memory::addDefaultLeafMemoryPool();
 
 folly::Function<BufferPtr(memory::MemoryPool*)> genConsecutiveRangeBuffer(
     int64_t begin,

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -99,7 +99,7 @@ StripeStreamsImpl createAndLoadStripeStreams(
 } // namespace
 
 TEST(StripeStream, planReads) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -141,7 +141,7 @@ TEST(StripeStream, planReads) {
 }
 
 TEST(StripeStream, filterSequences) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -197,7 +197,7 @@ TEST(StripeStream, filterSequences) {
 }
 
 TEST(StripeStream, zeroLength) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -250,7 +250,7 @@ TEST(StripeStream, zeroLength) {
 }
 
 TEST(StripeStream, planReadsIndex) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   google::protobuf::Arena arena;
 
   // build ps
@@ -354,7 +354,7 @@ void addNode(T& t, uint32_t node, uint32_t offset = 0) {
 }
 
 TEST(StripeStream, readEncryptedStreams) {
-  auto pool = getProcessDefaultMemoryManager().getPool("readEncryptedStreams");
+  auto pool = defaultMemoryManager().addRootPool("readEncryptedStreams");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
@@ -381,7 +381,7 @@ TEST(StripeStream, readEncryptedStreams) {
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
   TestEncrypter encrypter;
 
-  auto sinkPool = pool->addChild("sink");
+  auto sinkPool = pool->addLeafChild("sink");
   ProtoWriter pw{pool, *sinkPool};
   auto stripeFooter =
       google::protobuf::Arena::CreateMessage<proto::StripeFooter>(&arena);
@@ -398,7 +398,7 @@ TEST(StripeStream, readEncryptedStreams) {
   // add empty string to group3, so decoding will fail if read
   *stripeFooter->add_encryptiongroups() = "";
 
-  auto readerPool = pool->addChild("reader");
+  auto readerPool = pool->addLeafChild("reader");
   auto readerBase = std::make_shared<ReaderBase>(
       *readerPool,
       std::make_unique<BufferedInput>(
@@ -432,7 +432,7 @@ TEST(StripeStream, readEncryptedStreams) {
 }
 
 TEST(StripeStream, schemaMismatch) {
-  auto pool = getProcessDefaultMemoryManager().getPool("schemaMismatch");
+  auto pool = defaultMemoryManager().addRootPool("schemaMismatch");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
@@ -454,7 +454,7 @@ TEST(StripeStream, schemaMismatch) {
   auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
   TestEncrypter encrypter;
 
-  auto sinkPool = pool->addChild("sink");
+  auto sinkPool = pool->addLeafChild("sink");
   ProtoWriter pw{pool, *sinkPool};
   auto stripeFooter =
       google::protobuf::Arena::CreateMessage<proto::StripeFooter>(&arena);
@@ -466,7 +466,7 @@ TEST(StripeStream, schemaMismatch) {
   encrypter.setKey("key");
   pw.writeProto(*stripeFooter->add_encryptiongroups(), group, encrypter);
 
-  auto readerPool = pool->addChild("reader");
+  auto readerPool = pool->addLeafChild("reader");
   auto readerBase = std::make_shared<ReaderBase>(
       *readerPool,
       std::make_unique<BufferedInput>(
@@ -570,7 +570,8 @@ proto::ColumnEncoding genColumnEncoding(
 } // namespace
 
 TEST(StripeStream, shareDictionary) {
-  std::shared_ptr<MemoryPool> pool = getDefaultMemoryPool("shareDictionary");
+  std::shared_ptr<MemoryPool> pool =
+      addDefaultLeafMemoryPool("shareDictionary");
   TestStripeStreams ss(pool.get());
 
   auto nonSharedDictionaryEncoding =

--- a/velox/dwio/dwrf/test/TestWriterContext.cpp
+++ b/velox/dwio/dwrf/test/TestWriterContext.cpp
@@ -26,8 +26,7 @@ TEST(TestWriterContext, GetIntDictionaryEncoder) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
-      memory::getProcessDefaultMemoryManager().getPool(
-          "GetIntDictionaryEncoder")};
+      memory::defaultMemoryManager().addRootPool("GetIntDictionaryEncoder")};
 
   EXPECT_EQ(0, context.dictEncoders_.size());
   auto& intEncoder_1_0 = context.getIntDictionaryEncoder<int32_t>(
@@ -62,7 +61,7 @@ TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode) {
   config->set(Config::MAP_FLAT_DICT_SHARE, false);
   WriterContext context{
       config,
-      memory::getProcessDefaultMemoryManager().getPool(
+      memory::defaultMemoryManager().addRootPool(
           "RemoveIntDictionaryEncoderForNode")};
 
   context.getIntDictionaryEncoder<int32_t>(
@@ -114,7 +113,7 @@ TEST(TestWriterContext, BuildPhysicalSizeAggregators) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
-      memory::getProcessDefaultMemoryManager().getPool(
+      memory::defaultMemoryManager().addRootPool(
           "BuildPhysicalSizeAggregators")};
   auto type = ROW({
       {"array", ARRAY(REAL())},

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -117,7 +117,7 @@ void testWriterDefaultFlushPolicy(
 TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
   const size_t batchCount = 200;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -171,7 +171,7 @@ TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
 TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -313,7 +313,7 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
 TEST(E2EWriterTests, FlushPolicyNestedTypes) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -374,7 +374,7 @@ TEST(E2EWriterTests, FlushPolicyNestedTypes) {
 TEST(E2EWriterTests, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
   // A mixture of columns where dictionary sharing is not necessarily

--- a/velox/dwio/dwrf/test/WriterSinkTests.cpp
+++ b/velox/dwio/dwrf/test/WriterSinkTests.cpp
@@ -46,7 +46,7 @@ class WriterSinkTests : public Test {
 };
 
 TEST_F(WriterSinkTests, Checksum) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024 + 3};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);
@@ -87,7 +87,7 @@ TEST_F(WriterSinkTests, Checksum) {
 }
 
 TEST_F(WriterSinkTests, NoChecksum) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024 + 3};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -103,7 +103,7 @@ TEST_F(WriterSinkTests, NoChecksum) {
 }
 
 TEST_F(WriterSinkTests, NoCache) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -127,7 +127,7 @@ TEST_F(WriterSinkTests, NoCache) {
 }
 
 TEST_F(WriterSinkTests, CacheIndex) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -169,7 +169,7 @@ TEST_F(WriterSinkTests, CacheIndex) {
 }
 
 TEST_F(WriterSinkTests, CacheFooter) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -211,7 +211,7 @@ TEST_F(WriterSinkTests, CacheFooter) {
 }
 
 TEST_F(WriterSinkTests, CacheBothEmptyIndex) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -239,7 +239,7 @@ TEST_F(WriterSinkTests, CacheBothEmptyIndex) {
 }
 
 TEST_F(WriterSinkTests, CacheBoth) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -287,7 +287,7 @@ TEST_F(WriterSinkTests, CacheBoth) {
 }
 
 TEST_F(WriterSinkTests, CacheExceedsLimit) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -411,7 +411,7 @@ TEST_F(WriterSinkTests, CacheExceedsLimit) {
 }
 
 TEST_F(WriterSinkTests, CacheLarge) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 10 * 1024 * 1024 + 3};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -437,7 +437,7 @@ TEST_F(WriterSinkTests, CacheLarge) {
 }
 
 TEST_F(WriterSinkTests, SetModeOutOfOrder) {
-  auto pool = getDefaultMemoryPool();
+  auto pool = addDefaultLeafMemoryPool();
   MemorySink out{*pool, 1024};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -50,7 +50,7 @@ namespace facebook::velox::dwrf {
   auto writer = std::make_unique<Writer>(
       options,
       std::move(sink),
-      velox::memory::getProcessDefaultMemoryManager().getPool());
+      velox::memory::defaultMemoryManager().addRootPool());
 
   for (size_t i = 0; i < batches.size(); ++i) {
     writer->write(batches[i]);

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -173,11 +173,9 @@ class Writer : public WriterBase {
       : Writer{
             options,
             std::move(sink),
-            parentPool.addChild(
-                fmt::format(
-                    "writer_node_{}",
-                    folly::to<std::string>(folly::Random::rand64())),
-                memory::MemoryPool::Kind::kAggregate)} {}
+            parentPool.addAggregateChild(fmt::format(
+                "writer_node_{}",
+                folly::to<std::string>(folly::Random::rand64())))} {}
 
   ~Writer() override = default;
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -42,9 +42,9 @@ class WriterContext : public CompressionBufferPool {
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr)
       : config_{config},
         pool_{std::move(pool)},
-        dictionaryPool_{pool_->addChild(".dictionary")},
-        outputStreamPool_{pool_->addChild(".compression")},
-        generalPool_{pool_->addChild(".general")},
+        dictionaryPool_{pool_->addLeafChild(".dictionary")},
+        outputStreamPool_{pool_->addLeafChild(".compression")},
+        generalPool_{pool_->addLeafChild(".general")},
         handler_{std::move(handler)},
         compression{getConfig(Config::COMPRESSION)},
         compressionBlockSize{getConfig(Config::COMPRESSION_BLOCK_SIZE)},

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -145,7 +145,7 @@ class ParquetReaderTestBase : public testing::Test {
         "velox/dwio/parquet/tests/reader", "../examples/" + fileName);
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
 };

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
@@ -31,7 +31,7 @@ using namespace facebook::velox::dwio::parquet;
 using namespace facebook::velox::parquet::duckdb_reader;
 
 namespace {
-auto defaultPool = memory::getDefaultMemoryPool();
+auto defaultPool = memory::addDefaultLeafMemoryPool();
 
 std::unique_ptr<ParquetReader> createFileInput(
     const std::string& path,

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderBenchmark {
       : numValues_(numValues),
         definitionLevels_(new unsigned char[numValues]()),
         repetitionLevels_(new unsigned char[numValues]()),
-        pool_(memory::getDefaultMemoryPool()) {}
+        pool_(memory::addDefaultLeafMemoryPool()) {}
 
   void setUp(uint16_t maxDefinition, uint16_t maxRepetition) {
     dwio::common::ensureCapacity<uint64_t>(

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderTest : public testing::Test {
 
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
 
     dwio::common::ensureCapacity<bool>(
         nullsBuffer_, kMaxNumValues, pool_.get());

--- a/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -27,7 +27,7 @@ using namespace facebook::velox::parquet;
 class ParquetPageReaderTest : public ParquetReaderTestBase {};
 
 namespace {
-auto defaultPool = memory::getDefaultMemoryPool();
+auto defaultPool = memory::addDefaultLeafMemoryPool();
 }
 
 TEST_F(ParquetPageReaderTest, smallPage) {

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -42,7 +42,7 @@ class ParquetReaderBenchmark {
  public:
   explicit ParquetReaderBenchmark(bool disableDictionary)
       : disableDictionary_(disableDictionary) {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_.get(), 0);
     auto sink =
         std::make_unique<LocalFileSink>(fileFolder_->path + "/" + fileName_);

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox::dwio::parquet;
 using namespace facebook::velox::parquet;
 
 namespace {
-auto defaultPool = memory::getDefaultMemoryPool();
+auto defaultPool = memory::addDefaultLeafMemoryPool();
 }
 
 class ParquetReaderTest : public ParquetReaderTestBase {};

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -64,8 +64,8 @@ int main(int argc, char** argv) {
   // pointer to this pool can be obtained using execCtx.pool().
   //
   // Optionally, one can control the per-thread memory cap by passing it as an
-  // argument to getDefaultMemoryPool() - no limit by default.
-  auto pool = memory::getDefaultMemoryPool();
+  // argument to addDefaultLeafMemoryPool() - no limit by default.
+  auto pool = memory::addDefaultLeafMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, let's create an expression tree to be executed in this example. On a

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
 
   // Create memory pool and other query-related structures.
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, we need to generate an input batch of data (rowVector). We create a

--- a/velox/examples/OperatorExtensibility.cpp
+++ b/velox/examples/OperatorExtensibility.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
   // assert that the output results contain the dataset properly duplicated.
 
   // Create a new memory pool to in this example.
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   // VectorMaker is a test utility that helps you build vectors. Shouldn't be
   // used in production.

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
 
   // Default memory allocator used throughout this example.
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   // For this example, the input dataset will be comprised of a single BIGINT
   // column ("my_col"), containing 10 rows.

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -41,7 +41,7 @@ int main(int argc, char** argv) {
   // filesystem. We also need to register the dwrf reader factory:
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
-  auto pool = facebook::velox::memory::getDefaultMemoryPool();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   std::string filePath{argv[1]};
   ReaderOptions readerOpts{pool.get()};

--- a/velox/examples/VectorReaderWriter.cpp
+++ b/velox/examples/VectorReaderWriter.cpp
@@ -46,7 +46,7 @@ int main() {
   // Array<Map<int,int>>
   auto type = TypeFactory<TypeKind::ARRAY>::create(
       TypeFactory<TypeKind::MAP>::create(BIGINT(), BIGINT()));
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   // result vector
   VectorPtr result;

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -88,16 +88,10 @@ std::shared_ptr<connector::ConnectorQueryCtx>
 OperatorCtx::createConnectorQueryCtx(
     const std::string& connectorId,
     const std::string& planNodeId,
-    bool forScan) const {
+    memory::MemoryPool* connectorPool) const {
   return std::make_shared<connector::ConnectorQueryCtx>(
       pool_,
-      forScan ? nullptr
-              : driverCtx_->task->addConnectorWriterPoolLocked(
-                    planNodeId_,
-                    driverCtx_->pipelineId,
-                    driverCtx_->driverId,
-                    operatorType_,
-                    connectorId),
+      connectorPool,
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       std::make_unique<SimpleExpressionEvaluator>(
           execCtx()->queryCtx(), execCtx()->pool()),

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -213,12 +213,12 @@ class OperatorCtx {
 
   /// Makes an extract of QueryCtx for use in a connector. 'planNodeId'
   /// is the id of the calling TableScan. This and the task id identify the scan
-  /// for column access tracking. If 'forScan' is true, it is created for a
-  /// TableScan, otherwise for a TableWriter operator.
+  /// for column access tracking. 'connectorPool' is an aggregate memory pool
+  /// for connector use.
   std::shared_ptr<connector::ConnectorQueryCtx> createConnectorQueryCtx(
       const std::string& connectorId,
       const std::string& planNodeId,
-      bool forScan) const;
+      memory::MemoryPool* connectorPool) const;
 
   /// Generates the spiller config for a given spiller 'type' if the disk
   /// spilling is enabled, otherwise returns null.

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -651,7 +651,7 @@ void Spiller::fillSpillRuns(std::vector<SpillableStats>& statsList) {
 
 // static
 memory::MemoryPool& Spiller::spillPool() {
-  static auto pool = memory::getDefaultMemoryPool();
+  static auto pool = memory::addDefaultLeafMemoryPool();
   return *pool;
 }
 

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -74,11 +74,15 @@ class TableScan : public SourceOperator {
   // Adjust batch size according to split information.
   void setBatchSize();
 
+  // Process-wide IO wait time.
+  static std::atomic<uint64_t> ioWaitNanos_;
+
   const std::shared_ptr<connector::ConnectorTableHandle> tableHandle_;
   const std::
       unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
           columnHandles_;
-  DriverCtx* driverCtx_;
+  DriverCtx* const driverCtx_;
+  memory::MemoryPool* const connectorPool_;
   ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
   BlockingReason blockingReason_;
   bool needNewSplit_ = true;
@@ -114,8 +118,5 @@ class TableScan : public SourceOperator {
   // The last value of the IO wait time of 'this' that has been added to the
   // global static 'ioWaitNanos_'.
   uint64_t lastIoWaitNanos_{0};
-
-  // Process-wide IO wait time.
-  static std::atomic<uint64_t> ioWaitNanos_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -31,13 +31,19 @@ TableWriter::TableWriter(
           tableWriteNode->id(),
           "TableWrite"),
       driverCtx_(driverCtx),
+      connectorPool_(driverCtx_->task->addConnectorPoolLocked(
+          planNodeId(),
+          driverCtx_->pipelineId,
+          driverCtx_->driverId,
+          operatorType(),
+          tableWriteNode->insertTableHandle()->connectorId())),
       insertTableHandle_(
           tableWriteNode->insertTableHandle()->connectorInsertTableHandle()),
       commitStrategy_(tableWriteNode->commitStrategy()) {
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
   connector_ = connector::getConnector(connectorId);
-  connectorQueryCtx_ =
-      operatorCtx_->createConnectorQueryCtx(connectorId, planNodeId(), false);
+  connectorQueryCtx_ = operatorCtx_->createConnectorQueryCtx(
+      connectorId, planNodeId(), connectorPool_);
 
   auto names = tableWriteNode->columnNames();
   auto types = tableWriteNode->columns()->children();

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -64,7 +64,8 @@ class TableWriter : public Operator {
  private:
   void createDataSink();
 
-  const DriverCtx* driverCtx_;
+  const DriverCtx* const driverCtx_;
+  memory::MemoryPool* const connectorPool_;
   const std::shared_ptr<connector::ConnectorInsertTableHandle>
       insertTableHandle_;
   const connector::CommitStrategy commitStrategy_;

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -284,11 +284,10 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t driverId,
       const std::string& operatorType);
 
-  /// Creates new instance of MemoryPool for the connector writer used by a
-  /// table write operator, stores it in the task to ensure lifetime and returns
-  /// a raw pointer. Not thread safe, e.g. must be called from the Operator's
-  /// constructor.
-  velox::memory::MemoryPool* addConnectorWriterPoolLocked(
+  /// Creates new instance of MemoryPool with aggregate kind for the connector
+  /// use, stores it in the task to ensure lifetime and returns a raw pointer.
+  /// Not thread safe, e.g. must be called from the Operator's constructor.
+  velox::memory::MemoryPool* addConnectorPoolLocked(
       const core::PlanNodeId& planNodeId,
       int pipelineId,
       uint32_t driverId,

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -151,10 +151,8 @@ class ExchangeBenchmark : public VectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), std::make_shared<core::MemConfig>(configSettings_));
     queryCtx->testingOverrideMemoryPool(
-        memory::getProcessDefaultMemoryManager().getPool(
-            queryCtx->queryId(),
-            memory::MemoryPool::Kind::kAggregate,
-            maxMemory));
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
     return std::make_shared<Task>(
         taskId,

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -52,7 +52,7 @@ class BenchmarkBase {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -221,7 +221,7 @@ class AggregationFuzzer {
   FuzzerGenerator rng_;
   size_t currentSeed_{0};
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   VectorFuzzer vectorFuzzer_;
 
   Stats stats_;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -888,10 +888,8 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::getProcessDefaultMemoryManager().getPool(
-            queryCtx->queryId(),
-            memory::MemoryPool::Kind::kAggregate,
-            kMaxBytes));
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes));
     auto results = AssertQueryBuilder(
                        PlanBuilder()
                            .values(batches)
@@ -997,10 +995,8 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::getProcessDefaultMemoryManager().getPool(
-            queryCtx->queryId(),
-            memory::MemoryPool::Kind::kAggregate,
-            kMaxBytes));
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes));
 
     SCOPED_TESTVALUE_SET(
         "facebook::velox::exec::Spiller",
@@ -1121,10 +1117,8 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::getProcessDefaultMemoryManager().getPool(
-          queryCtx->queryId(),
-          memory::MemoryPool::Kind::kAggregate,
-          kMaxBytes));
+      memory::defaultMemoryManager().addRootPool(
+          queryCtx->queryId(), kMaxBytes));
 
   auto task =
       AssertQueryBuilder(PlanBuilder()

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -136,7 +136,7 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t maxNumPartitions_{8};
   const uint32_t numSpillFilesPerPartition_{20};
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -470,7 +470,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     ASSERT_EQ(0, table->listNullKeyRows(&iter, rows.size(), rows.data()));
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -113,7 +113,7 @@ class JoinFuzzer {
   FuzzerGenerator rng_;
   size_t currentSeed_{0};
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   VectorFuzzer vectorFuzzer_;
 };
 

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -68,10 +68,8 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::getProcessDefaultMemoryManager().getPool(
-          queryCtx->queryId(),
-          memory::MemoryPool::Kind::kAggregate,
-          kMaxBytes));
+      memory::defaultMemoryManager().addRootPool(
+          queryCtx->queryId(), kMaxBytes));
   CursorParameters params;
   params.planNode = plan;
   params.queryCtx = queryCtx;
@@ -115,10 +113,8 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::getProcessDefaultMemoryManager().getPool(
-          queryCtx->queryId(),
-          memory::MemoryPool::Kind::kAggregate,
-          kMaxBytes));
+      memory::defaultMemoryManager().addRootPool(
+          queryCtx->queryId(), kMaxBytes));
 
   const int32_t numDrivers = 10;
   CursorParameters params;

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -106,7 +106,7 @@ class OperatorUtilsTest
     }
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 
 TEST_F(OperatorUtilsTest, wrapChildConstant) {

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -431,10 +431,8 @@ TEST_F(OrderByTest, spill) {
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
   queryCtx->testingOverrideMemoryPool(
-      memory::getProcessDefaultMemoryManager().getPool(
-          queryCtx->queryId(),
-          memory::MemoryPool::Kind::kAggregate,
-          kMaxBytes));
+      memory::defaultMemoryManager().addRootPool(
+          queryCtx->queryId(), kMaxBytes));
   // Set 'kSpillableReservationGrowthPct' to an extreme large value to trigger
   // disk spilling by failed memory growth reservation.
   queryCtx->setConfigOverridesUnsafe({
@@ -486,10 +484,8 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::getProcessDefaultMemoryManager().getPool(
-            queryCtx->queryId(),
-            memory::MemoryPool::Kind::kAggregate,
-            kMaxBytes));
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes));
     auto results =
         AssertQueryBuilder(
             PlanBuilder()

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -29,7 +29,7 @@ using facebook::velox::test::BatchMaker;
 class PartitionedOutputBufferManagerTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = facebook::velox::memory::getDefaultMemoryPool();
+    pool_ = facebook::velox::memory::addDefaultLeafMemoryPool();
     bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -386,7 +386,7 @@ TEST_F(PartitionedOutputBufferManagerTest, setQueueErrorWithPendingPages) {
   std::memcpy(iobuf->writableData(), payload.data(), payloadSize);
   iobuf->append(payloadSize);
 
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto page = std::make_unique<SerializedPage>(std::move(iobuf), pool.get());
   ASSERT_EQ(payloadSize, pool->getCurrentBytes());
 

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -22,7 +22,7 @@ using namespace facebook::velox;
 TEST(RoundRobinPartitionFunctionTest, basic) {
   exec::RoundRobinPartitionFunction partitionFunction(10);
 
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   test::VectorMaker vm(pool.get());
 
   auto data = vm.rowVector(ROW({}, {}), 31);

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::exec;
 class SpillOperatorGroupTest : public testing::Test {
  protected:
   SpillOperatorGroupTest(int32_t numOperators = 1)
-      : numOperators_(numOperators), pool_(memory::getDefaultMemoryPool()) {
+      : numOperators_(numOperators), pool_(memory::addDefaultLeafMemoryPool()) {
     // All this is to prepare valid driver context for our mock operators.
     VectorMaker vectorMaker{pool_.get()};
     std::vector<RowVectorPtr> values = {vectorMaker.rowVector(

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox::exec;
 class VectorHasherTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = facebook::velox::memory::getDefaultMemoryPool();
+    pool_ = facebook::velox::memory::addDefaultLeafMemoryPool();
     allRows_ = SelectivityVector(100);
 
     oddRows_ = VectorHasherTest::makeOddRows(100);

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -62,7 +62,7 @@ class TaskQueue {
   };
 
   explicit TaskQueue(uint64_t maxBytes)
-      : pool_(memory::getDefaultMemoryPool()), maxBytes_(maxBytes) {}
+      : pool_(memory::addDefaultLeafMemoryPool()), maxBytes_(maxBytes) {}
 
   void setNumProducers(int32_t n) {
     numProducers_ = n;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -63,8 +63,7 @@ void HiveConnectorTestBase::writeToFile(
   options.schema = vectors[0]->type();
   auto sink =
       std::make_unique<facebook::velox::dwio::common::LocalFileSink>(filePath);
-  auto childPool = rootPool_->addChild(
-      "HiveConnectorTestBase.Writer", memory::MemoryPool::Kind::kAggregate);
+  auto childPool = rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
   facebook::velox::dwrf::Writer writer{options, std::move(sink), *childPool};
   for (size_t i = 0; i < vectors.size(); ++i) {
     writer.write(vectors[i]);

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -33,7 +33,7 @@ class RowContainerTestBase : public testing::Test,
                              public velox::test::VectorTestBase {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
           registerVectorSerde();

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -128,7 +128,8 @@ class TpchQueryBuilder {
   static constexpr const char* kPart = "part";
   static constexpr const char* kSupplier = "supplier";
   static constexpr const char* kPartsupp = "partsupp";
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -126,7 +126,7 @@ class CodegenBenchmark : public CodegenTestCore {
   CodegenBenchmark() {
     CodegenTestCore::init();
     queryCtx = std::make_shared<core::QueryCtx>();
-    pool = memory::getDefaultMemoryPool();
+    pool = memory::addDefaultLeafMemoryPool();
     execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
 

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -581,7 +581,7 @@ class ExpressionCodegenTestBase : public testing::Test {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<facebook::velox::core::ExecCtx>(
           pool_.get(),

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -57,7 +57,7 @@ class GenerateAstTest : public CodegenTestBase {
     registerVeloxArithmeticUDFs(udfManager_);
     useBuiltInForArithmetic_ = false;
 
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
 
     rowType_ = ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()});
 

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -104,7 +104,7 @@ class CodegenTestCore {
             udfManager_,
             useSymbolForArithmetic_,
             eventSequence_);
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     queryCtx_ = std::make_shared<core::QueryCtx>(executor_.get());
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -89,7 +89,7 @@ TEST(TestConcat, EvalConcatFunction) {
   auto outRowType =
       ROW({"pl", "mi"},
           {std::make_shared<DoubleType>(), std::make_shared<DoubleType>()});
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto inRowVector = BaseVector::create(inRowType, rowLength, pool.get());
   auto outRowVector = BaseVector::create(outRowType, rowLength, pool.get());
 
@@ -191,7 +191,7 @@ struct GeneratedVectorFunctionConfigBool {
 
 TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   // TODO: Move those to test class
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const size_t vectorSize = 1000;
   auto queryCtx = std::make_shared<core::QueryCtx>();
   auto execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx.get());

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -26,7 +26,7 @@ TEST(VectorReader, ReadDoublesVectors) {
   auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
   auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
 
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
   auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
@@ -54,7 +54,7 @@ TEST(VectorReader, ReadDoublesVectors) {
 
 TEST(VectorReader, ReadBoolVectors) {
   // TODO: Move those to test class
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   const size_t vectorSize = 1000;
 
   auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -27,7 +27,7 @@ namespace {
 VectorPtr toConstant(
     const core::TypedExprPtr& expr,
     const std::shared_ptr<core::QueryCtx>& queryCtx) {
-  static auto pool = memory::getDefaultMemoryPool();
+  static auto pool = memory::addDefaultLeafMemoryPool();
   auto data = std::make_shared<RowVector>(
       pool.get(), ROW({}, {}), nullptr, 1, std::vector<VectorPtr>{});
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -60,7 +60,8 @@ class ExprToSubfieldFilterTest : public testing::Test {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 TEST_F(ExprToSubfieldFilterTest, eq) {

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -309,7 +309,7 @@ class ExpressionFuzzer {
   std::unordered_map<std::string, ArgsOverrideFunc> funcArgOverrides_;
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   test::ExpressionVerifier verifier_;
 

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -118,7 +118,7 @@ void ExpressionRunner::run(
   VELOX_CHECK(!sql.empty());
 
   std::shared_ptr<core::QueryCtx> queryCtx{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   RowVectorPtr inputVector;

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -35,7 +35,7 @@ class ExpressionRunnerUnitTest : public testing::Test, public VectorTestBase {
   }
 
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -75,7 +75,7 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
     return core::Expressions::inferTypes(untyped, rowType, pool_.get());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -68,7 +68,7 @@ class FunctionBenchmarkBase {
 
  protected:
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
   parse::ParseOptions options_;

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -373,7 +373,7 @@ TEST(KllSketchTest, mergeDeserialized) {
 // 2. Otherwise it's \f$ K \sum_i \(\frac{2}{3}\)^i \f$ and it converges to
 //    about O(3K).
 TEST(KllSketchTest, memoryUsage) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   HashStringAllocator alloc(pool.get());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -72,7 +72,7 @@ class ValueListTest : public functions::test::FunctionBaseTest {
     return allocator_.get();
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   std::unique_ptr<HashStringAllocator> allocator_{
       std::make_unique<HashStringAllocator>(pool_.get())};
 };

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -48,7 +48,7 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -23,7 +23,8 @@ class InPredicateTest : public FunctionBaseTest {
  protected:
   template <typename T>
   void testIntegers() {
-    std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+    std::shared_ptr<memory::MemoryPool> pool{
+        memory::addDefaultLeafMemoryPool()};
 
     const vector_size_t size = 1'000;
     auto vector = makeFlatVector<T>(size, [](auto row) { return row % 17; });

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -54,7 +54,7 @@ class QueryPlannerTest : public testing::Test {
         std::vector<VectorPtr>{});
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 
 TEST_F(QueryPlannerTest, values) {

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -49,7 +49,8 @@ class UnsaferowBatchDeserializer : public Deserializer {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 class BenchmarkHelper {
@@ -114,7 +115,8 @@ class BenchmarkHelper {
       MAP(VARCHAR(), ARRAY(INTEGER())),
       ROW({INTEGER()})};
 
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 int deserialize(

--- a/velox/row/experimental/tests/UnsafeRow24DeserializerTest.cpp
+++ b/velox/row/experimental/tests/UnsafeRow24DeserializerTest.cpp
@@ -73,7 +73,7 @@ VectorPtr deserialize(
 class UnsafeRowVectorDeserializerTest : public ::testing::Test {
  public:
   UnsafeRowVectorDeserializerTest()
-      : pool_(memory::getDefaultMemoryPool()),
+      : pool_(memory::addDefaultLeafMemoryPool()),
         bufferPtr(AlignedBuffer::allocate<char>(1024, pool_.get(), true)),
         buffer(bufferPtr->asMutable<char>()) {}
 
@@ -565,7 +565,8 @@ class UnsafeRowComplexDeserializerTests : public exec::test::OperatorTestBase {
     assertEqualVectors(inputVector, outputVector);
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
   std::array<char[1024], kMaxBuffers> buffers_{};
 };
 

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -47,7 +47,8 @@ class UnsafeRowFuzzTests : public ::testing::Test {
 
   std::array<char[kBufferSize], 100> buffers_{};
 
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 };
 
 TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {

--- a/velox/row/tests/UnsafeRowSerdeTest.cpp
+++ b/velox/row/tests/UnsafeRowSerdeTest.cpp
@@ -1043,7 +1043,7 @@ TEST_F(UnsafeRowSerializerTests, complexNullsAndEncoding) {
 class UnsafeRowBatchDeserializerTest : public ::testing::Test {
  public:
   UnsafeRowBatchDeserializerTest()
-      : pool_(memory::getDefaultMemoryPool()),
+      : pool_(memory::addDefaultLeafMemoryPool()),
         bufferPtr_(AlignedBuffer::allocate<char>(1024, pool_.get(), true)),
         buffer_(bufferPtr_->asMutable<char>()) {}
 

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -29,7 +29,7 @@ using namespace facebook::velox::test;
 class PrestoSerializerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     serde_ = std::make_unique<serializer::presto::PrestoVectorSerde>();
     vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
   }

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox;
 class UnsafeRowSerializerTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     serde_ = std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
   }
 

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -35,7 +35,8 @@ class FunctionTest : public ::testing::Test {
   std::shared_ptr<core::QueryCtx> queryCtx_ =
       std::make_shared<core::QueryCtx>();
 
-  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
 
   std::shared_ptr<vestrait::SubstraitParser> substraitParser_ =
       std::make_shared<vestrait::SubstraitParser>();

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -117,7 +117,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
            VARCHAR(),
            VARCHAR(),
            VARCHAR()});
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   std::vector<VectorPtr> vectors;
   // TPC-H lineitem table has 16 columns.
   int colNum = 16;

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -31,8 +31,7 @@ using namespace facebook::velox::tpch;
 class TpchGenTestNationTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestNationTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestNationTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -135,8 +134,7 @@ TEST_F(TpchGenTestNationTest, reproducible) {
 class TpchGenTestRegionTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestRegionTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestRegionTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -198,8 +196,7 @@ TEST_F(TpchGenTestRegionTest, reproducible) {
 class TpchGenTestOrdersTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestOrdersTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestOrdersTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -305,8 +302,8 @@ TEST_F(TpchGenTestOrdersTest, reproducible) {
 class TpchGenTestLineItemTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestLineItemTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ =
+        memory::defaultMemoryManager().addLeafPool("TpchGenTestLineItemTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -417,8 +414,8 @@ TEST_F(TpchGenTestLineItemTest, reproducible) {
 class TpchGenTestSupplierTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestSupplierTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ =
+        memory::defaultMemoryManager().addLeafPool("TpchGenTestSupplierTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -510,8 +507,7 @@ TEST_F(TpchGenTestSupplierTest, reproducible) {
 class TpchGenTestPartTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestPartTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestPartTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -596,8 +592,8 @@ TEST_F(TpchGenTestPartTest, reproducible) {
 class TpchGenTestPartSuppTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestPartSuppTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ =
+        memory::defaultMemoryManager().addLeafPool("TpchGenTestPartSuppTest");
   }
 
   bool partSuppCheck(
@@ -741,8 +737,8 @@ TEST_F(TpchGenTestPartSuppTest, reproducible) {
 class TpchGenTestCustomerTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getProcessDefaultMemoryManager().getPool(
-        "TpchGenTestCustomerTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ =
+        memory::defaultMemoryManager().addLeafPool("TpchGenTestCustomerTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -33,8 +33,8 @@ void mockSchemaRelease(ArrowSchema*) {}
 void mockArrayRelease(ArrowArray*) {}
 
 void exportToArrow(const TypePtr& type, ArrowSchema& out) {
-  auto pool = &facebook::velox::memory::getProcessDefaultMemoryManager()
-                   .deprecatedGetPool();
+  auto pool =
+      &facebook::velox::memory::defaultMemoryManager().deprecatedLeafPool();
   exportToArrow(BaseVector::create(type, 0, pool), out);
 }
 
@@ -187,7 +187,7 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Boiler plate structures required by vectorMaker.
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
@@ -1133,7 +1133,7 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     EXPECT_NO_THROW(importFromArrow(arrowSchema, arrowArray, pool_.get()));
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 
 class ArrowBridgeArrayImportAsViewerTest : public ArrowBridgeArrayImportTest {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -28,8 +28,8 @@ using namespace facebook::velox;
 static void mockRelease(ArrowSchema*) {}
 
 void exportToArrow(const TypePtr& type, ArrowSchema& out) {
-  auto pool = &facebook::velox::memory::getProcessDefaultMemoryManager()
-                   .deprecatedGetPool();
+  auto pool =
+      &facebook::velox::memory::defaultMemoryManager().deprecatedLeafPool();
   exportToArrow(BaseVector::create(type, 0, pool), out);
 }
 

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -68,7 +68,7 @@ size_t runBenchmark(
 
 BENCHMARK_MULTI(copyArray) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -84,7 +84,7 @@ BENCHMARK_MULTI(copyArray) {
 
 BENCHMARK_MULTI(copyArrayWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -101,7 +101,7 @@ BENCHMARK_MULTI(copyArrayWithNulls) {
 
 BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -131,7 +131,7 @@ BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyArrayOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -147,7 +147,7 @@ BENCHMARK_MULTI(copyArrayOneAtATime) {
 
 BENCHMARK_MULTI(copyArrayTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -163,7 +163,7 @@ BENCHMARK_MULTI(copyArrayTwoAtATime) {
 
 BENCHMARK_MULTI(copyArrayOfVarchar) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 50'000;
@@ -192,7 +192,7 @@ BENCHMARK_MULTI(copyArrayOfVarchar) {
 
 BENCHMARK_MULTI(copyArrayOfArray) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -220,7 +220,7 @@ BENCHMARK_MULTI(copyArrayOfArray) {
 
 BENCHMARK_MULTI(copyMap) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -238,7 +238,7 @@ BENCHMARK_MULTI(copyMap) {
 
 BENCHMARK_MULTI(copyMapWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -257,7 +257,7 @@ BENCHMARK_MULTI(copyMapWithNulls) {
 
 BENCHMARK_MULTI(copyMapDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -290,7 +290,7 @@ BENCHMARK_MULTI(copyMapDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyMapOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -308,7 +308,7 @@ BENCHMARK_MULTI(copyMapOneAtATime) {
 
 BENCHMARK_MULTI(copyMapTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -326,7 +326,7 @@ BENCHMARK_MULTI(copyMapTwoAtATime) {
 
 BENCHMARK_MULTI(copyStructNonContiguous) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
   test::VectorMaker vectorMaker{pool.get()};
   constexpr vector_size_t kSize = 2'000;
   std::vector<VectorPtr> children = {

--- a/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
+++ b/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
@@ -89,7 +89,7 @@ void vectorBenchmark(
     bool sequences,
     VectorEncoding::Simple encoding) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {

--- a/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
@@ -38,7 +38,7 @@ int main() {
   auto uniform = std::uniform_int_distribution<int32_t>(lo, hi);
 
   FuzzerGenerator rng;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   GeneratorSpecPtr randomArray =
       RANDOM_ARRAY(RANDOM_DOUBLE(normal, nullProbability), uniform);

--- a/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
@@ -47,7 +47,7 @@ int main() {
   };
 
   FuzzerGenerator rng;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   GeneratorSpecPtr encodedNormalDoubleGenerator =
       ENCODE(RANDOM_DOUBLE(normal, nullProbability), encoding, 1, 5, 0.3);
 

--- a/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
@@ -39,7 +39,7 @@ int main() {
   auto normal = std::normal_distribution<double>(mu, sigma);
 
   FuzzerGenerator rng;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   GeneratorSpecPtr randomMap =
       RANDOM_MAP(RANDOM_INTEGER(uniform), RANDOM_DOUBLE(normal), lengthDist);

--- a/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
@@ -39,7 +39,7 @@ int main() {
   auto bernoulli = std::bernoulli_distribution(p);
 
   FuzzerGenerator rng;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   GeneratorSpecPtr randomRow = RANDOM_ROW(
       {RANDOM_INTEGER(uniform),

--- a/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
@@ -49,7 +49,7 @@ int main() {
   };
 
   FuzzerGenerator rng;
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
 
   GeneratorSpecPtr uniformIntGenerator =
       RANDOM_INTEGER(uniform, nullProbability);

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -78,7 +78,7 @@ class VectorFuzzerTest : public testing::Test {
   void validateMaxSizes(VectorPtr vector, size_t maxSize);
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 };
 
 TEST_F(VectorFuzzerTest, flatPrimitive) {

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -25,7 +25,7 @@ namespace facebook::velox::test {
 class BiasVectorTestBase : public testing::Test {
  protected:
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::getDefaultMemoryPool()};
+      memory::addDefaultLeafMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox;
 class EnsureWritableVectorTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     vectorMaker_ = std::make_unique<test::VectorMaker>(pool_.get());
   }
 

--- a/velox/vector/tests/IsWritableVectorTest.cpp
+++ b/velox/vector/tests/IsWritableVectorTest.cpp
@@ -25,7 +25,7 @@ using namespace facebook::velox::test;
 class IsWritableVectorTest : public testing::Test {
  protected:
   void SetUp() override {
-    pool_ = memory::getDefaultMemoryPool();
+    pool_ = memory::addDefaultLeafMemoryPool();
     vectorMaker_ = std::make_unique<VectorMaker>(pool_.get());
   }
 

--- a/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
+++ b/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
@@ -23,7 +23,7 @@ namespace facebook::velox::test {
 class MayHaveNullsRecursiveTest : public testing::Test {
  protected:
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::getDefaultMemoryPool()};
+      memory::addDefaultLeafMemoryPool()};
   VectorMaker vectorMaker_{pool_.get()};
 
   enum class TestOptions {

--- a/velox/vector/tests/SimpleVectorTestHelper.h
+++ b/velox/vector/tests/SimpleVectorTestHelper.h
@@ -102,7 +102,7 @@ class SimpleVectorTest : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -25,7 +25,7 @@
 using namespace facebook::velox;
 
 class VariantToVectorTest : public testing::Test {
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
 
  public:
   template <TypeKind KIND>

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -25,7 +25,7 @@ using facebook::velox::test::VectorMaker;
 
 class VectorMakerTest : public ::testing::Test {
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2027,7 +2027,7 @@ TEST_F(VectorTest, mapSliceMutability) {
 TEST_F(VectorTest, lifetime) {
   ASSERT_DEATH(
       {
-        auto childPool = memory::getDefaultMemoryPool();
+        auto childPool = memory::addDefaultLeafMemoryPool();
         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
         // BUG: Memory pool needs to stay alive until all memory allocated from

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -83,7 +83,7 @@ class VectorGeneratedData {
 
   // In case T is StringView, the buffer below holds their actual data.
   std::shared_ptr<memory::MemoryPool> scopedPool =
-      memory::getDefaultMemoryPool();
+      memory::addDefaultLeafMemoryPool();
   StringViewBufferHolder stringViewBufferHolder_ =
       StringViewBufferHolder(scopedPool.get());
 };
@@ -271,7 +271,7 @@ template <typename T>
 SimpleVectorPtr<T> createAndAssert(
     const ExpectedData<T>& expected,
     VectorEncoding::Simple encoding) {
-  auto pool = memory::getDefaultMemoryPool();
+  auto pool = memory::addDefaultLeafMemoryPool();
   VectorMaker maker(pool.get());
 
   auto vector = maker.encodedVector(encoding, expected);

--- a/velox/vector/tests/VectorUtilTest.cpp
+++ b/velox/vector/tests/VectorUtilTest.cpp
@@ -58,8 +58,7 @@ class VectorUtilTest : public testing::Test {
 
  protected:
   void SetUp() override {
-    pool_ = memoryManager_.getPool(
-        "VectorUtilTest", memory::MemoryPool::Kind::kLeaf);
+    pool_ = memoryManager_.addLeafPool("VectorUtilTest");
   }
 
   memory::MemoryManager memoryManager_;

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -739,8 +739,8 @@ class VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::getProcessDefaultMemoryManager().getPool()};
-  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addChild("leaf")};
+      memory::defaultMemoryManager().addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(


### PR DESCRIPTION
This PR includes the following memory management related API changes:
MemoryManager interface
Split getPool to getRootPool and getLeafPool. The former allocates root pool and
the latter allocates a leaf pool from the default root memory pool.
Keep deprecatedGetPool and rename it to leafPool which returns the leaf memory
pool owned by the memory manager for ease existing legacy use cases. The
leaf memory pool is a child pool of the default root pool

MemoryPool interface
Split addChild to addLeafChild and addAggregateChild.

Global memory management utilities
Rename getProcessDefaultMemoryManager to defaultMemoryManager to return
the default memory manager
Add defaultMemoryPool() to return the leaf memory pool owned by the default
memory manager

ConnectorQueryCtx change
Unconditionally create a connectorPool which is aggregate type in ConnectorQueryCtx
no matter it is for table scan or table write. It is per operator and the memory pool
creation overhead should be trivial
Rename aggregatePool to connectorMemoryPool

