### PR TITLE
close datasource when tablescan operator is closed

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -177,8 +177,7 @@ class DataSource {
   }
 
   // free all resource associated with datasource 
-  virtual void close() {
-  }
+  virtual void close() {}
 };
 
 /// Collection of context data for use in a DataSource or DataSink. One instance

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -176,7 +176,7 @@ class DataSource {
     return kUnknownRowSize;
   }
 
-  // free all resource associated with datasource 
+  // free all resource associated with datasource
   virtual void close() {}
 };
 

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -175,6 +175,10 @@ class DataSource {
   virtual int64_t estimatedRowSize() {
     return kUnknownRowSize;
   }
+
+  // free all resource associated with datasource 
+  virtual void close() {
+  }
 };
 
 /// Collection of context data for use in a DataSource or DataSink. One instance

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -279,4 +279,11 @@ void TableScan::addDynamicFilter(
   }
 }
 
+void TableScan::close() {
+  if (dataSource_) {
+    dataSource_->close();
+  }
+  SourceOperator::close();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -56,6 +56,8 @@ class TableScan : public SourceOperator {
     return ioWaitNanos_;
   }
 
+  void close() override;
+
  private:
   // Sets 'maxPreloadSplits' and 'splitPreloader' if prefetching
   // splits is appropriate. The preloader will be applied to the


### PR DESCRIPTION
Data source needs to cleanup resource when TableScan operator is finished.
in some case  e.g. Limit operator would short-circuit and terminate the execution pipeline after getting enough data, then,  there needs a way to tell DataSource to cancel the background disk reading. 
Although there is another way to do this , e.g. doing cleanup inside the destruction function of DataSource. But I don't think that is the best practice. because the lifetime of DataSource is indeterminate.
So, i add an explicit close function in DataSource.