### PR TITLE
Use references instead of pointers

### DIFF
--- a/velox/common/file/Utils.cpp
+++ b/velox/common/file/Utils.cpp
@@ -20,10 +20,10 @@
 namespace facebook::velox::file::utils {
 
 bool CoalesceIfDistanceLE::operator()(
-    const ReadFile::Segment* a,
-    const ReadFile::Segment* b) const {
-  VELOX_CHECK_LE(a->offset, b->offset, "Segments to combine must be sorted.");
-  const uint64_t beginGap = a->offset + a->buffer.size(), endGap = b->offset;
+    const ReadFile::Segment& a,
+    const ReadFile::Segment& b) const {
+  VELOX_CHECK_LE(a.offset, b.offset, "Segments to combine must be sorted.");
+  const uint64_t beginGap = a.offset + a.buffer.size(), endGap = b.offset;
 
   VELOX_CHECK_LE(beginGap, endGap, "Segments to combine can't overlap.");
   const uint64_t gap = endGap - beginGap;

--- a/velox/common/file/tests/TestUtils.cpp
+++ b/velox/common/file/tests/TestUtils.cpp
@@ -32,9 +32,6 @@ Result getSegments(
     }
     lastOffset += buffer.size();
   }
-  for (auto& segment : result.segments) {
-    result.segmentPtrs.emplace_back(&segment);
-  }
   return result;
 }
 

--- a/velox/common/file/tests/TestUtils.h
+++ b/velox/common/file/tests/TestUtils.h
@@ -23,7 +23,6 @@ namespace facebook::velox::tests::utils {
 struct Result {
   std::vector<std::string> buffers;
   std::vector<ReadFile::Segment> segments;
-  std::vector<ReadFile::Segment*> segmentPtrs;
 };
 
 Result getSegments(


### PR DESCRIPTION
Summary: Changing to pointers since we won't need to sort the input. We'll expect it to be sorted.

Differential Revision: D45821606

