### PR TITLE
Eagerly report completed split groups.

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -682,6 +682,10 @@ class Task : public std::enable_shared_from_this<Task> {
   /// returns true if task should transition to kFinished state.
   bool checkNoMoreSplitGroupsLocked();
 
+  /// Returns true when we had 'no more splits for split group' message for all
+  /// leaf nodes expecting splits in grouped execution mode.
+  bool isNoMoreSplitsForSplitGroupLocked(int32_t splitGroupId);
+
   /// Notifies listeners that the task is now complete.
   void onTaskCompletion();
 

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -57,6 +57,9 @@ struct SplitsState {
   /// Plan node-wide 'no more splits'.
   bool noMoreSplits{false};
 
+  /// Does this plan node run in grouped execution mode.
+  bool isGroupedExecution{false};
+
   /// Keep the max added split's sequence id to deduplicate incoming splits.
   long maxSequenceId{std::numeric_limits<long>::min()};
 


### PR DESCRIPTION
Summary:
We have found that during split execution with 1 concurrent
group (frequent setting) we have 5 seconds spent on a single split
group processing.
This is due to message roundtrip:
1. Splits come for group A
2. Drivers are created for group A and start running
3. "No more splits for group A" message comes (can be on step 1).
4. ALL drivers finished -> We mark split group A as finished.
5. Coordinator polls us and we send "split group A finished" info to it.
6. Splits come for group B
7. And so on.

The change here is to report a completed split group as soon as
we have received all splits for it.
Spits for queued split groups are simply waiting for their turn to be run.
The change does not affect what splits groups the worker get - there is
no competition between workers for split groups.
The result is the execution time reduction from 3 minutes to 25 seconds
on 60 worker cluster.

Differential Revision: D45360901

