### PR TITLE
Save all top level sibling expressions to file when evaluation fails

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -481,8 +481,9 @@ class ExprExceptionContext {
  public:
   ExprExceptionContext(
       const Expr* FOLLY_NONNULL expr,
-      const RowVector* FOLLY_NONNULL vector)
-      : expr_(expr), vector_(vector) {}
+      const RowVector* FOLLY_NONNULL vector,
+      const ExprSet* FOLLY_NULLABLE parentExprSet)
+      : expr_(expr), vector_(vector), parentExprSet_(parentExprSet) {}
 
   /// Persist data and sql on disk. Data will be persisted in $basePath/vector
   /// and sql will be persisted in $basePath/sql
@@ -521,6 +522,30 @@ class ExprExceptionContext {
       sqlPath_ = e.what();
       return;
     }
+
+    if (parentExprSet_ != nullptr) {
+      std::stringstream allSql;
+      auto exprs = parentExprSet_->exprs();
+      for (int i = 0; i < exprs.size(); ++i) {
+        if (i > 0) {
+          allSql << ", ";
+        }
+        allSql << exprs[i]->toSql();
+      }
+      try {
+        auto sqlPathOpt = common::generateTempFilePath(basePath, "allExprSql");
+        if (!sqlPathOpt.has_value()) {
+          allExprSqlPath_ =
+              "Failed to create file for saving all SQL expressions.";
+          return;
+        }
+        allExprSqlPath_ = sqlPathOpt.value();
+        saveStringToFile(allSql.str(), allExprSqlPath_.c_str());
+      } catch (std::exception& e) {
+        allExprSqlPath_ = e.what();
+        return;
+      }
+    }
   }
 
   const Expr* FOLLY_NONNULL expr() const {
@@ -539,6 +564,10 @@ class ExprExceptionContext {
     return sqlPath_;
   }
 
+  const std::string& allExprSqlPath() const {
+    return allExprSqlPath_;
+  }
+
  private:
   /// The expression.
   const Expr* FOLLY_NONNULL expr_;
@@ -548,6 +577,9 @@ class ExprExceptionContext {
   /// the time of exception.
   const RowVector* FOLLY_NONNULL vector_;
 
+  // The parent ExprSet that is executing this expression.
+  const ExprSet* FOLLY_NULLABLE parentExprSet_;
+
   /// Path of the file storing the serialized 'vector'. Used to avoid
   /// serializing vector repeatedly in cases when multiple rows generate
   /// exceptions. This happens when exceptions are suppressed by TRY/AND/OR.
@@ -556,6 +588,11 @@ class ExprExceptionContext {
   /// Path of the file storing the expression SQL. Used to avoid writing SQL
   /// repeatedly in cases when multiple rows generate exceptions.
   std::string sqlPath_{""};
+
+  /// Path of the file storing the SQL for all expressions in the ExprSet that
+  /// was executing this expression. Useful if the bug that caused the error was
+  /// encountered due to some mutation from running the other expressions.
+  std::string allExprSqlPath_{"N/A"};
 };
 
 /// Used to generate context for an error occurred while evaluating
@@ -592,10 +629,11 @@ std::string onTopLevelException(VeloxException::Type exceptionType, void* arg) {
   context->persistDataAndSql(basePath);
 
   return fmt::format(
-      "{}. Input data: {}. SQL expression: {}.",
+      "{}. Input data: {}. SQL expression: {}. All SQL expressions: {}.",
       context->expr()->toString(),
       context->dataPath(),
-      context->sqlPath());
+      context->sqlPath(),
+      context->allExprSqlPath());
 }
 
 /// Used to generate context for an error occurred while evaluating
@@ -610,7 +648,7 @@ void Expr::evalFlatNoNulls(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result,
-    bool topLevel) {
+    const ExprSet* parentExprSet) {
   if (shouldEvaluateSharedSubexp()) {
     evaluateSharedSubexpr(
         rows,
@@ -619,10 +657,10 @@ void Expr::evalFlatNoNulls(
         [&](const SelectivityVector& rows,
             EvalCtx& context,
             VectorPtr& result) {
-          evalFlatNoNullsImpl(rows, context, result, topLevel);
+          evalFlatNoNullsImpl(rows, context, result, parentExprSet);
         });
   } else {
-    evalFlatNoNullsImpl(rows, context, result, topLevel);
+    evalFlatNoNullsImpl(rows, context, result, parentExprSet);
   }
 }
 
@@ -630,11 +668,11 @@ void Expr::evalFlatNoNullsImpl(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result,
-    bool topLevel) {
-  ExprExceptionContext exprExceptionContext{this, context.row()};
+    const ExprSet* parentExprSet) {
+  ExprExceptionContext exprExceptionContext{this, context.row(), parentExprSet};
   ExceptionContextSetter exceptionContext(
-      {topLevel ? onTopLevelException : onException,
-       topLevel ? (void*)&exprExceptionContext : this});
+      {parentExprSet ? onTopLevelException : onException,
+       parentExprSet ? (void*)&exprExceptionContext : this});
 
   if (isSpecialForm()) {
     evalSpecialFormWithStats(rows, context, result);
@@ -669,19 +707,19 @@ void Expr::eval(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result,
-    bool topLevel) {
+    const ExprSet* parentExprSet) {
   if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
       context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
-    evalFlatNoNulls(rows, context, result, topLevel);
+    evalFlatNoNulls(rows, context, result, parentExprSet);
     return;
   }
 
   // Make sure to include current expression in the error message in case of an
   // exception.
-  ExprExceptionContext exprExceptionContext{this, context.row()};
+  ExprExceptionContext exprExceptionContext{this, context.row(), parentExprSet};
   ExceptionContextSetter exceptionContext(
-      {topLevel ? onTopLevelException : onException,
-       topLevel ? (void*)&exprExceptionContext : this});
+      {parentExprSet ? onTopLevelException : onException,
+       parentExprSet ? (void*)&exprExceptionContext : this});
 
   if (!rows.hasSelections()) {
     // empty input, return an empty vector of the right type
@@ -1645,7 +1683,7 @@ void ExprSet::eval(
   }
 
   for (int32_t i = begin; i < end; ++i) {
-    exprs_[i]->eval(rows, context, result[i], true /*topLevel*/);
+    exprs_[i]->eval(rows, context, result[i], this);
   }
 }
 

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -171,13 +171,15 @@ class Expr {
 
   /// Evaluates the expression for the specified 'rows'.
   ///
-  /// @param topLevel Boolean indicating whether this is a top-level expression
-  /// or one of the sub-expressions. Used to setup exception context.
+  /// @param parentExprSet pointer to the parent ExprSet which is calling
+  /// evaluate on this expression. Should only be set for top level expressions
+  /// and not passed on to child expressions as it is ssed to setup exception
+  /// context.
   void eval(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result,
-      bool topLevel = false);
+      const ExprSet* FOLLY_NULLABLE parentExprSet = nullptr);
 
   /// Evaluates the expression using fast path that assumes all inputs and
   /// intermediate results are flat or constant and have no nulls.
@@ -188,19 +190,21 @@ class Expr {
   /// path is enabled only for batch sizes less than 1'000 and expressions where
   /// all input and intermediate types are primitive and not strings.
   ///
-  /// @param topLevel Boolean indicating whether this is a top-level expression
-  /// or one of the sub-expressions. Used to setup exception context.
+  /// @param parentExprSet pointer to the parent ExprSet which is calling
+  /// evaluate on this expression. Should only be set for top level expressions
+  /// and not passed on to child expressions as it is ssed to setup exception
+  /// context.
   void evalFlatNoNulls(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result,
-      bool topLevel = false);
+      const ExprSet* FOLLY_NULLABLE parentExprSet = nullptr);
 
   void evalFlatNoNullsImpl(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result,
-      bool topLevel);
+      const ExprSet* FOLLY_NULLABLE parentExprSet);
 
   // Simplified path for expression evaluation (flattens all vectors).
   void evalSimplified(

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -54,6 +54,18 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
   }
 
+  std::vector<core::TypedExprPtr> parseMultipleExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    auto untyped = parse::parseMultipleExpressions(text, options_);
+    std::vector<core::TypedExprPtr> parsed;
+    for (auto& iExpr : untyped) {
+      parsed.push_back(
+          core::Expressions::inferTypes(iExpr, rowType, execCtx_->pool()));
+    }
+    return parsed;
+  }
+
   template <typename T = exec::ExprSet>
   std::unique_ptr<T> compileExpression(
       const std::string& expr,
@@ -71,6 +83,17 @@ class ExprTest : public testing::Test, public VectorTestBase {
     for (const auto& text : texts) {
       expressions.emplace_back(parseExpression(text, rowType));
     }
+    return std::make_unique<exec::ExprSet>(
+        std::move(expressions), execCtx_.get());
+  }
+
+  // Utility method to compile multiple expressions expected in a single sql
+  // text.
+  std::unique_ptr<exec::ExprSet> compileMultipleExprs(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    std::vector<core::TypedExprPtr> expressions =
+        parseMultipleExpression(text, rowType);
     return std::make_unique<exec::ExprSet>(
         std::move(expressions), execCtx_.get());
   }
@@ -197,19 +220,36 @@ class ExprTest : public testing::Test, public VectorTestBase {
     if (pos == std::string::npos) {
       return context;
     }
-
     return context.substr(0, pos);
   }
 
-  /// Extract input path from the 'context':
-  ///     "<expression>. Input data: <input path>."
-  std::string extractInputPath(const std::string& context) {
-    auto startPos = context.find(". Input data: ");
+  std::string extractFromErrorContext(
+      const std::string& context,
+      const char* key) {
+    auto startPos = context.find(key);
     VELOX_CHECK(startPos != std::string::npos);
-    startPos += strlen(". Input data: ");
+    startPos += strlen(key);
     auto endPos = context.find(".", startPos);
     VELOX_CHECK(endPos != std::string::npos);
     return context.substr(startPos, endPos - startPos);
+  }
+
+  /// Extract input path from the 'context':
+  ///     "<expression>. Input data: <input path>. ..."
+  std::string extractInputPath(const std::string& context) {
+    return extractFromErrorContext(context, ". Input data: ");
+  }
+
+  /// Extract expression sql's path from the 'context':
+  ///     "... <input path>. SQL expression: <sql path>"
+  std::string extractSqlPath(const std::string& context) {
+    return extractFromErrorContext(context, ". SQL expression: ");
+  }
+
+  /// Extract all expressions sqls' path from the 'context':
+  ///     "... <sql path>.  All SQL expressions: <all sql path>"
+  std::string extractAllExprSqlPath(const std::string& context) {
+    return extractFromErrorContext(context, ". All SQL expressions: ");
   }
 
   VectorPtr restoreVector(const std::string& path) {
@@ -220,15 +260,6 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return copy;
   }
 
-  std::string extractSqlPath(const std::string& context) {
-    auto startPos = context.find(". SQL expression: ");
-    VELOX_CHECK(startPos != std::string::npos);
-    startPos += strlen(". SQL expression: ");
-    auto endPos = context.find(".", startPos);
-    VELOX_CHECK(endPos != std::string::npos);
-    return context.substr(startPos, endPos - startPos);
-  }
-
   void verifyDataAndSqlPaths(const VeloxException& e, const VectorPtr& data) {
     auto inputPath = extractInputPath(e.topLevelContext());
     auto copy = restoreVector(inputPath);
@@ -237,6 +268,10 @@ class ExprTest : public testing::Test, public VectorTestBase {
     auto sqlPath = extractSqlPath(e.topLevelContext());
     auto sql = readSqlFromFile(sqlPath);
     ASSERT_NO_THROW(compileExpression(sql, asRowType(data->type())));
+
+    auto allSqlsPath = extractAllExprSqlPath(e.topLevelContext());
+    auto allSqls = readSqlFromFile(allSqlsPath);
+    ASSERT_NO_THROW(compileMultipleExprs(allSqls, asRowType(data->type())));
   }
 
   std::string readSqlFromFile(const std::string& path) {
@@ -2295,6 +2330,17 @@ TEST_F(ExprTest, exceptionContext) {
 
   try {
     evaluate("c0 + (c1 % 0)", data);
+    FAIL() << "Expected an exception";
+  } catch (const VeloxException& e) {
+    ASSERT_EQ("mod(cast((c1) as BIGINT), 0:BIGINT)", e.context());
+    ASSERT_EQ(
+        "plus(cast((c0) as BIGINT), mod(cast((c1) as BIGINT), 0:BIGINT))",
+        trimInputPath(e.topLevelContext()));
+    verifyDataAndSqlPaths(e, data);
+  }
+
+  try {
+    evaluateMultiple({"c0 + (c1 % 0)", "c0 + c1"}, data);
     FAIL() << "Expected an exception";
   } catch (const VeloxException& e) {
     ASSERT_EQ("mod(cast((c1) as BIGINT), 0:BIGINT)", e.context());


### PR DESCRIPTION
This adds the ability to save all top level expressions in an
expression set when any one of the expression trees fail during
execution. This is useful when any mutations/state from evaluating
previous expressions is required to reproducing the failure.

Test Plan:
Enhanced an existing unit test.