### PR TITLE
Add result type mismatch handling between DuckDB and Velox

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -127,6 +127,7 @@ TypePtr toVeloxType(LogicalType type) {
       type.GetDecimalProperties(width, scale);
       return DECIMAL(width, scale);
     case LogicalTypeId::HUGEINT:
+      return BIGINT();
     case LogicalTypeId::DOUBLE:
       return DOUBLE();
     case LogicalTypeId::VARCHAR:

--- a/velox/exec/tests/utils/OperatorTestBase.h
+++ b/velox/exec/tests/utils/OperatorTestBase.h
@@ -88,8 +88,14 @@ class OperatorTestBase : public testing::Test,
 
   std::shared_ptr<Task> assertQuery(
       const core::PlanNodePtr& plan,
-      const std::string& duckDbSql) {
-    return test::assertQuery(plan, duckDbSql, duckDbQueryRunner_);
+      const std::string& duckDbSql,
+      const std::optional<bool> enableResultTypeMismatch = std::nullopt) {
+    return test::assertQuery(
+        plan,
+        duckDbSql,
+        duckDbQueryRunner_,
+        std::nullopt,
+        enableResultTypeMismatch);
   }
 
   std::shared_ptr<Task> assertQuery(

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -42,10 +42,18 @@ class DuckDbQueryRunner {
   MaterializedRowMultiset execute(
       const std::string& sql,
       const std::shared_ptr<const RowType>& resultRowType) {
+    return execute(sql, resultRowType, std::nullopt);
+  };
+
+  MaterializedRowMultiset execute(
+      const std::string& sql,
+      const std::shared_ptr<const RowType>& resultRowType,
+      const std::optional<bool> enableResultTypeMismatch) {
     MaterializedRowMultiset allRows;
     execute(
         sql,
         resultRowType,
+        enableResultTypeMismatch,
         [&allRows](std::vector<MaterializedRow>& rows) mutable {
           std::copy(
               rows.begin(), rows.end(), std::inserter(allRows, allRows.end()));
@@ -56,10 +64,18 @@ class DuckDbQueryRunner {
   std::vector<MaterializedRow> executeOrdered(
       const std::string& sql,
       const std::shared_ptr<const RowType>& resultRowType) {
+    return executeOrdered(sql, resultRowType, std::nullopt);
+  };
+
+  std::vector<MaterializedRow> executeOrdered(
+      const std::string& sql,
+      const std::shared_ptr<const RowType>& resultRowType,
+      const std::optional<bool> enableResultTypeMismatch) {
     std::vector<MaterializedRow> allRows;
     execute(
         sql,
         resultRowType,
+        enableResultTypeMismatch,
         [&allRows](std::vector<MaterializedRow>& rows) mutable {
           std::copy(rows.begin(), rows.end(), std::back_inserter(allRows));
         });
@@ -85,6 +101,7 @@ class DuckDbQueryRunner {
   void execute(
       const std::string& sql,
       const std::shared_ptr<const RowType>& resultRowType,
+      const std::optional<bool> enableResultTypeMismatch,
       std::function<void(std::vector<MaterializedRow>&)> resultCallback);
 };
 
@@ -131,21 +148,24 @@ std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,
-    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
+    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt,
+    const std::optional<bool> enableResultTypeMismatch = std::nullopt);
 
 std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,
     std::function<void(exec::Task*)> addSplits,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,
-    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
+    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt,
+    const std::optional<bool> enableResultTypeMismatch = std::nullopt);
 
 std::shared_ptr<Task> assertQuery(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,
-    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt);
+    std::optional<std::vector<uint32_t>> sortingKeys = std::nullopt,
+    const std::optional<bool> enableResultTypeMismatch = std::nullopt);
 
 std::shared_ptr<Task> assertQueryReturnsEmptyResult(
     const core::PlanNodePtr& plan);
@@ -156,14 +176,16 @@ void assertResults(
     const std::vector<RowVectorPtr>& results,
     const std::shared_ptr<const RowType>& resultType,
     const std::string& duckDbSql,
-    DuckDbQueryRunner& duckDbQueryRunner);
+    DuckDbQueryRunner& duckDbQueryRunner,
+    const std::optional<bool> enableResultTypeMismatch = std::nullopt);
 
 void assertResultsOrdered(
     const std::vector<RowVectorPtr>& results,
     const std::shared_ptr<const RowType>& resultType,
     const std::string& duckDbSql,
     DuckDbQueryRunner& duckDbQueryRunner,
-    const std::vector<uint32_t>& sortingKeys);
+    const std::vector<uint32_t>& sortingKeys,
+    const std::optional<bool> enableResultTypeMismatch = std::nullopt);
 
 std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,


### PR DESCRIPTION
Follow-up for https://github.com/facebookincubator/velox/pull/4388.

This PR fixes an issue of result type mismatch in DuckDB. Currently there are three instances of such mismatch:
- DuckDB `Hugeint` cannot be reconciled with Velox `Bigint` type. Actually this is somewhat works because there is currently no compatibility check. Example: `sum(Bigint)` which returns `Hugeint` in DuckDB.
- Decimal division returns Double in DuckDB but Decimal in Velox.
- Decimal average returns Double in DuckDB but Decimal in Velox, example: `avg(decimal)`.

I have updated `materialize` method that converts DuckDB values to Velox to also check the type mismatch and introduce a code branch to handle such mismatch which currently only includes Double/Decimal combination, more could be added in the future.

The behaviour is controlled by `enableResultTypeMismatch` parameter which is set to `false` by default. This will be set in TPC-H tests when they are switched to using Decimal types.
