### PR TITLE
Refactor PartitionFunctionFactory to allow for serialization

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -279,7 +279,8 @@ LocalPartition::LocalPartition(
       partitionFunction_(
           numPartitions_ == 1
               ? nullptr
-              : planNode->partitionFunctionFactory()(numPartitions_)) {
+              : planNode->partitionFunctionSpec().create(numPartitions_)),
+      blockingReasons_{numPartitions_} {
   VELOX_CHECK(numPartitions_ == 1 || partitionFunction_ != nullptr);
 
   for (auto& queue : queues_) {

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -117,7 +117,7 @@ PartitionedOutput::PartitionedOutput(
       partitionFunction_(
           numDestinations_ == 1
               ? nullptr
-              : planNode->partitionFunctionFactory()(numDestinations_)),
+              : planNode->partitionFunctionSpec().create(numDestinations_)),
       outputChannels_(calculateOutputChannels(
           planNode->inputType(),
           planNode->outputType(),


### PR DESCRIPTION
PR #4303 adds support for serializing query plans using ISerializable framework.
LocalPartitionNode and PartitionedOutputNode use non-serializable
PartitionFunctionFactory. To enable serialization for PartitionFunctionFactory,
I change it from std::function to a class. A follow-up change will make this class 
inherit from ISerialiable, provide 'serialize' method and use it to serialize 
LocalPartitionNode and PartitionedOutputNode.