### PR TITLE
Remove copy constructor implementation for RowReaderOptions

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -104,20 +104,6 @@ class RowReaderOptions {
   bool appendRowNumberColumn_ = false;
 
  public:
-  RowReaderOptions(const RowReaderOptions& other) {
-    dataStart = other.dataStart;
-    dataLength = other.dataLength;
-    preloadStripe = other.preloadStripe;
-    projectSelectedType = other.projectSelectedType;
-    errorTolerance_ = other.errorTolerance_;
-    selector_ = other.selector_;
-    scanSpec_ = other.scanSpec_;
-    metadataFilter_ = other.metadataFilter_;
-    returnFlatVector_ = other.returnFlatVector_;
-    flatmapNodeIdAsStruct_ = other.flatmapNodeIdAsStruct_;
-    appendRowNumberColumn_ = other.appendRowNumberColumn_;
-  }
-
   RowReaderOptions() noexcept
       : dataStart(0),
         dataLength(std::numeric_limits<uint64_t>::max()),


### PR DESCRIPTION
Summary:
# Problem

`default` can do the job without making mistakes. At the moment, two members are not being copied.

```
std::shared_ptr<folly::Executor> decodingExecutor_;
std::shared_ptr<folly::Executor> ioExecutor_;
```

Differential Revision: D45411908

