### PR TITLE
Allow expression fuzzer persist repro info on VeloxRuntimeError

### DIFF
--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -122,6 +122,21 @@ target_link_libraries(
   velox_expression_runner_test velox_expression_runner velox_exec_test_lib
   velox_function_registry gtest gtest_main)
 
+add_executable(velox_expression_verifier_unit_test
+               ExpressionVerifierUnitTest.cpp)
+target_link_libraries(
+  velox_expression_verifier_unit_test
+  velox_expression_verifier
+  velox_file
+  velox_temp_path
+  velox_parse_expression
+  velox_parse_parser
+  velox_parse_utils
+  velox_type
+  velox_vector_test_lib
+  gtest
+  gtest_main)
+
 add_executable(velox_expression_runner_unit_test ExpressionRunnerUnitTest.cpp)
 target_link_libraries(
   velox_expression_runner_unit_test

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -78,6 +78,16 @@ class ExpressionVerifier {
       const std::string& sql,
       const std::vector<VectorPtr>& complexConstants);
 
+  // Utility method that calls persistReproInfo to save data and sql if
+  // options_.reproPersistPath is set and is not persistAndRunOnce. Do nothing
+  // otherwise.
+  void persistReproInfoIfNeeded(
+      const VectorPtr& inputVector,
+      const std::vector<column_index_t>& columnsToWarpInLazy,
+      const VectorPtr& resultVector,
+      const std::string& sql,
+      const std::vector<VectorPtr>& complexConstants);
+
  private:
   core::ExecCtx* FOLLY_NONNULL execCtx_;
   const ExpressionVerifierOptions options_;

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include <fstream>
+
+#include "velox/expression/tests/ExpressionVerifier.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/functions/Registerer.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/type/Type.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::test {
+
+namespace {
+
+template <typename T>
+struct AlwaysThrowsUserErrorFunction {
+  template <typename TResult, typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TResult&, const TInput&) {
+    VELOX_USER_FAIL("expected");
+  }
+};
+
+template <typename T>
+struct AlwaysThrowsRuntimeErrorFunction {
+  template <typename TResult, typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TResult&, const TInput&) {
+    VELOX_FAIL("expected");
+  }
+};
+
+void removeDirecrtoryIfExist(
+    std::shared_ptr<filesystems::FileSystem>& localFs,
+    const std::string& folderPath) {
+  if (localFs->exists(folderPath)) {
+    localFs->rmdir(folderPath);
+  }
+  EXPECT_FALSE(localFs->exists(folderPath));
+}
+
+} // namespace
+
+class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
+ public:
+  ExpressionVerifierUnitTest() {
+    parse::registerTypeResolver();
+  }
+
+ protected:
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    parse::ParseOptions options;
+    auto untyped = parse::parseExpr(text, options);
+    return core::Expressions::inferTypes(untyped, rowType, pool_.get());
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  core::QueryCtx queryCtx_{};
+  core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
+};
+
+TEST_F(ExpressionVerifierUnitTest, persistReproInfo) {
+  filesystems::registerLocalFileSystem();
+  auto reproFolder = exec::test::TempDirectoryPath::create();
+  const auto reproPath = reproFolder->path;
+  auto localFs = filesystems::getFileSystem(reproPath, nullptr);
+
+  ExpressionVerifierOptions options{false, reproPath.c_str(), false};
+  ExpressionVerifier verifier{&execCtx_, options};
+
+  auto testReproPersistency = [this](
+                                  ExpressionVerifier& verifier,
+                                  const std::string& reproPath,
+                                  auto& localFs) {
+    auto data = makeRowVector({makeFlatVector<int32_t>({1, 2, 3})});
+    auto plan = parseExpression("always_throws(c0)", asRowType(data->type()));
+
+    removeDirecrtoryIfExist(localFs, reproPath);
+    VELOX_ASSERT_THROW(verifier.verify(plan, data, nullptr, false), "");
+    EXPECT_TRUE(localFs->exists(reproPath));
+    EXPECT_FALSE(localFs->list(reproPath).empty());
+    removeDirecrtoryIfExist(localFs, reproPath);
+  };
+
+  // User errors.
+  {
+    registerFunction<AlwaysThrowsUserErrorFunction, int32_t, int32_t>(
+        {"always_throws"});
+    testReproPersistency(verifier, reproPath, localFs);
+  }
+
+  // Runtime errors.
+  {
+    registerFunction<AlwaysThrowsRuntimeErrorFunction, int32_t, int32_t>(
+        {"always_throws"});
+    testReproPersistency(verifier, reproPath, localFs);
+  }
+}
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
VeloxRuntimeError causes fuzzer test failures because only VeloxUserError is allowed
by fuzzer, but repro information is not persisted in this situation. This diff fixes fuzzer to
persist repro info when VeloxRuntimeError happens in either the common or simplified
path.

This diff fixes https://github.com/facebookincubator/velox/issues/4367.

Differential Revision: D44244143

