### PR TITLE
Fix spark Map function

### DIFF
--- a/velox/functions/sparksql/Map.cpp
+++ b/velox/functions/sparksql/Map.cpp
@@ -40,9 +40,8 @@ void setKeysResultTyped(
     exec::EvalCtx& context,
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
-  auto flatKeys = keysResult->asFlatVector<T>()
-                      ->mutableValues(rows.size() * mapSize)
-                      ->template asMutable<T>();
+  auto flatVector = keysResult->asFlatVector<T>();
+  flatVector->resize(rows.size() * mapSize);
 
   exec::LocalDecodedVector decoded(context);
   for (vector_size_t i = 0; i < mapSize; i++) {
@@ -50,7 +49,7 @@ void setKeysResultTyped(
     // For efficiency traverse one arg at the time
     rows.applyToSelected([&](vector_size_t row) {
       VELOX_CHECK(!decoded->isNullAt(row), "Cannot use null as map key!");
-      flatKeys[row * mapSize + i] = decoded->valueAt<T>(row);
+      flatVector->set(row * mapSize + i, decoded->valueAt<T>(row));
     });
   }
 }
@@ -63,18 +62,18 @@ void setValuesResultTyped(
     exec::EvalCtx& context,
     const SelectivityVector& rows) {
   using T = typename KindToFlatVector<kind>::WrapperType;
-  auto flatValues = valuesResult->asFlatVector<T>()
-                        ->mutableValues(rows.size() * mapSize)
-                        ->template asMutable<T>();
+  auto flatVector = valuesResult->asFlatVector<T>();
+  flatVector->resize(rows.size() * mapSize);
 
   exec::LocalDecodedVector decoded(context);
   for (vector_size_t i = 0; i < mapSize; i++) {
     decoded.get()->decode(*args[i * 2 + 1], rows);
+
     rows.applyToSelected([&](vector_size_t row) {
       if (decoded->isNullAt(row)) {
-        valuesResult->asFlatVector<T>()->setNull(row * mapSize + i, true);
+        flatVector->setNull(row * mapSize + i, true);
       } else {
-        flatValues[row * mapSize + i] = decoded->valueAt<T>(row);
+        flatVector->set(row * mapSize + i, decoded->valueAt<T>(row));
       }
     });
   }

--- a/velox/functions/sparksql/tests/MapTest.cpp
+++ b/velox/functions/sparksql/tests/MapTest.cpp
@@ -66,6 +66,13 @@ TEST_F(MapTest, DifferentTypes) {
   mapSimple("map(c0, c1)", {inputVector1, inputVector2}, false, mapVector);
 }
 
+TEST_F(MapTest, boolType) {
+  auto inputVector1 = makeNullableFlatVector<bool>({1, 1, 0});
+  auto inputVector2 = makeNullableFlatVector<bool>({0, 0, 1});
+  auto mapVector = makeMapVector<bool, bool>({{{1, 0}}, {{1, 0}}, {{0, 1}}});
+  mapSimple("map(c0, c1)", {inputVector1, inputVector2}, false, mapVector);
+}
+
 TEST_F(MapTest, Wide) {
   auto inputVector1 = makeNullableFlatVector<int64_t>({1, 2, 3});
   auto inputVector2 = makeNullableFlatVector<double>({4.0, 5.0, 6.0});


### PR DESCRIPTION
Summary:
Two bugs:
1. mutableValues(size) does not extend nulls size.
2. bool need special handling.

Differential Revision: D44742987

