### PR TITLE
Fix memory leak in UnsafeRowSerializer

### DIFF
--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
   velox_presto_serializer
   velox_vector_test_lib
   velox_vector_fuzzer
+  velox_row_fast
   gtest
   gtest_main
   gflags::gflags


### PR DESCRIPTION
Memory allocated from the pool was not managed by a smart pointer causing memory
leaks in error cases.

Also, migrate UnsafeRowSerializer to use UnsafeRowFast.