### PR TITLE
Fix ICU resolve_dependency

### DIFF
--- a/CMake/resolve_dependency_modules/boost.cmake
+++ b/CMake/resolve_dependency_modules/boost.cmake
@@ -12,14 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 include_guard(GLOBAL)
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/boost)
 
+if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  if(ON_APPLE_M1)
+    list(APPEND CMAKE_PREFIX_PATH "/opt/homebrew/opt/icu4c")
+  else()
+    list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/icu4c")
+  endif()
+endif()
+
+# ICU is only needed with Boost build from source
+set_source(ICU)
+resolve_dependency(
+  ICU
+  COMPONENTS
+  data
+  i18n
+  io
+  uc
+  tu
+  test)
 if(${ICU_SOURCE} STREQUAL "BUNDLED")
   # ensure ICU is built before Boost
   add_dependencies(boost_regex ICU ICU::i18n)
 endif()
 
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/boost)
 # This prevents system boost from leaking in
+
 set(Boost_NO_SYSTEM_PATHS ON)
 # We have to keep the FindBoost.cmake in an subfolder to prevent it from
 # overriding the system provided one when Boost_SOURCE=SYSTEM

--- a/CMake/resolve_dependency_modules/boost.cmake
+++ b/CMake/resolve_dependency_modules/boost.cmake
@@ -32,14 +32,14 @@ resolve_dependency(
   uc
   tu
   test)
+
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/boost)
 if(${ICU_SOURCE} STREQUAL "BUNDLED")
   # ensure ICU is built before Boost
   add_dependencies(boost_regex ICU ICU::i18n)
 endif()
 
-add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/boost)
 # This prevents system boost from leaking in
-
 set(Boost_NO_SYSTEM_PATHS ON)
 # We have to keep the FindBoost.cmake in an subfolder to prevent it from
 # overriding the system provided one when Boost_SOURCE=SYSTEM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,17 +308,6 @@ message("FINAL CMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-if(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-  if(ON_APPLE_M1)
-    set(CMAKE_PREFIX_PATH "/opt/homebrew/opt/icu4c" ${CMAKE_PREFIX_PATH})
-  else()
-    set(CMAKE_PREFIX_PATH "/usr/local/opt/icu4c" ${CMAKE_PREFIX_PATH})
-  endif()
-endif()
-
-set_source(ICU)
-resolve_dependency(ICU)
-
 set(BOOST_INCLUDE_LIBRARIES
     headers
     atomic


### PR DESCRIPTION
fixes #5022

The fuzzer failures where happenning because `FindICU` apparently requires components to be specified and does not fallback on looking for all. Additionally we really only need icu for Boost (from source) so it makes no sense to always look for it.