### PR TITLE
Parquet RowReader options_ is not a reference

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -297,7 +297,7 @@ class DwrfReader : public dwio::common::Reader {
 
  private:
   std::shared_ptr<ReaderBase> readerBase_;
-  const dwio::common::ReaderOptions& options_;
+  const dwio::common::ReaderOptions options_;
 
   friend class E2EEncryptionTest;
 };

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -102,7 +102,8 @@ class ReaderBase {
   memory::MemoryPool& pool_;
   const uint64_t directorySizeGuess_;
   const uint64_t filePreloadThreshold_;
-  const dwio::common::ReaderOptions& options_;
+  // Copy of options. Must be owned by 'this'.
+  const dwio::common::ReaderOptions options_;
   std::unique_ptr<velox::dwio::common::BufferedInput> input_;
   uint64_t fileLength_;
   std::unique_ptr<thrift::FileMetaData> fileMetaData_;
@@ -160,7 +161,7 @@ class ParquetRowReader : public dwio::common::RowReader {
 
   memory::MemoryPool& pool_;
   const std::shared_ptr<ReaderBase> readerBase_;
-  const dwio::common::RowReaderOptions& options_;
+  const dwio::common::RowReaderOptions options_;
 
   // All row groups from file metadata.
   const std::vector<thrift::RowGroup>& rowGroups_;


### PR DESCRIPTION
Readers/RowReaders must own their 'options_'

A Reader/RowReader reader  must own its Reader/RowReaderOptions.
Parquet Reader and RowReader and the DWRF RowReader were erroneously holding a reference to Options owned by the containing DataSource.

The reference will point to freed memory in the event of async inited
RowReader being used on a different DataSource. A Reader and RowReader
must be movable between DataSources, as is done in
setFromDataSource().

The error is demonstrated by e.g. velox_tpch_benchmark. The error has
previously not surfaced because after initialization the options were
typically not accessed. With the addition of mutability there are
checks that start failing.



