### PR TITLE
Disable 'copy on write' for SSD file.

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -27,7 +27,8 @@ SsdCache::SsdCache(
     uint64_t maxBytes,
     int32_t numShards,
     folly::Executor* executor,
-    int64_t checkpointIntervalBytes)
+    int64_t checkpointIntervalBytes,
+    bool disableFileCow)
     : filePrefix_(filePrefix),
       numShards_(numShards),
       groupStats_(std::make_unique<FileGroupStats>()),
@@ -42,7 +43,8 @@ SsdCache::SsdCache(
         fmt::format("{}{}", filePrefix_, i),
         i,
         fileMaxRegions,
-        checkpointIntervalBytes / numShards));
+        checkpointIntervalBytes / numShards,
+        disableFileCow));
   }
 }
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -22,22 +22,30 @@ namespace facebook::velox::cache {
 
 class SsdCache {
  public:
-  //  Constructs a cache with backing files at path
-  //  'filePrefix'.<ordinal>. <ordinal> ranges from 0 to 'numShards' -
-  //  1. '. 'maxBytes' is the total capacity of the cache. This is
-  //  rounded up to the next multiple of kRegionSize *
-  //  'numShards'. This means that all the shards have an equal number
-  //  of regions. For 2 shards and 200MB size, the size rounds up to
-  //  256M with 2 shards each of 128M (2 regions). If
-  //  'checkpointIntervalBytes' is non-0, the cache makes a durable
-  //  checkpointed state that survives restart after each
-  //  'checkpointIntervalBytes' written.
+  /// Constructs a cache with backing files at path 'filePrefix'.<ordinal>.
+  /// <ordinal> ranges from 0 to 'numShards' - 1.
+  /// 'maxBytes' is the total capacity of the cache. This is rounded up to the
+  /// next multiple of kRegionSize * 'numShards'. This means that all the shards
+  /// have an equal number of regions. For 2 shards and 200MB size, the size
+  /// rounds up to 256M with 2 shards each of 128M (2 regions).
+  /// If 'checkpointIntervalBytes' is non-0, the cache makes a durable
+  /// checkpointed state that survives restart after each
+  /// 'checkpointIntervalBytes' written.
+  /// If 'setNoCowFlagForSsdFiles' is true, the cache sets 'no copy on write'
+  /// flag to each file. This prevents the cache to go over the 'maxBytes',
+  /// eventually use up all disk space and stop working. Should be set to true
+  /// for file systems supporting COW (like brtfs).
+  /// If 'disableFileCow' is true, the cache disables the file COW (copy on
+  /// write) feature if the underlying filesystem (such as brtfs) supports it.
+  /// This prevents the actual cache space usage on disk from exceeding the
+  /// 'maxBytes' limit and stop working.
   SsdCache(
       std::string_view filePrefix,
       uint64_t maxBytes,
       int32_t numShards,
       folly::Executor* executor,
-      int64_t checkpointIntervalBytes = 0);
+      int64_t checkpointIntervalBytes = 0,
+      bool disableFileCow = false);
 
   // Returns the shard corresponding to 'fileId'. 'fileId' is a
   //  file id from e.g. FileCacheKey.

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -21,16 +21,44 @@
 #include "velox/common/caching/FileIds.h"
 
 #include <fcntl.h>
+#ifdef linux
+#include <linux/fs.h>
+#endif // linux
+#include <sys/ioctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <numeric>
-
 #include <fstream>
+#include <numeric>
 
 DEFINE_bool(ssd_odirect, true, "Use O_DIRECT for SSD cache IO");
 DEFINE_bool(ssd_verify_write, false, "Read back data after writing to SSD");
 
 namespace facebook::velox::cache {
+
+namespace {
+// Disable 'copy on write' on the given file. Will throw if failed for any
+// reason, including file system not supporting cow feature.
+void disableCow(int32_t fd) {
+#ifdef linux
+  int attr{0};
+  auto res = ioctl(fd, FS_IOC_GETFLAGS, &attr);
+  VELOX_CHECK_EQ(
+      0,
+      res,
+      "ioctl(FS_IOC_GETFLAGS) failed: {}, {}",
+      res,
+      folly::errnoStr(errno));
+  attr |= FS_NOCOW_FL;
+  res = ioctl(fd, FS_IOC_SETFLAGS, &attr);
+  VELOX_CHECK_EQ(
+      0,
+      res,
+      "ioctl(FS_IOC_SETFLAGS, FS_NOCOW_FL) failed: {}, {}",
+      res,
+      folly::errnoStr(errno));
+#endif // linux
+}
+} // namespace
 
 SsdPin::SsdPin(SsdFile& file, SsdRun run) : file_(&file), run_(run) {
   file_->checkPinned(run_.offset());
@@ -72,6 +100,7 @@ SsdFile::SsdFile(
     int32_t shardId,
     int32_t maxRegions,
     int64_t checkpointIntervalBytes,
+    bool disableFileCow,
     folly::Executor* FOLLY_NULLABLE executor)
     : fileName_(filename),
       shardId_(shardId),
@@ -82,12 +111,19 @@ SsdFile::SsdFile(
   int32_t oDirect = 0;
 #ifdef linux
   oDirect = FLAGS_ssd_odirect ? O_DIRECT : 0;
-#endif
+#endif // linux
   fd_ = open(filename_.c_str(), O_CREAT | O_RDWR | oDirect, S_IRUSR | S_IWUSR);
-  if (fd_ < 0) {
-    LOG(ERROR) << "Cannot open or create " << filename << " error " << errno;
-    exit(1);
+  VELOX_CHECK_GE(
+      fd_,
+      0,
+      "Cannot open or create {}. Error: {}",
+      filename,
+      folly::errnoStr(errno));
+
+  if (disableFileCow) {
+    disableCow(fd_);
   }
+
   readFile_ = std::make_unique<LocalReadFile>(fd_);
   uint64_t size = lseek(fd_, 0, SEEK_END);
   numRegions_ = size / kRegionSize;
@@ -641,6 +677,23 @@ void SsdFile::initializeCheckpoint() {
     } catch (const std::exception& e) {
     }
   }
+}
+
+bool SsdFile::testingIsCowDisabled() const {
+#ifdef linux
+  int attr{0};
+  const auto res = ioctl(fd_, FS_IOC_GETFLAGS, &attr);
+  VELOX_CHECK_EQ(
+      0,
+      res,
+      "ioctl(FS_IOC_GETFLAGS) failed: {}, {}",
+      res,
+      folly::errnoStr(errno));
+
+  return (attr & FS_NOCOW_FL) == FS_NOCOW_FL;
+#else
+  return false;
+#endif // linux
 }
 
 namespace {

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -164,6 +164,7 @@ class SsdFile {
       int32_t shardId,
       int32_t maxRegions,
       int64_t checkpointInternalBytes = 0,
+      bool disableFileCow = false,
       folly::Executor* FOLLY_NULLABLE executor = nullptr);
 
   // Adds entries of  'pins'  to this file. 'pins' must be in read mode and
@@ -229,6 +230,9 @@ class SsdFile {
   // rechecks that at least 'checkpointIntervalBytes_' have been
   // written since last checkpoint and silently returns if not.
   void checkpoint(bool force = false);
+
+  /// Returns true if copy on write is disabled for this file. Used in testing.
+  bool testingIsCowDisabled() const;
 
  private:
   // 4 first bytes of a checkpoint file. Allows distinguishing between format

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -47,7 +47,10 @@ class SsdFileTest : public testing::Test {
     }
   }
 
-  void initializeCache(int64_t maxBytes, int64_t ssdBytes = 0) {
+  void initializeCache(
+      int64_t maxBytes,
+      int64_t ssdBytes = 0,
+      bool setNoCowFlag = false) {
     // tmpfs does not support O_DIRECT, so turn this off for testing.
     FLAGS_ssd_odirect = false;
     cache_ = std::make_shared<AsyncDataCache>(
@@ -58,8 +61,10 @@ class SsdFileTest : public testing::Test {
     tempDirectory_ = exec::test::TempDirectoryPath::create();
     ssdFile_ = std::make_unique<SsdFile>(
         fmt::format("{}/ssdtest", tempDirectory_->path),
-        0,
-        bits::roundUp(ssdBytes, SsdFile::kRegionSize) / SsdFile::kRegionSize);
+        0, // shardId
+        bits::roundUp(ssdBytes, SsdFile::kRegionSize) / SsdFile::kRegionSize,
+        0, // checkpointInternalBytes
+        setNoCowFlag);
   }
 
   static void initializeContents(int64_t sequence, memory::Allocation& alloc) {
@@ -291,3 +296,17 @@ TEST_F(SsdFileTest, writeAndRead) {
     }
   }
 }
+
+#ifdef VELOX_SSD_FILE_TEST_SET_NO_COW_FLAG
+TEST_F(SsdFileTest, disabledCow) {
+  constexpr int64_t kSsdSize = 16 * SsdFile::kRegionSize;
+  initializeCache(128 * kMB, kSsdSize, true);
+  EXPECT_TRUE(ssdFile_->testingIsCowDisabled());
+}
+
+TEST_F(SsdFileTest, notDisabledCow) {
+  constexpr int64_t kSsdSize = 16 * SsdFile::kRegionSize;
+  initializeCache(128 * kMB, kSsdSize, false);
+  EXPECT_FALSE(ssdFile_->testingIsCowDisabled());
+}
+#endif // VELOX_SSD_FILE_TEST_SET_NO_COW_FLAG


### PR DESCRIPTION
Summary:
On btrfs overwriting file's blocks causes file system
to allocate more and more new blocks, eventually taking the
whole disk space, while the file is being only fraction of it.
Disabling 'copy on write' solves this issue.

Differential Revision: D45173587

