### PR TITLE
Add fuzzer support for feeding preloaded lazy vectors

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -227,7 +227,7 @@ class ExpressionFuzzer {
       std::vector<core::TypedExprPtr> plans,
       const RowVectorPtr& rowVector,
       const VectorPtr& resultVectors,
-      const std::vector<column_index_t>& columnsToWrapInLazy);
+      const std::vector<int>& columnsToWrapInLazy);
 
   /// Return a random signature mapped to functionName in expressionToSignature_
   /// whose return type can match returnType. Return nullptr if no such

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -135,10 +135,10 @@ void ExpressionRunner::run(
     VELOX_CHECK_GT(inputVector->size(), 0, "Input vector must not be empty.");
   }
 
-  std::vector<column_index_t> columnsToWrapInLazy;
+  std::vector<int> columnsToWrapInLazy;
   if (!lazyColumnListPath.empty()) {
     columnsToWrapInLazy =
-        restoreStdVectorFromFile<column_index_t>(lazyColumnListPath.c_str());
+        restoreStdVectorFromFile<int>(lazyColumnListPath.c_str());
   }
 
   parse::registerTypeResolver();

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -75,7 +75,7 @@ ResultOrError ExpressionVerifier::verify(
     const RowVectorPtr& rowVector,
     VectorPtr&& resultVector,
     bool canThrow,
-    std::vector<column_index_t> columnsToWrapInLazy) {
+    std::vector<int> columnsToWrapInLazy) {
   for (int i = 0; i < plans.size(); ++i) {
     LOG(INFO) << "Executing expression " << i << " : " << plans[i]->toString();
   }
@@ -224,7 +224,7 @@ ResultOrError ExpressionVerifier::verify(
 
 void ExpressionVerifier::persistReproInfoIfNeeded(
     const VectorPtr& inputVector,
-    const std::vector<column_index_t>& columnsToWrapInLazy,
+    const std::vector<int>& columnsToWrapInLazy,
     const VectorPtr& resultVector,
     const std::string& sql,
     const std::vector<VectorPtr>& complexConstants) {
@@ -238,7 +238,7 @@ void ExpressionVerifier::persistReproInfoIfNeeded(
 
 void ExpressionVerifier::persistReproInfo(
     const VectorPtr& inputVector,
-    std::vector<column_index_t> columnsToWrapInLazy,
+    std::vector<int> columnsToWrapInLazy,
     const VectorPtr& resultVector,
     const std::string& sql,
     const std::vector<VectorPtr>& complexConstants) {
@@ -272,8 +272,7 @@ void ExpressionVerifier::persistReproInfo(
     lazyListPath =
         fmt::format("{}/{}", dirPath->c_str(), kIndicesOfLazyColumnsFileName);
     try {
-      saveStdVectorToFile<column_index_t>(
-          columnsToWrapInLazy, lazyListPath.c_str());
+      saveStdVectorToFile<int>(columnsToWrapInLazy, lazyListPath.c_str());
     } catch (std::exception& e) {
       lazyListPath = e.what();
     }

--- a/velox/expression/tests/ExpressionVerifier.h
+++ b/velox/expression/tests/ExpressionVerifier.h
@@ -51,10 +51,13 @@ class ExpressionVerifier {
       : execCtx_(execCtx), options_(options) {}
 
   // Executes expressions both using common path (all evaluation
-  // optimizations) and simplified path. Additionally, a sorted list of column
+  // optimizations) and simplified path. Additionally, a list of column
   // indices can be passed via 'columnsToWrapInLazy' which specify the
   // columns/children in the input row vector that should be wrapped in a lazy
-  // layer before running it through the common evaluation path.
+  // layer before running it through the common evaluation path. The list can
+  // contain negative column indices that represent lazy vectors that should be
+  // preloaded before being fed to the evaluator. This list is sorted on the
+  // absolute value of the entries.
   // Returns:
   //  - result of evaluating the expressions if both paths succeeded and
   //  returned the exact same vectors.
@@ -66,14 +69,14 @@ class ExpressionVerifier {
       const RowVectorPtr& rowVector,
       VectorPtr&& resultVector,
       bool canThrow,
-      std::vector<column_index_t> columnsToWarpInLazy = {});
+      std::vector<int> columnsToWarpInLazy = {});
 
  private:
   // Utility method used to serialize the relevant data required to repro a
   // crash.
   void persistReproInfo(
       const VectorPtr& inputVector,
-      std::vector<column_index_t> columnsToWarpInLazy,
+      std::vector<int> columnsToWarpInLazy,
       const VectorPtr& resultVector,
       const std::string& sql,
       const std::vector<VectorPtr>& complexConstants);
@@ -83,7 +86,7 @@ class ExpressionVerifier {
   // otherwise.
   void persistReproInfoIfNeeded(
       const VectorPtr& inputVector,
-      const std::vector<column_index_t>& columnsToWarpInLazy,
+      const std::vector<int>& columnsToWarpInLazy,
       const VectorPtr& resultVector,
       const std::string& sql,
       const std::vector<VectorPtr>& complexConstants);

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -729,6 +729,9 @@ void saveStdVectorToFile(const std::vector<T>& list, const char* filePath) {
 template void saveStdVectorToFile<column_index_t>(
     const std::vector<column_index_t>& list,
     const char* filePath);
+template void saveStdVectorToFile<int>(
+    const std::vector<int>& list,
+    const char* filePath);
 
 template <typename T>
 std::vector<T> restoreStdVectorFromFile(const char* filePath) {
@@ -743,6 +746,7 @@ std::vector<T> restoreStdVectorFromFile(const char* filePath) {
 
 template std::vector<column_index_t> restoreStdVectorFromFile<column_index_t>(
     const char* filePath);
+template std::vector<int> restoreStdVectorFromFile<int>(const char* filePath);
 
 void saveSelectivityVector(const SelectivityVector& rows, std::ostream& out) {
   auto range = rows.asRange();

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -883,7 +883,7 @@ RowVectorPtr VectorFuzzer::fuzzRowChildrenToLazy(RowVectorPtr rowVector) {
 
 RowVectorPtr VectorFuzzer::fuzzRowChildrenToLazy(
     RowVectorPtr rowVector,
-    const std::vector<column_index_t>& columnsToWrapInLazy) {
+    const std::vector<int>& columnsToWrapInLazy) {
   if (columnsToWrapInLazy.empty()) {
     return rowVector;
   }
@@ -894,9 +894,13 @@ RowVectorPtr VectorFuzzer::fuzzRowChildrenToLazy(
     VELOX_USER_CHECK_NOT_NULL(child);
     VELOX_USER_CHECK(!child->isLazy());
     if (listIndex < columnsToWrapInLazy.size() &&
-        i == columnsToWrapInLazy[listIndex]) {
-      listIndex++;
+        i == (column_index_t)std::abs(columnsToWrapInLazy[listIndex])) {
       child = VectorFuzzer::wrapInLazyVector(child);
+      if (columnsToWrapInLazy[listIndex] < 0) {
+        // Negative index represents a lazy vector that is loaded.
+        child->loadedVector();
+      }
+      listIndex++;
     }
     children.push_back(child);
   }

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -286,10 +286,12 @@ class VectorFuzzer {
   // Returns a copy of 'rowVector' but with the columns having indices listed in
   // 'columnsToWrapInLazy' wrapped in lazy encoding. Must only be used for input
   // row vectors where all children are non-null and non-lazy.
-  // 'columnsToWrapInLazy' should be a sorted list of column indices.
+  // 'columnsToWrapInLazy' can contain negative column indices that represent
+  // lazy vectors that should be preloaded before being fed to the evaluator.
+  // This list is sorted on the absolute value of the entries.
   static RowVectorPtr fuzzRowChildrenToLazy(
       RowVectorPtr rowVector,
-      const std::vector<column_index_t>& columnsToWrapInLazy);
+      const std::vector<int>& columnsToWrapInLazy);
 
   // Generate a random null buffer.
   BufferPtr fuzzNulls(vector_size_t size);


### PR DESCRIPTION
This change adds the ability to randomly pick columns in the input
row vector to wrap in lazy and load before feeding to common
evaluation path. It helps to simulate the case where a lazy vector
is loaded in a previous step before being fed to the evaluator.
(It would help catch issues like the one fixed in #4547)
It re-purposed the mechanism already in place that generates a list
of column indices to wrap in lazy and enhances it to use negative
indices as well which represent columns indices that should be
preloaded. This makes the change backwards compatible with repro
files generated before it and ensures minimal code changes.