### PR TITLE
Rename cross join operators to NestedLoopJoin

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1423,12 +1423,13 @@ class MergeJoinNode : public AbstractJoinNode {
 };
 
 /// Represents inner/outer nested loop joins. Translates to an
-/// exec::CrossJoinProbe and exec::CrossJoinBuild(which will later be renamed to
-/// NestedLoopJoin{Probe, Build}). A separate pipeline is produced for the build
-/// side when generating exec::Operators.
+/// exec::NestedLoopJoinProbe and exec::NestedLoopJoinBuild. A separate pipeline
+/// is produced for the build side when generating exec::Operators.
+///
 /// Nested loop join supports both equal and non-equal joins. Expressions
 /// specified in joinCondition are evaluated on every combination of left/right
 /// tuple, to emit result.
+///
 /// This also replaces CrossJoinNode, as cross join is equivalent to inner join
 /// on TRUE. To create a plan node for cross join, use the constructor without
 /// `joinType` and `joinCondition` parameter.

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -19,8 +19,6 @@ add_library(
   AggregateWindow.cpp
   ArrowStream.cpp
   ContainerRowSerde.cpp
-  CrossJoinBuild.cpp
-  CrossJoinProbe.cpp
   Driver.cpp
   EnforceSingleRow.cpp
   Exchange.cpp
@@ -40,6 +38,8 @@ add_library(
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp
+  NestedLoopJoinBuild.cpp
+  NestedLoopJoinProbe.cpp
   Operator.cpp
   OperatorUtils.cpp
   OrderBy.cpp

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -448,9 +448,9 @@ struct DriverFactory {
   /// this pipeline.
   std::vector<core::PlanNodeId> needsHashJoinBridges() const;
 
-  /// Returns plan node IDs for which Cross Join Bridges must be created based
-  /// on this pipeline.
-  std::vector<core::PlanNodeId> needsCrossJoinBridges() const;
+  /// Returns plan node IDs for which Nested Loop Join Bridges must be created
+  /// based on this pipeline.
+  std::vector<core::PlanNodeId> needsNestedLoopJoinBridges() const;
 };
 
 // Begins and ends a section where a thread is running but not

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -29,7 +29,7 @@ namespace facebook::velox::exec {
 class PartitionedOutputBufferManager;
 
 class HashJoinBridge;
-class CrossJoinBridge;
+class NestedLoopJoinBridge;
 class Task : public std::enable_shared_from_this<Task> {
  public:
   /// Creates a task to execute a plan fragment, but doesn't start execution
@@ -397,8 +397,8 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const std::vector<core::PlanNodeId>& planNodeIds);
 
-  /// Adds CrossJoinBridge's for all the specified plan node IDs.
-  void addCrossJoinBridgesLocked(
+  /// Adds NestedLoopJoinBridge's for all the specified plan node IDs.
+  void addNestedLoopJoinBridgesLocked(
       uint32_t splitGroupId,
       const std::vector<core::PlanNodeId>& planNodeIds);
 
@@ -419,8 +419,8 @@ class Task : public std::enable_shared_from_this<Task> {
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 
-  /// Returns a CrossJoinBridge for 'planNodeId'.
-  std::shared_ptr<CrossJoinBridge> getCrossJoinBridge(
+  /// Returns a NestedLoopJoinBridge for 'planNodeId'.
+  std::shared_ptr<NestedLoopJoinBridge> getNestedLoopJoinBridge(
       uint32_t splitGroupId,
       const core::PlanNodeId& planNodeId);
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -277,7 +277,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
 
 // Here we test various aspects of grouped/bucketed execution involving
 // output buffer and 3 pipelines.
-TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndCrossJoin) {
+TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
   // Create source file - we will read from it in 6 splits.
   auto vectors = makeVectors(4, 20);
   auto filePath = TempFilePath::create();


### PR DESCRIPTION
Rename `exec::CrossJoin{Probe,Bridge,Build}` to `exec::NestedLoopJoin{Probe,Bridge,Build}`.