### PR TITLE
Convert wsVRead option into parameter

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -36,7 +36,7 @@ void BufferedInput::load(const LogType logType) {
   // sorting the regions from low to high
   std::sort(regions_.begin(), regions_.end());
 
-  if (UNLIKELY(FLAGS_wsVRLoad)) {
+  if (wsVRLoad_) {
     std::vector<void*> buffers;
     std::vector<Region> regions;
     uint64_t sizeToRead = 0;

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -14,10 +14,38 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/dwio/common/BufferedInput.h"
 
 using namespace facebook::velox::dwio::common;
+using namespace ::testing;
+
+namespace {
+
+class ReadFileMock : public ::facebook::velox::ReadFile {
+ public:
+  virtual ~ReadFileMock() override = default;
+
+  MOCK_METHOD(
+      std::string_view,
+      pread,
+      (uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf),
+      (const, override));
+
+  MOCK_METHOD(bool, shouldCoalesce, (), (const, override));
+  MOCK_METHOD(uint64_t, size, (), (const, override));
+  MOCK_METHOD(uint64_t, memoryUsage, (), (const, override));
+  MOCK_METHOD(std::string, getName, (), (const, override));
+  MOCK_METHOD(uint64_t, getNaturalReadSize, (), (const, override));
+  MOCK_METHOD(
+      void,
+      preadv,
+      (const std::vector<Segment>& segments),
+      (const, override));
+};
+
+} // namespace
 
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
@@ -30,4 +58,60 @@ TEST(TestBufferedInput, ZeroLengthStream) {
   int32_t size = 1;
   EXPECT_FALSE(ret->Next(&buf, &size));
   EXPECT_EQ(size, 0);
+}
+
+TEST(TestBufferedInput, UseRead) {
+  std::string content = "hello";
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  EXPECT_CALL(*readFileMock, pread(0, 5, _))
+      .Times(1)
+      .WillOnce(
+          [&](uint64_t offset, uint64_t length, void* buf) -> std::string_view {
+            memcpy(buf, content.data() + offset, length);
+            return content;
+          });
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  // Use read: by default
+  BufferedInput input(readFileMock, *pool);
+  auto ret = input.enqueue({0, 5});
+  ASSERT_NE(ret, nullptr);
+  input.load(LogType::TEST);
+  const void* buf = nullptr;
+  int32_t size;
+  EXPECT_TRUE(ret->Next(&buf, &size));
+  EXPECT_EQ(size, 5);
+  EXPECT_EQ(std::string(static_cast<const char*>(buf), size), content);
+}
+
+TEST(TestBufferedInput, UseVRead) {
+  std::string content = "hello";
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  EXPECT_CALL(*readFileMock, preadv(_))
+      .Times(1)
+      .WillOnce([&](const std::vector<::facebook::velox::ReadFile::Segment>&
+                        segments) {
+        ASSERT_EQ(segments.size(), 1);
+        ASSERT_LE(
+            segments[0].offset + segments[0].buffer.size(), content.size());
+        memcpy(
+            segments[0].buffer.data(),
+            content.data() + segments[0].offset,
+            segments[0].buffer.size());
+      });
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  // Use vread
+  BufferedInput input(
+      readFileMock,
+      *pool,
+      MetricsLog::voidLog(),
+      nullptr,
+      /* wsVRLoad = */ true);
+  auto ret = input.enqueue({0, 5});
+  ASSERT_NE(ret, nullptr);
+  input.load(LogType::TEST);
+  const void* buf = nullptr;
+  int32_t size;
+  EXPECT_TRUE(ret->Next(&buf, &size));
+  EXPECT_EQ(size, 5);
+  EXPECT_EQ(std::string(static_cast<const char*>(buf), size), content);
 }


### PR DESCRIPTION
Summary: Easier to use and test. We'll need this so we can choose vread programatically from our readers.

Differential Revision: D45894378

