### PR TITLE
Don't merge regions for vread

### DIFF
--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -98,6 +98,10 @@ void BufferedInput::sortRegions() {
   e.resize(r.size());
   std::iota(e.begin(), e.end(), 0);
 
+  if (std::is_sorted(r.cbegin(), r.cend())) {
+    return;
+  }
+
   // Sort indices from low to high regions
   // "e" will contain the positions to which each region should be sorted to
   std::sort(

--- a/velox/dwio/common/BufferedInput.cpp
+++ b/velox/dwio/common/BufferedInput.cpp
@@ -32,6 +32,7 @@ void BufferedInput::load(const LogType logType) {
   offsets_.reserve(regions_.size());
   buffers_.clear();
   buffers_.reserve(regions_.size());
+  allocPool_->clear();
 
   // sorting the regions from low to high
   std::sort(regions_.begin(), regions_.end());

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -172,6 +172,8 @@ class BufferedInput {
     action(buffers_.back().data(), region.length, region.offset, logType);
   }
 
+  void mergeRegions();
+
   // we either load data parallelly or sequentially according to flag
   void loadWithAction(
       const LogType logType,

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -105,6 +105,13 @@ std::optional<std::string> getNext(SeekableInputStream& input) {
 
 } // namespace
 
+TEST(TestBufferedInput, AllowMoveConstructor) {
+  auto readFileMock = std::make_shared<ReadFileMock>();
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  BufferedInput a(readFileMock, *pool);
+  BufferedInput b(std::move(a));
+}
+
 TEST(TestBufferedInput, ZeroLengthStream) {
   auto readFile =
       std::make_shared<facebook::velox::InMemoryReadFile>(std::string());

--- a/velox/dwio/common/tests/TestBufferedInput.cpp
+++ b/velox/dwio/common/tests/TestBufferedInput.cpp
@@ -276,7 +276,8 @@ TEST(TestBufferedInput, VReadSorting) {
   std::vector<Region> regions = {{6, 3}, {24, 3}, {3, 3}, {0, 3}, {29, 3}};
 
   auto readFileMock = std::make_shared<ReadFileMock>();
-  expectPreadvs(*readFileMock, content, {{0, 9}, {24, 3}, {29, 3}});
+  expectPreadvs(
+      *readFileMock, content, {{0, 3}, {3, 3}, {6, 3}, {24, 3}, {29, 3}});
   auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   BufferedInput input(
       readFileMock,


### PR DESCRIPTION
Summary: For wsVRead we need to pass all regions by separate.

Differential Revision: D46012935

