### PR TITLE
Fix SparkSql function might_contain cannot throw exception correctly

### DIFF
--- a/velox/functions/sparksql/MightContain.cpp
+++ b/velox/functions/sparksql/MightContain.cpp
@@ -37,9 +37,9 @@ class BloomFilterMightContainFunction final : public exec::VectorFunction {
     auto value = decodedArgs.at(1);
 
     HashStringAllocator allocator{context.pool()};
-    VELOX_USER_CHECK(serialized->isConstantMapping())
     BloomFilter output{StlAllocator<uint64_t>(&allocator)};
     try {
+      VELOX_USER_CHECK(serialized->isConstantMapping())
       auto sv = serialized->valueAt<StringView>(0);
       output.merge(sv.data());
     } catch (const std::exception& e) {


### PR DESCRIPTION
The exception which throws in `apply` function should be trapped in try block, otherwise it cannot treat the exception well.

Resolves: https://github.com/facebookincubator/velox/issues/4758#issuecomment-1526817945