### PR TITLE
Reduce LocalExchange Blocking Time

### DIFF
--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -16,6 +16,7 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include "velox/core/QueryConfig.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -28,6 +29,14 @@
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
 DEFINE_int32(width, 16, "Number of parties in shuffle");
+DEFINE_int32(num_local_tasks, 16, "Number of concurrent local shuffles");
+DEFINE_int32(num_local_repeat, 16, "Number of repeats of local exchange query");
+DEFINE_int32(flat_batch_mb, 1, "MB in a 10k row flat batch.");
+DEFINE_int64(
+    local_exchange_buffer_mb,
+    32,
+    "task-wide buffer in local exchange");
+DEFINE_int64(exchange_buffer_mb, 32, "task-wide buffer in remote exchange");
 
 /// Benchmarks repartition/exchange with different batch sizes,
 /// numbers of destinations and data type mixes.  Generates a plan
@@ -69,6 +78,8 @@ class ExchangeBenchmark : public VectorTestBase {
   void
   run(std::vector<RowVectorPtr>& vectors, int32_t width, Counters& counters) {
     assert(!vectors.empty());
+    configSettings_[core::QueryConfig::kMaxPartitionedOutputBufferSize] =
+        fmt::format("{}", FLAGS_exchange_buffer_mb << 20);
     std::vector<std::shared_ptr<Task>> tasks;
     std::vector<std::string> leafTaskIds;
     auto leafPlan = exec::test::PlanBuilder()
@@ -135,6 +146,84 @@ class ExchangeBenchmark : public VectorTestBase {
     counters.usec += elapsed;
   }
 
+  void runLocal(
+      std::vector<RowVectorPtr>& vectors,
+      int32_t taskWidth,
+      int32_t numTasks,
+      Counters& counters) {
+    assert(!vectors.empty());
+    std::vector<std::shared_ptr<Task>> tasks;
+    counters.bytes = vectors[0]->retainedSize() * vectors.size() * numTasks *
+        FLAGS_num_local_repeat;
+    std::vector<std::string> aggregates = {"count(1)"};
+    auto& rowType = vectors[0]->type()->as<TypeKind::ROW>();
+    for (auto i = 1; i < rowType.size(); ++i) {
+      aggregates.push_back(fmt::format("checksum({})", rowType.nameOf(i)));
+    }
+    core::PlanNodeId exchangeId;
+    auto plan = exec::test::PlanBuilder()
+                    .values(vectors, true)
+                    .localPartition({"c0"})
+                    .capturePlanNodeId(exchangeId)
+                    .singleAggregation({}, aggregates)
+                    .localPartition({})
+                    .singleAggregation({}, {"sum(a0)"})
+                    .planNode();
+    auto startMicros = getCurrentTimeMicro();
+
+    std::vector<std::thread> threads;
+    threads.reserve(numTasks);
+    auto expected =
+        makeRowVector({makeFlatVector<int64_t>(1, [&](auto /*row*/) {
+          return vectors.size() * vectors[0]->size() * taskWidth;
+        })});
+
+    std::mutex mutex;
+    for (int32_t i = 0; i < numTasks; ++i) {
+      threads.push_back(std::thread([&]() {
+        for (auto repeat = 0; repeat < FLAGS_num_local_repeat; ++repeat) {
+          auto task =
+              exec::test::AssertQueryBuilder(plan)
+                  .config(
+                      core::QueryConfig::kMaxLocalExchangeBufferSize,
+                      fmt::format("{}", FLAGS_local_exchange_buffer_mb << 20))
+                  .maxDrivers(taskWidth)
+                  .assertResults(expected);
+          {
+            std::lock_guard<std::mutex> l(mutex);
+            tasks.push_back(task);
+          }
+        }
+      }));
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+    counters.usec = getCurrentTimeMicro() - startMicros;
+    int64_t totalProducer = 0;
+    int64_t totalConsumer = 0;
+    std::vector<RuntimeMetric> waitConsumer;
+    std::vector<RuntimeMetric> waitProducer;
+    std::vector<int64_t> wallMs;
+    for (auto& task : tasks) {
+      auto taskStats = task->taskStats();
+      wallMs.push_back(
+          taskStats.executionEndTimeMs - taskStats.executionStartTimeMs);
+      auto planStats = toPlanStats(taskStats);
+      auto runtimeStats = planStats.at(exchangeId).customStats;
+      waitProducer.push_back(runtimeStats["blockedWaitForProducerWallNanos"]);
+      waitConsumer.push_back(runtimeStats["blockedWaitForConsumerWallNanos"]);
+      totalConsumer += waitConsumer.back().sum;
+      totalProducer += waitProducer.back().sum;
+    }
+    printMax("Producer", totalProducer, waitProducer);
+    printMax("Consumer", totalConsumer, waitConsumer);
+    std::sort(wallMs.begin(), wallMs.end());
+    std::cout << "Wall ms: " << wallMs.back() << " / "
+              << wallMs[wallMs.size() / 2] << " / " << wallMs.front()
+              << std::endl;
+  }
+
  private:
   static constexpr int64_t kMaxMemory = 6UL << 30; // 6GB
 
@@ -173,6 +262,26 @@ class ExchangeBenchmark : public VectorTestBase {
     task->noMoreSplits("0");
   }
 
+  void sortByMax(std::vector<RuntimeMetric>& metrics) {
+    std::sort(
+        metrics.begin(),
+        metrics.end(),
+        [](const RuntimeMetric& left, const RuntimeMetric& right) {
+          return left.max > right.max;
+        });
+  }
+
+  void printMax(
+      const char* title,
+      int64_t total,
+      std::vector<RuntimeMetric>& metrics) {
+    sortByMax(metrics);
+    std::cout << title << " Total " << succinctNanos(total)
+              << " Max: " << metrics.front().toString()
+              << " Median: " << metrics[metrics.size() / 2].toString()
+              << " Min: " << metrics.back().toString() << std::endl;
+  }
+
   std::unordered_map<std::string, std::string> configSettings_;
 };
 
@@ -187,6 +296,7 @@ Counters flat10kCounters;
 Counters deep10kCounters;
 Counters flat50Counters;
 Counters deep50Counters;
+Counters localFlat10kCounters;
 
 BENCHMARK(exchanegeFlat10k) {
   bm.run(flat10k, FLAGS_width, flat10kCounters);
@@ -203,6 +313,12 @@ BENCHMARK(exchanegeDeep10k) {
 BENCHMARK_RELATIVE(exchanegeDeep50) {
   bm.run(deep50, FLAGS_width, deep50Counters);
 }
+
+BENCHMARK(localFlat10k) {
+  bm.runLocal(
+      flat10k, FLAGS_width, FLAGS_num_local_tasks, localFlat10kCounters);
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -212,20 +328,33 @@ int main(int argc, char** argv) {
   parse::registerTypeResolver();
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   exec::ExchangeSource::registerFactory();
+  std::vector<std::string> flatNames = {"c0"};
+  std::vector<TypePtr> flatTypes = {BIGINT()};
+  std::vector<TypePtr> typeSelection = {
+      BOOLEAN(),
+      TINYINT(),
+      LONG_DECIMAL(20, 3),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      SHORT_DECIMAL(10, 2),
+      DOUBLE(),
+      VARCHAR()};
 
-  auto flatType = ROW({
-      {"c0", BIGINT()},
-      {"bool_val", BOOLEAN()},
-      {"tiny_val", TINYINT()},
-      {"long_decimal_val", LONG_DECIMAL(20, 3)},
-      {"small_val", SMALLINT()},
-      {"int_val", INTEGER()},
-      {"long_val", BIGINT()},
-      {"float_val", REAL()},
-      {"short_decimal_val", SHORT_DECIMAL(10, 2)},
-      {"double_val", DOUBLE()},
-      {"string_val", VARCHAR()},
-  });
+  int64_t flatSize = 0;
+  // Add enough columns of different types to make a 10K row batch be
+  // flat_batch_mb in flat size.
+  while (flatSize * 10000 < static_cast<int64_t>(FLAGS_flat_batch_mb) << 20) {
+    flatNames.push_back(fmt::format("c{}", flatNames.size()));
+    flatTypes.push_back(typeSelection[flatTypes.size() % typeSelection.size()]);
+    if (flatTypes.back()->isFixedWidth()) {
+      flatSize += flatTypes.back()->cppSizeInBytes();
+    } else {
+      flatSize += 20;
+    }
+  }
+  auto flatType = ROW(std::move(flatNames), std::move(flatTypes));
+
   auto deepType = ROW(
       {{"c0", BIGINT()},
        {"long_array_val", ARRAY(ARRAY(BIGINT()))},


### PR DESCRIPTION
Extreme latency spikes in production shadow are related to high blocking times on local exchange. A query can be 30x slower under concurrency than by itself. Also, concurrency alone does not make the slowness: The queries have low CPU time and 30x normal wall time in a few cases per day. The common factor in these cases is LocalExchange/LocalPartition blocking time.

Consider 18 producers and 18 consumers. The queue is 32MB. The producers produce up to 10MB batches. After all have produced one batch, the queue is 180MB and producers are blocked. The consumers typically have 18 times 10MB/18 size batches. After 15 consumers are done consuming, the queue will be under 32MB, at which point all producers will be unblocked. The consumers will then get unblocked after the first released producer produces something and adds it to the queue of each consumer. We oscillate between high utilization (18 consumers and 18 producers concurrently active and ~3 consumers active. This is OK for CPU time but bad for latency. Under high concurrency the latency gets even less predictable, leading to high tail latency.

We modify the queueing so that one comsumer, after consuming its last queued input, unblocks the longest waiting producer. This is controlled by the flag --local_partition_unblock_early. This slightly simplifies LocalPartition by getting rid of a vector of futures (one per queue) in favor of one future that depends on the queues and local partition memory manager collectively.

We add a benchmark for local exchange to ExchangeBenchmark.cpp. We run 16 concurrent threads each with 16 repeats of a local shuffle of 16 producers and 16 consumers. This is up to 512 potentially concurrent threads on a 8 thread executor. We track the cum/count./min/max of the blocking times for LocalExchange and LocalPartition and report the highest, median and lowest wait stats across each of the 16 * 16 queries. We notice similar wall and CPU times but about 2x less blocking time with the optimization enabled.

This is expected to cut down on tail latency on a cluster by making more threads runnable at a time, hence giving the OS a chance to schedule them fairly. This in turn improves the user experience since one user impression will depend on the outcome of multiple concurrent queries, increasing exposure to tail latency.

Example output:

./velox_exchange_benchmark  --bm_regex ocal --flat_batch_mb 10 --local_partition_unblock_early=true

Producer Total 2h 17m 57s Max: sum:42451793000, count:15, min:459107000, max:9134674000 Median: sum:38094979000, count:16, min:855494000, max:5531548000 Min: sum:10200692000, count:16, min:260485000, max:971314000
Consumer Total 11h 10m 41s Max: sum:212474180000, count:16, min:9560702000, max:15428950000 Median: sum:158541369000, count:16, min:8083319000, max:11558367000 Min: sum:63131806000, count:16, min:2547903000, max:4356620000
Wall ms: 22491 / 18537 / 11855

localFlat10k                                                4.92min    3.39m

./velox_exchange_benchmark  --bm_regex ocal --flat_batch_mb 10 --local_partition_unblock_early=false

Producer Total 4h 18m 48s Max: sum:86526266000, count:15, min:2350735000, max:12295202000 Median: sum:64807283000, count:15, min:2398516000, max:8522011000 Min: sum:42818808000, count:16, min:1935422000, max:4354070000 Consumer Total 16h 44m 6s Max: sum:283500571000, count:16, min:12085192000, max:19403768000 Median: sum:235983102000, count:16, min:12738252000, max:16175621000 Min: sum:152877804000, count:16, min:8647943000, max:10097357000 Wall ms: 22213 / 18852 / 12991
============================================================================ ../../velox/exec/benchmarks/ExchangeBenchmark.cpprelative  time/iter  iters/s ============================================================================
localFlat10k                                                4.99min    3.34m