### PR TITLE
Add testAggregationsWithCompanion() API and test avg() companion functions

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -229,6 +229,10 @@ class Aggregate {
     clearInternal();
   }
 
+  void enableValidateIntermediateInputs() {
+    validateIntermediateInputs_ = true;
+  }
+
   static std::unique_ptr<Aggregate> create(
       const std::string& name,
       core::AggregationNode::Step step,
@@ -349,6 +353,8 @@ class Aggregate {
   // different indices vector as the one we get from the DecodedVector is simply
   // sequential.
   std::vector<vector_size_t> pushdownCustomIndices_;
+
+  bool validateIntermediateInputs_ = false;
 };
 
 using AggregateFunctionFactory = std::function<std::unique_ptr<Aggregate>(

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -122,6 +122,7 @@ void AggregateCompanionAdapter::MergeFunction::addRawInput(
     const SelectivityVector& rows,
     const std::vector<VectorPtr>& args,
     bool mayPushdown) {
+  fn_->enableValidateIntermediateInputs();
   fn_->addIntermediateResults(groups, rows, args, mayPushdown);
 }
 
@@ -210,6 +211,7 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
   std::vector<vector_size_t> allSelectedRange;
   rows.applyToSelected([&](auto row) { allSelectedRange.push_back(row); });
   fn_->initializeNewGroups(groups, allSelectedRange);
+  fn_->enableValidateIntermediateInputs();
   fn_->addIntermediateResults(groups, rows, args, false);
 
   auto localResult = BaseVector::create(outputType, rows.end(), context.pool());

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -136,6 +136,10 @@ struct AggregateCompanionAdapter {
     explicit ExtractFunction(std::unique_ptr<Aggregate> fn)
         : fn_{std::move(fn)} {}
 
+    bool isDefaultNullBehavior() const override {
+      return false;
+    }
+
     void apply(
         const SelectivityVector& rows,
         std::vector<VectorPtr>& args,

--- a/velox/exec/tests/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/AggregationFuzzerRunner.h
@@ -70,7 +70,7 @@ class AggregationFuzzerRunner {
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
       const std::unordered_map<std::string, std::string>&
-          orderDependentFunctions) {
+          customVerificationFunctions) {
     auto signatures = facebook::velox::exec::getAggregateFunctionSignatures();
     if (signatures.empty()) {
       LOG(ERROR) << "No aggregate functions registered.";
@@ -91,7 +91,7 @@ class AggregationFuzzerRunner {
     facebook::velox::filesystems::registerLocalFileSystem();
 
     facebook::velox::exec::test::aggregateFuzzer(
-        filteredSignatures, seed, orderDependentFunctions);
+        filteredSignatures, seed, customVerificationFunctions);
     // Calling gtest here so that it can be recognized as tests in CI systems.
     return RUN_ALL_TESTS();
   }

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -54,11 +54,12 @@ int main(int argc, char** argv) {
   };
 
   // Functions whose results verification should be skipped. These can be
-  // order-dependent functions whose results depend on the order of input rows.
-  // For some functions, the result can be transformed to a value that can be
-  // verified. If such transformation exists, it can be specified to be used for
-  // results verification. If no transformation is specified, results are not
-  // verified.
+  // order-dependent functions whose results depend on the order of input rows,
+  // or functions that return complex-typed results containing floating-point
+  // fields. For some functions, the result can be transformed to a value that
+  // can be verified. If such transformation exists, it can be specified to be
+  // used for results verification. If no transformation is specified, results
+  // are not verified.
   std::unordered_map<std::string, std::string> customVerificationFunctions = {
       // Order-dependent functions.
       {"approx_distinct", ""},
@@ -70,6 +71,13 @@ int main(int argc, char** argv) {
       {"map_union_sum", "array_sort(map_keys({}))"},
       {"max_by", ""},
       {"min_by", ""},
+      // TODO: Skip result verification of companion functions that return
+      // complex types that contain floating-point fields for now, until we fix
+      // test utilities in QueryAssertions to tolerate floating-point
+      // imprecision in complex types.
+      // https://github.com/facebookincubator/velox/issues/4481
+      {"avg_partial", ""},
+      {"avg_merge", ""},
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return AggregationFuzzerRunner::run(

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -53,12 +53,14 @@ int main(int argc, char** argv) {
       "stddev_pop", // https://github.com/facebookincubator/velox/issues/3493
   };
 
-  // The results of the following functions depend on the order of input
-  // rows. For some functions, the result can be transformed to a value that
-  // doesn't dopend on the order of inputs. If such transformation exists, it
-  // can be specified to be used for results verification. If no transformation
-  // is specified, results are not verified.
-  std::unordered_map<std::string, std::string> orderDependentFunctions = {
+  // Functions whose results verification should be skipped. These can be
+  // order-dependent functions whose results depend on the order of input rows.
+  // For some functions, the result can be transformed to a value that can be
+  // verified. If such transformation exists, it can be specified to be used for
+  // results verification. If no transformation is specified, results are not
+  // verified.
+  std::unordered_map<std::string, std::string> customVerificationFunctions = {
+      // Order-dependent functions.
       {"approx_distinct", ""},
       {"approx_set", ""},
       {"arbitrary", ""},
@@ -71,5 +73,5 @@ int main(int argc, char** argv) {
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return AggregationFuzzerRunner::run(
-      FLAGS_only, initialSeed, skipFunctions, orderDependentFunctions);
+      FLAGS_only, initialSeed, skipFunctions, customVerificationFunctions);
 }

--- a/velox/functions/lib/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/tests/CMakeLists.txt
@@ -14,4 +14,5 @@
 
 add_library(velox_functions_aggregates_test_lib AggregationTestBase.cpp)
 
-target_link_libraries(velox_functions_aggregates_test_lib velox_exec_test_lib)
+target_link_libraries(velox_functions_aggregates_test_lib velox_exec_test_lib
+                      velox_vector_test_lib)

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -402,7 +402,7 @@ bool registerAverage(const std::string& name) {
                            .integerVariable("a_precision")
                            .integerVariable("a_scale")
                            .argumentType("DECIMAL(a_precision, a_scale)")
-                           .intermediateType("VARBINARY")
+                           .intermediateType("varbinary")
                            .returnType("DECIMAL(a_precision, a_scale)")
                            .build());
 
@@ -488,7 +488,8 @@ bool registerAverage(const std::string& name) {
                   resultType->kindName());
           }
         }
-      });
+      },
+      /*registerCompanionFunctions*/ true);
   return true;
 }
 


### PR DESCRIPTION
Summary: This diff adds a testAggregationsWithCompanion() API that tests aggregation plans using companion functions. It only tests with partial, merge, and extract companion functions. Testing with merge-extract companion function with be added later. This diff tests the avg() aggregation function with this new API.

Differential Revision: D44860582

