### PR TITLE
Return early in FlatMapColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -94,6 +94,7 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesFiltered(
         if (processed.count(sequence)) {
           return;
         }
+        processed.insert(sequence);
 
         EncodingKey seqEk(dataValueType->id, sequence);
         const auto& keyInfo = stripe.getEncoding(seqEk).key();
@@ -122,7 +123,6 @@ std::vector<std::unique_ptr<KeyNode<T>>> getKeyNodesFiltered(
             key,
             sequence,
             memoryPool));
-        processed.insert(sequence);
       });
 
   VLOG(1) << "[Flat-Map] Initialized a flat-map column reader for node "

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -124,6 +124,7 @@ std::vector<KeyNode<T>> getKeyNodes(
         if (sequence == 0 || processed.count(sequence) > 0) {
           return;
         }
+        processed.insert(sequence);
         EncodingKey seqEk(dataValueType->id, sequence);
         const auto& keyInfo = stripe.getEncoding(seqEk).key();
         auto key = extractKey<T>(keyInfo);
@@ -162,7 +163,6 @@ std::vector<KeyNode<T>> getKeyNodes(
             requestedValueType, dataValueType, childParams, *childSpec);
         keyNodes.emplace_back(
             key, sequence, std::move(reader), std::move(inMapDecoder));
-        processed.insert(sequence);
       });
 
   VLOG(1) << "[Flat-Map] Initialized a flat-map column reader for node "


### PR DESCRIPTION
Summary: Previously, this optimization to skip nodes already in `processed` would not work if the predicate check below it failed. This fixes that, and should help with upcoming flatmap efficiency metrics.

Reviewed By: Yuhta

Differential Revision: D45437211

