### PR TITLE
Fix memory pool kind breakage in HiveFileWriter

### DIFF
--- a/velox/common/memory/MemoryUsageTracker.h
+++ b/velox/common/memory/MemoryUsageTracker.h
@@ -105,7 +105,7 @@ class MemoryUsageTracker
   /// Create default usage tracker which is a 'root' tracker.
   static std::shared_ptr<MemoryUsageTracker> create(
       int64_t maxMemory = kMaxMemory) {
-    return create(nullptr, false, maxMemory);
+    return create(/*parent=*/nullptr, /*leafTracker=*/false, maxMemory);
   }
 
   ~MemoryUsageTracker();


### PR DESCRIPTION
Summary: We have some wiring issue on tracker kind and pool kind on the FileWriter and HiveFileWriter code path. This diff fixes aforementioned issues.

Reviewed By: xiaoxmeng

Differential Revision: D44246717

