### PR TITLE
Do not throw exception when parsing array/map subscript larger than 32 bits

### DIFF
--- a/velox/type/Tokenizer.cpp
+++ b/velox/type/Tokenizer.cpp
@@ -134,9 +134,9 @@ std::unique_ptr<Subfield::PathElement> Tokenizer::matchUnquotedSubscript() {
   if (token.empty()) {
     invalidSubfieldPath();
   }
-  int index = 0;
+  long index = 0;
   try {
-    index = std::stoi(token);
+    index = std::stol(token);
   } catch (...) {
     VELOX_FAIL("Invalid index {}", token);
   }

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -135,3 +135,12 @@ TEST(SubfieldTest, hash) {
   subfields.emplace("a[\"b\"]");
   EXPECT_EQ(subfields.size(), 3);
 }
+
+TEST(SubfieldTest, longSubscript) {
+  Subfield subfield("a[3309189884973035076]");
+  ASSERT_EQ(subfield.path().size(), 2);
+  auto* longSubscript =
+      dynamic_cast<const Subfield::LongSubscript*>(subfield.path()[1].get());
+  ASSERT_TRUE(longSubscript);
+  ASSERT_EQ(longSubscript->index(), 3309189884973035076);
+}


### PR DESCRIPTION
Differential Revision: D44673059

