### PR TITLE
Fix error vector handling in Coalesce

### DIFF
--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -58,6 +58,11 @@ void CoalesceExpr::evalSpecialForm(
 
     if (!result->mayHaveNulls()) {
       // No nulls left.
+      return;
+    }
+
+    if (context.errors()) {
+      context.deselectErrors(*activeRows);
     }
 
     decodedVector.get()->decode(*result, *activeRows);

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -73,11 +73,12 @@ void finalizeErrors(
   if (!errors) {
     return;
   }
-  // null flag of error |= initial active & ~final active.
+  // Pre-existing errors outside of initial active rows are preserved. Errors in
+  // the initial active rows but not in the final active rows are cleared.
   int32_t numWords = bits::nwords(errors->size());
   auto errorNulls = errors->mutableNulls(errors->size())->asMutable<uint64_t>();
   for (int32_t i = 0; i < numWords; ++i) {
-    errorNulls[i] &= rows.asRange().bits()[i] & activeRows.asRange().bits()[i];
+    errorNulls[i] &= ~rows.asRange().bits()[i] | activeRows.asRange().bits()[i];
     if (throwOnError && errorNulls[i]) {
       int32_t errorIndex = i * 64 + __builtin_ctzll(errorNulls[i]);
       if (errorIndex < errors->size() && errorIndex < rows.end()) {

--- a/velox/vector/tests/TestingAlwaysThrowsFunction.h
+++ b/velox/vector/tests/TestingAlwaysThrowsFunction.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::test {
+
+template <typename T>
+struct TestingAlwaysThrowsFunction {
+  template <typename TResult, typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TResult&, const TInput&) {
+    VELOX_FAIL();
+  }
+};
+
+// Throw a VeloxException if veloxException_ is true. Throw an std exception
+// otherwise.
+class TestingAlwaysThrowsVectorFunction : public exec::VectorFunction {
+ public:
+  static constexpr const char* kVeloxErrorMessage = "Velox Exception: Expected";
+  static constexpr const char* kStdErrorMessage = "Std Exception: Expected";
+
+  explicit TestingAlwaysThrowsVectorFunction(bool veloxException)
+      : veloxException_{veloxException} {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& /* args */,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& /* result */) const override {
+    if (veloxException_) {
+      auto error =
+          std::make_exception_ptr(std::invalid_argument(kVeloxErrorMessage));
+      context.setErrors(rows, error);
+      return;
+    }
+    throw std::invalid_argument(kStdErrorMessage);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .returnType("boolean")
+                .argumentType("integer")
+                .build()};
+  }
+
+ private:
+  const bool veloxException_;
+};
+
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
Expression fuzzer found that the result of an expression `try(coalesce(foo(...), or(...)))` is incorrect in that rows throwing in foo() have non-null values in the result. The root cause is that Coalesce passes the error vector from foo() to or(), whereas or() clears the error vector at rows that are not among the initial active rows or not among the final active rows. This diff fixes the problem by deselecting error rows after evaluating every argument of Coalesce and making Conjunct preserve pre-existing errors outside of `rows` that it evaluates on.

This diff is the first fix for https://github.com/facebookincubator/velox/issues/4337.

Differential Revision: D44321132

