### PR TITLE
Make memory pool leak check optional with gflag

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -59,14 +59,14 @@ MemoryManager::MemoryManager(const Options& options)
 }
 
 MemoryManager::~MemoryManager() {
-  VELOX_CHECK_EQ(
-      numPools(),
-      0,
-      "There are {} unexpected alive memory pools allocated by user on memory manager destruction:\n{}",
-      numPools(),
-      toString());
-
   if (FLAGS_velox_memory_leak_check_enabled) {
+    VELOX_CHECK_EQ(
+        numPools(),
+        0,
+        "There are {} unexpected alive memory pools allocated by user on memory manager destruction:\n{}",
+        numPools(),
+        toString());
+
     const auto currentBytes = getTotalBytes();
     VELOX_CHECK_EQ(
         currentBytes,


### PR DESCRIPTION
Summary:
Some Meta internal use cases still have memory pool leaks
so allow user to turn it off using gflag
The followup will add a flag inside the memory manager to allow
user to selective turn off this check instead of a global switch

Reviewed By: tanjialiang

Differential Revision: D44770581

