### PR TITLE
Fix a flaky test blockingOnLocalExchangeQueue in LocalPartitionTest

### DIFF
--- a/velox/exec/tests/LocalPartitionTest.cpp
+++ b/velox/exec/tests/LocalPartitionTest.cpp
@@ -283,8 +283,8 @@ TEST_F(LocalPartitionTest, maxBufferSizePartition) {
 
 TEST_F(LocalPartitionTest, blockingOnLocalExchangeQueue) {
   auto localExchangeBufferSize = "1024";
-  auto baseVector =
-      vectorMaker_.flatVector<int64_t>(1024, [](auto row) { return row; });
+  auto baseVector = vectorMaker_.flatVector<int64_t>(
+      1024 * 1024, [](auto row) { return row; });
   // Make a small dictionary vector of one row and roughly 8 bytes that is
   // smaller than the localExchangeBufferSize.
   auto smallInput = vectorMaker_.rowVector(


### PR DESCRIPTION
Increase the size of the large test input vector from 1K to 1M,
to make sure after the random 4-way partitioning each input batch size
is still larger than the configured local exchange buffer size 1K.