### PR TITLE
Fix Expr::eval overwrite partial result vector when called with empty selectivity vector

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -110,6 +110,15 @@ bool hasConditionals(Expr* expr) {
 
   return false;
 }
+
+void checkOrSetEmptyResult(
+    const TypePtr& type,
+    memory::MemoryPool* pool,
+    VectorPtr& result) {
+  if (!result) {
+    result = BaseVector::createNullConstant(type, 0, pool);
+  }
+}
 } // namespace
 
 Expr::Expr(
@@ -396,8 +405,7 @@ void Expr::evalSimplified(
     EvalCtx& context,
     VectorPtr& result) {
   if (!rows.hasSelections()) {
-    // empty input, return an empty vector of the right type
-    result = BaseVector::createNullConstant(type(), 0, context.pool());
+    checkOrSetEmptyResult(type(), context.pool(), result);
     return;
   }
 
@@ -674,6 +682,11 @@ void Expr::evalFlatNoNullsImpl(
       {parentExprSet ? onTopLevelException : onException,
        parentExprSet ? (void*)&exprExceptionContext : this});
 
+  if (!rows.hasSelections()) {
+    checkOrSetEmptyResult(type(), context.pool(), result);
+    return;
+  }
+
   if (isSpecialForm()) {
     evalSpecialFormWithStats(rows, context, result);
     return;
@@ -722,8 +735,7 @@ void Expr::eval(
        parentExprSet ? (void*)&exprExceptionContext : this});
 
   if (!rows.hasSelections()) {
-    // empty input, return an empty vector of the right type
-    result = BaseVector::createNullConstant(type(), 0, context.pool());
+    checkOrSetEmptyResult(type(), context.pool(), result);
     return;
   }
 
@@ -1063,8 +1075,7 @@ void Expr::evalWithNulls(
     EvalCtx& context,
     VectorPtr& result) {
   if (!rows.hasSelections()) {
-    // empty input, return an empty vector of the right type
-    result = BaseVector::createNullConstant(type(), 0, context.pool());
+    checkOrSetEmptyResult(type(), context.pool(), result);
     return;
   }
 
@@ -1276,8 +1287,7 @@ void Expr::evalAll(
     EvalCtx& context,
     VectorPtr& result) {
   if (!rows.hasSelections()) {
-    // empty input, return an empty vector of the right type
-    result = BaseVector::createNullConstant(type(), 0, context.pool());
+    checkOrSetEmptyResult(type(), context.pool(), result);
     return;
   }
 

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -90,6 +90,10 @@ void SwitchExpr::evalSpecialForm(
 
     if (context.errors()) {
       context.deselectErrors(*remainingRows);
+      if (!remainingRows->hasSelections()) {
+        context.releaseVector(condition);
+        break;
+      }
     }
 
     const auto booleanMix = getFlatBool(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -171,6 +171,25 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return result[0];
   }
 
+  template <typename T = exec::ExprSet>
+  void evalWithEmptyRows(
+      const std::string& expr,
+      const RowVectorPtr& input,
+      VectorPtr& result,
+      const VectorPtr& expected) {
+    parse::ParseOptions options;
+    auto untyped = parse::parseExpr(expr, options);
+    auto typedExpr = core::Expressions::inferTypes(
+        untyped, asRowType(input->type()), pool());
+
+    SelectivityVector rows{input->size(), false};
+    T exprSet({typedExpr}, execCtx_.get());
+    exec::EvalCtx evalCtx(execCtx_.get(), &exprSet, input.get());
+    std::vector<VectorPtr> results{result};
+    exprSet.eval(rows, evalCtx, results);
+    assertEqualVectors(result, expected);
+  }
+
   template <typename T = ComplexType>
   std::shared_ptr<core::ConstantTypedExpr> makeConstantExpr(
       const VectorPtr& base,
@@ -3900,4 +3919,34 @@ TEST_F(ExprTest, dictionaryResizeWithIndicesReset) {
       "coalesce(plus(c0, 1::BIGINT), 1::BIGINT)", makeRowVector({wrappedC0}));
   auto expected = makeNullableFlatVector<int64_t>({2, 2, 1});
   assertEqualVectors(expected, result);
+}
+
+TEST_F(ExprTest, noSelectedRows) {
+  VectorPtr result = makeFlatVector<int64_t>({7, 8, 9});
+  auto expected = makeFlatVector<int64_t>({7, 8, 9});
+
+  // Test evalFlatNoNulls code path.
+  {
+    auto input = makeRowVector(
+        {makeFlatVector<int64_t>({1, 2, 3}),
+         makeFlatVector<int64_t>({4, 5, 6})});
+    evalWithEmptyRows("c0 + c1", input, result, expected);
+  }
+
+  // Test regular evaluation path.
+  {
+    auto input = makeRowVector(
+        {makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+         makeNullableFlatVector<int64_t>({std::nullopt, 5, 6})});
+    evalWithEmptyRows("c0 + c1", input, result, expected);
+  }
+
+  // Test simplified evaluation path.
+  {
+    auto input = makeRowVector(
+        {makeNullableFlatVector<int64_t>({1, std::nullopt, 3}),
+         makeNullableFlatVector<int64_t>({std::nullopt, 5, 6})});
+    evalWithEmptyRows<exec::ExprSetSimplified>(
+        "c0 + c1", input, result, expected);
+  }
 }


### PR DESCRIPTION
Summary:
Fuzzer found a bug where SwitchExpr evaluates the second then clause with an empty SelectivityVector because all remaining rows threw during the evaluation of the second condition. However, Expr::eval overwrote the partial result vector with a constant NULL vector and caused incorrect result. This diff fixes the bug by skipping evaluation of then clause in SwitchExpr when there is no selected rows, and make Expr::eval and Expr::evalSimplified only assign a constant NULL vector to result if result is nullptr.

This diff fixes https://github.com/facebookincubator/velox/issues/4585.

Differential Revision: D44920187

