### PR TITLE
Add presto DATE function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -16,6 +16,10 @@ Date and Time Functions
 
     Returns ``timestamp`` as a UNIX timestamp.
 
+.. function:: date(x) -> date
+
+    Returns the same result as ``CAST(x AS DATE)``. The supported types for ``x`` are VARCHAR, TIMESTAMP, and TIMESTAMP WITH TIME ZONE.
+
 Truncation Function
 -------------------
 

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -1053,4 +1053,28 @@ struct ParseDateTimeFunction {
   }
 };
 
+template <typename T>
+struct DateFunction : public TimestampWithTimezoneSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Timestamp>& input) {
+    result = Date(input.getSeconds() / facebook::velox::util::kSecsPerDay);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<TimestampWithTimezone>& input) {
+    auto timestamp = this->toTimestamp(input);
+    result = Date(timestamp.getSeconds() / facebook::velox::util::kSecsPerDay);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Varchar>& input) {
+    result = facebook::velox::util::fromDateString(input.data(), input.size());
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -123,6 +123,10 @@ void registerSimpleFunctions(const std::string& prefix) {
       Varchar>({prefix + "parse_datetime"});
   registerFunction<DateParseFunction, Timestamp, Varchar, Varchar>(
       {prefix + "date_parse"});
+  registerFunction<DateFunction, Date, Timestamp>({prefix + "date"});
+  registerFunction<DateFunction, Date, TimestampWithTimezone>(
+      {prefix + "date"});
+  registerFunction<DateFunction, Date, Varchar>({prefix + "date"});
 }
 } // namespace
 


### PR DESCRIPTION
Addresses issue https://github.com/facebookincubator/velox/issues/4429.

Output of function test for initial commit
```
velox/_build/debug/velox/functions/prestosql/tests$ ./velox_functions_test --gtest_filter=DateTimeFunctionsTest.dateFunction
Running main() from /home/czentgr/gitspace/velox/_build/debug/_deps/gtest-src/googletest/src/gtest_main.cc
Note: Google Test filter = DateTimeFunctionsTest.dateFunction
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from DateTimeFunctionsTest
[ RUN      ] DateTimeFunctionsTest.dateFunction
WARNING: Logging before InitGoogleLogging() is written to STDERR
E0406 16:58:18.660641 48890 Exceptions.h:68] Line: /home/czentgr/gitspace/velox/velox/type/TimestampConversion.cpp:502, Function:fromDateString, Expression:  Unable to parse date value: "2012-08-09 06:00:00.000", expected format is (YYYY-MM-DD), Source: USER, ErrorCode: INVALID_ARGUMENT
E0406 16:58:18.662225 48890 Exceptions.h:68] Line: /home/czentgr/gitspace/velox/velox/type/TimestampConversion.cpp:502, Function:fromDateString, Expression:  Unable to parse date value: "foobar", expected format is (YYYY-MM-DD), Source: USER, ErrorCode: INVALID_ARGUMENT
E0406 16:58:18.663712 48890 Exceptions.h:68] Line: /home/czentgr/gitspace/velox/velox/parse/TypeResolver.cpp:111, Function:resolveScalarFunctionType, Expression:  Scalar function signature is not supported: date(BIGINT). Supported signatures: (varchar) -> date, (timestamp with time zone) -> date, (timestamp) -> date., Source: USER, ErrorCode: INVALID_ARGUMENT
[       OK ] DateTimeFunctionsTest.dateFunction (39 ms)
[----------] 1 test from DateTimeFunctionsTest (40 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (73 ms total)
[  PASSED  ] 1 test.
```


Output of fuzzer
```
velox/_build/debug/velox/expression/tests$ ./velox_expression_fuzzer_test --seed 123456 --duration_sec 60 --logtostderr=1 --minloglevel=0  --only date --v=1 2>&1 | tee fuzzertest.out
...
I0406 17:08:10.718812 49751 ExpressionFuzzer.cpp:1172] ==============================> Done with iteration 10477
I0406 17:08:10.718884 49751 ExpressionFuzzer.cpp:972] ==============================> Top 1 by number of rows processed
I0406 17:08:10.718889 49751 ExpressionFuzzer.cpp:974] Format: functionName numTimesSelected proportionOfTimesSelected numProcessedRows
I0406 17:08:10.718892 49751 ExpressionFuzzer.cpp:978] date 10478 100.00% 960982
I0406 17:08:10.718919 49751 ExpressionFuzzer.cpp:984] ==============================> Bottom 1 by number of rows processed
I0406 17:08:10.718922 49751 ExpressionFuzzer.cpp:986] Format: functionName numTimesSelected proportionOfTimesSelected numProcessedRows
I0406 17:08:10.718925 49751 ExpressionFuzzer.cpp:991] date 10478 100.00% 960982
I0406 17:08:10.718931 49751 ExpressionFuzzer.cpp:1004] ==============================> All stats sorted by number of times the function was chosen
I0406 17:08:10.718935 49751 ExpressionFuzzer.cpp:1006] Format: functionName numTimesSelected proportionOfTimesSelected numProcessedRows
I0406 17:08:10.718938 49751 ExpressionFuzzer.cpp:1010] date 10478 100.00% 960982
[==========] Running 0 tests from 0 test suites.
[==========] 0 tests from 0 test suites ran. (0 ms total)
[  PASSED  ] 0 tests.
```

