### PR TITLE
Fix document generation job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -579,7 +579,7 @@ jobs:
             git checkout gh-pages
             cp -R velox/docs/_build/html/* docs
             git add docs
-            if [ -n "$(git status --porcelain)" ]
+            if [ -n "$(git status --porcelain --untracked-files=no)" ]
             then
               git commit -m "Update documentation"
               git push


### PR DESCRIPTION
Fixes #4568

Job failed at the end because the condition that executes a commit and
push only checks for a non-trivial git status to check whether any
changes need to be added. However, it fails to account for untracked
files which also show up in the output. This results in the git commit
command to fail with an exit code of 1 and eventually fail the job.