### PR TITLE
Allow empty split in task

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -966,7 +966,9 @@ std::unique_ptr<ContinuePromise> Task::addSplitLocked(
   ++taskStats_.numTotalSplits;
   ++taskStats_.numQueuedSplits;
 
-  VELOX_CHECK_NULL(split.connectorSplit->dataSource);
+  if (split.connectorSplit) {
+    VELOX_CHECK_NULL(split.connectorSplit->dataSource);
+  }
 
   if (!split.hasGroup()) {
     return addSplitToStoreLocked(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1731,7 +1731,6 @@ TEST_F(TableScanTest, bucket) {
 
   for (int i = 0; i < buckets.size(); ++i) {
     int bucketValue = buckets[i];
-    auto connectorSplit = splits[i];
     auto hsplit = HiveConnectorSplitBuilder(filePaths[i]->path)
                       .tableBucketNumber(bucketValue)
                       .build();

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -100,6 +100,9 @@ TEST_F(TaskTest, wrongPlanNodeForSplit) {
   // Add split for the source node.
   task.addSplit("0", exec::Split(folly::copy(connectorSplit)));
 
+  // Add an empty split.
+  task.addSplit("0", exec::Split());
+
   // Try to add split for a non-source node.
   auto errorMessage =
       "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 1 doesn't refer to such plan node.";


### PR DESCRIPTION
Summary:
In a previous change I remove the check unintentionally.  Put it back to make sure empty split does not crash the worker.

Prestissimo seems never putting empty split though, put it back just in case other engines might need this.

Differential Revision: D45571469

