### PR TITLE
Error "not a scalar type" raised when OrderBy spills data with decimal type

### DIFF
--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -101,7 +101,7 @@ void gatherCopy(
     const std::vector<vector_size_t>& sourceIndices,
     column_index_t sourceChannel) {
   if (target->isScalar()) {
-    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+    VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
         scalarGatherCopy,
         target->type()->kind(),
         target,

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -531,7 +531,7 @@ TEST_F(OrderByTest, spillWithDecimal) {
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   auto rowType =
       ROW({"c0", "c1", "c2"},
-          {INTEGER(), SHORT_DECIMAL(10, 5), LONG_DECIMAL(30, 5)});
+          {INTEGER(), DECIMAL(10, 5), DECIMAL(30, 5)});
   VectorFuzzer fuzzer({}, pool());
   const int32_t numBatches = 5;
   std::vector<RowVectorPtr> batches;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -530,8 +530,7 @@ TEST_F(OrderByTest, spillWithDecimal) {
   constexpr int32_t kNumRows = 2000;
   constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
   auto rowType =
-      ROW({"c0", "c1", "c2"},
-          {INTEGER(), DECIMAL(10, 5), DECIMAL(30, 5)});
+      ROW({"c0", "c1", "c2"}, {INTEGER(), DECIMAL(10, 5), DECIMAL(30, 5)});
   VectorFuzzer fuzzer({}, pool());
   const int32_t numBatches = 5;
   std::vector<RowVectorPtr> batches;


### PR DESCRIPTION
Reason:
`gatherCopy` should accept decimal as well as other scalar types. I guess it's not included in code probably because decimal support is not 100% ready for spilling when the code was written. I am not sure.

Error:

```
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: not a scalar type! kind: LONG_DECIMAL
Retriable: False
Function: operator()
File: ../../velox/exec/OperatorUtils.cpp
Line: 105
Stack trace:
# 0  std::shared_ptr<facebook::velox::VeloxException::State const> facebook::velox::VeloxException::State::make<facebook::velox::VeloxException::make(char const*, unsigned long, char const*, std::basic_s
tring_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char
> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1}>(facebook::velox::VeloxException::Type, facebook::velox::VeloxException::make
(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char>
 >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)::{lambda(auto:1&)#1})
# 1  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >,
 std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<c
har> >)
# 2  facebook::velox::VeloxRuntimeError::VeloxRuntimeError(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<ch
ar> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, std::basic_string_view<char, std::char_traits<char> >)
# 3  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::Velo
xCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
# 4  facebook::velox::exec::(anonymous namespace)::gatherCopy(facebook::velox::BaseVector*, int, int, std::vector<facebook::velox::RowVector const*, std::allocator<facebook::velox::RowVector const*> > co
nst&, std::vector<int, std::allocator<int> > const&, unsigned int)::{lambda()#1}::operator()() const
# 5  facebook::velox::exec::(anonymous namespace)::gatherCopy(facebook::velox::BaseVector*, int, int, std::vector<facebook::velox::RowVector const*, std::allocator<facebook::velox::RowVector const*> > co
nst&, std::vector<int, std::allocator<int> > const&, unsigned int)
# 6  facebook::velox::exec::gatherCopy(facebook::velox::RowVector*, int, int, std::vector<facebook::velox::RowVector const*, std::allocator<facebook::velox::RowVector const*> > const&, std::vector<int, s
td::allocator<int> > const&, std::vector<facebook::velox::exec::IdentityProjection, std::allocator<facebook::velox::exec::IdentityProjection> > const&)
# 7  facebook::velox::exec::OrderBy::getOutputWithSpill()
# 8  facebook::velox::exec::OrderBy::getOutput()
# 9  facebook::velox::exec::Driver::runInternal(std::shared_ptr<facebook::velox::exec::Driver>&, std::shared_ptr<facebook::velox::exec::BlockingState>&, std::shared_ptr<facebook::velox::RowVector>&)
# 10 facebook::velox::exec::Driver::next(std::shared_ptr<facebook::velox::exec::BlockingState>&)
# 11 facebook::velox::exec::Task::next(folly::SemiFuture<folly::Unit>*)
```