### PR TITLE
Fix: Set indices, offsets and sizes to 0 when vectors resized/

### DIFF
--- a/velox/dwio/common/FlatMapHelper.cpp
+++ b/velox/dwio/common/FlatMapHelper.cpp
@@ -466,6 +466,7 @@ vector_size_t copyOffsets(
     vector_size_t count,
     vector_size_t& childOffset) {
   childOffset = 0;
+  target.resize(targetIndex + count);
   auto tgtOffsets = const_cast<vector_size_t*>(target.rawOffsets());
   auto tgtSizes = const_cast<vector_size_t*>(target.rawSizes());
   if (LIKELY(targetIndex > 0)) {
@@ -707,6 +708,7 @@ vector_size_t copyOffset(
     vector_size_t sourceIndex,
     vector_size_t& childOffset) {
   childOffset = 0;
+  target.resize(targetIndex + 1);
   auto tgtSizes = const_cast<vector_size_t*>(target.rawSizes());
   if (LIKELY(targetIndex > 0)) {
     auto index = targetIndex - 1;

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -611,10 +611,10 @@ void readRowVector(
       if (!rawOffsets) {
         BaseVector::resizeIndices(
             size,
-            0,
             pool,
             &offsets,
-            const_cast<const vector_size_t**>(&rawOffsets));
+            const_cast<const vector_size_t**>(&rawOffsets),
+            0);
         for (int32_t child = 0; child < i; ++child) {
           rawOffsets[child] = child;
         }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -402,10 +402,10 @@ void BaseVector::setNulls(const BufferPtr& nulls) {
 // static
 void BaseVector::resizeIndices(
     vector_size_t size,
-    vector_size_t initialValue,
     velox::memory::MemoryPool* pool,
     BufferPtr* indices,
-    const vector_size_t** raw) {
+    const vector_size_t** raw,
+    std::optional<vector_size_t> initialValue) {
   if (indices->get() && indices->get()->isMutable()) {
     auto newByteSize = byteSize<vector_size_t>(size);
     if (indices->get()->size() < newByteSize) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -579,18 +579,27 @@ class BaseVector {
   // point to element 0 of (*indices)->as<vector_size_t>().
   void resizeIndices(
       vector_size_t size,
-      vector_size_t initialValue,
       BufferPtr* indices,
-      const vector_size_t** raw) {
-    resizeIndices(size, initialValue, this->pool(), indices, raw);
+      const vector_size_t** raw,
+      std::optional<vector_size_t> initialValue = std::nullopt) {
+    resizeIndices(size, this->pool(), indices, raw, initialValue);
+  }
+
+  void
+  clearIndices(BufferPtr& indices, vector_size_t start, vector_size_t end) {
+    if (start == end) {
+      return;
+    }
+    auto* data = indices->asMutable<vector_size_t>();
+    std::fill(data + start, data + end, 0);
   }
 
   static void resizeIndices(
       vector_size_t size,
-      vector_size_t initialValue,
       velox::memory::MemoryPool* pool,
       BufferPtr* indices,
-      const vector_size_t** raw);
+      const vector_size_t** raw,
+      std::optional<vector_size_t> initialValue = std::nullopt);
 
   // Makes sure '*buffer' has space for 'size' items of T and is writable. Sets
   // 'raw' to point to the writable contents of '*buffer'.

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -187,7 +187,8 @@ class DictionaryVector : public SimpleVector<T> {
   /// If setNotNull is false then the values and isNull is undefined.
   void resize(vector_size_t size, bool setNotNull = true) override {
     if (size > BaseVector::length_) {
-      BaseVector::resizeIndices(size, 0, &indices_, &rawIndices_);
+      this->resizeIndices(size, &indices_, &rawIndices_);
+      this->clearIndices(indices_, BaseVector::length_, size);
     }
 
     BaseVector::resize(size, setNotNull);


### PR DESCRIPTION
Summary:
To avoid generating vector in invlaid non-serializable state. This diff sets offsets, sizes of
Map and Array vectors and indices of Dictionary vector to for the newly added
elements.

Differential Revision: D45576707

