### PR TITLE
Use WSReadFile::preadv from InputStream

### DIFF
--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -181,6 +181,11 @@ class ReadFileInputStream final : public InputStream {
 
   bool hasReadAsync() const override;
 
+  void vread(
+      const std::vector<void*>& buffers,
+      const std::vector<Region>& regions,
+      const LogType purpose) override;
+
   const std::shared_ptr<velox::ReadFile>& getReadFile() const {
     return readFile_;
   }

--- a/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
+++ b/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
@@ -44,3 +44,27 @@ TEST(ReadFileInputStream, SimpleUsage) {
   read_value = {buf.get(), 15};
   ASSERT_EQ(read_value, "aaaaabbbbbccccc");
 }
+
+TEST(ReadFileInputStream, vread) {
+  std::string fileData;
+  {
+    InMemoryWriteFile writeFile(&fileData);
+    writeFile.append("aaaaa");
+    writeFile.append("bbbbb");
+    writeFile.append("ccccc");
+  }
+  auto readFile = std::make_shared<InMemoryReadFile>(fileData);
+  ReadFileInputStream inputStream(readFile);
+  ASSERT_EQ(inputStream.getLength(), 15);
+
+  std::vector<std::string> buffers = {"1234567", "890"};
+
+  inputStream.vread(
+      {reinterpret_cast<void*>(buffers[0].data()),
+       reinterpret_cast<void*>(buffers[1].data())},
+      {{2, buffers[0].size()}, {10, buffers[1].size()}},
+      LogType::STREAM);
+
+  std::vector<std::string> result = {"aaabbbb", "ccc"};
+  ASSERT_EQ(buffers, result);
+}


### PR DESCRIPTION
Summary:
WSReadFile::preadv is implemented, but we can't call it from ReadFileInputStream yet.

Let's implement ReadFileInputStream::vread on top of it.

In the next diff I'll make [BufferedInput](https://fburl.com/code/j3fjppyh) to always call this vread API.

Differential Revision: D45789825

