### PR TITLE
Add AggregateCompanionAdapter for companion function generation

### DIFF
--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -1,0 +1,486 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/AggregateCompanionAdapter.h"
+
+#include "velox/exec/AggregateCompanionSignatures.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/expression/SignatureBinder.h"
+
+namespace facebook::velox::exec {
+
+void AggregateCompanionFunctionBase::setOffsetsInternal(
+    int32_t offset,
+    int32_t nullByte,
+    uint8_t nullMask,
+    int32_t rowSizeOffset) {
+  fn_->setOffsets(offset, nullByte, nullMask, rowSizeOffset);
+}
+
+int32_t AggregateCompanionFunctionBase::accumulatorFixedWidthSize() const {
+  return fn_->accumulatorFixedWidthSize();
+}
+
+int32_t AggregateCompanionFunctionBase::accumulatorAlignmentSize() const {
+  return fn_->accumulatorAlignmentSize();
+}
+
+int32_t AggregateCompanionFunctionBase::combineAlignmentInternal(
+    int32_t otherAlignment) const {
+  return fn_->combineAlignment(otherAlignment);
+}
+
+bool AggregateCompanionFunctionBase::accumulatorUsesExternalMemory() const {
+  return fn_->accumulatorUsesExternalMemory();
+}
+
+bool AggregateCompanionFunctionBase::isFixedSize() const {
+  return fn_->isFixedSize();
+}
+
+void AggregateCompanionFunctionBase::setAllocatorInternal(
+    HashStringAllocator* allocator) {
+  fn_->setAllocator(allocator);
+}
+
+void AggregateCompanionFunctionBase::destroy(folly::Range<char**> groups) {
+  fn_->destroy(groups);
+}
+
+void AggregateCompanionFunctionBase::clearInternal() {
+  fn_->clear();
+}
+
+void AggregateCompanionFunctionBase::initializeNewGroups(
+    char** groups,
+    folly::Range<const vector_size_t*> indices) {
+  fn_->initializeNewGroups(groups, indices);
+}
+
+void AggregateCompanionFunctionBase::addRawInput(
+    char** groups,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addRawInput(groups, rows, args, mayPushdown);
+}
+
+void AggregateCompanionFunctionBase::addSingleGroupRawInput(
+    char* group,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addSingleGroupRawInput(group, rows, args, mayPushdown);
+}
+
+void AggregateCompanionFunctionBase::addIntermediateResults(
+    char** groups,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addIntermediateResults(groups, rows, args, mayPushdown);
+}
+
+void AggregateCompanionFunctionBase::addSingleGroupIntermediateResults(
+    char* group,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addSingleGroupIntermediateResults(group, rows, args, mayPushdown);
+}
+
+void AggregateCompanionFunctionBase::extractAccumulators(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  fn_->extractAccumulators(groups, numGroups, result);
+}
+
+void AggregateCompanionAdapter::PartialFunction::extractValues(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  fn_->extractAccumulators(groups, numGroups, result);
+}
+
+void AggregateCompanionAdapter::MergeFunction::addRawInput(
+    char** groups,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addIntermediateResults(groups, rows, args, mayPushdown);
+}
+
+void AggregateCompanionAdapter::MergeFunction::addSingleGroupRawInput(
+    char* group,
+    const SelectivityVector& rows,
+    const std::vector<VectorPtr>& args,
+    bool mayPushdown) {
+  fn_->addSingleGroupIntermediateResults(group, rows, args, mayPushdown);
+}
+
+void AggregateCompanionAdapter::MergeFunction::extractValues(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  fn_->extractAccumulators(groups, numGroups, result);
+}
+
+void AggregateCompanionAdapter::MergeExtractFunction::extractValues(
+    char** groups,
+    int32_t numGroups,
+    VectorPtr* result) {
+  fn_->extractValues(groups, numGroups, result);
+}
+
+int32_t AggregateCompanionAdapter::ExtractFunction::setOffset() const {
+  int32_t rowSizeOffset = bits::nbytes(1);
+  int32_t offset = rowSizeOffset;
+  offset = bits::roundUp(offset, fn_->accumulatorAlignmentSize());
+  fn_->setOffsets(
+      offset,
+      RowContainer::nullByte(0),
+      RowContainer::nullMask(0),
+      rowSizeOffset);
+  return offset;
+}
+
+char** AggregateCompanionAdapter::ExtractFunction::allocateGroups(
+    AllocationPool& allocationPool,
+    const SelectivityVector& rows,
+    uint64_t offsetInGroup) const {
+  auto* groups =
+      (char**)allocationPool.allocateFixed(sizeof(char*) * rows.end());
+
+  auto size = fn_->accumulatorFixedWidthSize();
+  auto alignment = fn_->accumulatorAlignmentSize();
+  rows.applyToSelected([&](auto row) {
+    groups[row] = allocationPool.allocateFixed(size + offsetInGroup, alignment);
+  });
+  return groups;
+}
+
+std::tuple<vector_size_t, BufferPtr>
+AggregateCompanionAdapter::ExtractFunction::compactGroups(
+    memory::MemoryPool* pool,
+    const SelectivityVector& rows,
+    char** groups) const {
+  BufferPtr indices = allocateIndices(rows.end(), pool);
+  auto* rawIndices = indices->asMutable<vector_size_t>();
+  vector_size_t count = 0;
+  rows.applyToSelected([&](auto row) {
+    if (count < row) {
+      groups[count] = groups[row];
+    }
+    rawIndices[row] = count;
+    ++count;
+  });
+  return std::make_tuple(count, indices);
+}
+
+void AggregateCompanionAdapter::ExtractFunction::apply(
+    const SelectivityVector& rows,
+    std::vector<VectorPtr>& args,
+    const TypePtr& outputType,
+    exec::EvalCtx& context,
+    VectorPtr& result) const {
+  // Set up data members of fn_.
+  HashStringAllocator stringAllocator{context.pool()};
+  AllocationPool allocationPool{context.pool()};
+  fn_->setAllocator(&stringAllocator);
+
+  auto offset = setOffset();
+  char** groups = allocateGroups(allocationPool, rows, offset);
+
+  // Perform per-row aggregation.
+  std::vector<vector_size_t> allSelectedRange;
+  rows.applyToSelected([&](auto row) { allSelectedRange.push_back(row); });
+  fn_->initializeNewGroups(groups, allSelectedRange);
+  fn_->addIntermediateResults(groups, rows, args, false);
+
+  auto localResult = BaseVector::create(outputType, rows.end(), context.pool());
+  const auto& [groupCount, rowsToGroupsIndices] =
+      compactGroups(context.pool(), rows, groups);
+  fn_->extractValues(groups, groupCount, &localResult);
+  localResult = BaseVector::wrapInDictionary(
+      nullptr, rowsToGroupsIndices, rows.end(), localResult);
+  context.moveOrCopyResult(localResult, rows, result);
+}
+
+bool CompanionFunctionsRegistrar::registerPartialFunction(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  auto partialSignatures =
+      CompanionSignatures::partialFunctionSignatures(signatures);
+  if (partialSignatures.empty()) {
+    return false;
+  }
+
+  return exec::registerAggregateFunction(
+      CompanionSignatures::partialFunctionName(name),
+      std::move(partialSignatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<Aggregate> {
+        if (auto func = getAggregateFunctionEntry(name)) {
+          if (!exec::isRawInput(step)) {
+            step = core::AggregationNode::Step::kIntermediate;
+          }
+          auto fn = func->factory(step, argTypes, resultType);
+          VELOX_CHECK_NOT_NULL(fn);
+          return std::make_unique<AggregateCompanionAdapter::PartialFunction>(
+              std::move(fn), resultType);
+        }
+        VELOX_FAIL(
+            "Original aggregation function {} not found: {}",
+            name,
+            CompanionSignatures::partialFunctionName(name));
+      });
+}
+
+bool CompanionFunctionsRegistrar::registerMergeFunction(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  auto mergeSignatures =
+      CompanionSignatures::mergeFunctionSignatures(signatures);
+  if (mergeSignatures.empty()) {
+    return false;
+  }
+
+  return exec::registerAggregateFunction(
+      CompanionSignatures::mergeFunctionName(name),
+      std::move(mergeSignatures),
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<Aggregate> {
+        if (auto func = getAggregateFunctionEntry(name)) {
+          auto fn = func->factory(
+              core::AggregationNode::Step::kIntermediate, argTypes, resultType);
+          VELOX_CHECK_NOT_NULL(fn);
+          return std::make_unique<AggregateCompanionAdapter::MergeFunction>(
+              std::move(fn), resultType);
+        }
+        VELOX_FAIL(
+            "Original aggregation function {} not found: {}",
+            name,
+            CompanionSignatures::mergeFunctionName(name));
+      });
+}
+
+bool CompanionFunctionsRegistrar::registerMergeExtractFunctionWithSuffix(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  auto groupedSignatures =
+      CompanionSignatures::groupSignaturesByReturnType(signatures);
+  bool registered = false;
+  for (const auto& [type, signatureGroup] : groupedSignatures) {
+    auto mergeExtractSignatures =
+        CompanionSignatures::mergeExtractFunctionSignatures(signatureGroup);
+    if (mergeExtractSignatures.empty()) {
+      continue;
+    }
+
+    auto mergeExtractFunctionName =
+        CompanionSignatures::mergeExtractFunctionNameWithSuffix(name, type);
+
+    registered |= exec::registerAggregateFunction(
+        mergeExtractFunctionName,
+        std::move(mergeExtractSignatures),
+        [name, mergeExtractFunctionName](
+            core::AggregationNode::Step /*step*/,
+            const std::vector<TypePtr>& argTypes,
+            const TypePtr& resultType) -> std::unique_ptr<Aggregate> {
+          const auto& [originalResultType, _] =
+              resolveAggregateFunction(mergeExtractFunctionName, argTypes);
+          if (!originalResultType) {
+            // TODO: limitation -- result type must be resolveable given
+            // intermediate type of the original UDAF.
+            VELOX_UNREACHABLE(
+                "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
+          }
+
+          if (auto func = getAggregateFunctionEntry(name)) {
+            auto fn = func->factory(
+                core::AggregationNode::Step::kFinal,
+                argTypes,
+                originalResultType);
+            VELOX_CHECK_NOT_NULL(fn);
+            return std::make_unique<
+                AggregateCompanionAdapter::MergeExtractFunction>(
+                std::move(fn), resultType);
+          }
+          VELOX_FAIL(
+              "Original aggregation function {} not found: {}",
+              name,
+              mergeExtractFunctionName);
+        });
+  }
+  return registered;
+}
+
+bool CompanionFunctionsRegistrar::registerMergeExtractFunction(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  if (CompanionSignatures::hasSameIntermediateTypesAcrossSignatures(
+          signatures)) {
+    return registerMergeExtractFunctionWithSuffix(name, signatures);
+  }
+
+  auto mergeExtractSignatures =
+      CompanionSignatures::mergeExtractFunctionSignatures(signatures);
+  if (mergeExtractSignatures.empty()) {
+    return false;
+  }
+
+  auto mergeExtractFunctionName =
+      CompanionSignatures::mergeExtractFunctionName(name);
+  return exec::registerAggregateFunction(
+      mergeExtractFunctionName,
+      std::move(mergeExtractSignatures),
+      [name, mergeExtractFunctionName](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<Aggregate> {
+        const auto& [originalResultType, _] =
+            resolveAggregateFunction(mergeExtractFunctionName, argTypes);
+        if (!originalResultType) {
+          // TODO: limitation -- result type must be resolveable given
+          // intermediate type of the original UDAF.
+          VELOX_UNREACHABLE(
+              "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
+        }
+
+        if (auto func = getAggregateFunctionEntry(name)) {
+          auto fn = func->factory(
+              core::AggregationNode::Step::kFinal,
+              argTypes,
+              originalResultType);
+          VELOX_CHECK_NOT_NULL(fn);
+          return std::make_unique<
+              AggregateCompanionAdapter::MergeExtractFunction>(
+              std::move(fn), resultType);
+        }
+        VELOX_FAIL(
+            "Original aggregation function {} not found: {}",
+            name,
+            mergeExtractFunctionName);
+      });
+}
+
+bool CompanionFunctionsRegistrar::registerExtractFunctionWithSuffix(
+    const std::string& originalName,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  auto groupedSignatures =
+      CompanionSignatures::groupSignaturesByReturnType(signatures);
+  bool registered = false;
+  for (const auto& [type, signatureGroup] : groupedSignatures) {
+    auto extractSignatures =
+        CompanionSignatures::extractFunctionSignatures(signatureGroup);
+    if (extractSignatures.empty()) {
+      continue;
+    }
+
+    auto factory = [originalName](
+                       const std::string& name,
+                       const std::vector<VectorFunctionArg>& inputArgs)
+        -> std::shared_ptr<VectorFunction> {
+      std::vector<TypePtr> argTypes{inputArgs.size()};
+      std::transform(
+          inputArgs.begin(),
+          inputArgs.end(),
+          argTypes.begin(),
+          [](auto inputArg) { return inputArg.type; });
+
+      auto resultType = resolveVectorFunction(name, argTypes);
+      if (!resultType) {
+        // TODO: limitation -- result type must be resolveable given
+        // intermediate type of the original UDAF.
+        VELOX_UNREACHABLE(
+            "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
+      }
+
+      if (auto func = getAggregateFunctionEntry(originalName)) {
+        auto fn = func->factory(
+            core::AggregationNode::Step::kFinal, argTypes, resultType);
+        VELOX_CHECK_NOT_NULL(fn);
+        return std::make_shared<AggregateCompanionAdapter::ExtractFunction>(
+            std::move(fn));
+      }
+      VELOX_FAIL(
+          "Original aggregation function {} not found: {}", originalName, name);
+    };
+
+    registered |= exec::registerStatefulVectorFunction(
+        CompanionSignatures::extractFunctionNameWithSuffix(originalName, type),
+        extractSignatures,
+        factory);
+  }
+  return registered;
+}
+
+bool CompanionFunctionsRegistrar::registerExtractFunction(
+    const std::string& originalName,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  if (CompanionSignatures::hasSameIntermediateTypesAcrossSignatures(
+          signatures)) {
+    return registerExtractFunctionWithSuffix(originalName, signatures);
+  }
+
+  auto extractSignatures =
+      CompanionSignatures::extractFunctionSignatures(signatures);
+  if (extractSignatures.empty()) {
+    return false;
+  }
+
+  auto factory = [originalName](
+                     const std::string& name,
+                     const std::vector<VectorFunctionArg>& inputArgs)
+      -> std::shared_ptr<VectorFunction> {
+    std::vector<TypePtr> argTypes{inputArgs.size()};
+    std::transform(
+        inputArgs.begin(),
+        inputArgs.end(),
+        argTypes.begin(),
+        [](auto inputArg) { return inputArg.type; });
+
+    auto resultType = resolveVectorFunction(name, argTypes);
+    if (!resultType) {
+      // TODO: limitation -- result type must be resolveable given
+      // intermediate type of the original UDAF.
+      VELOX_UNREACHABLE(
+          "Signatures whose result types are not resolvable given intermediate types should have been excluded.");
+    }
+
+    if (auto func = getAggregateFunctionEntry(originalName)) {
+      auto fn = func->factory(
+          core::AggregationNode::Step::kFinal, argTypes, resultType);
+      VELOX_CHECK_NOT_NULL(fn);
+      return std::make_shared<AggregateCompanionAdapter::ExtractFunction>(
+          std::move(fn));
+    }
+    VELOX_FAIL(
+        "Original aggregation function {} not found: {}", originalName, name);
+  };
+  return exec::registerStatefulVectorFunction(
+      CompanionSignatures::extractFunctionName(originalName),
+      extractSignatures,
+      factory);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::exec {
+
+class AggregateCompanionFunctionBase : public Aggregate {
+ public:
+  explicit AggregateCompanionFunctionBase(
+      std::unique_ptr<Aggregate>&& fn,
+      const TypePtr& resultType)
+      : Aggregate{resultType}, fn_{std::move(fn)} {}
+
+  int32_t accumulatorFixedWidthSize() const override final;
+
+  int32_t accumulatorAlignmentSize() const override final;
+
+  bool accumulatorUsesExternalMemory() const override final;
+
+  bool isFixedSize() const override final;
+
+  void destroy(folly::Range<char**> groups) override final;
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override final;
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown) override;
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown) override;
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown) override final;
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool mayPushdown) override final;
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override final;
+
+ protected:
+  void setOffsetsInternal(
+      int32_t offset,
+      int32_t nullByte,
+      uint8_t nullMask,
+      int32_t rowSizeOffset) override final;
+
+  int32_t combineAlignmentInternal(int32_t otherAlignment) const override final;
+
+  void setAllocatorInternal(HashStringAllocator* allocator) override final;
+
+  void clearInternal() override final;
+
+  std::unique_ptr<Aggregate> fn_;
+};
+
+struct AggregateCompanionAdapter {
+  class PartialFunction : public AggregateCompanionFunctionBase {
+   public:
+    explicit PartialFunction(
+        std::unique_ptr<Aggregate> fn,
+        const TypePtr& resultType)
+        : AggregateCompanionFunctionBase{std::move(fn), resultType} {}
+
+    void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+        override;
+  };
+
+  class MergeFunction : public AggregateCompanionFunctionBase {
+   public:
+    explicit MergeFunction(
+        std::unique_ptr<Aggregate> fn,
+        const TypePtr& resultType)
+        : AggregateCompanionFunctionBase{std::move(fn), resultType} {}
+
+    void addRawInput(
+        char** groups,
+        const SelectivityVector& rows,
+        const std::vector<VectorPtr>& args,
+        bool mayPushdown) override;
+
+    void addSingleGroupRawInput(
+        char* group,
+        const SelectivityVector& rows,
+        const std::vector<VectorPtr>& args,
+        bool mayPushdown) override;
+
+    void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+        override;
+  };
+
+  class MergeExtractFunction : public MergeFunction {
+   public:
+    explicit MergeExtractFunction(
+        std::unique_ptr<Aggregate> fn,
+        const TypePtr& resultType)
+        : MergeFunction{std::move(fn), resultType} {}
+
+    void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+        override;
+  };
+
+  class ExtractFunction : public VectorFunction {
+   public:
+    explicit ExtractFunction(std::unique_ptr<Aggregate> fn)
+        : fn_{std::move(fn)} {}
+
+    void apply(
+        const SelectivityVector& rows,
+        std::vector<VectorPtr>& args,
+        const TypePtr& outputType,
+        exec::EvalCtx& context,
+        VectorPtr& result) const override;
+
+   private:
+    int32_t setOffset() const;
+
+    char** allocateGroups(
+        AllocationPool& allocationPool,
+        const SelectivityVector& rows,
+        uint64_t offsetInGroup) const;
+
+    // Compact `groups` into a contiguous array of groups for selected rows.
+    // Return the number of groups after compaction and a mapping from original
+    // indices in `groups` to new indices after compaction.
+    std::tuple<vector_size_t, BufferPtr> compactGroups(
+        memory::MemoryPool* pool,
+        const SelectivityVector& rows,
+        char** groups) const;
+
+    std::unique_ptr<Aggregate> fn_;
+  };
+};
+
+class CompanionFunctionsRegistrar {
+ public:
+  static bool registerPartialFunction(
+      const std::string& name,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static bool registerMergeFunction(
+      const std::string& name,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  // If there are multiple signatures of the original aggregation function
+  // with the same intermediate type, register extract functions with suffix
+  // of their result types in the function names for each of them. Otherwise,
+  // register one extract function of all supported signatures. The result
+  // type of the original aggregation function is required to be resolveable
+  // given its intermediate type.
+  static bool registerExtractFunction(
+      const std::string& originalName,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  // Similar to registerExtractFunction(), the result type of the original
+  // aggregation function is required to be resolveable given its intermediate
+  // type. If there are multiple signatures of the original aggregation function
+  // with the same intermediate type, register merge-extract functions with
+  // suffix of their result types in the function names for each of them.
+  static bool registerMergeExtractFunction(
+      const std::string& name,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+ private:
+  // Register a vector function {originalName}_extract_{suffixOfResultType}
+  // that takes input of the intermeidate type and returns the result type of
+  // the orignal agregate function.
+  static bool registerExtractFunctionWithSuffix(
+      const std::string& originalName,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static bool registerMergeExtractFunctionWithSuffix(
+      const std::string& name,
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/AggregateCompanionSignatures.cpp
+++ b/velox/exec/AggregateCompanionSignatures.cpp
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/AggregateCompanionSignatures.h"
+
+#include "velox/expression/FunctionSignature.h"
+#include "velox/type/Type.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+// Add type variables used in `type` to `usedVariables`.
+void addUsedVariablesInType(
+    const TypeSignature& type,
+    const std::unordered_map<std::string, SignatureVariable>& allVariables,
+    std::unordered_map<std::string, SignatureVariable>& usedVariables) {
+  auto iter = allVariables.find(type.baseName());
+  if (iter != allVariables.end()) {
+    usedVariables.emplace(iter->first, iter->second);
+  }
+  for (const auto& parameter : type.parameters()) {
+    addUsedVariablesInType(parameter, allVariables, usedVariables);
+  }
+}
+
+// Return type variables used in `types`.
+std::unordered_map<std::string, SignatureVariable> usedTypeVariables(
+    const std::vector<TypeSignature>& types,
+    const std::unordered_map<std::string, SignatureVariable>& allVariables) {
+  std::unordered_map<std::string, SignatureVariable> usedVariables;
+  for (const auto& type : types) {
+    addUsedVariablesInType(type, allVariables, usedVariables);
+  }
+  return usedVariables;
+}
+
+// Result type is resolvable from intermediate type iff all variables in the
+// result type appears in the intermediate type as well.
+bool isResultTypeResolvableGivenIntermediateType(
+    const AggregateFunctionSignaturePtr& signature) {
+  auto& allVariables = signature->variables();
+  if (allVariables.empty()) {
+    return true;
+  }
+
+  std::vector<TypeSignature> intermediateType{signature->intermediateType()};
+  std::vector<TypeSignature> resultType{signature->returnType()};
+  auto variablesInIntermediate =
+      usedTypeVariables(intermediateType, allVariables);
+  auto variablesInResult = usedTypeVariables(resultType, allVariables);
+
+  for (const auto& [variable, _] : variablesInResult) {
+    if (!variablesInIntermediate.count(variable)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Return a string that is preorder traveral of `type`. For example, for
+// row(bigint, array(double)), return a string "row_bigint_array_double".
+std::string toSuffixString(const TypeSignature& type) {
+  auto name = type.baseName();
+  // For primitive and decimal types, return their names.
+  if (type.parameters().empty() || isCommonDecimalName(name) ||
+      isDecimalName(name)) {
+    return name;
+  }
+  auto upperName = boost::algorithm::to_upper_copy(name);
+  if (upperName == "ARRAY") {
+    return "array_" + toSuffixString(type.parameters()[0]);
+  }
+  if (upperName == "MAP") {
+    return "map_" + toSuffixString(type.parameters()[0]) + "_" +
+        toSuffixString(type.parameters()[1]);
+  }
+  if (upperName == "ROW") {
+    std::string result = "row";
+    for (const auto& child : type.parameters()) {
+      result = result + "_" + toSuffixString(child);
+    }
+    result += "_endrow";
+    return result;
+  }
+  VELOX_UNREACHABLE("Unknown type: {}.", type.toString());
+}
+
+} // namespace
+
+std::vector<AggregateFunctionSignaturePtr>
+CompanionSignatures::partialFunctionSignatures(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  std::vector<AggregateFunctionSignaturePtr> partialSignatures;
+  for (const auto& signature : signatures) {
+    if (!isResultTypeResolvableGivenIntermediateType(signature)) {
+      continue;
+    }
+    std::vector<TypeSignature> usedTypes = signature->argumentTypes();
+    usedTypes.push_back(signature->intermediateType());
+    auto variables = usedTypeVariables(usedTypes, signature->variables());
+
+    partialSignatures.push_back(std::make_shared<AggregateFunctionSignature>(
+        /*variables*/ variables,
+        /*returnType*/ signature->intermediateType(),
+        /*intermediateType*/ signature->intermediateType(),
+        /*argumentTypes*/ signature->argumentTypes(),
+        /*constantArguments*/ signature->constantArguments(),
+        /*variableArity*/ signature->variableArity()));
+  }
+  return partialSignatures;
+}
+
+std::string CompanionSignatures::partialFunctionName(const std::string& name) {
+  return name + "_partial";
+}
+
+AggregateFunctionSignaturePtr CompanionSignatures::mergeFunctionSignature(
+    const AggregateFunctionSignaturePtr& signature) {
+  if (!isResultTypeResolvableGivenIntermediateType(signature)) {
+    return nullptr;
+  }
+
+  std::vector<TypeSignature> usedTypes = {signature->intermediateType()};
+  auto variables = usedTypeVariables(usedTypes, signature->variables());
+  return std::make_shared<AggregateFunctionSignature>(
+      /*variables*/ variables,
+      /*returnType*/ signature->intermediateType(),
+      /*intermediateType*/ signature->intermediateType(),
+      /*argumentTypes*/
+      std::vector<TypeSignature>{signature->intermediateType()},
+      /*constantArguments*/ std::vector<bool>{false},
+      /*variableArity*/ false);
+}
+
+std::vector<AggregateFunctionSignaturePtr>
+CompanionSignatures::mergeFunctionSignatures(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  return processSignaturesOfDistinctIntermediateTypes(
+      signatures, [](const AggregateFunctionSignaturePtr& signature) {
+        return mergeFunctionSignature(signature);
+      });
+}
+
+std::string CompanionSignatures::mergeFunctionName(const std::string& name) {
+  return name + "_merge";
+}
+
+bool CompanionSignatures::hasSameIntermediateTypesAcrossSignatures(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  std::unordered_set<TypeSignature> seenTypes;
+  for (const auto& signature : signatures) {
+    auto normalizdType =
+        normalizeType(signature->intermediateType(), signature->variables());
+    if (seenTypes.count(normalizdType)) {
+      return true;
+    }
+    seenTypes.insert(normalizdType);
+  }
+  return false;
+}
+
+AggregateFunctionSignaturePtr
+CompanionSignatures::mergeExtractFunctionSignature(
+    const AggregateFunctionSignaturePtr& signature) {
+  if (!isResultTypeResolvableGivenIntermediateType(signature)) {
+    return nullptr;
+  }
+
+  std::vector<TypeSignature> usedTypes = {
+      signature->intermediateType(), signature->returnType()};
+  auto variables = usedTypeVariables(usedTypes, signature->variables());
+  return std::make_shared<AggregateFunctionSignature>(
+      /*variables*/ variables,
+      /*returnType*/ signature->returnType(),
+      /*intermediateType*/ signature->intermediateType(),
+      /*argumentTypes*/
+      std::vector<TypeSignature>{signature->intermediateType()},
+      /*constantArguments*/ std::vector<bool>{false},
+      /*variableArity*/ false);
+}
+
+std::vector<AggregateFunctionSignaturePtr>
+CompanionSignatures::mergeExtractFunctionSignatures(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  return processSignaturesOfDistinctTypes<AggregateFunctionSignaturePtr>(
+      signatures, [](const AggregateFunctionSignaturePtr& signature) {
+        return mergeExtractFunctionSignature(signature);
+      });
+}
+
+std::string CompanionSignatures::mergeExtractFunctionNameWithSuffix(
+    const std::string& name,
+    const TypeSignature& resultType) {
+  return name + "_merge_extract_" + toSuffixString(resultType);
+}
+
+std::string CompanionSignatures::mergeExtractFunctionName(
+    const std::string& name) {
+  return name + "_merge_extract";
+}
+
+FunctionSignaturePtr CompanionSignatures::extractFunctionSignature(
+    const AggregateFunctionSignaturePtr& signature) {
+  if (!isResultTypeResolvableGivenIntermediateType(signature)) {
+    return nullptr;
+  }
+
+  std::vector<TypeSignature> usedTypes = {
+      signature->intermediateType(), signature->returnType()};
+  auto variables = usedTypeVariables(usedTypes, signature->variables());
+  return std::make_shared<FunctionSignature>(
+      /*variables*/ variables,
+      /*returnType*/ signature->returnType(),
+      /*argumentTypes*/
+      std::vector<TypeSignature>{signature->intermediateType()},
+      /*constantArguments*/ std::vector<bool>{false},
+      /*variableArity*/ false);
+}
+
+std::string CompanionSignatures::extractFunctionNameWithSuffix(
+    const std::string& name,
+    const TypeSignature& resultType) {
+  return name + "_extract_" + toSuffixString(resultType);
+}
+
+std::vector<FunctionSignaturePtr>
+CompanionSignatures::extractFunctionSignatures(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  return processSignaturesOfDistinctTypes<FunctionSignaturePtr>(
+      signatures, [](const AggregateFunctionSignaturePtr& signature) {
+        return extractFunctionSignature(signature);
+      });
+}
+
+std::string CompanionSignatures::extractFunctionName(const std::string& name) {
+  return name + "_extract";
+}
+
+std::unordered_map<TypeSignature, std::vector<AggregateFunctionSignaturePtr>>
+CompanionSignatures::groupSignaturesByReturnType(
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  std::unordered_map<TypeSignature, std::vector<AggregateFunctionSignaturePtr>>
+      result;
+  for (const auto& signature : signatures) {
+    result[signature->returnType()].push_back(signature);
+  }
+  return result;
+}
+
+TypeSignature CompanionSignatures::normalizeTypeImpl(
+    const TypeSignature& type,
+    const std::unordered_map<std::string, SignatureVariable>& allVariables,
+    std::unordered_map<std::string, std::string>& renamedVariables) {
+  auto baseName = type.baseName();
+
+  // Already renamed variables.
+  if (renamedVariables.count(baseName)) {
+    return TypeSignature{renamedVariables[baseName], {}};
+  }
+  // Variales to be renamed in consistent manner.
+  if (allVariables.count(baseName)) {
+    auto normalizedName = fmt::format("T{}", renamedVariables.size());
+    renamedVariables[baseName] = normalizedName;
+    return TypeSignature{normalizedName, {}};
+  }
+  // Primitive types.
+  if (type.parameters().empty()) {
+    return type;
+  }
+  // Complex types.
+  std::vector<TypeSignature> normalizedParameters;
+  for (const auto& param : type.parameters()) {
+    normalizedParameters.push_back(
+        normalizeTypeImpl(param, allVariables, renamedVariables));
+  }
+  return TypeSignature{baseName, normalizedParameters};
+}
+
+TypeSignature CompanionSignatures::normalizeType(
+    const TypeSignature& type,
+    const std::unordered_map<std::string, SignatureVariable>& allVariables) {
+  std::unordered_map<std::string, std::string> renamedVariables;
+  return normalizeTypeImpl(type, allVariables, renamedVariables);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/AggregateCompanionSignatures.h
+++ b/velox/exec/AggregateCompanionSignatures.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+
+namespace facebook::velox::exec {
+
+class CompanionSignatures {
+ public:
+  // Return signatures of the partial companion function for the original
+  // aggregate function of `signatures`.
+  static std::vector<AggregateFunctionSignaturePtr> partialFunctionSignatures(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static std::string partialFunctionName(const std::string& name);
+
+  static AggregateFunctionSignaturePtr mergeFunctionSignature(
+      const AggregateFunctionSignaturePtr& signature);
+
+  // Return signatures of the merge companion function for the original
+  // aggregate function of `signatures`.
+  static std::vector<AggregateFunctionSignaturePtr> mergeFunctionSignatures(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static std::string mergeFunctionName(const std::string& name);
+
+  // Return true if there are multiple signatures that have the same
+  // intermediate type.
+  static bool hasSameIntermediateTypesAcrossSignatures(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static AggregateFunctionSignaturePtr mergeExtractFunctionSignature(
+      const AggregateFunctionSignaturePtr& signature);
+
+  static std::vector<AggregateFunctionSignaturePtr>
+  mergeExtractFunctionSignatures(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static std::string mergeExtractFunctionNameWithSuffix(
+      const std::string& name,
+      const TypeSignature& resultType);
+
+  static std::string mergeExtractFunctionName(const std::string& name);
+
+  // Return signature of the extract companion function for the original
+  // aggregate function of `signature`.
+  static FunctionSignaturePtr extractFunctionSignature(
+      const AggregateFunctionSignaturePtr& signature);
+
+  static std::string extractFunctionNameWithSuffix(
+      const std::string& name,
+      const TypeSignature& resultType);
+
+  // Return signatures of the extract companion function for the original
+  // aggregate function of `signatures`.
+  static std::vector<FunctionSignaturePtr> extractFunctionSignatures(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+  static std::string extractFunctionName(const std::string& name);
+
+  static std::
+      unordered_map<TypeSignature, std::vector<AggregateFunctionSignaturePtr>>
+      groupSignaturesByReturnType(
+          const std::vector<AggregateFunctionSignaturePtr>& signatures);
+
+ private:
+  static TypeSignature normalizeTypeImpl(
+      const TypeSignature& type,
+      const std::unordered_map<std::string, SignatureVariable>& allVariables,
+      std::unordered_map<std::string, std::string>& renamedVariables);
+
+  // Rename variables used in `type` as T0, T1, ..., Tn, with the ordering of
+  // variables being visited in pre-order traversal.
+  static TypeSignature normalizeType(
+      const TypeSignature& type,
+      const std::unordered_map<std::string, SignatureVariable>& allVariables);
+
+  // Process signatures of distinct pairs of intermediate and result types and
+  // return a vector of the processed signatures.
+  template <class T>
+  static std::vector<T> processSignaturesOfDistinctTypes(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const std::function<T(const AggregateFunctionSignaturePtr&)>&
+          processSignature) {
+    std::unordered_set<std::pair<TypeSignature, TypeSignature>>
+        distinctIntermediateAndResultTypes;
+    std::vector<T> processedSignatures;
+
+    for (const auto& signature : signatures) {
+      auto normalizdIntermediateType =
+          normalizeType(signature->intermediateType(), signature->variables());
+      auto normalizedReturnType =
+          normalizeType(signature->returnType(), signature->variables());
+      if (distinctIntermediateAndResultTypes.count(std::make_pair(
+              normalizdIntermediateType, normalizedReturnType))) {
+        continue;
+      }
+
+      auto processedSignature = processSignature(signature);
+      if (processedSignature) {
+        processedSignatures.push_back(std::move(processedSignature));
+        // Only remember the intermediate and result types and skip subsequent
+        // signatures of the same types if we have already successfully
+        // processed one of them. There may be multiple signatures of the same
+        // intermediate type, some can be processed successfully while some
+        // cannot. We only need one processed signature for each pair of
+        // intermediate and result types.
+        distinctIntermediateAndResultTypes.emplace(
+            normalizdIntermediateType, normalizedReturnType);
+      }
+    }
+    return processedSignatures;
+  }
+
+  // Process signatures of distinct intermediate types and return a vector of
+  // the processed signatures.
+  static std::vector<AggregateFunctionSignaturePtr>
+  processSignaturesOfDistinctIntermediateTypes(
+      const std::vector<AggregateFunctionSignaturePtr>& signatures,
+      const std::function<AggregateFunctionSignaturePtr(
+          const AggregateFunctionSignaturePtr&)>& processSignature) {
+    std::unordered_set<TypeSignature> distinctIntermediateTypes;
+    std::vector<AggregateFunctionSignaturePtr> processedSignatures;
+
+    for (const auto& signature : signatures) {
+      auto normalizdIntermediateType =
+          normalizeType(signature->intermediateType(), signature->variables());
+      if (distinctIntermediateTypes.count(normalizdIntermediateType)) {
+        continue;
+      }
+
+      auto processedSignature = processSignature(signature);
+      if (processedSignature) {
+        processedSignatures.push_back(std::move(processedSignature));
+        // Only remember the intermediate type and skip subsequent signatures of
+        // the same type if we have already successfully processed one of them.
+        // There may be multiple signatures of the same intermediate type, some
+        // can be processed successfully while some cannot. We only need one
+        // processed signature for each intermediate type.
+        distinctIntermediateTypes.emplace(normalizdIntermediateType);
+      }
+    }
+    return processedSignatures;
+  }
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -14,6 +14,8 @@
 add_library(
   velox_exec
   Aggregate.cpp
+  AggregateCompanionAdapter.cpp
+  AggregateCompanionSignatures.cpp
   AggregateFunctionRegistry.cpp
   AggregationMasks.cpp
   AggregateWindow.cpp

--- a/velox/exec/tests/AggregateCompanionAdapterTest.cpp
+++ b/velox/exec/tests/AggregateCompanionAdapterTest.cpp
@@ -1,0 +1,497 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/AggregateCompanionAdapter.h"
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/functions/FunctionRegistry.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+class AggregateFunc : public Aggregate {
+ public:
+  explicit AggregateFunc(TypePtr resultType) : Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return 0;
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
+
+  void addRawInput(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addIntermediateResults(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupRawInput(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupIntermediateResults(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void extractValues(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+
+  void extractAccumulators(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+};
+
+bool registerAggregateFunc(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  registerAggregateFunction(
+      name,
+      signatures,
+      [&](core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(argTypes.size(), 1);
+        if (isPartialOutput(step)) {
+          return std::make_unique<AggregateFunc>(argTypes[0]);
+        }
+        return std::make_unique<AggregateFunc>(resultType);
+      },
+      /*registerCompanionFunctions*/ true);
+
+  return true;
+}
+
+class AggregateCompanionRegistryTest : public testing::Test {
+ protected:
+  void checkEqual(const TypePtr& actual, const TypePtr& expected) {
+    if (expected) {
+      EXPECT_NE(actual, nullptr);
+      EXPECT_TRUE(actual->equivalent(*expected));
+    } else {
+      EXPECT_EQ(actual, nullptr);
+    }
+  }
+
+  void checkAggregateSignaturesCount(
+      const std::string& name,
+      uint32_t numOfSignatures) {
+    auto signatures = getAggregateFunctionSignatures(name);
+    if (numOfSignatures > 0) {
+      EXPECT_TRUE(signatures.has_value());
+      EXPECT_EQ(signatures->size(), numOfSignatures);
+    } else {
+      EXPECT_FALSE(signatures.has_value());
+    }
+  }
+
+  void checkScalarSignaturesCount(
+      const std::string& name,
+      uint32_t numOfSignatures) {
+    auto signatures = getVectorFunctionSignatures(name);
+    if (numOfSignatures > 0) {
+      EXPECT_TRUE(signatures.has_value());
+      EXPECT_EQ(signatures->size(), numOfSignatures);
+    } else {
+      EXPECT_FALSE(signatures.has_value());
+    }
+  }
+
+  void checkAggregateTypeResolution(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& intermediateType,
+      const TypePtr& resultType) {
+    const auto& [resolvedResult, resolveIntermediate] =
+        resolveAggregateFunction(name, argTypes);
+    checkEqual(resolvedResult, resultType);
+    checkEqual(resolveIntermediate, intermediateType);
+  }
+
+  void checkScalarTypeResolution(
+      const std::string& name,
+      const std::vector<TypePtr>& argTypes,
+      const TypePtr& resultType) {
+    const auto& resolvedResult = resolveFunction(name, argTypes);
+    checkEqual(resolvedResult, resultType);
+  }
+};
+
+TEST_F(AggregateCompanionRegistryTest, basic) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .build()};
+  registerAggregateFunc("aggregateFunc1", signatures);
+
+  checkAggregateSignaturesCount("aggregateFunc1_partial", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc1_partial", {DOUBLE()}, ARRAY(DOUBLE()), ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc1_partial", {BIGINT()}, ARRAY(BIGINT()), ARRAY(BIGINT()));
+
+  checkAggregateSignaturesCount("aggregateFunc1_merge", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc1_merge",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc1_merge",
+      {ARRAY(BIGINT())},
+      ARRAY(BIGINT()),
+      ARRAY(BIGINT()));
+
+  checkAggregateSignaturesCount("aggregateFunc1_merge_extract", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc1_merge_extract",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      DOUBLE());
+  checkAggregateTypeResolution(
+      "aggregateFunc1_merge_extract",
+      {ARRAY(BIGINT())},
+      ARRAY(BIGINT()),
+      BIGINT());
+
+  checkScalarSignaturesCount("aggregateFunc1_extract", 2);
+  checkScalarTypeResolution(
+      "aggregateFunc1_extract", {ARRAY(DOUBLE())}, DOUBLE());
+  checkScalarTypeResolution(
+      "aggregateFunc1_extract", {ARRAY(BIGINT())}, BIGINT());
+}
+
+TEST_F(AggregateCompanionRegistryTest, extractFunctionNameWithSuffix) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("array(double)")
+          .argumentType("bigint")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("map(bigint,array(bigint))")
+          .intermediateType("array(double)")
+          .argumentType("map(bigint,array(bigint))")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("row(double, double)")
+          .argumentType("bigint")
+          .argumentType("double")
+          .build()};
+  registerAggregateFunc("aggregateFunc2", signatures);
+
+  checkAggregateSignaturesCount("aggregateFunc2_partial", 5);
+  checkAggregateTypeResolution(
+      "aggregateFunc2_partial", {DOUBLE()}, ARRAY(DOUBLE()), ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc2_partial",
+      {DOUBLE(), DOUBLE()},
+      ARRAY(DOUBLE()),
+      ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc2_partial", {BIGINT()}, ARRAY(DOUBLE()), ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc2_partial",
+      {MAP(BIGINT(), ARRAY(BIGINT()))},
+      ARRAY(DOUBLE()),
+      ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc2_partial",
+      {BIGINT(), DOUBLE()},
+      ROW({DOUBLE(), DOUBLE()}),
+      ROW({DOUBLE(), DOUBLE()}));
+
+  checkAggregateSignaturesCount("aggregateFunc2_merge", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      ARRAY(DOUBLE()));
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge",
+      {ROW({DOUBLE(), DOUBLE()})},
+      ROW({DOUBLE(), DOUBLE()}),
+      ROW({DOUBLE(), DOUBLE()}));
+
+  checkAggregateSignaturesCount("aggregateFunc2_merge_extract_double", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge_extract_double",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      DOUBLE());
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge_extract_double",
+      {ROW({DOUBLE(), DOUBLE()})},
+      ROW({DOUBLE(), DOUBLE()}),
+      DOUBLE());
+
+  checkAggregateSignaturesCount("aggregateFunc2_merge_extract_bigint", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge_extract_bigint",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      BIGINT());
+
+  checkAggregateSignaturesCount(
+      "aggregateFunc2_merge_extract_map_bigint_array_bigint", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc2_merge_extract_map_bigint_array_bigint",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      MAP(BIGINT(), ARRAY(BIGINT())));
+
+  checkScalarSignaturesCount("aggregateFunc2_extract_double", 2);
+  checkScalarTypeResolution(
+      "aggregateFunc2_extract_double", {ARRAY(DOUBLE())}, DOUBLE());
+  checkScalarTypeResolution(
+      "aggregateFunc2_extract_double", {ROW({DOUBLE(), DOUBLE()})}, DOUBLE());
+
+  checkScalarSignaturesCount("aggregateFunc2_extract_bigint", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc2_extract_bigint", {ARRAY(DOUBLE())}, BIGINT());
+
+  checkScalarSignaturesCount(
+      "aggregateFunc2_extract_map_bigint_array_bigint", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc2_extract_map_bigint_array_bigint",
+      {ARRAY(DOUBLE())},
+      MAP(BIGINT(), ARRAY(BIGINT())));
+}
+
+TEST_F(
+    AggregateCompanionRegistryTest,
+    extractFunctionNameWithSuffixOfNestedTypes) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("row(row(bigint, double))")
+          .intermediateType("row(bigint, double)")
+          .argumentType("bigint")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("row(row(bigint), double)")
+          .intermediateType("row(bigint, double)")
+          .argumentType("bigint")
+          .build()};
+  registerAggregateFunc("aggregateFunc3", signatures);
+
+  checkAggregateSignaturesCount(
+      "aggregateFunc3_merge_extract_row_row_bigint_double_endrow_endrow", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc3_merge_extract_row_row_bigint_double_endrow_endrow",
+      {ROW({BIGINT(), DOUBLE()})},
+      ROW({BIGINT(), DOUBLE()}),
+      ROW({ROW({BIGINT(), DOUBLE()})}));
+
+  checkAggregateSignaturesCount(
+      "aggregateFunc3_merge_extract_row_row_bigint_endrow_double_endrow", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc3_merge_extract_row_row_bigint_endrow_double_endrow",
+      {ROW({BIGINT(), DOUBLE()})},
+      ROW({BIGINT(), DOUBLE()}),
+      ROW({ROW({BIGINT()}), DOUBLE()}));
+
+  checkScalarSignaturesCount(
+      "aggregateFunc3_extract_row_row_bigint_double_endrow_endrow", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc3_extract_row_row_bigint_double_endrow_endrow",
+      {ROW({BIGINT(), DOUBLE()})},
+      ROW({ROW({BIGINT(), DOUBLE()})}));
+
+  checkScalarSignaturesCount(
+      "aggregateFunc3_extract_row_row_bigint_endrow_double_endrow", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc3_extract_row_row_bigint_endrow_double_endrow",
+      {ROW({BIGINT(), DOUBLE()})},
+      ROW({ROW({BIGINT()}), DOUBLE()}));
+}
+
+TEST_F(AggregateCompanionRegistryTest, templateSignature) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("T")
+          .intermediateType("array(T)")
+          .argumentType("T")
+          .build()};
+  registerAggregateFunc("aggregateFunc4", signatures);
+
+  checkAggregateSignaturesCount("aggregateFunc4_partial", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc4_partial", {BIGINT()}, ARRAY(BIGINT()), ARRAY(BIGINT()));
+  checkAggregateTypeResolution(
+      "aggregateFunc4_partial", {DOUBLE()}, ARRAY(DOUBLE()), ARRAY(DOUBLE()));
+
+  checkAggregateSignaturesCount("aggregateFunc4_merge", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc4_merge",
+      {ARRAY(BIGINT())},
+      ARRAY(BIGINT()),
+      ARRAY(BIGINT()));
+  checkAggregateTypeResolution(
+      "aggregateFunc4_merge",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      ARRAY(DOUBLE()));
+
+  checkAggregateSignaturesCount("aggregateFunc4_merge_extract", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc4_merge_extract",
+      {ARRAY(BIGINT())},
+      ARRAY(BIGINT()),
+      BIGINT());
+  checkAggregateTypeResolution(
+      "aggregateFunc4_merge_extract",
+      {ARRAY(DOUBLE())},
+      ARRAY(DOUBLE()),
+      DOUBLE());
+
+  checkScalarSignaturesCount("aggregateFunc4_extract", 2);
+  checkScalarTypeResolution(
+      "aggregateFunc4_extract", {ARRAY(BIGINT())}, BIGINT());
+  checkScalarTypeResolution(
+      "aggregateFunc4_extract", {ARRAY(DOUBLE())}, DOUBLE());
+  checkScalarTypeResolution(
+      "aggregateFunc4_extract",
+      {ARRAY(ROW({MAP(VARCHAR(), BIGINT())}))},
+      ROW({MAP(VARCHAR(), BIGINT())}));
+}
+
+TEST_F(
+    AggregateCompanionRegistryTest,
+    sameIntermediateTypeWithDifferentVariables) {
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("double")
+          .intermediateType("T")
+          .argumentType("double")
+          .argumentType("T")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("K")
+          .returnType("bigint")
+          .intermediateType("K")
+          .argumentType("bigint")
+          .argumentType("K")
+          .build()};
+  registerAggregateFunc("aggregateFunc5", signatures);
+
+  checkAggregateSignaturesCount("aggregateFunc5_partial", 2);
+  checkAggregateTypeResolution(
+      "aggregateFunc5_partial", {BIGINT(), BIGINT()}, BIGINT(), BIGINT());
+  checkAggregateTypeResolution(
+      "aggregateFunc5_partial", {DOUBLE(), DOUBLE()}, DOUBLE(), DOUBLE());
+
+  checkAggregateSignaturesCount("aggregateFunc5_merge", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc5_merge", {BIGINT()}, BIGINT(), BIGINT());
+  checkAggregateTypeResolution(
+      "aggregateFunc5_merge", {DOUBLE()}, DOUBLE(), DOUBLE());
+
+  checkAggregateSignaturesCount("aggregateFunc5_merge_extract_double", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc5_merge_extract_double",
+      {VARBINARY()},
+      VARBINARY(),
+      DOUBLE());
+
+  checkAggregateSignaturesCount("aggregateFunc5_merge_extract_bigint", 1);
+  checkAggregateTypeResolution(
+      "aggregateFunc5_merge_extract_bigint",
+      {VARBINARY()},
+      VARBINARY(),
+      BIGINT());
+
+  checkScalarSignaturesCount("aggregateFunc5_extract_double", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc5_extract_double", {VARBINARY()}, DOUBLE());
+
+  checkScalarSignaturesCount("aggregateFunc5_extract_bigint", 1);
+  checkScalarTypeResolution(
+      "aggregateFunc5_extract_bigint", {VARBINARY()}, BIGINT());
+}
+
+TEST_F(
+    AggregateCompanionRegistryTest,
+    resultTypeNotResolvableFromIntermediateType) {
+  // We only register companion functions for original signatures whose result
+  // type can be resolved from its intermediate type.
+  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures{
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("array(T)")
+          .intermediateType("varbinary")
+          .argumentType("T")
+          .build()};
+  registerAggregateFunc("aggregateFunc6", signatures);
+
+  checkAggregateSignaturesCount("aggregateFunc6_partial", 0);
+
+  checkAggregateSignaturesCount("aggregateFunc6_merge", 0);
+
+  checkAggregateSignaturesCount("aggregateFunc6_merge_extract", 0);
+
+  checkScalarSignaturesCount("aggregateFunc6_extract", 0);
+}
+
+} // namespace
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -13,6 +13,17 @@
 # limitations under the License.
 add_subdirectory(utils)
 
+add_executable(aggregate_companion_adapter_test
+               AggregateCompanionAdapterTest.cpp)
+
+add_test(
+  NAME aggregate_companion_adapter_test
+  COMMAND aggregate_companion_adapter_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(aggregate_companion_adapter_test velox_exec
+                      velox_function_registry gtest gtest_main)
+
 add_executable(
   velox_exec_test
   AggregationTest.cpp

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <boost/algorithm/string.hpp>
 #include <memory>
 #include <optional>
 #include <string>
@@ -28,7 +29,7 @@ namespace facebook::velox::exec {
 std::string sanitizeName(const std::string& name);
 
 inline bool isCommonDecimalName(const std::string& typeName) {
-  return (typeName == "DECIMAL");
+  return boost::iequals(typeName, "DECIMAL");
 }
 
 /// Return a list of primitive type names.
@@ -131,6 +132,8 @@ class FunctionSignature {
       std::vector<bool> constantArguments,
       bool variableArity);
 
+  virtual ~FunctionSignature() = default;
+
   const TypeSignature& returnType() const {
     return returnType_;
   }
@@ -147,7 +150,7 @@ class FunctionSignature {
     return variableArity_;
   }
 
-  std::string toString() const;
+  virtual std::string toString() const;
 
   const auto& variables() const {
     return variables_;
@@ -196,6 +199,9 @@ class AggregateFunctionSignature : public FunctionSignature {
  private:
   const TypeSignature intermediateType_;
 };
+
+using AggregateFunctionSignaturePtr =
+    std::shared_ptr<AggregateFunctionSignature>;
 
 namespace {
 


### PR DESCRIPTION
Summary:
This is the first diff to add AggregateCompanionAdapter and necessary code for 
registering companion functions. This adapter automatically produce and register 
companion functions that handle different aggregation steps of a given UDAF. The 
design can be found here: https://github.com/facebookincubator/velox/discussions/4493.

Differential Revision: D44840705

