### PR TITLE
Fix ascii Spark function for unicode input

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -6,7 +6,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
 .. spark:function:: ascii(string) -> integer
 
-    Returns the numeric value of the first character of ``string``.
+    Returns unicode code point of the first character of ``string``. Returns 0 if ``string`` is empty.
 
 .. spark:function:: chr(n) -> varchar
 

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -75,9 +75,19 @@ template <typename T>
 struct AsciiFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(int32_t& result, const arg_type<Varchar>& s) {
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Varchar>& s) {
+    if (s.empty()) {
+      result = 0;
+      return;
+    }
+    int size;
+    result = utf8proc_codepoint(s.data(), s.data() + s.size(), size);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      int32_t& result,
+      const arg_type<Varchar>& s) {
     result = s.empty() ? 0 : s.data()[0];
-    return true;
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -195,8 +195,18 @@ class StringTest : public SparkFunctionBaseTest {
 TEST_F(StringTest, Ascii) {
   EXPECT_EQ(ascii(std::string("\0", 1)), 0);
   EXPECT_EQ(ascii(" "), 32);
-  EXPECT_EQ(ascii("😋"), -16);
+  EXPECT_EQ(ascii("😋"), 128523);
   EXPECT_EQ(ascii(""), 0);
+  EXPECT_EQ(ascii("¥"), 165);
+  EXPECT_EQ(ascii("®"), 174);
+  EXPECT_EQ(ascii("©"), 169);
+  EXPECT_EQ(ascii("VELOX"), 86);
+  EXPECT_EQ(ascii("VIP"), 86);
+  EXPECT_EQ(ascii("Viod"), 86);
+  EXPECT_EQ(ascii("V®"), 86);
+  EXPECT_EQ(ascii("ÇÉµABC"), 199);
+  EXPECT_EQ(ascii("Ȼ %($)"), 571);
+  EXPECT_EQ(ascii("@£Ɇ123"), 64);
   EXPECT_EQ(ascii(std::nullopt), std::nullopt);
 }
 


### PR DESCRIPTION
Since spark's latest releases, like spark 3.2.3/3.3.1 or higher versions, ascii function will return the code point for initial character of given input string. Character with two or more bytes needs to be considered.