### PR TITLE
Fix memory leak when merging sparse HLL digests

### DIFF
--- a/velox/common/hyperloglog/SparseHll.cpp
+++ b/velox/common/hyperloglog/SparseHll.cpp
@@ -85,7 +85,7 @@ bool SparseHll::insertHash(uint64_t hash) {
     entries_.insert(entries_.begin() + insertionPosition, entry);
   }
 
-  return entries_.size() >= softNumEntriesLimit_;
+  return overLimit();
 }
 
 int64_t SparseHll::cardinality() const {

--- a/velox/common/hyperloglog/SparseHll.h
+++ b/velox/common/hyperloglog/SparseHll.h
@@ -32,6 +32,11 @@ class SparseHll {
     softNumEntriesLimit_ = softMemoryLimit / 4;
   }
 
+  /// Return whether soft memory limit has been reached.
+  bool overLimit() const {
+    return entries_.size() >= softNumEntriesLimit_;
+  }
+
   /// Returns true if soft memory limit has been reached. False, otherwise.
   bool insertHash(uint64_t hash);
 

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -63,6 +63,12 @@ struct HllAccumulator {
     if (SparseHll::canDeserialize(input)) {
       if (isSparse_) {
         sparseHll_.mergeWith(input);
+        if (indexBitLength_ < 0) {
+          setIndexBitLength(DenseHll::deserializeIndexBitLength(input));
+        }
+        if (sparseHll_.overLimit()) {
+          toDense();
+        }
       } else {
         SparseHll other{input, allocator};
         other.toDense(denseHll_);
@@ -84,11 +90,12 @@ struct HllAccumulator {
     return isSparse_ ? sparseHll_.serializedSize() : denseHll_.serializedSize();
   }
 
-  void serialize(int8_t indexBitLength, char* outputBuffer) {
-    return isSparse_ ? sparseHll_.serialize(indexBitLength, outputBuffer)
+  void serialize(char* outputBuffer) {
+    return isSparse_ ? sparseHll_.serialize(indexBitLength_, outputBuffer)
                      : denseHll_.serialize(outputBuffer);
   }
 
+ private:
   void toDense() {
     isSparse_ = false;
     denseHll_.initialize(indexBitLength_);
@@ -181,12 +188,12 @@ class ApproxDistinctAggregate : public exec::Aggregate {
           StringView serialized;
           if (StringView::isInline(size)) {
             std::string buffer(size, '\0');
-            accumulator->serialize(indexBitLength_, buffer.data());
+            accumulator->serialize(buffer.data());
             serialized = StringView::makeInline(buffer);
           } else {
             Buffer* buffer = flatResult->getBufferWithSpace(size);
             char* ptr = buffer->asMutable<char>() + buffer->size();
-            accumulator->serialize(indexBitLength_, ptr);
+            accumulator->serialize(ptr);
             buffer->setSize(buffer->size() + size);
             serialized = StringView(ptr, size);
           }


### PR DESCRIPTION
Summary:
When we merge sparse HLL, we do not check if the limit is exceeded and
just put them into one single large sparse HLL.  This causes unwanted memory
usage.  Fix it by converting to dense HLL when necessary.

Fix https://github.com/facebookincubator/velox/issues/5001

Differential Revision: D46022631

