### PR TITLE
Support element_at for floating keys

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -78,8 +78,15 @@ class SubscriptImpl : public exec::VectorFunction {
     }
 
     // map(K,V), K -> V
-    for (const auto& keyType :
-         {"tinyint", "smallint", "integer", "bigint", "varchar"}) {
+    const auto keyTypes = {
+        "tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        "real",
+        "double",
+        "varchar"};
+    for (const auto& keyType : keyTypes) {
       signatures.push_back(exec::FunctionSignatureBuilder()
                                .typeVariable("V")
                                .returnType("V")
@@ -136,6 +143,10 @@ class SubscriptImpl : public exec::VectorFunction {
         return applyMapTyped<int16_t>(rows, mapArg, indexArg, context);
       case TypeKind::TINYINT:
         return applyMapTyped<int8_t>(rows, mapArg, indexArg, context);
+      case TypeKind::REAL:
+        return applyMapTyped<float>(rows, mapArg, indexArg, context);
+      case TypeKind::DOUBLE:
+        return applyMapTyped<double>(rows, mapArg, indexArg, context);
       case TypeKind::VARCHAR:
         return applyMapTyped<StringView>(rows, mapArg, indexArg, context);
       default:

--- a/velox/functions/prestosql/tests/ElementAtTest.cpp
+++ b/velox/functions/prestosql/tests/ElementAtTest.cpp
@@ -657,6 +657,8 @@ TEST_F(ElementAtTest, variableInputMap) {
   testVariableInputMap<int32_t>(); // INTEGER
   testVariableInputMap<int16_t>(); // SMALLINT
   testVariableInputMap<int8_t>(); // TINYINT
+  testVariableInputMap<float>(); // REAL
+  testVariableInputMap<double>(); // DOUBLE
 
   testVariableInputMap<StringView>(); // VARCHAR
 }


### PR DESCRIPTION
Support element_at for floating keys, e.g map<double, T> and map<float, T>

Added test