### PR TITLE
[velox][PR] Make aggregation function registry thread-safe

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/Synchronized.h>
+
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/core/PlanNode.h"
 #include "velox/expression/FunctionSignature.h"
@@ -365,21 +367,20 @@ bool registerAggregateFunction(
 std::optional<std::vector<std::shared_ptr<AggregateFunctionSignature>>>
 getAggregateFunctionSignatures(const std::string& name);
 
-using AggregateFunctionSignatureMap = std::unordered_map<
-    std::string,
-    std::vector<std::shared_ptr<AggregateFunctionSignature>>>;
+using AggregateFunctionSignatureMap =
+    std::unordered_map<std::string, std::vector<AggregateFunctionSignaturePtr>>;
 
 /// Returns a mapping of all Aggregate functions in registry.
 /// The mapping is function name -> list of function signatures.
 AggregateFunctionSignatureMap getAggregateFunctionSignatures();
 
 struct AggregateFunctionEntry {
-  std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures;
+  std::vector<AggregateFunctionSignaturePtr> signatures;
   AggregateFunctionFactory factory;
 };
 
-using AggregateFunctionMap =
-    std::unordered_map<std::string, AggregateFunctionEntry>;
+using AggregateFunctionMap = folly::Synchronized<
+    std::unordered_map<std::string, AggregateFunctionEntry>>;
 
 AggregateFunctionMap& aggregateFunctions();
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -309,10 +309,12 @@ namespace {
 std::string throwAggregateFunctionDoesntExist(const std::string& name) {
   std::stringstream error;
   error << "Aggregate function doesn't exist: " << name << ".";
-  if (exec::aggregateFunctions().empty()) {
-    error << " Registry of aggregate functions is empty. "
-             "Make sure to register some aggregate functions.";
-  }
+  exec::aggregateFunctions().withRLock([&](const auto& functionsMap) {
+    if (functionsMap.empty()) {
+      error << " Registry of aggregate functions is empty. "
+               "Make sure to register some aggregate functions.";
+    }
+  });
   VELOX_USER_FAIL(error.str());
 }
 


### PR DESCRIPTION
Summary: Make aggregation function registry thread-safe to avoid potential race condition. A following PR disallows aggregation function registration with names already exists: https://github.com/facebookincubator/velox/pull/5080.

Differential Revision: D46076992

