### PR TITLE
[WIP] Adding ISAL optimization for parquet gzip decompression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
 option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
+option(VELOX_ENABLE_ISAL "Enable Intel ISAL optimizations" OFF)
 
 option(VELOX_BUILD_TEST_UTILS "Builds Velox test utilities" OFF)
 option(VELOX_BUILD_PYTHON_PACKAGE "Builds Velox Python bindings" OFF)
@@ -181,6 +182,9 @@ if(VELOX_ENABLE_PARQUET)
   # Native Parquet reader requires Apache Thrift and Arrow Parquet writer, which
   # are included in Arrow.
   set(VELOX_ENABLE_ARROW ON)
+  if(VELOX_ENABLE_ISAL)
+    add_definitions(-DVELOX_ENABLE_ISAL)
+  endif()
 endif()
 
 # Turn on Codegen only for Clang and non Mac systems.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -53,7 +53,8 @@ sudo --preserve-env apt update && apt install -y \
   bison \
   flex \
   tzdata \
-  wget
+  wget \
+  nasm
 
 function run_and_time {
   time "$@"

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,6 +15,14 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
                       "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 
+# Ensure that a default make is set
+if("${MAKE}" STREQUAL "")
+  if(NOT MSVC)
+    find_program(MAKE make)
+  endif()
+endif()
+
+
 include(ExternalProject)
 
 if(VELOX_ENABLE_ARROW)
@@ -38,6 +46,7 @@ if(VELOX_ENABLE_ARROW)
       -DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}/install
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DARROW_BUILD_STATIC=ON
+      -DSnappy_SOURCE=AUTO
       -DThrift_SOURCE=${THRIFT_SOURCE})
   set(ARROW_LIBDIR ${ARROW_PREFIX}/install/${CMAKE_INSTALL_LIBDIR})
 
@@ -90,4 +99,39 @@ if(VELOX_ENABLE_ARROW)
   set_target_properties(parquet PROPERTIES IMPORTED_LOCATION
                                            ${ARROW_LIBDIR}/libparquet.a)
 
+endif()
+
+if(VELOX_ENABLE_ISAL)
+  message(STATUS "Building isal from source")
+  set(ISAL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/isal_ep-install")
+  set(ISAL_INCLUDE_DIR "${ISAL_PREFIX}/include")
+  set(ISAL_STATIC_LIB "${ISAL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/libisal.a")
+
+  set(ISAL_CONFIGURE_ARGS
+      "--prefix=/"
+      "AR=${CMAKE_AR}"
+      "RANLIB=${CMAKE_RANLIB}"
+      "CC=${CMAKE_C_COMPILER}"
+      "CXX=${CMAKE_CXX_COMPILER}"
+      "CFLAGS=-fPIC -O3"
+      "CXXFLAGS=-fPIC -O3")
+  set(ISAL_BUILD_COMMAND ${MAKE} ${MAKE_BUILD_ARGS})
+  ExternalProject_Add(isal_ep
+                      PREFIX isal_ep
+                      UPDATE_COMMAND "./autogen.sh"
+                      CONFIGURE_COMMAND "./configure" ${ISAL_CONFIGURE_ARGS}
+                      BUILD_COMMAND ${ISAL_BUILD_COMMAND}
+                      INSTALL_COMMAND ${MAKE} install DESTDIR=${ISAL_PREFIX}
+                      BUILD_BYPRODUCTS ${ISAL_STATIC_LIB}
+                      BUILD_IN_SOURCE 1
+                      URL "https://github.com/intel/isa-l/archive/refs/tags/v2.30.0.tar.gz"
+  )
+  file(MAKE_DIRECTORY "${ISAL_INCLUDE_DIR}")
+  add_library(ISAL::isal STATIC IMPORTED GLOBAL)
+  set_target_properties(
+    ISAL::isal
+    PROPERTIES IMPORTED_LOCATION "${ISAL_STATIC_LIB}" INTERFACE_INCLUDE_DIRECTORIES
+               "${ISAL_INCLUDE_DIR}")
+  add_dependencies(ISAL::isal isal_ep)
+  include_directories(SYSTEM ${ISAL_INCLUDE_DIR})
 endif()

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -35,3 +35,10 @@ target_link_libraries(
   parquet
   thrift
   ${FMT})
+
+if(VELOX_ENABLE_ISAL)
+target_link_libraries(
+  velox_dwio_native_parquet_reader
+  ISAL::isal
+)
+endif()


### PR DESCRIPTION
This patch adds ISAL optimization on parquet gzip decompression code path. If ISAL is enabled(VELOX_ENABLE_ISAL=ON), new API from ISAl will be used for gzip decomress. On my local env, this patch could improve gzip parquet reading up to 50%, the TPCH data set is SF10 w/ gzip based Parquet format.

On this patch(w/ ISAL optmization)
```
============================================================================
[...]lox/benchmarks/tpch/TpchBenchmark.cpp     relative  time/iter   iters/s
============================================================================
q1                                                           1.45s   691.16m
q3                                                           1.53s   655.13m
q5                                                           1.64s   609.25m
q6                                                        569.27ms      1.76
q7                                                           1.41s   706.82m
q8                                                           1.48s   676.35m
q9                                                           4.53s   220.98m
q10                                                          3.35s   298.78m
q12                                                       838.26ms      1.19
q13                                                          2.75s   362.99m
q14                                                          1.50s   667.31m
q15                                                       836.71ms      1.20
q16                                                       902.75ms      1.11
q17                                                          6.21s   161.16m
q18                                                          3.19s   313.52m
q19                                                          1.45s   689.61m
q20                                                       962.05ms      1.04
q21                                                          6.87s   145.60m
q22                                                       837.19ms      1.19
```

On upstream(w/o ISAL optimization)
```
============================================================================
[...]lox/benchmarks/tpch/TpchBenchmark.cpp     relative  time/iter   iters/s
============================================================================
q1                                                           1.85s   539.15m
q3                                                           1.98s   504.54m
q5                                                           2.26s   442.76m
q6                                                        825.37ms      1.21
q7                                                           2.21s   453.31m
q8                                                           2.48s   402.95m
q9                                                           5.42s   184.58m
q10                                                          4.20s   237.85m
q12                                                          1.15s   866.29m
q13                                                          3.49s   286.67m
q14                                                          2.12s   472.52m
q15                                                          1.42s   705.89m
q16                                                       990.99ms      1.01
q17                                                          6.26s   159.77m
q18                                                          3.45s   289.79m
q19                                                          1.80s   556.69m
q20                                                          1.59s   627.49m
q21                                                          7.45s   134.28m
q22                                                          1.07s   933.02m
```

The parquet write code path is not changed in this patch.

ISA-L provides optimized low-level functions(CRC, Compression, Erasure coding) See below repo for details:
https://github.com/intel/isa-l