### PR TITLE
Enhance fuzzer to generate multiple expression trees per step

### DIFF
--- a/velox/docs/develop/testing/fuzzer.rst
+++ b/velox/docs/develop/testing/fuzzer.rst
@@ -132,6 +132,8 @@ There are also arguments that toggle certain fuzzer features:
 
 * ``--assign_function_tickets``: Comma separated list of function names and their tickets in the format <function_name>=<tickets>. Every ticket represents an opportunity for a function to be chosen from a pool of candidates. By default, every function has one ticket, and the likelihood of a function being picked can be increased by allotting it more tickets. Note that in practice, increasing the number of tickets does not proportionally increase the likelihood of selection, as the selection process involves filtering the pool of candidates by a required return type so not all functions may compete against the same number of functions at every instance. Number of tickets must be a positive integer. Example: eq=3,floor=5.
 
+* ``--max_expression_trees_per_step``: This sets an upper limit on the number of expression trees to generate per step. These trees would be executed in the same ExprSet and can re-use already generated columns and subexpressions (if re-use is enabled). Default is 1.
+
 In addition, Aggregation Fuzzer also supports tuning parameters:
 
 * ``--num_batches``: The number of input vectors of size `--batch_size` to generate. Default is 10.

--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -133,6 +133,14 @@ DEFINE_string(
     "of functions at every instance. Number of tickets must be a positive "
     "integer. Example: eq=3,floor=5");
 
+DEFINE_int32(
+    max_expression_trees_per_step,
+    1,
+    "This sets an upper limit on the number of expression trees to generate "
+    "per step. These trees would be executed in the same ExprSet and can "
+    "re-use already generated columns and subexpressions (if re-use is "
+    "enabled).");
+
 namespace facebook::velox::test {
 
 namespace {
@@ -299,22 +307,29 @@ std::vector<column_index_t> generateLazyColumnIds(
   return columnsToWrapInLazy;
 }
 
-/// Returns row numbers for non-null rows in 'data' or null if all rows are
-/// null.
-BufferPtr extractNonNullIndices(const VectorPtr& data) {
-  BufferPtr indices = allocateIndices(data->size(), data->pool());
-  auto rawIndices = indices->asMutable<vector_size_t>();
-  vector_size_t cnt = 0;
-  for (auto i = 0; i < data->size(); ++i) {
-    if (!data->isNullAt(i)) {
-      rawIndices[cnt++] = i;
+/// Returns row numbers for non-null rows among all children in'data' or null
+/// if all rows are null.
+BufferPtr extractNonNullIndices(const RowVectorPtr& data) {
+  DecodedVector decoded;
+  SelectivityVector nonNullRows(data->size());
+
+  for (auto& child : data->children()) {
+    decoded.decode(*child);
+    auto* rawNulls = decoded.nulls();
+    if (rawNulls) {
+      nonNullRows.deselectNulls(rawNulls, 0, data->size());
+    }
+    if (!nonNullRows.hasSelections()) {
+      return nullptr;
     }
   }
 
-  if (cnt == 0) {
-    return nullptr;
-  }
-
+  BufferPtr indices = allocateIndices(nonNullRows.end(), data->pool());
+  auto rawIndices = indices->asMutable<vector_size_t>();
+  vector_size_t cnt = 0;
+  nonNullRows.applyToSelected(
+      [&](vector_size_t row) { rawIndices[cnt++] = row; });
+  VELOX_CHECK_GT(cnt, 0);
   indices->setSize(cnt * sizeof(vector_size_t));
   return indices;
 }
@@ -1150,9 +1165,23 @@ core::TypedExprPtr ExpressionFuzzer::ExprBank::getRandomExpression(
   return nullptr;
 }
 
-VectorPtr ExpressionFuzzer::generateResultVector(TypePtr vectorType) {
-  return vectorFuzzer_.coinToss(0.5) ? vectorFuzzer_.fuzzFlat(vectorType)
-                                     : nullptr;
+// Generates a row vector with child vectors corresponding to the same type as
+// the return type of the expression trees in 'plans'. These are used as
+// pre-allocated result vectors to be passed during expression evaluation.
+RowVectorPtr ExpressionFuzzer::generateResultVectors(
+    std::vector<core::TypedExprPtr>& plans) {
+  std::vector<VectorPtr> results;
+  std::vector<std::shared_ptr<const Type>> resultTypes;
+  size_t vectorSize = vectorFuzzer_.getOptions().vectorSize;
+  for (auto& plan : plans) {
+    results.push_back(
+        vectorFuzzer_.coinToss(0.5) ? vectorFuzzer_.fuzzFlat(plan->type())
+                                    : nullptr);
+    resultTypes.push_back(plan->type());
+  }
+  auto rowType = ROW(std::move(resultTypes));
+  return std::make_shared<RowVector>(
+      pool_.get(), rowType, BufferPtr(nullptr), vectorSize, results);
 }
 
 TypePtr ExpressionFuzzer::generateRootType() {
@@ -1189,23 +1218,26 @@ TypePtr ExpressionFuzzer::generateRootType() {
 }
 
 void ExpressionFuzzer::retryWithTry(
-    core::TypedExprPtr plan,
+    std::vector<core::TypedExprPtr> plans,
     const RowVectorPtr& rowVector,
     const VectorPtr& resultVector,
     const std::vector<column_index_t>& columnsToWrapInLazy) {
-  auto tryPlan = std::make_shared<core::CallTypedExpr>(
-      plan->type(), std::vector<core::TypedExprPtr>{plan}, "try");
-
+  // Wrap each expression tree with 'try'.
+  std::vector<core::TypedExprPtr> tryPlans;
+  for (auto& plan : plans) {
+    tryPlans.push_back(std::make_shared<core::CallTypedExpr>(
+        plan->type(), std::vector<core::TypedExprPtr>{plan}, "try"));
+  }
   // The function throws if anything goes wrong.
   auto tryResult =
       verifier_
           .verify(
-              tryPlan,
+              tryPlans,
               rowVector,
               resultVector ? BaseVector::copy(*resultVector) : nullptr,
               false, // canThrow
               columnsToWrapInLazy)
-          .result->childAt(0);
+          .result;
 
   // Re-evaluate the original expression on rows that didn't produce an
   // error (i.e. returned non-NULL results when evaluated with TRY).
@@ -1218,7 +1250,7 @@ void ExpressionFuzzer::retryWithTry(
               << " rows without errors";
 
     verifier_.verify(
-        plan,
+        plans,
         noErrorRowVector,
         resultVector ? BaseVector::copy(*resultVector)
                            ->slice(0, noErrorRowVector->size())
@@ -1232,6 +1264,10 @@ void ExpressionFuzzer::go() {
   VELOX_CHECK(
       FLAGS_steps > 0 || FLAGS_duration_sec > 0,
       "Either --steps or --duration_sec needs to be greater than zero.")
+  VELOX_CHECK_GT(
+      FLAGS_max_expression_trees_per_step,
+      0,
+      "--max_expression_trees_per_step needs to be greater than zero.")
 
   auto startTime = std::chrono::system_clock::now();
   size_t i = 0;
@@ -1241,35 +1277,33 @@ void ExpressionFuzzer::go() {
               << " (seed: " << currentSeed_ << ")";
     reset();
 
-    // Generate expression tree and input data vectors.
-    auto plan = generateExpression(generateRootType());
+    // Generate multiple expression trees and input data vectors. They can
+    // re-use columns and share sub-expressions if the appropriate flag is set.
+    int numExpressionTrees = boost::random::uniform_int_distribution<int>(
+        1, FLAGS_max_expression_trees_per_step)(rng_);
+    std::vector<core::TypedExprPtr> plans(numExpressionTrees);
+    for (int j = 0; j < numExpressionTrees; ++j) {
+      plans[j] = generateExpression(generateRootType());
+    }
     auto rowVector = generateRowVector();
     auto columnsToWrapInLazy = generateLazyColumnIds(rowVector, vectorFuzzer_);
-    auto resultVector = generateResultVector(plan->type());
+    auto resultVectors = generateResultVectors(plans);
     ResultOrError result;
 
     result = verifier_.verify(
-        plan,
+        plans,
         rowVector,
-        resultVector ? BaseVector::copy(*resultVector) : nullptr,
+        resultVectors ? BaseVector::copy(*resultVectors) : nullptr,
         true, // canThrow
         columnsToWrapInLazy);
 
     // If both paths threw compatible exceptions, we add a try() function to
     // the expression's root and execute it again. This time the expression
     // cannot throw.
-    if (verifier_
-            .verify(
-                plan,
-                rowVector,
-                resultVector ? BaseVector::copy(*resultVector) : nullptr,
-                true, // canThrow
-                columnsToWrapInLazy)
-            .exceptionPtr &&
-        FLAGS_retry_with_try) {
+    if (result.exceptionPtr && FLAGS_retry_with_try) {
       LOG(INFO)
           << "Both paths failed with compatible exceptions. Retrying expression using try().";
-      retryWithTry(plan, rowVector, resultVector, columnsToWrapInLazy);
+      retryWithTry(plans, rowVector, resultVectors, columnsToWrapInLazy);
     }
 
     LOG(INFO) << "==============================> Done with iteration " << i;

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -167,7 +167,7 @@ class ExpressionFuzzer {
 
   /// Randomize initial result vector data to test for correct null and data
   /// setting in functions.
-  VectorPtr generateResultVector(TypePtr vectorType);
+  RowVectorPtr generateResultVectors(std::vector<core::TypedExprPtr>& plans);
 
   core::TypedExprPtr generateArgConstant(const TypePtr& arg);
 
@@ -224,9 +224,9 @@ class ExpressionFuzzer {
   ///
   /// Throws in case any of these steps fail.
   void retryWithTry(
-      core::TypedExprPtr plan,
+      std::vector<core::TypedExprPtr> plans,
       const RowVectorPtr& rowVector,
-      const VectorPtr& resultVector,
+      const VectorPtr& resultVectors,
       const std::vector<column_index_t>& columnsToWrapInLazy);
 
   /// Return a random signature mapped to functionName in expressionToSignature_

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -183,11 +183,9 @@ void ExpressionRunner::run(
   LOG(INFO) << "Evaluating SQL expression(s): " << sql;
 
   if (mode == "verify") {
-    VELOX_CHECK_EQ(
-        1, typedExprs.size(), "'verify' mode supports only one SQL expression");
     test::ExpressionVerifier(&execCtx, {false, ""})
         .verify(
-            typedExprs[0],
+            typedExprs,
             inputVector,
             std::move(resultVector),
             true,

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -50,19 +50,19 @@ class ExpressionVerifier {
       ExpressionVerifierOptions options)
       : execCtx_(execCtx), options_(options) {}
 
-  // Executes an expression both using common path (all evaluation
+  // Executes expressions both using common path (all evaluation
   // optimizations) and simplified path. Additionally, a sorted list of column
   // indices can be passed via 'columnsToWrapInLazy' which specify the
   // columns/children in the input row vector that should be wrapped in a lazy
   // layer before running it through the common evaluation path.
   // Returns:
-  //  - result of evaluating the expression if both paths succeeded and returned
-  //  the exact same vectors.
+  //  - result of evaluating the expressions if both paths succeeded and
+  //  returned the exact same vectors.
   //  - exception thrown by the common path if both paths failed with compatible
   //  exceptions.
   //  - throws otherwise (incompatible exceptions or different results).
   ResultOrError verify(
-      const core::TypedExprPtr& plan,
+      const std::vector<core::TypedExprPtr>& plans,
       const RowVectorPtr& rowVector,
       VectorPtr&& resultVector,
       bool canThrow,

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -97,7 +97,7 @@ TEST_F(ExpressionVerifierUnitTest, persistReproInfo) {
     auto plan = parseExpression("always_throws(c0)", asRowType(data->type()));
 
     removeDirecrtoryIfExist(localFs, reproPath);
-    VELOX_ASSERT_THROW(verifier.verify(plan, data, nullptr, false), "");
+    VELOX_ASSERT_THROW(verifier.verify({plan}, data, nullptr, false), "");
     EXPECT_TRUE(localFs->exists(reproPath));
     EXPECT_FALSE(localFs->list(reproPath).empty());
     removeDirecrtoryIfExist(localFs, reproPath);


### PR DESCRIPTION
This adds a feature in expression fuzzer that allows us to generate
multiple expressions in each step that would be executed in the same
ExprSet. This allows us to add coverage for cases where common sub
expressions and column references exist between expression trees
and verify that optimizations that are employed in these cases
work as expected.
Note: This changes how result vectors are generated and serialized
for repro however it ensures that the ExpressionRunner still remains
compatible with the previous format so that previous repro files work.