### PR TITLE
Fix decoding of percentiles in ApproxPercentileAggregate::addIntermediate

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -57,12 +57,7 @@ SelectivityVector* PeeledEncoding::translateToInnerRows(
   auto flatNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
 
   auto* newRows = innerRowsHolder.get(baseSize, false);
-  outerRows.applyToSelected([&](vector_size_t row) {
-    if (!(flatNulls && bits::isBitNull(flatNulls, row))) {
-      newRows->setValid(indices[row], true);
-    }
-  });
-  newRows->updateBounds();
+  velox::translateToInnerRows(outerRows, indices, flatNulls, *newRows);
 
   return newRows;
 }

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -445,5 +445,11 @@ inline bool SelectivityVector::testSelected(Callable func) const {
   }
   return bits::testSetBits(bits_.data(), begin_, end_, func);
 }
+
+void translateToInnerRows(
+    const SelectivityVector& outerRows,
+    const vector_size_t* indices,
+    const uint64_t* nulls,
+    SelectivityVector& innerRows);
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary:
ApproxPercentileAggregate::addIntermediate() receives an input vector of Row type and SelectivityVector `rows` for this input vector. addIntermediate() currently uses `rows` to decode a child of the base vector of the input vector.

This diff fixes it by translating `rows` to the selected base rows before decoding the child vector.

Reviewed By: Yuhta

Differential Revision: D45751685

