### PR TITLE
Add memory pool abort support and handle reclaim exception

### DIFF
--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -86,8 +86,11 @@ inline constexpr auto kUnreachableCode = "UNREACHABLE_CODE"_fs;
 // An error raised when a requested operation is not yet supported.
 inline constexpr auto kNotImplemented = "NOT_IMPLEMENTED"_fs;
 
-// An error raised when memory exceeded limits.
+// An error raised when memory pool exceeds limits.
 inline constexpr auto kMemCapExceeded = "MEM_CAP_EXCEEDED"_fs;
+
+// An error raised when memory pool is aborted.
+inline constexpr auto kMemAborted = "MEM_ABORTED"_fs;
 
 // Error caused by memory allocation failure.
 inline constexpr auto kMemAllocError = "MEM_ALLOC_ERROR"_fs;

--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -96,6 +96,12 @@ std::shared_ptr<MemoryPool> MemoryManager::addRootPool(
     const std::string& name,
     int64_t capacity,
     std::unique_ptr<MemoryReclaimer> reclaimer) {
+  if (arbitrator_ != nullptr) {
+    VELOX_CHECK_NOT_NULL(
+        reclaimer,
+        "Memory reclaimer must be set when configured with memory arbitrator");
+  }
+
   std::string poolName = name;
   if (poolName.empty()) {
     static std::atomic<int64_t> poolId{0};

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -20,6 +20,7 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/future/VeloxPromise.h"
 
 namespace facebook::velox::memory {
 
@@ -121,6 +122,8 @@ class MemoryArbitrator {
   struct Stats {
     /// The number of arbitration requests.
     uint64_t numRequests{0};
+    /// The number of aborted arbitration requests.
+    uint64_t numAborted{0};
     /// The number of arbitration request failures.
     uint64_t numFailures{0};
     /// The sum of all the arbitration request queue times in microseconds.
@@ -216,6 +219,13 @@ class MemoryReclaimer {
   /// reclaims all the reclaimable memory from the memory 'pool'. The function
   /// returns the actual reclaimed memory bytes.
   virtual uint64_t reclaim(MemoryPool* pool, uint64_t targetBytes);
+
+  /// Invoked by the memory arbitrator to abort memory 'pool' and the associated
+  /// query execution when encounters non-recoverable memory reclaim error or
+  /// fails to reclaim enough free capacity. The abort is a synchronous
+  /// operation and we expect most of used memory to be freed after the abort
+  /// completes.
+  virtual void abort(MemoryPool* pool);
 
  protected:
   MemoryReclaimer() = default;

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -63,7 +63,6 @@ class SharedArbitrator : public MemoryArbitrator {
     MemoryPool* const requestor_;
     SharedArbitrator* const arbitrator_;
     const std::chrono::steady_clock::time_point startTime_;
-    bool started_{false};
   };
 
   // Invoked to capture the candidate memory pools stats for arbitration.
@@ -102,8 +101,16 @@ class SharedArbitrator : public MemoryArbitrator {
   // NOTE: the function might sort 'candidates' based on each candidate's
   // reclaimable memory internally.
   uint64_t reclaimUsedMemoryFromCandidates(
+      MemoryPool* requestor,
       std::vector<Candidate>& candidates,
       uint64_t targetBytes);
+
+  // Invoked to reclaim used memory from 'pool' with specified 'targetBytes'.
+  // The function returns the actually freed capacity.
+  uint64_t reclaim(MemoryPool* pool, uint64_t targetBytes) noexcept;
+
+  // Invoked to abort memory 'pool'.
+  void abort(MemoryPool* pool);
 
   // Decrement free capacity from the arbitrator with up to 'bytes'. The
   // arbitrator might have less free available capacity. The function returns
@@ -119,20 +126,18 @@ class SharedArbitrator : public MemoryArbitrator {
 
   Stats statsLocked() const;
 
-  // Invoked to check if the memory capacity plus the freed capacity match the
-  // total capacity in the arbitrator.
-  // void debugCapacityCheckLocked(const std::vector<Candidate>& pools) const;
-
   mutable std::mutex mutex_;
   uint64_t freeCapacity_{0};
   // Indicates if there is a running arbitration request or not.
   bool running_{false};
+
   // The promises of the arbitration requests waiting for the serialized
   // execution.
   std::vector<ContinuePromise> waitPromises_;
 
   tsan_atomic<uint64_t> numRequests_{0};
-  tsan_atomic<uint64_t> numFailures_{0};
+  tsan_atomic<uint64_t> numAborted_{0};
+  std::atomic<uint64_t> numFailures_{0};
   tsan_atomic<uint64_t> queueTimeUs_{0};
   tsan_atomic<uint64_t> arbitrationTimeUs_{0};
   tsan_atomic<uint64_t> numShrunkBytes_{0};

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -36,6 +36,7 @@ class MemoryArbitrationTest : public testing::Test {};
 TEST_F(MemoryArbitrationTest, stats) {
   MemoryArbitrator::Stats stats;
   stats.numRequests = 2;
+  stats.numAborted = 3;
   stats.numFailures = 100;
   stats.queueTimeUs = 230'000;
   stats.arbitrationTimeUs = 1020;
@@ -43,7 +44,7 @@ TEST_F(MemoryArbitrationTest, stats) {
   stats.numReclaimedBytes = 10'000;
   ASSERT_EQ(
       stats.toString(),
-      "STATS[numRequests 2 numFailures 100 queueTime 230.00ms arbitrationTime 1.02ms shrunkMemory 95.37MB reclaimedMemory 9.77KB maxCapacity 0B freeCapacity 0B]");
+      "STATS[numRequests 2 numAborted 3 numFailures 100 queueTime 230.00ms arbitrationTime 1.02ms shrunkMemory 95.37MB reclaimedMemory 9.77KB maxCapacity 0B freeCapacity 0B]");
 }
 
 TEST_F(MemoryArbitrationTest, kind) {

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -163,21 +163,29 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   MOCK_CONST_METHOD0(alignment, uint16_t());
 
   uint64_t freeBytes() const override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
   uint64_t shrink(uint64_t /*unused*/) override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
-  uint64_t grow(uint64_t /*unused*/) override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
+  uint64_t grow(uint64_t /*unused*/) noexcept override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
   std::string toString() const override {
     return fmt::format(
         "Mock Memory Pool[{}]",
         velox::memory::MemoryAllocator::kindString(allocator_->kind()));
+  }
+
+  void abort() override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  bool aborted() const override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
  private:

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -150,16 +150,7 @@ class CancelGuard {
       onTerminate_(StopReason::kNone);
       onTerminateCalled = true;
     }
-    auto reason = task_->leave(*state_);
-    if (reason == StopReason::kTerminate) {
-      // Terminate requested via Task. The Driver is not on
-      // thread but 'terminated_' is set, hence no other threads will
-      // enter. onTerminateCalled will be true if both runtime error and
-      // terminate requested via Task.
-      if (!onTerminateCalled) {
-        onTerminate_(reason);
-      }
-    }
+    task_->leave(*state_, onTerminateCalled ? nullptr : onTerminate_);
   }
 
  private:

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -390,8 +390,6 @@ bool HashAggregation::isFinished() {
 void HashAggregation::reclaim(uint64_t targetBytes) {
   VELOX_CHECK(canReclaim());
   auto* driver = operatorCtx_->driver();
-  VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
-  VELOX_CHECK(driver->task()->pauseRequested());
 
   /// NOTE: an aggregation operator is reclaimable if it hasn't started output
   /// processing and is not under non-reclaimable execution section.
@@ -411,5 +409,12 @@ void HashAggregation::reclaim(uint64_t targetBytes) {
   VELOX_CHECK_EQ(groupingSet_->numDistinct(), 0);
   // Release the minimum reserved memory.
   pool()->release();
+}
+
+void HashAggregation::close() {
+  Operator::close();
+
+  output_ = nullptr;
+  groupingSet_.reset();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -43,12 +43,9 @@ class HashAggregation : public Operator {
 
   bool isFinished() override;
 
-  void close() override {
-    Operator::close();
-    groupingSet_.reset();
-  }
-
   void reclaim(uint64_t targetBytes) override;
+
+  void close() override;
 
  private:
   void prepareOutput(vector_size_t size);

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -993,8 +993,6 @@ bool HashBuild::testingTriggerSpill() {
 void HashBuild::reclaim(uint64_t /*unused*/) {
   VELOX_CHECK(canReclaim());
   auto* driver = operatorCtx_->driver();
-  VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
-  VELOX_CHECK(driver->task()->pauseRequested());
 
   TestValue::adjust("facebook::velox::exec::HashBuild::reclaim", this);
 
@@ -1043,5 +1041,14 @@ void HashBuild::reclaim(uint64_t /*unused*/) {
     // Release the minimum reserved memory.
     op->pool()->release();
   }
+}
+
+void HashBuild::close() {
+  Operator::close();
+
+  // Free up major memory usage.
+  joinBridge_.reset();
+  spiller_.reset();
+  table_.reset();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -79,6 +79,8 @@ class HashBuild final : public Operator {
 
   void reclaim(uint64_t targetBytes) override;
 
+  void close() override;
+
  private:
   void setState(State state);
   void checkStateTransition(State state);
@@ -233,7 +235,7 @@ class HashBuild final : public Operator {
 
   const bool nullAware_;
 
-  const std::shared_ptr<HashJoinBridge> joinBridge_;
+  std::shared_ptr<HashJoinBridge> joinBridge_;
 
   std::shared_ptr<SpillOperatorGroup> spillGroup_;
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -118,10 +118,10 @@ HashProbe::HashProbe(
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
       nullAware_{joinNode_->isNullAware()},
+      probeType_(joinNode_->sources()[0]->outputType()),
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
-      probeType_(joinNode_->sources()[0]->outputType()),
       filterResult_(1),
       outputTableRows_(outputBatchSize_) {
   VELOX_CHECK_NOT_NULL(joinBridge_);
@@ -1391,6 +1391,15 @@ void HashProbe::checkRunning() const {
 
 void HashProbe::setRunning() {
   setState(ProbeOperatorState::kRunning);
+}
+
+void HashProbe::close() {
+  Operator::close();
+
+  // Free up major memory usage.
+  joinBridge_.reset();
+  spiller_.reset();
+  table_.reset();
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -64,6 +64,8 @@ class HashProbe : public Operator {
     return false;
   }
 
+  void close() override;
+
   void clearDynamicFilters() override;
 
  private:
@@ -243,9 +245,9 @@ class HashProbe : public Operator {
 
   const bool nullAware_;
 
-  const std::shared_ptr<HashJoinBridge> joinBridge_;
-
   const RowTypePtr probeType_;
+
+  std::shared_ptr<HashJoinBridge> joinBridge_;
 
   ProbeOperatorState state_{ProbeOperatorState::kWaitForBuild};
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -495,12 +495,16 @@ class Operator : public BaseRuntimeStatWriter {
         Operator* op);
 
     void enterArbitration() override;
+
     void leaveArbitration() noexcept override;
 
     bool reclaimableBytes(
         const memory::MemoryPool& pool,
         uint64_t& reclaimableBytes) const override;
+
     uint64_t reclaim(memory::MemoryPool* pool, uint64_t targetBytes) override;
+
+    void abort(memory::MemoryPool* pool) override;
 
    private:
     MemoryReclaimer(const std::shared_ptr<Driver>& driver, Operator* op)

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -206,8 +206,6 @@ void OrderBy::ensureInputFits(const RowVectorPtr& input) {
 void OrderBy::reclaim(uint64_t targetBytes) {
   VELOX_CHECK(canReclaim());
   auto* driver = operatorCtx_->driver();
-  VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
-  VELOX_CHECK(driver->task()->pauseRequested());
 
   // NOTE: an order by operator is reclaimable if it hasn't started output
   // processing and is not under non-reclaimable execution section.
@@ -409,5 +407,13 @@ void OrderBy::prepareOutput() {
   for (auto& child : output_->children()) {
     child->resize(batchSize);
   }
+}
+
+void OrderBy::close() {
+  Operator::close();
+
+  output_ = nullptr;
+  spiller_.reset();
+  data_.reset();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -58,6 +58,8 @@ class OrderBy : public Operator {
 
   void reclaim(uint64_t targetBytes) override;
 
+  void close() override;
+
  private:
   // Checks if input will fit in the existing memory and increases
   // reservation if not. If reservation cannot be increased, spills enough to

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1847,18 +1847,17 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
           })));
 
   std::thread taskThread([&]() {
-    auto task = AssertQueryBuilder(
-                    PlanBuilder()
-                        .values(batches)
-                        .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                        .planNode())
-                    .queryCtx(queryCtx)
-                    .spillDirectory(tempDirectory->path)
-                    .config(QueryConfig::kSpillEnabled, "true")
-                    .config(QueryConfig::kAggregationSpillEnabled, "true")
-                    .config(core::QueryConfig::kSpillPartitionBits, "2")
-                    .maxDrivers(1)
-                    .assertResults(expectedResult);
+    AssertQueryBuilder(PlanBuilder()
+                           .values(batches)
+                           .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                           .planNode())
+        .queryCtx(queryCtx)
+        .spillDirectory(tempDirectory->path)
+        .config(QueryConfig::kSpillEnabled, "true")
+        .config(QueryConfig::kAggregationSpillEnabled, "true")
+        .config(core::QueryConfig::kSpillPartitionBits, "2")
+        .maxDrivers(1)
+        .assertResults(expectedResult);
   });
 
   testWait.wait(testWaitKey);
@@ -1963,27 +1962,27 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
 
     std::thread taskThread([&]() {
       if (enableSpilling) {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .spillDirectory(tempDirectory->path)
-                        .config(QueryConfig::kSpillEnabled, "true")
-                        .config(QueryConfig::kAggregationSpillEnabled, "true")
-                        .config(core::QueryConfig::kSpillPartitionBits, "2")
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -2084,27 +2083,27 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
 
     std::thread taskThread([&]() {
       if (enableSpilling) {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .spillDirectory(tempDirectory->path)
-                        .config(QueryConfig::kSpillEnabled, "true")
-                        .config(QueryConfig::kAggregationSpillEnabled, "true")
-                        .config(core::QueryConfig::kSpillPartitionBits, "2")
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -2201,24 +2200,24 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
 
     std::thread taskThread([&]() {
       if (enableSpilling) {
-        auto task = AssertQueryBuilder(nullptr)
-                        .plan(aggregationPlan)
-                        .queryCtx(queryCtx)
-                        .spillDirectory(tempDirectory->path)
-                        .config(QueryConfig::kSpillEnabled, "true")
-                        .config(QueryConfig::kAggregationSpillEnabled, "true")
-                        .config(core::QueryConfig::kSpillPartitionBits, "2")
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(nullptr)
+            .plan(aggregationPlan)
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -2255,6 +2254,195 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     ASSERT_EQ(stats[0].operatorStats[1].spilledBytes, 0);
     ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  }
+}
+
+DEBUG_ONLY_TEST_F(AggregationTest, abortDuringOutputProcessing) {
+  constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
+  auto rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
+  VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
+  const int32_t numBatches = 10;
+  std::vector<RowVectorPtr> batches;
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(fuzzer.fuzzRow(rowType));
+  }
+
+  struct {
+    bool abortFromRootMemoryPool;
+    int numDrivers;
+
+    std::string debugString() const {
+      return fmt::format(
+          "abortFromRootMemoryPool {} numDrivers {}",
+          abortFromRootMemoryPool,
+          numDrivers);
+    }
+  } testSettings[] = {{true, 1}, {false, 1}, {true, 4}, {false, 4}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    queryCtx->testingOverrideMemoryPool(
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto expectedResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .copyResults(pool_.get());
+
+    folly::EventCount driverWait;
+    auto driverWaitKey = driverWait.prepareWait();
+    folly::EventCount testWait;
+    auto testWaitKey = testWait.prepareWait();
+
+    std::atomic<bool> injectOnce{true};
+    Operator* op;
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::noMoreInput",
+        std::function<void(Operator*)>(([&](Operator* testOp) {
+          if (testOp->operatorType() != "Aggregation") {
+            return;
+          }
+          op = testOp;
+          if (!injectOnce.exchange(false)) {
+            return;
+          }
+          auto* driver = op->testingOperatorCtx()->driver();
+          ASSERT_EQ(
+              driver->task()->enterSuspended(driver->state()),
+              StopReason::kNone);
+          testWait.notify();
+          driverWait.wait(driverWaitKey);
+          ASSERT_EQ(
+              driver->task()->leaveSuspended(driver->state()),
+              StopReason::kAlreadyTerminated);
+          VELOX_MEM_POOL_ABORTED(op->pool());
+        })));
+
+    std::thread taskThread([&]() {
+      VELOX_ASSERT_THROW(
+          AssertQueryBuilder(
+              PlanBuilder()
+                  .values(batches)
+                  .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                  .planNode())
+              .queryCtx(queryCtx)
+              .maxDrivers(testData.numDrivers)
+              .assertResults(expectedResult),
+          "");
+    });
+
+    testWait.wait(testWaitKey);
+    ASSERT_TRUE(op != nullptr);
+    auto task = op->testingOperatorCtx()->task();
+    testData.abortFromRootMemoryPool ? queryCtx->pool()->abort()
+                                     : op->pool()->abort();
+    ASSERT_TRUE(op->pool()->aborted());
+    ASSERT_TRUE(queryCtx->pool()->aborted());
+    ASSERT_EQ(queryCtx->pool()->currentBytes(), 0);
+    driverWait.notify();
+    taskThread.join();
+    task.reset();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
+  constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
+  auto rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
+  VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
+  const int32_t numBatches = 10;
+  std::vector<RowVectorPtr> batches;
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(fuzzer.fuzzRow(rowType));
+  }
+
+  struct {
+    bool abortFromRootMemoryPool;
+    int numDrivers;
+
+    std::string debugString() const {
+      return fmt::format(
+          "abortFromRootMemoryPool {} numDrivers {}",
+          abortFromRootMemoryPool,
+          numDrivers);
+    }
+  } testSettings[] = {{true, 1}, {false, 1}, {true, 4}, {false, 4}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    queryCtx->testingOverrideMemoryPool(
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto expectedResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .planNode())
+            .queryCtx(queryCtx)
+            .copyResults(pool_.get());
+
+    folly::EventCount driverWait;
+    auto driverWaitKey = driverWait.prepareWait();
+    folly::EventCount testWait;
+    auto testWaitKey = testWait.prepareWait();
+
+    std::atomic<int> numInputs{0};
+    Operator* op;
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* testOp) {
+          if (testOp->operatorType() != "Aggregation") {
+            return;
+          }
+          op = testOp;
+          ++numInputs;
+          if (numInputs != 2) {
+            return;
+          }
+          auto* driver = op->testingOperatorCtx()->driver();
+          ASSERT_EQ(
+              driver->task()->enterSuspended(driver->state()),
+              StopReason::kNone);
+          testWait.notify();
+          driverWait.wait(driverWaitKey);
+          ASSERT_EQ(
+              driver->task()->leaveSuspended(driver->state()),
+              StopReason::kAlreadyTerminated);
+          VELOX_MEM_POOL_ABORTED(op->pool());
+        })));
+
+    std::thread taskThread([&]() {
+      VELOX_ASSERT_THROW(
+          AssertQueryBuilder(
+              PlanBuilder()
+                  .values(batches)
+                  .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                  .planNode())
+              .queryCtx(queryCtx)
+              .maxDrivers(testData.numDrivers)
+              .assertResults(expectedResult),
+          "");
+    });
+
+    testWait.wait(testWaitKey);
+    ASSERT_TRUE(op != nullptr);
+    auto task = op->testingOperatorCtx()->task();
+    testData.abortFromRootMemoryPool ? queryCtx->pool()->abort()
+                                     : op->pool()->abort();
+    ASSERT_TRUE(op->pool()->aborted());
+    ASSERT_TRUE(queryCtx->pool()->aborted());
+    ASSERT_EQ(queryCtx->pool()->currentBytes(), 0);
+    driverWait.notify();
+    taskThread.join();
+    task.reset();
+    Task::testingWaitForAllTasksToBeDeleted();
   }
 }
 

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -610,29 +610,27 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
 
     std::thread taskThread([&]() {
       if (testData.spillEnabled) {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .spillDirectory(tempDirectory->path)
-                .config(core::QueryConfig::kSpillEnabled, "true")
-                .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-                .config(core::QueryConfig::kSpillPartitionBits, "2")
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(core::QueryConfig::kSpillEnabled, "true")
+            .config(core::QueryConfig::kOrderBySpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -745,19 +743,18 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
           })));
 
   std::thread taskThread([&]() {
-    auto task =
-        AssertQueryBuilder(
-            PlanBuilder()
-                .values(batches)
-                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                .planNode())
-            .queryCtx(queryCtx)
-            .spillDirectory(tempDirectory->path)
-            .config(core::QueryConfig::kSpillEnabled, "true")
-            .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
-            .maxDrivers(1)
-            .assertResults(expectedResult);
+    AssertQueryBuilder(
+        PlanBuilder()
+            .values(batches)
+            .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+            .planNode())
+        .queryCtx(queryCtx)
+        .spillDirectory(tempDirectory->path)
+        .config(core::QueryConfig::kSpillEnabled, "true")
+        .config(core::QueryConfig::kOrderBySpillEnabled, "true")
+        .config(core::QueryConfig::kSpillPartitionBits, "2")
+        .maxDrivers(1)
+        .assertResults(expectedResult);
   });
 
   testWait.wait(testWaitKey);
@@ -859,29 +856,27 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
 
     std::thread taskThread([&]() {
       if (enableSpilling) {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .spillDirectory(tempDirectory->path)
-                .config(core::QueryConfig::kSpillEnabled, "true")
-                .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-                .config(core::QueryConfig::kSpillPartitionBits, "2")
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(core::QueryConfig::kSpillEnabled, "true")
+            .config(core::QueryConfig::kOrderBySpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -982,29 +977,27 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
 
     std::thread taskThread([&]() {
       if (enableSpilling) {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .spillDirectory(tempDirectory->path)
-                .config(core::QueryConfig::kSpillEnabled, "true")
-                .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-                .config(core::QueryConfig::kSpillPartitionBits, "2")
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .spillDirectory(tempDirectory->path)
+            .config(core::QueryConfig::kSpillEnabled, "true")
+            .config(core::QueryConfig::kOrderBySpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       } else {
-        auto task =
-            AssertQueryBuilder(
-                PlanBuilder()
-                    .values(batches)
-                    .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
-                    .planNode())
-                .queryCtx(queryCtx)
-                .maxDrivers(1)
-                .assertResults(expectedResult);
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .maxDrivers(1)
+            .assertResults(expectedResult);
       }
     });
 
@@ -1041,5 +1034,195 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     ASSERT_EQ(stats[0].operatorStats[1].spilledBytes, 0);
     ASSERT_EQ(stats[0].operatorStats[1].spilledPartitions, 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  }
+}
+
+DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
+  constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
+  auto rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
+  VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
+  const int32_t numBatches = 10;
+  std::vector<RowVectorPtr> batches;
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(fuzzer.fuzzRow(rowType));
+  }
+
+  struct {
+    bool abortFromRootMemoryPool;
+    int numDrivers;
+
+    std::string debugString() const {
+      return fmt::format(
+          "abortFromRootMemoryPool {} numDrivers {}",
+          abortFromRootMemoryPool,
+          numDrivers);
+    }
+  } testSettings[] = {{true, 1}, {false, 1}, {true, 4}, {false, 4}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    queryCtx->testingOverrideMemoryPool(
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto expectedResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .copyResults(pool_.get());
+
+    folly::EventCount driverWait;
+    auto driverWaitKey = driverWait.prepareWait();
+    folly::EventCount testWait;
+    auto testWaitKey = testWait.prepareWait();
+
+    std::atomic<bool> injectOnce{true};
+    Operator* op;
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::noMoreInput",
+        std::function<void(Operator*)>(([&](Operator* testOp) {
+          if (testOp->operatorType() != "OrderBy") {
+            return;
+          }
+          op = testOp;
+          if (!injectOnce.exchange(false)) {
+            return;
+          }
+          auto* driver = op->testingOperatorCtx()->driver();
+          ASSERT_EQ(
+              driver->task()->enterSuspended(driver->state()),
+              StopReason::kNone);
+          testWait.notify();
+          driverWait.wait(driverWaitKey);
+          ASSERT_EQ(
+              driver->task()->leaveSuspended(driver->state()),
+              StopReason::kAlreadyTerminated);
+          VELOX_MEM_POOL_ABORTED(op->pool());
+        })));
+
+    std::thread taskThread([&]() {
+      VELOX_ASSERT_THROW(
+          AssertQueryBuilder(
+              PlanBuilder()
+                  .values(batches)
+                  .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                  .planNode())
+              .queryCtx(queryCtx)
+              .maxDrivers(1)
+              .assertResults(expectedResult),
+          "");
+    });
+
+    testWait.wait(testWaitKey);
+    ASSERT_TRUE(op != nullptr);
+    auto task = op->testingOperatorCtx()->task();
+    testData.abortFromRootMemoryPool ? queryCtx->pool()->abort()
+                                     : op->pool()->abort();
+    ASSERT_TRUE(op->pool()->aborted());
+    ASSERT_TRUE(queryCtx->pool()->aborted());
+    ASSERT_EQ(queryCtx->pool()->currentBytes(), 0);
+    driverWait.notify();
+    taskThread.join();
+    task.reset();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(OrderByTest, abortDuringInputgProcessing) {
+  constexpr int64_t kMaxBytes = 1LL << 30; // 1GB
+  auto rowType = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
+  VectorFuzzer fuzzer({.vectorSize = 1000}, pool());
+  const int32_t numBatches = 10;
+  std::vector<RowVectorPtr> batches;
+  for (int32_t i = 0; i < numBatches; ++i) {
+    batches.push_back(fuzzer.fuzzRow(rowType));
+  }
+
+  struct {
+    bool abortFromRootMemoryPool;
+    int numDrivers;
+
+    std::string debugString() const {
+      return fmt::format(
+          "abortFromRootMemoryPool {} numDrivers {}",
+          abortFromRootMemoryPool,
+          numDrivers);
+    }
+  } testSettings[] = {{true, 1}, {false, 1}, {true, 4}, {false, 4}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    queryCtx->testingOverrideMemoryPool(
+        memory::defaultMemoryManager().addRootPool(
+            queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
+    auto expectedResult =
+        AssertQueryBuilder(
+            PlanBuilder()
+                .values(batches)
+                .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                .planNode())
+            .queryCtx(queryCtx)
+            .copyResults(pool_.get());
+
+    folly::EventCount driverWait;
+    auto driverWaitKey = driverWait.prepareWait();
+    folly::EventCount testWait;
+    auto testWaitKey = testWait.prepareWait();
+
+    std::atomic<int> numInputs{0};
+    Operator* op;
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* testOp) {
+          if (testOp->operatorType() != "OrderBy") {
+            return;
+          }
+          op = testOp;
+          ++numInputs;
+          if (numInputs != 2) {
+            return;
+          }
+          auto* driver = op->testingOperatorCtx()->driver();
+          ASSERT_EQ(
+              driver->task()->enterSuspended(driver->state()),
+              StopReason::kNone);
+          testWait.notify();
+          driverWait.wait(driverWaitKey);
+          ASSERT_EQ(
+              driver->task()->leaveSuspended(driver->state()),
+              StopReason::kAlreadyTerminated);
+          // Simulate the memory abort by memory arbitrator.
+          VELOX_MEM_POOL_ABORTED(op->pool());
+        })));
+
+    std::thread taskThread([&]() {
+      VELOX_ASSERT_THROW(
+          AssertQueryBuilder(
+              PlanBuilder()
+                  .values(batches)
+                  .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                  .planNode())
+              .queryCtx(queryCtx)
+              .maxDrivers(1)
+              .assertResults(expectedResult),
+          "");
+    });
+
+    testWait.wait(testWaitKey);
+    ASSERT_TRUE(op != nullptr);
+    auto task = op->testingOperatorCtx()->task();
+    testData.abortFromRootMemoryPool ? queryCtx->pool()->abort()
+                                     : op->pool()->abort();
+    ASSERT_TRUE(op->pool()->aborted());
+    ASSERT_TRUE(queryCtx->pool()->aborted());
+    ASSERT_EQ(queryCtx->pool()->currentBytes(), 0);
+    driverWait.notify();
+    taskThread.join();
+    task.reset();
+    Task::testingWaitForAllTasksToBeDeleted();
   }
 }

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1236,6 +1236,10 @@ bool waitForTaskAborted(exec::Task* task, uint64_t maxWaitMicros) {
   return waitForTaskFinish(task, TaskState::kAborted, maxWaitMicros);
 }
 
+bool waitForTaskCancelled(exec::Task* task, uint64_t maxWaitMicros) {
+  return waitForTaskFinish(task, TaskState::kCanceled, maxWaitMicros);
+}
+
 bool waitForTaskStateChange(
     exec::Task* task,
     TaskState state,

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -113,6 +113,9 @@ bool waitForTaskFailure(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
 /// Similar to waitForTaskFinish but wait for the task to abort.
 bool waitForTaskAborted(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
 
+/// Similar to waitForTaskFinish but wait for the task to cancel.
+bool waitForTaskCancelled(exec::Task* task, uint64_t maxWaitMicros = 1'000'000);
+
 /// Wait up to maxWaitMicros for 'task' state changes to 'state'. The function
 /// returns true if 'task' has changed to the expected 'state', otherwise false.
 bool waitForTaskStateChange(


### PR DESCRIPTION
- Add to handle memory reclaim exception in shared arbitrator and trigger
  memory pool abort once it happens as the memory reclaim might leaves
   the operator in an unexpected state
- Add to support abort a memory pool synchronously and integrate with
   Velox query execution
- Simplify shared memory arbitration's scoped arbitration processing logic
- Skip the initial memory reservation for a newly created memory pool
  if the memory arbitrator is under arbitration to ensure that the arbitrator
  see a consistent view of freed capacity in the system
- Improve shared arbitrator to only grow the request memory pool with
   the required grow capacity and returns the unused freed capacity
   back to the arbitrator.
- Improve Velox query execution to ensure the driver close is always executed
   on driver thread
- Fix a deadlock issue in MemoryPoolImpl::toString()
- Add driver tests to cover the race between the driver suspension and
   task yield
- Add driver test to cover the race between the driver suspension and
   different task termination types

The followup is to (1) support wait for a memory pool's usage drop to
allow us to sync wait for memory usage free of an aborted query. The
driver close is async executed after removed from the task; (2) extend
shared arbitrator to abort a query with most memory usage if the
arbitration fails instead of always failing the requestor.