### PR TITLE
Optimize non-null string functions

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -329,7 +329,7 @@ hmacMd5(TOutString& output, const TInString& key, const TInString& data) {
 }
 
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool toHex(TOutString& output, const TInString& input) {
+FOLLY_ALWAYS_INLINE void toHex(TOutString& output, const TInString& input) {
   static const char* const kHexTable =
       "000102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F"
       "202122232425262728292A2B2C2D2E2F303132333435363738393A3B3C3D3E3F"
@@ -351,8 +351,6 @@ FOLLY_ALWAYS_INLINE bool toHex(TOutString& output, const TInString& input) {
     resultBuffer[i * 2] = kHexTable[inputBuffer[i] * 2];
     resultBuffer[i * 2 + 1] = kHexTable[inputBuffer[i] * 2 + 1];
   }
-
-  return true;
 }
 
 FOLLY_ALWAYS_INLINE static uint8_t fromHex(char c) {
@@ -376,7 +374,7 @@ FOLLY_ALWAYS_INLINE unsigned char toHex(unsigned char c) {
 }
 
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool fromHex(TOutString& output, const TInString& input) {
+FOLLY_ALWAYS_INLINE void fromHex(TOutString& output, const TInString& input) {
   VELOX_USER_CHECK_EQ(
       input.size() % 2,
       0,
@@ -393,19 +391,16 @@ FOLLY_ALWAYS_INLINE bool fromHex(TOutString& output, const TInString& input) {
     resultBuffer[i] =
         (fromHex(inputBuffer[i * 2]) << 4) | fromHex(inputBuffer[i * 2 + 1]);
   }
-
-  return true;
 }
 
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool toBase64(TOutString& output, const TInString& input) {
+FOLLY_ALWAYS_INLINE void toBase64(TOutString& output, const TInString& input) {
   output.resize(encoding::Base64::calculateEncodedSize(input.size()));
   encoding::Base64::encode(input.data(), input.size(), output.data());
-  return true;
 }
 
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool fromBase64(
+FOLLY_ALWAYS_INLINE void fromBase64(
     TOutString& output,
     const TInString& input) {
   try {
@@ -416,7 +411,6 @@ FOLLY_ALWAYS_INLINE bool fromBase64(
   } catch (const encoding::Base64Exception& e) {
     VELOX_USER_FAIL(e.what());
   }
-  return true;
 }
 
 template <typename TOutString, typename TInString>
@@ -443,7 +437,7 @@ FOLLY_ALWAYS_INLINE void charEscape(unsigned char c, char* output) {
 ///    as the string ``%XX`` where ``XX`` is the uppercase hexadecimal
 ///    value of the UTF-8 byte.
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool urlEscape(TOutString& output, const TInString& input) {
+FOLLY_ALWAYS_INLINE void urlEscape(TOutString& output, const TInString& input) {
   auto inputSize = input.size();
   output.reserve(inputSize * 3);
 
@@ -466,11 +460,10 @@ FOLLY_ALWAYS_INLINE bool urlEscape(TOutString& output, const TInString& input) {
     }
   }
   output.resize(outIndex);
-  return true;
 }
 
 template <typename TOutString, typename TInString>
-FOLLY_ALWAYS_INLINE bool urlUnescape(
+FOLLY_ALWAYS_INLINE void urlUnescape(
     TOutString& output,
     const TInString& input) {
   auto inputSize = input.size();
@@ -505,7 +498,6 @@ FOLLY_ALWAYS_INLINE bool urlUnescape(
     }
   }
   output.resize(outputBuffer - output.data());
-  return true;
 }
 
 // Presto supports both ascii whitespace and unicode line separator \u2028.

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -32,11 +32,10 @@ template <typename T>
 struct ChrFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const int64_t& codePoint) {
     stringImpl::codePointToString(result, codePoint);
-    return true;
   }
 };
 
@@ -46,11 +45,10 @@ template <typename T>
 struct CodePointFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
       const arg_type<Varchar>& inputChar) {
     result = stringImpl::charToCodePoint(inputChar);
-    return true;
   }
 };
 
@@ -219,10 +217,10 @@ template <typename T>
 struct ToHexFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varbinary>& result,
       const arg_type<Varchar>& input) {
-    return stringImpl::toHex(result, input);
+    stringImpl::toHex(result, input);
   }
 };
 
@@ -230,10 +228,10 @@ template <typename T>
 struct FromHexFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    return stringImpl::fromHex(result, input);
+    stringImpl::fromHex(result, input);
   }
 };
 
@@ -241,10 +239,10 @@ template <typename T>
 struct ToBase64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    return stringImpl::toBase64(result, input);
+    stringImpl::toBase64(result, input);
   }
 };
 
@@ -252,10 +250,10 @@ template <typename T>
 struct FromBase64Function {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varbinary>& result,
       const arg_type<Varchar>& input) {
-    return stringImpl::fromBase64(result, input);
+    stringImpl::fromBase64(result, input);
   }
 };
 
@@ -274,10 +272,10 @@ template <typename T>
 struct UrlEncodeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    return stringImpl::urlEscape(result, input);
+    stringImpl::urlEscape(result, input);
   }
 };
 
@@ -285,10 +283,10 @@ template <typename T>
 struct UrlDecodeFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varbinary>& input) {
-    return stringImpl::urlUnescape(result, input);
+    stringImpl::urlUnescape(result, input);
   }
 };
 
@@ -314,25 +312,25 @@ struct SubstrFunction {
   static constexpr bool is_default_ascii_behavior = true;
 
   template <typename I>
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
       I length = std::numeric_limits<I>::max()) {
-    return doCall<false>(result, input, start, length);
+    doCall<false>(result, input, start, length);
   }
 
   template <typename I>
-  FOLLY_ALWAYS_INLINE bool callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
       I length = std::numeric_limits<I>::max()) {
-    return doCall<true>(result, input, start, length);
+    doCall<true>(result, input, start, length);
   }
 
   template <bool isAscii, typename I>
-  FOLLY_ALWAYS_INLINE bool doCall(
+  FOLLY_ALWAYS_INLINE void doCall(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input,
       I start,
@@ -340,7 +338,7 @@ struct SubstrFunction {
     // Following Presto semantics
     if (start == 0) {
       result.setEmpty();
-      return true;
+      return;
     }
 
     I numCharacters = stringImpl::length<isAscii>(input);
@@ -353,7 +351,7 @@ struct SubstrFunction {
     // Following Presto semantics
     if (start <= 0 || start > numCharacters || length <= 0) {
       result.setEmpty();
-      return true;
+      return;
     }
 
     // Adjusting length
@@ -369,7 +367,6 @@ struct SubstrFunction {
     // Generating output string
     result.setNoCopy(StringView(
         input.data() + byteRange.first, byteRange.second - byteRange.first));
-    return true;
   }
 };
 
@@ -390,18 +387,16 @@ struct TrimFunctionBase {
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input) {
     stringImpl::trimUnicodeWhiteSpace<leftTrim, rightTrim>(result, input);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& input) {
     stringImpl::trimAsciiWhiteSpace<leftTrim, rightTrim>(result, input);
-    return true;
   }
 };
 
@@ -419,14 +414,12 @@ template <typename T>
 struct LengthFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int64_t& result, const StringView& input) {
+  FOLLY_ALWAYS_INLINE void call(int64_t& result, const StringView& input) {
     result = stringImpl::length<false>(input);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callAscii(int64_t& result, const StringView& input) {
+  FOLLY_ALWAYS_INLINE void callAscii(int64_t& result, const StringView& input) {
     result = stringImpl::length<true>(input);
-    return true;
   }
 };
 
@@ -446,22 +439,20 @@ struct PadFunctionBase {
   // ASCII input always produces ASCII result.
   static constexpr bool is_default_ascii_behavior = true;
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size,
       const arg_type<Varchar>& padString) {
     stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, padString);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size,
       const arg_type<Varchar>& padString) {
     stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, padString);
-    return true;
   }
 };
 
@@ -491,24 +482,22 @@ template <typename T, bool lpos>
 struct StrPosFunctionBase {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       out_type<int64_t>& result,
       const arg_type<Varchar>& string,
       const arg_type<Varchar>& subString,
       const arg_type<int64_t>& instance = 1) {
     result = stringImpl::stringPosition<false /*isAscii*/, lpos>(
         string, subString, instance);
-    return true;
   }
 
-  FOLLY_ALWAYS_INLINE bool callAscii(
+  FOLLY_ALWAYS_INLINE void callAscii(
       out_type<int64_t>& result,
       const arg_type<Varchar>& string,
       const arg_type<Varchar>& subString,
       const arg_type<int64_t>& instance = 1) {
     result = stringImpl::stringPosition<true /*isAscii*/, lpos>(
         string, subString, instance);
-    return true;
   }
 };
 


### PR DESCRIPTION
Use `void call(...)` for string functions that never return null for non-null input.