### PR TITLE
Refactor aggregation functions code structure and sparksql aggregate function namespace

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -86,7 +86,6 @@ add_test(
 target_link_libraries(
   velox_exec_test
   velox_aggregates
-  velox_aggregates_test_lib
   velox_dwio_common
   velox_dwio_common_exception
   velox_dwio_common_test_utils

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -36,7 +36,7 @@ DEFINE_string(
     "(e.g: --only \"min\" or --only \"sum,avg\").");
 
 int main(int argc, char** argv) {
-  facebook::velox::functions::sparksql::aggregates::registerAggregateFunctions(
+  facebook::velox::functions::aggregate::sparksql::registerAggregateFunctions(
       "");
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(
 target_link_libraries(velox_functions_lib velox_vector re2::re2
                       ${FOLLY_WITH_DEPENDENCIES})
 
+add_subdirectory(aggregates)
 add_subdirectory(string)
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -17,9 +17,9 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::functions::aggregate {
 
 template <typename T>
 class BitwiseAggregateBase : public SimpleNumericAggregate<T, T, T> {
@@ -109,4 +109,4 @@ bool registerBitwise(const std::string& name) {
   return true;
 }
 
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/CMakeLists.txt
@@ -12,20 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-  velox_functions_spark_aggregates_test
-  BitwiseXorAggregationTest.cpp FirstAggregateTest.cpp LastAggregateTest.cpp
-  Main.cpp)
+add_library(velox_functions_aggregates SingleValueAccumulator.cpp)
 
-add_test(velox_functions_spark_aggregates_test
-         velox_functions_spark_aggregates_test)
+target_link_libraries(velox_functions_aggregates velox_exec
+                      velox_presto_serializer ${FOLLY_WITH_DEPENDENCIES})
 
-target_link_libraries(
-  velox_functions_spark_aggregates_test
-  velox_exec_test_lib
-  velox_vector_test_lib
-  velox_functions_aggregates_test_lib
-  velox_functions_spark_aggregates
-  gflags::gflags
-  gtest
-  gtest_main)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/functions/lib/aggregates/SimpleNumericAggregate.h
+++ b/velox/functions/lib/aggregates/SimpleNumericAggregate.h
@@ -21,7 +21,7 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/LazyVector.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::functions::aggregate {
 
 template <typename TInput, typename TAccumulator, typename TResult>
 class SimpleNumericAggregate : public exec::Aggregate {
@@ -96,7 +96,7 @@ class SimpleNumericAggregate : public exec::Aggregate {
     DecodedVector decoded(*arg, rows, !mayPushdown);
     auto encoding = decoded.base()->encoding();
     if (encoding == VectorEncoding::Simple::LAZY) {
-      SimpleCallableHook<TValue, TData, UpdateSingleValue> hook(
+      velox::aggregate::SimpleCallableHook<TValue, TData, UpdateSingleValue> hook(
           exec::Aggregate::offset_,
           exec::Aggregate::nullByte_,
           exec::Aggregate::nullMask_,
@@ -240,4 +240,4 @@ class SimpleNumericAggregate : public exec::Aggregate {
   }
 };
 
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::functions::aggregate {
 
 // An accumulator for a single variable-width value (a string, a map, an array
 // or a struct).
@@ -67,4 +67,4 @@ void SingleValueAccumulator::destroy(HashStringAllocator* allocator) {
   }
 }
 
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -15,10 +15,11 @@
  */
 
 #pragma once
+
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/ContainerRowSerde.h"
 
-namespace facebook::velox::aggregate {
+namespace facebook::velox::functions::aggregate {
 
 // An accumulator for a single variable-width value (a string, a map, an array
 // or a struct).
@@ -44,4 +45,4 @@ struct SingleValueAccumulator {
   HashStringAllocator::Header* begin_{nullptr};
 };
 
-} // namespace facebook::velox::aggregate
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
@@ -27,7 +27,7 @@ using facebook::velox::exec::test::AssertQueryBuilder;
 using facebook::velox::exec::test::CursorParameters;
 using facebook::velox::exec::test::PlanBuilder;
 
-namespace facebook::velox::aggregate::test {
+namespace facebook::velox::functions::aggregate::test {
 
 std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
     const RowTypePtr& rowType,
@@ -439,4 +439,4 @@ VectorPtr AggregationTestBase::testStreaming(
   return result;
 }
 
-} // namespace facebook::velox::aggregate::test
+} // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -22,7 +22,7 @@ namespace facebook::velox::exec::test {
 class AssertQueryBuilder;
 }
 
-namespace facebook::velox::aggregate::test {
+namespace facebook::velox::functions::aggregate::test {
 
 class AggregationTestBase : public exec::test::OperatorTestBase {
  protected:
@@ -151,4 +151,4 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   bool allowInputShuffle_{false};
 };
 
-} // namespace facebook::velox::aggregate::test
+} // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/lib/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/tests/CMakeLists.txt
@@ -12,20 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(
-  velox_functions_spark_aggregates_test
-  BitwiseXorAggregationTest.cpp FirstAggregateTest.cpp LastAggregateTest.cpp
-  Main.cpp)
+add_library(velox_functions_aggregates_test_lib AggregationTestBase.cpp)
 
-add_test(velox_functions_spark_aggregates_test
-         velox_functions_spark_aggregates_test)
-
-target_link_libraries(
-  velox_functions_spark_aggregates_test
-  velox_exec_test_lib
-  velox_vector_test_lib
-  velox_functions_aggregates_test_lib
-  velox_functions_spark_aggregates
-  gflags::gflags
-  gtest
-  gtest_main)
+target_link_libraries(velox_functions_aggregates_test_lib velox_exec_test_lib)

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -16,10 +16,11 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
-#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/functions/lib/BitwiseAggregateBase.h"
-
+#include "velox/functions/lib/aggregates/BitwiseAggregateBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -16,9 +16,10 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -14,7 +14,6 @@
 
 add_library(
   velox_aggregates
-  AggregateNames.h
   ApproxDistinctAggregate.cpp
   ApproxMostFrequentAggregate.cpp
   ApproxPercentileAggregate.cpp
@@ -28,7 +27,6 @@ add_library(
   ChecksumAggregate.cpp
   HistogramAggregate.cpp
   MapAggAggregate.cpp
-  MapAggregateBase.h
   MapAggregateBase.cpp
   MapUnionAggregate.cpp
   MapUnionSumAggregate.cpp
@@ -36,9 +34,7 @@ add_library(
   MinMaxByAggregates.cpp
   CountAggregate.cpp
   PrestoHasher.cpp
-  SingleValueAccumulator.cpp
   SumAggregate.cpp
-  SumAggregate.h
   ValueList.cpp
   VarianceAggregates.cpp
   MaxSizeForStatsAggregate.cpp
@@ -49,6 +45,7 @@ target_link_libraries(
   velox_common_hyperloglog
   velox_exec
   velox_presto_serializer
+  velox_functions_aggregates
   velox_functions_lib
   velox_functions_util
   ${FOLLY_WITH_DEPENDENCIES})

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -16,10 +16,11 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/serializers/PrestoSerializer.h"
-#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -18,9 +18,11 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregationHook.h"
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -16,11 +16,12 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/expression/FunctionSignature.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
-#include "velox/vector/ComplexVector.h"
-#include "velox/vector/DecodedVector.h"
 #include "velox/vector/FlatVector.h"
+
+using namespace facebook::velox::functions::aggregate;
+
 namespace facebook::velox::aggregate::prestosql {
 
 namespace {

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -16,9 +16,11 @@
 #pragma once
 
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/prestosql/CheckedArithmeticImpl.h"
 #include "velox/functions/prestosql/aggregates/DecimalAggregate.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxDistinctTest.cpp
@@ -15,10 +15,11 @@
  */
 #include "velox/common/hyperloglog/HllUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 namespace {

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 namespace {

--- a/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxPercentileTest.cpp
@@ -17,10 +17,11 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -15,9 +15,10 @@
  */
 
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -16,10 +16,11 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AverageAggregationTest.cpp
@@ -16,12 +16,13 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/prestosql/aggregates/DecimalAggregate.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
 #include "velox/parse/TypeResolver.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BitwiseAggregationTest.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/BoolAndOrTest.cpp
@@ -15,8 +15,9 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
+using namespace facebook::velox::functions::aggregate::test;
 using facebook::velox::exec::test::PlanBuilder;
 
 namespace facebook::velox::aggregate::test {

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_aggregates_test_lib AggregationTestBase.cpp)
-
-target_link_libraries(velox_aggregates_test_lib velox_exec_test_lib)
-
 add_executable(
   velox_aggregates_test
   AggregationFunctionRegTest.cpp
@@ -52,12 +48,13 @@ add_test(
 target_link_libraries(
   velox_aggregates_test
   velox_aggregates
-  velox_aggregates_test_lib
   velox_core
   velox_dwio_common_test_utils
   velox_exec
   velox_exec_test_lib
   velox_file
+  velox_functions_aggregates
+  velox_functions_aggregates_test_lib
   velox_functions_test_lib
   velox_functions_prestosql
   velox_functions_lib

--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -16,10 +16,11 @@
 #include <boost/algorithm/string/join.hpp>
 #include "velox/common/encode/Base64.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountIfAggregationTest.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CovarianceAggregationTest.cpp
@@ -15,9 +15,10 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/HistogramTest.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionAggregationTest.cpp
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapUnionSumTest.cpp
@@ -15,10 +15,11 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MaxSizeForStatsTest.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -15,13 +15,14 @@
  */
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 #include <fmt/format.h>
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 using facebook::velox::VectorFuzzer;
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
 using namespace facebook::velox;
@@ -29,7 +29,7 @@ std::string max(const std::string& column) {
   return fmt::format("max({})", column);
 }
 
-class MinMaxTest : public aggregate::test::AggregationTestBase {
+class MinMaxTest : public functions::aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -18,10 +18,11 @@
 #include "velox/exec/AggregationHook.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using facebook::velox::exec::test::PlanBuilder;
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/VarianceAggregationTest.cpp
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::aggregate::test {
 

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
@@ -16,14 +16,14 @@
 
 #include "velox/functions/sparksql/aggregates/BitwiseXorAggregate.h"
 
-#include "velox/functions/lib/BitwiseAggregateBase.h"
+#include "velox/functions/lib/aggregates/BitwiseAggregateBase.h"
 
-namespace facebook::velox::functions::sparksql::aggregates {
+namespace facebook::velox::functions::aggregate::sparksql {
 
 namespace {
 
 template <typename T>
-class BitwiseXorAggregate : public aggregate::BitwiseAggregateBase<T> {
+class BitwiseXorAggregate : public BitwiseAggregateBase<T> {
  public:
   explicit BitwiseXorAggregate(TypePtr resultType)
       : aggregate::BitwiseAggregateBase<T>(
@@ -66,7 +66,7 @@ class BitwiseXorAggregate : public aggregate::BitwiseAggregateBase<T> {
 } // namespace
 
 bool registerBitwiseXorAggregate(const std::string& name) {
-  return aggregate::registerBitwise<BitwiseXorAggregate>(name);
+  return functions::aggregate::registerBitwise<BitwiseXorAggregate>(name);
 }
 
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
@@ -18,8 +18,8 @@
 
 #include <string>
 
-namespace facebook::velox::functions::sparksql::aggregates {
+namespace facebook::velox::functions::aggregate::sparksql {
 
 bool registerBitwiseXorAggregate(const std::string& name);
 
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -17,12 +17,12 @@
 #include <string>
 
 #include "velox/expression/FunctionSignature.h"
-#include "velox/functions/lib/SimpleNumericAggregate.h"
-#include "velox/functions/prestosql/aggregates/SingleValueAccumulator.h"
+#include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 
-using namespace facebook::velox::aggregate;
+using namespace facebook::velox::functions::aggregate;
 
-namespace facebook::velox::functions::sparksql::aggregates {
+namespace facebook::velox::functions::aggregate::sparksql {
 
 namespace {
 
@@ -336,4 +336,4 @@ void registerFirstLastAggregates(const std::string& prefix) {
   registerFirstLast<LastAggregate, true>(prefix + "last_ignore_null");
 }
 
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -18,12 +18,12 @@
 
 #include "velox/functions/sparksql/aggregates/BitwiseXorAggregate.h"
 
-namespace facebook::velox::functions::sparksql::aggregates {
+namespace facebook::velox::functions::aggregate::sparksql {
 
 extern void registerFirstLastAggregates(const std::string& prefix);
 
 void registerAggregateFunctions(const std::string& prefix) {
   registerFirstLastAggregates(prefix);
-  aggregates::registerBitwiseXorAggregate(prefix + "bit_xor");
+  registerBitwiseXorAggregate(prefix + "bit_xor");
 }
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.h
+++ b/velox/functions/sparksql/aggregates/Register.h
@@ -17,6 +17,6 @@
 
 #include <string>
 
-namespace facebook::velox::functions::sparksql::aggregates {
+namespace facebook::velox::functions::aggregate::sparksql {
 void registerAggregateFunctions(const std::string& prefix);
-} // namespace facebook::velox::functions::sparksql::aggregates
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/tests/BitwiseXorAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BitwiseXorAggregationTest.cpp
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
-namespace facebook::velox::functions::sparksql::aggregates::test {
+namespace facebook::velox::functions::aggregate::sparksql::test {
 
 namespace {
 
@@ -55,4 +55,4 @@ TEST_F(BitwiseXorAggregationTest, bitwiseXor) {
 }
 
 } // namespace
-} // namespace facebook::velox::functions::sparksql::aggregates::test
+} // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/FirstAggregateTest.cpp
@@ -15,12 +15,12 @@
  */
 
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
-using namespace facebook::velox::aggregate::test;
+using namespace facebook::velox::functions::aggregate::test;
 
-namespace facebook::velox::functions::sparksql::aggregates::test {
+namespace facebook::velox::functions::aggregate::sparksql::test {
 
 namespace {
 
@@ -28,7 +28,7 @@ class FirstAggregateTest : public AggregationTestBase {
  protected:
   void SetUp() override {
     AggregationTestBase::SetUp();
-    aggregates::registerAggregateFunctions("spark_");
+    registerAggregateFunctions("spark_");
   }
 
   template <typename T>
@@ -434,4 +434,4 @@ TEST_F(FirstAggregateTest, mapGlobal) {
 }
 
 } // namespace
-} // namespace facebook::velox::functions::sparksql::aggregates::test
+} // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/LastAggregateTest.cpp
@@ -15,10 +15,10 @@
  */
 
 #include "velox/exec/tests/utils/PlanBuilder.h"
-#include "velox/functions/prestosql/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
-namespace facebook::velox::functions::sparksql::aggregates::test {
+namespace facebook::velox::functions::aggregate::sparksql::test {
 
 namespace {
 
@@ -26,7 +26,7 @@ class LastAggregateTest : public aggregate::test::AggregationTestBase {
  protected:
   void SetUp() override {
     aggregate::test::AggregationTestBase::SetUp();
-    aggregates::registerAggregateFunctions("spark_");
+    registerAggregateFunctions("spark_");
   }
 
   template <typename T>
@@ -435,4 +435,4 @@ TEST_F(LastAggregateTest, mapGlobal) {
 }
 
 } // namespace
-} // namespace facebook::velox::functions::sparksql::aggregates::test
+} // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/coverage/Coverage.cpp
+++ b/velox/functions/sparksql/coverage/Coverage.cpp
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
   functions::sparksql::registerFunctions("");
 
   // Register Spark aggregate functions.
-  functions::sparksql::aggregates::registerAggregateFunctions("");
+  functions::aggregate::sparksql::registerAggregateFunctions("");
 
   if (FLAGS_all) {
     functions::printCoverageMapForAll(":spark");

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(
   velox_exec
   velox_dwio_common
   velox_aggregates
-  velox_aggregates_test_lib
+  velox_functions_aggregates_test_lib
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector


### PR DESCRIPTION
Summary:

Move common aggregation functions code into velox/functions/lib/aggregates directory as velox_functions_aggregates static library, prestosql and sparksql can direct depend on it.
Use facebook::velox::functions::aggregate as top-level namespace for aggregate functions, refactor sparksql aggregate function namespace as facebook::velox::functions::aggregate::sparksql.
