### PR TITLE
Add support for Spark max_by and min_by aggregate functions

### DIFF
--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -68,3 +68,17 @@ General Aggregate Functions
 .. spark:function:: last_ignore_null(x) -> x
 
     Returns the last non-null value of `x`.
+
+.. spark:function:: max_by(x, y) -> x
+
+    Returns the value of `x` associated with the maximum value of `y`.
+    Note: Spark provides a non-strictly comparator which is greater than or equals to.
+    Eg. SELECT max_by(x, y) FROM VALUES (('a', 10)), (('b', 50)), (('c', 50)) AS tab(x, y);
+        > c
+
+.. spark:function:: min_by(x, y) -> x
+
+    Returns the value of `x` associated with the minimum value of `y`.
+    Note: Spark provides a non-strictly comparator which is less than or equals to.
+    Eg. SELECT min_by(x, y) FROM VALUES (('a', 10)), (('b', 10)), (('c', 50)) AS tab(x, y);
+        > b

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -67,7 +67,9 @@ int main(int argc, char** argv) {
       // imprecision in complex types.
       // https://github.com/facebookincubator/velox/issues/4481
       {"avg_partial", ""},
-      {"avg_merge", ""}};
+      {"avg_merge", ""},
+      {"max_by", ""},
+      {"min_by", ""}};
 
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return facebook::velox::exec::test::AggregationFuzzerRunner::runFuzzer(

--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -1,0 +1,649 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/ContainerRowSerde.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::functions::aggregate {
+
+namespace {
+void resizeRowVectorAndChildren(RowVector& rowVector, vector_size_t size) {
+  rowVector.resize(size);
+  for (auto& child : rowVector.children()) {
+    child->resize(size);
+  }
+}
+
+std::pair<vector_size_t*, vector_size_t*> rawOffsetAndSizes(
+    ArrayVector& arrayVector) {
+  return {
+      arrayVector.offsets()->asMutable<vector_size_t>(),
+      arrayVector.sizes()->asMutable<vector_size_t>()};
+}
+} // namespace
+
+template <typename T>
+constexpr bool isNumeric() {
+  return std::is_same_v<T, bool> || std::is_same_v<T, int8_t> ||
+      std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
+      std::is_same_v<T, int64_t> || std::is_same_v<T, float> ||
+      std::is_same_v<T, double> || std::is_same_v<T, Date> ||
+      std::is_same_v<T, Timestamp>;
+}
+
+template <typename T, typename TAccumulator>
+void extract(
+    TAccumulator* accumulator,
+    const VectorPtr& vector,
+    vector_size_t index,
+    T* rawValues,
+    uint64_t* rawBoolValues) {
+  if constexpr (isNumeric<T>()) {
+    if constexpr (std::is_same_v<T, bool>) {
+      bits::setBit(rawBoolValues, index, *accumulator);
+    } else {
+      rawValues[index] = *accumulator;
+    }
+  } else {
+    accumulator->read(vector, index);
+  }
+}
+
+template <typename T, typename TAccumulator>
+void store(
+    TAccumulator* accumulator,
+    const DecodedVector& decodedVector,
+    vector_size_t index,
+    HashStringAllocator* allocator) {
+  if constexpr (isNumeric<T>()) {
+    *accumulator = decodedVector.valueAt<T>(index);
+  } else {
+    accumulator->write(
+        decodedVector.base(), decodedVector.index(index), allocator);
+  }
+}
+
+template <typename T, typename = void>
+struct AccumulatorTypeTraits {};
+
+template <typename T>
+struct AccumulatorTypeTraits<T, std::enable_if_t<isNumeric<T>(), void>> {
+  using AccumulatorType = T;
+};
+
+template <typename T>
+struct AccumulatorTypeTraits<T, std::enable_if_t<!isNumeric<T>(), void>> {
+  using AccumulatorType = SingleValueAccumulator;
+};
+
+/// MinMaxByAggregateBase is the base class for min_by and max_by functions
+/// with numeric value and comparison types. These functions return the value of
+/// X associated with the minimum/maximum value of Y over all input values.
+/// Partial aggregation produces a pair of X and min/max Y. Final aggregation
+/// takes a pair of X and min/max Y and returns X. T is the type of X and U is
+/// the type of Y.
+template <
+    typename T,
+    typename U,
+    bool isMaxFunc,
+    template <bool B, typename C1, typename C2>
+    class Comparator>
+class MinMaxByAggregateBase : public exec::Aggregate {
+ public:
+  using ValueAccumulatorType =
+      typename AccumulatorTypeTraits<T>::AccumulatorType;
+  using ComparisonAccumulatorType =
+      typename AccumulatorTypeTraits<U>::AccumulatorType;
+
+  explicit MinMaxByAggregateBase(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(ValueAccumulatorType) + sizeof(ComparisonAccumulatorType) +
+        sizeof(bool);
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (const vector_size_t i : indices) {
+      auto group = groups[i];
+      valueIsNull(group) = true;
+
+      if constexpr (!isNumeric<T>()) {
+        new (group + offset_) SingleValueAccumulator();
+      } else {
+        *value(group) = ValueAccumulatorType();
+      }
+
+      if constexpr (isNumeric<U>()) {
+        *comparisonValue(group) = ComparisonAccumulatorType();
+      } else {
+        new (group + offset_ + sizeof(ValueAccumulatorType))
+            SingleValueAccumulator();
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*unused*/) override {
+    addRawInput(
+        groups,
+        rows,
+        args,
+        [&](auto* accumulator,
+            const auto& newComparisons,
+            auto index,
+            auto isFirstValue) {
+          return Comparator<isMaxFunc, U, ComparisonAccumulatorType>::compare(
+              accumulator, newComparisons, index, isFirstValue);
+        });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addIntermediateResults(
+        groups,
+        rows,
+        args,
+        [&](auto* accumulator,
+            const auto& newComparisons,
+            auto index,
+            auto isFirstValue) {
+          return Comparator<isMaxFunc, U, ComparisonAccumulatorType>::compare(
+              accumulator, newComparisons, index, isFirstValue);
+        });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*unused*/) override {
+    addSingleGroupRawInput(
+        group,
+        rows,
+        args,
+        [&](auto* accumulator,
+            const auto& newComparisons,
+            auto index,
+            auto isFirstValue) {
+          return Comparator<isMaxFunc, U, ComparisonAccumulatorType>::compare(
+              accumulator, newComparisons, index, isFirstValue);
+        });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    addSingleGroupIntermediateResults(
+        group,
+        rows,
+        args,
+        [&](auto* accumulator,
+            const auto& newComparisons,
+            auto index,
+            auto isFirstValue) {
+          return Comparator<isMaxFunc, U, ComparisonAccumulatorType>::compare(
+              accumulator, newComparisons, index, isFirstValue);
+        });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK(result);
+    (*result)->resize(numGroups);
+    uint64_t* rawNulls = getRawNulls(result->get());
+
+    T* rawValues = nullptr;
+    uint64_t* rawBoolValues = nullptr;
+    if constexpr (isNumeric<T>()) {
+      auto vector = (*result)->as<FlatVector<T>>();
+      VELOX_CHECK(vector != nullptr);
+      if constexpr (std::is_same_v<T, bool>) {
+        rawBoolValues = vector->template mutableRawValues<uint64_t>();
+      } else {
+        rawValues = vector->mutableRawValues();
+      }
+    }
+
+    for (int32_t i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group) || valueIsNull(group)) {
+        (*result)->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        extract<T, ValueAccumulatorType>(
+            value(group), *result, i, rawValues, rawBoolValues);
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    auto valueVector = rowVector->childAt(0);
+    auto comparisonVector = rowVector->childAt(1);
+
+    resizeRowVectorAndChildren(*rowVector, numGroups);
+    uint64_t* rawNulls = getRawNulls(rowVector);
+
+    T* rawValues = nullptr;
+    uint64_t* rawBoolValues = nullptr;
+    if constexpr (isNumeric<T>()) {
+      auto flatValueVector = valueVector->as<FlatVector<T>>();
+      VELOX_CHECK(flatValueVector != nullptr);
+      if constexpr (std::is_same_v<T, bool>) {
+        rawBoolValues = flatValueVector->template mutableRawValues<uint64_t>();
+      } else {
+        rawValues = flatValueVector->mutableRawValues();
+      }
+    }
+    U* rawComparisonValues = nullptr;
+    uint64_t* rawBoolComparisonValues = nullptr;
+    if constexpr (isNumeric<U>()) {
+      auto flatComparisonVector = comparisonVector->as<FlatVector<U>>();
+      VELOX_CHECK(flatComparisonVector != nullptr);
+      if constexpr (std::is_same_v<U, bool>) {
+        rawBoolComparisonValues =
+            flatComparisonVector->template mutableRawValues<uint64_t>();
+      } else {
+        rawComparisonValues = flatComparisonVector->mutableRawValues();
+      }
+    }
+    uint64_t* rawValueNulls =
+        valueVector->mutableNulls(rowVector->size())->asMutable<uint64_t>();
+    for (int32_t i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        rowVector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        const bool isValueNull = valueIsNull(group);
+        bits::setNull(rawValueNulls, i, isValueNull);
+        if (LIKELY(!isValueNull)) {
+          extract<T, ValueAccumulatorType>(
+              value(group), valueVector, i, rawValues, rawBoolValues);
+        }
+        extract<U, ComparisonAccumulatorType>(
+            comparisonValue(group),
+            comparisonVector,
+            i,
+            rawComparisonValues,
+            rawBoolComparisonValues);
+      }
+    }
+  }
+
+  void destroy(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      if constexpr (!isNumeric<T>()) {
+        value(group)->destroy(allocator_);
+      }
+      if constexpr (!isNumeric<U>()) {
+        comparisonValue(group)->destroy(allocator_);
+      }
+    }
+  }
+
+ protected:
+  template <typename MayUpdate>
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      MayUpdate mayUpdate) {
+    // decodedValue contains the values of column X. decodedComparisonValue
+    // contains the values of column Y which is used to select the minimum or
+    // the maximum.
+    decodedValue_.decode(*args[0], rows);
+    decodedComparison_.decode(*args[1], rows);
+
+    if (decodedValue_.isConstantMapping() &&
+        decodedComparison_.isConstantMapping() &&
+        decodedComparison_.isNullAt(0)) {
+      return;
+    }
+    if (decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedComparison_.isNullAt(i)) {
+          return;
+        }
+        updateValues(
+            groups[i],
+            decodedValue_,
+            decodedComparison_,
+            i,
+            decodedValue_.isNullAt(i),
+            mayUpdate);
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateValues(
+            groups[i], decodedValue_, decodedComparison_, i, false, mayUpdate);
+      });
+    }
+  }
+
+  template <typename MayUpdate>
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      MayUpdate mayUpdate) {
+    decodedIntermediateResult_.decode(*args[0], rows);
+    auto baseRowVector =
+        dynamic_cast<const RowVector*>(decodedIntermediateResult_.base());
+
+    decodedValue_.decode(*baseRowVector->childAt(0), rows);
+    decodedComparison_.decode(*baseRowVector->childAt(1), rows);
+
+    if (decodedIntermediateResult_.isConstantMapping() &&
+        decodedIntermediateResult_.isNullAt(0)) {
+      return;
+    }
+    if (decodedIntermediateResult_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedIntermediateResult_.isNullAt(i)) {
+          return;
+        }
+        const auto decodedIndex = decodedIntermediateResult_.index(i);
+        updateValues(
+            groups[i],
+            decodedValue_,
+            decodedComparison_,
+            decodedIndex,
+            decodedValue_.isNullAt(decodedIndex),
+            mayUpdate);
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        const auto decodedIndex = decodedIntermediateResult_.index(i);
+        updateValues(
+            groups[i],
+            decodedValue_,
+            decodedComparison_,
+            decodedIndex,
+            decodedValue_.isNullAt(decodedIndex),
+            mayUpdate);
+      });
+    }
+  }
+
+  template <typename MayUpdate>
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      MayUpdate mayUpdate) {
+    // decodedValue contains the values of column X. decodedComparisonValue
+    // contains the values of column Y which is used to select the minimum or
+    // the maximum.
+    decodedValue_.decode(*args[0], rows);
+    decodedComparison_.decode(*args[1], rows);
+    if (decodedValue_.isConstantMapping() &&
+        decodedComparison_.isConstantMapping()) {
+      if (decodedComparison_.isNullAt(0)) {
+        return;
+      }
+      updateValues(
+          group,
+          decodedValue_,
+          decodedComparison_,
+          0,
+          decodedValue_.isNullAt(0),
+          mayUpdate);
+    } else if (
+        decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedComparison_.isNullAt(i)) {
+          return;
+        }
+        updateValues(
+            group,
+            decodedValue_,
+            decodedComparison_,
+            i,
+            decodedValue_.isNullAt(i),
+            mayUpdate);
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateValues(
+            group, decodedValue_, decodedComparison_, i, false, mayUpdate);
+      });
+    }
+  }
+
+  /// Final aggregation takes (value, comparisonValue) structs as inputs. It
+  /// produces the Value associated with the maximum/minimum of comparisonValue
+  /// over all structs.
+  template <typename MayUpdate>
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      MayUpdate mayUpdate) {
+    // Decode struct(Value, ComparisonValue) as individual vectors.
+    decodedIntermediateResult_.decode(*args[0], rows);
+    auto baseRowVector =
+        dynamic_cast<const RowVector*>(decodedIntermediateResult_.base());
+
+    decodedValue_.decode(*baseRowVector->childAt(0), rows);
+    decodedComparison_.decode(*baseRowVector->childAt(1), rows);
+
+    if (decodedIntermediateResult_.isConstantMapping()) {
+      if (decodedIntermediateResult_.isNullAt(0)) {
+        return;
+      }
+      const auto decodedIndex = decodedIntermediateResult_.index(0);
+      updateValues(
+          group,
+          decodedValue_,
+          decodedComparison_,
+          decodedIndex,
+          decodedValue_.isNullAt(decodedIndex),
+          mayUpdate);
+    } else if (decodedIntermediateResult_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedIntermediateResult_.isNullAt(i)) {
+          return;
+        }
+        const auto decodedIndex = decodedIntermediateResult_.index(i);
+        updateValues(
+            group,
+            decodedValue_,
+            decodedComparison_,
+            decodedIndex,
+            decodedValue_.isNullAt(decodedIndex),
+            mayUpdate);
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        const auto decodedIndex = decodedIntermediateResult_.index(i);
+        updateValues(
+            group,
+            decodedValue_,
+            decodedComparison_,
+            decodedIndex,
+            decodedValue_.isNullAt(decodedIndex),
+            mayUpdate);
+      });
+    }
+  }
+
+ private:
+  template <typename MayUpdate>
+  inline void updateValues(
+      char* group,
+      const DecodedVector& decodedValues,
+      const DecodedVector& decodedComparisons,
+      vector_size_t index,
+      bool isValueNull,
+      MayUpdate mayUpdate) {
+    auto isFirstValue = isNull(group);
+    clearNull(group);
+    if (mayUpdate(
+            comparisonValue(group), decodedComparisons, index, isFirstValue)) {
+      valueIsNull(group) = isValueNull;
+      if (LIKELY(!isValueNull)) {
+        store<T, ValueAccumulatorType>(
+            value(group), decodedValues, index, allocator_);
+      }
+      store<U, ComparisonAccumulatorType>(
+          comparisonValue(group), decodedComparisons, index, allocator_);
+    }
+  }
+
+  inline ValueAccumulatorType* value(char* group) {
+    return reinterpret_cast<ValueAccumulatorType*>(group + Aggregate::offset_);
+  }
+
+  inline ComparisonAccumulatorType* comparisonValue(char* group) {
+    return reinterpret_cast<ComparisonAccumulatorType*>(
+        group + Aggregate::offset_ + sizeof(ValueAccumulatorType));
+  }
+
+  inline bool& valueIsNull(char* group) {
+    return *reinterpret_cast<bool*>(
+        group + Aggregate::offset_ + sizeof(ValueAccumulatorType) +
+        sizeof(ComparisonAccumulatorType));
+  }
+
+  DecodedVector decodedValue_;
+  DecodedVector decodedComparison_;
+  DecodedVector decodedIntermediateResult_;
+};
+
+template <
+    template <
+        typename U,
+        typename V,
+        bool B1,
+        template <bool B2, typename C1, typename C2>
+        class C>
+    class Aggregate,
+    bool isMaxFunc,
+    template <bool B2, typename C1, typename C2>
+    class Comparator,
+    typename W>
+std::unique_ptr<exec::Aggregate> create(
+    TypePtr resultType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  switch (compareType->kind()) {
+    case TypeKind::BOOLEAN:
+      return std::make_unique<Aggregate<W, bool, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::TINYINT:
+      return std::make_unique<Aggregate<W, int8_t, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::SMALLINT:
+      return std::make_unique<Aggregate<W, int16_t, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::INTEGER:
+      return std::make_unique<Aggregate<W, int32_t, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::BIGINT:
+      return std::make_unique<Aggregate<W, int64_t, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::REAL:
+      return std::make_unique<Aggregate<W, float, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::DOUBLE:
+      return std::make_unique<Aggregate<W, double, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::VARCHAR:
+      return std::make_unique<Aggregate<W, StringView, isMaxFunc, Comparator>>(
+          resultType);
+    case TypeKind::TIMESTAMP:
+      return std::make_unique<Aggregate<W, Timestamp, isMaxFunc, Comparator>>(
+          resultType);
+    default:
+      VELOX_FAIL("{}", errorMessage);
+      return nullptr;
+  }
+}
+
+template <
+    template <
+        typename U,
+        typename V,
+        bool B1,
+        template <bool B2, typename C1, typename C2>
+        class C>
+    class Aggregate,
+    template <bool B2, typename C1, typename C2>
+    class Comparator,
+    bool isMaxFunc>
+std::unique_ptr<exec::Aggregate> create(
+    TypePtr resultType,
+    TypePtr valueType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  switch (valueType->kind()) {
+    case TypeKind::BOOLEAN:
+      return create<Aggregate, isMaxFunc, Comparator, bool>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TINYINT:
+      return create<Aggregate, isMaxFunc, Comparator, int8_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::SMALLINT:
+      return create<Aggregate, isMaxFunc, Comparator, int16_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::INTEGER:
+      return create<Aggregate, isMaxFunc, Comparator, int32_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::BIGINT:
+      return create<Aggregate, isMaxFunc, Comparator, int64_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::REAL:
+      return create<Aggregate, isMaxFunc, Comparator, float>(
+          resultType, compareType, errorMessage);
+    case TypeKind::DOUBLE:
+      return create<Aggregate, isMaxFunc, Comparator, double>(
+          resultType, compareType, errorMessage);
+    case TypeKind::VARCHAR:
+      return create<Aggregate, isMaxFunc, Comparator, StringView>(
+          resultType, compareType, errorMessage);
+    case TypeKind::TIMESTAMP:
+      return create<Aggregate, isMaxFunc, Comparator, Timestamp>(
+          resultType, compareType, errorMessage);
+    case TypeKind::ARRAY:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::MAP:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::ROW:
+      return create<Aggregate, isMaxFunc, Comparator, ComplexType>(
+          resultType, compareType, errorMessage);
+    default:
+      VELOX_FAIL(errorMessage);
+  }
+}
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 
-#include "velox/exec/Aggregate.h"
-#include "velox/exec/ContainerRowSerde.h"
-#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
+#include "velox/functions/lib/aggregates/MinMaxByAggregatesBase.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/vector/FlatVector.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -26,648 +23,35 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-void resizeRowVectorAndChildren(RowVector& rowVector, vector_size_t size) {
-  rowVector.resize(size);
-  for (auto& child : rowVector.children()) {
-    child->resize(size);
-  }
-}
-
-std::pair<vector_size_t*, vector_size_t*> rawOffsetAndSizes(
-    ArrayVector& arrayVector) {
-  return {
-      arrayVector.offsets()->asMutable<vector_size_t>(),
-      arrayVector.sizes()->asMutable<vector_size_t>()};
-}
-
-template <typename T>
-constexpr bool isNumeric() {
-  return std::is_same_v<T, bool> || std::is_same_v<T, int8_t> ||
-      std::is_same_v<T, int16_t> || std::is_same_v<T, int32_t> ||
-      std::is_same_v<T, int64_t> || std::is_same_v<T, float> ||
-      std::is_same_v<T, double> || std::is_same_v<T, Date> ||
-      std::is_same_v<T, Timestamp>;
-}
-
-template <typename T, typename TAccumulator>
-void extract(
-    TAccumulator* accumulator,
-    const VectorPtr& vector,
-    vector_size_t index,
-    T* rawValues,
-    uint64_t* rawBoolValues) {
-  if constexpr (isNumeric<T>()) {
-    if constexpr (std::is_same_v<T, bool>) {
-      bits::setBit(rawBoolValues, index, *accumulator);
-    } else {
-      rawValues[index] = *accumulator;
-    }
-  } else {
-    accumulator->read(vector, index);
-  }
-}
-
-template <typename T, typename TAccumulator>
-void store(
-    TAccumulator* accumulator,
-    const DecodedVector& decodedVector,
-    vector_size_t index,
-    HashStringAllocator* allocator) {
-  if constexpr (isNumeric<T>()) {
-    *accumulator = decodedVector.valueAt<T>(index);
-  } else {
-    accumulator->write(
-        decodedVector.base(), decodedVector.index(index), allocator);
-  }
-}
-
 /// Returns true if the value in 'index' row of 'newComparisons' is strictly
-/// greater than the value in the 'accumulator'.
-template <typename T, typename TAccumulator>
-bool greaterThan(
-    TAccumulator* accumulator,
-    const DecodedVector& newComparisons,
-    vector_size_t index,
-    bool isFirstValue) {
-  if constexpr (isNumeric<T>()) {
-    if (isFirstValue) {
-      return true;
-    }
-    return newComparisons.valueAt<T>(index) > *accumulator;
-  } else {
-    // SingleValueAccumulator::compare has the semantics of accumulator value is
-    // less than vector value.
-    return !accumulator->hasValue() ||
-        (accumulator->compare(newComparisons, index) < 0);
-  }
-}
-
-/// Returns true if the value in 'index' row of 'newComparisons' is strictly
-/// less than the value in the 'accumulator'.
-template <typename T, typename TAccumulator>
-bool lessThan(
-    TAccumulator* accumulator,
-    const DecodedVector& newComparisons,
-    vector_size_t index,
-    bool isFirstValue) {
-  if constexpr (isNumeric<T>()) {
-    if (isFirstValue) {
-      return true;
-    }
-    return newComparisons.valueAt<T>(index) < *accumulator;
-  } else {
-    // SingleValueAccumulator::compare has the semantics of accumulator value is
-    // greater than vector value.
-    return !accumulator->hasValue() ||
-        (accumulator->compare(newComparisons, index) > 0);
-  }
-}
-
-template <typename T, typename = void>
-struct AccumulatorTypeTraits {};
-
-template <typename T>
-struct AccumulatorTypeTraits<T, std::enable_if_t<isNumeric<T>(), void>> {
-  using AccumulatorType = T;
-};
-
-template <typename T>
-struct AccumulatorTypeTraits<T, std::enable_if_t<!isNumeric<T>(), void>> {
-  using AccumulatorType = SingleValueAccumulator;
-};
-
-/// MinMaxByAggregate is the base class for min_by and max_by functions
-/// with numeric value and comparison types. These functions return the value of
-/// X associated with the minimum/maximum value of Y over all input values.
-/// Partial aggregation produces a pair of X and min/max Y. Final aggregation
-/// takes a pair of X and min/max Y and returns X. T is the type of X and U is
-/// the type of Y.
-template <typename T, typename U>
-class MinMaxByAggregate : public exec::Aggregate {
- public:
-  using ValueAccumulatorType =
-      typename AccumulatorTypeTraits<T>::AccumulatorType;
-  using ComparisonAccumulatorType =
-      typename AccumulatorTypeTraits<U>::AccumulatorType;
-
-  explicit MinMaxByAggregate(TypePtr resultType)
-      : exec::Aggregate(resultType) {}
-
-  int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(ValueAccumulatorType) + sizeof(ComparisonAccumulatorType) +
-        sizeof(bool);
-  }
-
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    exec::Aggregate::setAllNulls(groups, indices);
-    for (const vector_size_t i : indices) {
-      auto group = groups[i];
-      valueIsNull(group) = true;
-
-      if constexpr (!isNumeric<T>()) {
-        new (group + offset_) SingleValueAccumulator();
-      } else {
-        *value(group) = ValueAccumulatorType();
-      }
-
-      if constexpr (isNumeric<U>()) {
-        *comparisonValue(group) = ComparisonAccumulatorType();
-      } else {
-        new (group + offset_ + sizeof(ValueAccumulatorType))
-            SingleValueAccumulator();
-      }
-    }
-  }
-
-  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
-      override {
-    VELOX_CHECK(result);
-    (*result)->resize(numGroups);
-    uint64_t* rawNulls = getRawNulls(result->get());
-
-    T* rawValues = nullptr;
-    uint64_t* rawBoolValues = nullptr;
-    if constexpr (isNumeric<T>()) {
-      auto vector = (*result)->as<FlatVector<T>>();
-      VELOX_CHECK(vector != nullptr);
-      if constexpr (std::is_same_v<T, bool>) {
-        rawBoolValues = vector->template mutableRawValues<uint64_t>();
-      } else {
-        rawValues = vector->mutableRawValues();
-      }
-    }
-
-    for (int32_t i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      if (isNull(group) || valueIsNull(group)) {
-        (*result)->setNull(i, true);
-      } else {
-        clearNull(rawNulls, i);
-        extract<T, ValueAccumulatorType>(
-            value(group), *result, i, rawValues, rawBoolValues);
-      }
-    }
-  }
-
-  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
-      override {
-    auto rowVector = (*result)->as<RowVector>();
-    auto valueVector = rowVector->childAt(0);
-    auto comparisonVector = rowVector->childAt(1);
-
-    resizeRowVectorAndChildren(*rowVector, numGroups);
-    uint64_t* rawNulls = getRawNulls(rowVector);
-
-    T* rawValues = nullptr;
-    uint64_t* rawBoolValues = nullptr;
-    if constexpr (isNumeric<T>()) {
-      auto flatValueVector = valueVector->as<FlatVector<T>>();
-      VELOX_CHECK(flatValueVector != nullptr);
-      if constexpr (std::is_same_v<T, bool>) {
-        rawBoolValues = flatValueVector->template mutableRawValues<uint64_t>();
-      } else {
-        rawValues = flatValueVector->mutableRawValues();
-      }
-    }
-    U* rawComparisonValues = nullptr;
-    uint64_t* rawBoolComparisonValues = nullptr;
-    if constexpr (isNumeric<U>()) {
-      auto flatComparisonVector = comparisonVector->as<FlatVector<U>>();
-      VELOX_CHECK(flatComparisonVector != nullptr);
-      if constexpr (std::is_same_v<U, bool>) {
-        rawBoolComparisonValues =
-            flatComparisonVector->template mutableRawValues<uint64_t>();
-      } else {
-        rawComparisonValues = flatComparisonVector->mutableRawValues();
-      }
-    }
-    uint64_t* rawValueNulls =
-        valueVector->mutableNulls(rowVector->size())->asMutable<uint64_t>();
-    for (int32_t i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      if (isNull(group)) {
-        rowVector->setNull(i, true);
-      } else {
-        clearNull(rawNulls, i);
-        const bool isValueNull = valueIsNull(group);
-        bits::setNull(rawValueNulls, i, isValueNull);
-        if (LIKELY(!isValueNull)) {
-          extract<T, ValueAccumulatorType>(
-              value(group), valueVector, i, rawValues, rawBoolValues);
-        }
-        extract<U, ComparisonAccumulatorType>(
-            comparisonValue(group),
-            comparisonVector,
-            i,
-            rawComparisonValues,
-            rawBoolComparisonValues);
-      }
-    }
-  }
-
-  void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      if constexpr (!isNumeric<T>()) {
-        value(group)->destroy(allocator_);
-      }
-      if constexpr (!isNumeric<U>()) {
-        comparisonValue(group)->destroy(allocator_);
-      }
-    }
-  }
-
- protected:
-  template <typename MayUpdate>
-  void addRawInput(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      MayUpdate mayUpdate) {
-    // decodedValue contains the values of column X. decodedComparisonValue
-    // contains the values of column Y which is used to select the minimum or
-    // the maximum.
-    decodedValue_.decode(*args[0], rows);
-    decodedComparison_.decode(*args[1], rows);
-
-    if (decodedValue_.isConstantMapping() &&
-        decodedComparison_.isConstantMapping() &&
-        decodedComparison_.isNullAt(0)) {
-      return;
-    }
-    if (decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (decodedComparison_.isNullAt(i)) {
-          return;
-        }
-        updateValues(
-            groups[i],
-            decodedValue_,
-            decodedComparison_,
-            i,
-            decodedValue_.isNullAt(i),
-            mayUpdate);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        updateValues(
-            groups[i], decodedValue_, decodedComparison_, i, false, mayUpdate);
-      });
-    }
-  }
-
-  template <typename MayUpdate>
-  void addIntermediateResults(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      MayUpdate mayUpdate) {
-    decodedIntermediateResult_.decode(*args[0], rows);
-    auto baseRowVector =
-        dynamic_cast<const RowVector*>(decodedIntermediateResult_.base());
-
-    decodedValue_.decode(*baseRowVector->childAt(0), rows);
-    decodedComparison_.decode(*baseRowVector->childAt(1), rows);
-
-    if (decodedIntermediateResult_.isConstantMapping() &&
-        decodedIntermediateResult_.isNullAt(0)) {
-      return;
-    }
-    if (decodedIntermediateResult_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (decodedIntermediateResult_.isNullAt(i)) {
-          return;
-        }
-        const auto decodedIndex = decodedIntermediateResult_.index(i);
-        updateValues(
-            groups[i],
-            decodedValue_,
-            decodedComparison_,
-            decodedIndex,
-            decodedValue_.isNullAt(decodedIndex),
-            mayUpdate);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        const auto decodedIndex = decodedIntermediateResult_.index(i);
-        updateValues(
-            groups[i],
-            decodedValue_,
-            decodedComparison_,
-            decodedIndex,
-            decodedValue_.isNullAt(decodedIndex),
-            mayUpdate);
-      });
-    }
-  }
-
-  template <typename MayUpdate>
-  void addSingleGroupRawInput(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      MayUpdate mayUpdate) {
-    // decodedValue contains the values of column X. decodedComparisonValue
-    // contains the values of column Y which is used to select the minimum or
-    // the maximum.
-    decodedValue_.decode(*args[0], rows);
-    decodedComparison_.decode(*args[1], rows);
-    if (decodedValue_.isConstantMapping() &&
-        decodedComparison_.isConstantMapping()) {
-      if (decodedComparison_.isNullAt(0)) {
-        return;
-      }
-      updateValues(
-          group,
-          decodedValue_,
-          decodedComparison_,
-          0,
-          decodedValue_.isNullAt(0),
-          mayUpdate);
-    } else if (
-        decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (decodedComparison_.isNullAt(i)) {
-          return;
-        }
-        updateValues(
-            group,
-            decodedValue_,
-            decodedComparison_,
-            i,
-            decodedValue_.isNullAt(i),
-            mayUpdate);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        updateValues(
-            group, decodedValue_, decodedComparison_, i, false, mayUpdate);
-      });
-    }
-  }
-
-  /// Final aggregation takes (value, comparisonValue) structs as inputs. It
-  /// produces the Value associated with the maximum/minimum of comparisonValue
-  /// over all structs.
-  template <typename MayUpdate>
-  void addSingleGroupIntermediateResults(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      MayUpdate mayUpdate) {
-    // Decode struct(Value, ComparisonValue) as individual vectors.
-    decodedIntermediateResult_.decode(*args[0], rows);
-    auto baseRowVector =
-        dynamic_cast<const RowVector*>(decodedIntermediateResult_.base());
-
-    decodedValue_.decode(*baseRowVector->childAt(0), rows);
-    decodedComparison_.decode(*baseRowVector->childAt(1), rows);
-
-    if (decodedIntermediateResult_.isConstantMapping()) {
-      if (decodedIntermediateResult_.isNullAt(0)) {
-        return;
-      }
-      const auto decodedIndex = decodedIntermediateResult_.index(0);
-      updateValues(
-          group,
-          decodedValue_,
-          decodedComparison_,
-          decodedIndex,
-          decodedValue_.isNullAt(decodedIndex),
-          mayUpdate);
-    } else if (decodedIntermediateResult_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (decodedIntermediateResult_.isNullAt(i)) {
-          return;
-        }
-        const auto decodedIndex = decodedIntermediateResult_.index(i);
-        updateValues(
-            group,
-            decodedValue_,
-            decodedComparison_,
-            decodedIndex,
-            decodedValue_.isNullAt(decodedIndex),
-            mayUpdate);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        const auto decodedIndex = decodedIntermediateResult_.index(i);
-        updateValues(
-            group,
-            decodedValue_,
-            decodedComparison_,
-            decodedIndex,
-            decodedValue_.isNullAt(decodedIndex),
-            mayUpdate);
-      });
-    }
-  }
-
- private:
-  template <typename MayUpdate>
-  inline void updateValues(
-      char* group,
-      const DecodedVector& decodedValues,
-      const DecodedVector& decodedComparisons,
+/// greater than or less than the value in the 'accumulator'.
+template <bool greaterThan, typename T, typename TAccumulator>
+struct Comparator {
+  static bool compare(
+      TAccumulator* accumulator,
+      const DecodedVector& newComparisons,
       vector_size_t index,
-      bool isValueNull,
-      MayUpdate mayUpdate) {
-    auto isFirstValue = isNull(group);
-    clearNull(group);
-    if (mayUpdate(
-            comparisonValue(group), decodedComparisons, index, isFirstValue)) {
-      valueIsNull(group) = isValueNull;
-      if (LIKELY(!isValueNull)) {
-        store<T, ValueAccumulatorType>(
-            value(group), decodedValues, index, allocator_);
+      bool isFirstValue) {
+    if constexpr (isNumeric<T>()) {
+      if (isFirstValue) {
+        return true;
       }
-      store<U, ComparisonAccumulatorType>(
-          comparisonValue(group), decodedComparisons, index, allocator_);
+      if constexpr (greaterThan) {
+        return newComparisons.valueAt<T>(index) > *accumulator;
+      } else {
+        return newComparisons.valueAt<T>(index) < *accumulator;
+      }
+    } else {
+      // SingleValueAccumulator::compare has the semantics of accumulator value
+      // is less than vector value.
+      if constexpr (greaterThan) {
+        return !accumulator->hasValue() ||
+            (accumulator->compare(newComparisons, index) < 0);
+      } else {
+        return !accumulator->hasValue() ||
+            (accumulator->compare(newComparisons, index) > 0);
+      }
     }
-  }
-
-  inline ValueAccumulatorType* value(char* group) {
-    return reinterpret_cast<ValueAccumulatorType*>(group + Aggregate::offset_);
-  }
-
-  inline ComparisonAccumulatorType* comparisonValue(char* group) {
-    return reinterpret_cast<ComparisonAccumulatorType*>(
-        group + Aggregate::offset_ + sizeof(ValueAccumulatorType));
-  }
-
-  inline bool& valueIsNull(char* group) {
-    return *reinterpret_cast<bool*>(
-        group + Aggregate::offset_ + sizeof(ValueAccumulatorType) +
-        sizeof(ComparisonAccumulatorType));
-  }
-
-  DecodedVector decodedValue_;
-  DecodedVector decodedComparison_;
-  DecodedVector decodedIntermediateResult_;
-};
-
-template <typename T, typename U>
-class MaxByAggregate : public MinMaxByAggregate<T, U> {
- public:
-  using ComparisonAccumulatorType =
-      typename AccumulatorTypeTraits<U>::AccumulatorType;
-
-  explicit MaxByAggregate(TypePtr resultType)
-      : MinMaxByAggregate<T, U>(resultType) {}
-
-  void addRawInput(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*unused*/) override {
-    MinMaxByAggregate<T, U>::addRawInput(
-        groups,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return greaterThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addIntermediateResults(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*mayPushdown*/) override {
-    MinMaxByAggregate<T, U>::addIntermediateResults(
-        groups,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return greaterThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addSingleGroupRawInput(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*unused*/) override {
-    MinMaxByAggregate<T, U>::addSingleGroupRawInput(
-        group,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return greaterThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addSingleGroupIntermediateResults(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*mayPushdown*/) override {
-    MinMaxByAggregate<T, U>::addSingleGroupIntermediateResults(
-        group,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return greaterThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-};
-
-template <typename T, typename U>
-class MinByAggregate : public MinMaxByAggregate<T, U> {
- public:
-  using ComparisonAccumulatorType =
-      typename AccumulatorTypeTraits<U>::AccumulatorType;
-
-  explicit MinByAggregate(TypePtr resultType)
-      : MinMaxByAggregate<T, U>(resultType) {}
-
-  void addRawInput(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*unused*/) override {
-    MinMaxByAggregate<T, U>::addRawInput(
-        groups,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return lessThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addIntermediateResults(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*mayPushdown*/) override {
-    MinMaxByAggregate<T, U>::addIntermediateResults(
-        groups,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return lessThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addSingleGroupRawInput(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*unused*/) override {
-    MinMaxByAggregate<T, U>::addSingleGroupRawInput(
-        group,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return lessThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
-  }
-
-  void addSingleGroupIntermediateResults(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /*mayPushdown*/) override {
-    MinMaxByAggregate<T, U>::addSingleGroupIntermediateResults(
-        group,
-        rows,
-        args,
-        [&](auto* accumulator,
-            const auto& newComparisons,
-            auto index,
-            auto isFirstValue) {
-          return lessThan<U, ComparisonAccumulatorType>(
-              accumulator, newComparisons, index, isFirstValue);
-        });
   }
 };
 
@@ -1511,69 +895,76 @@ class MaxByNAggregate<ComplexType, C>
             Greater<HashStringAllocator::Position, C>>(resultType) {}
 };
 
-template <template <typename U, typename V> class Aggregate, typename W>
-std::unique_ptr<exec::Aggregate> create(
+template <template <typename U, typename V> class NAggregate, typename W>
+std::unique_ptr<exec::Aggregate> createNArg(
     TypePtr resultType,
     TypePtr compareType,
     const std::string& errorMessage) {
   switch (compareType->kind()) {
     case TypeKind::BOOLEAN:
-      return std::make_unique<Aggregate<W, bool>>(resultType);
+      return std::make_unique<NAggregate<W, bool>>(resultType);
     case TypeKind::TINYINT:
-      return std::make_unique<Aggregate<W, int8_t>>(resultType);
+      return std::make_unique<NAggregate<W, int8_t>>(resultType);
     case TypeKind::SMALLINT:
-      return std::make_unique<Aggregate<W, int16_t>>(resultType);
+      return std::make_unique<NAggregate<W, int16_t>>(resultType);
     case TypeKind::INTEGER:
-      return std::make_unique<Aggregate<W, int32_t>>(resultType);
+      return std::make_unique<NAggregate<W, int32_t>>(resultType);
     case TypeKind::BIGINT:
-      return std::make_unique<Aggregate<W, int64_t>>(resultType);
+      return std::make_unique<NAggregate<W, int64_t>>(resultType);
     case TypeKind::REAL:
-      return std::make_unique<Aggregate<W, float>>(resultType);
+      return std::make_unique<NAggregate<W, float>>(resultType);
     case TypeKind::DOUBLE:
-      return std::make_unique<Aggregate<W, double>>(resultType);
+      return std::make_unique<NAggregate<W, double>>(resultType);
     case TypeKind::VARCHAR:
-      return std::make_unique<Aggregate<W, StringView>>(resultType);
+      return std::make_unique<NAggregate<W, StringView>>(resultType);
     case TypeKind::TIMESTAMP:
-      return std::make_unique<Aggregate<W, Timestamp>>(resultType);
+      return std::make_unique<NAggregate<W, Timestamp>>(resultType);
     default:
       VELOX_FAIL("{}", errorMessage);
       return nullptr;
   }
 }
 
-template <template <typename U, typename V> class Aggregate>
-std::unique_ptr<exec::Aggregate> create(
+template <template <typename U, typename V> class NAggregate>
+std::unique_ptr<exec::Aggregate> createNArg(
     TypePtr resultType,
     TypePtr valueType,
     TypePtr compareType,
     const std::string& errorMessage) {
   switch (valueType->kind()) {
     case TypeKind::BOOLEAN:
-      return create<Aggregate, bool>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, bool>(
+          resultType, compareType, errorMessage);
     case TypeKind::TINYINT:
-      return create<Aggregate, int8_t>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, int8_t>(
+          resultType, compareType, errorMessage);
     case TypeKind::SMALLINT:
-      return create<Aggregate, int16_t>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, int16_t>(
+          resultType, compareType, errorMessage);
     case TypeKind::INTEGER:
-      return create<Aggregate, int32_t>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, int32_t>(
+          resultType, compareType, errorMessage);
     case TypeKind::BIGINT:
-      return create<Aggregate, int64_t>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, int64_t>(
+          resultType, compareType, errorMessage);
     case TypeKind::REAL:
-      return create<Aggregate, float>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, float>(
+          resultType, compareType, errorMessage);
     case TypeKind::DOUBLE:
-      return create<Aggregate, double>(resultType, compareType, errorMessage);
+      return createNArg<NAggregate, double>(
+          resultType, compareType, errorMessage);
     case TypeKind::VARCHAR:
-      return create<Aggregate, StringView>(
+      return createNArg<NAggregate, StringView>(
           resultType, compareType, errorMessage);
     case TypeKind::TIMESTAMP:
-      return create<Aggregate, Timestamp>(
+      return createNArg<NAggregate, Timestamp>(
           resultType, compareType, errorMessage);
     case TypeKind::ARRAY:
       FOLLY_FALLTHROUGH;
     case TypeKind::MAP:
       FOLLY_FALLTHROUGH;
     case TypeKind::ROW:
-      return create<Aggregate, ComplexType>(
+      return createNArg<NAggregate, ComplexType>(
           resultType, compareType, errorMessage);
     default:
       VELOX_FAIL(errorMessage);
@@ -1592,8 +983,14 @@ std::string toString(const std::vector<TypePtr>& types) {
 }
 
 template <
-    template <typename U, typename V>
+    template <
+        typename U,
+        typename V,
+        bool B1,
+        template <bool B2, typename C1, typename C2>
+        class C>
     class Aggregate,
+    bool isMaxFunc,
     template <typename U, typename V>
     class NAggregate>
 exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
@@ -1658,27 +1055,27 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
         if (nAgg) {
           if (isRawInput) {
             // Input is: V, C, BIGINT.
-            return create<NAggregate>(
+            return createNArg<NAggregate>(
                 resultType, argTypes[0], argTypes[1], errorMessage);
           } else {
             // Input is: ROW(BIGINT, ARRAY(C), ARRAY(V)).
             const auto& rowType = argTypes[0];
             const auto& compareType = rowType->childAt(1)->childAt(0);
             const auto& valueType = rowType->childAt(2)->childAt(0);
-            return create<NAggregate>(
+            return createNArg<NAggregate>(
                 resultType, valueType, compareType, errorMessage);
           }
         } else {
           if (isRawInput) {
             // Input is: V, C.
-            return create<Aggregate>(
+            return create<Aggregate, Comparator, isMaxFunc>(
                 resultType, argTypes[0], argTypes[1], errorMessage);
           } else {
             // Input is: ROW(V, C).
             const auto& rowType = argTypes[0];
             const auto& valueType = rowType->childAt(0);
             const auto& compareType = rowType->childAt(1);
-            return create<Aggregate>(
+            return create<Aggregate, Comparator, isMaxFunc>(
                 resultType, valueType, compareType, errorMessage);
           }
         }
@@ -1688,8 +1085,10 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
 } // namespace
 
 void registerMinMaxByAggregates(const std::string& prefix) {
-  registerMinMaxBy<MaxByAggregate, MaxByNAggregate>(prefix + kMaxBy);
-  registerMinMaxBy<MinByAggregate, MinByNAggregate>(prefix + kMinBy);
+  registerMinMaxBy<MinMaxByAggregateBase, true, MaxByNAggregate>(
+      prefix + kMaxBy);
+  registerMinMaxBy<MinMaxByAggregateBase, false, MinByNAggregate>(
+      prefix + kMinBy);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_library(
   velox_functions_spark_aggregates
   BitwiseXorAggregate.cpp BloomFilterAggAggregate.cpp FirstLastAggregate.cpp
-  AverageAggregate.cpp Register.cpp)
+  AverageAggregate.cpp MinMaxByAggregate.cpp Register.cpp)
 
 target_link_libraries(velox_functions_spark_aggregates fmt::fmt velox_exec
                       velox_expression_functions velox_aggregates velox_vector)

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/aggregates/MinMaxByAggregatesBase.h"
+
+using namespace facebook::velox::functions::aggregate;
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+namespace {
+
+/// Returns compare result align with Spark's specific behavior,
+/// which returns true if the value in 'index' row of 'newComparisons' is
+/// greater than/equal or less than/equal the value in the 'accumulator'.
+template <bool sparkGreaterThan, typename T, typename TAccumulator>
+struct SparkComparator {
+  static bool compare(
+      TAccumulator* accumulator,
+      const DecodedVector& newComparisons,
+      vector_size_t index,
+      bool isFirstValue) {
+    if constexpr (isNumeric<T>()) {
+      if (isFirstValue) {
+        return true;
+      }
+      if constexpr (sparkGreaterThan) {
+        return newComparisons.valueAt<T>(index) >= *accumulator;
+      } else {
+        return newComparisons.valueAt<T>(index) <= *accumulator;
+      }
+    } else {
+      if constexpr (sparkGreaterThan) {
+        return !accumulator->hasValue() ||
+            (accumulator->compare(newComparisons, index) <= 0);
+      } else {
+        return !accumulator->hasValue() ||
+            (accumulator->compare(newComparisons, index) >= 0);
+      }
+    }
+  }
+};
+
+std::string toString(const std::vector<TypePtr>& types) {
+  std::ostringstream out;
+  for (auto i = 0; i < types.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << types[i]->toString();
+  }
+  return out.str();
+}
+
+template <
+    template <
+        typename U,
+        typename V,
+        bool B1,
+        template <bool B2, typename C1, typename C2>
+        class C>
+    class Aggregate,
+    bool isMaxFunc>
+exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
+  const std::vector<std::string> supportedCompareTypes = {
+      "boolean",
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "real",
+      "double",
+      "varchar",
+      "date",
+      "timestamp"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  for (const auto& compareType : supportedCompareTypes) {
+    // V, C -> row(V, C) -> V.
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .typeVariable("T")
+            .returnType("T")
+            .intermediateType(fmt::format("row(T,{})", compareType))
+            .argumentType("T")
+            .argumentType(compareType)
+            .build());
+  }
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        const auto isRawInput = exec::isRawInput(step);
+        const std::string errorMessage = fmt::format(
+            "Unknown input types for {} ({}) aggregation: {}",
+            name,
+            mapAggregationStepToName(step),
+            toString(argTypes));
+
+        if (isRawInput) {
+          // Input is: V, C.
+          return create<Aggregate, SparkComparator, isMaxFunc>(
+              resultType, argTypes[0], argTypes[1], errorMessage);
+        } else {
+          // Input is: ROW(V, C).
+          const auto& rowType = argTypes[0];
+          const auto& valueType = rowType->childAt(0);
+          const auto& compareType = rowType->childAt(1);
+          return create<Aggregate, SparkComparator, isMaxFunc>(
+              resultType, valueType, compareType, errorMessage);
+        }
+      });
+}
+
+} // namespace
+
+void registerMinMaxByAggregates(const std::string& prefix) {
+  registerMinMaxBy<MinMaxByAggregateBase, true>(prefix + "max_by");
+  registerMinMaxBy<MinMaxByAggregateBase, false>(prefix + "min_by");
+}
+
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -23,9 +23,11 @@
 namespace facebook::velox::functions::aggregate::sparksql {
 
 extern void registerFirstLastAggregates(const std::string& prefix);
+extern void registerMinMaxByAggregates(const std::string& prefix);
 
 void registerAggregateFunctions(const std::string& prefix) {
   registerFirstLastAggregates(prefix);
+  registerMinMaxByAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
   registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
   registerAverage(prefix + "avg");

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -14,9 +14,13 @@
 
 add_executable(
   velox_functions_spark_aggregates_test
-  BitwiseXorAggregationTest.cpp BloomFilterAggAggregateTest.cpp
-  FirstAggregateTest.cpp LastAggregateTest.cpp AverageAggregationTest.cpp
-  Main.cpp)
+  BitwiseXorAggregationTest.cpp
+  BloomFilterAggAggregateTest.cpp
+  FirstAggregateTest.cpp
+  LastAggregateTest.cpp
+  AverageAggregationTest.cpp
+  Main.cpp
+  MinMaxByAggregationTest.cpp)
 
 add_test(velox_functions_spark_aggregates_test
          velox_functions_spark_aggregates_test)

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+
+namespace {
+
+class MinMaxByAggregateTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    AggregationTestBase::disallowInputShuffle();
+    registerAggregateFunctions("spark_");
+  }
+};
+
+TEST_F(MinMaxByAggregateTest, maxBy) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<int32_t>({11, 12, 12}),
+  })};
+
+  auto expected = {makeRowVector({
+      makeFlatVector<int32_t>(std::vector<int32_t>({3})),
+  })};
+
+  testAggregations(vectors, {}, {"spark_max_by(c0, c1)"}, expected);
+}
+
+TEST_F(MinMaxByAggregateTest, minBy) {
+  auto vectors = {makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+      makeFlatVector<int32_t>({12, 11, 11}),
+  })};
+
+  auto expected = {makeRowVector({
+      makeFlatVector<int32_t>(std::vector<int32_t>({3})),
+  })};
+
+  testAggregations(vectors, {}, {"spark_min_by(c0, c1)"}, expected);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
Summary:
1. Spark's max_by/min_by updates accumulator when new value is greater than or equal/less than or equal to old value, but Presto is greater than/less than, detailed #4970.
2. Extract common codes of 2-arg version MinMaxByAggregates into velox/functions/lib/aggregates/MinMaxByAggregateBase.h.
3. Add new UT for Spark specific behavior.

Fixed #4970 