### PR TITLE
Add Date type to InPredicate

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -196,6 +196,8 @@ variant duckValueToVariant(const Value& val) {
       return variant(val.GetValue<std::string>());
     case LogicalTypeId::BLOB:
       return variant::binary(val.GetValue<std::string>());
+    case LogicalTypeId::DATE:
+      return variant::date(val.GetValue<::duckdb::date_t>().days);
     default:
       throw std::runtime_error(
           "unsupported type for duckdb value -> velox  variant conversion: " +

--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -113,6 +113,29 @@ std::pair<std::unique_ptr<common::Filter>, bool> createBytesValuesFilter(
   return {std::make_unique<common::BytesValues>(values, nullAllowed), false};
 }
 
+std::pair<std::unique_ptr<common::Filter>, bool> createDateValuesFilter(
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  auto valuesPair = toValues<Date, Date>(inputArgs);
+  if (!valuesPair.has_value()) {
+    return {nullptr, false};
+  }
+
+  const auto& values = valuesPair.value().first;
+  bool nullAllowed = valuesPair.value().second;
+
+  if (values.empty() && nullAllowed) {
+    return {nullptr, true};
+  }
+  VELOX_USER_CHECK(
+      !values.empty(),
+      "IN predicate expects at least one non-null value in the in-list");
+  std::vector<int64_t> dayValues;
+  for (auto date : values) {
+    dayValues.push_back(date.days());
+  }
+  return {common::createBigintValues(dayValues, nullAllowed), false};
+}
+
 class InPredicate : public exec::VectorFunction {
  public:
   explicit InPredicate(std::unique_ptr<common::Filter> filter, bool alwaysNull)
@@ -142,6 +165,9 @@ class InPredicate : public exec::VectorFunction {
       case TypeKind::VARCHAR:
       case TypeKind::VARBINARY:
         filter = createBytesValuesFilter(inputArgs);
+        break;
+      case TypeKind::DATE:
+        filter = createDateValuesFilter(inputArgs);
         break;
       case TypeKind::UNKNOWN:
         filter = {nullptr, true};
@@ -196,6 +222,11 @@ class InPredicate : public exec::VectorFunction {
               return filter_->testBytes(value.data(), value.size());
             });
         break;
+      case TypeKind::DATE:
+        applyTyped<Date>(rows, input, context, result, [&](Date value) {
+          return filter_->testInt64(value.days());
+        });
+        break;
       default:
         VELOX_UNSUPPORTED(
             "Unsupported input type for the IN predicate: {}",
@@ -207,7 +238,13 @@ class InPredicate : public exec::VectorFunction {
     // tinyint|smallint|integer|bigint|varchar... -> boolean
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
     for (auto& type :
-         {"tinyint", "smallint", "integer", "bigint", "varchar", "varbinary"}) {
+         {"tinyint",
+          "smallint",
+          "integer",
+          "bigint",
+          "varchar",
+          "varbinary",
+          "date"}) {
       signatures.emplace_back(exec::FunctionSignatureBuilder()
                                   .returnType("boolean")
                                   .argumentType(type)

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -318,6 +318,33 @@ TEST_F(InPredicateTest, varbinary) {
   assertEqualVectors(makeConstant(true, input->size()), result);
 }
 
+TEST_F(InPredicateTest, date) {
+  auto dateValue = Date();
+  parseTo("2000-01-01", dateValue);
+
+  auto input = makeRowVector({
+      makeNullableFlatVector<Date>({dateValue}, DATE()),
+  });
+
+  assertEqualVectors(
+      makeConstant(true, input->size()),
+      evaluate("c0 IN (DATE '2000-01-01')", input));
+
+  assertEqualVectors(
+      makeConstant(false, input->size()),
+      evaluate("c0 IN (DATE '2000-02-01')", input));
+
+  assertEqualVectors(
+      makeConstant(false, input->size()),
+      evaluate("c0 IN (DATE '2000-02-01', DATE '2000-03-04')", input));
+
+  assertEqualVectors(
+      makeConstant(true, input->size()),
+      evaluate(
+          "c0 IN (DATE '2000-02-01', DATE '2000-03-04', DATE '2000-01-01')",
+          input));
+}
+
 TEST_F(InPredicateTest, reusableResult) {
   std::string predicate = "c0 IN (1, 2)";
   auto input = makeRowVector({makeNullableFlatVector<int32_t>({0, 1, 2, 3})});


### PR DESCRIPTION
This PR adds support for Date types in `InPredicate` expression.

This allows to run queries like this: 

```sql
SELECT * FROM table WHERE date in (DATE '2022-01-01', DATE '2022-02-01');
SELECT * FROM orders WHERE cast(orderdate as date) in (DATE '2000-06-30', DATE '2000-09-27')
```

Without this patch, the query above would fail with 
```
VeloxRuntimeError: Scalar function in not registered with arguments: (DATE, ARRAY<DATE>)
```

Note: the fix itself is very small, most of the code changes are for unit tests because DuckDB test code did not handle date literals.