### PR TITLE
Backport fmt config patch

### DIFF
--- a/CMake/resolve_dependency_modules/fmt.cmake
+++ b/CMake/resolve_dependency_modules/fmt.cmake
@@ -25,10 +25,12 @@ message(STATUS "Building fmt from source")
 FetchContent_Declare(
   fmt
   URL ${VELOX_FMT_SOURCE_URL}
-  URL_HASH ${VELOX_FMT_BUILD_SHA256_CHECKSUM})
+  URL_HASH ${VELOX_FMT_BUILD_SHA256_CHECKSUM}
+  PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/fmt/no-targets.patch)
 
 # Force fmt to create fmt-config.cmake which can be found by other dependecies
 # (e.g. folly)
 set(FMT_INSTALL ON)
 set(fmt_BUILD_TESTS OFF)
 FetchContent_MakeAvailable(fmt)
+list(APPEND CMAKE_PREFIX_PATH ${fmt_BINARY_DIR})

--- a/CMake/resolve_dependency_modules/fmt/no-targets.patch
+++ b/CMake/resolve_dependency_modules/fmt/no-targets.patch
@@ -1,0 +1,12 @@
+This can be removed once we upgrade to fmt >= 9
+--- a/support/cmake/fmt-config.cmake.in
++++ b/support/cmake/fmt-config.cmake.in
+@@ -1,4 +1,7 @@
+ @PACKAGE_INIT@
+ 
+-include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
++if (NOT TARGET fmt::fmt)
++  include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
++endif ()
++
+ check_required_components(fmt)


### PR DESCRIPTION
This backports a patch from fmt 9.0.0 that remove the inclusion of the "targets" file when `fmt::fmt` exists as a target. This would otherwise require us to set CMP0024 OLD which is deprecated behavior.