### PR TITLE
Push down delta delete into reader

### DIFF
--- a/velox/dwio/common/BitPackDecoder.h
+++ b/velox/dwio/common/BitPackDecoder.h
@@ -21,7 +21,7 @@
 #include "velox/vector/TypeAliases.h"
 
 #include <folly/Range.h>
-#include <xsimd/config/xsimd_config.hpp>
+#include <xsimd/config/xsimd_config.hpp> // @manual
 
 namespace facebook::velox::dwio::common {
 

--- a/velox/dwio/common/Mutation.h
+++ b/velox/dwio/common/Mutation.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace facebook::velox::dwio::common {
+
+struct Mutation {
+  /// Bit masks for row numbers to be deleted.
+  const uint64_t* deletedRows = nullptr;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -279,7 +279,9 @@ class RowReaderOptions {
 
   /*
    * Set to true, if you want to add a new column to the results containing the
-   * row numbers.
+   * row numbers.  These row numbers are relative to the beginning of file (0 as
+   * first row) and does not affected by filtering or deletion during the read
+   * (it always counts all rows in the file).
    */
   void setAppendRowNumberColumn(bool value) {
     appendRowNumberColumn_ = value;

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -20,6 +20,7 @@
 #include "velox/common/process/ProcessBase.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/FormatData.h"
+#include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/type/Filter.h"
 
@@ -140,10 +141,8 @@ class SelectiveColumnReader {
    * @param numValues the number of values to read
    * @param vector to read into
    */
-  virtual void next(
-      uint64_t /*numValues*/,
-      VectorPtr& /*result*/,
-      const uint64_t* FOLLY_NULLABLE /*incomingNulls*/ = nullptr) {
+  virtual void
+  next(uint64_t /*numValues*/, VectorPtr& /*result*/, const Mutation*) {
     VELOX_UNSUPPORTED("next() is only defined in SelectiveStructColumnReader");
   }
 
@@ -175,7 +174,7 @@ class SelectiveColumnReader {
   // read(). If 'this' has no filter, returns 'rows' passed to last
   // read().
   const RowSet outputRows() const {
-    if (scanSpec_->hasFilter()) {
+    if (scanSpec_->hasFilter() || hasMutation()) {
       return outputRows_;
     }
     return inputRows_;
@@ -505,6 +504,10 @@ class SelectiveColumnReader {
   // Copies 'value' to buffers owned by 'this' and returns the start of the
   // copy.
   char* FOLLY_NONNULL copyStringValue(folly::StringPiece value);
+
+  virtual bool hasMutation() const {
+    return false;
+  }
 
   memory::MemoryPool& memoryPool_;
 

--- a/velox/dwio/common/SelectiveColumnReaderInternal.h
+++ b/velox/dwio/common/SelectiveColumnReaderInternal.h
@@ -94,7 +94,7 @@ void SelectiveColumnReader::prepareRead(
   numValues_ = 0;
   valueSize_ = sizeof(T);
   inputRows_ = rows;
-  if (scanSpec_->filter()) {
+  if (scanSpec_->filter() || hasMutation()) {
     outputRows_.reserve(rows.size());
   }
   ensureValuesCapacity<T>(rows.size());

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -30,10 +30,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
 
   uint64_t skip(uint64_t numValues) override;
 
-  void next(
-      uint64_t numValues,
-      VectorPtr& result,
-      const uint64_t* incomingNulls) override;
+  void next(uint64_t numValues, VectorPtr& result, const Mutation*) override;
 
   void filterRowGroups(
       uint64_t rowGroupSize,
@@ -115,6 +112,10 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   // know how much to skip when seeking forward within the row group.
   void recordParentNullsInChildren(vector_size_t offset, RowSet rows);
 
+  bool hasMutation() const override {
+    return hasMutation_;
+  }
+
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
 
   std::vector<SelectiveColumnReader*> children_;
@@ -127,6 +128,12 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
 
   // Dense set of rows to read in next().
   raw_vector<vector_size_t> rows_;
+
+  const Mutation* mutation_ = nullptr;
+
+  // After read() call mutation_ could go out of scope.  Need to keep this
+  // around for lazy columns.
+  bool hasMutation_ = false;
 
   // Context information obtained from ExceptionContext. Stored here
   // so that LazyVector readers under this can add this to their

--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -137,6 +137,7 @@ void E2EFilterTestBase::readWithoutFilter(
 
 void E2EFilterTestBase::readWithFilter(
     std::shared_ptr<ScanSpec> spec,
+    const MutationSpec& mutationSpec,
     const std::vector<RowVectorPtr>& batches,
     const std::vector<uint64_t>& hitRows,
     uint64_t& time,
@@ -157,16 +158,38 @@ void E2EFilterTestBase::readWithFilter(
   auto resultBatch = BaseVector::create(rowType_, 1, leafPool_.get());
   resetReadBatchSizes();
   int32_t clearCnt = 0;
+  auto deletedRowsIter = mutationSpec.deletedRows.begin();
   while (true) {
     {
       MicrosecondTimer timer(&time);
       if (++clearCnt % 17 == 0) {
         rowReader->resetFilterCaches();
       }
-      bool hasData = rowReader->next(nextReadBatchSize(), resultBatch);
-      if (!hasData) {
+      auto nextRowNumber = rowReader->nextRowNumber();
+      if (nextRowNumber == RowReader::kAtEnd) {
         break;
       }
+      auto readSize = rowReader->nextReadSize(nextReadBatchSize());
+      std::vector<uint64_t> isDeleted(bits::nwords(readSize));
+      bool haveDelete = false;
+      for (; deletedRowsIter != mutationSpec.deletedRows.end();
+           ++deletedRowsIter) {
+        auto i = *deletedRowsIter;
+        if (i < nextRowNumber) {
+          continue;
+        }
+        if (i >= nextRowNumber + readSize) {
+          break;
+        }
+        bits::setBit(isDeleted.data(), i - nextRowNumber);
+        haveDelete = true;
+      }
+      Mutation mutation;
+      if (haveDelete) {
+        mutation.deletedRows = isDeleted.data();
+      }
+      auto rowsScanned = rowReader->next(readSize, resultBatch, &mutation);
+      ASSERT_EQ(rowsScanned, readSize);
       if (resultBatch->size() == 0) {
         // No hits in the last resultBatch of rows.
         continue;
@@ -248,8 +271,10 @@ bool E2EFilterTestBase::loadWithHook(
 
 void E2EFilterTestBase::testReadWithFilterLazy(
     const std::shared_ptr<common::ScanSpec>& spec,
+    const MutationSpec& mutations,
     const std::vector<RowVectorPtr>& batches,
     const std::vector<uint64_t>& hitRows) {
+  SCOPED_TRACE("Lazy");
   // Test with LazyVectors for non-filtered columns.
   uint64_t timeWithFilter = 0;
   for (auto& childSpec : spec->children()) {
@@ -258,24 +283,26 @@ void E2EFilterTestBase::testReadWithFilterLazy(
       grandchild->setExtractValues(false);
     }
   }
-  readWithFilter(spec, batches, hitRows, timeWithFilter, false);
+  readWithFilter(spec, mutations, batches, hitRows, timeWithFilter, false);
   timeWithFilter = 0;
-  readWithFilter(spec, batches, hitRows, timeWithFilter, true);
+  readWithFilter(spec, mutations, batches, hitRows, timeWithFilter, true);
 }
 
 void E2EFilterTestBase::testFilterSpecs(
     const std::vector<RowVectorPtr>& batches,
     const std::vector<FilterSpec>& filterSpecs) {
+  MutationSpec mutations;
   std::vector<uint64_t> hitRows;
-  auto filters =
-      filterGenerator_->makeSubfieldFilters(filterSpecs, batches, hitRows);
+  auto filters = filterGenerator_->makeSubfieldFilters(
+      filterSpecs, batches, &mutations, hitRows);
   auto spec = filterGenerator_->makeScanSpec(std::move(filters));
   uint64_t timeWithFilter = 0;
-  readWithFilter(spec, batches, hitRows, timeWithFilter, false);
+  readWithFilter(spec, mutations, batches, hitRows, timeWithFilter, false);
 
   if (FLAGS_timing_repeats) {
     for (auto i = 0; i < FLAGS_timing_repeats; ++i) {
-      readWithFilter(spec, batches, hitRows, timeWithFilter, false, true);
+      readWithFilter(
+          spec, mutations, batches, hitRows, timeWithFilter, false, true);
     }
     LOG(INFO) << fmt::format(
         "    {} hits in {} us, {} input rows/s\n",
@@ -284,13 +311,14 @@ void E2EFilterTestBase::testFilterSpecs(
         batches[0]->size() * batches.size() * FLAGS_timing_repeats /
             (timeWithFilter / 1000000.0));
   }
-  testReadWithFilterLazy(spec, batches, hitRows);
+  testReadWithFilterLazy(spec, mutations, batches, hitRows);
 }
 
 void E2EFilterTestBase::testNoRowGroupSkip(
     const std::vector<RowVectorPtr>& batches,
     const std::vector<std::string>& filterable,
     int32_t numCombinations) {
+  SCOPED_TRACE("No row group skip");
   auto spec = filterGenerator_->makeScanSpec(SubfieldFilters{});
 
   uint64_t timeWithNoFilter = 0;
@@ -306,6 +334,7 @@ void E2EFilterTestBase::testNoRowGroupSkip(
 void E2EFilterTestBase::testRowGroupSkip(
     const std::vector<RowVectorPtr>& batches,
     const std::vector<std::string>& filterable) {
+  SCOPED_TRACE("Row group skip");
   std::vector<FilterSpec> specs;
   // Makes a row group skipping filter for the first bigint column.
   for (auto& field : filterable) {
@@ -330,6 +359,7 @@ void E2EFilterTestBase::testRowGroupSkip(
 void E2EFilterTestBase::testPruningWithFilter(
     std::vector<RowVectorPtr>& batches,
     const std::vector<std::string>& filterable) {
+  SCOPED_TRACE("Subfield pruning");
   std::vector<std::string> prunable;
   for (int i = 0; i < rowType_->size(); ++i) {
     auto kind = rowType_->childAt(i)->kind();
@@ -356,14 +386,15 @@ void E2EFilterTestBase::testPruningWithFilter(
   }
   auto scanSpec =
       filterGenerator_->makeScanSpec(prunable, batches, leafPool_.get());
+  MutationSpec mutations;
   std::vector<uint64_t> hitRows;
   auto filterSpecs = filterGenerator_->makeRandomSpecs(filterable, 125);
-  auto filters =
-      filterGenerator_->makeSubfieldFilters(filterSpecs, batches, hitRows);
+  auto filters = filterGenerator_->makeSubfieldFilters(
+      filterSpecs, batches, &mutations, hitRows);
   FilterGenerator::addToScanSpec(filters, *scanSpec);
   uint64_t timeWithFilter = 0;
-  readWithFilter(scanSpec, batches, hitRows, timeWithFilter, false);
-  testReadWithFilterLazy(scanSpec, batches, hitRows);
+  readWithFilter(scanSpec, mutations, batches, hitRows, timeWithFilter, false);
+  testReadWithFilterLazy(scanSpec, mutations, batches, hitRows);
 }
 
 void E2EFilterTestBase::testScenario(
@@ -613,6 +644,105 @@ void E2EFilterTestBase::testSubfieldsPruning() {
       ++ii;
     }
   }
+}
+
+void E2EFilterTestBase::testMutationCornerCases() {
+  test::VectorMaker vectorMaker(leafPool_.get());
+  flushEveryNBatches_ = 1;
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 10; ++i) {
+    auto a = vectorMaker.flatVector<int64_t>(
+        100, [&](auto j) { return 100 * i + j; });
+    batches.push_back(vectorMaker.rowVector({"a"}, {a}));
+  }
+  auto& rowType = batches[0]->type();
+  writeToMemory(rowType, batches, false);
+  ReaderOptions readerOpts{leafPool_.get()};
+  std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
+  auto reader = makeReader(readerOpts, std::move(input));
+
+  // 1. Interleave batches with and without deletions.
+  // 2. Whole batch deletion.
+  // 3. Delete last a few rows in a batch.
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addAllChildFields(*rowType);
+  RowReaderOptions rowReaderOpts;
+  setUpRowReaderOptions(rowReaderOpts, spec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto result = BaseVector::create(rowType, 0, leafPool_.get());
+  constexpr int kReadBatchSize = 10;
+  auto nwords = bits::nwords(kReadBatchSize);
+  std::vector<uint64_t> allSet(nwords, static_cast<uint64_t>(-1));
+  std::vector<uint64_t> oddSet(nwords, 0xAAAAAAAAAAAAAAAAull);
+  std::vector<uint64_t> noneSet(nwords, 0);
+  int64_t totalScanned = 0;
+  for (int i = 0;; ++i) {
+    auto nextRowNumber = rowReader->nextRowNumber();
+    if (nextRowNumber == RowReader::kAtEnd) {
+      break;
+    }
+    ASSERT_EQ(nextRowNumber, totalScanned);
+    uint64_t size = kReadBatchSize;
+    Mutation mutation;
+    switch (i % 5) {
+      case 0:
+        mutation.deletedRows = allSet.data();
+        break;
+      case 1:
+        mutation.deletedRows = oddSet.data();
+        break;
+      case 2:
+        mutation.deletedRows = noneSet.data();
+        break;
+      case 3:
+        size = kReadBatchSize + 2;
+        break;
+    }
+    auto numScanned = rowReader->next(size, result, &mutation);
+    ASSERT_GT(numScanned, 0);
+    totalScanned += numScanned;
+    auto* a = result->asUnchecked<RowVector>()
+                  ->childAt(0)
+                  ->loadedVector()
+                  ->asFlatVector<int64_t>();
+    if (i % 5 == 0) {
+      ASSERT_EQ(result->size(), 0);
+    } else if (i % 5 == 1) {
+      ASSERT_EQ(2 * result->size(), numScanned);
+      for (int j = 0; j < result->size(); ++j) {
+        ASSERT_EQ(a->valueAtFast(j), nextRowNumber + j * 2);
+      }
+    } else {
+      ASSERT_EQ(result->size(), numScanned);
+      for (int j = 0; j < result->size(); ++j) {
+        ASSERT_EQ(a->valueAtFast(j), nextRowNumber + j);
+      }
+    }
+  }
+  ASSERT_EQ(totalScanned, 1000);
+
+  // No child reader.
+  spec = std::make_shared<common::ScanSpec>("<root>");
+  setUpRowReaderOptions(rowReaderOpts, spec);
+  rowReader = reader->createRowReader(rowReaderOpts);
+  result = BaseVector::create(ROW({}), 0, leafPool_.get());
+  totalScanned = 0;
+  for (;;) {
+    auto nextRowNumber = rowReader->nextRowNumber();
+    if (nextRowNumber == RowReader::kAtEnd) {
+      break;
+    }
+    ASSERT_EQ(nextRowNumber, totalScanned);
+    Mutation mutation;
+    mutation.deletedRows = oddSet.data();
+    auto numScanned = rowReader->next(kReadBatchSize, result, &mutation);
+    ASSERT_GT(numScanned, 0);
+    ASSERT_EQ(2 * result->size(), numScanned);
+    totalScanned += numScanned;
+  }
+  ASSERT_EQ(totalScanned, 1000);
 }
 
 void OwnershipChecker::check(const VectorPtr& batch) {

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -189,6 +189,7 @@ class E2EFilterTestBase : public testing::Test {
 
   void readWithFilter(
       std::shared_ptr<common::ScanSpec> spec,
+      const MutationSpec&,
       const std::vector<RowVectorPtr>& batches,
       const std::vector<uint64_t>& hitRows,
       uint64_t& time,
@@ -256,6 +257,7 @@ class E2EFilterTestBase : public testing::Test {
  private:
   void testReadWithFilterLazy(
       const std::shared_ptr<common::ScanSpec>& spec,
+      const MutationSpec&,
       const std::vector<RowVectorPtr>& batches,
       const std::vector<uint64_t>& hitRows);
 
@@ -283,6 +285,8 @@ class E2EFilterTestBase : public testing::Test {
   void testMetadataFilter();
 
   void testSubfieldsPruning();
+
+  void testMutationCornerCases();
 
   // Allows testing reading with different batch sizes.
   void resetReadBatchSizes() {

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -372,16 +372,22 @@ void FilterGenerator::addToScanSpec(
 SubfieldFilters FilterGenerator::makeSubfieldFilters(
     const std::vector<FilterSpec>& filterSpecs,
     const std::vector<RowVectorPtr>& batches,
+    MutationSpec* mutationSpec,
     std::vector<uint64_t>& hitRows) {
   vector_size_t totalSize = 0;
   for (auto& batch : batches) {
     totalSize += batch->size();
   }
   hitRows.reserve(totalSize);
+  int64_t index = 0;
   for (auto i = 0; i < batches.size(); ++i) {
     auto batch = batches[i];
-    for (auto j = 0; j < batch->size(); ++j) {
-      hitRows.push_back(batchPosition(i, j));
+    for (auto j = 0; j < batch->size(); ++j, ++index) {
+      if (mutationSpec && folly::Random::randDouble01(rng_) < 0.02) {
+        mutationSpec->deletedRows.push_back(index);
+      } else {
+        hitRows.push_back(batchPosition(i, j));
+      }
     }
   }
 

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "velox/common/memory/Memory.h"
+#include "velox/dwio/common/Mutation.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/exception/Exception.h"
 #include "velox/type/Filter.h"
@@ -58,6 +59,10 @@ struct FilterSpec {
   // row groups on min/max.
   bool isForRowGroupSkip{false};
   bool allowNulls_{true};
+};
+
+struct MutationSpec {
+  std::vector<int64_t> deletedRows;
 };
 
 // Encodes a batch number and an index into the batch into an int32_t
@@ -481,6 +486,7 @@ class FilterGenerator {
   SubfieldFilters makeSubfieldFilters(
       const std::vector<FilterSpec>& filterSpecs,
       const std::vector<RowVectorPtr>& batches,
+      MutationSpec*,
       std::vector<uint64_t>& hitRows);
   std::vector<std::string> makeFilterables(uint32_t count, float pct);
   std::vector<FilterSpec> makeRandomSpecs(

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -82,7 +82,10 @@ class DwrfRowReader : public StrideIndexProvider,
   std::optional<size_t> estimatedRowSize() const override;
 
   // Returns number of rows read. Guaranteed to be less then or equal to size.
-  uint64_t next(uint64_t size, VectorPtr& result) override;
+  uint64_t next(
+      uint64_t size,
+      VectorPtr& result,
+      const dwio::common::Mutation* = nullptr) override;
 
   void updateRuntimeStats(
       dwio::common::RuntimeStatistics& stats) const override {
@@ -107,6 +110,10 @@ class DwrfRowReader : public StrideIndexProvider,
   // Creates column reader tree and may start prefetch of frequently read
   // columns.
   void startNextStripe();
+
+  int64_t nextRowNumber() override;
+
+  int64_t nextReadSize(uint64_t size) override;
 
  private:
   // footer
@@ -157,15 +164,17 @@ class DwrfRowReader : public StrideIndexProvider,
     return (lastStripe == 0);
   }
 
-  void setStrideIndex(uint64_t index) {
-    strideIndex_ = index;
-  }
+  void checkSkipStrides(uint64_t strideSize);
 
-  void checkSkipStrides(const StatsContext& context, uint64_t strideSize);
+  void readNext(
+      uint64_t rowsToRead,
+      const dwio::common::Mutation*,
+      VectorPtr& result);
 
-  void readNext(uint64_t rowsToRead, VectorPtr& result);
-
-  void readWithRowNumber(uint64_t rowsToRead, VectorPtr& result);
+  void readWithRowNumber(
+      uint64_t rowsToRead,
+      const dwio::common::Mutation*,
+      VectorPtr& result);
 };
 
 class DwrfReader : public dwio::common::Reader {

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -244,6 +244,7 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       override {
     numReads_ = scanSpec_->newRead();
     prepareRead<char>(offset, rows, incomingNulls);
+    VELOX_DCHECK(!hasMutation());
     auto* mapNulls =
         nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
     for (auto* reader : children_) {

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -299,7 +299,7 @@ TEST_F(E2EFilterTest, listAndMap) {
 
 TEST_F(E2EFilterTest, nullCompactRanges) {
   // Makes a dataset with nulls at the beginning. Tries different
-  // filter ombinations on progressively larger batches. tests for a
+  // filter combinations on progressively larger batches. tests for a
   // bug in null compaction where null bits past end of nulls buffer
   // were compacted while there actually were no nulls.
 
@@ -395,6 +395,10 @@ TEST_F(E2EFilterTest, metadataFilter) {
 
 TEST_F(E2EFilterTest, subfieldsPruning) {
   testSubfieldsPruning();
+}
+
+TEST_F(E2EFilterTest, mutationCornerCases) {
+  testMutationCornerCases();
 }
 
 // Define main so that gflags get processed.

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -155,7 +155,7 @@ class ColumnReaderTestBase {
     if (columnReader_) {
       columnReader_->next(numValues, result);
     } else {
-      selectiveColumnReader_->next(numValues, result);
+      selectiveColumnReader_->next(numValues, result, nullptr);
     }
   }
 
@@ -181,7 +181,7 @@ class ColumnReaderTestBase {
     if (columnReader_) {
       columnReader_->next(readSize, batch);
     } else {
-      selectiveColumnReader_->next(readSize, batch);
+      selectiveColumnReader_->next(readSize, batch, nullptr);
     }
 
     ASSERT_EQ(readSize, batch->size());
@@ -1194,7 +1194,7 @@ TEST_P(StringReaderTests, testStringDictSkipNoNulls) {
     if (columnReader_) {
       columnReader_->next(rowsRead, batch);
     } else {
-      selectiveColumnReader_->next(rowsRead, batch);
+      selectiveColumnReader_->next(rowsRead, batch, nullptr);
     }
 
     ASSERT_EQ(rowsRead, batch->size());

--- a/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
@@ -257,7 +257,13 @@ ParquetRowReader::ParquetRowReader(
       state_, std::move(columnIds), std::move(groups), &filters_);
 }
 
-uint64_t ParquetRowReader::next(uint64_t /*size*/, velox::VectorPtr& result) {
+uint64_t ParquetRowReader::next(
+    uint64_t /*size*/,
+    velox::VectorPtr& result,
+    const dwio::common::Mutation* mutation) {
+  VELOX_CHECK(
+      !mutation || !mutation->deletedRows,
+      "Mutation pushdown is only supported in selective reader");
   ::duckdb::DataChunk output;
   // TODO: We are using the default duckdb allocator which uses Velox's default
   // memory manager, not the one specified in the ReaderOptions.

--- a/velox/dwio/parquet/duckdb_reader/ParquetReader.h
+++ b/velox/dwio/parquet/duckdb_reader/ParquetReader.h
@@ -35,7 +35,18 @@ class ParquetRowReader : public dwio::common::RowReader {
       memory::MemoryPool& pool);
   ~ParquetRowReader() override = default;
 
-  uint64_t next(uint64_t size, velox::VectorPtr& result) override;
+  int64_t nextRowNumber() override {
+    VELOX_NYI();
+  }
+
+  int64_t nextReadSize(uint64_t /*size*/) override {
+    VELOX_NYI();
+  }
+
+  uint64_t next(
+      uint64_t size,
+      velox::VectorPtr& result,
+      const dwio::common::Mutation*) override;
 
   void updateRuntimeStats(
       dwio::common::RuntimeStatistics& stats) const override;

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -138,6 +138,7 @@ class ParquetData : public dwio::common::FormatData {
       reader_->skipNullsOnly(numValues);
     }
     if (presetNulls_) {
+      VELOX_DCHECK_LE(numValues, presetNullsSize_ - presetNullsConsumed_);
       presetNullsConsumed_ += numValues;
     }
     return numValues;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -506,10 +506,10 @@ ParquetRowReader::ParquetRowReader(
       readerBase_(readerBase),
       options_(options),
       rowGroups_(readerBase_->fileMetaData().row_groups),
-      currentRowGroupIdsIdx_(0),
-      currentRowGroupPtr_(&rowGroups_[currentRowGroupIdsIdx_]),
-      rowsInCurrentRowGroup_(currentRowGroupPtr_->num_rows),
-      currentRowInGroup_(rowsInCurrentRowGroup_) {
+      nextRowGroupIdsIdx_(0),
+      currentRowGroupPtr_(nullptr),
+      rowsInCurrentRowGroup_(0),
+      currentRowInGroup_(0) {
   // Validate the requested type is compatible with what's in the file
   std::function<std::string()> createExceptionContext = [&]() {
     std::string exceptionMessageContext = fmt::format(
@@ -547,8 +547,8 @@ struct ParquetStatsContext : dwio::common::StatsContext {};
 } // namespace
 
 void ParquetRowReader::filterRowGroups() {
-  const auto& rowGroups = readerBase_->fileMetaData().row_groups;
-  rowGroupIds_.reserve(rowGroups.size());
+  rowGroupIds_.reserve(rowGroups_.size());
+  firstRowOfRowGroup_.reserve(rowGroups_.size());
 
   ParquetData::FilterRowGroupsResult res;
   columnReader_->filterRowGroups(0, ParquetStatsContext(), res);
@@ -556,7 +556,8 @@ void ParquetRowReader::filterRowGroups() {
     metadataFilter->eval(res.metadataFilterResults, res.filterResult);
   }
 
-  for (auto i = 0; i < rowGroups.size(); i++) {
+  uint64_t rowNumber = 0;
+  for (auto i = 0; i < rowGroups_.size(); i++) {
     VELOX_CHECK_GT(rowGroups_[i].columns.size(), 0);
     auto fileOffset = rowGroups_[i].__isset.file_offset
         ? rowGroups_[i].file_offset
@@ -571,46 +572,58 @@ void ParquetRowReader::filterRowGroups() {
         ++skippedRowGroups_;
       } else {
         rowGroupIds_.push_back(i);
+        firstRowOfRowGroup_.push_back(rowNumber);
       }
     }
+    rowNumber += rowGroups_[i].num_rows;
   }
 }
 
-uint64_t ParquetRowReader::next(uint64_t size, velox::VectorPtr& result) {
+int64_t ParquetRowReader::nextRowNumber() {
+  if (currentRowInGroup_ >= rowsInCurrentRowGroup_ &&
+      !advanceToNextRowGroup()) {
+    return kAtEnd;
+  }
+  return firstRowOfRowGroup_[nextRowGroupIdsIdx_ - 1] + currentRowInGroup_;
+}
+
+int64_t ParquetRowReader::nextReadSize(uint64_t size) {
   VELOX_CHECK_GT(size, 0);
-
-  if (currentRowInGroup_ >= rowsInCurrentRowGroup_) {
-    // attempt to advance to next row group
-    if (!advanceToNextRowGroup()) {
-      return 0;
-    }
+  if (nextRowNumber() == kAtEnd) {
+    return kAtEnd;
   }
+  return std::min(size, rowsInCurrentRowGroup_ - currentRowInGroup_);
+}
 
-  uint64_t rowsToRead = std::min(
-      static_cast<uint64_t>(size), rowsInCurrentRowGroup_ - currentRowInGroup_);
-
-  if (rowsToRead > 0) {
-    columnReader_->next(rowsToRead, result, nullptr);
-    currentRowInGroup_ += rowsToRead;
+uint64_t ParquetRowReader::next(
+    uint64_t size,
+    velox::VectorPtr& result,
+    const dwio::common::Mutation* mutation) {
+  VELOX_DCHECK(!options_.getAppendRowNumberColumn());
+  auto rowsToRead = nextReadSize(size);
+  if (rowsToRead == kAtEnd) {
+    return 0;
   }
-
+  VELOX_DCHECK_GT(rowsToRead, 0);
+  columnReader_->next(rowsToRead, result, mutation);
+  currentRowInGroup_ += rowsToRead;
   return rowsToRead;
 }
 
 bool ParquetRowReader::advanceToNextRowGroup() {
-  if (currentRowGroupIdsIdx_ == rowGroupIds_.size()) {
+  if (nextRowGroupIdsIdx_ == rowGroupIds_.size()) {
     return false;
   }
 
-  auto nextRowGroupIndex = rowGroupIds_[currentRowGroupIdsIdx_];
+  auto nextRowGroupIndex = rowGroupIds_[nextRowGroupIdsIdx_];
   readerBase_->scheduleRowGroups(
       rowGroupIds_,
-      currentRowGroupIdsIdx_,
-      dynamic_cast<StructColumnReader&>(*columnReader_));
-  currentRowGroupPtr_ = &rowGroups_[rowGroupIds_[currentRowGroupIdsIdx_]];
+      nextRowGroupIdsIdx_,
+      static_cast<StructColumnReader&>(*columnReader_));
+  currentRowGroupPtr_ = &rowGroups_[rowGroupIds_[nextRowGroupIdsIdx_]];
   rowsInCurrentRowGroup_ = currentRowGroupPtr_->num_rows;
   currentRowInGroup_ = 0;
-  currentRowGroupIdsIdx_++;
+  nextRowGroupIdsIdx_++;
   columnReader_->seekToRowGroup(nextRowGroupIndex);
   return true;
 }
@@ -626,10 +639,10 @@ void ParquetRowReader::resetFilterCaches() {
 
 std::optional<size_t> ParquetRowReader::estimatedRowSize() const {
   auto index =
-      currentRowGroupIdsIdx_ < 1 ? 0 : rowGroupIds_[currentRowGroupIdsIdx_ - 1];
+      nextRowGroupIdsIdx_ < 1 ? 0 : rowGroupIds_[nextRowGroupIdsIdx_ - 1];
   return readerBase_->rowGroupUncompressedSize(
              index, *readerBase_->schemaWithId()) /
-      rowsInCurrentRowGroup_;
+      rowGroups_[index].num_rows;
 }
 
 ParquetReader::ParquetReader(

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -124,7 +124,14 @@ class ParquetRowReader : public dwio::common::RowReader {
       const dwio::common::RowReaderOptions& options);
   ~ParquetRowReader() override = default;
 
-  uint64_t next(uint64_t size, velox::VectorPtr& result) override;
+  int64_t nextRowNumber() override;
+
+  int64_t nextReadSize(uint64_t size) override;
+
+  uint64_t next(
+      uint64_t size,
+      velox::VectorPtr& result,
+      const dwio::common::Mutation* = nullptr) override;
 
   void updateRuntimeStats(
       dwio::common::RuntimeStatistics& stats) const override;
@@ -160,7 +167,8 @@ class ParquetRowReader : public dwio::common::RowReader {
 
   // Indices of row groups where stats match filters.
   std::vector<uint32_t> rowGroupIds_;
-  uint32_t currentRowGroupIdsIdx_;
+  std::vector<uint64_t> firstRowOfRowGroup_;
+  uint32_t nextRowGroupIdsIdx_;
   const thrift::RowGroup* FOLLY_NULLABLE currentRowGroupPtr_{nullptr};
   uint64_t rowsInCurrentRowGroup_;
   uint64_t currentRowInGroup_;

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -494,6 +494,10 @@ TEST_F(E2EFilterTest, subfieldsPruning) {
   testSubfieldsPruning();
 }
 
+TEST_F(E2EFilterTest, mutationCornerCases) {
+  testMutationCornerCases();
+}
+
 TEST_F(E2EFilterTest, map) {
   // Break up the leaf data in small pages to cover coalescing repdefs.
   writerProperties_ =

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -110,8 +110,8 @@ class ParquetReaderBenchmark {
       std::vector<uint64_t>& hitRows) {
     std::unique_ptr<FilterGenerator> filterGenerator =
         std::make_unique<FilterGenerator>(rowType, 0);
-    auto filters =
-        filterGenerator->makeSubfieldFilters(filterSpecs, batches, hitRows);
+    auto filters = filterGenerator->makeSubfieldFilters(
+        filterSpecs, batches, nullptr, hitRows);
     auto scanSpec = filterGenerator->makeScanSpec(std::move(filters));
     return scanSpec;
   }


### PR DESCRIPTION
Summary:
1. Pass `Mutation` object in `RowReader::next()` interface, and use it inside the reader to do filtering
2. Add `nextRowNumber()` and `nextSize()` to `RowReader`, so that we can generate the bit masks of deletion for each batch, based on multiple streams of row numbers
3. Integrate the new interface in `PrismConnector`

Differential Revision: D45238631

