### PR TITLE
Start prefetch and coalesce of large colunnbs earlier

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -297,7 +297,7 @@ class DwrfReader : public dwio::common::Reader {
 
  private:
   std::shared_ptr<ReaderBase> readerBase_;
-  const dwio::common::ReaderOptions& options_;
+  const dwio::common::ReaderOptions options_;
 
   friend class E2EEncryptionTest;
 };

--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -102,7 +102,8 @@ class ReaderBase {
   memory::MemoryPool& pool_;
   const uint64_t directorySizeGuess_;
   const uint64_t filePreloadThreshold_;
-  const dwio::common::ReaderOptions& options_;
+  // Copy of options. Must be owned by 'this'.
+  const dwio::common::ReaderOptions options_;
   std::unique_ptr<velox::dwio::common::BufferedInput> input_;
   uint64_t fileLength_;
   std::unique_ptr<thrift::FileMetaData> fileMetaData_;
@@ -160,7 +161,7 @@ class ParquetRowReader : public dwio::common::RowReader {
 
   memory::MemoryPool& pool_;
   const std::shared_ptr<ReaderBase> readerBase_;
-  const dwio::common::RowReaderOptions& options_;
+  const dwio::common::RowReaderOptions options_;
 
   // All row groups from file metadata.
   const std::vector<thrift::RowGroup>& rowGroups_;


### PR DESCRIPTION
A column spanning multiple load quanta is coalescable to surrounding columns if it qualifies for prefetch. Like this, the cache entries of all the quanta are filled from one IO.

The test for prefetch compares references to reads. However the current CachedBufferedInput has recorded the reference but not the read since the read is only future. So, a fully read large column comes out wiht a read density of 50% on the second time unless the reference added by the current load is subtracted.

With multiple threads the references will still outpace the reads for the first few row groups, e.g. The column has been referenced 30 times for 15 reads with 15 reading threads. On the third row group there will be 45 references and 30 reads.

Therefore we also drop the minimum read density (% of referenced data that is accessed) to 60 from 80.