### PR TITLE
Fix spark pmod function

### DIFF
--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -38,6 +38,7 @@ TEST_F(PmodTest, int8) {
   EXPECT_EQ(std::nullopt, pmod<int8_t>(std::nullopt, 3));
   EXPECT_EQ(INT8_MAX, pmod<int8_t>(INT8_MAX, INT8_MIN));
   EXPECT_EQ(INT8_MAX - 1, pmod<int8_t>(INT8_MIN, INT8_MAX));
+  EXPECT_EQ(0, pmod<int64_t>(INT8_MIN, -1));
 }
 
 TEST_F(PmodTest, int16) {
@@ -47,6 +48,7 @@ TEST_F(PmodTest, int16) {
   EXPECT_EQ(-8, pmod<int16_t>(-1052, -12));
   EXPECT_EQ(INT16_MAX, pmod<int16_t>(INT16_MAX, INT16_MIN));
   EXPECT_EQ(INT16_MAX - 1, pmod<int16_t>(INT16_MIN, INT16_MAX));
+  EXPECT_EQ(0, pmod<int64_t>(INT16_MIN, -1));
 }
 
 TEST_F(PmodTest, int32) {
@@ -56,6 +58,7 @@ TEST_F(PmodTest, int32) {
   EXPECT_EQ(-11, pmod<int32_t>(-15181535, -12));
   EXPECT_EQ(INT32_MAX, pmod<int32_t>(INT32_MAX, INT32_MIN));
   EXPECT_EQ(INT32_MAX - 1, pmod<int32_t>(INT32_MIN, INT32_MAX));
+  EXPECT_EQ(0, pmod<int64_t>(INT32_MIN, -1));
 }
 
 TEST_F(PmodTest, int64) {
@@ -65,6 +68,7 @@ TEST_F(PmodTest, int64) {
   EXPECT_EQ(-5, pmod<int64_t>(-15181561541535, -23));
   EXPECT_EQ(INT64_MAX, pmod<int64_t>(INT64_MAX, INT64_MIN));
   EXPECT_EQ(INT64_MAX - 1, pmod<int64_t>(INT64_MIN, INT64_MAX));
+  EXPECT_EQ(0, pmod<int64_t>(INT64_MIN, -1));
 }
 
 class RemainderTest : public SparkFunctionBaseTest {


### PR DESCRIPTION
Summary:
std::numeric_limits<int64_t>::min() % -1 could crash the program since
abs(std::numeric_limits<int64_t>::min()) can not be represented in int64_t.

Differential Revision: D44702047

