### PR TITLE
Fix inconsistent element orders in the result of map()

### DIFF
--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -320,6 +320,15 @@ TEST_F(MapTest, constantKeys) {
           makeFlatVector<int32_t>(size, valueAt),
       }));
   assertEqualVectors(nullMap, result);
+
+  // Same order of keys regardless of input keys being constant or not.
+  auto result1 = evaluate(
+      "map_keys(map(array[1, 2, 3], array_constructor(c0, c0, c0)))",
+      makeRowVector({makeFlatVector<int32_t>(size, valueAt)}));
+  auto result2 = evaluate(
+      "map_keys(map(array[3, 2, 1], array_constructor(c0, c0, c0)))",
+      makeRowVector({makeFlatVector<int32_t>(size, valueAt)}));
+  assertEqualVectors(result1, result2);
 }
 
 // Test map function applied to a flat array of keys and constant array of


### PR DESCRIPTION
Summary:
The map() function produces a map vector where the order of elements depends 
on the input vector encodings. Specifically, when the first input has constant 
mapping, the keys in the result vector are not sorted, whereas keys are sorted in 
other situations. This caused unmatched result in expression fuzzer of an expression 
`map_keys(map(...))` when the first input to map() has constant mapping. This 
diff makes the keys sorted in the result vector when the first input has constant 
mapping.

Benchmark reuslt before the change:
```
============================================================================
[...]prestosql/benchmarks/MapBenchmark.cpp     relative  time/iter   iters/s
============================================================================
constantKeys                                               70.08ns    14.27M
flatKeys                                                  246.59ns     4.06M
```

after the change:
```
============================================================================
[...]prestosql/benchmarks/MapBenchmark.cpp     relative  time/iter   iters/s
============================================================================
constantKeys                                               72.01ns    13.89M
flatKeys                                                  259.68ns     3.85M
```

This diff fixes https://github.com/facebookincubator/velox/issues/4951.

Differential Revision: D45957356

