### PR TITLE
Add getCompanionFunctionSignatures() API

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -391,4 +391,22 @@ AggregateFunctionMap& aggregateFunctions();
 const AggregateFunctionEntry* FOLLY_NULLABLE
 getAggregateFunctionEntry(const std::string& name);
 
+struct CompanionSignatureEntry {
+  std::string functionName;
+  std::vector<FunctionSignaturePtr> signatures;
+};
+
+struct CompanionFunctionSignatureMap {
+  std::vector<CompanionSignatureEntry> partial;
+  std::vector<CompanionSignatureEntry> merge;
+  std::vector<CompanionSignatureEntry> extract;
+  std::vector<CompanionSignatureEntry> mergeExtract;
+};
+
+// Returns a map of potential companion function signatures the specified
+// aggregation function would have. Notice that the registration of the
+// specified aggregation function needs to register companion functions together
+// for them to be used in queries.
+std::optional<CompanionFunctionSignatureMap> getCompanionFunctionSignatures(
+    const std::string& name);
 } // namespace facebook::velox::exec

--- a/velox/exec/AggregateCompanionSignatures.cpp
+++ b/velox/exec/AggregateCompanionSignatures.cpp
@@ -37,7 +37,8 @@ void addUsedVariablesInType(
   }
 }
 
-// Return type variables used in `types`.
+} // namespace
+
 std::unordered_map<std::string, SignatureVariable> usedTypeVariables(
     const std::vector<TypeSignature>& types,
     const std::unordered_map<std::string, SignatureVariable>& allVariables) {
@@ -48,8 +49,6 @@ std::unordered_map<std::string, SignatureVariable> usedTypeVariables(
   return usedVariables;
 }
 
-// Result type is resolvable from intermediate type iff all variables in the
-// result type appears in the intermediate type as well.
 bool isResultTypeResolvableGivenIntermediateType(
     const AggregateFunctionSignaturePtr& signature) {
   auto& allVariables = signature->variables();
@@ -71,8 +70,6 @@ bool isResultTypeResolvableGivenIntermediateType(
   return true;
 }
 
-// Return a string that is preorder traveral of `type`. For example, for
-// row(bigint, array(double)), return a string "row_bigint_array_double".
 std::string toSuffixString(const TypeSignature& type) {
   auto name = type.baseName();
   // For primitive and decimal types, return their names.
@@ -98,8 +95,6 @@ std::string toSuffixString(const TypeSignature& type) {
   }
   VELOX_UNREACHABLE("Unknown type: {}.", type.toString());
 }
-
-} // namespace
 
 std::vector<AggregateFunctionSignaturePtr>
 CompanionSignatures::partialFunctionSignatures(
@@ -265,7 +260,7 @@ TypeSignature CompanionSignatures::normalizeTypeImpl(
     const TypeSignature& type,
     const std::unordered_map<std::string, SignatureVariable>& allVariables,
     std::unordered_map<std::string, std::string>& renamedVariables) {
-  auto baseName = type.baseName();
+  const auto& baseName = type.baseName();
 
   // Already renamed variables.
   if (renamedVariables.count(baseName)) {

--- a/velox/exec/AggregateCompanionSignatures.h
+++ b/velox/exec/AggregateCompanionSignatures.h
@@ -159,4 +159,18 @@ class CompanionSignatures {
   }
 };
 
+// Return type variables used in `types`.
+std::unordered_map<std::string, SignatureVariable> usedTypeVariables(
+    const std::vector<TypeSignature>& types,
+    const std::unordered_map<std::string, SignatureVariable>& allVariables);
+
+// Return true if the result type of `signature` can be resolved from a concrete
+// intermediate type of it.
+bool isResultTypeResolvableGivenIntermediateType(
+    const AggregateFunctionSignaturePtr& signature);
+
+// Return a string that is preorder traveral of `type`. For example, for
+// row(bigint, array(double)), return a string "row_bigint_array_double".
+std::string toSuffixString(const TypeSignature& type);
+
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/AggregateCompanionSignaturesTest.cpp
+++ b/velox/exec/tests/AggregateCompanionSignaturesTest.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/tests/DummyAggregateFunction.h"
+#include "velox/expression/FunctionSignature.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+
+namespace {
+
+struct TestCompanionSignatureEntry {
+  std::string functionName;
+  std::vector<std::string> signatures;
+};
+
+struct TestCompanionSignatureMap {
+  std::vector<TestCompanionSignatureEntry> partial;
+  std::vector<TestCompanionSignatureEntry> merge;
+  std::vector<TestCompanionSignatureEntry> extract;
+  std::vector<TestCompanionSignatureEntry> mergeExtract;
+};
+
+class AggregateCompanionSignaturesTest : public testing::Test {
+ protected:
+  void assertEqual(
+      const std::vector<CompanionSignatureEntry>& actual,
+      const std::vector<TestCompanionSignatureEntry>& expected) {
+    EXPECT_EQ(actual.size(), expected.size());
+    for (int i = 0; i < actual.size(); ++i) {
+      EXPECT_EQ(actual[i].functionName, expected[i].functionName);
+      for (int j = 0; j < actual[i].signatures.size(); ++j) {
+        EXPECT_EQ(
+            actual[i].signatures[j]->toString(), expected[i].signatures[j]);
+      }
+    }
+  }
+
+  void assertEqual(
+      const CompanionFunctionSignatureMap& actual,
+      const TestCompanionSignatureMap& expected) {
+    assertEqual(actual.partial, expected.partial);
+    assertEqual(actual.merge, expected.merge);
+    assertEqual(actual.extract, expected.extract);
+    assertEqual(actual.mergeExtract, expected.mergeExtract);
+  }
+};
+
+TEST_F(AggregateCompanionSignaturesTest, basic) {
+  std::vector<AggregateFunctionSignaturePtr> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("array(bigint)")
+          .argumentType("bigint")
+          .build()};
+  registerDummyAggregateFunction("aggregateFunc1", signatures);
+  auto companionSignatures = getCompanionFunctionSignatures("aggregateFunc1");
+  EXPECT_TRUE(companionSignatures.has_value());
+
+  TestCompanionSignatureMap expected;
+  expected.partial = {
+      {"aggregateFunc1_partial",
+       {"(double) -> array(double) -> array(double)",
+        "(bigint) -> array(bigint) -> array(bigint)"}}};
+  expected.merge = {
+      {"aggregateFunc1_merge",
+       {"(array(double)) -> array(double) -> array(double)",
+        "(array(bigint)) -> array(bigint) -> array(bigint)"}}};
+  expected.mergeExtract = {
+      {"aggregateFunc1_merge_extract",
+       {"(array(double)) -> array(double) -> double",
+        "(array(bigint)) -> array(bigint) -> bigint"}}};
+  expected.extract = {
+      {"aggregateFunc1_extract",
+       {"(array(double)) -> double", "(array(bigint)) -> bigint"}}};
+
+  assertEqual(*companionSignatures, expected);
+}
+
+TEST_F(AggregateCompanionSignaturesTest, extractFunctionNameWithSuffix) {
+  std::vector<AggregateFunctionSignaturePtr> signatures{
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType("array(double)")
+          .argumentType("double")
+          .argumentType("double")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .returnType("array(row(bigint))")
+          .intermediateType("array(double)")
+          .argumentType("bigint")
+          .build()};
+  registerDummyAggregateFunction("aggregateFunc2", signatures);
+  auto companionSignatures = getCompanionFunctionSignatures("aggregateFunc2");
+  EXPECT_TRUE(companionSignatures.has_value());
+
+  TestCompanionSignatureMap expected;
+  expected.partial = {
+      {"aggregateFunc2_partial",
+       {"(double) -> array(double) -> array(double)",
+        "(double,double) -> array(double) -> array(double)",
+        "(bigint) -> array(double) -> array(double)"}}};
+  expected.merge = {
+      {"aggregateFunc2_merge",
+       {"(array(double)) -> array(double) -> array(double)"}}};
+  expected.mergeExtract = {
+      {"aggregateFunc2_merge_extract_array_row_bigint_endrow",
+       {"(array(double)) -> array(double) -> array(row(bigint))"}},
+      {"aggregateFunc2_merge_extract_double",
+       {"(array(double)) -> array(double) -> double"}}};
+  expected.extract = {
+      {"aggregateFunc2_extract_array_row_bigint_endrow",
+       {"(array(double)) -> array(row(bigint))"}},
+      {"aggregateFunc2_extract_double", {"(array(double)) -> double"}}};
+
+  assertEqual(*companionSignatures, expected);
+}
+
+TEST_F(AggregateCompanionSignaturesTest, templateSignature) {
+  std::vector<AggregateFunctionSignaturePtr> signatures{
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("double")
+          .intermediateType("T")
+          .argumentType("double")
+          .argumentType("T")
+          .build(),
+      AggregateFunctionSignatureBuilder()
+          .typeVariable("K")
+          .returnType("bigint")
+          .intermediateType("K")
+          .argumentType("bigint")
+          .argumentType("K")
+          .build()};
+  registerDummyAggregateFunction("aggregateFunc3", signatures);
+  auto companionSignatures = getCompanionFunctionSignatures("aggregateFunc3");
+  EXPECT_TRUE(companionSignatures.has_value());
+
+  TestCompanionSignatureMap expected;
+  expected.partial = {
+      {"aggregateFunc3_partial",
+       {"(double,T) -> T -> T", "(bigint,K) -> K -> K"}}};
+  expected.merge = {{"aggregateFunc3_merge", {"(T) -> T -> T"}}};
+  expected.mergeExtract = {
+      {"aggregateFunc3_merge_extract_bigint", {"(K) -> K -> bigint"}},
+      {"aggregateFunc3_merge_extract_double", {"(T) -> T -> double"}}};
+  expected.extract = {
+      {"aggregateFunc3_extract_bigint", {"(K) -> bigint"}},
+      {"aggregateFunc3_extract_double", {"(T) -> double"}}};
+
+  assertEqual(*companionSignatures, expected);
+}
+
+} // namespace
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/AggregateFunctionRegistryTest.cpp
+++ b/velox/exec/tests/AggregateFunctionRegistryTest.cpp
@@ -206,9 +206,11 @@ TEST_F(FunctionRegistryTest, aggregateWindowFunctionSignature) {
   for (const auto& signature : windowFunctionSignatures.value()) {
     functionSignatures.insert(signature->toString());
   }
-  ASSERT_EQ(functionSignatures.count("(bigint,double) -> bigint"), 1);
-  ASSERT_EQ(functionSignatures.count("() -> date"), 1);
-  ASSERT_EQ(functionSignatures.count("(T,T) -> T"), 1);
+  ASSERT_EQ(
+      functionSignatures.count("(bigint,double) -> array(bigint) -> bigint"),
+      1);
+  ASSERT_EQ(functionSignatures.count("() -> date -> date"), 1);
+  ASSERT_EQ(functionSignatures.count("(T,T) -> array(T) -> T"), 1);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -13,15 +13,17 @@
 # limitations under the License.
 add_subdirectory(utils)
 
-add_executable(aggregate_companion_adapter_test
-               AggregateCompanionAdapterTest.cpp)
+add_executable(
+  aggregate_companion_functions_test
+  AggregateCompanionAdapterTest.cpp AggregateCompanionSignaturesTest.cpp
+  DummyAggregateFunction.cpp)
 
 add_test(
-  NAME aggregate_companion_adapter_test
-  COMMAND aggregate_companion_adapter_test
+  NAME aggregate_companion_functions_test
+  COMMAND aggregate_companion_functions_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-target_link_libraries(aggregate_companion_adapter_test velox_exec
+target_link_libraries(aggregate_companion_functions_test velox_exec
                       velox_function_registry gtest gtest_main)
 
 add_executable(

--- a/velox/exec/tests/DummyAggregateFunction.cpp
+++ b/velox/exec/tests/DummyAggregateFunction.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/DummyAggregateFunction.h"
+
+namespace facebook::velox::exec::test {
+
+bool registerDummyAggregateFunction(
+    const std::string& name,
+    const std::vector<AggregateFunctionSignaturePtr>& signatures) {
+  registerAggregateFunction(
+      name,
+      signatures,
+      [&](core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_GE(argTypes.size(), 1);
+        if (isPartialOutput(step)) {
+          return std::make_unique<DummyDicitonaryFunction>(argTypes[0]);
+        }
+        return std::make_unique<DummyDicitonaryFunction>(resultType);
+      },
+      /*registerCompanionFunctions*/ true);
+
+  return true;
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/DummyAggregateFunction.h
+++ b/velox/exec/tests/DummyAggregateFunction.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+
+namespace facebook::velox::exec::test {
+
+class DummyDicitonaryFunction : public exec::Aggregate {
+ public:
+  explicit DummyDicitonaryFunction(TypePtr resultType)
+      : Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return 0;
+  }
+
+  void initializeNewGroups(
+      char** /*groups*/,
+      folly::Range<const vector_size_t*> /*indices*/) override {}
+
+  void addRawInput(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addIntermediateResults(
+      char** /*groups*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupRawInput(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void addSingleGroupIntermediateResults(
+      char* /*group*/,
+      const SelectivityVector& /*rows*/,
+      const std::vector<VectorPtr>& /*args*/,
+      bool /*mayPushdown*/) override {}
+
+  void extractValues(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+
+  void extractAccumulators(
+      char** /*groups*/,
+      int32_t /*numGroups*/,
+      VectorPtr* /*result*/) override {}
+};
+
+bool registerDummyAggregateFunction(
+    const std::string& name,
+    const std::vector<exec::AggregateFunctionSignaturePtr>& signatures);
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -202,7 +202,8 @@ TEST_F(FunctionSignatureBuilderTest, aggregateConstantFlags) {
     EXPECT_FALSE(aggSignature->constantArguments().at(0));
     EXPECT_TRUE(aggSignature->constantArguments().at(1));
     EXPECT_FALSE(aggSignature->constantArguments().at(2));
-    EXPECT_EQ("(T,constant bigint,T) -> T", aggSignature->toString());
+    EXPECT_EQ(
+        "(T,constant bigint,T) -> array(T) -> T", aggSignature->toString());
   }
 
   {
@@ -220,7 +221,7 @@ TEST_F(FunctionSignatureBuilderTest, aggregateConstantFlags) {
     EXPECT_TRUE(aggSignature->constantArguments().at(1));
     EXPECT_FALSE(aggSignature->constantArguments().at(2));
     EXPECT_EQ(
-        "(bigint,constant T,T,constant double...) -> T",
+        "(bigint,constant T,T,constant double...) -> array(T) -> T",
         aggSignature->toString());
   }
 }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -66,7 +66,7 @@ std::string TypeSignature::toString() const {
   return out.str();
 }
 
-std::string FunctionSignature::toString() const {
+std::string FunctionSignature::argumentsToString() const {
   std::vector<std::string> arguments;
   auto size = argumentTypes_.size();
   arguments.reserve(size);
@@ -79,11 +79,16 @@ std::string FunctionSignature::toString() const {
     }
   }
   std::ostringstream out;
-  out << "(" << folly::join(",", arguments);
+  out << folly::join(",", arguments);
   if (variableArity_) {
     out << "...";
   }
-  out << ") -> " << returnType_.toString();
+  return out.str();
+}
+
+std::string FunctionSignature::toString() const {
+  std::ostringstream out;
+  out << "(" << argumentsToString() << ") -> " << returnType_.toString();
   return out.str();
 }
 
@@ -249,6 +254,13 @@ FunctionSignature::FunctionSignature(
       constantArguments_{std::move(constantArguments)},
       variableArity_{variableArity} {
   validate(variables_, returnType_, argumentTypes_, constantArguments_);
+}
+
+std::string AggregateFunctionSignature::toString() const {
+  std::ostringstream out;
+  out << "(" << argumentsToString() << ") -> " << intermediateType_.toString()
+      << " -> " << returnType().toString();
+  return out.str();
 }
 
 FunctionSignaturePtr FunctionSignatureBuilder::build() {

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -165,6 +165,10 @@ class FunctionSignature {
         variableArity_ == rhs.variableArity_;
   }
 
+ protected:
+  // Return a string of the list of argument types.
+  std::string argumentsToString() const;
+
  private:
   const std::unordered_map<std::string, SignatureVariable> variables_;
   const TypeSignature returnType_;
@@ -195,6 +199,8 @@ class AggregateFunctionSignature : public FunctionSignature {
   const TypeSignature& intermediateType() const {
     return intermediateType_;
   }
+
+  std::string toString() const override;
 
  private:
   const TypeSignature intermediateType_;


### PR DESCRIPTION
Summary: Add the getCompanionFunctionSignatures() API to retrieve signatures of potential companion functions of a UDAF. This API doesn't query the registry but follow the same logic as CompanionFunctionsRegistrar. It can be used to get the potential companion function signatures before register them.

Differential Revision: D45207179

