### PR TITLE
Support a non-thread safe leaf memory usage tracker

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -120,6 +120,11 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// but sensitive to its cpu cost so we provide an options for user to turn
     /// it off.
     bool trackUsage{true};
+    /// If true, track the leaf memory pool usage in a thread-safe mode
+    /// otherwise not. This only applies for leaf memory pool with memory usage
+    /// tracking enabled. We use non-thread safe tracking mode for single
+    /// threaded use case.
+    bool threadSafe{true};
     /// If true, check the memory usage leak on destruction.
     ///
     /// TODO: deprecate this flag after all the existing memory leak use cases
@@ -171,6 +176,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual std::shared_ptr<MemoryPool> addChild(
       const std::string& name,
       Kind kind = MemoryPool::Kind::kLeaf,
+      bool threadSafe = true,
       std::shared_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Allocates a buffer with specified 'size'.
@@ -315,6 +321,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       std::shared_ptr<MemoryPool> parent,
       const std::string& name,
       Kind kind,
+      bool threadSafe,
       std::shared_ptr<MemoryReclaimer>) = 0;
 
   /// Invoked only on destruction to remove this memory pool from its parent's
@@ -418,6 +425,7 @@ class MemoryPoolImpl : public MemoryPool {
       std::shared_ptr<MemoryPool> parent,
       const std::string& name,
       Kind kind,
+      bool threadSafe,
       std::shared_ptr<MemoryReclaimer> reclaimer) override;
 
   // Gets the memory allocation stats of the MemoryPoolImpl attached to the

--- a/velox/common/memory/MemoryUsageTracker.cpp
+++ b/velox/common/memory/MemoryUsageTracker.cpp
@@ -25,13 +25,30 @@ DECLARE_bool(velox_memory_leak_check_enabled);
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
+
+std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::addChild(
+    bool leafTracker,
+    bool threadSafe) {
+  VELOX_CHECK(
+      !leafTracker_,
+      "Can only create child usage tracker from a non-leaf memory usage tracker: {}",
+      toString());
+  VELOX_CHECK(
+      leafTracker || threadSafe,
+      "Can only create leaf memory usage tracker with thread-safe off");
+  ++numChildren_;
+  return create(
+      shared_from_this(), leafTracker, threadSafe, kMaxMemory, checkUsageLeak_);
+}
+
 std::shared_ptr<MemoryUsageTracker> MemoryUsageTracker::create(
     const std::shared_ptr<MemoryUsageTracker>& parent,
     bool leafTracker,
+    bool threadSafe,
     int64_t maxMemory,
     bool checkUsageLeak) {
-  auto* tracker =
-      new MemoryUsageTracker(parent, leafTracker, maxMemory, checkUsageLeak);
+  auto* tracker = new MemoryUsageTracker(
+      parent, leafTracker, threadSafe, maxMemory, checkUsageLeak);
   return std::shared_ptr<MemoryUsageTracker>(tracker);
 }
 
@@ -73,6 +90,15 @@ void MemoryUsageTracker::reserve(uint64_t size) {
 }
 
 void MemoryUsageTracker::reserve(uint64_t size, bool reserveOnly) {
+  if (threadSafe_) {
+    reserveThreadSafe(size, reserveOnly);
+  } else {
+    reserveNonThreadSafe(size, reserveOnly);
+  }
+}
+
+void MemoryUsageTracker::reserveThreadSafe(uint64_t size, bool reserveOnly) {
+  VELOX_CHECK(threadSafe_);
   VELOX_CHECK_GT(size, 0);
 
   int32_t numAttempts = 0;
@@ -80,20 +106,20 @@ void MemoryUsageTracker::reserve(uint64_t size, bool reserveOnly) {
   for (;; ++numAttempts) {
     {
       std::lock_guard<std::mutex> l(mutex_);
-      increment = reservationSizeLocked(size);
+      increment = reservationSizeNoLock(size);
       if (increment == 0) {
         if (reserveOnly) {
           minReservationBytes_ = reservationBytes_;
         } else {
           usedReservationBytes_ += size;
         }
-        sanityCheckLocked();
+        sanityCheckNoLock();
         break;
       }
     }
     TestValue::adjust(
-        "facebook::velox::memory::MemoryUsageTracker::reserve", this);
-    incrementReservation(increment);
+        "facebook::velox::memory::MemoryUsageTracker::reserveThreadSafe", this);
+    incrementReservationThreadSafe(increment);
   }
 
   // NOTE: in case of concurrent reserve and release requests, we might see
@@ -106,43 +132,37 @@ void MemoryUsageTracker::reserve(uint64_t size, bool reserveOnly) {
   }
 }
 
-void MemoryUsageTracker::release() {
-  reservationCheck();
-  ++numReleases_;
-  release(0);
-}
+void MemoryUsageTracker::reserveNonThreadSafe(uint64_t size, bool reserveOnly) {
+  VELOX_CHECK(!threadSafe_);
+  VELOX_CHECK_GT(size, 0);
 
-void MemoryUsageTracker::release(uint64_t size) {
-  int64_t freeable = 0;
-  {
-    std::lock_guard<std::mutex> l(mutex_);
-    int64_t newQuantized;
-    if (size == 0) {
-      if (minReservationBytes_ == 0) {
-        return;
+  int32_t numAttempts{0};
+  for (;; ++numAttempts) {
+    int64_t increment = reservationSizeNoLock(size);
+    if (FOLLY_LIKELY(increment == 0)) {
+      if (FOLLY_UNLIKELY(reserveOnly)) {
+        minReservationBytes_ = reservationBytes_;
+      } else {
+        usedReservationBytes_ += size;
       }
-      newQuantized = quantizedSize(usedReservationBytes_);
-      minReservationBytes_ = 0;
-    } else {
-      usedReservationBytes_ -= size;
-      const int64_t newCap =
-          std::max(minReservationBytes_, usedReservationBytes_);
-      newQuantized = quantizedSize(newCap);
+      sanityCheckNoLock();
+      break;
     }
-    freeable = reservationBytes_ - newQuantized;
-    if (freeable > 0) {
-      reservationBytes_ = newQuantized;
-    }
-    sanityCheckLocked();
+    incrementReservationNonThreadSafe(increment);
   }
-  if (freeable > 0) {
-    // NOTE: we can only release memory from a leaf memory usage tracker.
-    VELOX_DCHECK_NOT_NULL(parent_);
-    parent_->decrementReservation(freeable);
+
+  // NOTE: in case of concurrent reserve requests to the same root memory pool
+  // from the other leaf memory pools, we might have to retry
+  // incrementReservation(). This should happen rarely in production
+  // as the leaf tracker does quantized memory reservation so that we don't
+  // expect high concurrency at the root memory pool.
+  if (FOLLY_UNLIKELY(numAttempts > 1)) {
+    numCollisions_ += numAttempts - 1;
   }
 }
 
-bool MemoryUsageTracker::incrementReservation(uint64_t size) {
+bool MemoryUsageTracker::incrementReservationThreadSafe(uint64_t size) {
+  VELOX_CHECK(threadSafe_);
   VELOX_CHECK_GT(size, 0);
 
   // Update parent first. If one of the ancestor's limits are exceeded, it will
@@ -151,7 +171,7 @@ bool MemoryUsageTracker::incrementReservation(uint64_t size) {
   // makeMemoryCapExceededMessage_ is set.
   if (parent_ != nullptr) {
     try {
-      if (!parent_->incrementReservation(size)) {
+      if (!parent_->incrementReservationThreadSafe(size)) {
         return false;
       }
     } catch (const VeloxRuntimeError& e) {
@@ -174,7 +194,7 @@ bool MemoryUsageTracker::incrementReservation(uint64_t size) {
 
   if ((growCallback_ != nullptr) && growCallback_(size, *this)) {
     TestValue::adjust(
-        "facebook::velox::memory::MemoryUsageTracker::incrementReservation::AfterGrowCallback",
+        "facebook::velox::memory::MemoryUsageTracker::incrementReservationThreadSafe::AfterGrowCallback",
         this);
     // NOTE: the memory reservation might still fail even if the memory grow
     // callback succeeds. The reason is that we don't hold the root tracker's
@@ -198,6 +218,97 @@ bool MemoryUsageTracker::incrementReservation(uint64_t size) {
   VELOX_MEM_CAP_EXCEEDED(errorMessage);
 }
 
+bool MemoryUsageTracker::incrementReservationNonThreadSafe(uint64_t size) {
+  VELOX_CHECK_NOT_NULL(parent_);
+  VELOX_CHECK(!threadSafe_ && leafTracker_);
+  try {
+    if (!parent_->incrementReservationThreadSafe(size)) {
+      return false;
+    }
+  } catch (const VeloxRuntimeError& e) {
+    if (makeMemoryCapExceededMessage_ == nullptr) {
+      throw;
+    }
+    auto errorMessage =
+        e.message() + ". " + makeMemoryCapExceededMessage_(*this);
+    VELOX_MEM_CAP_EXCEEDED(errorMessage);
+  }
+
+  reservationBytes_ += size;
+  cumulativeBytes_ += size;
+  maybeUpdatePeakBytesNoLock(reservationBytes_);
+  return true;
+}
+
+void MemoryUsageTracker::release() {
+  reservationCheck();
+  ++numReleases_;
+  release(0);
+}
+
+void MemoryUsageTracker::release(uint64_t size) {
+  if (threadSafe_) {
+    releaseThreadSafe(size);
+  } else {
+    releaseNonThreadSafe(size);
+  }
+}
+
+void MemoryUsageTracker::releaseThreadSafe(uint64_t size) {
+  int64_t freeable = 0;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    int64_t newQuantized;
+    if (size == 0) {
+      if (minReservationBytes_ == 0) {
+        return;
+      }
+      newQuantized = quantizedSize(usedReservationBytes_);
+      minReservationBytes_ = 0;
+    } else {
+      usedReservationBytes_ -= size;
+      const int64_t newCap =
+          std::max(minReservationBytes_, usedReservationBytes_);
+      newQuantized = quantizedSize(newCap);
+    }
+    freeable = reservationBytes_ - newQuantized;
+    if (freeable > 0) {
+      reservationBytes_ = newQuantized;
+    }
+    sanityCheckNoLock();
+  }
+  if (freeable > 0) {
+    // NOTE: we can only release memory from a leaf memory usage tracker.
+    VELOX_DCHECK_NOT_NULL(parent_);
+    parent_->decrementReservation(freeable);
+  }
+}
+
+void MemoryUsageTracker::releaseNonThreadSafe(uint64_t size) {
+  int64_t newQuantized;
+  if (FOLLY_UNLIKELY(size == 0)) {
+    if (minReservationBytes_ == 0) {
+      return;
+    }
+    newQuantized = quantizedSize(usedReservationBytes_);
+    minReservationBytes_ = 0;
+  } else {
+    usedReservationBytes_ -= size;
+    const int64_t newCap =
+        std::max(minReservationBytes_, usedReservationBytes_);
+    newQuantized = quantizedSize(newCap);
+  }
+
+  const int64_t freeable = reservationBytes_ - newQuantized;
+  if (FOLLY_UNLIKELY(freeable > 0)) {
+    // NOTE: we can only release memory from a leaf memory usage tracker.
+    VELOX_DCHECK_NOT_NULL(parent_);
+    reservationBytes_ = newQuantized;
+    sanityCheckNoLock();
+    parent_->decrementReservation(freeable);
+  }
+}
+
 bool MemoryUsageTracker::maybeIncrementReservation(uint64_t size) {
   std::lock_guard<std::mutex> l(mutex_);
   return maybeIncrementReservationLocked(size);
@@ -207,7 +318,7 @@ bool MemoryUsageTracker::maybeIncrementReservationLocked(uint64_t size) {
   if (parent_ != nullptr || (reservationBytes_ + size <= maxMemory_)) {
     reservationBytes_ += size;
     cumulativeBytes_ += size;
-    maybeUpdatePeakBytesLocked(reservationBytes_);
+    maybeUpdatePeakBytesNoLock(reservationBytes_);
     return true;
   }
   return false;
@@ -224,13 +335,12 @@ void MemoryUsageTracker::decrementReservation(uint64_t size) noexcept {
   VELOX_CHECK_GE(reservationBytes_, 0, "decrement reservation size {}", size);
 }
 
-void MemoryUsageTracker::sanityCheckLocked() const {
-  VELOX_CHECK(
-      (reservationBytes_ >= usedReservationBytes_) &&
-          (reservationBytes_ >= minReservationBytes_) &&
-          (usedReservationBytes_ >= 0),
-      "Bad tracker state: {}",
-      toStringLocked());
+void MemoryUsageTracker::sanityCheckNoLock() const {
+  if ((reservationBytes_ < usedReservationBytes_) ||
+      (reservationBytes_ < minReservationBytes_) ||
+      (usedReservationBytes_ < 0)) {
+    VELOX_FAIL("Bad tracker state: {}", toStringNoLock());
+  }
 }
 
 bool MemoryUsageTracker::maybeReserve(uint64_t increment) {
@@ -247,11 +357,16 @@ bool MemoryUsageTracker::maybeReserve(uint64_t increment) {
   return true;
 }
 
-void MemoryUsageTracker::maybeUpdatePeakBytesLocked(int64_t newPeak) {
+void MemoryUsageTracker::maybeUpdatePeakBytesNoLock(int64_t newPeak) {
   peakBytes_ = std::max(peakBytes_, newPeak);
 }
 
-std::string MemoryUsageTracker::toStringLocked() const {
+std::string MemoryUsageTracker::toString() const {
+  std::lock_guard<std::mutex> l(mutex_);
+  return toStringNoLock();
+}
+
+std::string MemoryUsageTracker::toStringNoLock() const {
   std::stringstream out;
   out << "<tracker used " << succinctBytes(currentBytesLocked())
       << " available " << succinctBytes(availableReservationLocked());
@@ -269,7 +384,7 @@ std::string MemoryUsageTracker::toStringLocked() const {
   return out.str();
 }
 
-int64_t MemoryUsageTracker::reservationSizeLocked(int64_t size) {
+int64_t MemoryUsageTracker::reservationSizeNoLock(int64_t size) {
   const int64_t neededSize = size - (reservationBytes_ - usedReservationBytes_);
   if (neededSize <= 0) {
     return 0;
@@ -331,5 +446,4 @@ std::ostream& operator<<(
     const MemoryUsageTracker::Stats& stats) {
   return os << stats.toString();
 }
-
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -132,6 +132,8 @@ TEST_F(MemoryReclaimerTest, default) {
         "shrinkAPIs",
         MemoryPool::Kind::kAggregate,
         kMaxMemory,
+        true,
+        true,
         memory::MemoryReclaimer::create());
     pools.push_back(pool);
 
@@ -146,12 +148,13 @@ TEST_F(MemoryReclaimerTest, default) {
           ? MemoryPool::Kind::kLeaf
           : MemoryPool::Kind::kAggregate;
       auto childPool = pool->addChild(
-          std::to_string(i), kind, memory::MemoryReclaimer::create());
+          std::to_string(i), kind, true, memory::MemoryReclaimer::create());
       pools.push_back(childPool);
       for (int j = 0; j < testData.numGrandchildren; ++j) {
         auto grandchild = childPool->addChild(
             std::to_string(j),
             MemoryPool::Kind::kLeaf,
+            true,
             memory::MemoryReclaimer::create());
         pools.push_back(grandchild);
       }
@@ -257,18 +260,22 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
       "mockReclaim",
       MemoryPool::Kind::kAggregate,
       kMaxMemory,
+      true,
+      true,
       MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
     auto childPool = root->addChild(
         std::to_string(i),
         MemoryPool::Kind::kAggregate,
+        true,
         MemoryReclaimer::create());
     childPools.push_back(childPool);
     for (int j = 0; j < numGrandchildren; ++j) {
       auto grandchildPool = childPool->addChild(
           std::to_string(j),
           MemoryPool::Kind::kLeaf,
+          true,
           std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
       childPools.push_back(grandchildPool);
       auto* reclaimer =
@@ -312,12 +319,15 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
       "mockReclaimMoreThanAvailable",
       MemoryPool::Kind::kAggregate,
       kMaxMemory,
+      true,
+      true,
       MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
     auto childPool = root->addChild(
         std::to_string(i),
         MemoryPool::Kind::kLeaf,
+        true,
         std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
     childPools.push_back(childPool);
     auto* reclaimer =
@@ -343,6 +353,8 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
       "concurrentRandomMockReclaims",
       MemoryPool::Kind::kAggregate,
       kMaxMemory,
+      true,
+      true,
       MemoryReclaimer::create());
 
   std::atomic<uint64_t> totalUsedBytes{0};
@@ -353,11 +365,13 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
     childPools.push_back(root->addChild(
         std::to_string(i),
         MemoryPool::Kind::kAggregate,
+        true,
         MemoryReclaimer::create()));
     for (int j = 0; j < 5; ++j) {
       auto leafPool = childPools.back()->addChild(
           std::to_string(j),
           MemoryPool::Kind::kLeaf,
+          true,
           std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
       leafPools.push_back(leafPool);
       auto* reclaimer =

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -67,6 +67,21 @@ TEST(MemoryManagerTest, Ctor) {
   { ASSERT_ANY_THROW(MemoryManager manager{{.capacity = -1}}); }
 }
 
+TEST(MemoryManagerTest, getPool) {
+  MemoryManager manager{};
+
+  auto rootPool = manager.getPool(
+      "getRootPool", MemoryPool::Kind::kAggregate, kMaxMemory, true, true);
+  {
+    ASSERT_ANY_THROW(manager.getPool(
+        "getPool", MemoryPool::Kind::kAggregate, kMaxMemory, true, false));
+  }
+  auto threadSafeLeafPool = manager.getPool(
+      "getChildPool", MemoryPool::Kind::kLeaf, kMaxMemory, true, true);
+  auto nonThreadSafeLeafPool = manager.getPool(
+      "getPool", MemoryPool::Kind::kLeaf, kMaxMemory, true, true);
+}
+
 TEST(MemoryManagerTest, defaultMemoryManager) {
   auto& managerA = toMemoryManager(getProcessDefaultMemoryManager());
   auto& managerB = toMemoryManager(getProcessDefaultMemoryManager());

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -125,6 +125,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       std::shared_ptr<MemoryPool> parent,
       const std::string& name,
       MemoryPool::Kind kind,
+      bool /*unused*/,
       std::shared_ptr<memory::MemoryReclaimer> /*unused*/) override {
     return std::make_shared<MockMemoryPool>(
         name, kind, parent, memoryUsageTracker_->maxMemory());

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -95,3 +95,10 @@ DEFINE_bool(
     velox_memory_leak_check_enabled,
     false,
     "If true, check fails on any memory leaks in memory pool and memory manager");
+
+// TODO: deprecate this after solves all the use cases that can cause
+// significant performance regression by memory usage tracking.
+DEFINE_bool(
+    velox_enable_memory_usage_track_in_default_memory_pool,
+    false,
+    "If true, enable memory usage tracking in the default memory pool");


### PR DESCRIPTION
Support non-thread safe memory usage tracker for use case which
is single-thread executed and cpu sensitive which can't afford the 
cost of taking a mutex lock on execution path. The VectorSlice
benchmark which previously showed significant regression ~20-40%
now has almost no cost:
```
Non-Thread-Safe-Memory-Usage-Tracking
============================================================================
[...]elox/benchmarks/basic/VectorSlice.cpp     relative  time/iter   iters/s
============================================================================
flatSlice                                                 297.84ns     3.36M
flatSliceUnaligned                              85.592%   347.98ns     2.87M
flatCopy                                        61.447%   484.72ns     2.06M
arraySlice                                                483.97ns     2.07M
arraySliceUnaligned                             91.642%   528.11ns     1.89M
arrayCopy                                       3.4295%    14.11us    70.86K
mapSlice                                                  544.12ns     1.84M
mapSliceUnaligned                               94.725%   574.42ns     1.74M
mapCopy                                         4.0913%    13.30us    75.19K
rowSlice                                                    1.08us   923.19K
rowSliceUnaligned                               81.720%     1.33us   754.43K
rowCopy                                         12.444%     8.70us   114.88K

Thread-Safe-Memory-Usage-Tracking
============================================================================
[...]elox/benchmarks/basic/VectorSlice.cpp     relative  time/iter   iters/s
============================================================================
flatSlice                                                 257.29ns     3.89M
flatSliceUnaligned                              65.245%   394.35ns     2.54M
flatCopy                                        44.351%   580.12ns     1.72M
arraySlice                                                442.85ns     2.26M
arraySliceUnaligned                             71.694%   617.70ns     1.62M
arrayCopy                                       3.0764%    14.40us    69.47K
mapSlice                                                  535.15ns     1.87M
mapSliceUnaligned                               80.553%   664.34ns     1.51M
mapCopy                                         3.4033%    15.72us    63.59K
rowSlice                                                    1.08us   927.70K
rowSliceUnaligned                               65.644%     1.64us   608.98K
rowCopy                                         9.8384%    10.96us    91.27K

No-Memory-Usage-Tracking
============================================================================
[...]elox/benchmarks/basic/VectorSlice.cpp     relative  time/iter   iters/s
============================================================================
flatSlice                                                 321.49ns     3.11M
flatSliceUnaligned                              87.519%   367.34ns     2.72M
flatCopy                                        68.224%   471.23ns     2.12M
arraySlice                                                463.59ns     2.16M
arraySliceUnaligned                             89.495%   518.01ns     1.93M
arrayCopy                                       3.6044%    12.86us    77.75K
mapSlice                                                  511.62ns     1.95M
mapSliceUnaligned                               90.062%   568.08ns     1.76M
mapCopy                                         3.8914%    13.15us    76.06K
rowSlice                                                    1.00us   996.30K
rowSliceUnaligned                               80.942%     1.24us   806.42K
rowCopy                                         11.439%     8.77us   113.96K
```

This PR also provides an option to allow user to turn on/off thread-safe
memory usage tracking selectively