### PR TITLE
Replace gmtime with gmtime_r

### DIFF
--- a/velox/type/Date.cpp
+++ b/velox/type/Date.cpp
@@ -27,15 +27,16 @@ std::string Date::toString() const {
   // Find the number of seconds for the days_;
   // Casting 86400 to int64 to handle overflows gracefully.
   int64_t daySeconds = days_ * (int64_t)(86400);
-  auto tmValue = gmtime((const time_t*)&daySeconds);
-  if (!tmValue) {
-    VELOX_FAIL("Can't convert days to dates: {}", days_);
-  }
+  std::tm tmValue;
+  VELOX_USER_CHECK_NOT_NULL(
+      gmtime_r((const time_t*)&daySeconds, &tmValue),
+      "Can't convert days to dates: {}",
+      days_);
 
   // return ISO 8601 time format.
   // %F - equivalent to "%Y-%m-%d" (the ISO 8601 date format)
   std::ostringstream oss;
-  oss << std::put_time(tmValue, "%F");
+  oss << std::put_time(&tmValue, "%F");
   return oss.str();
 }
 

--- a/velox/type/Date.cpp
+++ b/velox/type/Date.cpp
@@ -25,11 +25,11 @@ void parseTo(folly::StringPiece in, Date& out) {
 
 std::string Date::toString() const {
   // Find the number of seconds for the days_;
-  // Casting 86400 to int64 to handle overflows gracefully.
-  int64_t daySeconds = days_ * (int64_t)(86400);
+  // Casting 'days_' to time_t to avoid overflow in multiplication.
+  const time_t daySeconds = static_cast<time_t>(days_) * 86400L;
   std::tm tmValue;
   VELOX_USER_CHECK_NOT_NULL(
-      gmtime_r((const time_t*)&daySeconds, &tmValue),
+      gmtime_r(&daySeconds, &tmValue),
       "Can't convert days to dates: {}",
       days_);
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -151,14 +151,11 @@ struct Timestamp {
       const Precision& precision = Precision::kNanoseconds) const {
     // mbasmanova: error: no matching function for call to 'gmtime_r'
     // mbasmanova: time_t is long not long long
-    // struct tm tmValue;
-    // auto bt = gmtime_r(&seconds_, &tmValue);
-    auto bt = gmtime((const time_t*)&seconds_);
-    if (!bt) {
-      const auto& error_message = folly::to<std::string>(
-          "Can't convert Seconds to time: ", folly::to<std::string>(seconds_));
-      throw std::runtime_error{error_message};
-    }
+    std::tm tmValue;
+    VELOX_USER_CHECK_NOT_NULL(
+        gmtime_r((const time_t*)&seconds_, &tmValue),
+        "Can't convert seconds to time: {}",
+        folly::to<std::string>(seconds_));
 
     // return ISO 8601 time format.
     // %F - equivalent to "%Y-%m-%d" (the ISO 8601 date format)
@@ -172,7 +169,7 @@ struct Timestamp {
     auto value =
         precision == Precision::kMilliseconds ? nanos_ / 1'000'000 : nanos_;
     std::ostringstream oss;
-    oss << std::put_time(bt, "%FT%T");
+    oss << std::put_time(&tmValue, "%FT%T");
     oss << '.' << std::setfill('0') << std::setw(width) << value;
 
     return oss.str();

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -149,7 +149,6 @@ struct Timestamp {
 
   std::string toString(
       const Precision& precision = Precision::kNanoseconds) const {
-    // mbasmanova: error: no matching function for call to 'gmtime_r'
     // mbasmanova: time_t is long not long long
     std::tm tmValue;
     VELOX_USER_CHECK_NOT_NULL(


### PR DESCRIPTION
`std::gmtime()` is not thread safe and will cause wrong results in multithreading. We replace it with `std::gmtime_r()` to avoid this problem.

Fixes #5028 and #5907