### PR TITLE
Fix spark isEmpty and In functions

### DIFF
--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -95,7 +95,7 @@ FOLLY_ALWAYS_INLINE std::shared_ptr<const JsonType> JSON() {
 
 // Type used for function registration.
 struct JsonT {
-  using type = StringView;
+  using type = Varchar;
   static constexpr const char* typeName = "json";
 };
 

--- a/velox/functions/sparksql/In.cpp
+++ b/velox/functions/sparksql/In.cpp
@@ -103,7 +103,7 @@ struct InFunctionOuter {
     }
 
    private:
-    Set<TInput> elements_;
+    Set<arg_type<TInput>> elements_;
     bool hasNull_{false};
   };
 
@@ -127,7 +127,7 @@ void registerIn(const std::string& prefix) {
   registerInFn<float>(prefix);
   registerInFn<double>(prefix);
   registerInFn<bool>(prefix);
-  registerInFn<StringView>(prefix);
+  registerInFn<Varchar>(prefix);
   registerInFn<Timestamp>(prefix);
   registerInFn<Date>(prefix);
 }


### PR DESCRIPTION
Summary: use Varchar instead of StringView and std::string

Reviewed By: mbasmanova

Differential Revision: D44062294

