### PR TITLE
Add sequence Presto function

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -214,6 +214,15 @@ Array Functions
     Returns a subarray starting from index ``start``(or starting from the end
     if ``start`` is negative) with a length of ``length``.
 
+.. function:: sequence(start, stop) -> array
+
+    Generate a sequence of integers from start to stop, incrementing by 1 if start is less than or equal to stop,
+    otherwise -1.
+
+.. function:: sequence(start, stop, step) -> array
+
+    Generate a sequence of integers from start to stop, incrementing by step.
+
 .. function:: subscript(array(E), index) -> E
 
     Returns element of ``array`` at given ``index``. The index starts from one.

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
   Repeat.cpp
   Reverse.cpp
   RowFunction.cpp
+  Sequence.cpp
   Slice.cpp
   Split.cpp
   StringFunctions.cpp

--- a/velox/functions/prestosql/Sequence.cpp
+++ b/velox/functions/prestosql/Sequence.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/vector/ConstantVector.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+// See documentation at https://prestodb.io/docs/current/functions/array.html
+class SequenceFunction : public exec::VectorFunction {
+ public:
+  static constexpr int32_t kMaxResultEntries = 10'000;
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VectorPtr localResult = applyNumber(rows, args, outputType, context);
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+
+ private:
+  static VectorPtr applyNumber(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context) {
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto startVector = decodedArgs.at(0);
+    auto stopVector = decodedArgs.at(1);
+    DecodedVector* stepVector = nullptr;
+    if (args.size() == 3) {
+      stepVector = decodedArgs.at(2);
+    }
+
+    const auto numRows = rows.end();
+    auto pool = context.pool();
+    vector_size_t numElements = 0;
+
+    BufferPtr sizes = allocateSizes(numRows, pool);
+    BufferPtr offsets = allocateOffsets(numRows, pool);
+    auto rawSizes = sizes->asMutable<vector_size_t>();
+    auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      auto start = startVector->valueAt<int64_t>(row);
+      auto stop = stopVector->valueAt<int64_t>(row);
+      const int64_t step = (stepVector == nullptr)
+          ? (stop >= start ? 1 : -1)
+          : stepVector->valueAt<int64_t>(row);
+      rawSizes[row] = checkArguments(start, stop, step);
+      numElements += rawSizes[row];
+    });
+
+    VectorPtr elements = BaseVector::create(BIGINT(), numElements, pool);
+    auto rawElements = elements->asFlatVector<int64_t>()->mutableRawValues();
+
+    vector_size_t elementsOffset = 0;
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      const auto sequenceCount = rawSizes[row];
+      if (sequenceCount) {
+        rawOffsets[row] = elementsOffset;
+        writeToElements(
+            rawElements + elementsOffset,
+            sequenceCount,
+            startVector,
+            stopVector,
+            stepVector,
+            row);
+        elementsOffset += rawSizes[row];
+      }
+    });
+
+    return std::make_shared<ArrayVector>(
+        pool, outputType, nullptr, numRows, offsets, sizes, elements);
+  }
+
+  static vector_size_t
+  checkArguments(int64_t start, int64_t stop, int64_t step) {
+    VELOX_USER_CHECK_NE(step, 0, "step must not be zero");
+    VELOX_USER_CHECK(
+        step > 0 ? stop >= start : stop <= start,
+        "sequence stop value should be greater than or equal to start value if "
+        "step is greater than zero otherwise stop should be less than or equal to start")
+    auto sequenceCount = (stop - start) / step + 1;
+    VELOX_USER_CHECK_LE(
+        sequenceCount,
+        kMaxResultEntries,
+        "result of sequence function must not have more than 10000 entries");
+    return sequenceCount;
+  }
+
+  static void writeToElements(
+      int64_t* elements,
+      vector_size_t sequenceCount,
+      DecodedVector* startVector,
+      DecodedVector* stopVector,
+      DecodedVector* stepVector,
+      vector_size_t row) {
+    auto start = startVector->valueAt<int64_t>(row);
+    auto stop = stopVector->valueAt<int64_t>(row);
+    const int64_t step = (stepVector == nullptr)
+        ? (stop >= start ? 1 : -1)
+        : stepVector->valueAt<int64_t>(row);
+    for (auto i = 0; i < sequenceCount; ++i) {
+      elements[i] = start + step * i;
+    }
+  }
+};
+
+} // namespace
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+  std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
+  signatures = {
+      exec::FunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("array(bigint)")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .argumentType("bigint")
+          .build()};
+  return signatures;
+}
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_sequence,
+    signatures(),
+    std::make_unique<SequenceFunction>());
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -97,6 +97,7 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, prefix + "array_sort");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, prefix + "repeat");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_sequence, prefix + "sequence");
 
   exec::registerStatefulVectorFunction(
       prefix + "width_bucket",

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_executable(
   RoundTest.cpp
   ScalarFunctionRegTest.cpp
   SliceTest.cpp
+  SequenceTest.cpp
   SplitTest.cpp
   StringFunctionsTest.cpp
   TransformTest.cpp

--- a/velox/functions/prestosql/tests/SequenceTest.cpp
+++ b/velox/functions/prestosql/tests/SequenceTest.cpp
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class SequenceTest : public FunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  void testExpressionWithError(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const std::string& expectedError) {
+    VELOX_ASSERT_THROW(
+        evaluate(expression, makeRowVector(input)), expectedError);
+  }
+};
+} // namespace
+
+TEST_F(SequenceTest, sequence) {
+  const auto startVector = makeFlatVector<int64_t>({1, 2, 10});
+  const auto stopVector = makeFlatVector<int64_t>({2, 5, 9});
+  VectorPtr expected =
+      makeArrayVector<int64_t>({{1, 2}, {2, 3, 4, 5}, {10, 9}});
+  testExpression("sequence(C0, C1)", {startVector, stopVector}, expected);
+}
+
+TEST_F(SequenceTest, negative) {
+  const auto startVector = makeFlatVector<int64_t>({-1, -2, -10});
+  const auto stopVector = makeFlatVector<int64_t>({-2, -5, -9});
+  VectorPtr expected =
+      makeArrayVector<int64_t>({{-1, -2}, {-2, -3, -4, -5}, {-10, -9}});
+  testExpression("sequence(C0, C1)", {startVector, stopVector}, expected);
+}
+
+TEST_F(SequenceTest, step) {
+  const auto startVector = makeFlatVector<int64_t>({1, 2, 10});
+  const auto stopVector = makeFlatVector<int64_t>({2, 5, 9});
+  const auto stepVector = makeFlatVector<int64_t>({2, 2, -1});
+  VectorPtr expected = makeArrayVector<int64_t>({{1}, {2, 4}, {10, 9}});
+  testExpression(
+      "sequence(C0, C1, C2)", {startVector, stopVector, stepVector}, expected);
+}
+
+TEST_F(SequenceTest, constant) {
+  const auto endVector = makeFlatVector<int64_t>({2, 5, 1});
+  VectorPtr expected = makeArrayVector<int64_t>({{1, 2}, {1, 2, 3, 4, 5}, {1}});
+  testExpression("sequence(1, C0)", {endVector}, expected);
+}
+
+TEST_F(SequenceTest, null) {
+  const auto startVector = makeNullableFlatVector<int64_t>({std::nullopt, 2});
+  const auto stopVector = makeFlatVector<int64_t>({2, 5});
+  VectorPtr expected = makeNullableArrayVector<int64_t>({
+      std::nullopt,
+      {{2, 3, 4, 5}},
+  });
+  testExpression("sequence(C0, C1)", {startVector, stopVector}, expected);
+}
+
+TEST_F(SequenceTest, exceedMaxEntries) {
+  const auto startVector = makeFlatVector<int64_t>({1, 100});
+  const auto stopVector = makeFlatVector<int64_t>({100000, 100});
+  testExpressionWithError(
+      "sequence(C0, C1)",
+      {startVector, stopVector},
+      "result of sequence function must not have more than 10000 entries");
+
+  VectorPtr expected = makeNullableArrayVector<int64_t>({
+      std::nullopt,
+      {{100}},
+  });
+  testExpression("try(sequence(C0, C1))", {startVector, stopVector}, expected);
+}
+
+TEST_F(SequenceTest, invalidStep) {
+  const auto startVector = makeFlatVector<int64_t>({1, 2});
+  const auto stopVector = makeFlatVector<int64_t>({2, 5});
+  const auto stepVector = makeFlatVector<int64_t>({0, 1});
+  testExpressionWithError(
+      "sequence(C0, C1, C2)",
+      {startVector, stopVector, stepVector},
+      "(0 vs. 0) step must not be zero");
+
+  VectorPtr expected = makeNullableArrayVector<int64_t>({
+      std::nullopt,
+      {{2, 3, 4, 5}},
+  });
+  testExpression(
+      "try(sequence(C0, C1, C2))",
+      {startVector, stopVector, stepVector},
+      expected);
+}


### PR DESCRIPTION
Added 
- [x] sequence(bigint, bigint) -> array(bigint)
- [x] sequence(bigint, bigint, bigint) -> array(bigint)

Since this is my first velox function, I will first try to finish this functionality alone in this PR before it gets too big and the rest can be a followup
- [ ] [Optimization] Add fast path when step is constant
- [ ] sequence(date, date)
- [ ] sequence(date, date, interval day to second)
- [ ] sequence(date, date, interval year to month)
- [ ] sequence(timestamp, timestamp, interval day to second)
- [ ] sequence(timestamp, timestamp, interval year to month)