### PR TITLE
Forgot to do some checks

### DIFF
--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -79,6 +79,8 @@ void expectPreadvs(
         for (size_t i = 0; i < reads.size(); ++i) {
           const auto& segment = segments[i];
           const auto& read = reads[i];
+          ASSERT_EQ(segment.offset, read.first);
+          ASSERT_EQ(segment.buffer.size(), read.second);
           ASSERT_LE(segment.offset + segment.buffer.size(), content.size());
           ASSERT_EQ(segment.offset, read.first);
           ASSERT_EQ(segment.buffer.size(), read.second);


### PR DESCRIPTION
Summary: `read` was unused because I forgot to do those checks

Differential Revision: D45955863

