### PR TITLE
Add non-local fs support and parameter tuning to velox_tpch_benchmark

### DIFF
--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_tpch_benchmark TpchBenchmark.cpp)
+add_library(velox_tpch_benchmark_lib TpchBenchmark.cpp)
 
 target_link_libraries(
-  velox_tpch_benchmark
+  velox_tpch_benchmark_lib
   velox_aggregates
   velox_exec
   velox_exec_test_lib
@@ -36,3 +36,7 @@ target_link_libraries(
   ${FOLLY_WITH_DEPENDENCIES}
   ${FOLLY_BENCHMARK}
   ${FMT})
+
+add_executable(velox_tpch_benchmark TpchBenchmarkMain.cpp)
+
+target_link_libraries(velox_tpch_benchmark velox_tpch_benchmark_lib)

--- a/velox/benchmarks/tpch/TpchBenchmark.h
+++ b/velox/benchmarks/tpch/TpchBenchmark.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+void tpchBenchmarkMain();

--- a/velox/benchmarks/tpch/TpchBenchmarkMain.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmarkMain.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/init/Init.h>
+#include <gflags/gflags.h>
+
+#include "velox/benchmarks/tpch/TpchBenchmark.h"
+
+int main(int argc, char** argv) {
+  std::string kUsage(
+      "This program benchmarks TPC-H queries. Run 'velox_tpch_benchmark -helpon=TpchBenchmark' for available options.\n");
+  gflags::SetUsageMessage(kUsage);
+  folly::init(&argc, &argv, false);
+  tpchBenchmarkMain();
+}

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -427,6 +427,9 @@ class CoalescedLoad {
     setEndState(LoadState::kCancelled);
   }
 
+  /// Returns the cache space 'this' will occupy after loaded.
+  virtual int64_t size() const = 0;
+
   virtual std::string toString() const {
     return "<CoalescedLoad>";
   }

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -254,6 +254,14 @@ class TestingCoalescedLoad : public CoalescedLoad {
     return pins;
   }
 
+  int64_t size() const override {
+    int64_t sum = 0;
+    for (auto& request : requests_) {
+      sum += request.size;
+    }
+    return sum;
+  }
+
  protected:
   std::shared_ptr<AsyncDataCache> cache_;
   std::vector<Request> requests_;

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -745,6 +745,9 @@ std::unordered_map<std::string, RuntimeCounter> HiveDataSource::runtimeStats() {
         RuntimeCounter(
             ioStats_->queryThreadIoLatency().sum() * 1000,
             RuntimeCounter::Unit::kNanos)},
+       {"overreadBytes",
+        RuntimeCounter(
+            ioStats_->rawOverreadBytes(), RuntimeCounter::Unit::kBytes)},
        {"queryThreadIoLatency",
         RuntimeCounter(ioStats_->queryThreadIoLatency().count())}});
   return res;

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -120,6 +120,10 @@ class BufferedInput {
     return nullptr;
   }
 
+  virtual int64_t prefetchSize() const {
+    return 0;
+  }
+
  protected:
   std::shared_ptr<ReadFileInputStream> input_;
   memory::MemoryPool& pool_;

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -164,6 +164,10 @@ class CachedBufferedInput : public BufferedInput {
     return executor_;
   }
 
+  int64_t prefetchSize() const override {
+    return prefetchSize_;
+  }
+
  private:
   // Sorts requests and makes CoalescedLoads for nearby requests. If 'prefetch'
   // is true, starts background loading.
@@ -198,6 +202,7 @@ class CachedBufferedInput : public BufferedInput {
   const uint64_t fileSize_;
   const int32_t loadQuantum_;
   const int32_t maxCoalesceDistance_;
+  int64_t prefetchSize_{0};
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -21,6 +21,13 @@
 #include "velox/dwio/parquet/reader/StructColumnReader.h"
 #include "velox/dwio/parquet/thrift/ThriftTransport.h"
 
+DEFINE_int32(
+    parquet_prefetch_rowgroups,
+    1,
+    "Number of next row groups to "
+    "prefetch. 1 means prefetch the next row group before decoding "
+    "the current one");
+
 namespace facebook::velox::parquet {
 
 ReaderBase::ReaderBase(
@@ -457,11 +464,20 @@ void ReaderBase::scheduleRowGroups(
     newInput->load(dwio::common::LogType::STRIPE);
     inputs_[thisGroup] = std::move(newInput);
   }
-  if (nextGroup) {
-    auto newInput = input_->clone();
-    reader.enqueueRowGroup(nextGroup, *newInput);
-    newInput->load(dwio::common::LogType::STRIPE);
-    inputs_[nextGroup] = std::move(newInput);
+  for (auto counter = 0; counter < FLAGS_parquet_prefetch_rowgroups;
+       ++counter) {
+    if (nextGroup) {
+      if (inputs_.count(nextGroup) != 0) {
+        auto newInput = input_->clone();
+        reader.enqueueRowGroup(nextGroup, *newInput);
+        newInput->load(dwio::common::LogType::STRIPE);
+        inputs_[nextGroup] = std::move(newInput);
+      }
+    } else {
+      break;
+    }
+    nextGroup =
+        nextGroup + 1 < rowGroupIds.size() ? rowGroupIds[nextGroup + 1] : 0;
   }
   if (currentGroup > 1) {
     inputs_.erase(rowGroupIds[currentGroup - 1]);

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -191,6 +191,7 @@ TEST_F(PrintPlanWithStatsTest, innerJoinWithTableScan) {
        {"          numPrefetch         [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          numRamRead          [ ]* sum: 40, count: 1, min: 40, max: 40"},
        {"          numStorageRead      [ ]* sum: .+, count: 1, min: .+, max: .+"},
+       {"          overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
        {"          prefetchBytes       [ ]* sum: .+, count: 1, min: .+, max: .+"},
        {"          preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
         true},
@@ -277,6 +278,8 @@ TEST_F(PrintPlanWithStatsTest, partialAggregateWithTableScan) {
          {"        numPrefetch      [ ]* sum: .+, count: .+, min: .+, max: .+"},
          {"        numRamRead       [ ]* sum: 6, count: 1, min: 6, max: 6"},
          {"        numStorageRead   [ ]* sum: .+, count: 1, min: .+, max: .+"},
+         {"        overreadBytes[ ]* sum: 0B, count: 1, min: 0B, max: 0B"},
+
          {"        prefetchBytes    [ ]* sum: .+, count: 1, min: .+, max: .+"},
          {"        preloadedSplits[ ]+sum: .+, count: .+, min: .+, max: .+",
           true},

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -108,7 +108,9 @@ HiveConnectorTestBase::makeHiveConnectorSplits(
     const std::string& filePath,
     uint32_t splitCount,
     dwio::common::FileFormat format) {
-  const int fileSize = fs::file_size(filePath);
+  auto file =
+      filesystems::getFileSystem(filePath, nullptr)->openFileForRead(filePath);
+  const int64_t fileSize = file->size();
   // Take the upper bound.
   const int splitSize = std::ceil((fileSize) / splitCount);
   std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>> splits;

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -65,7 +65,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       uint64_t start = 0,
       uint64_t length = std::numeric_limits<uint64_t>::max());
 
-  /// Split file at path 'filePath' into 'splitCount' splits.
+  /// Split file at path 'filePath' into 'splitCount' splits. If not local file,
+  /// file size can be given as 'externalSize'.
   static std::vector<std::shared_ptr<connector::hive::HiveConnectorSplit>>
   makeHiveConnectorSplits(
       const std::string& filePath,

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -72,10 +72,24 @@ class TpchQueryBuilder {
   /// @param queryId TPC-H query number
   TpchPlan getQueryPlan(int queryId) const;
 
+  /// Returns a plan for select max(c1), max(c2), .. from lineitem where partkey
+  /// between
+  /// ... such that 'columnPct' columns are aggregated with max(c) for numbers
+  /// and with max(length(c)) for strings. To select the columns, we sort them
+  /// by column name and take the first columnPct percent.
+  TpchPlan getIoMeterPlan(int columnPct) const;
+
   /// Get the TPC-H table names present.
   static const std::vector<std::string>& getTableNames();
 
  private:
+  // Initializes the schema information for 'tableName' from sample file at
+  // 'filePath'.
+  void readFileSchema(
+      const std::string& tableName,
+      const std::string& filePath,
+      const std::vector<std::string>& columns);
+
   TpchPlan getQ1Plan() const;
   TpchPlan getQ3Plan() const;
   TpchPlan getQ5Plan() const;


### PR DESCRIPTION
Makes TpchQueryBuilder.cpp accept a data path where each table is represented with a file listing paths to the data files.  Adds a --test_flags_file to flag to velox_tpch_benchmark. This file has one line for each flag to be included in the parameter comparison.  The line is of the form

flag:value1,value2, ... value-n

The workload will be done for all listed values of flag. If there are multiple lines all combinations of flags will be tried.

The results are presented with run times followed by the flag values used for the run, fastest run first.

Detailed output for each run, fastest first follows.

Adds flags for clearing RAM and SSD caches between runs and for adding a warmup run before the measured run.