### PR TITLE
Add fast path to AllocationPool::allocateFixed

### DIFF
--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -31,6 +31,11 @@ void AllocationPool::clear() {
 
 char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
   VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
+  if (availableInRun() >= bytes && alignment == 1) {
+    auto* result = currentRun().data<char>() + currentOffset_;
+    currentOffset_ += bytes;
+    return result;
+  }
   VELOX_CHECK_EQ(
       __builtin_popcount(alignment), 1, "Alignment can only be power of 2");
 


### PR DESCRIPTION
Almost all uses of the function allocate an unaligned small piece from an already allocated range in AllocationPool. Test for this first. Most existing tests hit this fast path.