### PR TITLE
Fix NOT handling in metadata filter

### DIFF
--- a/velox/dwio/common/MetadataFilter.h
+++ b/velox/dwio/common/MetadataFilter.h
@@ -45,7 +45,6 @@ class MetadataFilter {
   class Node;
   class AndNode;
   class OrNode;
-  class NotNode;
 
   std::shared_ptr<Node> root_;
 };

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -380,6 +380,7 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
 /// execution.
 std::unique_ptr<common::Filter> leafCallToSubfieldFilter(
     const core::CallTypedExpr&,
-    common::Subfield&);
+    common::Subfield&,
+    bool negated = false);
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -193,8 +193,7 @@ TEST_F(ExprToSubfieldFilterTest, isNull) {
 
 TEST_F(ExprToSubfieldFilterTest, isNotNull) {
   auto call = parseCallExpr("a is not null", ROW({{"a", BIGINT()}}));
-  Subfield subfield;
-  auto filter = leafCallToSubfieldFilter(*call, subfield);
+  auto [subfield, filter] = toSubfieldFilter(call);
   ASSERT_TRUE(filter);
   validateSubfield(subfield, {"a"});
   ASSERT_TRUE(filter->testInt64(0));


### PR DESCRIPTION
Summary:
If a condition is evaluated to true for a row group, it means there are
some rows in the group that can pass the condition.  Negating the condition
should mean whether there are some rows that does not pass the condition.  When
some rows pass the condition and some others not in the group, we can not simply
negate the result for a inner node.  We must push the NOT down to leaf node and
combine it with leaf filter in this case.

Fix https://github.com/facebookincubator/velox/issues/4749

Differential Revision: D45324976

