### PR TITLE
Do not block LocalPartition operator waiting for peers

### DIFF
--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -183,19 +183,11 @@ class LocalPartition : public Operator {
 
   bool isFinished() override;
 
-  void close() override {
-    Operator::close();
-    for (auto& queue : queues_) {
-      queue->close();
-    }
-  }
-
  private:
   const std::vector<std::shared_ptr<LocalExchangeQueue>> queues_;
   const size_t numPartitions_;
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
 
-  uint32_t numBlockedPartitions_{0};
   std::vector<BlockingReason> blockingReasons_;
   std::vector<ContinueFuture> futures_;
 


### PR DESCRIPTION
LocalPartition operator doesn't need to be blocked waiting for peers to finish
processing or for LocalExchanges to drain the queues. It can finish as soon as
it pushed all input into the queues.

Modify LocalPartition::close() to not close the queues and let LocalExchange 
operators (the consumers) close the queues.