### PR TITLE
Fix use rows.end() instead of rows.size() in functions.

### DIFF
--- a/velox/duckdb/functions/DuckFunctions.cpp
+++ b/velox/duckdb/functions/DuckFunctions.cpp
@@ -347,7 +347,7 @@ static void toDuck(
   if (args.size() == 0) {
     return;
   }
-  auto numRows = args[0]->size();
+  auto numRows = rows.end();
   auto cardinality = std::min<size_t>(numRows - offset, STANDARD_VECTOR_SIZE);
   result.SetCardinality(cardinality);
 
@@ -453,7 +453,7 @@ class DuckDBFunction : public exec::VectorFunction {
     auto state = initializeState(std::move(inputTypes), duckDBAllocator);
     assert(state->functionIndex < set_.size());
     auto& function = set_[state->functionIndex];
-    idx_t nrow = rows.size();
+    idx_t nrow = rows.end();
 
     if (!result) {
       result = createVeloxVector(rows, function.return_type, nrow, context);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -316,7 +316,7 @@ void Expr::evalSimplifiedImpl(
     if (!remainingRows.hasSelections()) {
       releaseInputValues(context);
       result =
-          BaseVector::createNullConstant(type(), rows.size(), context.pool());
+          BaseVector::createNullConstant(type(), rows.end(), context.pool());
       return;
     }
 
@@ -338,7 +338,7 @@ void Expr::evalSimplifiedImpl(
         if (!remainingRows.hasSelections()) {
           releaseInputValues(context);
           result = BaseVector::createNullConstant(
-              type(), rows.size(), context.pool());
+              type(), rows.end(), context.pool());
           return;
         }
       }
@@ -535,7 +535,7 @@ void Expr::evalFlatNoNullsImpl(
       // No need to re-evaluate constant expression. Simply move constant values
       // from constantInputs_.
       inputValues_[i] = std::move(constantInputs_[i]);
-      inputValues_[i]->resize(rows.size());
+      inputValues_[i]->resize(rows.end());
     } else {
       inputs_[i]->evalFlatNoNulls(rows, context, inputValues_[i]);
     }
@@ -643,7 +643,7 @@ void Expr::evaluateSharedSubexpr(
     eval(rows, context, result);
 
     if (!sharedSubexprRows) {
-      sharedSubexprRows = context.execCtx()->getSelectivityVector(rows.size());
+      sharedSubexprRows = context.execCtx()->getSelectivityVector(rows.end());
     }
 
     *sharedSubexprRows = rows;
@@ -1035,7 +1035,7 @@ void Expr::setAllNulls(
     result->addNulls(notNulls.get()->asRange().bits(), rows);
     return;
   }
-  result = BaseVector::createNullConstant(type(), rows.size(), context.pool());
+  result = BaseVector::createNullConstant(type(), rows.end(), context.pool());
 }
 
 namespace {

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -75,13 +75,13 @@ void FieldReference::evalSpecialForm(
     }
     // The caller relies on vectors having a meaningful size. If we
     // have a constant that is not wrapped in anything we set its size
-    // to correspond to rows.size(). This is in place for unique ones
+    // to correspond to rows.end(). This is in place for unique ones
     // and a copy otherwise.
     if (!useDecode && child->isConstantEncoding()) {
       if (isUniqueChild) {
-        child->resize(rows.size());
+        child->resize(rows.end());
       } else {
-        child = BaseVector::wrapInConstant(rows.size(), 0, child);
+        child = BaseVector::wrapInConstant(rows.end(), 0, child);
       }
     }
     result = useDecode ? std::move(decoded.wrap(child, *input, rows.end()))

--- a/velox/functions/lib/IsNull.cpp
+++ b/velox/functions/lib/IsNull.cpp
@@ -38,7 +38,7 @@ class IsNullFunction : public exec::VectorFunction {
     if (arg->isConstantEncoding()) {
       bool isNull = arg->isNullAt(rows.begin());
       auto localResult = BaseVector::createConstant(
-          BOOLEAN(), IsNotNULL ? !isNull : isNull, rows.size(), pool);
+          BOOLEAN(), IsNotNULL ? !isNull : isNull, rows.end(), pool);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }
@@ -46,7 +46,7 @@ class IsNullFunction : public exec::VectorFunction {
     if (!arg->mayHaveNulls()) {
       // No nulls.
       auto localResult = BaseVector::createConstant(
-          BOOLEAN(), IsNotNULL ? true : false, rows.size(), pool);
+          BOOLEAN(), IsNotNULL ? true : false, rows.end(), pool);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }
@@ -56,7 +56,7 @@ class IsNullFunction : public exec::VectorFunction {
       if constexpr (IsNotNULL) {
         isNull = arg->nulls();
       } else {
-        isNull = AlignedBuffer::allocate<bool>(rows.size(), pool);
+        isNull = AlignedBuffer::allocate<bool>(rows.end(), pool);
         memcpy(
             isNull->asMutable<int64_t>(),
             arg->rawNulls(),
@@ -66,7 +66,7 @@ class IsNullFunction : public exec::VectorFunction {
     } else {
       exec::DecodedArgs decodedArgs(rows, args, context);
 
-      isNull = AlignedBuffer::allocate<bool>(rows.size(), pool);
+      isNull = AlignedBuffer::allocate<bool>(rows.end(), pool);
       memcpy(
           isNull->asMutable<int64_t>(),
           decodedArgs.at(0)->nulls(),
@@ -78,12 +78,7 @@ class IsNullFunction : public exec::VectorFunction {
     }
 
     auto localResult = std::make_shared<FlatVector<bool>>(
-        pool,
-        BOOLEAN(),
-        nullptr,
-        rows.size(),
-        isNull,
-        std::vector<BufferPtr>{});
+        pool, BOOLEAN(), nullptr, rows.end(), isNull, std::vector<BufferPtr>{});
     context.moveOrCopyResult(localResult, rows, result);
   }
 

--- a/velox/functions/lib/LambdaFunctionUtil.cpp
+++ b/velox/functions/lib/LambdaFunctionUtil.cpp
@@ -25,7 +25,7 @@ BufferPtr flattenNulls(
   }
 
   BufferPtr nulls =
-      AlignedBuffer::allocate<bool>(rows.size(), decodedVector.base()->pool());
+      AlignedBuffer::allocate<bool>(rows.end(), decodedVector.base()->pool());
   auto rawNulls = nulls->asMutable<uint64_t>();
   rows.applyToSelected([&](vector_size_t row) {
     bits::setNull(rawNulls, row, decodedVector.isNullAt(row));
@@ -104,7 +104,7 @@ ArrayVectorPtr flattenArray(
       array->pool(),
       array->type(),
       newNulls,
-      rows.size(),
+      rows.end(),
       newOffsets,
       newSizes,
       BaseVector::wrapInDictionary(
@@ -142,7 +142,7 @@ MapVectorPtr flattenMap(
       map->pool(),
       map->type(),
       newNulls,
-      rows.size(),
+      rows.end(),
       newOffsets,
       newSizes,
       BaseVector::wrapInDictionary(

--- a/velox/functions/lib/MapConcat.cpp
+++ b/velox/functions/lib/MapConcat.cpp
@@ -67,10 +67,10 @@ class MapConcatFunction : public exec::VectorFunction {
 
     // Initialize offsets and sizes to 0 so that canonicalize() will
     // work also for sparse 'rows'.
-    BufferPtr offsets = allocateOffsets(rows.size(), pool);
+    BufferPtr offsets = allocateOffsets(rows.end(), pool);
     auto rawOffsets = offsets->asMutable<vector_size_t>();
 
-    BufferPtr sizes = allocateSizes(rows.size(), pool);
+    BufferPtr sizes = allocateSizes(rows.end(), pool);
     auto rawSizes = sizes->asMutable<vector_size_t>();
 
     vector_size_t offset = 0;
@@ -99,7 +99,7 @@ class MapConcatFunction : public exec::VectorFunction {
         pool,
         outputType,
         BufferPtr(nullptr),
-        rows.size(),
+        rows.end(),
         offsets,
         sizes,
         combinedKeys,
@@ -148,7 +148,7 @@ class MapConcatFunction : public exec::VectorFunction {
           pool,
           outputType,
           BufferPtr(nullptr),
-          rows.size(),
+          rows.end(),
           offsets,
           sizes,
           keys,

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -156,11 +156,11 @@ class SubscriptImpl : public exec::VectorFunction {
       exec::EvalCtx& context) const {
     auto* pool = context.pool();
 
-    BufferPtr indices = allocateIndices(rows.size(), pool);
+    BufferPtr indices = allocateIndices(rows.end(), pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
 
     // Create nulls for lazy initialization.
-    NullsBuilder nullsBuilder(rows.size(), pool);
+    NullsBuilder nullsBuilder(rows.end(), pool);
 
     exec::LocalDecodedVector arrayHolder(context, *arrayArg, rows);
     auto decodedArray = arrayHolder.get();
@@ -211,11 +211,11 @@ class SubscriptImpl : public exec::VectorFunction {
     // to ensure user error checks for indices are not skipped.
     if (baseArray->elements()->size() == 0) {
       return BaseVector::createNullConstant(
-          baseArray->elements()->type(), rows.size(), context.pool());
+          baseArray->elements()->type(), rows.end(), context.pool());
     }
 
     return BaseVector::wrapInDictionary(
-        nullsBuilder.build(), indices, rows.size(), baseArray->elements());
+        nullsBuilder.build(), indices, rows.end(), baseArray->elements());
   }
 
   // Normalize indices from 1 or 0-based into always 0-based (according to
@@ -290,11 +290,11 @@ class SubscriptImpl : public exec::VectorFunction {
       exec::EvalCtx& context) const {
     auto* pool = context.pool();
 
-    BufferPtr indices = allocateIndices(rows.size(), pool);
+    BufferPtr indices = allocateIndices(rows.end(), pool);
     auto rawIndices = indices->asMutable<vector_size_t>();
 
     // Create nulls for lazy initialization.
-    NullsBuilder nullsBuilder(rows.size(), pool);
+    NullsBuilder nullsBuilder(rows.end(), pool);
 
     // Get base MapVector.
     // TODO: Optimize the case when indices are identity.
@@ -364,11 +364,11 @@ class SubscriptImpl : public exec::VectorFunction {
     // ensure user error checks for indices are not skipped.
     if (baseMap->mapValues()->size() == 0) {
       return BaseVector::createNullConstant(
-          baseMap->mapValues()->type(), rows.size(), context.pool());
+          baseMap->mapValues()->type(), rows.end(), context.pool());
     }
 
     return BaseVector::wrapInDictionary(
-        nullsBuilder.build(), indices, rows.size(), baseMap->mapValues());
+        nullsBuilder.build(), indices, rows.end(), baseMap->mapValues());
   }
 };
 

--- a/velox/functions/prestosql/ArrayConstructor.cpp
+++ b/velox/functions/prestosql/ArrayConstructor.cpp
@@ -37,9 +37,9 @@ class ArrayConstructor : public exec::VectorFunction {
     context.ensureWritable(rows, outputType, result);
     result->clearNulls(rows);
     auto arrayResult = result->as<ArrayVector>();
-    auto sizes = arrayResult->mutableSizes(rows.size());
+    auto sizes = arrayResult->mutableSizes(rows.end());
     auto rawSizes = sizes->asMutable<int32_t>();
-    auto offsets = arrayResult->mutableOffsets(rows.size());
+    auto offsets = arrayResult->mutableOffsets(rows.end());
     auto rawOffsets = offsets->asMutable<int32_t>();
 
     auto elementsResult = arrayResult->elements();

--- a/velox/functions/prestosql/ArrayDistinct.cpp
+++ b/velox/functions/prestosql/ArrayDistinct.cpp
@@ -62,7 +62,7 @@ class ArrayDistinctFunction : public exec::VectorFunction {
       exec::LocalSingleRow singleRow(context, flatIndex);
       localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
-          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+          BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
     } else {
       localResult = applyFlat(rows, arg, context);
     }
@@ -81,8 +81,8 @@ class ArrayDistinctFunction : public exec::VectorFunction {
         toElementRows(elementsVector->size(), rows, arrayVector);
     exec::LocalDecodedVector elements(context, *elementsVector, elementsRows);
 
-    vector_size_t elementsCount = elementsRows.size();
-    vector_size_t rowCount = arrayVector->size();
+    vector_size_t elementsCount = elementsRows.end();
+    vector_size_t rowCount = rows.end();
 
     // Allocate new vectors for indices, length and offsets.
     memory::MemoryPool* pool = context.pool();

--- a/velox/functions/prestosql/ArrayDuplicates.cpp
+++ b/velox/functions/prestosql/ArrayDuplicates.cpp
@@ -63,7 +63,7 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
       exec::LocalSingleRow singleRow(context, flatIndex);
       localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
-          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+          BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
     } else {
       localResult = applyFlat(rows, arg, context);
     }
@@ -84,8 +84,8 @@ class ArrayDuplicatesFunction : public exec::VectorFunction {
         toElementRows(elementsVector->size(), rows, arrayVector);
     exec::LocalDecodedVector elements(context, *elementsVector, elementsRows);
 
-    vector_size_t numElements = elementsRows.size();
-    vector_size_t numRows = arrayVector->size();
+    vector_size_t numElements = elementsRows.end();
+    vector_size_t numRows = rows.end();
 
     // Allocate new vectors for indices, length and offsets.
     memory::MemoryPool* pool = context.pool();

--- a/velox/functions/prestosql/ArrayShuffle.cpp
+++ b/velox/functions/prestosql/ArrayShuffle.cpp
@@ -69,8 +69,8 @@ class ArrayShuffleFunction : public exec::VectorFunction {
 
     // Allocate new buffer to hold shuffled indices.
     BufferPtr shuffledIndices = allocateIndices(numElements, context.pool());
-    BufferPtr offsets = allocateOffsets(rows.size(), context.pool());
-    BufferPtr sizes = allocateSizes(rows.size(), context.pool());
+    BufferPtr offsets = allocateOffsets(rows.end(), context.pool());
+    BufferPtr sizes = allocateSizes(rows.end(), context.pool());
 
     vector_size_t* rawIndices = shuffledIndices->asMutable<vector_size_t>();
     vector_size_t* rawOffsets = offsets->asMutable<vector_size_t>();
@@ -98,7 +98,7 @@ class ArrayShuffleFunction : public exec::VectorFunction {
         context.pool(),
         arrayVector->type(),
         nullptr,
-        rows.size(),
+        rows.end(),
         std::move(offsets),
         std::move(sizes),
         std::move(resultElements));

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -101,7 +101,7 @@ void applyScalarType(
   VELOX_DCHECK(kind == inputElements->typeKind());
   const SelectivityVector inputElementRows =
       toElementRows(inputElements->size(), rows, inputArray);
-  const vector_size_t elementsCount = inputElementRows.size();
+  const vector_size_t elementsCount = inputElementRows.end();
 
   // TODO: consider to use dictionary wrapping to avoid the direct sorting on
   // the scalar values as we do for complex data type if this runs slow in
@@ -186,7 +186,7 @@ class ArraySortFunction : public exec::VectorFunction {
       exec::LocalSingleRow singleRow(context, flatIndex);
       localResult = applyFlat(*singleRow, flatArray, context);
       localResult =
-          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+          BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
     } else {
       localResult = applyFlat(rows, arg, context);
     }

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -64,8 +64,8 @@ class FilterFunctionBase : public exec::VectorFunction {
     auto inputSizes = input->rawSizes();
 
     auto* pool = context.pool();
-    resultSizes = allocateSizes(rows.size(), pool);
-    resultOffsets = allocateOffsets(rows.size(), pool);
+    resultSizes = allocateSizes(rows.end(), pool);
+    resultOffsets = allocateOffsets(rows.end(), pool);
     auto rawResultSizes = resultSizes->asMutable<vector_size_t>();
     auto rawResultOffsets = resultOffsets->asMutable<vector_size_t>();
     auto numElements = lambdaArgs[0]->size();
@@ -163,7 +163,7 @@ class ArrayFilterFunction : public FilterFunctionBase {
         flatArray->pool(),
         flatArray->type(),
         flatArray->nulls(),
-        rows.size(),
+        rows.end(),
         std::move(resultOffsets),
         std::move(resultSizes),
         wrappedElements);
@@ -228,7 +228,7 @@ class MapFilterFunction : public FilterFunctionBase {
         flatMap->pool(),
         outputType,
         flatMap->nulls(),
-        rows.size(),
+        rows.end(),
         std::move(resultOffsets),
         std::move(resultSizes),
         wrappedKeys,

--- a/velox/functions/prestosql/FromUnixTime.cpp
+++ b/velox/functions/prestosql/FromUnixTime.cpp
@@ -77,7 +77,7 @@ class FromUnixtimeFunction : public exec::VectorFunction {
         pool,
         outputType,
         BufferPtr(nullptr),
-        rows.size(),
+        rows.end(),
         std::vector<VectorPtr>{timestamps, timezones},
         0 /*nullCount*/);
 

--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -244,7 +244,7 @@ class InPredicate : public exec::VectorFunction {
       VectorPtr& result,
       F&& testFunction) const {
     if (alwaysNull_) {
-      auto localResult = createBoolConstantNull(rows.size(), context);
+      auto localResult = createBoolConstantNull(rows.end(), context);
       context.moveOrCopyResult(localResult, rows, result);
       return;
     }
@@ -257,13 +257,13 @@ class InPredicate : public exec::VectorFunction {
       auto simpleArg = arg->asUnchecked<SimpleVector<T>>();
       VectorPtr localResult;
       if (simpleArg->isNullAt(rows.begin())) {
-        localResult = createBoolConstantNull(rows.size(), context);
+        localResult = createBoolConstantNull(rows.end(), context);
       } else {
         bool pass = testFunction(simpleArg->valueAt(rows.begin()));
         if (!pass && passOrNull) {
-          localResult = createBoolConstantNull(rows.size(), context);
+          localResult = createBoolConstantNull(rows.end(), context);
         } else {
-          localResult = createBoolConstant(pass, rows.size(), context);
+          localResult = createBoolConstant(pass, rows.end(), context);
         }
       }
 

--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -119,10 +119,10 @@ class MapFunction : public exec::VectorFunction {
         totalElements += keysArray->sizeAt(keyIndices[row]);
       });
 
-      BufferPtr offsets = allocateOffsets(rows.size(), context.pool());
+      BufferPtr offsets = allocateOffsets(rows.end(), context.pool());
       auto rawOffsets = offsets->asMutable<vector_size_t>();
 
-      BufferPtr sizes = allocateSizes(rows.size(), context.pool());
+      BufferPtr sizes = allocateSizes(rows.end(), context.pool());
       auto rawSizes = sizes->asMutable<vector_size_t>();
 
       BufferPtr valuesIndices = allocateIndices(totalElements, context.pool());

--- a/velox/functions/prestosql/MapKeysAndValues.cpp
+++ b/velox/functions/prestosql/MapKeysAndValues.cpp
@@ -40,7 +40,7 @@ class MapKeyValueFunction : public exec::VectorFunction {
       exec::LocalSingleRow singleRow(context, flatIndex);
       localResult = applyFlat(*singleRow, flatMap, context);
       localResult =
-          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+          BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
     } else {
       localResult = applyFlat(rows, arg, context);
     }

--- a/velox/functions/prestosql/Not.cpp
+++ b/velox/functions/prestosql/Not.cpp
@@ -39,9 +39,9 @@ class NotFunction : public exec::VectorFunction {
     if (input->isConstantEncoding()) {
       bool value = input->as<ConstantVector<bool>>()->valueAt(0);
       negated =
-          AlignedBuffer::allocate<bool>(rows.size(), context.pool(), !value);
+          AlignedBuffer::allocate<bool>(rows.end(), context.pool(), !value);
     } else {
-      negated = AlignedBuffer::allocate<bool>(rows.size(), context.pool());
+      negated = AlignedBuffer::allocate<bool>(rows.end(), context.pool());
       auto rawNegated = negated->asMutable<char>();
 
       auto rawInput = input->asFlatVector<bool>()->rawValues<uint64_t>();
@@ -54,7 +54,7 @@ class NotFunction : public exec::VectorFunction {
         context.pool(),
         BOOLEAN(),
         nullptr,
-        rows.size(),
+        rows.end(),
         negated,
         std::vector<BufferPtr>{});
 

--- a/velox/functions/prestosql/Repeat.cpp
+++ b/velox/functions/prestosql/Repeat.cpp
@@ -66,7 +66,7 @@ class RepeatFunction : public exec::VectorFunction {
       std::vector<VectorPtr>& args,
       const TypePtr& outputType,
       exec::EvalCtx& context) const {
-    const auto numRows = rows.size();
+    const auto numRows = rows.end();
     auto pool = context.pool();
 
     if (args[1]->as<ConstantVector<int32_t>>()->isNullAt(0)) {
@@ -120,7 +120,7 @@ class RepeatFunction : public exec::VectorFunction {
       totalCount += count;
     });
 
-    const auto numRows = rows.size();
+    const auto numRows = rows.end();
     auto pool = context.pool();
 
     // Allocate new vector for nulls if necessary.

--- a/velox/functions/prestosql/Reverse.cpp
+++ b/velox/functions/prestosql/Reverse.cpp
@@ -129,7 +129,7 @@ class ReverseFunction : public exec::VectorFunction {
       exec::LocalSingleRow singleRow(context, flatIndex);
       localResult = applyArrayFlat(*singleRow, flatArray, context);
       localResult =
-          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+          BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
     } else {
       localResult = applyArrayFlat(rows, arg, context);
     }

--- a/velox/functions/prestosql/RowFunction.cpp
+++ b/velox/functions/prestosql/RowFunction.cpp
@@ -32,7 +32,7 @@ class RowFunction : public exec::VectorFunction {
         context.pool(),
         outputType,
         BufferPtr(nullptr),
-        rows.size(),
+        rows.end(),
         std::move(argsCopy),
         0 /*nullCount*/);
     context.moveOrCopyResult(row, rows, result);

--- a/velox/functions/prestosql/VectorArithmetic.cpp
+++ b/velox/functions/prestosql/VectorArithmetic.cpp
@@ -139,7 +139,7 @@ class VectorArithmetic : public VectorFunction {
           args[1].unique() && rightEncoding == VectorEncoding::Simple::FLAT) {
         result = std::move(args[1]);
       } else {
-        result = BaseVector::create(outputType, rows.size(), context.pool());
+        result = BaseVector::create(outputType, rows.end(), context.pool());
       }
     } else {
       // if the output is previously initialized, we prepare it for writing

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -250,7 +250,7 @@ class ZipWithFunction : public exec::VectorFunction {
     auto* sizes = base->rawSizes();
 
     if (!needsPadding && decoded->isIdentityMapping() && rows.isAllSelected() &&
-        areSameOffsets(offsets, resultOffsets, rows.size())) {
+        areSameOffsets(offsets, resultOffsets, rows.end())) {
       return base->elements();
     }
 

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1371,7 +1371,7 @@ class MultiStringFunction : public exec::VectorFunction {
       const TypePtr& /* outputType */,
       exec::EvalCtx& /*context*/,
       VectorPtr& result) const override {
-    result = BaseVector::wrapInConstant(rows.size(), 0, args[0]);
+    result = BaseVector::wrapInConstant(rows.end(), 0, args[0]);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/sparksql/ArraySort.cpp
+++ b/velox/functions/sparksql/ArraySort.cpp
@@ -176,7 +176,7 @@ void ArraySort::apply(
     exec::LocalSingleRow singleRow(context, flatIndex);
     localResult = applyFlat(*singleRow, flatArray, context);
     localResult =
-        BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+        BaseVector::wrapInConstant(rows.end(), flatIndex, localResult);
   } else {
     localResult = applyFlat(rows, arg, context);
   }

--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -41,7 +41,7 @@ void setKeysResultTyped(
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
   auto flatVector = keysResult->asFlatVector<T>();
-  flatVector->resize(rows.size() * mapSize);
+  flatVector->resize(rows.end() * mapSize);
 
   exec::LocalDecodedVector decoded(context);
   for (vector_size_t i = 0; i < mapSize; i++) {
@@ -63,7 +63,7 @@ void setValuesResultTyped(
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
   auto flatVector = valuesResult->asFlatVector<T>();
-  flatVector->resize(rows.size() * mapSize);
+  flatVector->resize(rows.end() * mapSize);
 
   exec::LocalDecodedVector decoded(context);
   for (vector_size_t i = 0; i < mapSize; i++) {
@@ -116,9 +116,9 @@ class MapFunction : public exec::VectorFunction {
         rows, std::make_shared<MapType>(keyType, valueType), result);
 
     auto mapResult = result->as<MapVector>();
-    auto sizes = mapResult->mutableSizes(rows.size());
+    auto sizes = mapResult->mutableSizes(rows.end());
     auto rawSizes = sizes->asMutable<int32_t>();
-    auto offsets = mapResult->mutableOffsets(rows.size());
+    auto offsets = mapResult->mutableOffsets(rows.end());
     auto rawOffsets = offsets->asMutable<int32_t>();
 
     // Setting size and offsets
@@ -130,8 +130,8 @@ class MapFunction : public exec::VectorFunction {
     // Setting keys and value elements
     auto keysResult = mapResult->mapKeys();
     auto valuesResult = mapResult->mapValues();
-    keysResult->resize(rows.size() * mapSize);
-    valuesResult->resize(rows.size() * mapSize);
+    keysResult->resize(rows.end() * mapSize);
+    valuesResult->resize(rows.end() * mapSize);
 
     VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
         setKeysResultTyped,

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -489,7 +489,7 @@ std::string BaseVector::toString(
 }
 
 void BaseVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), length_);
   if (nulls_ && !(nulls_->unique() && nulls_->isMutable())) {
     BufferPtr newNulls = AlignedBuffer::allocate<bool>(newSize, pool_);
     auto rawNewNulls = newNulls->asMutable<uint64_t>();
@@ -511,9 +511,9 @@ void BaseVector::ensureWritable(
     VectorPool* vectorPool) {
   if (!result) {
     if (vectorPool) {
-      result = vectorPool->get(type, rows.size());
+      result = vectorPool->get(type, rows.end());
     } else {
-      result = BaseVector::create(type, rows.size(), pool);
+      result = BaseVector::create(type, rows.end(), pool);
     }
     return;
   }
@@ -542,7 +542,7 @@ void BaseVector::ensureWritable(
 
   // The copy-on-write size is the max of the writable row set and the
   // vector.
-  auto targetSize = std::max<vector_size_t>(rows.size(), result->size());
+  auto targetSize = std::max<vector_size_t>(rows.end(), result->size());
 
   VectorPtr copy;
   if (vectorPool) {

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -209,8 +209,7 @@ void RowVector::copy(
     BufferPtr mappedIndices;
     vector_size_t* rawMappedIndices = nullptr;
     if (toSourceRow) {
-      mappedIndices =
-          AlignedBuffer::allocate<vector_size_t>(rows.size(), pool_);
+      mappedIndices = AlignedBuffer::allocate<vector_size_t>(rows.end(), pool_);
       rawMappedIndices = mappedIndices->asMutable<vector_size_t>();
       nonNullRows.applyToSelected(
           [&](auto row) { rawMappedIndices[row] = indices[toSourceRow[row]]; });
@@ -688,7 +687,7 @@ std::string ArrayVector::toString(vector_size_t index) const {
 }
 
 void ArrayVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (offsets_ && !offsets_->unique()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
@@ -950,7 +949,7 @@ std::string MapVector::toString(vector_size_t index) const {
 }
 
 void MapVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (offsets_ && !offsets_->unique()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -349,7 +349,7 @@ void FlatVector<T>::resize(vector_size_t newSize, bool setNotNull) {
 
 template <typename T>
 void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (values_ && !(values_->unique() && values_->isMutable())) {
     BufferPtr newValues;
     if constexpr (std::is_same_v<T, StringView>) {

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -421,18 +421,17 @@ TEST_F(EnsureWritableVectorTest, constant) {
   }
 
   // If constant has smaller size, check that we follow the selectivity vector
-  // size.
+  // max seleced row size.
   {
     const vector_size_t selectivityVectorSize = 100;
     auto constant = BaseVector::createConstant(
         BIGINT(), variant::create<TypeKind::BIGINT>(123), 1, pool_.get());
-    BaseVector::ensureWritable(
-        SelectivityVector::empty(selectivityVectorSize),
-        BIGINT(),
-        pool_.get(),
-        constant);
+    SelectivityVector rows(selectivityVectorSize);
+    rows.setValid(99, false);
+    rows.updateBounds();
+    BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
-    EXPECT_EQ(selectivityVectorSize, constant->size());
+    EXPECT_EQ(99, constant->size());
   }
 
   // If constant has larger size, check that we follow the constant vector


### PR DESCRIPTION
Summary:
Using rows.size() over-allocates, over copies, and in some cases can lead to bugs,
when manually constructing vectors with some reuse of input vectors
components. Since inputs sizes could be less than rows.size()

Differential Revision: D44518108

