### PR TITLE
Fix reporting of number of input/output batches in sink and source operators

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -381,9 +381,7 @@ StopReason Driver::runInternal(
                 resultBytes = result->estimateFlatSize();
                 {
                   auto lockedStats = op->stats().wlock();
-                  lockedStats->outputVectors += 1;
-                  lockedStats->outputPositions += result->size();
-                  lockedStats->outputBytes += resultBytes;
+                  lockedStats->addOutputVector(resultBytes, result->size());
                 }
               }
             }
@@ -395,9 +393,7 @@ StopReason Driver::runInternal(
                   });
               {
                 auto lockedStats = nextOp->stats().wlock();
-                lockedStats->inputVectors += 1;
-                lockedStats->inputPositions += result->size();
-                lockedStats->inputBytes += resultBytes;
+                lockedStats->addInputVector(resultBytes, result->size());
               }
               RuntimeStatWriterScopeGuard statsWriterGuard(nextOp);
               nextOp->addInput(result);
@@ -455,9 +451,8 @@ StopReason Driver::runInternal(
                   op->operatorType());
               {
                 auto lockedStats = op->stats().wlock();
-                lockedStats->outputVectors += 1;
-                lockedStats->outputPositions += result->size();
-                lockedStats->outputBytes += result->estimateFlatSize();
+                lockedStats->addOutputVector(
+                    result->estimateFlatSize(), result->size());
               }
 
               // This code path is used only in single-threaded execution.

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -376,8 +376,7 @@ RowVectorPtr Exchange::getOutput() {
   {
     auto lockedStats = stats_.wlock();
     lockedStats->rawInputBytes += rawInputBytes;
-    lockedStats->inputPositions += result_->size();
-    lockedStats->inputBytes += result_->retainedSize();
+    lockedStats->addInputVector(result_->estimateFlatSize(), result_->size());
   }
 
   if (inputStream_->atEnd()) {

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -254,8 +254,7 @@ RowVectorPtr LocalExchange::getOutput() {
   }
   if (data != nullptr) {
     auto lockedStats = stats_.wlock();
-    lockedStats->inputPositions += data->size();
-    lockedStats->inputBytes += data->estimateFlatSize();
+    lockedStats->addInputVector(data->estimateFlatSize(), data->size());
   }
   return data;
 }
@@ -328,8 +327,7 @@ wrapChildren(const RowVectorPtr& input, vector_size_t size, BufferPtr indices) {
 void LocalPartition::addInput(RowVectorPtr input) {
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->outputBytes += input->estimateFlatSize();
-    lockedStats->outputPositions += input->size();
+    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
   }
 
   // Lazy vectors must be loaded or processed.

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -158,8 +158,7 @@ class MergeExchangeSource : public MergeSource {
           &data);
 
       auto lockedStats = mergeExchange_->stats().wlock();
-      lockedStats->inputPositions += data->size();
-      lockedStats->inputBytes += data->retainedSize();
+      lockedStats->addInputVector(data->estimateFlatSize(), data->size());
     }
 
     // Since VectorStreamGroup::read() may cause inputStream to be at end,

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -154,6 +154,18 @@ struct OperatorStats {
         planNodeId(std::move(_planNodeId)),
         operatorType(std::move(_operatorType)) {}
 
+  void addInputVector(uint64_t bytes, uint64_t positions) {
+    inputBytes += bytes;
+    inputPositions += positions;
+    inputVectors += 1;
+  }
+
+  void addOutputVector(uint64_t bytes, uint64_t positions) {
+    outputBytes += bytes;
+    outputPositions += positions;
+    outputVectors += 1;
+  }
+
   void addRuntimeStat(const std::string& name, const RuntimeCounter& value);
   void add(const OperatorStats& other);
   void clear();

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -199,8 +199,7 @@ void PartitionedOutput::addInput(RowVectorPtr input) {
   // TODO Report outputBytes as bytes after serialization
   {
     auto lockedStats = stats_.wlock();
-    lockedStats->outputBytes += input->retainedSize();
-    lockedStats->outputPositions += input->size();
+    lockedStats->addOutputVector(input->estimateFlatSize(), input->size());
   }
 
   initializeInput(std::move(input));

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -166,8 +166,7 @@ RowVectorPtr TableScan::getOutput() {
       auto data = dataOptional.value();
       if (data) {
         if (data->size() > 0) {
-          lockedStats->inputPositions += data->size();
-          lockedStats->inputBytes += data->retainedSize();
+          lockedStats->addInputVector(data->estimateFlatSize(), data->size());
           return data;
         }
         continue;


### PR DESCRIPTION
Each operator reports number of input and output rows, bytes and batches. For
most operators these stats are collected by the Driver, but source and sink
operators need to collect these separately. Before this change, source and sink
operators didn't report number of batches and used BaseVector::retainedSize
instead of BaseVector::estimateFlatSize for 'bytes'. This change makes sure
that source and sink operators report number of input and output batches
correctly and use BaseVector::estimateFlatSize for reporting 'bytes'.

The following source operators are updated to report the number of input
batches:

- Exchange
- LocalExchange
- MergeExchangeSource
- TableScan

The following sink operators are updated to report the number of output
batches:

- LocalPartition
- PartitionedOutput
