### PR TITLE
Optimize flattenVector and add unit test

### DIFF
--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -652,8 +652,8 @@ void pruneRandomSubfield(
             BaseVector::wrapInDictionary(nullptr, indices, offset, keys);
         auto newValues = BaseVector::wrapInDictionary(
             nullptr, indices, offset, data->mapValues());
-        BaseVector::flattenVector(newKeys, newKeys->size());
-        BaseVector::flattenVector(newValues, newValues->size());
+        BaseVector::flattenVector(newKeys);
+        BaseVector::flattenVector(newValues);
         data->setKeysAndValues(newKeys, newValues);
       }
       spec.childByName(ScanSpec::kMapKeysFieldName)

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -439,7 +439,7 @@ void Expr::evalSimplifiedImpl(
   auto evalArg = [&](int32_t i) {
     auto& inputValue = inputValues_[i];
     inputs_[i]->evalSimplified(remainingRows.rows(), context, inputValue);
-    BaseVector::flattenVector(inputValue, rows.end());
+    BaseVector::flattenVector(inputValue);
     VELOX_CHECK(
         inputValue->encoding() == VectorEncoding::Simple::FLAT ||
         inputValue->encoding() == VectorEncoding::Simple::ARRAY ||

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -110,7 +110,7 @@ void FieldReference::evalSpecialFormSimplified(
   } else {
     VELOX_CHECK_EQ(inputs_.size(), 1);
     inputs_[0]->evalSimplified(rows, context, input);
-    BaseVector::flattenVector(input, rows.end());
+    BaseVector::flattenVector(input);
     row = input->as<RowVector>();
     VELOX_CHECK(row);
   }

--- a/velox/functions/prestosql/Slice.cpp
+++ b/velox/functions/prestosql/Slice.cpp
@@ -74,7 +74,7 @@ class SliceFunction : public exec::VectorFunction {
     // overlapping ranges. To prevent this, we flatten the first parameter in
     // these cases.
     if (!args[1]->isConstantEncoding() || !args[2]->isConstantEncoding()) {
-      BaseVector::flattenVector(args[0], args[0]->size());
+      BaseVector::flattenVector(args[0]);
     }
 
     VectorPtr localResult =

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -49,6 +49,8 @@ template <typename T>
 class FlatVector;
 
 class VectorPool;
+class BaseVector;
+using VectorPtr = std::shared_ptr<BaseVector>;
 
 /**
  * Base class for all columnar-based vectors of any type.
@@ -512,22 +514,8 @@ class BaseVector {
     return false;
   }
 
-  // Flattens the input vector.
-  //
-  // TODO: This method reuses ensureWritable(), which ensures that both:
-  //  (a) the vector is flattened, and
-  //  (b) it's singly-referenced
-  //
-  // We don't necessarily need (b) if we only want to flatten vectors.
-  static void flattenVector(
-      std::shared_ptr<BaseVector>& vector,
-      size_t vectorSize) {
-    BaseVector::ensureWritable(
-        SelectivityVector::empty(vectorSize),
-        vector->type(),
-        vector->pool(),
-        vector);
-  }
+  // Flattens the input vector and all of its children.
+  static void flattenVector(VectorPtr& vector);
 
   template <typename T>
   static inline uint64_t byteSize(vector_size_t count) {
@@ -860,8 +848,6 @@ template <>
 inline uint64_t BaseVector::byteSize<UnknownValue>(vector_size_t) {
   return 0;
 }
-
-using VectorPtr = std::shared_ptr<BaseVector>;
 
 // Returns true if vector is a Lazy vector, possibly wrapped, that hasn't
 // been loaded yet.

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2196,3 +2196,97 @@ TEST_F(VectorTest, testCopyWithZeroCount) {
   runTest(
       makeRowVector({makeFlatVector<int32_t>(1, [](auto i) { return i; })}));
 }
+
+TEST_F(VectorTest, flattenVector) {
+  auto test = [&](VectorPtr& vector, bool stayTheSame) {
+    auto original = vector;
+    BaseVector::flattenVector(vector);
+    if (stayTheSame) {
+      EXPECT_EQ(original.get(), vector.get());
+    } else {
+      EXPECT_NE(original.get(), vector.get());
+    }
+    test::assertEqualVectors(original, vector);
+  };
+
+  // Flat input.
+  VectorPtr flat = makeFlatVector<int32_t>({1, 2, 3});
+  test(flat, true);
+
+  VectorPtr array = makeArrayVector<int32_t>({{1, 2, 3}, {1}, {1}});
+  test(array, true);
+
+  VectorPtr map =
+      makeMapVector<int32_t, int32_t>({{{4, 40}, {3, 30}}, {{4, 41}}, {}});
+  test(map, true);
+
+  VectorPtr row = makeRowVector({flat, array, map});
+  test(row, true);
+
+  // Constant
+  VectorPtr constant = BaseVector::wrapInConstant(100, 1, flat);
+  test(constant, false);
+  EXPECT_TRUE(constant->isFlatEncoding());
+
+  // Dictionary
+  VectorPtr dictionary = BaseVector::wrapInDictionary(
+      nullptr, makeIndices(100, [](auto row) { return row % 2; }), 100, flat);
+  test(dictionary, false);
+  EXPECT_TRUE(dictionary->isFlatEncoding());
+
+  // Array with constant elements.
+  auto* arrayVector = array->as<ArrayVector>();
+  arrayVector->elements() = BaseVector::wrapInConstant(100, 1, flat);
+  auto originalElements = arrayVector->elements();
+  auto original = array;
+
+  BaseVector::flattenVector(array);
+  test::assertEqualVectors(original, array);
+
+  EXPECT_EQ(array->encoding(), VectorEncoding::Simple::ARRAY);
+  EXPECT_TRUE(array->as<ArrayVector>()->elements()->isFlatEncoding());
+
+  EXPECT_EQ(original.get(), array.get());
+  EXPECT_NE(originalElements.get(), array->as<ArrayVector>()->elements().get());
+
+  // Map with constant keys and values.
+  auto* mapVector = map->as<MapVector>();
+  auto originalValues = mapVector->mapValues() =
+      BaseVector::wrapInConstant(100, 1, flat);
+  auto originalKeys = mapVector->mapKeys() =
+      BaseVector::wrapInConstant(100, 1, flat);
+
+  original = map;
+  BaseVector::flattenVector(map);
+  test::assertEqualVectors(original, map);
+
+  EXPECT_EQ(map->encoding(), VectorEncoding::Simple::MAP);
+  EXPECT_TRUE(map->as<MapVector>()->mapValues()->isFlatEncoding());
+  EXPECT_TRUE(map->as<MapVector>()->mapKeys()->isFlatEncoding());
+
+  EXPECT_EQ(original.get(), map.get());
+  EXPECT_NE(originalValues.get(), map->as<MapVector>()->mapValues().get());
+  EXPECT_NE(originalKeys.get(), map->as<MapVector>()->mapKeys().get());
+
+  // Row with constant field.
+  row = makeRowVector({flat, BaseVector::wrapInConstant(3, 1, flat)});
+  auto* rowVector = row->as<RowVector>();
+  auto originalRow0 = rowVector->children()[0];
+  auto originalRow1 = rowVector->children()[1];
+  original = row;
+  BaseVector::flattenVector(row);
+  EXPECT_EQ(row->encoding(), VectorEncoding::Simple::ROW);
+  EXPECT_TRUE(row->as<RowVector>()->children()[0]->isFlatEncoding());
+  EXPECT_TRUE(row->as<RowVector>()->children()[1]->isFlatEncoding());
+  test::assertEqualVectors(original, row);
+
+  EXPECT_EQ(original.get(), row.get());
+  EXPECT_EQ(originalRow0.get(), row->as<RowVector>()->children()[0].get());
+  EXPECT_NE(originalRow1.get(), row->as<RowVector>()->children()[1].get());
+
+  // Row with constant field.
+  // Null input
+  VectorPtr nullVector = nullptr;
+  BaseVector::flattenVector(nullVector);
+  EXPECT_EQ(nullVector, nullptr);
+}


### PR DESCRIPTION
Summary:
- Avoid copying in flattenVector when not needed.
- if input is null, vector is not changed.
- add test that values are the same before and after.

Differential Revision: D45552222

