### PR TITLE
Add feature projection visibility metrics

### DIFF
--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -102,6 +102,12 @@ class RowReaderOptions {
   std::shared_ptr<folly::Executor> decodingExecutor_;
   std::shared_ptr<folly::Executor> ioExecutor_;
   bool appendRowNumberColumn_ = false;
+  // Function to populate metrics related to feature projection stats
+  // in Koski. This gets fired in FlatMapColumnReader.
+  // This is a bit of a hack as there is (by design) no good way
+  // To propogate information from column reader to Koski
+  std::function<void(uint64_t numTotalKeys, uint64_t numSelectedKeys)>
+      keySelectionCallback_;
 
  public:
   RowReaderOptions() noexcept
@@ -275,6 +281,17 @@ class RowReaderOptions {
 
   bool getAppendRowNumberColumn() const {
     return appendRowNumberColumn_;
+  }
+
+  void setKeySelectionCallback(
+      std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+          keySelectionCallback) {
+    keySelectionCallback_ = std::move(keySelectionCallback);
+  }
+
+  const std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+  getKeySelectionCallback() const {
+    return keySelectionCallback_;
   }
 
   const std::shared_ptr<folly::Executor>& getDecodingExecutor() const {

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1573,6 +1573,13 @@ class StructColumnReader : public ColumnReader {
       override;
 };
 
+FlatMapContext makeCopyWithNullDecoder(FlatMapContext& original) {
+  return FlatMapContext{
+      .sequence = original.sequence,
+      .inMapDecoder = nullptr,
+      .keySelectionCallback = original.keySelectionCallback};
+}
+
 // From reading side - all sequences are by default 0
 // except it's turned into a sequence level filtering
 // Sequence level fitlering to be added in the future.
@@ -1607,7 +1614,7 @@ StructColumnReader::StructColumnReader(
             child,
             nodeType_->childAt(i),
             stripe,
-            FlatMapContext{flatMapContext_.sequence, nullptr}));
+            makeCopyWithNullDecoder(flatMapContext_)));
       } else {
         children_.push_back(
             std::make_unique<NullColumnReader>(stripe, child->type));
@@ -1739,7 +1746,7 @@ ListColumnReader::ListColumnReader(
         childType,
         nodeType_->childAt(0),
         stripe,
-        FlatMapContext{flatMapContext_.sequence, nullptr});
+        makeCopyWithNullDecoder(flatMapContext_));
   }
 }
 
@@ -1901,7 +1908,7 @@ MapColumnReader::MapColumnReader(
         keyType,
         nodeType_->childAt(0),
         stripe,
-        FlatMapContext{flatMapContext_.sequence, nullptr});
+        makeCopyWithNullDecoder(flatMapContext_));
   }
 
   auto& valueType = requestedType_->childAt(1);
@@ -1910,7 +1917,7 @@ MapColumnReader::MapColumnReader(
         valueType,
         nodeType_->childAt(1),
         stripe,
-        FlatMapContext{flatMapContext_.sequence, nullptr});
+        makeCopyWithNullDecoder(flatMapContext_));
   }
 
   VLOG(1) << "[Map] Initialized map column reader for node " << nodeType_->id;

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -404,6 +404,7 @@ void DwrfRowReader::startNextStripe() {
   auto requestedType = getColumnSelector().getSchemaWithId();
   auto dataType = getReader().getSchemaWithId();
   auto flatMapContext = FlatMapContext::nonFlatMapContext();
+  flatMapContext.keySelectionCallback = options_.getKeySelectionCallback();
 
   if (scanSpec) {
     selectiveColumnReader_ = SelectiveDwrfReader::build(

--- a/velox/dwio/dwrf/reader/EncodingContext.h
+++ b/velox/dwio/dwrf/reader/EncodingContext.h
@@ -21,16 +21,16 @@
 namespace facebook::velox::dwrf {
 struct FlatMapContext {
  public:
-  explicit FlatMapContext(uint32_t sequence, BooleanRleDecoder* inMapDecoder)
-      : sequence{sequence}, inMapDecoder{inMapDecoder} {}
-
   static FlatMapContext nonFlatMapContext() {
-    return FlatMapContext{0, nullptr};
+    return FlatMapContext{0, nullptr, nullptr};
   }
 
   uint32_t sequence;
   // Kept alive by key nodes
-  BooleanRleDecoder* inMapDecoder;
+  BooleanRleDecoder* inMapDecoder{nullptr};
+
+  std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+      keySelectionCallback;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -26,6 +26,13 @@
 
 namespace facebook::velox::dwrf {
 
+// Stats used by callback passed from Koski layer
+// to give visibility into flatmap efficiency
+struct KeySelectionStats {
+  size_t totalKeyStreams{0};
+  size_t selectedKeyStreams{0};
+};
+
 class StringKeyBuffer;
 
 // represent a branch of a value node in a flat map
@@ -157,6 +164,7 @@ class FlatMapColumnReader : public ColumnReader {
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  KeySelectionStats keySelectionStats_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
@@ -185,6 +193,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
+  KeySelectionStats keySelectionStats_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<NullColumnReader> nullColumnReader_;
   BufferPtr mergedNulls_;

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -158,7 +158,11 @@ std::vector<KeyNode<T>> getKeyNodes(
         VELOX_CHECK(inMap, "In map stream is required");
         auto inMapDecoder = createBooleanRleDecoder(std::move(inMap), seqEk);
         DwrfParams childParams(
-            stripe, FlatMapContext(sequence, inMapDecoder.get()));
+            stripe,
+            FlatMapContext{
+                .sequence = sequence,
+                .inMapDecoder = inMapDecoder.get(),
+                .keySelectionCallback = nullptr});
         auto reader = SelectiveDwrfReader::build(
             requestedValueType, dataValueType, childParams, *childSpec);
         keyNodes.emplace_back(

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -37,6 +37,13 @@ std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> makeLengthDecoder(
 }
 } // namespace
 
+FlatMapContext flatMapContextFromEncodingKey(EncodingKey& encodingKey) {
+  return FlatMapContext{
+      .sequence = encodingKey.sequence,
+      .inMapDecoder = nullptr,
+      .keySelectionCallback = nullptr};
+}
+
 SelectiveListColumnReader::SelectiveListColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
@@ -65,7 +72,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
   scanSpec_->children()[0]->setExtractValues(true);
 
   auto childParams =
-      DwrfParams(stripe, FlatMapContext{encodingKey.sequence, nullptr});
+      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
   child_ = SelectiveDwrfReader::build(
       childType, nodeType_->childAt(0), childParams, *scanSpec_->children()[0]);
   children_ = {child_.get()};
@@ -102,7 +109,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       cs.shouldReadNode(keyType->id),
       "Map key must be selected in SelectiveMapColumnReader");
   auto keyParams =
-      DwrfParams(stripe, FlatMapContext{encodingKey.sequence, nullptr});
+      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
   keyReader_ = SelectiveDwrfReader::build(
       keyType,
       nodeType_->childAt(0),
@@ -114,7 +121,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       cs.shouldReadNode(valueType->id),
       "Map Values must be selected in SelectiveMapColumnReader");
   auto elementParams =
-      DwrfParams(stripe, FlatMapContext{encodingKey.sequence, nullptr});
+      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
   elementReader_ = SelectiveDwrfReader::build(
       valueType,
       nodeType_->childAt(1),

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -53,8 +53,12 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     auto childDataType = nodeType_->childByName(childSpec->fieldName());
     auto childRequestedType =
         requestedType_->childByName(childSpec->fieldName());
-    auto childParams =
-        DwrfParams(stripe, FlatMapContext{encodingKey.sequence, nullptr});
+    auto childParams = DwrfParams(
+        stripe,
+        FlatMapContext{
+            .sequence = encodingKey.sequence,
+            .inMapDecoder = nullptr,
+            .keySelectionCallback = nullptr});
     VELOX_CHECK(cs.shouldReadNode(childDataType->id));
     addChild(SelectiveDwrfReader::build(
         childRequestedType, childDataType, childParams, *childSpec));

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -337,7 +337,13 @@ void testDataTypeWriter(
     auto typeWithId = TypeWithId::create(rowType);
     auto reqType = typeWithId->childAt(0);
     auto reader = ColumnReader::build(
-        reqType, reqType, streams, FlatMapContext{sequence, nullptr});
+        reqType,
+        reqType,
+        streams,
+        FlatMapContext{
+            .sequence = sequence,
+            .inMapDecoder = nullptr,
+            .keySelectionCallback = nullptr});
     VectorPtr out;
     for (auto strideI = 0; strideI < strideCount; ++strideI) {
       reader->next(size, out);


### PR DESCRIPTION
Summary:
To know when feature projection is failing or succeeding, we want to provide some data from reader level on how many keys we are filtering with flatmap.

This:
- Creates a callback from the Koski layer which adds to aggregator used by koski QueryStats, and stores it to dwio config
- Passes callback from dwio config to row reader options
- Passes callback from row reader options to flatmap context
- Passes callback from row reader options t
- Aggregates total and selected key streams in flatmap column reader. The delta between these reflects filtering done by feature projection
- Fires callback in flatmap column reader once filtering is done

The reason for so many handoffs is because dwio is not designed to have config available in column reader level. Exposing metrics from this level to koski user is a bit of a hack with our current metrics framework.

This is behind a JustKnobs flag:

https://www.internalfb.com/intern/justknobs/?name=xldb_ml_engine%2Fkoski#enable_feature_projection_metrics

Reviewed By: Magoja

Differential Revision: D45508059

