### PR TITLE
Fix builds in gcc 12+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ cmake_minimum_required(VERSION 3.14)
 cmake_policy(SET CMP0077 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
+# Sets new behavior for CMP0135, which controls how timestamps are extracted
+# when using ExternalProject_Add():
+# - https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 # set the project name
 project(velox)
 
@@ -277,7 +285,8 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-format-overflow \
          -Wno-strict-aliasing \
          -Wno-type-limits \
-         -Wno-stringop-overflow")
+         -Wno-stringop-overflow \
+         -Wno-return-type")
   endif()
 
   set(KNOWN_WARNINGS

--- a/velox/external/duckdb/CMakeLists.txt
+++ b/velox/external/duckdb/CMakeLists.txt
@@ -14,13 +14,10 @@ add_subdirectory(tpch)
 add_compile_definitions(DISABLE_DUCKDB_REMOTE_INSTALL)
 add_compile_definitions(BUILD_PARQUET_EXTENSION)
 
-# Certain Clang compiler versions throw "deprecated declarations" warnings for
+# Certain compiler versions throw "deprecated declarations" warnings for
 # DuckDB's parquet-amalgamation.h. This warning is from the Thrift library
 # that DuckDB embeds and is also on Thrift master.
-# The workaround, for now, is to disable this warning if the compiler is Clang.
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-deprecated-declarations)
-endif()
+add_compile_options(-Wno-deprecated-declarations)
 
 # This stringop-overflow warning seems to have lots of false positives and has
 # been the source of a lot of compiler bug reports

--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/json.h>
+
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/remote/client/ThriftClient.h"
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunctionServiceAsyncClient.h"
+#include "velox/functions/remote/lib/SerDeLib.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+class RemoteFunction : public exec::VectorFunction {
+ public:
+  RemoteFunction(
+      const std::string& functionName,
+      folly::SocketAddress location,
+      const std::vector<exec::VectorFunctionArg>& inputArgs)
+      : functionName_(functionName),
+        location_(location),
+        thriftClient_(getThriftClient(location_)) {
+    std::vector<TypePtr> types;
+    types.reserve(inputArgs.size());
+    serializedTypes_.reserve(inputArgs.size());
+
+    for (const auto& arg : inputArgs) {
+      types.emplace_back(arg.type);
+      serializedTypes_.emplace_back(folly::toJson(arg.type->serialize()));
+    }
+    remoteInputType_ = ROW(std::move(types));
+  }
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    try {
+      applyRemote(rows, args, outputType, context, result);
+    } catch (const std::exception&) {
+      context.setErrors(rows, std::current_exception());
+    }
+  }
+
+ private:
+  void applyRemote(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const {
+    std::vector<VectorPtr> vectors;
+    vectors.reserve(args.size());
+
+    for (const auto& arg : args) {
+      vectors.emplace_back(arg);
+    }
+
+    // Create type and row vector for serialization.
+    auto remoteRowVector = std::make_shared<RowVector>(
+        context.pool(),
+        remoteInputType_,
+        BufferPtr{},
+        rows.end(),
+        std::move(vectors));
+
+    // Send to remote server.
+    remote::RemoteFunctionResponse remoteResponse;
+    remote::RemoteFunctionRequest request;
+    request.throwOnError_ref() = context.throwOnError();
+
+    auto functionHandle = request.functionHandle_ref();
+    functionHandle->name_ref() = functionName_;
+    functionHandle->returnType_ref() = folly::toJson(outputType->serialize());
+    functionHandle->argumentTypes_ref() = serializedTypes_;
+
+    auto requestInputs = request.inputs_ref();
+    requestInputs->rowCount_ref() = remoteRowVector->size();
+    requestInputs->pageFormat_ref() = remote::PageFormat::PRESTO_PAGE;
+    requestInputs->payload_ref() =
+        serializeIOBuf(remoteRowVector, rows.end(), *context.pool());
+
+    thriftClient_->sync_invokeFunction(remoteResponse, request);
+    auto outputRowVector = deserializeIOBuf(
+        remoteResponse.get_result().get_payload(),
+        ROW({outputType}),
+        *context.pool());
+    result = outputRowVector->childAt(0);
+  }
+
+  const std::string functionName_;
+  folly::SocketAddress location_;
+  std::unique_ptr<RemoteFunctionClient> thriftClient_;
+
+  // Structures we construct once to cache:
+  RowTypePtr remoteInputType_;
+  std::vector<std::string> serializedTypes_;
+};
+
+std::shared_ptr<exec::VectorFunction> createRemoteFunction(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    folly::SocketAddress location) {
+  return std::make_unique<RemoteFunction>(name, location, inputArgs);
+}
+
+} // namespace
+
+void registerRemoteFunction(
+    const std::string& name,
+    std::vector<exec::FunctionSignaturePtr> signatures,
+    folly::SocketAddress location,
+    exec::VectorFunctionMetadata metadata) {
+  exec::registerStatefulVectorFunction(
+      name,
+      signatures,
+      std::bind(
+          createRemoteFunction,
+          std::placeholders::_1,
+          std::placeholders::_2,
+          location),
+      metadata);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/client/Remote.h
+++ b/velox/functions/remote/client/Remote.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/SocketAddress.h>
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::functions {
+
+void registerRemoteFunction(
+    const std::string& name,
+    std::vector<exec::FunctionSignaturePtr> signatures,
+    folly::SocketAddress location,
+    exec::VectorFunctionMetadata metadata = {});
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/client/ThriftClient.cpp
+++ b/velox/functions/remote/client/ThriftClient.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/remote/client/ThriftClient.h"
+#include <folly/io/async/EventBaseManager.h>
+
+namespace facebook::velox::functions {
+
+std::unique_ptr<RemoteFunctionClient> getThriftClient(
+    folly::SocketAddress location) {
+  return newHeaderClient<RemoteFunctionClient>(
+      folly::EventBaseManager::get()->getEventBase(), location);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/client/ThriftClient.h
+++ b/velox/functions/remote/client/ThriftClient.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <thrift/perf/cpp2/util/Util.h>
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunctionServiceAsyncClient.h"
+
+namespace facebook::velox::functions {
+
+using RemoteFunctionClient =
+    apache::thrift::Client<remote::RemoteFunctionService>;
+
+std::unique_ptr<RemoteFunctionClient> getThriftClient(
+    folly::SocketAddress location);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/SocketAddress.h>
+#include <folly/init/Init.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "common/network/PortUtil.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/functions/Registerer.h"
+#include "velox/functions/prestosql/Arithmetic.h"
+#include "velox/functions/prestosql/CheckedArithmetic.h"
+#include "velox/functions/prestosql/StringFunctions.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/functions/remote/client/Remote.h"
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunctionService.h"
+#include "velox/functions/remote/server/RemoteFunctionService.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+using ::apache::thrift::ThriftServer;
+using ::facebook::velox::test::assertEqualVectors;
+
+namespace facebook::velox::functions {
+namespace {
+
+class RemoteFunctionTest : public functions::test::FunctionBaseTest {
+ public:
+  RemoteFunctionTest() {
+    serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    initializeServer();
+    registerRemoteFunctions();
+  }
+
+  // Registers a few remote functions to be used in this test.
+  void registerRemoteFunctions() {
+    // Register the remote adapter.
+    auto plusSignatures = {exec::FunctionSignatureBuilder()
+                               .returnType("bigint")
+                               .argumentType("bigint")
+                               .argumentType("bigint")
+                               .build()};
+    registerRemoteFunction("remote_plus", plusSignatures, {"::1", port_});
+    registerRemoteFunction("remote_wrong_port", plusSignatures, {"::1", 1});
+
+    auto divSignatures = {exec::FunctionSignatureBuilder()
+                              .returnType("double")
+                              .argumentType("double")
+                              .argumentType("double")
+                              .build()};
+    registerRemoteFunction("remote_divide", divSignatures, {"::1", port_});
+
+    auto substrSignatures = {exec::FunctionSignatureBuilder()
+                                 .returnType("varchar")
+                                 .argumentType("varchar")
+                                 .argumentType("integer")
+                                 .build()};
+    registerRemoteFunction("remote_substr", substrSignatures, {"::1", port_});
+
+    // Registers the actual function under a different prefix. This is only
+    // needed for tests since the thrift service runs in the same process.
+    registerFunction<PlusFunction, int64_t, int64_t, int64_t>(
+        {remotePrefix_ + ".remote_plus"});
+    registerFunction<CheckedDivideFunction, double, double, double>(
+        {remotePrefix_ + ".remote_divide"});
+    registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
+        {remotePrefix_ + ".remote_substr"});
+  }
+
+  void initializeServer() {
+    auto handler =
+        std::make_shared<RemoteFunctionServiceHandler>(remotePrefix_);
+    server_ = std::make_shared<ThriftServer>();
+
+    port_ = network::getFreePort();
+    server_->setPort(port_);
+    server_->setInterface(handler);
+
+    thread_ = std::make_unique<std::thread>([&] { server_->serve(); });
+    VELOX_CHECK(waitForRunning(), "Unable to initialize thrift server.");
+    LOG(INFO) << "Thrift server is up and running in local port " << port_;
+  }
+
+  ~RemoteFunctionTest() {
+    server_->stop();
+    thread_->join();
+    LOG(INFO) << "Thrift server stopped.";
+  }
+
+ private:
+  // Loop until the server is up and running.
+  bool waitForRunning() {
+    for (size_t i = 0; i < 10; ++i) {
+      if (server_->getServerStatus() == ThriftServer::ServerStatus::RUNNING) {
+        return true;
+      }
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return false;
+  }
+
+  uint16_t port_;
+  std::shared_ptr<apache::thrift::ThriftServer> server_;
+  std::unique_ptr<std::thread> thread_;
+
+  const std::string remotePrefix_{"remote"};
+};
+
+TEST_F(RemoteFunctionTest, simple) {
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto results = evaluate<SimpleVector<int64_t>>(
+      "remote_plus(c0, c0)", makeRowVector({inputVector}));
+
+  auto expected = makeFlatVector<int64_t>({2, 4, 6, 8, 10});
+  assertEqualVectors(expected, results);
+}
+
+TEST_F(RemoteFunctionTest, string) {
+  auto inputVector =
+      makeFlatVector<StringView>({"hello", "my", "remote", "world"});
+  auto inputVector1 = makeFlatVector<int32_t>({2, 1, 3, 5});
+  auto results = evaluate<SimpleVector<StringView>>(
+      "remote_substr(c0, c1)", makeRowVector({inputVector, inputVector1}));
+
+  auto expected = makeFlatVector<StringView>({"ello", "my", "mote", "d"});
+  assertEqualVectors(expected, results);
+}
+
+/*
+// Test case to exercise throwOnError, once it is implemented.
+TEST_F(RemoteFunctionTest, remoteException) {
+  auto input1 = makeFlatVector<double>({1, 2, 3});
+  auto input2 = makeFlatVector<double>({1, 0, 3});
+
+  EXPECT_THROW(
+      evaluate<SimpleVector<double>>(
+          "remote_divide(c0, c1)", makeRowVector({input1, input2})),
+      VeloxUserError);
+
+  auto results = evaluate<SimpleVector<double>>(
+      "try(remote_divide(c0, c1))", makeRowVector({input1, input2}));
+
+  auto expected = makeNullableFlatVector<double>({1, std::nullopt, 1});
+  assertEqualVectors(expected, results);
+}
+*/
+
+TEST_F(RemoteFunctionTest, connectionError) {
+  auto inputVector = makeFlatVector<int64_t>({1, 2, 3, 4, 5});
+  auto func = [&]() {
+    evaluate<SimpleVector<int64_t>>(
+        "remote_wrong_port(c0, c0)", makeRowVector({inputVector}));
+  };
+
+  // Check it throw and that the exception has the "connection refused"
+  // substring.
+  EXPECT_THROW(func(), VeloxUserError);
+  try {
+    func();
+  } catch (const VeloxUserError& e) {
+    EXPECT_THAT(e.message(), testing::HasSubstr("Connection refused"));
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::functions
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}

--- a/velox/functions/remote/if/RemoteFunction.thrift
+++ b/velox/functions/remote/if/RemoteFunction.thrift
@@ -1,0 +1,72 @@
+# Copyright 2014-present Facebook. All Rights Reserved.
+
+namespace cpp2 facebook.velox.functions.remote
+
+cpp_include "folly/io/IOBuf.h"
+
+typedef binary (cpp2.type = "folly::IOBuf") IOBuf
+
+/// The format used to serialize buffers/payloads.
+enum PageFormat {
+  PRESTO_PAGE = 1,
+  SPARK_UNSAFE_ROW = 2,
+}
+
+/// Identifies the remote function being called.
+struct RemoteFunctionHandle {
+  /// The function name
+  1: string name;
+
+  /// The function return and argument types. The types are serialized using
+  /// Velox's type serialization format.
+  2: string returnType;
+  3: list<string> argumentTypes;
+}
+
+/// A page of data to be sent to, or got as a return from a remote function
+/// execution.
+struct RemoteFunctionPage {
+  /// The serialization format used to encode the payload.
+  1: PageFormat pageFormat;
+
+  /// The actual data.
+  2: IOBuf payload;
+
+  /// The number of logical rows in this page.
+  3: i64 rowCount;
+}
+
+/// The parameters passed to the remote thrift call.
+struct RemoteFunctionRequest {
+  /// Function handle to identify te function being called.
+  1: RemoteFunctionHandle functionHandle;
+
+  /// The page containing serialized input parameters.
+  2: RemoteFunctionPage inputs;
+
+  /// Whether the function is supposed to throw an exception if errors are
+  /// found, or capture exceptions and return back to the user. This is used
+  /// to implement special forms (if the function is inside a try() construct,
+  /// for example).
+  ///
+  /// TODO: the format to return serialized exceptions back to the client needs
+  /// to be defined and implemented.
+  3: bool throwOnError;
+}
+
+/// Statistics that may be returned from server to client.
+struct RemoteFunctionStats {
+  1: map<string, string> stats;
+}
+
+/// Structured returned from server to client. Contains the serialized output
+/// page and optional statistics.
+struct RemoteFunctionResponse {
+  1: RemoteFunctionPage result;
+  2: optional RemoteFunctionStats remoteFunctionStats;
+}
+
+/// Service definition.
+service RemoteFunctionService {
+  RemoteFunctionResponse invokeFunction(1: RemoteFunctionRequest request);
+}

--- a/velox/functions/remote/lib/SerDeLib.cpp
+++ b/velox/functions/remote/lib/SerDeLib.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/remote/lib/SerDeLib.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::functions {
+
+folly::IOBuf serializeIOBuf(
+    const RowVectorPtr rowVector,
+    vector_size_t rangeEnd,
+    memory::MemoryPool& pool) {
+  auto streamGroup = std::make_unique<VectorStreamGroup>(&pool);
+  streamGroup->createStreamTree(asRowType(rowVector->type()), 1000);
+
+  IndexRange range{0, rangeEnd};
+  streamGroup->append(rowVector, folly::Range<IndexRange*>(&range, 1));
+
+  IOBufOutputStream stream(pool);
+  streamGroup->flush(&stream);
+  return std::move(*stream.getIOBuf());
+}
+
+RowVectorPtr deserializeIOBuf(
+    const folly::IOBuf& ioBuf,
+    const RowTypePtr& outputType,
+    memory::MemoryPool& pool) {
+  std::vector<ByteRange> ranges;
+  ranges.reserve(4);
+
+  for (const auto& range : ioBuf) {
+    ranges.emplace_back(ByteRange{
+        const_cast<uint8_t*>(range.data()), (int32_t)range.size(), 0});
+  }
+
+  ByteStream byteStream;
+  byteStream.resetInput(std::move(ranges));
+  RowVectorPtr outputVector;
+  VectorStreamGroup::read(&byteStream, &pool, outputType, &outputVector);
+  return outputVector;
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/lib/SerDeLib.h
+++ b/velox/functions/remote/lib/SerDeLib.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/io/IOBuf.h>
+
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::functions {
+
+folly::IOBuf serializeIOBuf(
+    const RowVectorPtr rowVector,
+    vector_size_t rangeEnd,
+    memory::MemoryPool& pool);
+
+RowVectorPtr deserializeIOBuf(
+    const folly::IOBuf& ioBuf,
+    const RowTypePtr& outputType,
+    memory::MemoryPool& pool);
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/server/RemoteFunctionService.cpp
+++ b/velox/functions/remote/server/RemoteFunctionService.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/remote/server/RemoteFunctionService.h"
+#include "velox/expression/Expr.h"
+#include "velox/functions/remote/lib/SerDeLib.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+std::string getFunctionName(
+    const std::string& prefix,
+    const std::string& functionName) {
+  return fmt::format("{}.{}", prefix, functionName);
+}
+
+RowTypePtr deserializeArgTypes(const std::vector<std::string>& argTypes) {
+  const size_t argCount = argTypes.size();
+
+  std::vector<TypePtr> argumentTypes;
+  std::vector<std::string> typeNames;
+  argumentTypes.reserve(argCount);
+  typeNames.reserve(argCount);
+
+  for (size_t i = 0; i < argCount; ++i) {
+    argumentTypes.emplace_back(Type::create(folly::parseJson(argTypes[i])));
+    typeNames.emplace_back(fmt::format("c{}", i));
+  }
+  return ROW(std::move(typeNames), std::move(argumentTypes));
+}
+
+} // namespace
+
+std::vector<core::TypedExprPtr> getExpressions(
+    const RowTypePtr& inputType,
+    const TypePtr& returnType,
+    const std::string& functionName) {
+  std::vector<core::TypedExprPtr> inputs;
+  for (size_t i = 0; i < inputType->size(); ++i) {
+    inputs.push_back(std::make_shared<core::FieldAccessTypedExpr>(
+        inputType->childAt(i), inputType->nameOf(i)));
+  }
+
+  return {std::make_shared<core::CallTypedExpr>(
+      returnType, std::move(inputs), functionName)};
+}
+
+void RemoteFunctionServiceHandler::invokeFunction(
+    remote::RemoteFunctionResponse& response,
+    std::unique_ptr<remote::RemoteFunctionRequest> request) {
+  const auto& functionHandle = request->get_functionHandle();
+  LOG(INFO) << "Got a request for '" << functionHandle.get_name() << "'.";
+
+  if (!request->get_throwOnError()) {
+    VELOX_NYI("throwOnError not implemented yet on remote server.");
+  }
+
+  // Deserialize types and data.
+  auto inputType = deserializeArgTypes(functionHandle.get_argumentTypes());
+  auto outputType =
+      Type::create(folly::parseJson(functionHandle.get_returnType()));
+
+  auto inputVector =
+      deserializeIOBuf(request->get_inputs().get_payload(), inputType, *pool_);
+
+  // Execute the expression.
+  const vector_size_t numRows = inputVector->size();
+  SelectivityVector rows{numRows};
+
+  // Expression boilerplate.
+  core::QueryCtx queryCtx;
+  core::ExecCtx execCtx{pool_.get(), &queryCtx};
+  exec::ExprSet exprSet{
+      getExpressions(
+          inputType,
+          outputType,
+          getFunctionName(functionPrefix_, functionHandle.get_name())),
+      &execCtx};
+  exec::EvalCtx evalCtx(&execCtx, &exprSet, inputVector.get());
+
+  std::vector<VectorPtr> expressionResult;
+  exprSet.eval(rows, evalCtx, expressionResult);
+
+  // Create output vector.
+  auto outputRowVector = std::make_shared<RowVector>(
+      pool_.get(), ROW({outputType}), BufferPtr(), numRows, expressionResult);
+
+  auto result = response.result_ref();
+  result->rowCount_ref() = outputRowVector->size();
+  result->pageFormat_ref() = remote::PageFormat::PRESTO_PAGE;
+  result->payload_ref() = serializeIOBuf(outputRowVector, rows.end(), *pool_);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/server/RemoteFunctionService.h
+++ b/velox/functions/remote/server/RemoteFunctionService.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <thrift/lib/cpp2/server/ThriftServer.h>
+#include "velox/common/memory/Memory.h"
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunctionService.h"
+
+namespace facebook::velox::functions {
+
+// Simple implementation of the thrift server handler.
+class RemoteFunctionServiceHandler
+    : virtual public apache::thrift::ServiceHandler<
+          remote::RemoteFunctionService> {
+ public:
+  RemoteFunctionServiceHandler(const std::string functionPrefix = "")
+      : functionPrefix_(functionPrefix) {}
+
+  void invokeFunction(
+      remote::RemoteFunctionResponse& response,
+      std::unique_ptr<remote::RemoteFunctionRequest> request) override;
+
+ private:
+  std::shared_ptr<memory::MemoryPool> pool_{memory::getDefaultMemoryPool()};
+  const std::string functionPrefix_;
+};
+
+} // namespace facebook::velox::functions


### PR DESCRIPTION
A couple of fixes for builds in fedora 36 with gcc 12.2

- Disable deprecated declarations warning in duckdb compilation for gcc (not only clang)
- Disable missing return type warning in gcc, since in newer version it does the check for lambda functions as well, failing in multiple callsites. 
- Manually setting cmake's CMP0135 behavior, which apparently changed and starts spitting warnings in cmake 3.25+