### PR TITLE
Docs typo for scalar-functions

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -1207,7 +1207,7 @@ The map_keys function takes any map and returns an array of map keys.
 
     // map(K,V) -> array(K)
     exec::FunctionSignatureBuilder()
-      .knownTypeVariable("K)
+      .knownTypeVariable("K")
       .typeVariable("V")
       .returnType("array(K)")
       .argumentType("map(K,V)")


### PR DESCRIPTION
Fix docs typo for scalar-functions.rst.