### PR TITLE
Simplify UnsafeRow serializer APIs

### DIFF
--- a/velox/row/UnsafeRow.h
+++ b/velox/row/UnsafeRow.h
@@ -38,11 +38,6 @@ struct ScalarTraits {
     return v.valueAt<InMemoryType>(i);
   }
 
-  static void set(VectorPtr v, vector_size_t i, SerializedType val) {
-    auto flatVector = v->template asFlatVector<InMemoryType>();
-    flatVector->set(i, val);
-  }
-
   static void set(
       FlatVector<InMemoryType>* flatVector,
       vector_size_t i,
@@ -62,11 +57,6 @@ struct ScalarTraits<TypeKind::TIMESTAMP> {
 
   static int64_t get(const DecodedVector& v, vector_size_t i) {
     return v.valueAt<Timestamp>(i).toMicros();
-  }
-
-  static void set(VectorPtr v, vector_size_t i, SerializedType val) {
-    auto flatVector = v->template asFlatVector<InMemoryType>();
-    flatVector->set(i, Timestamp::fromMicros(val));
   }
 
   static void
@@ -92,11 +82,6 @@ struct ScalarTraits<TypeKind::TIMESTAMP> {
                                                                             \
     static const StringView& get(const DecodedVector& v, vector_size_t i) { \
       return v.data<StringView>()[v.index(i)];                              \
-    }                                                                       \
-                                                                            \
-    static void set(VectorPtr v, vector_size_t i, const StringView& val) {  \
-      auto flatVector = v->template asFlatVector<StringView>();             \
-      flatVector->set(i, val);                                              \
     }                                                                       \
                                                                             \
     static void set(                                                        \
@@ -131,16 +116,6 @@ class UnsafeRow {
    * UnsafeRow field width in bytes.
    */
   static const size_t kFieldWidthBytes = 8;
-
-  /**
-   * Number of bits in a byte.
-   */
-  static const size_t kNumBitsInByte = 8;
-
-  /**
-   * UnsafeRow word size in bits.
-   */
-  static const size_t kWordSizeBits = kFieldWidthBytes * kNumBitsInByte;
 
   /**
    * UnsafeRow class constructor.
@@ -255,16 +230,6 @@ class UnsafeRow {
   }
 
   /**
-   * Set all not null, used when a new unsafe is initialized.
-   * @param pos
-   */
-  void setAllNotNull(size_t pos) {
-    size_t nullLength = getNullLength(elementCapacity_);
-    // clear the buffer, assume all elements are valid
-    memset(nullSet_, 0, nullLength);
-  }
-
-  /**
    * @param pos
    * @return true if the element is null, false otherwise
    */
@@ -299,56 +264,6 @@ class UnsafeRow {
       return readFixedLengthDataAt(pos, fixedDataWidth);
     }
     return readVariableLengthDataAt(pos);
-  }
-
-  /**
-   * Writes a string_view of serialized data at the given index. If the element
-   * is fixed length, we write it at the fixed length data field. If the
-   * element is variable length, we append the serialized string_view to the
-   * unsafe row and write an offset pointer at the fixed length data field.
-   * @param pos
-   * @param type
-   * @param data string_view over the serialized element
-   */
-  void writeSerializedDataAt(
-      size_t pos,
-      const TypePtr& type,
-      const std::string_view& data) {
-    writeOffsetAndNullAt(pos, data.size(), type->isFixedWidth());
-    if (type->isFixedWidth()) {
-      return writeFixedLengthDataAt(pos, data);
-    }
-    return appendVariableLengthData(data);
-  }
-
-  /**
-   * Writes primitive data to the fixed length data field, bypasses the need to
-   * serialize.
-   * @tparam DataType a fundamental data type
-   * @param pos
-   * @param data
-   */
-  template <typename DataType>
-  void writePrimitiveAt(size_t pos, const DataType data) {
-    reinterpret_cast<uint64_t*>(fixedLengthData_)[pos] = data;
-  }
-
-  /**
-   * Writes a Timestamp as seconds, bypasses the need to serialize.
-   * @param pos
-   * @param data
-   */
-  void writeTimestampSecondsAt(size_t pos, const Timestamp& data) {
-    reinterpret_cast<uint64_t*>(fixedLengthData_)[pos] = data.getSeconds();
-  }
-
-  /**
-   * Writes a Timestamp as nanos, bypasses the need to serialize.
-   * @param pos
-   * @param data
-   */
-  void writeTimestampNanosAt(size_t pos, const Timestamp& data) {
-    reinterpret_cast<uint64_t*>(fixedLengthData_)[pos] = data.getNanos();
   }
 
   /**
@@ -462,16 +377,6 @@ class UnsafeRow {
   }
 
   /**
-   * Given the elementSize, return the amount of padding (in bytes) required
-   * so that the element aligns to field width.
-   * @param elementSize
-   * @return size_t
-   */
-  static const size_t getPaddingLength(size_t elementSize) {
-    return alignToFieldWidth(elementSize) - elementSize;
-  }
-
-  /**
    * Reads the data field as a fixed length data.
    * @param pos
    * @param width The element width in bytes
@@ -481,22 +386,6 @@ class UnsafeRow {
     VELOX_CHECK_LE(width, 8);
     uint64_t* dataPointer = &reinterpret_cast<uint64_t*>(fixedLengthData_)[pos];
     return std::string_view(reinterpret_cast<char*>(dataPointer), width);
-  }
-
-  /**
-   * Writes the data field as a fixed length data, vector should have exactly
-   * one element
-   * @param pos
-   * @param data
-   * @param width The element width in bytes
-   */
-  void writeFixedLengthDataAt(size_t pos, const std::string_view& data) {
-    VELOX_CHECK_EQ(data.size(), 1);
-    VELOX_CHECK_LE(data.size(), 8);
-    std::memcpy(
-        &reinterpret_cast<uint64_t*>(fixedLengthData_)[pos],
-        data.begin(),
-        data.size());
   }
 
   /**

--- a/velox/row/UnsafeRowParser.h
+++ b/velox/row/UnsafeRowParser.h
@@ -144,7 +144,7 @@ struct UnsafeRowDynamicParser {
    * @param idx
    * @return the element type at the given index.
    */
-  const TypePtr typeAt(size_t idx) const {
+  const TypePtr& typeAt(size_t idx) const {
     return types.at(idx);
   }
 

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -45,8 +45,7 @@ class UnsaferowBatchDeserializer : public Deserializer {
   void deserialize(
       const std::vector<std::optional<std::string_view>>& data,
       const TypePtr& type) override {
-    UnsafeRowDynamicVectorBatchDeserializer::deserializeComplex(
-        data, type, pool_.get());
+    UnsafeRowDeserializer::deserialize(data, type, pool_.get());
   }
 
  private:
@@ -93,8 +92,8 @@ class BenchmarkHelper {
       BufferPtr bufferPtr =
           AlignedBuffer::allocate<char>(1024, pool_.get(), true);
       char* buffer = bufferPtr->asMutable<char>();
-      auto rowSize = UnsafeRowDynamicSerializer::serialize(
-          rowType, inputVector, buffer, /*idx=*/0);
+      auto rowSize =
+          UnsafeRowSerializer::serialize(inputVector, buffer, /*idx=*/0);
       results.push_back(std::string_view(buffer, rowSize.value()));
     }
     return {results, rowType};

--- a/velox/row/experimental/tests/UnsafeRow24DeserializerTest.cpp
+++ b/velox/row/experimental/tests/UnsafeRow24DeserializerTest.cpp
@@ -552,8 +552,8 @@ class UnsafeRowComplexDeserializerTests : public exec::test::OperatorTestBase {
     std::vector<std::optional<std::string_view>> serializedVector;
     for (size_t i = 0; i < inputVector->size(); ++i) {
       // Serialize rowVector into bytes.
-      auto rowSize = UnsafeRowDynamicSerializer::serialize(
-          inputVector->type(), inputVector, this->buffers_[i], /*idx=*/i);
+      auto rowSize = UnsafeRowSerializer::serialize(
+          inputVector, this->buffers_[i], /*idx=*/i);
       serializedVector.push_back(
           rowSize.has_value()
               ? std::optional<std::string_view>(
@@ -625,7 +625,7 @@ TEST_F(UnsafeRowComplexDeserializerTests, DISABLED_Testfuzzer) {
     std::vector<std::optional<std::string_view>> rowData;
     char* data = &buffer[0];
     for (int j = 0; j < input->size(); ++j) {
-      auto size = UnsafeRowDynamicSerializer::serialize(type, input, data, j);
+      auto size = UnsafeRowSerializer::serialize(input, data, j);
       ASSERT_TRUE(size);
       rowData.emplace_back(std::string_view(data, *size));
       data += *size;

--- a/velox/serializers/UnsafeRowSerializer.cpp
+++ b/velox/serializers/UnsafeRowSerializer.cpp
@@ -38,8 +38,7 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
     size_t totalSize = 0;
     for (auto& range : ranges) {
       for (auto i = range.begin; i < range.begin + range.size; ++i) {
-        auto rowSize = velox::row::UnsafeRowDynamicSerializer::getSizeRow(
-            vector->type(), vector.get(), i);
+        auto rowSize = row::UnsafeRowSerializer::getSizeRow(vector.get(), i);
         totalSize += rowSize + sizeof(size_t);
       }
     }
@@ -56,12 +55,10 @@ class UnsafeRowVectorSerializer : public VectorSerializer {
     for (auto& range : ranges) {
       for (auto i = range.begin; i < range.begin + range.size; ++i) {
         // Write row data.
-        auto rowSize = velox::row::UnsafeRowDynamicSerializer::getSizeRow(
-            vector->type(), vector.get(), i);
-        auto size =
-            velox::row::UnsafeRowDynamicSerializer::serialize(
-                vector->type(), vector, buffer + offset + sizeof(size_t), i)
-                .value_or(0);
+        auto rowSize = row::UnsafeRowSerializer::getSizeRow(vector.get(), i);
+        auto size = row::UnsafeRowSerializer::serialize(
+                        vector, buffer + offset + sizeof(size_t), i)
+                        .value_or(0);
 
         // Sanity check.
         VELOX_CHECK_EQ(rowSize, size);
@@ -116,7 +113,7 @@ void UnsafeRowVectorSerde::deserialize(
   }
 
   *result = std::dynamic_pointer_cast<RowVector>(
-      velox::row::UnsafeRowDynamicVectorBatchDeserializer::deserializeComplex(
+      velox::row::UnsafeRowDeserializer::deserialize(
           serializedRows, type, pool));
 }
 


### PR DESCRIPTION
UnsafeRowSerializer:

```
static size_t getSizeRow(const RowVector* data, size_t idx);

static std::optional<size_t>::serialize(const VectorPtr& data, char* buffer, size_t idx);
```

UnsafeRowDeserializer:

```
static VectorPtr deserialize(
      const std::vector<std::optional<std::string_view>>& data,
      const TypePtr& type,
      memory::MemoryPool* pool)
```