### PR TITLE
[Substrait to Velox] Support the conversion between SingularOrList and Velox IN expression

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -378,7 +378,8 @@ std::shared_ptr<const core::IExpr> parseOperatorExpr(
     params.emplace_back(parseExpr(*operExpr.children[0], options));
     params.emplace_back(std::make_shared<const core::ConstantExpr>(
         ARRAY(valueType), variant::array(values), std::nullopt));
-    auto inExpr = callExpr("in", std::move(params), getAlias(expr));
+    auto inExpr = callExpr(
+        options.functionPrefix + "in", std::move(params), getAlias(expr));
     // Translate COMPARE_NOT_IN into NOT(IN()).
     return (expr.GetExpressionType() == ExpressionType::COMPARE_IN)
         ? inExpr

--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -30,6 +30,11 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Velox expression.
+  std::string functionPrefix = "";
 };
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<const core::IExpr> parseExpr(
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
-
+  duckConversionOptions.functionPrefix = options.functionPrefix;
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
@@ -34,6 +34,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
+  duckConversionOptions.functionPrefix = options.functionPrefix;
   return facebook::velox::duckdb::parseMultipleExpressions(
       expr, duckConversionOptions);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -27,6 +27,11 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Velox expression.
+  std::string functionPrefix = "";
 };
 
 std::shared_ptr<const core::IExpr> parseExpr(

--- a/velox/substrait/SubstraitParser.cpp
+++ b/velox/substrait/SubstraitParser.cpp
@@ -221,10 +221,11 @@ const std::string& SubstraitParser::findFunctionSpec(
 
 std::string SubstraitParser::findVeloxFunction(
     const std::unordered_map<uint64_t, std::string>& functionMap,
-    uint64_t id) const {
+    uint64_t id,
+    const std::string& prefix) const {
   std::string funcSpec = findFunctionSpec(functionMap, id);
   std::string_view funcName = getNameBeforeDelimiter(funcSpec, ":");
-  return mapToVeloxFunction({funcName.begin(), funcName.end()});
+  return prefix + mapToVeloxFunction({funcName.begin(), funcName.end()});
 }
 
 std::string SubstraitParser::mapToVeloxFunction(

--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -72,9 +72,11 @@ class SubstraitParser {
 
   /// Find the Velox function name according to the function id
   /// from a pre-constructed function map.
+  /// @param prefix: the prefix of registered SQL functions.
   std::string findVeloxFunction(
       const std::unordered_map<uint64_t, std::string>& functionMap,
-      uint64_t id) const;
+      uint64_t id,
+      const std::string& prefix) const;
 
   /// Map the Substrait function keyword into Velox function keyword.
   std::string mapToVeloxFunction(const std::string& substraitFunction) const;

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -143,7 +143,9 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
 
     const auto& aggFunction = measure.measure();
     auto funcName = substraitParser_->findVeloxFunction(
-        functionMap_, aggFunction.function_reference());
+        functionMap_,
+        aggFunction.function_reference(),
+        exprConverter_->getFuncPrefix());
     std::vector<core::TypedExprPtr> aggParams;
     aggParams.reserve(aggFunction.arguments().size());
     for (const auto& arg : aggFunction.arguments()) {
@@ -561,8 +563,8 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
   constructFunctionMap(substraitPlan);
 
   // Construct the expression converter.
-  exprConverter_ =
-      std::make_shared<SubstraitVeloxExprConverter>(pool_, functionMap_);
+  exprConverter_ = std::make_shared<SubstraitVeloxExprConverter>(
+      pool_, functionMap_, prefix_);
 
   // In fact, only one RelRoot or Rel is expected here.
   VELOX_CHECK_EQ(substraitPlan.relations_size(), 1);

--- a/velox/substrait/VeloxToSubstraitExpr.h
+++ b/velox/substrait/VeloxToSubstraitExpr.h
@@ -28,8 +28,9 @@ namespace facebook::velox::substrait {
 class VeloxToSubstraitExprConvertor {
  public:
   explicit VeloxToSubstraitExprConvertor(
-      const SubstraitExtensionCollectorPtr& extensionCollector)
-      : extensionCollector_(extensionCollector) {}
+      const SubstraitExtensionCollectorPtr& extensionCollector,
+      const std::string& funcPrefix)
+      : extensionCollector_(extensionCollector), funcPrefix_(funcPrefix) {}
 
   /// Convert Velox Expression to Substrait Expression.
   /// @param arena Arena to use for allocating Substrait plan objects.
@@ -96,9 +97,22 @@ class VeloxToSubstraitExprConvertor {
       google::protobuf::Arena& arena,
       const std::shared_ptr<ConstantVector<ComplexType>>& constantVector);
 
+  /// Convert Velox IN expression to Substrait SingularOrList.
+  const ::substrait::Expression& toSubstraitSingularOrList(
+      google::protobuf::Arena& arena,
+      const std::vector<core::TypedExprPtr>& inputs,
+      const RowTypePtr& inputType,
+      ::substrait::Expression* substraitExpr);
+
   VeloxToSubstraitTypeConvertorPtr typeConvertor_;
 
   SubstraitExtensionCollectorPtr extensionCollector_;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Substrait plan during Velox-to-Substrait
+  /// conversion.
+  const std::string funcPrefix_;
 };
 
 using VeloxToSubstraitExprConvertorPtr =

--- a/velox/substrait/VeloxToSubstraitPlan.cpp
+++ b/velox/substrait/VeloxToSubstraitPlan.cpp
@@ -69,8 +69,8 @@ namespace {
   // Construct the extension colllector.
   extensionCollector_ = std::make_shared<SubstraitExtensionCollector>();
   // Construct the expression converter.
-  exprConvertor_ =
-      std::make_shared<VeloxToSubstraitExprConvertor>(extensionCollector_);
+  exprConvertor_ = std::make_shared<VeloxToSubstraitExprConvertor>(
+      extensionCollector_, prefix_);
 
   auto substraitPlan =
       google::protobuf::Arena::CreateMessage<::substrait::Plan>(&arena);

--- a/velox/substrait/VeloxToSubstraitPlan.h
+++ b/velox/substrait/VeloxToSubstraitPlan.h
@@ -33,6 +33,9 @@ namespace facebook::velox::substrait {
 /// Convert the Velox plan into Substrait plan.
 class VeloxToSubstraitPlanConvertor {
  public:
+  VeloxToSubstraitPlanConvertor(const std::string& prefix = "")
+      : prefix_(prefix) {}
+
   /// Convert Velox PlanNode into Substrait Plan.
   /// @param vPlan Velox query plan to convert.
   /// @param arena Arena to use for allocating Substrait plan objects.
@@ -113,6 +116,12 @@ class VeloxToSubstraitPlanConvertor {
   /// The Extension collector storing the relations between the function
   /// signature and the function reference number.
   SubstraitExtensionCollectorPtr extensionCollector_;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Substrait plan during Velox-to-Substrait
+  /// conversion.
+  std::string prefix_;
 };
 
 } // namespace facebook::velox::substrait

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   velox_dwio_common
   velox_aggregates
   velox_functions_aggregates_test_lib
+  velox_functions_spark
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector


### PR DESCRIPTION
SingularOrList ([link](https://github.com/facebookincubator/velox/blob/main/velox/substrait/proto/substrait/algebra.proto#L927-L930)) in Substrait is a specialized structure that is often used is a large list of possible values. In SQL, these are typically large IN lists. For single value expressions, these are a compact equivalent of `expression = value1 OR expression = value2 OR .. OR expression = valueN`. (Reference: [or-list-equality-expression](https://substrait.io/expressions/specialized_record_expressions/#or-list-equality-expression))
This PR supports the conversion between SingularOrList and Velox IN expression. The conversion process is similar as what is done in [InTest.cpp](https://github.com/facebookincubator/velox/blob/main/velox/functions/sparksql/tests/InTest.cpp#L86-L90). I drew below flow chart, and hope it can help illustrate.

![Screenshot from 2023-06-06 07-11-30](https://github.com/facebookincubator/velox/assets/41687378/4389f0be-ec64-4d8d-be9b-149c3ec2a459)

In this picture, `value` and `options` are two items of SingularOrList. The value is the variable, and the options are the possible values to be compared with. They represent two arguments for the creation of a Velox IN expression.



