### PR TITLE
Add memory arbitration support for query execution

### DIFF
--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -96,13 +96,11 @@ class IMemoryManager {
 
   /// Creates a root memory pool with specified 'name' and 'capacity'. If 'name'
   /// is missing, the memory manager generates a default name internally to
-  /// ensure uniqueness. If 'trackUsage' is true, then set the memory usage
-  /// tracker in the created root memory pool.
+  /// ensure uniqueness.
   virtual std::shared_ptr<MemoryPool> addRootPool(
       const std::string& name = "",
       int64_t capacity = kMaxMemory,
-      bool trackUsage = true,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr) = 0;
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr) = 0;
 
   /// Creates a leaf memory pool for direct memory allocation use with specified
   /// 'name'. If 'name' is missing, the memory manager generates a default name
@@ -112,8 +110,7 @@ class IMemoryManager {
   /// its cpu cost.
   virtual std::shared_ptr<MemoryPool> addLeafPool(
       const std::string& name = "",
-      bool threadSafe = true,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr) = 0;
+      bool threadSafe = true) = 0;
 
   /// Invoked to grows a memory pool's free capacity with at least
   /// 'incrementBytes'. The function returns true on success, otherwise false.
@@ -187,13 +184,11 @@ class MemoryManager final : public IMemoryManager {
   std::shared_ptr<MemoryPool> addRootPool(
       const std::string& name = "",
       int64_t maxBytes = kMaxMemory,
-      bool trackUsage = true,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr) final;
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr) final;
 
   std::shared_ptr<MemoryPool> addLeafPool(
       const std::string& name = "",
-      bool threadSafe = true,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr) final;
+      bool threadSafe = true) final;
 
   bool growPool(MemoryPool* pool, uint64_t incrementBytes) final;
 
@@ -227,7 +222,6 @@ class MemoryManager final : public IMemoryManager {
 
   //  Returns the shared references to all the alive memory pools in 'pools_'.
   std::vector<std::shared_ptr<MemoryPool>> getAlivePools() const;
-  std::vector<std::shared_ptr<MemoryPool>> getAlivePoolsLocked() const;
 
   const int64_t capacity_;
   const std::shared_ptr<MemoryAllocator> allocator_;

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -50,8 +50,8 @@ std::unique_ptr<MemoryArbitrator> MemoryArbitrator::create(
   }
 }
 
-std::shared_ptr<MemoryReclaimer> MemoryReclaimer::create() {
-  return std::shared_ptr<MemoryReclaimer>(new MemoryReclaimer());
+std::unique_ptr<MemoryReclaimer> MemoryReclaimer::create() {
+  return std::unique_ptr<MemoryReclaimer>(new MemoryReclaimer());
 }
 
 bool MemoryReclaimer::reclaimableBytes(

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -183,7 +183,7 @@ class MemoryReclaimer {
  public:
   virtual ~MemoryReclaimer() = default;
 
-  static std::shared_ptr<MemoryReclaimer> create();
+  static std::unique_ptr<MemoryReclaimer> create();
 
   /// Invoked by the memory arbitrator before entering the memory arbitration
   /// processing. The default implementation does nothing but user can override

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -135,13 +135,6 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
     /// memory pools from the same root memory pool independently.
     bool threadSafe{true};
 
-    /// Used by memory arbitration to reclaim memory from the associated query
-    /// object if not null. For example, a memory pool can reclaim the used
-    /// memory from a spillable operator through disk spilling. If null, we
-    /// can't reclaim memory from this memory pool. This also only applies if
-    /// the memory usage tracking is enabled.
-    std::shared_ptr<MemoryReclaimer> reclaimer{nullptr};
-
     /// TODO: deprecate this flag after all the existing memory leak use cases
     /// have been fixed.
     ///
@@ -160,6 +153,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       const std::string& name,
       Kind kind,
       std::shared_ptr<MemoryPool> parent,
+      std::unique_ptr<MemoryReclaimer> reclaimer,
       const Options& options);
 
   /// Removes this memory pool's tracking from its parent through dropChild().
@@ -200,7 +194,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
 
   /// Invoked to traverse the memory pool subtree rooted at this, and calls
   /// 'visitor' on each visited child memory pool with the parent pool's
-  /// 'childrenMutex_' reader lock held. The 'visitor' must not access the
+  /// 'poolMutex_' reader lock held. The 'visitor' must not access the
   /// parent memory pool to avoid the potential recursive locking issues. Note
   /// that the traversal stops if 'visitor' returns false.
   virtual void visitChildren(
@@ -213,7 +207,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   virtual std::shared_ptr<MemoryPool> addLeafChild(
       const std::string& name,
       bool threadSafe = true,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr);
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Invoked to create a named aggregate child memory pool.
   ///
@@ -221,7 +215,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// memory usage tracking which inherits from its parent.
   virtual std::shared_ptr<MemoryPool> addAggregateChild(
       const std::string& name,
-      std::shared_ptr<MemoryReclaimer> reclaimer = nullptr);
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr);
 
   /// Allocates a buffer with specified 'size'.
   virtual void* allocate(int64_t size) = 0;
@@ -336,8 +330,14 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// returns the memory pool's capacity after the growth.
   virtual uint64_t grow(uint64_t bytes) = 0;
 
+  /// Sets the memory reclaimer for this memory pool.
+  ///
+  /// NOTE: this shall only be called at most once if the memory pool hasn't set
+  /// reclaimer on construction.
+  virtual void setReclaimer(std::unique_ptr<MemoryReclaimer> reclaimer);
+
   /// Returns the memory reclaimer of this memory pool if not null.
-  MemoryReclaimer* reclaimer() const;
+  virtual MemoryReclaimer* reclaimer() const;
 
   /// Invoked by the memory arbitrator to enter memory arbitration processing.
   /// It is a noop if 'reclaimer_' is not set, otherwise invoke the reclaimer's
@@ -360,7 +360,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// with specified reclaim target bytes. If 'targetBytes' is zero, then it
   /// tries to reclaim all the reclaimable memory from the memory pool. It is
   /// noop if the reclaimer is not set, otherwise invoke the reclaimer's
-  /// corresponding method.
+  /// corresponding method. The function returns the actually freed capacity
+  /// from the root of this memory pool.
   virtual uint64_t reclaim(uint64_t targetBytes);
 
   /// The memory pool's execution stats.
@@ -444,7 +445,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
       const std::string& name,
       Kind kind,
       bool threadSafe,
-      std::shared_ptr<MemoryReclaimer> reclaimer) = 0;
+      std::unique_ptr<MemoryReclaimer> reclaimer) = 0;
 
   /// Invoked only on destruction to remove this memory pool from its parent's
   /// child memory pool tracking.
@@ -456,11 +457,14 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   const std::shared_ptr<MemoryPool> parent_;
   const bool trackUsage_;
   const bool threadSafe_;
-  const std::shared_ptr<MemoryReclaimer> reclaimer_;
   const bool checkUsageLeak_;
 
-  // Protects 'children_'.
-  mutable folly::SharedMutex childrenMutex_;
+  mutable folly::SharedMutex poolMutex_;
+  /// Used by memory arbitration to reclaim memory from the associated query
+  /// object if not null. For example, a memory pool can reclaim the used memory
+  /// from a spillable operator through disk spilling. If null, we can't reclaim
+  /// memory from this memory pool.
+  std::unique_ptr<MemoryReclaimer> reclaimer_;
   // NOTE: we use raw pointer instead of weak pointer here to minimize
   // visitChildren() cost as we don't have to upgrade the weak pointer and copy
   // out the upgraded shared pointers.git
@@ -480,6 +484,7 @@ class MemoryPoolImpl : public MemoryPool {
       const std::string& name,
       Kind kind,
       std::shared_ptr<MemoryPool> parent,
+      std::unique_ptr<MemoryReclaimer> reclaimer = nullptr,
       DestructionCallback destructionCb = nullptr,
       const Options& options = Options{});
 
@@ -569,7 +574,7 @@ class MemoryPoolImpl : public MemoryPool {
       const std::string& name,
       Kind kind,
       bool threadSafe,
-      std::shared_ptr<MemoryReclaimer> reclaimer) override;
+      std::unique_ptr<MemoryReclaimer> reclaimer) override;
 
   FOLLY_ALWAYS_INLINE int64_t capacityLocked() const {
     return parent_ != nullptr ? toImpl(parent_)->capacity_ : capacity_;

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -180,6 +180,7 @@ uint64_t SharedArbitrator::reclaimUsedMemoryFromCandidates(
     const int64_t bytesToReclaim = std::max<int64_t>(
         targetBytes - freedBytes, minMemoryPoolCapacityTransferSize_);
     VELOX_CHECK_GT(bytesToReclaim, 0);
+    // TODO: add to handle the exception raised from memory pool reclaim.
     freedBytes += candidate.pool->reclaim(bytesToReclaim);
     if (freedBytes >= targetBytes) {
       break;

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -29,7 +29,9 @@ target_link_libraries(
   velox_memory
   velox_caching
   velox_exception
+  velox_exec_test_lib
   velox_test_util
+  velox_vector_fuzzer
   gtest
   gtest_main
   gflags::gflags

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -135,7 +135,7 @@ TEST_F(MemoryReclaimerTest, default) {
     SCOPED_TRACE(testData.debugString());
     std::vector<std::shared_ptr<MemoryPool>> pools;
     auto pool = defaultMemoryManager().addRootPool(
-        "shrinkAPIs", kMaxMemory, true, memory::MemoryReclaimer::create());
+        "shrinkAPIs", kMaxMemory, memory::MemoryReclaimer::create());
     pools.push_back(pool);
 
     struct Allocation {
@@ -255,7 +255,7 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
   const int allocBytes = 10;
   std::atomic<uint64_t> totalUsedBytes{0};
   auto root = defaultMemoryManager().addRootPool(
-      "mockReclaim", kMaxMemory, true, MemoryReclaimer::create());
+      "mockReclaim", kMaxMemory, MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
     auto childPool =
@@ -265,7 +265,7 @@ TEST_F(MemoryReclaimerTest, mockReclaim) {
       auto grandchildPool = childPool->addLeafChild(
           std::to_string(j),
           true,
-          std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
+          std::make_unique<MockLeafMemoryReclaimer>(totalUsedBytes));
       childPools.push_back(grandchildPool);
       auto* reclaimer =
           static_cast<MockLeafMemoryReclaimer*>(grandchildPool->reclaimer());
@@ -307,16 +307,13 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
   const int allocBytes = 100;
   std::atomic<uint64_t> totalUsedBytes{0};
   auto root = defaultMemoryManager().addRootPool(
-      "mockReclaimMoreThanAvailable",
-      kMaxMemory,
-      true,
-      MemoryReclaimer::create());
+      "mockReclaimMoreThanAvailable", kMaxMemory, MemoryReclaimer::create());
   std::vector<std::shared_ptr<MemoryPool>> childPools;
   for (int i = 0; i < numChildren; ++i) {
     auto childPool = root->addLeafChild(
         std::to_string(i),
         true,
-        std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
+        std::make_unique<MockLeafMemoryReclaimer>(totalUsedBytes));
     childPools.push_back(childPool);
     auto* reclaimer =
         static_cast<MockLeafMemoryReclaimer*>(childPool->reclaimer());
@@ -339,10 +336,7 @@ TEST_F(MemoryReclaimerTest, mockReclaimMoreThanAvailable) {
 
 TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
   auto root = defaultMemoryManager().addRootPool(
-      "concurrentRandomMockReclaims",
-      kMaxMemory,
-      true,
-      MemoryReclaimer::create());
+      "concurrentRandomMockReclaims", kMaxMemory, MemoryReclaimer::create());
 
   std::atomic<uint64_t> totalUsedBytes{0};
   const int numLeafPools = 50;
@@ -355,7 +349,7 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
       auto leafPool = childPools.back()->addLeafChild(
           std::to_string(j),
           true,
-          std::make_shared<MockLeafMemoryReclaimer>(totalUsedBytes));
+          std::make_unique<MockLeafMemoryReclaimer>(totalUsedBytes));
       leafPools.push_back(leafPool);
       auto* reclaimer =
           static_cast<MockLeafMemoryReclaimer*>(leafPool->reclaimer());

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -16,19 +16,29 @@
 
 #include <gtest/gtest.h>
 
+#include <boost/regex.hpp>
+#include <folly/Singleton.h>
 #include <deque>
 
 #include "folly/experimental/EventCount.h"
+#include "folly/futures/Barrier.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
 
 using namespace ::testing;
 using namespace facebook::velox::common::testutil;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::memory {
 namespace {
@@ -49,8 +59,8 @@ using ReclaimInjectionCallback =
 using ArbitrationInjectionCallback = std::function<void()>;
 
 struct Allocation {
-  void* buffer;
-  size_t size;
+  void* buffer{nullptr};
+  size_t size{0};
 };
 
 class MockQuery {
@@ -59,7 +69,6 @@ class MockQuery {
       : root_(manager->addRootPool(
             fmt::format("RootPool-{}", poolId_++),
             capacity,
-            true,
             MemoryReclaimer::create())) {}
 
   ~MockQuery();
@@ -110,7 +119,6 @@ class MockMemoryOperator {
     totalBytes_ += bytes;
     allocations_.emplace(buffer, bytes);
     VELOX_CHECK_EQ(allocations_.count(buffer), 1);
-    ++numAllocs_;
     return buffer;
   }
 
@@ -122,7 +130,6 @@ class MockMemoryOperator {
       size = allocations_[buffer];
       totalBytes_ -= size;
       allocations_.erase(buffer);
-      ++numFrees_;
     }
     pool_->free(buffer, size);
   }
@@ -132,7 +139,6 @@ class MockMemoryOperator {
     {
       std::lock_guard<std::mutex> l(mu_);
       for (auto entry : allocations_) {
-        ++numFrees_;
         totalBytes_ -= entry.second;
       }
       allocations.swap(allocations_);
@@ -154,7 +160,6 @@ class MockMemoryOperator {
       allocation.size = allocations_.begin()->second;
       totalBytes_ -= allocation.size;
       allocations_.erase(allocations_.begin());
-      ++numFrees_;
     }
     pool_->free(allocation.buffer, allocation.size);
   }
@@ -182,7 +187,6 @@ class MockMemoryOperator {
       auto allocIt = allocations_.begin();
       while (allocIt != allocations_.end() &&
              ((targetBytes != 0) && (bytesReclaimed < targetBytes))) {
-        ++numFrees_;
         allocationsToFree.push_back({allocIt->first, allocIt->second});
         bytesReclaimed += allocIt->second;
         allocIt = allocations_.erase(allocIt);
@@ -215,8 +219,6 @@ class MockMemoryOperator {
  private:
   mutable std::mutex mu_;
   MemoryPool* pool_{nullptr};
-  uint64_t numAllocs_{0};
-  uint64_t numFrees_{0};
   uint64_t totalBytes_{0};
   std::unordered_map<void*, size_t> allocations_;
 };
@@ -304,7 +306,7 @@ MockMemoryOperator* MockQuery::addMemoryOp(
   pools_.push_back(root_->addLeafChild(
       std::to_string(poolId_++),
       true,
-      std::make_shared<MockMemoryReclaimer>(
+      std::make_unique<MockMemoryReclaimer>(
           ops_.back(),
           isReclaimable,
           std::move(reclaimInjectCb),
@@ -958,5 +960,1636 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
   }
   controlThread.join();
 }
+
+namespace {
+
+// Custom node for the custom factory.
+class FakeMemoryNode : public core::PlanNode {
+ public:
+  FakeMemoryNode(const core::PlanNodeId& id, core::PlanNodePtr input)
+      : PlanNode(id), sources_{input} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "FakeMemoryNode";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+using AllocationCallback = std::function<Allocation(Operator* op)>;
+
+// Custom operator for the custom factory.
+class FakeMemoryOperator : public Operator {
+ public:
+  FakeMemoryOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      core::PlanNodePtr node,
+      bool canReclaim,
+      AllocationCallback allocationCb)
+      : Operator(ctx, node->outputType(), id, node->id(), "FakeMemoryNode"),
+        canReclaim_(canReclaim),
+        allocationCb_(std::move(allocationCb)) {}
+
+  ~FakeMemoryOperator() override {
+    clear();
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+    if (allocationCb_ != nullptr) {
+      Allocation allocation = allocationCb_(this);
+      if (allocation.buffer != nullptr) {
+        allocations_.push_back(allocation);
+      }
+      totalBytes_ += allocation.size;
+    }
+  }
+
+  void noMoreInput() override {
+    clear();
+    Operator::noMoreInput();
+  }
+
+  RowVectorPtr getOutput() override {
+    return std::move(input_);
+  }
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr && allocations_.empty();
+  }
+
+  void close() override {
+    clear();
+    Operator::close();
+  }
+
+  bool canReclaim() const override {
+    return canReclaim_;
+  }
+
+  void reclaim(uint64_t targetBytes) override {
+    VELOX_CHECK(canReclaim());
+    auto* driver = operatorCtx_->driver();
+    VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
+    VELOX_CHECK(driver->task()->pauseRequested());
+    VELOX_CHECK_GT(targetBytes, 0);
+
+    uint64_t bytesReclaimed{0};
+    auto allocIt = allocations_.begin();
+    while (allocIt != allocations_.end() &&
+           ((targetBytes != 0) && (bytesReclaimed < targetBytes))) {
+      bytesReclaimed += allocIt->size;
+      totalBytes_ -= allocIt->size;
+      pool()->free(allocIt->buffer, allocIt->size);
+      allocIt = allocations_.erase(allocIt);
+    }
+    VELOX_CHECK_GE(totalBytes_, 0);
+  }
+
+ private:
+  void clear() {
+    for (auto& allocation : allocations_) {
+      totalBytes_ -= allocation.size;
+      VELOX_CHECK_GE(totalBytes_, 0);
+      pool()->free(allocation.buffer, allocation.size);
+    }
+    allocations_.clear();
+    VELOX_CHECK_EQ(totalBytes_, 0);
+  }
+
+  const bool canReclaim_;
+  const AllocationCallback allocationCb_;
+
+  std::atomic<size_t> totalBytes_{0};
+  std::vector<Allocation> allocations_;
+};
+
+// Custom factory that creates fake memory operator.
+class FakeMemoryOperatorFactory : public Operator::PlanNodeTranslator {
+ public:
+  FakeMemoryOperatorFactory() = default;
+
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (std::dynamic_pointer_cast<const FakeMemoryNode>(node)) {
+      return std::make_unique<FakeMemoryOperator>(
+          ctx, id, node, canReclaim_, allocationCallback_);
+    }
+    return nullptr;
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    if (std::dynamic_pointer_cast<const FakeMemoryNode>(node)) {
+      return maxDrivers_;
+    }
+    return std::nullopt;
+  }
+
+  void setMaxDrivers(uint32_t maxDrivers) {
+    maxDrivers_ = maxDrivers;
+  }
+
+  void setCanReclaim(bool canReclaim) {
+    canReclaim_ = canReclaim;
+  }
+
+  void setAllocationCallback(AllocationCallback allocCb) {
+    allocationCallback_ = std::move(allocCb);
+  }
+
+ private:
+  bool canReclaim_{true};
+  AllocationCallback allocationCallback_{nullptr};
+  uint32_t maxDrivers_{1};
+};
+
+} // namespace
+
+class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    exec::test::HiveConnectorTestBase::SetUpTestCase();
+    auto fakeOperatorFactory = std::make_unique<FakeMemoryOperatorFactory>();
+    fakeOperatorFactory_ = fakeOperatorFactory.get();
+    Operator::registerOperator(std::move(fakeOperatorFactory));
+  }
+
+  void SetUp() override {
+    OperatorTestBase::SetUp();
+
+    setupMemory();
+    auto fakeOperatorFactory = std::make_unique<FakeMemoryOperatorFactory>();
+
+    rowType_ = ROW(
+        {{"c0", INTEGER()},
+         {"c1", INTEGER()},
+         {"c2", VARCHAR()},
+         {"c3", VARCHAR()}});
+    fuzzerOpts_.vectorSize = 1024;
+    fuzzerOpts_.nullRatio = 0;
+    fuzzerOpts_.stringVariableLength = false;
+    fuzzerOpts_.stringLength = 1024;
+    fuzzerOpts_.allowLazyVector = false;
+    VectorFuzzer fuzzer(fuzzerOpts_, pool());
+    vector_ = newVector();
+    executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(32);
+  }
+
+  void TearDown() override {
+    OperatorTestBase::TearDown();
+  }
+
+  void setupMemory(
+      int64_t memoryCapacity = 0,
+      uint64_t initMemoryPoolCapacity = 0,
+      uint64_t minMemoryPoolCapacityTransferSize = 0) {
+    if (initMemoryPoolCapacity == 0) {
+      initMemoryPoolCapacity = kInitMemoryPoolCapacity;
+    }
+    if (minMemoryPoolCapacityTransferSize == 0) {
+      minMemoryPoolCapacityTransferSize = kMinMemoryPoolCapacityTransferSize;
+    }
+    IMemoryManager::Options options;
+    options.capacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
+    options.arbitratorConfig = {
+        .kind = MemoryArbitrator::Kind::kShared,
+        .capacity = options.capacity,
+        .initMemoryPoolCapacity = initMemoryPoolCapacity,
+        .minMemoryPoolCapacityTransferSize = minMemoryPoolCapacityTransferSize};
+    options.checkUsageLeak = true;
+    memoryManager_ = std::make_unique<MemoryManager>(options);
+    ASSERT_EQ(
+        memoryManager_->arbitrator()->kind(), MemoryArbitrator::Kind::kShared);
+    arbitrator_ = static_cast<SharedArbitrator*>(memoryManager_->arbitrator());
+  }
+
+  RowVectorPtr newVector() {
+    VectorFuzzer fuzzer(fuzzerOpts_, pool());
+    return fuzzer.fuzzRow(rowType_);
+  }
+
+  std::shared_ptr<core::QueryCtx> newQueryCtx(
+      int64_t memoryCapacity = kMaxMemory) {
+    std::unordered_map<std::string, std::shared_ptr<Config>> configs;
+    std::shared_ptr<MemoryPool> pool = memoryManager_->addRootPool(
+        "", memoryCapacity, MemoryReclaimer::create());
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        executor_.get(),
+        std::make_shared<core::MemConfig>(),
+        configs,
+        memory::MemoryAllocator::getInstance(),
+        std::move(pool));
+    return queryCtx;
+  }
+
+  static inline FakeMemoryOperatorFactory* fakeOperatorFactory_;
+  std::unique_ptr<MemoryManager> memoryManager_;
+  SharedArbitrator* arbitrator_;
+  RowTypePtr rowType_;
+  VectorFuzzer::Options fuzzerOpts_;
+  RowVectorPtr vector_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+};
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromOrderBy) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> orderByQueryCtx;
+    if (sameQuery) {
+      orderByQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      orderByQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto orderByMemoryUsage = 32L << 20;
+    const auto fakeAllocationSize = kMemoryCapacity - orderByMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectOrderByOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "OrderBy") {
+            return;
+          }
+          if (op->pool()->capacity() < orderByMemoryUsage) {
+            return;
+          }
+          if (!injectOrderByOnce.exchange(false)) {
+            return;
+          }
+          fakeAllocationWait.notify();
+          // Wait for pause to be triggered.
+          taskPauseWait.wait(taskPauseWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread orderByThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kOrderBySpillEnabled, "true")
+              .queryCtx(orderByQueryCtx)
+              .plan(
+                  PlanBuilder()
+                      .values(vectors)
+                      .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                      .planNode())
+              .assertResults("SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST");
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_GT(stats[0].operatorStats[1].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    orderByThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToOrderBy) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto oldStats = arbitrator_->stats();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> orderByQueryCtx;
+    if (sameQuery) {
+      orderByQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      orderByQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount orderByWait;
+    auto orderByWaitKey = orderByWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity - (32L << 20);
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      orderByWait.notify();
+      // Wait for pause to be triggered.
+      taskPauseWait.wait(taskPauseWaitKey);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectOrderByOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "OrderBy") {
+            return;
+          }
+          if (!injectOrderByOnce.exchange(false)) {
+            return;
+          }
+          orderByWait.wait(orderByWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread orderByThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(orderByQueryCtx)
+              .plan(
+                  PlanBuilder()
+                      .values(vectors)
+                      .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                      .planNode())
+              .assertResults("SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST");
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    orderByThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+    const auto newStats = arbitrator_->stats();
+    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
+  }
+}
+
+TEST_F(SharedArbitrationTest, reclaimFromCompletedOrderBy) {
+  const int numVectors = 2;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> orderByQueryCtx;
+    if (sameQuery) {
+      orderByQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      orderByQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::thread orderByThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(orderByQueryCtx)
+              .plan(
+                  PlanBuilder()
+                      .values(vectors)
+                      .orderBy({fmt::format("{} ASC NULLS LAST", "c0")}, false)
+                      .planNode())
+              .assertResults("SELECT * FROM tmp ORDER BY c0 ASC NULLS LAST");
+      waitForTaskCompletion(task.get());
+      fakeAllocationWait.notify();
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    orderByThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromAggregation) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
+    if (sameQuery) {
+      aggregationQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      aggregationQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto aggregationMemoryUsage = 32L << 20;
+    const auto fakeAllocationSize =
+        kMemoryCapacity - aggregationMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectAggregationByOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "Aggregation") {
+            return;
+          }
+          if (op->pool()->capacity() < aggregationMemoryUsage) {
+            return;
+          }
+          if (!injectAggregationByOnce.exchange(false)) {
+            return;
+          }
+          fakeAllocationWait.notify();
+          // Wait for pause to be triggered.
+          taskPauseWait.wait(taskPauseWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread aggregationThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kAggregationSpillEnabled, "true")
+              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              .queryCtx(aggregationQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                        .planNode())
+              .assertResults(
+                  "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_GT(stats[0].operatorStats[1].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    aggregationThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToAggregation) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto oldStats = arbitrator_->stats();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
+    if (sameQuery) {
+      aggregationQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      aggregationQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount aggregationWait;
+    auto aggregationWaitKey = aggregationWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity - (32L << 20);
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      aggregationWait.notify();
+      // Wait for pause to be triggered.
+      taskPauseWait.wait(taskPauseWaitKey);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectAggregationOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "Aggregation") {
+            return;
+          }
+          if (!injectAggregationOnce.exchange(false)) {
+            return;
+          }
+          aggregationWait.wait(aggregationWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread aggregationThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(aggregationQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                        .planNode())
+              .assertResults(
+                  "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    aggregationThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+
+    const auto newStats = arbitrator_->stats();
+    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
+  }
+}
+
+TEST_F(SharedArbitrationTest, reclaimFromCompletedAggregation) {
+  const int numVectors = 2;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> aggregationQueryCtx;
+    if (sameQuery) {
+      aggregationQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      aggregationQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::thread aggregationThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(aggregationQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                        .planNode())
+              .assertResults(
+                  "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+      waitForTaskCompletion(task.get());
+      fakeAllocationWait.notify();
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    aggregationThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromJoinBuilder) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto joinMemoryUsage = 32L << 20;
+    const auto fakeAllocationSize = kMemoryCapacity - joinMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectAggregationByOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          if (op->pool()->currentBytes() < joinMemoryUsage) {
+            return;
+          }
+          if (!injectAggregationByOnce.exchange(false)) {
+            return;
+          }
+          fakeAllocationWait.notify();
+          // Wait for pause to be triggered.
+          taskPauseWait.wait(taskPauseWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread aggregationThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kJoinSpillEnabled, "true")
+              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u0"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kAnti)
+                        .planNode())
+              .assertResults(
+                  "SELECT c1 FROM tmp WHERE c0 NOT IN (SELECT c0 FROM tmp)");
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_GT(stats[1].operatorStats[2].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    aggregationThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToJoinBuilder) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto oldStats = arbitrator_->stats();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount joinWait;
+    auto joinWaitKey = joinWait.prepareWait();
+    folly::EventCount taskPauseWait;
+    auto taskPauseWaitKey = taskPauseWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity - (32L << 20);
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      joinWait.notify();
+      // Wait for pause to be triggered.
+      taskPauseWait.wait(taskPauseWaitKey);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<bool> injectJoinOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          if (!injectJoinOnce.exchange(false)) {
+            return;
+          }
+          joinWait.wait(joinWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            ([&](Task* /*unused*/) { taskPauseWait.notify(); })));
+
+    std::thread joinThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u0"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kAnti)
+                        .planNode())
+              .assertResults(
+                  "SELECT c1 FROM tmp WHERE c0 NOT IN (SELECT c0 FROM tmp)");
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    joinThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+
+    const auto newStats = arbitrator_->stats();
+    ASSERT_GT(newStats.numReclaimedBytes, oldStats.numReclaimedBytes);
+  }
+}
+
+TEST_F(SharedArbitrationTest, reclaimFromCompletedJoinBuilder) {
+  const int numVectors = 2;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+
+    const auto fakeAllocationSize = kMemoryCapacity;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::thread joinThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u0"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kAnti)
+                        .planNode())
+              .assertResults(
+                  "SELECT c1 FROM tmp WHERE c0 NOT IN (SELECT c0 FROM tmp)");
+      waitForTaskCompletion(task.get());
+      fakeAllocationWait.notify();
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+
+    joinThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(
+    SharedArbitrationTest,
+    reclaimFromJoinBuilderWithMultiDrivers) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  fuzzerOpts_.vectorSize = 128;
+  fuzzerOpts_.stringVariableLength = false;
+  fuzzerOpts_.stringLength = 512;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  const int numDrivers = 4;
+  createDuckDbTable(vectors);
+  // std::vector<bool> sameQueries = {false, true};
+  std::vector<bool> sameQueries = {false};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount fakeAllocationWait;
+    auto fakeAllocationWaitKey = fakeAllocationWait.prepareWait();
+    folly::EventCount taskPauseWait;
+
+    const auto joinMemoryUsage = 8L << 20;
+    const auto fakeAllocationSize = kMemoryCapacity - joinMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{nullptr, 0};
+      }
+      fakeAllocationWait.wait(fakeAllocationWaitKey);
+      auto buffer = op->pool()->allocate(fakeAllocationSize);
+      return Allocation{buffer, fakeAllocationSize};
+    });
+
+    std::atomic<int> injectCount{0};
+    folly::futures::Barrier builderBarrier(numDrivers);
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          // Check all the hash build operators' memory usage instead of
+          // individual operator.
+          if (op->pool()->parent()->currentBytes() < joinMemoryUsage) {
+            return;
+          }
+          if (++injectCount > numDrivers) {
+            return;
+          }
+          auto future = builderBarrier.wait();
+          if (future.wait().value()) {
+            fakeAllocationWait.notify();
+          }
+
+          auto taskPauseWaitKey = taskPauseWait.prepareWait();
+          // Wait for pause to be triggered.
+          taskPauseWait.wait(taskPauseWaitKey);
+        })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>(
+            [&](Task* /*unused*/) { taskPauseWait.notifyAll(); }));
+
+    std::thread joinThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kJoinSpillEnabled, "true")
+              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              // NOTE: set an extreme large value to avoid non-reclaimable
+              // section in test.
+              .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
+              .maxDrivers(numDrivers)
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors, true)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u1"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors, true)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kInner)
+                        .planNode())
+              .assertResults(
+                  "SELECT t.c1 FROM tmp as t, tmp AS u WHERE t.c0 == u.c1");
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_GT(stats[1].operatorStats[2].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+    joinThread.join();
+    memThread.join();
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(
+    SharedArbitrationTest,
+    failedToReclaimFromHashJoinBuildersInNonReclaimableSection) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  fuzzerOpts_.vectorSize = 128;
+  fuzzerOpts_.stringVariableLength = false;
+  fuzzerOpts_.stringLength = 512;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  const int numDrivers = 4;
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount allocationWait;
+    auto allocationWaitKey = allocationWait.prepareWait();
+    folly::EventCount allocationDoneWait;
+    auto allocationDoneWaitKey = allocationDoneWait.prepareWait();
+
+    const auto joinMemoryUsage = 8L << 20;
+    const auto fakeAllocationSize = kMemoryCapacity - joinMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{};
+      }
+      allocationWait.wait(allocationWaitKey);
+      EXPECT_ANY_THROW(op->pool()->allocate(fakeAllocationSize));
+      allocationDoneWait.notify();
+      return Allocation{};
+    });
+
+    std::atomic<int> injectCount{0};
+    folly::futures::Barrier builderBarrier(numDrivers);
+    folly::futures::Barrier pauseBarrier(numDrivers + 1);
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          // Check all the hash build operators' memory usage instead of
+          // individual operator.
+          if (op->pool()->parent()->currentBytes() < joinMemoryUsage) {
+            return;
+          }
+          if (++injectCount > numDrivers - 1) {
+            return;
+          }
+          if (builderBarrier.wait().get()) {
+            allocationWait.notify();
+          }
+          pauseBarrier.wait();
+        })));
+
+    std::atomic<bool> injectNonReclaimableSectionOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::common::memory::MemoryPoolImpl::allocateNonContiguous",
+        std::function<void(memory::MemoryPoolImpl*)>(
+            ([&](memory::MemoryPoolImpl* pool) {
+              const boost::regex re(".*HashBuild");
+              if (!regex_match(pool->name(), re)) {
+                return;
+              }
+              if (pool->parent()->currentBytes() < joinMemoryUsage) {
+                return;
+              }
+              if (!injectNonReclaimableSectionOnce.exchange(false)) {
+                return;
+              }
+              if (builderBarrier.wait().get()) {
+                allocationWait.notify();
+              }
+              pauseBarrier.wait();
+              // Suspend the driver to simulate the arbitration.
+              pool->reclaimer()->enterArbitration();
+              allocationDoneWait.wait(allocationDoneWaitKey);
+              pool->reclaimer()->leaveArbitration();
+            })));
+
+    std::atomic<bool> injectPauseOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>([&](Task* /*unused*/) {
+          if (!injectPauseOnce.exchange(false)) {
+            return;
+          }
+          pauseBarrier.wait();
+        }));
+
+    // Verifies that we only trigger the hash build reclaim once.
+    std::atomic<int> numHashBuildReclaims{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::HashBuild::reclaim",
+        std::function<void(Operator*)>([&](Operator* /*unused*/) {
+          ++numHashBuildReclaims;
+          ASSERT_EQ(numHashBuildReclaims, 1);
+        }));
+
+    std::thread joinThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kJoinSpillEnabled, "true")
+              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              // NOTE: set an extreme large value to avoid non-reclaimable
+              // section in test.
+              .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
+              .maxDrivers(numDrivers)
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors, true)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u1"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors, true)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kInner)
+                        .planNode())
+              .assertResults(
+                  "SELECT t.c1 FROM tmp as t, tmp AS u WHERE t.c0 == u.c1");
+      // We expect the spilling is not triggered because of non-reclaimable
+      // section.
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_EQ(stats[1].operatorStats[2].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+    joinThread.join();
+    memThread.join();
+    // We only expect to reclaim from one hash build operator once.
+    ASSERT_EQ(numHashBuildReclaims, 1);
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+DEBUG_ONLY_TEST_F(
+    SharedArbitrationTest,
+    failedToReclaimFromHashJoinBuildersInNotRunningState) {
+  const int numVectors = 32;
+  std::vector<RowVectorPtr> vectors;
+  fuzzerOpts_.vectorSize = 128;
+  fuzzerOpts_.stringVariableLength = false;
+  fuzzerOpts_.stringLength = 512;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  const int numDrivers = 4;
+  createDuckDbTable(vectors);
+  std::vector<bool> sameQueries = {false, true};
+  for (bool sameQuery : sameQueries) {
+    SCOPED_TRACE(fmt::format("sameQuery {}", sameQuery));
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    std::shared_ptr<core::QueryCtx> fakeMemoryQueryCtx =
+        newQueryCtx(kMemoryCapacity);
+    std::shared_ptr<core::QueryCtx> joinQueryCtx;
+    if (sameQuery) {
+      joinQueryCtx = fakeMemoryQueryCtx;
+    } else {
+      joinQueryCtx = newQueryCtx(kMemoryCapacity);
+    }
+
+    folly::EventCount allocationWait;
+    auto allocationWaitKey = allocationWait.prepareWait();
+
+    const auto joinMemoryUsage = 8L << 20;
+    const auto fakeAllocationSize = kMemoryCapacity - joinMemoryUsage / 2;
+
+    std::atomic<bool> injectAllocationOnce{true};
+    fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+      if (!injectAllocationOnce.exchange(false)) {
+        return Allocation{};
+      }
+      allocationWait.wait(allocationWaitKey);
+      EXPECT_ANY_THROW(op->pool()->allocate(fakeAllocationSize));
+      return Allocation{};
+    });
+
+    std::atomic<int> injectCount{0};
+    folly::futures::Barrier builderBarrier(numDrivers);
+    folly::futures::Barrier pauseBarrier(numDrivers + 1);
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::addInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          // Check all the hash build operators' memory usage instead of
+          // individual operator.
+          if (op->pool()->parent()->currentBytes() < joinMemoryUsage) {
+            return;
+          }
+          if (++injectCount > numDrivers - 1) {
+            return;
+          }
+          if (builderBarrier.wait().get()) {
+            allocationWait.notify();
+          }
+          // Wait for pause to be triggered.
+          pauseBarrier.wait();
+        })));
+
+    std::atomic<bool> injectNoMoreInputOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Driver::runInternal::noMoreInput",
+        std::function<void(Operator*)>(([&](Operator* op) {
+          if (op->operatorType() != "HashBuild") {
+            return;
+          }
+          if (!injectNoMoreInputOnce.exchange(false)) {
+            return;
+          }
+          if (builderBarrier.wait().get()) {
+            allocationWait.notify();
+          }
+          // Wait for pause to be triggered.
+          pauseBarrier.wait();
+        })));
+
+    std::atomic<bool> injectPauseOnce{true};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::Task::requestPauseLocked",
+        std::function<void(Task*)>([&](Task* /*unused*/) {
+          if (!injectPauseOnce.exchange(false)) {
+            return;
+          }
+          pauseBarrier.wait();
+        }));
+
+    // Verifies that we only trigger the hash build reclaim once.
+    std::atomic<int> numHashBuildReclaims{0};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::exec::HashBuild::reclaim",
+        std::function<void(Operator*)>(([&](Operator* /*unused*/) {
+          ++numHashBuildReclaims;
+          ASSERT_EQ(numHashBuildReclaims, 1);
+        })));
+
+    std::thread joinThread([&]() {
+      auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .spillDirectory(spillDirectory->path)
+              .config(core::QueryConfig::kSpillEnabled, "true")
+              .config(core::QueryConfig::kJoinSpillEnabled, "true")
+              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              // NOTE: set an extreme large value to avoid non-reclaimable
+              // section in test.
+              .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
+              .maxDrivers(numDrivers)
+              .queryCtx(joinQueryCtx)
+              .plan(PlanBuilder(planNodeIdGenerator)
+                        .values(vectors, true)
+                        .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                        .hashJoin(
+                            {"t0"},
+                            {"u1"},
+                            PlanBuilder(planNodeIdGenerator)
+                                .values(vectors, true)
+                                .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                                .planNode(),
+                            "",
+                            {"t1"},
+                            core::JoinType::kInner)
+                        .planNode())
+              .assertResults(
+                  "SELECT t.c1 FROM tmp as t, tmp AS u WHERE t.c0 == u.c1");
+      // We expect the spilling is not triggered because of non-reclaimable
+      // section.
+      auto stats = task->taskStats().pipelineStats;
+      ASSERT_EQ(stats[1].operatorStats[2].spilledBytes, 0);
+    });
+
+    std::thread memThread([&]() {
+      auto task =
+          AssertQueryBuilder(duckDbQueryRunner_)
+              .queryCtx(fakeMemoryQueryCtx)
+              .plan(PlanBuilder()
+                        .values(vectors)
+                        .addNode([&](std::string id, core::PlanNodePtr input) {
+                          return std::make_shared<FakeMemoryNode>(id, input);
+                        })
+                        .planNode())
+              .assertResults("SELECT * FROM tmp");
+    });
+    joinThread.join();
+    memThread.join();
+    // We only expect to reclaim from one hash build operator once.
+    ASSERT_EQ(numHashBuildReclaims, 1);
+    Task::testingWaitForAllTasksToBeDeleted();
+  }
+}
+
+TEST_F(SharedArbitrationTest, DISABLED_concurrentArbitration) {
+  const int numVectors = 8;
+  std::vector<RowVectorPtr> vectors;
+  fuzzerOpts_.vectorSize = 32;
+  fuzzerOpts_.stringVariableLength = false;
+  fuzzerOpts_.stringLength = 32;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  const int numDrivers = 4;
+  createDuckDbTable(vectors);
+
+  const auto queryPlan =
+      PlanBuilder()
+          .values(vectors, true)
+          .addNode([&](std::string id, core::PlanNodePtr input) {
+            return std::make_shared<FakeMemoryNode>(id, input);
+          })
+          .planNode();
+  const std::string referenceSQL = "SELECT * FROM tmp";
+
+  std::atomic<bool> stopped{false};
+
+  std::mutex mutex;
+  std::vector<std::shared_ptr<core::QueryCtx>> queries;
+  std::deque<std::shared_ptr<Task>> zombieTasks;
+
+  fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {
+    if (folly::Random::oneIn(4)) {
+      auto task = op->testingOperatorCtx()->driverCtx()->task;
+      if (folly::Random::oneIn(3)) {
+        task->requestAbort();
+      } else {
+        task->requestYield();
+      }
+    }
+    const size_t allocationSize = std::max(
+        kMemoryCapacity / 16, folly::Random::rand32() % kMemoryCapacity);
+    auto buffer = op->pool()->allocate(allocationSize);
+    return Allocation{buffer, allocationSize};
+  });
+  fakeOperatorFactory_->setMaxDrivers(numDrivers);
+
+  const int numThreads = 30;
+  const int maxNumZombieTasks = 128;
+  std::vector<std::thread> queryThreads;
+  for (int i = 0; i < numThreads; ++i) {
+    queryThreads.emplace_back([&, i]() {
+      folly::Random::DefaultGenerator rng;
+      rng.seed(i);
+      while (!stopped) {
+        std::shared_ptr<core::QueryCtx> query;
+        {
+          std::lock_guard<std::mutex> l(mutex);
+          if (queries.empty()) {
+            queries.emplace_back(newQueryCtx());
+          }
+          const int index = folly::Random::rand32() % queries.size();
+          query = queries[index];
+        }
+        std::shared_ptr<Task> task;
+        try {
+          task = AssertQueryBuilder(duckDbQueryRunner_)
+                     .queryCtx(query)
+                     .plan(PlanBuilder()
+                               .values(vectors)
+                               .addNode([&](std::string id,
+                                            core::PlanNodePtr input) {
+                                 return std::make_shared<FakeMemoryNode>(
+                                     id, input);
+                               })
+                               .planNode())
+                     .assertResults("SELECT * FROM tmp");
+        } catch (const VeloxException& e) {
+          continue;
+        }
+        std::lock_guard<std::mutex> l(mutex);
+        zombieTasks.emplace_back(std::move(task));
+        while (zombieTasks.size() > maxNumZombieTasks) {
+          zombieTasks.pop_front();
+        }
+      }
+    });
+  }
+
+  const int maxNumQueries = 64;
+  std::thread controlThread([&]() {
+    folly::Random::DefaultGenerator rng;
+    rng.seed(1000);
+    while (!stopped) {
+      std::shared_ptr<core::QueryCtx> queryToDelete;
+      {
+        std::lock_guard<std::mutex> l(mutex);
+        if (queries.empty() ||
+            ((queries.size() < maxNumQueries) &&
+             folly::Random::oneIn(4, rng))) {
+          queries.emplace_back(newQueryCtx());
+        } else {
+          const int deleteIndex = folly::Random::rand32(rng) % queries.size();
+          queryToDelete = queries[deleteIndex];
+          queries.erase(queries.begin() + deleteIndex);
+        }
+      }
+      std::this_thread::sleep_for(std::chrono::microseconds(5));
+    }
+  });
+
+  std::this_thread::sleep_for(std::chrono::seconds(5));
+  stopped = true;
+
+  for (auto& queryThread : queryThreads) {
+    queryThread.join();
+  }
+  controlThread.join();
+}
+
+// TODO: add more tests.
+
 } // namespace
 } // namespace facebook::velox::memory
+
+int main(int argc, char** argv) {
+  folly::SingletonVault::singleton()->registrationComplete();
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -40,7 +40,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
+      : MemoryPool{name, kind, parent, nullptr, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
         capacity_(cap) {}
 
   int64_t capacity() const override {
@@ -150,7 +150,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       const std::string& name,
       MemoryPool::Kind kind,
       bool /*unused*/,
-      std::shared_ptr<memory::MemoryReclaimer> /*unused*/) override {
+      std::unique_ptr<memory::MemoryReclaimer> /*unused*/) override {
     return std::make_shared<MockMemoryPool>(
         name, kind, parent, parent->capacity());
   }

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
   // Task is the top-level execution concept. A task needs a taskId (as a
   // string), the plan fragment to execute, a destination (only used for
   // shuffles), and a QueryCtx containing metadata and configs for a query.
-  auto writeTask = std::make_shared<exec::Task>(
+  auto writeTask = exec::Task::create(
       "my_write_task",
       writerPlanFragment,
       /*destination=*/0,
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
                               .planFragment();
 
   // Create the reader task.
-  auto readTask = std::make_shared<exec::Task>(
+  auto readTask = exec::Task::create(
       "my_read_task",
       readPlanFragment,
       /*destination=*/0,

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -110,7 +110,7 @@ class HashBuild final : public Operator {
     return spillConfig_.has_value();
   }
 
-  const Spiller::Config* FOLLY_NULLABLE spillConfig() const {
+  const Spiller::Config* spillConfig() const {
     return spillConfig_.has_value() ? &spillConfig_.value() : nullptr;
   }
 
@@ -127,7 +127,7 @@ class HashBuild final : public Operator {
   // source. The function will need to setup a spill input reader to read input
   // from the spilled data for restoring. If the spilled data can't still fit
   // in memory, then we will recursively spill part(s) of its data on disk.
-  void setupSpiller(SpillPartition* FOLLY_NULLABLE spillPartition = nullptr);
+  void setupSpiller(SpillPartition* spillPartition = nullptr);
 
   // Invoked when either there is no more input from the build source or from
   // the spill input reader during the restoring.

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -134,4 +134,17 @@ class HashJoinBridge : public JoinBridge {
 // has filter set.
 bool isLeftNullAwareJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode);
+
+class HashJoinMemoryReclaimer final : public memory::MemoryReclaimer {
+ public:
+  static std::unique_ptr<memory::MemoryReclaimer> create() {
+    return std::unique_ptr<memory::MemoryReclaimer>(
+        new HashJoinMemoryReclaimer());
+  }
+
+  uint64_t reclaim(memory::MemoryPool* pool, uint64_t targetBytes) final;
+
+ private:
+  HashJoinMemoryReclaimer() : MemoryReclaimer() {}
+};
 } // namespace facebook::velox::exec

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -110,7 +110,10 @@ HashProbe::HashProbe(
           joinNode->outputType(),
           operatorId,
           joinNode->id(),
-          "HashProbe"),
+          "HashProbe",
+          joinNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId)
+              : std::nullopt),
       outputBatchSize_{outputBatchRows()},
       joinNode_(std::move(joinNode)),
       joinType_{joinNode_->joinType()},
@@ -122,9 +125,6 @@ HashProbe::HashProbe(
       filterResult_(1),
       outputTableRows_(outputBatchSize_) {
   VELOX_CHECK_NOT_NULL(joinBridge_);
-  spillConfig_ = joinNode_->canSpill(driverCtx->queryConfig())
-      ? operatorCtx_->makeSpillConfig(Spiller::Type::kHashJoinProbe)
-      : std::nullopt;
 
   auto numKeys = joinNode_->leftKeys().size();
   keyChannels_.reserve(numKeys);

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -366,6 +366,8 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     std::unique_ptr<DriverCtx> ctx,
     std::shared_ptr<ExchangeClient> exchangeClient,
     std::function<int(int pipelineId)> numDrivers) {
+  auto driver = std::shared_ptr<Driver>(new Driver());
+  ctx->driver = driver.get();
   std::vector<std::unique_ptr<Operator>> operators;
   operators.reserve(planNodes.size());
 
@@ -536,7 +538,8 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     operators.push_back(consumerSupplier(operators.size(), ctx.get()));
   }
 
-  return std::make_shared<Driver>(std::move(ctx), std::move(operators));
+  driver->init(std::move(ctx), std::move(operators));
+  return driver;
 }
 
 std::vector<core::PlanNodeId> DriverFactory::needsHashJoinBridges() const {

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -38,15 +38,15 @@ OrderBy::OrderBy(
           orderByNode->outputType(),
           operatorId,
           orderByNode->id(),
-          "OrderBy"),
+          "OrderBy",
+          orderByNode->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId)
+              : std::nullopt),
       numSortKeys_(orderByNode->sortingKeys().size()),
       spillMemoryThreshold_(operatorCtx_->driverCtx()
                                 ->queryConfig()
                                 .orderBySpillMemoryThreshold()) {
   VELOX_CHECK(pool()->trackUsage());
-  spillConfig_ = orderByNode->canSpill(driverCtx->queryConfig())
-      ? operatorCtx_->makeSpillConfig(Spiller::Type::kOrderBy)
-      : std::nullopt;
 
   std::vector<TypePtr> keyTypes;
   std::vector<TypePtr> dependentTypes;
@@ -209,9 +209,14 @@ void OrderBy::reclaim(uint64_t targetBytes) {
   VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
   VELOX_CHECK(driver->task()->pauseRequested());
 
-  /// NOTE: an order by operator is reclaimable if it hasn't started output
-  /// processing and is not under non-reclaimable execution section.
+  // NOTE: an order by operator is reclaimable if it hasn't started output
+  // processing and is not under non-reclaimable execution section.
   if (noMoreInput_ || nonReclaimableSection_) {
+    // TODO: add stats to record the non-reclaimable case and reduce the log
+    // frequency if it is too verbose.
+    LOG(WARNING) << "Can't reclaim from order by operator, noMoreInput_["
+                 << noMoreInput_ << "], nonReclaimableSection_["
+                 << nonReclaimableSection_ << "], " << toString();
     return;
   }
 

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -249,7 +249,7 @@ class ExchangeBenchmark : public VectorTestBase {
         memory::defaultMemoryManager().addRootPool(
             queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
-    return std::make_shared<Task>(
+    return Task::create(
         taskId,
         std::move(planFragment),
         destination,

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -255,7 +255,7 @@ class DriverTest : public OperatorTestBase {
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
     auto plan =
         PlanBuilder(planNodeIdGenerator).values(batches, true).planFragment();
-    auto task = std::make_shared<exec::Task>(
+    auto task = Task::create(
         "t0",
         plan,
         0,

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -117,8 +117,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task =
-      std::make_shared<exec::Task>("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
       task->start(task, 3, 1),
       "groupedExecutionLeafNodeIds must be empty in ungrouped execution mode");
@@ -127,8 +126,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.executionStrategy = core::ExecutionStrategy::kGrouped;
   planFragment.groupedExecutionLeafNodeIds.clear();
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task =
-      std::make_shared<exec::Task>("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
       task->start(task, 3, 1),
       "groupedExecutionLeafNodeIds must not be empty in "
@@ -139,8 +137,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task =
-      std::make_shared<exec::Task>("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
       task->start(task, 3, 1),
       fmt::format(
@@ -153,8 +150,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.groupedExecutionLeafNodeIds.emplace(projectNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task =
-      std::make_shared<exec::Task>("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
       task->start(task, 3, 1),
       fmt::format(
@@ -167,8 +163,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   planFragment.groupedExecutionLeafNodeIds.clear();
   planFragment.groupedExecutionLeafNodeIds.emplace(localPartitionNodeId);
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  task =
-      std::make_shared<exec::Task>("0", planFragment, 0, std::move(queryCtx));
+  task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
       task->start(task, 3, 1),
       fmt::format(
@@ -209,8 +204,8 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
   planFragment.groupedExecutionLeafNodeIds.emplace(tableScanNodeId);
   planFragment.numSplitGroups = 10;
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-  auto task = std::make_shared<exec::Task>(
-      "0", std::move(planFragment), 0, std::move(queryCtx));
+  auto task =
+      exec::Task::create("0", std::move(planFragment), 0, std::move(queryCtx));
   // 3 drivers max and 1 concurrent split group.
   task->start(task, 3, 1);
 
@@ -360,7 +355,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
     planFragment.groupedExecutionLeafNodeIds.emplace(probeScanNodeId);
     planFragment.numSplitGroups = 10;
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
-    auto task = std::make_shared<exec::Task>(
+    auto task = exec::Task::create(
         "0", std::move(planFragment), 0, std::move(queryCtx));
     // 3 drivers max and 1 concurrent split group.
     task->start(task, 3, 1);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5053,6 +5053,4 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
 
   taskThread.join();
 }
-
-// TODO: add memory reclaim with multiple hash builder test.
 } // namespace

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -54,7 +54,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
         memory::defaultMemoryManager().addRootPool(
             queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
-    return std::make_shared<Task>(
+    return Task::create(
         taskId,
         std::move(planFragment),
         destination,

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -52,7 +52,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
                             .values({std::dynamic_pointer_cast<RowVector>(
                                 BatchMaker::createBatch(rowType, 100, *pool_))})
                             .planFragment();
-    auto task = std::make_shared<Task>(
+    auto task = Task::create(
         taskId,
         std::move(planFragment),
         0,

--- a/velox/exec/tests/PrintPlanWithStatsTest.cpp
+++ b/velox/exec/tests/PrintPlanWithStatsTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 
-#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <re2/re2.h>
 

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -39,7 +39,7 @@ class SpillOperatorGroupTest : public testing::Test {
     const core::PlanNodeId id{"0"};
     planFragment.planNode = std::make_shared<core::ValuesNode>(id, values);
 
-    task_ = std::make_shared<exec::Task>(
+    task_ = Task::create(
         "SpillOperatorGroupTest_task",
         std::move(planFragment),
         0,

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -131,7 +131,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
       params.groupedExecutionLeafNodeIds};
   const std::string taskId = fmt::format("test_cursor {}", ++serial_);
 
-  task_ = std::make_shared<exec::Task>(
+  task_ = Task::create(
       taskId,
       std::move(planFragment),
       params.destination,

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -141,7 +141,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
   std::shared_ptr<exec::Task> makeTask(
       core::PlanFragment plan,
       vector_size_t& numResultRows) {
-    return std::make_shared<exec::Task>(
+    return exec::Task::create(
         "t",
         std::move(plan),
         0,


### PR DESCRIPTION
- Make the ownership of memory reclaimer more clears by using unique
  ptr instead of shared ptr
- Remove the track usage configuration from addRootPool interface to
   enforce enabling memory usage tracking for non-default memory pool.
- Change Driver initialization procedure to allow operator to hold weak pointer
   to the associated driver to handle the completed driver during the memory
   arbitration
- Add Operator::MemoryReclaimer to handle the memory reclamation
   from the operator as well as ensures its liveness during the memory
   reclamation
- Add HashJoinMemoryReclaimer to custom the memory reclaim logic for
   hash build as we only need to reclaim once from any one of its peers
- Pass the memory reclaimer when creating memory pool for query, task
   node and operator memory pool. The reclaimer is not set if its parent 
   memory pool's reclaimer is not set (enforce the check in memory pool
   construtor)
- Add to allow driver thread to enter suspension when task yield requested
- Refactor disk spilling config setup on operator constructor to avoid the
   race condition with memory arbitration execution
