### PR TITLE
Make fmt formatter methods const

### DIFF
--- a/velox/common/base/tests/ExceptionTest.cpp
+++ b/velox/common/base/tests/ExceptionTest.cpp
@@ -39,7 +39,7 @@ struct fmt::formatter<Counter> {
   }
 
   template <typename FormatContext>
-  auto format(const Counter& c, FormatContext& ctx) {
+  auto format(const Counter& c, FormatContext& ctx) const {
     auto x = c.counter++;
     return format_to(ctx.out(), "{}", x);
   }

--- a/velox/external/duckdb/duckdb-internal.hpp
+++ b/velox/external/duckdb/duckdb-internal.hpp
@@ -6721,7 +6721,7 @@ struct formatter<T, Char,
   }
 
   template <typename FormatContext>
-  auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const T& val, FormatContext& ctx) const -> decltype(ctx.out()) {
     internal::handle_dynamic_spec<internal::width_checker>(
         specs_.width, specs_.width_ref, ctx);
     internal::handle_dynamic_spec<internal::precision_checker>(
@@ -6741,7 +6741,7 @@ struct formatter<T, Char,
   template <typename Char>                                                    \
   struct formatter<Type, Char> : formatter<Base, Char> {                      \
     template <typename FormatContext>                                         \
-    auto format(const Type& val, FormatContext& ctx) -> decltype(ctx.out()) { \
+    auto format(const Type& val, FormatContext& ctx) const -> decltype(ctx.out()) { \
       return formatter<Base, Char>::format(val, ctx);                         \
     }                                                                         \
   }
@@ -6760,7 +6760,7 @@ FMT_FORMAT_AS(internal::std_string_view<Char>, basic_string_view<Char>);
 template <typename Char>
 struct formatter<void*, Char> : formatter<const void*, Char> {
   template <typename FormatContext>
-  auto format(void* val, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(void* val, FormatContext& ctx) const -> decltype(ctx.out()) {
     return formatter<const void*, Char>::format(val, ctx);
   }
 };
@@ -6768,7 +6768,7 @@ struct formatter<void*, Char> : formatter<const void*, Char> {
 template <typename Char, size_t N>
 struct formatter<Char[N], Char> : formatter<basic_string_view<Char>, Char> {
   template <typename FormatContext>
-  auto format(const Char* val, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const Char* val, FormatContext& ctx) const -> decltype(ctx.out()) {
     return formatter<basic_string_view<Char>, Char>::format(val, ctx);
   }
 };
@@ -6803,7 +6803,7 @@ template <typename Char = char> class dynamic_formatter {
   }
 
   template <typename T, typename FormatContext>
-  auto format(const T& val, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const T& val, FormatContext& ctx) const -> decltype(ctx.out()) {
     handle_specs(ctx);
     internal::specs_checker<null_handler> checker(
         null_handler(),
@@ -7764,7 +7764,7 @@ template <typename T> struct printf_formatter {
   }
 
   template <typename FormatContext>
-  auto format(const T& value, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
     internal::format_value(internal::get_container(ctx.out()), value);
     return ctx.out();
   }
@@ -13160,11 +13160,11 @@ struct IntervalToStringCast {
 // the Software, and to permit persons to whom the Software
 // is furnished to do so, subject to the following
 // conditions:
-// 
+//
 // The above copyright notice and this permission notice
 // shall be included in all copies or substantial portions
 // of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
 // ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
 // TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
@@ -14625,9 +14625,9 @@ namespace detail {
  * where
  *   p = log(5**q)/log(2) = q * log(5)/log(2)
  *
- * For negative values of q in (-400,0), we have that 
+ * For negative values of q in (-400,0), we have that
  *  f = (((152170 + 65536) * q ) >> 16);
- * is equal to 
+ * is equal to
  *   -ceil(p) + q
  * where
  *   p = log(5**-q)/log(2) = -q * log(5)/log(2)
@@ -14675,7 +14675,7 @@ adjusted_mantissa compute_float(int64_t q, uint64_t w)  noexcept  {
     // In some very rare cases, this could happen, in which case we might need a more accurate
     // computation that what we can provide cheaply. This is very, very unlikely.
     //
-    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0, 
+    const bool inside_safe_exponent = (q >= -27) && (q <= 55); // always good because 5**q <2**128 when q>=0,
     // and otherwise, for q<0, we have 5**-q<2**64 and the 128-bit reciprocal allows for exact computation.
     if(!inside_safe_exponent) {
       answer.power2 = -1; // This (a negative value) indicates an error condition.
@@ -15205,7 +15205,7 @@ inline uint64_t round(decimal &h) {
   }
   bool round_up = false;
   if (dp < h.num_digits) {
-    round_up = h.digits[dp] >= 5; // normally, we round up  
+    round_up = h.digits[dp] >= 5; // normally, we round up
     // but we may need to round to even!
     if ((h.digits[dp] == 5) && (dp + 1 == h.num_digits)) {
       round_up = h.truncated || ((dp > 0) && (1 & h.digits[dp - 1]));
@@ -15334,7 +15334,7 @@ adjusted_mantissa compute_float(decimal &d) {
     return answer;
   } else if(d.decimal_point >= 310) {
     // We have something at least as large as 0.1e310 which is
-    // always infinite.  
+    // always infinite.
     answer.power2 = binary::infinite_power();
     answer.mantissa = 0;
     return answer;
@@ -45769,7 +45769,7 @@ namespace duckdb_moodycamel { namespace details {
 #elif defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) || (defined(__APPLE__) && TARGET_OS_IPHONE)
 namespace duckdb_moodycamel { namespace details {
 	static_assert(sizeof(std::thread::id) == 4 || sizeof(std::thread::id) == 8, "std::thread::id is expected to be either 4 or 8 bytes");
-	
+
 	typedef std::thread::id thread_id_t;
 	static const thread_id_t invalid_thread_id;         // Default ctor creates invalid ID
 
@@ -45887,7 +45887,7 @@ namespace duckdb_moodycamel { namespace details {
 #endif
 #endif
 
-// VS2012 doesn't support deleted functions. 
+// VS2012 doesn't support deleted functions.
 // In this case, we declare the function normally but don't define it. A link error will be generated if the function is called.
 #ifndef MOODYCAMEL_DELETE_FUNCTION
 #if defined(_MSC_VER) && _MSC_VER < 1800
@@ -45957,7 +45957,7 @@ struct ConcurrentQueueDefaultTraits
 {
 	// General-purpose size type. std::size_t is strongly recommended.
 	typedef std::size_t size_t;
-	
+
 	// The type used for the enqueue and dequeue indices. Must be at least as
 	// large as size_t. Should be significantly larger than the number of elements
 	// you expect to hold at once, especially if you have a high turnover rate;
@@ -45969,47 +45969,47 @@ struct ConcurrentQueueDefaultTraits
 	// whether the queue is lock-free with a 64-int type depends on the whether
 	// std::atomic<std::uint64_t> is lock-free, which is platform-specific.
 	typedef std::size_t index_t;
-	
+
 	// Internally, all elements are enqueued and dequeued from multi-element
 	// blocks; this is the smallest controllable unit. If you expect few elements
 	// but many producers, a smaller block size should be favoured. For few producers
 	// and/or many elements, a larger block size is preferred. A sane default
 	// is provided. Must be a power of 2.
 	static const size_t BLOCK_SIZE = 32;
-	
+
 	// For explicit producers (i.e. when using a producer token), the block is
 	// checked for being empty by iterating through a list of flags, one per element.
 	// For large block sizes, this is too inefficient, and switching to an atomic
 	// counter-based approach is faster. The switch is made for block sizes strictly
 	// larger than this threshold.
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = 32;
-	
+
 	// How many full blocks can be expected for a single explicit producer? This should
 	// reflect that number's maximum for optimal performance. Must be a power of 2.
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = 32;
-	
+
 	// How many full blocks can be expected for a single implicit producer? This should
 	// reflect that number's maximum for optimal performance. Must be a power of 2.
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = 32;
-	
+
 	// The initial size of the hash table mapping thread IDs to implicit producers.
 	// Note that the hash is resized every time it becomes half full.
 	// Must be a power of two, and either 0 or at least 1. If 0, implicit production
 	// (using the enqueue methods without an explicit producer token) is disabled.
 	static const size_t INITIAL_IMPLICIT_PRODUCER_HASH_SIZE = 32;
-	
+
 	// Controls the number of items that an explicit consumer (i.e. one with a token)
 	// must consume before it causes all consumers to rotate and move on to the next
 	// internal queue.
 	static const std::uint32_t EXPLICIT_CONSUMER_CONSUMPTION_QUOTA_BEFORE_ROTATE = 256;
-	
+
 	// The maximum number of elements (inclusive) that can be enqueued to a sub-queue.
 	// Enqueue operations that would cause this limit to be surpassed will fail. Note
 	// that this limit is enforced at the block level (for performance reasons), i.e.
 	// it's rounded up to the nearest block size.
 	static const size_t MAX_SUBQUEUE_SIZE = details::const_numeric_max<size_t>::value;
-	
-	
+
+
 #ifndef MCDBGQ_USE_RELACY
 	// Memory allocation can be customized if needed.
 	// malloc should return nullptr on failure, and handle alignment like std::malloc.
@@ -46055,13 +46055,13 @@ namespace details
 		ConcurrentQueueProducerTypelessBase* next;
 		std::atomic<bool> inactive;
 		ProducerToken* token;
-		
+
 		ConcurrentQueueProducerTypelessBase()
 			: next(nullptr), inactive(false), token(nullptr)
 		{
 		}
 	};
-	
+
 	template<bool use32> struct _hash_32_or_64 {
 		static inline std::uint32_t hash(std::uint32_t h)
 		{
@@ -46087,14 +46087,14 @@ namespace details
 		}
 	};
 	template<std::size_t size> struct hash_32_or_64 : public _hash_32_or_64<(size > 4)> {  };
-	
+
 	static inline size_t hash_thread_id(thread_id_t id)
 	{
 		static_assert(sizeof(thread_id_t) <= 8, "Expected a platform where thread IDs are at most 64-bit values");
 		return static_cast<size_t>(hash_32_or_64<sizeof(thread_id_converter<thread_id_t>::thread_id_hash_t)>::hash(
 			thread_id_converter<thread_id_t>::prehash(id)));
 	}
-	
+
 	template<typename T>
 	static inline bool circular_less_than(T a, T b)
 	{
@@ -46108,7 +46108,7 @@ namespace details
 #pragma warning(pop)
 #endif
 	}
-	
+
 	template<typename U>
 	static inline char* align_for(char* ptr)
 	{
@@ -46132,7 +46132,7 @@ namespace details
 		++x;
 		return x;
 	}
-	
+
 	template<typename T>
 	static inline void swap_relaxed(std::atomic<T>& left, std::atomic<T>& right)
 	{
@@ -46140,13 +46140,13 @@ namespace details
 		left.store(std::move(right.load(std::memory_order_relaxed)), std::memory_order_relaxed);
 		right.store(std::move(temp), std::memory_order_relaxed);
 	}
-	
+
 	template<typename T>
 	static inline T const& nomove(T const& x)
 	{
 		return x;
 	}
-	
+
 	template<bool Enable>
 	struct nomove_if
 	{
@@ -46156,7 +46156,7 @@ namespace details
 			return x;
 		}
 	};
-	
+
 	template<>
 	struct nomove_if<false>
 	{
@@ -46167,19 +46167,19 @@ namespace details
 			return std::forward<U>(x);
 		}
 	};
-	
+
 	template<typename It>
 	static inline auto deref_noexcept(It& it) MOODYCAMEL_NOEXCEPT -> decltype(*it)
 	{
 		return *it;
 	}
-	
+
 #if defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 	template<typename T> struct is_trivially_destructible : std::is_trivially_destructible<T> { };
 #else
 	template<typename T> struct is_trivially_destructible : std::has_trivial_destructor<T> { };
 #endif
-	
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 #ifdef MCDBGQ_USE_RELACY
 	typedef RelacyThreadExitListener ThreadExitListener;
@@ -46190,11 +46190,11 @@ namespace details
 		typedef void (*callback_t)(void*);
 		callback_t callback;
 		void* userData;
-		
+
 		ThreadExitListener* next;		// reserved for use by the ThreadExitNotifier
 	};
-	
-	
+
+
 	class ThreadExitNotifier
 	{
 	public:
@@ -46204,7 +46204,7 @@ namespace details
 			listener->next = tlsInst.tail;
 			tlsInst.tail = listener;
 		}
-		
+
 		static void unsubscribe(ThreadExitListener* listener)
 		{
 			auto& tlsInst = instance();
@@ -46217,12 +46217,12 @@ namespace details
 				prev = &ptr->next;
 			}
 		}
-		
+
 	private:
 		ThreadExitNotifier() : tail(nullptr) { }
 		ThreadExitNotifier(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
 		ThreadExitNotifier& operator=(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
-		
+
 		~ThreadExitNotifier()
 		{
 			// This thread is about to exit, let everyone know!
@@ -46231,20 +46231,20 @@ namespace details
 				ptr->callback(ptr->userData);
 			}
 		}
-		
+
 		// Thread-local
 		static inline ThreadExitNotifier& instance()
 		{
 			static thread_local ThreadExitNotifier notifier;
 			return notifier;
 		}
-		
+
 	private:
 		ThreadExitListener* tail;
 	};
 #endif
 #endif
-	
+
 	template<typename T> struct static_is_lock_free_num { enum { value = 0 }; };
 	template<> struct static_is_lock_free_num<signed char> { enum { value = ATOMIC_CHAR_LOCK_FREE }; };
 	template<> struct static_is_lock_free_num<short> { enum { value = ATOMIC_SHORT_LOCK_FREE }; };
@@ -46261,10 +46261,10 @@ struct ProducerToken
 {
 	template<typename T, typename Traits>
 	explicit ProducerToken(ConcurrentQueue<T, Traits>& queue);
-	
+
 	template<typename T, typename Traits>
 	explicit ProducerToken(BlockingConcurrentQueue<T, Traits>& queue);
-	
+
 	ProducerToken(ProducerToken&& other) MOODYCAMEL_NOEXCEPT
 		: producer(other.producer)
 	{
@@ -46273,13 +46273,13 @@ struct ProducerToken
 			producer->token = this;
 		}
 	}
-	
+
 	inline ProducerToken& operator=(ProducerToken&& other) MOODYCAMEL_NOEXCEPT
 	{
 		swap(other);
 		return *this;
 	}
-	
+
 	void swap(ProducerToken& other) MOODYCAMEL_NOEXCEPT
 	{
 		std::swap(producer, other.producer);
@@ -46290,7 +46290,7 @@ struct ProducerToken
 			other.producer->token = &other;
 		}
 	}
-	
+
 	// A token is always valid unless:
 	//     1) Memory allocation failed during construction
 	//     2) It was moved via the move constructor
@@ -46300,7 +46300,7 @@ struct ProducerToken
 	// that the token is valid for use with a specific queue,
 	// but not which one; that's up to the user to track.
 	inline bool valid() const { return producer != nullptr; }
-	
+
 	~ProducerToken()
 	{
 		if (producer != nullptr) {
@@ -46308,15 +46308,15 @@ struct ProducerToken
 			producer->inactive.store(true, std::memory_order_release);
 		}
 	}
-	
+
 	// Disable copying and assignment
 	ProducerToken(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
 	ProducerToken& operator=(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
-	
+
 private:
 	template<typename T, typename Traits> friend class ConcurrentQueue;
 	friend class ConcurrentQueueTests;
-	
+
 protected:
 	details::ConcurrentQueueProducerTypelessBase* producer;
 };
@@ -46326,21 +46326,21 @@ struct ConsumerToken
 {
 	template<typename T, typename Traits>
 	explicit ConsumerToken(ConcurrentQueue<T, Traits>& q);
-	
+
 	template<typename T, typename Traits>
 	explicit ConsumerToken(BlockingConcurrentQueue<T, Traits>& q);
-	
+
 	ConsumerToken(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT
 		: initialOffset(other.initialOffset), lastKnownGlobalOffset(other.lastKnownGlobalOffset), itemsConsumedFromCurrent(other.itemsConsumedFromCurrent), currentProducer(other.currentProducer), desiredProducer(other.desiredProducer)
 	{
 	}
-	
+
 	inline ConsumerToken& operator=(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT
 	{
 		swap(other);
 		return *this;
 	}
-	
+
 	void swap(ConsumerToken& other) MOODYCAMEL_NOEXCEPT
 	{
 		std::swap(initialOffset, other.initialOffset);
@@ -46349,7 +46349,7 @@ struct ConsumerToken
 		std::swap(currentProducer, other.currentProducer);
 		std::swap(desiredProducer, other.desiredProducer);
 	}
-	
+
 	// Disable copying and assignment
 	ConsumerToken(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
 	ConsumerToken& operator=(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
@@ -46357,7 +46357,7 @@ struct ConsumerToken
 private:
 	template<typename T, typename Traits> friend class ConcurrentQueue;
 	friend class ConcurrentQueueTests;
-	
+
 private: // but shared with ConcurrentQueue
 	std::uint32_t initialOffset;
 	std::uint32_t lastKnownGlobalOffset;
@@ -46378,10 +46378,10 @@ class ConcurrentQueue
 public:
 	typedef ::duckdb_moodycamel::ProducerToken producer_token_t;
 	typedef ::duckdb_moodycamel::ConsumerToken consumer_token_t;
-	
+
 	typedef typename Traits::index_t index_t;
 	typedef typename Traits::size_t size_t;
-	
+
 	static const size_t BLOCK_SIZE = static_cast<size_t>(Traits::BLOCK_SIZE);
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = static_cast<size_t>(Traits::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD);
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = static_cast<size_t>(Traits::EXPLICIT_INITIAL_INDEX_SIZE);
@@ -46429,7 +46429,7 @@ public:
 		implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 		populate_initial_implicit_producer_hash();
 		populate_initial_block_list(capacity / BLOCK_SIZE + ((capacity & (BLOCK_SIZE - 1)) == 0 ? 0 : 1));
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		// Track all the producers using a fully-resolved typed list for
 		// each kind; this makes it possible to debug them starting from
@@ -46439,7 +46439,7 @@ public:
 		implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
 	}
-	
+
 	// Computes the correct amount of pre-allocated blocks for you based
 	// on the minimum number of elements you want available at any given
 	// time, and the maximum concurrent number of each type of producer.
@@ -46454,13 +46454,13 @@ public:
 		populate_initial_implicit_producer_hash();
 		size_t blocks = (((minCapacity + BLOCK_SIZE - 1) / BLOCK_SIZE) - 1) * (maxExplicitProducers + 1) + 2 * (maxExplicitProducers + maxImplicitProducers);
 		populate_initial_block_list(blocks);
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		explicitProducers.store(nullptr, std::memory_order_relaxed);
 		implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
 	}
-	
+
 	// Note: The queue should not be accessed concurrently while it's
 	// being deleted. It's up to the user to synchronize this.
 	// This method is not thread safe.
@@ -46476,7 +46476,7 @@ public:
 			destroy(ptr);
 			ptr = next;
 		}
-		
+
 		// Destroy implicit producer hash tables
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE != 0) {
 			auto hash = implicitProducerHash.load(std::memory_order_relaxed);
@@ -46492,7 +46492,7 @@ public:
 				hash = prev;
 			}
 		}
-		
+
 		// Destroy global free list
 		auto block = freeList.head_unsafe();
 		while (block != nullptr) {
@@ -46502,7 +46502,7 @@ public:
 			}
 			block = next;
 		}
-		
+
 		// Destroy initial free list
 		destroy_array(initialBlockPool, initialBlockPoolSize);
 	}
@@ -46510,7 +46510,7 @@ public:
 	// Disable copying and copy assignment
 	ConcurrentQueue(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
 	ConcurrentQueue& operator=(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
-	
+
 	// Moving is supported, but note that it is *not* a thread-safe operation.
 	// Nobody can use the queue while it's being moved, and the memory effects
 	// of that move must be propagated to other threads before they can use it.
@@ -46531,31 +46531,31 @@ public:
 		implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 		populate_initial_implicit_producer_hash();
 		swap_implicit_producer_hashes(other);
-		
+
 		other.producerListTail.store(nullptr, std::memory_order_relaxed);
 		other.producerCount.store(0, std::memory_order_relaxed);
 		other.nextExplicitConsumerId.store(0, std::memory_order_relaxed);
 		other.globalExplicitConsumerOffset.store(0, std::memory_order_relaxed);
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		explicitProducers.store(other.explicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
 		other.explicitProducers.store(nullptr, std::memory_order_relaxed);
 		implicitProducers.store(other.implicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
 		other.implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
-		
+
 		other.initialBlockPoolIndex.store(0, std::memory_order_relaxed);
 		other.initialBlockPoolSize = 0;
 		other.initialBlockPool = nullptr;
-		
+
 		reown_producers();
 	}
-	
+
 	inline ConcurrentQueue& operator=(ConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT
 	{
 		return swap_internal(other);
 	}
-	
+
 	// Swaps this queue's state with the other's. Not thread-safe.
 	// Swapping two queues does not invalidate their tokens, however
 	// the tokens that were created for one queue must be used with
@@ -46565,14 +46565,14 @@ public:
 	{
 		swap_internal(other);
 	}
-	
+
 private:
 	ConcurrentQueue& swap_internal(ConcurrentQueue& other)
 	{
 		if (this == &other) {
 			return *this;
 		}
-		
+
 		details::swap_relaxed(producerListTail, other.producerListTail);
 		details::swap_relaxed(producerCount, other.producerCount);
 		details::swap_relaxed(initialBlockPoolIndex, other.initialBlockPoolIndex);
@@ -46581,20 +46581,20 @@ private:
 		freeList.swap(other.freeList);
 		details::swap_relaxed(nextExplicitConsumerId, other.nextExplicitConsumerId);
 		details::swap_relaxed(globalExplicitConsumerOffset, other.globalExplicitConsumerOffset);
-		
+
 		swap_implicit_producer_hashes(other);
-		
+
 		reown_producers();
 		other.reown_producers();
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		details::swap_relaxed(explicitProducers, other.explicitProducers);
 		details::swap_relaxed(implicitProducers, other.implicitProducers);
 #endif
-		
+
 		return *this;
 	}
-	
+
 public:
 	// Enqueues a single item (by copying it).
 	// Allocates memory if required. Only fails if memory allocation fails (or implicit
@@ -46606,7 +46606,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CanAlloc>(item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible).
 	// Allocates memory if required. Only fails if memory allocation fails (or implicit
 	// production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE is 0,
@@ -46617,7 +46617,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CanAlloc>(std::move(item));
 	}
-	
+
 	// Enqueues a single item (by copying it) using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -46626,7 +46626,7 @@ public:
 	{
 		return inner_enqueue<CanAlloc>(token, item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible) using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -46635,7 +46635,7 @@ public:
 	{
 		return inner_enqueue<CanAlloc>(token, std::move(item));
 	}
-	
+
 	// Enqueues several items.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// implicit production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE
@@ -46648,7 +46648,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue_bulk<CanAlloc>(itemFirst, count);
 	}
-	
+
 	// Enqueues several items using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails
 	// (or Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -46660,7 +46660,7 @@ public:
 	{
 		return inner_enqueue_bulk<CanAlloc>(token, itemFirst, count);
 	}
-	
+
 	// Enqueues a single item (by copying it).
 	// Does not allocate memory. Fails if not enough room to enqueue (or implicit
 	// production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE
@@ -46671,7 +46671,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CannotAlloc>(item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible).
 	// Does not allocate memory (except for one-time implicit producer).
 	// Fails if not enough room to enqueue (or implicit production is
@@ -46682,7 +46682,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CannotAlloc>(std::move(item));
 	}
-	
+
 	// Enqueues a single item (by copying it) using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Thread-safe.
@@ -46690,7 +46690,7 @@ public:
 	{
 		return inner_enqueue<CannotAlloc>(token, item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible) using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Thread-safe.
@@ -46698,7 +46698,7 @@ public:
 	{
 		return inner_enqueue<CannotAlloc>(token, std::move(item));
 	}
-	
+
 	// Enqueues several items.
 	// Does not allocate memory (except for one-time implicit producer).
 	// Fails if not enough room to enqueue (or implicit production is
@@ -46712,7 +46712,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue_bulk<CannotAlloc>(itemFirst, count);
 	}
-	
+
 	// Enqueues several items using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Note: Use std::make_move_iterator if the elements should be moved
@@ -46723,9 +46723,9 @@ public:
 	{
 		return inner_enqueue_bulk<CannotAlloc>(token, itemFirst, count);
 	}
-	
-	
-	
+
+
+
 	// Attempts to dequeue from the queue.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -46748,7 +46748,7 @@ public:
 				++nonEmptyCount;
 			}
 		}
-		
+
 		// If there was at least one non-empty queue but it appears empty at the time
 		// we try to dequeue from it, we need to make sure every queue's been tried
 		if (nonEmptyCount > 0) {
@@ -46763,7 +46763,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue from the queue.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -46783,7 +46783,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue from the queue using an explicit consumer token.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -46796,13 +46796,13 @@ public:
 		// If you see that the global offset has changed, you must reset your consumption counter and move to your designated place
 		// If there's no items where you're supposed to be, keep moving until you find a producer with some items
 		// If the global offset has not changed but you've run out of items to consume, move over from your current position until you find an producer with something in it
-		
+
 		if (token.desiredProducer == nullptr || token.lastKnownGlobalOffset != globalExplicitConsumerOffset.load(std::memory_order_relaxed)) {
 			if (!update_current_producer_after_rotation(token)) {
 				return false;
 			}
 		}
-		
+
 		// If there was at least one non-empty queue but it appears empty at the time
 		// we try to dequeue from it, we need to make sure every queue's been tried
 		if (static_cast<ProducerBase*>(token.currentProducer)->dequeue(item)) {
@@ -46811,7 +46811,7 @@ public:
 			}
 			return true;
 		}
-		
+
 		auto tail = producerListTail.load(std::memory_order_acquire);
 		auto ptr = static_cast<ProducerBase*>(token.currentProducer)->next_prod();
 		if (ptr == nullptr) {
@@ -46830,7 +46830,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue several elements from the queue.
 	// Returns the number of items actually dequeued.
 	// Returns 0 if all producer streams appeared empty at the time they
@@ -46848,7 +46848,7 @@ public:
 		}
 		return count;
 	}
-	
+
 	// Attempts to dequeue several elements from the queue using an explicit consumer token.
 	// Returns the number of items actually dequeued.
 	// Returns 0 if all producer streams appeared empty at the time they
@@ -46862,7 +46862,7 @@ public:
 				return 0;
 			}
 		}
-		
+
 		size_t count = static_cast<ProducerBase*>(token.currentProducer)->dequeue_bulk(itemFirst, max);
 		if (count == max) {
 			if ((token.itemsConsumedFromCurrent += static_cast<std::uint32_t>(max)) >= EXPLICIT_CONSUMER_CONSUMPTION_QUOTA_BEFORE_ROTATE) {
@@ -46872,7 +46872,7 @@ public:
 		}
 		token.itemsConsumedFromCurrent += static_cast<std::uint32_t>(count);
 		max -= count;
-		
+
 		auto tail = producerListTail.load(std::memory_order_acquire);
 		auto ptr = static_cast<ProducerBase*>(token.currentProducer)->next_prod();
 		if (ptr == nullptr) {
@@ -46896,9 +46896,9 @@ public:
 		}
 		return count;
 	}
-	
-	
-	
+
+
+
 	// Attempts to dequeue from a specific producer's inner queue.
 	// If you happen to know which producer you want to dequeue from, this
 	// is significantly faster than using the general-case try_dequeue methods.
@@ -46910,7 +46910,7 @@ public:
 	{
 		return static_cast<ExplicitProducer*>(producer.producer)->dequeue(item);
 	}
-	
+
 	// Attempts to dequeue several elements from a specific producer's inner queue.
 	// Returns the number of items actually dequeued.
 	// If you happen to know which producer you want to dequeue from, this
@@ -46923,8 +46923,8 @@ public:
 	{
 		return static_cast<ExplicitProducer*>(producer.producer)->dequeue_bulk(itemFirst, max);
 	}
-	
-	
+
+
 	// Returns an estimate of the total number of elements currently in the queue. This
 	// estimate is only accurate if the queue has completely stabilized before it is called
 	// (i.e. all enqueue and dequeue operations have completed and their memory effects are
@@ -46939,8 +46939,8 @@ public:
 		}
 		return size;
 	}
-	
-	
+
+
 	// Returns true if the underlying atomic variables used by
 	// the queue are lock-free (they should be on most platforms).
 	// Thread-safe.
@@ -46964,40 +46964,40 @@ private:
 	struct ImplicitProducer;
 	friend struct ImplicitProducer;
 	friend class ConcurrentQueueTests;
-		
+
 	enum AllocationMode { CanAlloc, CannotAlloc };
-	
-	
+
+
 	///////////////////////////////
 	// Queue methods
 	///////////////////////////////
-	
+
 	template<AllocationMode canAlloc, typename U>
 	inline bool inner_enqueue(producer_token_t const& token, U&& element)
 	{
 		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
 	}
-	
+
 	template<AllocationMode canAlloc, typename U>
 	inline bool inner_enqueue(U&& element)
 	{
 		auto producer = get_or_add_implicit_producer();
 		return producer == nullptr ? false : producer->ConcurrentQueue::ImplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
 	}
-	
+
 	template<AllocationMode canAlloc, typename It>
 	inline bool inner_enqueue_bulk(producer_token_t const& token, It itemFirst, size_t count)
 	{
 		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
 	}
-	
+
 	template<AllocationMode canAlloc, typename It>
 	inline bool inner_enqueue_bulk(It itemFirst, size_t count)
 	{
 		auto producer = get_or_add_implicit_producer();
 		return producer == nullptr ? false : producer->ConcurrentQueue::ImplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
 	}
-	
+
 	inline bool update_current_producer_after_rotation(consumer_token_t& token)
 	{
 		// Ah, there's been a rotation, figure out where we should be!
@@ -47020,7 +47020,7 @@ private:
 				}
 			}
 		}
-		
+
 		std::uint32_t delta = globalOffset - token.lastKnownGlobalOffset;
 		if (delta >= prodCount) {
 			delta = delta % prodCount;
@@ -47031,27 +47031,27 @@ private:
 				token.desiredProducer = tail;
 			}
 		}
-		
+
 		token.lastKnownGlobalOffset = globalOffset;
 		token.currentProducer = token.desiredProducer;
 		token.itemsConsumedFromCurrent = 0;
 		return true;
 	}
-	
-	
+
+
 	///////////////////////////
 	// Free list
 	///////////////////////////
-	
+
 	template <typename N>
 	struct FreeListNode
 	{
 		FreeListNode() : freeListRefs(0), freeListNext(nullptr) { }
-		
+
 		std::atomic<std::uint32_t> freeListRefs;
 		std::atomic<N*> freeListNext;
 	};
-	
+
 	// A simple CAS-based lock-free free list. Not the fastest thing in the world under heavy contention, but
 	// simple and correct (assuming nodes are never freed until after the free list is destroyed), and fairly
 	// speedy under low contention.
@@ -47061,15 +47061,15 @@ private:
 		FreeList() : freeListHead(nullptr) { }
 		FreeList(FreeList&& other) : freeListHead(other.freeListHead.load(std::memory_order_relaxed)) { other.freeListHead.store(nullptr, std::memory_order_relaxed); }
 		void swap(FreeList& other) { details::swap_relaxed(freeListHead, other.freeListHead); }
-		
+
 		FreeList(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
 		FreeList& operator=(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
-		
+
 		inline void add(N* node)
 		{
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 			debug::DebugLock lock(mutex);
-#endif		
+#endif
 			// We know that the should-be-on-freelist bit is 0 at this point, so it's safe to
 			// set it using a fetch_add
 			if (node->freeListRefs.fetch_add(SHOULD_BE_ON_FREELIST, std::memory_order_acq_rel) == 0) {
@@ -47078,12 +47078,12 @@ private:
 		 		add_knowing_refcount_is_zero(node);
 			}
 		}
-		
+
 		inline N* try_get()
 		{
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 			debug::DebugLock lock(mutex);
-#endif		
+#endif
 			auto head = freeListHead.load(std::memory_order_acquire);
 			while (head != nullptr) {
 				auto prevHead = head;
@@ -47092,7 +47092,7 @@ private:
 					head = freeListHead.load(std::memory_order_acquire);
 					continue;
 				}
-				
+
 				// Good, reference count has been incremented (it wasn't at zero), which means we can read the
 				// next and not worry about it changing between now and the time we do the CAS
 				auto next = head->freeListNext.load(std::memory_order_relaxed);
@@ -47100,12 +47100,12 @@ private:
 					// Yay, got the node. This means it was on the list, which means shouldBeOnFreeList must be false no
 					// matter the refcount (because nobody else knows it's been taken off yet, it can't have been put back on).
 					assert((head->freeListRefs.load(std::memory_order_relaxed) & SHOULD_BE_ON_FREELIST) == 0);
-					
+
 					// Decrease refcount twice, once for our ref, and once for the list's ref
 					head->freeListRefs.fetch_sub(2, std::memory_order_release);
 					return head;
 				}
-				
+
 				// OK, the head must have changed on us, but we still need to decrease the refcount we increased.
 				// Note that we don't need to release any memory effects, but we do need to ensure that the reference
 				// count decrement happens-after the CAS on the head.
@@ -47114,13 +47114,13 @@ private:
 					add_knowing_refcount_is_zero(prevHead);
 				}
 			}
-			
+
 			return nullptr;
 		}
-		
+
 		// Useful for traversing the list when there's no contention (e.g. to destroy remaining nodes)
 		N* head_unsafe() const { return freeListHead.load(std::memory_order_relaxed); }
-		
+
 	private:
 		inline void add_knowing_refcount_is_zero(N* node)
 		{
@@ -47145,26 +47145,26 @@ private:
 				return;
 			}
 		}
-		
+
 	private:
 		// Implemented like a stack, but where node order doesn't matter (nodes are inserted out of order under contention)
 		std::atomic<N*> freeListHead;
-	
+
 	static const std::uint32_t REFS_MASK = 0x7FFFFFFF;
 	static const std::uint32_t SHOULD_BE_ON_FREELIST = 0x80000000;
-		
+
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 		debug::DebugMutex mutex;
 #endif
 	};
-	
-	
+
+
 	///////////////////////////
 	// Block
 	///////////////////////////
-	
+
 	enum InnerQueueContext { implicit_context = 0, explicit_context = 1 };
-	
+
 	struct Block
 	{
 		Block()
@@ -47174,7 +47174,7 @@ private:
 			owner = nullptr;
 #endif
 		}
-		
+
 		template<InnerQueueContext context>
 		inline bool is_empty() const
 		{
@@ -47185,7 +47185,7 @@ private:
 						return false;
 					}
 				}
-				
+
 				// Aha, empty; make sure we have all other memory effects that happened before the empty flags were set
 				std::atomic_thread_fence(std::memory_order_acquire);
 				return true;
@@ -47200,7 +47200,7 @@ private:
 				return false;
 			}
 		}
-		
+
 		// Returns true if the block is now empty (does not apply in explicit context)
 		template<InnerQueueContext context>
 		inline bool set_empty(MOODYCAMEL_MAYBE_UNUSED index_t i)
@@ -47218,7 +47218,7 @@ private:
 				return prevVal == BLOCK_SIZE - 1;
 			}
 		}
-		
+
 		// Sets multiple contiguous item statuses to 'empty' (assumes no wrapping and count > 0).
 		// Returns true if the block is now empty (does not apply in explicit context).
 		template<InnerQueueContext context>
@@ -47241,7 +47241,7 @@ private:
 				return prevVal + count == BLOCK_SIZE;
 			}
 		}
-		
+
 		template<InnerQueueContext context>
 		inline void set_all_empty()
 		{
@@ -47256,7 +47256,7 @@ private:
 				elementsCompletelyDequeued.store(BLOCK_SIZE, std::memory_order_relaxed);
 			}
 		}
-		
+
 		template<InnerQueueContext context>
 		inline void reset_empty()
 		{
@@ -47271,10 +47271,10 @@ private:
 				elementsCompletelyDequeued.store(0, std::memory_order_relaxed);
 			}
 		}
-		
+
 		inline T* operator[](index_t idx) MOODYCAMEL_NOEXCEPT { return static_cast<T*>(static_cast<void*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
 		inline T const* operator[](index_t idx) const MOODYCAMEL_NOEXCEPT { return static_cast<T const*>(static_cast<void const*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
-		
+
 	private:
 		static_assert(std::alignment_of<T>::value <= sizeof(T), "The queue does not support types with an alignment greater than their size at this time");
 		MOODYCAMEL_ALIGNAS(MOODYCAMEL_ALIGNOF(T)) char elements[sizeof(T) * BLOCK_SIZE];
@@ -47287,7 +47287,7 @@ private:
 		std::atomic<Block*> freeListNext;
 		std::atomic<bool> shouldBeOnFreeList;
 		bool dynamicallyAllocated;		// Perhaps a better name for this would be 'isNotPartOfInitialBlockPool'
-		
+
 #ifdef MCDBGQ_TRACKMEM
 		void* owner;
 #endif
@@ -47300,11 +47300,11 @@ public:
 	struct MemStats;
 private:
 #endif
-	
+
 	///////////////////////////
 	// Producer base
 	///////////////////////////
-	
+
 	struct ProducerBase : public details::ConcurrentQueueProducerTypelessBase
 	{
 		ProducerBase(ConcurrentQueue* parent_, bool isExplicit_) :
@@ -47317,9 +47317,9 @@ private:
 			parent(parent_)
 		{
 		}
-		
+
 		virtual ~ProducerBase() { };
-		
+
 		template<typename U>
 		inline bool dequeue(U& element)
 		{
@@ -47330,7 +47330,7 @@ private:
 				return static_cast<ImplicitProducer*>(this)->dequeue(element);
 			}
 		}
-		
+
 		template<typename It>
 		inline size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -47341,41 +47341,41 @@ private:
 				return static_cast<ImplicitProducer*>(this)->dequeue_bulk(itemFirst, max);
 			}
 		}
-		
+
 		inline ProducerBase* next_prod() const { return static_cast<ProducerBase*>(next); }
-		
+
 		inline size_t size_approx() const
 		{
 			auto tail = tailIndex.load(std::memory_order_relaxed);
 			auto head = headIndex.load(std::memory_order_relaxed);
 			return details::circular_less_than(head, tail) ? static_cast<size_t>(tail - head) : 0;
 		}
-		
+
 		inline index_t getTail() const { return tailIndex.load(std::memory_order_relaxed); }
 	protected:
 		std::atomic<index_t> tailIndex;		// Where to enqueue to next
 		std::atomic<index_t> headIndex;		// Where to dequeue from next
-		
+
 		std::atomic<index_t> dequeueOptimisticCount;
 		std::atomic<index_t> dequeueOvercommit;
-		
+
 		Block* tailBlock;
-		
+
 	public:
 		bool isExplicit;
 		ConcurrentQueue* parent;
-		
+
 	protected:
 #ifdef MCDBGQ_TRACKMEM
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	///////////////////////////
 	// Explicit queue
 	///////////////////////////
-		
+
 	struct ExplicitProducer : public ProducerBase
 	{
 		explicit ExplicitProducer(ConcurrentQueue* parent_) :
@@ -47391,10 +47391,10 @@ private:
 			if (poolBasedIndexSize > pr_blockIndexSize) {
 				pr_blockIndexSize = poolBasedIndexSize;
 			}
-			
+
 			new_block_index(0);		// This creates an index with double the number of current entries, i.e. EXPLICIT_INITIAL_INDEX_SIZE
 		}
-		
+
 		~ExplicitProducer()
 		{
 			// Destruct any elements not yet dequeued.
@@ -47413,7 +47413,7 @@ private:
 					assert(details::circular_less_than<index_t>(pr_blockIndexEntries[i].base, this->headIndex.load(std::memory_order_relaxed)));
 					halfDequeuedBlock = pr_blockIndexEntries[i].block;
 				}
-				
+
 				// Start at the head block (note the first line in the loop gives us the head from the tail on the first iteration)
 				auto block = this->tailBlock;
 				do {
@@ -47421,12 +47421,12 @@ private:
 					if (block->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
 						continue;
 					}
-					
+
 					size_t i = 0;	// Offset into block
 					if (block == halfDequeuedBlock) {
 						i = static_cast<size_t>(this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
 					}
-					
+
 					// Walk through all the items in the block; if this is the tail block, we need to stop when we reach the tail index
 					auto lastValidIndex = (this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 ? BLOCK_SIZE : static_cast<size_t>(this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
 					while (i != BLOCK_SIZE && (block != this->tailBlock || i != lastValidIndex)) {
@@ -47434,7 +47434,7 @@ private:
 					}
 				} while (block != this->tailBlock);
 			}
-			
+
 			// Destroy all blocks that we own
 			if (this->tailBlock != nullptr) {
 				auto block = this->tailBlock;
@@ -47449,7 +47449,7 @@ private:
 					block = nextBlock;
 				} while (block != this->tailBlock);
 			}
-			
+
 			// Destroy the block indices
 			auto header = static_cast<BlockIndexHeader*>(pr_blockIndexRaw);
 			while (header != nullptr) {
@@ -47459,7 +47459,7 @@ private:
 				header = prev;
 			}
 		}
-		
+
 		template<AllocationMode allocMode, typename U>
 		inline bool enqueue(U&& element)
 		{
@@ -47470,10 +47470,10 @@ private:
 				auto startBlock = this->tailBlock;
 				auto originalBlockIndexSlotsUsed = pr_blockIndexSlotsUsed;
 				if (this->tailBlock != nullptr && this->tailBlock->next->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
-					// We can re-use the block ahead of us, it's empty!					
+					// We can re-use the block ahead of us, it's empty!
 					this->tailBlock = this->tailBlock->next;
 					this->tailBlock->ConcurrentQueue::Block::template reset_empty<explicit_context>();
-					
+
 					// We'll put the block on the block index (guaranteed to be room since we're conceptually removing the
 					// last block from it first -- except instead of removing then adding, we can just overwrite).
 					// Note that there must be a valid block index here, since even if allocation failed in the ctor,
@@ -47498,7 +47498,7 @@ private:
 						// Hmm, the circular block index is already full -- we'll need
 						// to allocate a new index. Note pr_blockIndexRaw can only be nullptr if
 						// the initial allocation failed in the constructor.
-						
+
 						MOODYCAMEL_CONSTEXPR_IF (allocMode == CannotAlloc) {
 							return false;
 						}
@@ -47506,7 +47506,7 @@ private:
 							return false;
 						}
 					}
-					
+
 					// Insert a new block in the circular linked list
 					auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 					if (newBlock == nullptr) {
@@ -47545,27 +47545,27 @@ private:
 					(void)startBlock;
 					(void)originalBlockIndexSlotsUsed;
 				}
-				
+
 				// Add block to block index
 				auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 				entry.base = currentTailIndex;
 				entry.block = this->tailBlock;
 				blockIndex.load(std::memory_order_relaxed)->front.store(pr_blockIndexFront, std::memory_order_release);
 				pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
-				
+
 				if (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new ((T*)nullptr) T(std::forward<U>(element)))) {
 					this->tailIndex.store(newTailIndex, std::memory_order_release);
 					return true;
 				}
 			}
-			
+
 			// Enqueue
 			new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element));
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename U>
 		bool dequeue(U& element)
 		{
@@ -47573,10 +47573,10 @@ private:
 			auto overcommit = this->dequeueOvercommit.load(std::memory_order_relaxed);
 			if (details::circular_less_than<index_t>(this->dequeueOptimisticCount.load(std::memory_order_relaxed) - overcommit, tail)) {
 				// Might be something to dequeue, let's give it a try
-				
+
 				// Note that this if is purely for performance purposes in the common case when the queue is
 				// empty and the values are eventually consistent -- we may enter here spuriously.
-				
+
 				// Note that whatever the values of overcommit and tail are, they are not going to change (unless we
 				// change them) and must be the same value at this point (inside the if) as when the if condition was
 				// evaluated.
@@ -47589,24 +47589,24 @@ private:
 				// unfortunately that can't be shown to be correct using only the C++11 standard.
 				// See http://stackoverflow.com/questions/18223161/what-are-the-c11-memory-ordering-guarantees-in-this-corner-case
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				// Increment optimistic counter, then check if it went over the boundary
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(1, std::memory_order_relaxed);
-				
+
 				// Note that since dequeueOvercommit must be <= dequeueOptimisticCount (because dequeueOvercommit is only ever
 				// incremented after dequeueOptimisticCount -- this is enforced in the `else` block below), and since we now
 				// have a version of dequeueOptimisticCount that is at least as recent as overcommit (due to the release upon
 				// incrementing dequeueOvercommit and the acquire above that synchronizes with it), overcommit <= myDequeueCount.
 				// However, we can't assert this since both dequeueOptimisticCount and dequeueOvercommit may (independently)
 				// overflow; in such a case, though, the logic still holds since the difference between the two is maintained.
-				
+
 				// Note that we reload tail here in case it changed; it will be the same value as before or greater, since
 				// this load is sequenced after (happens after) the earlier load above. This is supported by read-read
 				// coherency (as defined in the standard), explained here: http://en.cppreference.com/w/cpp/atomic/memory_order
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				if ((details::likely)(details::circular_less_than<index_t>(myDequeueCount - overcommit, tail))) {
 					// Guaranteed to be at least one element to dequeue!
-					
+
 					// Get the index. Note that since there's guaranteed to be at least one element, this
 					// will never exceed tail. We need to do an acquire-release fence here since it's possible
 					// that whatever condition got us to this point was for an earlier enqueued element (that
@@ -47616,13 +47616,13 @@ private:
 					// place with the more current condition (they must have acquired a tail that is at least
 					// as recent).
 					auto index = this->headIndex.fetch_add(1, std::memory_order_acq_rel);
-					
-					
+
+
 					// Determine which block the element is in
-					
+
 					auto localBlockIndex = blockIndex.load(std::memory_order_acquire);
 					auto localBlockIndexHead = localBlockIndex->front.load(std::memory_order_acquire);
-					
+
 					// We need to be careful here about subtracting and dividing because of index wrap-around.
 					// When an index wraps, we need to preserve the sign of the offset when dividing it by the
 					// block size (in order to get a correct signed block count offset in all cases):
@@ -47630,7 +47630,7 @@ private:
 					auto blockBaseIndex = index & ~static_cast<index_t>(BLOCK_SIZE - 1);
 					auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(blockBaseIndex - headBase) / BLOCK_SIZE);
 					auto block = localBlockIndex->entries[(localBlockIndexHead + offset) & (localBlockIndex->size - 1)].block;
-					
+
 					// Dequeue
 					auto& el = *((*block)[index]);
 					if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
@@ -47639,7 +47639,7 @@ private:
 						struct Guard {
 							Block* block;
 							index_t index;
-							
+
 							~Guard()
 							{
 								(*block)[index]->~T();
@@ -47654,7 +47654,7 @@ private:
 						el.~T(); // NOLINT
 						block->ConcurrentQueue::Block::template set_empty<explicit_context>(index);
 					}
-					
+
 					return true;
 				}
 				else {
@@ -47662,10 +47662,10 @@ private:
 					this->dequeueOvercommit.fetch_add(1, std::memory_order_release);		// Release so that the fetch_add on dequeueOptimisticCount is guaranteed to happen before this write
 				}
 			}
-		
+
 			return false;
 		}
-		
+
 		template<AllocationMode allocMode, typename It>
 		bool enqueue_bulk(It itemFirst, size_t count)
 		{
@@ -47676,9 +47676,9 @@ private:
 			auto startBlock = this->tailBlock;
 			auto originalBlockIndexFront = pr_blockIndexFront;
 			auto originalBlockIndexSlotsUsed = pr_blockIndexSlotsUsed;
-			
+
 			Block* firstAllocatedBlock = nullptr;
-			
+
 			// Figure out how many blocks we'll need to allocate, and do so
 			size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
 			index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
@@ -47687,21 +47687,21 @@ private:
 				while (blockBaseDiff > 0 && this->tailBlock != nullptr && this->tailBlock->next != firstAllocatedBlock && this->tailBlock->next->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					this->tailBlock = this->tailBlock->next;
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? this->tailBlock : firstAllocatedBlock;
-					
+
 					auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 					entry.base = currentTailIndex;
 					entry.block = this->tailBlock;
 					pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
 				}
-				
+
 				// Now allocate as many blocks as necessary from the block pool
 				while (blockBaseDiff > 0) {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					auto head = this->headIndex.load(std::memory_order_relaxed);
 					assert(!details::circular_less_than<index_t>(currentTailIndex, head));
 					bool full = !details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head));
@@ -47720,13 +47720,13 @@ private:
 							this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
 							return false;
 						}
-						
+
 						// pr_blockIndexFront is updated inside new_block_index, so we need to
 						// update our fallback value too (since we keep the new index even if we
 						// later fail)
 						originalBlockIndexFront = originalBlockIndexSlotsUsed;
 					}
-					
+
 					// Insert a new block in the circular linked list
 					auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 					if (newBlock == nullptr) {
@@ -47735,7 +47735,7 @@ private:
 						this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
 						return false;
 					}
-					
+
 #ifdef MCDBGQ_TRACKMEM
 					newBlock->owner = this;
 #endif
@@ -47749,15 +47749,15 @@ private:
 					}
 					this->tailBlock = newBlock;
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? this->tailBlock : firstAllocatedBlock;
-					
+
 					++pr_blockIndexSlotsUsed;
-					
+
 					auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 					entry.base = currentTailIndex;
 					entry.block = this->tailBlock;
 					pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
 				}
-				
+
 				// Excellent, all allocations succeeded. Reset each block's emptiness before we fill them up, and
 				// publish the new block index front
 				auto block = firstAllocatedBlock;
@@ -47768,12 +47768,12 @@ private:
 					}
 					block = block->next;
 				}
-				
+
 				if (MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new ((T*)nullptr) T(details::deref_noexcept(itemFirst)))) {
 					blockIndex.load(std::memory_order_relaxed)->front.store((pr_blockIndexFront - 1) & (pr_blockIndexSize - 1), std::memory_order_release);
 				}
 			}
-			
+
 			// Enqueue, one block at a time
 			index_t newTailIndex = startTailIndex + static_cast<index_t>(count);
 			currentTailIndex = startTailIndex;
@@ -47814,11 +47814,11 @@ private:
 						// any allocated blocks in our linked list for later, though).
 						auto constructedStopIndex = currentTailIndex;
 						auto lastBlockEnqueued = this->tailBlock;
-						
+
 						pr_blockIndexFront = originalBlockIndexFront;
 						pr_blockIndexSlotsUsed = originalBlockIndexSlotsUsed;
 						this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
-						
+
 						if (!details::is_trivially_destructible<T>::value) {
 							auto block = startBlock;
 							if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
@@ -47842,22 +47842,22 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				if (this->tailBlock == endBlock) {
 					assert(currentTailIndex == newTailIndex);
 					break;
 				}
 				this->tailBlock = this->tailBlock->next;
 			}
-			
+
 			if (!MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new ((T*)nullptr) T(details::deref_noexcept(itemFirst))) && firstAllocatedBlock != nullptr) {
 				blockIndex.load(std::memory_order_relaxed)->front.store((pr_blockIndexFront - 1) & (pr_blockIndexSize - 1), std::memory_order_release);
 			}
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename It>
 		size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -47867,9 +47867,9 @@ private:
 			if (details::circular_less_than<size_t>(0, desiredCount)) {
 				desiredCount = desiredCount < max ? desiredCount : max;
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(desiredCount, std::memory_order_relaxed);;
-				
+
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				auto actualCount = static_cast<size_t>(tail - (myDequeueCount - overcommit));
 				if (details::circular_less_than<size_t>(0, actualCount)) {
@@ -47877,20 +47877,20 @@ private:
 					if (actualCount < desiredCount) {
 						this->dequeueOvercommit.fetch_add(desiredCount - actualCount, std::memory_order_release);
 					}
-					
+
 					// Get the first index. Note that since there's guaranteed to be at least actualCount elements, this
 					// will never exceed tail.
 					auto firstIndex = this->headIndex.fetch_add(actualCount, std::memory_order_acq_rel);
-					
+
 					// Determine which block the first element is in
 					auto localBlockIndex = blockIndex.load(std::memory_order_acquire);
 					auto localBlockIndexHead = localBlockIndex->front.load(std::memory_order_acquire);
-					
+
 					auto headBase = localBlockIndex->entries[localBlockIndexHead].base;
 					auto firstBlockBaseIndex = firstIndex & ~static_cast<index_t>(BLOCK_SIZE - 1);
 					auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(firstBlockBaseIndex - headBase) / BLOCK_SIZE);
 					auto indexIndex = (localBlockIndexHead + offset) & (localBlockIndex->size - 1);
-					
+
 					// Iterate the blocks and dequeue
 					auto index = firstIndex;
 					do {
@@ -47927,19 +47927,19 @@ private:
 									}
 									block->ConcurrentQueue::Block::template set_many_empty<explicit_context>(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 									indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
-									
+
 									firstIndexInBlock = index;
 									endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 									endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
 								} while (index != firstIndex + actualCount);
-								
+
 								MOODYCAMEL_RETHROW;
 							}
 						}
 						block->ConcurrentQueue::Block::template set_many_empty<explicit_context>(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 						indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
 					} while (index != firstIndex + actualCount);
-					
+
 					return actualCount;
 				}
 				else {
@@ -47947,17 +47947,17 @@ private:
 					this->dequeueOvercommit.fetch_add(desiredCount, std::memory_order_release);
 				}
 			}
-			
+
 			return 0;
 		}
-		
+
 	private:
 		struct BlockIndexEntry
 		{
 			index_t base;
 			Block* block;
 		};
-		
+
 		struct BlockIndexHeader
 		{
 			size_t size;
@@ -47965,12 +47965,12 @@ private:
 			BlockIndexEntry* entries;
 			void* prev;
 		};
-		
-		
+
+
 		bool new_block_index(size_t numberOfFilledSlotsToExpose)
 		{
 			auto prevBlockSizeMask = pr_blockIndexSize - 1;
-			
+
 			// Create the new block
 			pr_blockIndexSize <<= 1;
 			auto newRawPtr = static_cast<char*>((Traits::malloc)(sizeof(BlockIndexHeader) + std::alignment_of<BlockIndexEntry>::value - 1 + sizeof(BlockIndexEntry) * pr_blockIndexSize));
@@ -47978,9 +47978,9 @@ private:
 				pr_blockIndexSize >>= 1;		// Reset to allow graceful retry
 				return false;
 			}
-			
+
 			auto newBlockIndexEntries = reinterpret_cast<BlockIndexEntry*>(details::align_for<BlockIndexEntry>(newRawPtr + sizeof(BlockIndexHeader)));
-			
+
 			// Copy in all the old indices, if any
 			size_t j = 0;
 			if (pr_blockIndexSlotsUsed != 0) {
@@ -47990,50 +47990,50 @@ private:
 					i = (i + 1) & prevBlockSizeMask;
 				} while (i != pr_blockIndexFront);
 			}
-			
+
 			// Update everything
 			auto header = new (newRawPtr) BlockIndexHeader;
 			header->size = pr_blockIndexSize;
 			header->front.store(numberOfFilledSlotsToExpose - 1, std::memory_order_relaxed);
 			header->entries = newBlockIndexEntries;
 			header->prev = pr_blockIndexRaw;		// we link the new block to the old one so we can free it later
-			
+
 			pr_blockIndexFront = j;
 			pr_blockIndexEntries = newBlockIndexEntries;
 			pr_blockIndexRaw = newRawPtr;
 			blockIndex.store(header, std::memory_order_release);
-			
+
 			return true;
 		}
-		
+
 	private:
 		std::atomic<BlockIndexHeader*> blockIndex;
-		
+
 		// To be used by producer only -- consumer must use the ones in referenced by blockIndex
 		size_t pr_blockIndexSlotsUsed;
 		size_t pr_blockIndexSize;
 		size_t pr_blockIndexFront;		// Next slot (not current)
 		BlockIndexEntry* pr_blockIndexEntries;
 		void* pr_blockIndexRaw;
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	public:
 		ExplicitProducer* nextExplicitProducer;
 	private:
 #endif
-		
+
 #ifdef MCDBGQ_TRACKMEM
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	//////////////////////////////////
 	// Implicit queue
 	//////////////////////////////////
-	
+
 	struct ImplicitProducer : public ProducerBase
-	{			
+	{
 		ImplicitProducer(ConcurrentQueue* parent_) :
 			ProducerBase(parent_, false),
 			nextBlockIndexCapacity(IMPLICIT_INITIAL_INDEX_SIZE),
@@ -48041,21 +48041,21 @@ private:
 		{
 			new_block_index();
 		}
-		
+
 		~ImplicitProducer()
 		{
 			// Note that since we're in the destructor we can assume that all enqueue/dequeue operations
 			// completed already; this means that all undequeued elements are placed contiguously across
 			// contiguous blocks, and that only the first and last remaining blocks can be only partially
 			// empty (all other remaining blocks must be completely full).
-			
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 			// Unregister ourselves for thread termination notification
 			if (!this->inactive.load(std::memory_order_relaxed)) {
 				details::ThreadExitNotifier::unsubscribe(&threadExitListener);
 			}
 #endif
-			
+
 			// Destroy all remaining elements!
 			auto tail = this->tailIndex.load(std::memory_order_relaxed);
 			auto index = this->headIndex.load(std::memory_order_relaxed);
@@ -48068,10 +48068,10 @@ private:
 						// Free the old block
 						this->parent->add_block_to_free_list(block);
 					}
-					
+
 					block = get_block_index_entry_for_index(index)->value.load(std::memory_order_relaxed);
 				}
-				
+
 				((*block)[index])->~T();
 				++index;
 			}
@@ -48081,7 +48081,7 @@ private:
 			if (this->tailBlock != nullptr && (forceFreeLastBlock || (tail & static_cast<index_t>(BLOCK_SIZE - 1)) != 0)) {
 				this->parent->add_block_to_free_list(this->tailBlock);
 			}
-			
+
 			// Destroy block index
 			auto localBlockIndex = blockIndex.load(std::memory_order_relaxed);
 			if (localBlockIndex != nullptr) {
@@ -48096,7 +48096,7 @@ private:
 				} while (localBlockIndex != nullptr);
 			}
 		}
-		
+
 		template<AllocationMode allocMode, typename U>
 		inline bool enqueue(U&& element)
 		{
@@ -48117,7 +48117,7 @@ private:
 				if (!insert_block_index_entry<allocMode>(idxEntry, currentTailIndex)) {
 					return false;
 				}
-				
+
 				// Get ahold of a new block
 				auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 				if (newBlock == nullptr) {
@@ -48129,7 +48129,7 @@ private:
 				newBlock->owner = this;
 #endif
 				newBlock->ConcurrentQueue::Block::template reset_empty<implicit_context>();
-				
+
 				if (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new ((T*)nullptr) T(std::forward<U>(element)))) {
 					// May throw, try to insert now before we publish the fact that we have this new block
 					MOODYCAMEL_TRY {
@@ -48142,25 +48142,25 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				// Insert the new block into the index
 				idxEntry->value.store(newBlock, std::memory_order_relaxed);
-				
+
 				this->tailBlock = newBlock;
-				
+
 				if (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new ((T*)nullptr) T(std::forward<U>(element)))) {
 					this->tailIndex.store(newTailIndex, std::memory_order_release);
 					return true;
 				}
 			}
-			
+
 			// Enqueue
 			new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element));
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename U>
 		bool dequeue(U& element)
 		{
@@ -48169,19 +48169,19 @@ private:
 			index_t overcommit = this->dequeueOvercommit.load(std::memory_order_relaxed);
 			if (details::circular_less_than<index_t>(this->dequeueOptimisticCount.load(std::memory_order_relaxed) - overcommit, tail)) {
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				index_t myDequeueCount = this->dequeueOptimisticCount.fetch_add(1, std::memory_order_relaxed);
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				if ((details::likely)(details::circular_less_than<index_t>(myDequeueCount - overcommit, tail))) {
 					index_t index = this->headIndex.fetch_add(1, std::memory_order_acq_rel);
-					
+
 					// Determine which block the element is in
 					auto entry = get_block_index_entry_for_index(index);
-					
+
 					// Dequeue
 					auto block = entry->value.load(std::memory_order_relaxed);
 					auto& el = *((*block)[index]);
-					
+
 					if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
 						// Note: Acquiring the mutex with every dequeue instead of only when a block
@@ -48193,7 +48193,7 @@ private:
 							index_t index;
 							BlockIndexEntry* entry;
 							ConcurrentQueue* parent;
-							
+
 							~Guard()
 							{
 								(*block)[index]->~T();
@@ -48221,34 +48221,34 @@ private:
 							this->parent->add_block_to_free_list(block);		// releases the above store
 						}
 					}
-					
+
 					return true;
 				}
 				else {
 					this->dequeueOvercommit.fetch_add(1, std::memory_order_release);
 				}
 			}
-		
+
 			return false;
 		}
-		
+
 		template<AllocationMode allocMode, typename It>
 		bool enqueue_bulk(It itemFirst, size_t count)
 		{
 			// First, we need to make sure we have enough room to enqueue all of the elements;
 			// this means pre-allocating blocks and putting them in the block index (but only if
 			// all the allocations succeeded).
-			
+
 			// Note that the tailBlock we start off with may not be owned by us any more;
 			// this happens if it was filled up exactly to the top (setting tailIndex to
 			// the first index of the next block which is not yet allocated), then dequeued
 			// completely (putting it on the free list) before we enqueue again.
-			
+
 			index_t startTailIndex = this->tailIndex.load(std::memory_order_relaxed);
 			auto startBlock = this->tailBlock;
 			Block* firstAllocatedBlock = nullptr;
 			auto endBlock = this->tailBlock;
-			
+
 			// Figure out how many blocks we'll need to allocate, and do so
 			size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
 			index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
@@ -48259,7 +48259,7 @@ private:
 				do {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					// Find out where we'll be inserting this block in the block index
 					BlockIndexEntry* idxEntry = nullptr;  // initialization here unnecessary but compiler can't always tell
 					Block* newBlock;
@@ -48283,19 +48283,19 @@ private:
 						}
 						this->parent->add_blocks_to_free_list(firstAllocatedBlock);
 						this->tailBlock = startBlock;
-						
+
 						return false;
 					}
-					
+
 #ifdef MCDBGQ_TRACKMEM
 					newBlock->owner = this;
 #endif
 					newBlock->ConcurrentQueue::Block::template reset_empty<implicit_context>();
 					newBlock->next = nullptr;
-					
+
 					// Insert the new block into the index
 					idxEntry->value.store(newBlock, std::memory_order_relaxed);
-					
+
 					// Store the chain of blocks so that we can undo if later allocations fail,
 					// and so that we can find the blocks when we do the actual enqueueing
 					if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr) {
@@ -48307,7 +48307,7 @@ private:
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? newBlock : firstAllocatedBlock;
 				} while (blockBaseDiff > 0);
 			}
-			
+
 			// Enqueue, one block at a time
 			index_t newTailIndex = startTailIndex + static_cast<index_t>(count);
 			currentTailIndex = startTailIndex;
@@ -48337,7 +48337,7 @@ private:
 					MOODYCAMEL_CATCH (...) {
 						auto constructedStopIndex = currentTailIndex;
 						auto lastBlockEnqueued = this->tailBlock;
-						
+
 						if (!details::is_trivially_destructible<T>::value) {
 							auto block = startBlock;
 							if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
@@ -48358,7 +48358,7 @@ private:
 								block = block->next;
 							}
 						}
-						
+
 						currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
 						for (auto block = firstAllocatedBlock; block != nullptr; block = block->next) {
 							currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
@@ -48371,7 +48371,7 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				if (this->tailBlock == endBlock) {
 					assert(currentTailIndex == newTailIndex);
 					break;
@@ -48381,7 +48381,7 @@ private:
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename It>
 		size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -48391,9 +48391,9 @@ private:
 			if (details::circular_less_than<size_t>(0, desiredCount)) {
 				desiredCount = desiredCount < max ? desiredCount : max;
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(desiredCount, std::memory_order_relaxed);
-				
+
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				auto actualCount = static_cast<size_t>(tail - (myDequeueCount - overcommit));
 				if (details::circular_less_than<size_t>(0, actualCount)) {
@@ -48401,11 +48401,11 @@ private:
 					if (actualCount < desiredCount) {
 						this->dequeueOvercommit.fetch_add(desiredCount - actualCount, std::memory_order_release);
 					}
-					
+
 					// Get the first index. Note that since there's guaranteed to be at least actualCount elements, this
 					// will never exceed tail.
 					auto firstIndex = this->headIndex.fetch_add(actualCount, std::memory_order_acq_rel);
-					
+
 					// Iterate the blocks and dequeue
 					auto index = firstIndex;
 					BlockIndexHeader* localBlockIndex;
@@ -48414,7 +48414,7 @@ private:
 						auto blockStartIndex = index;
 						auto endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 						endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
-						
+
 						auto entry = localBlockIndex->index[indexIndex];
 						auto block = entry->value.load(std::memory_order_relaxed);
 						if (MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, details::deref_noexcept(itemFirst) = std::move((*(*block)[index])))) {
@@ -48442,7 +48442,7 @@ private:
 									while (index != endIndex) {
 										(*block)[index++]->~T();
 									}
-									
+
 									if (block->ConcurrentQueue::Block::template set_many_empty<implicit_context>(blockStartIndex, static_cast<size_t>(endIndex - blockStartIndex))) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
 										debug::DebugLock lock(mutex);
@@ -48451,12 +48451,12 @@ private:
 										this->parent->add_block_to_free_list(block);
 									}
 									indexIndex = (indexIndex + 1) & (localBlockIndex->capacity - 1);
-									
+
 									blockStartIndex = index;
 									endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 									endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
 								} while (index != firstIndex + actualCount);
-								
+
 								MOODYCAMEL_RETHROW;
 							}
 						}
@@ -48473,27 +48473,27 @@ private:
 						}
 						indexIndex = (indexIndex + 1) & (localBlockIndex->capacity - 1);
 					} while (index != firstIndex + actualCount);
-					
+
 					return actualCount;
 				}
 				else {
 					this->dequeueOvercommit.fetch_add(desiredCount, std::memory_order_release);
 				}
 			}
-			
+
 			return 0;
 		}
-		
+
 	private:
 		// The block size must be > 1, so any number with the low bit set is an invalid block base index
 		static const index_t INVALID_BLOCK_BASE = 1;
-		
+
 		struct BlockIndexEntry
 		{
 			std::atomic<index_t> key;
 			std::atomic<Block*> value;
 		};
-		
+
 		struct BlockIndexHeader
 		{
 			size_t capacity;
@@ -48502,7 +48502,7 @@ private:
 			BlockIndexEntry** index;
 			BlockIndexHeader* prev;
 		};
-		
+
 		template<AllocationMode allocMode>
 		inline bool insert_block_index_entry(BlockIndexEntry*& idxEntry, index_t blockStartIndex)
 		{
@@ -48514,12 +48514,12 @@ private:
 			idxEntry = localBlockIndex->index[newTail];
 			if (idxEntry->key.load(std::memory_order_relaxed) == INVALID_BLOCK_BASE ||
 				idxEntry->value.load(std::memory_order_relaxed) == nullptr) {
-				
+
 				idxEntry->key.store(blockStartIndex, std::memory_order_relaxed);
 				localBlockIndex->tail.store(newTail, std::memory_order_release);
 				return true;
 			}
-			
+
 			// No room in the old block index, try to allocate another one!
 			MOODYCAMEL_CONSTEXPR_IF (allocMode == CannotAlloc) {
 				return false;
@@ -48535,20 +48535,20 @@ private:
 			localBlockIndex->tail.store(newTail, std::memory_order_release);
 			return true;
 		}
-		
+
 		inline void rewind_block_index_tail()
 		{
 			auto localBlockIndex = blockIndex.load(std::memory_order_relaxed);
 			localBlockIndex->tail.store((localBlockIndex->tail.load(std::memory_order_relaxed) - 1) & (localBlockIndex->capacity - 1), std::memory_order_relaxed);
 		}
-		
+
 		inline BlockIndexEntry* get_block_index_entry_for_index(index_t index) const
 		{
 			BlockIndexHeader* localBlockIndex;
 			auto idx = get_block_index_index_for_index(index, localBlockIndex);
 			return localBlockIndex->index[idx];
 		}
-		
+
 		inline size_t get_block_index_index_for_index(index_t index, BlockIndexHeader*& localBlockIndex) const
 		{
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
@@ -48566,7 +48566,7 @@ private:
 			assert(localBlockIndex->index[idx]->key.load(std::memory_order_relaxed) == index && localBlockIndex->index[idx]->value.load(std::memory_order_relaxed) != nullptr);
 			return idx;
 		}
-		
+
 		bool new_block_index()
 		{
 			auto prev = blockIndex.load(std::memory_order_relaxed);
@@ -48579,7 +48579,7 @@ private:
 			if (raw == nullptr) {
 				return false;
 			}
-			
+
 			auto header = new (raw) BlockIndexHeader;
 			auto entries = reinterpret_cast<BlockIndexEntry*>(details::align_for<BlockIndexEntry>(raw + sizeof(BlockIndexHeader)));
 			auto index = reinterpret_cast<BlockIndexEntry**>(details::align_for<BlockIndexEntry*>(reinterpret_cast<char*>(entries) + sizeof(BlockIndexEntry) * entryCount));
@@ -48603,14 +48603,14 @@ private:
 			header->index = index;
 			header->capacity = nextBlockIndexCapacity;
 			header->tail.store((prevCapacity - 1) & (nextBlockIndexCapacity - 1), std::memory_order_relaxed);
-			
+
 			blockIndex.store(header, std::memory_order_release);
-			
+
 			nextBlockIndexCapacity <<= 1;
-			
+
 			return true;
 		}
-		
+
 	private:
 		size_t nextBlockIndexCapacity;
 		std::atomic<BlockIndexHeader*> blockIndex;
@@ -48620,7 +48620,7 @@ private:
 		details::ThreadExitListener threadExitListener;
 	private:
 #endif
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	public:
 		ImplicitProducer* nextImplicitProducer;
@@ -48634,12 +48634,12 @@ private:
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	//////////////////////////////////
 	// Block pool manipulation
 	//////////////////////////////////
-	
+
 	void populate_initial_block_list(size_t blockCount)
 	{
 		initialBlockPoolSize = blockCount;
@@ -48647,7 +48647,7 @@ private:
 			initialBlockPool = nullptr;
 			return;
 		}
-		
+
 		initialBlockPool = create_array<Block>(blockCount);
 		if (initialBlockPool == nullptr) {
 			initialBlockPoolSize = 0;
@@ -48656,18 +48656,18 @@ private:
 			initialBlockPool[i].dynamicallyAllocated = false;
 		}
 	}
-	
+
 	inline Block* try_get_block_from_initial_pool()
 	{
 		if (initialBlockPoolIndex.load(std::memory_order_relaxed) >= initialBlockPoolSize) {
 			return nullptr;
 		}
-		
+
 		auto index = initialBlockPoolIndex.fetch_add(1, std::memory_order_relaxed);
-		
+
 		return index < initialBlockPoolSize ? (initialBlockPool + index) : nullptr;
 	}
-	
+
 	inline void add_block_to_free_list(Block* block)
 	{
 #ifdef MCDBGQ_TRACKMEM
@@ -48675,7 +48675,7 @@ private:
 #endif
 		freeList.add(block);
 	}
-	
+
 	inline void add_blocks_to_free_list(Block* block)
 	{
 		while (block != nullptr) {
@@ -48684,12 +48684,12 @@ private:
 			block = next;
 		}
 	}
-	
+
 	inline Block* try_get_block_from_free_list()
 	{
 		return freeList.try_get();
 	}
-	
+
 	// Gets a free block from one of the memory pools, or allocates a new one (if applicable)
 	template<AllocationMode canAlloc>
 	Block* requisition_block()
@@ -48698,12 +48698,12 @@ private:
 		if (block != nullptr) {
 			return block;
 		}
-		
+
 		block = try_get_block_from_free_list();
 		if (block != nullptr) {
 			return block;
 		}
-		
+
 		MOODYCAMEL_CONSTEXPR_IF (canAlloc == CanAlloc) {
 			return create<Block>();
 		}
@@ -48711,7 +48711,7 @@ private:
 			return nullptr;
 		}
 	}
-	
+
 
 #ifdef MCDBGQ_TRACKMEM
 	public:
@@ -48728,28 +48728,28 @@ private:
 			size_t queueClassBytes;
 			size_t implicitBlockIndexBytes;
 			size_t explicitBlockIndexBytes;
-			
+
 			friend class ConcurrentQueue;
-			
+
 		private:
 			static MemStats getFor(ConcurrentQueue* q)
 			{
 				MemStats stats = { 0 };
-				
+
 				stats.elementsEnqueued = q->size_approx();
-			
+
 				auto block = q->freeList.head_unsafe();
 				while (block != nullptr) {
 					++stats.allocatedBlocks;
 					++stats.freeBlocks;
 					block = block->freeListNext.load(std::memory_order_relaxed);
 				}
-				
+
 				for (auto ptr = q->producerListTail.load(std::memory_order_acquire); ptr != nullptr; ptr = ptr->next_prod()) {
 					bool implicit = dynamic_cast<ImplicitProducer*>(ptr) != nullptr;
 					stats.implicitProducers += implicit ? 1 : 0;
 					stats.explicitProducers += implicit ? 0 : 1;
-					
+
 					if (implicit) {
 						auto prod = static_cast<ImplicitProducer*>(ptr);
 						stats.queueClassBytes += sizeof(ImplicitProducer);
@@ -48797,18 +48797,18 @@ private:
 						}
 					}
 				}
-				
+
 				auto freeOnInitialPool = q->initialBlockPoolIndex.load(std::memory_order_relaxed) >= q->initialBlockPoolSize ? 0 : q->initialBlockPoolSize - q->initialBlockPoolIndex.load(std::memory_order_relaxed);
 				stats.allocatedBlocks += freeOnInitialPool;
 				stats.freeBlocks += freeOnInitialPool;
-				
+
 				stats.blockClassBytes = sizeof(Block) * stats.allocatedBlocks;
 				stats.queueClassBytes += sizeof(ConcurrentQueue);
-				
+
 				return stats;
 			}
 		};
-		
+
 		// For debugging only. Not thread-safe.
 		MemStats getMemStats()
 		{
@@ -48817,18 +48817,18 @@ private:
 	private:
 		friend struct MemStats;
 #endif
-	
-	
+
+
 	//////////////////////////////////
 	// Producer list manipulation
-	//////////////////////////////////	
-	
+	//////////////////////////////////
+
 	ProducerBase* recycle_or_create_producer(bool isExplicit)
 	{
 		bool recycled;
 		return recycle_or_create_producer(isExplicit, recycled);
 	}
-	
+
 	ProducerBase* recycle_or_create_producer(bool isExplicit, bool& recycled)
 	{
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
@@ -48845,26 +48845,26 @@ private:
 				}
 			}
 		}
-		
+
 		recycled = false;
 		return add_producer(isExplicit ? static_cast<ProducerBase*>(create<ExplicitProducer>(this)) : create<ImplicitProducer>(this));
 	}
-	
+
 	ProducerBase* add_producer(ProducerBase* producer)
 	{
 		// Handle failed memory allocation
 		if (producer == nullptr) {
 			return nullptr;
 		}
-		
+
 		producerCount.fetch_add(1, std::memory_order_relaxed);
-		
+
 		// Add it to the lock-free list
 		auto prevTail = producerListTail.load(std::memory_order_relaxed);
 		do {
 			producer->next = prevTail;
 		} while (!producerListTail.compare_exchange_weak(prevTail, producer, std::memory_order_release, std::memory_order_relaxed));
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		if (producer->isExplicit) {
 			auto prevTailExplicit = explicitProducers.load(std::memory_order_relaxed);
@@ -48879,10 +48879,10 @@ private:
 			} while (!implicitProducers.compare_exchange_weak(prevTailImplicit, static_cast<ImplicitProducer*>(producer), std::memory_order_release, std::memory_order_relaxed));
 		}
 #endif
-		
+
 		return producer;
 	}
-	
+
 	void reown_producers()
 	{
 		// After another instance is moved-into/swapped-with this one, all the
@@ -48892,31 +48892,31 @@ private:
 			ptr->parent = this;
 		}
 	}
-	
-	
+
+
 	//////////////////////////////////
 	// Implicit producer hash
 	//////////////////////////////////
-	
+
 	struct ImplicitProducerKVP
 	{
 		std::atomic<details::thread_id_t> key;
 		ImplicitProducer* value;		// No need for atomicity since it's only read by the thread that sets it in the first place
-		
+
 		ImplicitProducerKVP() : value(nullptr) { }
-		
+
 		ImplicitProducerKVP(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT
 		{
 			key.store(other.key.load(std::memory_order_relaxed), std::memory_order_relaxed);
 			value = other.value;
 		}
-		
+
 		inline ImplicitProducerKVP& operator=(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT
 		{
 			swap(other);
 			return *this;
 		}
-		
+
 		inline void swap(ImplicitProducerKVP& other) MOODYCAMEL_NOEXCEPT
 		{
 			if (this != &other) {
@@ -48925,17 +48925,17 @@ private:
 			}
 		}
 	};
-	
+
 	template<typename XT, typename XTraits>
 	friend void duckdb_moodycamel::swap(typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&, typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&) MOODYCAMEL_NOEXCEPT;
-	
+
 	struct ImplicitProducerHash
 	{
 		size_t capacity;
 		ImplicitProducerKVP* entries;
 		ImplicitProducerHash* prev;
 	};
-	
+
 	inline void populate_initial_implicit_producer_hash()
 	{
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) {
@@ -48953,7 +48953,7 @@ private:
 			implicitProducerHash.store(hash, std::memory_order_relaxed);
 		}
 	}
-	
+
 	void swap_implicit_producer_hashes(ConcurrentQueue& other)
 	{
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) {
@@ -48964,9 +48964,9 @@ private:
 			initialImplicitProducerHashEntries.swap(other.initialImplicitProducerHashEntries);
 			initialImplicitProducerHash.entries = &initialImplicitProducerHashEntries[0];
 			other.initialImplicitProducerHash.entries = &other.initialImplicitProducerHashEntries[0];
-			
+
 			details::swap_relaxed(implicitProducerHashCount, other.implicitProducerHashCount);
-			
+
 			details::swap_relaxed(implicitProducerHash, other.implicitProducerHash);
 			if (implicitProducerHash.load(std::memory_order_relaxed) == &other.initialImplicitProducerHash) {
 				implicitProducerHash.store(&initialImplicitProducerHash, std::memory_order_relaxed);
@@ -48990,27 +48990,27 @@ private:
 			}
 		}
 	}
-	
+
 	// Only fails (returns nullptr) if memory allocation fails
 	ImplicitProducer* get_or_add_implicit_producer()
 	{
 		// Note that since the data is essentially thread-local (key is thread ID),
 		// there's a reduced need for fences (memory ordering is already consistent
 		// for any individual thread), except for the current table itself.
-		
+
 		// Start by looking for the thread ID in the current and all previous hash tables.
 		// If it's not found, it must not be in there yet, since this same thread would
 		// have added it previously to one of the tables that we traversed.
-		
+
 		// Code and algorithm adapted from http://preshing.com/20130605/the-worlds-simplest-lock-free-hash-table
-		
+
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
 		debug::DebugLock lock(implicitProdMutex);
 #endif
-		
+
 		auto id = details::thread_id();
 		auto hashedId = details::hash_thread_id(id);
-		
+
 		auto mainHash = implicitProducerHash.load(std::memory_order_acquire);
 		assert(mainHash != nullptr);  // silence clang-tidy and MSVC warnings (hash cannot be null)
 		for (auto hash = mainHash; hash != nullptr; hash = hash->prev) {
@@ -49018,7 +49018,7 @@ private:
 			auto index = hashedId;
 			while (true) {		// Not an infinite loop because at least one slot is free in the hash table
 				index &= hash->capacity - 1;
-				
+
 				auto probedKey = hash->entries[index].key.load(std::memory_order_relaxed);
 				if (probedKey == id) {
 					// Found it! If we had to search several hashes deep, though, we should lazily add it
@@ -49046,7 +49046,7 @@ private:
 							++index;
 						}
 					}
-					
+
 					return value;
 				}
 				if (probedKey == details::invalid_thread_id) {
@@ -49055,7 +49055,7 @@ private:
 				++index;
 			}
 		}
-		
+
 		// Insert!
 		auto newCount = 1 + implicitProducerHashCount.fetch_add(1, std::memory_order_relaxed);
 		while (true) {
@@ -49078,7 +49078,7 @@ private:
 						implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 						return nullptr;
 					}
-					
+
 					auto newHash = new (raw) ImplicitProducerHash;
 					newHash->capacity = newCapacity;
 					newHash->entries = reinterpret_cast<ImplicitProducerKVP*>(details::align_for<ImplicitProducerKVP>(raw + sizeof(ImplicitProducerHash)));
@@ -49095,7 +49095,7 @@ private:
 					implicitProducerHashResizeInProgress.clear(std::memory_order_release);
 				}
 			}
-			
+
 			// If it's < three-quarters full, add to the old one anyway so that we don't have to wait for the next table
 			// to finish being allocated by another thread (and if we just finished allocating above, the condition will
 			// always be true)
@@ -49109,18 +49109,18 @@ private:
 				if (recycled) {
 					implicitProducerHashCount.fetch_sub(1, std::memory_order_relaxed);
 				}
-				
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 				producer->threadExitListener.callback = &ConcurrentQueue::implicit_producer_thread_exited_callback;
 				producer->threadExitListener.userData = producer;
 				details::ThreadExitNotifier::subscribe(&producer->threadExitListener);
 #endif
-				
+
 				auto index = hashedId;
 				while (true) {
 					index &= mainHash->capacity - 1;
 					auto probedKey = mainHash->entries[index].key.load(std::memory_order_relaxed);
-					
+
 					auto empty = details::invalid_thread_id;
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 					auto reusable = details::invalid_thread_id2;
@@ -49136,20 +49136,20 @@ private:
 				}
 				return producer;
 			}
-			
+
 			// Hmm, the old hash is quite full and somebody else is busy allocating a new one.
 			// We need to wait for the allocating thread to finish (if it succeeds, we add, if not,
 			// we try to allocate ourselves).
 			mainHash = implicitProducerHash.load(std::memory_order_acquire);
 		}
 	}
-	
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 	void implicit_producer_thread_exited(ImplicitProducer* producer)
 	{
 		// Remove from thread exit listeners
 		details::ThreadExitNotifier::unsubscribe(&producer->threadExitListener);
-		
+
 		// Remove from hash
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
 		debug::DebugLock lock(implicitProdMutex);
@@ -49159,7 +49159,7 @@ private:
 		auto id = details::thread_id();
 		auto hashedId = details::hash_thread_id(id);
 		details::thread_id_t probedKey;
-		
+
 		// We need to traverse all the hashes just in case other threads aren't on the current one yet and are
 		// trying to add an entry thinking there's a free slot (because they reused a producer)
 		for (; hash != nullptr; hash = hash->prev) {
@@ -49174,11 +49174,11 @@ private:
 				++index;
 			} while (probedKey != details::invalid_thread_id);		// Can happen if the hash has changed but we weren't put back in it yet, or if we weren't added to this hash in the first place
 		}
-		
+
 		// Mark the queue as being recyclable
 		producer->inactive.store(true, std::memory_order_release);
 	}
-	
+
 	static void implicit_producer_thread_exited_callback(void* userData)
 	{
 		auto producer = static_cast<ImplicitProducer*>(userData);
@@ -49186,7 +49186,7 @@ private:
 		queue->implicit_producer_thread_exited(producer);
 	}
 #endif
-	
+
 	//////////////////////////////////
 	// Utility functions
 	//////////////////////////////////
@@ -49262,30 +49262,30 @@ private:
 private:
 	std::atomic<ProducerBase*> producerListTail;
 	std::atomic<std::uint32_t> producerCount;
-	
+
 	std::atomic<size_t> initialBlockPoolIndex;
 	Block* initialBlockPool;
 	size_t initialBlockPoolSize;
-	
+
 #ifndef MCDBGQ_USEDEBUGFREELIST
 	FreeList<Block> freeList;
 #else
 	debug::DebugFreeList<Block> freeList;
 #endif
-	
+
 	std::atomic<ImplicitProducerHash*> implicitProducerHash;
 	std::atomic<size_t> implicitProducerHashCount;		// Number of slots logically used
 	ImplicitProducerHash initialImplicitProducerHash;
 	std::array<ImplicitProducerKVP, INITIAL_IMPLICIT_PRODUCER_HASH_SIZE> initialImplicitProducerHashEntries;
 	std::atomic_flag implicitProducerHashResizeInProgress;
-	
+
 	std::atomic<std::uint32_t> nextExplicitConsumerId;
 	std::atomic<std::uint32_t> globalExplicitConsumerOffset;
-	
+
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
 	debug::DebugMutex implicitProdMutex;
 #endif
-	
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	std::atomic<ExplicitProducer*> explicitProducers;
 	std::atomic<ImplicitProducer*> implicitProducers;

--- a/velox/type/Date.h
+++ b/velox/type/Date.h
@@ -105,12 +105,12 @@ std::string to_string(const ::facebook::velox::Date& ts);
 template <>
 struct fmt::formatter<facebook::velox::Date> {
   template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
+  constexpr auto parse(ParseContext& ctx) const {
     return ctx.begin();
   }
 
   template <typename FormatContext>
-  auto format(const facebook::velox::Date& d, FormatContext& ctx) {
+  auto format(const facebook::velox::Date& d, FormatContext& ctx) const {
     return fmt::format_to(ctx.out(), "{}", std::to_string(d));
   }
 };

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -2184,7 +2184,7 @@ struct fmt::formatter<facebook::velox::TypeKind> {
   }
 
   template <typename FormatContext>
-  auto format(const facebook::velox::TypeKind& k, FormatContext& ctx) {
+  auto format(const facebook::velox::TypeKind& k, FormatContext& ctx) const {
     return format_to(ctx.out(), "{}", facebook::velox::mapTypeKindToName(k));
   }
 };
@@ -2199,7 +2199,7 @@ struct fmt::formatter<
   }
 
   template <typename FormatContext>
-  auto format(const std::shared_ptr<T>& k, FormatContext& ctx) {
+  auto format(const std::shared_ptr<T>& k, FormatContext& ctx) const {
     return format_to(ctx.out(), "{}", k->toString());
   }
 };

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -932,7 +932,7 @@ struct fmt::formatter<facebook::velox::VectorEncoding::Simple> {
   template <typename FormatContext>
   auto format(
       const facebook::velox::VectorEncoding::Simple& x,
-      FormatContext& ctx) {
+      FormatContext& ctx) const {
     return format_to(
         ctx.out(), "{}", facebook::velox::VectorEncoding::mapSimpleToName(x));
   }


### PR DESCRIPTION
Summary:
Staging an update to the latest fmt version triggered lots of build errors due to non-`const` methods on custom formatters. This fixes the `format()` methods to be `const` as they don't mutate any state anyway, as well as `parse()` methods that don't need to mutate internal state. This mitigates many future build errors.

Updates were identified and executed by using regular expression search/replacements such as:
`(constexpr auto parse\(ParseContext& [^)]*\)) \{` -> `$1 const {`
`(constexpr auto parse\(ParseContext& [^)]*\)) ->` -> `$1 const ->`
`(auto format\(.*, FormatContext& [^)]*\)) \{` -> `$1 const {`
`(auto format\(.*, FormatContext& [^)]*\)) ->` -> `$1 const ->`

Any changes to third-party code was then reverted. Some small changes detected from subsequent build errors were then applied.

Differential Revision: D45420944

