### PR TITLE
remove CppToType usage from SimpleFunctionAdapter and ComplexViewTypes (#4304)

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -191,14 +191,16 @@ struct TypeAnalysis {
   void run(TypeAnalysisResults& results) {
     // This should only handle primitives and OPAQUE.
     static_assert(
-        CppToType<T>::isPrimitiveType ||
-        CppToType<T>::typeKind == TypeKind::OPAQUE);
+        SimpleTypeTrait<T>::isPrimitiveType ||
+        SimpleTypeTrait<T>::typeKind == TypeKind::OPAQUE);
     results.stats.concreteCount++;
-    if (isDecimalKind(CppToType<T>::typeKind)) {
-      results.out << detail::strToLowerCopy(std::string(CppToType<T>::name))
+    if (isDecimalKind(SimpleTypeTrait<T>::typeKind)) {
+      results.out << detail::strToLowerCopy(
+                         std::string(SimpleTypeTrait<T>::name))
                   << "(" << kPrecisionVariable << "," << kScaleVariable << ")";
     } else {
-      results.out << detail::strToLowerCopy(std::string(CppToType<T>::name));
+      results.out << detail::strToLowerCopy(
+          std::string(SimpleTypeTrait<T>::name));
     }
   }
 };

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1026,11 +1026,11 @@ class GenericView {
   GenericView(
       const DecodedVector& decoded,
       std::array<std::shared_ptr<void>, 3>& castReaders,
-      TypePtr& castType,
+      std::optional<const std::type_info*>& castTypeInfo,
       vector_size_t index)
       : decoded_(decoded),
         castReaders_(castReaders),
-        castType_(castType),
+        castTypeInfo_(castTypeInfo),
         index_(index) {}
 
   uint64_t hash() const {
@@ -1064,9 +1064,8 @@ class GenericView {
     VELOX_DCHECK(
         CastTypeChecker<ToType>::check(type()),
         fmt::format(
-            "castTo type is not compatible with type of vector, vector type is {}, casted to type is {}",
-            type()->toString(),
-            CppToType<ToType>::create()->toString()));
+            "castTo type is not compatible with type of vector, vector type is {}",
+            type()->toString()));
 
     // TODO: We can distinguish if this is a null-free or not null-free
     // generic. And based on that determine if we want to call operator[] or
@@ -1103,17 +1102,18 @@ class GenericView {
         // This is basically Array<Any>, Map<Any,Any>, Row<Any....>.
         return ensureReaderImpl<B, 1>();
       } else {
-        auto requestedType = CppToType<B>::create();
-        if (castType_) {
+        auto* requestedTypeId = &typeid(B);
+        if (castTypeInfo_.has_value()) {
           VELOX_USER_CHECK(
-              castType_->operator==(*requestedType),
+              std::type_index(**castTypeInfo_) ==
+                  std::type_index(*requestedTypeId),
               fmt::format(
                   "Not allowed to cast to the two types {} and {} within the same batch."
                   "Consider creating a new type set to allow it.",
-                  castType_->toString(),
-                  requestedType->toString()));
+                  typeid(B).name(),
+                  castTypeInfo_.value()->name()));
         } else {
-          castType_ = std::move(requestedType);
+          castTypeInfo_ = {requestedTypeId};
         }
         return ensureReaderImpl<B, 2>();
       }
@@ -1133,7 +1133,7 @@ class GenericView {
 
   const DecodedVector& decoded_;
   std::array<std::shared_ptr<void>, 3>& castReaders_;
-  TypePtr& castType_;
+  std::optional<const std::type_info*>& castTypeInfo_;
   vector_size_t index_;
 };
 

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -62,19 +62,10 @@ struct udf_reuse_strings_from_arg<
     util::detail::void_t<decltype(T::reuse_strings_from_arg)>>
     : std::integral_constant<int32_t, T::reuse_strings_from_arg> {};
 
-struct GenericOutputTypeTrait {
-  static constexpr TypeKind typeKind = TypeKind::INVALID;
-  static constexpr bool isPrimitiveType = false;
-  static constexpr bool isFixedWidth = false;
-};
-
 template <typename FUNC>
 class SimpleFunctionAdapter : public VectorFunction {
   using T = typename FUNC::exec_return_type;
-  using return_type_traits = std::conditional_t<
-      isGenericType<typename FUNC::return_type>::value,
-      GenericOutputTypeTrait,
-      CppToType<typename FUNC::return_type>>;
+  using return_type_traits = SimpleTypeTrait<typename FUNC::return_type>;
 
   template <int32_t POSITION>
   using exec_arg_at = typename std::
@@ -94,9 +85,8 @@ class SimpleFunctionAdapter : public VectorFunction {
   // boolean.
   template <int32_t POSITION>
   static constexpr bool isArgFlatConstantFastPathEligible =
-      !isGenericType<arg_at<POSITION>>::value &&
-      CppToType<arg_at<POSITION>>::isPrimitiveType &&
-      CppToType<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN;
+      SimpleTypeTrait<arg_at<POSITION>>::isPrimitiveType&&
+          SimpleTypeTrait<arg_at<POSITION>>::typeKind != TypeKind::BOOLEAN;
 
   constexpr int32_t reuseStringsFromArgValue() const {
     return udf_reuse_strings_from_arg<typename FUNC::udf_struct_t>();
@@ -241,7 +231,8 @@ class SimpleFunctionAdapter : public VectorFunction {
           VectorPtr* findReusableArg(std::vector<VectorPtr>& args) const {
     if constexpr (isVariadicType<arg_at<POSITION>>::value) {
       if constexpr (
-          CppToType<typename arg_at<POSITION>::underlying_type>::typeKind ==
+          SimpleTypeTrait<
+              typename arg_at<POSITION>::underlying_type>::typeKind ==
           return_type_traits::typeKind) {
         for (auto i = POSITION; i < args.size(); i++) {
           if (BaseVector::isVectorWritable(args[i])) {
@@ -253,7 +244,8 @@ class SimpleFunctionAdapter : public VectorFunction {
       // yet, we know for sure that we won't.
       return nullptr;
     } else if constexpr (
-        CppToType<arg_at<POSITION>>::typeKind == return_type_traits::typeKind) {
+        SimpleTypeTrait<arg_at<POSITION>>::typeKind ==
+        return_type_traits::typeKind) {
       using type =
           typename VectorExec::template resolver<arg_at<POSITION>>::in_type;
       if (args[POSITION]->isFlatEncoding() && args[POSITION].unique() &&

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -22,6 +22,8 @@
 #include <optional>
 #include <string_view>
 #include <type_traits>
+#include <typeindex>
+#include <typeinfo>
 #include <utility>
 
 #include "velox/expression/ComplexViewTypes.h"
@@ -697,7 +699,7 @@ struct VectorReader<Generic<T>> {
   // Those two variables are mutated by the GenericView during cast operations,
   // and are shared across GenericViews constructed by the reader.
   mutable std::array<std::shared_ptr<void>, 3> castReaders_;
-  mutable TypePtr castType_ = nullptr;
+  mutable std::optional<const std::type_info*> castType_ = std::nullopt;
 };
 
 template <typename T>

--- a/velox/vector/VectorTypeUtils.h
+++ b/velox/vector/VectorTypeUtils.h
@@ -109,7 +109,7 @@ struct KindToFlatVector<TypeKind::OPAQUE> {
 
 template <typename T>
 struct TypeToFlatVector {
-  using type = typename KindToFlatVector<CppToType<T>::typeKind>::type;
+  using type = typename KindToFlatVector<SimpleTypeTrait<T>::typeKind>::type;
 };
 
 } // namespace velox


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/4304

There is one remaining place, ComplexWriterTypes for the generic writer
I will address that in a different diff since there are pending changes on that file that needs to land first.

Differential Revision: D44388667

