### PR TITLE
Add DATE, INTERVAL_DAY_TIME, and DECIMAL in fromVeloxType() in DuckConversion

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -79,6 +79,16 @@ LogicalType fromVeloxType(const TypePtr& type) {
       return LogicalType::VARCHAR;
     case TypeKind::TIMESTAMP:
       return LogicalType::TIMESTAMP;
+    case TypeKind::DATE:
+      return LogicalType::DATE;
+    case TypeKind::INTERVAL_DAY_TIME:
+      return LogicalType::INTERVAL;
+    case TypeKind::LONG_DECIMAL:
+      return LogicalType::DECIMAL(
+          type->asLongDecimal().precision(), type->asLongDecimal().scale());
+    case TypeKind::SHORT_DECIMAL:
+      return LogicalType::DECIMAL(
+          type->asShortDecimal().precision(), type->asShortDecimal().scale());
     case TypeKind::ARRAY:
       return LogicalType::LIST(fromVeloxType(type->childAt(0)));
     case TypeKind::MAP:

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -120,6 +120,13 @@ TEST(DuckConversionTest, types) {
   testRoundTrip(REAL());
   testRoundTrip(DOUBLE());
 
+  testRoundTrip(TIMESTAMP());
+  testRoundTrip(DATE());
+  testRoundTrip(INTERVAL_DAY_TIME());
+
+  testRoundTrip(LONG_DECIMAL(22, 5));
+  testRoundTrip(SHORT_DECIMAL(16, 8));
+
   testRoundTrip(ARRAY(BIGINT()));
   testRoundTrip(MAP(VARCHAR(), REAL()));
   testRoundTrip(ROW(


### PR DESCRIPTION
Summary: Join fuzzer fails due to the lack of support for DATE in fromVeloxType() (https://github.com/facebookincubator/velox/issues/4437). This diff fixes this issue by adding the support for conversions from DATE, INTERVAL_DAY_TIME, and DECIMAL.

Differential Revision: D44425715

