### PR TITLE
getdeps: remove test-getdeps from Sapling manifest

### DIFF
--- a/build/fbcode_builder/manifests/sapling
+++ b/build/fbcode_builder/manifests/sapling
@@ -22,9 +22,6 @@ getdepsbuild
 [make.install_args]
 install-getdeps
 
-[make.test_args]
-test-getdeps
-
 [shipit.pathmap]
 fbcode/configerator/structs/scm/hg = configerator/structs/scm/hg
 fbcode/configerator/structs/scm/hg/public_autocargo = configerator/structs/scm/hg


### PR DESCRIPTION
Summary:
We are now planning to remove the Sapling getdeps build since Sapling
doesn't use it for open source anyway. The EdenFS getdeps build will adapt one
way or another.

This diff only remove the test step of the Sapling getdeps, which is failing
now. Will remove the entire Sapling manifest the following diff.

Reviewed By: quark-zju

Differential Revision: D44233463

