### PR TITLE
Replace CrossJoinNode with NestedLoopJoinNode

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1422,10 +1422,27 @@ class MergeJoinNode : public AbstractJoinNode {
   static PlanNodePtr create(const folly::dynamic& obj, void* context);
 };
 
-// Cross join.
-class CrossJoinNode : public PlanNode {
+/// Represents inner/outer nested loop joins. Translates to an
+/// exec::CrossJoinProbe and exec::CrossJoinBuild(which will later be renamed to
+/// NestedLoopJoin{Probe, Build}). A separate pipeline is produced for the build
+/// side when generating exec::Operators.
+/// Nested loop join supports both equal and non-equal joins. Expressions
+/// specified in joinCondition are evaluated on every combination of left/right
+/// tuple, to emit result.
+/// This also replaces CrossJoinNode, as cross join is equivalent to inner join
+/// on TRUE. To create a plan node for cross join, use the constructor without
+/// `joinType` and `joinCondition` parameter.
+class NestedLoopJoinNode : public PlanNode {
  public:
-  CrossJoinNode(
+  NestedLoopJoinNode(
+      const PlanNodeId& id,
+      JoinType joinType,
+      TypedExprPtr joinCondition,
+      PlanNodePtr left,
+      PlanNodePtr right,
+      RowTypePtr outputType);
+
+  NestedLoopJoinNode(
       const PlanNodeId& id,
       PlanNodePtr left,
       PlanNodePtr right,
@@ -1440,7 +1457,15 @@ class CrossJoinNode : public PlanNode {
   }
 
   std::string_view name() const override {
-    return "CrossJoin";
+    return "NestedLoopJoin";
+  }
+
+  const TypedExprPtr& joinCondition() const {
+    return joinCondition_;
+  }
+
+  JoinType joinType() const {
+    return joinType_;
   }
 
   folly::dynamic serialize() const override;
@@ -1450,6 +1475,8 @@ class CrossJoinNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
+  const JoinType joinType_;
+  const TypedExprPtr joinCondition_;
   const std::vector<PlanNodePtr> sources_;
   const RowTypePtr outputType_;
 };

--- a/velox/exec/CrossJoinBuild.cpp
+++ b/velox/exec/CrossJoinBuild.cpp
@@ -44,7 +44,7 @@ std::optional<std::vector<VectorPtr>> CrossJoinBridge::dataOrFuture(
 CrossJoinBuild::CrossJoinBuild(
     int32_t operatorId,
     DriverCtx* driverCtx,
-    std::shared_ptr<const core::CrossJoinNode> joinNode)
+    std::shared_ptr<const core::NestedLoopJoinNode> joinNode)
     : Operator(
           driverCtx,
           nullptr,

--- a/velox/exec/CrossJoinBuild.h
+++ b/velox/exec/CrossJoinBuild.h
@@ -35,7 +35,7 @@ class CrossJoinBuild : public Operator {
   CrossJoinBuild(
       int32_t operatorId,
       DriverCtx* driverCtx,
-      std::shared_ptr<const core::CrossJoinNode> joinNode);
+      std::shared_ptr<const core::NestedLoopJoinNode> joinNode);
 
   void addInput(RowVectorPtr input) override;
 

--- a/velox/exec/CrossJoinProbe.cpp
+++ b/velox/exec/CrossJoinProbe.cpp
@@ -21,7 +21,7 @@ namespace facebook::velox::exec {
 CrossJoinProbe::CrossJoinProbe(
     int32_t operatorId,
     DriverCtx* driverCtx,
-    const std::shared_ptr<const core::CrossJoinNode>& joinNode)
+    const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode)
     : Operator(
           driverCtx,
           joinNode->outputType(),

--- a/velox/exec/CrossJoinProbe.h
+++ b/velox/exec/CrossJoinProbe.h
@@ -24,7 +24,7 @@ class CrossJoinProbe : public Operator {
   CrossJoinProbe(
       int32_t operatorId,
       DriverCtx* driverCtx,
-      const std::shared_ptr<const core::CrossJoinNode>& hashJoinNode);
+      const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
 
   void addInput(RowVectorPtr input) override;
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -387,8 +387,8 @@ struct DriverFactory {
   /// and grouped execution and must be created in ungrouped execution pipeline
   /// and skipped in grouped execution pipeline.
   folly::F14FastSet<core::PlanNodeId> mixedExecutionModeHashJoinNodeIds;
-  /// Same as 'mixedExecutionModeHashJoinNodeIds' but for Cross Joins.
-  folly::F14FastSet<core::PlanNodeId> mixedExecutionModeCrossJoinNodeIds;
+  /// Same as 'mixedExecutionModeHashJoinNodeIds' but for Nested Loop Joins.
+  folly::F14FastSet<core::PlanNodeId> mixedExecutionModeNestedLoopJoinNodeIds;
 
   std::shared_ptr<Driver> createDriver(
       std::unique_ptr<DriverCtx> ctx,

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -20,7 +20,6 @@ add_executable(
   ArrowStreamTest.cpp
   AssignUniqueIdTest.cpp
   AsyncConnectorTest.cpp
-  CrossJoinTest.cpp
   CustomJoinTest.cpp
   EnforceSingleRowTest.cpp
   FilterProjectTest.cpp
@@ -36,6 +35,7 @@ add_executable(
   MergeJoinTest.cpp
   MergeTest.cpp
   MultiFragmentTest.cpp
+  NestedLoopJoinTest.cpp
   OrderByTest.cpp
   PartitionedOutputBufferManagerTest.cpp
   PlanNodeSerdeTest.cpp

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -291,7 +291,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndCrossJoin) {
     core::PlanNodePtr pipe0Node;
     core::PlanNodePtr pipe1Node;
 
-    // Hash or Cross join.
+    // Hash or Nested Loop join.
     if (i == 0) {
       pipe0Node =
           PlanBuilder(planNodeIdGenerator)
@@ -320,7 +320,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndCrossJoin) {
               .tableScan(rowType_)
               .capturePlanNodeId(probeScanNodeId)
               .project({"c3 as x", "c2 as y", "c1 as z", "c0 as w", "c4", "c5"})
-              .crossJoin(
+              .nestedLoopJoin(
                   PlanBuilder(planNodeIdGenerator)
                       .tableScan(rowType_, {"c0 > 0"})
                       .capturePlanNodeId(buildScanNodeId)

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -20,7 +20,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::exec::test;
 
-class CrossJoinTest : public HiveConnectorTestBase {
+class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
@@ -39,7 +39,7 @@ class CrossJoinTest : public HiveConnectorTestBase {
   }
 };
 
-TEST_F(CrossJoinTest, basic) {
+TEST_F(NestedLoopJoinTest, basic) {
   auto leftVectors = {
       makeRowVector({sequence<int32_t>(10)}),
       makeRowVector({sequence<int32_t>(100, 10)}),
@@ -61,7 +61,7 @@ TEST_F(CrossJoinTest, basic) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
-                .crossJoin(
+                .nestedLoopJoin(
                     PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .filter("c0 < 13")
@@ -77,7 +77,7 @@ TEST_F(CrossJoinTest, basic) {
   op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .filter("c0 < 13")
-           .crossJoin(
+           .nestedLoopJoin(
                PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .project({"c0 AS u_c0"})
@@ -91,7 +91,7 @@ TEST_F(CrossJoinTest, basic) {
   planNodeIdGenerator->reset();
   op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
-           .crossJoin(
+           .nestedLoopJoin(
                PlanBuilder(planNodeIdGenerator)
                    .values({vectorMaker_.rowVector(ROW({}, {}), 13)})
                    .planNode(),
@@ -105,7 +105,7 @@ TEST_F(CrossJoinTest, basic) {
   op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
            .filter("c0 < 13")
-           .crossJoin(
+           .nestedLoopJoin(
                PlanBuilder(planNodeIdGenerator)
                    .values({vectorMaker_.rowVector(ROW({}, {}), 1121)})
                    .planNode(),
@@ -120,7 +120,7 @@ TEST_F(CrossJoinTest, basic) {
   planNodeIdGenerator->reset();
   op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
-           .crossJoin(
+           .nestedLoopJoin(
                PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .filter("c0 < 0")
@@ -137,7 +137,7 @@ TEST_F(CrossJoinTest, basic) {
   params.maxDrivers = 4;
   params.planNode = PlanBuilder(planNodeIdGenerator)
                         .values({leftVectors})
-                        .crossJoin(
+                        .nestedLoopJoin(
                             PlanBuilder(planNodeIdGenerator, pool_.get())
                                 .values({rightVectors}, true)
                                 .filter("c0 in (10, 17)")
@@ -152,7 +152,7 @@ TEST_F(CrossJoinTest, basic) {
       "SELECT * FROM t, (SELECT * FROM UNNEST (ARRAY[10, 17, 10, 17, 10, 17, 10, 17])) u");
 }
 
-TEST_F(CrossJoinTest, lazyVectors) {
+TEST_F(NestedLoopJoinTest, lazyVectors) {
   auto leftVectors = {
       makeRowVector({lazySequence<int32_t>(10)}),
       makeRowVector({lazySequence<int32_t>(100, 10)}),
@@ -173,7 +173,7 @@ TEST_F(CrossJoinTest, lazyVectors) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
-                .crossJoin(
+                .nestedLoopJoin(
                     PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .project({"c0 AS u_c0"})
@@ -186,7 +186,7 @@ TEST_F(CrossJoinTest, lazyVectors) {
 }
 
 // Test cross join with a build side that has rows, but no columns.
-TEST_F(CrossJoinTest, zeroColumnBuild) {
+TEST_F(NestedLoopJoinTest, zeroColumnBuild) {
   auto leftVectors = {
       makeRowVector({sequence<int32_t>(10)}),
       makeRowVector({sequence<int32_t>(100, 10)}),
@@ -204,7 +204,7 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
   auto op = PlanBuilder(planNodeIdGenerator)
                 .values({leftVectors})
-                .crossJoin(
+                .nestedLoopJoin(
                     PlanBuilder(planNodeIdGenerator)
                         .values({rightVectors})
                         .project({})
@@ -219,7 +219,7 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
   planNodeIdGenerator->reset();
   op = PlanBuilder(planNodeIdGenerator)
            .values({leftVectors})
-           .crossJoin(
+           .nestedLoopJoin(
                PlanBuilder(planNodeIdGenerator)
                    .values({rightVectors})
                    .filter("c0 = 1")
@@ -232,11 +232,11 @@ TEST_F(CrossJoinTest, zeroColumnBuild) {
 }
 
 // Test multi-threaded build and probe sides.
-TEST_F(CrossJoinTest, parallelism) {
+TEST_F(NestedLoopJoinTest, parallelism) {
   // Setup 5 threads for build and probe. Each build thread gets 3 identical
   // rows of input from the Values operator. The build thread that finishes last
   // combines data from all other threads making it 3x5=15 rows and puts them
-  // into the CrossJoinBridge. All probe threads get 2 identical ros of input
+  // into the NestedLoopJoinBridge. All probe threads get 2 identical ros of input
   // from the Values operator and join them with 15 rows of build side data from
   // the bridge. Each probe thread is expected to produce 30 rows.
 
@@ -249,7 +249,7 @@ TEST_F(CrossJoinTest, parallelism) {
   params.planNode =
       PlanBuilder(planNodeIdGenerator)
           .values({left}, true)
-          .crossJoin(
+          .nestedLoopJoin(
               PlanBuilder(planNodeIdGenerator).values({right}, true).planNode(),
               {"c0", "u_c0"})
           .partialAggregation({}, {"count(1)"})

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -72,7 +72,7 @@ TEST_F(PlanNodeSerdeTest, assignUniqueId) {
   testSerde(plan);
 }
 
-TEST_F(PlanNodeSerdeTest, crossJoin) {
+TEST_F(PlanNodeSerdeTest, nestedLoopJoin) {
   auto left = makeRowVector(
       {"t0", "t1", "t2"},
       {
@@ -93,7 +93,7 @@ TEST_F(PlanNodeSerdeTest, crossJoin) {
   auto plan =
       PlanBuilder(planNodeIdGenerator)
           .values({left})
-          .crossJoin(
+          .nestedLoopJoin(
               PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
               {"t0", "u1", "t2", "t1"})
           .planNode();

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -377,11 +377,11 @@ TEST_F(PlanNodeToStringTest, mergeJoin) {
       plan->toString(true, false));
 }
 
-TEST_F(PlanNodeToStringTest, crossJoin) {
+TEST_F(PlanNodeToStringTest, nestedLoopJoin) {
   auto plan = PlanBuilder()
                   .values({data_})
                   .project({"c0 as t_c0", "c1 as t_c1"})
-                  .crossJoin(
+                  .nestedLoopJoin(
                       PlanBuilder()
                           .values({data_})
                           .project({"c0 as u_c0", "c1 as u_c1"})
@@ -389,9 +389,9 @@ TEST_F(PlanNodeToStringTest, crossJoin) {
                       {"t_c0", "t_c1", "u_c1"})
                   .planNode();
 
-  ASSERT_EQ("-- CrossJoin\n", plan->toString());
+  ASSERT_EQ("-- NestedLoopJoin\n", plan->toString());
   ASSERT_EQ(
-      "-- CrossJoin[] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
+      "-- NestedLoopJoin[INNER] -> t_c0:SMALLINT, t_c1:INTEGER, u_c1:INTEGER\n",
       plan->toString(true, false));
 }
 

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -596,7 +596,7 @@ TEST_F(TaskTest, singleThreadedCrossJoin) {
   auto plan = PlanBuilder(planNodeIdGenerator)
                   .tableScan(asRowType(left->type()))
                   .capturePlanNodeId(leftScanId)
-                  .crossJoin(
+                  .nestedLoopJoin(
                       PlanBuilder(planNodeIdGenerator)
                           .tableScan(asRowType(right->type()))
                           .capturePlanNodeId(rightScanId)

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1026,13 +1026,13 @@ PlanBuilder& PlanBuilder::mergeJoin(
   return *this;
 }
 
-PlanBuilder& PlanBuilder::crossJoin(
+PlanBuilder& PlanBuilder::nestedLoopJoin(
     const core::PlanNodePtr& right,
     const std::vector<std::string>& outputLayout) {
   auto resultType = concat(planNode_->outputType(), right->outputType());
   auto outputType = extract(resultType, outputLayout);
 
-  planNode_ = std::make_shared<core::CrossJoinNode>(
+  planNode_ = std::make_shared<core::NestedLoopJoinNode>(
       nextPlanNodeId(), std::move(planNode_), right, outputType);
   return *this;
 }

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -611,15 +611,15 @@ class PlanBuilder {
       const std::vector<std::string>& outputLayout,
       core::JoinType joinType = core::JoinType::kInner);
 
-  /// Add a CrossJoinNode to produce a cross product of the inputs. First input
-  /// comes from the preceding plan node. Second input is specified in 'right'
-  /// parameter.
+  /// Add a NestedLoopJoinNode to produce a cross product of the inputs. First
+  /// input comes from the preceding plan node. Second input is specified in
+  /// 'right' parameter.
   ///
   /// @param right Right-side input. Typically, to reduce memory usage, the
   /// smaller input is placed on the right-side.
   /// @param outputLayout Output layout consisting of columns from left and
   /// right sides.
-  PlanBuilder& crossJoin(
+  PlanBuilder& nestedLoopJoin(
       const core::PlanNodePtr& right,
       const std::vector<std::string>& outputLayout);
 

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -1937,7 +1937,7 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
               {},
               phoneFilter)
           .capturePlanNodeId(customerScanNodeIdWithKey)
-          .crossJoin(
+          .nestedLoopJoin(
               customerAvgAccountBalance,
               {"c_acctbal", "avg_acctbal", "c_custkey", "c_phone"})
           .filter("c_acctbal > avg_acctbal")

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -386,7 +386,7 @@ PlanNodePtr toVeloxPlan(
     types.push_back(rightInputType.childAt(i));
   }
 
-  return std::make_shared<CrossJoinNode>(
+  return std::make_shared<NestedLoopJoinNode>(
       queryContext.nextNodeId(),
       std::move(sources[0]),
       std::move(sources[1]),

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -113,7 +113,7 @@ TEST_F(QueryPlannerTest, tableScan) {
       inMemoryTables,
       "-- Project\n"
       "  -- Filter\n"
-      "    -- CrossJoin\n"
+      "    -- NestedLoopJoin\n"
       "      -- Values\n"
       "      -- Values\n");
 }


### PR DESCRIPTION
- Add `NestedLoopJoinNode` to represents a nested loop join. Translate to `exec::CrossJoinProbe` and `exec::CrossJoinBuild`:
    - only support inner join type and null join condition for now;
    - will support outer joins and equal / non-equal expression as join condition in the future.
- Replace `CrossJoinNode` with `NestedLoopJoinNode` as cross join is equivalent to inner join on TRUE
    - rename `PlanBuilder& crossJoin()` to `PlanBuilder& nestedLoopJoin()`