### PR TITLE
Fix bind expression conversion

### DIFF
--- a/velox/core/ITypedExpr.h
+++ b/velox/core/ITypedExpr.h
@@ -20,15 +20,17 @@
 
 namespace facebook::velox::core {
 
+class ITypedExpr;
+
+using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
+
 /* a strongly-typed expression, such as literal, function call, etc... */
 class ITypedExpr : public ISerializable {
  public:
   explicit ITypedExpr(std::shared_ptr<const Type> type)
       : type_{std::move(type)}, inputs_{} {}
 
-  ITypedExpr(
-      std::shared_ptr<const Type> type,
-      std::vector<std::shared_ptr<const ITypedExpr>> inputs)
+  ITypedExpr(std::shared_ptr<const Type> type, std::vector<TypedExprPtr> inputs)
       : type_{std::move(type)}, inputs_{std::move(inputs)} {}
 
   const std::shared_ptr<const Type>& type() const {
@@ -37,17 +39,18 @@ class ITypedExpr : public ISerializable {
 
   virtual ~ITypedExpr() = default;
 
-  const std::vector<std::shared_ptr<const ITypedExpr>>& inputs() const {
+  const std::vector<TypedExprPtr>& inputs() const {
     return inputs_;
   }
 
-  /// Returns a copy of this expression with input fields renamed according
-  /// to specified 'mapping'. Fields specified in the 'mapping are renamed.
+  /// Returns a copy of this expression with input fields replaced according
+  /// to specified 'mapping'. Fields specified in the 'mapping are replaced
+  /// by the corresponding expression in 'mapping'.
   /// Fields not present in 'mapping' are left unmodified.
   ///
   /// Used to bind inputs to lambda functions.
   virtual std::shared_ptr<const ITypedExpr> rewriteInputNames(
-      const std::unordered_map<std::string, std::string>& mapping) const = 0;
+      const std::unordered_map<std::string, TypedExprPtr>& mapping) const = 0;
 
   virtual std::string toString() const = 0;
 
@@ -86,9 +89,9 @@ class ITypedExpr : public ISerializable {
  protected:
   folly::dynamic serializeBase(std::string_view name) const;
 
-  std::vector<std::shared_ptr<const ITypedExpr>> rewriteInputsRecursive(
-      const std::unordered_map<std::string, std::string>& mapping) const {
-    std::vector<std::shared_ptr<const ITypedExpr>> newInputs;
+  std::vector<TypedExprPtr> rewriteInputsRecursive(
+      const std::unordered_map<std::string, TypedExprPtr>& mapping) const {
+    std::vector<TypedExprPtr> newInputs;
     newInputs.reserve(inputs().size());
     for (const auto& input : inputs()) {
       newInputs.emplace_back(input->rewriteInputNames(mapping));
@@ -104,7 +107,5 @@ class ITypedExpr : public ISerializable {
   std::shared_ptr<const Type> type_;
   std::vector<std::shared_ptr<const ITypedExpr>> inputs_;
 };
-
-using TypedExprPtr = std::shared_ptr<const ITypedExpr>;
 
 } // namespace facebook::velox::core

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -74,6 +74,7 @@ PlanBuilder& PlanBuilder::tableScan(
     const std::string& remainingFilter) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
+  std::unordered_map<std::string, core::TypedExprPtr> typedMapping;
   for (uint32_t i = 0; i < outputType->size(); ++i) {
     const auto& name = outputType->nameOf(i);
     const auto& type = outputType->childAt(i);
@@ -82,6 +83,9 @@ PlanBuilder& PlanBuilder::tableScan(
     auto it = columnAliases.find(name);
     if (it != columnAliases.end()) {
       hiveColumnName = it->second;
+      typedMapping.emplace(
+          name,
+          std::make_shared<core::FieldAccessTypedExpr>(type, hiveColumnName));
     }
 
     assignments.insert(
@@ -116,7 +120,7 @@ PlanBuilder& PlanBuilder::tableScan(
   if (!remainingFilter.empty()) {
     remainingFilterExpr =
         parseExpr(remainingFilter, outputType, options_, pool_)
-            ->rewriteInputNames(columnAliases);
+            ->rewriteInputNames(typedMapping);
   }
 
   auto tableHandle = std::make_shared<HiveTableHandle>(

--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -48,7 +48,6 @@ class Expressions {
     return resolverHook_;
   }
 
- private:
   static TypedExprPtr inferTypes(
       const std::shared_ptr<const IExpr>& expr,
       const TypePtr& input,
@@ -56,6 +55,7 @@ class Expressions {
       memory::MemoryPool* pool,
       const VectorPtr& complexConstants = nullptr);
 
+ private:
   static TypedExprPtr resolveLambdaExpr(
       const std::shared_ptr<const core::LambdaExpr>& lambdaExpr,
       const TypePtr& inputRow,


### PR DESCRIPTION
Summary:
Issue: https://github.com/prestodb/presto/issues/19589

Let's rework the rewriteNames() api. This is used to replace names in an expression. Consider expression:

BIND((field_0) * (field_0), (expr_17, expr) -> (expr) * (expr_17)))

BIND is just a syntactic sugar, that is needed by Presto. This is evaluated as

expr -> (expr) * ((field_0) * (field_0))

So our mapping needs to be string -> Expression instead of string -> string.

Also we should not rewrite things like dereferences(x in a.x), and names(x in ROW(x int)). We previously did this and that is unsound.

Differential Revision: D46031146

