### PR TITLE
Support multiple HDFS endpoints

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -31,7 +31,8 @@ constexpr std::string_view kFileScheme("file:");
 
 using RegisteredFileSystems = std::vector<std::pair<
     std::function<bool(std::string_view)>,
-    std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>>>;
+    std::function<std::shared_ptr<
+        FileSystem>(std::shared_ptr<const Config>, std::string_view)>>>;
 
 RegisteredFileSystems& registeredFileSystems() {
   // Meyers singleton.
@@ -43,21 +44,22 @@ RegisteredFileSystems& registeredFileSystems() {
 
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
-    std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
-        fileSystemGenerator) {
+    std::function<std::shared_ptr<FileSystem>(
+        std::shared_ptr<const Config>,
+        std::string_view)> fileSystemGenerator) {
   registeredFileSystems().emplace_back(schemeMatcher, fileSystemGenerator);
 }
 
 std::shared_ptr<FileSystem> getFileSystem(
-    std::string_view filename,
+    std::string_view filePath,
     std::shared_ptr<const Config> properties) {
   const auto& filesystems = registeredFileSystems();
   for (const auto& p : filesystems) {
-    if (p.first(filename)) {
-      return p.second(properties);
+    if (p.first(filePath)) {
+      return p.second(properties, filePath);
     }
   }
-  VELOX_FAIL("No registered file system matched with filename '{}'", filename);
+  VELOX_FAIL("No registered file system matched with file path '{}'", filePath);
 }
 
 namespace {
@@ -171,15 +173,16 @@ class LocalFileSystem : public FileSystem {
   static std::function<bool(std::string_view)> schemeMatcher() {
     // Note: presto behavior is to prefix local paths with 'file:'.
     // Check for that prefix and prune to absolute regular paths as needed.
-    return [](std::string_view filename) {
-      return filename.find("/") == 0 || filename.find(kFileScheme) == 0;
+    return [](std::string_view filePath) {
+      return filePath.find("/") == 0 || filePath.find(kFileScheme) == 0;
     };
   }
 
-  static std::function<
-      std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
+  static std::function<std::shared_ptr<
+      FileSystem>(std::shared_ptr<const Config>, std::string_view)>
   fileSystemGenerator() {
-    return [](std::shared_ptr<const Config> properties) {
+    return [](std::shared_ptr<const Config> properties,
+              std::string_view filePath) {
       // One instance of Local FileSystem is sufficient.
       // Initialize on first access and reuse after that.
       static std::shared_ptr<FileSystem> lfs;

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -97,7 +97,7 @@ std::shared_ptr<FileSystem> getFileSystem(
 /// generates the actual file system.
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
-    std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
+    std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>, std::string_view)>
         fileSystemGenerator);
 
 /// Register the local filesystem.

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -97,8 +97,9 @@ std::shared_ptr<FileSystem> getFileSystem(
 /// generates the actual file system.
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
-    std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>, std::string_view)>
-        fileSystemGenerator);
+    std::function<std::shared_ptr<FileSystem>(
+        std::shared_ptr<const Config>,
+        std::string_view)> fileSystemGenerator);
 
 /// Register the local filesystem.
 void registerLocalFileSystem();

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -15,14 +15,16 @@
  */
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
 #include <hdfs/hdfs.h>
+#include <mutex>
+#include "folly/concurrency/ConcurrentHashMap.h"
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h"
 #include "velox/core/Context.h"
 
 namespace facebook::velox::filesystems {
-folly::once_flag hdfsInitiationFlag;
 std::string_view HdfsFileSystem::kScheme("hdfs://");
+std::mutex mtx;
 
 class HdfsFileSystem::Impl {
  public:
@@ -38,6 +40,18 @@ class HdfsFileSystem::Impl {
         hdfsGetLastError())
   }
 
+  explicit Impl(const Config* config, const HdfsServiceEndpoint& endpoint) {
+    auto builder = hdfsNewBuilder();
+    hdfsBuilderSetNameNode(builder, endpoint.host.c_str());
+    hdfsBuilderSetNameNodePort(builder, endpoint.port);
+    hdfsClient_ = hdfsBuilderConnect(builder);
+    VELOX_CHECK_NOT_NULL(
+        hdfsClient_,
+        "Unable to connect to HDFS: {}, got error: {}.",
+        endpoint.identity,
+        hdfsGetLastError())
+  }
+
   ~Impl() {
     LOG(INFO) << "Disconnecting HDFS file system";
     int disconnectResult = hdfsDisconnect(hdfsClient_);
@@ -45,19 +59,6 @@ class HdfsFileSystem::Impl {
       LOG(WARNING) << "hdfs disconnect failure in HdfsReadFile close: "
                    << errno;
     }
-  }
-
-  static HdfsServiceEndpoint getServiceEndpoint(const Config* config) {
-    auto hdfsHost = config->get("hive.hdfs.host");
-    VELOX_CHECK(
-        hdfsHost.hasValue(),
-        "hdfsHost is empty, configuration missing for hdfs host");
-    auto hdfsPort = config->get("hive.hdfs.port");
-    VELOX_CHECK(
-        hdfsPort.hasValue(),
-        "hdfsPort is empty, configuration missing for hdfs port");
-    HdfsServiceEndpoint endpoint{*hdfsHost, atoi(hdfsPort->data())};
-    return endpoint;
   }
 
   hdfsFS hdfsClient() {
@@ -71,6 +72,13 @@ class HdfsFileSystem::Impl {
 HdfsFileSystem::HdfsFileSystem(const std::shared_ptr<const Config>& config)
     : FileSystem(config) {
   impl_ = std::make_shared<Impl>(config.get());
+}
+
+HdfsFileSystem::HdfsFileSystem(
+    const std::shared_ptr<const Config>& config,
+    const HdfsServiceEndpoint& endpoint)
+    : FileSystem(config) {
+  impl_ = std::make_shared<Impl>(config.get(), endpoint);
 }
 
 std::string HdfsFileSystem::name() const {
@@ -96,17 +104,86 @@ std::unique_ptr<WriteFile> HdfsFileSystem::openFileForWrite(
   return std::make_unique<HdfsWriteFile>(impl_->hdfsClient(), path);
 }
 
-bool HdfsFileSystem::isHdfsFile(const std::string_view filename) {
-  return filename.find(kScheme) == 0;
+bool HdfsFileSystem::isHdfsFile(const std::string_view filePath) {
+  return filePath.find(kScheme) == 0;
 }
 
-static std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
-    filesystemGenerator = [](std::shared_ptr<const Config> properties) {
-      static std::shared_ptr<FileSystem> filesystem;
-      folly::call_once(hdfsInitiationFlag, [&properties]() {
-        filesystem = std::make_shared<HdfsFileSystem>(properties);
-      });
-      return filesystem;
+/**
+ * Get hdfs endpoint from config. This is applicable to the case that only one
+ * hdfs endpoint will be used.
+ */
+HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(const Config* config) {
+  auto hdfsHost = config->get("hive.hdfs.host");
+  VELOX_CHECK(
+      hdfsHost.hasValue(),
+      "hdfsHost is empty, configuration missing for hdfs host");
+  auto hdfsPort = config->get("hive.hdfs.port");
+  VELOX_CHECK(
+      hdfsPort.hasValue(),
+      "hdfsPort is empty, configuration missing for hdfs port");
+  HdfsServiceEndpoint endpoint{*hdfsHost, *hdfsPort};
+  return endpoint;
+}
+
+/**
+ * Get hdfs endpoint from a given file path, instead of getting a fixed one from
+ * configuration.
+ */
+HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(
+    const std::string_view filePath) {
+  auto index1 = filePath.find('/', kScheme.size() + 1);
+  std::string hdfsIdentity{
+      filePath.data(), kScheme.size(), index1 - kScheme.size()};
+  VELOX_CHECK(
+      !hdfsIdentity.empty(),
+      "hdfsIdentity is empty, expect hdfs endpoint host[:port] is contained in file path");
+  auto index2 = hdfsIdentity.find(':', 0);
+  // In HDFS HA mode, the hdfsIdentity is a nameservice ID with no port.
+  if (index2 == std::string::npos) {
+    HdfsServiceEndpoint endpoint{hdfsIdentity, ""};
+    return endpoint;
+  }
+  std::string host{hdfsIdentity.data(), 0, index2};
+  std::string port{
+      hdfsIdentity.data(), index2 + 1, hdfsIdentity.size() - index2 - 1};
+  HdfsServiceEndpoint endpoint{host, port};
+  return endpoint;
+}
+
+static std::function<std::shared_ptr<FileSystem>(
+    std::shared_ptr<const Config>,
+    std::string_view)>
+    filesystemGenerator = [](std::shared_ptr<const Config> properties,
+                             std::string_view filePath) {
+      static folly::ConcurrentHashMap<std::string, std::shared_ptr<FileSystem>>
+          filesystems;
+      static folly::
+          ConcurrentHashMap<std::string, std::shared_ptr<folly::once_flag>>
+              hdfsInitiationFlags;
+      auto endpoint = HdfsFileSystem::getServiceEndpoint(filePath);
+      std::string hdfsIdentity = endpoint.identity;
+      if (filesystems.find(hdfsIdentity) != filesystems.end()) {
+        return filesystems[hdfsIdentity];
+      }
+      std::unique_lock<std::mutex> lk(mtx, std::defer_lock);
+      if (hdfsInitiationFlags.find(hdfsIdentity) == hdfsInitiationFlags.end()) {
+        lk.lock();
+        if (hdfsInitiationFlags.find(hdfsIdentity) ==
+            hdfsInitiationFlags.end()) {
+          std::shared_ptr<folly::once_flag> initiationFlagPtr =
+              std::make_shared<folly::once_flag>();
+          hdfsInitiationFlags.insert(hdfsIdentity, initiationFlagPtr);
+        }
+        lk.unlock();
+      }
+      folly::call_once(
+          *hdfsInitiationFlags[hdfsIdentity].get(),
+          [&properties, endpoint, hdfsIdentity]() {
+            auto filesystem =
+                std::make_shared<HdfsFileSystem>(properties, endpoint);
+            filesystems.insert(hdfsIdentity, filesystem);
+          });
+      return filesystems[hdfsIdentity];
     };
 
 void HdfsFileSystem::remove(std::string_view path) {

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -92,20 +92,6 @@ bool HdfsFileSystem::isHdfsFile(const std::string_view filePath) {
   return filePath.find(kScheme) == 0;
 }
 
-/// Gets a fixed hdfs endpoint from config. It is used in the case that hdfs
-/// endpoint is not contained in a given file path.
-HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(const Config* config) {
-  auto hdfsHost = config->get("hive.hdfs.host");
-  VELOX_CHECK(
-      hdfsHost.hasValue(),
-      "hdfsHost is empty, configuration missing for hdfs host");
-  auto hdfsPort = config->get("hive.hdfs.port");
-  VELOX_CHECK(
-      hdfsPort.hasValue(),
-      "hdfsPort is empty, configuration missing for hdfs port");
-  return HdfsServiceEndpoint{*hdfsHost, *hdfsPort};
-}
-
 /// Gets hdfs endpoint from a given file path. If not found, fall back to get a
 /// fixed one from configuration.
 HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(
@@ -116,7 +102,15 @@ HdfsServiceEndpoint HdfsFileSystem::getServiceEndpoint(
       filePath.data(), kScheme.size(), endOfIdentityInfo - kScheme.size()};
   if (hdfsIdentity.empty()) {
     // Fall back to get a fixed endpoint from config.
-    return getServiceEndpoint(config);
+    auto hdfsHost = config->get("hive.hdfs.host");
+    VELOX_CHECK(
+        hdfsHost.hasValue(),
+        "hdfsHost is empty, configuration missing for hdfs host");
+    auto hdfsPort = config->get("hive.hdfs.port");
+    VELOX_CHECK(
+        hdfsPort.hasValue(),
+        "hdfsPort is empty, configuration missing for hdfs port");
+    return HdfsServiceEndpoint{*hdfsHost, *hdfsPort};
   }
 
   auto hostAndPortSeparator = hdfsIdentity.find(':', 0);

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -17,8 +17,14 @@
 
 namespace facebook::velox::filesystems {
 struct HdfsServiceEndpoint {
+  HdfsServiceEndpoint(std::string host, std::string port) {
+    this->host = host;
+    this->port = atoi(port.data());
+    this->identity = host + (port.empty() ? "" : ":" + port);
+  }
   std::string host;
   int port;
+  std::string identity;
 };
 
 /**
@@ -34,6 +40,9 @@ class HdfsFileSystem : public FileSystem {
 
  public:
   explicit HdfsFileSystem(const std::shared_ptr<const Config>& config);
+  explicit HdfsFileSystem(
+      const std::shared_ptr<const Config>& config,
+      const HdfsServiceEndpoint& endpoint);
 
   std::string name() const override;
 
@@ -71,6 +80,9 @@ class HdfsFileSystem : public FileSystem {
   }
 
   static bool isHdfsFile(std::string_view filename);
+  static HdfsServiceEndpoint getServiceEndpoint(const Config* config);
+  static HdfsServiceEndpoint getServiceEndpoint(
+      const std::string_view filePath);
 
  protected:
   class Impl;

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -20,6 +20,11 @@ struct HdfsServiceEndpoint {
   HdfsServiceEndpoint(const std::string& hdfsHost, const std::string& hdfsPort)
       : host(hdfsHost), port(hdfsPort) {}
 
+  /// In HDFS HA mode, the identity is a nameservice ID with no port, e.g.,
+  /// the identity is nameservice_id for
+  /// hdfs://nameservice_id/file/path/in/hdfs. Otherwise, a port must be
+  /// contained, e.g., the identity is hdfs_namenode:9000 for
+  /// hdfs://hdfs_namenode:9000/file/path/in/hdfs.
   std::string identity() const {
     return host + (port.empty() ? "" : ":" + port);
   }
@@ -80,7 +85,11 @@ class HdfsFileSystem : public FileSystem {
   }
 
   static bool isHdfsFile(std::string_view filename);
+  // Gets a fixed endpoint from config.
   static HdfsServiceEndpoint getServiceEndpoint(const Config* config);
+  /// The given filePath is used to infer hdfs endpoint. If hdfs identity is
+  /// missing from filePath, the configured "hive.hdfs.host" & "hive.hdfs.port"
+  /// will be used.
   static HdfsServiceEndpoint getServiceEndpoint(
       const std::string_view filePath,
       const Config* config);

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -85,8 +85,7 @@ class HdfsFileSystem : public FileSystem {
   }
 
   static bool isHdfsFile(std::string_view filename);
-  // Gets a fixed endpoint from config.
-  static HdfsServiceEndpoint getServiceEndpoint(const Config* config);
+
   /// The given filePath is used to infer hdfs endpoint. If hdfs identity is
   /// missing from filePath, the configured "hive.hdfs.host" & "hive.hdfs.port"
   /// will be used.

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -17,14 +17,15 @@
 
 namespace facebook::velox::filesystems {
 struct HdfsServiceEndpoint {
-  HdfsServiceEndpoint(std::string host, std::string port) {
-    this->host = host;
-    this->port = atoi(port.data());
-    this->identity = host + (port.empty() ? "" : ":" + port);
+  HdfsServiceEndpoint(const std::string& hdfsHost, const std::string& hdfsPort)
+      : host(hdfsHost), port(hdfsPort) {}
+
+  std::string identity() const {
+    return host + (port.empty() ? "" : ":" + port);
   }
-  std::string host;
-  int port;
-  std::string identity;
+
+  const std::string host;
+  const std::string port;
 };
 
 /**
@@ -39,7 +40,6 @@ class HdfsFileSystem : public FileSystem {
   static std::string_view kScheme;
 
  public:
-  explicit HdfsFileSystem(const std::shared_ptr<const Config>& config);
   explicit HdfsFileSystem(
       const std::shared_ptr<const Config>& config,
       const HdfsServiceEndpoint& endpoint);

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -82,7 +82,8 @@ class HdfsFileSystem : public FileSystem {
   static bool isHdfsFile(std::string_view filename);
   static HdfsServiceEndpoint getServiceEndpoint(const Config* config);
   static HdfsServiceEndpoint getServiceEndpoint(
-      const std::string_view filePath);
+      const std::string_view filePath,
+      const Config* config);
 
  protected:
   class Impl;

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -184,6 +184,23 @@ TEST_F(HdfsFileSystemTest, viaFileSystem) {
   readData(readFile.get());
 }
 
+TEST_F(HdfsFileSystemTest, initializeFsWithEndpointInfoInFilePath) {
+  facebook::velox::filesystems::registerHdfsFileSystem();
+  auto hdfsFileSystem =
+      filesystems::getFileSystem(fullDestinationPath, nullptr);
+  auto readFile = hdfsFileSystem->openFileForRead(fullDestinationPath);
+  readData(readFile.get());
+}
+
+TEST_F(HdfsFileSystemTest, oneFsInstanceForOneEndpoint) {
+  facebook::velox::filesystems::registerHdfsFileSystem();
+  auto hdfsFileSystem1 =
+      filesystems::getFileSystem(fullDestinationPath, nullptr);
+  auto hdfsFileSystem2 =
+      filesystems::getFileSystem(fullDestinationPath, nullptr);
+  ASSERT_TRUE(hdfsFileSystem1 == hdfsFileSystem2);
+}
+
 TEST_F(HdfsFileSystemTest, missingFileViaFileSystem) {
   try {
     facebook::velox::filesystems::registerHdfsFileSystem();
@@ -262,7 +279,7 @@ TEST_F(HdfsFileSystemTest, schemeMatching) {
     EXPECT_THAT(
         error.message(),
         testing::HasSubstr(
-            "No registered file system matched with filename '/'"));
+            "No registered file system matched with file path '/'"));
   }
   auto fs =
       std::dynamic_pointer_cast<facebook::velox::filesystems::HdfsFileSystem>(

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -149,10 +149,10 @@ void verifyFailures(ReadFile* readFile) {
           .str();
   auto builderErrorMessage =
       (boost::format(
-           "Unable to connect to HDFS, got error: Hdfs::HdfsRpcException: HdfsFailoverException: "
+           "Unable to connect to HDFS: %s, got error: Hdfs::HdfsRpcException: HdfsFailoverException: "
            "Failed to invoke RPC call \"getFsStats\" on server \"%s\"\tCaused by: "
            "HdfsNetworkConnectException: Connect to \"%s\" failed") %
-       serverAddress % serverAddress)
+       serverAddress % serverAddress % serverAddress)
           .str();
   checkReadErrorMessages(readFile, offsetErrorMessage, kOneMB);
   HdfsFileSystemTest::miniCluster->stop();
@@ -160,7 +160,10 @@ void verifyFailures(ReadFile* readFile) {
   try {
     auto memConfig =
         std::make_shared<const core::MemConfig>(configurationValues);
-    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(memConfig);
+    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(
+        memConfig,
+        facebook::velox::filesystems::HdfsFileSystem::getServiceEndpoint(
+            memConfig.get()));
     FAIL() << "expected VeloxException";
   } catch (facebook::velox::VeloxException const& error) {
     EXPECT_THAT(error.message(), testing::HasSubstr(builderErrorMessage));
@@ -245,7 +248,10 @@ TEST_F(HdfsFileSystemTest, missingHost) {
         {{"hive.hdfs.port", hdfsPort}});
     auto memConfig =
         std::make_shared<const core::MemConfig>(missingHostConfiguration);
-    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(memConfig);
+    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(
+        memConfig,
+        facebook::velox::filesystems::HdfsFileSystem::getServiceEndpoint(
+            memConfig.get()));
     FAIL() << "expected VeloxException";
   } catch (facebook::velox::VeloxException const& error) {
     EXPECT_THAT(
@@ -262,7 +268,10 @@ TEST_F(HdfsFileSystemTest, missingPort) {
         {{"hive.hdfs.host", localhost}});
     auto memConfig =
         std::make_shared<const core::MemConfig>(missingPortConfiguration);
-    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(memConfig);
+    facebook::velox::filesystems::HdfsFileSystem hdfsFileSystem(
+        memConfig,
+        facebook::velox::filesystems::HdfsFileSystem::getServiceEndpoint(
+            memConfig.get()));
     FAIL() << "expected VeloxException";
   } catch (facebook::velox::VeloxException const& error) {
     EXPECT_THAT(

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -190,6 +190,13 @@ TEST_F(HdfsFileSystemTest, initializeFsWithEndpointInfoInFilePath) {
       filesystems::getFileSystem(fullDestinationPath, nullptr);
   auto readFile = hdfsFileSystem->openFileForRead(fullDestinationPath);
   readData(readFile.get());
+
+  // Wrong endpoint info specified in hdfs file path.
+  const std::string wrongFullDestinationPath =
+      "hdfs://not_exist_host:" + hdfsPort + destinationPath;
+  VELOX_ASSERT_THROW(
+      filesystems::getFileSystem(wrongFullDestinationPath, nullptr),
+      "Unable to connect to HDFS");
 }
 
 TEST_F(HdfsFileSystemTest, oneFsInstanceForOneEndpoint) {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -365,8 +365,11 @@ std::string S3FileSystem::name() const {
   return "S3";
 }
 
-static std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
-    filesystemGenerator = [](std::shared_ptr<const Config> properties) {
+static std::function<std::shared_ptr<FileSystem>(
+    std::shared_ptr<const Config>,
+    std::string_view)>
+    filesystemGenerator = [](std::shared_ptr<const Config> properties,
+                             std::string_view filePath) {
       // Only one instance of S3FileSystem is supported for now.
       // TODO: Support multiple S3FileSystem instances using a cache
       // Initialize on first access and reuse after that.


### PR DESCRIPTION
Currently, velox only supports one hdfs endpoint, depending on user's configuration for `hive.hdfs.host` & `hive.hdfs.port`. But in the real world, user's data can be stored on multiple hdfs endpoints and multi-endpoint data accessing is possible even for one single query.

In this PR, we are proposing to support multiple hdfs endpoints in velox. The idea is quite straightforward. As we know, when a read request comes, the full hdfs file path is always specified by user with hdfs endpoint info (host/port) contained, e.g., `hdfs://my_namenode:9000/test.parquet`. So we can extract the endpoint info from the given hdfs file path and initialize a filesystem (client) accordingly if not done yet.

As before, we only get one filesystem created for one endpoint. In addition, each hdfs filesystem's initialization is independent with each other's. So their initialization is done in parallel, considering building connection during it can be time-consuming.

For the original approach which gets single endpoint info from configuration, it looks useless after the new approach is introduced, but we still keep it temporarily.