### PR TITLE
Fix enable sparksql aggregate compile config in CmakeList

### DIFF
--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -36,9 +36,12 @@ target_link_libraries(
 set_property(TARGET velox_functions_spark PROPERTY JOB_POOL_COMPILE
                                                    high_memory_pool)
 
+if(${VELOX_ENABLE_AGGREGATES})
+  add_subdirectory(aggregates)
+endif()
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
-  add_subdirectory(aggregates)
   add_subdirectory(coverage)
 endif()
 


### PR DESCRIPTION
Unify with Presto aggregate, and if we build without `VELOX_BUILD_TESTING`, we will not find SparkSql aggregate functions