### PR TITLE
Revert refine StringIdMap change and add to log non-existing reference id

### DIFF
--- a/velox/common/caching/StringIdMap.h
+++ b/velox/common/caching/StringIdMap.h
@@ -63,10 +63,6 @@ class StringIdMap {
     return it == idToString_.end() ? "" : it->second.string;
   }
 
-  void testingSetLastId(uint64_t lastId) {
-    lastId_ = lastId;
-  }
-
  private:
   struct Entry {
     std::string string;

--- a/velox/common/caching/tests/StringIdMapTest.cpp
+++ b/velox/common/caching/tests/StringIdMapTest.cpp
@@ -53,10 +53,3 @@ TEST(StringIdMapTest, rehash) {
     EXPECT_EQ(ids[i].id(), StringIdLease(map, name).id());
   }
 }
-
-TEST(StringIdMapTest, overflow) {
-  StringIdMap map;
-  map.testingSetLastId(StringIdMap::kNoId - 1);
-  map.makeId("test");
-  ASSERT_EQ(map.id("test"), 0);
-}


### PR DESCRIPTION
Summary:
Original commit changeset: 121eb2397190

Original Phabricator Diff: D45286483

Also add a log on non-existing file id

Reviewed By: Yuhta

Differential Revision: D45545517

