### PR TITLE
Add Abs and Negate for Decimal Types

### DIFF
--- a/velox/functions/lib/RegistrationHelpers.h
+++ b/velox/functions/lib/RegistrationHelpers.h
@@ -79,6 +79,12 @@ void registerUnaryFloatingPoint(const std::vector<std::string>& aliases) {
 }
 
 template <template <class> class T>
+void registerUnaryDecimals(const std::vector<std::string>& aliases) {
+  registerFunction<T, UnscaledShortDecimal, UnscaledShortDecimal>(aliases);
+  registerFunction<T, UnscaledLongDecimal, UnscaledLongDecimal>(aliases);
+}
+
+template <template <class> class T>
 void registerUnaryNumeric(const std::vector<std::string>& aliases) {
   registerUnaryIntegral<T>(aliases);
   registerUnaryFloatingPoint<T>(aliases);

--- a/velox/functions/prestosql/Arithmetic.h
+++ b/velox/functions/prestosql/Arithmetic.h
@@ -120,7 +120,13 @@ template <typename T>
 struct AbsFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, const TInput& a) {
-    result = abs(a);
+    if constexpr (
+        std::is_same_v<UnscaledShortDecimal, TInput> ||
+        std::is_same_v<UnscaledLongDecimal, TInput>) {
+      result = a < 0 ? TInput(-a.unscaledValue()) : a;
+    } else {
+      result = abs(a);
+    }
   }
 };
 
@@ -128,7 +134,13 @@ template <typename T>
 struct NegateFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, const TInput& a) {
-    result = negate(a);
+    if constexpr (
+        std::is_same_v<UnscaledShortDecimal, TInput> ||
+        std::is_same_v<UnscaledLongDecimal, TInput>) {
+      result = TInput(-a.unscaledValue());
+    } else {
+      result = negate(a);
+    }
   }
 };
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -31,6 +31,8 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerUnaryNumeric<CeilFunction>({prefix + "ceil", prefix + "ceiling"});
   registerUnaryNumeric<FloorFunction>({prefix + "floor"});
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});
+  registerUnaryDecimals<AbsFunction>({prefix + "abs"});
+  registerUnaryDecimals<NegateFunction>({prefix + "negate"});
   registerUnaryFloatingPoint<NegateFunction>({prefix + "negate"});
   registerFunction<RadiansFunction, double, double>({prefix + "radians"});
   registerFunction<DegreesFunction, double, double>({prefix + "degrees"});

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -699,5 +699,72 @@ TEST_F(ArithmeticTest, truncate) {
   EXPECT_DOUBLE_EQ(truncate(123456789012345678901.23, -21).value(), 0.0);
 }
 
+TEST_F(ArithmeticTest, absDecimals) {
+  const auto absShort = [&](std::optional<int64_t> shortValue) {
+    return evaluateOnce<UnscaledShortDecimal>(
+        "abs(c0)",
+        makeRowVector({makeNullableShortDecimalFlatVector(
+            {shortValue}, DECIMAL(18, 1))}));
+  };
+  EXPECT_EQ(absShort(10), 10);
+  EXPECT_EQ(absShort(-10), 10);
+  EXPECT_EQ(
+      absShort(
+          std::numeric_limits<UnscaledShortDecimal>::min().unscaledValue()),
+      std::numeric_limits<UnscaledShortDecimal>::max());
+  EXPECT_EQ(absShort(0), 0);
+  const auto absLong = [&](int128_t longValue) {
+    return evaluateOnce<UnscaledLongDecimal>(
+        "abs(c0)",
+        makeRowVector(
+            {makeNullableLongDecimalFlatVector({longValue}, DECIMAL(38, 1))}));
+  };
+  EXPECT_EQ(absLong(buildInt128(0xFFF, 0)), buildInt128(0xFFF, 0));
+  EXPECT_EQ(absLong(-buildInt128(0xFFF, 0)), buildInt128(0xFFF, 0));
+  EXPECT_EQ(
+      absLong(std::numeric_limits<UnscaledLongDecimal>::min().unscaledValue()),
+      std::numeric_limits<UnscaledLongDecimal>::max());
+  EXPECT_EQ(
+      absLong(std::numeric_limits<UnscaledLongDecimal>::max().unscaledValue()),
+      std::numeric_limits<UnscaledLongDecimal>::max());
+  EXPECT_EQ(absLong(0), 0);
+}
+
+TEST_F(ArithmeticTest, negateDecimals) {
+  const auto negateShort = [&](std::optional<int64_t> shortValue) {
+    return evaluateOnce<UnscaledShortDecimal>(
+        "negate(c0)",
+        makeRowVector({makeNullableShortDecimalFlatVector(
+            {shortValue}, DECIMAL(18, 1))}));
+  };
+  EXPECT_EQ(negateShort(10), -10);
+  EXPECT_EQ(negateShort(-10), 10);
+  EXPECT_EQ(
+      negateShort(
+          std::numeric_limits<UnscaledShortDecimal>::min().unscaledValue()),
+      std::numeric_limits<UnscaledShortDecimal>::max());
+  EXPECT_EQ(
+      negateShort(
+          std::numeric_limits<UnscaledShortDecimal>::max().unscaledValue()),
+      std::numeric_limits<UnscaledShortDecimal>::min());
+  EXPECT_EQ(negateShort(0), 0);
+  const auto negateLong = [&](std::optional<int128_t> longValue) {
+    return evaluateOnce<UnscaledLongDecimal>(
+        "negate(c0)",
+        makeRowVector(
+            {makeNullableLongDecimalFlatVector({longValue}, DECIMAL(38, 1))}));
+  };
+  EXPECT_EQ(negateLong(buildInt128(0xFFF, 0)), -buildInt128(0xFFF, 0));
+  EXPECT_EQ(negateLong(-buildInt128(0xFFF, 0)), buildInt128(0xFFF, 0));
+  EXPECT_EQ(
+      negateLong(
+          std::numeric_limits<UnscaledLongDecimal>::min().unscaledValue()),
+      std::numeric_limits<UnscaledLongDecimal>::max());
+  EXPECT_EQ(
+      negateLong(
+          std::numeric_limits<UnscaledLongDecimal>::max().unscaledValue()),
+      std::numeric_limits<UnscaledLongDecimal>::min());
+  EXPECT_EQ(negateLong(0), 0);
+}
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/UnscaledLongDecimal.h
+++ b/velox/type/UnscaledLongDecimal.h
@@ -99,6 +99,10 @@ struct UnscaledLongDecimal {
     return unscaledValue_ == other.unscaledValue_;
   }
 
+  bool operator==(const int128_t& other) const {
+    return unscaledValue_ == other;
+  }
+
   bool operator!=(const UnscaledLongDecimal& other) const {
     return unscaledValue_ != other.unscaledValue_;
   }

--- a/velox/type/UnscaledShortDecimal.h
+++ b/velox/type/UnscaledShortDecimal.h
@@ -55,6 +55,10 @@ struct UnscaledShortDecimal {
     return unscaledValue_ == other.unscaledValue_;
   }
 
+  bool operator==(const int64_t& other) const {
+    return unscaledValue_ == other;
+  }
+
   bool operator!=(const UnscaledShortDecimal& other) const {
     return unscaledValue_ != other.unscaledValue_;
   }


### PR DESCRIPTION
Absolute, Negate are decimal types registered as scalar functions. Added unit tests.

These are required for the TPC-DS workload.