### PR TITLE
Add options to disable usage tracking in memory pool

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -84,7 +84,8 @@ uint16_t MemoryManager::alignment() const {
 std::shared_ptr<MemoryPool> MemoryManager::getPool(
     const std::string& name,
     MemoryPool::Kind kind,
-    int64_t maxBytes) {
+    int64_t maxBytes,
+    bool trackUsage) {
   std::string poolName = name;
   if (poolName.empty()) {
     static std::atomic<int64_t> poolId{0};
@@ -98,6 +99,7 @@ std::shared_ptr<MemoryPool> MemoryManager::getPool(
   MemoryPool::Options options;
   options.alignment = alignment_;
   options.capacity = maxBytes;
+  options.trackUsage = trackUsage;
   auto pool = std::make_shared<MemoryPoolImpl>(
       this,
       poolName,

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -89,11 +89,14 @@ class IMemoryManager {
   /// 'name' is missing, the memory manager generates a default name internally
   /// to ensure uniqueness. If 'kind' is kAggregate, a root memory pool is
   /// created. Otherwise, a leaf memory pool is created as the child of the
-  /// memory manager's default root memory pool.
+  /// memory manager's default root memory pool. If 'kind' is kAggregate and
+  /// 'trackUsage' is true, then set the memory usage tracker in the created
+  /// memory pool.
   virtual std::shared_ptr<MemoryPool> getPool(
       const std::string& name = "",
       MemoryPool::Kind kind = MemoryPool::Kind::kAggregate,
-      int64_t maxBytes = kMaxMemory) = 0;
+      int64_t maxBytes = kMaxMemory,
+      bool trackUsage = true) = 0;
 
   /// Returns the number of alive memory pools allocated from getPool().
   ///
@@ -160,7 +163,8 @@ class MemoryManager final : public IMemoryManager {
   std::shared_ptr<MemoryPool> getPool(
       const std::string& name = "",
       MemoryPool::Kind kind = MemoryPool::Kind::kAggregate,
-      int64_t maxBytes = kMaxMemory) final;
+      int64_t maxBytes = kMaxMemory,
+      bool trackUsage = true) final;
 
   MemoryPool& deprecatedGetPool() final;
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -31,6 +31,21 @@ namespace {
       /* isRetriable */ true,                                       \
       "Exceeded memory manager cap of {} MB",                       \
       (cap) / 1024 / 1024);
+
+std::shared_ptr<MemoryUsageTracker> createMemoryUsageTracker(
+    MemoryPool* parent,
+    MemoryPool::Kind kind,
+    const MemoryPool::Options& options) {
+  if (parent == nullptr) {
+    return options.trackUsage ? MemoryUsageTracker::create(options.capacity)
+                              : nullptr;
+  }
+  if (parent->getMemoryUsageTracker() == nullptr) {
+    return nullptr;
+  }
+  return parent->getMemoryUsageTracker()->addChild(
+      kind == MemoryPool::Kind::kLeaf);
+}
 } // namespace
 
 MemoryPool::MemoryPool(
@@ -170,16 +185,15 @@ MemoryPoolImpl::MemoryPoolImpl(
     const Options& options)
     : MemoryPool{name, kind, parent, options},
       memoryUsageTracker_(
-          parent_ == nullptr ? MemoryUsageTracker::create(options.capacity)
-                             : parent->getMemoryUsageTracker()->addChild(
-                                   kind == MemoryPool::Kind::kLeaf)),
+          createMemoryUsageTracker(parent_.get(), kind, options)),
       memoryManager_{memoryManager},
       allocator_{&memoryManager_->getAllocator()},
       destructionCb_(std::move(destructionCb)),
       localMemoryUsage_{} {}
 
 MemoryPoolImpl::~MemoryPoolImpl() {
-  if (FLAGS_velox_memory_leak_check_enabled) {
+  if (FLAGS_velox_memory_leak_check_enabled &&
+      (memoryUsageTracker_ != nullptr)) {
     const auto remainingBytes = memoryUsageTracker_->currentBytes();
     VELOX_CHECK_EQ(
         0,
@@ -427,7 +441,9 @@ void MemoryPoolImpl::updateSubtreeMemoryUsage(
 void MemoryPoolImpl::reserve(int64_t size) {
   checkMemoryAllocation();
 
-  memoryUsageTracker_->update(size);
+  if (memoryUsageTracker_ != nullptr) {
+    memoryUsageTracker_->update(size);
+  }
   localMemoryUsage_.incrementCurrentBytes(size);
 
   bool success = memoryManager_->reserve(size);
@@ -446,6 +462,8 @@ void MemoryPoolImpl::release(int64_t size) {
 
   memoryManager_->release(size);
   localMemoryUsage_.incrementCurrentBytes(-size);
-  memoryUsageTracker_->update(-size);
+  if (memoryUsageTracker_ != nullptr) {
+    memoryUsageTracker_->update(-size);
+  }
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -105,6 +105,13 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     uint16_t alignment{MemoryAllocator::kMaxAlignment};
     /// Specifies the memory capacity of this memory pool.
     int64_t capacity{kMaxMemory};
+    /// If true, creates the memory usage tracker on constructor to track usage.
+    /// Otherwise not.
+    ///
+    /// NOTE: there are some use cases which doesn't need memory usage tracking
+    /// but sensitive to its cpu cost so we provide an options for user to turn
+    /// it off.
+    bool trackUsage{true};
   };
 
   /// Constructs a named memory pool with specified 'name', 'parent' and 'kind'.

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -1873,6 +1873,21 @@ TEST_P(MemoryPoolTest, concurrentPoolStructureAccess) {
   ASSERT_EQ(root->getChildCount(), 0);
 }
 
+TEST_P(MemoryPoolTest, usageTrackerOptionTest) {
+  auto manager = getMemoryManager(8 * GB);
+  std::vector<bool> trackUsages = {false, true};
+  for (const auto trackUsage : trackUsages) {
+    auto root = manager->getPool(
+        "usageTrackerOptionTest",
+        MemoryPool::Kind::kAggregate,
+        kMaxMemory,
+        trackUsage);
+    ASSERT_EQ(trackUsage, root->getMemoryUsageTracker() != nullptr);
+    auto child = root->addChild("usageTrackerOptionTest");
+    ASSERT_EQ(trackUsage, child->getMemoryUsageTracker() != nullptr);
+  }
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     MemoryPoolTestSuite,
     MemoryPoolTest,


### PR DESCRIPTION
Some meta internal user are very sensitive to cpu cost of memory
usage tracking and provide an option to allow user to turn it off.
The option is only provided for the root memory pool creation and
all the child pools inherit this property.