### PR TITLE
Change the condition to set maxPartialAggregationMemoryUsage

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -88,12 +88,6 @@ class QueryConfig {
   static constexpr const char* kMaxExtendedPartialAggregationMemory =
       "max_extended_partial_aggregation_memory";
 
-  /// Output volume as percentage of input volume below which we will not seek
-  /// to increase reduction by using more memory. the data volume is measured as
-  /// the number of rows.
-  static constexpr const char* kPartialAggregationGoodPct =
-      "partial_aggregation_reduction_ratio_threshold";
-
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "driver.max-page-partitioning-buffer-size";
 
@@ -178,18 +172,13 @@ class QueryConfig {
   }
 
   uint64_t maxExtendedPartialAggregationMemoryUsage() const {
-    static constexpr uint64_t kDefault = 1L << 24;
+    static constexpr uint64_t kDefault = 1L << 26;
     return get<uint64_t>(kMaxExtendedPartialAggregationMemory, kDefault);
   }
 
   uint64_t aggregationSpillMemoryThreshold() const {
     static constexpr uint64_t kDefault = 0;
     return get<uint64_t>(kAggregationSpillMemoryThreshold, kDefault);
-  }
-
-  double partialAggregationGoodPct() const {
-    static constexpr double kDefault = 0.5;
-    return get<double>(kPartialAggregationGoodPct, kDefault);
   }
 
   uint64_t joinSpillMemoryThreshold() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -33,18 +33,6 @@ the value of `max_extended_partial_aggregation_memory` equals the value of
 `max_partial_aggregation_memory`. Specify higher value for `max_extended_partial_aggregation_memory`
 to enable.
 
-``partial_aggregation_reduction_ratio_threshold``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    * **Type:** ``double``
-    * **Default value:** ``0.5``
-
-Cardinality reduction threshold for partial aggregation to enable adaptive memory limit increase
-up to `max_extended_partial_aggregation_memory`. Valid values are between 0 and 1. If
-partial aggregation results reach `max_partial_aggregation_memory` limit and
-`number of result rows / number of input rows > partial_aggregation_reduction_ratio_threshold`
-the limit is automatically doubled up to `max_extended_partial_aggregation_memory`.
-
 Spilling
 --------
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -38,8 +38,6 @@ HashAggregation::HashAggregation(
       isDistinct_(aggregationNode->aggregates().empty()),
       isGlobal_(aggregationNode->groupingKeys().empty()),
       memoryTracker_(operatorCtx_->pool()->getMemoryUsageTracker()),
-      partialAggregationGoodPct_(
-          driverCtx->queryConfig().partialAggregationGoodPct()),
       maxExtendedPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxExtendedPartialAggregationMemoryUsage()),
       spillConfig_(
@@ -244,9 +242,8 @@ void HashAggregation::maybeIncreasePartialAggregationMemoryUsage(
   VELOX_DCHECK(isPartialOutput_);
   // Do not increase the aggregation memory usage further if we have already
   // achieved good aggregation ratio with the current size.
-  if (aggregationPct < partialAggregationGoodPct_ ||
-      maxPartialAggregationMemoryUsage_ >=
-          maxExtendedPartialAggregationMemoryUsage_) {
+  if (maxPartialAggregationMemoryUsage_ >=
+      maxExtendedPartialAggregationMemoryUsage_) {
     return;
   }
   const int64_t extendedPartialAggregationMemoryUsage = std::min(

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -71,7 +71,6 @@ class HashAggregation : public Operator {
   const bool isDistinct_;
   const bool isGlobal_;
   const std::shared_ptr<memory::MemoryUsageTracker> memoryTracker_;
-  const double partialAggregationGoodPct_;
   const int64_t maxExtendedPartialAggregationMemoryUsage_;
   const std::optional<Spiller::Config> spillConfig_;
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -695,33 +695,26 @@ TEST_F(AggregationTest, partialAggregationMemoryLimitIncrease) {
   struct {
     int64_t initialPartialMemoryLimit;
     int64_t extendedPartialMemoryLimit;
-    double partialAggregationGoodPct;
     bool expectedPartialOutputFlush;
     bool expectedPartialAggregationMemoryLimitIncrease;
 
     std::string debugString() const {
       return fmt::format(
-          "initialPartialMemoryLimit: {}, extendedPartialMemoryLimit: {}, partialAggregationGoodPct: {}, expectedPartialOutputFlush: {}, expectedPartialAggregationMemoryLimitIncrease: {}",
+          "initialPartialMemoryLimit: {}, extendedPartialMemoryLimit: {}, expectedPartialOutputFlush: {}, expectedPartialAggregationMemoryLimitIncrease: {}",
           initialPartialMemoryLimit,
           extendedPartialMemoryLimit,
-          partialAggregationGoodPct,
           expectedPartialOutputFlush,
           expectedPartialAggregationMemoryLimitIncrease);
     }
   } testSettings[] = {// Set with a large initial partial aggregation memory
                       // limit and expect no flush and memory limit bump.
-                      {kGB, kB, 100, false, false},
-                      {kGB, kB, 0.01, false, false},
-                      {kGB, 2 * kGB, 100, false, false},
-                      {kGB, 2 * kGB, 0.01, false, false},
+                      {kGB, 2 * kGB, false, false},
                       // Set with a very small initial and extended partial
                       // aggregation memory limit.
-                      {100, 100, 0.01, true, false},
-                      {100, 100, 100, true, false},
+                      {100, 100, true, false},
                       // Set with a very small initial partial aggregation
                       // memory limit but large extended memory limit.
-                      {100, kGB, 0.01, true, true},
-                      {100, kGB, 100, true, false}};
+                      {100, kGB, true, true}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
 
@@ -734,9 +727,6 @@ TEST_F(AggregationTest, partialAggregationMemoryLimitIncrease) {
                     .config(
                         QueryConfig::kMaxExtendedPartialAggregationMemory,
                         std::to_string(testData.extendedPartialMemoryLimit))
-                    .config(
-                        QueryConfig::kPartialAggregationGoodPct,
-                        std::to_string(testData.partialAggregationGoodPct))
                     .plan(PlanBuilder()
                               .values(vectors)
                               .partialAggregation({"c0"}, {})


### PR DESCRIPTION
Remove the check on kPartialAggregationGoodPct when increasing
maxPartialAggregationMemoryUsage. We would like to not check
kPartialAggregationGoodPct and increase
maxPartialAggregationMemoryUsage as long as it does not hit
kMaxExtendedPartialAggregationMemory during partial aggregation,
in order to reduce the record flushing.