### PR TITLE
Handle empty frames in Rank functions

### DIFF
--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -70,4 +70,18 @@ std::unique_ptr<WindowFunction> WindowFunction::create(
   VELOX_USER_FAIL("Window function not registered: {}", name);
 }
 
+void WindowFunction::setNullEmptyFramesResults(
+    const SelectivityVector& validRows,
+    vector_size_t resultOffset,
+    const VectorPtr& result) {
+  if (validRows.isAllSelected()) {
+    return;
+  }
+
+  invalidRows_.resizeFill(validRows.size(), true);
+  invalidRows_.deselect(validRows);
+  invalidRows_.applyToSelected(
+      [&](auto i) { result->setNull(resultOffset + i, true); });
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -104,9 +104,19 @@ class WindowFunction {
       HashStringAllocator* stringAllocator);
 
  protected:
+  // This utility function can be used across WindowFunctions to set NULL for
+  // rows with invalid frames in the input.
+  void setNullEmptyFramesResults(
+      const SelectivityVector& validRows,
+      vector_size_t resultOffset,
+      const VectorPtr& result);
+
   const TypePtr resultType_;
   memory::MemoryPool* pool_;
   HashStringAllocator* const stringAllocator_;
+
+  // Used for setting null for empty frames.
+  SelectivityVector invalidRows_;
 };
 
 /// Information from the Window operator that is useful for the function logic.

--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -38,7 +38,7 @@ class CumeDistFunction : public exec::WindowFunction {
       const BufferPtr& peerGroupEnds,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
-      const SelectivityVector& /*validRows*/,
+      const SelectivityVector& validRows,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);
@@ -55,6 +55,9 @@ class CumeDistFunction : public exec::WindowFunction {
       }
       rawValues[resultOffset + i] = cumeDist_;
     }
+
+    // Set NULL values for rows with empty frames.
+    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -67,7 +67,7 @@ class NtileFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
-      const SelectivityVector& /*validRows*/,
+      const SelectivityVector& validRows,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);
@@ -79,6 +79,9 @@ class NtileFunction : public exec::WindowFunction {
     }
 
     partitionOffset_ += numRows;
+
+    // Set NULL values for rows with empty frames.
+    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -48,7 +48,7 @@ class RankFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
-      const SelectivityVector& /*validRows*/,
+      const SelectivityVector& validRows,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);
@@ -78,6 +78,9 @@ class RankFunction : public exec::WindowFunction {
       }
       previousPeerCount_ += 1;
     }
+
+    // Set NULL values for rows with empty frames.
+    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/RowNumber.cpp
+++ b/velox/functions/prestosql/window/RowNumber.cpp
@@ -36,7 +36,7 @@ class RowNumberFunction : public exec::WindowFunction {
       const BufferPtr& /*peerGroupEnds*/,
       const BufferPtr& /*frameStarts*/,
       const BufferPtr& /*frameEnds*/,
-      const SelectivityVector& /*validRows*/,
+      const SelectivityVector& validRows,
       vector_size_t resultOffset,
       const VectorPtr& result) override {
     int numRows = peerGroupStarts->size() / sizeof(vector_size_t);
@@ -44,6 +44,9 @@ class RowNumberFunction : public exec::WindowFunction {
     for (int i = 0; i < numRows; i++) {
       rawValues[resultOffset + i] = rowNumber_++;
     }
+
+    // Set NULL values for rows with empty frames.
+    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -27,7 +27,8 @@ class NtileTest : public WindowTestBase {
     // Tests ntile with constant value arguments.
     testNtileWithConstants(vectors, kOverClauses);
     // Tests ntile with a column.
-    WindowTestBase::testWindowFunction(vectors, "ntile(c2)", kOverClauses);
+    WindowTestBase::testWindowFunction(
+        vectors, "ntile(c2)", kOverClauses, kFrameClauses);
   }
 
  private:
@@ -41,7 +42,7 @@ class NtileTest : public WindowTestBase {
     // TODO: Add null value testing also pending issues with DuckDB.
     for (auto i = 1; i < 20; i += 3) {
       WindowTestBase::testWindowFunction(
-          vectors, fmt::format("ntile({})", i), overClauses);
+          vectors, fmt::format("ntile({})", i), overClauses, kFrameClauses);
     }
   }
 };

--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -46,7 +46,8 @@ class RankTestBase : public WindowTestBase {
       : function_(testParam.function), overClause_(testParam.overClause) {}
 
   void testWindowFunction(const std::vector<RowVectorPtr>& vectors) {
-    WindowTestBase::testWindowFunction(vectors, function_, {overClause_});
+    WindowTestBase::testWindowFunction(
+        vectors, function_, {overClause_}, kFrameClauses);
   }
 
   const std::string function_;


### PR DESCRIPTION
In rank functions, computation has to be performed across all rows. However, null values have to be assigned post processing to the rows with empty frames.