### PR TITLE
Fix VectorTest.findDuplicateValue in release build

### DIFF
--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2320,10 +2320,4 @@ TEST_F(VectorTest, findDuplicateValue) {
   // Verify that empty range doesn't throw.
   dup = data->findDuplicateValue(2, 0, flags);
   ASSERT_FALSE(dup.has_value());
-
-  // Verify that out-of-bound range throws.
-  VELOX_ASSERT_THROW(
-      data->findDuplicateValue(2, 8, flags), "Size is too large");
-  VELOX_ASSERT_THROW(
-      data->findDuplicateValue(22, 8, flags), "Start index is too large");
 }


### PR DESCRIPTION
Fixes #4897 

Cannot test debug-only checks since tests sometimes run on release builds.