### PR TITLE
Fix Presto arraysort to use right bounds.

### DIFF
--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -101,7 +101,7 @@ void applyScalarType(
   VELOX_DCHECK(kind == inputElements->typeKind());
   const SelectivityVector inputElementRows =
       toElementRows(inputElements->size(), rows, inputArray);
-  const vector_size_t elementsCount = inputElementRows.end();
+  const vector_size_t elementsCount = inputElementRows.size();
 
   // TODO: consider to use dictionary wrapping to avoid the direct sorting on
   // the scalar values as we do for complex data type if this runs slow in

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -556,8 +556,7 @@ void BaseVector::ensureWritable(
     copy =
         BaseVector::create(isUnknownType ? type : resultType, targetSize, pool);
   }
-  SelectivityVector copyRows(
-      std::min<vector_size_t>(targetSize, result->size()));
+  SelectivityVector copyRows(result->size());
   copyRows.deselect(rows);
   if (copyRows.hasSelections()) {
     copy->copy(result.get(), copyRows, nullptr);


### PR DESCRIPTION
A recent change to Presto arraysort (#4458) changed the bounds of the element vector returned by arraysort. This caused it to return ill formed vectors (element vector size < offsets ) under certain conditions. 

Fixes : https://github.com/facebookincubator/velox/issues/4754