### PR TITLE
Add fbthrift to build system

### DIFF
--- a/CMake/resolve_dependency_modules/boost.cmake
+++ b/CMake/resolve_dependency_modules/boost.cmake
@@ -24,3 +24,6 @@ set(Boost_NO_SYSTEM_PATHS ON)
 # We have to keep the FindBoost.cmake in an subfolder to prevent it from
 # overriding the system provided one when Boost_SOURCE=SYSTEM
 list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/boost)
+
+set(Boost_LIBRARIES headers;boost;atomic;context;date_time;filesystem;math;program_options;regex;system;thread)
+file(GLOB Boost_INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}/_deps/boost-src/libs/*/include/")

--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -59,5 +59,6 @@ FetchContent_MakeAvailable(Boost)
 # To aling with Boost system install we create Boost::headers target
 add_library(boost_headers INTERFACE)
 add_library(Boost::headers ALIAS boost_headers)
+add_library(Boost::boost ALIAS boost_headers)
 list(TRANSFORM BOOST_HEADER_ONLY PREPEND Boost::)
 target_link_libraries(boost_headers INTERFACE ${BOOST_HEADER_ONLY})

--- a/CMake/resolve_dependency_modules/fbthrift.cmake
+++ b/CMake/resolve_dependency_modules/fbthrift.cmake
@@ -1,0 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/fbthrift)

--- a/CMake/resolve_dependency_modules/fbthrift/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/fbthrift/CMakeLists.txt
@@ -1,0 +1,46 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FBTHRIFT_VERSION "2023.05.01.00")
+set(VELOX_FBTHRIFT_BUILD_SHA256_CHECKSUM 
+    7d6b9272c637a44767cb30e75d6f703fdfd6966bababa61fca773e68d299bfe0)
+set(VELOX_FBTHRIFT_SOURCE_URL 
+    "https://github.com/facebook/fbthrift/archive/refs/tags/v${VELOX_FBTHRIFT_VERSION}.tar.gz") 
+
+resolve_dependency_url(FBTHRIFT)
+message(STATUS "SEEE: ${Boost_INCLUDE_DIR}")
+message(STATUS "SEEE: ${folly_DIR}")
+message(STATUS "SEEE: ${folly_BINARY_DIR}")
+
+message(STATUS "Building FBThrift from source")
+
+FetchContent_Declare(
+  fbthrift
+  GIT_REPOSITORY https://github.com/facebook/fbthrift
+  GIT_TAG v2022.11.14.00
+  #PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/fbthrift-no-export.patch
+)
+
+set_source(fizz)
+resolve_dependency(fizz)
+
+set_source(wangle)
+resolve_dependency(wangle)
+
+set(enable_tests OFF)
+set(BUILD_SHARED_LIBS ON)
+
+add_compile_options(-w)
+FetchContent_MakeAvailable(fbthrift)

--- a/CMake/resolve_dependency_modules/fbthrift/fbthrift-no-export.patch
+++ b/CMake/resolve_dependency_modules/fbthrift/fbthrift-no-export.patch
@@ -1,0 +1,204 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 766130e072..8e30d0863e 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -89,7 +89,7 @@ if (compiler_only OR build_all)
+   set(THRIFT1 thrift1)
+   set(THRIFTCPP2 thriftcpp2)
+   include(ThriftLibrary.cmake)
+-  install(FILES ThriftLibrary.cmake DESTINATION ${INCLUDE_INSTALL_DIR}/thrift)
++  #install(FILES ThriftLibrary.cmake DESTINATION ${INCLUDE_INSTALL_DIR}/thrift)
+ endif ()
+ 
+ # Find required dependencies for thrift/lib
+diff --git a/thrift/CMakeLists.txt b/thrift/CMakeLists.txt
+index e03c78bc5a..55a0cc1127 100644
+--- a/thrift/CMakeLists.txt
++++ b/thrift/CMakeLists.txt
+@@ -36,22 +36,22 @@ configure_package_config_file(
+     BIN_INSTALL_DIR
+     INCLUDE_INSTALL_DIR
+ )
+-install(
+-  FILES ${CMAKE_CURRENT_BINARY_DIR}/FBThriftConfig.cmake
+-  DESTINATION ${CMAKE_INSTALL_DIR}
+-)
+-install(
+-  EXPORT fbthrift-exports
+-  FILE FBThriftTargets.cmake
+-  NAMESPACE FBThrift::
+-  DESTINATION ${CMAKE_INSTALL_DIR}
+-)
++#install(
++#  FILES ${CMAKE_CURRENT_BINARY_DIR}/FBThriftConfig.cmake
++#  DESTINATION ${CMAKE_INSTALL_DIR}
++#)
++#install(
++#  EXPORT fbthrift-exports
++#  FILE FBThriftTargets.cmake
++#  NAMESPACE FBThrift::
++#  DESTINATION ${CMAKE_INSTALL_DIR}
++#)
+ 
+-install(
+-  DIRECTORY annotation "${CMAKE_CURRENT_BINARY_DIR}/annotation"
+-  DESTINATION include/thrift
+-  FILES_MATCHING
+-    PATTERN "*.h"
+-    PATTERN "*.tcc"
+-    PATTERN CMakeFiles EXCLUDE
+-)
++#install(
++#  DIRECTORY annotation "${CMAKE_CURRENT_BINARY_DIR}/annotation"
++#  DESTINATION include/thrift
++#  FILES_MATCHING
++#    PATTERN "*.h"
++#    PATTERN "*.tcc"
++#    PATTERN CMakeFiles EXCLUDE
++#)
+diff --git a/thrift/compiler/CMakeLists.txt b/thrift/compiler/CMakeLists.txt
+index 4e32281d19..dcfedf1512 100644
+--- a/thrift/compiler/CMakeLists.txt
++++ b/thrift/compiler/CMakeLists.txt
+@@ -151,10 +151,10 @@ if (BUILD_SHARED_LIBS)
+   )
+ endif ()
+ 
+-install(
+-  TARGETS thrift1 compiler_ast compiler_base compiler mustache
+-  EXPORT fbthrift-exports
+-  RUNTIME DESTINATION ${BIN_INSTALL_DIR}
+-  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+-  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+-)
++#install(
++#  TARGETS thrift1 compiler_ast compiler_base compiler mustache
++#  EXPORT fbthrift-exports
++#  RUNTIME DESTINATION ${BIN_INSTALL_DIR}
++#  LIBRARY DESTINATION ${LIB_INSTALL_DIR}
++#  ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
++#)
+diff --git a/thrift/lib/CMakeLists.txt b/thrift/lib/CMakeLists.txt
+index 101f2d1ddc..a1ac0f8f35 100644
+--- a/thrift/lib/CMakeLists.txt
++++ b/thrift/lib/CMakeLists.txt
+@@ -30,11 +30,11 @@ set(LIB_DIRS
+   cpp2
+   py3
+ )
+-foreach(dir ${LIB_DIRS})
+-  install(DIRECTORY ${dir} "${CMAKE_CURRENT_BINARY_DIR}/${dir}"
+-        DESTINATION include/thrift/lib
+-        FILES_MATCHING
+-          PATTERN "*.h"
+-          PATTERN "*.tcc"
+-          PATTERN CMakeFiles EXCLUDE)
+-endforeach()
++#foreach(dir ${LIB_DIRS})
++#  install(DIRECTORY ${dir} "${CMAKE_CURRENT_BINARY_DIR}/${dir}"
++#        DESTINATION include/thrift/lib
++#        FILES_MATCHING
++#          PATTERN "*.h"
++#          PATTERN "*.tcc"
++#          PATTERN CMakeFiles EXCLUDE)
++#endforeach()
+diff --git a/thrift/lib/cpp/CMakeLists.txt b/thrift/lib/cpp/CMakeLists.txt
+index 678ce38b41..1ef6ea3bc7 100644
+--- a/thrift/lib/cpp/CMakeLists.txt
++++ b/thrift/lib/cpp/CMakeLists.txt
+@@ -136,12 +136,12 @@ set(THRIFT1_HEADER_DIRS
+   server
+   transport
+ )
+-foreach(dir ${THRIFT1_HEADER_DIRS})
+-  install(DIRECTORY ${dir} DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp
+-          FILES_MATCHING PATTERN "*.h")
+-  install(DIRECTORY ${dir} DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp
+-          FILES_MATCHING PATTERN "*.tcc")
+-endforeach()
++#foreach(dir ${THRIFT1_HEADER_DIRS})
++#  install(DIRECTORY ${dir} DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp
++#          FILES_MATCHING PATTERN "*.h")
++#  install(DIRECTORY ${dir} DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp
++#          FILES_MATCHING PATTERN "*.tcc")
++#endforeach()
+ 
+ if (BUILD_SHARED_LIBS)
+   # all but thrift since it's an interface
+@@ -150,13 +150,13 @@ if (BUILD_SHARED_LIBS)
+     )
+ endif()
+ 
+-install(
+-  TARGETS
+-    thrift-core
+-    concurrency
+-    transport
+-    async
+-    thrift
+-  EXPORT fbthrift-exports
+-  DESTINATION ${LIB_INSTALL_DIR}
+-)
++#install(
++#  TARGETS
++#    thrift-core
++#    concurrency
++#    transport
++#    async
++#    thrift
++#  EXPORT fbthrift-exports
++#  DESTINATION ${LIB_INSTALL_DIR}
++#)
+diff --git a/thrift/lib/cpp2/CMakeLists.txt b/thrift/lib/cpp2/CMakeLists.txt
+index 71b6018747..172bf42999 100644
+--- a/thrift/lib/cpp2/CMakeLists.txt
++++ b/thrift/lib/cpp2/CMakeLists.txt
+@@ -370,11 +370,11 @@ set(THRIFT2_HEADER_DIRS
+   transport
+   util
+ )
+-install(
+-  DIRECTORY ${THRIFT2_HEADER_DIRS}
+-  DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp2
+-  FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc"
+-)
++#install(
++#  DIRECTORY ${THRIFT2_HEADER_DIRS}
++#  DESTINATION ${INCLUDE_INSTALL_DIR}/thrift/lib/cpp2
++#  FILES_MATCHING PATTERN "*.h" PATTERN "*.tcc"
++#)
+ 
+ if (BUILD_SHARED_LIBS)
+   set_target_properties(rpcmetadata thriftannotation thriftmetadata
+@@ -383,17 +383,17 @@ if (BUILD_SHARED_LIBS)
+     )
+ endif()
+ 
+-install(
+-  TARGETS
+-    rpcmetadata
+-    thriftannotation
+-    thriftmetadata
+-    thriftfrozen2
+-    thrifttyperep
+-    thrifttype
+-    thriftanyrep
+-    thriftprotocol
+-    thriftcpp2
+-  EXPORT fbthrift-exports
+-  DESTINATION ${LIB_INSTALL_DIR}
+-)
++#install(
++#  TARGETS
++#    rpcmetadata
++#    thriftannotation
++#    thriftmetadata
++#    thriftfrozen2
++#    thrifttyperep
++#    thrifttype
++#    thriftanyrep
++#    thriftprotocol
++#    thriftcpp2
++#  EXPORT fbthrift-exports
++#  DESTINATION ${LIB_INSTALL_DIR}
++#)

--- a/CMake/resolve_dependency_modules/fizz.cmake
+++ b/CMake/resolve_dependency_modules/fizz.cmake
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_FIZZ_VERSION "2023.05.08.00")
+set(VELOX_FIZZ_BUILD_SHA256_CHECKSUM 
+    ad1bad61b1079aa1f5b73682672145c8bec558fa91b3511253fc9673b84b3e4b)
+set(VELOX_FIZZ_SOURCE_URL 
+    "https://github.com/facebookincubator/fizz/archive/refs/tags/v${VELOX_FIZZ_VERSION}.tar.gz")
+
+resolve_dependency_url(FIZZ)
+
+message(STATUS "Building Fizz from source ${VELOX_FIZZ_SOURCE_URL} - ${VELOX_FIZZ_BUILD_SHA256_CHECKSUM}")
+FetchContent_Declare(
+  fizz
+  URL ${VELOX_FIZZ_SOURCE_URL}
+  URL_HASH ${VELOX_FIZZ_BUILD_SHA256_CHECKSUM}
+  OVERRIDE_FIND_PACKAGE)
+
+FetchContent_MakeAvailable(fizz)
+list(APPEND CMAKE_PREFIX_PATH ${fizz_BINARY_DIR})

--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -34,7 +34,8 @@ FetchContent_Declare(
   URL ${VELOX_FOLLY_SOURCE_URL}
   URL_HASH ${VELOX_FOLLY_BUILD_SHA256_CHECKSUM}
   PATCH_COMMAND git apply ${CMAKE_CURRENT_LIST_DIR}/folly-no-export.patch
-                ${glog_patch})
+                ${glog_patch}
+  OVERRIDE_FIND_PACKAGE)
 
 if(ON_APPLE_M1)
   # folly will wrongly assume x86_64 if this is not set

--- a/CMake/resolve_dependency_modules/wangle.cmake
+++ b/CMake/resolve_dependency_modules/wangle.cmake
@@ -1,0 +1,35 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_WANGLE_VERSION "2023.05.08.00")
+set(VELOX_WANGLE_BUILD_SHA256_CHECKSUM 
+    e43d9035cf5e403287c2c7ba2b4b29f52afeae7bc50abb8dbb2b62cdfd9638da)
+set(VELOX_WANGLE_SOURCE_URL 
+    "https://github.com/facebook/wangle/archive/refs/tags/v${VELOX_WANGLE_VERSION}.tar.gz")
+
+resolve_dependency_url(WANGLE)
+
+message(STATUS "Building Wangle from source")
+FetchContent_Declare(
+  wangle
+  URL ${VELOX_WANGLE_SOURCE_URL}
+  URL_HASH ${VELOX_WANGLE_BUILD_SHA256_CHECKSUM}
+  OVERRIDE_FIND_PACKAGE)
+
+FetchContent_MakeAvailable(wangle)
+list(APPEND CMAKE_PREFIX_PATH ${wangle_BINARY_DIR})
+
+add_library(wangle INTERFACE)
+add_library(wangle::wangle ALIAS wangle)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ option(VELOX_ENABLE_S3 "Build S3 Connector" OFF)
 option(VELOX_ENABLE_HDFS "Build Hdfs Connector" OFF)
 option(VELOX_ENABLE_PARQUET "Enable Parquet support" OFF)
 option(VELOX_ENABLE_ARROW "Enable Arrow support" OFF)
+option(VELOX_ENABLE_FBTHRIFT "Enable FBThrift support" OFF)
 option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 
 option(VELOX_BUILD_TEST_UTILS "Builds Velox test utilities" OFF)
@@ -290,6 +291,8 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-strict-aliasing \
          -Wno-type-limits \
          -Wno-stringop-overflow \
+         -Wno-stringop-overread \
+         -Wno-deprecated-declarations \
          -Wno-return-type")
   endif()
 
@@ -320,10 +323,12 @@ resolve_dependency(ICU)
 
 set(BOOST_INCLUDE_LIBRARIES
     headers
+    boost
     atomic
     context
     date_time
     filesystem
+    math
     program_options
     regex
     system
@@ -393,6 +398,11 @@ if(DEFINED FOLLY_BENCHMARK_STATIC_LIB)
   set(FOLLY_BENCHMARK ${FOLLY_BENCHMARK_STATIC_LIB})
 else()
   set(FOLLY_BENCHMARK Folly::follybenchmark)
+endif()
+
+if(VELOX_ENABLE_REMOTE_FUNCTION)
+  set_source(FBThrift)
+  resolve_dependency(FBThrift)
 endif()
 
 if(NOT ${VELOX_BUILD_MINIMAL})

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ release:				#: Build the release version
 	$(MAKE) build BUILD_DIR=release
 
 min_debug:				#: Minimal build with debugging symbols
-	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=debug EXTRA_CMAKE_FLAGS=-DVELOX_BUILD_MINIMAL=ON
+	$(MAKE) cmake BUILD_DIR=debug BUILD_TYPE=debug EXTRA_CMAKE_FLAGS="-DVELOX_BUILD_MINIMAL=ON ${EXTRA_CMAKE_FLAGS}"
 	$(MAKE) build BUILD_DIR=debug
 
 benchmarks-basic-build:


### PR DESCRIPTION
Adding fbthrift and its dependencies to our build system. It will be used in the next PR for remote function execution. 