### PR TITLE
Fix UnsafeRowDynamicSerializer::serialize for variable width data

### DIFF
--- a/velox/row/UnsafeRow.h
+++ b/velox/row/UnsafeRow.h
@@ -376,7 +376,7 @@ class UnsafeRow {
 
     // write the data pointer
     reinterpret_cast<uint64_t*>(fixedLengthData_)[pos] = dataPointer;
-    setVariableLengthOffset(variableLengthOffset_ + size);
+    setVariableLengthOffset(alignToFieldWidth(variableLengthOffset_ + size));
   }
 
   /**


### PR DESCRIPTION
UnsafeRowDynamicSerializer::serialize failed to align variable width values to 8 bytes.