### PR TITLE
Create SegmentMerger

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # for generated headers
 include_directories(.)
-add_library(velox_file File.cpp FileSystems.cpp FileSystems.h)
+add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
 target_link_libraries(velox_file Folly::folly)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/common/file/Utils.cpp
+++ b/velox/common/file/Utils.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/file/Utils.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::file::utils {
+
+bool CoalesceIfDistanceLE::operator()(
+    const ReadFile::Segment* a,
+    const ReadFile::Segment* b) const {
+  VELOX_CHECK_LE(a->offset, b->offset, "Segments to combine must be sorted.");
+  const uint64_t beginGap = a->offset + a->buffer.size(), endGap = b->offset;
+
+  VELOX_CHECK_LE(beginGap, endGap, "Segments to combine can't overlap.");
+  const uint64_t gap = endGap - beginGap;
+
+  return gap <= maxCoalescingDistance_;
+}
+
+} // namespace facebook::velox::file::utils

--- a/velox/common/file/Utils.h
+++ b/velox/common/file/Utils.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "velox/common/file/File.h"
+
+namespace facebook::velox::file::utils {
+
+// Iterable class that produces pairs of iterators pointing to the beginning and
+// end of the segments that are coalesced from the the input range, according to
+// the ShouldCoalesce condition
+template <typename SegmentIter, typename ShouldCoalesce>
+class CoalesceSegments {
+ public:
+  class Iter {
+   public:
+    Iter(SegmentIter begin, SegmentIter end, ShouldCoalesce shouldCoalesce)
+        : begin_{begin},
+          end_{end},
+          theEnd_{end},
+          shouldCoalesce_(shouldCoalesce) {
+      findNextEnd();
+    }
+
+    friend bool operator==(const Iter& lhs, const Iter& rhs) {
+      return lhs.begin_ == rhs.begin_ && lhs.end_ == rhs.end_;
+    }
+
+    friend bool operator!=(const Iter& lhs, const Iter& rhs) {
+      return !(lhs == rhs);
+    }
+
+    std::pair<SegmentIter, SegmentIter> operator*() const {
+      return {begin_, end_};
+    }
+
+    Iter operator++() {
+      begin_ = end_;
+      end_ = theEnd_;
+      findNextEnd();
+      return *this;
+    }
+
+    Iter operator++(int) {
+      Iter tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+
+   private:
+    void findNextEnd() {
+      if (begin_ != theEnd_) {
+        for (auto itA = begin_, itB = std::next(itA); itB != theEnd_;
+             itA = itB, ++itB) {
+          if (!shouldCoalesce_(*itA, *itB)) {
+            end_ = itB;
+            break;
+          }
+        }
+      }
+    }
+
+    SegmentIter begin_;
+    SegmentIter end_;
+    SegmentIter theEnd_;
+    ShouldCoalesce shouldCoalesce_;
+  };
+
+  CoalesceSegments(
+      SegmentIter begin,
+      SegmentIter end,
+      ShouldCoalesce& shouldCoalesce)
+      : begin_{begin}, end_{end}, shouldCoalesce_(shouldCoalesce) {}
+
+  Iter begin() {
+    return Iter{begin_, end_, shouldCoalesce_};
+  }
+
+  Iter end() {
+    return Iter{end_, end_, shouldCoalesce_};
+  }
+
+ private:
+  SegmentIter begin_;
+  SegmentIter end_;
+  ShouldCoalesce shouldCoalesce_;
+};
+
+class CoalesceIfDistanceLE {
+ public:
+  explicit CoalesceIfDistanceLE(uint64_t maxCoalescingDistance)
+      : maxCoalescingDistance_(maxCoalescingDistance) {}
+
+  bool operator()(const ReadFile::Segment* a, const ReadFile::Segment* b) const;
+
+ private:
+  uint64_t maxCoalescingDistance_;
+};
+
+} // namespace facebook::velox::file::utils

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_file_test FileTest.cpp)
+add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
 target_link_libraries(
   velox_file_test
@@ -22,4 +22,5 @@ target_link_libraries(
   fmt::fmt
   Folly::folly
   gtest
-  gtest_main)
+  gtest_main
+  gmock)

--- a/velox/common/file/tests/UtilsTest.cpp
+++ b/velox/common/file/tests/UtilsTest.cpp
@@ -1,0 +1,249 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "velox/common/file/Utils.h"
+
+using namespace ::testing;
+using namespace ::facebook::velox;
+using namespace ::facebook::velox::file::utils;
+
+namespace {
+
+class MockShouldCoalesce {
+ public:
+  virtual ~MockShouldCoalesce() = default;
+
+  MOCK_METHOD(
+      bool,
+      shouldCoalesce,
+      (const ReadFile::Segment* a, const ReadFile::Segment* b),
+      (const));
+};
+
+class ShouldCoalesceWrapper {
+ public:
+  explicit ShouldCoalesceWrapper(MockShouldCoalesce& shouldCoalesce)
+      : shouldCoalesce_(shouldCoalesce) {}
+
+  bool operator()(const ReadFile::Segment* a, const ReadFile::Segment* b)
+      const {
+    return shouldCoalesce_.shouldCoalesce(a, b);
+  }
+
+ private:
+  MockShouldCoalesce& shouldCoalesce_;
+};
+
+struct Result {
+  std::vector<std::string> buffers;
+  std::vector<ReadFile::Segment> segments;
+  std::vector<ReadFile::Segment*> segmentPtrs;
+};
+
+Result getSegments(
+    std::vector<std::string> buffers,
+    const std::unordered_set<size_t>& skip = {}) {
+  Result result;
+  result.buffers = std::move(buffers);
+  uint64_t lastOffset = 0;
+  size_t i = 0;
+  for (auto& buffer : result.buffers) {
+    if (skip.count(i++) == 0) {
+      result.segments.emplace_back(ReadFile::Segment{
+          lastOffset, folly::Range<char*>(&buffer[0], buffer.size()), {}});
+    }
+    lastOffset += buffer.size();
+  }
+  for (auto& segment : result.segments) {
+    result.segmentPtrs.emplace_back(&segment);
+  }
+  return result;
+}
+
+template <typename Iter, typename ShouldCoalesce>
+std::vector<std::pair<size_t, size_t>>
+coalescedIndices(Iter begin, Iter end, ShouldCoalesce& shouldCoalesce) {
+  std::vector<std::pair<size_t, size_t>> result;
+  ShouldCoalesceWrapper shouldCoalesceWrapper{shouldCoalesce};
+  for (auto [coalescedBegin, coalescedEnd] :
+       CoalesceSegments(begin, end, shouldCoalesceWrapper)) {
+    result.push_back(
+        {std::distance(begin, coalescedBegin),
+         std::distance(begin, coalescedEnd)});
+  }
+  return result;
+}
+
+bool willCoalesceIfDistanceLE(
+    uint64_t distance,
+    const std::pair<uint64_t, uint64_t>& segA,
+    const std::pair<uint64_t, uint64_t>& segB) {
+  std::string bufA(segA.second /* size */, '-');
+  std::string bufB(segB.second /* size */, '-');
+  ReadFile::Segment a{
+      segA.first, folly::Range<char*>(bufA.data(), bufA.size()), {}};
+  ReadFile::Segment b{
+      segB.first, folly::Range<char*>(bufB.data(), bufB.size()), {}};
+  return CoalesceIfDistanceLE(distance)(&a, &b);
+}
+
+} // namespace
+
+TEST(CoalesceSegmentsTest, EmptyCase) {
+  const auto testData = getSegments({});
+  ASSERT_EQ(testData.segments.size(), testData.segmentPtrs.size());
+  const auto& p = testData.segmentPtrs;
+
+  MockShouldCoalesce shouldCoalesce;
+  EXPECT_CALL(shouldCoalesce, shouldCoalesce(_, _)).Times(0);
+
+  std::vector<std::pair<size_t, size_t>> expected = {};
+  std::vector<std::pair<size_t, size_t>> result =
+      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(CoalesceSegmentsTest, MergeAll) {
+  const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
+  ASSERT_EQ(testData.segments.size(), testData.segmentPtrs.size());
+  const auto& p = testData.segmentPtrs;
+
+  MockShouldCoalesce shouldCoalesce;
+  for (size_t i = 1; i < p.size(); ++i) {
+    EXPECT_CALL(shouldCoalesce, shouldCoalesce(p[i - 1], p[i]))
+        .Times(1)
+        .WillOnce(Return(true));
+  }
+
+  std::vector<std::pair<size_t, size_t>> expected = {{0UL, 5UL}};
+  std::vector<std::pair<size_t, size_t>> result =
+      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(CoalesceSegmentsTest, MergeNone) {
+  const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
+  ASSERT_EQ(testData.segments.size(), testData.segmentPtrs.size());
+  const auto& p = testData.segmentPtrs;
+
+  MockShouldCoalesce shouldCoalesce;
+  for (size_t i = 1; i < p.size(); ++i) {
+    EXPECT_CALL(shouldCoalesce, shouldCoalesce(p[i - 1], p[i]))
+        .Times(1)
+        .WillOnce(Return(false));
+  }
+
+  std::vector<std::pair<size_t, size_t>> expected = {
+      {0UL, 1UL}, {1UL, 2UL}, {2UL, 3UL}, {3UL, 4UL}, {4UL, 5UL}};
+  std::vector<std::pair<size_t, size_t>> result =
+      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(CoalesceSegmentsTest, MergeOdd) {
+  const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
+  ASSERT_EQ(testData.segments.size(), testData.segmentPtrs.size());
+  const auto& p = testData.segmentPtrs;
+
+  auto isOdd = [](size_t i) { return i % 2 == 1; };
+
+  MockShouldCoalesce shouldCoalesce;
+  for (size_t i = 1; i < p.size(); ++i) {
+    EXPECT_CALL(shouldCoalesce, shouldCoalesce(p[i - 1], p[i]))
+        .Times(1)
+        .WillOnce(Return(isOdd(i)));
+  }
+
+  std::vector<std::pair<size_t, size_t>> expected = {
+      {0UL, 2UL}, {2UL, 4UL}, {4UL, 5UL}};
+  std::vector<std::pair<size_t, size_t>> result =
+      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(CoalesceSegmentsTest, MergeEven) {
+  const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
+  ASSERT_EQ(testData.segments.size(), testData.segmentPtrs.size());
+  const auto& p = testData.segmentPtrs;
+  auto isEven = [](size_t i) { return i % 2 == 0; };
+
+  MockShouldCoalesce shouldCoalesce;
+  for (size_t i = 1; i < p.size(); ++i) {
+    EXPECT_CALL(shouldCoalesce, shouldCoalesce(p[i - 1], p[i]))
+        .Times(1)
+        .WillOnce(Return(isEven(i)));
+  }
+
+  std::vector<std::pair<size_t, size_t>> expected = {
+      {0UL, 1UL}, {1UL, 3UL}, {3UL, 5UL}};
+  std::vector<std::pair<size_t, size_t>> result =
+      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
+  EXPECT_EQ(result, expected);
+}
+
+TEST(CoalesceIfDistanceLETest, MultipleCases) {
+  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 1}, {1, 1}));
+  EXPECT_FALSE(willCoalesceIfDistanceLE(0, {0, 1}, {2, 1}));
+
+  EXPECT_TRUE(willCoalesceIfDistanceLE(1, {0, 1}, {2, 1}));
+
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 1}, {1, 1}));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {10, 1}, {11, 1}));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {19, 5}));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {20, 5}));
+  EXPECT_FALSE(willCoalesceIfDistanceLE(10, {0, 10}, {21, 5}));
+
+  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 0}, {0, 1}));
+}
+
+TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(0, {1, 1}, {0, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(10, {1, 1}, {0, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(0, {1000, 1}, {2, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(10, {1000, 1}, {2, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+}
+
+TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(0, {0, 1}, {0, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(10, {0, 1}, {0, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(0, {0, 2}, {1, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(10, {0, 2}, {1, 1}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(0, {0, 2}, {1, 2}),
+      ::facebook::velox::VeloxRuntimeError);
+  EXPECT_THROW(
+      willCoalesceIfDistanceLE(10, {0, 2}, {1, 2}),
+      ::facebook::velox::VeloxRuntimeError);
+}


### PR DESCRIPTION
Summary:
Helper class to merge sorted segments if a condition is satisfied.

This will be used by the preadv api (D45455551) in WSReadFile to merge segments.

The merging will look like the one that's happening [here in Tablet.cpp](https://www.internalfb.com/code/fbsource/[ad3845519932]/fbcode/dwio/alpha/tablet/Tablet.cpp?lines=795-909)

Differential Revision: D45579823

