### PR TITLE
Add MemConfigMutable class.

### DIFF
--- a/velox/core/Context.cpp
+++ b/velox/core/Context.cpp
@@ -43,6 +43,22 @@ bool MemConfig::isValueExists(const std::string& key) const {
   return values_.find(key) != values_.end();
 }
 
+folly::Optional<std::string> MemConfigMutable::get(
+    const std::string& key) const {
+  auto lockedValues = values_.rlock();
+  folly::Optional<std::string> val;
+  auto it = lockedValues->find(key);
+  if (it != lockedValues->end()) {
+    val = it->second;
+  }
+  return val;
+}
+
+bool MemConfigMutable::isValueExists(const std::string& key) const {
+  auto lockedValues = values_.rlock();
+  return lockedValues->find(key) != lockedValues->end();
+}
+
 folly::Optional<std::string> ConfigStack::get(const std::string& key) const {
   folly::Optional<std::string> val;
   for (int64_t i = configs_.size(); --i >= 0;) {

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -19,9 +19,7 @@
 #include "velox/core/QueryConfig.h"
 #include "velox/core/QueryCtx.h"
 
-using ::facebook::velox::core::MemConfig;
-using ::facebook::velox::core::QueryConfig;
-using ::facebook::velox::core::QueryCtx;
+namespace facebook::velox::core::test {
 
 TEST(TestQueryConfig, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
@@ -47,3 +45,49 @@ TEST(TestQueryConfig, setConfig) {
   ASSERT_EQ(config.codegenConfigurationFilePath(), path);
   ASSERT_FALSE(config.isCastIntByTruncate());
 }
+
+TEST(TestQueryConfig, memConfig) {
+  const std::string tz = "timezone1";
+  const std::unordered_map<std::string, std::string> configData(
+      {{QueryConfig::kCodegenEnabled, "true"},
+       {QueryConfig::kSessionTimezone, tz}});
+
+  {
+    MemConfig cfg{configData};
+    MemConfig cfg2{};
+    auto configDataCopy = configData;
+    MemConfig cfg3{std::move(configDataCopy)};
+    ASSERT_TRUE(cfg.Config::get<bool>(QueryConfig::kCodegenEnabled));
+    ASSERT_TRUE(cfg3.Config::get<bool>(QueryConfig::kCodegenEnabled));
+    ASSERT_EQ(
+        tz,
+        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
+    ASSERT_FALSE(cfg.Config::get<std::string>("missing-entry").has_value());
+    ASSERT_EQ(configData, cfg.values());
+    ASSERT_EQ(configData, cfg.valuesCopy());
+  }
+
+  {
+    MemConfigMutable cfg{configData};
+    MemConfigMutable cfg2{};
+    auto configDataCopy = configData;
+    MemConfigMutable cfg3{std::move(configDataCopy)};
+    ASSERT_TRUE(cfg.Config::get<bool>(QueryConfig::kCodegenEnabled).value());
+    ASSERT_TRUE(cfg3.Config::get<bool>(QueryConfig::kCodegenEnabled).value());
+    ASSERT_EQ(
+        tz,
+        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
+    ASSERT_FALSE(cfg.Config::get<std::string>("missing-entry").has_value());
+    ASSERT_NO_THROW(cfg.setValue(QueryConfig::kCodegenEnabled, "false"));
+    ASSERT_FALSE(cfg.Config::get<bool>(QueryConfig::kCodegenEnabled).value());
+    const std::string tz2 = "timezone2";
+    ASSERT_NO_THROW(cfg.setValue(QueryConfig::kSessionTimezone, tz2));
+    ASSERT_EQ(
+        tz2,
+        cfg.Config::get<std::string>(QueryConfig::kSessionTimezone).value());
+    ASSERT_THROW(cfg.values(), VeloxException);
+    ASSERT_EQ(configData, cfg3.valuesCopy());
+  }
+}
+
+} // namespace facebook::velox::core::test


### PR DESCRIPTION
Summary:
MemConfigMutable acts just like MemConfig, but allows
modifying existing properties and adding new ones.
It also protects the storage with folly::Synchronized.

It is planned to be used in Presto Native, where we, based on
a single property will either create MemConfig (in production)
or MemConfigMutable (in test and staging).

The goals is to allow changing some properties on the fly w/o
restarting/pushing pkg to the clusters.

Differential Revision: D45580035

