### PR TITLE
Update Types documentation

### DIFF
--- a/velox/docs/develop/scalar-functions.rst
+++ b/velox/docs/develop/scalar-functions.rst
@@ -359,11 +359,6 @@ we need to call registerFunction again:
 
 We need to call registerFunction for each signature we want to support.
 
-For decimal arguments, we use UnscaledLongDecimal or UnscaledShortDecimal for
-registration. Simple functions always require decimal arguments to have the same
-precision and scale. We must explicitly :func:`cast` the decimal arguments if
-required before passing them to simple functions.
-
 Codegen
 ^^^^^^^
 

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -22,34 +22,41 @@ BIGINT                  int64_t                         8
 DATE                    struct Date                     8
 REAL                    float                           4
 DOUBLE                  double                          8
-SHORT_DECIMAL           struct UnscaledShortDecimal     8
-LONG_DECIMAL            struct UnscaledLongDecimal     16
+DECIMAL                 int64_t / int128_t              8 / 16
 TIMESTAMP               struct Timestamp               16
-INTERVAL DAY TO SECOND  struct IntervalDayTime          8
+INTERVAL DAY TO SECOND  int64_t                        8
 VARCHAR                 struct StringView              16
 VARBINARY               struct StringView              16
 ======================  ===========================    ==================
 
-All scalar types except DECIMAL have a one-to-one mapping with their C++ types.
-
-DECIMAL type is a special scalar type since it carries additional `precision`,
-and `scale` information. Similar to SQL decimal, `precision` is the number of
+DECIMAL type is a logical type and carries additional `precision`,
+and `scale` information. `Precision` is the number of
 digits in a number. `Scale` is the number of digits to the right of the decimal
 point in a number. For example, the number `123.45` has a precision of `5` and a
-scale of `2`. Velox supports two types of decimals, SHORT_DECIMAL and LONG_DECIMAL.
-SHORT_DECIMAL has a maximum precision of 18, with a range of
-[:math:`-10^{18} + 1, +10^{18} - 1`]. LONG_DECIMAL has a maximum precision of 38,
-with a range of [:math:`-10^{38} + 1, +10^{38} - 1`].
-Their corresponding C++ types, UnscaledShortDecimal and UnscaledLongDecimal carry
-the unscaled value. For example, the unscaled value of decimal `123.45` is `12345`.
+scale of `2`. Decimal types are backed by `int64_t` and `int128_t` C++ types which
+store the unscaled value.
+`int64_t` is used upto 18 precision, and has a range of
+[:math:`-10^{18} + 1, +10^{18} - 1`]. `int128_t` is used starting from 19 precision
+upto 38 precision, with a range of [:math:`-10^{38} + 1, +10^{38} - 1`].
+For example, the unscaled value of decimal `123.45` is `12345`.
 All the three values, precision, scale, unscaled value are required to represent a
-decimal value. UnscaledLongDecimal is a wrapper around the `int128_t` type.
-Some systems implement a similar wrapper around two `int64_t` values.
+decimal value.
+Some systems use two `int64_t` values instead of a single `int128_t` value.
 Velox chose `int128_t` since most compilers now support this type and
 it simplifies the implementation.
 
+Presto Types
+~~~~~~~~~~~~
+Velox also supports certain types specific to Presto.
+
+========================  =========================    ==================
+Presto Type               C++ Type                     Bytes per Value
+========================  =========================    ==================
+HYPERLOGLOG               struct StringView            16
+JSON                      struct StringView            16
+TIMESTAMP WITH TIME ZONE  struct<int64_t, int16_t>     20
+========================  =========================    ==================
 
 Complex Types
 ~~~~~~~~~~~~~
 Velox supports the ARRAY, MAP, and ROW complex types.
-


### PR DESCRIPTION
`Decimal Type` and `Interval Day to Second` are now logical types.
Update the corresponding documentation.
Add documentation for Presto Types.