### PR TITLE
Add SIMD-based implementation of json_array_length/contains Presto functions

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -123,4 +123,35 @@ struct SIMDJsonArrayContainsFunction {
   }
 };
 
+template <typename T>
+struct SIMDJsonArrayLengthFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(int64_t& len, const arg_type<Json>& json) {
+    ParserContext ctx(json.data(), json.size());
+    bool result = false;
+
+    try {
+      ctx.parseDocument();
+    } catch (simdjson::simdjson_error& e) {
+      return result;
+    }
+
+    if (ctx.jsonDoc.type() != simdjson::ondemand::json_type::array) {
+      return result;
+    }
+
+    len = 0;
+    try {
+      for (auto&& v : ctx.jsonDoc) {
+        len++;
+      }
+      result = true;
+    } catch (simdjson::simdjson_error& e) {
+      return result;
+    }
+    return result;
+  }
+};
+
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -151,8 +151,7 @@ void FollyJsonArrayLength(int iter, int vectorSize, int jsonSize) {
   JsonBenchmark benchmark;
   auto json = benchmark.prepareData(jsonSize);
   suspender.dismiss();
-  benchmark.runWithJson(
-      iter, vectorSize, "folly_json_array_length", json);
+  benchmark.runWithJson(iter, vectorSize, "folly_json_array_length", json);
 }
 
 void SIMDJsonArrayLength(int iter, int vectorSize, int jsonSize) {
@@ -160,8 +159,7 @@ void SIMDJsonArrayLength(int iter, int vectorSize, int jsonSize) {
   JsonBenchmark benchmark;
   auto json = benchmark.prepareData(jsonSize);
   suspender.dismiss();
-  benchmark.runWithJson(
-      iter, vectorSize, "simd_json_array_length", json);
+  benchmark.runWithJson(iter, vectorSize, "simd_json_array_length", json);
 }
 
 BENCHMARK_DRAW_LINE();
@@ -252,11 +250,7 @@ BENCHMARK_RELATIVE_NAMED_PARAM(
     10);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(
-    FollyJsonArrayLength,
-    100_iters_100bytes_size,
-    100,
-    100);
+BENCHMARK_NAMED_PARAM(FollyJsonArrayLength, 100_iters_100bytes_size, 100, 100);
 BENCHMARK_RELATIVE_NAMED_PARAM(
     SIMDJsonArrayLength,
     100_iters_100bytes_size,

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -39,6 +39,10 @@ class JsonBenchmark : public velox::functions::test::FunctionBenchmarkBase {
         {"folly_is_json_scalar"});
     registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
         {"simd_is_json_scalar"});
+    registerFunction<JsonArrayContainsFunction, bool, Json, bool>(
+        {"folly_json_array_contains"});
+    registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
+        {"simd_json_array_contains"});
   }
 
   std::string prepareData(int jsonSize) {
@@ -75,6 +79,23 @@ class JsonBenchmark : public velox::functions::test::FunctionBenchmarkBase {
     doRun(iter, exprSet, rowVector);
   }
 
+  void runWithJsonContains(
+      int iter,
+      int vectorSize,
+      const std::string& fnName,
+      const std::string& json) {
+    folly::BenchmarkSuspender suspender;
+
+    auto jsonVector = makeJsonData(json, vectorSize);
+    auto boolVector = vectorMaker_.flatVector<bool>({true});
+
+    auto rowVector = vectorMaker_.rowVector({jsonVector, boolVector});
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0, c1)", fnName), rowVector->type());
+    suspender.dismiss();
+    doRun(iter, exprSet, rowVector);
+  }
+
   void doRun(
       const int iter,
       velox::exec::ExprSet& exprSet,
@@ -103,28 +124,99 @@ void SIMDIsJsonScalar(int iter, int vectorSize, int jsonSize) {
   benchmark.runWithJson(iter, vectorSize, "simd_is_json_scalar", json);
 }
 
+void FollyJsonArrayContains(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJsonContains(
+      iter, vectorSize, "folly_json_array_contains", json);
+}
+
+void SIMDJsonArrayContains(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJsonContains(
+      iter, vectorSize, "simd_json_array_contains", json);
+}
+
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_1k_size, 100, 10);
-BENCHMARK_RELATIVE_NAMED_PARAM(SIMDIsJsonScalar, 100_iters_1k_size, 100, 10);
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_10k_size, 100, 100);
-BENCHMARK_RELATIVE_NAMED_PARAM(SIMDIsJsonScalar, 100_iters_10k_size, 100, 100);
-BENCHMARK_DRAW_LINE();
-
-BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_100k_size, 100, 1000);
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_10bytes_size, 100, 10);
 BENCHMARK_RELATIVE_NAMED_PARAM(
     SIMDIsJsonScalar,
-    100_iters_100k_size,
+    100_iters_10bytes_size,
+    100,
+    10);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_100bytes_size, 100, 100);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDIsJsonScalar,
+    100_iters_100bytes_size,
+    100,
+    100);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_1000bytes_size, 100, 1000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDIsJsonScalar,
+    100_iters_1000bytes_size,
     100,
     1000);
 BENCHMARK_DRAW_LINE();
 
-BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_1000k_size, 100, 10000);
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_10000bytes_size, 100, 10000);
 BENCHMARK_RELATIVE_NAMED_PARAM(
     SIMDIsJsonScalar,
-    100_iters_1000k_size,
+    100_iters_10000bytes_size,
+    100,
+    10000);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(FollyJsonArrayContains, 100_iters_10bytes_size, 100, 10);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayContains,
+    100_iters_10bytes_size,
+    100,
+    10);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayContains,
+    100_iters_100bytes_size,
+    100,
+    100);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayContains,
+    100_iters_100bytes_size,
+    100,
+    100);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayContains,
+    100_iters_1000bytes_size,
+    100,
+    1000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayContains,
+    100_iters_1000bytes_size,
+    100,
+    1000);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayContains,
+    100_iters_10000bytes_size,
+    100,
+    10000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayContains,
+    100_iters_10000bytes_size,
     100,
     10000);
 BENCHMARK_DRAW_LINE();

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -43,6 +43,10 @@ class JsonBenchmark : public velox::functions::test::FunctionBenchmarkBase {
         {"folly_json_array_contains"});
     registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
         {"simd_json_array_contains"});
+    registerFunction<JsonArrayLengthFunction, int64_t, Json>(
+        {"folly_json_array_length"});
+    registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(
+        {"simd_json_array_length"});
   }
 
   std::string prepareData(int jsonSize) {
@@ -142,6 +146,24 @@ void SIMDJsonArrayContains(int iter, int vectorSize, int jsonSize) {
       iter, vectorSize, "simd_json_array_contains", json);
 }
 
+void FollyJsonArrayLength(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJson(
+      iter, vectorSize, "folly_json_array_length", json);
+}
+
+void SIMDJsonArrayLength(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJson(
+      iter, vectorSize, "simd_json_array_length", json);
+}
+
 BENCHMARK_DRAW_LINE();
 
 BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_10bytes_size, 100, 10);
@@ -216,6 +238,51 @@ BENCHMARK_NAMED_PARAM(
     10000);
 BENCHMARK_RELATIVE_NAMED_PARAM(
     SIMDJsonArrayContains,
+    100_iters_10000bytes_size,
+    100,
+    10000);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_DRAW_LINE();
+BENCHMARK_NAMED_PARAM(FollyJsonArrayLength, 100_iters_10bytes_size, 100, 10);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayLength,
+    100_iters_10bytes_size,
+    100,
+    10);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayLength,
+    100_iters_100bytes_size,
+    100,
+    100);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayLength,
+    100_iters_100bytes_size,
+    100,
+    100);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayLength,
+    100_iters_1000bytes_size,
+    100,
+    1000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayLength,
+    100_iters_1000bytes_size,
+    100,
+    1000);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(
+    FollyJsonArrayLength,
+    100_iters_10000bytes_size,
+    100,
+    10000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDJsonArrayLength,
     100_iters_10000bytes_size,
     100,
     10000);

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -28,13 +28,13 @@ void registerJsonFunctions(const std::string& prefix) {
       {prefix + "json_extract_scalar"});
   registerFunction<JsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
-  registerFunction<JsonArrayContainsFunction, bool, Json, bool>(
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
       {prefix + "json_array_contains"});
-  registerFunction<JsonArrayContainsFunction, bool, Json, int64_t>(
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, int64_t>(
       {prefix + "json_array_contains"});
-  registerFunction<JsonArrayContainsFunction, bool, Json, double>(
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, double>(
       {prefix + "json_array_contains"});
-  registerFunction<JsonArrayContainsFunction, bool, Json, Varchar>(
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Json, Varchar>(
       {prefix + "json_array_contains"});
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
       {prefix + "json_size"});

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -26,7 +26,7 @@ void registerJsonFunctions(const std::string& prefix) {
       {prefix + "is_json_scalar"});
   registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
-  registerFunction<JsonArrayLengthFunction, int64_t, Json>(
+  registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
       {prefix + "json_array_contains"});


### PR DESCRIPTION
A follow up to #4598 which added SIMD-based implementation of is_json_scalar function.

Add SIMD-based implementation of json_array_length and json_array_contains Presto functions.

See #3658, #4486 for context.