### PR TITLE
Fix using the Thrift annotation library

### DIFF
--- a/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
+++ b/build/fbcode_builder/CMake/FBThriftCppLibrary.cmake
@@ -115,6 +115,7 @@ function(add_fbthrift_cpp_library LIB_NAME THRIFT_FILE)
       --legacy-strict
       --gen "mstch_cpp2:${GEN_ARG_STR}"
       "${thrift_include_options}"
+      -I "${FBTHRIFT_INCLUDE_DIR}"
       -o "${output_dir}"
       "${CMAKE_CURRENT_SOURCE_DIR}/${THRIFT_FILE}"
     WORKING_DIRECTORY


### PR DESCRIPTION
Summary:
Pass the include directory to the Thrift compiler to fix using the annotation library.

Fixes the following error when building openr:

```
$ opensource/fbcode_builder/getdeps.py build openr
...
[ERROR:/data/users/viz/scratch/dataZusersZvizZfbsource/fbcode_builder_getdeps/shipit/openr/openr/if/Dual.thrift:17] Could not find include file thrift/annotation/cpp.thrift
```

Reviewed By: avalonalex

Differential Revision: D45530515

