### PR TITLE
Replace find_library with find_package

### DIFF
--- a/CMake/FindSnappy.cmake
+++ b/CMake/FindSnappy.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# - Try to find snappy
+# Once done, this will define
+#
+# SNAPPY_FOUND - system has Glog
+# SNAPPY_INCLUDE_DIRS - deprecated
+# SNAPPY_LIBRARIES -  deprecated
+# Snappy::snappy will be defined based on CMAKE_FIND_LIBRARY_SUFFIXES priority
+
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+
+find_library(SNAPPY_LIBRARY_RELEASE snappy PATHS $SNAPPY_LIBRARYDIR})
+find_library(SNAPPY_LIBRARY_DEBUG snappyd PATHS ${SNAPPY_LIBRARYDIR})
+
+find_path(SNAPPY_INCLUDE_DIR snappy.h PATHS ${SNAPPY_INCLUDEDIR})
+
+select_library_configurations(SNAPPY)
+
+find_package_handle_standard_args(Snappy DEFAULT_MSG SNAPPY_LIBRARY
+                                  SNAPPY_INCLUDE_DIR)
+
+mark_as_advanced(SNAPPY_LIBRARY SNAPPY_INCLUDE_DIR)
+
+get_filename_component(libsnappy_ext ${SNAPPY_LIBRARY} EXT)
+if(libsnappy_ext STREQUAL ".a")
+  set(libsnappy_type STATIC)
+else()
+  set(libsnappy_type SHARED)
+endif()
+
+if(NOT TARGET Snappy::snappy)
+  add_library(Snappy::snappy ${libsnappy_type} IMPORTED)
+  set_target_properties(Snappy::snappy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                  "${SNAPPY_INCLUDE_DIR}")
+  set_target_properties(
+    Snappy::snappy PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                              IMPORTED_LOCATION "${SNAPPY_LIBRARIES}")
+endif()

--- a/CMake/Findlz4.cmake
+++ b/CMake/Findlz4.cmake
@@ -1,0 +1,38 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# - Try to find lz4
+# Once done, this will define
+#
+# LZ4_FOUND - system has Glog
+# LZ4_INCLUDE_DIRS - deprecated
+# LZ4_LIBRARIES -  deprecated
+# lz4::lz4 will be defined based on CMAKE_FIND_LIBRARY_SUFFIXES priority
+
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+
+find_library(LZ4_LIBRARY_RELEASE lz4 PATHS $LZ4_LIBRARYDIR})
+find_library(LZ4_LIBRARY_DEBUG lz4d PATHS ${LZ4_LIBRARYDIR})
+
+find_path(LZ4_INCLUDE_DIR lz4.h PATHS ${LZ4_INCLUDEDIR})
+
+select_library_configurations(LZ4)
+
+find_package_handle_standard_args(lz4 DEFAULT_MSG LZ4_LIBRARY LZ4_INCLUDE_DIR)
+
+mark_as_advanced(LZ4_LIBRARY LZ4_INCLUDE_DIR)
+
+get_filename_component(liblz4_ext ${LZ4_LIBRARY} EXT)
+if(liblz4_ext STREQUAL ".a")
+  set(liblz4_type STATIC)
+else()
+  set(liblz4_type SHARED)
+endif()
+
+if(NOT TARGET lz4::lz4)
+  add_library(lz4::lz4 ${liblz4_type} IMPORTED)
+  set_target_properties(lz4::lz4 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                            "${LZ4_INCLUDE_DIR}")
+  set_target_properties(
+    lz4::lz4 PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                        IMPORTED_LOCATION "${LZ4_LIBRARIES}")
+endif()

--- a/CMake/Findlzo2.cmake
+++ b/CMake/Findlzo2.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# - Try to find lzo2
+# Once done, this will define
+#
+# LZO2_FOUND - system has Glog
+# LZO2_INCLUDE_DIRS - deprecated
+# LZO2_LIBRARIES -  deprecated
+# lzo2::lzo2 will be defined based on CMAKE_FIND_LIBRARY_SUFFIXES priority
+
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+
+find_library(LZO2_LIBRARY_RELEASE lzo2 PATHS $LZO2_LIBRARYDIR})
+find_library(LZO2_LIBRARY_DEBUG lzo2d PATHS ${LZO2_LIBRARYDIR})
+
+find_path(LZO2_INCLUDE_DIR lzo/lzo1a.h PATHS ${LZO2_INCLUDEDIR})
+
+select_library_configurations(LZO2)
+
+find_package_handle_standard_args(lzo2 DEFAULT_MSG LZO2_LIBRARY
+                                  LZO2_INCLUDE_DIR)
+
+mark_as_advanced(LZO2_LIBRARY LZO2_INCLUDE_DIR)
+
+get_filename_component(liblzo2_ext ${LZO2_LIBRARY} EXT)
+if(liblzo2_ext STREQUAL ".a")
+  set(liblzo2_type STATIC)
+else()
+  set(liblzo2_type SHARED)
+endif()
+
+if(NOT TARGET lzo2::lzo2)
+  add_library(lzo2::lzo2 ${liblzo2_type} IMPORTED)
+  set_target_properties(lzo2::lzo2 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                              "${LZO2_INCLUDE_DIR}")
+  set_target_properties(
+    lzo2::lzo2 PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${LZO2_LIBRARIES}")
+endif()

--- a/CMake/Findzstd.cmake
+++ b/CMake/Findzstd.cmake
@@ -1,0 +1,39 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# - Try to find zstd
+# Once done, this will define
+#
+# ZSTD_FOUND - system has Glog
+# ZSTD_INCLUDE_DIRS - deprecated
+# ZSTD_LIBRARIES -  deprecated
+# zstd::zstd will be defined based on CMAKE_FIND_LIBRARY_SUFFIXES priority
+
+include(FindPackageHandleStandardArgs)
+include(SelectLibraryConfigurations)
+
+find_library(ZSTD_LIBRARY_RELEASE zstd PATHS $ZSTD_LIBRARYDIR})
+find_library(ZSTD_LIBRARY_DEBUG zstdd PATHS ${ZSTD_LIBRARYDIR})
+
+find_path(ZSTD_INCLUDE_DIR zstd.h PATHS ${ZSTD_INCLUDEDIR})
+
+select_library_configurations(ZSTD)
+
+find_package_handle_standard_args(zstd DEFAULT_MSG ZSTD_LIBRARY
+                                  ZSTD_INCLUDE_DIR)
+
+mark_as_advanced(ZSTD_LIBRARY ZSTD_INCLUDE_DIR)
+
+get_filename_component(libzstd_ext ${ZSTD_LIBRARY} EXT)
+if(libzstd_ext STREQUAL ".a")
+  set(libzstd_type STATIC)
+else()
+  set(libzstd_type SHARED)
+endif()
+
+if(NOT TARGET zstd::zstd)
+  add_library(zstd::zstd ${libzstd_type} IMPORTED)
+  set_target_properties(zstd::zstd PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                              "${ZSTD_INCLUDE_DIR}")
+  set_target_properties(
+    zstd::zstd PROPERTIES IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${ZSTD_LIBRARIES}")
+endif()

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -29,10 +29,10 @@ FetchContent_Declare(
   URL_HASH ${VELOX_GFLAGS_BUILD_SHA256_CHECKSUM}
   PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/gflags/gflags-config.patch)
 
-set(GFLAGS_BUILD_SHARED_LIBS ON)
+#set(GFLAGS_BUILD_SHARED_LIBS ON)
 set(GFLAGS_BUILD_STATIC_LIBS ON)
 set(GFLAGS_BUILD_gflags_LIB ON)
-set(GFLAGS_BUILD_gflags_nothreads_LIB OFF)
+set(GFLAGS_BUILD_gflags_nothreads_LIB ON)
 set(GFLAGS_IS_SUBPROJECT ON)
 # glog relies on the old `google` namespace
 set(GFLAGS_NAMESPACE "google;gflags")
@@ -41,8 +41,9 @@ FetchContent_MakeAvailable(gflags)
 
 # the flag has to be added to each target we build so adjust to settings choosen
 # above
+#target_compile_options(gflags_shared PRIVATE -Wno-cast-function-type)
 target_compile_options(gflags_static PRIVATE -Wno-cast-function-type)
-target_compile_options(gflags_shared PRIVATE -Wno-cast-function-type)
+target_compile_options(gflags_nothreads_static PRIVATE -Wno-cast-function-type)
 
 # this causes find_package(gflags) to search in the build directory and prevents
 # the system gflags from being found

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -29,7 +29,6 @@ FetchContent_Declare(
   URL_HASH ${VELOX_GFLAGS_BUILD_SHA256_CHECKSUM}
   PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/gflags/gflags-config.patch)
 
-# set(GFLAGS_BUILD_SHARED_LIBS ON)
 set(GFLAGS_BUILD_STATIC_LIBS ON)
 set(GFLAGS_BUILD_gflags_LIB ON)
 set(GFLAGS_BUILD_gflags_nothreads_LIB ON)

--- a/CMake/resolve_dependency_modules/gflags.cmake
+++ b/CMake/resolve_dependency_modules/gflags.cmake
@@ -29,7 +29,7 @@ FetchContent_Declare(
   URL_HASH ${VELOX_GFLAGS_BUILD_SHA256_CHECKSUM}
   PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/gflags/gflags-config.patch)
 
-#set(GFLAGS_BUILD_SHARED_LIBS ON)
+# set(GFLAGS_BUILD_SHARED_LIBS ON)
 set(GFLAGS_BUILD_STATIC_LIBS ON)
 set(GFLAGS_BUILD_gflags_LIB ON)
 set(GFLAGS_BUILD_gflags_nothreads_LIB ON)
@@ -41,7 +41,6 @@ FetchContent_MakeAvailable(gflags)
 
 # the flag has to be added to each target we build so adjust to settings choosen
 # above
-#target_compile_options(gflags_shared PRIVATE -Wno-cast-function-type)
 target_compile_options(gflags_static PRIVATE -Wno-cast-function-type)
 target_compile_options(gflags_nothreads_static PRIVATE -Wno-cast-function-type)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,10 @@ if(VELOX_ENABLE_CCACHE
   endif()
 endif()
 
+# At the moment we prefer static linking but by default cmake looks for shared
+# libs first. This will still fallback to shared libs when static ones are not
+# found
+list(INSERT CMAKE_FIND_LIBRARY_SUFFIXES 0 a)
 if(VELOX_ENABLE_S3)
   # Set AWS_ROOT_DIR if you have a custom install location of AWS SDK CPP.
   if(AWSSDK_ROOT_DIR)
@@ -359,14 +363,20 @@ resolve_dependency(glog)
 set_source(fmt)
 resolve_dependency(fmt)
 
-# Required for boost.
-find_package(ZLIB)
-
 if(NOT ${VELOX_BUILD_MINIMAL})
-  find_library(LZ4 lz4)
-  find_library(LZO lzo2)
-  find_library(ZSTD zstd)
-  find_library(SNAPPY snappy)
+  find_package(ZLIB REQUIRED)
+  find_package(lz4 REQUIRED)
+  find_package(lzo2 REQUIRED)
+  find_package(zstd REQUIRED)
+  find_package(Snappy REQUIRED)
+  if(NOT TARGET zstd::zstd)
+    if(TARGET zstd::libzstd_static)
+      set(ZSTD_TYPE static)
+    else()
+      set(ZSTD_TYPE shared)
+    endif()
+    add_library(zstd::zstd ALIAS zstd::libzstd_${ZSTD_TYPE})
+  endif()
 endif()
 
 set_source(re2)
@@ -389,12 +399,8 @@ if(NOT DEFINED Boost_LIBRARIES)
 endif()
 
 set(FOLLY_WITH_DEPENDENCIES
-    ${FOLLY_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${DOUBLE_CONVERSION}
-    ${SNAPPY}
-    ${CMAKE_DL_LIBS}
-    ${FMT})
+    ${FOLLY_LIBRARIES} ${Boost_LIBRARIES} ${DOUBLE_CONVERSION} ${SNAPPY}
+    ${CMAKE_DL_LIBS} ${FMT})
 
 if(DEFINED FOLLY_BENCHMARK_STATIC_LIB)
   set(FOLLY_BENCHMARK ${FOLLY_BENCHMARK_STATIC_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,10 +359,6 @@ resolve_dependency(glog)
 set_source(fmt)
 resolve_dependency(fmt)
 
-find_library(EVENT event)
-
-find_library(DOUBLE_CONVERSION double-conversion)
-
 # Required for boost.
 find_package(ZLIB)
 
@@ -396,7 +392,6 @@ set(FOLLY_WITH_DEPENDENCIES
     ${FOLLY_LIBRARIES}
     ${Boost_LIBRARIES}
     ${DOUBLE_CONVERSION}
-    ${EVENT}
     ${SNAPPY}
     ${CMAKE_DL_LIBS}
     ${FMT})

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -66,10 +66,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 if(VELOX_ENABLE_ARROW)

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -36,5 +36,11 @@ add_library(
 add_dependencies(velox_dwio_dwrf_common velox_dwio_dwrf_proto)
 
 target_link_libraries(
-  velox_dwio_dwrf_common velox_common_base velox_dwio_common
-  velox_dwio_common_compression velox_dwio_dwrf_proto velox_caching)
+  velox_dwio_dwrf_common
+  velox_common_base
+  velox_dwio_common
+  velox_dwio_common_compression
+  velox_dwio_dwrf_proto
+  velox_caching
+  Snappy::snappy
+  zstd::zstd)

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -50,10 +50,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   glog::glog
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_decompression_test TestDecompression.cpp)
@@ -66,10 +66,10 @@ target_link_libraries(
   velox_dwio_dwrf_decompression_test
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_stripe_stream_test TestStripeStream.cpp)
@@ -81,10 +81,10 @@ target_link_libraries(
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_stripe_dictionary_cache_test
@@ -98,10 +98,10 @@ target_link_libraries(
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_dictionary_encoder_test
@@ -150,10 +150,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_writer_context_test TestWriterContext.cpp)
@@ -165,10 +165,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_writer_encoding_manager_test
@@ -181,10 +181,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_writer_sink_test WriterSinkTests.cpp)
@@ -212,10 +212,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_decryption_test DecryptionTests.cpp)
@@ -240,10 +240,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_reader_base_test ReaderBaseTests.cpp)
@@ -254,10 +254,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   glog::glog
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_config_test ConfigTests.cpp)
@@ -338,10 +338,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_e2e_filter_test E2EFilterTest.cpp)
@@ -353,10 +353,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_statistics_builder_utils_test
@@ -378,10 +378,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_column_writer_index_test ColumnWriterIndexTests.cpp)
@@ -394,10 +394,10 @@ target_link_libraries(
   velox_dwrf_test_utils
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_writer_flush_test WriterFlushTest.cpp)
@@ -409,10 +409,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_e2e_writer_test E2EWriterTests.cpp)
@@ -426,10 +426,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_writer_extended_test WriterExtendedTests.cpp)
@@ -440,10 +440,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_column_writer_stats_test ColumnWriterStatsTests.cpp)
@@ -456,10 +456,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(physical_size_aggregator_test PhysicalSizeAggregatorTest.cpp)
@@ -471,10 +471,10 @@ target_link_libraries(
   ${VELOX_LINK_LIBS}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwrf_int_encoder_benchmark IntEncoderBenchmark.cpp)
@@ -504,8 +504,8 @@ target_link_libraries(
   ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -78,7 +78,6 @@ add_test(velox_dwio_dwrf_stripe_stream_test velox_dwio_dwrf_stripe_stream_test)
 target_link_libraries(
   velox_dwio_dwrf_stripe_stream_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
   lz4::lz4
@@ -95,7 +94,6 @@ add_test(velox_dwio_dwrf_stripe_dictionary_cache_test
 target_link_libraries(
   velox_dwio_dwrf_stripe_dictionary_cache_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
   lz4::lz4
@@ -117,9 +115,8 @@ add_executable(velox_dwio_dwrf_encoding_selector_test TestEncodingSelector.cpp)
 add_test(velox_dwio_dwrf_encoding_selector_test
          velox_dwio_dwrf_encoding_selector_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_encoding_selector_test ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_encoding_selector_test ${VELOX_LINK_LIBS}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_index_builder_test IndexBuilderTests.cpp)
 add_test(velox_dwio_dwrf_index_builder_test velox_dwio_dwrf_index_builder_test)
@@ -148,7 +145,6 @@ add_test(velox_dwio_dwrf_writer_test velox_dwio_dwrf_writer_test)
 target_link_libraries(
   velox_dwio_dwrf_writer_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   lz4::lz4
   lzo2::lzo2
@@ -163,7 +159,6 @@ add_test(velox_dwio_dwrf_writer_context_test
 target_link_libraries(
   velox_dwio_dwrf_writer_context_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   lz4::lz4
   lzo2::lzo2
@@ -179,7 +174,6 @@ add_test(velox_dwio_dwrf_writer_encoding_manager_test
 target_link_libraries(
   velox_dwio_dwrf_writer_encoding_manager_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   lz4::lz4
   lzo2::lzo2
@@ -190,9 +184,8 @@ target_link_libraries(
 add_executable(velox_dwio_dwrf_writer_sink_test WriterSinkTests.cpp)
 add_test(velox_dwio_dwrf_writer_sink_test velox_dwio_dwrf_writer_sink_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_writer_sink_test ${VELOX_LINK_LIBS} ${DOUBLE_CONVERSION}
-  ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_writer_sink_test ${VELOX_LINK_LIBS}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_data_buffer_holder_test
                DataBufferHolderTests.cpp)
@@ -201,7 +194,7 @@ add_test(velox_dwio_dwrf_data_buffer_holder_test
 
 target_link_libraries(
   velox_dwio_dwrf_data_buffer_holder_test ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+  ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_layout_planner_test LayoutPlannerTests.cpp)
 add_test(velox_dwio_dwrf_layout_planner_test
@@ -210,7 +203,6 @@ add_test(velox_dwio_dwrf_layout_planner_test
 target_link_libraries(
   velox_dwio_dwrf_layout_planner_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   lz4::lz4
   lzo2::lzo2
@@ -238,7 +230,6 @@ add_test(velox_dwio_dwrf_stripe_reader_base_test
 target_link_libraries(
   velox_dwio_dwrf_stripe_reader_base_test
   ${VELOX_LINK_LIBS}
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   lz4::lz4
   lzo2::lzo2
@@ -281,17 +272,15 @@ target_link_libraries(velox_dwio_dwrf_flush_policy_test ${VELOX_LINK_LIBS}
 add_executable(velox_dwio_dwrf_byte_rle_test TestByteRle.cpp)
 add_test(velox_dwio_dwrf_byte_rle_test velox_dwio_dwrf_byte_rle_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_byte_rle_test ${VELOX_LINK_LIBS} ${DOUBLE_CONVERSION} ${FMT}
-  ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_byte_rle_test ${VELOX_LINK_LIBS} ${FMT}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_byte_rle_encoder_test TestByteRLEEncoder.cpp)
 add_test(velox_dwio_dwrf_byte_rle_encoder_test
          velox_dwio_dwrf_byte_rle_encoder_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_byte_rle_encoder_test ${VELOX_LINK_LIBS} ${DOUBLE_CONVERSION}
-  ${FMT} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_byte_rle_encoder_test ${VELOX_LINK_LIBS}
+                      ${FMT} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_int_encoder_test TestIntEncoder.cpp)
 add_test(velox_dwio_dwrf_int_encoder_test velox_dwio_dwrf_int_encoder_test)
@@ -308,16 +297,14 @@ target_link_libraries(velox_dwio_dwrf_rle_test ${VELOX_LINK_LIBS}
 add_executable(velox_dwio_dwrf_int_direct_test TestIntDirect.cpp)
 add_test(velox_dwio_dwrf_int_direct_test velox_dwio_dwrf_int_direct_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_int_direct_test ${VELOX_LINK_LIBS} ${DOUBLE_CONVERSION}
-  ${FMT} ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_int_direct_test ${VELOX_LINK_LIBS} ${FMT}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_rlev1_encoder_test TestRLEv1Encoder.cpp)
 add_test(velox_dwio_dwrf_rlev1_encoder_test velox_dwio_dwrf_rlev1_encoder_test)
 
-target_link_libraries(
-  velox_dwio_dwrf_rlev1_encoder_test ${VELOX_LINK_LIBS} ${DOUBLE_CONVERSION}
-  ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
+target_link_libraries(velox_dwio_dwrf_rlev1_encoder_test ${VELOX_LINK_LIBS}
+                      ${FOLLY_WITH_DEPENDENCIES} ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_column_reader_test TestColumnReader.cpp)
 add_test(velox_dwio_dwrf_column_reader_test velox_dwio_dwrf_column_reader_test)
@@ -501,7 +488,6 @@ target_link_libraries(
   velox_dwio_cache_test
   ${VELOX_LINK_LIBS}
   velox_temp_path
-  ${DOUBLE_CONVERSION}
   ${FOLLY_WITH_DEPENDENCIES}
   ${FMT}
   lz4::lz4

--- a/velox/dwio/dwrf/writer/CMakeLists.txt
+++ b/velox/dwio/dwrf/writer/CMakeLists.txt
@@ -34,7 +34,7 @@ target_link_libraries(
   velox_process
   velox_time
   velox_vector
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES})
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB)

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(
   velox_type
   velox_dwio_common
   arrow
+  fmt::fmt
   parquet
+  Snappy::snappy
   thrift
-  ${FMT})
+  zstd::zstd)

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -37,10 +37,10 @@ target_link_libraries(
   velox_e2e_filter_test_base
   velox_dwio_parquet_writer
   velox_dwio_native_parquet_reader
-  ${LZ4}
-  ${LZO}
-  ${ZSTD}
-  ${ZLIB_LIBRARIES}
+  lz4::lz4
+  lzo2::lzo2
+  zstd::zstd
+  ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_parquet_reader_benchmark ParquetReaderBenchmark.cpp)

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -125,7 +125,6 @@ target_link_libraries(
   gtest_main
   gmock
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}
@@ -160,7 +159,6 @@ target_link_libraries(
   gtest_main
   gmock
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}

--- a/velox/experimental/codegen/compiler_utils/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/compiler_utils/tests/CMakeLists.txt
@@ -33,7 +33,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT})

--- a/velox/experimental/codegen/external_process/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/external_process/tests/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
   ${Boost_FILESYSTEM_LIBRARIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT})

--- a/velox/experimental/codegen/library_loader/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/library_loader/tests/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT})

--- a/velox/experimental/codegen/transform/utils/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/transform/utils/tests/CMakeLists.txt
@@ -37,7 +37,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -54,7 +54,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}

--- a/velox/functions/prestosql/types/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/types/tests/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(
   velox_presto_types_test
   velox_presto_types
   ${FOLLY}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gmock

--- a/velox/row/experimental/tests/CMakeLists.txt
+++ b/velox/row/experimental/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_vector_test_lib
   ${FOLLY}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(
   velox_vector_fuzzer
   velox_vector_test_lib
   ${FOLLY}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -59,7 +59,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}

--- a/velox/type/tests/CMakeLists.txt
+++ b/velox/type/tests/CMakeLists.txt
@@ -30,7 +30,6 @@ target_link_libraries(
   velox_serialization
   velox_external_date
   ${FOLLY}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gmock
@@ -45,7 +44,6 @@ target_link_libraries(
   velox_serialization
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags
@@ -60,7 +58,6 @@ target_link_libraries(
   velox_serialization
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags
@@ -75,7 +72,6 @@ target_link_libraries(
   velox_serialization
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags
@@ -90,7 +86,6 @@ target_link_libraries(
   velox_serialization
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags
@@ -105,7 +100,6 @@ target_link_libraries(
   velox_serialization
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags
@@ -118,7 +112,6 @@ target_link_libraries(
   velox_type
   ${FOLLY}
   ${FOLLY_BENCHMARK}
-  ${DOUBLE_CONVERSION}
   gtest
   gtest_main
   gflags::gflags

--- a/velox/vector/tests/CMakeLists.txt
+++ b/velox/vector/tests/CMakeLists.txt
@@ -57,7 +57,6 @@ target_link_libraries(
   gtest
   gtest_main
   ${FOLLY_WITH_DEPENDENCIES}
-  ${DOUBLE_CONVERSION}
   gflags::gflags
   glog::glog
   ${FMT}


### PR DESCRIPTION
This PR  replaces calls to `find_library` with `find_package`, this enables us to use targets instead of variables for the affected dependencies. 

libevent and double-conversion are folly dependencies that we don't need to call `find_library` on as folly handles that internaly. We can add these back in with resolve_dependency later on.