### PR TITLE
Teach getdeps to find VS 2022 Professional's dumpbin.exe

### DIFF
--- a/build/fbcode_builder/getdeps/dyndeps.py
+++ b/build/fbcode_builder/getdeps/dyndeps.py
@@ -190,6 +190,9 @@ class WinDeps(DepBase):
                 "VC/bin/dumpbin.exe"
             ),
             ("c:/Program Files (x86)/Microsoft Visual Studio */VC/bin/dumpbin.exe"),
+            (
+                "C:/Program Files/Microsoft Visual Studio/*/Professional/VC/Tools/MSVC/*/bin/HostX64/x64/dumpbin.exe"
+            ),
         ]
         for pattern in globs:
             for exe in glob.glob(pattern):


### PR DESCRIPTION
Summary:
Allows one to do getdeps builds on machines using Visual Studio 2022
Professional.

Reviewed By: chadaustin

Differential Revision: D44804055

