### PR TITLE
Unify the memory pool and manager capacity exceeded error messages

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -21,15 +21,6 @@ DECLARE_int32(velox_memory_num_shared_leaf_pools);
 
 namespace facebook::velox::memory {
 namespace {
-#define VELOX_MEM_MANAGER_CAP_EXCEEDED(cap)                         \
-  _VELOX_THROW(                                                     \
-      ::facebook::velox::VeloxRuntimeError,                         \
-      ::facebook::velox::error_source::kErrorSourceRuntime.c_str(), \
-      ::facebook::velox::error_code::kMemCapExceeded.c_str(),       \
-      /* isRetriable */ true,                                       \
-      "Exceeded memory manager cap of {} MB",                       \
-      (cap) / 1024 / 1024);
-
 constexpr folly::StringPiece kDefaultRootName{"__default_root__"};
 constexpr folly::StringPiece kDefaultLeafName("__default_leaf__");
 } // namespace

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -751,7 +751,7 @@ class MemoryPoolImpl : public MemoryPool {
   // , Source: RUNTIME, ErrorCode: MEM_CAP_EXCEEDED
   std::string capExceedingMessage(
       MemoryPool* requestor,
-      uint64_t incrementBytes);
+      const std::string& errorMessage);
 
   FOLLY_ALWAYS_INLINE void sanityCheckLocked() const {
     if (FOLLY_UNLIKELY(

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -522,7 +522,7 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
         ASSERT_EQ(
-            "\nExceeded memory cap of 127.00MB when requesting 128.00MB\nMemoryCapExceptions usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
+            "\nExceeded memory pool cap of 127.00MB when requesting 128.00MB, memory manager cap is 127.00MB\nMemoryCapExceptions usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
             ex.message());
       }
     }
@@ -541,7 +541,9 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         ASSERT_EQ(error_source::kErrorSourceRuntime.c_str(), ex.errorSource());
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
-        ASSERT_EQ("Exceeded memory manager cap of 127.00MB", ex.message());
+        ASSERT_EQ(
+            "\nExceeded memory manager cap of 127.00MB when requesting 127.00MB, memory pool cap is 254.00MB\nMemoryCapExceptions usage 0B peak 128.00MB\n\nFailed memory pool: static_quota: 0B\n",
+            ex.message());
       }
     }
   }

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -877,7 +877,7 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrations) {
           } catch (VeloxException& e) {
             // Ignore memory limit exception.
             ASSERT_TRUE(
-                e.message().find("Exceeded memory cap") != std::string::npos);
+                e.message().find("Exceeded memory") != std::string::npos);
           }
         }
       }
@@ -924,7 +924,7 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
           } catch (VeloxException& e) {
             // Ignore the memory capacity limit exception.
             ASSERT_TRUE(
-                e.message().find("Exceeded memory cap") != std::string::npos);
+                e.message().find("Exceeded memory") != std::string::npos);
           }
         }
         std::this_thread::sleep_for(std::chrono::microseconds(1));

--- a/velox/exec/tests/MemoryCapExceededTest.cpp
+++ b/velox/exec/tests/MemoryCapExceededTest.cpp
@@ -35,7 +35,7 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
   // We look for these lines separately, since their order can change (not sure
   // why).
   std::array<std::string, 14> expectedTexts = {
-      "Exceeded memory cap of 5.00MB when requesting 2.00MB",
+      "Exceeded memory pool cap of 5.00MB when requesting 2.00MB",
       "node.1 usage 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
       "node.2 usage 4.00MB peak 4.00MB",
@@ -72,7 +72,7 @@ TEST_F(MemoryCapExceededTest, singleDriver) {
     readCursor(params, [](Task*) {});
     FAIL() << "Expected a MEM_CAP_EXCEEDED RuntimeException.";
   } catch (const VeloxException& e) {
-    auto errorMessage = e.message();
+    const auto errorMessage = e.message();
     for (const auto& expectedText : expectedTexts) {
       ASSERT_TRUE(errorMessage.find(expectedText) != std::string::npos)
           << "Expected error message to contain '" << expectedText
@@ -132,13 +132,73 @@ TEST_F(MemoryCapExceededTest, multipleDrivers) {
     readCursor(params, [](Task*) {});
     FAIL() << "Expected a MEM_CAP_EXCEEDED RuntimeException.";
   } catch (const VeloxException& e) {
-    auto errorMessage = e.message();
+    const auto errorMessage = e.message();
     for (const auto& expectedText : expectedTexts) {
       ASSERT_TRUE(errorMessage.find(expectedText) != std::string::npos)
           << "Expected error message to contain '" << expectedText
           << "', but received '" << errorMessage << "'.";
     }
   }
+}
+
+TEST_F(MemoryCapExceededTest, memoryManagerCapacityExeededError) {
+  // Executes a plan with no memory pool capacity limit but very small memory
+  // manager's limit.
+  memory::IMemoryManager::Options options{.capacity = 1 << 20};
+  memory::MemoryManager manager{options};
+
+  vector_size_t size = 1'024;
+  // This limit ensures that only the Aggregation Operator fails.
+  constexpr int64_t kMaxBytes = 5LL << 20; // 5MB
+  // We look for these lines separately, since their order can change (not sure
+  // why).
+  std::array<std::string, 14> expectedTexts = {
+      "Exceeded memory manager cap of 1.00MB when requesting 368.00KB, memory pool cap is 5.00MB",
+      "node.2 usage 1.00MB peak 2.00MB",
+      "op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB",
+      "node.1 usage 1.00MB peak 1.00MB",
+      "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
+      "Top 2 leaf memory pool usages:",
+      "op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB",
+      "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
+      "Failed memory pool: op.2.0.0.Aggregation: 1012.00KB"};
+
+  std::vector<RowVectorPtr> data;
+  for (auto i = 0; i < 100; ++i) {
+    data.push_back(makeRowVector({
+        makeFlatVector<int64_t>(
+            size, [&i](auto row) { return row + (i * 1000); }),
+        makeFlatVector<int64_t>(size, [](auto row) { return row + 3; }),
+    }));
+  }
+
+  // Plan created to allow multiple operators to show up in the top 3 memory
+  // usage list in the error message.
+  auto plan = PlanBuilder()
+                  .values(data)
+                  .project({"c0", "c0 + c1"})
+                  .singleAggregation({"c0"}, {"sum(p1)"})
+                  .orderBy({"c0"}, false)
+                  .planNode();
+  auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+  queryCtx->testingOverrideMemoryPool(
+      manager.addRootPool(queryCtx->queryId(), kMaxBytes));
+  CursorParameters params;
+  params.planNode = plan;
+  params.queryCtx = queryCtx;
+  params.maxDrivers = 1;
+  try {
+    readCursor(params, [](Task*) {});
+    FAIL() << "Expected a MEM_CAP_EXCEEDED RuntimeException.";
+  } catch (const VeloxException& e) {
+    const auto errorMessage = e.message();
+    for (const auto& expectedText : expectedTexts) {
+      ASSERT_TRUE(errorMessage.find(expectedText) != std::string::npos)
+          << "Expected error message to contain '" << expectedText
+          << "', but received '" << errorMessage << "'.";
+    }
+  }
+  Task::testingWaitForAllTasksToBeDeleted();
 }
 
 } // namespace


### PR DESCRIPTION
Add to log out the memory pool's memory usage distribution
when exceeded memory manager's capacity

The example memory pool's capacity exceeded error message
```
Exceeded memory pool cap of 5.00MB when requesting 2.00MB, memory manager cap is UNLIMITED
default_root_1 usage 5.00MB peak 5.00MB
    task.test_cursor 1 usage 5.00MB peak 5.00MB
        node.2 usage 4.00MB peak 4.00MB
            op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
        node.1 usage 1.00MB peak 1.00MB
            op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Top 2 leaf memory pool usages:
    op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
    op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Failed memory pool: op.2.0.0.Aggregation: 3.77MB
, Source: RUNTIME, ErrorCode: MEM_CAP_EXCEEDED
E20230510 11:03:40.772047 463647 MemoryCapExceededTest.cpp:76] 
Exceeded memory pool cap of 5.00MB when requesting 2.00MB
default_root_1 usage 5.00MB peak 5.00MB
    task.test_cursor 1 usage 5.00MB peak 5.00MB
        node.2 usage 4.00MB peak 4.00MB
            op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
        node.1 usage 1.00MB peak 1.00MB
            op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Top 2 leaf memory pool usages:
    op.2.0.0.Aggregation usage 3.77MB peak 3.77MB
    op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Failed memory pool: op.2.0.0.Aggregation: 3.77MB
```

The example memory manager's capacity exceeded error message
```
Exceeded memory manager cap of 1.00MB when requesting 368.00KB, memory pool cap is 5.00MB
default_root_1 usage 2.00MB peak 3.00MB
    task.test_cursor 1 usage 2.00MB peak 3.00MB
        node.2 usage 1.00MB peak 2.00MB
            op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB
        node.1 usage 1.00MB peak 1.00MB
            op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Top 2 leaf memory pool usages:
    op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB
    op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Failed memory pool: op.2.0.0.Aggregation: 1012.00KB
, Source: RUNTIME, ErrorCode: MEM_CAP_EXCEEDED
E20230510 11:05:18.476295 466903 MemoryCapExceededTest.cpp:195] 
Exceeded memory manager cap of 1.00MB when requesting 368.00KB
default_root_1 usage 2.00MB peak 3.00MB
    task.test_cursor 1 usage 2.00MB peak 3.00MB
        node.2 usage 1.00MB peak 2.00MB
            op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB
        node.1 usage 1.00MB peak 1.00MB
            op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Top 2 leaf memory pool usages:
    op.2.0.0.Aggregation usage 1012.00KB peak 1.35MB
    op.1.0.0.FilterProject usage 12.00KB peak 12.00KB

Failed memory pool: op.2.0.0.Aggregation: 1012.00KB
```
