### PR TITLE
Fix error semantics  in null-propagating switch

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3543,3 +3543,21 @@ TEST_F(ExprTest, peelingWithSmallerConstantInput) {
   auto result = evaluate("coalesce(c0, c1)", makeRowVector({d0, c1}));
   assertEqualVectors(c1, result);
 }
+
+TEST_F(ExprTest, ifWithLazyNulls) {
+  // Makes a null-propagating switch. Evaluates it so that null propagation
+  // masks out errors.
+  constexpr int32_t kSize = 100;
+  const char* kExpr =
+      "CASE WHEN 10 % (c0 - 2) < 0 then c0 + c1 when 10 % (c0 - 4) = 3 then c0 + c1 * 2 else c0 + c1 end";
+  auto c0 = makeFlatVector<int64_t>(kSize, [](auto row) { return row % 10; });
+  auto c1 = makeFlatVector<int64_t>(
+      kSize,
+      [](auto row) { return row; },
+      [](auto row) { return row % 10 == 2 || row % 10 == 4; });
+
+  auto result = evaluate(kExpr, makeRowVector({c0, c1}));
+  auto resultFromLazy =
+      evaluate(kExpr, makeRowVector({c0, wrapInLazyDictionary(c1)}));
+  assertEqualVectors(result, resultFromLazy);
+}


### PR DESCRIPTION
A null propagating switch can have inconsistent behavior with nulls and errors. If a condition on a row with nulls has an error, we do not see the error if the arguments are known. If they are lazy, we can hit the error before loading the lazy. Switches do not generally preload lazies because the whole point is to avoid loading lazies that are never accessed.

A null propagating switch however requires that all thens and else depend on the same columns, so load all lazies regardless of which way the condition goes. Therefore for null propagating switches, we first load the lazies, then resolve the null rows and then run the switch for the remaining rows.