### PR TITLE
Optimize null-aware anti join with filter

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -328,4 +328,6 @@ int main(int argc, char** argv) {
                      *queryPlan.plan, stats, FLAGS_include_custom_stats)
               << std::endl;
   }
+  queryBuilder.reset();
+  return 0;
 }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -298,6 +298,21 @@ void HashBuild::addInput(RowVectorPtr input) {
       !isRightSemiProjectJoin(joinType_) &&
       !isLeftNullAwareJoinWithFilter(joinNode_)) {
     deselectRowsWithNulls(hashers, activeRows_);
+    if (nullAware_ && !joinHasNullKeys_ &&
+        activeRows_.countSelected() < input->size()) {
+      joinHasNullKeys_ = true;
+    }
+  } else if (nullAware_ && !joinHasNullKeys_) {
+    for (auto& hasher : hashers) {
+      auto& decoded = hasher->decodedVector();
+      if (decoded.mayHaveNulls()) {
+        auto* nulls = decoded.nulls();
+        if (nulls && bits::countNulls(nulls, 0, activeRows_.end()) > 0) {
+          joinHasNullKeys_ = true;
+          break;
+        }
+      }
+    }
   }
 
   for (auto i = 0; i < dependentChannels_.size(); ++i) {
@@ -309,14 +324,11 @@ void HashBuild::addInput(RowVectorPtr input) {
     if (filterPropagatesNulls_) {
       removeInputRowsForAntiJoinFilter();
     }
-  } else if (nullAware_ && activeRows_.countSelected() < input->size()) {
-    joinHasNullKeys_ = true;
-    if (isAntiJoin(joinType_)) {
-      // Null-aware anti join with no extra filter returns no rows if build side
-      // has nulls in join keys. Hence, we can stop processing on first null.
-      noMoreInput();
-      return;
-    }
+  } else if (isAntiJoin(joinType_) && nullAware_ && joinHasNullKeys_) {
+    // Null-aware anti join with no extra filter returns no rows if build side
+    // has nulls in join keys. Hence, we can stop processing on first null.
+    noMoreInput();
+    return;
   }
 
   spillInput(input);
@@ -689,7 +701,8 @@ bool HashBuild::finishHashBuild() {
   otherTables.reserve(peers.size());
   SpillPartitionSet spillPartitions;
   Spiller::Stats spillStats;
-  if (joinHasNullKeys_ && (isAntiJoin(joinType_) && nullAware_)) {
+  if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
+      !joinNode_->filter()) {
     joinBridge_->setAntiJoinHasNullKeys();
   } else {
     for (auto& peer : peers) {
@@ -698,7 +711,7 @@ bool HashBuild::finishHashBuild() {
       VELOX_CHECK(build);
       if (build->joinHasNullKeys_) {
         joinHasNullKeys_ = true;
-        if (isAntiJoin(joinType_) && nullAware_) {
+        if (isAntiJoin(joinType_) && nullAware_ && !joinNode_->filter()) {
           break;
         }
       }
@@ -709,7 +722,8 @@ bool HashBuild::finishHashBuild() {
       }
     }
 
-    if (joinHasNullKeys_ && (isAntiJoin(joinType_) && nullAware_)) {
+    if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
+        !joinNode_->filter()) {
       joinBridge_->setAntiJoinHasNullKeys();
     } else {
       if (spiller_ != nullptr) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -106,6 +106,11 @@ class BaseHashTable {
     }
   };
 
+  struct NullKeyRowsIterator {
+    bool initialized = false;
+    char* nextHit;
+  };
+
   /// Takes ownership of 'hashers'. These are used to keep key-level
   /// encodings like distinct values, ranges. These are stateful for
   /// kArray and kNormalizedKey hash modes and track the data
@@ -161,6 +166,11 @@ class BaseHashTable {
       int32_t maxRows,
       uint64_t maxBytes,
       char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) = 0;
+
+  /// Returns all rows with null keys.  Used by null-aware joins (e.g. anti or
+  /// left semi project).
+  virtual int32_t
+  listNullKeyRows(NullKeyRowsIterator* iter, int32_t maxRows, char** rows) = 0;
 
   virtual void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
@@ -372,6 +382,11 @@ class HashTable : public BaseHashTable {
       int32_t maxRows,
       uint64_t maxBytes,
       char* FOLLY_NULLABLE* FOLLY_NULLABLE rows) override;
+
+  int32_t listNullKeyRows(
+      NullKeyRowsIterator* iter,
+      int32_t maxRows,
+      char** rows) override;
 
   void clear() override;
 

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1866,7 +1866,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
               "l_suppkey_3 <> l_suppkey_1",
               {"s_name"},
               core::JoinType::kAnti,
-              true /*nullAware*/)
+              false /*nullAware*/)
           .partialAggregation({"s_name"}, {"count(1) as numwait"})
           .localPartition({})
           .finalAggregation()

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -200,7 +200,7 @@ class Expr {
     return deterministic_;
   }
 
-  bool isConstant() const;
+  virtual bool isConstant() const;
 
   bool supportsFlatNoNullsFastPath() const {
     return supportsFlatNoNullsFastPath_;

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -37,6 +37,10 @@ class FieldReference : public SpecialForm {
     return field_;
   }
 
+  bool isConstant() const override {
+    return SpecialForm::isConstant() && !inputs_.empty();
+  }
+
   int32_t index(const EvalCtx& context) {
     if (index_ != -1) {
       return index_;


### PR DESCRIPTION
Summary:
In current implementation, we still try to apply filter on build side rows with null keys even when we know from `HashBuild` that there is no null key on build side.  This change optimizes this step away, and brings the performance of null-aware and regular anti join to be the same on null-free data.

Also fix some minor issues in TPC-H benchmark.

Differential Revision: D44388495

