### PR TITLE
Add options for per-file operations

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -83,11 +83,15 @@ class LocalFileSystem : public FileSystem {
     return path;
   }
 
-  std::unique_ptr<ReadFile> openFileForRead(std::string_view path) override {
+  std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view path,
+      const FileOptions& /*unused*/) override {
     return std::make_unique<LocalReadFile>(extractPath(path));
   }
 
-  std::unique_ptr<WriteFile> openFileForWrite(std::string_view path) override {
+  std::unique_ptr<WriteFile> openFileForWrite(
+      std::string_view path,
+      const FileOptions& /*unused*/) override {
     return std::make_unique<LocalWriteFile>(extractPath(path));
   }
 
@@ -192,5 +196,4 @@ void registerLocalFileSystem() {
   registerFileSystem(
       LocalFileSystem::schemeMatcher(), LocalFileSystem::fileSystemGenerator());
 }
-
 } // namespace facebook::velox::filesystems

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -29,49 +29,57 @@ class WriteFile;
 
 namespace facebook::velox::filesystems {
 
-// An abstract FileSystem
+/// Defines the options for per-file operations. It contains a key-value pairs
+/// which can be easily extended to different storage systems.
+struct FileOptions {
+  std::unordered_map<std::string, std::string> values;
+};
+
+/// An abstract FileSystem
 class FileSystem {
  public:
   FileSystem(std::shared_ptr<const Config> config)
       : config_(std::move(config)) {}
-  virtual ~FileSystem() {}
+  virtual ~FileSystem() = default;
 
-  // Returns the name of the File System
+  /// Returns the name of the File System
   virtual std::string name() const = 0;
 
-  // Returns a ReadFile handle for a given file path
-  virtual std::unique_ptr<ReadFile> openFileForRead(std::string_view path) = 0;
+  /// Returns a ReadFile handle for a given file path
+  virtual std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view path,
+      const FileOptions& options = {}) = 0;
 
-  // Returns a WriteFile handle for a given file path
+  /// Returns a WriteFile handle for a given file path
   virtual std::unique_ptr<WriteFile> openFileForWrite(
-      std::string_view path) = 0;
+      std::string_view path,
+      const FileOptions& options = {}) = 0;
 
-  // Deletes the file at 'path'. Throws on error.
+  /// Deletes the file at 'path'. Throws on error.
   virtual void remove(std::string_view path) = 0;
 
-  // Rename the file at 'path' to `newpath`. Throws on error.
-  // If 'overwrite' is true, then rename does overwrite if file at
-  // 'newPath' already exists.
-  // Throws a velox user exception on error.
+  /// Rename the file at 'path' to `newpath`. Throws on error. If 'overwrite' is
+  /// true, then rename does overwrite if file at 'newPath' already exists.
+  /// Throws a velox user exception on error.
   virtual void rename(
       std::string_view oldPath,
       std::string_view newPath,
       bool overwrite = false) = 0;
 
-  // Returns true if the file exists.
+  /// Returns true if the file exists.
   virtual bool exists(std::string_view path) = 0;
 
-  // Returns the list of files or folders in a path.
-  // Currently, this method will be used for testing, but we will need
-  // change this to an iterator output method to avoid potential heavy
-  // output if there are many entries in the folder.
+  /// Returns the list of files or folders in a path. Currently, this method
+  /// will be used for testing, but we will need change this to an iterator
+  /// output method to avoid potential heavy output if there are many entries in
+  /// the folder.
   virtual std::vector<std::string> list(std::string_view path) = 0;
 
-  // Create a directory (recursively). Throws velox exception on failure.
+  /// Create a directory (recursively). Throws velox exception on failure.
   virtual void mkdir(std::string_view path) = 0;
 
-  // Remove a directory (all the files and sub-directories underneath
-  // recursively). Throws velox exception on failure.
+  /// Remove a directory (all the files and sub-directories underneath
+  /// recursively). Throws velox exception on failure.
   virtual void rmdir(std::string_view path) = 0;
 
  protected:
@@ -82,17 +90,17 @@ std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filename,
     std::shared_ptr<const Config> config);
 
-// FileSystems must be registered explicitly.
-// The registration function takes two parameters:
-// a std::function<bool(std::string_view)> that says whether the registered
-// FileSystem subclass should be used for that filename,
-// and a lambda that generates the actual file system.
+/// FileSystems must be registered explicitly.
+/// The registration function takes two parameters:
+/// a std::function<bool(std::string_view)> that says whether the registered
+/// FileSystem subclass should be used for that filename, and a lambda that
+/// generates the actual file system.
 void registerFileSystem(
     std::function<bool(std::string_view)> schemeMatcher,
     std::function<std::shared_ptr<FileSystem>(std::shared_ptr<const Config>)>
         fileSystemGenerator);
 
-// Register the local filesystem.
+/// Register the local filesystem.
 void registerLocalFileSystem();
 
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.cpp
@@ -78,7 +78,8 @@ std::string HdfsFileSystem::name() const {
 }
 
 std::unique_ptr<ReadFile> HdfsFileSystem::openFileForRead(
-    std::string_view path) {
+    std::string_view path,
+    const FileOptions& /*unused*/) {
   if (path.find(kScheme) == 0) {
     path.remove_prefix(kScheme.length());
   }
@@ -90,7 +91,8 @@ std::unique_ptr<ReadFile> HdfsFileSystem::openFileForRead(
 }
 
 std::unique_ptr<WriteFile> HdfsFileSystem::openFileForWrite(
-    std::string_view path) {
+    std::string_view path,
+    const FileOptions& /*unused*/) {
   return std::make_unique<HdfsWriteFile>(impl_->hdfsClient(), path);
 }
 

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -37,9 +37,13 @@ class HdfsFileSystem : public FileSystem {
 
   std::string name() const override;
 
-  std::unique_ptr<ReadFile> openFileForRead(std::string_view path) override;
+  std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view path,
+      const FileOptions& options = {}) override;
 
-  std::unique_ptr<WriteFile> openFileForWrite(std::string_view path) override;
+  std::unique_ptr<WriteFile> openFileForWrite(
+      std::string_view path,
+      const FileOptions& options = {}) override;
 
   void remove(std::string_view path) override;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -396,7 +396,9 @@ std::string S3FileSystem::getLogLevelName() const {
   return impl_->getLogLevelName();
 }
 
-std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(std::string_view path) {
+std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(
+    std::string_view path,
+    const FileOptions& /*unused*/) {
   const std::string file = s3Path(path);
   auto s3file = std::make_unique<S3ReadFile>(file, impl_->s3Client());
   s3file->initialize();
@@ -404,7 +406,8 @@ std::unique_ptr<ReadFile> S3FileSystem::openFileForRead(std::string_view path) {
 }
 
 std::unique_ptr<WriteFile> S3FileSystem::openFileForWrite(
-    std::string_view path) {
+    std::string_view path,
+    const FileOptions& /*unused*/) {
   VELOX_NYI();
 }
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -33,9 +33,13 @@ class S3FileSystem : public FileSystem {
 
   std::string name() const override;
 
-  std::unique_ptr<ReadFile> openFileForRead(std::string_view path) override;
+  std::unique_ptr<ReadFile> openFileForRead(
+      std::string_view path,
+      const FileOptions& options = {}) override;
 
-  std::unique_ptr<WriteFile> openFileForWrite(std::string_view path) override;
+  std::unique_ptr<WriteFile> openFileForWrite(
+      std::string_view path,
+      const FileOptions& options = {}) override;
 
   void remove(std::string_view path) override {
     VELOX_UNSUPPORTED("remove for S3 not implemented");


### PR DESCRIPTION
Add FileOptions for per-file operations such as open a read file
and open a write file. The structure contains a key value set internally
which allows us to extend to different storage backends easily which
might have quite different semantics. For example, if a query system
needs to pass a security token for file access on a particular storage
system. Then the query system needs to set a k/v pair in the options
which can be interpreted by that particular storage system, such as
K"storageA.security_token":V"security_token_value".