### PR TITLE
Ensure sharedConstantValue_ is unique before calling computeAndSetIsAscii in ConstantExpr

### DIFF
--- a/velox/expression/ConstantExpr.h
+++ b/velox/expression/ConstantExpr.h
@@ -29,7 +29,10 @@ class ConstantExpr : public SpecialForm {
             false /* trackCpuUsage */),
         needToSetIsAscii_{value->type()->isVarchar()} {
     VELOX_CHECK_EQ(value->encoding(), VectorEncoding::Simple::CONSTANT);
-    sharedConstantValue_ = std::move(value);
+    // sharedConstantValue_ may be modified so we should take our own copy to
+    // prevent sharing across threads.
+    sharedConstantValue_ =
+        BaseVector::wrapInConstant(1, 0, std::move(value), true);
   }
 
   void evalSpecialForm(

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -106,8 +106,8 @@ TEST_F(ExpressionRunnerUnitTest, persistAndReproComplexSql) {
   auto reproExprs = ExpressionRunner::parseSql(
       reproSql, nullptr, pool_.get(), reproComplexConstants);
   ASSERT_EQ(reproExprs.size(), 1);
-  ASSERT_EQ(
-      reproExprs[0]->toString(),
-      "4 elements starting at 0 {[0->2] 3, [1->4] 5, [2->0] 1, [3->1] 2}");
+  // Note that ConstantExpr makes a copy of sharedConstantValue_ to guard
+  // against race conditions, which in effect falttens the array.
+  ASSERT_EQ(reproExprs[0]->toString(), "4 elements starting at 0 {3, 5, 1, 2}");
 }
 } // namespace facebook::velox::test

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -469,9 +469,14 @@ class BaseVector {
   // before making a new ConstantVector. The result vector is either a
   // ConstantVector holding a scalar value or a ConstantVector wrapping flat or
   // lazy vector. The result cannot be a wrapping over another constant or
-  // dictionary vector.
-  static VectorPtr
-  wrapInConstant(vector_size_t length, vector_size_t index, VectorPtr vector);
+  // dictionary vector. If copyBase is true and the result vector wraps a
+  // vector, the wrapped vector is newly constructed by copying the value from
+  // the original, guaranteeing no Vectors are shared with 'vector'.
+  static VectorPtr wrapInConstant(
+      vector_size_t length,
+      vector_size_t index,
+      VectorPtr vector,
+      bool copyBase = false);
 
   // Makes 'result' writable for 'rows'. A wrapper (e.g. dictionary, constant,
   // sequence) is flattened and a multiply referenced flat vector is copied.


### PR DESCRIPTION
Summary:
sharedConstantValue_ in ConstantExpr may be shared with ConstantTypedExpr if the ConstantTypedExpr was initialized with a valueVector_

If the same Plans are compiled on different threads, as the ConstantExprs on these threads will share the same sharedConstantValue_ during compilation (after evalSpecialForm is called as part of constant folding sharedConstantValue_ will have a unique Vector).

Since computeAndSetIsAscii called in ConstantExpr modifies the sharedConstantValue_ in a thread-unsafe way, this can lead to race conditions.

Differential Revision: D46133155

