### PR TITLE
Use rethrow for memory reservation failure in mmap allocator

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -267,7 +267,7 @@ bool MmapAllocator::allocateContiguousImpl(
       // We failed to grow by 'newPages. So we record the freeing off the whole
       // collateral and the unmap of former 'allocation'.
       reservationCB(AllocationTraits::pageBytes(totalCollateralPages), false);
-      throw;
+      std::rethrow_exception(std::current_exception());
     }
   }
 


### PR DESCRIPTION
Make sure we rethrow the caught exception on mmap allocator
failure. We have seen in Prestissimo that the coordinator gets
std::exception on memory capacity exceeded error. The place changed
in this diff is call site where we have seen this problem in prod.
On Mac, throw and rethrow are different but not sure if the other
compiler or platform handles the same way. Added unit test to
catch this as well.