### PR TITLE
Add result->clearNulls() to InPredicate

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -276,6 +276,7 @@ class InPredicate : public exec::VectorFunction {
     auto rawValues = flatArg->rawValues();
 
     context.ensureWritable(rows, BOOLEAN(), result);
+    result->clearNulls(rows);
     auto* boolResult = result->asUnchecked<FlatVector<bool>>();
 
     auto* rawResults = boolResult->mutableRawValues<uint64_t>();

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -330,7 +330,6 @@ TEST_F(InPredicateTest, reusableResult) {
   auto b2 = makeFlatVector<int64_t>({100, 105, 110, 115, 120, 125});
   auto data2 = makeRowVector({"a", "b"}, {a2, b2});
 
-  // Queries.
   std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
   auto plan = PlanBuilder(pool_.get())
                   .values({data1, data2})
@@ -339,6 +338,7 @@ TEST_F(InPredicateTest, reusableResult) {
                   .planNode();
 
   auto result = AssertQueryBuilder(plan).copyResults(pool());
-  auto expected =makeRowVector({"b"}, {makeFlatVector<int64_t>({5, 105, 110})});
+  auto expected =
+      makeRowVector({"b"}, {makeFlatVector<int64_t>({5, 105, 110})});
   assertEqualVectors(expected, result);
 }

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -13,13 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/tests/utils/AssertQueryBuilder.h"
-#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::test;
-using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::test;
 
 class InPredicateTest : public FunctionBaseTest {


### PR DESCRIPTION
`InPredicate::applyTyped()` does not clear nulls before processing flat vectors,
which results in wrong `nulls` when the previous vector has nulls but the
current one does not. 

Fixes #4715