### PR TITLE
Set output batch rows adaptively for operators

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -91,10 +91,24 @@ class QueryConfig {
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "driver.max-page-partitioning-buffer-size";
 
-  /// Preffered number of rows to be returned by operators from
-  /// Operator::getOutput.
-  static constexpr const char* kPreferredOutputBatchSize =
-      "preferred_output_batch_size";
+  /// Preferred size of batches in bytes to be returned by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// known. Otherwise kPreferredOutputBatchRows is used.
+  static constexpr const char* kPreferredOutputBatchBytes =
+      "preferred_output_batch_bytes";
+
+  /// Preferred number of rows to be returned by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// not known. When the estimate of average row size is known,
+  /// kPreferredOutputBatchBytes is used.
+  static constexpr const char* kPreferredOutputBatchRows =
+      "preferred_output_batch_rows";
+
+  /// Max number of rows that could be return by operators from
+  /// Operator::getOutput. It is used when an estimate of average row size is
+  /// known and kPreferredOutputBatchBytes is used to compute the number of
+  /// output rows.
+  static constexpr const char* kMaxOutputBatchRows = "max_output_batch_rows";
 
   static constexpr const char* kHashAdaptivityEnabled =
       "driver.hash_adaptivity_enabled";
@@ -205,8 +219,17 @@ class QueryConfig {
     return get<uint64_t>(kMaxLocalExchangeBufferSize, kDefault);
   }
 
-  uint32_t preferredOutputBatchSize() const {
-    return get<uint32_t>(kPreferredOutputBatchSize, 1024);
+  uint64_t preferredOutputBatchBytes() const {
+    static constexpr uint64_t kDefault = 10UL << 20;
+    return get<uint64_t>(kPreferredOutputBatchBytes, kDefault);
+  }
+
+  uint32_t preferredOutputBatchRows() const {
+    return get<uint32_t>(kPreferredOutputBatchRows, 1024);
+  }
+
+  uint32_t maxOutputBatchRows() const {
+    return get<uint32_t>(kMaxOutputBatchRows, 10'000);
   }
 
   bool hashAdaptivityEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -2,6 +2,38 @@
 Configuration properties
 ========================
 
+Generic Configuration
+---------------------
+
+``preferred_output_batch_bytes``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``10MB``
+
+Preferred size of batches in bytes to be returned by operators from Operator::getOutput.
+It is used when an estimate of average row size is known. Otherwise preferred_output_batch_rows is used.
+
+``preferred_output_batch_rows``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``1024``
+
+Preferred number of rows to be returned by operators from Operator::getOutput. It is used
+when an estimate of average row size is not known. When the estimate of average row size is known,
+preferred_output_batch_bytes is used.
+
+``max_output_batch_rows``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``integer``
+    * **Default value:** ``10000``
+
+Max number of rows that could be return by operators from Operator::getOutput. It is used
+when an estimate of average row size is known and preferred_output_batch_bytes is used to compute
+the number of output rows.
+
 Memory Management
 -----------------
 
@@ -189,7 +221,7 @@ True if appending data to an existing unpartitioned table is allowed.
 Currently this configuration does not support appending to existing partitions.
 
 
-Spark-specific configuration
+Spark-specific Configuration
 ----------------------------
 
 ``spark.legacy-size-of-null``

--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -28,7 +28,7 @@ CrossJoinProbe::CrossJoinProbe(
           operatorId,
           joinNode->id(),
           "CrossJoinProbe"),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()} {
+      outputBatchSize_{outputBatchRows()} {
   bool isIdentityProjection = true;
 
   auto probeType = joinNode->sources()[0]->outputType();

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -715,4 +715,12 @@ void GroupingSet::updateRow(SpillMergeStream& input, char* FOLLY_NONNULL row) {
   mergeSelection_.setValid(input.currentIndex(), false);
 }
 
+std::optional<int64_t> GroupingSet::estimateRowSize() const {
+  const RowContainer* rows =
+      table_ ? table_->rows() : rowsWhileReadingSpill_.get();
+  return rows && rows->estimateRowSize() >= 0
+      ? std::optional<int64_t>(rows->estimateRowSize())
+      : std::nullopt;
+};
+
 } // namespace facebook::velox::exec

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -100,6 +100,9 @@ class GroupingSet {
     return table_ ? table_->rows()->numRows() : 0;
   }
 
+  /// Returns an estimate of the average row size.
+  std::optional<int64_t> estimateRowSize() const;
+
  private:
   void addInputForActiveRows(const RowVectorPtr& input, bool mayPushdown);
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -33,7 +33,6 @@ HashAggregation::HashAggregation(
           aggregationNode->step() == core::AggregationNode::Step::kPartial
               ? "PartialAggregation"
               : "Aggregation"),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
       isPartialOutput_(isPartialOutput(aggregationNode->step())),
       isDistinct_(aggregationNode->aggregates().empty()),
       isGlobal_(aggregationNode->groupingKeys().empty()),
@@ -309,7 +308,8 @@ RowVectorPtr HashAggregation::getOutput() {
     return output;
   }
 
-  const auto batchSize = isGlobal_ ? 1 : outputBatchSize_;
+  const auto batchSize =
+      isGlobal_ ? 1 : outputBatchRows(groupingSet_->estimateRowSize());
 
   // Reuse output vectors if possible.
   prepareOutput(batchSize);

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -64,9 +64,6 @@ class HashAggregation : public Operator {
   // measure of the effectiveness of the partial aggregation.
   void maybeIncreasePartialAggregationMemoryUsage(double aggregationPct);
 
-  // Maximum number of rows in the output batch.
-  const uint32_t outputBatchSize_;
-
   const bool isPartialOutput_;
   const bool isDistinct_;
   const bool isGlobal_;

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -122,7 +122,7 @@ HashProbe::HashProbe(
           operatorId,
           joinNode->id(),
           "HashProbe"),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
+      outputBatchSize_{outputBatchRows()},
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -37,7 +37,7 @@ Merge::Merge(
           operatorId,
           planNodeId,
           operatorType),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()} {
+      outputBatchSize_{outputBatchRows()} {
   auto numKeys = sortingKeys.size();
   sortingKeys_.reserve(numKeys);
   for (int i = 0; i < numKeys; ++i) {

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -30,7 +30,7 @@ MergeJoin::MergeJoin(
           operatorId,
           joinNode->id(),
           "MergeJoin"),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
+      outputBatchSize_{outputBatchRows()},
       joinType_{joinNode->joinType()},
       numKeys_{joinNode->leftKeys().size()} {
   VELOX_USER_CHECK(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -294,6 +294,30 @@ OperatorStats Operator::stats(bool clear) {
   return ret;
 }
 
+uint32_t Operator::outputBatchRows(
+    std::optional<uint64_t> averageRowSize) const {
+  const auto& queryConfig = operatorCtx_->task()->queryCtx()->queryConfig();
+
+  if (!averageRowSize.has_value()) {
+    return queryConfig.preferredOutputBatchRows();
+  }
+
+  uint64_t rowSize = averageRowSize.value();
+  VELOX_CHECK_GE(
+      rowSize,
+      0,
+      "The given average row size of {}.{} is negative.",
+      operatorType(),
+      operatorId());
+
+  if (rowSize * queryConfig.maxOutputBatchRows() <
+      queryConfig.preferredOutputBatchBytes()) {
+    return queryConfig.maxOutputBatchRows();
+  }
+  return std::max<uint32_t>(
+      queryConfig.preferredOutputBatchBytes() / rowSize, 1);
+}
+
 void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
   uint64_t now =
       std::chrono::duration_cast<std::chrono::microseconds>(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -476,6 +476,15 @@ class Operator : public BaseRuntimeStatWriter {
   // 'identityProjections_' and 'resultProjections_'.
   RowVectorPtr fillOutput(vector_size_t size, BufferPtr mapping);
 
+  // Returns the number of rows for the output batch. This uses averageRowSize
+  // to calculate how many rows fit in preferredOutputBatchBytes. It caps the
+  // number of rows at 10K and returns at least one row. The averageRowSize must
+  // not be negative. If the averageRowSize is 0 which is not advised, returns
+  // maxOutputBatchRows. If the averageRowSize is not given, returns
+  // preferredOutputBatchRows.
+  uint32_t outputBatchRows(
+      std::optional<uint64_t> averageRowSize = std::nullopt) const;
+
   std::unique_ptr<OperatorCtx> operatorCtx_;
   folly::Synchronized<OperatorStats> stats_;
   const RowTypePtr outputType_;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -91,12 +91,9 @@ OrderBy::OrderBy(
   }
 #endif
 
-  outputBatchSize_ = std::max<uint32_t>(
-      operatorCtx_->execCtx()
-          ->queryCtx()
-          ->queryConfig()
-          .preferredOutputBatchSize(),
-      data_->estimatedNumRowsPerBatch(kBatchSizeInBytes));
+  // TODO(gaoge): Move to where we can estimate the average row size and set the
+  // output batch rows based on it.
+  outputBatchSize_ = outputBatchRows();
 }
 
 void OrderBy::addInput(RowVectorPtr input) {

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -57,8 +57,6 @@ class OrderBy : public Operator {
   }
 
  private:
-  static const int32_t kBatchSizeInBytes{2 * 1024 * 1024};
-
   // Checks if input will fit in the existing memory and increases
   // reservation if not. If reservation cannot be increased, spills enough to
   // make 'input' fit.

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -525,6 +525,9 @@ class RowContainer {
         stringAllocator_.freeSpace());
   }
 
+  // Returns the average size of rows in bytes stored in this container.
+  std::optional<int64_t> estimateRowSize() const;
+
   // Returns a cap on  extra memory that may be needed when adding 'numRows'
   // and variableLengthBytes of out-of-line variable length data.
   int64_t sizeIncrement(vector_size_t numRows, int64_t variableLengthBytes)
@@ -546,14 +549,6 @@ class RowContainer {
       }
     }
     return 0;
-  }
-
-  // Returns estimated number of rows a batch can support for
-  // the given batchSizeInBytes.
-  // FIXME(venkatra): estimate num rows for variable length fields.
-  int32_t estimatedNumRowsPerBatch(int32_t batchSizeInBytes) {
-    return (batchSizeInBytes / fixedRowSize_) +
-        ((batchSizeInBytes % fixedRowSize_) ? 1 : 0);
   }
 
   // Extract column values for 'rows' into 'result'.

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -31,7 +31,7 @@ StreamingAggregation::StreamingAggregation(
           aggregationNode->step() == core::AggregationNode::Step::kPartial
               ? "PartialAggregation"
               : "Aggregation"),
-      outputBatchSize_{driverCtx->queryConfig().preferredOutputBatchSize()},
+      outputBatchSize_{outputBatchRows()},
       step_{aggregationNode->step()} {
   auto numKeys = aggregationNode->groupingKeys().size();
   decodedKeys_.resize(numKeys);

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -52,8 +52,6 @@ Window::Window(
           operatorId,
           windowNode->id(),
           "Window"),
-      outputBatchSizeInBytes_(
-          driverCtx->queryConfig().preferredOutputBatchSize()),
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
       data_(std::make_unique<RowContainer>(
           windowNode->sources()[0]->outputType()->children(),
@@ -190,7 +188,7 @@ inline bool Window::compareRowsWithKeys(
 void Window::createPeerAndFrameBuffers() {
   // TODO: This computation needs to be revised. It only takes into account
   // the input columns size. We need to also account for the output columns.
-  numRowsPerOutput_ = data_->estimatedNumRowsPerBatch(outputBatchSizeInBytes_);
+  numRowsPerOutput_ = outputBatchRows(data_->estimateRowSize());
 
   peerStartBuffer_ = AlignedBuffer::allocate<vector_size_t>(
       numRowsPerOutput_, operatorCtx_->pool());

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -159,7 +159,6 @@ class Window : public Operator {
       vector_size_t* rawFrameBounds);
 
   bool finished_ = false;
-  const vector_size_t outputBatchSizeInBytes_;
   const vector_size_t numInputColumns_;
 
   // The Window operator needs to see all the input rows before starting

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1027,6 +1027,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
             .config(
                 QueryConfig::kSpillStartPartitionBit,
                 std::to_string(kPartitionStartBit))
+            .config(QueryConfig::kPreferredOutputBatchBytes, "1024")
             .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats;
@@ -1140,6 +1141,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
           // Set to increase the hash table a little bit to only trigger spill
           // on the partition with most spillable data.
           .config(QueryConfig::kSpillableReservationGrowthPct, "25")
+          .config(QueryConfig::kPreferredOutputBatchBytes, "1024")
           .assertResults(results);
 
   auto stats = task->taskStats().pipelineStats;
@@ -1360,39 +1362,55 @@ TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
   for (int32_t i = 0; i < numBatches; ++i) {
     batches.push_back(fuzzer.fuzzRow(rowType_));
   }
-  std::vector<uint32_t> outputBufferSizes({1, 10, 1'000'000});
-  for (const auto& outputBufferSize : outputBufferSizes) {
+
+  auto plan = PlanBuilder()
+                  .values(batches)
+                  .singleAggregation({"c0", "c1"}, {"sum(c2)"})
+                  .planNode();
+  auto results = AssertQueryBuilder(plan).copyResults(pool_.get());
+
+  {
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    uint64_t outputBufferSize = 10UL << 20;
     SCOPED_TRACE(fmt::format("outputBufferSize: {}", outputBufferSize));
 
-    auto results =
-        AssertQueryBuilder(PlanBuilder()
-                               .values(batches)
-                               .singleAggregation({"c0", "c1"}, {"sum(c2)"})
-                               .planNode())
-            .copyResults(pool_.get());
-
-    auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto task =
-        AssertQueryBuilder(PlanBuilder()
-                               .values(batches)
-                               .singleAggregation({"c0", "c1"}, {"sum(c2)"})
-                               .planNode())
-            .spillDirectory(tempDirectory->path)
-            .config(QueryConfig::kSpillEnabled, "true")
-            .config(QueryConfig::kAggregationSpillEnabled, "true")
-            // Set one spill partition to avoid the test flakiness.
-            .config(QueryConfig::kSpillPartitionBits, "0")
-            .config(
-                QueryConfig::kPreferredOutputBatchSize,
-                std::to_string(outputBufferSize))
-            // Set the memory trigger limit to be a very small value.
-            .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
-            .assertResults(results);
+    auto task = AssertQueryBuilder(plan)
+                    .spillDirectory(tempDirectory->path)
+                    .config(
+                        QueryConfig::kPreferredOutputBatchBytes,
+                        std::to_string(outputBufferSize))
+                    .config(QueryConfig::kSpillEnabled, "true")
+                    .config(QueryConfig::kAggregationSpillEnabled, "true")
+                    // Set one spill partition to avoid the test flakiness.
+                    .config(QueryConfig::kSpillPartitionBits, "0")
+                    // Set the memory trigger limit to be a very small value.
+                    .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
+                    .assertResults(results);
 
     const auto opStats = task->taskStats().pipelineStats[0].operatorStats[1];
-    ASSERT_EQ(
-        folly::divCeil(opStats.outputPositions, outputBufferSize),
-        opStats.outputVectors);
+    ASSERT_EQ(opStats.outputVectors, 1);
+    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  }
+  {
+    auto tempDirectory = exec::test::TempDirectoryPath::create();
+    uint64_t outputBufferSize = 1;
+    SCOPED_TRACE(fmt::format("outputBufferSize: {}", outputBufferSize));
+
+    auto task = AssertQueryBuilder(plan)
+                    .spillDirectory(tempDirectory->path)
+                    .config(
+                        QueryConfig::kPreferredOutputBatchBytes,
+                        std::to_string(outputBufferSize))
+                    .config(QueryConfig::kSpillEnabled, "true")
+                    .config(QueryConfig::kAggregationSpillEnabled, "true")
+                    // Set one spill partition to avoid the test flakiness.
+                    .config(QueryConfig::kSpillPartitionBits, "0")
+                    // Set the memory trigger limit to be a very small value.
+                    .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
+                    .assertResults(results);
+
+    const auto opStats = task->taskStats().pipelineStats[0].operatorStats[1];
+    ASSERT_EQ(opStats.outputVectors, opStats.outputPositions);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
 }
@@ -1454,6 +1472,54 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
   // Verify that spilling is not triggered.
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+}
+
+TEST_F(AggregationTest, adaptiveOutputBatchRows) {
+  int32_t defaultOutputBatchRows = 10;
+  vector_size_t size = defaultOutputBatchRows * 5;
+  auto vectors = std::vector<RowVectorPtr>(
+      8,
+      makeRowVector(
+          {"k0", "c0"},
+          {makeFlatVector<int32_t>(size, [&](auto row) { return row; }),
+           makeFlatVector<int8_t>(size, [&](auto row) { return row % 2; })}));
+
+  createDuckDbTable(vectors);
+
+  auto plan = PlanBuilder()
+                  .values(vectors)
+                  .singleAggregation({"k0"}, {"sum(c0)"})
+                  .planNode();
+
+  // Test setting larger output batch bytes will create batches of greater
+  // number of rows.
+  {
+    auto outputBatchBytes = "1000";
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .config(QueryConfig::kPreferredOutputBatchBytes, outputBatchBytes)
+            .assertResults("SELECT k0, SUM(c0) FROM tmp GROUP BY k0");
+
+    auto aggOpStats = task->taskStats().pipelineStats[0].operatorStats[1];
+    ASSERT_GT(
+        aggOpStats.outputPositions / aggOpStats.outputVectors,
+        defaultOutputBatchRows);
+  }
+
+  // Test setting smaller output batch bytes will create batches of fewer
+  // number of rows.
+  {
+    auto outputBatchBytes = "1";
+    auto task =
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .config(QueryConfig::kPreferredOutputBatchBytes, outputBatchBytes)
+            .assertResults("SELECT k0, SUM(c0) FROM tmp GROUP BY k0");
+
+    auto aggOpStats = task->taskStats().pipelineStats[0].operatorStats[1];
+    ASSERT_LT(
+        aggOpStats.outputPositions / aggOpStats.outputVectors,
+        defaultOutputBatchRows);
+  }
 }
 
 } // namespace

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -4360,7 +4360,7 @@ TEST_F(HashJoinTest, smallOutputBatchSize) {
   // probe-side rows to load lazy vectors for.
   HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
       .planNode(std::move(plan))
-      .config(core::QueryConfig::kPreferredOutputBatchSize, std::to_string(10))
+      .config(core::QueryConfig::kPreferredOutputBatchRows, std::to_string(10))
       .referenceQuery("SELECT c0, u_c1 FROM t, u WHERE c0 = u_c0 AND c1 < u_c1")
       .injectSpill(false)
       .run();

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -37,7 +37,7 @@ class MergeJoinTest : public HiveConnectorTestBase {
     params.planNode = planNode;
     params.queryCtx = queryCtx;
     params.queryCtx->setConfigOverridesUnsafe(
-        {{core::QueryConfig::kPreferredOutputBatchSize,
+        {{core::QueryConfig::kPreferredOutputBatchRows,
           std::to_string(preferredOutputBatchSize)}});
     return params;
   }

--- a/velox/exec/tests/MergeTest.cpp
+++ b/velox/exec/tests/MergeTest.cpp
@@ -179,6 +179,6 @@ TEST_F(MergeTest, offByOne) {
   params.planNode = plan;
   params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
-      {{core::QueryConfig::kPreferredOutputBatchSize, "6"}});
+      {{core::QueryConfig::kPreferredOutputBatchRows, "6"}});
   assertQueryOrdered(params, "VALUES (0), (1), (2), (3), (4), (5), (10)", {0});
 }

--- a/velox/exec/tests/StreamingAggregationTest.cpp
+++ b/velox/exec/tests/StreamingAggregationTest.cpp
@@ -34,7 +34,7 @@ class StreamingAggregationTest : public OperatorTestBase {
     params.planNode = planNode;
     params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     params.queryCtx->setConfigOverridesUnsafe(
-        {{core::QueryConfig::kPreferredOutputBatchSize,
+        {{core::QueryConfig::kPreferredOutputBatchRows,
           std::to_string(preferredOutputBatchSize)}});
     return params;
   }

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -910,7 +910,7 @@ DEBUG_ONLY_TEST_F(TaskTest, outputDriverFinishEarly) {
   params.planNode = plan;
   params.queryCtx = std::make_shared<core::QueryCtx>(driverExecutor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
-      {{core::QueryConfig::kPreferredOutputBatchSize, "1"}});
+      {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
   {
     auto cursor = std::make_unique<TaskCursor>(params);
@@ -956,7 +956,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
   params.planNode = plan;
   params.queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   params.queryCtx->setConfigOverridesUnsafe(
-      {{core::QueryConfig::kPreferredOutputBatchSize, "1"}});
+      {{core::QueryConfig::kPreferredOutputBatchRows, "1"}});
 
   auto cursor = std::make_unique<TaskCursor>(params);
   std::vector<RowVectorPtr> result;


### PR DESCRIPTION
Add the outputBatchRows() to Operator interface to determine the number
of output batch rows based on the total batch size config
preferred_output_batch_bytes and the given average row size.
If the average row size is not given, return the config
preferred_output_batch_rows.

Make the HashAggregation, OrderBy and Windown operator use the above logic
to adaptively set the number of output batch rows based on the estimated
output row size.