### PR TITLE
Add validateIntermediateInputs() to ApproxPercentileAggregate for companion functions

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -63,7 +63,13 @@ int main(int argc, char** argv) {
   std::unordered_map<std::string, std::string> customVerificationFunctions = {
       // Order-dependent functions.
       {"approx_distinct", ""},
+      {"approx_distinct_partial", ""},
+      {"approx_distinct_merge", ""},
       {"approx_set", ""},
+      {"approx_set_partial", ""},
+      {"approx_set_merge", ""},
+      {"approx_percentile_partial", ""},
+      {"approx_percentile_merge", ""},
       {"arbitrary", ""},
       {"array_agg", "array_sort({})"},
       {"map_agg", "array_sort(map_keys({}))"},

--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -57,12 +57,7 @@ SelectivityVector* PeeledEncoding::translateToInnerRows(
   auto flatNulls = wrapNulls_ ? wrapNulls_->as<uint64_t>() : nullptr;
 
   auto* newRows = innerRowsHolder.get(baseSize, false);
-  outerRows.applyToSelected([&](vector_size_t row) {
-    if (!(flatNulls && bits::isBitNull(flatNulls, row))) {
-      newRows->setValid(indices[row], true);
-    }
-  });
-  newRows->updateBounds();
+  velox::translateToInnerRows(outerRows, indices, flatNulls, *newRows);
 
   return newRows;
 }

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -550,10 +550,51 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       std::conditional_t<kSingleGroup, char*, char**> group,
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args) {
+    if (validateIntermediateInputs_) {
+      addIntermediateImpl<kSingleGroup, true>(group, rows, args);
+    } else {
+      addIntermediateImpl<kSingleGroup, false>(group, rows, args);
+    }
+  }
+
+  struct Percentiles {
+    std::vector<double> values;
+    bool isArray;
+  };
+
+  static constexpr double kMissingNormalizedValue = -1;
+  const bool hasWeight_;
+  const bool hasAccuracy_;
+  std::optional<Percentiles> percentiles_;
+  double accuracy_{kMissingNormalizedValue};
+  DecodedVector decodedValue_;
+  DecodedVector decodedWeight_;
+  DecodedVector decodedAccuracy_;
+  DecodedVector decodedDigest_;
+
+ private:
+  template <bool kSingleGroup, bool checkIntermediateInputs>
+  void addIntermediateImpl(
+      std::conditional_t<kSingleGroup, char*, char**> group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args) {
     VELOX_CHECK_EQ(args.size(), 1);
     DecodedVector decoded(*args[0], rows);
     auto rowVec = decoded.base()->as<RowVector>();
-    VELOX_CHECK(rowVec);
+    if constexpr (checkIntermediateInputs) {
+      VELOX_USER_CHECK(rowVec);
+      for (int i = kPercentiles; i <= kMaxValue; ++i) {
+        VELOX_USER_CHECK(
+            rowVec->childAt(i)->isFlatEncoding() ||
+            rowVec->childAt(i)->isConstantEncoding());
+      }
+      for (int i = kItems; i <= kLevels; ++i) {
+        VELOX_USER_CHECK(
+            rowVec->childAt(i)->encoding() == VectorEncoding::Simple::ARRAY);
+      }
+    } else {
+      VELOX_CHECK(rowVec);
+    }
 
     const SelectivityVector* baseRows = &rows;
     SelectivityVector innerRows{rowVec->size(), false};
@@ -581,10 +622,17 @@ class ApproxPercentileAggregate : public exec::Aggregate {
     auto levels = rowVec->childAt(kLevels)->asUnchecked<ArrayVector>();
 
     auto itemsElements = items->elements()->asFlatVector<T>();
-    VELOX_CHECK(itemsElements);
+    auto levelElements = levels->elements()->asFlatVector<int32_t>();
+    if constexpr (checkIntermediateInputs) {
+      VELOX_USER_CHECK(itemsElements);
+      VELOX_USER_CHECK(levelElements);
+    } else {
+      VELOX_CHECK(itemsElements);
+      VELOX_CHECK(levelElements);
+    }
     auto rawItems = itemsElements->rawValues();
-    auto rawLevels =
-        levels->elements()->asFlatVector<int32_t>()->rawValues<uint32_t>();
+    auto rawLevels = levelElements->rawValues<uint32_t>();
+
     KllSketchAccumulator<T>* accumulator = nullptr;
     std::vector<typename KllSketch<T>::View> views;
     if constexpr (kSingleGroup) {
@@ -601,8 +649,13 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       if (!accumulator) {
         int j = percentiles.index(i);
         auto percentilesBase = percentiles.base()->asUnchecked<ArrayVector>();
-        auto rawPercentiles =
-            percentilesBase->elements()->asFlatVector<double>()->rawValues();
+        auto percentileBaseElements =
+            percentilesBase->elements()->asFlatVector<double>();
+        if constexpr (checkIntermediateInputs) {
+          VELOX_USER_CHECK(percentileBaseElements);
+          VELOX_USER_CHECK(!percentilesBase->isNullAt(j));
+        }
+        auto rawPercentiles = percentileBaseElements->rawValues();
         checkSetPercentile(
             percentileIsArray->valueAt(i),
             rawPercentiles + percentilesBase->offsetAt(j),
@@ -617,6 +670,13 @@ class ApproxPercentileAggregate : public exec::Aggregate {
         }
       } else {
         accumulator = initRawAccumulator(group[row]);
+      }
+
+      if constexpr (checkIntermediateInputs) {
+        VELOX_USER_CHECK(
+            !(k->isNullAt(i) || n->isNullAt(i) || minValue->isNullAt(i) ||
+              maxValue->isNullAt(i) || items->isNullAt(i) ||
+              levels->isNullAt(i)));
       }
       typename KllSketch<T>::View v{
           .k = static_cast<uint32_t>(k->valueAt(i)),
@@ -644,21 +704,6 @@ class ApproxPercentileAggregate : public exec::Aggregate {
       }
     }
   }
-
-  struct Percentiles {
-    std::vector<double> values;
-    bool isArray;
-  };
-
-  static constexpr double kMissingNormalizedValue = -1;
-  const bool hasWeight_;
-  const bool hasAccuracy_;
-  std::optional<Percentiles> percentiles_;
-  double accuracy_{kMissingNormalizedValue};
-  DecodedVector decodedValue_;
-  DecodedVector decodedWeight_;
-  DecodedVector decodedAccuracy_;
-  DecodedVector decodedDigest_;
 };
 
 bool validPercentileType(const Type& type) {
@@ -806,7 +851,8 @@ bool registerApproxPercentile(const std::string& name) {
                 name,
                 type->toString());
         }
-      });
+      },
+      /*registerCompanionFunctions*/ true);
   return true;
 }
 

--- a/velox/vector/SelectivityVector.h
+++ b/velox/vector/SelectivityVector.h
@@ -445,5 +445,11 @@ inline bool SelectivityVector::testSelected(Callable func) const {
   }
   return bits::testSetBits(bits_.data(), begin_, end_, func);
 }
+
+void translateToInnerRows(
+    const SelectivityVector& outerRows,
+    const vector_size_t* indices,
+    const uint64_t* nulls,
+    SelectivityVector& innerRows);
 } // namespace velox
 } // namespace facebook


### PR DESCRIPTION
Summary: The approx_percentile_merge and approx_percentile_merge_extract companion functions may take arbitrarily encoded idntermediate state vector as inputs that is not supported by ApproxPercentileAggregate right now. This diff adds check for unsupported encodings and throw an user error if an unsupported case is found. This is needed for fuzzer test of approx_percentile companion functions.

Differential Revision: D45719738

