### PR TITLE
Run benchmark without docker

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -36,7 +36,6 @@ jobs:
   benchmark:
     if: github.repository == 'facebookincubator/velox'
     runs-on: 8-core
-    container: ghcr.io/facebookincubator/velox-dev:amd64-ubuntu-22.04-avx
     env:
       CCACHE_DIR: "${{ github.workspace }}/.ccache/"
       CCACHE_BASEDIR: "${{ github.workspace }}"
@@ -46,11 +45,6 @@ jobs:
       BASELINE_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/baseline/"
       CONTENDER_OUTPUT_PATH: "${{ github.workspace }}/benchmark-results/contender/"
     steps:
-      - name: "Setup ccache and python"
-        run: |
-            # Set up ccache configs .
-            mkdir -p .ccache
-            ccache -sz -M 5Gi
 
       - name: "Restore ccache"
         uses: actions/cache/restore@v3
@@ -70,6 +64,10 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
           submodules: 'recursive'
+
+      - name: "Install dependencies"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: source(velox/scripts/setup-ubuntu.sh)
 
       - name: "Checkout Merge Base"
         if: ${{ github.event_name == 'pull_request' }}
@@ -111,6 +109,9 @@ jobs:
           path: 'velox'
           ref: ${{ github.sha }}
           submodules: 'recursive'
+
+      - name: "Install dependencies"
+        run: source(velox/scripts/setup-ubuntu.sh)
 
       - name: Build Contender Benchmarks
         working-directory: velox

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: "Install dependencies"
         if: ${{ github.event_name == 'pull_request' }}
-        run: source(velox/scripts/setup-ubuntu.sh)
+        run: source velox/scripts/setup-ubuntu.sh
 
       - name: "Checkout Merge Base"
         if: ${{ github.event_name == 'pull_request' }}
@@ -111,7 +111,7 @@ jobs:
           submodules: 'recursive'
 
       - name: "Install dependencies"
-        run: source(velox/scripts/setup-ubuntu.sh)
+        run: source velox/scripts/setup-ubuntu.sh
 
       - name: Build Contender Benchmarks
         working-directory: velox

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -29,7 +29,7 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
 
 # Install all velox and folly dependencies.
-sudo --preserve-env apt update && apt install -y \
+sudo --preserve-env apt update && sudo apt install -y \
   g++ \
   cmake \
   ccache \

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -52,9 +52,11 @@ sudo --preserve-env apt update && sudo apt install -y libunwind-dev && \
   libzstd-dev \
   libre2-dev \
   libsnappy-dev \
+  libthrift-dev \
   liblzo2-dev \
   bison \
   flex \
+  libfl-dev \
   tzdata \
   wget
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -28,8 +28,11 @@ NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
 
-# Install all velox and folly dependencies.
-sudo --preserve-env apt update && sudo apt install -y \
+# Install all velox and folly dependencies. 
+# The is an issue on 22.04 where a version conflict prevents glog install,
+# installing libunwind first fixes this.
+sudo --preserve-env apt update && sudo apt install -y libunwind-dev && \
+  sudo apt install -y \
   g++ \
   cmake \
   ccache \


### PR DESCRIPTION
This removes the docker image previously used to save  dependency install time and runs the benchmarks directly on the runner. This should improve variance by removing a layer of indirection.