### PR TITLE
Reduce HiveConnector file handle cache default size

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -33,7 +33,7 @@ using namespace facebook::velox::dwrf;
 
 DEFINE_int32(
     file_handle_cache_mb,
-    1024,
+    16,
     "Amount of space for the file handle cache in mb.");
 
 namespace facebook::velox::connector::hive {


### PR DESCRIPTION
Summary: The memory estimate for file handle is off by multiple folds. This can cause memory to build up significantly. This diff is a temporary mitigation of the memory buildup issue. In the future we need to have a clean design and fix for this untracked memory issue.

Differential Revision: D44263716

