### PR TITLE
Refine StringIdMap::makeId

### DIFF
--- a/velox/common/caching/StringIdMap.cpp
+++ b/velox/common/caching/StringIdMap.cpp
@@ -59,9 +59,8 @@ uint64_t StringIdMap::makeId(std::string_view string) {
   if (it != stringToId_.end()) {
     auto entry = idToString_.find(it->second);
     VELOX_CHECK(entry != idToString_.end());
-    if (++entry->second.numInUse == 1) {
-      pinnedSize_ += entry->second.string.size();
-    }
+    VELOX_CHECK_LT(0, entry->second.numInUse);
+    ++entry->second.numInUse;
 
     return it->second;
   }
@@ -74,7 +73,8 @@ uint64_t StringIdMap::makeId(std::string_view string) {
   // be in the 100K range.
   do {
     entry.id = ++lastId_;
-  } while (idToString_.find(entry.id) != idToString_.end());
+  } while (entry.id == kNoId ||
+           idToString_.find(entry.id) != idToString_.end());
   entry.numInUse = 1;
   pinnedSize_ += entry.string.size();
   auto id = entry.id;

--- a/velox/common/caching/StringIdMap.h
+++ b/velox/common/caching/StringIdMap.h
@@ -63,6 +63,10 @@ class StringIdMap {
     return it == idToString_.end() ? "" : it->second.string;
   }
 
+  void testingSetLastId(uint64_t lastId) {
+    lastId_ = lastId;
+  }
+
  private:
   struct Entry {
     std::string string;

--- a/velox/common/caching/tests/StringIdMapTest.cpp
+++ b/velox/common/caching/tests/StringIdMapTest.cpp
@@ -53,3 +53,10 @@ TEST(StringIdMapTest, rehash) {
     EXPECT_EQ(ids[i].id(), StringIdLease(map, name).id());
   }
 }
+
+TEST(StringIdMapTest, overflow) {
+  StringIdMap map;
+  map.testingSetLastId(StringIdMap::kNoId - 1);
+  map.makeId("test");
+  ASSERT_EQ(map.id("test"), 0);
+}


### PR DESCRIPTION
This PR does two things.

First, in StringIdMap::makeId, the intension of the while loop is to avoid duplicate id
```
  do {
    entry.id = ++lastId_;
  } while (idToString_.find(entry.id) != idToString_.end());
```
However, when lastId reaches ```kNoId - 1```, the next id will be ```kNoId```, which is incorrect.

Second, in StringIdMap::makeId, the following check is unnecessary
```
    if (++entry->second.numInUse == 1) {
      pinnedSize_ += entry->second.string.size();
    }
```
the logic in StringIdMap ensures that ```numInUse``` will never be zero because when ```StringIdMap::release``` decreases ```numInUse``` to zero, it will remove from ```stringToId_``` and ```idToString_```. So it's better to use ```VELOX_CHECK_LT``` to check instead of an if block.