### PR TITLE
Ensure signatures are namespaced.

### DIFF
--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -34,10 +34,10 @@ class bcolors:
 def export(args):
     """Exports Velox function signatures."""
     if args.spark:
-        pv.register_spark_signatures()
+        pv.register_spark_signatures("spark_")
 
     if args.presto:
-        pv.register_presto_signatures()
+        pv.register_presto_signatures("presto_")
 
     signatures = pv.get_function_signatures()
 


### PR DESCRIPTION
We need to namespace signatures that are imported so that we can differentiate between spark and presto signatures.  Currently PR: https://github.com/facebookincubator/velox/pull/4794 has a problem where it considers the spark and presto signature for dates in `in predicate` to be similar. 