### PR TITLE
Fix all null values in map cast

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -608,7 +608,7 @@ void CastExpr::apply(
   VectorPtr localResult;
   if (!nonNullRows->hasSelections()) {
     localResult =
-        BaseVector::createNullConstant(toType, rows.end(), context.pool());
+        BaseVector::createNullConstant(toType, rows.size(), context.pool());
   } else if (decoded->isIdentityMapping()) {
     applyPeeled(
         *nonNullRows, *decoded->base(), context, fromType, toType, localResult);


### PR DESCRIPTION
If a cast of a map value fails, the value becomes a null if errors are not thrown. The case of all nulls resulted in a null constant with 0 values, which is an inconsistent map. Instead, the values constant must have the size of the keys vector.