### PR TITLE
Fix join fuzzer failure due to creation of empty list in DuckDB

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -110,6 +110,10 @@ template <>
   auto offset = arrayVector->offsetAt(arrayRow);
   auto size = arrayVector->sizeAt(arrayRow);
 
+  if (size == 0) {
+    return ::duckdb::Value::EMPTYLIST(duckdb::fromVeloxType(elements->type()));
+  }
+
   std::vector<::duckdb::Value> array;
   array.reserve(size);
   for (auto i = 0; i < size; i++) {


### PR DESCRIPTION
Summary: This diff fixes https://github.com/facebookincubator/velox/issues/4405.

Differential Revision: D44353439

