### PR TITLE
Rename orderDependentFunctions to specialVerificationFunctions in aggregation fuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/AggregationFuzzerRunner.h
@@ -70,7 +70,7 @@ class AggregationFuzzerRunner {
       size_t seed,
       const std::unordered_set<std::string>& skipFunctions,
       const std::unordered_map<std::string, std::string>&
-          orderDependentFunctions) {
+          customVerificationFunctions) {
     auto signatures = facebook::velox::exec::getAggregateFunctionSignatures();
     if (signatures.empty()) {
       LOG(ERROR) << "No aggregate functions registered.";
@@ -91,7 +91,7 @@ class AggregationFuzzerRunner {
     facebook::velox::filesystems::registerLocalFileSystem();
 
     facebook::velox::exec::test::aggregateFuzzer(
-        filteredSignatures, seed, orderDependentFunctions);
+        filteredSignatures, seed, customVerificationFunctions);
     // Calling gtest here so that it can be recognized as tests in CI systems.
     return RUN_ALL_TESTS();
   }

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -53,12 +53,14 @@ int main(int argc, char** argv) {
       "stddev_pop", // https://github.com/facebookincubator/velox/issues/3493
   };
 
-  // The results of the following functions depend on the order of input
-  // rows. For some functions, the result can be transformed to a value that
-  // doesn't dopend on the order of inputs. If such transformation exists, it
-  // can be specified to be used for results verification. If no transformation
-  // is specified, results are not verified.
-  std::unordered_map<std::string, std::string> orderDependentFunctions = {
+  // Functions whose results verification should be skipped. These can be
+  // order-dependent functions whose results depend on the order of input rows.
+  // For some functions, the result can be transformed to a value that can be
+  // verified. If such transformation exists, it can be specified to be used for
+  // results verification. If no transformation is specified, results are not
+  // verified.
+  std::unordered_map<std::string, std::string> customVerificationFunctions = {
+      // Order-dependent functions.
       {"approx_distinct", ""},
       {"approx_set", ""},
       {"arbitrary", ""},
@@ -71,5 +73,5 @@ int main(int argc, char** argv) {
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return AggregationFuzzerRunner::run(
-      FLAGS_only, initialSeed, skipFunctions, orderDependentFunctions);
+      FLAGS_only, initialSeed, skipFunctions, customVerificationFunctions);
 }


### PR DESCRIPTION
Summary: Rename orderDependentFunctions to specialVerificationFunctions. This is needed for the next diff to skip verification of some aggregation companion functions.

Differential Revision: D45456468

