### PR TITLE
[PyVelox] Add type specification support while creating vectors from list

### DIFF
--- a/pyvelox/pyvelox.cpp
+++ b/pyvelox/pyvelox.cpp
@@ -149,6 +149,20 @@ static VectorPtr pyListToVector(
       variantsToFlatVector, first_kind, variants, pool);
 }
 
+static VectorPtr pyListToVector(
+    const py::list& list,
+    const facebook::velox::Type& dtype,
+    facebook::velox::memory::MemoryPool* pool) {
+  std::vector<velox::variant> variants;
+  variants.reserve(list.size());
+  for (auto item : list) {
+    variants.push_back(pyToVariant(item, dtype));
+  }
+
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      variantsToFlatVector, dtype.kind() , variants, pool);
+}
+
 template <typename NativeType>
 static py::object getItemFromSimpleVector(
     SimpleVectorPtr<NativeType>& vector,

--- a/pyvelox/pyvelox.cpp
+++ b/pyvelox/pyvelox.cpp
@@ -160,7 +160,7 @@ static VectorPtr pyListToVector(
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      variantsToFlatVector, dtype.kind() , variants, pool);
+      variantsToFlatVector, dtype.kind(), variants, pool);
 }
 
 template <typename NativeType>

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -104,9 +104,6 @@ inline velox::variant pyToVariant(const py::handle& obj, const Type& dtype) {
     case TypeKind::TIMESTAMP: {
       return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
     }
-    case TypeKind::DATE: {
-      return pyToVariant<velox::TypeKind::DATE>(obj);
-    }
     default:
       throw py::type_error("Unsupported type supplied");
   }
@@ -464,20 +461,19 @@ static void addVectorBindings(
         checkBounds(indices, idx);
         return indices.indices->as<vector_size_t>()[idx];
       });
-
   m.def(
       "from_list",
       [](const py::list& list, const Type* dtype = nullptr) mutable {
         if (!dtype || py::isinstance<py::none>(py::cast(*dtype))) {
-          return pyListToVector(list, PyVeloxContext::getInstance().pool());
+          return pyListToVector(
+              list, PyVeloxContext::getSingletonInstance().pool());
         } else {
           return pyListToVector(
-              list, *dtype, PyVeloxContext::getInstance().pool());
+              list, *dtype, PyVeloxContext::getSingletonInstance().pool());
         }
       },
       py::arg("list"),
       py::arg("dtype") = nullptr);
-
   m.def(
       "constant_vector",
       [](const py::handle& obj, vector_size_t length, TypePtr type) {

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -71,7 +71,7 @@ inline velox::variant pyToVariant(const py::handle& obj) {
 
 inline velox::variant pyToVariant(const py::handle& obj, const Type& dtype) {
   if (obj.is_none()) {
-    return velox::variant();
+    return velox::variant(dtype.kind());
   }
   switch (dtype.kind()) {
     case TypeKind::BOOLEAN: {

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -72,44 +72,43 @@ inline velox::variant pyToVariant(const py::handle& obj) {
 inline velox::variant pyToVariant(const py::handle& obj, const Type& dtype) {
   if (obj.is_none()) {
     return velox::variant();
-  } else {
-    switch (dtype.kind()) {
-      case TypeKind::BOOLEAN: {
-        return pyToVariant<velox::TypeKind::BOOLEAN>(obj);
-      }
-      case TypeKind::TINYINT: {
-        return pyToVariant<velox::TypeKind::TINYINT>(obj);
-      }
-      case TypeKind::SMALLINT: {
-        return pyToVariant<velox::TypeKind::SMALLINT>(obj);
-      }
-      case TypeKind::INTEGER: {
-        return pyToVariant<velox::TypeKind::INTEGER>(obj);
-      }
-      case TypeKind::BIGINT: {
-        return pyToVariant<velox::TypeKind::BIGINT>(obj);
-      }
-      case TypeKind::REAL: {
-        return pyToVariant<velox::TypeKind::REAL>(obj);
-      }
-      case TypeKind::DOUBLE: {
-        return pyToVariant<velox::TypeKind::DOUBLE>(obj);
-      }
-      case TypeKind::VARCHAR: {
-        return pyToVariant<velox::TypeKind::VARCHAR>(obj);
-      }
-      case TypeKind::VARBINARY: {
-        return pyToVariant<velox::TypeKind::VARBINARY>(obj);
-      }
-      case TypeKind::TIMESTAMP: {
-        return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
-      }
-      case TypeKind::DATE: {
-        return pyToVariant<velox::TypeKind::DATE>(obj);
-      }
-      default:
-        throw py::type_error("Unsupported type supplied");
+  }
+  switch (dtype.kind()) {
+    case TypeKind::BOOLEAN: {
+      return pyToVariant<velox::TypeKind::BOOLEAN>(obj);
     }
+    case TypeKind::TINYINT: {
+      return pyToVariant<velox::TypeKind::TINYINT>(obj);
+    }
+    case TypeKind::SMALLINT: {
+      return pyToVariant<velox::TypeKind::SMALLINT>(obj);
+    }
+    case TypeKind::INTEGER: {
+      return pyToVariant<velox::TypeKind::INTEGER>(obj);
+    }
+    case TypeKind::BIGINT: {
+      return pyToVariant<velox::TypeKind::BIGINT>(obj);
+    }
+    case TypeKind::REAL: {
+      return pyToVariant<velox::TypeKind::REAL>(obj);
+    }
+    case TypeKind::DOUBLE: {
+      return pyToVariant<velox::TypeKind::DOUBLE>(obj);
+    }
+    case TypeKind::VARCHAR: {
+      return pyToVariant<velox::TypeKind::VARCHAR>(obj);
+    }
+    case TypeKind::VARBINARY: {
+      return pyToVariant<velox::TypeKind::VARBINARY>(obj);
+    }
+    case TypeKind::TIMESTAMP: {
+      return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
+    }
+    case TypeKind::DATE: {
+      return pyToVariant<velox::TypeKind::DATE>(obj);
+    }
+    default:
+      throw py::type_error("Unsupported type supplied");
   }
 }
 
@@ -466,12 +465,18 @@ static void addVectorBindings(
         return indices.indices->as<vector_size_t>()[idx];
       });
 
-  m.def("from_list", [](const py::list& list) mutable {
-    return pyListToVector(list, PyVeloxContext::getSingletonInstance().pool());
-  });
-  m.def("from_list", [](const py::list& list, const Type& dtype) mutable {
-    return pyListToVector(list, dtype, PyVeloxContext::getInstance().pool());
-  });
+  m.def(
+      "from_list",
+      [](const py::list& list, const Type* dtype = nullptr) mutable {
+        if (!dtype || py::isinstance<py::none>(py::cast(*dtype))) {
+          return pyListToVector(list, PyVeloxContext::getInstance().pool());
+        } else {
+          return pyListToVector(
+              list, *dtype, PyVeloxContext::getInstance().pool());
+        }
+      },
+      py::arg("list"),
+      py::arg("dtype") = nullptr);
 
   m.def(
       "constant_vector",

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -69,6 +69,50 @@ inline velox::variant pyToVariant(const py::handle& obj) {
   }
 }
 
+inline velox::variant pyToVariant(const py::handle& obj, const Type& dtype) {
+  if (obj.is_none()) {
+    return velox::variant();
+  } else {
+    switch(dtype.kind()){
+      case TypeKind::BOOLEAN : {
+            return pyToVariant<velox::TypeKind::BOOLEAN>(obj);
+      }
+      case TypeKind::TINYINT : {
+            return pyToVariant<velox::TypeKind::TINYINT>(obj);
+      }
+      case TypeKind::SMALLINT : {
+            return pyToVariant<velox::TypeKind::SMALLINT>(obj);
+      }
+      case TypeKind::INTEGER : {
+            return pyToVariant<velox::TypeKind::INTEGER>(obj);
+      }
+      case TypeKind::BIGINT : {
+            return pyToVariant<velox::TypeKind::BIGINT>(obj);
+      }
+      case TypeKind::REAL : {
+            return pyToVariant<velox::TypeKind::REAL>(obj);
+      }
+      case TypeKind::DOUBLE : {
+            return pyToVariant<velox::TypeKind::DOUBLE>(obj);
+      }
+      case TypeKind::VARCHAR : {
+            return pyToVariant<velox::TypeKind::VARCHAR>(obj);
+      }
+      case TypeKind::VARBINARY : {
+            return pyToVariant<velox::TypeKind::VARBINARY>(obj);
+      }
+      case TypeKind::TIMESTAMP : {
+            return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
+      }
+      case TypeKind::DATE : {
+            return pyToVariant<velox::TypeKind::DATE>(obj);
+      }
+      default:
+            throw py::type_error("Unsupported type supplied");
+    }
+  }
+}
+
 static VectorPtr pyToConstantVector(
     const py::handle& obj,
     vector_size_t length,
@@ -82,6 +126,11 @@ static VectorPtr variantsToFlatVector(
 
 static inline VectorPtr pyListToVector(
     const py::list& list,
+    facebook::velox::memory::MemoryPool* pool);
+
+static inline VectorPtr pyListToVector(
+    const py::list& list,
+    const Type& dtype,
     facebook::velox::memory::MemoryPool* pool);
 
 template <TypeKind T>
@@ -420,6 +469,10 @@ static void addVectorBindings(
   m.def("from_list", [](const py::list& list) mutable {
     return pyListToVector(list, PyVeloxContext::getSingletonInstance().pool());
   });
+  m.def("from_list", [](const py::list& list, const Type& dtype) mutable {
+    return pyListToVector(list, dtype, PyVeloxContext::getInstance().pool());
+  });
+
   m.def(
       "constant_vector",
       [](const py::handle& obj, vector_size_t length, TypePtr type) {

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -73,42 +73,42 @@ inline velox::variant pyToVariant(const py::handle& obj, const Type& dtype) {
   if (obj.is_none()) {
     return velox::variant();
   } else {
-    switch(dtype.kind()){
-      case TypeKind::BOOLEAN : {
-            return pyToVariant<velox::TypeKind::BOOLEAN>(obj);
+    switch (dtype.kind()) {
+      case TypeKind::BOOLEAN: {
+        return pyToVariant<velox::TypeKind::BOOLEAN>(obj);
       }
-      case TypeKind::TINYINT : {
-            return pyToVariant<velox::TypeKind::TINYINT>(obj);
+      case TypeKind::TINYINT: {
+        return pyToVariant<velox::TypeKind::TINYINT>(obj);
       }
-      case TypeKind::SMALLINT : {
-            return pyToVariant<velox::TypeKind::SMALLINT>(obj);
+      case TypeKind::SMALLINT: {
+        return pyToVariant<velox::TypeKind::SMALLINT>(obj);
       }
-      case TypeKind::INTEGER : {
-            return pyToVariant<velox::TypeKind::INTEGER>(obj);
+      case TypeKind::INTEGER: {
+        return pyToVariant<velox::TypeKind::INTEGER>(obj);
       }
-      case TypeKind::BIGINT : {
-            return pyToVariant<velox::TypeKind::BIGINT>(obj);
+      case TypeKind::BIGINT: {
+        return pyToVariant<velox::TypeKind::BIGINT>(obj);
       }
-      case TypeKind::REAL : {
-            return pyToVariant<velox::TypeKind::REAL>(obj);
+      case TypeKind::REAL: {
+        return pyToVariant<velox::TypeKind::REAL>(obj);
       }
-      case TypeKind::DOUBLE : {
-            return pyToVariant<velox::TypeKind::DOUBLE>(obj);
+      case TypeKind::DOUBLE: {
+        return pyToVariant<velox::TypeKind::DOUBLE>(obj);
       }
-      case TypeKind::VARCHAR : {
-            return pyToVariant<velox::TypeKind::VARCHAR>(obj);
+      case TypeKind::VARCHAR: {
+        return pyToVariant<velox::TypeKind::VARCHAR>(obj);
       }
-      case TypeKind::VARBINARY : {
-            return pyToVariant<velox::TypeKind::VARBINARY>(obj);
+      case TypeKind::VARBINARY: {
+        return pyToVariant<velox::TypeKind::VARBINARY>(obj);
       }
-      case TypeKind::TIMESTAMP : {
-            return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
+      case TypeKind::TIMESTAMP: {
+        return pyToVariant<velox::TypeKind::TIMESTAMP>(obj);
       }
-      case TypeKind::DATE : {
-            return pyToVariant<velox::TypeKind::DATE>(obj);
+      case TypeKind::DATE: {
+        return pyToVariant<velox::TypeKind::DATE>(obj);
       }
       default:
-            throw py::type_error("Unsupported type supplied");
+        throw py::type_error("Unsupported type supplied");
     }
   }
 }

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -56,15 +56,23 @@ class TestVeloxVector(unittest.TestCase):
             pv.from_list([])
 
     def test_from_list_with_type(self):
-        a = pv.from_list([0, 1, 3], pv.BooleanType())
+        list_a = [0, 1, 3]
+        a = pv.from_list(list_a, pv.BooleanType())
         self.assertEqual(a.typeKind().name, 'BOOLEAN')
         for i in range(len(a)):
             self.assertTrue(isinstance(a[i], bool))
+            self.assertEqual(a[i], bool(list_a[i]))
         self.assertTrue(isinstance(pv.from_list([None, None, None], pv.VarcharType()), pv.BaseVector))
         empty_vector = pv.from_list([], pv.IntegerType())
         self.assertTrue(isinstance(empty_vector, pv.BaseVector))
         with self.assertRaises(IndexError):
             a = empty_vector[0]
+        with self.assertRaises(RuntimeError):
+            a = pv.from_list([0, 1, 3], pv.VarcharType()) # Conversion not possible from int to varchar
+        list_b = [0.2, 1.2, 3.23]
+        b = pv.from_list(list_b, pv.RealType())
+        for i in range(len(list_b)):
+            self.assertNotAlmostEqual(list_b[i], b[i], places=17)
 
     def test_constant_encoding(self):
         ints = pv.constant_vector(1000, 10)

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -55,6 +55,17 @@ class TestVeloxVector(unittest.TestCase):
         with self.assertRaises(ValueError):
             pv.from_list([])
 
+    def test_from_list_with_type(self):
+        a = pv.from_list([0, 1, 3], pv.BooleanType())
+        self.assertEqual(a.typeKind().name, 'BOOLEAN')
+        for i in range(len(a)):
+            self.assertTrue(isinstance(a[i], bool))
+        self.assertTrue(isinstance(pv.from_list([None, None, None], pv.VarcharType()), pv.BaseVector))
+        empty_vector = pv.from_list([], pv.IntegerType())
+        self.assertTrue(isinstance(empty_vector, pv.BaseVector))
+        with self.assertRaises(IndexError):
+            a = empty_vector[0]
+
     def test_constant_encoding(self):
         ints = pv.constant_vector(1000, 10)
         strings = pv.constant_vector("hello", 100)

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -58,17 +58,23 @@ class TestVeloxVector(unittest.TestCase):
     def test_from_list_with_type(self):
         list_a = [0, 1, 3]
         a = pv.from_list(list_a, pv.BooleanType())
-        self.assertEqual(a.typeKind().name, 'BOOLEAN')
+        self.assertEqual(a.typeKind().name, "BOOLEAN")
         for i in range(len(a)):
             self.assertTrue(isinstance(a[i], bool))
             self.assertEqual(a[i], bool(list_a[i]))
-        self.assertTrue(isinstance(pv.from_list([None, None, None], pv.VarcharType()), pv.BaseVector))
+        self.assertTrue(
+            isinstance(
+                pv.from_list([None, None, None], pv.VarcharType()), pv.BaseVector
+            )
+        )
         empty_vector = pv.from_list([], pv.IntegerType())
         self.assertTrue(isinstance(empty_vector, pv.BaseVector))
         with self.assertRaises(IndexError):
             a = empty_vector[0]
         with self.assertRaises(RuntimeError):
-            a = pv.from_list([0, 1, 3], pv.VarcharType()) # Conversion not possible from int to varchar
+            a = pv.from_list(
+                [0, 1, 3], pv.VarcharType()
+            )  # Conversion not possible from int to varchar
         list_b = [0.2, 1.2, 3.23]
         b = pv.from_list(list_b, pv.RealType())
         for i in range(len(list_b)):

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -80,6 +80,11 @@ class TestVeloxVector(unittest.TestCase):
         for i in range(len(list_b)):
             self.assertNotAlmostEqual(list_b[i], b[i], places=17)
 
+        # dtype as a keyword argument
+        integerVector = pv.from_list([1, 3, 11], dtype=pv.IntegerType())
+        self.assertTrue(isinstance(integerVector, pv.BaseVector))
+        self.assertEqual(integerVector.typeKind().name, "INTEGER")
+
     def test_constant_encoding(self):
         ints = pv.constant_vector(1000, 10)
         strings = pv.constant_vector("hello", 100)


### PR DESCRIPTION
This PR adds the support to specify data type while creating a vector from a Python list. With this change, the user can also create empty or null vectors.