### PR TITLE
Return nullptr from getOutput of finished HashProbe - Fix yield

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -827,6 +827,9 @@ void HashProbe::checkStateTransition(ProbeOperatorState state) {
 }
 
 RowVectorPtr HashProbe::getOutput() {
+  if (isFinished()) {
+    return nullptr;
+  }
   checkRunning();
 
   clearIdentityProjectedOutput();


### PR DESCRIPTION
Operators allow calling getOutput() repeatedly after being finished. They are expected to return nullptr. Add check to HashProbe for this. This behavior was broken when adding 'state_' and spilling.

Tested by adding a requestYield() after addInput() and noMoreInput() call in Driver::runInternal().  Original error surfaced in timer-based yield on a cluster, where infrequently the time slice would hit after nomoreInput() to a HashProbe. The subsequent getOutput when the Driver came back on thread would trigger the error.