### PR TITLE
Allow Region label

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -109,7 +109,7 @@ bool BufferedInput::tryMerge(Region& first, const Region& second) {
   int64_t gap = second.offset - first.offset - first.length;
 
   // compare with 0 since it's comparison in different types
-  if (gap < 0 || gap <= kMaxMergeDistance) {
+  if (gap < 0 || gap <= maxMergeDistance_) {
     // ensure try merge will handle duplicate regions (extension==0)
     int64_t extension = gap + second.length;
 

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -36,7 +36,7 @@ void BufferedInput::load(const LogType logType) {
   // sorting the regions from low to high
   std::sort(regions_.begin(), regions_.end());
 
-  if (UNLIKELY(FLAGS_wsVRLoad)) {
+  if (wsVRLoad_) {
     std::vector<void*> buffers;
     std::vector<Region> regions;
     uint64_t sizeToRead = 0;

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -34,19 +34,25 @@ class BufferedInput {
       memory::MemoryPool& pool,
       const MetricsLogPtr& metricsLog = MetricsLog::voidLog(),
       IoStatistics* FOLLY_NULLABLE stats = nullptr,
+      uint64_t maxMergeDistance = kMaxMergeDistance,
       bool wsVRLoad = FLAGS_wsVRLoad)
       : input_{std::make_shared<ReadFileInputStream>(
             std::move(readFile),
             metricsLog,
             stats)},
         pool_{pool},
+        maxMergeDistance_{maxMergeDistance},
         wsVRLoad_{wsVRLoad} {}
 
   BufferedInput(
       std::shared_ptr<ReadFileInputStream> input,
       memory::MemoryPool& pool,
+      uint64_t maxMergeDistance = kMaxMergeDistance,
       bool wsVRLoad = FLAGS_wsVRLoad)
-      : input_(std::move(input)), pool_(pool), wsVRLoad_{wsVRLoad} {}
+      : input_(std::move(input)),
+        pool_(pool),
+        maxMergeDistance_{maxMergeDistance},
+        wsVRLoad_{wsVRLoad} {}
 
   BufferedInput(BufferedInput&&) = default;
   virtual ~BufferedInput() = default;
@@ -136,6 +142,7 @@ class BufferedInput {
   memory::MemoryPool& pool_;
 
  private:
+  uint64_t maxMergeDistance_;
   bool wsVRLoad_;
   std::vector<uint64_t> offsets_;
   std::vector<DataBuffer<char>> buffers_;

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -43,9 +43,11 @@ constexpr uint64_t DEFAULT_AUTO_PRELOAD_SIZE =
 struct Region {
   uint64_t offset;
   uint64_t length;
+  // Label used for caching purposes
+  std::string label;
 
-  Region(uint64_t offset = 0, uint64_t length = 0)
-      : offset{offset}, length{length} {}
+  Region(uint64_t offset = 0, uint64_t length = 0, std::string label = {})
+      : offset{offset}, length{length}, label{std::move(label)} {}
 
   bool operator<(const Region& other) const;
 };

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -14,10 +14,38 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/dwio/common/BufferedInput.h"
 
 using namespace facebook::velox::dwio::common;
+using namespace ::testing;
+
+namespace {
+
+class ReadFileMock : public ::facebook::velox::ReadFile {
+ public:
+  virtual ~ReadFileMock() override = default;
+
+  MOCK_METHOD(
+      std::string_view,
+      pread,
+      (uint64_t offset, uint64_t length, void* FOLLY_NONNULL buf),
+      (const, override));
+
+  MOCK_METHOD(bool, shouldCoalesce, (), (const, override));
+  MOCK_METHOD(uint64_t, size, (), (const, override));
+  MOCK_METHOD(uint64_t, memoryUsage, (), (const, override));
+  MOCK_METHOD(std::string, getName, (), (const, override));
+  MOCK_METHOD(uint64_t, getNaturalReadSize, (), (const, override));
+  MOCK_METHOD(
+      void,
+      preadv,
+      (const std::vector<Segment>& segments),
+      (const, override));
+};
+
+} // namespace
 
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
@@ -30,4 +58,60 @@ TEST(TestBufferedInput, ZeroLengthStream) {
   int32_t size = 1;
   EXPECT_FALSE(ret->Next(&buf, &size));
   EXPECT_EQ(size, 0);
+}
+
+TEST(TestBufferedInput, UseRead) {
+  std::string content = "hello";
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  EXPECT_CALL(*readFileMock, pread(0, 5, _))
+      .Times(1)
+      .WillOnce(
+          [&](uint64_t offset, uint64_t length, void* buf) -> std::string_view {
+            memcpy(buf, content.data() + offset, length);
+            return content;
+          });
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  // Use read: by default
+  BufferedInput input(readFileMock, *pool);
+  auto ret = input.enqueue({0, 5});
+  ASSERT_NE(ret, nullptr);
+  input.load(LogType::TEST);
+  const void* buf = nullptr;
+  int32_t size;
+  EXPECT_TRUE(ret->Next(&buf, &size));
+  EXPECT_EQ(size, 5);
+  EXPECT_EQ(std::string(static_cast<const char*>(buf), size), content);
+}
+
+TEST(TestBufferedInput, UseVRead) {
+  std::string content = "hello";
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  EXPECT_CALL(*readFileMock, preadv(_))
+      .Times(1)
+      .WillOnce([&](const std::vector<::facebook::velox::ReadFile::Segment>&
+                        segments) {
+        ASSERT_EQ(segments.size(), 1);
+        ASSERT_LE(
+            segments[0].offset + segments[0].buffer.size(), content.size());
+        memcpy(
+            segments[0].buffer.data(),
+            content.data() + segments[0].offset,
+            segments[0].buffer.size());
+      });
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  // Use vread
+  BufferedInput input(
+      readFileMock,
+      *pool,
+      MetricsLog::voidLog(),
+      nullptr,
+      /* wsVRLoad = */ true);
+  auto ret = input.enqueue({0, 5});
+  ASSERT_NE(ret, nullptr);
+  input.load(LogType::TEST);
+  const void* buf = nullptr;
+  int32_t size;
+  EXPECT_TRUE(ret->Next(&buf, &size));
+  EXPECT_EQ(size, 5);
+  EXPECT_EQ(std::string(static_cast<const char*>(buf), size), content);
 }


### PR DESCRIPTION
Summary:
We want readers to be able to pass a label to the ReadFile::preadv implementation, so the implementations can use this label for caching purposes.

The label is expected to contain the name of the column or the feature.

Differential Revision: D45898286

