### PR TITLE
Add support to check changes in function signatures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,14 +265,6 @@ jobs:
             ccache -s
           no_output_timeout: 1h
       - run:
-          name: "Build and Test PyVelox"
-          command: |
-            conda init bash
-            source ~/.bashrc
-            conda create -y --name pyveloxenv python=3.7
-            conda activate pyveloxenv
-            LD_LIBRARY_PATH=/usr/local/lib make python-test
-      - run:
           name: "Run Unit Tests"
           command: |
             cd _build/debug && ctest -j 16 -VV --output-on-failure
@@ -338,6 +330,28 @@ jobs:
          name: "Run Example Binaries"
          command: |
            find _build/debug/velox/examples/ -maxdepth 1 -type f -executable -exec "{}" \;
+      - run:
+          name: "Build and Test PyVelox"
+          command: |
+            conda init bash
+            source ~/.bashrc
+            conda create -y --name pyveloxenv python=3.7
+            conda activate pyveloxenv
+            LD_LIBRARY_PATH=/usr/local/lib make python-test
+      - run:
+          name: "Check function signatures"
+          command: |
+            source ~/.bashrc
+            conda activate pyveloxenv
+            pip install deepdiff
+            python ./scripts/signature.py export --spark --presto /tmp/pr_signatures.json
+            cp ./scripts/signature.py /tmp/signature.py
+            git checkout main
+            LD_LIBRARY_PATH=/usr/local/lib make python-clean
+            LD_LIBRARY_PATH=/usr/local/lib make python-build
+            cp /tmp/signature.py ./scripts/signature.py
+            python ./scripts/signature.py export --spark --presto /tmp/main_signatures.json
+            python ./scripts/signature.py diff /tmp/main_signatures.json /tmp/pr_signatures.json
       - post-steps
 
   linux-build-release:

--- a/scripts/cci.py
+++ b/scripts/cci.py
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
+
 import os
 import sys
-import json
-
+import argparse
 import util
 
 CIRCLECI_V2 = "https://circleci.com/api/v2"
@@ -30,7 +29,7 @@ def get_circleci_token():
     if token is None:
         print(
             """
-            CIRCLECI_API_TOKEN is not set in the environment.  An API key is 
+            CIRCLECI_API_TOKEN is not set in the environment.  An API key is
             required to access CircleCi.  You can create an API token here :
 
                 https://circleci.com/account/api
@@ -80,7 +79,6 @@ def get_action_output(token, url):
 
 
 def output(args):
-
     github_upstream = util.run("git remote get-url --push upstream")[1].extract(
         r".*:(.*)[.]git"
     )

--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -1,0 +1,120 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import argparse
+import json
+import sys
+
+import pyvelox.pyvelox as pv
+from deepdiff import DeepDiff
+
+
+# Utility to export and diff function signatures.
+
+
+# From https://stackoverflow.com/questions/287871/how-do-i-print-colored-text-to-the-terminal
+class bcolors:
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    BOLD = "\033[1m"
+
+
+def export(args):
+    """Exports Velox function signatures."""
+    if args.spark:
+        pv.register_spark_signatures()
+
+    if args.presto:
+        pv.register_presto_signatures()
+
+    signatures = pv.get_function_signatures()
+
+    # Convert signatures to json
+    jsoned_signatures = {}
+    for key in signatures.keys():
+        jsoned_signatures[key] = [str(value) for value in signatures[key]]
+
+    # Persist to file
+    json.dump(jsoned_signatures, args.output_file)
+    return 0
+
+
+def diff(args):
+    """Diffs Velox function signatures."""
+    first_signatures = json.load(args.first)
+    second_signatures = json.load(args.second)
+    delta = DeepDiff(
+        first_signatures, second_signatures, ignore_order=True, report_repetition=True
+    )
+    exit_status = 0
+    if delta:
+        if "dictionary_item_removed" in delta:
+            print(
+                f"Signature removed: {bcolors.FAIL}{delta['dictionary_item_removed']}"
+            )
+            exit_status = 1
+
+        if "values_changed" in delta:
+            print(f"Signature changed: {bcolors.FAIL}{delta['values_changed']}")
+            exit_status = 1
+
+        if "repetition_change" in delta:
+            print(f"Signature repeated: {bcolors.FAIL}{delta['repetition_change']}")
+            exit_status = 1
+
+        if "iterable_item_removed" in delta:
+            print(
+                f"Iterable item removed: {bcolors.FAIL}{delta['iterable_item_removed']}"
+            )
+            exit_status = 1
+
+        print(f"Found differences: {bcolors.OKGREEN}{delta}")
+
+    else:
+        print(f"{bcolors.BOLD}No differences found.")
+
+    return exit_status
+
+
+def parse_args():
+    global parser
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="""Velox Function Signature Utility""",
+    )
+
+    command = parser.add_subparsers(dest="command")
+    export_command_parser = command.add_parser("export")
+    export_command_parser.add_argument("--spark", action="store_true")
+    export_command_parser.add_argument("--presto", action="store_false")
+    export_command_parser.add_argument("output_file", type=argparse.FileType("w"))
+
+    diff_command_parser = command.add_parser("diff")
+    diff_command_parser.add_argument("first", type=argparse.FileType("r"))
+    diff_command_parser.add_argument("second", type=argparse.FileType("r"))
+
+    parser.set_defaults(command="help")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    return globals()[args.command](args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Created a utility scripts/signature.py to export and diff function signatures. 

```
python ./scripts/signature.py --help                   
Usage: signature.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  diff    Diffs Velox function signatures.
  export  Exports Velox function signatures.
```

**Signature Diffs**

The diff tool will error out when :

1.  A function / or signature is removed from the incoming PR. 

```
python ./scripts/signature.py diff /tmp/presto_signatures_new.json /tmp/orig_sigs_change.json 
Signature removed: [root['test_from_base64']]
```

2. A function/ signature is changed from the incoming PR (e.g type changed etc). 

  ```
     python ./scripts/signature.py diff /tmp/orig_sigs_change.json /tmp/presto_signatures_new.json
Signature changed: {"root['to_utf8'][0]": {'new_value': '(varchar) -> varbinary', 'old_value': '(int) -> varbinary'}}
```

3. A signature is repeated from incoming PR. 
```
python ./scripts/signature.py diff /tmp/presto_signatures_new.json /tmp/presto_signatures_new_change.json
Signature repeated: {"root['to_utf8'][0]": {'old_repeat': 1, 'new_repeat': 2, 'old_indexes': [0], 'new_indexes': [0, 1], 'value': '(varchar) -> varbinary'}}
```

Addition of signatures and functions is detected but is not considered an error. 



**NOTE** 
Templated functions which have a concrete signature added which will override the template is not considered an error. 


**User workflow**

 This is intended as a tool and as such there might be cases where we genuinely need to remove / modify signatures etc. In these cases even though this tool will fail the build the merge engineer is supposed to use discretion and override the failure.  

