### PR TITLE
Fix bug in DwrfReader estimatedSize()

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -506,9 +506,10 @@ std::optional<size_t> DwrfRowReader::estimatedRowSizeHelper(
     case TypeKind::ROW: {
       // start the estimate with the offsets and hasNulls vectors sizes
       size_t totalEstimate = valueCount * (sizeof(uint8_t) + sizeof(uint64_t));
-      for (int32_t i = 0; i < t.subtypesSize() &&
-           columnSelector_->shouldReadNode(t.subtypes(i));
-           ++i) {
+      for (int32_t i = 0; i < t.subtypesSize(); ++i) {
+        if (!columnSelector_->shouldReadNode(t.subtypes(i))) {
+          continue;
+        }
         auto subtypeEstimate =
             estimatedRowSizeHelper(footer, stats, t.subtypes(i));
         if (subtypeEstimate.has_value()) {

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -308,7 +308,7 @@ add_test(velox_dwio_dwrf_column_reader_test velox_dwio_dwrf_column_reader_test)
 target_link_libraries(velox_dwio_dwrf_column_reader_test velox_link_libs
                       Folly::folly fmt::fmt ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_dwrf_reader_test TestReader.cpp)
+add_executable(velox_dwio_dwrf_reader_test ReaderTest.cpp)
 add_test(
   NAME velox_dwio_dwrf_reader_test
   COMMAND velox_dwio_dwrf_reader_test


### PR DESCRIPTION
Fix bug so we can calculate estimatedSize() correctly. For RowType(which is also the case when we get information about all columns), skip subtypes where we don't want to add size. 

Previously, it was breaking early instead of just skipping