### PR TITLE
Use single buffer in BufferedInput

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -32,6 +32,7 @@ void BufferedInput::load(const LogType logType) {
   offsets_.reserve(regions_.size());
   buffers_.clear();
   buffers_.reserve(regions_.size());
+  allocPool_->clear();
 
   // sorting the regions from low to high
   std::sort(regions_.begin(), regions_.end());

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -105,6 +105,13 @@ std::optional<std::string> getNext(SeekableInputStream& input) {
 
 } // namespace
 
+TEST(TestBufferedInput, AllowMoveConstructor) {
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  BufferedInput a(readFileMock, *pool);
+  BufferedInput b(std::move(a));
+}
+
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
       std::make_shared<facebook::velox::InMemoryReadFile>(std::string());


### PR DESCRIPTION
Summary:
Basically:
- We don't merge Regions anymore for the `vread` case.
- This means that, with the previous implementation, we'll potentially reserve tens of thousands of small `buffers_`: one for each stream to read.
- There's no advantage in that, since returned `SeekableInputStream`s returned don't own those buffers. They all live from `load()` to `load()`.
- Let's then just reserve one `buffer_` for all the reads in a `load()`.

Differential Revision: D45931848

