### PR TITLE
Remove "spiller-spill-path" query config property.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -127,9 +127,6 @@ class QueryConfig {
   /// Global enable spilling flag.
   static constexpr const char* kSpillEnabled = "spill_enabled";
 
-  /// Spill path. "/tmp" by default.
-  static constexpr const char* kSpillPath = "spiller-spill-path";
-
   /// Aggregation spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kAggregationSpillEnabled =
       "aggregation_spill_enabled";
@@ -303,17 +300,6 @@ class QueryConfig {
   /// Returns true if spilling is enabled.
   bool spillEnabled() const {
     return get<bool>(kSpillEnabled, false);
-  }
-
-  /// Returns the path for writing spill files. The path should be
-  /// interpretable by filesystems::getFileSystem and may refer to any writable
-  /// location. Actual file names are composed by appending '/' and a filename
-  /// composed of Task id and serial numbers. The files are automatically
-  /// deleted when no longer needed. Files may be left behind after crashes but
-  /// are identifiable based on the Task id in the name.
-  /// TODO(spershin): This method and kSpillPath will be removed.
-  std::optional<std::string> spillPath() const {
-    return get<std::string>(kSpillPath);
   }
 
   /// Returns 'is aggregation spilling enabled' flag. Must also check the

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -70,10 +70,6 @@ Spilling
      - boolean
      - false
      - Spill memory to disk to avoid exceeding memory limits for the query.
-   * - spiller-spill-path
-     - string
-     - /tmp
-     - Directory where spilled content is written.
    * - aggregation_spill_enabled
      - boolean
      - false

--- a/velox/docs/develop/spilling.rst
+++ b/velox/docs/develop/spilling.rst
@@ -277,11 +277,6 @@ For storage systems that support time to live (TTL), we can leverage that
 feature to implement the spill file garbage collection. If not, we might need
 to build a lightweight garbage collection (GC) service running out of band.
 
-Configuration property :doc:`spiller-spill-path <../configs>` sets the base path for spilling. It
-can be a directory path on the underlying storage system to store all the
-generated spill files. The spill file name is built by concatenating query task
-id, driver id, and the operator id together which is unique within a query.
-
 .. code-block:: c++
 
   std::string makeOperatorSpillPath(


### PR DESCRIPTION
Summary: It is not being used and had a TODO.

Differential Revision: D45410363

