### PR TITLE
Fix failing M1 CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,7 +189,7 @@ executors:
     resource_class: macos.x86.medium.gen2
   macos-m1:
     macos:
-      xcode: "14.3.0"
+      xcode: "14.2.0"
     resource_class: macos.m1.large.gen1
 
 jobs:


### PR DESCRIPTION
 CircleCI M1 jobs have been failing silently (not shown as :x: on PRs) since yesterday. It seems CCI changed/removed the xcode 14.3.0 image.

Downgrading xcode on M1 to 14.2.0 fixes the issue.