### PR TITLE
Fix null handling in inputs of AggregateCompanionAdapter::MergeFunction

### DIFF
--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -131,6 +131,7 @@ void AggregateCompanionAdapter::MergeFunction::addSingleGroupRawInput(
     const SelectivityVector& rows,
     const std::vector<VectorPtr>& args,
     bool mayPushdown) {
+  fn_->enableValidateIntermediateInputs();
   fn_->addSingleGroupIntermediateResults(group, rows, args, mayPushdown);
 }
 


### PR DESCRIPTION
Summary: Aggregation fuzzer reports an error due to the lack of checks for input null fields in AggregateCompanionAdapter::MergeFunction::addSingleGroupRawInput(). This diff adds the checks for input null fields.

Differential Revision: D45678213

