### PR TITLE
Replace nonFlatMapContext() usage with aggregate initializer

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -358,7 +358,7 @@ class IntegerDirectColumnReader : public ColumnReader {
       TypePtr requestedType,
       StripeStreams& stripe,
       uint32_t numBytes,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
+      FlatMapContext flatMapContext = {});
 
   ~IntegerDirectColumnReader() override = default;
 
@@ -443,7 +443,7 @@ class IntegerDictionaryColumnReader : public ColumnReader {
       TypePtr requestedType,
       StripeStreams& stripe,
       uint32_t numBytes,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
+      FlatMapContext flatMapContext = FlatMapContext{});
 
   ~IntegerDictionaryColumnReader() override = default;
 
@@ -933,7 +933,7 @@ class StringDictionaryColumnReader : public ColumnReader {
   StringDictionaryColumnReader(
       std::shared_ptr<const dwio::common::TypeWithId> nodeType,
       StripeStreams& stripe,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
+      FlatMapContext flatMapContext = {});
   ~StringDictionaryColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -39,7 +39,7 @@ class ColumnReader {
       : notNullDecoder_{},
         nodeType_{type},
         memoryPool_{memoryPool},
-        flatMapContext_{FlatMapContext::nonFlatMapContext()} {}
+        flatMapContext_{} {}
 
   // Reads nulls, if any. Sets '*nulls' to nullptr if void
   // the reader has no nulls and there are no incoming
@@ -67,7 +67,7 @@ class ColumnReader {
   ColumnReader(
       std::shared_ptr<const dwio::common::TypeWithId> nodeId,
       StripeStreams& stripe,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
+      FlatMapContext flatMapContext = {});
 
   virtual ~ColumnReader() = default;
 
@@ -111,7 +111,7 @@ class ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext());
+      FlatMapContext flatMapContext = {});
 };
 
 class ColumnReaderFactory {
@@ -121,7 +121,7 @@ class ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext()) {
+      FlatMapContext flatMapContext = {}) {
     return ColumnReader::build(
         requestedType, dataType, stripe, std::move(flatMapContext));
   }

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -115,9 +115,7 @@ class DwrfData : public dwio::common::FormatData {
 // DWRF specific initialization.
 class DwrfParams : public dwio::common::FormatParams {
  public:
-  DwrfParams(
-      StripeStreams& stripeStreams,
-      FlatMapContext context = FlatMapContext::nonFlatMapContext())
+  explicit DwrfParams(StripeStreams& stripeStreams, FlatMapContext context = {})
       : FormatParams(stripeStreams.getMemoryPool()),
         stripeStreams_(stripeStreams),
         flatMapContext_(context) {}

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -403,7 +403,7 @@ void DwrfRowReader::startNextStripe() {
   auto scanSpec = options_.getScanSpec().get();
   auto requestedType = getColumnSelector().getSchemaWithId();
   auto dataType = getReader().getSchemaWithId();
-  auto flatMapContext = FlatMapContext::nonFlatMapContext();
+  FlatMapContext flatMapContext;
   flatMapContext.keySelectionCallback = options_.getKeySelectionCallback();
 
   if (scanSpec) {

--- a/velox/dwio/dwrf/reader/EncodingContext.h
+++ b/velox/dwio/dwrf/reader/EncodingContext.h
@@ -19,18 +19,18 @@
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 
 namespace facebook::velox::dwrf {
+
+// Struct containing context for flatmap encoding.
+// Default initialization is non-flatmap context.
 struct FlatMapContext {
  public:
-  static FlatMapContext nonFlatMapContext() {
-    return FlatMapContext{0, nullptr, nullptr};
-  }
+  uint32_t sequence{0};
 
-  uint32_t sequence;
   // Kept alive by key nodes
   BooleanRleDecoder* inMapDecoder{nullptr};
 
   std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
-      keySelectionCallback;
+      keySelectionCallback{nullptr};
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -38,7 +38,7 @@ class SelectiveDwrfReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
       common::ScanSpec* FOLLY_NONNULL scanSpec,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext()) {
+      FlatMapContext flatMapContext = {}) {
     auto params = DwrfParams(stripe, flatMapContext);
     return build(requestedType, dataType, params, *scanSpec);
   }
@@ -54,7 +54,7 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
-      FlatMapContext flatMapContext = FlatMapContext::nonFlatMapContext()) {
+      FlatMapContext flatMapContext = {}) {
     auto params = DwrfParams(stripe, std::move(flatMapContext));
     auto reader =
         SelectiveDwrfReader::build(requestedType, dataType, params, *scanSpec_);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -141,7 +141,7 @@ class ColumnReaderTestBase {
           dataTypeWithId,
           streams_,
           scanSpec,
-          FlatMapContext::nonFlatMapContext());
+          FlatMapContext{});
       selectiveColumnReader_->setIsTopLevel();
       columnReader_ = nullptr;
     } else {

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -942,10 +942,7 @@ TEST(TestReader, testUpcastBoolean) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType),
-      TypeWithId::create(rowType),
-      streams,
-      FlatMapContext::nonFlatMapContext());
+      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
 
   VectorPtr batch;
   reader->next(104, batch);
@@ -989,10 +986,7 @@ TEST(TestReader, testUpcastIntDirect) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType),
-      TypeWithId::create(rowType),
-      streams,
-      FlatMapContext::nonFlatMapContext());
+      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1053,10 +1047,7 @@ TEST(TestReader, testUpcastIntDict) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType),
-      TypeWithId::create(rowType),
-      streams,
-      FlatMapContext::nonFlatMapContext());
+      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1105,10 +1096,7 @@ TEST(TestReader, testUpcastFloat) {
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType),
-      TypeWithId::create(rowType),
-      streams,
-      FlatMapContext::nonFlatMapContext());
+      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
 
   VectorPtr batch;
   reader->next(100, batch);


### PR DESCRIPTION
Summary: Proposed change by Jake. I think it makes things a little cleaner, but we may also lose some explicitness. We don't have to merge if someone has a problem with it.

Differential Revision: D45646698

