### PR TITLE
Supprt materialize for OpaqueCustomTypes nested in arrays

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -491,10 +491,13 @@ template <typename VeloxType, typename T>
 auto materializeElement(const T& element) {
   if constexpr (MaterializeType<VeloxType>::requiresMaterialization) {
     return element.materialize();
-  } else if constexpr (util::is_shared_ptr<VeloxType>::value) {
-    return *element;
   } else {
-    return element;
+    using unwrapped_type = typename UnwrapCustomType<VeloxType>::type;
+    if constexpr (util::is_shared_ptr<unwrapped_type>::value) {
+      return *element;
+    } else {
+      return element;
+    }
   }
 }
 

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1673,6 +1673,16 @@ struct CustomType {
   CustomType() {}
 };
 
+template <typename T>
+struct UnwrapCustomType {
+  using type = T;
+};
+
+template <typename T>
+struct UnwrapCustomType<CustomType<T>> {
+  using type = typename T::type;
+};
+
 struct IntervalDayTime {
  private:
   IntervalDayTime() {}
@@ -1682,6 +1692,7 @@ struct Varbinary {
  private:
   Varbinary() {}
 };
+
 struct Varchar {
  private:
   Varchar() {}
@@ -2092,6 +2103,15 @@ struct MaterializeType<std::shared_ptr<T>> {
   using nullable_t = T;
   using null_free_t = T;
   static constexpr bool requiresMaterialization = false;
+};
+
+template <typename T>
+struct MaterializeType<CustomType<T>> {
+  using inner_materialize_t = MaterializeType<typename T::type>;
+  using nullable_t = typename inner_materialize_t::nullable_t;
+  using null_free_t = typename inner_materialize_t::null_free_t;
+  static constexpr bool requiresMaterialization =
+      inner_materialize_t::requiresMaterialization;
 };
 
 template <>


### PR DESCRIPTION
Summary: This is needed specifically for opaqueCustomTypes for some meta internal use cases.

Differential Revision: D44850887

