### PR TITLE
Fix map key pruning when all keys are filtered out

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -256,7 +256,9 @@ void SelectiveMapColumnReader::read(
   if (keyReader_ && elementReader_ && !nestedRows_.empty()) {
     keyReader_->read(keyReader_->readOffset(), nestedRows_, nullptr);
     nestedRows_ = keyReader_->outputRows();
-    elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
+    if (!nestedRows_.empty()) {
+      elementReader_->read(elementReader_->readOffset(), nestedRows_, nullptr);
+    }
   }
   numValues_ = activeRows.size();
   readOffset_ = offset + rows.back() + 1;


### PR DESCRIPTION
Summary:
Currently when all keys are filtered out in a map, we call
`SelectiveColumnReader::read` on values reader with an empty `RowSet`, which
causes crash.  This change fixes this corner case.

Differential Revision: D45058992

