### PR TITLE
Make array_frequency() deterministic

### DIFF
--- a/velox/expression/StringWriter.h
+++ b/velox/expression/StringWriter.h
@@ -108,6 +108,12 @@ class StringWriter<false /*reuseInput*/> : public UDFOutputString {
   }
 
   template <typename T>
+  void operator=(const T& input) {
+    resize(0);
+    append(input);
+  }
+
+  template <typename T>
   void append(const T& input) {
     DCHECK(!finalized_);
     auto oldSize = size();

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -61,7 +61,6 @@ int main(int argc, char** argv) {
       "in",
       "element_at",
       "width_bucket",
-      "array_frequency", // https://github.com/facebookincubator/velox/issues/3906
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -52,6 +52,31 @@ TEST_F(StringWriterTest, plusOperator) {
   ASSERT_EQ(vector->valueAt(0), "1 2 3 4 5 "_sv);
 }
 
+TEST_F(StringWriterTest, assignment) {
+  auto vector = makeFlatVector<StringView>(4);
+
+  auto writer0 = exec::StringWriter<>(vector.get(), 0);
+  writer0 = "string0"_sv;
+  writer0.finalize();
+
+  auto writer1 = exec::StringWriter<>(vector.get(), 1);
+  writer1 = std::string("string1");
+  writer1.finalize();
+
+  auto writer2 = exec::StringWriter<>(vector.get(), 2);
+  writer2 = std::string_view("string2");
+  writer2.finalize();
+
+  auto writer3 = exec::StringWriter<>(vector.get(), 3);
+  writer3 = folly::StringPiece("string3");
+  writer3.finalize();
+
+  ASSERT_EQ(vector->valueAt(0), "string0"_sv);
+  ASSERT_EQ(vector->valueAt(1), "string1"_sv);
+  ASSERT_EQ(vector->valueAt(2), "string2"_sv);
+  ASSERT_EQ(vector->valueAt(3), "string3"_sv);
+}
+
 TEST_F(StringWriterTest, copyFromStringView) {
   auto vector = makeFlatVector<StringView>(1);
   auto writer = exec::StringWriter<>(vector.get(), 0);

--- a/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayFrequencyTest.cpp
@@ -16,18 +16,21 @@
 
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::test;
+using facebook::velox::test::assertEqualVectors;
+
+namespace facebook::velox::functions::test {
 
 namespace {
+
 class ArrayFrequencyTest : public functions::test::FunctionBaseTest {
  protected:
-  void testExpr(const VectorPtr& expected, const VectorPtr& input) {
+  void testArrayFrequency(const VectorPtr& expected, const VectorPtr& input) {
     auto result =
         evaluate<BaseVector>("array_frequency(C0)", makeRowVector({input}));
     assertEqualVectors(expected, result);
   }
 };
+
 } // namespace
 
 TEST_F(ArrayFrequencyTest, integerArray) {
@@ -52,7 +55,7 @@ TEST_F(ArrayFrequencyTest, integerArray) {
        {{-1, 3}},
        {{std::numeric_limits<int64_t>::max(), 2}, {1, 2}, {0, 2}}});
 
-  testExpr(expected, array);
+  testArrayFrequency(expected, array);
 }
 
 TEST_F(ArrayFrequencyTest, integerArrayWithoutNull) {
@@ -62,7 +65,7 @@ TEST_F(ArrayFrequencyTest, integerArrayWithoutNull) {
   auto expected = makeMapVector<int64_t, int>(
       {{{1, 2}, {2, 1}, {-2, 1}}, {}, {{1, 5}, {2, 1}}});
 
-  testExpr(expected, array);
+  testArrayFrequency(expected, array);
 }
 
 TEST_F(ArrayFrequencyTest, varcharArray) {
@@ -83,7 +86,7 @@ TEST_F(ArrayFrequencyTest, varcharArray) {
        {{"hello"_sv, 1}, {"world"_sv, 1}, {"!"_sv, 2}},
        {{"helloworldhelloworld"_sv, 2}, {"!"_sv, 2}}});
 
-  testExpr(expected, array);
+  testArrayFrequency(expected, array);
 }
 
 TEST_F(ArrayFrequencyTest, varcharArrayWithoutNull) {
@@ -97,5 +100,7 @@ TEST_F(ArrayFrequencyTest, varcharArrayWithoutNull) {
        {},
        {{"helloworldhelloworld"_sv, 2}, {"!"_sv, 2}}});
 
-  testExpr(expected, array);
+  testArrayFrequency(expected, array);
 }
+
+} // namespace facebook::velox::functions::test


### PR DESCRIPTION
Summary:
Changing how F14 is used to make the output of array_frequency()
deterministic. Since F14 does not provide ordering guarantees, we do another
pass in the input to ensure the output matches the input order (and hence is
deterministic), updating the map frequencies to prevent duplicated values.

Also moving the map to a class member to prevent re-allocations per row.

Differential Revision: D44425744

