### PR TITLE
Back out "Add drilldown to minimal failing expr to expression fuzzer"

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -138,37 +138,6 @@ class ExpressionFuzzer {
     std::unordered_map<std::string, ExprUsageStats>& exprNameToStats_;
   };
 
-  // Central point for failure exit.
-  void errorExit(const std::string& message);
-
-  // Tries subexpressions of [plan until finding the minimal failing subtree.
-  void drilldown(
-      core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::vector<column_index_t>& columnsToWrapInLazy);
-
-  // Verifies children of 'plan'. If all succeed, sets minimalFound to
-  // true and reruns 'plan' wth and without lazy vectors. Set
-  // breakpoint inside this to debug failures.
-  void drilldownRecursive(
-      core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::vector<column_index_t>& columnsToWrapInLazy,
-      bool& minimalFound);
-  // Tries 'plan' against 'rowVector' with and without pre-existing contents in
-  // result vector.
-  bool tryExpr(
-      core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::vector<column_index_t>& columnsToWrapInLazy);
-
-  // Tries 'plan' against 'rowVector' with results set to 'results'.
-  bool tryWithResult(
-      core::TypedExprPtr plan,
-      const RowVectorPtr& rowVector,
-      const std::vector<column_index_t>& columnsToWrapInLazy,
-      VectorPtr result);
-
   const std::string kTypeParameterName = "T";
 
   enum ArgumentKind { kArgConstant = 0, kArgColumn = 1, kArgExpression = 2 };


### PR DESCRIPTION
Reverting this change as currently the logs generated are more confusing. We will re-enable this with a flag in a subsequent PR. 


Pull Request resolved: https://github.com/facebookincubator/velox/pull/4409


Original commit changeset: 0e4490ff0d32
Original Phabricator Diff: D44205202