### PR TITLE
Add to support threshold based hash join build spilling

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -61,7 +61,9 @@ HashBuild::HashBuild(
       nullAware_{joinNode_->isNullAware()},
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
-          planNodeId())) {
+          planNodeId())),
+      spillMemoryThreshold_(
+          operatorCtx_->driverCtx()->queryConfig().joinSpillMemoryThreshold()) {
   VELOX_CHECK(pool()->trackUsage());
   VELOX_CHECK_NOT_NULL(joinBridge_);
 
@@ -439,6 +441,18 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   // Test-only spill path.
   if (testingTriggerSpill()) {
     numSpillRows_ = std::max<int64_t>(1, numRows / 10);
+    numSpillBytes_ = numSpillRows_ * outOfLineBytesPerRow;
+    return false;
+  }
+
+  // We check usage from the parent pool to take peers' allocations into
+  // account.
+  const auto currentUsage = pool()->parent()->currentBytes();
+  if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
+    const int64_t bytesToSpill =
+        currentUsage * spillConfig()->spillableReservationGrowthPct / 100;
+    numSpillRows_ = std::max<int64_t>(
+        1, bytesToSpill / (rows->fixedRowSize() + outOfLineBytesPerRow));
     numSpillBytes_ = numSpillRows_ * outOfLineBytesPerRow;
     return false;
   }

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -237,6 +237,10 @@ class HashBuild final : public Operator {
 
   std::shared_ptr<HashJoinBridge> joinBridge_;
 
+  // The maximum memory usage that a hash build can hold before spilling.
+  // If it is zero, then there is no such limit.
+  const uint64_t spillMemoryThreshold_;
+
   std::shared_ptr<SpillOperatorGroup> spillGroup_;
 
   State state_{State::kRunning};

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -305,6 +305,11 @@ class HashJoinBuilder {
     return *this;
   }
 
+  HashJoinBuilder& spillMemoryThreshold(uint64_t threshold) {
+    spillMemoryThreshold_ = threshold;
+    return *this;
+  }
+
   HashJoinBuilder& injectSpill(bool injectSpill) {
     injectSpill_ = injectSpill;
     return *this;
@@ -520,6 +525,15 @@ class HashJoinBuilder {
       config(core::QueryConfig::kMaxSpillLevel, std::to_string(maxSpillLevel));
       config(core::QueryConfig::kJoinSpillEnabled, "true");
       config(core::QueryConfig::kTestingSpillPct, "100");
+    } else if (spillMemoryThreshold_ != 0) {
+      spillDirectory = exec::test::TempDirectoryPath::create();
+      builder.spillDirectory(spillDirectory->path);
+      config(core::QueryConfig::kSpillEnabled, "true");
+      config(core::QueryConfig::kMaxSpillLevel, std::to_string(maxSpillLevel));
+      config(core::QueryConfig::kJoinSpillEnabled, "true");
+      config(
+          core::QueryConfig::kJoinSpillMemoryThreshold,
+          std::to_string(spillMemoryThreshold_));
     } else if (!spillDirectory_.empty()) {
       builder.spillDirectory(spillDirectory_);
       config(core::QueryConfig::kSpillEnabled, "true");
@@ -555,9 +569,9 @@ class HashJoinBuilder {
           ASSERT_EQ(maxHashBuildSpillLevel(*task), maxSpillLevel);
         }
       }
-      // NOTE: if 'spillDirectory_' is not empty, the test might trigger
-      // spilling by its own.
-    } else if (spillDirectory_.empty()) {
+      // NOTE: if 'spillDirectory_' is not empty and spill threshold is not set,
+      // the test might trigger spilling by its own.
+    } else if (spillDirectory_.empty() && spillMemoryThreshold_ == 0) {
       ASSERT_EQ(spillStats.spilledRows, 0);
       ASSERT_EQ(spillStats.spilledBytes, 0);
       ASSERT_EQ(spillStats.spilledPartitions, 0);
@@ -598,6 +612,7 @@ class HashJoinBuilder {
   std::vector<std::string> joinOutputLayout_;
   std::vector<std::string> outputProjections_;
 
+  uint64_t spillMemoryThreshold_{0};
   bool injectSpill_{true};
   // If not set, then the test will run the test with different settings: 0, 2.
   std::optional<int32_t> maxSpillLevel_;
@@ -821,6 +836,26 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
       .buildVectors(1500, 5)
       .referenceQuery(
           "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
+      .run();
+}
+
+TEST_P(MultiThreadedHashJoinTest, emptyProbeWithspillMemoryThreshold) {
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .numDrivers(numDrivers_)
+      .keyTypes({BIGINT()})
+      .probeVectors(0, 5)
+      .buildVectors(1500, 5)
+      .injectSpill(false)
+      .spillMemoryThreshold(1)
+      .referenceQuery(
+          "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        const auto spillStats = taskSpilledStats(*task);
+        ASSERT_GT(spillStats.spilledRows, 0);
+        ASSERT_GT(spillStats.spilledBytes, 0);
+        ASSERT_GT(spillStats.spilledPartitions, 0);
+        ASSERT_GT(spillStats.spilledFiles, 0);
+      })
       .run();
 }
 


### PR DESCRIPTION
The option `join_spill_memory_threshold` is declared in query config but not get implemented yet. The PR is to add the implementation.

`join_spill_memory_threshold`: Maximum amount of memory in bytes that a hash join build side can use before spilling. 0 means unlimited.