### PR TITLE
Fix presto checkedModulus function

### DIFF
--- a/velox/common/base/CheckedArithmetic.h
+++ b/velox/common/base/CheckedArithmetic.h
@@ -66,6 +66,12 @@ T checkedModulus(const T& a, const T& b) {
   if (UNLIKELY(b == 0)) {
     VELOX_ARITHMETIC_ERROR("Cannot divide by 0");
   }
+  // std::numeric_limits<int64_t>::min() % -1 could crash the program since
+  // abs(std::numeric_limits<int64_t>::min()) can not be represented in
+  // int64_t.
+  if (b == -1) {
+    return 0;
+  }
   return (a % b);
 }
 

--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -115,9 +115,10 @@ TEST_F(ArithmeticTest, mod) {
 }
 
 TEST_F(ArithmeticTest, modInt) {
-  std::vector<int64_t> numerInt = {9, 10, 0, -9, -10, -11};
-  std::vector<int64_t> denomInt = {3, -3, 11, -1, 199999, 77};
-  std::vector<int64_t> expectedInt = {0, 1, 0, 0, -10, -11};
+  std::vector<int64_t> numerInt = {
+      9, 10, 0, -9, -10, -11, std::numeric_limits<int64_t>::min()};
+  std::vector<int64_t> denomInt = {3, -3, 11, -1, 199999, 77, -1};
+  std::vector<int64_t> expectedInt = {0, 1, 0, 0, -10, -11, 0};
 
   assertExpression<int64_t, int64_t>(
       "mod(c0, c1)", numerInt, denomInt, expectedInt);


### PR DESCRIPTION
Summary:
std::numeric_limits<int64_t>::min() % -1 could crash the program since
abs(std::numeric_limits<int64_t>::min()) can not be represented in
int64_t.

Differential Revision: D44702959

