### PR TITLE
Support UNKNOWN type in Unsaferow serde

### DIFF
--- a/velox/docs/develop/unsaferow.rst
+++ b/velox/docs/develop/unsaferow.rst
@@ -24,6 +24,14 @@ fixed-width columns (booleans, integers, floating point numbers) are stored
 directly. These values must fit within 8 bytes. Long decimal columns are not
 supported.
 
+For UNKNOWN type (i.e NullType in Spark type system) serialization,
+Spark doesn't define how should the UNKNOWN type be serialized into UnsafeRow,
+during query evaluation, Spark won't serialzie anything into the
+UnsafRow byte buffer. During deserializtion, if the caller wants to access
+the value with UNKNOWN type, Spark returns a null value directly without
+doing any actual deserialization. We implemented the same behavior in Velox's
+UnsafeRow serializer/deserializer for consistency.
+
 Values of the variable-width columns (strings, arrays, maps) are split between
 fixed-width and variable-width sections. 8 bytes of the fixed-width section
 store the size and location of the value in the variable-width section.

--- a/velox/row/UnsafeRow.h
+++ b/velox/row/UnsafeRow.h
@@ -421,7 +421,7 @@ FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes<TypeKind::VARBINARY>() {
 /// Returns the number of bytes needed to serialized fixed-width type. Throws if
 /// 'type' is ot fixed-width.
 FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes(const TypePtr& type) {
-  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
       serializedSizeInBytes, type->kind());
 }
 

--- a/velox/row/UnsafeRowDeserializers.h
+++ b/velox/row/UnsafeRowDeserializers.h
@@ -755,7 +755,7 @@ struct UnsafeRowDeserializer {
     const TypePtr& type = dataIterator->type();
     assert(type->isPrimitiveType());
 
-    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
         createFlatVector, type->kind(), dataIterator, type, pool);
   }
 

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_row_test UnsafeRowFuzzTest.cpp)
+add_executable(velox_row_test UnsafeRowFuzzTest.cpp UnsafeRowSerdeTest.cpp)
 
 add_test(velox_row_test velox_row_test)
 

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -106,6 +106,7 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       DOUBLE(),
       VARCHAR(),
       VARBINARY(),
+      UNKNOWN(),
       // Arrays.
       ARRAY(BOOLEAN()),
       ARRAY(TINYINT()),
@@ -116,10 +117,12 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       ARRAY(DOUBLE()),
       ARRAY(VARCHAR()),
       ARRAY(VARBINARY()),
+      ARRAY(UNKNOWN()),
       // Nested arrays.
       ARRAY(ARRAY(INTEGER())),
       ARRAY(ARRAY(BIGINT())),
       ARRAY(ARRAY(VARCHAR())),
+      ARRAY(ARRAY(UNKNOWN())),
       // Maps.
       MAP(BIGINT(), REAL()),
       MAP(BIGINT(), BIGINT()),
@@ -127,6 +130,8 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       MAP(INTEGER(), MAP(BIGINT(), DOUBLE())),
       MAP(VARCHAR(), BOOLEAN()),
       MAP(INTEGER(), MAP(BIGINT(), ARRAY(REAL()))),
+      MAP(BIGINT(), UNKNOWN()),
+      MAP(BIGINT(), MAP(BIGINT(), UNKNOWN())),
       // Timestamp and date types.
       TIMESTAMP(),
       DATE(),
@@ -139,7 +144,9 @@ TEST_F(UnsafeRowFuzzTests, fast) {
           {BOOLEAN(),
            ROW({INTEGER(), TIMESTAMP()}),
            VARCHAR(),
+           ROW({UNKNOWN()}),
            ARRAY(BIGINT())}),
+      ROW({UNKNOWN()}),
       ARRAY({ROW({BIGINT(), VARCHAR()})}),
       MAP(BIGINT(), ROW({BOOLEAN(), TINYINT(), REAL()})),
   });

--- a/velox/row/tests/UnsafeRowSerdeTest.cpp
+++ b/velox/row/tests/UnsafeRowSerdeTest.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <optional>
+
+#include "velox/row/UnsafeRowDeserializers.h"
+
+#include "velox/row/UnsafeRowFast.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+
+namespace facebook::velox::row {
+class UnsafeRowSerdeTest : public testing::Test, public test::VectorTestBase {
+ public:
+  RowVectorPtr createInputRowWithUnknownType(int32_t batchSize) {
+    auto flatVector = makeAllNullFlatVector<UnknownValue>(batchSize);
+    auto arrayVector = makeAllNullArrayVector(batchSize, UNKNOWN());
+    auto mapVector = makeAllNullMapVector(batchSize, UNKNOWN(), UNKNOWN());
+    auto rowVector = makeRowVector({flatVector, arrayVector, mapVector});
+    return makeRowVector({arrayVector, mapVector, flatVector, rowVector});
+  }
+
+  void testVectorSerde(const RowVectorPtr& inputVector) {
+    std::vector<std::optional<std::string_view>> serializedRows;
+    serializedRows.reserve(inputVector->size());
+    buffers_.reserve(inputVector->size());
+    UnsafeRowFast fast(inputVector);
+
+    for (size_t i = 0; i < inputVector->size(); ++i) {
+      const auto expectedRowSize = fast.rowSize(i);
+      buffers_.push_back(
+          AlignedBuffer::allocate<char>(expectedRowSize, pool_.get()));
+
+      // Serialize rowVector into bytes.
+      const auto rowSize = fast.serialize(i, buffers_[i]->asMutable<char>());
+
+      EXPECT_EQ(expectedRowSize, rowSize);
+
+      serializedRows.push_back(
+          std::string_view(buffers_[i]->asMutable<char>(), rowSize));
+    }
+    const auto outputVector = UnsafeRowDeserializer::deserialize(
+        serializedRows, inputVector->type(), pool());
+    test::assertEqualVectors(inputVector, outputVector);
+  }
+
+ private:
+  std::vector<BufferPtr> buffers_{};
+};
+
+TEST_F(UnsafeRowSerdeTest, unknownRows) {
+  for (int32_t batchSize : {1, 5, 10}) {
+    const auto& inputVector = createInputRowWithUnknownType(batchSize);
+    testVectorSerde(inputVector);
+  }
+}
+
+} // namespace facebook::velox::row


### PR DESCRIPTION
Summary: We have several presto-on-spark native end-2-end unit tests failures due to Unsaferow serde doesn't support UNKNOWN (null) type. This commit add the support.

Differential Revision: D45949003

