### PR TITLE
Fix substr function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -134,13 +134,15 @@ String Functions
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string.
+    as being relative to the end of the string.  Return empty When the negative
+    starting position is left of the first character.
 
 .. function:: substr(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
+    Return empty When the negative starting position is left of the first character.
 
 .. function:: trim(string) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -106,19 +106,25 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string. Type of 'start' must be an INTEGER. 
+    as being relative to the end of the string. When the starting position is 0,
+    the meaning is to refer to the first character.Type of 'start' must be an INTEGER. 
 
 .. spark:function:: substring(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
+    When the starting position is 0, the meaning is to refer to the first character.
     Type of 'start' must be an INTEGER. ::
 
-        SELECT substring('Spark SQL', 5, 1); -- k
+        SELECT substring('Spark SQL', 0, 2); -- Sp
+        SELECT substring('Spark SQL', 1, 2); -- Sp
         SELECT substring('Spark SQL', 5, 0); -- ""
         SELECT substring('Spark SQL', 5, -1); -- ""
         SELECT substring('Spark SQL', 5, 10000); -- "k SQL"
+        SELECT substring('Spark SQL', -9, 3); -- "Spa"
+        SELECT substring('Spark SQL', -10, 3); -- "Sp"
+        SELECT substring('Spark SQL', -20, 3); -- ""
 
 .. spark:function:: trim(string) -> varchar
 

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -521,6 +521,22 @@ TEST_F(StringFunctionsTest, substrNegativeStarts) {
 }
 
 /**
+ * The test for overflow of the sum of start and length
+ */
+TEST_F(StringFunctionsTest, substrNumericalverflow) {
+  const auto substr = [&](std::optional<std::string> str,
+                          std::optional<int32_t> start,
+                          std::optional<int32_t> length) {
+    return evaluateOnce<std::string>("substr(c0, c1, c2)", str, start, length);
+  };
+
+  EXPECT_EQ(substr("example", 4, 2147483645), "mple");
+  EXPECT_EQ(substr("example", 2147483645, 4), "");
+  EXPECT_EQ(substr("example", -4, -2147483645), "");
+  EXPECT_EQ(substr("example", -2147483645, -4), "");
+}
+
+/**
  * The test for substr operating on single buffers with two string functions
  * using a conditional
  */

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -81,9 +81,9 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<sparksql::ChrFunction, Varchar, int64_t>({prefix + "chr"});
   registerFunction<AsciiFunction, int32_t, Varchar>({prefix + "ascii"});
 
-  registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
+  registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});
-  registerFunction<SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
+  registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
       {prefix + "substring"});
   exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -83,8 +83,12 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});
-  registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
-      {prefix + "substring"});
+  registerFunction<
+      sparksql::SubstrFunction,
+      Varchar,
+      Varchar,
+      int32_t,
+      int32_t>({prefix + "substring"});
   exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(
       "length", lengthSignatures(), makeLength);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -363,8 +363,8 @@ struct RTrimSpaceFunction : public TrimSpaceFunctionBase<T, false, true> {};
 ///
 ///     Returns the rest of string from the starting position start.
 ///     Positions start with 1. A negative starting position is interpreted as
-///     being relative to the end of the string. When the starting position is 0,
-///     the meaning is to refer to the first character.
+///     being relative to the end of the string. When the starting position is
+///     0, the meaning is to refer to the first character.
 
 ///
 /// substr(string, start, length) -> varchar
@@ -417,7 +417,7 @@ struct SubstrFunction {
 
     int32_t numCharacters = stringImpl::length<isAscii>(input);
 
-    // negative starting position 
+    // negative starting position
     if (start < 0) {
       start = numCharacters + start + 1;
     }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -359,4 +359,95 @@ struct LTrimSpaceFunction : public TrimSpaceFunctionBase<T, true, false> {};
 template <typename T>
 struct RTrimSpaceFunction : public TrimSpaceFunctionBase<T, false, true> {};
 
+/// substr(string, start) -> varchar
+///
+///     Returns the rest of string from the starting position start.
+///     Positions start with 1. A negative starting position is interpreted as
+///     being relative to the end of the string. When the starting position is 0,
+///     the meaning is to refer to the first character.
+
+///
+/// substr(string, start, length) -> varchar
+///
+///     Returns a substring from string of length length from the
+///     starting position start. Positions start with 1. A negative starting
+///     position is interpreted as being relative to the end of the string.
+///     When the starting position is 0, the meaning is to refer to the
+///     first character.
+template <typename T>
+struct SubstrFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    doCall<false>(result, input, start, length);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    doCall<true>(result, input, start, length);
+  }
+
+  template <bool isAscii>
+  FOLLY_ALWAYS_INLINE void doCall(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    if (length <= 0) {
+      result.setEmpty();
+      return;
+    }
+    // Following Spark semantics
+    if (start == 0) {
+      start = 1;
+    }
+
+    int32_t numCharacters = stringImpl::length<isAscii>(input);
+
+    // negative starting position 
+    if (start < 0) {
+      start = numCharacters + start + 1;
+    }
+
+    // Adjusting last
+    int32_t last;
+    bool lastOverflow = __builtin_add_overflow(start, length - 1, &last);
+    if (lastOverflow || last > numCharacters) {
+      last = numCharacters;
+    }
+
+    // Following Spark semantics
+    if (start <= 0) {
+      start = 1;
+    }
+
+    // Adjusting length
+    length = last - start + 1;
+    if (length <= 0) {
+      result.setEmpty();
+      return;
+    }
+
+    auto byteRange =
+        stringCore::getByteRange<isAscii>(input.data(), start, length);
+
+    // Generating output string
+    result.setNoCopy(StringView(
+        input.data() + byteRange.first, byteRange.second - byteRange.first));
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -119,6 +119,19 @@ class StringTest : public SparkFunctionBaseTest {
       const std::optional<std::string>& pattern) {
     return evaluateOnce<bool>("contains(c0, c1)", str, pattern);
   }
+
+  std::optional<std::string> substring(
+      std::optional<std::string> str,
+      std::optional<int32_t> start) {
+    return evaluateOnce<std::string>("substring(c0, c1)", str, start);
+  }
+
+  std::optional<std::string> substring(
+      std::optional<std::string> str,
+      std::optional<int32_t> start,
+      std::optional<int32_t> length) {
+    return evaluateOnce<std::string>("substring(c0, c1, c2)", str, start, length);
+  }
 };
 
 TEST_F(StringTest, Ascii) {
@@ -367,6 +380,39 @@ TEST_F(StringTest, rtrim) {
   EXPECT_EQ(
       rtrim("\u6570", "\u6574\u6570 \u6570\u636E!"),
       "\u6574\u6570 \u6570\u636E!");
+}
+
+TEST_F(StringTest, substring) {
+  EXPECT_EQ(substring("example", 0, 2), "ex");
+  EXPECT_EQ(substring("example", 1, -1), "");
+  EXPECT_EQ(substring("example", 1, 0), "");
+  EXPECT_EQ(substring("example", 1, 2), "ex");
+  EXPECT_EQ(substring("example", 1, 7), "example");
+  EXPECT_EQ(substring("example", 1, 100), "example");
+  EXPECT_EQ(substring("example", 2, 2), "xa");
+  EXPECT_EQ(substring("example", 8, 2), "");
+  EXPECT_EQ(substring("example", -2, 2), "le");
+  EXPECT_EQ(substring("example", -7, 2), "ex");
+  EXPECT_EQ(substring("example", -8, 2), "e");
+  EXPECT_EQ(substring("example", -9, 2), "");
+  EXPECT_EQ(substring("example", 4, 2147483645), "mple");
+  EXPECT_EQ(substring("example", 2147483645, 4), "");
+  EXPECT_EQ(substring("example", -2147483648, 1), "");
+  EXPECT_EQ(substring("da\u6570\u636Eta", 2, 4), "a\u6570\u636Et");
+  EXPECT_EQ(substring("da\u6570\u636Eta", -3, 2), "\u636Et");
+
+  EXPECT_EQ(substring("example", 0), "example");
+  EXPECT_EQ(substring("example", 1), "example");
+  EXPECT_EQ(substring("example", 2), "xample");
+  EXPECT_EQ(substring("example", 8), "");
+  EXPECT_EQ(substring("example", 2147483647), "");
+  EXPECT_EQ(substring("example", -2), "le");
+  EXPECT_EQ(substring("example", -7), "example");
+  EXPECT_EQ(substring("example", -8), "example");
+  EXPECT_EQ(substring("example", -9), "example");
+  EXPECT_EQ(substring("example", -2147483647), "example");
+  EXPECT_EQ(substring("da\u6570\u636Eta", 3), "\u6570\u636Eta");
+  EXPECT_EQ(substring("da\u6570\u636Eta", -3), "\u636Eta");
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -130,7 +130,8 @@ class StringTest : public SparkFunctionBaseTest {
       std::optional<std::string> str,
       std::optional<int32_t> start,
       std::optional<int32_t> length) {
-    return evaluateOnce<std::string>("substring(c0, c1, c2)", str, start, length);
+    return evaluateOnce<std::string>(
+        "substring(c0, c1, c2)", str, start, length);
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -396,6 +396,8 @@ TEST_F(StringTest, substring) {
   EXPECT_EQ(substring("example", -7, 2), "ex");
   EXPECT_EQ(substring("example", -8, 2), "e");
   EXPECT_EQ(substring("example", -9, 2), "");
+  EXPECT_EQ(substring("example", -7, 7), "example");
+  EXPECT_EQ(substring("example", -9, 9), "example");
   EXPECT_EQ(substring("example", 4, 2147483645), "mple");
   EXPECT_EQ(substring("example", 2147483645, 4), "");
   EXPECT_EQ(substring("example", -2147483648, 1), "");


### PR DESCRIPTION
1. The `start + length`  in the function implementation may overflow, which causes an out-of-bounds error

This expression can be used to reproduce the error:

```sql
substr("example", 4, 2147483645)
```



2. Two behavior differences between Spark and Presto

When `start=0`, presto return empty string, but the spark start position refers to the first character:

| Presto                            | Spark                                |
| --------------------------------- | ------------------------------------ |
| substr("example", 0, 2)  ->  ""   | substring("example", 0, 2)  ->  "ex" |
| substr("example", 1, 2)  ->  "ex" | substring("example", 1, 2)  ->  "ex" |



When `start<0` and refers to the left of the first character, presto always return empty string, but spark follows the normal logic:

| Presto                              | Spark                                  |
| ----------------------------------- | -------------------------------------- |
| substr("example", -7, 3)  ->  "exa" | substring("example", -7, 3)  ->  "exa" |
| substr("example", -8, 3)  ->  ""    | substring("example", -8, 3)  ->  "ex"  |
| substr("example", -9, 3)  ->  ""    | substring("example", -9, 3)  ->  "e"   |
| substr("example", -10, 3)  ->  ""   | substring("example", 10, 3)  ->  ""    |



BTW:

The sum of the int32 min(`-2147483648`) and int32 max(`2147483647`) values is `-1`, and the default value of length is the max value, so `substring('example', -2147483648)  ->  exampl` doesn't match the semantics. But the vanilla version of spark also returns the same result, so I think we can maybe ignore it for now.

```
./spark-3.3.1-bin-hadoop2/bin/spark-sql -e "SELECT substring('example', -2147483648);"

exampl
Time taken: 1.562 seconds, Fetched 1 row(s)
```

