### PR TITLE
Safer decoding for ConstantVector<bool>

### DIFF
--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -385,6 +385,10 @@ class DecodedVector {
   // complex type.
   const void* data_ = nullptr;
 
+  // The first bit holds the value when a constant bool is decoded, and data_ in
+  // that case will refer to the address of this variable.
+  uint64_t constantBoolDataHolder_;
+
   // Null bitmask of the base vector if wrappings didn't add nulls
   // (hasExtraNulls_ is false). Otherwise, null bitmask of the base vector
   // combined with null bitmasks in all the wrappings (hasExtraNulls_ is true).


### PR DESCRIPTION
Summary:
I found a thing that I feel is "dangerous " that we do when we decode constantVector<bool> which does not produce bugs in the current usage.
but its just dangerous.

what we do is that we store a pointer to the bool value_ variable in the
constant vector and refer to that by data_ where its assumed to be
uint64_t* and not bool*
 bits::isBitSet(reinterpret_cast<const uint64_t*>(data_), index(idx))

so if dereferenced it will access that field plus other random memory.
in the case of flatVector it refers to to actual uint64_t*.

we do not have issues right with this because we isBitSet will reference the
first bit only because index would be zero, and we know the first byte is
valid.

also note that we do expose  const T* data() const {..} to user and usually with the bool case
T is considered  uint64_t*.

Differential Revision: D44743242

