### PR TITLE
Add support for decimal round, abs and negate functions

### DIFF
--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -131,6 +131,10 @@ class DecimalUnaryBaseFunction : public exec::VectorFunction {
     }
   }
 
+  bool supportsFlatNoNullsFastPath() const override {
+    return true;
+  }
+
  private:
   R* prepareResults(
       const SelectivityVector& rows,

--- a/velox/functions/prestosql/DecimalArithmetic.cpp
+++ b/velox/functions/prestosql/DecimalArithmetic.cpp
@@ -97,6 +97,54 @@ class DecimalBaseFunction : public exec::VectorFunction {
   const uint8_t bRescale_;
 };
 
+template <
+    typename R /* Result Type */,
+    typename A /* Argument */,
+    typename Operation /* Arithmetic operation */>
+class DecimalUnaryBaseFunction : public exec::VectorFunction {
+ public:
+  DecimalUnaryBaseFunction(uint8_t aRescale) : aRescale_(aRescale) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& resultType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    // Single-arg deterministic functions receive their only
+    // argument as flat or constant only.
+    auto rawResults = prepareResults(rows, resultType, context, result);
+    if (args[0]->isConstantEncoding()) {
+      // Fast path for constant vectors.
+      auto constant = args[0]->asUnchecked<SimpleVector<A>>()->valueAt(0);
+      context.applyToSelectedNoThrow(rows, [&](auto row) {
+        Operation::template apply<R, A>(rawResults[row], constant, aRescale_);
+      });
+    } else {
+      // Fast path for flat.
+      auto flatA = args[0]->asUnchecked<FlatVector<A>>();
+      auto rawA = flatA->mutableRawValues();
+      context.applyToSelectedNoThrow(rows, [&](auto row) {
+        Operation::template apply<R, A>(rawResults[row], rawA[row], aRescale_);
+      });
+    }
+  }
+
+ private:
+  R* prepareResults(
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, resultType, result);
+    result->clearNulls(rows);
+    return result->asUnchecked<FlatVector<R>>()->mutableRawValues();
+  }
+
+ private:
+  const uint8_t aRescale_;
+};
+
 class Addition {
  public:
   template <typename R, typename A, typename B>
@@ -233,6 +281,30 @@ class Divide {
   }
 };
 
+class Round {
+ public:
+  template <typename R, typename A>
+  inline static void apply(R& r, const A& a, uint8_t aRescale) {
+    // aRescale holds the scale of the input.
+    auto temp = a;
+    DecimalUtil::divideWithRoundUp<A, A, int128_t>(
+        temp, a, DecimalUtil::kPowersOfTen[aRescale], false, 0, 0);
+    r = R(temp.unscaledValue());
+  }
+
+  inline static uint8_t
+  computeRescaleFactor(uint8_t fromScale, uint8_t toScale, uint8_t rScale) {
+    return fromScale;
+  }
+
+  inline static std::pair<uint8_t, uint8_t> computeResultPrecisionScale(
+      const uint8_t aPrecision,
+      const uint8_t aScale) {
+    return {
+        std::min(38, aPrecision - aScale + std::min((uint8_t)1, aScale)), 0};
+  }
+};
+
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 decimalMultiplySignature() {
   return {
@@ -281,6 +353,48 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> decimalDivideSignature() {
               .argumentType("DECIMAL(a_precision, a_scale)")
               .argumentType("DECIMAL(b_precision, b_scale)")
               .build()};
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>> decimalRoundSignature() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable(
+              "r_precision", "min(38, a_precision - a_scale + min(1, a_scale))")
+          .integerVariable("r_scale", "0")
+          .returnType("DECIMAL(r_precision, r_scale)")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .build()};
+}
+
+template <typename Operation>
+std::shared_ptr<exec::VectorFunction> createDecimalUnary(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  auto aType = inputArgs[0].type;
+  auto [aPrecision, aScale] = getDecimalPrecisionScale(*aType);
+  auto [rPrecision, rScale] =
+      Operation::computeResultPrecisionScale(aPrecision, aScale);
+  uint8_t aRescale = Operation::computeRescaleFactor(aScale, 0, rScale);
+  if (aType->kind() == TypeKind::SHORT_DECIMAL) {
+    return std::make_shared<DecimalUnaryBaseFunction<
+        UnscaledShortDecimal /*result*/,
+        UnscaledShortDecimal,
+        Operation>>(aRescale);
+  } else if (aType->kind() == TypeKind::LONG_DECIMAL) {
+    if (rPrecision <= DecimalType<TypeKind::SHORT_DECIMAL>::kMaxPrecision) {
+      return std::make_shared<DecimalUnaryBaseFunction<
+          UnscaledShortDecimal /*result*/,
+          UnscaledLongDecimal,
+          Operation>>(aRescale);
+    }
+    return std::make_shared<DecimalUnaryBaseFunction<
+        UnscaledLongDecimal /*result*/,
+        UnscaledLongDecimal,
+        Operation>>(aRescale);
+  }
+  VELOX_UNSUPPORTED();
 }
 
 template <typename Operation>
@@ -360,4 +474,9 @@ VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_div,
     decimalDivideSignature(),
     createDecimalFunction<Divide>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_round,
+    decimalRoundSignature(),
+    createDecimalUnary<Round>);
 }; // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -110,6 +110,7 @@ void registerArithmeticFunctions(const std::string& prefix = "") {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_sub, prefix + "minus");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, prefix + "multiply");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_round, prefix + "round");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -111,6 +111,8 @@ void registerArithmeticFunctions(const std::string& prefix = "") {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, prefix + "multiply");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_round, prefix + "round");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_abs, prefix + "abs");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_negate, prefix + "negate");
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -379,3 +379,39 @@ TEST_F(DecimalArithmeticTest, round) {
            UnscaledLongDecimal::min().unscaledValue()},
           DECIMAL(38, 1))});
 }
+
+TEST_F(DecimalArithmeticTest, abs) {
+  testDecimalExpr<TypeKind::SHORT_DECIMAL>(
+      {makeShortDecimalFlatVector({1111, 1112, 9999, 0}, DECIMAL(5, 1))},
+      "abs(c0)",
+      {makeShortDecimalFlatVector({-1111, 1112, -9999, 0}, DECIMAL(5, 1))});
+  testDecimalExpr<TypeKind::LONG_DECIMAL>(
+      {makeLongDecimalFlatVector(
+          {11111111, 11112112, 99999999, 0}, DECIMAL(19, 19))},
+      "abs(c0)",
+      {makeLongDecimalFlatVector(
+          {-11111111, 11112112, -99999999, 0}, DECIMAL(19, 19))});
+}
+
+TEST_F(DecimalArithmeticTest, negate) {
+  testDecimalExpr<TypeKind::SHORT_DECIMAL>(
+      {makeShortDecimalFlatVector({1111, -1112, 9999, 0}, DECIMAL(5, 1))},
+      "negate(c0)",
+      {makeShortDecimalFlatVector({-1111, 1112, -9999, 0}, DECIMAL(5, 1))});
+  testDecimalExpr<TypeKind::LONG_DECIMAL>(
+      {makeLongDecimalFlatVector(
+          {11111111,
+           -11112112,
+           99999999,
+           -UnscaledLongDecimal::max().unscaledValue(),
+           -UnscaledLongDecimal::min().unscaledValue()},
+          DECIMAL(38, 19))},
+      "negate(c0)",
+      {makeLongDecimalFlatVector(
+          {-11111111,
+           11112112,
+           -99999999,
+           UnscaledLongDecimal::max().unscaledValue(),
+           UnscaledLongDecimal::min().unscaledValue()},
+          DECIMAL(38, 19))});
+}

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -350,3 +350,32 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
               {UnscaledLongDecimal::max().unscaledValue()}, DECIMAL(38, 0))}),
       "Decimal overflow: 99999999999999999999999999999999999999 * 100");
 }
+
+TEST_F(DecimalArithmeticTest, round) {
+  // Round short decimals.
+  testDecimalExpr<TypeKind::SHORT_DECIMAL>(
+      {makeShortDecimalFlatVector({0, 1, -1, 0}, DECIMAL(1, 0))},
+      "round(c0)",
+      {makeShortDecimalFlatVector({123, 542, -999, 0}, DECIMAL(3, 3))});
+  testDecimalExpr<TypeKind::SHORT_DECIMAL>(
+      {makeShortDecimalFlatVector({1111, 1112, -9999, 10000}, DECIMAL(5, 0))},
+      "round(c0)",
+      {makeShortDecimalFlatVector(
+          {11112, 11115, -99989, 99999}, DECIMAL(5, 1))});
+  // Round long decimals.
+  testDecimalExpr<TypeKind::SHORT_DECIMAL>(
+      {makeShortDecimalFlatVector({0, 1, -1, 0}, DECIMAL(1, 0))},
+      "round(c0)",
+      {makeLongDecimalFlatVector(
+          {1234567890123456789, 5000000000000000000, -9000000000000000000, 0},
+          DECIMAL(19, 19))});
+  testDecimalExpr<TypeKind::LONG_DECIMAL>(
+      {makeLongDecimalFlatVector(
+          {DecimalUtil::kPowersOfTen[37], -DecimalUtil::kPowersOfTen[37]},
+          DECIMAL(38, 0))},
+      "round(c0)",
+      {makeLongDecimalFlatVector(
+          {UnscaledLongDecimal::max().unscaledValue(),
+           UnscaledLongDecimal::min().unscaledValue()},
+          DECIMAL(38, 1))});
+}


### PR DESCRIPTION
This PR implements Abs and Negate functions as VectorFunctions for decimal type. The existing wrapper for abs() and negate() in ArithmeticImpl.h cannot be extended for int128, hence these functions are customized.