### PR TITLE
Pass ExpressionEvaluator to leafCallToSubfieldFilter

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -132,7 +132,7 @@ class HiveDataSource : public DataSource {
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
       FileHandleFactory* fileHandleFactory,
       velox::memory::MemoryPool* pool,
-      ExpressionEvaluator* expressionEvaluator,
+      core::ExpressionEvaluator* expressionEvaluator,
       memory::MemoryAllocator* allocator,
       const std::string& scanId,
       folly::Executor* executor);
@@ -237,7 +237,7 @@ class HiveDataSource : public DataSource {
   dwio::common::RuntimeStatistics runtimeStats_;
 
   FileHandleCachedPtr fileHandle_;
-  ExpressionEvaluator* expressionEvaluator_;
+  core::ExpressionEvaluator* expressionEvaluator_;
   uint64_t completedRows_ = 0;
 
   // Reusable memory for remaining filter evaluation.

--- a/velox/core/ExpressionEvaluator.h
+++ b/velox/core/ExpressionEvaluator.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+class ExprSet;
+}
+
+namespace facebook::velox::core {
+
+class ITypedExpr;
+
+// Exposes expression evaluation functionality of the engine to other parts of
+// the code base.  Connector may use it, for example, to evaluate pushed down
+// filters.  This is not thread safe and serializing operations is the
+// responsibility of the caller.  This is self-contained and does not reference
+// objects from the thread which constructs this.  Passing this between threads
+// is allowed as long as uses are sequential.  May reference query-level
+// structures like QueryCtx.
+class ExpressionEvaluator {
+ public:
+  virtual ~ExpressionEvaluator() = default;
+
+  // Compiles an expression. Returns an instance of exec::ExprSet that can be
+  // used to evaluate that expression on multiple vectors using evaluate method.
+  virtual std::unique_ptr<exec::ExprSet> compile(
+      const std::shared_ptr<const ITypedExpr>& expression) = 0;
+
+  // Evaluates previously compiled expression on the specified rows.
+  // Re-uses result vector if it is not null.
+  virtual void evaluate(
+      exec::ExprSet* exprSet,
+      const SelectivityVector& rows,
+      const RowVector& input,
+      VectorPtr& result) = 0;
+
+  // Memory pool used to construct input or output vectors.
+  virtual memory::MemoryPool* pool() = 0;
+};
+
+} // namespace facebook::velox::core

--- a/velox/dwio/common/MetadataFilter.h
+++ b/velox/dwio/common/MetadataFilter.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/core/ExpressionEvaluator.h"
 #include "velox/core/ITypedExpr.h"
 
 namespace facebook::velox::common {
@@ -31,7 +32,10 @@ class MetadataFilter {
 
   /// Construct from a ScanSpec and an expression.  The leaf filter nodes
   /// generated will be added to the corresponding position in ScanSpec.
-  explicit MetadataFilter(ScanSpec&, const core::ITypedExpr&);
+  MetadataFilter(
+      ScanSpec&,
+      const core::ITypedExpr&,
+      core::ExpressionEvaluator*);
 
   /// Evaluate the filter results based on logical conjunctions tracked in this
   /// object.  `leafNodeResults` could be reused for intermediate results.  The

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -278,6 +278,7 @@ class E2EFilterTestBase : public testing::Test {
       const std::vector<RowVectorPtr>& batches,
       common::Subfield filterField,
       std::unique_ptr<common::Filter> filter,
+      core::ExpressionEvaluator*,
       const std::string& remainingFilter,
       std::function<bool(int64_t a, int64_t c)> validationFilter);
 

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -53,7 +53,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
     parse::ParseOptions options;
     options.parseDecimalAsDouble = false;
 
-    auto plan = PlanBuilder()
+    auto plan = PlanBuilder(pool_.get())
                     .setParseOptions(options)
                     .tableScan(rowType, subfieldFilters, remainingFilter)
                     .planNode();

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -310,14 +310,14 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
     // Hash or Nested Loop join.
     if (i == 0) {
       pipe0Node =
-          PlanBuilder(planNodeIdGenerator)
+          PlanBuilder(planNodeIdGenerator, pool_.get())
               .tableScan(rowType_)
               .capturePlanNodeId(probeScanNodeId)
               .project({"c3 as x", "c2 as y", "c1 as z", "c0 as w", "c4", "c5"})
               .hashJoin(
                   {"w"},
                   {"r"},
-                  PlanBuilder(planNodeIdGenerator)
+                  PlanBuilder(planNodeIdGenerator, pool_.get())
                       .tableScan(rowType_, {"c0 > 0"})
                       .capturePlanNodeId(buildScanNodeId)
                       .project({"c0 as r"})
@@ -326,18 +326,18 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
                   {"x", "y", "z", "w", "c4", "c5"})
               .planNode();
       pipe1Node =
-          PlanBuilder(planNodeIdGenerator)
+          PlanBuilder(planNodeIdGenerator, pool_.get())
               .localPartitionRoundRobin({pipe0Node})
               .project({"w as c0", "z as c1", "y as c2", "x as c3", "c4", "c5"})
               .planNode();
     } else {
       pipe0Node =
-          PlanBuilder(planNodeIdGenerator)
+          PlanBuilder(planNodeIdGenerator, pool_.get())
               .tableScan(rowType_)
               .capturePlanNodeId(probeScanNodeId)
               .project({"c3 as x", "c2 as y", "c1 as z", "c0 as w", "c4", "c5"})
               .nestedLoopJoin(
-                  PlanBuilder(planNodeIdGenerator)
+                  PlanBuilder(planNodeIdGenerator, pool_.get())
                       .tableScan(rowType_, {"c0 > 0"})
                       .capturePlanNodeId(buildScanNodeId)
                       .project({"c0 as r"})
@@ -345,13 +345,13 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
                   {"x", "y", "z", "r", "c4", "c5"})
               .planNode();
       pipe1Node =
-          PlanBuilder(planNodeIdGenerator)
+          PlanBuilder(planNodeIdGenerator, pool_.get())
               .localPartitionRoundRobin({pipe0Node})
               .project({"r as c0", "z as c1", "y as c2", "x as c3", "c4", "c5"})
               .planNode();
     }
     auto planFragment =
-        PlanBuilder(planNodeIdGenerator)
+        PlanBuilder(planNodeIdGenerator, pool_.get())
             .localPartitionRoundRobin({pipe1Node})
             .partitionedOutput({}, 1, {"c0", "c1", "c2", "c3", "c4", "c5"})
             .planFragment();

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -3502,11 +3502,11 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
-  auto buildSide = PlanBuilder(planNodeIdGenerator)
+  auto buildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
                        .values(buildVectors)
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
                        .planNode();
-  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator)
+  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
                               .values(keyOnlyBuildVectors)
                               .project({"c0 AS u_c0"})
                               .planNode();
@@ -3515,7 +3515,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     // Inner join.
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType)
                   .capturePlanNodeId(probeScanId)
                   .hashJoin(
@@ -3551,7 +3551,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     }
 
     // Left semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType)
              .capturePlanNodeId(probeScanId)
              .hashJoin(
@@ -3589,7 +3589,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     }
 
     // Right semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType)
              .capturePlanNodeId(probeScanId)
              .hashJoin(
@@ -3637,7 +3637,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
     core::PlanNodeId probeScanId;
     auto op =
-        PlanBuilder(planNodeIdGenerator)
+        PlanBuilder(planNodeIdGenerator, pool_.get())
             .tableScan(
                 scanOutputType,
                 makeTableHandle(common::test::SubfieldFiltersBuilder().build()),
@@ -3673,7 +3673,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // Push-down that requires merging filters.
   {
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType, {"c0 < 500::INTEGER"})
                   .capturePlanNodeId(probeScanId)
                   .hashJoin({"c0"}, {"u_c0"}, buildSide, "", {"c1", "u_c1"})
@@ -3707,7 +3707,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   {
     core::PlanNodeId probeScanId;
     auto op =
-        PlanBuilder(planNodeIdGenerator)
+        PlanBuilder(planNodeIdGenerator, pool_.get())
             .tableScan(probeType)
             .capturePlanNodeId(probeScanId)
             .hashJoin({"c0"}, {"u_c0"}, keyOnlyBuildSide, "", {"c0", "c1"})
@@ -3742,7 +3742,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // number of columns than the input.
   {
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType)
                   .capturePlanNodeId(probeScanId)
                   .hashJoin({"c0"}, {"u_c0"}, keyOnlyBuildSide, "", {"c0"})
@@ -3775,7 +3775,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // Push-down that requires merging filters and turns join into a no-op.
   {
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType, {"c0 < 500::INTEGER"})
                   .capturePlanNodeId(probeScanId)
                   .hashJoin({"c0"}, {"u_c0"}, keyOnlyBuildSide, "", {"c1"})
@@ -3810,7 +3810,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     // Inner join.
     core::PlanNodeId probeScanId;
     auto op =
-        PlanBuilder(planNodeIdGenerator)
+        PlanBuilder(planNodeIdGenerator, pool_.get())
             .tableScan(probeType, {"c0 < 200::INTEGER"})
             .capturePlanNodeId(probeScanId)
             .hashJoin(
@@ -3843,7 +3843,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     }
 
     // Left semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType, {"c0 < 200::INTEGER"})
              .capturePlanNodeId(probeScanId)
              .hashJoin(
@@ -3881,7 +3881,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
     }
 
     // Right semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType, {"c0 < 200::INTEGER"})
              .capturePlanNodeId(probeScanId)
              .hashJoin(
@@ -3921,7 +3921,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
 
   // Disable filter push-down by using values in place of scan.
   {
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .values(probeVectors)
                   .hashJoin({"c0"}, {"u_c0"}, buildSide, "", {"c1"})
                   .project({"c1 + 1"})
@@ -3942,7 +3942,7 @@ TEST_F(HashJoinTest, dynamicFilters) {
   // probe side.
   {
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType)
                   .capturePlanNodeId(probeScanId)
                   .project({"cast(c0 + 1 as integer) AS t_key", "c1"})
@@ -4042,11 +4042,11 @@ TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
 
-  auto buildSide = PlanBuilder(planNodeIdGenerator)
+  auto buildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
                        .values(buildVectors)
                        .project({"c0 AS u_c0", "c1 AS u_c1"})
                        .planNode();
-  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator)
+  auto keyOnlyBuildSide = PlanBuilder(planNodeIdGenerator, pool_.get())
                               .values(keyOnlyBuildVectors)
                               .project({"c0 AS u_c0"})
                               .planNode();
@@ -4055,7 +4055,7 @@ TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
   {
     // Inner join.
     core::PlanNodeId probeScanId;
-    auto op = PlanBuilder(planNodeIdGenerator)
+    auto op = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(probeType, {"c2 > 0"})
                   .capturePlanNodeId(probeScanId)
                   .hashJoin(
@@ -4096,7 +4096,7 @@ TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
     }
 
     // Left semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType, {"c2 > 0"})
              .capturePlanNodeId(probeScanId)
              .hashJoin(
@@ -4139,7 +4139,7 @@ TEST_F(HashJoinTest, dynamicFiltersWithSkippedSplits) {
     }
 
     // Right semi join.
-    op = PlanBuilder(planNodeIdGenerator)
+    op = PlanBuilder(planNodeIdGenerator, pool_.get())
              .tableScan(probeType, {"c2 > 0"})
              .capturePlanNodeId(probeScanId)
              .hashJoin(

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -35,7 +35,7 @@ class PlanBuilderTest : public testing::Test,
 
 TEST_F(PlanBuilderTest, duplicateSubfield) {
   VELOX_ASSERT_THROW(
-      PlanBuilder()
+      PlanBuilder(pool_.get())
           .tableScan(
               ROW({"a", "b"}, {BIGINT(), BIGINT()}),
               {"a < 5", "b = 7", "a > 0"},

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -582,7 +582,7 @@ TEST_F(PlanNodeToStringTest, tableScan) {
       ROW({"discount", "quantity", "shipdate", "comment"},
           {DOUBLE(), DOUBLE(), VARCHAR(), VARCHAR()})};
   {
-    auto plan = PlanBuilder()
+    auto plan = PlanBuilder(pool_.get())
                     .tableScan(
                         rowType,
                         {"shipdate between '1994-01-01' and '1994-12-31'",
@@ -603,7 +603,7 @@ TEST_F(PlanNodeToStringTest, tableScan) {
   }
   {
     auto plan =
-        PlanBuilder()
+        PlanBuilder(pool_.get())
             .tableScan(rowType, {}, "comment NOT LIKE '%special%request%'")
             .planNode();
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -91,9 +91,12 @@ PlanBuilder& PlanBuilder::tableScan(
   }
   SubfieldFilters filters;
   filters.reserve(subfieldFilters.size());
+  core::QueryCtx queryCtx;
+  SimpleExpressionEvaluator evaluator(&queryCtx, pool_);
   for (const auto& filter : subfieldFilters) {
     auto filterExpr = parseExpr(filter, outputType, options_, pool_);
-    auto [subfield, subfieldFilter] = exec::toSubfieldFilter(filterExpr);
+    auto [subfield, subfieldFilter] =
+        exec::toSubfieldFilter(filterExpr, &evaluator);
 
     auto it = columnAliases.find(subfield.toString());
     if (it != columnAliases.end()) {

--- a/velox/exec/tests/utils/TpchQueryBuilder.cpp
+++ b/velox/exec/tests/utils/TpchQueryBuilder.cpp
@@ -208,7 +208,7 @@ TpchPlan TpchQueryBuilder::getQ1Plan() const {
   core::PlanNodeId lineitemPlanNodeId;
 
   auto plan =
-      PlanBuilder()
+      PlanBuilder(pool_.get())
           .tableScan(kLineitem, selectedRowType, fileColumnNames, {filter})
           .capturePlanNodeId(lineitemPlanNodeId)
           .project(
@@ -268,7 +268,7 @@ TpchPlan TpchQueryBuilder::getQ3Plan() const {
   core::PlanNodeId ordersPlanNodeId;
   core::PlanNodeId customerPlanNodeId;
 
-  auto customers = PlanBuilder(planNodeIdGenerator)
+  auto customers = PlanBuilder(planNodeIdGenerator, pool_.get())
                        .tableScan(
                            kCustomer,
                            customerSelectedRowType,
@@ -278,7 +278,7 @@ TpchPlan TpchQueryBuilder::getQ3Plan() const {
                        .planNode();
 
   auto custkeyJoinNode =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kOrders,
               ordersSelectedRowType,
@@ -294,7 +294,7 @@ TpchPlan TpchQueryBuilder::getQ3Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -366,7 +366,7 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
   core::PlanNodeId nationScanNodeId;
   core::PlanNodeId regionScanNodeId;
 
-  auto region = PlanBuilder(planNodeIdGenerator)
+  auto region = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kRegion,
                         regionSelectedRowType,
@@ -375,7 +375,7 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
                     .capturePlanNodeId(regionScanNodeId)
                     .planNode();
 
-  auto orders = PlanBuilder(planNodeIdGenerator)
+  auto orders = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kOrders,
                         ordersSelectedRowType,
@@ -385,13 +385,13 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
                     .planNode();
 
   auto customer =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
           .capturePlanNodeId(customerScanNodeId)
           .planNode();
 
   auto nationJoinRegion =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kNation, nationSelectedRowType, nationFileColumns)
           .capturePlanNodeId(nationScanNodeId)
           .hashJoin(
@@ -403,7 +403,7 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
           .planNode();
 
   auto supplierJoinNationRegion =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .hashJoin(
@@ -415,7 +415,7 @@ TpchPlan TpchQueryBuilder::getQ5Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemSelectedRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemScanNodeId)
           .project(
@@ -471,7 +471,7 @@ TpchPlan TpchQueryBuilder::getQ6Plan() const {
       shipDate, selectedRowType, "'1994-01-01'", "'1994-12-31'");
 
   core::PlanNodeId lineitemPlanNodeId;
-  auto plan = PlanBuilder()
+  auto plan = PlanBuilder(pool_.get())
                   .tableScan(
                       kLineitem,
                       selectedRowType,
@@ -531,7 +531,7 @@ TpchPlan TpchQueryBuilder::getQ7Plan() const {
           .planNode();
 
   auto customerJoinNation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
           .capturePlanNodeId(customerScanNodeId)
           .hashJoin(
@@ -544,7 +544,7 @@ TpchPlan TpchQueryBuilder::getQ7Plan() const {
           .planNode();
 
   auto ordersJoinCustomer =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns)
           .capturePlanNodeId(ordersScanNodeId)
           .hashJoin(
@@ -563,7 +563,7 @@ TpchPlan TpchQueryBuilder::getQ7Plan() const {
           .planNode();
 
   auto supplierJoinNation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .hashJoin(
@@ -576,7 +576,7 @@ TpchPlan TpchQueryBuilder::getQ7Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -674,13 +674,13 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
   core::PlanNodeId regionScanNodeId;
 
   auto nationWithName =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kNation, nationSelectedRowTypeWithName, nationFileColumnsWithName)
           .capturePlanNodeId(nationScanNodeIdWithName)
           .planNode();
 
-  auto region = PlanBuilder(planNodeIdGenerator)
+  auto region = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kRegion,
                         regionSelectedRowType,
@@ -689,7 +689,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
                     .capturePlanNodeId(regionScanNodeId)
                     .planNode();
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kPart,
                       partSelectedRowType,
@@ -699,7 +699,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
                   .planNode();
 
   auto nationJoinRegion =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kNation, nationSelectedRowType, nationFileColumns)
           .capturePlanNodeId(nationScanNodeId)
           .hashJoin(
@@ -707,7 +707,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
           .planNode();
 
   auto customerJoinNationJoinRegion =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
           .capturePlanNodeId(customerScanNodeId)
           .hashJoin(
@@ -719,7 +719,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
           .planNode();
 
   auto ordersJoinCustomerJoinNationJoinRegion =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kOrders,
               ordersSelectedRowType,
@@ -735,7 +735,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
           .planNode();
 
   auto supplierJoinNation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .hashJoin(
@@ -747,7 +747,7 @@ TpchPlan TpchQueryBuilder::getQ8Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemSelectedRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemScanNodeId)
           .hashJoin(
@@ -847,7 +847,7 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
   const std::vector<std::string> lineitemCommonColumns = {
       "l_extendedprice", "l_discount", "l_quantity"};
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kPart,
                       partSelectedRowType,
@@ -858,19 +858,19 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
                   .planNode();
 
   auto supplier =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .planNode();
 
   auto nation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kNation, nationSelectedRowType, nationFileColumns)
           .capturePlanNodeId(nationScanNodeId)
           .planNode();
 
   auto lineitemJoinPartJoinSupplier =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemSelectedRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemScanNodeId)
           .hashJoin({"l_partkey"}, {"p_partkey"}, part, "", lineitemColumns)
@@ -883,7 +883,7 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
           .planNode();
 
   auto partsuppJoinLineitemJoinPartJoinSupplier =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kPartsupp, partsuppSelectedRowType, partsuppFileColumns)
           .capturePlanNodeId(partsuppScanNodeId)
           .hashJoin(
@@ -897,7 +897,7 @@ TpchPlan TpchQueryBuilder::getQ9Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns)
           .capturePlanNodeId(ordersScanNodeId)
           .hashJoin(
@@ -978,12 +978,12 @@ TpchPlan TpchQueryBuilder::getQ10Plan() const {
   core::PlanNodeId ordersScanNodeId;
 
   auto nation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kNation, nationSelectedRowType, nationFileColumns)
           .capturePlanNodeId(nationScanNodeId)
           .planNode();
 
-  auto orders = PlanBuilder(planNodeIdGenerator)
+  auto orders = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kOrders,
                         ordersSelectedRowType,
@@ -993,7 +993,7 @@ TpchPlan TpchQueryBuilder::getQ10Plan() const {
                     .planNode();
 
   auto partialPlan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
           .capturePlanNodeId(customerScanNodeId)
           .hashJoin(
@@ -1011,7 +1011,7 @@ TpchPlan TpchQueryBuilder::getQ10Plan() const {
               mergeColumnNames(customerOutputColumns, {"n_name", "o_orderkey"}))
           .planNode();
 
-  auto plan = PlanBuilder(planNodeIdGenerator)
+  auto plan = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kLineitem,
                       lineitemSelectedRowType,
@@ -1102,7 +1102,7 @@ TpchPlan TpchQueryBuilder::getQ12Plan() const {
                       .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns, {})
           .capturePlanNodeId(ordersScanNodeId)
           .hashJoin(
@@ -1148,13 +1148,13 @@ TpchPlan TpchQueryBuilder::getQ13Plan() const {
   core::PlanNodeId ordersScanNodeId;
 
   auto customers =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kCustomer, customerSelectedRowType, customerFileColumns)
           .capturePlanNodeId(customerScanNodeId)
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kOrders,
               ordersSelectedRowType,
@@ -1203,13 +1203,13 @@ TpchPlan TpchQueryBuilder::getQ14Plan() const {
   core::PlanNodeId lineitemScanNodeId;
   core::PlanNodeId partScanNodeId;
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(kPart, partSelectedRowType, partFileColumns)
                   .capturePlanNodeId(partScanNodeId)
                   .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -1268,7 +1268,7 @@ TpchPlan TpchQueryBuilder::getQ15Plan() const {
   core::PlanNodeId supplierScanNodeId;
 
   auto maxRevenue =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -1286,7 +1286,7 @@ TpchPlan TpchQueryBuilder::getQ15Plan() const {
           .planNode();
 
   auto supplierWithMaxRevenue =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -1309,7 +1309,7 @@ TpchPlan TpchQueryBuilder::getQ15Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .hashJoin(
@@ -1361,7 +1361,7 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
                   .filter("p_brand <> 'Brand#45'")
                   .planNode();
 
-  auto supplier = PlanBuilder(planNodeIdGenerator)
+  auto supplier = PlanBuilder(planNodeIdGenerator, pool_.get())
                       .tableScan(
                           kSupplier,
                           supplierSelectedRowType,
@@ -1372,7 +1372,7 @@ TpchPlan TpchQueryBuilder::getQ16Plan() const {
                       .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kPartsupp, partsuppSelectedRowType, partsuppFileColumns)
           .capturePlanNodeId(partsuppScanNodeId)
           .hashJoin(
@@ -1431,7 +1431,7 @@ TpchPlan TpchQueryBuilder::getQ17Plan() const {
   core::PlanNodeId partScanId;
   core::PlanNodeId partAggScanId;
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kPart,
                       partRowType,
@@ -1440,13 +1440,13 @@ TpchPlan TpchQueryBuilder::getQ17Plan() const {
                   .capturePlanNodeId(partScanId)
                   .planNode();
 
-  auto partAgg = PlanBuilder(planNodeIdGenerator)
+  auto partAgg = PlanBuilder(planNodeIdGenerator, pool_.get())
                      .tableScan(kPart, partRowType, partFileColumns, {})
                      .capturePlanNodeId(partAggScanId)
                      .planNode();
 
   auto lineitemJoinPart =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemScanId)
           .hashJoin(
@@ -1458,7 +1458,7 @@ TpchPlan TpchQueryBuilder::getQ17Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemAggScanId)
           .hashJoin(
@@ -1513,7 +1513,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
   core::PlanNodeId lineitemScanNodeId;
 
   auto bigOrders =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitemSelectedRowType, lineitemFileColumns)
           .capturePlanNodeId(lineitemScanNodeId)
           .partialAggregation(
@@ -1525,7 +1525,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns)
           .capturePlanNodeId(ordersScanNodeId)
           .hashJoin(
@@ -1542,7 +1542,7 @@ TpchPlan TpchQueryBuilder::getQ18Plan() const {
           .hashJoin(
               {"o_custkey"},
               {"c_custkey"},
-              PlanBuilder(planNodeIdGenerator)
+              PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kCustomer, customerSelectedRowType, customerFileColumns)
                   .capturePlanNodeId(customerScanNodeId)
@@ -1605,7 +1605,7 @@ TpchPlan TpchQueryBuilder::getQ19Plan() const {
       "     AND (l_quantity between 20.0 and 30.0)"
       "     AND (p_size BETWEEN 1 AND 15))";
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(kPart, partSelectedRowType, partFileColumns)
                   .capturePlanNodeId(partScanNodeId)
                   .planNode();
@@ -1674,7 +1674,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
   core::PlanNodeId partsuppScanId;
   core::PlanNodeId nationScanId;
 
-  auto part = PlanBuilder(planNodeIdGenerator)
+  auto part = PlanBuilder(planNodeIdGenerator, pool_.get())
                   .tableScan(
                       kPart,
                       partSelectedRowType,
@@ -1684,7 +1684,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
                   .capturePlanNodeId(partScanId)
                   .planNode();
 
-  auto partAgg = PlanBuilder(planNodeIdGenerator)
+  auto partAgg = PlanBuilder(planNodeIdGenerator, pool_.get())
                      .tableScan(
                          kPart,
                          partSelectedRowType,
@@ -1694,7 +1694,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
                      .capturePlanNodeId(partAggScanId)
                      .planNode();
 
-  auto nation = PlanBuilder(planNodeIdGenerator)
+  auto nation = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kNation,
                         nationSelectedRowType,
@@ -1704,7 +1704,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
                     .planNode();
 
   auto partsuppJoinPart =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kPartsupp, partsuppSelectedRowType, partsuppFileColumns)
           .capturePlanNodeId(partsuppScanId)
           .hashJoin(
@@ -1717,7 +1717,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
           .planNode();
 
   auto supplierJoinNation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierSelectedRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanId)
           .hashJoin(
@@ -1729,7 +1729,7 @@ TpchPlan TpchQueryBuilder::getQ20Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitemSelectedRowType,
@@ -1807,7 +1807,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
   const std::string receiptCommitFilter = "l_receiptdate > l_commitdate";
 
   auto lineitem3 =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitem3RowType,
@@ -1818,7 +1818,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
           .project({"l_orderkey as l_orderkey_3", "l_suppkey as l_suppkey_3"})
           .planNode();
 
-  auto nation = PlanBuilder(planNodeIdGenerator)
+  auto nation = PlanBuilder(planNodeIdGenerator, pool_.get())
                     .tableScan(
                         kNation,
                         nationRowType,
@@ -1828,7 +1828,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
                     .planNode();
 
   auto supplierJoinNation =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kSupplier, supplierRowType, supplierFileColumns)
           .capturePlanNodeId(supplierScanNodeId)
           .hashJoin(
@@ -1840,7 +1840,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
           .planNode();
 
   auto lineitemJoinSupplier =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kLineitem,
               lineitem1RowType,
@@ -1858,7 +1858,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
           .planNode();
 
   auto ordersJoinLineitem1 =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(
               kOrders,
               ordersRowType,
@@ -1874,7 +1874,7 @@ TpchPlan TpchQueryBuilder::getQ21Plan() const {
           .planNode();
 
   auto plan =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kLineitem, lineitem2RowType, lineitem2FileColumns)
           .capturePlanNodeId(lineitem2ScanNodeId)
           .project({"l_orderkey as l_orderkey_2", "l_suppkey as l_suppkey_2"})
@@ -1935,7 +1935,7 @@ TpchPlan TpchQueryBuilder::getQ22Plan() const {
   core::PlanNodeId ordersScanNodeId;
 
   auto orders =
-      PlanBuilder(planNodeIdGenerator)
+      PlanBuilder(planNodeIdGenerator, pool_.get())
           .tableScan(kOrders, ordersSelectedRowType, ordersFileColumns)
           .capturePlanNodeId(ordersScanNodeId)
           .planNode();
@@ -2028,7 +2028,7 @@ TpchPlan TpchQueryBuilder::getIoMeterPlan(int columnPct) const {
   for (auto& name : names) {
     aliases[name] = name;
   }
-  auto plan = PlanBuilder()
+  auto plan = PlanBuilder(pool_.get())
                   .tableScan(kLineitem, selectedRowType, aliases, {filter})
                   .capturePlanNodeId(lineitemPlanNodeId)
                   .project(projectExprs)

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1702,4 +1702,23 @@ std::string printExprWithStats(const exec::ExprSet& exprSet) {
   }
   return out.str();
 }
+
+void SimpleExpressionEvaluator::evaluate(
+    exec::ExprSet* exprSet,
+    const SelectivityVector& rows,
+    const RowVector& input,
+    VectorPtr& result) {
+  EvalCtx context(ensureExecCtx(), exprSet, &input);
+  std::vector<VectorPtr> results = {result};
+  exprSet->eval(0, 1, true, rows, context, results);
+  result = results[0];
+}
+
+core::ExecCtx* SimpleExpressionEvaluator::ensureExecCtx() {
+  if (!execCtx_) {
+    execCtx_ = std::make_unique<core::ExecCtx>(pool_, queryCtx_);
+  }
+  return execCtx_.get();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/core/ExpressionEvaluator.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/type/Filter.h"
@@ -371,7 +372,8 @@ betweenHugeint(int128_t min, int128_t max, bool nullAllowed = false) {
 }
 
 std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
-    const core::TypedExprPtr& expr);
+    const core::TypedExprPtr& expr,
+    core::ExpressionEvaluator*);
 
 /// Convert a leaf call expression (no conjunction like AND/OR) to subfield and
 /// filter.  Return nullptr if not supported for pushdown.  This is needed
@@ -381,6 +383,7 @@ std::pair<common::Subfield, std::unique_ptr<common::Filter>> toSubfieldFilter(
 std::unique_ptr<common::Filter> leafCallToSubfieldFilter(
     const core::CallTypedExpr&,
     common::Subfield&,
+    core::ExpressionEvaluator*,
     bool negated = false);
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Currently in `ExprToSubfieldFilter.cpp`, `toConstant` is using an adhoc
`ExecCtx` and global static memory pool.  This should be passed in from the
operator.

Differential Revision: D45625193

