### PR TITLE
Use thread local pools instead of deprecatedGetPool

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -119,13 +119,13 @@ class IMemoryManager {
   /// 'incrementBytes'. The function returns true on success, otherwise false.
   virtual bool growPool(MemoryPool* pool, uint64_t incrementBytes) = 0;
 
-  /// Returns the default leaf memory pool for direct memory allocation use. The
-  /// pool is created as the child of the memory manager's default root memory
-  /// pool and is owned by the memory manager.
+  /// Default unmanaged leaf pool with no threadsafe stats support. Libraries
+  /// using this method can get a pool that is shared with other threads. The
+  /// goal is to minimize lock contention while supporting such use cases.
   ///
   /// TODO: deprecate this API after all the use cases are able to manage the
   /// lifecycle of the allocated memory pools properly.
-  virtual MemoryPool& deprecatedLeafPool() = 0;
+  virtual MemoryPool& deprecatedSharedLeafPool() = 0;
 
   /// Returns the number of alive memory pools allocated from addRootPool() and
   /// addLeafPool().
@@ -197,7 +197,7 @@ class MemoryManager final : public IMemoryManager {
 
   bool growPool(MemoryPool* pool, uint64_t incrementBytes) final;
 
-  MemoryPool& deprecatedLeafPool() final;
+  MemoryPool& deprecatedSharedLeafPool() final;
 
   int64_t getTotalBytes() const final;
 
@@ -216,6 +216,10 @@ class MemoryManager final : public IMemoryManager {
   /// purpose.
   MemoryPool& testingDefaultRoot() const {
     return *defaultRoot_;
+  }
+
+  const std::vector<std::shared_ptr<MemoryPool>>& testingSharedLeafPools() {
+    return sharedLeafPools_;
   }
 
  private:
@@ -237,10 +241,7 @@ class MemoryManager final : public IMemoryManager {
   const MemoryPoolImpl::DestructionCallback poolDestructionCb_;
 
   const std::shared_ptr<MemoryPool> defaultRoot_;
-  // The leaf memory pool created as child of 'defaultRoot_' on memory manager
-  // construction. This is for legacy use cases that can't manage the memory
-  // pool's lifecycle properly, and will be deprecated later.
-  const std::shared_ptr<MemoryPool> deprecatedDefaultLeafPool_;
+  std::vector<std::shared_ptr<MemoryPool>> sharedLeafPools_;
 
   mutable folly::SharedMutex mutex_;
   std::atomic_long totalBytes_{0};
@@ -255,6 +256,15 @@ IMemoryManager& defaultMemoryManager();
 std::shared_ptr<MemoryPool> addDefaultLeafMemoryPool(
     const std::string& name = "",
     bool threadSafe = true);
+
+/// Default unmanaged leaf pool with no threadsafe stats support. Libraries
+/// using this method can get a pool that is shared with other threads. The goal
+/// is to minimize lock contention while supporting such use cases.
+///
+///
+/// TODO: deprecate this API after all the use cases are able to manage the
+/// lifecycle of the allocated memory pools properly.
+MemoryPool& deprecatedSharedLeafPool();
 
 FOLLY_ALWAYS_INLINE int32_t alignmentPadding(void* address, int32_t alignment) {
   auto extra = reinterpret_cast<uintptr_t>(address) % alignment;

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -20,6 +20,8 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 
+DECLARE_int32(velox_memory_num_shared_leaf_pools);
+
 using namespace ::testing;
 
 namespace facebook {
@@ -28,7 +30,6 @@ namespace memory {
 
 namespace {
 constexpr folly::StringPiece kDefaultRootName{"__default_root__"};
-constexpr folly::StringPiece kDefaultLeafName("__default_leaf__");
 
 MemoryManager& toMemoryManager(IMemoryManager& manager) {
   return *static_cast<MemoryManager*>(&manager);
@@ -36,6 +37,7 @@ MemoryManager& toMemoryManager(IMemoryManager& manager) {
 } // namespace
 
 TEST(MemoryManagerTest, Ctor) {
+  const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
   {
     MemoryManager manager{};
     ASSERT_EQ(manager.numPools(), 0);
@@ -43,7 +45,6 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(0, manager.getTotalBytes());
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
     ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
     ASSERT_EQ(manager.arbitrator(), nullptr);
   }
   {
@@ -52,16 +53,14 @@ TEST(MemoryManagerTest, Ctor) {
     ASSERT_EQ(manager.numPools(), 0);
     ASSERT_EQ(0, manager.getTotalBytes());
     ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
   }
   {
     MemoryManager manager{{.alignment = 0, .capacity = 8L * 1024 * 1024}};
 
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
     ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
     // TODO: replace with root pool memory tracker quota check.
-    ASSERT_EQ(1, manager.testingDefaultRoot().getChildCount());
+    ASSERT_EQ(kSharedPoolCount, manager.testingDefaultRoot().getChildCount());
     ASSERT_EQ(8L * 1024 * 1024, manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
@@ -93,17 +92,20 @@ TEST(MemoryManagerTest, addPool) {
 TEST(MemoryManagerTest, defaultMemoryManager) {
   auto& managerA = toMemoryManager(defaultMemoryManager());
   auto& managerB = toMemoryManager(defaultMemoryManager());
+  const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
   ASSERT_EQ(managerA.numPools(), 0);
-  ASSERT_EQ(managerA.testingDefaultRoot().getChildCount(), 1);
+  ASSERT_EQ(managerA.testingDefaultRoot().getChildCount(), kSharedPoolCount);
   ASSERT_EQ(managerB.numPools(), 0);
-  ASSERT_EQ(managerB.testingDefaultRoot().getChildCount(), 1);
+  ASSERT_EQ(managerB.testingDefaultRoot().getChildCount(), kSharedPoolCount);
 
   auto child1 = managerA.addLeafPool("child_1");
   ASSERT_EQ(child1->parent()->name(), managerA.testingDefaultRoot().name());
   auto child2 = managerB.addLeafPool("child_2");
   ASSERT_EQ(child2->parent()->name(), managerA.testingDefaultRoot().name());
-  EXPECT_EQ(3, managerA.testingDefaultRoot().getChildCount());
-  EXPECT_EQ(3, managerB.testingDefaultRoot().getChildCount());
+  EXPECT_EQ(
+      kSharedPoolCount + 2, managerA.testingDefaultRoot().getChildCount());
+  EXPECT_EQ(
+      kSharedPoolCount + 2, managerB.testingDefaultRoot().getChildCount());
   ASSERT_EQ(managerA.numPools(), 2);
   ASSERT_EQ(managerB.numPools(), 2);
   auto pool = managerB.addRootPool();
@@ -116,9 +118,10 @@ TEST(MemoryManagerTest, defaultMemoryManager) {
       managerB.toString(),
       "Memory Manager[capacity 8388608.00TB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__default_root__\n\tdefault_root_0\n]");
   child1.reset();
-  EXPECT_EQ(2, managerA.testingDefaultRoot().getChildCount());
+  EXPECT_EQ(
+      kSharedPoolCount + 1, managerA.testingDefaultRoot().getChildCount());
   child2.reset();
-  EXPECT_EQ(1, managerB.testingDefaultRoot().getChildCount());
+  EXPECT_EQ(kSharedPoolCount, managerB.testingDefaultRoot().getChildCount());
   ASSERT_EQ(managerA.numPools(), 1);
   ASSERT_EQ(managerB.numPools(), 1);
   pool.reset();
@@ -134,27 +137,33 @@ TEST(MemoryManagerTest, defaultMemoryManager) {
 
 TEST(MemoryHeaderTest, addDefaultLeafMemoryPool) {
   auto& manager = toMemoryManager(defaultMemoryManager());
-  ASSERT_EQ(manager.testingDefaultRoot().getChildCount(), 1);
+  const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
+  ASSERT_EQ(manager.testingDefaultRoot().getChildCount(), kSharedPoolCount);
   {
     auto poolA = addDefaultLeafMemoryPool();
     ASSERT_EQ(poolA->kind(), MemoryPool::Kind::kLeaf);
     auto poolB = addDefaultLeafMemoryPool();
     ASSERT_EQ(poolB->kind(), MemoryPool::Kind::kLeaf);
-    EXPECT_EQ(3, manager.testingDefaultRoot().getChildCount());
+    EXPECT_EQ(
+        kSharedPoolCount + 2, manager.testingDefaultRoot().getChildCount());
     {
       auto poolC = addDefaultLeafMemoryPool();
       ASSERT_EQ(poolC->kind(), MemoryPool::Kind::kLeaf);
-      EXPECT_EQ(4, manager.testingDefaultRoot().getChildCount());
+      EXPECT_EQ(
+          kSharedPoolCount + 3, manager.testingDefaultRoot().getChildCount());
       {
         auto poolD = addDefaultLeafMemoryPool();
         ASSERT_EQ(poolD->kind(), MemoryPool::Kind::kLeaf);
-        EXPECT_EQ(5, manager.testingDefaultRoot().getChildCount());
+        EXPECT_EQ(
+            kSharedPoolCount + 4, manager.testingDefaultRoot().getChildCount());
       }
-      EXPECT_EQ(4, manager.testingDefaultRoot().getChildCount());
+      EXPECT_EQ(
+          kSharedPoolCount + 3, manager.testingDefaultRoot().getChildCount());
     }
-    EXPECT_EQ(3, manager.testingDefaultRoot().getChildCount());
+    EXPECT_EQ(
+        kSharedPoolCount + 2, manager.testingDefaultRoot().getChildCount());
   }
-  EXPECT_EQ(1, manager.testingDefaultRoot().getChildCount());
+  EXPECT_EQ(kSharedPoolCount, manager.testingDefaultRoot().getChildCount());
 
   auto namedPool = addDefaultLeafMemoryPool("namedPool");
   ASSERT_EQ(namedPool->name(), "namedPool");
@@ -206,46 +215,40 @@ TEST(MemoryManagerTest, memoryPoolManagement) {
 TEST(MemoryManagerTest, globalMemoryManager) {
   auto& manager = MemoryManager::getInstance();
   auto& managerII = MemoryManager::getInstance();
-
+  const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
   {
     auto& rootI = manager.testingDefaultRoot();
     const std::string childIName("some_child");
     auto childI = rootI.addLeafChild(childIName);
-    ASSERT_EQ(rootI.getChildCount(), 2);
+    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
 
     auto& rootII = managerII.testingDefaultRoot();
-    ASSERT_EQ(2, rootII.getChildCount());
+    ASSERT_EQ(kSharedPoolCount + 1, rootII.getChildCount());
     std::vector<MemoryPool*> pools{};
     rootII.visitChildren([&pools](MemoryPool* child) {
       pools.emplace_back(child);
       return true;
     });
-    ASSERT_EQ(pools.size(), 2);
+    ASSERT_EQ(pools.size(), kSharedPoolCount + 1);
     int matchedCount = 0;
     for (const auto* pool : pools) {
       if (pool->name() == childIName) {
         ++matchedCount;
       }
-      if (pool->name() == kDefaultLeafName.str()) {
-        ++matchedCount;
-      }
     }
-    ASSERT_EQ(matchedCount, 2);
-
-    auto& defaultChild = manager.deprecatedLeafPool();
-    ASSERT_EQ(defaultChild.name(), kDefaultLeafName.str());
+    ASSERT_EQ(matchedCount, 1);
 
     auto childII = manager.addLeafPool("another_child");
     ASSERT_EQ(childII->kind(), MemoryPool::Kind::kLeaf);
-    ASSERT_EQ(rootI.getChildCount(), 3);
+    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 2);
     ASSERT_EQ(childII->parent()->name(), kDefaultRootName.str());
     childII.reset();
-    ASSERT_EQ(rootI.getChildCount(), 2);
-    ASSERT_EQ(rootII.getChildCount(), 2);
+    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
+    ASSERT_EQ(rootII.getChildCount(), kSharedPoolCount + 1);
     auto userRootChild = manager.addRootPool("rootChild");
     ASSERT_EQ(userRootChild->kind(), MemoryPool::Kind::kAggregate);
-    ASSERT_EQ(rootI.getChildCount(), 2);
-    ASSERT_EQ(rootII.getChildCount(), 2);
+    ASSERT_EQ(rootI.getChildCount(), kSharedPoolCount + 1);
+    ASSERT_EQ(rootII.getChildCount(), kSharedPoolCount + 1);
     ASSERT_EQ(manager.numPools(), 2);
   }
   ASSERT_EQ(manager.numPools(), 0);
@@ -257,9 +260,10 @@ TEST(MemoryManagerTest, globalMemoryManager) {
     ASSERT_EQ(pool->kind(), MemoryPool::Kind::kLeaf);
     ASSERT_EQ(pool->parent()->name(), kDefaultRootName.str());
     ASSERT_EQ(manager.numPools(), 1);
-    ASSERT_EQ(manager.testingDefaultRoot().getChildCount(), 2);
+    ASSERT_EQ(
+        manager.testingDefaultRoot().getChildCount(), kSharedPoolCount + 1);
     pool.reset();
-    ASSERT_EQ(manager.testingDefaultRoot().getChildCount(), 1);
+    ASSERT_EQ(manager.testingDefaultRoot().getChildCount(), kSharedPoolCount);
   }
   ASSERT_EQ(manager.numPools(), 0);
 }
@@ -342,9 +346,6 @@ TEST(MemoryManagerTest, alignmentOptionCheck) {
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     ASSERT_EQ(
         manager.testingDefaultRoot().alignment(),
-        std::max(testData.alignment, MemoryAllocator::kMinAlignment));
-    ASSERT_EQ(
-        manager.deprecatedLeafPool().alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     auto leafPool = manager.addLeafPool("leafPool");
     ASSERT_EQ(

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -38,6 +38,11 @@ DEFINE_int32(
     4 * 1024,
     "Size of file cache/operator working memory in MB");
 
+DEFINE_int32(
+    velox_memory_num_shared_leaf_pools,
+    32,
+    "Number of shared leaf memory pools per process");
+
 DEFINE_bool(
     velox_time_allocations,
     true,

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -33,8 +33,7 @@ void mockSchemaRelease(ArrowSchema*) {}
 void mockArrayRelease(ArrowArray*) {}
 
 void exportToArrow(const TypePtr& type, ArrowSchema& out) {
-  auto pool =
-      &facebook::velox::memory::defaultMemoryManager().deprecatedLeafPool();
+  auto pool = &facebook::velox::memory::deprecatedSharedLeafPool();
   exportToArrow(BaseVector::create(type, 0, pool), out);
 }
 

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -28,8 +28,7 @@ using namespace facebook::velox;
 static void mockRelease(ArrowSchema*) {}
 
 void exportToArrow(const TypePtr& type, ArrowSchema& out) {
-  auto pool =
-      &facebook::velox::memory::defaultMemoryManager().deprecatedLeafPool();
+  auto pool = &facebook::velox::memory::deprecatedSharedLeafPool();
   exportToArrow(BaseVector::create(type, 0, pool), out);
 }
 


### PR DESCRIPTION
Summary:
To alleviate lock contention under default leaf pool access, we make them per thread instead.

Next diff will make the koski query memory manager use this api from the memory manager, to enable better bisects.

Differential Revision: D45056924

