### PR TITLE
Fix numeric overflow in substr Presto function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -134,13 +134,15 @@ String Functions
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string.
+    as being relative to the end of the string. Return empty When the negative
+    starting position is left of the first character.
 
 .. function:: substr(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
+    Return empty When the negative starting position is left of the first character.
 
 .. function:: trim(string) -> varchar
 

--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -134,15 +134,16 @@ String Functions
 
     Returns the rest of ``string`` from the starting position ``start``.
     Positions start with ``1``. A negative starting position is interpreted
-    as being relative to the end of the string. Return empty When the negative
-    starting position is left of the first character.
+    as being relative to the end of the string. Returns empty string if absolute
+    value of ``start`` is greater then length of the ``string``.
 
 .. function:: substr(string, start, length) -> varchar
 
     Returns a substring from ``string`` of length ``length`` from the starting
     position ``start``. Positions start with ``1``. A negative starting
     position is interpreted as being relative to the end of the string.
-    Return empty When the negative starting position is left of the first character.
+    Returns empty string if absolute value of ``'start`` is greater then
+    length of the ``string``.
 
 .. function:: trim(string) -> varchar
 

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -116,7 +116,7 @@ struct SubstrFunction {
     }
 
     // Adjusting length
-    if (numCharacters - start < length - 1) {
+    if (numCharacters - start + 1 < length) {
       // set length to the max valid length
       length = numCharacters - start + 1;
     }

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -51,8 +51,8 @@ struct CodePointFunction {
 ///
 ///     Returns the rest of string from the starting position start.
 ///     Positions start with 1. A negative starting position is interpreted as
-///     being relative to the end of the string. Return empty When the negative
-///     starting position is left of the first character.
+///     being relative to the end of the string. Returns empty string if
+///     absolute value of start is greater then length of the string.
 
 ///
 /// substr(string, start, length) -> varchar
@@ -60,8 +60,8 @@ struct CodePointFunction {
 ///     Returns a substring from string of length length from the
 ///     starting position start. Positions start with 1. A negative starting
 ///     position is interpreted as being relative to the end of the string.
-///     Return empty When the negative starting position is left of
-///     the first character.
+///     Returns empty string if absolute value of start is greater then length
+///     of the string.
 template <typename T>
 struct SubstrFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -93,7 +93,7 @@ struct SubstrFunction {
       I start,
       I length = std::numeric_limits<I>::max()) {
     // Following Presto semantics
-    if (start == 0) {
+    if (start == 0 || length <= 0) {
       result.setEmpty();
       return;
     }
@@ -106,14 +106,15 @@ struct SubstrFunction {
     }
 
     // Following Presto semantics
-    if (start <= 0 || start > numCharacters || length <= 0) {
+    if (start <= 0 || start > numCharacters) {
       result.setEmpty();
       return;
     }
 
     // Adjusting length
-    if (length == std::numeric_limits<I>::max() ||
-        length + start - 1 > numCharacters) {
+    I last;
+    bool lastOverflow = __builtin_add_overflow(start, length - 1, &last);
+    if (lastOverflow || last > numCharacters) {
       // set length to the max valid length
       length = numCharacters - start + 1;
     }

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -51,13 +51,17 @@ struct CodePointFunction {
 ///
 ///     Returns the rest of string from the starting position start.
 ///     Positions start with 1. A negative starting position is interpreted as
-///     being relative to the end of the string.
+///     being relative to the end of the string. Return empty When the negative
+///     starting position is left of the first character.
+
 ///
 /// substr(string, start, length) -> varchar
 ///
 ///     Returns a substring from string of length length from the
 ///     starting position start. Positions start with 1. A negative starting
 ///     position is interpreted as being relative to the end of the string.
+///     Return empty When the negative starting position is left of
+///     the first character.
 template <typename T>
 struct SubstrFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -116,9 +116,7 @@ struct SubstrFunction {
     }
 
     // Adjusting length
-    I last;
-    bool lastOverflow = __builtin_add_overflow(start, length - 1, &last);
-    if (lastOverflow || last > numCharacters) {
+    if (numCharacters - start < length - 1) {
       // set length to the max valid length
       length = numCharacters - start + 1;
     }

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -499,6 +499,22 @@ TEST_F(StringFunctionsTest, substrNegativeStarts) {
 }
 
 /**
+ * The test for overflow of start + length
+ */
+TEST_F(StringFunctionsTest, substrNumericOverflow) {
+  const auto substr = [&](std::optional<std::string> str,
+                          std::optional<int32_t> start,
+                          std::optional<int32_t> length) {
+    return evaluateOnce<std::string>("substr(c0, c1, c2)", str, start, length);
+  };
+
+  EXPECT_EQ(substr("example", 4, 2147483645), "mple");
+  EXPECT_EQ(substr("example", 2147483645, 4), "");
+  EXPECT_EQ(substr("example", -4, -2147483645), "");
+  EXPECT_EQ(substr("example", -2147483645, -4), "");
+}
+
+/**
  * The test for substr operating on single buffers with two string functions
  * using a conditional
  */

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -498,9 +498,6 @@ TEST_F(StringFunctionsTest, substrNegativeStarts) {
   EXPECT_EQ(result->valueAt(0).getString(), "");
 }
 
-/**
- * The test for overflow of start + length
- */
 TEST_F(StringFunctionsTest, substrNumericOverflow) {
   const auto substr = [&](std::optional<std::string> str,
                           std::optional<int32_t> start,


### PR DESCRIPTION
The `start + length`  in the function implementation may overflow, which causes an out-of-bounds error.


This expression can be used to reproduce the error:

```sql
substr("example", 4, 2147483645)
```