### PR TITLE
Fix memory leak in expression eval

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -159,18 +159,7 @@ class Expr {
   virtual void computeMetadata();
 
   virtual void reset() {
-    for (auto& [_, sharedSubexprResults] : sharedSubexprResults_) {
-      auto& [sharedSubexprRows, sharedSubexprValues] = sharedSubexprResults;
-      if (sharedSubexprRows) {
-        sharedSubexprRows->clearAll();
-      }
-      if (BaseVector::isVectorWritable(sharedSubexprValues) &&
-          sharedSubexprValues->isFlatEncoding()) {
-        sharedSubexprValues->resize(0);
-      } else {
-        sharedSubexprValues = nullptr;
-      }
-    }
+    sharedSubexprResults_.clear();
   }
 
   void clearMemo() {


### PR DESCRIPTION
Summary:
clearSharedSubexprs() calls reset on the expression, a previous change (PR4441) that caches
shared expression along with the inputs introduced a leak. This diff fix that.

Differential Revision: D44940147

