### PR TITLE
Add memory leak check options for memory pool and manager

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -43,6 +43,7 @@
 #include "velox/common/memory/MemoryUsage.h"
 
 DECLARE_int32(memory_usage_aggregation_interval_millis);
+DECLARE_bool(velox_memory_leak_check_enabled);
 
 namespace facebook::velox::memory {
 #define VELOX_MEM_LOG_PREFIX "[MEM] "
@@ -70,6 +71,12 @@ class IMemoryManager {
 
     /// Specifies the max memory capacity in bytes.
     int64_t capacity{kMaxMemory};
+
+    /// If true, check the memory pool and usage leaks on destruction.
+    ///
+    /// TODO: deprecate this flag after all the existing memory leak use cases
+    /// have been fixed.
+    bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
 
     /// Specifies the backing memory allocator.
     MemoryAllocator* allocator{MemoryAllocator::getInstance()};
@@ -191,6 +198,7 @@ class MemoryManager final : public IMemoryManager {
   const std::shared_ptr<MemoryAllocator> allocator_;
   const int64_t memoryQuota_;
   const uint16_t alignment_;
+  const bool checkUsageLeak_;
   // The destruction callback set for the root memory pools created by getPool()
   // which are tracked by 'pools_'. It is invoked on the root pool destruction
   // and removes the pool from 'pools_'.

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -34,6 +34,8 @@
 #include "velox/common/memory/MemoryUsage.h"
 #include "velox/common/memory/MemoryUsageTracker.h"
 
+DECLARE_bool(velox_memory_leak_check_enabled);
+
 namespace facebook::velox::memory {
 
 class MemoryManager;
@@ -112,6 +114,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// but sensitive to its cpu cost so we provide an options for user to turn
     /// it off.
     bool trackUsage{true};
+    /// If true, check the memory usage leak on destruction.
+    ///
+    /// TODO: deprecate this flag after all the existing memory leak use cases
+    /// have been fixed.
+    bool checkUsageLeak{FLAGS_velox_memory_leak_check_enabled};
   };
 
   /// Constructs a named memory pool with specified 'name', 'parent' and 'kind'.
@@ -276,6 +283,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const Kind kind_;
   const uint16_t alignment_;
   const std::shared_ptr<MemoryPool> parent_;
+  const bool checkUsageLeak_;
 
   /// Protects 'children_'.
   mutable folly::SharedMutex childrenMutex_;

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -28,13 +28,15 @@ namespace facebook::velox::memory {
 std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
     const std::shared_ptr<MemoryUsageTracker>& parent,
     bool leafTracker,
-    int64_t maxMemory) {
-  auto* tracker = new MemoryUsageTracker(parent, leafTracker, maxMemory);
+    int64_t maxMemory,
+    bool checkUsageLeak) {
+  auto* tracker =
+      new MemoryUsageTracker(parent, leafTracker, maxMemory, checkUsageLeak);
   return std::shared_ptr<MemoryUsageTracker>(tracker);
 }
 
 MemoryUsageTracker::~MemoryUsageTracker() {
-  if (FLAGS_velox_memory_leak_check_enabled) {
+  if (checkUsageLeak_) {
     VELOX_CHECK(
         (usedReservationBytes_ == 0) && (reservationBytes_ == 0) &&
             (minReservationBytes_ == 0),


### PR DESCRIPTION
The memory pool usage and memory pool leak check options are
default to FLAGS_velox_memory_leak_check_enabled