### PR TITLE
Refactor the SimpleLRUCache

### DIFF
--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -38,100 +38,13 @@
 
 namespace facebook::velox {
 
-// A smart pointer that represents data that may be in a cache and is thus
-// not owned, or is owned like a unique_ptr. We could also implement this
-// by a unique_ptr with a custom deleter, but I find this representation nicer.
-template <
-    typename Key,
-    typename Value,
-    typename Comparator = std::equal_to<Key>,
-    typename Hash = std::hash<Key>>
-class CachedPtr {
- public:
-  // Nullptr case.
-  CachedPtr();
-
-  // Data is not in cache, ownership taken by *this.
-  explicit CachedPtr(Value* value);
-
-  // Data is in the provided cache referenced by the given key. The cache is
-  // not guarded by a mutex.
-  CachedPtr(
-      bool wasCached,
-      Value* value,
-      SimpleLRUCache<Key, Value, Comparator, Hash>* cache,
-      std::unique_ptr<Key> key);
-  // Same as above, but the cache IS guarded by a mutex.
-  CachedPtr(
-      bool wasCached,
-      Value* value,
-      SimpleLRUCache<Key, Value, Comparator, Hash>* cache,
-      std::unique_ptr<Key> key,
-      std::mutex* mu);
-
-  // The destructor handles the in-cache and non-in-cache cases appropriately.
-  ~CachedPtr();
-
-  // Move allowed, copy disallowed. Moving a new value into a non-null CachedPtr
-  // will clear the previous value.
-  CachedPtr(CachedPtr&&);
-  CachedPtr& operator=(CachedPtr&&);
-  CachedPtr(const CachedPtr&) = delete;
-  CachedPtr& operator=(const CachedPtr&) = delete;
-
-  // Whether this value was cached. If we had to wait for a generation
-  // (whether the actual generation was done in this thread or another) then
-  // this is false. Has no effect on this's behavior, but may be useful for
-  // monitoring cache hit rates/etc.
-  bool wasCached() {
-    return wasCached_;
-  }
-
-  Value* operator->() const {
-    return value_;
-  }
-  Value& operator*() const {
-    return *value_;
-  }
-  Value* get() const {
-    return value_;
-  }
-
- private:
-  // Delete or release owned value.
-  void clear();
-
-  bool wasCached_;
-  Value* value_;
-  // If value_ is in the cache, cache_ and key_ will be non-null,
-  // and mu_ MAY be non-null. If mu_ is non-null_, we use it
-  // to protect our cache operations.
-  SimpleLRUCache<Key, Value, Comparator, Hash>* cache_;
-  std::unique_ptr<Key> key_;
-  std::mutex* mu_;
-};
-
-template <typename Value>
-struct DefaultSizer {
-  int64_t operator()(const Value& value) const {
-    return 1;
-  }
-};
-
 // CachedFactory provides a thread-safe way of backing a keyed generator
 // (e.g. the key is filename, and the value is the file data) by a cache.
 //
-// Generator should take a single Key argument and return a unique_ptr<Value>;
-// If it is not thread-safe it must do its own internal locking.
-// Sizer takes a Value and returns how much cache space it will occupy. The
-// DefaultSizer says each value occupies 1 space.
-template <
-    typename Key,
-    typename Value,
-    typename Generator,
-    typename Sizer = DefaultSizer<Value>,
-    typename Comparator = std::equal_to<Key>,
-    typename Hash = std::hash<Key>>
+// Generator should take a single Key argument and return a Value;
+// The Value should be either a value type or should manage its own lifecycle
+// (shared_ptr). If it is not thread-safe it must do its own internal locking.
+template <typename Key, typename Value, typename Generator>
 class CachedFactory {
  public:
   // It is generally expected that most inserts into the cache will succeed,
@@ -139,31 +52,24 @@ class CachedFactory {
   // of elements that are pinned. Everything should still work if this is not
   // true, but performance will suffer.
   CachedFactory(
-      std::unique_ptr<SimpleLRUCache<Key, Value, Comparator, Hash>> cache,
+      std::unique_ptr<SimpleLRUCache<Key, Value>> cache,
       std::unique_ptr<Generator> generator)
       : cache_(std::move(cache)), generator_(std::move(generator)) {}
 
   // Returns the generator's output on the given key. If the output is
   // in the cache, returns immediately. Otherwise, blocks until the output
-  // is ready. For a given key we will only ever be running the Generator
-  // function once. E.g., if N threads ask for the same key at once, the
-  // generator will be fired once and all N will receive a pointer from
-  // the cache.
-  //
-  // Actually the last sentence is not quite true in the edge case where
-  // inserts into the cache fail; in that case we will re-run the generator
-  // repeatedly, handing off the results to one thread at a time until the
-  // all pending requests are satisfied or a cache insert succeeds. This
-  // will probably mess with your memory model, so really try to avoid it.
-  CachedPtr<Key, Value, Comparator, Hash> generate(const Key& key);
+  // is ready.
+  // The function returns a pair. The boolean in the pair indicates whether a
+  // cache hit or miss. The Value is the generator output for the key if cache
+  // miss, or Value in the cache if cache hit.
+  std::pair<bool, Value> generate(const Key& key);
 
   // Advanced function taking in a group of keys. Separates those keys into
   // one's present in the cache (returning CachedPtrs for them) and those not
   // in the cache. Does NOT call the Generator for any key.
   void retrieveCached(
       const std::vector<Key>& keys,
-      std::vector<std::pair<Key, CachedPtr<Key, Value, Comparator, Hash>>>*
-          cached,
+      std::vector<std::pair<Key, Value>>* cached,
       std::vector<Key>* missing);
 
   // Total size of elements cached (NOT the maximum size/limit).
@@ -184,7 +90,7 @@ class CachedFactory {
   // Clear the cache and return the current cache status
   SimpleLRUCacheStats clearCache() {
     std::lock_guard l(cacheMu_);
-    cache_->free(cache_->maxSize());
+    cache_->clear();
     return cache_->getStats();
   }
 
@@ -195,9 +101,9 @@ class CachedFactory {
   CachedFactory& operator=(const CachedFactory&) = delete;
 
  private:
-  std::unique_ptr<SimpleLRUCache<Key, Value, Comparator, Hash>> cache_;
+  std::unique_ptr<SimpleLRUCache<Key, Value>> cache_;
   std::unique_ptr<Generator> generator_;
-  folly::F14FastSet<Key, Hash, Comparator> pending_;
+  folly::F14FastSet<Key> pending_;
 
   std::mutex cacheMu_;
   std::mutex pendingMu_;
@@ -208,127 +114,26 @@ class CachedFactory {
 // End of public API. Implementation follows.
 //
 
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::CachedPtr()
-    : wasCached_(false),
-      value_(nullptr),
-      cache_(nullptr),
-      key_(nullptr),
-      mu_(nullptr) {}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::CachedPtr(Value* value)
-    : wasCached_(false),
-      value_(value),
-      cache_(nullptr),
-      key_(nullptr),
-      mu_(nullptr) {}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::CachedPtr(
-    bool wasCached,
-    Value* value,
-    SimpleLRUCache<Key, Value, Comparator, Hash>* cache,
-    std::unique_ptr<Key> key)
-    : wasCached_(wasCached),
-      value_(value),
-      cache_(cache),
-      key_(std::move(key)),
-      mu_(nullptr) {}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::CachedPtr(
-    bool wasCached,
-    Value* value,
-    SimpleLRUCache<Key, Value, Comparator, Hash>* cache,
-    std::unique_ptr<Key> key,
-    std::mutex* mu)
-    : wasCached_(wasCached),
-      value_(value),
-      cache_(cache),
-      key_(std::move(key)),
-      mu_(mu) {}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::~CachedPtr() {
-  clear();
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>::CachedPtr(CachedPtr&& other) {
-  wasCached_ = other.wasCached_;
-  value_ = other.value_;
-  key_ = std::move(other.key_);
-  cache_ = other.cache_;
-  mu_ = other.mu_;
-  other.value_ = nullptr;
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>&
-CachedPtr<Key, Value, Comparator, Hash>::operator=(CachedPtr&& other) {
-  clear();
-  wasCached_ = other.wasCached_;
-  value_ = other.value_;
-  key_ = std::move(other.key_);
-  cache_ = other.cache_;
-  mu_ = other.mu_;
-  other.value_ = nullptr;
-  return *this;
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-void CachedPtr<Key, Value, Comparator, Hash>::clear() {
-  if (!value_)
-    return;
-  if (cache_) {
-    if (mu_) {
-      std::lock_guard<std::mutex> l(*mu_);
-      cache_->release(*key_);
-    } else {
-      cache_->release(*key_);
-    }
-  } else {
-    delete value_;
-  }
-}
-
-template <
-    typename Key,
-    typename Value,
-    typename Generator,
-    typename Sizer,
-    typename Comparator,
-    typename Hash>
-CachedPtr<Key, Value, Comparator, Hash>
-CachedFactory<Key, Value, Generator, Sizer, Comparator, Hash>::generate(
+template <typename Key, typename Value, typename Generator>
+std::pair<bool, Value> CachedFactory<Key, Value, Generator>::generate(
     const Key& key) {
   std::unique_lock<std::mutex> pending_lock(pendingMu_);
   {
     std::lock_guard<std::mutex> cache_lock(cacheMu_);
-    Value* value = cache_->get(key);
+    auto value = cache_->get(key);
     if (value) {
-      return CachedPtr<Key, Value, Comparator, Hash>(
-          /*wasCached=*/true,
-          value,
-          cache_.get(),
-          std::make_unique<Key>(key),
-          &cacheMu_);
+      return std::make_pair(true, value.value());
     }
   }
+
   if (pending_.contains(key)) {
     pendingCv_.wait(pending_lock, [&]() { return !pending_.contains(key); });
     // Will normally hit the cache now.
     {
       std::lock_guard<std::mutex> cache_lock(cacheMu_);
-      Value* value = cache_->get(key);
+      auto value = cache_->get(key);
       if (value) {
-        return CachedPtr<Key, Value, Comparator, Hash>(
-            /*wasCached=*/false,
-            value,
-            cache_.get(),
-            std::make_unique<Key>(key),
-            &cacheMu_);
+        return std::make_pair(true, value.value());
       }
     }
     pending_lock.unlock();
@@ -336,7 +141,7 @@ CachedFactory<Key, Value, Generator, Sizer, Comparator, Hash>::generate(
   } else {
     pending_.insert(key);
     pending_lock.unlock();
-    std::unique_ptr<Value> generatedValue;
+    Value generatedValue;
     // TODO: consider using folly/ScopeGuard here.
     try {
       generatedValue = (*generator_)(key);
@@ -348,59 +153,32 @@ CachedFactory<Key, Value, Generator, Sizer, Comparator, Hash>::generate(
       pendingCv_.notify_all();
       throw;
     }
-    const uint64_t sizeOccupied = Sizer()(*generatedValue);
-    Value* rawValue = generatedValue.release();
     cacheMu_.lock();
-    const bool inserted = cache_->addPinned(key, rawValue, sizeOccupied);
+    cache_->add(key, generatedValue);
     cacheMu_.unlock();
-    CachedPtr<Key, Value, Comparator, Hash> result;
-    if (inserted) {
-      result = CachedPtr<Key, Value, Comparator, Hash>(
-          /*wasCached=*/false,
-          rawValue,
-          cache_.get(),
-          std::make_unique<Key>(key),
-          &cacheMu_);
-    } else {
-      // We want a LOG_EVERY_N_SEC warning here, but it doesn't seem to
-      // be available in glog?
-      // LOG_EVERY_N_SEC(WARNING, 60) << "Unable to insert into cache!";
-      result = CachedPtr<Key, Value, Comparator, Hash>(rawValue);
-    }
+
+    // TODO: this code is exception unsafe and can leave pending_ in an
+    // inconsistent state. Eventually this code should move to
+    // folly:synchronized and rewritten with better primitives.
     {
       std::lock_guard<std::mutex> pending_lock(pendingMu_);
       pending_.erase(key);
     }
     pendingCv_.notify_all();
-    return result;
+    return std::make_pair(false, generatedValue);
   }
 }
 
-template <
-    typename Key,
-    typename Value,
-    typename Generator,
-    typename Sizer,
-    typename Comparator,
-    typename Hash>
-void CachedFactory<Key, Value, Generator, Sizer, Comparator, Hash>::
-    retrieveCached(
-        const std::vector<Key>& keys,
-        std::vector<std::pair<Key, CachedPtr<Key, Value, Comparator, Hash>>>*
-            cached,
-        std::vector<Key>* missing) {
+template <typename Key, typename Value, typename Generator>
+void CachedFactory<Key, Value, Generator>::retrieveCached(
+    const std::vector<Key>& keys,
+    std::vector<std::pair<Key, Value>>* cached,
+    std::vector<Key>* missing) {
   std::lock_guard<std::mutex> cache_lock(cacheMu_);
   for (const Key& key : keys) {
-    Value* value = cache_->get(key);
+    auto value = cache_->get(key);
     if (value) {
-      cached->emplace_back(
-          key,
-          CachedPtr<Key, Value, Comparator, Hash>(
-              /*wasCached=*/true,
-              value,
-              cache_.get(),
-              std::make_unique<Key>(key),
-              &cacheMu_));
+      cached->emplace_back(key, value.value());
     } else {
       missing->push_back(key);
     }

--- a/velox/common/caching/SimpleLRUCache.h
+++ b/velox/common/caching/SimpleLRUCache.h
@@ -18,271 +18,147 @@
 #include <cstdint>
 #include <functional>
 #include <list>
+#include <optional>
 
-#include "folly/container/F14Map.h"
+#include "folly/container/EvictingCacheMap.h"
 #include "glog/logging.h"
 
 namespace facebook::velox {
 
 struct SimpleLRUCacheStats {
+  SimpleLRUCacheStats(
+      size_t _maxSize,
+      size_t _curSize,
+      size_t _numHits,
+      size_t _numLookups)
+      : maxSize{_maxSize},
+        curSize{_curSize},
+        numHits{_numHits},
+        numLookups{_numLookups},
+        numElements{curSize},
+        pinnedSize{curSize} {}
+
   // Capacity of the cache.
-  size_t maxSize{0};
+  const size_t maxSize;
 
   // Current cache size used.
-  size_t curSize{0};
-
-  // Current cache size used by pinned entries.
-  size_t pinnedSize{0};
-
-  // Total number of elements in the cache.
-  size_t numElements{0};
+  const size_t curSize;
 
   // Total number of cache hits since server start.
-  size_t numHits{0};
+  const size_t numHits;
 
   // Total number of cache lookups since server start.
-  size_t numLookups{0};
+  const size_t numLookups;
+
+  // TODO: These 2 are unused, but open source Presto depends on them
+  // Remove the usage in open source presto and get rid of them.
+  const size_t numElements;
+  const size_t pinnedSize;
 
   std::string toString() const {
     return fmt::format(
         "{{\n"
         "  maxSize: {}\n"
         "  curSize: {}\n"
-        "  pinnedSize: {}\n"
-        "  numElements: {}\n"
         "  numHits: {}\n"
         "  numLookups: {}\n"
         "}}\n",
         maxSize,
         curSize,
-        pinnedSize,
-        numElements,
         numHits,
         numLookups);
   }
+
+  bool operator==(const SimpleLRUCacheStats& rhs) const {
+    return std::tie(curSize, maxSize, numHits, numLookups) ==
+        std::tie(rhs.curSize, rhs.maxSize, rhs.numHits, rhs.numLookups);
+  }
 };
 
-/// A simple LRU cache that allows each element to occupy an arbitrary
-/// amount of space in the cache. Useful when your the size of the
-/// cached elements can vary a lot; if they are all roughly the same
-/// size something that only tracks the number of elements in the
-/// cache like common/datastruct/LRUCacheMap.h may be better.
+/// A simple wrapper on top of the folly::EvictingCacheMap that tracks
+/// hit/miss counters. Key/Value evicted are immediately destructed.
+/// So the Key/Value should be a value type or self managing lifecycle
+/// shared_ptr.
 ///
 /// NOTE:
 /// 1. NOT Thread-Safe: All the public calls modify internal structures
 /// and hence require external write locks if used from multiple threads.
-/// 2. 'Key' is required to be copyable and movable.
-template <
-    typename Key,
-    typename Value,
-    typename Comparator = std::equal_to<Key>,
-    typename Hash = std::hash<Key>>
+template <typename Key, typename Value>
 class SimpleLRUCache {
  public:
-  /// Constructs a cache of the specified size. This size can represent whatever
-  /// you want -- slots, or bytes, or etc; you provide the size of each element
-  /// whenever you add a new value to the cache. Note that in certain
-  /// circumstances this max_size may be exceeded -- see add().
-  explicit SimpleLRUCache(size_t maxSize);
+  /// Constructs a cache of the specified size. The maxSize represents the
+  /// number of entries in the cache. clearSize represents the number of entries
+  /// to evict in a given time, when the cache is full.
+  explicit SimpleLRUCache(size_t maxSize, size_t clearSize = 1);
 
-  /// Frees all owned data. Check-fails if any element remains pinned.
-  ~SimpleLRUCache();
+  /// Add an item to the cache. Returns true if the item is successfully
+  /// added, false otherwise.
+  bool add(const Key& key, const Value& value);
 
-  /// Add a key-value pair that will occupy the provided size, evicting
-  /// older elements repeatedly until enough room is avialable in the cache.
-  /// Returns whether insertion succeeded. If it did, the cache takes
-  /// ownership of |value|. Insertion will fail in two cases:
-  ///   1) There isn't enough room in the cache even after all unpinned
-  ///      elements are freed.
-  ///   2) The key you are adding is already present in the cache. In
-  ///      this case the element currently existing in the cache remains
-  ///      totally unchanged.
-  ///
-  /// If you use size to represent in-memory size, keep in mind that the
-  /// total space used per entry is roughly 2 * key_size + value_size + 30 bytes
-  /// (nonexact because we use a hash map internally, so the ratio of reserved
-  /// slot to used slots will vary).
-  bool add(Key key, Value* value, size_t size);
+  /// Gets value associated with key.
+  /// returns std::nullopt when the key is missing
+  /// returns the cached value, when the key is present.
+  std::optional<Value> get(const Key& key);
 
-  /// Same as add(), but the value starts pinned. Saves a map lookup if you
-  /// would otherwise do add() then get(). Keep in mind that if insertion
-  /// fails the key's pin count has NOT been incremented.
-  bool addPinned(Key key, Value* value, size_t size);
-
-  /// Gets an unowned pointer to the value associated with key.
-  /// Returns nullptr if the key is not present in the cache.
-  /// Once you are done using the returned non-null *value, you must call
-  /// release with the same key you passed to get.
-  ///
-  /// The returned pointer is guaranteed to remain valid until release
-  /// is called.
-  ///
-  /// Note that we return a non-const pointer, and multiple callers
-  /// can lease the same object, so if you're mutating it you need
-  /// to manage your own locking.
-  Value* get(const Key& key);
-
-  /// Unpins a key. You MUST call release on every key you have
-  /// get'd once are you done using the value or bad things will
-  /// happen (namely, memory leaks).
-  void release(const Key& key);
+  void clear();
 
   /// Total size of elements in the cache (NOT the maximum size/limit).
   size_t currentSize() const {
-    return curSize_;
+    return lru_.size();
   }
 
   /// The maximum size of the cache.
   size_t maxSize() const {
-    return maxSize_;
+    return lru_.getMaxSize();
   }
 
   SimpleLRUCacheStats getStats() const {
     return {
-        maxSize_,
-        curSize_,
-        pinnedSize_,
-        elements_.size(),
+        lru_.getMaxSize(),
+        lru_.size(),
         numHits_,
         numLookups_,
     };
   }
 
-  /// Remove unpinned elements until at least size space is freed. Returns
-  /// the size actually freed, which may be less than requested if the
-  /// remaining are all pinned.
-  size_t free(size_t size);
-
  private:
-  bool addInternal(Key key, Value* value, size_t size, bool pinned);
-
-  const size_t maxSize_;
-  size_t curSize_{0};
-  size_t pinnedSize_{0};
   size_t numHits_{0};
   size_t numLookups_{0};
 
-  struct Element {
-    Key key;
-    Value* value;
-    size_t size;
-    uint32_t pinCount;
-  };
-  // Elements get newer as we move from elements_.begin() to elements_.end().
-  std::list<Element*> elements_;
-  folly::F14FastMap<Key, Element*, Hash, Comparator> keys_;
+  folly::EvictingCacheMap<Key, Value> lru_;
 };
 
 //
 //  End of public API. Imlementation follows.
 //
 
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline SimpleLRUCache<Key, Value, Comparator, Hash>::SimpleLRUCache(
-    size_t maxSize)
-    : maxSize_(maxSize) {}
+template <typename Key, typename Value>
+inline SimpleLRUCache<Key, Value>::SimpleLRUCache(
+    size_t maxSize,
+    size_t clearSize)
+    : lru_(maxSize, clearSize) {}
 
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline SimpleLRUCache<Key, Value, Comparator, Hash>::~SimpleLRUCache() {
-  // We could be more optimal than calling free here, but in
-  // general this destructor will never get called during normal
-  // usage so we don't bother.
-  free(maxSize_);
-  CHECK(elements_.empty());
-  CHECK(keys_.empty());
-  CHECK_EQ(curSize_, 0);
+template <typename Key, typename Value>
+inline bool SimpleLRUCache<Key, Value>::add(
+    const Key& key,
+    const Value& value) {
+  return lru_.insert(key, value).second;
 }
 
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline bool SimpleLRUCache<Key, Value, Comparator, Hash>::add(
-    Key key,
-    Value* value,
-    size_t size) {
-  return addInternal(key, value, size, /*pinned=*/false);
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline bool SimpleLRUCache<Key, Value, Comparator, Hash>::addPinned(
-    Key key,
-    Value* value,
-    size_t size) {
-  return addInternal(key, value, size, /*pinned=*/true);
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline bool SimpleLRUCache<Key, Value, Comparator, Hash>::addInternal(
-    Key key,
-    Value* value,
-    size_t size,
-    bool pinned) {
-  if (keys_.find(key) != keys_.end()) {
-    return false;
-  }
-  if (pinnedSize_ + size > maxSize_) {
-    return false;
-  }
-  const int64_t spaceNeeded = curSize_ + size - maxSize_;
-  if (spaceNeeded > 0) {
-    free(spaceNeeded);
-  }
-  Element* e = new Element;
-  e->key = std::move(key);
-  e->value = value;
-  e->size = size;
-  e->pinCount = pinned;
-  if (pinned)
-    pinnedSize_ += size;
-  keys_.emplace(e->key, e);
-  elements_.push_back(e);
-  curSize_ += size;
-  return true;
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline Value* SimpleLRUCache<Key, Value, Comparator, Hash>::get(
-    const Key& key) {
+template <typename Key, typename Value>
+inline std::optional<Value> SimpleLRUCache<Key, Value>::get(const Key& key) {
   ++numLookups_;
-  auto it = keys_.find(key);
-  if (it == keys_.end()) {
-    return nullptr;
+  auto it = lru_.find(key);
+  if (it == lru_.end()) {
+    return std::nullopt;
   }
-  if (it->second->pinCount == 0) {
-    pinnedSize_ += it->second->size;
-  }
-  it->second->pinCount++;
+
   ++numHits_;
-  return it->second->value;
+  return it->second;
 }
 
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline void SimpleLRUCache<Key, Value, Comparator, Hash>::release(
-    const Key& key) {
-  Element* e = keys_[key];
-  --e->pinCount;
-  if (e->pinCount == 0) {
-    pinnedSize_ -= e->size;
-  }
-}
-
-template <typename Key, typename Value, typename Comparator, typename Hash>
-inline size_t SimpleLRUCache<Key, Value, Comparator, Hash>::free(size_t size) {
-  auto it = elements_.begin();
-  auto end = elements_.end();
-  size_t freed = 0;
-  while (it != end && freed < size) {
-    if ((*it)->pinCount == 0) {
-      freed += (*it)->size;
-      curSize_ -= (*it)->size;
-      keys_.erase((*it)->key);
-      delete (*it)->value;
-      delete *it;
-      auto to_be_erased = it;
-      ++it;
-      elements_.erase(to_be_erased);
-    } else {
-      ++it;
-    }
-  }
-  return freed;
+template <typename Key, typename Value>
+inline void SimpleLRUCache<Key, Value>::clear() {
+  lru_.clear();
 }
 } // namespace facebook::velox

--- a/velox/common/caching/tests/SimpleLRUCacheTest.cpp
+++ b/velox/common/caching/tests/SimpleLRUCacheTest.cpp
@@ -15,146 +15,75 @@
  */
 
 #include "velox/common/caching/SimpleLRUCache.h"
+#include <optional>
 
 #include "gtest/gtest.h"
 
 using namespace facebook::velox;
 
+namespace {
+void verifyCacheStats(
+    const SimpleLRUCacheStats& actual,
+    size_t maxSize,
+    size_t curSize,
+    size_t numHits,
+    size_t numLookups) {
+  SimpleLRUCacheStats expectedStats{maxSize, curSize, numHits, numLookups};
+  EXPECT_EQ(actual, expectedStats) << " Actual " << actual.toString()
+                                   << " Expected " << expectedStats.toString();
+}
+} // namespace
+
 TEST(SimpleLRUCache, basicCaching) {
   SimpleLRUCache<int, int> cache(1000);
 
-  ASSERT_TRUE(cache.add(1, new int(11), 1));
-  int* value = cache.get(1);
-  ASSERT_NE(value, nullptr);
-  ASSERT_EQ(*value, 11);
-  cache.release(1);
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_FALSE(cache.get(2).has_value());
 
-  int* secondValue = new int(22);
-  ASSERT_TRUE(cache.addPinned(2, secondValue, 1));
-  *secondValue += 5;
-  cache.release(2);
+  verifyCacheStats(cache.getStats(), 1000, 0, 0, 2);
+
+  int firstValue = 11;
+  ASSERT_TRUE(cache.add(1, firstValue));
+  auto value = cache.get(1);
+  ASSERT_EQ(value, std::make_optional(11));
+
+  int secondValue = 22;
+  ASSERT_TRUE(cache.add(2, secondValue));
+
+  verifyCacheStats(cache.getStats(), 1000, 2, 1, 3);
 
   value = cache.get(1);
-  ASSERT_NE(value, nullptr);
-  ASSERT_EQ(*value, 11);
-  cache.release(1);
+  ASSERT_EQ(value, std::make_optional(11));
 
   value = cache.get(2);
-  ASSERT_NE(value, nullptr);
-  ASSERT_EQ(*value, 27);
-  cache.release(2);
+  ASSERT_EQ(value, std::make_optional(22));
 
   value = cache.get(1);
-  ASSERT_NE(value, nullptr);
-  ASSERT_EQ(*value, 11);
-  secondValue = cache.get(1);
-  ASSERT_EQ(value, secondValue);
-  cache.release(1);
-  cache.release(1);
+  ASSERT_EQ(value, std::make_optional(11));
+
+  value = cache.get(2);
+  ASSERT_EQ(value, std::make_optional(22));
+  verifyCacheStats(cache.getStats(), 1000, 2, 5, 7);
+
+  cache.clear();
+  verifyCacheStats(cache.getStats(), 1000, 0, 5, 7);
+  EXPECT_FALSE(cache.get(1).has_value());
+  EXPECT_FALSE(cache.get(2).has_value());
 }
 
 TEST(SimpleLRUCache, eviction) {
   SimpleLRUCache<int, int> cache(1000);
 
   for (int i = 0; i < 1010; ++i) {
-    ASSERT_TRUE(cache.add(i, new int(i), 1));
+    ASSERT_TRUE(cache.add(i, i));
   }
 
   for (int i = 0; i < 10; ++i) {
-    ASSERT_EQ(cache.get(i), nullptr);
+    ASSERT_FALSE(cache.get(i).has_value());
   }
+
   for (int i = 10; i < 1010; ++i) {
-    int* value = cache.get(i);
-    ASSERT_NE(value, nullptr);
-    ASSERT_EQ(*value, i);
-    cache.release(i);
+    auto value = cache.get(i);
+    ASSERT_EQ(value, std::make_optional(i));
   }
-}
-
-TEST(SimpleLRUCache, pinnedEviction) {
-  SimpleLRUCache<int, int> cache(100);
-
-  for (int i = 0; i < 10; ++i) {
-    ASSERT_TRUE(cache.addPinned(i, new int(i), 1));
-  }
-  for (int i = 10; i < 110; ++i) {
-    ASSERT_TRUE(cache.add(i, new int(i), 1));
-  }
-
-  for (int i = 0; i < 10; ++i) {
-    int* value = cache.get(i);
-    ASSERT_NE(value, nullptr);
-    ASSERT_EQ(*value, i);
-    cache.release(i);
-    cache.release(i); // Release the original pin too.
-  }
-  for (int i = 10; i < 20; ++i) {
-    ASSERT_EQ(cache.get(i), nullptr);
-  }
-  for (int i = 20; i < 110; ++i) {
-    int* value = cache.get(i);
-    ASSERT_NE(value, nullptr);
-    ASSERT_EQ(*value, i);
-    cache.release(i);
-  }
-}
-
-TEST(SimpleLRUCache, fullyPinned) {
-  SimpleLRUCache<int, int> cache(10);
-
-  for (int i = 0; i < 10; ++i) {
-    ASSERT_TRUE(cache.addPinned(i, new int(i), 1));
-  }
-  for (int i = 10; i < 20; ++i) {
-    int* value = new int(i);
-    ASSERT_FALSE(cache.add(i, value, 1));
-    delete value;
-  }
-  for (int i = 20; i < 30; ++i) {
-    int* value = new int(i);
-    ASSERT_FALSE(cache.addPinned(i, value, 1));
-    delete value;
-  }
-
-  for (int i = 0; i < 10; ++i) {
-    int* value = cache.get(i);
-    ASSERT_NE(value, nullptr);
-    ASSERT_EQ(*value, i);
-    cache.release(i);
-    cache.release(i); // Release the original pin too.
-  }
-  for (int i = 10; i < 30; ++i) {
-    ASSERT_EQ(cache.get(i), nullptr);
-  }
-}
-
-TEST(SimpleLRUCache, size) {
-  SimpleLRUCache<int, int> cache(10);
-  ASSERT_EQ(cache.maxSize(), 10);
-
-  for (int i = 0; i < 5; ++i) {
-    ASSERT_TRUE(cache.addPinned(i, new int(i), 2));
-    ASSERT_EQ(cache.currentSize(), 2 * (i + 1));
-  }
-  int* value = new int(5);
-  ASSERT_FALSE(cache.addPinned(5, value, 1));
-
-  for (int i = 0; i < 5; ++i) {
-    cache.release(i);
-  }
-  ASSERT_TRUE(cache.addPinned(5, value, 10));
-  ASSERT_EQ(cache.currentSize(), 10);
-
-  for (int i = 0; i < 5; ++i) {
-    ASSERT_EQ(cache.get(i), nullptr);
-  }
-  cache.release(5);
-}
-
-TEST(SimpleLRUCache, insertLargerThanCacheFails) {
-  SimpleLRUCache<int, int> cache(10);
-
-  int* value = new int(42);
-  ASSERT_FALSE(cache.add(123, value, 11));
-  delete value;
 }

--- a/velox/connectors/hive/FileHandle.cpp
+++ b/velox/connectors/hive/FileHandle.cpp
@@ -24,12 +24,6 @@
 
 namespace facebook::velox {
 
-uint64_t FileHandleSizer::operator()(const FileHandle& fileHandle) {
-  // TODO: remember to add in the size of the hash map and its contents
-  // when we add it later.
-  return fileHandle.file->memoryUsage();
-}
-
 namespace {
 // The group tracking is at the level of the directory, i.e. Hive partition.
 std::string groupName(const std::string& filename) {
@@ -39,13 +33,13 @@ std::string groupName(const std::string& filename) {
 }
 } // namespace
 
-std::unique_ptr<FileHandle> FileHandleGenerator::operator()(
+std::shared_ptr<FileHandle> FileHandleGenerator::operator()(
     const std::string& filename) {
   uint64_t elapsedTimeUs{0};
-  std::unique_ptr<FileHandle> fileHandle;
+  std::shared_ptr<FileHandle> fileHandle;
   {
     MicrosecondTimer timer(&elapsedTimeUs);
-    fileHandle = std::make_unique<FileHandle>();
+    fileHandle = std::make_shared<FileHandle>();
     fileHandle->file = filesystems::getFileSystem(filename, properties_)
                            ->openFileForRead(filename);
     fileHandle->uuid = StringIdLease(fileIds(), filename);

--- a/velox/connectors/hive/FileHandle.h
+++ b/velox/connectors/hive/FileHandle.h
@@ -58,11 +58,6 @@ struct FileHandle {
   // first diff we'll not include the map.
 };
 
-// Estimates the memory usage of a FileHandle object.
-struct FileHandleSizer {
-  uint64_t operator()(const FileHandle& a);
-};
-
 using FileHandleCache = SimpleLRUCache<std::string, FileHandle>;
 
 // Creates FileHandles via the Generator interface the CachedFactory requires.
@@ -71,7 +66,7 @@ class FileHandleGenerator {
   FileHandleGenerator() {}
   FileHandleGenerator(std::shared_ptr<const Config> properties)
       : properties_(std::move(properties)) {}
-  std::unique_ptr<FileHandle> operator()(const std::string& filename);
+  std::shared_ptr<FileHandle> operator()(const std::string& filename);
 
  private:
   const std::shared_ptr<const Config> properties_;
@@ -79,11 +74,8 @@ class FileHandleGenerator {
 
 using FileHandleFactory = CachedFactory<
     std::string,
-    FileHandle,
-    FileHandleGenerator,
-    FileHandleSizer>;
-
-using FileHandleCachedPtr = CachedPtr<std::string, FileHandle>;
+    std::shared_ptr<FileHandle>,
+    FileHandleGenerator>;
 
 using FileHandleCacheStats = SimpleLRUCacheStats;
 

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -236,7 +236,7 @@ class HiveDataSource : public DataSource {
 
   dwio::common::RuntimeStatistics runtimeStats_;
 
-  FileHandleCachedPtr fileHandle_;
+  std::shared_ptr<FileHandle> fileHandle_;
   core::ExpressionEvaluator* expressionEvaluator_;
   uint64_t completedRows_ = 0;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -146,9 +146,10 @@ TEST_F(S3FileSystemTest, fileHandle) {
   }
   auto hiveConfig = minioServer_->hiveConfig();
   FileHandleFactory factory(
-      std::make_unique<SimpleLRUCache<std::string, FileHandle>>(1000),
+      std::make_unique<
+          SimpleLRUCache<std::string, std::shared_ptr<FileHandle>>>(1000),
       std::make_unique<FileHandleGenerator>(hiveConfig));
-  auto fileHandle = factory.generate(s3File);
+  auto fileHandle = factory.generate(s3File).second;
   readData(fileHandle->file.get());
 }
 

--- a/velox/connectors/hive/tests/FileHandleTest.cpp
+++ b/velox/connectors/hive/tests/FileHandleTest.cpp
@@ -37,9 +37,10 @@ TEST(FileHandleTest, localFile) {
   }
 
   FileHandleFactory factory(
-      std::make_unique<SimpleLRUCache<std::string, FileHandle>>(1000),
+      std::make_unique<
+          SimpleLRUCache<std::string, std::shared_ptr<FileHandle>>>(1000),
       std::make_unique<FileHandleGenerator>());
-  auto fileHandle = factory.generate(filename);
+  auto fileHandle = factory.generate(filename).second;
   ASSERT_EQ(fileHandle->file->size(), 3);
   char buffer[3];
   ASSERT_EQ(fileHandle->file->pread(0, 3, &buffer), "foo");


### PR DESCRIPTION
Summary:
SimpleLRUCache today handles the lifetime by pinning the entry and unpinning the entry on the destructor.  The code is complicated and implements the LRU cache by itself.

This refactor replaces the SimpleLRUCache with [folly::EvictingCacheMap](https://github.com/facebook/folly/blob/main/folly/container/EvictingCacheMap.h#L33)

Some of the key differences are

1. EvictingCacheMap does not manage the lifetime of the value. When an item is evicted it is immediately destroyed. So the values should use a value type or shared_ptr to manage the lifetime.
2. There is no pinning/unpinning for correctness.
3. There is no special code required on the destructor path.
4. The simpleLRUCache only lets you control the number of entries in the cache. Individual entry size can't be controlled.

Found couple of bugs while making these changes, and commented on them.

Differential Revision: D45507362

