### PR TITLE
Increase memory thresholds for partial aggregation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -167,12 +167,12 @@ class QueryConfig {
       "spillable-reservation-growth-pct";
 
   uint64_t maxPartialAggregationMemoryUsage() const {
-    static constexpr uint64_t kDefault = 1L << 24;
+    static constexpr uint64_t kDefault = 20UL * 1024 * 1024;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
   }
 
   uint64_t maxExtendedPartialAggregationMemoryUsage() const {
-    static constexpr uint64_t kDefault = 1L << 26;
+    static constexpr uint64_t kDefault = 80UL * 1024 * 1024;
     return get<uint64_t>(kMaxExtendedPartialAggregationMemory, kDefault);
   }
 


### PR DESCRIPTION
Increase kMaxPartialAggregationMemory from 16MB to 20MB. Increase kMaxExtendedPartialAggregationMemory from 64MB to 80MB. This will help reduce record flushing from partial aggregation.