### PR TITLE
[repro] TableScan generates invalid string vectors

### DIFF
--- a/velox/vector/tests/utils/VectorMaker-inl.h
+++ b/velox/vector/tests/utils/VectorMaker-inl.h
@@ -255,7 +255,8 @@ FlatVectorPtr<VectorMaker::EvalType<T>> VectorMaker::flatVector(
     const std::vector<T>& data,
     const TypePtr& type) {
   using TEvalType = EvalType<T>;
-  BufferPtr dataBuffer = AlignedBuffer::allocate<TEvalType>(data.size(), pool_);
+  BufferPtr dataBuffer =
+      AlignedBuffer::allocate<TEvalType>(data.size(), pool_, TEvalType());
 
   auto stats = genVectorMakerStats(data);
   auto flatVector = std::make_shared<FlatVector<TEvalType>>(


### PR DESCRIPTION
Adding sanity check to FlatVector to make sure StringViews point somewhere within the string buffers reveals a bug in TableScan where it produces vectors that fail that check.

CC: @Yuhta @oerling 

```
TEST_F(TableScanTest, statsBasedSkippingWithoutDecompression) {

VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: String view points outside of the string buffers
Retriable: False
Context: Split [file file:/tmp/velox_test_pnCdHG 0 - 18446744073709551615] Task test_cursor 1
Top-Level Context: Same as context.
Function: computeStringOffset
File: /Users/mbasmanova/cpp/velox-1/./velox/vector/FlatVector.h
Line: 401
```