### PR TITLE
Add MakeCleanup utility to ease error handling

### DIFF
--- a/velox/common/base/Cleanup.h
+++ b/velox/common/base/Cleanup.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook {
+namespace velox {
+
+/// A scoped helper object invokes user provided cleanup callback on
+/// destruction. This simplifies the error handling in different branches within
+/// a function.
+class MakeCleanup {
+ public:
+  MakeCleanup(std::function<void()>&& cleanupCb)
+      : cleanupCb_(std::move(cleanupCb)) {}
+  ~MakeCleanup() {
+    if (!cancelled_) {
+      cleanupCb_();
+    }
+  }
+
+  /// Cancels the gcleanup callback execution.
+  void cancel() {
+    cancelled_ = true;
+  }
+
+ private:
+  bool cancelled_{false};
+  std::function<void()> cleanupCb_;
+};
+
+} // namespace velox
+} // namespace facebook

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   AsyncSourceTest.cpp
   BitUtilTest.cpp
   BloomFilterTest.cpp
+  CleanupTest.cpp
   CoalesceIoTest.cpp
   ExceptionTest.cpp
   FsTest.cpp

--- a/velox/common/base/tests/CleanupTest.cpp
+++ b/velox/common/base/tests/CleanupTest.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/Cleanup.h"
+
+#include <gtest/gtest.h>
+
+namespace facebook {
+namespace velox {
+
+TEST(CleanupTest, basic) {
+  int count = 0;
+  {
+    MakeCleanup cleanup([&]{ ++count; });
+    ASSERT_EQ(count, 0);
+  }
+  ASSERT_EQ(count, 1);
+  {
+    MakeCleanup cleanup([&]{ ++count; });
+    ASSERT_EQ(count, 1);
+  }
+  ASSERT_EQ(count, 2);
+  {
+    MakeCleanup cleanup([&]{ ++count; });
+    ASSERT_EQ(count, 2);
+    cleanup.cancel();
+    ASSERT_EQ(count, 2);
+  }
+  ASSERT_EQ(count, 2);
+  {
+    MakeCleanup cleanup([&]{ ++count; });
+    ASSERT_EQ(count, 2);
+  }
+  ASSERT_EQ(count, 3);
+}
+
+} // namespace velox
+} // namespace facebook


### PR DESCRIPTION
Add MakeCleanup utility to ease error handling in different
branches within a function. See example in unit test.