### PR TITLE
Fix batch of all inactive conditional aggregates

### DIFF
--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -299,6 +299,9 @@ class GroupingSet {
   std::unique_ptr<RowContainer> intermediateRows_;
   std::vector<char*> intermediateGroups_;
   std::vector<vector_size_t> intermediateRowNumbers_;
+  // Temporary for case where an aggregate in toIntermediate() outputs post-init
+  // state of aggregate for all rows.
+  std::vector<char*> firstGroup_;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CountAggregationTest.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
@@ -80,34 +82,39 @@ TEST_F(CountAggregationTest, count) {
 }
 
 TEST_F(CountAggregationTest, mask) {
-  auto data = makeRowVector(
-      {"c", "m"},
-      {
-          makeFlatVector<int64_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
-          makeFlatVector<bool>(
-              {true,
-               false,
-               true,
-               false,
-               true,
-               false,
-               true,
-               false,
-               true,
-               false}),
-      });
+  std::vector<RowVectorPtr> data;
+  // Make batches where some batches have mask all true, some half and half and
+  // some all false. All batches repeat the same grouping keys. The data to
+  // count is null for 1/3 of the rows.
+  constexpr int32_t kNumBatches = 10;
+  constexpr int32_t kRowsInBatch = 100;
+  for (auto counter = 0; counter < kNumBatches; ++counter) {
+    data.push_back(makeRowVector(
+        {"k", "c", "m"},
+        {makeFlatVector<int64_t>(
+             kRowsInBatch, [](auto row) { return row / 10; }),
+         makeFlatVector<int64_t>(
+             kRowsInBatch,
+             [](auto row) { return row; },
+             [](auto row) { return row % 3 == 0; }),
+         makeFlatVector<bool>(kRowsInBatch, [&](auto row) {
+           return counter % 3 == 0 ? false
+               : counter % 3 == 1  ? false
+                                   : row % 2 == 0;
+         })}));
+  }
 
-  createDuckDbTable({data});
+  createDuckDbTable(data);
 
   // count(c)
   auto plan = PlanBuilder()
-                  .values({data})
+                  .values(data)
                   .singleAggregation({}, {"count(c)"}, {"m"})
                   .planNode();
   assertQuery(plan, "SELECT count(c) FILTER (where m) FROM tmp");
 
   plan = PlanBuilder()
-             .values({data})
+             .values(data)
              .partialAggregation({}, {"count(c)"}, {"m"})
              .finalAggregation()
              .planNode();
@@ -115,17 +122,35 @@ TEST_F(CountAggregationTest, mask) {
 
   // count(1)
   plan = PlanBuilder()
-             .values({data})
+             .values(data)
              .singleAggregation({}, {"count()"}, {"m"})
              .planNode();
   assertQuery(plan, "SELECT count(1) FILTER (where m) FROM tmp");
 
   plan = PlanBuilder()
-             .values({data})
+             .values(data)
              .partialAggregation({}, {"count()"}, {"m"})
              .finalAggregation()
              .planNode();
   assertQuery(plan, "SELECT count(1) FILTER (where m) FROM tmp");
+
+  core::PlanNodeId partialNodeId;
+  plan = PlanBuilder()
+             .values(data)
+             .partialAggregation({"k"}, {"count(c)"}, {"m"})
+             .capturePlanNodeId(partialNodeId)
+             .finalAggregation()
+             .planNode();
+  auto task =
+      AssertQueryBuilder(plan, duckDbQueryRunner_)
+          .maxDrivers(1)
+          .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+          .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+          .assertResults(
+              "SELECT k, count(c) FILTER (where m) FROM tmp GROUP BY k");
+  auto taskStats = toPlanStats(task->taskStats());
+  auto partialStats = taskStats.at(partialNodeId).customStats;
+  EXPECT_LT(0, partialStats.at("abandonedPartialAggregation").count);
 }
 
 } // namespace


### PR DESCRIPTION
In GroupingSet::toIntermediate, when there is a batch of all masked out inputs for an aggregate, the result is not a column of all nulls in all cases. For example, count has a column of all zeros. Therefore, if all inputs are masked out, initialize the aggregate on one row and read this post-initialization state to all elements of the result vector. The result vector is always a preallocated, reused flat vector, so there is no point with constant wrapping or the like for a rare special case.