### PR TITLE
Fix from_utf8 Presto function

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -61,7 +61,6 @@ int main(int argc, char** argv) {
       "in",
       "element_at",
       "width_bucket",
-      "from_utf8",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(


### PR DESCRIPTION
Summary:
DecodedVector::wrap method is tricky to use. It doesn't work if vector was
decoded for a subset of rows. In this case, indices for non-decoded rows can
have garbage values causing failures in DictionaryVector constructor.

Modify from_utf8 function to not use DecodedVector::wrap.

Fixes https://github.com/facebookincubator/velox/issues/4496

Differential Revision: D44659796

