### PR TITLE
Enable MmapAllocator to be able to reserve space for std::malloc

### DIFF
--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -187,8 +187,6 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   virtual ~MemoryAllocator() = default;
 
   static constexpr int32_t kMaxSizeClasses = 12;
-  /// Allocations smaller than 3K should go to malloc.
-  static constexpr int32_t kMaxMallocBytes = 3072;
   static constexpr uint16_t kMinAlignment = alignof(max_align_t);
   static constexpr uint16_t kMaxAlignment = 64;
 
@@ -247,19 +245,11 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// Frees contiguous 'allocation'. 'allocation' is empty on return.
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
 
-  /// Allocates 'bytes' contiguous bytes and returns the pointer to the first
-  /// byte. If 'bytes' is less than 'kMaxMallocBytes', delegates the allocation
-  /// to malloc. If the size is above that and below the largest size classes'
-  /// size, allocates one element of the next size classes' size. If 'size' is
-  /// greater than the largest size classes' size, calls allocateContiguous().
-  /// Returns nullptr if there is no space. The amount to allocate is subject to
-  /// the size limit of 'this'. This function is not virtual but calls the
-  /// virtual functions allocateNonContiguous and allocateContiguous, which can
-  /// track sizes and enforce caps etc. If 'alignment' is not kMinAlignment,
-  /// then 'bytes' must be a multiple of 'alignment'.
+  /// Allocates contiguous 'bytes' and return the first byte. Returns nullptr if
+  /// there is no space.
   ///
-  /// NOTE: 'alignment' must be power of two and in range of [kMinAlignment,
-  /// kMaxAlignment].
+  /// NOTE: 'alignment' must be power of two and in range of
+  /// [kMinAlignment, kMaxAlignment].
   virtual void* allocateBytes(
       uint64_t bytes,
       uint16_t alignment = kMinAlignment) = 0;

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -25,8 +25,13 @@ namespace facebook::velox::memory {
 MmapAllocator::MmapAllocator(const Options& options)
     : kind_(MemoryAllocator::Kind::kMmap),
       useMmapArena_(options.useMmapArena),
+      maxMallocBytes_(options.maxMallocBytes),
+      mallocReservedBytes_(
+          maxMallocBytes_ == 0
+              ? 0
+              : options.capacity * options.smallAllocationReservePct / 100),
       capacity_(bits::roundUp(
-          options.capacity / AllocationTraits::kPageSize,
+          AllocationTraits::numPages(options.capacity - mallocReservedBytes_),
           64 * sizeClassSizes_.back())) {
   for (const auto& size : sizeClassSizes_) {
     sizeClasses_.push_back(std::make_unique<SizeClass>(capacity_ / size, size));
@@ -367,7 +372,7 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
 void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
   alignmentCheck(bytes, alignment);
 
-  if (bytes <= kMaxMallocBytes) {
+  if (useMalloc(bytes)) {
     auto* result = alignment > kMinAlignment ? ::aligned_alloc(alignment, bytes)
                                              : ::malloc(bytes);
     if (FOLLY_UNLIKELY(result == nullptr)) {
@@ -405,7 +410,7 @@ void* MmapAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
 }
 
 void MmapAllocator::freeBytes(void* p, uint64_t bytes) noexcept {
-  if (bytes <= kMaxMallocBytes) {
+  if (useMalloc(bytes)) {
     ::free(p); // NOLINT
     return;
   }
@@ -877,6 +882,10 @@ bool MmapAllocator::checkConsistency() const {
                          << " errors";
   }
   return numErrors == 0;
+}
+
+bool MmapAllocator::useMalloc(uint64_t bytes) {
+  return (maxMallocBytes_ != 0) && (bytes <= maxMallocBytes_);
 }
 
 std::string MmapAllocator::toString() const {

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -60,6 +60,21 @@ class MmapAllocator : public MemoryAllocator {
     /// Used to determine MmapArena capacity. The ratio represents system memory
     /// capacity to single MmapArena capacity ratio.
     int32_t mmapArenaCapacityRatio = 10;
+
+    /// If not zero, reserve 'smallAllocationReservePct'% of space from
+    /// 'capacity' for ad hoc small allocations. And those allocations are
+    /// delegated to std::malloc.
+    ///
+    /// NOTE: if 'maxMallocBytes' is 0, this value will be disregarded.
+    uint32_t smallAllocationReservePct = 0;
+
+    /// The allocation threshold less than which an allocation is delegated to
+    /// std::malloc().
+    ///
+    /// NOTE: if it is zero, then we don't delegate any allocation std::malloc,
+    /// and 'smallAllocationReservePct' will be automatically set to 0
+    /// disregarding any passed in value.
+    int32_t maxMallocBytes = 3072;
   };
 
   explicit MmapAllocator(const Options& options);
@@ -97,6 +112,19 @@ class MmapAllocator : public MemoryAllocator {
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
 
+  /// Allocates 'bytes' contiguous bytes and returns the pointer to the first
+  /// byte. If 'bytes' is less than 'maxMallocBytes_', delegates the allocation
+  /// to malloc. If the size is above that and below the largest size classes'
+  /// size, allocates one element of the next size classes' size. If 'size' is
+  /// greater than the largest size classes' size, calls allocateContiguous().
+  /// Returns nullptr if there is no space. The amount to allocate is subject to
+  /// the size limit of 'this'. This function is not virtual but calls the
+  /// virtual functions allocateNonContiguous and allocateContiguous, which can
+  /// track sizes and enforce caps etc. If 'alignment' is not kMinAlignment,
+  /// then 'bytes' must be a multiple of 'alignment'.
+  ///
+  /// NOTE: 'alignment' must be power of two and in range of [kMinAlignment,
+  /// kMaxAlignment].
   void* allocateBytes(uint64_t bytes, uint16_t alignment) override;
 
   void freeBytes(void* p, uint64_t bytes) noexcept override;
@@ -111,6 +139,14 @@ class MmapAllocator : public MemoryAllocator {
 
   MachinePageCount capacity() const {
     return capacity_;
+  }
+
+  int32_t maxMallocBytes() const {
+    return maxMallocBytes_;
+  }
+
+  size_t mallocReservedBytes() const {
+    return mallocReservedBytes_;
   }
 
   MachinePageCount numAllocated() const override {
@@ -317,6 +353,8 @@ class MmapAllocator : public MemoryAllocator {
   // advises them away. Returns the number of pages advised away.
   MachinePageCount adviseAway(MachinePageCount target);
 
+  bool useMalloc(uint64_t bytes);
+
   const Kind kind_;
 
   // If set true, allocations larger than the largest size class size will be
@@ -334,7 +372,24 @@ class MmapAllocator : public MemoryAllocator {
   // 'numAllocated_' and 'numMapped_'. This counter is informational
   // only.
   std::atomic<MachinePageCount> numExternalMapped_{0};
-  MachinePageCount capacity_ = 0;
+
+  // Allocations smaller than 'maxMallocBytes' will be delegated to
+  // std::malloc().
+  //
+  // NOTE: if it is zero, then there is no delegation to std::malloc.
+  const int32_t maxMallocBytes_ = 0;
+
+  // Reserved capacity for small allocations made by MmapAllocator through
+  // std::malloc().
+  //
+  // TODO: we don't put limit on the ad hoc small memory allocation usage for
+  // now. Might consider to add later after analyzing memory metrics in prod if
+  // required.
+  const size_t mallocReservedBytes_ = 0;
+
+  // Capacity for allocations made by MmapAllocator excluding the ones delegated
+  // to std::malloc().
+  const MachinePageCount capacity_ = 0;
 
   std::vector<std::unique_ptr<SizeClass>> sizeClasses_;
 

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -52,10 +52,20 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     pool_.reset();
     MemoryAllocator::testingDestroyInstance();
     useMmap_ = GetParam();
+    maxMallocBytes_ = 3072;
     if (useMmap_) {
       MmapAllocator::Options options;
       options.capacity = kMaxMemoryAllocator;
+      options.smallAllocationReservePct = 4;
+      options.maxMallocBytes = maxMallocBytes_;
       allocator_ = std::make_shared<MmapAllocator>(options);
+      auto mmapAllocator = std::dynamic_pointer_cast<MmapAllocator>(allocator_);
+      ASSERT_EQ(
+          mmapAllocator->capacity(),
+          bits::roundUp(
+              kMaxMemoryAllocator * (100 - options.smallAllocationReservePct) /
+                  100 / AllocationTraits::kPageSize,
+              64 * mmapAllocator->sizeClasses().back()));
       MemoryAllocator::setDefaultInstance(allocator_.get());
     } else {
       allocator_ = MemoryAllocator::createDefaultInstance();
@@ -337,12 +347,65 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
   }
 
   bool useMmap_;
+  int32_t maxMallocBytes_;
   std::shared_ptr<MemoryAllocator> allocator_;
   MemoryAllocator* instance_;
   std::unique_ptr<MemoryManager> memoryManager_;
   std::shared_ptr<MemoryPool> pool_;
   std::atomic<int32_t> sequence_ = {};
 };
+
+TEST_P(MemoryAllocatorTest, mmapAllocatorInitTest) {
+  if (!useMmap_) {
+    return;
+  }
+  {
+    MmapAllocator::Options options;
+    options.capacity = kMaxMemoryAllocator;
+    options.smallAllocationReservePct = 39;
+    options.maxMallocBytes = 2999;
+    auto mmapAllocator = std::make_shared<MmapAllocator>(options);
+    auto smallAllocationBytes =
+        options.capacity * options.smallAllocationReservePct / 100;
+    EXPECT_EQ(
+        bits::roundUp(
+            AllocationTraits::numPages(options.capacity - smallAllocationBytes),
+            64 * mmapAllocator->sizeClasses().back()),
+        mmapAllocator->capacity());
+    EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
+    EXPECT_EQ(smallAllocationBytes, mmapAllocator->mallocReservedBytes());
+  }
+  {
+    MmapAllocator::Options options;
+    options.capacity = kMaxMemoryAllocator;
+    options.smallAllocationReservePct = 39;
+    options.maxMallocBytes = 0;
+    auto mmapAllocator = std::make_shared<MmapAllocator>(options);
+    EXPECT_EQ(
+        bits::roundUp(
+            AllocationTraits::numPages(kMaxMemoryAllocator),
+            64 * mmapAllocator->sizeClasses().back()),
+        mmapAllocator->capacity());
+    EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
+    EXPECT_EQ(0, mmapAllocator->mallocReservedBytes());
+  }
+  {
+    MmapAllocator::Options options;
+    options.capacity = 64 * 256 * AllocationTraits::kPageSize - 100;
+    options.smallAllocationReservePct = 10;
+    options.maxMallocBytes = 3072;
+    auto mmapAllocator = std::make_shared<MmapAllocator>(options);
+    auto smallAllocationBytes =
+        options.capacity * options.smallAllocationReservePct / 100;
+    EXPECT_EQ(
+        bits::roundUp(
+            AllocationTraits::numPages(options.capacity),
+            64 * mmapAllocator->sizeClasses().back()),
+        mmapAllocator->capacity());
+    EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
+    EXPECT_EQ(smallAllocationBytes, mmapAllocator->mallocReservedBytes());
+  }
+}
 
 TEST_P(MemoryAllocatorTest, allocationPoolTest) {
   const size_t kNumLargeAllocPages = instance_->largestSizeClass() * 2;
@@ -848,7 +911,7 @@ TEST_P(MemoryAllocatorTest, allocateBytes) {
   constexpr int32_t kNumAllocs = 50;
   // Different sizes, including below minimum and above largest size class.
   std::vector<MachinePageCount> sizes = {
-      MemoryAllocator::kMaxMallocBytes / 2,
+      (size_t)(maxMallocBytes_ / 2),
       100000,
       1000000,
       instance_->sizeClasses().back() * AllocationTraits::kPageSize + 100000};
@@ -956,7 +1019,7 @@ TEST_P(MemoryAllocatorTest, allocateZeroFilled) {
   constexpr int32_t kNumAllocs = 50;
   // Different sizes, including below minimum and above largest size class.
   const std::vector<MachinePageCount> sizes = {
-      MemoryAllocator::kMaxMallocBytes / 2,
+      (size_t)(maxMallocBytes_ / 2),
       100000,
       1000000,
       instance_->sizeClasses().back() * AllocationTraits::kPageSize + 100000};

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -113,6 +113,7 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
     return std::make_shared<MemoryManager>(options);
   }
 
+  const int32_t maxMallocBytes_ = 3072;
   const bool useMmap_;
   const bool useCache_;
   folly::Random::DefaultGenerator rng_;
@@ -1480,12 +1481,12 @@ TEST_P(MemoryPoolTest, mmapAllocatorCapAllocationError) {
     }
   } testSettings[] = {// NOTE: the failure injection only applies for
                       // allocations that are not delegated to malloc.
-                      {MemoryAllocator::kMaxMallocBytes - 1, false, false},
-                      {MemoryAllocator::kMaxMallocBytes, false, false},
-                      {MemoryAllocator::kMaxMallocBytes + 1, true, false},
-                      {MemoryAllocator::kMaxMallocBytes - 1, false, true},
-                      {MemoryAllocator::kMaxMallocBytes, false, true},
-                      {MemoryAllocator::kMaxMallocBytes + 1, true, true}};
+                      {maxMallocBytes_ - 1, false, false},
+                      {maxMallocBytes_, false, false},
+                      {maxMallocBytes_ + 1, true, false},
+                      {maxMallocBytes_ - 1, false, true},
+                      {maxMallocBytes_, false, true},
+                      {maxMallocBytes_ + 1, true, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto manager = getMemoryManager(8 * GB);
@@ -1527,12 +1528,12 @@ TEST_P(MemoryPoolTest, mmapAllocatorCapAllocationZeroFilledError) {
     }
   } testSettings[] = {// NOTE: the failure injection only applies for
                       // allocations that are not delegated to malloc.
-                      {MemoryAllocator::kMaxMallocBytes - 1, 1, false, false},
-                      {MemoryAllocator::kMaxMallocBytes, 1, false, false},
-                      {MemoryAllocator::kMaxMallocBytes + 1, 1, true, false},
-                      {MemoryAllocator::kMaxMallocBytes - 1, 1, false, true},
-                      {MemoryAllocator::kMaxMallocBytes, 1, false, true},
-                      {MemoryAllocator::kMaxMallocBytes + 1, 1, true, true}};
+                      {maxMallocBytes_ - 1, 1, false, false},
+                      {maxMallocBytes_, 1, false, false},
+                      {maxMallocBytes_ + 1, 1, true, false},
+                      {maxMallocBytes_ - 1, 1, false, true},
+                      {maxMallocBytes_, 1, false, true},
+                      {maxMallocBytes_ + 1, 1, true, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto manager = getMemoryManager(8 * GB);
@@ -1574,12 +1575,12 @@ TEST_P(MemoryPoolTest, mmapAllocatorCapReallocateError) {
     }
   } testSettings[] = {// NOTE: the failure injection only applies for
                       // allocations that are not delegated to malloc.
-                      {MemoryAllocator::kMaxMallocBytes - 1, false, false},
-                      {MemoryAllocator::kMaxMallocBytes, false, false},
-                      {MemoryAllocator::kMaxMallocBytes + 1, true, false},
-                      {MemoryAllocator::kMaxMallocBytes - 1, false, true},
-                      {MemoryAllocator::kMaxMallocBytes, false, true},
-                      {MemoryAllocator::kMaxMallocBytes + 1, true, true}};
+                      {maxMallocBytes_ - 1, false, false},
+                      {maxMallocBytes_, false, false},
+                      {maxMallocBytes_ + 1, true, false},
+                      {maxMallocBytes_ - 1, false, true},
+                      {maxMallocBytes_, false, true},
+                      {maxMallocBytes_ + 1, true, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     auto manager = getMemoryManager(8 * GB);


### PR DESCRIPTION
This PR adds 2 additional options used to construct MmapAllocator:
* smallAllocationReservePct that allows MmapAllocator to reserve a certain amount of memory space for std::malloc delegations
* maxMallocBytes that allows a configurable std::malloc delegation threshold