### PR TITLE
Back out "Use target_compile_options instead of setting CMAKE_CXX_FLAGS"

### DIFF
--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -73,15 +73,13 @@ target_link_libraries(
   ${TEST_LINK_LIBS})
 
 if(VELOX_ENABLE_ARROW)
-  add_executable(velox_dwio_common_bitpack_decoder_benchmark
-                 BitPackDecoderBenchmark.cpp)
-
   # The duckdb include on BitPackDecoderTest.cpp triggers this error in gcc.
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    target_compile_options(velox_dwio_common_bitpack_decoder_benchmark
-                           PRIVATE -Wno-deprecated-declarations)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
   endif()
 
+  add_executable(velox_dwio_common_bitpack_decoder_benchmark
+                 BitPackDecoderBenchmark.cpp)
   target_link_libraries(
     velox_dwio_common_bitpack_decoder_benchmark velox_dwio_common arrow duckdb
     Folly::folly ${FOLLY_BENCHMARK})

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -369,7 +369,7 @@ ExprPtr compileExpression(
   auto compiledInputs = compileInputs(
       expr, scope, config, pool, flatteningCandidates, enableConstantFolding);
   auto inputTypes = getTypes(compiledInputs);
-
+  bool isConstantExpr = false;
   if (dynamic_cast<const core::ConcatTypedExpr*>(expr.get())) {
     result = getRowConstructorExpr(
         resultType, std::move(compiledInputs), trackCpuUsage);
@@ -465,6 +465,7 @@ ExprPtr compileExpression(
       auto constant =
           dynamic_cast<const core::ConstantTypedExpr*>(expr.get())) {
     result = std::make_shared<ConstantExpr>(constant->toConstantVector(pool));
+    isConstantExpr = true;
   } else if (
       auto lambda = dynamic_cast<const core::LambdaTypedExpr*>(expr.get())) {
     result = compileLambda(
@@ -480,8 +481,9 @@ ExprPtr compileExpression(
 
   result->computeMetadata();
 
-  auto folded =
-      enableConstantFolding ? tryFoldIfConstant(result, scope) : result;
+  auto folded = enableConstantFolding && !isConstantExpr
+      ? tryFoldIfConstant(result, scope)
+      : result;
   scope->visited[expr.get()] = folded;
   return folded;
 }

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -224,4 +224,12 @@ TEST_F(ExprCompilerTest, customTypeConstant) {
   ASSERT_EQ("[1, 2, 3]:JSON", compile(expression)->toString());
 }
 
+TEST_F(ExprCompilerTest, customTypeConstant222) {
+  auto expression =
+      std::make_shared<core::ConstantTypedExpr>(VARCHAR(), "[1, 2, 3]");
+
+  auto exprSet = compile(expression);
+  ASSERT_EQ("[1, 2, 3]:JSON", compile(expression)->toString());
+}
+
 } // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
+# up failing compilation in an openssl header included by a hash-related
+# function.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 add_library(
   velox_functions_prestosql
   ArithmeticFunctionsRegistration.cpp
@@ -28,14 +35,6 @@ add_library(
   BitwiseFunctionsRegistration.cpp
   URLFunctionsRegistration.cpp
   RegistrationFunctions.cpp)
-
-# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
-# up failing compilation in an openssl header included by a hash-related
-# function.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(velox_functions_prestosql
-                         PRIVATE -Wno-deprecated-declarations)
-endif()
 
 target_link_libraries(velox_functions_prestosql velox_functions_prestosql_impl
                       velox_is_null_functions simdjson)

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -12,6 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
+# up failing compilation in an openssl header included by a hash-related
+# function.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
+endif()
+
 add_library(
   velox_functions_spark
   ArraySort.cpp
@@ -28,14 +35,6 @@ add_library(
   Size.cpp
   SplitFunctions.cpp
   String.cpp)
-
-# GCC 12 has a bug where it does not respect "pragma ignore" directives and ends
-# up failing compilation in an openssl header included by a hash-related
-# function.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-  target_compile_options(velox_functions_spark
-                         PRIVATE -Wno-deprecated-declarations)
-endif()
 
 target_link_libraries(
   velox_functions_spark velox_functions_lib velox_functions_prestosql_impl


### PR DESCRIPTION
Summary:
Original commit changeset: dbb0cb17c31f

this diff breaks building all nightly fuzzer tests
https://github.com/facebookincubator/velox/issues/5022

Differential Revision: D46107147

