### PR TITLE
Let ExchangeSource to have shared ownership of MemoryPool

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -127,8 +127,8 @@ class LocalExchangeSource : public ExchangeSource {
               continue;
             }
             inputPage->unshare();
-            pages.push_back(
-                std::make_unique<SerializedPage>(std::move(inputPage), pool_));
+            pages.push_back(std::make_unique<SerializedPage>(
+                std::move(inputPage), pool_.get()));
             inputPage = nullptr;
           }
           int64_t ackSequence;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -267,7 +267,7 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
       : taskId_(taskId),
         destination_(destination),
         queue_(std::move(queue)),
-        pool_(pool) {}
+        pool_(pool->shared_from_this()) {}
 
   virtual ~ExchangeSource() = default;
 
@@ -323,7 +323,12 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   bool atEnd_ = false;
 
  protected:
-  memory::MemoryPool* pool_;
+
+  // Shared ownership for 'MemoryPool' as the pool might still be used after the
+  // task owning the pool gets destroyed. This scenario can happen when a super
+  // slow remote response gets back. And at the time it gets back its task is
+  // already destroyed.
+  const std::shared_ptr<memory::MemoryPool> pool_;
 };
 
 struct RemoteConnectorSplit : public connector::ConnectorSplit {


### PR DESCRIPTION
The shared ownership of MemoryPool in ExchangeSource allows the successful processing of a super late remote response. Because at that point the resources of the task could have already been cleaned up completely.