### PR TITLE
Rename 'kWaitForExchange' to 'kWaitForProducer'.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -701,12 +701,14 @@ std::string blockingReasonToString(BlockingReason reason) {
       return "kWaitForConsumer";
     case BlockingReason::kWaitForSplit:
       return "kWaitForSplit";
-    case BlockingReason::kWaitForExchange:
-      return "kWaitForExchange";
+    case BlockingReason::kWaitForProducer:
+      return "kWaitForProducer";
     case BlockingReason::kWaitForJoinBuild:
       return "kWaitForJoinBuild";
     case BlockingReason::kWaitForJoinProbe:
       return "kWaitForJoinProbe";
+    case BlockingReason::kWaitForMergeJoinRightSide:
+      return "kWaitForMergeJoinRightSide";
     case BlockingReason::kWaitForMemory:
       return "kWaitForMemory";
     case BlockingReason::kWaitForConnector:

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -128,7 +128,10 @@ enum class BlockingReason {
   kNotBlocked,
   kWaitForConsumer,
   kWaitForSplit,
-  kWaitForExchange,
+  /// Some operators can get blocked due to the producer(s) (they are currently
+  /// waiting data from) not having anything produced. Used by LocalExchange,
+  /// LocalMergeExchange, Exchange and MergeExchange operators.
+  kWaitForProducer,
   kWaitForJoinBuild,
   /// For a build operator, it is blocked waiting for the probe operators to
   /// finish probing before build the next hash table from one of the previously
@@ -137,6 +140,9 @@ enum class BlockingReason {
   /// operators to finish probing before notifying the build operators to build
   /// the next hash table from the previously spilled data.
   kWaitForJoinProbe,
+  /// Used by MergeJoin operator, indicating that it was blocked by the right
+  /// side input being unavailable.
+  kWaitForMergeJoinRightSide,
   kWaitForMemory,
   kWaitForConnector,
   /// Build operator is blocked waiting for all its peers to stop to run group

--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -344,14 +344,13 @@ BlockingReason Exchange::isBlocked(ContinueFuture* future) {
     std::vector<ContinueFuture> futures;
     futures.push_back(std::move(splitFuture_));
     futures.push_back(std::move(dataFuture));
-
     *future = folly::collectAny(futures).unit();
-  } else {
-    // Block until data becomes available.
-    *future = std::move(dataFuture);
+    return BlockingReason::kWaitForSplit;
   }
-  return stats_.rlock()->numSplits == 0 ? BlockingReason::kWaitForSplit
-                                        : BlockingReason::kWaitForExchange;
+
+  // Block until data becomes available.
+  *future = std::move(dataFuture);
+  return BlockingReason::kWaitForProducer;
 }
 
 bool Exchange::isFinished() {

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -143,7 +143,7 @@ BlockingReason LocalExchangeQueue::next(
       consumerPromises_.emplace_back("LocalExchangeQueue::next");
       *future = consumerPromises_.back().getSemiFuture();
 
-      return BlockingReason::kWaitForExchange;
+      return BlockingReason::kWaitForProducer;
     }
 
     *data = queue.front();

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -74,7 +74,7 @@ class LocalExchangeQueue {
 
   /// Used by a consumer to fetch some data. Returns kNotBlocked and sets data
   /// to nullptr if all data has been fetched and all producers are done
-  /// producing data. Returns kWaitForExchange if there is no data, but some
+  /// producing data. Returns kWaitForProducer if there is no data, but some
   /// producers are not done producing data. Sets future that will be completed
   /// once there is data to fetch or if all producers report completion.
   ///

--- a/velox/exec/Merge.cpp
+++ b/velox/exec/Merge.cpp
@@ -93,7 +93,7 @@ BlockingReason Merge::isBlocked(ContinueFuture* future) {
   if (!sourceBlockingFutures_.empty()) {
     *future = std::move(sourceBlockingFutures_.back());
     sourceBlockingFutures_.pop_back();
-    return BlockingReason::kWaitForExchange;
+    return BlockingReason::kWaitForProducer;
   }
 
   return BlockingReason::kNotBlocked;

--- a/velox/exec/MergeJoin.h
+++ b/velox/exec/MergeJoin.h
@@ -391,7 +391,7 @@ class MergeJoin : public Operator {
   vector_size_t outputSize_;
 
   /// A future that will be completed when right side input becomes available.
-  ContinueFuture future_{ContinueFuture::makeEmpty()};
+  ContinueFuture futureRightSideInput_{ContinueFuture::makeEmpty()};
 
   /// True if all the right side data has been received.
   bool noMoreRightInput_{false};

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -54,7 +54,7 @@ class LocalMergeSource : public MergeSource {
         }
         consumerPromises_.emplace_back("LocalMergeSourceQueue::next");
         *future = consumerPromises_.back().getSemiFuture();
-        return BlockingReason::kWaitForExchange;
+        return BlockingReason::kWaitForProducer;
       }
 
       data = data_.front();
@@ -141,7 +141,7 @@ class MergeExchangeSource : public MergeSource {
       }
 
       if (!currentPage_) {
-        return BlockingReason::kWaitForExchange;
+        return BlockingReason::kWaitForProducer;
       }
     }
     if (!inputStream_) {
@@ -234,7 +234,7 @@ BlockingReason MergeJoinSource::next(
 
     consumerPromise_ = ContinuePromise("MergeJoinSource::next");
     *future = consumerPromise_->getSemiFuture();
-    return BlockingReason::kWaitForExchange;
+    return BlockingReason::kWaitForProducer;
   });
 }
 


### PR DESCRIPTION
Summary:
* To make blocking reason clearer we rename 'kWaitForExchange' to 'kWaitForProducer'.
* To make runtime counters clearer we return kWaitForSplit from Exchange::isBlocked() only when splitFuture_ is valid (expecting splits).
* Added new blocking reason kWaitForMergeJoinRightSide to use in the MergeJoin.
* Renamed future member of MergeJoin to reflect its semantics..

Differential Revision: D44851240

