### PR TITLE
Add unix_timestamp() and to_unix_timestamp() Spark functions

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -10,3 +10,30 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: year(x) -> integer
 
     Returns the year from ``x``.
+
+.. spark:function:: unix_timestamp() -> integer
+
+    Returns the current UNIX timestamp in seconds.
+
+.. spark:function:: unix_timestamp(string) -> integer
+
+    Returns the UNIX timestamp of time specified by ``string``. Assumes the 
+    format ``yyyy-MM-dd HH:mm:ss``. Returns null if ``string`` does not match
+    ``format``.
+
+.. spark:function:: unix_timestamp(string, format) -> integer
+
+    Returns the UNIX timestamp of time specified by ``string`` using the
+    format described in the ``format`` string. The format follows Spark's
+    `Datetime patterns for formatting and parsing
+    <https://spark.apache.org/docs/latest/sql-ref-datetime-pattern.html>`_.
+    Returns null if ``string`` does not match ``format`` or if ``format``
+    is invalid.
+
+.. spark:function:: to_unix_timestamp(string) -> integer
+
+    Alias for ``unix_timestamp(string) -> integer``.
+
+.. spark:function:: to_unix_timestamp(string, format) -> integer
+
+    Alias for ``unix_timestamp(string, format) -> integer``.

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions::sparksql {
 
@@ -36,4 +38,118 @@ struct YearFunction : public InitSessionTimezone<T> {
     result = getYear(getDateTime(date));
   }
 };
+
+template <typename T>
+struct UnixTimestampFunction {
+  // unix_timestamp();
+  // If no parameters, return the current unix timestamp without adjusting
+  // timezones.
+  FOLLY_ALWAYS_INLINE void call(int64_t& result) {
+    result = Timestamp::now().getSeconds();
+  }
+};
+
+template <typename T>
+struct UnixTimestampParseFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // unix_timestamp(input);
+  // If format is not specified, assume kDefaultFormat.
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* /*input*/) {
+    format_ = buildJodaDateTimeFormatter(kDefaultFormat_);
+    setTimezone(config);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Varchar>& input) {
+    DateTimeResult dateTimeResult;
+    try {
+      dateTimeResult =
+          format_->parse(std::string_view(input.data(), input.size()));
+    } catch (const VeloxUserError&) {
+      // Return null if could not parse.
+      return false;
+    }
+    dateTimeResult.timestamp.toGMT(getTimezoneId(dateTimeResult));
+    result = dateTimeResult.timestamp.getSeconds();
+    return true;
+  }
+
+ protected:
+  void setTimezone(const core::QueryConfig& config) {
+    auto sessionTzName = config.sessionTimezone();
+    if (!sessionTzName.empty()) {
+      sessionTzID_ = util::getTimeZoneID(sessionTzName);
+    }
+  }
+
+  int16_t getTimezoneId(const DateTimeResult& result) {
+    // If timezone was not parsed, fallback to the session timezone. If there's
+    // no session timezone, fallback to 0 (GMT).
+    return result.timezoneId != -1 ? result.timezoneId
+                                   : sessionTzID_.value_or(0);
+  }
+
+  // Default if format is not specified, as per Spark documentation.
+  constexpr static std::string_view kDefaultFormat_{"yyyy-MM-dd HH:mm:ss"};
+  std::shared_ptr<DateTimeFormatter> format_;
+  std::optional<int64_t> sessionTzID_;
+};
+
+template <typename T>
+struct UnixTimestampParseWithFormatFunction
+    : public UnixTimestampParseFunction<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // unix_timestamp(input, format):
+  // If format is constant, compile it just once per batch.
+  FOLLY_ALWAYS_INLINE void initialize(
+      const core::QueryConfig& config,
+      const arg_type<Varchar>* /*input*/,
+      const arg_type<Varchar>* format) {
+    if (format != nullptr) {
+      try {
+        this->format_ = buildJodaDateTimeFormatter(
+            std::string_view(format->data(), format->size()));
+      } catch (const VeloxUserError&) {
+        invalidFormat_ = true;
+      }
+      isConstFormat_ = true;
+    }
+    this->setTimezone(config);
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int64_t& result,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& format) {
+    if (invalidFormat_) {
+      return false;
+    }
+
+    // Format or parsing error returns null.
+    try {
+      if (!isConstFormat_) {
+        this->format_ = buildJodaDateTimeFormatter(
+            std::string_view(format.data(), format.size()));
+      }
+
+      auto dateTimeResult =
+          this->format_->parse(std::string_view(input.data(), input.size()));
+      dateTimeResult.timestamp.toGMT(this->getTimezoneId(dateTimeResult));
+      result = dateTimeResult.timestamp.getSeconds();
+    } catch (const VeloxUserError&) {
+      return false;
+    }
+    return true;
+  }
+
+ private:
+  bool isConstFormat_{false};
+  bool invalidFormat_{false};
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -152,8 +152,19 @@ void registerFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "sort_array", sortArraySignatures(), makeSortArray);
 
+  // Register date functions.
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
+
+  registerFunction<UnixTimestampFunction, int64_t>({prefix + "unix_timestamp"});
+
+  registerFunction<UnixTimestampParseFunction, int64_t, Varchar>(
+      {prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
+  registerFunction<
+      UnixTimestampParseWithFormatFunction,
+      int64_t,
+      Varchar,
+      Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/Register.h
+++ b/velox/functions/sparksql/Register.h
@@ -18,5 +18,7 @@
 #include <string>
 
 namespace facebook::velox::functions::sparksql {
+
 void registerFunctions(const std::string& prefix);
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -65,5 +65,82 @@ TEST_F(DateTimeFunctionsTest, yearDate) {
   EXPECT_EQ(1920, year(Date(-18262)));
 }
 
+TEST_F(DateTimeFunctionsTest, unixTimestamp) {
+  const auto unixTimestamp = [&](std::optional<StringView> dateStr) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0)", dateStr);
+  };
+
+  EXPECT_EQ(0, unixTimestamp("1970-01-01 00:00:00"));
+  EXPECT_EQ(1, unixTimestamp("1970-01-01 00:00:01"));
+  EXPECT_EQ(61, unixTimestamp("1970-01-01 00:01:01"));
+
+  setQueryTimeZone("America/Los_Angeles");
+
+  EXPECT_EQ(28800, unixTimestamp("1970-01-01 00:00:00"));
+  EXPECT_EQ(1670859931, unixTimestamp("2022-12-12 07:45:31"));
+
+  // Empty or malformed input returns null.
+  EXPECT_EQ(std::nullopt, unixTimestamp(std::nullopt));
+  EXPECT_EQ(std::nullopt, unixTimestamp("1970-01-01"));
+  EXPECT_EQ(std::nullopt, unixTimestamp("00:00:00"));
+  EXPECT_EQ(std::nullopt, unixTimestamp(""));
+  EXPECT_EQ(std::nullopt, unixTimestamp("malformed input"));
+}
+
+TEST_F(DateTimeFunctionsTest, unixTimestampCurrent) {
+  // Need a mock row vector so we can pump exactly one record out.
+  auto mockRowVector =
+      makeRowVector({BaseVector::createNullConstant(UNKNOWN(), 1, pool())});
+
+  // Safe bet that unix epoch (in seconds) should be between 500M and 5B.
+  auto epoch = evaluateOnce<int64_t>("unix_timestamp()", mockRowVector);
+  EXPECT_GE(epoch, 500'000'000);
+  EXPECT_LT(epoch, 5'000'000'000);
+
+  // Spark doesn't seem to adjust based on timezones.
+  auto gmtEpoch = evaluateOnce<int64_t>("unix_timestamp()", mockRowVector);
+  setQueryTimeZone("America/Los_Angeles");
+  auto laEpoch = evaluateOnce<int64_t>("unix_timestamp()", mockRowVector);
+  EXPECT_EQ(gmtEpoch, laEpoch);
+}
+
+TEST_F(DateTimeFunctionsTest, unixTimestampCustomFormat) {
+  const auto unixTimestamp = [&](std::optional<StringView> dateStr,
+                                 std::optional<StringView> formatStr) {
+    return evaluateOnce<int64_t>("unix_timestamp(c0, c1)", dateStr, formatStr);
+  };
+
+  EXPECT_EQ(0, unixTimestamp("1970-01-01", "yyyy-MM-dd"));
+  EXPECT_EQ(-31536000, unixTimestamp("1969", "YYYY"));
+  EXPECT_EQ(86400, unixTimestamp("1970-01-02", "yyyy-MM-dd"));
+  EXPECT_EQ(86410, unixTimestamp("1970-01-02 00:00:10", "yyyy-MM-dd HH:mm:ss"));
+
+  // Literal.
+  EXPECT_EQ(
+      1670831131,
+      unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd' HH:mm:ss"));
+
+  // Invalid format returns null (unclosed quoted literal).
+  EXPECT_EQ(
+      std::nullopt,
+      unixTimestamp("2022-12-12 asd 07:45:31", "yyyy-MM-dd 'asd HH:mm:ss"));
+}
+
+// unix_timestamp and to_unix_timestamp are aliases.
+TEST_F(DateTimeFunctionsTest, toUnixTimestamp) {
+  std::optional<StringView> dateStr = "1970-01-01 08:32:11"_sv;
+  std::optional<StringView> formatStr = "YYYY-MM-dd HH:mm:ss"_sv;
+
+  EXPECT_EQ(
+      evaluateOnce<int64_t>("unix_timestamp(c0)", dateStr),
+      evaluateOnce<int64_t>("to_unix_timestamp(c0)", dateStr));
+  EXPECT_EQ(
+      evaluateOnce<int64_t>("unix_timestamp(c0, c1)", dateStr, formatStr),
+      evaluateOnce<int64_t>("to_unix_timestamp(c0, c1)", dateStr, formatStr));
+
+  // to_unix_timestamp does not provide an overoaded without any parameters.
+  EXPECT_THROW(evaluateOnce<int64_t>("to_unix_timestamp()"), VeloxUserError);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -35,6 +35,15 @@ inline int64_t getPrestoTZOffsetInSeconds(int16_t tzID) {
 
 } // namespace
 
+// static
+Timestamp Timestamp::now() {
+  auto now = std::chrono::system_clock::now();
+  auto epochMs = std::chrono::duration_cast<std::chrono::milliseconds>(
+                     now.time_since_epoch())
+                     .count();
+  return fromMillis(epochMs);
+}
+
 void Timestamp::toGMT(const date::time_zone& zone) {
   // Magic number -2^39 + 24*3600. This number and any number lower than that
   // will cause time_zone::to_sys() to SIGABRT. We don't want that to happen.

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -37,6 +37,9 @@ struct Timestamp {
   constexpr Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {}
 
+  // Returns the current unix timestamp (ms precision).
+  static Timestamp now();
+
   int64_t getSeconds() const {
     return seconds_;
   }

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -122,5 +122,20 @@ TEST(TimestampTest, toAppend) {
       folly::to<std::string>(Timestamp(946729316, 129900000)));
 }
 
+TEST(TimestampTest, now) {
+  using namespace std::chrono;
+
+  auto now = Timestamp::now();
+
+  auto expectedEpochSecs =
+      duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+  auto expectedEpochMs =
+      duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+          .count();
+
+  EXPECT_GE(expectedEpochSecs, now.getSeconds());
+  EXPECT_GE(expectedEpochMs, now.toMillis());
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Adding unix_timestamp() and to_unix_timestamp() Spark functions to
Velox since they are used by many pipelines. They are aliases, except that
unix_timestamp() has an overload without parameters that returns the current
epoch.

Differential Revision: D44810400

