### PR TITLE
FIX: context.nullsPruned() is not sufficient condition that vecotor function inputs are null free

### DIFF
--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -539,11 +539,7 @@ class SimpleFunctionAdapter : public VectorFunction {
     if constexpr (FUNC::is_default_null_behavior) {
       allNotNull = true;
     } else {
-      if (applyContext.context.nullsPruned()) {
-        allNotNull = true;
-      } else {
-        allNotNull = (!readers.mayHaveNulls() && ...);
-      }
+      allNotNull = (!readers.mayHaveNulls() && ...);
     }
 
     // Iterate the rows.


### PR DESCRIPTION
Summary:
title.
this fix https://github.com/facebookincubator/velox/issues/4587

Differential Revision: D45027063

