### PR TITLE
Use estimateFlatSize for dictionary input vector for LocalExchangeQueue

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -85,7 +85,7 @@ void LocalExchangeQueue::noMoreProducers() {
 BlockingReason LocalExchangeQueue::enqueue(
     RowVectorPtr input,
     ContinueFuture* future) {
-  auto inputBytes = input->retainedSize();
+  auto inputBytes = input->estimateFlatSize();
 
   std::vector<ContinuePromise> consumerPromises;
   bool isClosed = queue_.withWLock([&](auto& queue) {
@@ -150,7 +150,7 @@ BlockingReason LocalExchangeQueue::next(
     queue.pop();
 
     memoryPromises =
-        memoryManager_->decreaseMemoryUsage((*data)->retainedSize());
+        memoryManager_->decreaseMemoryUsage((*data)->estimateFlatSize());
 
     if (noMoreProducers_ && pendingProducers_ == 0 && queue.empty()) {
       producerPromises = std::move(producerPromises_);
@@ -200,7 +200,7 @@ void LocalExchangeQueue::close() {
   queue_.withWLock([&](auto& queue) {
     uint64_t freedBytes = 0;
     while (!queue.empty()) {
-      freedBytes += queue.front()->retainedSize();
+      freedBytes += queue.front()->estimateFlatSize();
       queue.pop();
     }
 
@@ -279,8 +279,7 @@ LocalPartition::LocalPartition(
       partitionFunction_(
           numPartitions_ == 1
               ? nullptr
-              : planNode->partitionFunctionSpec().create(numPartitions_)),
-      blockingReasons_{numPartitions_} {
+              : planNode->partitionFunctionSpec().create(numPartitions_)) {
   VELOX_CHECK(numPartitions_ == 1 || partitionFunction_ != nullptr);
 
   for (auto& queue : queues_) {


### PR DESCRIPTION
LocalPartition is blocked if the total buffered input size of the LocalExchangeQueue hits the max_local_exchange_buffer_size. Since the input is dictionary vector, we should use estimateFlatSize() instead of retainedSize() for size estimate for the input. retainedSize() is the size of the wrapped base vector, and thus is ~15 times larger than the actual size. This makes LocalPartition blocked for every input vector.