### PR TITLE
Memory related code improvement and refactor

### DIFF
--- a/velox/buffer/Buffer.h
+++ b/velox/buffer/Buffer.h
@@ -321,7 +321,7 @@ class AlignedBuffer : public Buffer {
       const std::optional<T>& initValue = std::nullopt) {
     size_t size = checkedMultiply(numElements, sizeof(T));
     size_t preferredSize =
-        pool->getPreferredSize(checkedPlus<size_t>(size, kPaddedSize));
+        pool->preferredSize(checkedPlus<size_t>(size, kPaddedSize));
     void* memory = pool->allocate(preferredSize);
     auto* buffer = new (memory) ImplClass<T>(pool, preferredSize - kPaddedSize);
     // set size explicitly instead of setSize because `fillNewMemory` already
@@ -386,7 +386,7 @@ class AlignedBuffer : public Buffer {
     }
     auto oldCapacity = checkedPlus<size_t>(old->capacity(), kPaddedSize);
     auto preferredSize =
-        pool->getPreferredSize(checkedPlus<size_t>(size, kPaddedSize));
+        pool->preferredSize(checkedPlus<size_t>(size, kPaddedSize));
     // Make the buffer no longer owned by '*buffer' because reallocate
     // may free the old buffer. Reassigning the new buffer to
     // '*buffer' would be a double free.

--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -74,8 +74,7 @@ TEST_F(BufferTest, testAlignedBuffer) {
         testStringLength);
     buffer->setIsMutable(false);
     other = buffer;
-    EXPECT_EQ(
-        pool_->getCurrentBytes(), pool_->getPreferredSize(sizeWithHeader));
+    EXPECT_EQ(pool_->currentBytes(), pool_->preferredSize(sizeWithHeader));
     EXPECT_THROW(other->setIsMutable(true), VeloxException);
     AlignedBuffer::reallocate<char>(&other, size * 3, 'e');
     EXPECT_NE(other, buffer);
@@ -91,19 +90,18 @@ TEST_F(BufferTest, testAlignedBuffer) {
         0);
     EXPECT_EQ(other->as<char>()[buffer->capacity()], 'e');
     EXPECT_EQ(
-        pool_->getCurrentBytes(),
-        pool_->getPreferredSize(sizeWithHeader) +
-            pool_->getPreferredSize(3 * size + kHeaderSize));
+        pool_->currentBytes(),
+        pool_->preferredSize(sizeWithHeader) +
+            pool_->preferredSize(3 * size + kHeaderSize));
   }
   EXPECT_EQ(
-      pool_->getCurrentBytes(),
-      pool_->getPreferredSize(3 * size + kHeaderSize));
+      pool_->currentBytes(), pool_->preferredSize(3 * size + kHeaderSize));
   other = nullptr;
   BufferPtr bits = AlignedBuffer::allocate<bool>(65, pool_.get(), true);
   EXPECT_EQ(bits->size(), 9);
   EXPECT_EQ(bits->as<uint8_t>()[8], 0xff);
   bits = nullptr;
-  EXPECT_EQ(pool_->getCurrentBytes(), 0);
+  EXPECT_EQ(pool_->currentBytes(), 0);
 }
 
 TEST_F(BufferTest, testAsRange) {
@@ -186,7 +184,7 @@ TEST_F(BufferTest, testReallocate) {
     }
   }
   buffers.clear();
-  EXPECT_EQ(pool_->getCurrentBytes(), 0);
+  EXPECT_EQ(pool_->currentBytes(), 0);
   EXPECT_GT(numInPlace, 0);
   EXPECT_GT(numMoved, 0);
 }
@@ -337,9 +335,9 @@ TEST_F(BufferTest, testNonPOD) {
 
 TEST_F(BufferTest, testNonPODMemoryUsage) {
   using T = std::shared_ptr<void>;
-  const int64_t currentBytes = pool_->getCurrentBytes();
+  const int64_t currentBytes = pool_->currentBytes();
   { auto buffer = AlignedBuffer::allocate<T>(0, pool_.get()); }
-  EXPECT_EQ(pool_->getCurrentBytes(), currentBytes);
+  EXPECT_EQ(pool_->currentBytes(), currentBytes);
 }
 
 TEST_F(BufferTest, testAllocateSizeOverflow) {

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -76,7 +76,7 @@ char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
 void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
   ++currentRun_;
   if (currentRun_ >= allocation_.numRuns()) {
-    if (allocation_.numRuns()) {
+    if (allocation_.numRuns() > 0) {
       allocations_.push_back(
           std::make_unique<memory::Allocation>(std::move(allocation_)));
     }
@@ -88,10 +88,7 @@ void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
 }
 
 void AllocationPool::newRun(int32_t preferredSize) {
-  auto numPages =
-      bits::roundUp(preferredSize, memory::AllocationTraits::kPageSize) /
-      memory::AllocationTraits::kPageSize;
-  newRunImpl(numPages);
+  newRunImpl(memory::AllocationTraits::numPages(preferredSize));
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -93,7 +93,7 @@ class AllocationPool {
 
   // Returns pointer to first unallocated byte in the current run.
   char* firstFreeInRun() {
-    VELOX_DCHECK(availableInRun() > 0);
+    VELOX_DCHECK_GT(availableInRun(), 0);
     return currentRun().data<char>() + currentOffset_;
   }
 

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -331,7 +331,7 @@ void MemoryPool::dropChild(const MemoryPool* child) {
       toString());
 }
 
-size_t MemoryPool::getPreferredSize(size_t size) {
+size_t MemoryPool::preferredSize(size_t size) {
   if (size < 8) {
     return 8;
   }
@@ -389,7 +389,7 @@ MemoryPoolImpl::MemoryPoolImpl(
     const Options& options)
     : MemoryPool{name, kind, parent, options},
       manager_{memoryManager},
-      allocator_{&manager_->getAllocator()},
+      allocator_{&manager_->allocator()},
       destructionCb_(std::move(destructionCb)),
       capacity_(parent_ == nullptr ? options.capacity : kMaxMemory) {
   VELOX_CHECK(options.threadSafe || isLeaf());
@@ -621,7 +621,7 @@ void MemoryPoolImpl::reserve(uint64_t size, bool reserveOnly) {
     // is low-pri because we can only have inflated aggregates, and be on the
     // more conservative side.
     release(size);
-    VELOX_MEM_MANAGER_CAP_EXCEEDED(manager_->getMemoryQuota());
+    VELOX_MEM_MANAGER_CAP_EXCEEDED(manager_->capacity());
   }
 }
 
@@ -822,7 +822,7 @@ std::string MemoryPoolImpl::capExceedingMessage(
   }
 
   out << "\nFailed memory pool: " << requestor->name() << ": "
-      << succinctBytes(requestor->getCurrentBytes()) << "\n";
+      << succinctBytes(requestor->currentBytes()) << "\n";
   return out.str();
 }
 

--- a/velox/common/memory/MmapArena.h
+++ b/velox/common/memory/MmapArena.h
@@ -39,9 +39,9 @@ class MmapArena {
   MmapArena(size_t capacityBytes);
   ~MmapArena();
 
-  void* FOLLY_NULLABLE allocate(uint64_t bytes);
-  void free(void* FOLLY_NONNULL address, uint64_t bytes);
-  void* FOLLY_NONNULL address() const {
+  void* allocate(uint64_t bytes);
+  void free(void* address, uint64_t bytes);
+  void* address() const {
     return reinterpret_cast<void*>(address_);
   }
 
@@ -85,6 +85,8 @@ class MmapArena {
     return lookupStr.str();
   }
 
+  std::string toString() const;
+
  private:
   // Rounds up size to the next power of 2.
   static uint64_t roundBytes(uint64_t bytes);
@@ -99,11 +101,11 @@ class MmapArena {
 
   void removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& itr);
 
-  // Total capacity size of this arena
+  // Total capacity size of this arena.
   const uint64_t byteSize_;
 
-  // Starting address of this arena
-  uint8_t* FOLLY_NONNULL address_;
+  // Starting address of this arena.
+  uint8_t* address_;
 
   std::atomic<uint64_t> freeBytes_;
 
@@ -123,24 +125,24 @@ class ManagedMmapArenas {
  public:
   ManagedMmapArenas(uint64_t singleArenaCapacity);
 
-  void* FOLLY_NULLABLE allocate(uint64_t bytes);
+  void* allocate(uint64_t bytes);
 
-  void free(void* FOLLY_NONNULL address, uint64_t bytes);
+  void free(void* address, uint64_t bytes);
 
   const std::map<uint64_t, std::shared_ptr<MmapArena>>& arenas() const {
     return arenas_;
   }
 
  private:
-  /// A sorted list of MmapArena by its initial address
+  // Capacity in bytes for a single MmapArena managed by this.
+  const uint64_t singleArenaCapacity_;
+
+  // A sorted list of MmapArena by its initial address
   std::map<uint64_t, std::shared_ptr<MmapArena>> arenas_;
 
-  /// All allocations should come from this MmapArena. When it is no longer able
-  /// to handle allocations it will be updated to a newly created MmapArena.
+  // All allocations should come from this MmapArena. When it is no longer able
+  // to handle allocations it will be updated to a newly created MmapArena.
   std::shared_ptr<MmapArena> currentArena_;
-
-  /// Capacity in bytes for a single MmapArena managed by this.
-  const uint64_t singleArenaCapacity_;
 };
 
 } // namespace facebook::velox::memory

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -39,30 +39,30 @@ TEST(MemoryManagerTest, Ctor) {
   {
     MemoryManager manager{};
     ASSERT_EQ(manager.numPools(), 0);
-    ASSERT_EQ(manager.getMemoryQuota(), kMaxMemory);
+    ASSERT_EQ(manager.capacity(), kMaxMemory);
     ASSERT_EQ(0, manager.getTotalBytes());
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMaxAlignment);
-    ASSERT_EQ(manager.testingDefaultRoot().getAlignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().getAlignment(), manager.alignment());
+    ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
+    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
     ASSERT_EQ(manager.arbitrator(), nullptr);
   }
   {
     MemoryManager manager{{.capacity = 8L * 1024 * 1024}};
-    ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
+    ASSERT_EQ(8L * 1024 * 1024, manager.capacity());
     ASSERT_EQ(manager.numPools(), 0);
     ASSERT_EQ(0, manager.getTotalBytes());
-    ASSERT_EQ(manager.testingDefaultRoot().getAlignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().getAlignment(), manager.alignment());
+    ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
+    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
   }
   {
     MemoryManager manager{{.alignment = 0, .capacity = 8L * 1024 * 1024}};
 
     ASSERT_EQ(manager.alignment(), MemoryAllocator::kMinAlignment);
-    ASSERT_EQ(manager.testingDefaultRoot().getAlignment(), manager.alignment());
-    ASSERT_EQ(manager.deprecatedLeafPool().getAlignment(), manager.alignment());
+    ASSERT_EQ(manager.testingDefaultRoot().alignment(), manager.alignment());
+    ASSERT_EQ(manager.deprecatedLeafPool().alignment(), manager.alignment());
     // TODO: replace with root pool memory tracker quota check.
     ASSERT_EQ(1, manager.testingDefaultRoot().getChildCount());
-    ASSERT_EQ(8L * 1024 * 1024, manager.getMemoryQuota());
+    ASSERT_EQ(8L * 1024 * 1024, manager.capacity());
     ASSERT_EQ(0, manager.getTotalBytes());
   }
   { ASSERT_ANY_THROW(MemoryManager manager{{.capacity = -1}}); }
@@ -111,10 +111,10 @@ TEST(MemoryManagerTest, defaultMemoryManager) {
   ASSERT_EQ(managerB.numPools(), 3);
   ASSERT_EQ(
       managerA.toString(),
-      "Memory Manager[limit 8388608.00TB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__default_root__\n\tdefault_root_0\n]");
+      "Memory Manager[capacity 8388608.00TB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__default_root__\n\tdefault_root_0\n]");
   ASSERT_EQ(
       managerB.toString(),
-      "Memory Manager[limit 8388608.00TB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__default_root__\n\tdefault_root_0\n]");
+      "Memory Manager[capacity 8388608.00TB alignment 64B usedBytes 0B number of pools 3\nList of root pools:\n\t__default_root__\n\tdefault_root_0\n]");
   child1.reset();
   EXPECT_EQ(2, managerA.testingDefaultRoot().getChildCount());
   child2.reset();
@@ -126,10 +126,10 @@ TEST(MemoryManagerTest, defaultMemoryManager) {
   ASSERT_EQ(managerB.numPools(), 0);
   ASSERT_EQ(
       managerA.toString(),
-      "Memory Manager[limit 8388608.00TB alignment 64B usedBytes 0B number of pools 0\nList of root pools:\n\t__default_root__\n]");
+      "Memory Manager[capacity 8388608.00TB alignment 64B usedBytes 0B number of pools 0\nList of root pools:\n\t__default_root__\n]");
   ASSERT_EQ(
       managerB.toString(),
-      "Memory Manager[limit 8388608.00TB alignment 64B usedBytes 0B number of pools 0\nList of root pools:\n\t__default_root__\n]");
+      "Memory Manager[capacity 8388608.00TB alignment 64B usedBytes 0B number of pools 0\nList of root pools:\n\t__default_root__\n]");
 }
 
 TEST(MemoryHeaderTest, addDefaultLeafMemoryPool) {
@@ -306,7 +306,7 @@ TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
       velox::VeloxUserError);
 
   auto& coercedManager = MemoryManager::getInstance({.capacity = 42});
-  ASSERT_EQ(manager.getMemoryQuota(), coercedManager.getMemoryQuota());
+  ASSERT_EQ(manager.capacity(), coercedManager.capacity());
 }
 
 TEST(MemoryManagerTest, alignmentOptionCheck) {
@@ -341,18 +341,18 @@ TEST(MemoryManagerTest, alignmentOptionCheck) {
         manager.alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     ASSERT_EQ(
-        manager.testingDefaultRoot().getAlignment(),
+        manager.testingDefaultRoot().alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     ASSERT_EQ(
-        manager.deprecatedLeafPool().getAlignment(),
+        manager.deprecatedLeafPool().alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     auto leafPool = manager.addLeafPool("leafPool");
     ASSERT_EQ(
-        leafPool->getAlignment(),
+        leafPool->alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
     auto rootPool = manager.addRootPool("rootPool");
     ASSERT_EQ(
-        rootPool->getAlignment(),
+        rootPool->alignment(),
         std::max(testData.alignment, MemoryAllocator::kMinAlignment));
   }
 }

--- a/velox/dwio/common/tests/DataBufferTests.cpp
+++ b/velox/dwio/common/tests/DataBufferTests.cpp
@@ -162,15 +162,15 @@ TEST(DataBuffer, Move) {
     }
     ASSERT_EQ(15, buffer.size());
     ASSERT_EQ(16, buffer.capacity());
-    const auto usedBytes = pool->getCurrentBytes();
+    const auto usedBytes = pool->currentBytes();
 
     // Expect no double freeing from memory pool.
     DataBuffer<uint8_t> newBuffer{std::move(buffer)};
     ASSERT_EQ(15, newBuffer.size());
     ASSERT_EQ(16, newBuffer.capacity());
-    ASSERT_EQ(usedBytes, pool->getCurrentBytes());
+    ASSERT_EQ(usedBytes, pool->currentBytes());
   }
-  ASSERT_EQ(0, pool->getCurrentBytes());
+  ASSERT_EQ(0, pool->currentBytes());
 }
 } // namespace common
 } // namespace dwio

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -141,7 +141,6 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
     EXPECT_EQ(2500, intDictEncoder.getTotalCount());
     EXPECT_EQ(1, intDictEncoder.refCount_);
     EXPECT_EQ(0, intDictEncoder.clearCount_);
-    // auto peakMemory = pool.getCurrentBytes();
     intDictEncoder.clear();
     EXPECT_EQ(0, intDictEncoder.size());
     EXPECT_EQ(0, intDictEncoder.keyIndex_.size());
@@ -157,7 +156,7 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
     // down. On test experiment it deallocated 4K and rellocated 64K.
     // When not compiled with ASAN, it correctly frees up the memory.
     // so disabling this check in the test for now.
-    // EXPECT_LT(pool.getCurrentBytes(), peakMemory);
+    // EXPECT_LT(pool.currentBytes(), peakMemory);
   }
   {
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
@@ -177,7 +176,6 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
     EXPECT_EQ(4, intDictEncoder.refCount_);
     EXPECT_EQ(0, intDictEncoder.clearCount_);
 
-    // auto peakMemory = pool.getCurrentBytes();
     intDictEncoder.clear();
     intDictEncoder.clear();
     EXPECT_EQ(2500, intDictEncoder.size());
@@ -204,7 +202,7 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
     // down. On test experiment it deallocated 4K and rellocated 64K.
     // When not compiled with ASAN, it correctly frees up the memory.
     // so disabling this check in the test for now.
-    // EXPECT_LT(pool.getCurrentBytes(), peakMemory);
+    // EXPECT_LT(pool.currentBytes(), peakMemory);
   }
 }
 

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -225,7 +225,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
   for (size_t i = 0; i != 2500; ++i) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
-  auto peakMemory = pool->getCurrentBytes();
+  auto peakMemory = pool->currentBytes();
   stringDictEncoder.clear();
   EXPECT_EQ(0, stringDictEncoder.size());
   EXPECT_EQ(0, stringDictEncoder.keyIndex_.size());
@@ -237,7 +237,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
   EXPECT_EQ(0, stringDictEncoder.counts_.capacity());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.size());
   EXPECT_EQ(0, stringDictEncoder.firstSeenStrideIndex_.capacity());
-  EXPECT_LT(pool->getCurrentBytes(), peakMemory);
+  EXPECT_LT(pool->currentBytes(), peakMemory);
 }
 
 TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
@@ -248,7 +248,7 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
     stringDictEncoder.addKey(baseString + genPaddedIntegerString(i, 4), 0);
   }
 
-  LOG(INFO) << "Total memory bytes: " << pool->getCurrentBytes();
+  LOG(INFO) << "Total memory bytes: " << pool->currentBytes();
 }
 
 TEST_F(TestStringDictionaryEncoder, Limit) {

--- a/velox/dwio/dwrf/writer/FlushPolicy.cpp
+++ b/velox/dwio/dwrf/writer/FlushPolicy.cpp
@@ -41,8 +41,7 @@ FlushDecision DefaultFlushPolicy::shouldFlushDictionary(
   return shouldFlushDictionary(
       stripeProgressDecision,
       overMemoryBudget,
-      context.getMemoryUsage(MemoryUsageCategory::DICTIONARY)
-          .getCurrentBytes());
+      context.getMemoryUsage(MemoryUsageCategory::DICTIONARY).currentBytes());
 }
 
 RowsPerStripeFlushPolicy::RowsPerStripeFlushPolicy(

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -173,10 +173,9 @@ bool Writer::shouldFlush(const WriterContext& context, size_t nextWriteLength) {
     VLOG(1) << fmt::format(
         "overMemoryBudget: {}, dictionaryMemUsage: {}, outputStreamSize: {}, generalMemUsage: {}, estimatedStripeSize: {}",
         overBudget,
-        context.getMemoryUsage(MemoryUsageCategory::DICTIONARY)
-            .getCurrentBytes(),
+        context.getMemoryUsage(MemoryUsageCategory::DICTIONARY).currentBytes(),
         context.getEstimatedOutputStreamSize(),
-        context.getMemoryUsage(MemoryUsageCategory::GENERAL).getCurrentBytes(),
+        context.getMemoryUsage(MemoryUsageCategory::GENERAL).currentBytes(),
         context.getEstimatedStripeSize(context.stripeRawSize));
   }
   return decision;
@@ -205,8 +204,7 @@ void Writer::enterLowMemoryMode() {
 void Writer::flushStripe(bool close) {
   auto& context = getContext();
   int64_t preFlushStreamMemoryUsage =
-      context.getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM)
-          .getCurrentBytes();
+      context.getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM).currentBytes();
   if (context.stripeRowCount == 0) {
     return;
   }
@@ -234,7 +232,7 @@ void Writer::flushStripe(bool close) {
   // Collects the memory increment from flushing data to output streams.
   auto flushOverhead =
       context.getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM)
-          .getCurrentBytes() -
+          .currentBytes() -
       preFlushStreamMemoryUsage;
   context.recordFlushOverhead(flushOverhead);
   metrics.flushOverhead = flushOverhead;
@@ -348,7 +346,7 @@ void Writer::flushStripe(bool close) {
 
   auto& dictionaryDataMemoryUsage =
       context.getMemoryUsage(MemoryUsageCategory::DICTIONARY);
-  metrics.dictionaryMemory = dictionaryDataMemoryUsage.getCurrentBytes();
+  metrics.dictionaryMemory = dictionaryDataMemoryUsage.currentBytes();
   // TODO: what does this try to capture?
   metrics.maxDictSize = dictionaryDataMemoryUsage.stats().peakBytes;
 
@@ -480,10 +478,10 @@ void Writer::flushInternal(bool close) {
             .totalMemory = context.getTotalMemoryUsage(),
             .dictionaryMemory =
                 context.getMemoryUsage(MemoryUsageCategory::DICTIONARY)
-                    .getCurrentBytes(),
+                    .currentBytes(),
             .generalMemory =
                 context.getMemoryUsage(MemoryUsageCategory::GENERAL)
-                    .getCurrentBytes()});
+                    .currentBytes()});
   }
 }
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -239,8 +239,8 @@ class WriterContext : public CompressionBufferPool {
         getMemoryUsage(MemoryUsageCategory::DICTIONARY);
     const auto& generalPool = getMemoryUsage(MemoryUsageCategory::GENERAL);
 
-    return outputStreamPool.getCurrentBytes() +
-        dictionaryPool.getCurrentBytes() + generalPool.getCurrentBytes();
+    return outputStreamPool.currentBytes() + dictionaryPool.currentBytes() +
+        generalPool.currentBytes();
   }
 
   int64_t getMemoryBudget() const {
@@ -329,7 +329,7 @@ class WriterContext : public CompressionBufferPool {
   void recordFlushOverhead(uint64_t flushOverhead) {
     flushOverheadRatioTracker_.takeSample(
         stripeRawSize +
-            getMemoryUsage(MemoryUsageCategory::DICTIONARY).getCurrentBytes(),
+            getMemoryUsage(MemoryUsageCategory::DICTIONARY).currentBytes(),
         flushOverhead);
   }
 
@@ -362,8 +362,8 @@ class WriterContext : public CompressionBufferPool {
 
   int64_t getEstimatedOutputStreamSize() const {
     return (int64_t)std::ceil(
-        (getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM).getCurrentBytes() +
-         getMemoryUsage(MemoryUsageCategory::DICTIONARY).getCurrentBytes()) /
+        (getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM).currentBytes() +
+         getMemoryUsage(MemoryUsageCategory::DICTIONARY).currentBytes()) /
         getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO));
   }
 

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -34,16 +34,6 @@ class SerializedPage {
       std::unique_ptr<folly::IOBuf> iobuf,
       std::function<void(folly::IOBuf&)> onDestructionCb = nullptr);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  explicit SerializedPage(
-      std::unique_ptr<folly::IOBuf> iobuf,
-      memory::MemoryPool* pool = nullptr,
-      std::function<void(folly::IOBuf&)> onDestructionCb = nullptr)
-      : SerializedPage(std::move(iobuf), std::move(onDestructionCb)) {
-    VELOX_CHECK_NULL(pool);
-  }
-#endif
-
   ~SerializedPage();
 
   // Returns the size of the serialized data in bytes.

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -526,7 +526,7 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  const auto currentUsage = pool_.getCurrentBytes();
+  const auto currentUsage = pool_.currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
         currentUsage * spillConfig_->spillableReservationGrowthPct / 100;

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -448,7 +448,7 @@ bool HashBuild::reserveMemory(const RowVectorPtr& input) {
   // 'spillableReservationGrowthPct_' of the current reservation.
   auto targetIncrement = std::max<int64_t>(
       increment * 2,
-      pool()->getCurrentBytes() * spillConfig()->spillableReservationGrowthPct /
+      pool()->currentBytes() * spillConfig()->spillableReservationGrowthPct /
           100);
   if (pool()->maybeReserve(targetIncrement)) {
     return true;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -154,7 +154,7 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
     return;
   }
 
-  const auto currentUsage = pool()->getCurrentBytes();
+  const auto currentUsage = pool()->currentBytes();
   if (spillMemoryThreshold_ != 0 && currentUsage > spillMemoryThreshold_) {
     const int64_t bytesToSpill =
         currentUsage * spillConfig.spillableReservationGrowthPct / 100;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -850,7 +850,7 @@ TEST_F(AggregationTest, partialAggregationMaybeReservationReleaseCheck) {
   EXPECT_EQ(0, runtimeStats.count("partialAggregationPct"));
   // Check all the reserved memory have been released.
   EXPECT_EQ(0, task->pool()->availableReservation());
-  EXPECT_GT(kMaxPartialMemoryUsage, task->pool()->getCurrentBytes());
+  EXPECT_GT(kMaxPartialMemoryUsage, task->pool()->currentBytes());
 }
 
 TEST_F(AggregationTest, spillWithMemoryLimit) {


### PR DESCRIPTION
- Fix buffer free handling in ManagedMmapArenas with unit tests
- Make quantizedSize calculation utility a public method which
   will be used by memory arbitrator for memory capacity transfer
   calculation so as to align with the size calculation in memory pool
- Some API naming cleanup in memory manager and memory pool