### PR TITLE
Support TinyInt/SmallInt/Integer for greatest()/least()

### DIFF
--- a/velox/functions/prestosql/GreatestLeast.cpp
+++ b/velox/functions/prestosql/GreatestLeast.cpp
@@ -112,6 +112,18 @@ class ExtremeValueFunction : public exec::VectorFunction {
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     switch (outputType.get()->kind()) {
+      case TypeKind::TINYINT:
+        applyTyped<TypeTraits<TypeKind::TINYINT>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      case TypeKind::SMALLINT:
+        applyTyped<TypeTraits<TypeKind::SMALLINT>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
+      case TypeKind::INTEGER:
+        applyTyped<TypeTraits<TypeKind::INTEGER>::NativeType>(
+            rows, args, outputType, context, result);
+        return;
       case TypeKind::BIGINT:
         applyTyped<TypeTraits<TypeKind::BIGINT>::NativeType>(
             rows, args, outputType, context, result);
@@ -146,7 +158,14 @@ class ExtremeValueFunction : public exec::VectorFunction {
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
     std::vector<std::string> types = {
-        "bigint", "double", "varchar", "timestamp", "date"};
+        "tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        "double",
+        "varchar",
+        "timestamp",
+        "date"};
     std::vector<std::shared_ptr<exec::FunctionSignature>> signatures;
     for (const auto& type : types) {
       signatures.emplace_back(exec::FunctionSignatureBuilder()

--- a/velox/functions/prestosql/tests/GreatestLeastTest.cpp
+++ b/velox/functions/prestosql/tests/GreatestLeastTest.cpp
@@ -93,14 +93,44 @@ TEST_F(GreatestLeastTest, greatestDouble) {
       {100, 1.1, 1});
 }
 
-TEST_F(GreatestLeastTest, leastBigInt) {
+TEST_F(GreatestLeastTest, leastInteger) {
+  // TinyInt
+  runTest<int8_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int8_t>("least(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
+  // SmallInt
+  runTest<int16_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int16_t>(
+      "least(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
+  // Integer
+  runTest<int32_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int32_t>(
+      "least(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
+  // BigInt
   runTest<int64_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>("least(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>(
+      "least(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
   runTest<int64_t>("least(c0, 1)", {{0, 1, -1}}, {0, 1, -1});
   runTest<int64_t>(
       "least(c0, 1 , c1)", {{0, 1, -1}, {100, -100, 0}}, {0, -100, -1});
 }
 
-TEST_F(GreatestLeastTest, greatestBigInt) {
+TEST_F(GreatestLeastTest, greatestInteger) {
+  // TinyInt
+  runTest<int8_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int8_t>(
+      "greatest(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {100, 1, 0});
+  // SmallInt
+  runTest<int16_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int16_t>(
+      "greatest(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {100, 1, 0});
+  // Integer
+  runTest<int32_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int32_t>(
+      "greatest(c0, c1)", {{0, 1, -1}, {100, -100, 0}}, {100, 1, 0});
+  // BigInt
+  runTest<int64_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
+  runTest<int64_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
   runTest<int64_t>("greatest(c0)", {{0, 1, -1}}, {0, 1, -1});
   runTest<int64_t>("greatest(c0, 1)", {{0, 1, -1}}, {1, 1, 1});
   runTest<int64_t>(


### PR DESCRIPTION
Currently greatest()/least() doesn't support TinyInt/SmallInt/Integer. The following query would fail.
```SQL
WITH num_test AS (
    SELECT
        CAST(c1 AS TINYINT) AS t1,
        CAST(c2 AS TINYINT) AS t2,
        CAST(c3 AS SMALLINT) AS s1,
        CAST(c4 AS SMALLINT) AS s2,
        CAST(c5 AS INTEGER) AS i1,
        CAST(c6 AS INTEGER) AS i2
    FROM (
        VALUES
            (1, 3, 100, 200, 33333, 55555),
            (3, 1, 100, 99, 12356, 12322)
    ) AS t (c1, c2, c3, c4, c5, c6)
)
SELECT
    GREATEST(t1, t2),
    LEAST(t1, t2),
    GREATEST(s1, s2),
    LEAST(s1, s2),
    GREATEST(i1, i2),
    LEAST(i1, i2)
FROM num_test
```

This change expands the functions to add TinyInt/SmallInt/Integer and updates the test accordingly.