### PR TITLE
Fix compilation issues in GCC 12

### DIFF
--- a/CMake/resolve_dependency_modules/boost/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/boost/CMakeLists.txt
@@ -48,7 +48,15 @@ FetchContent_Declare(
 configure_file(${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake.in
                ${CMAKE_CURRENT_LIST_DIR}/FindBoost.cmake @ONLY)
 
-set(BOOST_HEADER_ONLY crc circular_buffer multi_index random uuid variant)
+set(BOOST_HEADER_ONLY
+    crc
+    circular_buffer
+    math
+    multi_index
+    numeric_conversion
+    random
+    uuid
+    variant)
 list(APPEND BOOST_INCLUDE_LIBRARIES ${BOOST_HEADER_ONLY})
 
 # The `headers` target is not created by Boost cmake and leads to a warning

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -290,6 +290,7 @@ if("${ENABLE_ALL_WARNINGS}")
          -Wno-strict-aliasing \
          -Wno-type-limits \
          -Wno-stringop-overflow \
+         -Wno-stringop-overread \
          -Wno-return-type")
   endif()
 

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -73,6 +73,11 @@ target_link_libraries(
   ${TEST_LINK_LIBS})
 
 if(VELOX_ENABLE_ARROW)
+  # The duckdb include on BitPackDecoderTest.cpp triggers this error in gcc.
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+  endif()
+
   add_executable(velox_dwio_common_bitpack_decoder_benchmark
                  BitPackDecoderBenchmark.cpp)
   target_link_libraries(

--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -27,10 +27,6 @@
 #include <vector>
 #include "folly/CPortability.h"
 #include "folly/Likely.h"
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#include "folly/ssl/OpenSSLHash.h"
-#pragma GCC diagnostic pop
 #include "velox/common/base/Exceptions.h"
 #include "velox/external/md5/md5.h"
 #include "velox/functions/lib/string/StringCore.h"

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
+# up failing compilation in an openssl header included by a hash-related
+# function.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 add_library(
   velox_functions_prestosql
   ArithmeticFunctionsRegistration.cpp

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -11,6 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
+# up failing compilation in an openssl header included by a hash-related
+# function.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 add_library(
   velox_functions_spark
   ArraySort.cpp

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -15,6 +15,11 @@
  */
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#include "folly/ssl/OpenSSLHash.h"
+#pragma GCC diagnostic pop
+
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/UDFOutputString.h"


### PR DESCRIPTION
Fix a few more compilation issues in Fedora with GCC 12:

- Add boost math missing dependency.
- Disabling "deprecated-declarations" in two libraries. It looks like GCC 12 has a bug where it does not respect the explicit pragma ignore directives added for that very purpose. Added a check to ignore in the two libraries that fail - error comes from an include from openssl. 
- Disabling stringop-overread warning coming from folly. Warning seems legit, disabling it for now. 
