### PR TITLE
Fix: addNulls should ensure vector and its resizable buffers are unique before resizing it

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1004,6 +1004,8 @@ void Expr::addNulls(
   }
 
   if (result->size() < rows.end()) {
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(), type, context.pool(), result);
     result->resize(rows.end());
   }
 


### PR DESCRIPTION
Summary:
Add nulls calls resize without any checks, a previous diff (https://github.com/facebookincubator/velox/pull/4884) updates
resize functions to make them initialize indices and sizes to 0.

This resulted in addNulls doing the resize on invalid vectors.
This diff is a hotfix to unblock the fuzzer test failures and will be
followed up by a more thorough solution.

solves:
https://github.com/facebookincubator/velox/issues/4977
https://github.com/facebookincubator/velox/issues/4979
https://github.com/facebookincubator/velox/issues/4978

Differential Revision: D45970472

