### PR TITLE
Fix build issues in gcc 12+

### DIFF
--- a/CMake/resolve_dependency_modules/folly.cmake
+++ b/CMake/resolve_dependency_modules/folly.cmake
@@ -23,25 +23,9 @@ set(VELOX_FOLLY_SOURCE_URL
 resolve_dependency_url(FOLLY)
 
 message(STATUS "Building Folly from source")
-# FOLLY_CXX_FLAGS is used internally on folly to define some extra
-# CMAKE_CXX_FLAGS for some known warnings to avoid possible errors on some
-# OS/archs
-set(EXTRA_CXX_FLAGS -Wno-deprecated-declarations)
-check_cxx_compiler_flag(-Wnullability-completeness
-                        COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
-if(COMPILER_HAS_W_NULLABILITY_COMPLETENESS)
-  list(APPEND EXTRA_CXX_FLAGS -Wno-nullability-completeness)
-endif()
-check_cxx_compiler_flag(-Wstringop-overflow COMPILER_HAS_W_STRINGOP_OVERFLOW)
-if(COMPILER_HAS_W_STRINGOP_OVERFLOW)
-  list(APPEND EXTRA_CXX_FLAGS -Wno-stringop-overflow)
-endif()
-check_cxx_compiler_flag(-Wundef-prefix COMPILER_HAS_W_UNDEF_PREFIX)
-if(COMPILER_HAS_W_UNDEF_PREFIX)
-  list(APPEND EXTRA_CXX_FLAGS -Wno-undef-prefix)
-endif()
-set(FOLLY_CXX_FLAGS -Wno-unused -Wno-unused-parameter -Wno-overloaded-virtual
-                    ${EXTRA_CXX_FLAGS})
+
+# Suppress warnings when compiling folly.
+set(FOLLY_CXX_FLAGS -w)
 
 if(gflags_SOURCE STREQUAL "BUNDLED")
   set(glog_patch && git apply

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,14 @@ cmake_minimum_required(VERSION 3.14)
 cmake_policy(SET CMP0077 NEW)
 set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
+# Sets new behavior for CMP0135, which controls how timestamps are extracted
+# when using ExternalProject_Add():
+# https://cmake.org/cmake/help/latest/policy/CMP0135.html
+if(POLICY CMP0135)
+  cmake_policy(SET CMP0135 NEW)
+  set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 # set the project name
 project(velox)
 
@@ -277,7 +285,8 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-format-overflow \
          -Wno-strict-aliasing \
          -Wno-type-limits \
-         -Wno-stringop-overflow")
+         -Wno-stringop-overflow \
+         -Wno-return-type")
   endif()
 
   set(KNOWN_WARNINGS

--- a/velox/external/duckdb/CMakeLists.txt
+++ b/velox/external/duckdb/CMakeLists.txt
@@ -14,31 +14,6 @@ add_subdirectory(tpch)
 add_compile_definitions(DISABLE_DUCKDB_REMOTE_INSTALL)
 add_compile_definitions(BUILD_PARQUET_EXTENSION)
 
-# Certain Clang compiler versions throw "deprecated declarations" warnings for
-# DuckDB's parquet-amalgamation.h. This warning is from the Thrift library
-# that DuckDB embeds and is also on Thrift master.
-# The workaround, for now, is to disable this warning if the compiler is Clang.
-check_cxx_compiler_flag(-Wno-unqualified-std-cast-call UNQUALIFIED_STD_CAST)
-check_cxx_compiler_flag(-Wno-bitwise-instead-of-logical BITWISE_INSTEAD_OF_LOGICAL)
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-deprecated-declarations)
-  if(UNQUALIFIED_STD_CAST)
-    add_compile_options(-Wno-unqualified-std-cast-call)
-  endif()
-  if(BITWISE_INSTEAD_OF_LOGICAL)
-    add_compile_options(-Wno-bitwise-instead-of-logical)
-  endif()
-endif()
-
-# This stringop-overflow warning seems to have lots of false positives and has
-# been the source of a lot of compiler bug reports
-# (e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578), which causes
-# parquet-amalgamation.cpp to fail to compile. For now, we disable this warning
-# on the affected compiler (GCC). 
-if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-  add_compile_options(-Wno-stringop-overflow)
-endif()
-
 add_library(
   duckdb
   duckdb-1.cpp
@@ -59,3 +34,6 @@ add_library(
   parquet-amalgamation.cpp)
 
 set_property(TARGET duckdb PROPERTY JOB_POOL_COMPILE high_memory_pool)
+
+# Suppress warnings when compiling duckdb.
+target_compile_options(duckdb PRIVATE -w)

--- a/velox/external/duckdb/tpch/dbgen/CMakeLists.txt
+++ b/velox/external/duckdb/tpch/dbgen/CMakeLists.txt
@@ -7,16 +7,6 @@ include_directories(include)
 
 add_definitions(-DDBNAME=dss -DMAC -DORACLE -DTPCH)
 
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set_source_files_properties(
-    build.cpp dbgen.cpp permute.cpp
-    PROPERTIES COMPILE_FLAGS "-Wno-writable-strings -Wno-deprecated-declarations")
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  set_source_files_properties(
-    build.cpp dbgen.cpp permute.cpp
-    PROPERTIES COMPILE_FLAGS -Wno-write-strings)
-endif()
-
 add_library(
   dbgen STATIC
   dbgen.cpp
@@ -28,3 +18,6 @@ add_library(
   rng64.cpp
   speed_seed.cpp
   text.cpp)
+
+# Suppress warnings when compiling dbgen.
+target_compile_options(dbgen PRIVATE -w)


### PR DESCRIPTION
A couple of fixes for builds in fedora 36 with gcc 12.2

- Disable missing return type warning in gcc, since in newer version it does the check for lambda functions as well, failing in multiple callsites within Velox.
- Manually setting cmake's CMP0135 behavior, which apparently changed and starts spitting warnings in cmake 3.25+
- Suppress warnings in the compilation of dependencies (folly, duckdb, and dbgen).