### PR TITLE
Implement velox_ssb_benchmark including 13 ssb queries 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ option(VELOX_ENABLE_EXAMPLES
        "Build examples. This will enable VELOX_ENABLE_EXPRESSION automatically."
        OFF)
 option(VELOX_ENABLE_SUBSTRAIT "Buid Substrait-to-Velox converter." OFF)
-option(VELOX_ENABLE_BENCHMARKS "Enable Velox top level benchmarks." ON)
+option(VELOX_ENABLE_BENCHMARKS "Enable Velox top level benchmarks." OFF)
 option(VELOX_ENABLE_BENCHMARKS_BASIC "Enable Velox basic benchmarks." OFF)
 option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)
 option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
-option(VELOX_ENABLE_PARQUET "Enable Parquet support" ON)
+option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,11 +62,11 @@ option(VELOX_ENABLE_EXAMPLES
        "Build examples. This will enable VELOX_ENABLE_EXPRESSION automatically."
        OFF)
 option(VELOX_ENABLE_SUBSTRAIT "Buid Substrait-to-Velox converter." OFF)
-option(VELOX_ENABLE_BENCHMARKS "Enable Velox top level benchmarks." OFF)
+option(VELOX_ENABLE_BENCHMARKS "Enable Velox top level benchmarks." ON)
 option(VELOX_ENABLE_BENCHMARKS_BASIC "Enable Velox basic benchmarks." OFF)
 option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)
 option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
-option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
+option(VELOX_ENABLE_PARQUET "Enable Parquet support" ON)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 

--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -15,4 +15,5 @@ add_subdirectory(basic)
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)
+  add_subdirectory(ssb)
 endif()

--- a/velox/benchmarks/ssb/CMakeLists.txt
+++ b/velox/benchmarks/ssb/CMakeLists.txt
@@ -11,10 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_tpch_gen TpchGen.cpp DBGenIterator.cpp SsbGen.cpp)
 
-target_link_libraries(velox_tpch_gen velox_memory velox_vector dbgen duckdb)
+add_executable(velox_ssb_benchmark SsbBenchmark.cpp)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
+target_link_libraries(
+  velox_ssb_benchmark
+  velox_aggregates
+  velox_exec
+  velox_exec_test_lib
+  velox_dwio_common
+  velox_dwio_common_exception
+  velox_dwio_parquet_reader
+  velox_dwio_type_fbhive
+  velox_dwio_common_test_utils
+  velox_hive_connector
+  velox_exception
+  velox_memory
+  velox_process
+  velox_serialization
+  velox_encode
+  velox_type
+  velox_caching
+  velox_vector_test_lib
+  ${FOLLY_WITH_DEPENDENCIES}
+  ${FOLLY_BENCHMARK}
+  ${FMT})

--- a/velox/benchmarks/ssb/SsbBenchmark.cpp
+++ b/velox/benchmarks/ssb/SsbBenchmark.cpp
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/Split.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/SsbQueryBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/TypeResolver.h"
+
+#include <sys/time.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::dwio::common;
+
+namespace {
+static bool notEmpty(const char* /*flagName*/, const std::string& value) {
+  return !value.empty();
+}
+
+static bool validateDataFormat(const char* flagname, const std::string& value) {
+  if ((value.compare("parquet") == 0) || (value.compare("dwrf") == 0)) {
+    return true;
+  }
+  std::cout
+      << fmt::format(
+             "Invalid value for --{}: {}. Allowed values are [\"parquet\", \"dwrf\"]",
+             flagname,
+             value)
+      << std::endl;
+  return false;
+}
+
+void ensureTaskCompletion(exec::Task* task) {
+  // ASSERT_TRUE requires a function with return type void.
+  ASSERT_TRUE(waitForTaskCompletion(task));
+}
+
+void printResults(const std::vector<RowVectorPtr>& results) {
+  std::cout << "Results:" << std::endl;
+  bool printType = true;
+  for (const auto& vector : results) {
+    // Print RowType only once.
+    if (printType) {
+      std::cout << vector->type()->asRow().toString() << std::endl;
+      printType = false;
+    }
+    for (vector_size_t i = 0; i < vector->size(); ++i) {
+      std::cout << vector->toString(i) << std::endl;
+    }
+  }
+}
+} // namespace
+
+DEFINE_string(data_path, "", "Root path of TPC-H data");
+DEFINE_int32(
+    run_query_verbose,
+    -1,
+    "Run a given query and print execution statistics");
+DEFINE_bool(
+    include_custom_stats,
+    false,
+    "Include custom statistics along with execution statistics");
+DEFINE_bool(include_results, false, "Include results in the output");
+DEFINE_bool(use_native_parquet_reader, true, "Use Native Parquet Reader");
+DEFINE_int32(num_drivers, 4, "Number of drivers");
+DEFINE_string(data_format, "parquet", "Data format");
+DEFINE_int32(num_splits_per_file, 10, "Number of splits per file");
+
+DEFINE_validator(data_path, &notEmpty);
+DEFINE_validator(data_format, &validateDataFormat);
+
+class SsbBenchmark {
+ public:
+  void initialize() {
+    functions::prestosql::registerAllScalarFunctions();
+    aggregate::prestosql::registerAllAggregateFunctions();
+    parse::registerTypeResolver();
+    filesystems::registerLocalFileSystem();
+    if (FLAGS_use_native_parquet_reader) {
+      parquet::registerParquetReaderFactory(parquet::ParquetReaderType::NATIVE);
+    } else {
+      parquet::registerParquetReaderFactory(parquet::ParquetReaderType::DUCKDB);
+    }
+    dwrf::registerDwrfReaderFactory();
+    auto hiveConnector =
+        connector::getConnectorFactory(
+            connector::hive::HiveConnectorFactory::kHiveConnectorName)
+            ->newConnector(kHiveConnectorId, nullptr);
+    connector::registerConnector(hiveConnector);
+  }
+
+  std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> run(
+      const SsbPlan& ssbPlan) {
+    CursorParameters params;
+    params.maxDrivers = FLAGS_num_drivers;
+    params.planNode = ssbPlan.plan;
+    const int numSplitsPerFile = FLAGS_num_splits_per_file;
+
+    bool noMoreSplits = false;
+    auto addSplits = [&](exec::Task* task) {
+      if (!noMoreSplits) {
+        for (const auto& entry : ssbPlan.dataFiles) {
+          for (const auto& path : entry.second) {
+            auto const splits = HiveConnectorTestBase::makeHiveConnectorSplits(
+                path, numSplitsPerFile, ssbPlan.dataFileFormat);
+            for (const auto& split : splits) {
+              task->addSplit(entry.first, exec::Split(split));
+            }
+          }
+          task->noMoreSplits(entry.first);
+        }
+      }
+      noMoreSplits = true;
+    };
+    return readCursor(params, addSplits);
+  }
+};
+
+SsbBenchmark benchmark;
+std::shared_ptr<SsbQueryBuilder> queryBuilder;
+
+BENCHMARK(q1) {
+  const auto planContext = queryBuilder->getQueryPlan(1);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q2) {
+  const auto planContext = queryBuilder->getQueryPlan(2);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q3) {
+  const auto planContext = queryBuilder->getQueryPlan(3);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q4) {
+  const auto planContext = queryBuilder->getQueryPlan(4);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q5) {
+  const auto planContext = queryBuilder->getQueryPlan(5);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q6) {
+  const auto planContext = queryBuilder->getQueryPlan(6);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q7) {
+  const auto planContext = queryBuilder->getQueryPlan(7);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q8) {
+  const auto planContext = queryBuilder->getQueryPlan(8);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q9) {
+  const auto planContext = queryBuilder->getQueryPlan(9);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q10) {
+  const auto planContext = queryBuilder->getQueryPlan(10);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q11) {
+  const auto planContext = queryBuilder->getQueryPlan(11);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q12) {
+  const auto planContext = queryBuilder->getQueryPlan(12);
+  benchmark.run(planContext);
+}
+
+BENCHMARK(q13) {
+  const auto planContext = queryBuilder->getQueryPlan(13);
+  benchmark.run(planContext);
+}
+
+int main(int argc, char** argv) {
+  std::string kUsage(
+      "This program benchmarks SSB queries. Run 'velox_ssb_benchmark -helpon=SsbBenchmark' for available options.\n");
+  gflags::SetUsageMessage(kUsage);
+  folly::init(&argc, &argv, false);
+  benchmark.initialize();
+  queryBuilder =
+      std::make_shared<SsbQueryBuilder>(toFileFormat(FLAGS_data_format));
+  queryBuilder->initialize(FLAGS_data_path);
+  if (FLAGS_run_query_verbose == -1) {
+    folly::runBenchmarks();
+  } else {
+    const auto queryPlan = queryBuilder->getQueryPlan(FLAGS_run_query_verbose);
+    const auto [cursor, actualResults] = benchmark.run(queryPlan);
+    if (!cursor) {
+      LOG(ERROR) << "Query terminated with error. Exiting";
+      exit(1);
+    }
+    auto task = cursor->task();
+    ensureTaskCompletion(task.get());
+    if (FLAGS_include_results) {
+      printResults(actualResults);
+      std::cout << std::endl;
+    }
+    const auto stats = task->taskStats();
+    std::cout << fmt::format(
+                     "Execution time: {}",
+                     succinctMillis(
+                         stats.executionEndTimeMs - stats.executionStartTimeMs))
+              << std::endl;
+    std::cout << fmt::format(
+                     "Splits total: {}, finished: {}",
+                     stats.numTotalSplits,
+                     stats.numFinishedSplits)
+              << std::endl;
+    std::cout << printPlanWithStats(
+                     *queryPlan.plan, stats, FLAGS_include_custom_stats)
+              << std::endl;
+  }
+}

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(
   PlanBuilder.cpp
   QueryAssertions.cpp
   SumNonPODAggregate.cpp
-  TpchQueryBuilder.cpp)
+  TpchQueryBuilder.cpp
+  SsbQueryBuilder.cpp)
 
 target_link_libraries(
   velox_exec_test_lib

--- a/velox/exec/tests/utils/SsbQueryBuilder.cpp
+++ b/velox/exec/tests/utils/SsbQueryBuilder.cpp
@@ -1,0 +1,1374 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/SsbQueryBuilder.h"
+
+#include "velox/common/base/Fs.h"
+#include "velox/dwio/common/ReaderFactory.h"
+#include "velox/tpch/gen/SsbGen.h"
+
+namespace facebook::velox::exec::test {
+
+namespace {
+int64_t toDate(std::string_view stringDate) {
+  Date date;
+  parseTo(stringDate, date);
+  return date.days();
+}
+
+/// DWRF does not support Date type and Varchar is used.
+/// Return the Date filter expression as per data format.
+std::string formatDateFilter(
+    const std::string& stringDate,
+    const RowTypePtr& rowType,
+    const std::string& lowerBound,
+    const std::string& upperBound) {
+  bool isDwrf = rowType->findChild(stringDate)->isVarchar();
+  auto suffix = isDwrf ? "" : "::DATE";
+
+  if (!lowerBound.empty() && !upperBound.empty()) {
+    return fmt::format(
+        "{} between {}{} and {}{}",
+        stringDate,
+        lowerBound,
+        suffix,
+        upperBound,
+        suffix);
+  } else if (!lowerBound.empty()) {
+    return fmt::format("{} > {}{}", stringDate, lowerBound, suffix);
+  } else if (!upperBound.empty()) {
+    return fmt::format("{} < {}{}", stringDate, upperBound, suffix);
+  }
+
+  VELOX_FAIL(
+      "Date range check expression must have either a lower or an upper bound");
+}
+
+std::vector<std::string> mergeColumnNames(
+    const std::vector<std::string>& firstColumnVector,
+    const std::vector<std::string>& secondColumnVector) {
+  std::vector<std::string> mergedColumnVector = std::move(firstColumnVector);
+  mergedColumnVector.insert(
+      mergedColumnVector.end(),
+      secondColumnVector.begin(),
+      secondColumnVector.end());
+  return mergedColumnVector;
+};
+} // namespace
+
+void SsbQueryBuilder::initialize(const std::string& dataPath) {
+  for (const auto& [tableName, columns] : kTables_) {
+    const fs::path tablePath{dataPath + "/" + tableName};
+    for (auto const& dirEntry : fs::directory_iterator{tablePath}) {
+      if (!dirEntry.is_regular_file()) {
+        continue;
+      }
+      // Ignore hidden files.
+      if (dirEntry.path().filename().c_str()[0] == '.') {
+        continue;
+      }
+      if (tableMetadata_[tableName].dataFiles.empty()) {
+        dwio::common::ReaderOptions readerOptions{pool_.get()};
+        readerOptions.setFileFormat(format_);
+        auto input = std::make_unique<dwio::common::BufferedInput>(
+            std::make_shared<LocalReadFile>(dirEntry.path().string()),
+            readerOptions.getMemoryPool());
+        std::unique_ptr<dwio::common::Reader> reader =
+            dwio::common::getReaderFactory(readerOptions.getFileFormat())
+                ->createReader(std::move(input), readerOptions);
+        const auto fileType = reader->rowType();
+        const auto fileColumnNames = fileType->names();
+        // There can be extra columns in the file towards the end.
+        VELOX_CHECK_GE(fileColumnNames.size(), columns.size());
+        std::unordered_map<std::string, std::string> fileColumnNamesMap(
+            columns.size());
+        std::transform(
+            columns.begin(),
+            columns.end(),
+            fileColumnNames.begin(),
+            std::inserter(fileColumnNamesMap, fileColumnNamesMap.begin()),
+            [](std::string a, std::string b) { return std::make_pair(a, b); });
+        auto columnNames = columns;
+        auto types = fileType->children();
+        types.resize(columnNames.size());
+        tableMetadata_[tableName].type =
+            std::make_shared<RowType>(std::move(columnNames), std::move(types));
+        tableMetadata_[tableName].fileColumnNames =
+            std::move(fileColumnNamesMap);
+      }
+      tableMetadata_[tableName].dataFiles.push_back(dirEntry.path());
+    }
+  }
+}
+
+const std::vector<std::string>& SsbQueryBuilder::getTableNames() {
+  return kTableNames_;
+}
+
+SsbPlan SsbQueryBuilder::getQueryPlan(int queryId) const {
+  switch (queryId) {
+    case 1:
+      return getQ1Plan();
+    case 2:
+      return getQ2Plan();
+    case 3:
+      return getQ3Plan();
+    case 4:
+      return getQ4Plan();
+    case 5:
+      return getQ5Plan();
+    case 6:
+      return getQ6Plan();
+    case 7:
+      return getQ7Plan();
+    case 8:
+      return getQ8Plan();
+    case 9:
+      return getQ9Plan();
+    case 10:
+      return getQ10Plan();
+    case 11:
+      return getQ11Plan();
+    case 12:
+      return getQ12Plan();
+    case 13:
+      return getQ13Plan();
+    default:
+      VELOX_NYI("SSB query {} is not supported yet", queryId);
+  }
+}
+
+SsbPlan SsbQueryBuilder::getQ1Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_extendedprice", "lo_discount", "lo_orderdate", "lo_quantity"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter("d_year = 1993")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .filter("(lo_discount between 1 and 3) AND (lo_quantity < 25) ")
+          .project(
+              {"lo_extendedprice * lo_discount AS part_revenue",
+               "lo_orderdate"})
+          .hashJoin(
+              {"lo_orderdate"}, {"d_datekey"}, dates, "", {"part_revenue"})
+          .partialAggregation({}, {"sum(part_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .project({"revenue"})
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ2Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_extendedprice", "lo_discount", "lo_orderdate", "lo_quantity"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_yearmonthnum"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter("d_yearmonthnum = 199401")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .filter(
+              "(lo_discount between 4 and 6) AND (lo_quantity between 26 and 35) ")
+          .project(
+              {"lo_extendedprice * lo_discount AS part_revenue",
+               "lo_orderdate"})
+          .hashJoin(
+              {"lo_orderdate"}, {"d_datekey"}, dates, "", {"part_revenue"})
+          .partialAggregation({}, {"sum(part_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .project({"revenue"})
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ3Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_extendedprice", "lo_discount", "lo_orderdate", "lo_quantity"};
+  std::vector<std::string> dateColumns = {
+      "d_datekey", "d_year", "d_weeknuminyear"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter("(d_year = 1994) and (d_weeknuminyear = 6)")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .filter(
+              "(lo_discount between 5 and 7) AND (lo_quantity between 26 and 35) ")
+          .project(
+              {"lo_extendedprice * lo_discount AS part_revenue",
+               "lo_orderdate"})
+          .hashJoin(
+              {"lo_orderdate"}, {"d_datekey"}, dates, "", {"part_revenue"})
+          .partialAggregation({}, {"sum(part_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .project({"revenue"})
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ4Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_partkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> partColumns = {
+      "p_brand1", "p_partkey", "p_category"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_region"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .planNode();
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'ASIA'")
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_category = 'MFGR#12'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_partkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_partkey", "d_year"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue", "d_year", "p_brand1"})
+          .project({"d_year", "lo_revenue", "p_brand1"})
+          .partialAggregation(
+              {"d_year", "p_brand1"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "p_brand1 ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ5Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_partkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> partColumns = {"p_brand1", "p_partkey"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_region"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .planNode();
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'ASIA'")
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_brand1 between 'MFGR#2221' and 'MFGR#2228'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_partkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_partkey", "d_year"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue", "d_year", "p_brand1"})
+          .project({"d_year", "lo_revenue", "p_brand1"})
+          .partialAggregation(
+              {"d_year", "p_brand1"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "p_brand1 ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ6Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_partkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> partColumns = {"p_brand1", "p_partkey"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_region"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .planNode();
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'EUROPE'")
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_brand1 = 'MFGR#2239'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_partkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_partkey", "d_year"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue", "d_year", "p_brand1"})
+          .project({"d_year", "lo_revenue", "p_brand1"})
+          .partialAggregation(
+              {"d_year", "p_brand1"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "p_brand1 ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ7Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_custkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {
+      "c_nation", "c_custkey", "c_region"};
+  std::vector<std::string> supplierColumns = {
+      "s_suppkey", "s_region", "s_nation"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter({"d_year >= 1992 and d_year <= 1997"})
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'ASIA'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_region = 'ASIA'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_custkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_custkey", "d_year", "s_nation"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue", "d_year", "s_nation", "c_nation"})
+          .project({"d_year", "lo_revenue", "s_nation", "c_nation"})
+          .partialAggregation(
+              {"c_nation", "s_nation", "d_year"},
+              {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "revenue DESC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ8Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_custkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {
+      "c_nation", "c_custkey", "c_city"};
+  std::vector<std::string> supplierColumns = {
+      "s_suppkey", "s_city", "s_nation"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter({"d_year >= 1992 and d_year <= 1997"})
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_nation = 'UNITED STATES'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_nation = 'UNITED STATES'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_custkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_custkey", "d_year", "s_city"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue", "d_year", "s_city", "c_city"})
+          .project({"d_year", "lo_revenue", "s_city", "c_city"})
+          .partialAggregation(
+              {"c_city", "s_city", "d_year"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "revenue DESC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ9Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_custkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {"c_custkey", "c_city"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_city"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter({"d_year >= 1992 and d_year <= 1997"})
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_city='UNITED KI1' or s_city='UNITED KI5'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_city='UNITED KI1' or c_city='UNITED KI5'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_custkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_custkey", "d_year", "s_city"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue", "d_year", "s_city", "c_city"})
+          .project({"d_year", "lo_revenue", "s_city", "c_city"})
+          .partialAggregation(
+              {"c_city", "s_city", "d_year"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "revenue DESC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ10Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue", "lo_orderdate", "lo_custkey", "lo_suppkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year", "d_yearmonth"};
+  std::vector<std::string> customerColumns = {"c_custkey", "c_city"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_city"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter({"d_yearmonth = 'Dec1997'"})
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_city='UNITED KI1' or s_city='UNITED KI5'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_city='UNITED KI1' or c_city='UNITED KI5'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue", "lo_custkey", "lo_suppkey", "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue", "lo_custkey", "d_year", "s_city"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue", "d_year", "s_city", "c_city"})
+          .project({"d_year", "lo_revenue", "s_city", "c_city"})
+          .partialAggregation(
+              {"c_city", "s_city", "d_year"}, {"sum(lo_revenue) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "revenue DESC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ11Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue",
+      "lo_supplycost",
+      "lo_orderdate",
+      "lo_custkey",
+      "lo_suppkey",
+      "lo_partkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {
+      "c_region", "c_custkey", "c_nation"};
+  std::vector<std::string> supplierColumns = {"s_suppkey", "s_region"};
+  std::vector<std::string> partColumns = {"p_partkey", "p_mfgr"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'AMERICA'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_region = 'AMERICA'")
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_suppkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue",
+               "lo_partkey",
+               "d_year",
+               "lo_supplycost",
+               "c_nation"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue", "d_year", "lo_supplycost", "c_nation"})
+          .project(
+              {"d_year",
+               "c_nation",
+               "(lo_revenue-lo_supplycost) AS part_profit"})
+          .partialAggregation(
+              {"d_year", "c_nation"}, {"sum(part_profit) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "c_nation ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ12Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue",
+      "lo_supplycost",
+      "lo_orderdate",
+      "lo_custkey",
+      "lo_suppkey",
+      "lo_partkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {"c_region", "c_custkey"};
+  std::vector<std::string> supplierColumns = {
+      "s_suppkey", "s_region", "s_nation"};
+  std::vector<std::string> partColumns = {"p_partkey", "p_mfgr", "p_category"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter("d_year = 1997 or d_year = 1998")
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_region = 'AMERICA'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .filter("c_region = 'AMERICA'")
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_suppkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year",
+               "s_nation"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue",
+               "lo_partkey",
+               "d_year",
+               "lo_supplycost",
+               "s_nation"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue",
+               "d_year",
+               "lo_supplycost",
+               "s_nation",
+               "p_category"})
+          .project(
+              {"d_year",
+               "s_nation",
+               "p_category",
+               "(lo_revenue-lo_supplycost) AS part_profit"})
+          .partialAggregation(
+              {"d_year", "s_nation", "p_category"},
+              {"sum(part_profit) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "s_nation ASC", "p_category ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+SsbPlan SsbQueryBuilder::getQ13Plan() const {
+  std::vector<std::string> lineorderColumns = {
+      "lo_revenue",
+      "lo_supplycost",
+      "lo_orderdate",
+      "lo_custkey",
+      "lo_suppkey",
+      "lo_partkey"};
+  std::vector<std::string> dateColumns = {"d_datekey", "d_year"};
+  std::vector<std::string> customerColumns = {"c_custkey"};
+  std::vector<std::string> supplierColumns = {
+      "s_suppkey", "s_nation", "s_city"};
+  std::vector<std::string> partColumns = {
+      "p_partkey", "p_brand1", "p_category"};
+
+  const auto lineorderSelectedRowType =
+      getRowType(kLineorder, lineorderColumns);
+  const auto& lineorderFileColumns = getFileColumnNames(kLineorder);
+
+  const auto dateSelectedRowType = getRowType(kDate, dateColumns);
+  const auto& dateFileColumns = getFileColumnNames(kDate);
+
+  const auto customerSelectedRowType = getRowType(kCustomer, customerColumns);
+  const auto& customerFileColumns = getFileColumnNames(kCustomer);
+
+  const auto supplierSelectedRowType = getRowType(kSupplier, supplierColumns);
+  const auto& supplierFileColumns = getFileColumnNames(kSupplier);
+
+  const auto partSelectedRowType = getRowType(kPart, partColumns);
+  const auto& partFileColumns = getFileColumnNames(kPart);
+
+  // shipdate <= '1998-09-02'
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId lineorderPlanNodeId;
+  core::PlanNodeId datePlanNodeId;
+  core::PlanNodeId customerPlanNodeId;
+  core::PlanNodeId supplierPlanNodeId;
+  core::PlanNodeId partPlanNodeId;
+
+  auto dates =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kDate, dateSelectedRowType, dateFileColumns, {}, {})
+          .capturePlanNodeId(datePlanNodeId)
+          .filter("d_year = 1997 or d_year = 1998")
+          .planNode();
+
+  auto suppliers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kSupplier, supplierSelectedRowType, supplierFileColumns, {}, {})
+          .capturePlanNodeId(supplierPlanNodeId)
+          .filter("s_nation = 'UNITED STATES'")
+          .planNode();
+  auto customers =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(
+              kCustomer, customerSelectedRowType, customerFileColumns, {}, {})
+          .capturePlanNodeId(customerPlanNodeId)
+          .planNode();
+  auto parts =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kPart, partSelectedRowType, partFileColumns, {}, {})
+          .capturePlanNodeId(partPlanNodeId)
+          .filter("p_category = 'MFGR#14'")
+          .planNode();
+
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .tableScan(kLineorder, lineorderSelectedRowType, lineorderFileColumns)
+          .capturePlanNodeId(lineorderPlanNodeId)
+          .hashJoin(
+              {"lo_orderdate"},
+              {"d_datekey"},
+              dates,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_suppkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year"})
+          .hashJoin(
+              {"lo_suppkey"},
+              {"s_suppkey"},
+              suppliers,
+              "",
+              {"lo_revenue",
+               "lo_custkey",
+               "lo_partkey",
+               "lo_supplycost",
+               "d_year",
+               "s_city"})
+          .hashJoin(
+              {"lo_custkey"},
+              {"c_custkey"},
+              customers,
+              "",
+              {"lo_revenue", "lo_partkey", "d_year", "lo_supplycost", "s_city"})
+          .hashJoin(
+              {"lo_partkey"},
+              {"p_partkey"},
+              parts,
+              "",
+              {"lo_revenue", "d_year", "lo_supplycost", "s_city", "p_brand1"})
+          .project(
+              {"d_year",
+               "s_city",
+               "p_brand1",
+               "(lo_revenue-lo_supplycost) AS part_profit"})
+          .partialAggregation(
+              {"d_year", "s_city", "p_brand1"}, {"sum(part_profit) as revenue"})
+          .localPartition({})
+          .finalAggregation()
+          .orderBy({"d_year ASC", "s_city ASC", "p_brand1 ASC"}, false)
+          .planNode();
+
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[datePlanNodeId] = getTableFilePaths(kDate);
+  context.dataFiles[supplierPlanNodeId] = getTableFilePaths(kSupplier);
+  context.dataFiles[customerPlanNodeId] = getTableFilePaths(kCustomer);
+  context.dataFiles[partPlanNodeId] = getTableFilePaths(kPart);
+  context.dataFiles[lineorderPlanNodeId] = getTableFilePaths(kLineorder);
+  context.dataFileFormat = format_;
+  return context;
+}
+
+/*SsbPlan SsbQueryBuilder::getQ23Plan() const {
+  std::vector<std::string> selectedColumns =
+{"l_orderkey","l_partkey","l_suppkey","l_linenumber","l_returnflag","l_linestatus","l_receiptdate","l_shipinstruct","l_shipmode",
+      "l_shipdate", "l_extendedprice", "l_quantity",
+"l_discount","l_tax","l_commitdate","l_comment"};
+
+  const auto selectedRowType = getRowType(kLineitem, selectedColumns);
+  const auto& fileColumnNames = getFileColumnNames(kLineitem);
+
+
+  core::PlanNodeId lineitemPlanNodeId;
+  auto plan = PlanBuilder()
+                  .tableScan(
+                      kLineitem,
+                      selectedRowType,
+                      fileColumnNames)
+                  .capturePlanNodeId(lineitemPlanNodeId)
+                  //.project({"l_extendedprice * l_discount*l_quantity"})
+                  //.partialAggregation({}, {"sum(p0)"})
+                  //.localPartition({})
+                  //.finalAggregation()
+                  .planNode();
+  SsbPlan context;
+  context.plan = std::move(plan);
+  context.dataFiles[lineitemPlanNodeId] = getTableFilePaths(kLineitem);
+  context.dataFileFormat = format_;
+  return context;
+}*/
+
+const std::vector<std::string> SsbQueryBuilder::kTableNames_ =
+    {kLineorder, kSupplier, kCustomer, kPart, kDate};
+
+const std::unordered_map<std::string, std::vector<std::string>>
+    SsbQueryBuilder::kTables_ = {
+        std::make_pair(
+            "lineorder",
+            ssb::getTableSchema(ssb::SSB_Table::TBL_LINEORDER)->names()),
+        std::make_pair(
+            "customer",
+            ssb::getTableSchema(ssb::SSB_Table::TBL_CUSTOMER)->names()),
+        std::make_pair(
+            "supplier",
+            ssb::getTableSchema(ssb::SSB_Table::TBL_SUPPLIER)->names()),
+        std::make_pair(
+            "part",
+            ssb::getTableSchema(ssb::SSB_Table::TBL_PART)->names()),
+        std::make_pair(
+            "date",
+            ssb::getTableSchema(ssb::SSB_Table::TBL_DATE)->names())};
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/SsbQueryBuilder.h
+++ b/velox/exec/tests/utils/SsbQueryBuilder.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/dwio/common/Options.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+
+namespace facebook::velox::exec::test {
+
+/// Contains the query plan and input data files keyed on source plan node ID.
+/// All data files use the same file format specified in 'dataFileFormat'.
+struct SsbPlan {
+  core::PlanNodePtr plan;
+  std::unordered_map<core::PlanNodeId, std::vector<std::string>> dataFiles;
+  dwio::common::FileFormat dataFileFormat;
+};
+
+/// Contains type information, data files, and file column names for a table.
+/// This information is inferred from the input data files.
+/// The type names are mapped to the standard names.
+/// Example: If the file has a 'returnflag' column, the corresponding type name
+/// will be 'l_returnflag'. fileColumnNames store the mapping between standard
+/// names and the corresponding name in the file.
+struct SsbTableMetadata {
+  RowTypePtr type;
+  std::vector<std::string> dataFiles;
+  std::unordered_map<std::string, std::string> fileColumnNames;
+};
+
+/// Builds TPC-H queries using TPC-H data files located in the specified
+/// directory. Each table data must be placed in hive-style partitioning. That
+/// is, the top-level directory is expected to contain a sub-directory per table
+/// name and the name of the sub-directory must match the table name. Example:
+/// ls -R data/
+///  customer   lineitem
+///
+///  data/customer:
+///  customer1.parquet  customer2.parquet
+///
+///  data/lineitem:
+///  lineitem1.parquet  lineitem2.parquet  lineitem3.parquet
+
+/// The column names can vary. Additional columns may exist towards the end.
+/// The class uses standard names (example: l_returnflag) to build TPC-H plans.
+/// Since the column names in the file can vary, they are mapped to the standard
+/// names. Therefore, the order of the columns in the file is important and
+/// should be in the same order as in the TPC-H standard.
+class SsbQueryBuilder {
+ public:
+  explicit SsbQueryBuilder(dwio::common::FileFormat format) : format_(format) {}
+
+  /// Read each data file, initialize row types, and determine data paths for
+  /// each table.
+  /// @param dataPath path to the data files
+  void initialize(const std::string& dataPath);
+
+  /// Get the query plan for a given TPC-H query number.
+  /// @param queryId TPC-H query number
+  SsbPlan getQueryPlan(int queryId) const;
+
+  /// Get the TPC-H table names present.
+  static const std::vector<std::string>& getTableNames();
+
+ private:
+  SsbPlan getQ1Plan() const;
+  SsbPlan getQ2Plan() const;
+  SsbPlan getQ3Plan() const;
+  SsbPlan getQ4Plan() const;
+  SsbPlan getQ5Plan() const;
+  SsbPlan getQ6Plan() const;
+  SsbPlan getQ7Plan() const;
+  SsbPlan getQ8Plan() const;
+  SsbPlan getQ9Plan() const;
+  SsbPlan getQ10Plan() const;
+  SsbPlan getQ11Plan() const;
+  SsbPlan getQ12Plan() const;
+  SsbPlan getQ13Plan() const;
+
+  const std::vector<std::string>& getTableFilePaths(
+      const std::string& tableName) const {
+    return tableMetadata_.at(tableName).dataFiles;
+  }
+
+  std::shared_ptr<const RowType> getRowType(
+      const std::string& tableName,
+      const std::vector<std::string>& columnNames) const {
+    auto columnSelector = std::make_shared<dwio::common::ColumnSelector>(
+        tableMetadata_.at(tableName).type, columnNames);
+    return columnSelector->buildSelectedReordered();
+  }
+
+  const std::unordered_map<std::string, std::string>& getFileColumnNames(
+      const std::string& tableName) const {
+    return tableMetadata_.at(tableName).fileColumnNames;
+  }
+
+  std::unordered_map<std::string, SsbTableMetadata> tableMetadata_;
+  const dwio::common::FileFormat format_;
+  static const std::unordered_map<std::string, std::vector<std::string>>
+      kTables_;
+  static const std::vector<std::string> kTableNames_;
+
+  static constexpr const char* kLineorder = "lineorder";
+  static constexpr const char* kCustomer = "customer";
+  static constexpr const char* kPart = "part";
+  static constexpr const char* kSupplier = "supplier";
+  static constexpr const char* kDate = "date";
+  std::shared_ptr<memory::MemoryPool> pool_ = memory::getDefaultMemoryPool();
+};
+
+} // namespace facebook::velox::exec::test

--- a/velox/tpch/gen/SsbGen.cpp
+++ b/velox/tpch/gen/SsbGen.cpp
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/tpch/gen/SsbGen.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dbgen_gunk.hpp"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dss.h"
+#include "velox/external/duckdb/tpch/dbgen/include/dbgen/dsstypes.h"
+#include "velox/tpch/gen/DBGenIterator.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::ssb {
+
+namespace {
+
+// The cardinality of the LINEITEM table is not a strict multiple of SF since
+// the number of lineitems in an order is chosen at random with an average of
+// four. This function contains the row count for all authorized scale factors
+// (as described by the TPC-H spec), and approximates the remaining.
+constexpr size_t getLineItemRowCount(double scaleFactor) {
+  auto longScaleFactor = static_cast<long>(scaleFactor);
+  switch (longScaleFactor) {
+    case 1:
+      return 6'001'215;
+    case 10:
+      return 59'986'052;
+    case 30:
+      return 179'998'372;
+    case 100:
+      return 600'037'902;
+    case 300:
+      return 1'799'989'091;
+    case 1'000:
+      return 5'999'989'709;
+    case 3'000:
+      return 18'000'048'306;
+    case 10'000:
+      return 59'999'994'267;
+    case 30'000:
+      return 179'999'978'268;
+    case 100'000:
+      return 599'999'969'200;
+    default:
+      break;
+  }
+  return 6'000'000 * scaleFactor;
+}
+
+size_t getVectorSize(size_t rowCount, size_t maxRows, size_t offset) {
+  if (offset >= rowCount) {
+    return 0;
+  }
+  return std::min(rowCount - offset, maxRows);
+}
+
+std::vector<VectorPtr> allocateVectors(
+    const RowTypePtr& type,
+    size_t vectorSize,
+    memory::MemoryPool* pool) {
+  std::vector<VectorPtr> vectors;
+  vectors.reserve(type->size());
+
+  for (const auto& childType : type->children()) {
+    vectors.emplace_back(BaseVector::create(childType, vectorSize, pool));
+  }
+  return vectors;
+}
+
+double decimalToDouble(int64_t value) {
+  return (double)value * 0.01;
+}
+
+Date toDate(std::string_view stringDate) {
+  Date date;
+  parseTo(stringDate, date);
+  return date;
+}
+
+} // namespace
+
+std::string_view toTableName(SSB_Table table) {
+  switch (table) {
+    case SSB_Table ::TBL_PART:
+      return "part";
+    case SSB_Table ::TBL_SUPPLIER:
+      return "supplier";
+    case SSB_Table ::TBL_CUSTOMER:
+      return "customer";
+    case SSB_Table ::TBL_LINEORDER:
+      return "";
+    case SSB_Table ::TBL_DATE:
+      return "date";
+  }
+  return ""; // make gcc happy.
+}
+
+SSB_Table fromTableName(std::string_view tableName) {
+  static std::unordered_map<std::string_view, SSB_Table> map{
+      {"part", SSB_Table ::TBL_PART},
+      {"supplier", SSB_Table ::TBL_SUPPLIER},
+      {"customer", SSB_Table ::TBL_CUSTOMER},
+      {"lineorder", SSB_Table ::TBL_LINEORDER},
+      {"date", SSB_Table ::TBL_DATE},
+  };
+
+  auto it = map.find(tableName);
+  if (it != map.end()) {
+    return it->second;
+  }
+  throw std::invalid_argument(
+      fmt::format("Invalid TPC-H table name: '{}'", tableName));
+}
+size_t getRowCount(SSB_Table table, double scaleFactor) {
+  return 0;
+}
+/* size_t getRowCount(SSB_Table table, double scaleFactor) {
+  VELOX_CHECK_GE(scaleFactor, 0, "Ssb scale factor must be non-negative");
+  switch (table) {
+    case SSB_Table ::TBL_PART:
+      return 200'000 * scaleFactor;
+    case SSB_Table ::TBL_SUPPLIER:
+      return 10'000 * scaleFactor;
+    case SSB_Table ::TBL_PARTSUPP:
+      return 800'000 * scaleFactor;
+    case SSB_Table ::TBL_CUSTOMER:
+      return 150'000 * scaleFactor;
+    case SSB_Table ::TBL_ORDERS:
+      return 1'500'000 * scaleFactor;
+    case SSB_Table ::TBL_NATION:
+      return 25;
+    case SSB_Table ::TBL_REGION:
+      return 5;
+    case SSB_Table ::TBL_LINEITEM:
+      return getLineItemRowCount(scaleFactor);
+  }
+  return 0; // make gcc happy.
+} */
+
+RowTypePtr getTableSchema(SSB_Table table) {
+  switch (table) {
+    case SSB_Table ::TBL_PART: {
+      static RowTypePtr type = ROW(
+          {
+              "p_partkey",
+              "p_name",
+              "p_mfgr",
+              "p_category",
+              "p_brand1",
+              "p_color",
+              "p_type",
+              "p_size",
+              "p_container",
+          },
+          {
+              BIGINT(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              BIGINT(),
+              VARCHAR(),
+          });
+      return type;
+    }
+
+    case SSB_Table ::TBL_SUPPLIER: {
+      static RowTypePtr type = ROW(
+          {
+              "s_suppkey",
+              "s_name",
+              "s_address",
+              "s_city",
+              "s_nation",
+              "s_region",
+              "s_phone",
+          },
+          {
+              BIGINT(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+          });
+      return type;
+    }
+    case SSB_Table ::TBL_CUSTOMER: {
+      static RowTypePtr type = ROW(
+          {
+              "c_custkey",
+              "c_name",
+              "c_address",
+              "c_city",
+              "c_nation",
+              "c_region",
+              "c_phone",
+              "c_mktsegment",
+          },
+          {
+              BIGINT(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+          });
+      return type;
+    }
+
+    case SSB_Table ::TBL_LINEORDER: {
+      static RowTypePtr type = ROW(
+          {
+              "lo_orderkey",
+              "lo_linenumber",
+              "lo_custkey",
+              "lo_partkey",
+              "lo_suppkey",
+              "lo_orderdate",
+              "lo_orderpriority",
+              "lo_shippriority",
+              "lo_quantity",
+              "lo_extendedprice",
+              "lo_ordtotalprice",
+              "lo_discount",
+              "lo_revenue",
+              "lo_supplycost",
+              "lo_tax",
+              "lo_commitdate",
+              "lo_shipmod",
+
+          },
+          {
+              BIGINT(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              VARCHAR(),
+              VARCHAR(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              VARCHAR(),
+          });
+      return type;
+    }
+
+    case SSB_Table ::TBL_DATE: {
+      static RowTypePtr type = ROW(
+          {
+              "d_datekey",
+              "d_date",
+              "d_dayofweek",
+              "d_month",
+              "d_year",
+              "d_yearmonthnum",
+              "d_yearmonth",
+              "d_daynuminweek",
+              "d_daynuminmonth",
+              "d_daynuminyear",
+              "d_monthnuminyear",
+              "d_weeknuminyear",
+              "d_sellingseason",
+              "d_lastdayinweekfl",
+              "d_lastdayinmonthfl",
+              "d_holidayfl",
+              "d_weekdayfl",
+          },
+          {
+              INTEGER(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              INTEGER(),
+              INTEGER(),
+              VARCHAR(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              INTEGER(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+              VARCHAR(),
+          });
+      return type;
+    }
+  }
+  return nullptr; // make gcc happy.
+}
+
+TypePtr resolveSsbColumn(SSB_Table table, const std::string& columnName) {
+  return getTableSchema(table)->findChild(columnName);
+}
+
+} // namespace facebook::velox::ssb

--- a/velox/tpch/gen/SsbGen.h
+++ b/velox/tpch/gen/SsbGen.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::ssb {
+
+/// This file uses TPC-H DBGEN to generate data encoded using Velox Vectors.
+///
+/// The basic input for the API is the TPC-H table name (the Table enum), the
+/// TPC-H scale factor, the maximum batch size, and the offset. The common usage
+/// is to make successive calls to this API advancing the offset parameter,
+/// until all records were read. Clients might also assign different slices of
+/// the range "[0, getRowCount(Table, scaleFactor)[" to different threads in
+/// order to generate datasets in parallel.
+///
+/// If not enough records are available given a particular scale factor and
+/// offset, less than maxRows records might be returned.
+///
+/// Data is always returned in a RowVector.
+
+enum class SSB_Table : uint8_t {
+  TBL_SUPPLIER,
+  TBL_CUSTOMER,
+  TBL_PART,
+  TBL_DATE,
+  TBL_LINEORDER
+};
+
+/// Returns table name as a string.
+std::string_view toTableName(SSB_Table table);
+
+/// Returns the table enum value given a table name.
+SSB_Table fromTableName(std::string_view tableName);
+
+/// Returns the row count for a particular TPC-H table given a scale factor, as
+/// defined in the spec available at:
+///
+///  https://www.tpc.org/tpch/
+size_t getRowCount(SSB_Table table, double scaleFactor);
+
+/// Returns the schema (RowType) for a particular TPC-H table.
+RowTypePtr getTableSchema(SSB_Table table);
+
+/// Returns the type of a particular table:column pair. Throws if `columnName`
+/// does not exist in `table`.
+TypePtr resolveSsbColumn(SSB_Table table, const std::string& columnName);
+
+/// Returns a row vector containing at most `maxRows` rows of the "orders"
+/// table, starting at `offset`, and given the scale factor. The row vector
+/// returned has the following schema:
+///
+///  o_orderkey: BIGINT
+///  o_custkey: BIGINT
+///  o_orderstatus: VARCHAR
+///  o_totalprice: DOUBLE
+///  o_orderdate: DATE
+///  o_orderpriority: VARCHAR
+///  o_clerk: VARCHAR
+///  o_shippriority: INTEGER
+///  o_comment: VARCHAR
+///
+
+} // namespace facebook::velox::ssb


### PR DESCRIPTION
The SSB is designed to measure performance of database products in support of classical data warehousing applications, and is based on the TPC-H benchmark. The SSB is also used for benchmarking in many bigdata and OLAP database. For this, I implemented velox_ssb_benchmark script like velox_tpch_benchmark so we can run SSB benchmark quickly on Velox. 

The SSB benchmark includes 13 queries as follows:
Q1:
```
select sum(lo_extendedprice*lo_discount) as revenue
from ssb.lineorder, ssb.dwdate
where lo_orderdate = d_datekey
and d_year = 1993
and lo_discount between 1 and 3
and lo_quantity < 25;
```

Q2:
```
select sum(lo_extendedprice*lo_discount) as revenue
from ssb.lineorder, ssb.dwdate
where lo_orderdate = d_datekey
and d_yearmonthnum = 199401
and lo_discount between 4 and 6
and lo_quantity between 26 and 35;
```

Q3:
```
select sum(lo_extendedprice*lo_discount) as revenue
from ssb.lineorder, ssb.dwdate
where lo_orderdate = d_datekey
and d_weeknuminyear = 6
and d_year = 1994
and lo_discount between 5 and 7
and lo_quantity between 26 and 35;
```

Q4:
```
select sum(lo_revenue), d_year, p_brand1
from ssb.lineorder, ssb.dwdate, ssb.part, ssb.supplier
where lo_orderdate = d_datekey
and lo_partkey = p_partkey
and lo_suppkey = s_suppkey
and p_category = 'MFGR#12'
and s_region = 'AMERICA'
group by d_year, p_brand1
order by d_year, p_brand1;
```

Q5:
```
select sum(lo_revenue), d_year, p_brand1
from ssb.lineorder, ssb.dwdate, ssb.part, ssb.supplier
where lo_orderdate = d_datekey
and lo_partkey = p_partkey
and lo_suppkey = s_suppkey
and p_brand1 between 'MFGR#2221' and 'MFGR#2228'
and s_region = 'ASIA'
group by d_year, p_brand1
order by d_year, p_brand1;
```

Q6:
```
select sum(lo_revenue), d_year, p_brand1
from ssb.lineorder, ssb.dwdate, ssb.part, ssb.supplier
where lo_orderdate = d_datekey
and lo_partkey = p_partkey
and lo_suppkey = s_suppkey
and p_brand1 = 'MFGR#2221'
and s_region = 'EUROPE'
group by d_year, p_brand1
order by d_year, p_brand1;
```

Q7:
```
select c_nation, s_nation, d_year, sum(lo_revenue) as revenue
from ssb.customer, ssb.lineorder, ssb.supplier, ssb.dwdate
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_orderdate = d_datekey
and c_region = 'ASIA' and s_region = 'ASIA'
and d_year >= 1992 and d_year <= 1997
group by c_nation, s_nation, d_year
order by d_year asc, revenue desc;
```

Q8:
```
select c_city, s_city, d_year, sum(lo_revenue) as revenue
from ssb.customer, ssb.lineorder, ssb.supplier, ssb.dwdate
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_orderdate = d_datekey
and c_nation = 'UNITED STATES'
and s_nation = 'UNITED STATES'
and d_year >= 1992 and d_year <= 1997
group by c_city, s_city, d_year
order by d_year asc, revenue desc;
```

Q9:
```
select c_city, s_city, d_year, sum(lo_revenue) as revenue
from ssb.customer, ssb.lineorder, ssb.supplier, ssb.dwdate
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_orderdate = d_datekey
and (c_city='UNITED KI1' or c_city='UNITED KI5')
and (s_city='UNITED KI1' or s_city='UNITED KI5')
and d_year >= 1992 and d_year <= 1997
group by c_city, s_city, d_year
order by d_year asc, revenue desc;
```

Q10:
```
select c_city, s_city, d_year, sum(lo_revenue) as revenue
from ssb.customer, ssb.lineorder, ssb.supplier, ssb.dwdate
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_orderdate = d_datekey
and (c_city='UNITED KI1' or c_city='UNITED KI5')
and (s_city='UNITED KI1' or s_city='UNITED KI5')
and d_yearmonth = 'Dec1997'
group by c_city, s_city, d_year
order by d_year asc, revenue desc;
```

Q11：
```
select d_year, c_nation, sum(lo_revenue - lo_supplycost) as profit
from ssb.dwdate, ssb.customer, ssb.supplier, ssb.part, ssb.lineorder
where lo_custkey = c_custkey
 and lo_suppkey = s_suppkey
 and lo_partkey = p_partkey
 and lo_orderdate = d_datekey
 and c_region = 'AMERICA'
 and s_region = 'AMERICA'
 and (p_mfgr = 'MFGR#1' or p_mfgr = 'MFGR#2')
group by d_year, c_nation
order by d_year, c_nation;
```

Q12：
```
select d_year, s_nation, p_category, sum(lo_revenue - lo_supplycost) as profit
from ssb.dwdate, ssb.customer, ssb.supplier, ssb.part, ssb.lineorder
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_partkey = p_partkey
and lo_orderdate = d_datekey
and c_region = 'AMERICA'
and s_region = 'AMERICA'
and (d_year = 1997 or d_year = 1998)
and (p_mfgr = 'MFGR#1'
or p_mfgr = 'MFGR#2')
group by d_year, s_nation, p_category order by d_year, s_nation, p_category;
```

Q13:
```
select d_year, s_city, p_brand1, sum(lo_revenue - lo_supplycost) as profit
from ssb.dwdate, ssb.customer, ssb.supplier, ssb.part, ssb.lineorder
where lo_custkey = c_custkey
and lo_suppkey = s_suppkey
and lo_partkey = p_partkey
and lo_orderdate = d_datekey
and c_region = 'AMERICA'
and s_nation = 'UNITED STATES'
and (d_year = 1997 or d_year = 1998)
and p_category = 'MFGR#14'
group by d_year, s_city, p_brand1 order by d_year, s_city, p_brand1;
```

The SSB 100SF benchmark result on  Intel(R) Xeon(R) Platinum 8480+ is shown in the figure, the test num_drivers is set to 64,   num_splits_per_file is set to 1, the parquet data is compressed by snappy.
![image](https://user-images.githubusercontent.com/46258124/227852439-366bbf24-155e-467b-bbe4-8fed714f1971.png)
