### PR TITLE
Fix decimal result type when LHS and RHS have different precision in DecimalBaseFunction 

### DIFF
--- a/velox/functions/prestosql/DecimalVectorFunctions.cpp
+++ b/velox/functions/prestosql/DecimalVectorFunctions.cpp
@@ -538,12 +538,23 @@ std::shared_ptr<exec::VectorFunction> createDecimalFunction(
             Operation>>(aRescale, bRescale);
       }
     } else {
-      // LHS is short decimal and rhs is a long decimal, result is long decimal.
-      return std::make_shared<DecimalBaseFunction<
-          int128_t /*result*/,
-          int64_t,
-          int128_t,
-          Operation>>(aRescale, bRescale);
+      if (rPrecision > ShortDecimalType::kMaxPrecision) {
+        // LHS is short decimal and rhs is a long decimal, result is long
+        // decimal.
+        return std::make_shared<DecimalBaseFunction<
+            int128_t /*result*/,
+            int64_t,
+            int128_t,
+            Operation>>(aRescale, bRescale);
+      } else {
+        // In some cases such as division, the result type can still be a short
+        // decimal even though RHS is a long decimal.
+        return std::make_shared<DecimalBaseFunction<
+            int64_t /*result*/,
+            int64_t,
+            int128_t,
+            Operation>>(aRescale, bRescale);
+      }
     }
   } else {
     if (bType->isShortDecimal()) {

--- a/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/DecimalArithmeticTest.cpp
@@ -351,6 +351,20 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
       "Decimal overflow: 99999999999999999999999999999999999999 * 10000");
 }
 
+TEST_F(DecimalArithmeticTest, decimalDivDifferentTypes) {
+  testDecimalExpr<TypeKind::BIGINT>(
+      {makeShortDecimalFlatVector({1, 1, -1, 1}, DECIMAL(12, 2))},
+      "cast(c0 as decimal(12,2)) / c1",
+      {makeShortDecimalFlatVector({100, 200, -300, 400}, DECIMAL(12, 2)),
+       makeLongDecimalFlatVector({100, 200, 300, 400}, DECIMAL(19, 0))});
+
+  testDecimalExpr<TypeKind::BIGINT>(
+      {makeShortDecimalFlatVector({100, 100, -100, 100}, DECIMAL(14, 2))},
+      "cast(c0 as decimal(12,2)) / c1",
+      {makeLongDecimalFlatVector({1, 2, 3, 4}, DECIMAL(19, 0)),
+       makeShortDecimalFlatVector({100, 200, -300, 400}, DECIMAL(12, 2))});
+}
+
 TEST_F(DecimalArithmeticTest, round) {
   // Round short decimals.
   testDecimalExpr<TypeKind::BIGINT>(


### PR DESCRIPTION
This PR fixes an issue in DecimalBaseFunction when a query would fail with 
```
F20230516 07:23:06.503842 810508 BaseVector.h:115] Check failed: dynamic_cast<const T*>(this) != nullptr 
*** Check failure stack trace: ***
    @        0x12498f310  google::LogMessage::Flush()
    @        0x124992ca4  google::LogMessageFatal::~LogMessageFatal()
    @        0x12499007c  google::LogMessageFatal::~LogMessageFatal()
    @        0x106bfd9a8  facebook::velox::BaseVector::asUnchecked<>()
    @        0x106bfd9a8  facebook::velox::BaseVector::asUnchecked<>()
    @        0x106bfd9a8  facebook::velox::BaseVector::asUnchecked<>()
    @        0x106c3f1e0  facebook::velox::functions::(anonymous namespace)::DecimalBaseFunction<>::prepareResults()
    @        0x106c3f1e0  facebook::velox::functions::(anonymous namespace)::DecimalBaseFunction<>::prepareResults()
```

This was due to a missing case when LHS and RHS have different precision and if RHS type was long decimal, the result does not have to be a long decimal necessarily. For example, in case of division, LHS `DECIMAL(12, 2)` / RHS `DECIMAL(19,0)` would produce a short decimal result `DECIMAL(12,2)`.

This fixes https://github.com/prestodb/presto/issues/19599