### PR TITLE
Add conv Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -23,6 +23,14 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT contains('Spark SQL', null); -- NULL
         SELECT contains(x'537061726b2053514c', x'537061726b'); -- true
 
+.. spark:function:: conv(num, fromBase, toBase) -> string
+
+    Converts ``num`` represented in string from one base to another. Only supports ``fromBase``
+    belonging to [2, 36] and ``toBase`` belonging to [2, 36] or [-36, -2].
+
+        SELECT conv('100', 2, 10); -- 4
+        SELECT conv('-10', 16, -10); -- -16
+
 .. spark:function:: endswith(left, right) -> boolean
 
     Returns true if 'left' ends with 'right'. Otherwise, returns false. ::

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -23,13 +23,20 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT contains('Spark SQL', null); -- NULL
         SELECT contains(x'537061726b2053514c', x'537061726b'); -- true
 
-.. spark:function:: conv(num, fromBase, toBase) -> string
+.. spark:function:: conv(number, fromBase, toBase) -> varchar
 
-    Converts ``num`` represented in string from one base to another. Only supports ``fromBase``
-    belonging to [2, 36] and ``toBase`` belonging to [2, 36] or [-36, -2].
+    Converts ``number`` represented as a string from ``fromBase`` to ``toBase``.
+    ``fromBase`` must be a value between 2 and 36. ``toBase`` must be a a value between 2
+    and 36 or between -36 and -2. Negative ``toBase`` means output will be a signed number
+    and positive ``toBase`` means it will be unsigned.
+    If ``number`` is empty or given base is invalid, returns NULL.
+    Only converts valid characters till the first occurence of illegal character. If the
+    start is illegal, just returns "0". ::
 
-        SELECT conv('100', 2, 10); -- 4
-        SELECT conv('-10', 16, -10); -- -16
+        SELECT conv('100', 2, 10); -- '4'
+        SELECT conv('-10', 16, -10); -- -'16'
+        SELECT conv('H1F', 16, 10); -- '0'
+        SELECT conv("-1", 10, 16); -- 'FFFFFFFFFFFFFFFF'
 
 .. spark:function:: endswith(left, right) -> boolean
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -26,17 +26,22 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: conv(number, fromBase, toBase) -> varchar
 
     Converts ``number`` represented as a string from ``fromBase`` to ``toBase``.
-    ``fromBase`` must be a value inclusively between 2 and 36. ``toBase`` must be a value
-    inclusively between 2 and 36 or between -36 and -2. Negative ``toBase`` means output
-    will be a signed number and positive ``toBase`` means it will be an unsigned number.
-    If ``number`` is empty or given base is invalid, returns NULL.
-    Only converts valid characters till the first occurence of illegal character. If the
-    start is illegal, just returns '0'. ::
+    ``fromBase`` must be an INTEGER value between 2 and 36 inclusively. ``toBase`` must
+    be an INTEGER value between 2 and 36 inclusively or between -36 and -2 inclusively.
+    Otherwise, returns NULL.
+    Returns a signed number if ``toBase`` is negative. Otherwise, returns an unsigned one.
+    Returns NULL if ``number`` is empty.
+    Leading spaces will be skipped. ``number`` may contain other characters not valid for
+    ``fromBase``. All characters starting from the first invalid character till the end of
+    the string are ignored. Returns '0' if no valid character is found in such rule. ::
 
         SELECT conv('100', 2, 10); -- '4'
-        SELECT conv('-10', 16, -10); -- -'16'
-        SELECT conv('H1F', 16, 10); -- '0'
+        SELECT conv('-10', 16, -10); -- '-16'
         SELECT conv("-1", 10, 16); -- 'FFFFFFFFFFFFFFFF'
+        SELECT conv("123", 10, 39); -- NULL
+        SELECT conv('', 16, 10); -- NULL
+        SELECT conv("11ABC", 10, 16); -- 'B'
+        SELECT conv('H016F', 16, 10); -- '0'
 
 .. spark:function:: endswith(left, right) -> boolean
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -33,7 +33,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Returns NULL if ``number`` is empty.
     Leading spaces will be skipped. ``number`` may contain other characters not valid for
     ``fromBase``. All characters starting from the first invalid character till the end of
-    the string are ignored. Returns '0' if no valid character is found in such rule. ::
+    the string are ignored. Returns '0' if no valid character is found in this rule. ::
 
         SELECT conv('100', 2, 10); -- '4'
         SELECT conv('-10', 16, -10); -- '-16'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -26,12 +26,12 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 .. spark:function:: conv(number, fromBase, toBase) -> varchar
 
     Converts ``number`` represented as a string from ``fromBase`` to ``toBase``.
-    ``fromBase`` must be a value between 2 and 36. ``toBase`` must be a a value between 2
-    and 36 or between -36 and -2. Negative ``toBase`` means output will be a signed number
-    and positive ``toBase`` means it will be unsigned.
+    ``fromBase`` must be a value inclusively between 2 and 36. ``toBase`` must be a value
+    inclusively between 2 and 36 or between -36 and -2. Negative ``toBase`` means output
+    will be a signed number and positive ``toBase`` means it will be an unsigned number.
     If ``number`` is empty or given base is invalid, returns NULL.
     Only converts valid characters till the first occurence of illegal character. If the
-    start is illegal, just returns "0". ::
+    start is illegal, just returns '0'. ::
 
         SELECT conv('100', 2, 10); -- '4'
         SELECT conv('-10', 16, -10); -- -'16'

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -31,16 +31,20 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Otherwise, returns NULL.
     Returns a signed number if ``toBase`` is negative. Otherwise, returns an unsigned one.
     Returns NULL if ``number`` is empty.
-    Leading spaces will be skipped. ``number`` may contain other characters not valid for
-    ``fromBase``. All characters starting from the first invalid character till the end of
-    the string are ignored. Returns '0' if no valid character is found in this rule. ::
+    Skips leading spaces. ``number`` may contain other characters not valid for ``fromBase``.
+    All characters starting from the first invalid character till the end of the string are
+    ignored. Only converts valid characters even though ``fromBase`` = ``toBase``. Returns
+    '0' if no valid character is found. ::
 
         SELECT conv('100', 2, 10); -- '4'
         SELECT conv('-10', 16, -10); -- '-16'
         SELECT conv("-1", 10, 16); -- 'FFFFFFFFFFFFFFFF'
         SELECT conv("123", 10, 39); -- NULL
         SELECT conv('', 16, 10); -- NULL
+        SELECT conv(' ', 2, 10); -- NULL
+        SELECT conv("11", 10, 16); -- 'B'
         SELECT conv("11ABC", 10, 16); -- 'B'
+        SELECT conv("11abc", 10, 10); -- '11'
         SELECT conv('H016F', 16, 10); -- '0'
 
 .. spark:function:: endswith(left, right) -> boolean

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -211,6 +211,9 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<TranslateFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "translate"});
 
+  registerFunction<ConvFunction, Varchar, Varchar, int32_t, int32_t>(
+      {prefix + "conv"});
+
   // Register array sort functions.
   exec::registerStatefulVectorFunction(
       prefix + "array_sort", arraySortSignatures(), makeArraySort);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -927,13 +927,13 @@ struct ConvFunction {
 
     // Fast path for case "0", regardless of fromBase/toBase.
     if (input.data()[0] == '0' && input.size() == 1) {
-      result.setNoCopy(StringView(input.data(), 1));
+      result.append(input);
       return true;
     }
 
     // No need to do the conversion.
     if (fromBase == toBase) {
-      result.setNoCopy(StringView(input.data(), input.size()));
+      result.append(input);
       return true;
     }
 
@@ -983,8 +983,12 @@ struct ConvFunction {
     if (resultSize == 0) {
       return false;
     }
+    if (resultSize != 64) {
+      for (int k = 0; k < resultSize; k++) {
+        std::memcpy(result.data() + k, result.data() + i + 1 + k, 1);
+      }
+    }
     result.resize(resultSize);
-    result.setNoCopy(StringView(result.data() + i + 1, resultSize));
     return true;
   }
 };

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -971,21 +971,34 @@ struct ConvFunction {
       }
     }
 
-    result.resize(64);
-    auto resultBuffer = result.data();
+    int32_t resultSize;
     std::to_chars_result toStatus;
     if (toBase < 0) {
+      resultSize = (int32_t)std::floor(
+                       std::log(std::abs(signedValue)) / std::log(-toBase)) +
+          1;
+      // Negative symbol is considered.
+      if (signedValue < 0) {
+        ++resultSize;
+      }
+      result.resize(resultSize);
       toStatus = std::to_chars(
-          resultBuffer, resultBuffer + 64, signedValue, std::abs(toBase));
+          result.data(), result.data() + result.size(), signedValue, -toBase);
     } else {
+      resultSize =
+          (int32_t)std::floor(std::log(unsignedValue) / std::log(toBase)) + 1;
+      result.resize(resultSize);
       toStatus = std::to_chars(
-          resultBuffer, resultBuffer + 64, unsignedValue, std::abs(toBase));
+          result.data(),
+          result.data() + result.size(),
+          unsignedValue,
+          std::abs(toBase));
     }
+    result.resize(toStatus.ptr - result.data());
 
-    result.resize(toStatus.ptr - resultBuffer);
     // Converts to uppper case, consistent with Spark.
     for (int i = 0; i < result.size(); i++) {
-      resultBuffer[i] = std::toupper(resultBuffer[i]);
+      result.data()[i] = std::toupper(result.data()[i]);
     }
     return true;
   }

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -950,28 +950,30 @@ struct ConvFunction {
       return true;
     }
 
-    bool isOutputNegative = false;
+    int64_t signedValue;
     if (isInputNegative) {
       if (toBase < 0) {
-        toBase = -toBase;
-        isOutputNegative = true;
+        signedValue = -unsignedValue;
       } else {
         // If toBase > 0, the result is unsigned. Converts the original nagative
         // value to unsigned one.
         unsignedValue = kMaxUnsignedInt64_ - unsignedValue + 1;
+      }
+    } else {
+      if (toBase < 0) {
+        signedValue = (int64_t)unsignedValue;
       }
     }
 
     result.resize(64);
     auto resultBuffer = result.data();
     std::to_chars_result toStatus;
-    if (isOutputNegative) {
-      int64_t signedValue = -unsignedValue;
-      toStatus =
-          std::to_chars(resultBuffer, resultBuffer + 64, signedValue, toBase);
+    if (toBase < 0) {
+      toStatus = std::to_chars(
+          resultBuffer, resultBuffer + 64, signedValue, std::abs(toBase));
     } else {
-      toStatus =
-          std::to_chars(resultBuffer, resultBuffer + 64, unsignedValue, toBase);
+      toStatus = std::to_chars(
+          resultBuffer, resultBuffer + 64, unsignedValue, std::abs(toBase));
     }
 
     result.resize(toStatus.ptr - resultBuffer);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -943,10 +943,13 @@ struct ConvFunction {
     uint64_t unsignedValue;
     auto fromStatus = std::from_chars(
         input.data() + i, input.data() + input.size(), unsignedValue, fromBase);
+    if (fromStatus.ec == std::errc::invalid_argument) {
+      result.append("0");
+      return true;
+    }
     if (fromStatus.ec == std::errc::result_out_of_range) {
       unsignedValue = kMaxUnsignedInt64_;
     }
-
     if (unsignedValue == 0) {
       result.append("0");
       return true;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -956,7 +956,8 @@ struct ConvFunction {
     if (isNegativeInput && toBase < 0) {
       hasNegativeMark = true;
     } else if (isNegativeInput && toBase > 0) {
-      // Use the max value for 64-bit to convert unsignedValue to positive.
+      // If toBase > 0, the result is unsigned. Converts the original nagative
+      // value to unsigned one.
       unsignedValue = MAX_UNSIGNED_INT64 - unsignedValue + 1;
     }
     toBase = toBase < 0 ? -toBase : toBase;

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -917,15 +917,16 @@ struct ConvFunction {
       return false;
     }
 
-    // Consistent with spark, only supports base belonging to [2, 36].
-    const int MIN_BASE = 2;
-    const int MAX_BASE = 36;
-    if (fromBase < MIN_BASE || fromBase > MAX_BASE ||
-        std::abs(toBase) < MIN_BASE || std::abs(toBase) > MAX_BASE) {
+    // Consistent with spark, only supports fromBase belonging to [2, 36]
+    // and toBase belonging to [2, 36] or [-36, -2].
+    const int minBase = 2;
+    const int maxBase = 36;
+    if (fromBase < minBase || fromBase > maxBase ||
+        std::abs(toBase) < minBase || std::abs(toBase) > maxBase) {
       return false;
     }
 
-    // Fast path for case "0", regardless of fromBase/toBase.
+    // Fast path for case '0', regardless of fromBase/toBase.
     if (input.data()[0] == '0' && input.size() == 1) {
       result.append(input);
       return true;
@@ -952,13 +953,13 @@ struct ConvFunction {
     free(inputChars);
 
     bool hasNegativeMark = false;
-    const unsigned long MAX_UNSIGNED_INT64 = 0xFFFFFFFFFFFFFFFF;
+    const unsigned long maxUnsignedInt64 = 0xFFFFFFFFFFFFFFFF;
     if (isNegativeInput && toBase < 0) {
       hasNegativeMark = true;
     } else if (isNegativeInput && toBase > 0) {
       // If toBase > 0, the result is unsigned. Converts the original nagative
       // value to unsigned one.
-      unsignedValue = MAX_UNSIGNED_INT64 - unsignedValue + 1;
+      unsignedValue = maxUnsignedInt64 - unsignedValue + 1;
     }
     toBase = toBase < 0 ? -toBase : toBase;
 
@@ -983,12 +984,10 @@ struct ConvFunction {
     if (resultSize == 0) {
       return false;
     }
-    if (resultSize != 64) {
-      for (int k = 0; k < resultSize; k++) {
-        std::memcpy(result.data() + k, result.data() + i + 1 + k, 1);
-      }
+    if (resultSize < 64) {
+      std::memcpy(result.data(), result.data() + i + 1, resultSize);
+      result.resize(resultSize);
     }
-    result.resize(resultSize);
     return true;
   }
 };

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -912,8 +912,7 @@ struct ConvFunction {
   static const int kMinBase = 2;
   static const int kMaxBase = 36;
 
-  static bool
-  checkInput(const StringView& input, int32_t fromBase, int32_t toBase) {
+  static bool checkInput(StringView input, int32_t fromBase, int32_t toBase) {
     if (input.empty()) {
       return false;
     }
@@ -926,7 +925,7 @@ struct ConvFunction {
     return true;
   }
 
-  static int32_t skipLeadingSpaces(const StringView& input) {
+  static int32_t skipLeadingSpaces(StringView input) {
     // Ignore leading spaces.
     int i = 0;
     for (; i < input.size(); i++) {
@@ -937,8 +936,8 @@ struct ConvFunction {
     return i;
   }
 
-  uint64_t
-  toUnsigned(const StringView& input, int32_t start, int32_t fromBase) {
+  static uint64_t
+  toUnsigned(StringView input, int32_t start, int32_t fromBase) {
     uint64_t unsignedValue;
     auto fromStatus = std::from_chars(
         input.data() + start,
@@ -961,7 +960,8 @@ struct ConvFunction {
   }
 
   // For signed value, toBase is negative.
-  void toChars(out_type<Varchar>& result, int64_t signedValue, int32_t toBase) {
+  static void
+  toChars(out_type<Varchar>& result, int64_t signedValue, int32_t toBase) {
     int32_t resultSize =
         (int32_t)std::floor(
             std::log(std::abs(signedValue)) / std::log(-toBase)) +
@@ -977,7 +977,7 @@ struct ConvFunction {
   }
 
   // For unsigned value, toBase is positive.
-  void
+  static void
   toChars(out_type<Varchar>& result, uint64_t unsignedValue, int32_t toBase) {
     int32_t resultSize =
         (int32_t)std::floor(std::log(unsignedValue) / std::log(toBase)) + 1;
@@ -1016,10 +1016,10 @@ struct ConvFunction {
       return true;
     }
 
-    int64_t signedValue;
     // When toBase is negative, converts to signed value. Otherwise, converts to
     // unsigned value. Overflow is allowed, consistent with Spark.
     if (toBase < 0) {
+      int64_t signedValue;
       if (isNegativeInput) {
         signedValue = -std::abs((int64_t)unsignedValue);
       } else {
@@ -1030,7 +1030,7 @@ struct ConvFunction {
       if (isNegativeInput) {
         int64_t negativeInput = -std::abs((int64_t)unsignedValue);
         unsignedValue = (uint64_t)negativeInput;
-      } // Here directly use unsignedValue for isNegativeInput=false.
+      } // Here directly use unsignedValue if isNegativeInput = false.
       toChars(result, unsignedValue, toBase);
     }
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -733,9 +733,11 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("4", 10, 2), "100");
   EXPECT_EQ(conv("110", 2, 10), "6");
   EXPECT_EQ(conv("15", 10, 16), "F");
+  EXPECT_EQ(conv("15", 10, -16), "F");
   EXPECT_EQ(conv("big", 36, 16), "3A48");
   EXPECT_EQ(conv("-15", 10, -16), "-F");
   EXPECT_EQ(conv("-1", 10, 16), "FFFFFFFFFFFFFFFF");
+  EXPECT_EQ(conv("FFFFFFFFFFFFFFFF", 16, -10), "-1");
   EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("-10", 16, -10), "-16");
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -746,11 +746,11 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("9223372036854775807", 36, 16), "FFFFFFFFFFFFFFFF");
 
-  // Test with space contained.
+  // Leading and trailing spaces.
   EXPECT_EQ(conv("15 ", 10, 16), "F");
   EXPECT_EQ(conv(" 15 ", 10, 16), "F");
 
-  // Test with invalid characters.
+  // Invalid characters.
   // Only converts "11".
   EXPECT_EQ(conv("11abc", 10, 16), "B");
   // Only converts "F".
@@ -763,8 +763,12 @@ TEST_F(StringTest, conv) {
   // All are invalid for binary base.
   EXPECT_EQ(conv("2345", 2, 10), "0");
 
-  // Test null result.
+  // Negative symbol only.
+  EXPECT_EQ(conv("-", 10, 16), "0");
+
+  // Null result.
   EXPECT_EQ(conv("", 10, 16), std::nullopt);
+  EXPECT_EQ(conv(" ", 10, 16), std::nullopt);
   EXPECT_EQ(conv("", std::nullopt, 16), std::nullopt);
   EXPECT_EQ(conv("", 10, std::nullopt), std::nullopt);
 }

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -736,12 +736,14 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("15", 10, -16), "F");
   EXPECT_EQ(conv("big", 36, 16), "3A48");
   EXPECT_EQ(conv("-15", 10, -16), "-F");
-  EXPECT_EQ(conv("-1", 10, 16), "FFFFFFFFFFFFFFFF");
-  EXPECT_EQ(conv("FFFFFFFFFFFFFFFF", 16, -10), "-1");
-  EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("-10", 16, -10), "-16");
 
   // Overflow case.
+  EXPECT_EQ(conv("-1", 10, 16), "FFFFFFFFFFFFFFFF");
+  EXPECT_EQ(conv("FFFFFFFFFFFFFFFF", 16, -10), "-1");
+  EXPECT_EQ(conv("-FFFFFFFFFFFFFFFF", 16, -10), "-1");
+  EXPECT_EQ(conv("-FFFFFFFFFFFFFFFF", 16, 10), "18446744073709551615");
+  EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("9223372036854775807", 36, 16), "FFFFFFFFFFFFFFFF");
 
   // Test with space contained.
@@ -754,6 +756,7 @@ TEST_F(StringTest, conv) {
   // Only converts "F".
   EXPECT_EQ(conv("FH", 16, 10), "15");
   // Discards followed invalid character even though converting to same base.
+  EXPECT_EQ(conv("11abc", 10, 10), "11");
   EXPECT_EQ(conv("FH", 16, 16), "F");
   // Begins with invalid character.
   EXPECT_EQ(conv("HF", 16, 10), "0");

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -734,15 +734,29 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("110", 2, 10), "6");
   EXPECT_EQ(conv("15", 10, 16), "F");
   EXPECT_EQ(conv("big", 36, 16), "3A48");
-  EXPECT_EQ(conv("9223372036854775807", 36, 16), "FFFFFFFFFFFFFFFF");
-  // Space is contained, but has no impact on the conversion.
-  EXPECT_EQ(conv(" 15 ", 10, 16), "F");
   EXPECT_EQ(conv("-15", 10, -16), "-F");
   EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("-10", 16, -10), "-16");
-  // If there is an invalid digit in the number, the longest
-  // valid prefix should be converted.
+
+  // Overflow case.
+  EXPECT_EQ(conv("9223372036854775807", 36, 16), "FFFFFFFFFFFFFFFF");
+
+  // Test with space contained.
+  EXPECT_EQ(conv("15 ", 10, 16), "F");
+  EXPECT_EQ(conv(" 15 ", 10, 16), "F");
+
+  // Test with invalid characters.
+  // Only converts "11".
   EXPECT_EQ(conv("11abc", 10, 16), "B");
+  // Only converts "F".
+  EXPECT_EQ(conv("FH", 16, 10), "15");
+  // Discards followed invalid character even though converting to same base.
+  EXPECT_EQ(conv("FH", 16, 16), "F");
+  // Begins with invalid character.
+  EXPECT_EQ(conv("HF", 16, 10), "0");
+  // All are invalid for binary base.
+  EXPECT_EQ(conv("2345", 2, 10), "0");
+
   // Test null result.
   EXPECT_EQ(conv("", 10, 16), std::nullopt);
   EXPECT_EQ(conv("", std::nullopt, 16), std::nullopt);

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -740,12 +740,13 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("-15", 10, -16), "-F");
   EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("-10", 16, -10), "-16");
+  // If there is an invalid digit in the number, the longest
+  // valid prefix should be converted.
   EXPECT_EQ(conv("11abc", 10, 16), "B");
   // Test null result.
   EXPECT_EQ(conv("", 10, 16), std::nullopt);
   EXPECT_EQ(conv("", std::nullopt, 16), std::nullopt);
   EXPECT_EQ(conv("", 10, std::nullopt), std::nullopt);
 }
-
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -735,6 +735,7 @@ TEST_F(StringTest, conv) {
   EXPECT_EQ(conv("15", 10, 16), "F");
   EXPECT_EQ(conv("big", 36, 16), "3A48");
   EXPECT_EQ(conv("-15", 10, -16), "-F");
+  EXPECT_EQ(conv("-1", 10, 16), "FFFFFFFFFFFFFFFF");
   EXPECT_EQ(conv("-15", 10, 16), "FFFFFFFFFFFFFFF1");
   EXPECT_EQ(conv("-10", 16, -10), "-16");
 


### PR DESCRIPTION
Converts a number represented by string from one base to another.

Spark link [here](https://github.com/apache/spark/blob/39cc4abaff73cb49f9d79d1d844fe5c9fa14c917/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L426).