### PR TITLE
Add fast implementation of UnsafeRow serialization

### DIFF
--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(velox_row_fast UnsafeRowFast.cpp)
+
+target_link_libraries(velox_row_fast velox_vector)
+
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)
 endif()

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -1,0 +1,398 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/row/UnsafeRowFast.h"
+
+namespace facebook::velox::row {
+
+namespace {
+static const int32_t kFieldWidth = 8;
+
+int32_t alignBits(int32_t numBits) {
+  return bits::nwords(numBits) * 8;
+}
+
+int32_t alignBytes(int32_t numBytes) {
+  return bits::roundUp(numBytes, 8);
+}
+} // namespace
+
+// static
+std::optional<int32_t> UnsafeRowFast::fixedRowSize(const RowTypePtr& rowType) {
+  for (const auto& child : rowType->children()) {
+    if (!child->isFixedWidth()) {
+      return std::nullopt;
+    }
+  }
+
+  const size_t numFields = rowType->size();
+  const size_t nullLength = alignBits(numFields);
+
+  return nullLength + numFields * kFieldWidth;
+}
+
+UnsafeRowFast::UnsafeRowFast(const RowVectorPtr& vector)
+    : typeKind_{vector->typeKind()}, decoded_{*vector} {
+  initialize(vector->type());
+}
+
+UnsafeRowFast::UnsafeRowFast(const VectorPtr& vector)
+    : typeKind_{vector->typeKind()}, decoded_{*vector} {
+  initialize(vector->type());
+}
+
+void UnsafeRowFast::initialize(const TypePtr& type) {
+  auto base = decoded_.base();
+  switch (typeKind_) {
+    case TypeKind::ARRAY: {
+      auto arrayBase = base->as<ArrayVector>();
+      children_.push_back(UnsafeRowFast(arrayBase->elements()));
+      childIsFixedWidth_.push_back(
+          arrayBase->elements()->type()->isFixedWidth());
+      break;
+    }
+    case TypeKind::MAP: {
+      auto mapBase = base->as<MapVector>();
+      children_.push_back(UnsafeRowFast(mapBase->mapKeys()));
+      children_.push_back(UnsafeRowFast(mapBase->mapValues()));
+      childIsFixedWidth_.push_back(mapBase->mapKeys()->type()->isFixedWidth());
+      childIsFixedWidth_.push_back(
+          mapBase->mapValues()->type()->isFixedWidth());
+      break;
+    }
+    case TypeKind::ROW: {
+      auto rowBase = base->as<RowVector>();
+      for (const auto& child : rowBase->children()) {
+        children_.push_back(UnsafeRowFast(child));
+        childIsFixedWidth_.push_back(child->type()->isFixedWidth());
+      }
+
+      rowNullBytes_ = alignBits(type->size());
+      break;
+    }
+    case TypeKind::BOOLEAN:
+      valueBytes_ = 1;
+      fixedWidthTypeKind_ = true;
+      break;
+    case TypeKind::TINYINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::SMALLINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::INTEGER:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::BIGINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::REAL:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::DOUBLE:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::DATE:
+      valueBytes_ = type->cppSizeInBytes();
+      fixedWidthTypeKind_ = true;
+      supportsBulkCopy_ = decoded_.isIdentityMapping();
+      break;
+    case TypeKind::TIMESTAMP:
+      valueBytes_ = sizeof(int64_t);
+      fixedWidthTypeKind_ = true;
+      break;
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY:
+      // Nothing to do.
+      break;
+    default:
+      VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
+  }
+}
+
+int32_t UnsafeRowFast::rowSize(vector_size_t index) {
+  return rowRowSize(index);
+}
+
+int32_t UnsafeRowFast::variableWidthRowSize(vector_size_t index) {
+  switch (typeKind_) {
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY: {
+      auto value = decoded_.valueAt<StringView>(index);
+      return alignBytes(value.size());
+    }
+    case TypeKind::ARRAY:
+      return arrayRowSize(index);
+    case TypeKind::MAP:
+      return mapRowSize(index);
+    case TypeKind::ROW:
+      return rowRowSize(index);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+  };
+}
+
+bool UnsafeRowFast::isNullAt(vector_size_t index) {
+  return decoded_.isNullAt(index);
+}
+
+int32_t UnsafeRowFast::serialize(vector_size_t index, char* buffer) {
+  return serializeRow(index, buffer);
+}
+
+void UnsafeRowFast::serializeFixedWidth(vector_size_t index, char* buffer) {
+  VELOX_DCHECK(fixedWidthTypeKind_);
+  switch (typeKind_) {
+    case TypeKind::BOOLEAN:
+      *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
+      break;
+    case TypeKind::TIMESTAMP:
+      *reinterpret_cast<int64_t*>(buffer) =
+          decoded_.valueAt<Timestamp>(index).toMicros();
+      break;
+    default:
+      memcpy(
+          buffer,
+          decoded_.data<char>() + decoded_.index(index) * valueBytes_,
+          valueBytes_);
+  }
+}
+
+void UnsafeRowFast::serializeFixedWidth(
+    vector_size_t offset,
+    vector_size_t size,
+    char* buffer) {
+  VELOX_DCHECK(supportsBulkCopy_);
+  memcpy(
+      buffer,
+      decoded_.data<char>() + decoded_.index(offset) * valueBytes_,
+      valueBytes_ * size);
+}
+
+int32_t UnsafeRowFast::serializeVariableWidth(
+    vector_size_t index,
+    char* buffer) {
+  switch (typeKind_) {
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY: {
+      auto value = decoded_.valueAt<StringView>(index);
+      memcpy(buffer, value.data(), value.size());
+      return value.size();
+    }
+    case TypeKind::ARRAY:
+      return serializeArray(index, buffer);
+    case TypeKind::MAP:
+      return serializeMap(index, buffer);
+    case TypeKind::ROW:
+      return serializeRow(index, buffer);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+  };
+}
+
+int32_t UnsafeRowFast::arrayRowSize(vector_size_t index) {
+  auto baseIndex = decoded_.index(index);
+
+  // array size | null bits | fixed-width data | variable-width data
+  auto arrayBase = decoded_.base()->asUnchecked<ArrayVector>();
+  auto offset = arrayBase->offsetAt(baseIndex);
+  auto size = arrayBase->sizeAt(baseIndex);
+
+  return arrayRowSize(children_[0], offset, size, childIsFixedWidth_[0]);
+}
+
+int32_t UnsafeRowFast::serializeArray(vector_size_t index, char* buffer) {
+  auto baseIndex = decoded_.index(index);
+
+  // array size | null bits | fixed-width data | variable-width data
+  auto arrayBase = decoded_.base()->asUnchecked<ArrayVector>();
+  auto offset = arrayBase->offsetAt(baseIndex);
+  auto size = arrayBase->sizeAt(baseIndex);
+
+  return serializeAsArray(
+      children_[0], offset, size, childIsFixedWidth_[0], buffer);
+}
+
+int32_t UnsafeRowFast::mapRowSize(vector_size_t index) {
+  auto baseIndex = decoded_.index(index);
+
+  //  size of serialized keys array in bytes | <keys array> | <values array>
+
+  auto mapBase = decoded_.base()->asUnchecked<MapVector>();
+  auto offset = mapBase->offsetAt(baseIndex);
+  auto size = mapBase->sizeAt(baseIndex);
+
+  return kFieldWidth +
+      arrayRowSize(children_[0], offset, size, childIsFixedWidth_[0]) +
+      arrayRowSize(children_[1], offset, size, childIsFixedWidth_[1]);
+}
+
+int32_t UnsafeRowFast::serializeMap(vector_size_t index, char* buffer) {
+  auto baseIndex = decoded_.index(index);
+
+  //  size of serialized keys array in bytes | <keys array> | <values array>
+
+  auto mapBase = decoded_.base()->asUnchecked<MapVector>();
+  auto offset = mapBase->offsetAt(baseIndex);
+  auto size = mapBase->sizeAt(baseIndex);
+
+  int32_t serializedBytes = kFieldWidth;
+
+  auto keysSerializedBytes = serializeAsArray(
+      children_[0],
+      offset,
+      size,
+      childIsFixedWidth_[0],
+      buffer + serializedBytes);
+  serializedBytes += keysSerializedBytes;
+
+  auto valuesSerializedBytes = serializeAsArray(
+      children_[1],
+      offset,
+      size,
+      childIsFixedWidth_[1],
+      buffer + serializedBytes);
+  serializedBytes += valuesSerializedBytes;
+
+  // Write the size of serialized keys.
+  *reinterpret_cast<int64_t*>(buffer) = keysSerializedBytes;
+
+  return serializedBytes;
+}
+
+int32_t UnsafeRowFast::arrayRowSize(
+    UnsafeRowFast& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    bool fixedWidth) {
+  int32_t nullBytes = alignBits(size);
+
+  int32_t rowSize = kFieldWidth + nullBytes;
+  if (fixedWidth) {
+    return rowSize + size * elements.valueBytes();
+  }
+
+  rowSize += size * kFieldWidth;
+
+  for (auto i = 0; i < size; ++i) {
+    if (!elements.isNullAt(offset + i)) {
+      rowSize += alignBytes(elements.variableWidthRowSize(offset + i));
+    }
+  }
+
+  return rowSize;
+}
+
+int32_t UnsafeRowFast::serializeAsArray(
+    UnsafeRowFast& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    bool fixedWidth,
+    char* buffer) {
+  // array size | null bits | fixed-width data | variable-width data
+
+  // Write array size.
+  *reinterpret_cast<int64_t*>(buffer) = size;
+
+  int32_t nullBytes = alignBits(size);
+
+  int32_t nullsOffset = sizeof(int64_t);
+  int32_t fixedWidthOffset = nullsOffset + nullBytes;
+
+  auto childSize = fixedWidth ? elements.valueBytes() : kFieldWidth;
+
+  int64_t variableWidthOffset = fixedWidthOffset + size * childSize;
+
+  if (elements.supportsBulkCopy_) {
+    if (elements.decoded_.mayHaveNulls()) {
+      for (auto i = 0; i < size; ++i) {
+        if (elements.isNullAt(offset + i)) {
+          bits::setBit(buffer + nullsOffset, i, true);
+        }
+      }
+    }
+    elements.serializeFixedWidth(offset, size, buffer + fixedWidthOffset);
+    return variableWidthOffset;
+  }
+
+  for (auto i = 0; i < size; ++i) {
+    if (elements.isNullAt(offset + i)) {
+      bits::setBit(buffer + nullsOffset, i, true);
+    } else {
+      if (fixedWidth) {
+        elements.serializeFixedWidth(
+            offset + i, buffer + fixedWidthOffset + i * childSize);
+      } else {
+        auto serializedBytes = elements.serializeVariableWidth(
+            offset + i, buffer + variableWidthOffset);
+
+        // Write size and offset.
+        uint64_t sizeAndOffset = variableWidthOffset << 32 | serializedBytes;
+        reinterpret_cast<uint64_t*>(buffer + fixedWidthOffset)[i] =
+            sizeAndOffset;
+
+        variableWidthOffset += alignBytes(serializedBytes);
+      }
+    }
+  }
+  return variableWidthOffset;
+}
+
+int32_t UnsafeRowFast::rowRowSize(vector_size_t index) {
+  auto childIndex = decoded_.index(index);
+
+  const auto numFields = children_.size();
+  int32_t size = rowNullBytes_ + numFields * kFieldWidth;
+
+  for (auto i = 0; i < numFields; ++i) {
+    if (!childIsFixedWidth_[i] && !children_[i].isNullAt(childIndex)) {
+      size += alignBytes(children_[i].variableWidthRowSize(childIndex));
+    }
+  }
+
+  return size;
+}
+
+int32_t UnsafeRowFast::serializeRow(vector_size_t index, char* buffer) {
+  auto childIndex = decoded_.index(index);
+
+  int64_t variableWidthOffset = rowNullBytes_ + kFieldWidth * children_.size();
+
+  for (auto i = 0; i < children_.size(); ++i) {
+    auto& child = children_[i];
+
+    // Write null bit.
+    if (child.isNullAt(childIndex)) {
+      bits::setBit(buffer, i, true);
+      continue;
+    }
+
+    // Write value.
+    if (childIsFixedWidth_[i]) {
+      child.serializeFixedWidth(
+          childIndex, buffer + rowNullBytes_ + i * kFieldWidth);
+    } else {
+      auto size = child.serializeVariableWidth(
+          childIndex, buffer + variableWidthOffset);
+      // Write size and offset.
+      uint64_t sizeAndOffset = variableWidthOffset << 32 | size;
+      reinterpret_cast<uint64_t*>(buffer + rowNullBytes_)[i] = sizeAndOffset;
+
+      variableWidthOffset += alignBytes(size);
+    }
+  }
+
+  return variableWidthOffset;
+}
+} // namespace facebook::velox::row

--- a/velox/row/UnsafeRowFast.h
+++ b/velox/row/UnsafeRowFast.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::row {
+
+class UnsafeRowFast {
+ public:
+  explicit UnsafeRowFast(const RowVectorPtr& vector);
+
+  /// Returns row size if all fields are fixed width. Return std::nullopt if
+  /// there are variable-width fields.
+  static std::optional<int32_t> fixedRowSize(const RowTypePtr& rowType);
+
+  /// Returns serialized size of the row at specified index. Use only if
+  /// 'fixedRowSize' returned std::nullopt.
+  int32_t rowSize(vector_size_t index);
+
+  /// Serializes row at specified index into 'buffer'.
+  /// 'buffer' must have sufficient capacity and set to all zeros.
+  int32_t serialize(vector_size_t index, char* buffer);
+
+ protected:
+  explicit UnsafeRowFast(const VectorPtr& vector);
+
+  void initialize(const TypePtr& type);
+
+  bool isNullAt(vector_size_t);
+
+  /// Fixed-width types only. Returns number of bytes used by single value.
+  int32_t valueBytes() const {
+    return valueBytes_;
+  }
+
+  /// Writes fixed-width value at specified index into 'buffer'. Value must not
+  /// be null.
+  void serializeFixedWidth(vector_size_t index, char* buffer);
+
+  /// Writes range of fixed-width values between 'offset' and 'offset + size'
+  /// into 'buffer'. Values can be null.
+  void
+  serializeFixedWidth(vector_size_t offset, vector_size_t size, char* buffer);
+
+  /// Returns serialized size of variable-width row.
+  int32_t variableWidthRowSize(vector_size_t index);
+
+  /// Writes variable-width value at specified index into 'buffer'. Value must
+  /// not be null. Returns number of bytes written to 'buffer'.
+  int32_t serializeVariableWidth(vector_size_t index, char* buffer);
+
+ private:
+  /// Returns serialized size of array row.
+  int32_t arrayRowSize(vector_size_t index);
+
+  /// Serializes array value to buffer. Value must not be null. Returns number
+  /// of bytes written to 'buffer'.
+  int32_t serializeArray(vector_size_t index, char* buffer);
+
+  /// Returns serialized size of map row.
+  int32_t mapRowSize(vector_size_t index);
+
+  /// Serializes map value to buffer. Value must not be null. Returns number of
+  /// bytes written to 'buffer'.
+  int32_t serializeMap(vector_size_t index, char* buffer);
+
+  /// Returns serialized size of a range of values.
+  int32_t arrayRowSize(
+      UnsafeRowFast& elements,
+      vector_size_t offset,
+      vector_size_t size,
+      bool fixedWidth);
+
+  /// Serializes a range of values into buffer using UnsafeRow Array
+  /// serialization. Returns number of bytes written to 'buffer'.
+  int32_t serializeAsArray(
+      UnsafeRowFast& elements,
+      vector_size_t offset,
+      vector_size_t size,
+      bool fixedWidth,
+      char* buffer);
+
+  /// Returns serialized size of struct value.
+  int32_t rowRowSize(vector_size_t index);
+
+  /// Serializes struct value to buffer. Value must not be null.
+  int32_t serializeRow(vector_size_t index, char* buffer);
+
+  const TypeKind typeKind_;
+  DecodedVector decoded_;
+
+  /// True if values of 'typeKind_' have fixed width.
+  bool fixedWidthTypeKind_{false};
+
+  /// ARRAY, MAP and ROW types only.
+  std::vector<UnsafeRowFast> children_;
+  std::vector<bool> childIsFixedWidth_;
+
+  /// True if this is a flat fixed-width vector whose consecutive values can be
+  /// copied into UnsafeRow Array in bulk.
+  bool supportsBulkCopy_{false};
+
+  // ROW type only. Number of bytes used by null flags.
+  size_t rowNullBytes_;
+
+  // Fixed-width types only. Number of bytes used for a single value.
+  size_t valueBytes_;
+};
+} // namespace facebook::velox::row

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_test(velox_row_test velox_row_test)
 
 target_link_libraries(
   velox_row_test
+  velox_row_fast
   velox_exec
   velox_exec_test_lib
   velox_functions_lib

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -20,9 +20,8 @@
 #include <folly/init/Init.h>
 
 #include "velox/row/UnsafeRowDeserializers.h"
+#include "velox/row/UnsafeRowFast.h"
 #include "velox/row/UnsafeRowSerializers.h"
-#include "velox/type/Type.h"
-#include "velox/vector/BaseVector.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -43,75 +42,161 @@ class UnsafeRowFuzzTests : public ::testing::Test {
     }
   }
 
-  static constexpr uint64_t kBufferSize = 20 << 10; // 20k
+  void doTest(
+      const RowTypePtr& rowType,
+      std::function<std::vector<std::optional<std::string_view>>(
+          const RowVectorPtr& data)> serializeFunc) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kNumBuffers;
+    opts.nullRatio = 0.1;
+    opts.containerHasNulls = false;
+    opts.dictionaryHasNulls = false;
+    opts.stringVariableLength = true;
+    opts.stringLength = 20;
+    opts.containerVariableLength = true;
+    opts.complexElementsMaxSize = 10'000;
 
-  std::array<char[kBufferSize], 100> buffers_{};
+    // Spark uses microseconds to store timestamp
+    opts.timestampPrecision =
+        VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
+    opts.containerLength = 10;
+
+    VectorFuzzer fuzzer(opts, pool_.get());
+
+    const auto iterations = 200;
+    for (size_t i = 0; i < iterations; ++i) {
+      clearBuffers();
+
+      auto seed = folly::Random::rand32();
+
+      LOG(INFO) << "seed: " << seed;
+      SCOPED_TRACE(fmt::format("seed: {}", seed));
+
+      fuzzer.reSeed(seed);
+      const auto& inputVector = fuzzer.fuzzInputRow(rowType);
+
+      // Serialize rowVector into bytes.
+      auto serialized = serializeFunc(inputVector);
+
+      // Deserialize previous bytes back to row vector
+      VectorPtr outputVector =
+          UnsafeRowDeserializer::deserialize(serialized, rowType, pool_.get());
+
+      assertEqualVectors(inputVector, outputVector);
+    }
+  }
+
+  static constexpr uint64_t kBufferSize = 50 << 10; // 50kb
+  static constexpr uint64_t kNumBuffers = 100;
+
+  std::array<char[kBufferSize], kNumBuffers> buffers_{};
 
   std::shared_ptr<memory::MemoryPool> pool_ =
       memory::addDefaultLeafMemoryPool();
 };
 
 TEST_F(UnsafeRowFuzzTests, simpleTypeRoundTripTest) {
-  auto rowType = ROW(
-      {BOOLEAN(),
-       TINYINT(),
-       SMALLINT(),
-       INTEGER(),
-       BIGINT(),
-       REAL(),
-       DOUBLE(),
-       VARCHAR(),
-       TIMESTAMP(),
-       ROW({VARCHAR(), INTEGER()}),
-       ARRAY(INTEGER()),
-       ARRAY(INTEGER()),
-       MAP(VARCHAR(), ARRAY(INTEGER()))});
+  auto rowType = ROW({
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      TIMESTAMP(),
+      ROW({VARCHAR(), INTEGER()}),
+      ARRAY(INTEGER()),
+      ARRAY(INTEGER()),
+      MAP(VARCHAR(), ARRAY(INTEGER())),
+  });
 
-  VectorFuzzer::Options opts;
-  opts.vectorSize = 100;
-  opts.nullRatio = 0.1;
-  opts.containerHasNulls = false;
-  opts.dictionaryHasNulls = false;
-  opts.stringVariableLength = true;
-  opts.stringLength = 20;
-  opts.containerVariableLength = true;
-  opts.complexElementsMaxSize = 10'000;
-
-  // Spark uses microseconds to store timestamp
-  opts.timestampPrecision =
-      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
-  opts.containerLength = 10;
-
-  auto seed = folly::Random::rand32();
-  LOG(INFO) << "seed: " << seed;
-  SCOPED_TRACE(fmt::format("seed: {}", seed));
-  VectorFuzzer fuzzer(opts, pool_.get(), seed);
-
-  const auto iterations = 1000;
-  for (size_t i = 0; i < iterations; ++i) {
-    clearBuffers();
-
-    const auto& inputVector = fuzzer.fuzzInputRow(rowType);
-    // Serialize rowVector into bytes.
+  doTest(rowType, [&](const RowVectorPtr& data) {
     std::vector<std::optional<std::string_view>> serialized;
-    serialized.reserve(inputVector->size());
-    for (auto j = 0; j < inputVector->size(); ++j) {
-      UnsafeRowSerializer::preloadVector(inputVector);
-      auto rowSize =
-          UnsafeRowSerializer::serialize(inputVector, buffers_[j], j);
+    serialized.reserve(data->size());
+    for (auto i = 0; i < data->size(); ++i) {
+      UnsafeRowSerializer::preloadVector(data);
+      auto rowSize = UnsafeRowSerializer::serialize(data, buffers_[i], i);
+      VELOX_CHECK(rowSize.has_value())
+      VELOX_CHECK_LE(rowSize.value(), kBufferSize);
 
-      auto rowSizeMeasured =
-          UnsafeRowSerializer::getSizeRow(inputVector.get(), j);
-      EXPECT_EQ(rowSize.value_or(0), rowSizeMeasured);
-      serialized.push_back(std::string_view(buffers_[j], rowSize.value()));
+      auto rowSizeMeasured = UnsafeRowSerializer::getSizeRow(data.get(), i);
+      EXPECT_EQ(rowSize.value(), rowSizeMeasured);
+      serialized.push_back(std::string_view(buffers_[i], rowSize.value()));
     }
+    return serialized;
+  });
+}
 
-    // Deserialize previous bytes back to row vector
-    VectorPtr outputVector =
-        UnsafeRowDeserializer::deserialize(serialized, rowType, pool_.get());
+TEST_F(UnsafeRowFuzzTests, fast) {
+  auto rowType = ROW({
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      VARCHAR(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      VARBINARY(),
+      // Arrays.
+      ARRAY(BOOLEAN()),
+      ARRAY(TINYINT()),
+      ARRAY(SMALLINT()),
+      ARRAY(INTEGER()),
+      ARRAY(BIGINT()),
+      ARRAY(REAL()),
+      ARRAY(DOUBLE()),
+      ARRAY(VARCHAR()),
+      ARRAY(VARBINARY()),
+      // Nested arrays.
+      ARRAY(ARRAY(INTEGER())),
+      ARRAY(ARRAY(BIGINT())),
+      ARRAY(ARRAY(VARCHAR())),
+      // Maps.
+      MAP(BIGINT(), REAL()),
+      MAP(BIGINT(), BIGINT()),
+      MAP(BIGINT(), VARCHAR()),
+      MAP(INTEGER(), MAP(BIGINT(), DOUBLE())),
+      MAP(VARCHAR(), BOOLEAN()),
+      MAP(INTEGER(), MAP(BIGINT(), ARRAY(REAL()))),
+      // Timestamp and date types.
+      TIMESTAMP(),
+      DATE(),
+      ARRAY(TIMESTAMP()),
+      ARRAY(DATE()),
+      MAP(DATE(), ARRAY(TIMESTAMP())),
+      // Structs.
+      ROW({BOOLEAN(), INTEGER(), TIMESTAMP(), VARCHAR(), ARRAY(BIGINT())}),
+      ROW(
+          {BOOLEAN(),
+           ROW({INTEGER(), TIMESTAMP()}),
+           VARCHAR(),
+           ARRAY(BIGINT())}),
+      ARRAY({ROW({BIGINT(), VARCHAR()})}),
+      MAP(BIGINT(), ROW({BOOLEAN(), TINYINT(), REAL()})),
+  });
 
-    assertEqualVectors(inputVector, outputVector);
-  }
+  doTest(rowType, [&](const RowVectorPtr& data) {
+    std::vector<std::optional<std::string_view>> serialized;
+    serialized.reserve(data->size());
+
+    UnsafeRowFast fast(data);
+    for (auto i = 0; i < data->size(); ++i) {
+      UnsafeRowSerializer::preloadVector(data);
+      auto rowSize = fast.serialize(i, buffers_[i]);
+      VELOX_CHECK_LE(rowSize, kBufferSize);
+
+      EXPECT_EQ(rowSize, fast.rowSize(i)) << i << ", " << data->toString(i);
+
+      auto rowSizeMeasured = UnsafeRowSerializer::getSizeRow(data.get(), i);
+      EXPECT_EQ(rowSize, rowSizeMeasured);
+      serialized.push_back(std::string_view(buffers_[i], rowSize));
+    }
+    return serialized;
+  });
 }
 
 } // namespace


### PR DESCRIPTION
UnsafeRow serialization is quite slow and shows up at 85% of the CPU profile for
map stages of some simple queries.

This implementation is 3x faster. 

Before: 

```
============================================================================
[...]hmark/UnsafeRowSerializeBenchmark.cpp     relative  time/iter   iters/s
============================================================================
fixedWidth5                                               147.71us     6.77K
fixedWidth10                                              345.15us     2.90K
fixedWidth20                                              746.18us     1.34K
strings1                                                  102.66us     9.74K
strings5                                                  337.83us     2.96K
arrays                                                    212.90us     4.70K
nestedArrays                                                1.07ms    938.89
maps                                                      282.18us     3.54K
structs                                                   291.11us     3.44K
```

After:

```
============================================================================
[...]hmark/UnsafeRowSerializeBenchmark.cpp     relative  time/iter   iters/s
============================================================================
fixedWidth5                                                50.12us    19.95K
fixedWidth10                                               88.00us    11.36K
fixedWidth20                                              168.27us     5.94K
strings1                                                   40.47us    24.71K
strings5                                                  128.80us     7.76K
arrays                                                     53.50us    18.69K
nestedArrays                                              295.72us     3.38K
maps                                                      124.99us     8.00K
structs                                                    95.06us    10.52K
```