### PR TITLE
Peel past a loaded lazy layer during expression evaluation

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -124,6 +124,10 @@ bool PeeledEncoding::peelInternal(
       if (leaf == nullptr) {
         continue;
       }
+      if (leaf->isLazy() && leaf->asUnchecked<LazyVector>()->isLoaded()) {
+        auto lazy = leaf->asUnchecked<LazyVector>();
+        leaf = lazy->loadedVectorShared();
+      }
       if (!constantFields.empty() && constantFields[fieldIndex]) {
         setPeeled(leaf, fieldIndex, maybePeeled);
         continue;


### PR DESCRIPTION
Summary:
This patch enables peeling past a loaded lazy layer. This ensures
that vectors are consistently peeled across instances of shared
sub-expressions. This avoids a bug where partial peeling from a
parent expression can result in removal of lazy layer during
evaluation of children and as a result a shared sub-expressions
can sometimes be executed with inputs peeled till the lazy layer
and sometimes peeled past it.

Differential Revision: D44765830

