### PR TITLE
Add constant-encoded vectors

### DIFF
--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -120,9 +120,8 @@ inline velox::variant pyToVariant(const py::handle& obj) {
     py::dict objAsDict = py::cast<py::dict>(obj);
     std::map<velox::variant, velox::variant> map;
     for (auto item : objAsDict) {
-      velox::variant key = pyToVariant(item.first);
-      velox::variant value = pyToVariant(item.second);
-      map.emplace(std::make_pair(pyToVariant(item.first)), pyToVariant(item.second));
+      map.emplace(
+          std::make_pair(pyToVariant(item.first), pyToVariant(item.second)));
     }
     return velox::variant::map(std::move(map));
   } else if (py::isinstance<py::tuple>(obj)) {
@@ -138,6 +137,20 @@ inline velox::variant pyToVariant(const py::handle& obj) {
   }
 }
 
+static VectorPtr pyToConstantVector(
+    const py::handle& obj,
+    vector_size_t length,
+    facebook::velox::memory::MemoryPool* pool,
+    TypePtr type = nullptr);
+
+template <TypeKind T>
+static VectorPtr variantsToFlatVector(
+    const std::vector<velox::variant>& variants,
+    facebook::velox::memory::MemoryPool* pool);
+
+static inline VectorPtr pyListToVector(
+    const py::list& list,
+    facebook::velox::memory::MemoryPool* pool);
 
 template <TypeKind T>
 static VectorPtr createDictionaryVector(

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -107,9 +107,9 @@ inline velox::variant pyToVariant(const py::handle& obj) {
   } else if (py::isinstance<py::str>(obj)) {
     return pyToVariant<velox::TypeKind::VARCHAR>(obj);
   } else if (py::isinstance<py::list>(obj)) {
-    py::list obj_as_list = py::cast<py::list>(obj);
+    py::list objAsList = py::cast<py::list>(obj);
     std::vector<velox::variant> result;
-    for (auto& item : obj_as_list) {
+    for (auto& item : objAsList) {
       result.push_back(pyToVariant(item));
       if (result.front().kind() != result.back().kind()) {
         throw py::type_error("Array must consist of elements of only one kind");
@@ -117,19 +117,19 @@ inline velox::variant pyToVariant(const py::handle& obj) {
     }
     return velox::variant::array(std::move(result));
   } else if (py::isinstance<py::dict>(obj)) {
-    py::dict obj_as_dict = py::cast<py::dict>(obj);
+    py::dict objAsDict = py::cast<py::dict>(obj);
     std::map<velox::variant, velox::variant> map;
-    for (auto item : obj_as_dict) {
+    for (auto item : objAsDict) {
       velox::variant key = pyToVariant(item.first);
       velox::variant value = pyToVariant(item.second);
-      map.emplace(std::make_pair(std::move(key), std::move(value)));
+      map.emplace(std::make_pair(pyToVariant(item.first)), pyToVariant(item.second));
     }
     return velox::variant::map(std::move(map));
   } else if (py::isinstance<py::tuple>(obj)) {
-    py::tuple obj_as_tuple = py::cast<py::tuple>(obj);
+    py::tuple objAsTuple = py::cast<py::tuple>(obj);
     std::vector<velox::variant> elements;
-    elements.reserve(py::len(obj_as_tuple));
-    for (auto item : obj_as_tuple) {
+    elements.reserve(py::len(objAsTuple));
+    for (auto item : objAsTuple) {
       elements.emplace_back(pyToVariant(item));
     }
     return velox::variant::row(std::move(elements));
@@ -137,88 +137,7 @@ inline velox::variant pyToVariant(const py::handle& obj) {
     throw py::type_error("Invalid type of object");
   }
 }
-template <TypeKind T>
-inline VectorPtr variantToConstantVector(
-    velox::variant variant,
-    vector_size_t length,
-    facebook::velox::memory::MemoryPool* pool) {
-  using NativeType = typename TypeTraits<T>::NativeType;
 
-  TypePtr typePtr = fromKindToScalerType(T);
-  NativeType value;
-  if constexpr (std::is_same_v<NativeType, StringView>) {
-    const std::string& str = variant.value<std::string>();
-    value = StringView(str);
-  } else {
-    value = variant.value<NativeType>();
-  }
-  auto result = std::make_shared<ConstantVector<NativeType>>(
-      pool,
-      length,
-      /*isNull=*/false,
-      typePtr,
-      std::move(value));
-  return result;
-}
-
-inline VectorPtr pyToConstantVector(
-    const py::handle& obj,
-    vector_size_t length,
-    facebook::velox::memory::MemoryPool* pool) {
-  if (obj.is_none()) {
-    throw py::type_error("Cannot infer type of constant None vector");
-  }
-  velox::variant variant = pyToVariant(obj);
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      variantToConstantVector,
-      variant.kind(),
-      std::move(variant),
-      length,
-      pool);
-}
-
-static VectorPtr pyToConstantVector(
-    const py::handle& obj,
-    vector_size_t length,
-    facebook::velox::memory::MemoryPool* pool,
-    TypePtr type = nullptr);
-
-template <TypeKind T>
-static VectorPtr variantsToFlatVector(
-    const std::vector<velox::variant>& variants,
-    facebook::velox::memory::MemoryPool* pool);
-
-static inline VectorPtr pyListToVector(
-    const py::list& list,
-    facebook::velox::memory::MemoryPool* pool) {
-  std::vector<velox::variant> variants;
-  variants.reserve(list.size());
-  for (auto item : list) {
-    variants.push_back(pyToVariant(item));
-  }
-
-  if (variants.empty()) {
-    throw py::value_error("Can't create a Velox vector from an empty list");
-  }
-
-  velox::TypeKind first_kind = velox::TypeKind::INVALID;
-  for (velox::variant& var : variants) {
-    if (var.hasValue()) {
-      if (first_kind == velox::TypeKind::INVALID) {
-        first_kind = var.kind();
-      } else if (var.kind() != first_kind) {
-        throw py::type_error(
-            "Velox Vector must consist of items of the same type");
-      }
-    }
-  }
-
-  if (first_kind == velox::TypeKind::INVALID) {
-    throw py::value_error(
-        "Can't create a Velox vector consisting of only None");
-  }
-  return velox::core::variantsToVector(variants, pool);
-}
 
 template <TypeKind T>
 static VectorPtr createDictionaryVector(

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -126,6 +126,71 @@ class TestVeloxVector(unittest.TestCase):
             pv.dictionary_vector(pv.from_list([1, 2, 3]), [1, 2, 1000000])
             pv.dictionary_vector(pv.from_list([1, 2, 3]), [0, -1, -2])
 
+    def test_array_vector(self):
+        v1 = pv.from_list([[1, 2, 3], [1, 2, 3]])
+        self.assertTrue(isinstance(v1, pv.ArrayVector))
+        self.assertTrue(isinstance(v1.elements(), pv.FlatVector_BIGINT))
+        self.assertEqual(len(v1), 2)
+        expected_flat = [1, 2, 3, 1, 2, 3]
+        self.assertEqual(len(expected_flat), len(v1.elements()))
+        for i in range(len(expected_flat)):
+            self.assertEqual(expected_flat[i], v1.elements()[i])
+
+    def test_map_vector(self):
+        v = pv.from_list([{"a": 1}, {"b": 2}])
+        self.assertTrue(isinstance(v, pv.MapVector))
+        self.assertTrue(isinstance(v.mapKeys(), pv.FlatVector_VARBINARY))
+        self.assertTrue(isinstance(v.mapValues(), pv.FlatVector_BIGINT))
+        self.assertEqual(len(v), 2)
+        expected_keys = ["a", "b"]
+        expected_values = [1, 2]
+        for i in range(len(v)):
+            self.assertEqual(expected_keys[i], v.mapKeys()[i])
+            self.assertEqual(expected_values[i], v.mapValues()[i])
+
+    def test_row_vector(self):
+        expected = [(1, "hi", 3), (4, "bye", 6), None, (7, "kek", None)]
+        v = pv.from_list(expected)
+        self.assertTrue(isinstance(v, pv.RowVector))
+        self.assertEqual(len(v.children()), 3)
+        self.assertTrue(isinstance(v.childAt(0), pv.FlatVector_BIGINT))
+        self.assertTrue(isinstance(v.childAt(1), pv.FlatVector_VARBINARY))
+        self.assertTrue(isinstance(v.childAt(2), pv.FlatVector_BIGINT))
+
+        self.assertEqual(len(v), len(expected))
+        for i in range(len(expected)):
+            if expected[i] is None:
+                self.assertTrue(v.isNullAt(i))
+            else:
+                for j in range(3):
+                    self.assertEqual(v.childAt(j)[i], expected[i][j])
+
+    def test_crazy_vector(self):
+        crazy_vector = pv.from_list(
+            [
+                (1000, ["hi", "bye"], [{"a": 1, "b": 2}, {"c": 3, "d": 4}]),
+                (2000, ["good", "morning"], [{"e": 5}]),
+            ]
+        )
+        self.assertTrue(isinstance(crazy_vector, pv.RowVector))
+        self.assertTrue(isinstance(crazy_vector.childAt(0), pv.FlatVector_BIGINT))
+        self.assertTrue(isinstance(crazy_vector.childAt(1), pv.ArrayVector))
+        self.assertTrue(isinstance(crazy_vector.childAt(2), pv.ArrayVector))
+        self.assertTrue(
+            isinstance(crazy_vector.childAt(1).elements(), pv.FlatVector_VARBINARY)
+        )
+        self.assertTrue(isinstance(crazy_vector.childAt(2).elements(), pv.MapVector))
+        self.assertTrue(
+            isinstance(
+                crazy_vector.childAt(2).elements().mapKeys(), pv.FlatVector_VARBINARY
+            )
+        )
+        self.assertTrue(
+            isinstance(
+                crazy_vector.childAt(2).elements().mapValues(), pv.FlatVector_BIGINT
+            )
+        )
+
     def test_to_string(self):
         self.assertEqual(
             str(pv.from_list([1, 2, 3])),

--- a/velox/duckdb/memory/CMakeLists.txt
+++ b/velox/duckdb/memory/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_duckdb_allocator Allocator.cpp)
 
-target_link_libraries(velox_duckdb_allocator velox_dwio_common duckdb fmt::fmt)
+target_link_libraries(velox_duckdb_allocator velox_dwio_common duckdb fmt::fmt
+                      ${FOLLY_WITH_DEPENDENCIES})
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(velox_duckdb_allocator gtest)

--- a/velox/duckdb/memory/CMakeLists.txt
+++ b/velox/duckdb/memory/CMakeLists.txt
@@ -14,8 +14,7 @@
 
 add_library(velox_duckdb_allocator Allocator.cpp)
 
-target_link_libraries(velox_duckdb_allocator velox_dwio_common duckdb fmt::fmt
-                      ${FOLLY_WITH_DEPENDENCIES})
+target_link_libraries(velox_duckdb_allocator velox_dwio_common duckdb fmt::fmt)
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(velox_duckdb_allocator gtest)

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -77,4 +77,275 @@ ArrayVectorPtr variantArrayToVector(
       pool);
 }
 
+struct NestedTypeCounter {
+  TypeKind kind = TypeKind::UNKNOWN;
+  vector_size_t rowCount = 0;
+  vector_size_t rowsInserted = 0;
+  std::vector<NestedTypeCounter> children;
+  uint8_t precision = 0;
+  uint8_t scale = 0;
+};
+
+static void validateOrSetType(NestedTypeCounter& counter, const variant& v) {
+  if (v.isNull()) // If a row is null, it can be UNKNOWN, INVALID, or matching
+                  // our expected kind
+  {
+    if (v.kind() != TypeKind::UNKNOWN && v.kind() != TypeKind::INVALID &&
+        v.kind() != counter.kind) {
+      throw std::invalid_argument("Variant was of an unexpected kind");
+    }
+    return;
+  } else {
+    if (v.kind() == TypeKind::UNKNOWN || v.kind() == TypeKind::INVALID) {
+      throw std::invalid_argument(
+          "Non-null variant has unknown or invalid kind");
+    }
+    if (v.kind() != counter.kind) {
+      if (counter.kind == TypeKind::UNKNOWN) {
+        counter.kind = v.kind();
+        if (v.kind() == TypeKind::SHORT_DECIMAL) {
+          auto dec = v.value<TypeKind::SHORT_DECIMAL>();
+          counter.precision = dec.precision;
+          counter.scale = dec.scale;
+        } else if (v.kind() == TypeKind::LONG_DECIMAL) {
+          auto dec = v.value<TypeKind::LONG_DECIMAL>();
+          counter.precision = dec.precision;
+          counter.scale = dec.scale;
+        }
+      } else {
+        throw std::invalid_argument("Variant kind doesn't match predecessors");
+      }
+    } else if (v.kind() == TypeKind::SHORT_DECIMAL) {
+      auto dec = v.value<TypeKind::SHORT_DECIMAL>();
+      if (counter.precision != dec.precision || counter.scale != dec.scale) {
+        throw std::invalid_argument(
+            "Mismatch between expected and actual precision and scale");
+      }
+    } else if (v.kind() == TypeKind::LONG_DECIMAL) {
+      auto dec = v.value<TypeKind::LONG_DECIMAL>();
+      if (counter.precision != dec.precision || counter.scale != dec.scale) {
+        throw std::invalid_argument(
+            "Mismatch between expected and actual precision and scale");
+      }
+    }
+  }
+}
+
+static void computeRowCountsAndType(
+    NestedTypeCounter& counter,
+    const variant& v) {
+  validateOrSetType(counter, v);
+  counter.rowCount += 1;
+  if (v.isNull()) {
+    return;
+  }
+  // At this point, we know that v.kind() equals counter.kind
+  switch (counter.kind) {
+    case TypeKind::ROW: {
+      const std::vector<variant>& children = v.row();
+      if (counter.children.size() != children.size()) {
+        if (counter.children.size() == 0) {
+          counter.children.resize(children.size());
+        } else {
+          throw std::invalid_argument("Unexpected number of children");
+        }
+      }
+      for (size_t i = 0; i < children.size(); i++) {
+        computeRowCountsAndType(counter.children[i], children[i]);
+        counter.children[i].rowCount = counter.rowCount;
+      }
+    } break;
+    case TypeKind::ARRAY: {
+      const std::vector<variant>& elements = v.array();
+      counter.children.resize(1);
+      for (const variant& elt : elements) {
+        computeRowCountsAndType(counter.children[0], elt);
+      }
+    } break;
+    case TypeKind::MAP: {
+      const std::map<variant, variant>& elements = v.map();
+      counter.children.resize(2);
+      for (const std::pair<variant, variant> pair : elements) {
+        computeRowCountsAndType(counter.children[0], pair.first);
+        computeRowCountsAndType(counter.children[1], pair.second);
+      }
+    } break;
+    default:
+      // we have a simple type with no children
+      break;
+  }
+}
+
+static VectorPtr allocateVector(
+    const NestedTypeCounter& counter,
+    velox::memory::MemoryPool* pool) {
+  switch (counter.kind) {
+    case TypeKind::ROW: {
+      std::vector<VectorPtr> children;
+      std::vector<TypePtr> types;
+      children.reserve(counter.children.size());
+      types.reserve(counter.children.size());
+      for (auto child_counter : counter.children) {
+        children.push_back(allocateVector(child_counter, pool));
+        types.push_back(children.back()->type());
+      }
+      return std::make_shared<RowVector>(
+          pool,
+          ROW(std::move(types)),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(children));
+    }
+    case TypeKind::ARRAY: {
+      BufferPtr sizes =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      BufferPtr offsets =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      VectorPtr elements = allocateVector(counter.children.at(0), pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(elements->type()),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(elements));
+    }
+    case TypeKind::MAP: {
+      BufferPtr sizes =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      BufferPtr offsets =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      VectorPtr keys = allocateVector(counter.children.at(0), pool);
+      VectorPtr values = allocateVector(counter.children.at(1), pool);
+      return std::make_shared<MapVector>(
+          pool,
+          MAP(keys->type(), values->type()),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(keys),
+          std::move(values));
+    }
+    default: {
+      TypePtr type;
+      if (counter.kind == TypeKind::SHORT_DECIMAL) {
+        type = SHORT_DECIMAL(counter.precision, counter.scale);
+      } else if (counter.kind == TypeKind::LONG_DECIMAL) {
+        type = LONG_DECIMAL(counter.precision, counter.scale);
+      } else {
+        type = createScalarType(counter.kind);
+      }
+      return BaseVector::create(std::move(type), counter.rowCount, pool);
+    }
+  }
+}
+
+template <TypeKind Kind>
+void setElementInFlatVector(
+    vector_size_t idx,
+    const variant& v,
+    VectorPtr& vector) {
+  using NativeType = typename TypeTraits<Kind>::NativeType;
+  auto asFlat = vector->asFlatVector<NativeType>();
+  if constexpr (
+      Kind == TypeKind::SHORT_DECIMAL || Kind == TypeKind::LONG_DECIMAL) {
+    asFlat->set(idx, NativeType{v.value<NativeType>().value()});
+  } else {
+    asFlat->set(idx, NativeType{v.value<NativeType>()});
+  }
+}
+
+static void incrementChildRowsInserted(NestedTypeCounter& counter) {
+  for (NestedTypeCounter& child : counter.children) {
+    incrementChildRowsInserted(child);
+    child.rowsInserted += 1;
+  }
+}
+
+static void insertVariantIntoVector(
+    NestedTypeCounter& counter,
+    const variant& v,
+    VectorPtr& vector) {
+  if (v.isNull()) {
+    vector->setNull(counter.rowsInserted, true);
+    if (counter.kind == TypeKind::ROW) {
+      incrementChildRowsInserted(counter);
+    }
+  } else
+    switch (counter.kind) {
+      case TypeKind::ROW: {
+        auto asRow = vector->as<RowVector>();
+        const std::vector<variant>& children = v.row();
+        for (size_t i = 0; i < counter.children.size(); i++) {
+          insertVariantIntoVector(
+              counter.children[i], children[i], asRow->childAt(i));
+        }
+        break;
+      }
+      case TypeKind::ARRAY: {
+        auto asArray = vector->as<ArrayVector>();
+        const std::vector<variant>& elements = v.array();
+        vector_size_t offset = 0;
+        if (counter.rowsInserted != 0) {
+          offset = asArray->offsetAt(counter.rowsInserted - 1) +
+              asArray->sizeAt(counter.rowsInserted - 1);
+        }
+        asArray->setOffsetAndSize(
+            counter.rowsInserted, offset, elements.size());
+        for (const variant& elt : elements) {
+          insertVariantIntoVector(
+              counter.children.at(0), elt, asArray->elements());
+        }
+        break;
+      }
+      case TypeKind::MAP: {
+        auto asMap = vector->as<MapVector>();
+        const std::map<variant, variant>& elements = v.map();
+        VectorPtr& keys = asMap->mapKeys();
+        VectorPtr& values = asMap->mapValues();
+        for (const std::pair<variant, variant>& pair : elements) {
+          insertVariantIntoVector(counter.children.at(0), pair.first, keys);
+          insertVariantIntoVector(counter.children.at(1), pair.second, values);
+        }
+        break;
+      }
+      case TypeKind::SHORT_DECIMAL: {
+        setElementInFlatVector<TypeKind::SHORT_DECIMAL>(
+            counter.rowsInserted, v, vector);
+        break;
+      }
+      case TypeKind::LONG_DECIMAL: {
+        setElementInFlatVector<TypeKind::LONG_DECIMAL>(
+            counter.rowsInserted, v, vector);
+        break;
+      }
+      default: {
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            setElementInFlatVector,
+            counter.kind,
+            counter.rowsInserted,
+            v,
+            vector);
+        break;
+      }
+    }
+  counter.rowsInserted += 1;
+}
+
+VectorPtr variantsToVector(
+    const std::vector<variant>& rows,
+    velox::memory::MemoryPool* pool) {
+  NestedTypeCounter counter;
+  for (const variant& v : rows) {
+    computeRowCountsAndType(counter, v);
+  }
+  VectorPtr resultVector = allocateVector(counter, pool);
+  for (const variant& v : rows) {
+    insertVariantIntoVector(counter, v, resultVector);
+  }
+  return resultVector;
+}
+
 } // namespace facebook::velox::core

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -305,7 +305,7 @@ static void insertVariantIntoVector(
         const std::map<variant, variant>& elements = v.map();
         VectorPtr& keys = asMap->mapKeys();
         VectorPtr& values = asMap->mapValues();
-        for (const std::pair<variant, variant>& pair : elements) {
+        for (const auto& pair : elements) {
           insertVariantIntoVector(counter.children.at(0), pair.first, keys);
           insertVariantIntoVector(counter.children.at(1), pair.second, values);
         }

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -311,16 +311,6 @@ static void insertVariantIntoVector(
         }
         break;
       }
-      case TypeKind::SHORT_DECIMAL: {
-        setElementInFlatVector<TypeKind::SHORT_DECIMAL>(
-            counter.rowsInserted, v, vector);
-        break;
-      }
-      case TypeKind::LONG_DECIMAL: {
-        setElementInFlatVector<TypeKind::LONG_DECIMAL>(
-            counter.rowsInserted, v, vector);
-        break;
-      }
       default: {
         VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
             setElementInFlatVector,

--- a/velox/vector/VariantToVector.h
+++ b/velox/vector/VariantToVector.h
@@ -27,4 +27,10 @@ ArrayVectorPtr variantArrayToVector(
     const std::vector<variant>& variantArray,
     velox::memory::MemoryPool* pool);
 
+// Converts an array of variants into the appropriate vector. Each input variant
+// is a row in the final vector.
+VectorPtr variantsToVector(
+    const std::vector<variant>& rows,
+    velox::memory::MemoryPool* pool);
+
 } // namespace facebook::velox::core


### PR DESCRIPTION
Picking up on @save-buffer work done here: https://github.com/facebookincubator/velox/pull/4113

Rebased on top of latest main

Add support for complex types (ROW, MAP, ARRAY)

