### PR TITLE
Fix: avoid out of bound access in utf8proc_codepoint.

### DIFF
--- a/velox/external/utf8proc/utf8procImpl.h
+++ b/velox/external/utf8proc/utf8procImpl.h
@@ -923,13 +923,17 @@ UTF8PROC_DLLEXPORT utf8proc_uint8_t* utf8proc_NFKC_Casefold(
 // This function is not part of the utf8proc, it copy it from duckdb.cpp
 // it should be faster than utf8proc_iterate
 // from http://www.zedwood.com/article/cpp-utf8-char-to-codepoint
+// `end` is a pointer to the first byte past the end of the string.
 UTF8PROC_DLLEXPORT utf8proc_int32_t
-utf8proc_codepoint(const char* u_input, int& sz) {
+utf8proc_codepoint(const char* u_input, const char* end, int& sz) {
   auto u = (const unsigned char*)u_input;
   unsigned char u0 = u[0];
   if (u0 <= 127) {
     sz = 1;
     return u0;
+  }
+  if (end - u_input < 2) {
+    return -1;
   }
   unsigned char u1 = u[1];
   if (u0 >= 192 && u0 <= 223) {
@@ -939,10 +943,16 @@ utf8proc_codepoint(const char* u_input, int& sz) {
   if (u[0] == 0xed && (u[1] & 0xa0) == 0xa0) {
     return -1; // code points, 0xd800 to 0xdfff
   }
+  if (end - u_input < 3) {
+    return -1;
+  }
   unsigned char u2 = u[2];
   if (u0 >= 224 && u0 <= 239) {
     sz = 3;
     return (u0 - 224) * 4096 + (u1 - 128) * 64 + (u2 - 128);
+  }
+  if (end - u_input < 4) {
+    return -1;
   }
   unsigned char u3 = u[3];
   if (u0 >= 240 && u0 <= 247) {

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -143,7 +143,8 @@ FOLLY_ALWAYS_INLINE int32_t charToCodePoint(const T& inputString) {
       length);
 
   int size;
-  auto codePoint = utf8proc_codepoint(inputString.data(), size);
+  auto codePoint = utf8proc_codepoint(
+      inputString.data(), inputString.data() + inputString.size(), size);
   return codePoint;
 }
 
@@ -387,8 +388,10 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
   if constexpr (leftTrim) {
     int codePointSize = 0;
     while (curStartPos < input.size()) {
-      auto codePoint =
-          utf8proc_codepoint(input.data() + curStartPos, codePointSize);
+      auto codePoint = utf8proc_codepoint(
+          input.data() + curStartPos,
+          input.data() + input.size(),
+          codePointSize);
       if (!isUnicodeWhiteSpace(codePoint)) {
         break;
       }

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -496,3 +496,44 @@ TEST_F(StringImplTest, pad) {
   runTestUserError(
       "text", ((int64_t)std::numeric_limits<int32_t>::max()) + 1, "a");
 }
+
+// Make sure that utf8proc_codepoint returns invalid codepoint (-1) for
+// incomplete character of length>1.
+TEST_F(StringImplTest, utf8proc_codepoint) {
+  int size;
+
+  std::string twoBytesChar = "\xdd\x81";
+  EXPECT_EQ(
+      utf8proc_codepoint(twoBytesChar.data(), twoBytesChar.data() + 1, size),
+      -1);
+  EXPECT_NE(
+      utf8proc_codepoint(twoBytesChar.data(), twoBytesChar.data() + 2, size),
+      -1);
+  EXPECT_EQ(size, 2);
+
+  std::string threeBytesChar = "\xe0\xa4\x86";
+  for (int i = 1; i <= 2; i++) {
+    EXPECT_EQ(
+        utf8proc_codepoint(
+            threeBytesChar.data(), threeBytesChar.data() + i, size),
+        -1);
+  }
+
+  EXPECT_NE(
+      utf8proc_codepoint(
+          threeBytesChar.data(), threeBytesChar.data() + 3, size),
+      -1);
+  EXPECT_EQ(size, 3);
+
+  std::string fourBytesChar = "\xf0\x92\x80\x85";
+  for (int i = 1; i <= 3; i++) {
+    EXPECT_EQ(
+        utf8proc_codepoint(
+            fourBytesChar.data(), fourBytesChar.data() + i, size),
+        -1);
+  }
+  EXPECT_NE(
+      utf8proc_codepoint(fourBytesChar.data(), fourBytesChar.data() + 4, size),
+      -1);
+  EXPECT_EQ(size, 4);
+}

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1324,13 +1324,8 @@ TEST_F(StringFunctionsTest, reverse) {
   EXPECT_EQ(expectedInvalidStr, reverse(invalidStr));
 
   // Test unicode out of the valid range.
-  std::string invalidUnicodeStr;
-  invalidUnicodeStr.resize(3);
-  // An invalid unicode within 0xD800--0xDFFF.
-  int16_t invalidUnicode = 0xeda0;
-  memcpy(invalidUnicodeStr.data(), &invalidUnicode, 2);
-  invalidUnicodeStr[2] = '\0';
-  EXPECT_THROW(reverse(invalidUnicodeStr), VeloxUserError);
+  std::string invalidIncompleteString = "\xed\xa0";
+  EXPECT_EQ(reverse(invalidIncompleteString), "\xa0\xed");
 }
 
 TEST_F(StringFunctionsTest, toUtf8) {


### PR DESCRIPTION
Summary:
when utf8proc_codepoint is called with an invalid string where the last x
bytes are a prefix of an incomplete utf8 char, then the function
utf8proc_codepoint accesses memory outside the input string.

This diff changes utf8proc_codepoint to take the `end` of the input string
as input and return invalid codepoint for incomplete characters described
above.

this fixes.
https://github.com/facebookincubator/velox/issues/4554

Differential Revision: D45026804

