### PR TITLE
Fix: make CSE and peeling orthogonal.

### DIFF
--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -29,11 +29,8 @@ class ConstantExpr : public SpecialForm {
             false /* trackCpuUsage */),
         needToSetIsAscii_{value->type()->isVarchar()} {
     VELOX_CHECK_EQ(value->encoding(), VectorEncoding::Simple::CONSTANT);
-    sharedSubexprValues_ = std::move(value);
+    sharedConstantValue_ = std::move(value);
   }
-
-  // Do not clear sharedSubexprValues_.
-  void reset() override {}
 
   void evalSpecialForm(
       const SelectivityVector& rows,
@@ -46,7 +43,7 @@ class ConstantExpr : public SpecialForm {
       VectorPtr& result) override;
 
   const VectorPtr& value() const {
-    return sharedSubexprValues_;
+    return sharedConstantValue_;
   }
 
   std::string toString(bool recursive = true) const override;
@@ -55,6 +52,7 @@ class ConstantExpr : public SpecialForm {
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
  private:
+  VectorPtr sharedConstantValue_;
   bool needToSetIsAscii_;
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -72,6 +72,10 @@ class EvalCtx {
     peeledFields_[index] = vector;
   }
 
+  const std::vector<VectorPtr>& peeledFields() {
+    return peeledFields_;
+  }
+
   /// Used by peelEncodings.
   void saveAndReset(ScopedContextSaver& saver, const SelectivityVector& rows);
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -629,31 +629,41 @@ void Expr::evaluateSharedSubexpr(
     EvalCtx& context,
     VectorPtr& result,
     TEval eval) {
-  if (sharedSubexprValues_ == nullptr) {
+  // Captures the inputs referenced by distinctFields_.
+  std::vector<const BaseVector*> expressionInputFields;
+  for (const auto& field : distinctFields_) {
+    expressionInputFields.push_back(
+        context.getField(field->index(context)).get());
+  }
+
+  auto& [sharedSubexprRows, sharedSubexprValues] =
+      sharedSubexprResults_[expressionInputFields];
+
+  if (sharedSubexprValues == nullptr) {
     eval(rows, context, result);
 
-    if (!sharedSubexprRows_) {
-      sharedSubexprRows_ = context.execCtx()->getSelectivityVector(rows.size());
+    if (!sharedSubexprRows) {
+      sharedSubexprRows = context.execCtx()->getSelectivityVector(rows.size());
     }
 
-    *sharedSubexprRows_ = rows;
+    *sharedSubexprRows = rows;
     if (context.errors()) {
       // Clear the rows which failed to compute.
-      context.deselectErrors(*sharedSubexprRows_);
-      if (!sharedSubexprRows_->hasSelections()) {
+      context.deselectErrors(*sharedSubexprRows);
+      if (!sharedSubexprRows->hasSelections()) {
         // Do not store a reference to 'result' if we cannot use any rows from
         // it.
         return;
       }
     }
 
-    sharedSubexprValues_ = result;
+    sharedSubexprValues = result;
     return;
   }
 
-  if (rows.isSubset(*sharedSubexprRows_)) {
+  if (rows.isSubset(*sharedSubexprRows)) {
     // We have results for all requested rows. No need to compute anything.
-    context.moveOrCopyResult(sharedSubexprValues_, rows, result);
+    context.moveOrCopyResult(sharedSubexprValues, rows, result);
     return;
   }
 
@@ -664,13 +674,13 @@ void Expr::evaluateSharedSubexpr(
   // sharedSubexprRows_.
   LocalSelectivityVector missingRowsHolder(context, rows);
   auto missingRows = missingRowsHolder.get();
-  missingRows->deselect(*sharedSubexprRows_);
+  missingRows->deselect(*sharedSubexprRows);
   VELOX_DCHECK(missingRows->hasSelections());
 
   // Fix finalSelection to avoid losing values outside missingRows.
   // Final selection of rows need to include sharedSubexprRows_, missingRows and
   // current final selection of rows if set.
-  LocalSelectivityVector newFinalSelectionHolder(context, *sharedSubexprRows_);
+  LocalSelectivityVector newFinalSelectionHolder(context, *sharedSubexprRows);
   auto newFinalSelection = newFinalSelectionHolder.get();
   newFinalSelection->select(*missingRows);
   if (!context.isFinalSelection()) {
@@ -680,13 +690,13 @@ void Expr::evaluateSharedSubexpr(
   ScopedFinalSelectionSetter setter(
       context, newFinalSelection, true /*checkCondition*/, true /*override*/);
 
-  eval(*missingRows, context, sharedSubexprValues_);
+  eval(*missingRows, context, sharedSubexprValues);
 
   // Clear the rows which failed to compute.
   context.deselectErrors(*missingRows);
 
-  sharedSubexprRows_->select(*missingRows);
-  context.moveOrCopyResult(sharedSubexprValues_, rows, result);
+  sharedSubexprRows->select(*missingRows);
+  context.moveOrCopyResult(sharedSubexprValues, rows, result);
 }
 
 SelectivityVector* singleRow(


### PR DESCRIPTION
Summary:
CSE implementation requires that when evaluateSharedSubexpr on the same expression the inputs are the same to the expressions.

This can break when peeling happens, it is possible for example for the
expressions f(b(c0), c0) and b(c0). It is possible that b(c0) is evaluated on the
 peeled c0 the first time it is executed BUT  on the non-peeled c0 the second
time (see the tests for example). Furthermore, this property is not trivial to
maintain.

To solve this problem, I changed CSE to capture the inputs and the rows during
the expression evaluation and then look up shared results using both of them
instead of just the rows.

This does not prohibit vector reuse, because the inputs vectors anyway are not
 re-usable since they are assumed to be held by the expression evaluation
caller.

This solves https://github.com/facebookincubator/velox/issues/4351

Differential Revision: D44442738

