### PR TITLE
Allow bits::toString to be called on memory as small as one byte

### DIFF
--- a/velox/common/base/BitUtil.cpp
+++ b/velox/common/base/BitUtil.cpp
@@ -90,13 +90,13 @@ void copyBitsBackward(
   }
 }
 
-void toString(const uint64_t* bits, int offset, int size, char* out) {
+void toString(const void* bits, int offset, int size, char* out) {
   for (int i = 0; i < size; ++i) {
-    out[i] = '0' + isBitSet(bits, offset + i);
+    out[i] = '0' + isBitSet(reinterpret_cast<const uint8_t*>(bits), offset + i);
   }
 }
 
-std::string toString(const uint64_t* bits, int offset, int size) {
+std::string toString(const void* bits, int offset, int size) {
   std::string ans(size, '\0');
   toString(bits, offset, size, ans.data());
   return ans;

--- a/velox/common/base/BitUtil.h
+++ b/velox/common/base/BitUtil.h
@@ -37,9 +37,9 @@ inline bool isBitSet(const T* bits, int32_t idx) {
 }
 
 /// Return the binary representation of bits in the range specified.
-std::string toString(const uint64_t* bits, int offset, int size);
+std::string toString(const void* bits, int offset, int size);
 
-void toString(const uint64_t* bits, int offset, int size, char* out);
+void toString(const void* bits, int offset, int size, char* out);
 
 // The reason we do this is that it's slightly faster for
 // setNthBit<Value> in benchmarks compared to doing the calculation

--- a/velox/common/base/tests/BitUtilTest.cpp
+++ b/velox/common/base/tests/BitUtilTest.cpp
@@ -649,6 +649,8 @@ TEST_F(BitUtilTest, toString) {
   EXPECT_EQ(
       toString(&bits, 0, 64),
       "1111011110110011110101010000100100011110011010100010110001001000");
+  uint8_t byte = 0x42;
+  EXPECT_EQ(toString(&byte, 0, 8), "01000010");
 }
 
 TEST_F(BitUtilTest, scatterBits) {


### PR DESCRIPTION
Summary:
`bits::toString` was required to be called on memory at least 64 bits
large.  In some new use case we want to call it on smaller memory range.

Reviewed By: mbasmanova

Differential Revision: D45695651

