### PR TITLE
Skip unix_timestamp in Spark expression fuzzer

### DIFF
--- a/velox/expression/tests/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/SparkExpressionFuzzerTest.cpp
@@ -57,7 +57,12 @@ int main(int argc, char** argv) {
   // For rlike you need the following combo in the only list:
   // rlike, md5 and upper
   std::unordered_set<std::string> skipFunctions = {
-      "regexp_extract", "rlike", "chr", "replace", "might_contain"};
+      "regexp_extract",
+      "rlike",
+      "chr",
+      "replace",
+      "might_contain",
+      "unix_timestamp"};
   return FuzzerRunner::run(
       FLAGS_only, FLAGS_seed, skipFunctions, FLAGS_special_forms);
 }


### PR DESCRIPTION
Summary: `unix_timestamp` will return different values on different runs so that we cannot compare the results in the fuzzer.  Shall we add a `isPure` in addition to `isDeterministic` in function metadata to handle this kind of behavior?

Differential Revision: D45499738

