### PR TITLE
Improve lookup for BufferedInput

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -32,6 +32,7 @@ void BufferedInput::load(const LogType logType) {
   offsets_.reserve(regions_.size());
   buffers_.clear();
   buffers_.reserve(regions_.size());
+  allocPool_->clear();
 
   // sorting the regions from low to high
   std::sort(regions_.begin(), regions_.end());

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -172,6 +172,8 @@ class BufferedInput {
     action(buffers_.back().data(), region.length, region.offset, logType);
   }
 
+  void mergeRegions();
+
   // we either load data parallelly or sequentially according to flag
   void loadWithAction(
       const LogType logType,

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -105,6 +105,13 @@ std::optional<std::string> getNext(SeekableInputStream& input) {
 
 } // namespace
 
+TEST(TestBufferedInput, AllowMoveConstructor) {
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  BufferedInput a(readFileMock, *pool);
+  BufferedInput b(std::move(a));
+}
+
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
       std::make_shared<facebook::velox::InMemoryReadFile>(std::string());


### PR DESCRIPTION
Summary: We won't coalesce anymore for vread cases, which mean that we'll potentially have tens of thousands of regions. In the previous diff I changed the lookup from `O(N)` to `O(logN)`. Now I'm moving to `O(1)`.

Differential Revision: D46008377

