### PR TITLE
Fix Expression::rewriteInputNames

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -21,22 +21,6 @@
 
 namespace facebook::velox::core {
 
-namespace {
-inline RowTypePtr rewriteNames(
-    const RowTypePtr& rowType,
-    const std::unordered_map<std::string, std::string>& mapping) {
-  std::vector<std::string> newNames;
-  newNames.reserve(rowType->size());
-  for (const auto& name : rowType->names()) {
-    auto it = mapping.find(name);
-    auto newName = it == mapping.end() ? name : it->second;
-    newNames.emplace_back(newName);
-  }
-  auto newTypes = rowType->children();
-  return ROW(std::move(newNames), std::move(newTypes));
-}
-} // namespace
-
 class InputTypedExpr : public ITypedExpr {
  public:
   InputTypedExpr(std::shared_ptr<const Type> type)
@@ -57,13 +41,8 @@ class InputTypedExpr : public ITypedExpr {
   }
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& /*mapping*/)
       const override {
-    if (type()->isRow()) {
-      auto rowType = std::dynamic_pointer_cast<const RowType>(type());
-      return std::make_shared<InputTypedExpr>(rewriteNames(rowType, mapping));
-    }
-
     return std::make_shared<InputTypedExpr>(type());
   }
 
@@ -134,7 +113,7 @@ class ConstantTypedExpr : public ITypedExpr {
   }
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& /*mapping*/)
+      const std::unordered_map<std::string, TypedExprPtr>& /*mapping*/)
       const override {
     if (hasValueVector()) {
       return std::make_shared<ConstantTypedExpr>(valueVector_);
@@ -195,7 +174,7 @@ class CallTypedExpr : public ITypedExpr {
   }
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
     return std::make_shared<CallTypedExpr>(
         type(), rewriteInputsRecursive(mapping), name_);
@@ -271,18 +250,32 @@ class FieldAccessTypedExpr : public ITypedExpr {
   }
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
-    auto it = mapping.find(name_);
-    auto newName = it == mapping.end() ? name_ : it->second;
     if (inputs().empty()) {
-      return std::make_shared<FieldAccessTypedExpr>(type(), std::move(newName));
+      auto it = mapping.find(name_);
+      return it != mapping.end()
+          ? it->second
+          : std::make_shared<FieldAccessTypedExpr>(type(), name_);
     }
 
     auto newInputs = rewriteInputsRecursive(mapping);
     VELOX_CHECK_EQ(1, newInputs.size());
-    return std::make_shared<FieldAccessTypedExpr>(
-        type(), newInputs[0], std::move(newName));
+    // Only rewrite name if input in InputTypedExpr. Rewrite in other
+    // cases(like dereference) is unsound.
+    if (std::dynamic_pointer_cast<const InputTypedExpr>(newInputs[0]) !=
+        nullptr) {
+      auto it = mapping.find(name_);
+      if (it != mapping.end()) {
+        auto name =
+            std::dynamic_pointer_cast<const FieldAccessTypedExpr>(it->second);
+        if (name != nullptr) {
+          return std::make_shared<FieldAccessTypedExpr>(
+              type(), newInputs[0], name->name());
+        }
+      }
+    }
+    return std::make_shared<FieldAccessTypedExpr>(type(), newInputs[0], name_);
   }
 
   std::string toString() const override {
@@ -343,7 +336,7 @@ class ConcatTypedExpr : public ITypedExpr {
       : ITypedExpr{toType(names, inputs), inputs} {}
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
     return std::make_shared<ConcatTypedExpr>(
         type()->asRow().names(), rewriteInputsRecursive(mapping));
@@ -417,10 +410,15 @@ class LambdaTypedExpr : public ITypedExpr {
   }
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
+    for (const auto& name : signature_->names()) {
+      if (mapping.count(name)) {
+        VELOX_USER_FAIL("Ambiguous variable: {}", name);
+      }
+    }
     return std::make_shared<LambdaTypedExpr>(
-        rewriteNames(signature_, mapping), body_->rewriteInputNames(mapping));
+        signature_, body_->rewriteInputNames(mapping));
   }
 
   std::string toString() const override {
@@ -459,7 +457,7 @@ class CastTypedExpr : public ITypedExpr {
       : ITypedExpr{type, inputs}, nullOnFailure_(nullOnFailure) {}
 
   TypedExprPtr rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping)
+      const std::unordered_map<std::string, TypedExprPtr>& mapping)
       const override {
     return std::make_shared<CastTypedExpr>(
         type(), rewriteInputsRecursive(mapping), nullOnFailure_);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -74,6 +74,7 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& remainingFilter) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
+  std::unordered_map<std::string, core::TypedExprPtr> typedMapping;
   for (uint32_t i = 0; i < outputType->size(); ++i) {
     const auto& name = outputType->nameOf(i);
     const auto& type = outputType->childAt(i);
@@ -82,6 +83,9 @@ PlanBuilder& PlanBuilder::tableScan(
     auto it = columnAliases.find(name);
     if (it != columnAliases.end()) {
       hiveColumnName = it->second;
+      typedMapping.emplace(
+          name,
+          std::make_shared<core::FieldAccessTypedExpr>(type, hiveColumnName));
     }
 
     assignments.insert(
@@ -116,7 +120,7 @@ PlanBuilder& PlanBuilder::tableScan(
   if (!remainingFilter.empty()) {
     remainingFilterExpr =
         parseExpr(remainingFilter, outputType, options_, pool_)
-            ->rewriteInputNames(columnAliases);
+            ->rewriteInputNames(typedMapping);
   }
 
   auto tableHandle = std::make_shared<HiveTableHandle>(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -54,6 +54,15 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType,
+      const std::vector<TypePtr>& lambdaInputTypes) {
+    auto untyped = parse::parseExpr(text, options_);
+    return core::Expressions::inferTypes(
+        untyped, rowType, lambdaInputTypes, execCtx_->pool(), nullptr);
+  }
+
   template <typename T = exec::ExprSet>
   std::unique_ptr<T> compileExpression(
       const std::string& expr,
@@ -1932,9 +1941,11 @@ TEST_F(ExprTest, complexNullOutput) {
 TEST_F(ExprTest, rewriteInputs) {
   // rewrite one field
   {
+    auto alpha =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "alpha");
     auto expr = parseExpression(
         "(a + b) * 2.1", ROW({"a", "b"}, {INTEGER(), DOUBLE()}));
-    expr = expr->rewriteInputNames({{"a", "alpha"}});
+    expr = expr->rewriteInputNames({{"a", alpha}});
 
     auto expectedExpr = parseExpression(
         "(alpha + b) * 2.1", ROW({"alpha", "b"}, {INTEGER(), DOUBLE()}));
@@ -1943,13 +1954,42 @@ TEST_F(ExprTest, rewriteInputs) {
 
   // rewrite 2 fields
   {
+    auto alpha =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "alpha");
+    auto beta = std::make_shared<core::FieldAccessTypedExpr>(DOUBLE(), "beta");
     auto expr = parseExpression(
         "a + b * c", ROW({"a", "b", "c"}, {INTEGER(), DOUBLE(), DOUBLE()}));
-    expr = expr->rewriteInputNames({{"a", "alpha"}, {"b", "beta"}});
+    expr = expr->rewriteInputNames({{"a", alpha}, {"b", beta}});
 
     auto expectedExpr = parseExpression(
         "alpha + beta * c",
         ROW({"alpha", "beta", "c"}, {INTEGER(), DOUBLE(), DOUBLE()}));
+    ASSERT_EQ(*expectedExpr, *expr);
+  }
+
+  // rewrite with lambda
+  {
+    auto alpha =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "alpha");
+    auto expr =
+        parseExpression("i -> i * a", ROW({"a"}, {INTEGER()}), {INTEGER()});
+    expr = expr->rewriteInputNames({{"a", alpha}});
+
+    auto expectedExpr = parseExpression(
+        "i -> i * alpha", ROW({"alpha"}, {INTEGER()}), {INTEGER()});
+    ASSERT_EQ(*expectedExpr, *expr);
+  }
+
+  // no rewrite with dereference
+  {
+    auto alpha =
+        std::make_shared<core::FieldAccessTypedExpr>(INTEGER(), "alpha");
+    auto expr = parseExpression(
+        "i -> i * b.a", ROW({"b"}, {ROW({"a"}, {INTEGER()})}), {INTEGER()});
+    expr = expr->rewriteInputNames({{"a", alpha}});
+
+    auto expectedExpr = parseExpression(
+        "i -> i * b.a", ROW({"b"}, {ROW({"a"}, {INTEGER()})}), {INTEGER()});
     ASSERT_EQ(*expectedExpr, *expr);
   }
 }

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -38,6 +38,13 @@ class Expressions {
       memory::MemoryPool* pool,
       const VectorPtr& complexConstants = nullptr);
 
+  static TypedExprPtr inferTypes(
+      const std::shared_ptr<const IExpr>& expr,
+      const TypePtr& input,
+      const std::vector<TypePtr>& lambdaInputTypes,
+      memory::MemoryPool* pool,
+      const VectorPtr& complexConstants = nullptr);
+
   static TypePtr getInputRowType(const TypedExprPtr& expr);
 
   static void setTypeResolverHook(TypeResolverHook hook) {
@@ -49,13 +56,6 @@ class Expressions {
   }
 
  private:
-  static TypedExprPtr inferTypes(
-      const std::shared_ptr<const IExpr>& expr,
-      const TypePtr& input,
-      const std::vector<TypePtr>& lambdaInputTypes,
-      memory::MemoryPool* pool,
-      const VectorPtr& complexConstants = nullptr);
-
   static TypedExprPtr resolveLambdaExpr(
       const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
       const TypePtr& inputRow,


### PR DESCRIPTION
Issue: https://github.com/prestodb/presto/issues/19589

Let's rework the rewriteNames() api. This is used to replace names in an expression. Consider expression:

BIND((field_0) * (field_0), (expr_17, expr) -> (expr) * (expr_17)))

BIND is just a syntactic sugar, that is needed by Presto. This is evaluated as 

expr -> (expr) * ((field_0) * (field_0))

So our mapping needs to be string -> Expression instead of string -> string.

Also we should not rewrite things like dereferences(x in a.x), and names(x in ROW(x int)). Added unit tests for this.

PrestoCpp change for this: https://github.com/facebookincubator/velox/pull/4928/files

Added e2e query tests there, for nested lambda as well. We should advance velox version after this and merge that asap. What's the policy for failing CI due to breaking changes?