### PR TITLE
Fix CrossJoinProbe logic around isIdentityProjection_

### DIFF
--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -29,17 +29,12 @@ CrossJoinProbe::CrossJoinProbe(
           joinNode->id(),
           "CrossJoinProbe"),
       outputBatchSize_{outputBatchRows()} {
-  bool isIdentityProjection = true;
-
   auto probeType = joinNode->sources()[0]->outputType();
   for (auto i = 0; i < probeType->size(); ++i) {
     auto name = probeType->nameOf(i);
     auto outIndex = outputType_->getChildIdxIfExists(name);
     if (outIndex.has_value()) {
       identityProjections_.emplace_back(i, outIndex.value());
-      if (outIndex != i) {
-        isIdentityProjection = false;
-      }
     }
   }
 
@@ -49,10 +44,6 @@ CrossJoinProbe::CrossJoinProbe(
     if (tableChannel.has_value()) {
       buildProjections_.emplace_back(tableChannel.value(), i);
     }
-  }
-
-  if (isIdentityProjection && buildProjections_.empty()) {
-    isIdentityProjection_ = true;
   }
 }
 

--- a/velox/exec/tests/CrossJoinTest.cpp
+++ b/velox/exec/tests/CrossJoinTest.cpp
@@ -195,9 +195,8 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
   };
 
   auto rightVectors = {
-      makeRowVector({sequence<int32_t>(5)}),
-      //      vectorMaker_.rowVector(ROW({}, {}), 5),
-  };
+      makeRowVector({sequence<int32_t>(1)}),
+      makeRowVector({sequence<int32_t>(4, 1)})};
 
   createDuckDbTable("t", {leftVectors});
 


### PR DESCRIPTION
A unit test that reproduces the bug mentioned in #4600 is added.
As the optimization based on `isIdentityProjection_` is rare and caused incorrect result, remove this optimization.
