### PR TITLE
Fix BaseVector::findDuplicateValue for empty vectors

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -827,9 +827,13 @@ std::optional<vector_size_t> BaseVector::findDuplicateValue(
     vector_size_t start,
     vector_size_t size,
     CompareFlags flags) {
+  if (length_ == 0 || size == 0) {
+    return std::nullopt;
+  }
+
   VELOX_DCHECK_GE(start, 0, "Start index must not be negative");
   VELOX_DCHECK_LT(start, length_, "Start index is too large");
-  VELOX_DCHECK_GE(size, 0, "Size must not be negative");
+  VELOX_DCHECK_GT(size, 0, "Size must not be negative");
   VELOX_DCHECK_LE(start + size, length_, "Size is too large");
 
   std::vector<vector_size_t> indices(size);

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2320,4 +2320,17 @@ TEST_F(VectorTest, findDuplicateValue) {
   // Verify that empty range doesn't throw.
   dup = data->findDuplicateValue(2, 0, flags);
   ASSERT_FALSE(dup.has_value());
+
+// Verify that out-of-bound range throws in debug mode.
+#ifndef NDEBUG
+  VELOX_ASSERT_THROW(
+      data->findDuplicateValue(2, 8, flags), "Size is too large");
+  VELOX_ASSERT_THROW(
+      data->findDuplicateValue(22, 8, flags), "Start index is too large");
+#endif
+
+  // Verify that empty vector doesn't throw.
+  auto noData = makeFlatVector<int32_t>({});
+  dup = noData->findDuplicateValue(0, 0, flags);
+  ASSERT_FALSE(dup.has_value());
 }


### PR DESCRIPTION
vector->findDuplicateValue(0, 0) should not throw if vector is empty.

```
Reason: (0 vs. 0) Start index is too large
Retriable: False
Expression: start < length_
Context: map(<empty>:ARRAY<VARCHAR>, 19 elements starting at 105 {[105->370] 4247909-02-12, null, [107->248] 3935164-06-12, null, [109->255] 1861743-11-16, ...}:ARRAY<DATE>)
Top-Level Context: Same as context.
Function: findDuplicateValue
File: ../../velox/vector/BaseVector.cpp
Line: 831
```

Fixes #4906