### PR TITLE
Add Plan Fuzzer

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -907,6 +907,9 @@ bool Task::addSplitWithSequence(
       // duplicate splits would be ignored.
       auto& splitsState = getPlanNodeSplitsStateLocked(planNodeId);
       if (sequenceId > splitsState.maxSequenceId) {
+        if (rememberSplits_) {
+          rememberedSplits_.push_back({planNodeId, split});
+        }
         promise = addSplitLocked(splitsState, std::move(split));
         added = true;
       }
@@ -931,6 +934,10 @@ void Task::addSplit(const core::PlanNodeId& planNodeId, exec::Split&& split) {
     std::lock_guard<std::mutex> l(mutex_);
     isTaskRunning = isRunningLocked();
     if (isTaskRunning) {
+      if (rememberSplits_) {
+        rememberedSplits_.push_back({planNodeId, split});
+      }
+
       promise = addSplitLocked(
           getPlanNodeSplitsStateLocked(planNodeId), std::move(split));
     }

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -193,6 +193,21 @@ class Task : public std::enable_shared_from_this<Task> {
   /// corresponding to plan node with specified ID.
   void noMoreSplits(const core::PlanNodeId& planNodeId);
 
+  /// Causes all added splits to be recorded for possible replay.
+  void testingRememberAllSplits() {
+    rememberSplits_ = true;
+  }
+
+  struct TaskSplit {
+    core::PlanNodeId nodeId;
+    Split split;
+  };
+
+  // Returns all added splits.
+  std::vector<TaskSplit> moveRememberedSplits() {
+    return std::move(rememberedSplits_);
+  }
+
   /// Updates the total number of output buffers to broadcast the results of the
   /// execution to. Used when plan tree ends with a PartitionedOutputNode with
   /// broadcast flag set to true.
@@ -963,6 +978,9 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Base spill directory for this task.
   std::string spillDirectory_;
+
+  bool rememberSplits_{false};
+  std::vector<TaskSplit> rememberedSplits_;
 };
 
 /// Listener invoked on task completion.

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -23,6 +23,8 @@ add_library(
   HiveConnectorTestBase.cpp
   OperatorTestBase.cpp
   PlanBuilder.cpp
+  PlanFuzzer.cpp
+  Rebatch.cpp
   QueryAssertions.cpp
   SumNonPODAggregate.cpp
   TpchQueryBuilder.cpp

--- a/velox/exec/tests/utils/PlanFuzzer.cpp
+++ b/velox/exec/tests/utils/PlanFuzzer.cpp
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/PlanFuzzer.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+DEFINE_int32(
+    plan_fuzzer_encodings,
+    facebook::velox::bits::lowMask(
+        facebook::velox::exec::test::TestingRebatch::kNumEncodings),
+    "Bit mask of encoding fuzzes to try");
+
+namespace facebook::velox::exec::test {
+
+namespace {
+void addSplitVector(Task* task, const std::vector<Task::TaskSplit>& splits) {
+  for (auto& split : splits) {
+    auto splitCopy = split.split;
+    task->addSplit(split.nodeId, std::move(splitCopy));
+  }
+}
+} // namespace
+
+core::PlanNodePtr fuzzOutput(
+    const core::PlanNodePtr& node,
+    core::PlanNodeIdGenerator& idGenerator) {
+  return std::make_shared<TestingRebatchNode>(idGenerator.next(), node);
+}
+
+int32_t maxNodeId(const core::PlanNodePtr& node, std::vector<int32_t>& allIds) {
+  auto& sources = node->sources();
+  allIds.push_back(atoi(node->id().c_str()));
+  if (sources.empty()) {
+    return atoi(node->id().c_str());
+  }
+  int32_t max = atoi(node->id().c_str());
+  for (auto& source : sources) {
+    max = std::max<int32_t>(max, maxNodeId(source, allIds));
+  }
+  return max;
+}
+
+#define COPY_PLAN_CASE(className)                                             \
+  else if (                                                                   \
+      const className* node = dynamic_cast<const className*>(source.get())) { \
+    return std::make_shared<className>(*node);                                \
+  }
+
+// Copies any non-leaf PlanNode.
+core::PlanNodePtr copyNode(const core::PlanNodePtr& source) {
+  if (0) {
+  }
+  COPY_PLAN_CASE(core::ProjectNode)
+  COPY_PLAN_CASE(core::FilterNode)
+  COPY_PLAN_CASE(core::FilterNode)
+  COPY_PLAN_CASE(core::TableWriteNode)
+  COPY_PLAN_CASE(core::AggregationNode)
+  COPY_PLAN_CASE(core::GroupIdNode)
+  COPY_PLAN_CASE(core::LocalPartitionNode)
+  COPY_PLAN_CASE(core::PartitionedOutputNode)
+  COPY_PLAN_CASE(core::HashJoinNode)
+  COPY_PLAN_CASE(core::MergeJoinNode)
+  COPY_PLAN_CASE(core::NestedLoopJoinNode)
+  COPY_PLAN_CASE(core::OrderByNode)
+  COPY_PLAN_CASE(core::TopNNode)
+  COPY_PLAN_CASE(core::LimitNode)
+  COPY_PLAN_CASE(core::UnnestNode)
+  COPY_PLAN_CASE(core::EnforceSingleRowNode)
+  COPY_PLAN_CASE(core::AssignUniqueIdNode)
+  COPY_PLAN_CASE(core::WindowNode)
+  else {
+    VELOX_UNREACHABLE("Unsupported node type {}", source->toString(true, true));
+  }
+}
+
+core::PlanNodePtr fuzzPlan(
+    const core::PlanNodePtr& node,
+    int32_t& counter,
+    const SelectivityVector& fuzzable,
+    core::PlanNodeIdGenerator& idGenerator) {
+  auto& sources = node->sources();
+  if (sources.empty()) {
+    if (fuzzable.isValid(counter)) {
+      ++counter;
+
+      return fuzzOutput(node, idGenerator);
+    }
+    ++counter;
+    return node;
+  }
+  std::vector<core::PlanNodePtr> newSources;
+  for (auto& source : sources) {
+    newSources.push_back(fuzzPlan(source, counter, fuzzable, idGenerator));
+  }
+  auto copy = copyNode(node);
+  auto& copySources =
+      const_cast<std::vector<core::PlanNodePtr>&>(copy->sources());
+  copySources = newSources;
+  if (fuzzable.isValid(counter)) {
+    return fuzzOutput(copy, idGenerator);
+  } else {
+    return copy;
+  }
+}
+
+void drillDownPlanFuzz(
+    const CursorParameters& params,
+    const std::vector<RowVectorPtr>& result,
+    const std::vector<Task::TaskSplit>& previousSplits,
+    const std::vector<int32_t>& allNodes) {}
+
+void checkFuzzedPlans(
+    const CursorParameters& params,
+    const std::vector<RowVectorPtr>& result,
+    const std::shared_ptr<Task>& referenceTask) {
+  int32_t nodeCounter = 0;
+  CursorParameters fuzzParams = params;
+  std::vector<int32_t> allIds;
+  int32_t maxNode = maxNodeId(params.planNode, allIds);
+  SelectivityVector fuzzable(maxNode);
+  core::PlanNodeIdGenerator idGenerator(maxNode + 1);
+  fuzzParams.planNode =
+      fuzzPlan(params.planNode, nodeCounter, fuzzable, idGenerator);
+  auto previousSplits = referenceTask->moveRememberedSplits();
+  bool firstTime = true;
+  auto [cursor, fuzzResult] = readCursorOnly(fuzzParams, [&](auto task) {
+    if (firstTime) {
+      addSplitVector(task, previousSplits);
+    }
+    firstTime = false;
+  });
+  if (!assertEqualResults(result, fuzzResult)) {
+    drillDownPlanFuzz(params, result, previousSplits, allIds);
+  }
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/PlanFuzzer.h
+++ b/velox/exec/tests/utils/PlanFuzzer.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/tests/utils/Cursor.h"
+#include "velox/exec/tests/utils/Rebatch.h"
+
+namespace facebook::velox::exec::test {
+
+/// Reruns the Task of 'params' with plan fuzzing against splits recorded in
+/// 'referenceTask'. Checks the results of each fuzzed plan against 'results'.
+void checkFuzzedPlans(
+    const CursorParameters& params,
+    const std::vector<RowVectorPtr>& result,
+    const std::shared_ptr<Task>& referencetask);
+
+core::PlanNodePtr fuzzPlan(core::PlanNodePtr input, SelectivityVector& nodeSet);
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -92,6 +92,14 @@ std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>> readCursor(
     const CursorParameters& params,
     std::function<void(exec::Task*)> addSplits);
 
+/// Like readCursor but will not do extra checks wit fuzzed
+/// plans. Used for checking fuzzed plans from readCursor wen plan
+/// fuzzing is enabled.
+std::pair<std::unique_ptr<TaskCursor>, std::vector<RowVectorPtr>>
+readCursorOnly(
+    const CursorParameters& params,
+    std::function<void(exec::Task*)> addSplits);
+
 /// The Task can return results before the Driver is finished executing.
 /// Wait upto maxWaitMicros for the Task to finish as 'expectedState' before
 /// returning to ensure it's stable e.g. the Driver isn't updating it anymore.

--- a/velox/exec/tests/utils/Rebatch.cpp
+++ b/velox/exec/tests/utils/Rebatch.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/Rebatch.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::exec::test {
+
+// static
+void TestingRebatchNode::registerNode() {
+  static bool registered;
+  if (!registered) {
+    registered = true;
+    Operator::registerOperator(std::make_unique<TestingRebatchFactory>());
+  }
+}
+
+void TestingRebatch::nextEncoding() {
+  encoding_ = static_cast<Encoding>(
+      (static_cast<int32_t>(encoding_) + 1) % kNumEncodings);
+  nthSlice_ = 0;
+}
+
+RowVectorPtr TestingRebatch::getOutput() {
+  if (!input_) {
+    return nullptr;
+  }
+
+  switch (encoding_) {
+    case Encoding::kConstant: {
+      output_ =
+          BaseVector::create<RowVector>(input_->type(), 1, input_->pool());
+      for (auto i = 0; i < input_->type()->size(); ++i) {
+        output_->childAt(i) =
+            BaseVector::wrapInConstant(1, currentRow_, input_->childAt(i));
+      }
+      ++currentRow_;
+      if (input_->size() > 10 && currentRow_ >= 10) {
+        nextEncoding();
+      }
+      break;
+    }
+    case Encoding::kSlice: {
+      auto sliceSize = nthSlice_++;
+      if (currentRow_ + sliceSize > input_->size()) {
+        sliceSize = input_->size() - currentRow_;
+      }
+      output_ = BaseVector::create<RowVector>(
+          input_->type(), sliceSize, input_->pool());
+      for (auto i = 0; i < input_->type()->size(); ++i) {
+        output_->childAt(i) = input_->childAt(i)->slice(currentRow_, sliceSize);
+      }
+      currentRow_ += sliceSize;
+
+      break;
+    }
+    case Encoding::kSameDoubleDict:
+    default: {
+      auto indices =
+          velox::test::makeIndicesInReverse(input_->size(), input_->pool());
+      output_ = BaseVector::create<RowVector>(
+          input_->type(), input_->size(), input_->pool());
+      for (auto i = 0; i < input_->type()->size(); ++i) {
+        output_->childAt(i) = BaseVector::wrapInDictionary(
+            BufferPtr(nullptr),
+            indices,
+            input_->size(),
+            BaseVector::wrapInDictionary(
+                BufferPtr(nullptr),
+                indices,
+                input_->size(),
+                input_->childAt(i)));
+      }
+      currentRow_ += input_->size();
+      break;
+    }
+  }
+
+  if (currentRow_ == input_->size()) {
+    input_ = nullptr;
+    nextEncoding();
+  }
+
+  return std::move(output_);
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/Rebatch.h
+++ b/velox/exec/tests/utils/Rebatch.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec::test {
+
+class TestingRebatchNode : public core::PlanNode {
+ public:
+  explicit TestingRebatchNode(core::PlanNodeId id, core::PlanNodePtr input)
+      : PlanNode(id), sources_({input}) {
+    registerNode();
+  }
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<std::shared_ptr<const PlanNode>>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "Rebatch";
+  }
+
+ private:
+  static void registerNode();
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+class TestingRebatch : public Operator {
+ public:
+  enum class Encoding {
+    kConstant,
+    kSlice,
+    kLongFlat,
+    kShortFlat,
+    kDicts,
+    kSameDict,
+    kSameDoubleDict,
+    kLastEncoding // Must be last in enum.
+  };
+  static constexpr int32_t kNumEncodings =
+      static_cast<int32_t>(Encoding::kLastEncoding);
+
+  TestingRebatch(DriverCtx* ctx, int32_t id, const core::PlanNodePtr& node)
+      : Operator(ctx, node->outputType(), id, node->id(), "Rebatch") {}
+
+  bool needsInput() const override {
+    return !noMoreInput_ && !input_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+    currentRow_ = 0;
+  }
+
+  void noMoreInput() override {
+    Operator::noMoreInput();
+  }
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* future) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_ && input_ == nullptr;
+  }
+
+ private:
+  void nextEncoding();
+
+  // Counter deciding the next action in getOutput().
+  int32_t counter_;
+
+  // Flat concatenation of multiple batches of input
+  RowVectorPtr output_;
+
+  // Next row of input to be sent to output.
+  vector_size_t currentRow_{0};
+
+  Encoding encoding_;
+  int32_t nthSlice_{0};
+
+  // Drop rows between batches. Used for introducing a predictable error to test
+  // drilldown into minimal breaking fuzziness.
+  bool injectError_{false};
+};
+
+class TestingRebatchFactory : public Operator::PlanNodeTranslator {
+ public:
+  TestingRebatchFactory() = default;
+
+  std::unique_ptr<Operator> toOperator(
+      DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto rebatch =
+            std::dynamic_pointer_cast<const TestingRebatchNode>(node)) {
+      return std::make_unique<TestingRebatch>(ctx, id, rebatch);
+    }
+    return nullptr;
+  }
+
+  std::optional<uint32_t> maxDrivers(const core::PlanNodePtr& node) override {
+    return std::nullopt;
+  }
+};
+
+} // namespace facebook::velox::exec::test


### PR DESCRIPTION
Takes any plan and adds fuzzing for intermediate batch sizes and encodings and configs for operators that support configs.  Compares fuzzed and unfuzzed executions. If different, gradually unfuzzes the plan being tested until finding a minimal set of fuzzes that causes a failure.