### PR TITLE
Improve decimal overflow message

### DIFF
--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -123,7 +123,7 @@ TEST_F(DecimalArithmeticTest, add) {
           {makeFlatVector(
               std::vector<int128_t>{DecimalUtil::kLongDecimalMax},
               DECIMAL(38, 0))}),
-      "Value '100000000000000000000000000000000000000' is not in the range of Decimal Type");
+      "Decimal overflow. Value '100000000000000000000000000000000000000' is not in the range of Decimal Type");
 
   // Rescaling LHS overflows.
   VELOX_ASSERT_THROW(
@@ -209,7 +209,7 @@ TEST_F(DecimalArithmeticTest, subtract) {
           {makeFlatVector(
               std::vector<int128_t>{DecimalUtil::kLongDecimalMin},
               DECIMAL(38, 0))}),
-      "Value '-100000000000000000000000000000000000000' is not in the range of Decimal Type");
+      "Decimal overflow. Value '-100000000000000000000000000000000000000' is not in the range of Decimal Type");
   // Rescaling LHS overflows.
   VELOX_ASSERT_THROW(
       testDecimalExpr<TypeKind::HUGEINT>(
@@ -279,7 +279,7 @@ TEST_F(DecimalArithmeticTest, multiply) {
               std::vector<int128_t>{
                   HugeInt::build(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
               DECIMAL(38, 0))}),
-      "Value '119630519620642428561342635425231011830' is not in the range of Decimal Type");
+      "Decimal overflow. Value '119630519620642428561342635425231011830' is not in the range of Decimal Type");
 
   // Rescaling the final result overflows.
   VELOX_ASSERT_THROW(
@@ -290,7 +290,7 @@ TEST_F(DecimalArithmeticTest, multiply) {
               std::vector<int128_t>{
                   HugeInt::build(0x08FFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF)},
               DECIMAL(38, 0))}),
-      "Value '119630519620642428561342635425231011830' is not in the range of Decimal Type");
+      "Decimal overflow. Value '119630519620642428561342635425231011830' is not in the range of Decimal Type");
 }
 
 TEST_F(DecimalArithmeticTest, decimalDivTest) {

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -82,7 +82,7 @@ class DecimalUtil {
   FOLLY_ALWAYS_INLINE static void valueInRange(int128_t value) {
     VELOX_CHECK(
         (value >= kLongDecimalMin && value <= kLongDecimalMax),
-        "Value '{}' is not in the range of Decimal Type",
+        "Decimal overflow. Value '{}' is not in the range of Decimal Type",
         value);
   }
 


### PR DESCRIPTION
Add "Decimal overflow." prefix to the existing message to be consistent with Presto messaging.