### PR TITLE
Change type of feature projection metric callback

### DIFF
--- a/velox/dwio/common/FlatMapHelper.h
+++ b/velox/dwio/common/FlatMapHelper.h
@@ -47,6 +47,13 @@ void initializeStringVector(
 
 } // namespace detail
 
+// Struct for keeping track flatmap key stream metrics.
+// Used by keySelectionCallback_ in FlatMapColumnReader
+struct FlatMapKeySelectionStats {
+  uint64_t totalKeys = 0;
+  uint64_t selectedKeys = 0;
+};
+
 // Initialize flat vector
 template <typename T>
 void initializeFlatVector(

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -23,6 +23,7 @@
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
+#include "velox/dwio/common/FlatMapHelper.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
@@ -106,7 +107,8 @@ class RowReaderOptions {
   // in Koski. This gets fired in FlatMapColumnReader.
   // This is a bit of a hack as there is (by design) no good way
   // To propogate information from column reader to Koski
-  std::function<void(uint64_t numTotalKeys, uint64_t numSelectedKeys)>
+  std::function<void(
+      facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
       keySelectionCallback_;
 
  public:
@@ -284,12 +286,14 @@ class RowReaderOptions {
   }
 
   void setKeySelectionCallback(
-      std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+      std::function<void(
+          facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
           keySelectionCallback) {
     keySelectionCallback_ = std::move(keySelectionCallback);
   }
 
-  const std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+  const std::function<
+      void(facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
   getKeySelectionCallback() const {
     return keySelectionCallback_;
   }

--- a/velox/dwio/dwrf/reader/EncodingContext.h
+++ b/velox/dwio/dwrf/reader/EncodingContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/FlatMapHelper.h"
 #include "velox/dwio/dwrf/common/ByteRLE.h"
 
 namespace facebook::velox::dwrf {
@@ -29,7 +30,8 @@ struct FlatMapContext {
   // Kept alive by key nodes
   BooleanRleDecoder* inMapDecoder{nullptr};
 
-  std::function<void(uint64_t totalKeys, uint64_t selectedKeys)>
+  std::function<void(
+      facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
       keySelectionCallback{nullptr};
 };
 

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -26,13 +26,6 @@
 
 namespace facebook::velox::dwrf {
 
-// Stats used by callback passed from Koski layer
-// to give visibility into flatmap efficiency
-struct KeySelectionStats {
-  size_t totalKeyStreams{0};
-  size_t selectedKeyStreams{0};
-};
-
 class StringKeyBuffer;
 
 // represent a branch of a value node in a flat map
@@ -164,7 +157,8 @@ class FlatMapColumnReader : public ColumnReader {
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
-  KeySelectionStats keySelectionStats_;
+  facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats
+      keySelectionStats_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<StringKeyBuffer> stringKeyBuffer_;
   bool returnFlatVector_;
@@ -193,7 +187,8 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
 
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
-  KeySelectionStats keySelectionStats_;
+  facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats
+      keySelectionStats_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<NullColumnReader> nullColumnReader_;
   BufferPtr mergedNulls_;

--- a/velox/dwio/dwrf/test/TestReader.cpp
+++ b/velox/dwio/dwrf/test/TestReader.cpp
@@ -479,9 +479,10 @@ TEST(TestReader, testStatsCallbackFiredWithFiltering) {
 
   rowReaderOpts.setKeySelectionCallback(
       [&totalKeyStreamsAggregate, &selectedKeyStreamsAggregate](
-          uint64_t totalKeyStreams, uint64_t selectedKeyStreams) {
-        totalKeyStreamsAggregate += totalKeyStreams;
-        selectedKeyStreamsAggregate += selectedKeyStreams;
+          facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats
+              keySelectionStats) {
+        totalKeyStreamsAggregate += keySelectionStats.totalKeys;
+        selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
   ReaderOptions readerOpts{defaultPool.get()};
@@ -528,9 +529,10 @@ TEST(TestReader, testStatsCallbackFiredWithoutFiltering) {
 
   rowReaderOpts.setKeySelectionCallback(
       [&totalKeyStreamsAggregate, &selectedKeyStreamsAggregate](
-          uint64_t totalKeyStreams, uint64_t selectedKeyStreams) {
-        totalKeyStreamsAggregate += totalKeyStreams;
-        selectedKeyStreamsAggregate += selectedKeyStreams;
+          facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats
+              keySelectionStats) {
+        totalKeyStreamsAggregate += keySelectionStats.totalKeys;
+        selectedKeyStreamsAggregate += keySelectionStats.selectedKeys;
       });
 
   ReaderOptions readerOpts{defaultPool.get()};


### PR DESCRIPTION
Summary:
Defines FlatMapKeySelectionStats struct in common file in Velox layer, makes velox and koski layers use this struct

Doing this as 2 separate commits would risk an unfortunately timed deployment breaking Koski, and the workaround would be temporarily disabling FP metrics. Both were considered, but ultimately just doing this as 1 commit makes the most sense.

Differential Revision: D45977374

