### PR TITLE
Fix RemoteConnectorSplit::toString

### DIFF
--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -57,13 +57,13 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
   std::string toString() const override {
     if (tableBucketNumber.has_value()) {
       return fmt::format(
-          "[file {} {} - {} {}]",
+          "Hive: {} {} - {} {}",
           filePath,
           start,
           length,
           tableBucketNumber.value());
     }
-    return fmt::format("[file {} {} - {}]", filePath, start, length);
+    return fmt::format("Hive: {} {} - {}", filePath, start, length);
   }
 
   std::string getFileName() const {

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -341,8 +341,12 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
 struct RemoteConnectorSplit : public connector::ConnectorSplit {
   const std::string taskId;
 
-  explicit RemoteConnectorSplit(const std::string& t, int32_t groupId = -1)
-      : ConnectorSplit(""), taskId(t) {}
+  explicit RemoteConnectorSplit(const std::string& _taskId)
+      : ConnectorSplit(""), taskId(_taskId) {}
+
+  std::string toString() const override {
+    return fmt::format("Remote: {}", taskId);
+  }
 };
 
 // Handle for a set of producers. This may be shared by multiple Exchanges, one

--- a/velox/exec/Split.h
+++ b/velox/exec/Split.h
@@ -57,7 +57,7 @@ struct Split {
 
   std::string toString() const {
     return fmt::format(
-        "[split: [{}] {}]",
+        "Split: [{}] {}",
         hasConnectorSplit() ? connectorSplit->toString() : "NULL",
         groupId);
   }

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -114,7 +114,7 @@ RowVectorPtr TableScan::getOutput() {
       }
 
       debugString_ = fmt::format(
-          "Split {} Task {}",
+          "Split [{}] Task {}",
           connectorSplit->toString(),
           operatorCtx_->task()->taskId());
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -60,6 +60,7 @@ add_executable(
   SpillTest.cpp
   SpillOperatorGroupTest.cpp
   SpillerTest.cpp
+  SplitToStringTest.cpp
   SqlTest.cpp
   StreamingAggregationTest.cpp
   TableScanTest.cpp

--- a/velox/exec/tests/SplitToStringTest.cpp
+++ b/velox/exec/tests/SplitToStringTest.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/exec/Exchange.h"
+#include "velox/exec/Split.h"
+
+namespace facebook::velox::exec {
+
+TEST(SplitToStringTest, remoteSplit) {
+  Split split{std::make_shared<RemoteConnectorSplit>("test")};
+  ASSERT_EQ("Split: [Remote: test] -1", split.toString());
+
+  split.groupId = 7;
+  ASSERT_EQ("Split: [Remote: test] 7", split.toString());
+}
+
+TEST(SplitToStringTest, hiveSplit) {
+  Split split{std::make_shared<connector::hive::HiveConnectorSplit>(
+      "hive",
+      "path/to/file.parquet",
+      dwio::common::FileFormat::PARQUET,
+      7,
+      100)};
+  ASSERT_EQ("Split: [Hive: path/to/file.parquet 7 - 100] -1", split.toString());
+
+  split.groupId = 7;
+  ASSERT_EQ("Split: [Hive: path/to/file.parquet 7 - 100] 7", split.toString());
+}
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Add missing RemoteConnectorSplit::toString implementation.

Also, remove unused groupId parameter from RemoteConnectorSplit's constructor.

Also, make Split::toString and HiveConnectorSplit::toSplit output easier to read.