### PR TITLE
Improve error message for unsupported aggregation function signatures

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -218,17 +218,25 @@ TypePtr Aggregate::intermediateType(
     const std::vector<TypePtr>& argTypes) {
   auto signatures = getAggregateFunctionSignatures(name);
   if (!signatures.has_value()) {
-    VELOX_FAIL("Aggregate {} not registered", name);
+    VELOX_FAIL("Aggregate function '{}' not registered", name);
   }
   for (auto& signature : signatures.value()) {
     SignatureBinder binder(*signature, argTypes);
     if (binder.tryBind()) {
       auto type = binder.tryResolveType(signature->intermediateType());
-      VELOX_CHECK(type, "failed to resolve intermediate type for {}", name);
+      VELOX_CHECK(
+          type,
+          "Cannot resolve intermediate type for aggregate function {}",
+          toString(name, argTypes));
       return type;
     }
   }
-  VELOX_FAIL("Could not infer intermediate type for aggregate {}", name);
+
+  std::stringstream error;
+  error << "Aggregate function signature is not supported: "
+        << toString(name, argTypes)
+        << ". Supported signatures: " << toString(signatures.value()) << ".";
+  VELOX_USER_FAIL(error.str());
 }
 
 int32_t Aggregate::combineAlignmentInternal(int32_t otherAlignment) const {

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -225,3 +225,30 @@ TEST_F(FunctionSignatureBuilderTest, aggregateConstantFlags) {
         aggSignature->toString());
   }
 }
+
+TEST_F(FunctionSignatureBuilderTest, toString) {
+  auto signature = FunctionSignatureBuilder()
+                       .returnType("bigint")
+                       .argumentType("integer")
+                       .build();
+
+  ASSERT_EQ("(integer) -> bigint", toString({signature}));
+
+  signature = FunctionSignatureBuilder()
+                  .returnType("bigint")
+                  .argumentType("varchar")
+                  .argumentType("integer")
+                  .build();
+
+  ASSERT_EQ("(varchar,integer) -> bigint", toString({signature}));
+
+  signature = AggregateFunctionSignatureBuilder()
+                  .returnType("bigint")
+                  .argumentType("varchar")
+                  .intermediateType("varbinary")
+                  .build();
+
+  ASSERT_EQ("(varchar) -> varbinary -> bigint", toString({signature}));
+
+  ASSERT_EQ("foo(BIGINT, VARCHAR)", toString("foo", {BIGINT(), VARCHAR()}));
+}

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -312,34 +312,6 @@ std::string throwAggregateFunctionDoesntExist(const std::string& name) {
   VELOX_USER_FAIL(error.str());
 }
 
-std::string toString(
-    const std::string& name,
-    const std::vector<TypePtr>& types) {
-  std::ostringstream signature;
-  signature << name << "(";
-  for (auto i = 0; i < types.size(); i++) {
-    if (i > 0) {
-      signature << ", ";
-    }
-    signature << types[i]->toString();
-  }
-  signature << ")";
-  return signature.str();
-}
-
-std::string toString(
-    const std::vector<std::shared_ptr<AggregateFunctionSignature>>&
-        signatures) {
-  std::stringstream out;
-  for (auto i = 0; i < signatures.size(); ++i) {
-    if (i > 0) {
-      out << ", ";
-    }
-    out << signatures[i]->toString();
-  }
-  return out.str();
-}
-
 std::string throwAggregateFunctionSignatureNotSupported(
     const std::string& name,
     const std::vector<TypePtr>& types,
@@ -1031,10 +1003,6 @@ PlanBuilder& PlanBuilder::unnest(
 }
 
 namespace {
-std::string toString(const std::vector<FunctionSignaturePtr>& signatures) {
-  return fmt::format("{}", fmt::join(signatures, ","));
-}
-
 std::string throwWindowFunctionDoesntExist(const std::string& name) {
   std::stringstream error;
   error << "Window function doesn't exist: " << name << ".";

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -286,4 +286,44 @@ AggregateFunctionSignatureBuilder::build() {
       std::move(constantArguments_),
       variableArity_);
 }
+
+std::string toString(
+    const std::string& name,
+    const std::vector<TypePtr>& types) {
+  std::ostringstream signature;
+  signature << name << "(";
+  for (auto i = 0; i < types.size(); i++) {
+    if (i > 0) {
+      signature << ", ";
+    }
+    signature << types[i]->toString();
+  }
+  signature << ")";
+  return signature.str();
+}
+
+std::string toString(const std::vector<FunctionSignaturePtr>& signatures) {
+  std::stringstream out;
+  for (auto i = 0; i < signatures.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << signatures[i]->toString();
+  }
+  return out.str();
+}
+
+std::string toString(
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>&
+        signatures) {
+  std::stringstream out;
+  for (auto i = 0; i < signatures.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << signatures[i]->toString();
+  }
+  return out.str();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/type/Type.h"
 
 namespace facebook::velox::exec {
 
@@ -380,6 +381,22 @@ class AggregateFunctionSignatureBuilder {
   std::vector<bool> constantArguments_;
   bool variableArity_{false};
 };
+
+/// Return a string representation of function signature: name(type1,
+/// type1,...). For example, foo(bigint, boolean, varchar).
+std::string toString(
+    const std::string& name,
+    const std::vector<TypePtr>& types);
+
+/// Return a string representation of a list of scalar function signatures.
+/// For example, (boolean) -> integer, (varchar, integer) -> varchar.
+std::string toString(const std::vector<FunctionSignaturePtr>& signatures);
+
+/// Return a string representation of a list of aggregate function signatures.
+/// For example, (boolean) -> varbinary -> integer, (varchar, integer) ->
+/// varbinary -> varchar.
+std::string toString(
+    const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures);
 
 } // namespace facebook::velox::exec
 


### PR DESCRIPTION
Before:

```
Could not infer intermediate type for aggregate presto.default.max_by
```

After:

```
Aggregate function signature is not supported: presto.default.max_by(array(bigint), varchar). Supported signatures: ...
```

See #4986