### PR TITLE
Fix AggregationFunctionSignature::toString()

### DIFF
--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -206,9 +206,11 @@ TEST_F(FunctionRegistryTest, aggregateWindowFunctionSignature) {
   for (const auto& signature : windowFunctionSignatures.value()) {
     functionSignatures.insert(signature->toString());
   }
-  ASSERT_EQ(functionSignatures.count("(bigint,double) -> bigint"), 1);
-  ASSERT_EQ(functionSignatures.count("() -> date"), 1);
-  ASSERT_EQ(functionSignatures.count("(T,T) -> T"), 1);
+  ASSERT_EQ(
+      functionSignatures.count("(bigint,double) -> array(bigint) -> bigint"),
+      1);
+  ASSERT_EQ(functionSignatures.count("() -> date -> date"), 1);
+  ASSERT_EQ(functionSignatures.count("(T,T) -> array(T) -> T"), 1);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -202,7 +202,8 @@ TEST_F(FunctionSignatureBuilderTest, aggregateConstantFlags) {
     EXPECT_FALSE(aggSignature->constantArguments().at(0));
     EXPECT_TRUE(aggSignature->constantArguments().at(1));
     EXPECT_FALSE(aggSignature->constantArguments().at(2));
-    EXPECT_EQ("(T,constant bigint,T) -> T", aggSignature->toString());
+    EXPECT_EQ(
+        "(T,constant bigint,T) -> array(T) -> T", aggSignature->toString());
   }
 
   {
@@ -220,7 +221,7 @@ TEST_F(FunctionSignatureBuilderTest, aggregateConstantFlags) {
     EXPECT_TRUE(aggSignature->constantArguments().at(1));
     EXPECT_FALSE(aggSignature->constantArguments().at(2));
     EXPECT_EQ(
-        "(bigint,constant T,T,constant double...) -> T",
+        "(bigint,constant T,T,constant double...) -> array(T) -> T",
         aggSignature->toString());
   }
 }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -66,7 +66,7 @@ std::string TypeSignature::toString() const {
   return out.str();
 }
 
-std::string FunctionSignature::toString() const {
+std::string FunctionSignature::argumentsToString() const {
   std::vector<std::string> arguments;
   auto size = argumentTypes_.size();
   arguments.reserve(size);
@@ -79,11 +79,16 @@ std::string FunctionSignature::toString() const {
     }
   }
   std::ostringstream out;
-  out << "(" << folly::join(",", arguments);
+  out << folly::join(",", arguments);
   if (variableArity_) {
     out << "...";
   }
-  out << ") -> " << returnType_.toString();
+  return out.str();
+}
+
+std::string FunctionSignature::toString() const {
+  std::ostringstream out;
+  out << "(" << argumentsToString() << ") -> " << returnType_.toString();
   return out.str();
 }
 
@@ -249,6 +254,13 @@ FunctionSignature::FunctionSignature(
       constantArguments_{std::move(constantArguments)},
       variableArity_{variableArity} {
   validate(variables_, returnType_, argumentTypes_, constantArguments_);
+}
+
+std::string AggregateFunctionSignature::toString() const {
+  std::ostringstream out;
+  out << "(" << argumentsToString() << ") -> " << intermediateType_.toString()
+      << " -> " << returnType().toString();
+  return out.str();
 }
 
 FunctionSignaturePtr FunctionSignatureBuilder::build() {

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -165,6 +165,10 @@ class FunctionSignature {
         variableArity_ == rhs.variableArity_;
   }
 
+ protected:
+  // Return a string of the list of argument types.
+  std::string argumentsToString() const;
+
  private:
   const std::unordered_map<std::string, SignatureVariable> variables_;
   const TypeSignature returnType_;
@@ -195,6 +199,8 @@ class AggregateFunctionSignature : public FunctionSignature {
   const TypeSignature& intermediateType() const {
     return intermediateType_;
   }
+
+  std::string toString() const override;
 
  private:
   const TypeSignature intermediateType_;


### PR DESCRIPTION
AggregationFunctionSignature inherits FunctionSignature but doesn't overwrite the
 toString() function. As the result, when calling toString on an aggregation function 
signature, only argument types and the return type are included, but not the 
intermediate type. This diff overwrites toString in AggregationFunctionSignature to 
include the intermediate type information.

Differential Revision: D45207239

