### PR TITLE
Do not add info on empty Memory Pools into the memory message.

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -116,6 +116,10 @@ void capExceedingMessageVisitor(
     MemoryUsageHeap& topLeafMemUsages,
     std::stringstream& out) {
   const MemoryPool::Stats stats = pool->stats();
+  // Avoid logging empty pools.
+  if (stats.empty()) {
+    return;
+  }
   const MemoryUsage usage{
       .name = pool->name(),
       .currentUsage = stats.currentBytes,

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -397,6 +397,13 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     bool operator==(const Stats& rhs) const;
 
     std::string toString() const;
+
+    /// Returns true if the current bytes is zero.
+    /// Note that peak or cumulative bytes might be non-zero and we are still
+    /// empty at this moment.
+    bool empty() const {
+      return currentBytes == 0;
+    }
   };
 
   /// Returns the stats of this memory pool.

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -522,7 +522,7 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
         ASSERT_EQ(
-            "\nExceeded memory cap of 127.00MB when requesting 128.00MB\nMemoryCapExceptions usage 0B peak 0B\n    static_quota usage 0B peak 0B\n\nTop 1 leaf memory pool usages:\n    static_quota usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
+            "\nExceeded memory cap of 127.00MB when requesting 128.00MB\nMemoryCapExceptions usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
             ex.message());
       }
     }

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -74,8 +74,8 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
   std::move(state->future_)
       .via(&exec)
       .thenValue([state](auto&& /* unused */) {
-        auto driver = state->driver_;
-        auto task = driver->task();
+        auto& driver = state->driver_;
+        auto& task = driver->task();
 
         std::lock_guard<std::mutex> l(task->mutex());
         if (!driver->state().isTerminated) {
@@ -93,9 +93,9 @@ void BlockingState::setResume(std::shared_ptr<BlockingState> state) {
       })
       .thenError(
           folly::tag_t<std::exception>{}, [state](std::exception const& e) {
-            LOG(ERROR)
-                << "A ContinueFuture should not be realized with an error"
-                << e.what();
+            LOG(ERROR) << "A ContinueFuture for task "
+                       << state->driver_->task()->taskId()
+                       << " should not be realized with an error: " << e.what();
             state->driver_->setError(std::make_exception_ptr(e));
           });
 }

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -39,6 +39,10 @@ std::string taskStateString(TaskState state);
 struct BarrierState {
   int32_t numRequested;
   std::vector<std::shared_ptr<Driver>> drivers;
+  /// Promises given to non-last peer drivers that the last driver will collect
+  /// all hashtables from the peers and assembles them into one (HashBuilder
+  /// operator does that). After the last drier done its work, the promises are
+  /// fulfilled and the non-last drivers can continue.
   std::vector<ContinuePromise> promises;
 };
 

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -36,17 +36,11 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
   // why).
   std::array<std::string, 14> expectedTexts = {
       "Exceeded memory cap of 5.00MB when requesting 2.00MB",
-      "node.0 usage 0B peak 0B",
-      "op.0.0.0.Values usage 0B peak 0B",
       "node.1 usage 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
       "node.2 usage 4.00MB peak 4.00MB",
       "op.2.0.0.Aggregation usage 3.77MB peak 3.77MB",
-      "node.3 usage 0B peak 0B",
-      "op.3.0.0.OrderBy usage 0B peak 0B",
-      "node.N/A usage 0B peak 0B",
-      "op.N/A.0.0.CallbackSink usage 0B peak 0B",
-      "Top 5 leaf memory pool usages:",
+      "Top 2 leaf memory pool usages:",
       "Failed memory pool: op.2.0.0.Aggregation: 3.77MB"};
 
   std::vector<RowVectorPtr> data;
@@ -107,21 +101,18 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
     data.push_back(rowVector);
   }
 
-  std::array<std::string, 28> expectedTexts = {
-      "op.N/A.0.8.CallbackSink usage", "op.N/A.0.7.CallbackSink usage",
-      "op.N/A.0.6.CallbackSink usage", "op.N/A.0.5.CallbackSink usage",
-      "op.N/A.0.4.CallbackSink usage", "op.N/A.0.3.CallbackSink usage",
-      "op.N/A.0.2.CallbackSink usage", "op.N/A.0.1.CallbackSink usage",
-      "op.N/A.0.0.CallbackSink usage", "op.1.0.9.Aggregation usage",
-      "op.1.0.8.Aggregation usage",    "op.1.0.7.Aggregation usage",
-      "op.1.0.6.Aggregation usage",    "op.1.0.5.Aggregation usage",
-      "op.1.0.4.Aggregation usage",    "op.1.0.3.Aggregation usage",
-      "op.1.0.2.Aggregation usage",    "op.1.0.1.Aggregation usage",
-      "op.0.0.9.Values usage",         "op.0.0.8.Values usage",
-      "op.0.0.7.Values usage",         "op.0.0.6.Values usage",
-      "op.0.0.5.Values usage",         "op.0.0.4.Values usage",
-      "op.0.0.3.Values usage",         "op.0.0.2.Values usage",
-      "op.0.0.1.Values usage"};
+  std::array<std::string, 10> expectedTexts = {
+      "op.1.0.9.Aggregation usage",
+      "op.1.0.8.Aggregation usage",
+      "op.1.0.7.Aggregation usage",
+      "op.1.0.6.Aggregation usage",
+      "op.1.0.5.Aggregation usage",
+      "op.1.0.4.Aggregation usage",
+      "op.1.0.3.Aggregation usage",
+      "op.1.0.2.Aggregation usage",
+      "op.1.0.1.Aggregation usage",
+      "op.1.0.0.Aggregation usage",
+  };
 
   auto plan = PlanBuilder()
                   .values(data, true)


### PR DESCRIPTION
Do not add info on empty Memory Pools into the memory message.
Avoid copying shared pointers in BlockingState::setResume()