### PR TITLE
Introduce Type::name() and Type::parameters()

### DIFF
--- a/velox/expression/tests/CustomTypeTest.cpp
+++ b/velox/expression/tests/CustomTypeTest.cpp
@@ -45,6 +45,10 @@ class FancyIntType : public OpaqueType {
   }
 
   std::string toString() const override {
+    return name();
+  }
+
+  const char* name() const override {
     return "fancy_int";
   }
 };

--- a/velox/expression/tests/SignatureBinderTest.cpp
+++ b/velox/expression/tests/SignatureBinderTest.cpp
@@ -55,14 +55,14 @@ TEST(SignatureBinderTest, decimals) {
             .integerVariable("r_scale", "max(a_scale, b_scale)")
             .returnType("decimal(r_precision, r_scale)")
             .argumentType("decimal(a_precision, a_scale)")
-            .argumentType("DECIMAL(b_precision, b_scale)")
+            .argumentType("decimal(b_precision, b_scale)")
             .build();
     ASSERT_EQ(
         signature->argumentTypes()[0].toString(),
         "decimal(a_precision,a_scale)");
     ASSERT_EQ(
         signature->argumentTypes()[1].toString(),
-        "DECIMAL(b_precision,b_scale)");
+        "decimal(b_precision,b_scale)");
     testSignatureBinder(
         signature, {DECIMAL(11, 5), DECIMAL(10, 6)}, DECIMAL(13, 6));
   }

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -394,14 +394,15 @@ bool registerApproxDistinct(
     const std::string& name,
     bool hllAsFinalResult,
     bool hllAsRawInput) {
+  auto returnType = hllAsFinalResult ? "hyperloglog" : "bigint";
+
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   if (hllAsRawInput) {
-    signatures.push_back(
-        exec::AggregateFunctionSignatureBuilder()
-            .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
-            .intermediateType("varbinary")
-            .argumentType("varbinary")
-            .build());
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .returnType(returnType)
+                             .intermediateType("varbinary")
+                             .argumentType("hyperloglog")
+                             .build());
   } else {
     for (const auto& inputType :
          {"boolean",
@@ -414,20 +415,18 @@ bool registerApproxDistinct(
           "varchar",
           "timestamp",
           "date"}) {
-      signatures.push_back(
-          exec::AggregateFunctionSignatureBuilder()
-              .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
-              .intermediateType("varbinary")
-              .argumentType(inputType)
-              .build());
+      signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                               .returnType(returnType)
+                               .intermediateType("varbinary")
+                               .argumentType(inputType)
+                               .build());
 
-      signatures.push_back(
-          exec::AggregateFunctionSignatureBuilder()
-              .returnType(hllAsFinalResult ? "hyperloglog" : "bigint")
-              .intermediateType("varbinary")
-              .argumentType(inputType)
-              .argumentType("double")
-              .build());
+      signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                               .returnType(returnType)
+                               .intermediateType("varbinary")
+                               .argumentType(inputType)
+                               .argumentType("double")
+                               .build());
     }
   }
 

--- a/velox/functions/prestosql/types/HyperLogLogType.h
+++ b/velox/functions/prestosql/types/HyperLogLogType.h
@@ -36,14 +36,18 @@ class HyperLogLogType : public VarbinaryType {
     return this == &other;
   }
 
-  std::string toString() const override {
+  const char* name() const override {
     return "HYPERLOGLOG";
+  }
+
+  std::string toString() const override {
+    return name();
   }
 
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";
-    obj["type"] = "HYPERLOGLOG";
+    obj["type"] = name();
     return obj;
   }
 };

--- a/velox/functions/prestosql/types/JsonType.h
+++ b/velox/functions/prestosql/types/JsonType.h
@@ -72,14 +72,18 @@ class JsonType : public VarcharType {
     return this == &other;
   }
 
-  std::string toString() const override {
+  const char* name() const override {
     return "JSON";
+  }
+
+  std::string toString() const override {
+    return name();
   }
 
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";
-    obj["type"] = "JSON";
+    obj["type"] = name();
     return obj;
   }
 };

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -40,14 +40,23 @@ class TimestampWithTimeZoneType : public RowType {
     return this == &other;
   }
 
-  std::string toString() const override {
+  const char* name() const override {
     return "TIMESTAMP WITH TIME ZONE";
+  }
+
+  const std::vector<TypeParameter>& parameters() const override {
+    static const std::vector<TypeParameter> kEmpty = {};
+    return kEmpty;
+  }
+
+  std::string toString() const override {
+    return name();
   }
 
   folly::dynamic serialize() const override {
     folly::dynamic obj = folly::dynamic::object;
     obj["name"] = "Type";
-    obj["type"] = "TIMESTAMP WITH TIME ZONE";
+    obj["type"] = name();
     return obj;
   }
 };

--- a/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/HyperLogLogTypeTest.cpp
@@ -25,6 +25,16 @@ class HyperLogLogTypeTest : public testing::Test, public TypeTestBase {
   }
 };
 
+TEST_F(HyperLogLogTypeTest, basic) {
+  ASSERT_EQ(HYPERLOGLOG()->name(), "HYPERLOGLOG");
+  ASSERT_EQ(HYPERLOGLOG()->kindName(), "VARBINARY");
+  ASSERT_TRUE(HYPERLOGLOG()->parameters().empty());
+  ASSERT_EQ(HYPERLOGLOG()->toString(), "HYPERLOGLOG");
+
+  ASSERT_TRUE(hasType("HYPERLOGLOG"));
+  ASSERT_EQ(*getType("HYPERLOGLOG", {}), *HYPERLOGLOG());
+}
+
 TEST_F(HyperLogLogTypeTest, serde) {
   testTypeSerde(HYPERLOGLOG());
 }

--- a/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/JsonTypeTest.cpp
@@ -25,6 +25,16 @@ class JsonTypeTest : public testing::Test, public TypeTestBase {
   }
 };
 
+TEST_F(JsonTypeTest, basic) {
+  ASSERT_EQ(JSON()->name(), "JSON");
+  ASSERT_EQ(JSON()->kindName(), "VARCHAR");
+  ASSERT_TRUE(JSON()->parameters().empty());
+  ASSERT_EQ(JSON()->toString(), "JSON");
+
+  ASSERT_TRUE(hasType("JSON"));
+  ASSERT_EQ(*getType("JSON", {}), *JSON());
+}
+
 TEST_F(JsonTypeTest, serde) {
   testTypeSerde(JSON());
 }

--- a/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
+++ b/velox/functions/prestosql/types/tests/TimestampWithTimeZoneTypeTest.cpp
@@ -26,6 +26,17 @@ class TimestampWithTimeZoneTypeTest : public testing::Test,
   }
 };
 
+TEST_F(TimestampWithTimeZoneTypeTest, basic) {
+  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->name(), "TIMESTAMP WITH TIME ZONE");
+  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->kindName(), "ROW");
+  ASSERT_TRUE(TIMESTAMP_WITH_TIME_ZONE()->parameters().empty());
+  ASSERT_EQ(TIMESTAMP_WITH_TIME_ZONE()->toString(), "TIMESTAMP WITH TIME ZONE");
+
+  ASSERT_TRUE(hasType("TIMESTAMP WITH TIME ZONE"));
+  ASSERT_EQ(
+      *getType("TIMESTAMP WITH TIME ZONE", {}), *TIMESTAMP_WITH_TIME_ZONE());
+}
+
 TEST_F(TimestampWithTimeZoneTypeTest, serde) {
   testTypeSerde(TIMESTAMP_WITH_TIME_ZONE());
 }

--- a/velox/type/OpaqueCustomTypes.h
+++ b/velox/type/OpaqueCustomTypes.h
@@ -30,18 +30,18 @@ class CastOperator;
 // OpaqueCustomTypeRegister<T, "type"> wont compile.
 // but static constexpr char* type = "type", OpaqueCustomTypeRegister<T, type>
 // works.
-template <typename T, const char* name>
+template <typename T, const char* customTypeName>
 class OpaqueCustomTypeRegister {
  public:
   static void registerType() {
     facebook::velox::registerCustomType(
-        name, std::make_unique<const TypeFactory>());
+        customTypeName, std::make_unique<const TypeFactory>());
   }
 
   // Type used in the simple function interface as CustomType<TypeT>.
   struct TypeT {
     using type = std::shared_ptr<T>;
-    static constexpr const char* typeName = name;
+    static constexpr const char* typeName = customTypeName;
   };
 
   using SimpleType = CustomType<TypeT>;
@@ -65,7 +65,11 @@ class OpaqueCustomTypeRegister {
     }
 
     std::string toString() const override {
-      return name;
+      return customTypeName;
+    }
+
+    const char* name() const override {
+      return customTypeName;
     }
   };
 


### PR DESCRIPTION
We are working towards clean separation of logical and physical types
(see #4406).

The new Type::name() method returns logical type name. Logical type name must be
unique and can be different from the physical type name(Type::kindName()).

The new Type::parameters() method returns a possibly empty list of type
parameters. Two kinds of type parameters are supported:

- kType - a Type; for example, element type in the array type, key and value
  types in the map type, field types in the row type.
- kLongLiteral - an integer; for example, precision in a decimal type.

The new getType(name, parameters) API creates a type given logical name and a
list of parameters.

These new APIs allow to implement SignatureBinder in a cleaner way with fewer 
special cases.