### PR TITLE
Optimize map Presto function for constant keys

### DIFF
--- a/velox/functions/prestosql/Map.cpp
+++ b/velox/functions/prestosql/Map.cpp
@@ -66,7 +66,7 @@ class MapFunction : public exec::VectorFunction {
       auto mapVector = std::make_shared<MapVector>(
           context.pool(),
           outputType,
-          BufferPtr(nullptr),
+          nullptr,
           rows.end(),
           keysArray->offsets(),
           keysArray->sizes(),
@@ -77,6 +77,94 @@ class MapFunction : public exec::VectorFunction {
         checkDuplicateKeys(mapVector, rows, context);
       }
       context.moveOrCopyResult(mapVector, rows, result);
+    } else if (decodedKeys->isConstantMapping()) {
+      // Constant keys.
+      auto keysIndex = decodedKeys->index(rows.begin());
+      auto valueIndices = decodedValues->indices();
+
+      auto keysArray = decodedKeys->base()->as<ArrayVector>();
+      auto valuesArray = decodedValues->base()->as<ArrayVector>();
+
+      // Verify there are no null keys and no duplicate keys.
+      auto numKeys = keysArray->sizeAt(keysIndex);
+      auto keysElements = keysArray->elements();
+      auto keysOffset = keysArray->offsetAt(keysIndex);
+
+      try {
+        if (keysElements->mayHaveNulls()) {
+          for (auto i = 0; i < numKeys; ++i) {
+            VELOX_USER_CHECK(!keysElements->isNullAt(keysOffset + i), kNullKey);
+          }
+        }
+
+        if constexpr (!AllowDuplicateKeys) {
+          checkDuplicateConstantKeys(numKeys, keysOffset, keysElements);
+        }
+      } catch (const std::exception&) {
+        context.setErrors(rows, std::current_exception());
+      }
+
+      // When context.throwOnError is false, some rows will be marked as
+      // 'failed'. These rows should not be processed further. 'remainingRows'
+      // will contain a subset of 'rows' that have passed all the checks (e.g.
+      // keys are not nulls and number of keys and values is the same).
+      SelectivityVector remainingRows = rows;
+
+      // Check array lengths
+      context.applyToSelectedNoThrow(remainingRows, [&](vector_size_t row) {
+        VELOX_USER_CHECK_EQ(
+            numKeys,
+            valuesArray->sizeAt(valueIndices[row]),
+            "{}",
+            kArrayLengthsMismatch);
+      });
+
+      context.deselectErrors(remainingRows);
+
+      vector_size_t totalElements = remainingRows.countSelected() * numKeys;
+
+      BufferPtr offsets = allocateOffsets(rows.end(), context.pool());
+      auto rawOffsets = offsets->asMutable<vector_size_t>();
+
+      BufferPtr sizes = allocateSizes(rows.end(), context.pool());
+      auto rawSizes = sizes->asMutable<vector_size_t>();
+
+      BufferPtr keysIndices = allocateIndices(totalElements, context.pool());
+      auto rawKeysIndices = keysIndices->asMutable<vector_size_t>();
+
+      BufferPtr valuesIndices = allocateIndices(totalElements, context.pool());
+      auto rawValuesIndices = valuesIndices->asMutable<vector_size_t>();
+
+      vector_size_t offset = 0;
+      remainingRows.applyToSelected([&](vector_size_t row) {
+        rawOffsets[row] = offset;
+        rawSizes[row] = numKeys;
+
+        auto valuesOffset = valuesArray->offsetAt(valueIndices[row]);
+        for (vector_size_t i = 0; i < numKeys; i++) {
+          rawKeysIndices[offset + i] = keysOffset + i;
+          rawValuesIndices[offset + i] = valuesOffset + i;
+        }
+
+        offset += numKeys;
+      });
+
+      auto wrappedKeys = BaseVector::wrapInDictionary(
+          nullptr, keysIndices, totalElements, keysArray->elements());
+
+      auto wrappedValues = BaseVector::wrapInDictionary(
+          nullptr, valuesIndices, totalElements, valuesArray->elements());
+
+      auto mapVector = std::make_shared<MapVector>(
+          context.pool(),
+          outputType,
+          nullptr,
+          rows.end(),
+          offsets,
+          sizes,
+          wrappedKeys,
+          wrappedValues);
+      context.moveOrCopyResult(mapVector, remainingRows, result);
     } else {
       auto keyIndices = decodedKeys->indices();
       auto valueIndices = decodedValues->indices();
@@ -148,21 +236,15 @@ class MapFunction : public exec::VectorFunction {
       });
 
       auto wrappedKeys = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
-          keysIndices,
-          totalElements,
-          keysArray->elements());
+          nullptr, keysIndices, totalElements, keysArray->elements());
 
       auto wrappedValues = BaseVector::wrapInDictionary(
-          BufferPtr(nullptr),
-          valuesIndices,
-          totalElements,
-          valuesArray->elements());
+          nullptr, valuesIndices, totalElements, valuesArray->elements());
 
       auto mapVector = std::make_shared<MapVector>(
           context.pool(),
           outputType,
-          BufferPtr(nullptr),
+          nullptr,
           rows.end(),
           offsets,
           sizes,
@@ -212,6 +294,21 @@ class MapFunction : public exec::VectorFunction {
       }
     }
     return true;
+  }
+
+  void checkDuplicateConstantKeys(
+      vector_size_t numKeys,
+      vector_size_t keysOffset,
+      const VectorPtr& keysElements) const {
+    static const char* kDuplicateKey =
+        "Duplicate map keys ({}) are not allowed";
+
+    if (auto duplicateIndex = keysElements->findDuplicateValue(
+            keysOffset, numKeys, CompareFlags())) {
+      auto duplicateKey = keysElements->wrappedVector()->toString(
+          keysElements->wrappedIndex(duplicateIndex.value()));
+      VELOX_USER_FAIL(kDuplicateKey, duplicateKey);
+    }
   }
 };
 } // namespace

--- a/velox/functions/prestosql/benchmarks/MapBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapBenchmark.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+
+namespace {
+
+class MapBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  MapBenchmark() {
+    functions::prestosql::registerAllScalarFunctions();
+
+    VectorFuzzer::Options options;
+    options.vectorSize = 10'000;
+
+    VectorFuzzer fuzzer(options, pool());
+
+    // Generate flat vectors to use as keys and values for the map.
+    data_ = std::dynamic_pointer_cast<RowVector>(fuzzer.fuzzFlat(
+        ROW({"k0", "k1", "k2", "v0", "v1", "v2"},
+            {BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT(), BIGINT()})));
+  }
+
+  size_t runConstantKeys(size_t times) {
+    return run(
+        "map(array_constructor(35, 2, 101), array_constructor(v0, v1, v2))",
+        times);
+  }
+
+  size_t runFlatKeys(size_t times) {
+    return run(
+        "map(array_constructor(k0, k1, k2), array_constructor(v0, v1, v2))",
+        times);
+  }
+
+ private:
+  size_t run(const std::string& expression, size_t times) {
+    folly::BenchmarkSuspender suspender;
+    auto exprSet = compileExpression(expression, asRowType(data_->type()));
+    suspender.dismiss();
+
+    int cnt = 0;
+    for (auto i = 0; i < times * 1'000; i++) {
+      cnt += evaluate(exprSet, data_)->size();
+    }
+    return cnt;
+  }
+
+  RowVectorPtr data_;
+};
+
+BENCHMARK_MULTI(constantKeys, n) {
+  MapBenchmark benchmark;
+  return benchmark.runConstantKeys(n);
+}
+
+BENCHMARK_MULTI(flatKeys, n) {
+  MapBenchmark benchmark;
+  return benchmark.runFlatKeys(n);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -280,12 +280,46 @@ TEST_F(MapTest, constantKeys) {
   auto expectedMap =
       makeMapVector<StringView, int32_t>(size, sizeAt, keyAt, valueAt);
 
-  auto result = evaluate<MapVector>(
+  auto result = evaluate(
       "map(array['key'], array_constructor(c0))",
       makeRowVector({
           makeFlatVector<int32_t>(size, valueAt),
       }));
   assertEqualVectors(expectedMap, result);
+
+  // Duplicate key.
+  VELOX_ASSERT_THROW(
+      evaluate<MapVector>(
+          "map(array['key', 'key'], array_constructor(c0, c0))",
+          makeRowVector({
+              makeFlatVector<int32_t>(size, valueAt),
+          })),
+      "Duplicate map keys (key) are not allowed");
+
+  result = evaluate(
+      "try(map(array['key', 'key'], array_constructor(c0, c0)))",
+      makeRowVector({
+          makeFlatVector<int32_t>(size, valueAt),
+      }));
+  auto nullMap =
+      BaseVector::createNullConstant(MAP(VARCHAR(), INTEGER()), size, pool());
+  assertEqualVectors(nullMap, result);
+
+  // Wrong number of values.
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "map(array['key1', 'key2'], array_constructor(c0, c0, c0))",
+          makeRowVector({
+              makeFlatVector<int32_t>(size, valueAt),
+          })),
+      "(2 vs. 3) Key and value arrays must be the same length");
+
+  result = evaluate(
+      "try(map(array['key1', 'key2'], array_constructor(c0, c0, c0)))",
+      makeRowVector({
+          makeFlatVector<int32_t>(size, valueAt),
+      }));
+  assertEqualVectors(nullMap, result);
 }
 
 // Test map function applied to a flat array of keys and constant array of

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -823,6 +823,28 @@ BufferPtr BaseVector::sliceBuffer(
   return ans;
 }
 
+std::optional<vector_size_t> BaseVector::findDuplicateValue(
+    vector_size_t start,
+    vector_size_t size,
+    CompareFlags flags) {
+  VELOX_DCHECK_GE(start, 0, "Start index must not be negative");
+  VELOX_DCHECK_LT(start, length_, "Start index is too large");
+  VELOX_DCHECK_GE(size, 0, "Size must not be negative");
+  VELOX_DCHECK_LE(start + size, length_, "Size is too large");
+
+  std::vector<vector_size_t> indices(size);
+  std::iota(indices.begin(), indices.end(), start);
+  sortIndices(indices, flags);
+
+  for (auto i = 1; i < size; ++i) {
+    if (equalValueAt(this, indices[i], indices[i - 1])) {
+      return indices[i];
+    }
+  }
+
+  return std::nullopt;
+}
+
 std::string printNulls(const BufferPtr& nulls, vector_size_t maxBitsToPrint) {
   VELOX_CHECK_GE(maxBitsToPrint, 0);
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -284,6 +284,13 @@ class BaseVector {
         });
   }
 
+  /// Compares values in range [start, start + size) and returns an index of a
+  /// duplicate value if found.
+  std::optional<vector_size_t> findDuplicateValue(
+      vector_size_t start,
+      vector_size_t size,
+      CompareFlags flags);
+
   /**
    * @return the hash of the value at the given index in this vector
    */


### PR DESCRIPTION
Summary:
A common pattern in queries to apply 'map' function to a constant array of keys:

```
SELECT map(array[1, 2, 3], array[a, b, c])) ...
```

In this case, a lot of CPU cycles are spent checking for duplicate map keys again and again for each row. It is sufficient to check once.

Benchmark results before

```
============================================================================
[...]prestosql/benchmarks/MapBenchmark.cpp     relative  time/iter   iters/s
============================================================================
constantKeys                                              256.17ns     3.90M
flatKeys                                                  237.76ns     4.21M
```

and after the optimization

```
============================================================================
[...]prestosql/benchmarks/MapBenchmark.cpp     relative  time/iter   iters/s
============================================================================
constantKeys                                               71.09ns    14.07M
flatKeys                                                  248.60ns     4.02M
```

Differential Revision: D45720372

