### PR TITLE
Remove duplicated VELOX_MEM_MANAGER_CAP_EXCEEDED marco

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -20,15 +20,6 @@ DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
 
 namespace facebook::velox::memory {
 namespace {
-#define VELOX_MEM_MANAGER_CAP_EXCEEDED(cap)                         \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Exceeded memory manager cap of {} MB",                       \
-      (cap) / 1024 / 1024);
-
 constexpr folly::StringPiece kDefaultRootName{"__default_root__"};
 constexpr folly::StringPiece kDefaultLeafName("__default_leaf__");
 } // namespace


### PR DESCRIPTION
The `VELOX_MEM_MANAGER_CAP_EXCEEDED` macro has already been defined in
MemoryPool.cpp and is only used in that file, so defining it again in
Memory.cpp is duplicated and should be removed.