### PR TITLE
Fix race condition task pause handling

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -701,7 +701,9 @@ class Task : public std::enable_shared_from_this<Task> {
       SplitsStore& splitsStore,
       exec::Split&& split);
 
-  void finishedLocked();
+  // Invoked when all the driver threads are off thread. The function returns
+  // 'threadFinishPromises_' to fulfill.
+  std::vector<ContinuePromise> allThreadsFinishedLocked();
 
   StopReason shouldStopLocked();
 


### PR DESCRIPTION
The operator memory reclaim unit test expose a race condition in Task
pause handling that a driver thread can still be on-thread state after task
pause wait complete. Here is the race condition:
T1: thread-A request task pause and gets a future of the promise
       stored in Task::threadFinishPromises_
T2: thread-A wait for the future returned by task pause
T3: the last driver thread call Task::leave which grabs a lock and
       set promise in Task::threadFinishPromises_ as Task::numThreads_
       becomes zero
T4:  thread-A returns from wait for the task finish future in T2
T5:  thread-A checks the last driver thread state and found
        ThreadState::isOnThread is still true which is unexpected
T6:  the last driver thread calls Task::clearThread() to clear the on
        thread flag

There are two problems: (1) the last driver thread's on thread state
is confusing as when task pause completes, we expect all the driver
threads must be off thread; (2) the current code set
threadFinishPromises_ promise under the task lock in both Task::leave
and Task::enterSuspended can easily lead to deadlock. The previously
reported deadlock issue in Task::enterSuspended unit test might be
caused by this issue.

Simply fixes the issue by set threadFinishPromises_ promise out of task
lock.