### PR TITLE
Bypass non-reducing partial aggregation

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -88,6 +88,12 @@ class QueryConfig {
   static constexpr const char* kMaxExtendedPartialAggregationMemory =
       "max_extended_partial_aggregation_memory";
 
+  static constexpr const char* kAbandonPartialAggregationMinRows =
+      "abandon_partial_aggregation_min_rows";
+
+  static constexpr const char* kAbandonPartialAggregationMinPct =
+      "abandon_partial_aggregation_min_pct";
+
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "driver.max-page-partitioning-buffer-size";
 
@@ -188,6 +194,14 @@ class QueryConfig {
   uint64_t maxExtendedPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 26;
     return get<uint64_t>(kMaxExtendedPartialAggregationMemory, kDefault);
+  }
+
+  int32_t abandonPartialAggregationMinRows() const {
+    return get<int32_t>(kAbandonPartialAggregationMinRows, 10000);
+  }
+
+  int32_t abandonPartialAggregationMinPct() const {
+    return get<int32_t>(kAbandonPartialAggregationMinPct, 80);
   }
 
   uint64_t aggregationSpillMemoryThreshold() const {

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -78,6 +78,11 @@ class Aggregate {
     return true;
   }
 
+  /// Returns true if toIntermediate() is supported.
+  virtual bool supportsToIntermediate() const {
+    return false;
+  }
+
   void setAllocator(HashStringAllocator* allocator) {
     setAllocatorInternal(allocator);
   }
@@ -200,6 +205,18 @@ class Aggregate {
   // See comment on 'result' in extractValues().
   virtual void
   extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result) = 0;
+
+  /// Produces an accumulator initialized from a single value for each
+  /// row in 'rows'. The raw arguments of the aggregate are in 'args',
+  /// which have the same meaning as in addRawInput. The result is
+  /// placed in 'result'. 'result is allocated if nullptr, otherwise
+  /// it is expected to be a writable flat vector of the right type.
+  virtual void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const {
+    VELOX_NYI("toIntermediate not supported");
+  }
 
   // Frees any out of line storage for the accumulator in
   // 'groups'. No-op for fixed length accumulators.

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -64,6 +64,11 @@ class HashAggregation : public Operator {
   // measure of the effectiveness of the partial aggregation.
   void maybeIncreasePartialAggregationMemoryUsage(double aggregationPct);
 
+  // True if we have enough rows and not enough reduction, i.e. more than
+  // 'abandonPartialAggregationMinRows_' rows and more than
+  // 'abandonPartialAggregationMinPct_' % of rows are unique.
+  bool abandonPartialAggregationEarly(int64_t numOutput) const;
+
   const bool isPartialOutput_;
   const bool isDistinct_;
   const bool isGlobal_;
@@ -76,6 +81,17 @@ class HashAggregation : public Operator {
   bool partialFull_ = false;
   bool newDistincts_ = false;
   bool finished_ = false;
+  // True if partial aggregation has been found to be non-reducing.
+  bool abandonedPartialAggregation_{false};
+
+  // Minimum number of rows to see before deciding to give up on partial
+  // aggregation.
+  const int32_t abandonPartialAggregationMinRows_;
+
+  // Min unique rows pct for partial aggregation. If more than this many rows
+  // are unique, the partial aggregation is not worthwhile.
+  const int32_t abandonPartialAggregationMinPct_;
+
   RowContainerIterator resultIterator_;
   bool pushdownChecked_ = false;
   bool mayPushdown_ = false;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -187,6 +187,16 @@ class RowContainer {
              : 0);
   }
 
+  /// Sets all fields, aggregates, keys and dependents to null. Used
+  /// when making a row with uninitialized keys for aggregates with
+  /// no-op partial aggregation.
+  void setAllNull(char* FOLLY_NONNULL row) {
+    if (!nullOffsets_.empty()) {
+      memset(row + nullByte(nullOffsets_[0]), 0xff, initialNulls_.size());
+      bits::clearBit(row, freeFlagOffset_);
+    }
+  }
+
   // The row size excluding any out-of-line stored variable length values.
   int32_t fixedRowSize() const {
     return fixedRowSize_;

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -221,6 +221,45 @@ void AggregationTestBase::testAggregations(
     }
   }
 
+  if (!groupingKeys.empty() && allowInputShuffle_) {
+    SCOPED_TRACE("Run partial + final with abandon partial agg");
+    PlanBuilder builder(pool());
+    makeSource(builder);
+
+    core::PlanNodeId partialNodeId;
+    core::PlanNodeId intermediateNodeId;
+    builder.partialAggregation(groupingKeys, aggregates)
+        .capturePlanNodeId(partialNodeId)
+        .intermediateAggregation()
+        .capturePlanNodeId(intermediateNodeId)
+        .finalAggregation();
+
+    if (!postAggregationProjections.empty()) {
+      builder.project(postAggregationProjections);
+    }
+
+    AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder
+        .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+        .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+        .config(core::QueryConfig::kMaxPartialAggregationMemory, "0")
+        .config(core::QueryConfig::kMaxExtendedPartialAggregationMemory, "0")
+        .maxDrivers(1);
+
+    auto task = assertResults(queryBuilder);
+
+    // Expect partial aggregation was turned off if there were more than 1 input
+    // batches.
+    auto taskStats = toPlanStats(task->taskStats());
+    auto inputVectors = taskStats.at(partialNodeId).inputVectors;
+    auto partialStats = taskStats.at(partialNodeId).customStats;
+    auto intermediateStats = taskStats.at(intermediateNodeId).customStats;
+    if (inputVectors > 1) {
+      EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
+      EXPECT_LT(0, intermediateStats.at("abandonedPartialAggregation").count);
+    }
+  }
+
   {
     SCOPED_TRACE("Run single");
     PlanBuilder builder(pool());


### PR DESCRIPTION
If a partial aggregation does not reduce data size even after increasing its memory, we stop doing it. Adds a toIntermediate method to GroupingSet and Aggregates. This translates a vector of raw input into a vector of accumulators, each initialized from the single input value on the row.

If toIntermediate is not defined for one or more of the aggregates, GroupingSet::toIntermediate makes temporary rows in the RowContainer and uses the regular Aggregate methods to make a single-value accumulator.

Fixes #3194