### PR TITLE
Make layout planner immutable

### DIFF
--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -18,6 +18,75 @@
 #include "velox/dwio/dwrf/writer/LayoutPlanner.h"
 
 namespace facebook::velox::dwrf {
+namespace {
+class TestLayoutPlanner : public LayoutPlanner {
+ public:
+  using LayoutPlanner::LayoutPlanner;
+
+  const folly::F14FastMap<uint32_t, uint32_t>& getNodeToColumnMap() const {
+    return nodeToColumnMap_;
+  }
+};
+
+void testCreateNodeToColumnIdMapping(
+    const std::shared_ptr<const Type>& type,
+    const folly::F14FastMap<uint32_t, uint32_t>& expected) {
+  auto typeWithId = dwio::common::TypeWithId::create(type);
+  EXPECT_EQ(expected, TestLayoutPlanner{*typeWithId}.getNodeToColumnMap());
+}
+} // namespace
+
+TEST(LayoutPlannerTests, CreateNodeToColumnIdMapping) {
+  testCreateNodeToColumnIdMapping(ROW({BOOLEAN()}), {{0, 0}, {1, 0}});
+  testCreateNodeToColumnIdMapping(
+      ROW(
+          {BOOLEAN(),
+           TINYINT(),
+           SMALLINT(),
+           INTEGER(),
+           BIGINT(),
+           REAL(),
+           DOUBLE(),
+           VARCHAR(),
+           VARBINARY()}),
+      {{0, 0},
+       {1, 0},
+       {2, 1},
+       {3, 2},
+       {4, 3},
+       {5, 4},
+       {6, 5},
+       {7, 6},
+       {8, 7},
+       {9, 8}});
+
+  testCreateNodeToColumnIdMapping(
+      ROW(
+          {TIMESTAMP(),
+           ARRAY(REAL()),
+           MAP(INTEGER(), DOUBLE()),
+           MAP(BIGINT(), DOUBLE()),
+           MAP(BIGINT(), MAP(VARCHAR(), INTEGER())),
+           ROW({REAL(), DOUBLE()})}),
+      {{0, 0},
+       {1, 0},
+       {2, 1},
+       {3, 1},
+       {4, 2},
+       {5, 2},
+       {6, 2},
+       {7, 3},
+       {8, 3},
+       {9, 3},
+       {10, 4},
+       {11, 4},
+       {12, 4},
+       {13, 4},
+       {14, 4},
+       {15, 5},
+       {16, 5},
+       {17, 5}});
+}
 
 TEST(LayoutPlannerTests, Basic) {
   auto config = std::make_shared<Config>();
@@ -41,6 +110,22 @@ TEST(LayoutPlannerTests, Basic) {
         out.flush();
       };
 
+  auto encryptionHandler =
+      std::make_unique<velox::dwrf::encryption::EncryptionHandler>();
+  EncodingManager encodingManager{*encryptionHandler};
+  auto addEncoding = [&](uint32_t node,
+                         uint32_t seq,
+                         proto::ColumnEncoding_Kind kind,
+                         std::optional<int64_t> key = std::nullopt) {
+    auto& encoding = encodingManager.addEncodingToFooter(node);
+    encoding.set_node(node);
+    encoding.set_sequence(seq);
+    encoding.set_kind(kind);
+    if (key.has_value()) {
+      encoding.mutable_key()->set_intkey(*key);
+    }
+  };
+
   addStream(1, 2, StreamKind::StreamKind_PRESENT, 15); // 0
   addStream(1, 1, StreamKind::StreamKind_DATA, 10); // 1
   addStream(1, 1, StreamKind::StreamKind_PRESENT, 12); // 2
@@ -51,12 +136,30 @@ TEST(LayoutPlannerTests, Basic) {
   addStream(2, 0, StreamKind::StreamKind_ROW_INDEX, 100); // 7
   addStream(2, 0, StreamKind::StreamKind_DATA, 6); // 8
 
+  addEncoding(1, 0, proto::ColumnEncoding::DIRECT);
+  addEncoding(2, 0, proto::ColumnEncoding::DIRECT);
+  addEncoding(3, 0, proto::ColumnEncoding::MAP_FLAT);
+  addEncoding(5, 0, proto::ColumnEncoding::DICTIONARY);
+  addEncoding(5, 1, proto::ColumnEncoding::DIRECT, 1);
+  addEncoding(5, 2, proto::ColumnEncoding::DIRECT, 2);
+  addEncoding(6, 1, proto::ColumnEncoding::DIRECT, 1);
+  addEncoding(7, 0, proto::ColumnEncoding::MAP_FLAT);
+  addEncoding(9, 1, proto::ColumnEncoding::DIRECT, 3);
+
+  auto type = ROW({
+      INTEGER(),
+      INTEGER(),
+      MAP(INTEGER(), ARRAY(INTEGER())),
+      MAP(INTEGER(), INTEGER()),
+  });
+
   // we expect index streams to be sorted by ascending size (7, 6)
-  LayoutPlanner planner{getStreamList(context)};
-  planner.plan();
+  auto typeWithId = dwio::common::TypeWithId::create(type);
+  LayoutPlanner planner{*typeWithId};
+  auto result = planner.plan(encodingManager, getStreamList(context));
   std::vector<size_t> indices{7, 6};
   size_t pos = 0;
-  planner.iterateIndexStreams([&](auto& stream, auto& /* ignored */) {
+  result.iterateIndexStreams([&](auto& stream, auto& /* ignored */) {
     ASSERT_LT(pos, indices.size());
     ASSERT_EQ(stream, streams.at(indices[pos++]));
   });
@@ -70,7 +173,7 @@ TEST(LayoutPlannerTests, Basic) {
   // 4. for same sequence, small kind first
   std::vector<size_t> dataStreams{8, 4, 3, 5, 0, 2, 1};
   pos = 0;
-  planner.iterateDataStreams([&](auto& stream, auto& /* ignored */) {
+  result.iterateDataStreams([&](auto& stream, auto& /* ignored */) {
     ASSERT_LT(pos, dataStreams.size());
     ASSERT_EQ(stream, streams.at(dataStreams[pos++]));
   });

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -35,8 +35,7 @@ namespace facebook::velox::dwrf {
     const std::vector<VectorPtr>& batches,
     const std::shared_ptr<Config>& config,
     std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory,
-    std::function<
-        std::unique_ptr<LayoutPlanner>(StreamList, const EncodingContainer&)>
+    std::function<std::unique_ptr<LayoutPlanner>(const TypeWithId&)>
         layoutPlannerFactory,
     const int64_t writerMemoryCap) {
   // write file to memory
@@ -70,8 +69,7 @@ namespace facebook::velox::dwrf {
     size_t numStripesUpper,
     const std::shared_ptr<Config>& config,
     std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory,
-    std::function<
-        std::unique_ptr<LayoutPlanner>(StreamList, const EncodingContainer&)>
+    std::function<std::unique_ptr<LayoutPlanner>(const TypeWithId&)>
         layoutPlannerFactory,
     const int64_t writerMemoryCap,
     const bool verifyContent) {

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.h
@@ -45,9 +45,8 @@ class E2EWriterTestUtil {
       const std::shared_ptr<Config>& config,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
-      std::function<
-          std::unique_ptr<LayoutPlanner>(StreamList, const EncodingContainer&)>
-          layoutPlannerFactory = nullptr,
+      std::function<std::unique_ptr<LayoutPlanner>(
+          const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max());
 
   /**
@@ -66,9 +65,8 @@ class E2EWriterTestUtil {
       const std::shared_ptr<Config>& config,
       std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory =
           nullptr,
-      std::function<
-          std::unique_ptr<LayoutPlanner>(StreamList, const EncodingContainer&)>
-          layoutPlannerFactory = nullptr,
+      std::function<std::unique_ptr<LayoutPlanner>(
+          const dwio::common::TypeWithId&)> layoutPlannerFactory = nullptr,
       const int64_t writerMemoryCap = std::numeric_limits<int64_t>::max(),
       const bool verifyContent = true);
 

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/container/F14Map.h>
 #include "velox/common/base/GTestMacros.h"
 #include "velox/dwio/common/Common.h"
 #include "velox/dwio/dwrf/common/Common.h"
@@ -107,29 +108,40 @@ class EncodingManager : public EncodingContainer {
   std::vector<proto::StripeEncryptionGroup> encryptionGroups_;
 };
 
-class LayoutPlanner {
+class LayoutResult {
  public:
-  explicit LayoutPlanner(StreamList streamList);
-  virtual ~LayoutPlanner() = default;
+  LayoutResult(StreamList streams, size_t indexCount)
+      : streams_{std::move(streams)}, indexCount_{indexCount} {}
 
   void iterateIndexStreams(
-      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
-          consumer);
+      const std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>&
+          consumer) const;
 
   void iterateDataStreams(
-      std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>
-          consumer);
+      const std::function<void(const DwrfStreamIdentifier&, DataBufferHolder&)>&
+          consumer) const;
 
-  virtual void plan();
-
- protected:
+ private:
   StreamList streams_;
   size_t indexCount_;
+};
 
+class LayoutPlanner {
+ public:
+  explicit LayoutPlanner(const dwio::common::TypeWithId& schema);
+  virtual ~LayoutPlanner() = default;
+
+  virtual LayoutResult plan(
+      const EncodingContainer& encoding,
+      StreamList streamList) const;
+
+ protected:
   class NodeSizeSorter {
    public:
     static void sort(StreamList::iterator begin, StreamList::iterator end);
   };
+
+  folly::F14FastMap<uint32_t, uint32_t> nodeToColumnMap_;
 
   VELOX_FRIEND_TEST(LayoutPlannerTests, Basic);
 };

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -278,9 +278,8 @@ void Writer::flushStripe(bool close) {
   // deals with streams
   uint64_t indexLength = 0;
   sink.setMode(WriterSink::Mode::Index);
-  auto planner = layoutPlannerFactory_(getStreamList(context), encodingManager);
-  planner->plan();
-  planner->iterateIndexStreams([&](auto& streamId, auto& content) {
+  auto result = layoutPlanner_->plan(encodingManager, getStreamList(context));
+  result.iterateIndexStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE(
         isIndexStream(streamId.kind()),
         "unexpected stream kind ",
@@ -292,7 +291,7 @@ void Writer::flushStripe(bool close) {
 
   uint64_t dataLength = 0;
   sink.setMode(WriterSink::Mode::Data);
-  planner->iterateDataStreams([&](auto& streamId, auto& content) {
+  result.iterateDataStreams([&](auto& streamId, auto& content) {
     DWIO_ENSURE(
         !isIndexStream(streamId.kind()),
         "unexpected stream kind ",


### PR DESCRIPTION
Summary: Follow up of the previous change, that make layout planner take encoding and streams in plan() method and return layout result which in turn will have the method iterating through the streams

Differential Revision: D44699416

