### PR TITLE
fix ExprDedupMap Comparer function to also check type

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -44,12 +44,6 @@ struct ITypedExprHasher {
   }
 };
 
-struct ITypedExprComparer {
-  bool operator()(const ITypedExpr* lhs, const ITypedExpr* rhs) const {
-    return *lhs == *rhs;
-  }
-};
-
 // Map for deduplicating ITypedExpr trees.
 using ExprDedupMap = folly::F14FastMap<
     const ITypedExpr*,

--- a/velox/expression/ExprCompiler.h
+++ b/velox/expression/ExprCompiler.h
@@ -31,4 +31,12 @@ std::vector<std::shared_ptr<Expr>> compileExpressions(
     ExprSet* exprSet,
     bool enableConstantFolding = true);
 
+struct ITypedExprComparer {
+  bool operator()(const core::ITypedExpr* lhs, const core::ITypedExpr* rhs)
+      const {
+    // Add check for type as == operator only checks for type kind equivalence
+    return (*lhs == *rhs) && (lhs->type() == rhs->type());
+  }
+};
+
 } // namespace facebook::velox::exec


### PR DESCRIPTION
**Root Cause**

A bug is observed for the following expression

`if(a > 0, (coalesce(cast(b as decimal(24,2)), 0) * 1), 0)`

The bug for the IF statement is actually coming up due to an incorrect result while looking for already compiled expression in scope->visited hashmap. To understand this we make note of the parser inferred types for the subexpressions with numbered ordering in then-clause and else-clause as follows:

```c++
if -> condition: (gt 
                 -> a
                 -> 0) 
   -> then-clause: (multiply                // 5. Decimal(34, 2) add both the precision, scale of expr1 & expr2
                 -> (coalesce               // 3. Decimal(24, 2)
                       -> (cast -> b),      // 1. Decimal(24, 2)
                       -> 0)                // 2. Decimal(24, 2)
                 -> 1)                      // 4. Decimal(10, 0) -> default for short decimal type
   -> else-clause: 0)                       // 6. Decimal(34, 2)
```

After inferring the types, the expressions are compiled. 
1. During this phase, the 0 from coalesce() expr is compiled and stored in the hashmap ExprDeDup under scope->visited. 
2. When compiling the else-clause, hashmap is searched for an already compiled 0. Here the hashmap uses '==' operator within the comparer function.

Since `==` ignores the precision & length difference, the 0 with type decimal(24,2) from `2.` and 0 with type decimal(34, 2) from `6.` are treated as the same ITypedExpression and cache in the same key in the hashmap. This results in the following VELOX_CHECK failure:

`thenType->equivalent(*elseClauseType) Else clause of a SWITCH statement must have the same type as 'then' clauses. Expected DECIMAL(34,2), but got DECIMAL(24,2).`

**Solution**

This issue is unique to decimal type as the other types don't differ in precision / length. So this PR adds explicit type checking to the comparator logic to differentiate them. The impact should be minimal as there can be more expressions cached in the hashmap but it doesn't impact the correctness.

Also moved the comparer to .h file and out of anonymous namespace in order to test it directly with constExprDecimalTypeCheck unit test in ExprCompileTest.cpp