### PR TITLE
FIX: use rows.end() instead of rows.size() in vector operations and expression eval.

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -316,7 +316,7 @@ void Expr::evalSimplifiedImpl(
     if (!remainingRows.hasSelections()) {
       releaseInputValues(context);
       result =
-          BaseVector::createNullConstant(type(), rows.size(), context.pool());
+          BaseVector::createNullConstant(type(), rows.end(), context.pool());
       return;
     }
 
@@ -338,7 +338,7 @@ void Expr::evalSimplifiedImpl(
         if (!remainingRows.hasSelections()) {
           releaseInputValues(context);
           result = BaseVector::createNullConstant(
-              type(), rows.size(), context.pool());
+              type(), rows.end(), context.pool());
           return;
         }
       }
@@ -535,7 +535,7 @@ void Expr::evalFlatNoNullsImpl(
       // No need to re-evaluate constant expression. Simply move constant values
       // from constantInputs_.
       inputValues_[i] = std::move(constantInputs_[i]);
-      inputValues_[i]->resize(rows.size());
+      inputValues_[i]->resize(rows.end());
     } else {
       inputs_[i]->evalFlatNoNulls(rows, context, inputValues_[i]);
     }
@@ -643,7 +643,7 @@ void Expr::evaluateSharedSubexpr(
     eval(rows, context, result);
 
     if (!sharedSubexprRows) {
-      sharedSubexprRows = context.execCtx()->getSelectivityVector(rows.size());
+      sharedSubexprRows = context.execCtx()->getSelectivityVector(rows.end());
     }
 
     *sharedSubexprRows = rows;
@@ -1035,7 +1035,7 @@ void Expr::setAllNulls(
     result->addNulls(notNulls.get()->asRange().bits(), rows);
     return;
   }
-  result = BaseVector::createNullConstant(type(), rows.size(), context.pool());
+  result = BaseVector::createNullConstant(type(), rows.end(), context.pool());
 }
 
 namespace {

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -75,13 +75,13 @@ void FieldReference::evalSpecialForm(
     }
     // The caller relies on vectors having a meaningful size. If we
     // have a constant that is not wrapped in anything we set its size
-    // to correspond to rows.size(). This is in place for unique ones
+    // to correspond to rows.end(). This is in place for unique ones
     // and a copy otherwise.
     if (!useDecode && child->isConstantEncoding()) {
       if (isUniqueChild) {
-        child->resize(rows.size());
+        child->resize(rows.end());
       } else {
-        child = BaseVector::wrapInConstant(rows.size(), 0, child);
+        child = BaseVector::wrapInConstant(rows.end(), 0, child);
       }
     }
     result = useDecode ? std::move(decoded.wrap(child, *input, rows.end()))

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -489,7 +489,7 @@ std::string BaseVector::toString(
 }
 
 void BaseVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), length_);
   if (nulls_ && !(nulls_->unique() && nulls_->isMutable())) {
     BufferPtr newNulls = AlignedBuffer::allocate<bool>(newSize, pool_);
     auto rawNewNulls = newNulls->asMutable<uint64_t>();
@@ -511,9 +511,9 @@ void BaseVector::ensureWritable(
     VectorPool* vectorPool) {
   if (!result) {
     if (vectorPool) {
-      result = vectorPool->get(type, rows.size());
+      result = vectorPool->get(type, rows.end());
     } else {
-      result = BaseVector::create(type, rows.size(), pool);
+      result = BaseVector::create(type, rows.end(), pool);
     }
     return;
   }
@@ -542,7 +542,7 @@ void BaseVector::ensureWritable(
 
   // The copy-on-write size is the max of the writable row set and the
   // vector.
-  auto targetSize = std::max<vector_size_t>(rows.size(), result->size());
+  auto targetSize = std::max<vector_size_t>(rows.end(), result->size());
 
   VectorPtr copy;
   if (vectorPool) {

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -209,8 +209,7 @@ void RowVector::copy(
     BufferPtr mappedIndices;
     vector_size_t* rawMappedIndices = nullptr;
     if (toSourceRow) {
-      mappedIndices =
-          AlignedBuffer::allocate<vector_size_t>(rows.size(), pool_);
+      mappedIndices = AlignedBuffer::allocate<vector_size_t>(rows.end(), pool_);
       rawMappedIndices = mappedIndices->asMutable<vector_size_t>();
       nonNullRows.applyToSelected(
           [&](auto row) { rawMappedIndices[row] = indices[toSourceRow[row]]; });
@@ -688,7 +687,7 @@ std::string ArrayVector::toString(vector_size_t index) const {
 }
 
 void ArrayVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (offsets_ && !offsets_->unique()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);
@@ -950,7 +949,7 @@ std::string MapVector::toString(vector_size_t index) const {
 }
 
 void MapVector::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (offsets_ && !offsets_->unique()) {
     BufferPtr newOffsets =
         AlignedBuffer::allocate<vector_size_t>(newSize, BaseVector::pool_);

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -349,7 +349,7 @@ void FlatVector<T>::resize(vector_size_t newSize, bool setNotNull) {
 
 template <typename T>
 void FlatVector<T>::ensureWritable(const SelectivityVector& rows) {
-  auto newSize = std::max<vector_size_t>(rows.size(), BaseVector::length_);
+  auto newSize = std::max<vector_size_t>(rows.end(), BaseVector::length_);
   if (values_ && !(values_->unique() && values_->isMutable())) {
     BufferPtr newValues;
     if constexpr (std::is_same_v<T, StringView>) {

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -421,18 +421,17 @@ TEST_F(EnsureWritableVectorTest, constant) {
   }
 
   // If constant has smaller size, check that we follow the selectivity vector
-  // size.
+  // max seleced row size.
   {
     const vector_size_t selectivityVectorSize = 100;
     auto constant = BaseVector::createConstant(
         BIGINT(), variant::create<TypeKind::BIGINT>(123), 1, pool_.get());
-    BaseVector::ensureWritable(
-        SelectivityVector::empty(selectivityVectorSize),
-        BIGINT(),
-        pool_.get(),
-        constant);
+    SelectivityVector rows(selectivityVectorSize);
+    rows.setValid(99, false);
+    rows.updateBounds();
+    BaseVector::ensureWritable(rows, BIGINT(), pool_.get(), constant);
     EXPECT_EQ(VectorEncoding::Simple::FLAT, constant->encoding());
-    EXPECT_EQ(selectivityVectorSize, constant->size());
+    EXPECT_EQ(99, constant->size());
   }
 
   // If constant has larger size, check that we follow the constant vector


### PR DESCRIPTION
Summary:
Using rows.size() instead of rows.end() over-allocates, over copies, and
in some cases can lead to bugs, e.x:when manually constructing vectors
with some reuse of input vectors components. Since inputs sizes could be less than rows.size()

Differential Revision: D44520759

