### PR TITLE
Use sudo when installing dependencies on Linux

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -409,11 +409,11 @@ class InstallSysDepsCmd(ProjectCmdBase):
         if manager == "rpm":
             packages = sorted(set(all_packages["rpm"]))
             if packages:
-                cmd_args = ["dnf", "install", "-y"] + packages
+                cmd_args = ["sudo", "dnf", "install", "-y"] + packages
         elif manager == "deb":
             packages = sorted(set(all_packages["deb"]))
             if packages:
-                cmd_args = ["apt-get", "install", "-y"] + packages
+                cmd_args = ["sudo", "apt", "install", "-y"] + packages
         elif manager == "homebrew":
             packages = sorted(set(all_packages["homebrew"]))
             if packages:


### PR DESCRIPTION
Summary:
`brew` no longer supports running as root:

```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
Command '['brew', 'install', 'autoconf', 'automake', 'boost', 'cmake', 'double-conversion', 'icu4c', 'libevent', 'libsodium', 'libtool', 'lz4', 'ninja', 'openssl@1.1', 'xz', 'zlib', 'zstd']' returned non-zero exit status 1.
!! Failed
```

And as a result the recommended install instructions no longer work:

```
sudo ./build/fbcode_builder/getdeps.py install-system-deps ...
```

and cannot be made to work portably across platforms because Linux requires `sudo` be there while macOS requires `sudo` not be there.

To fix this move `sudo` to Linux system dependency installation only.

Also update `apt-get` to `apt` while at it.

Resolves https://github.com/facebook/fbthrift/issues/545.

Reviewed By: somasun

Differential Revision: D45371004

