### PR TITLE
Make layout planner group streams from same sequence together

### DIFF
--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -373,7 +373,7 @@ TEST(E2EWriterTests, FlushPolicyNestedTypes) {
 // Flat map has 1.5 orders of magnitude inflated stream memory usage.
 TEST(E2EWriterTests, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
-  const size_t size = 1000;
+  const size_t size = 500;
   auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
 
   HiveTypeParser parser;
@@ -391,48 +391,48 @@ TEST(E2EWriterTests, FlushPolicyFlatMap) {
       FlatMapFlushPolicyTestCase{
           /*stripeSize*/ 256 * kSizeKB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 10,
-          /*numStripesUpper*/ 10,
-          /*enableDictionary*/ true,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
-      FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
           /*numStripesLower*/ 6,
           /*numStripesUpper*/ 6,
           /*enableDictionary*/ true,
           /*enableDictionarySharing*/ false,
           /*seed*/ 1321904009},
       FlatMapFlushPolicyTestCase{
+          /*stripeSize*/ 512 * kSizeKB,
+          /*dictSize*/ std::numeric_limits<int64_t>::max(),
+          /*numStripesLower*/ 4,
+          /*numStripesUpper*/ 4,
+          /*enableDictionary*/ true,
+          /*enableDictionarySharing*/ false,
+          /*seed*/ 1321904009},
+      FlatMapFlushPolicyTestCase{
           /*stripeSize*/ 2 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 3,
-          /*numStripesUpper*/ 3,
+          /*numStripesLower*/ 2,
+          /*numStripesUpper*/ 2,
           /*enableDictionary*/ true,
           /*enableDictionarySharing*/ true,
           /*seed*/ 1321904009},
       FlatMapFlushPolicyTestCase{
           /*stripeSize*/ 256 * kSizeKB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 10,
-          /*numStripesUpper*/ 10,
-          /*enableDictionary*/ false,
-          /*enableDictionarySharing*/ false,
-          /*seed*/ 1321904009},
-      FlatMapFlushPolicyTestCase{
-          /*stripeSize*/ 512 * kSizeKB,
-          /*dictSize*/ std::numeric_limits<int64_t>::max(),
           /*numStripesLower*/ 6,
           /*numStripesUpper*/ 6,
           /*enableDictionary*/ false,
           /*enableDictionarySharing*/ false,
           /*seed*/ 1321904009},
       FlatMapFlushPolicyTestCase{
+          /*stripeSize*/ 512 * kSizeKB,
+          /*dictSize*/ std::numeric_limits<int64_t>::max(),
+          /*numStripesLower*/ 4,
+          /*numStripesUpper*/ 4,
+          /*enableDictionary*/ false,
+          /*enableDictionarySharing*/ false,
+          /*seed*/ 1321904009},
+      FlatMapFlushPolicyTestCase{
           /*stripeSize*/ 2 * kSizeMB,
           /*dictSize*/ std::numeric_limits<int64_t>::max(),
-          /*numStripesLower*/ 3,
-          /*numStripesUpper*/ 3,
+          /*numStripesLower*/ 2,
+          /*numStripesUpper*/ 2,
           /*enableDictionary*/ false,
           /*enableDictionarySharing*/ true,
           /*seed*/ 1321904009});

--- a/velox/dwio/dwrf/writer/LayoutPlanner.h
+++ b/velox/dwio/dwrf/writer/LayoutPlanner.h
@@ -136,10 +136,16 @@ class LayoutPlanner {
       StreamList streamList) const;
 
  protected:
-  class NodeSizeSorter {
-   public:
-    static void sort(StreamList::iterator begin, StreamList::iterator end);
-  };
+  static void sortBySize(
+      StreamList::iterator begin,
+      StreamList::iterator end,
+      const folly::F14FastSet<uint32_t>& flatMapCols);
+
+  // This method assumes flatmap can only be top level fields, which is enforced
+  // through the way how flatmap is configured.
+  static folly::F14FastSet<uint32_t> getFlatMapColumns(
+      const EncodingContainer& encoding,
+      const folly::F14FastMap<uint32_t, uint32_t>& nodeToColumnMap);
 
   folly::F14FastMap<uint32_t, uint32_t> nodeToColumnMap_;
 


### PR DESCRIPTION
Summary: It's highly likely same sequence of a flatmap is read together, so instead of spreading them all around, make them next to each other.

Differential Revision: D44700738

