### PR TITLE
Add type check to VectorHasher::decode

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -172,6 +172,11 @@ class VectorHasher {
   // computeValueIds(). The decoded vector can be accessed via decodedVector()
   // getter.
   void decode(const BaseVector& vector, const SelectivityVector& rows) {
+    VELOX_CHECK(
+        type_->kindEquals(vector.type()),
+        "Type mismatch: {} vs. {}",
+        type_->toString(),
+        vector.type()->toString());
     decoded_.decode(vector, rows);
   }
 

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/exec/VectorHasher.h"
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/type/Type.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
 
@@ -941,4 +942,16 @@ TEST_F(VectorHasherTest, simdRange) {
           result[i]);
     }
   }
+}
+
+TEST_F(VectorHasherTest, typeMismatch) {
+  auto hasher = VectorHasher::create(BIGINT(), 0);
+
+  auto data = vectorMaker_->flatVector<std::string>(
+      {"a",
+       "b"
+       "c"});
+  SelectivityVector rows(data->size());
+  VELOX_ASSERT_THROW(
+      hasher->decode(*data, rows), "Type mismatch: BIGINT vs. VARCHAR");
 }


### PR DESCRIPTION
Type mismatch between type passed to VectorHasher's constructor and vector type
passed to VectorHasher::decode causes hard-to-debug crashes. Add explicit check
to fail fast and avoid the crash.

```
*** Aborted at 1683747754 (Unix time, try 'date -d @1683747754') ***
*** Signal 11 (SIGSEGV) (0x0) received by PID 72 (pthread TID 0x7f6aa2a00640) (linux TID 692) (code: address not mapped to object), stack trace: ***
@ 000000000e88b72d folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
./fbcode/folly/experimental/symbolizer/SignalHandler.cpp:449
@ 000000000004459f (unknown)
@ 000000000301463d folly::hash::SpookyHashV2::Hash128(void const*, unsigned long, unsigned long*, unsigned long*)
./fbcode/folly/hash/SpookyHashV2.h:148
-> ./fbcode/folly/hash/SpookyHashV2.cpp
@ 000000000c2a2bbb facebook::velox::exec::VectorHasher::hashValues<(facebook::velox::TypeKind)7>(facebook::velox::SelectivityVector const&, bool, unsigned long*)::{lambda(int)#2}::operator()(int) const
```