### PR TITLE
Enforce capacity on MallocAllocator

### DIFF
--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -170,8 +170,8 @@ class Allocation {
   friend class MmapAllocator;
   friend class MallocAllocator;
 
-  VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationTest);
-  VELOX_FRIEND_TEST(MemoryAllocatorTest, allocation);
+  VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass1);
+  VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
 };
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -209,8 +209,8 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// returns true if the allocation succeeded. If it returns false, 'out'
   /// references no memory and any partially allocated memory is freed.
   ///
-  /// NOTE: user needs to explicitly release allocation 'out' by calling
-  /// 'freeNonContiguous' on the same memory allocator object.
+  /// NOTE: Allocation is not guaranteed even if collateral 'out' is larger than
+  /// 'numPages', because this method is not atomic.
   virtual bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,
@@ -253,7 +253,8 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
       uint64_t bytes,
       uint16_t alignment = kMinAlignment) = 0;
 
-  /// Allocates a zero-filled contiguous bytes.
+  /// Allocates a zero-filled contiguous bytes. Returns nullptr if there is no
+  /// space
   virtual void* allocateZeroFilled(uint64_t bytes);
 
   /// Frees contiguous memory allocated by allocateBytes, allocateZeroFilled,
@@ -284,7 +285,13 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   virtual std::string toString() const = 0;
 
   /// Invoked to check if 'alignmentBytes' is valid and 'allocateBytes' is
-  /// multiple of 'alignmentBytes'.
+  /// multiple of 'alignmentBytes'. Returns true if check succeeds, false
+  /// otherwise
+  static bool isAlignmentValid(uint64_t allocateBytes, uint16_t alignmentBytes);
+
+  /// Invoked to check if 'alignmentBytes' is valid and 'allocateBytes' is
+  /// multiple of 'alignmentBytes'. Semantically the same as isAlignmentValid().
+  /// Throws if check fails.
   static void alignmentCheck(uint64_t allocateBytes, uint16_t alignmentBytes);
 
   /// Causes 'failure' to occur in memory allocation calls. This is a test-only
@@ -365,8 +372,17 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   const std::vector<MachinePageCount>
       sizeClassSizes_{1, 2, 4, 8, 16, 32, 64, 128, 256};
 
+  // Tracks the number of allocated pages. Allocated pages are the memory pages
+  // that are currently being used.
   std::atomic<MachinePageCount> numAllocated_{0};
-  // Tracks the number of mapped pages.
+
+  // Tracks the number of mapped pages. Mapped pages are the memory pages that
+  // meet following requirements:
+  // 1. They are obtained from the operating system from mmap calls directly,
+  // without going through std::malloc.
+  // 2. They are currently being allocated (used) or they were allocated (used)
+  // and freed in the past but haven't been returned to the operating system by
+  // 'this' (via madvise calls).
   std::atomic<MachinePageCount> numMapped_{0};
 
   // Indicates if the failure injection is persistent or transient.


### PR DESCRIPTION
MallocAllocator does not have capacity enforcement currently. Allocations can lead to system OOM. Adding capacity enforcement to MallocAllocator to make it system safe.