### PR TITLE
Fix excessive array hash size for sparse tables

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -66,6 +66,14 @@ class GroupingSet {
 
   void resetPartial();
 
+  /// Returns true if 'this' should start producing partial
+  /// aggregation results. Checks the memory consumption against
+  /// 'maxBytes'. If exceeding 'maxBytes', sees if changing hash mode
+  /// can free up space and rehashes and returns false if significant
+  /// space was recovered. In specific, changing from an array hash
+  /// based on value ranges to one based on value ids can save a lot.
+  bool isPartialFull(int64_t maxBytes);
+
   const HashLookup& hashLookup() const;
 
   /// Spills content until under 'targetRows' and under 'targetBytes'

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -188,7 +188,7 @@ void HashAggregation::addInput(RowVectorPtr input) {
   // aggregation as the final aggregator will handle it the same way as the
   // partial aggregator. Hence, we have to use more memory anyway.
   if (isPartialOutput_ && !isGlobal_ &&
-      groupingSet_->allocatedBytes() > maxPartialAggregationMemoryUsage_) {
+      groupingSet_->isPartialFull(maxPartialAggregationMemoryUsage_)) {
     partialFull_ = true;
   }
 


### PR DESCRIPTION
An array of up to 16 MB can be allocated for an array based hash table with only two keys if these kays are about one million apart. This will cause a partial aggregation hash table to hit the 16 MB default limit immediately after creation. This in turn will cause it to flush in the worst case after every batch of input, which will convert a 100% reducing partial agg into no reduction and high overhead.

To fix this, we check, when about to flush a partial aggregation, if we are in array hash mode with a large array and sparse entries. If so, we disable range value ids for array based aggregation and reselect a hash mode. The choice to disable array hash tables for range value ids stays on for the lifetime of the hash table.