### PR TITLE
Add Date support for sequence function

### DIFF
--- a/velox/functions/prestosql/Sequence.cpp
+++ b/velox/functions/prestosql/Sequence.cpp
@@ -22,7 +22,34 @@
 namespace facebook::velox::functions {
 namespace {
 
+template <typename T>
+int64_t toInt64(T value);
+
+template <>
+int64_t toInt64(int64_t value) {
+  return value;
+}
+
+template <>
+int64_t toInt64(Date value) {
+  return value.days();
+}
+
+template <typename T>
+T add(T value, int64_t steps);
+
+template <>
+int64_t add(int64_t value, int64_t steps) {
+  return value + steps;
+}
+
+template <>
+Date add(Date value, int64_t steps) {
+  return Date(value.days() + steps);
+}
+
 // See documentation at https://prestodb.io/docs/current/functions/array.html
+template <typename T>
 class SequenceFunction : public exec::VectorFunction {
  public:
   static constexpr int32_t kMaxResultEntries = 10'000;
@@ -33,16 +60,6 @@ class SequenceFunction : public exec::VectorFunction {
       const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
-    VectorPtr localResult = applyNumber(rows, args, outputType, context);
-    context.moveOrCopyResult(localResult, rows, result);
-  }
-
- private:
-  static VectorPtr applyNumber(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      const TypePtr& outputType,
-      exec::EvalCtx& context) {
     exec::DecodedArgs decodedArgs(rows, args, context);
     auto startVector = decodedArgs.at(0);
     auto stopVector = decodedArgs.at(1);
@@ -61,8 +78,8 @@ class SequenceFunction : public exec::VectorFunction {
     auto rawOffsets = offsets->asMutable<vector_size_t>();
 
     context.applyToSelectedNoThrow(rows, [&](auto row) {
-      auto start = startVector->valueAt<int64_t>(row);
-      auto stop = stopVector->valueAt<int64_t>(row);
+      auto start = toInt64(startVector->valueAt<T>(row));
+      auto stop = toInt64(stopVector->valueAt<T>(row));
       const int64_t step = (stepVector == nullptr)
           ? (stop >= start ? 1 : -1)
           : stepVector->valueAt<int64_t>(row);
@@ -70,8 +87,9 @@ class SequenceFunction : public exec::VectorFunction {
       numElements += rawSizes[row];
     });
 
-    VectorPtr elements = BaseVector::create(BIGINT(), numElements, pool);
-    auto rawElements = elements->asFlatVector<int64_t>()->mutableRawValues();
+    VectorPtr elements =
+        BaseVector::create(outputType->childAt(0), numElements, pool);
+    auto rawElements = elements->asFlatVector<T>()->mutableRawValues();
 
     vector_size_t elementsOffset = 0;
     context.applyToSelectedNoThrow(rows, [&](auto row) {
@@ -88,11 +106,14 @@ class SequenceFunction : public exec::VectorFunction {
         elementsOffset += rawSizes[row];
       }
     });
-
-    return std::make_shared<ArrayVector>(
-        pool, outputType, nullptr, numRows, offsets, sizes, elements);
+    context.moveOrCopyResult(
+        std::make_shared<ArrayVector>(
+            pool, outputType, nullptr, numRows, offsets, sizes, elements),
+        rows,
+        result);
   }
 
+ private:
   static vector_size_t
   checkArguments(int64_t start, int64_t stop, int64_t step) {
     VELOX_USER_CHECK_NE(step, 0, "step must not be zero");
@@ -109,24 +130,22 @@ class SequenceFunction : public exec::VectorFunction {
   }
 
   static void writeToElements(
-      int64_t* elements,
+      T* elements,
       vector_size_t sequenceCount,
       DecodedVector* startVector,
       DecodedVector* stopVector,
       DecodedVector* stepVector,
       vector_size_t row) {
-    auto start = startVector->valueAt<int64_t>(row);
-    auto stop = stopVector->valueAt<int64_t>(row);
+    auto start = startVector->valueAt<T>(row);
+    auto stop = stopVector->valueAt<T>(row);
     const int64_t step = (stepVector == nullptr)
-        ? (stop >= start ? 1 : -1)
-        : stepVector->valueAt<int64_t>(row);
+        ? (toInt64(stop) >= toInt64(start) ? 1 : -1)
+        : toInt64(stepVector->valueAt<T>(row));
     for (auto i = 0; i < sequenceCount; ++i) {
-      elements[i] = start + step * i;
+      elements[i] = add(start, step * i);
     }
   }
 };
-
-} // namespace
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
   std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
@@ -141,12 +160,28 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
           .argumentType("bigint")
           .argumentType("bigint")
           .argumentType("bigint")
+          .build(),
+      exec::FunctionSignatureBuilder()
+          .returnType("array(date)")
+          .argumentType("date")
+          .argumentType("date")
           .build()};
   return signatures;
 }
 
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_sequence,
-    signatures(),
-    std::make_unique<SequenceFunction>());
+std::shared_ptr<exec::VectorFunction> create(
+    const std::string& /* name */,
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  switch (inputArgs[0].type->kind()) {
+    case TypeKind::BIGINT:
+      return std::make_shared<SequenceFunction<int64_t>>();
+    case TypeKind::DATE:
+      return std::make_shared<SequenceFunction<Date>>();
+    default:
+      VELOX_UNREACHABLE();
+  }
+}
+} // namespace
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(udf_sequence, signatures(), create);
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/tests/SequenceTest.cpp
+++ b/velox/functions/prestosql/tests/SequenceTest.cpp
@@ -117,3 +117,37 @@ TEST_F(SequenceTest, invalidStep) {
       {startVector, stopVector, stepVector},
       expected);
 }
+
+TEST_F(SequenceTest, dateArguments) {
+  const auto startVector =
+      makeFlatVector<Date>({Date(1991), Date(1992), Date(1992)});
+  const auto stopVector =
+      makeFlatVector<Date>({Date(1996), Date(1988), Date(1992)});
+  const auto expected = makeArrayVector<Date>(
+      {{Date(1991), Date(1992), Date(1993), Date(1994), Date(1995), Date(1996)},
+       {Date(1992), Date(1991), Date(1990), Date(1989), Date(1988)},
+       {Date(1992)}});
+  testExpression("sequence(C0, C1)", {startVector, stopVector}, expected);
+}
+
+TEST_F(SequenceTest, dateArgumentsExceedMaxEntries) {
+  const auto startVector =
+      makeFlatVector<Date>({Date(1991), Date(1992), Date(1992)});
+  const auto stopVector =
+      makeFlatVector<Date>({Date(1996), Date(198800), Date(1992)});
+  testExpressionWithError(
+      "sequence(C0, C1)",
+      {startVector, stopVector},
+      "result of sequence function must not have more than 10000 entries");
+
+  auto expected = makeNullableArrayVector<Date>(
+      {{{Date(1991),
+         Date(1992),
+         Date(1993),
+         Date(1994),
+         Date(1995),
+         Date(1996)}},
+       std::nullopt,
+       {{Date(1992)}}});
+  testExpression("try(sequence(C0, C1))", {startVector, stopVector}, expected);
+}


### PR DESCRIPTION
Added
- [x] sequence(date, date)

Followup
- [ ] [Optimization] Add fast path when step is constant
- [ ] sequence(date, date, interval day to second)
- [ ] sequence(date, date, interval year to month)
- [ ] sequence(timestamp, timestamp, interval day to second)
- [ ] sequence(timestamp, timestamp, interval year to month)