### PR TITLE
Add support for ReadFile::preadv() labels

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -36,7 +36,8 @@ std::string ReadFile::pread(uint64_t offset, uint64_t length) const {
 
 uint64_t ReadFile::preadv(
     uint64_t offset,
-    const std::vector<folly::Range<char*>>& buffers) const {
+    const std::vector<folly::Range<char*>>& buffers,
+    const std::vector<std::string_view>& /* labels */) const {
   auto fileSize = size();
   uint64_t numRead = 0;
   if (offset >= fileSize) {
@@ -123,7 +124,8 @@ LocalReadFile::pread(uint64_t offset, uint64_t length, void* buf) const {
 
 uint64_t LocalReadFile::preadv(
     uint64_t offset,
-    const std::vector<folly::Range<char*>>& buffers) const {
+    const std::vector<folly::Range<char*>>& buffers,
+    const std::vector<std::string_view>& /* labels */) const {
   // Dropped bytes sized so that a typical dropped range of 50K is not
   // too many iovecs.
   static thread_local std::vector<char> droppedBytes(16 * 1024);

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -56,9 +56,11 @@ class ReadFile {
   // Reads starting at 'offset' into the memory referenced by the
   // Ranges in 'buffers'. The buffers are filled left to right. A
   // buffer with nullptr data will cause its size worth of bytes to be skipped.
+  // Labels is optional and may be used for caching purposes by implementations.
   virtual uint64_t preadv(
       uint64_t /*offset*/,
-      const std::vector<folly::Range<char*>>& /*buffers*/) const;
+      const std::vector<folly::Range<char*>>& /*buffers*/,
+      const std::vector<std::string_view>& /* labels */ = {}) const;
 
   // Like preadv but may execute asynchronously and returns the read
   // size or exception via SemiFuture. Use hasPreadvAsync() to check
@@ -216,7 +218,8 @@ class LocalReadFile final : public ReadFile {
 
   uint64_t preadv(
       uint64_t offset,
-      const std::vector<folly::Range<char*>>& buffers) const final;
+      const std::vector<folly::Range<char*>>& buffers,
+      const std::vector<std::string_view>& labels) const final;
 
   uint64_t memoryUsage() const final;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -101,7 +101,8 @@ class S3ReadFile final : public ReadFile {
 
   uint64_t preadv(
       uint64_t offset,
-      const std::vector<folly::Range<char*>>& buffers) const override {
+      const std::vector<folly::Range<char*>>& buffers,
+      const std::vector<std::string_view>& /* labels */ = {}) const override {
     // 'buffers' contains Ranges(data, size)  with some gaps (data = nullptr) in
     // between. This call must populate the ranges (except gap ranges)
     // sequentially starting from 'offset'. AWS S3 GetObject does not support


### PR DESCRIPTION
Summary: Add optional "labels" for each range so caching mechanisms can have information on what is being read in each range.

Differential Revision: D45187467

