### PR TITLE
Fix constant vector toString

### DIFF
--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -146,23 +146,27 @@ class SimpleVector : public BaseVector {
 
   using BaseVector::toString;
 
+  std::string valueToString(T value) const {
+    if constexpr (std::is_same_v<T, bool>) {
+      return value ? "true" : "false";
+    } else if constexpr (std::is_same_v<T, std::shared_ptr<void>>) {
+      return "<opaque>";
+    } else if constexpr (
+        std::is_same_v<T, UnscaledShortDecimal> ||
+        std::is_same_v<T, UnscaledLongDecimal>) {
+      return DecimalUtil::toString(value, type());
+    } else {
+      return velox::to<std::string>(value);
+    }
+  }
+
   std::string toString(vector_size_t index) const override {
     VELOX_CHECK_LT(index, length_, "Vector index should be less than length.");
     std::stringstream out;
     if (isNullAt(index)) {
       out << "null";
     } else {
-      if constexpr (std::is_same_v<T, bool>) {
-        out << (valueAt(index) ? "true" : "false");
-      } else if constexpr (std::is_same_v<T, std::shared_ptr<void>>) {
-        out << "<opaque>";
-      } else if constexpr (
-          std::is_same_v<T, UnscaledShortDecimal> ||
-          std::is_same_v<T, UnscaledLongDecimal>) {
-        out << DecimalUtil::toString(valueAt(index), type());
-      } else {
-        out << velox::to<std::string>(valueAt(index));
-      }
+      out << valueToString(valueAt(index));
     }
     return out.str();
   }

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -308,4 +308,27 @@ TEST_F(VectorToStringTest, indexOverflow) {
   auto flat = makeFlatVector<int32_t>({1, 2, 3});
   ASSERT_THROW(flat->toString(4), VeloxException);
 }
+
+TEST_F(VectorToStringTest, constantgPrimitiveTypes) {
+  auto flat = makeFlatVector<int64_t>(100, [](vector_size_t i) { return i; });
+
+  // Index in values vector > constant vector size.
+  auto constantVector = BaseVector::wrapInConstant(10, 20, flat);
+  EXPECT_EQ(
+      constantVector->toString(true), "[CONSTANT BIGINT: 10 elements, 20]");
+
+  // Empty vector.
+  constantVector->resize(0);
+  EXPECT_EQ(
+      constantVector->toString(true), "[CONSTANT BIGINT: 0 elements, 20]");
+
+  // Null constant.
+  auto nulls = vectorMaker_.flatVectorNullable<int64_t>({std::nullopt});
+  auto nullConstant = BaseVector::wrapInConstant(20, 0, nulls);
+  EXPECT_EQ(
+      nullConstant->toString(true), "[CONSTANT BIGINT: 20 elements, null]");
+  nullConstant->resize(0);
+  EXPECT_EQ(
+      nullConstant->toString(true), "[CONSTANT BIGINT: 0 elements, null]");
+}
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
When index_ is  larger than constantVector.size() we used to throw
because we call SimpleVector<T>::toString(index).
We also cant pass 0, since then we cant print constant vector of size 0
values.
The diff address the above and fix the circleCI issue.

Differential Revision: D45135065

