### PR TITLE
[Feat] Add 'max_coalesce_distance_bytes' as a gflag.

### DIFF
--- a/velox/dwio/common/Options.cpp
+++ b/velox/dwio/common/Options.cpp
@@ -16,6 +16,11 @@
 
 #include "velox/dwio/common/Options.h"
 
+DEFINE_int32(
+    max_coalesce_distance_bytes,
+    512 << 10, // 512K
+    "Maximum distance in which coalesce will combine requests.");
+
 namespace facebook {
 namespace velox {
 namespace dwio {

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -27,6 +27,8 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
 
+DECLARE_int32(max_coalesce_distance_bytes);
+
 namespace facebook {
 namespace velox {
 namespace dwio {
@@ -348,7 +350,7 @@ class ReaderOptions {
   uint64_t autoPreloadLength;
   PrefetchMode prefetchMode;
   int32_t loadQuantum_{kDefaultLoadQuantum};
-  int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
+  int32_t maxCoalesceDistance_{FLAGS_max_coalesce_distance_bytes};
   SerDeOptions serDeOptions;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
   uint64_t directorySizeGuess{kDefaultDirectorySizeGuess};
@@ -356,7 +358,6 @@ class ReaderOptions {
 
  public:
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
-  static constexpr int32_t kDefaultCoalesceDistance = 512 << 10; // 512K
   static constexpr uint64_t kDefaultDirectorySizeGuess = 1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB

--- a/velox/dwio/common/tests/OptionsTests.cpp
+++ b/velox/dwio/common/tests/OptionsTests.cpp
@@ -40,3 +40,9 @@ TEST(OptionsTests, testAppendRowNumberColumnInCopy) {
   RowReaderOptions rowReaderOptionsSecondCopy{rowReaderOptions};
   ASSERT_EQ(true, rowReaderOptionsSecondCopy.getAppendRowNumberColumn());
 }
+
+TEST(OptionsTests, testForDefaultMaxCoalesce) {
+  ReaderOptions readerOptions(nullptr);
+  ASSERT_EQ(
+      FLAGS_max_coalesce_distance_bytes, readerOptions.maxCoalesceDistance());
+}


### PR DESCRIPTION
As general work toward improving S3 performance this gflag will be useful to improve request sizes. (Issue# 3938)