### PR TITLE
Add write support for other file formats in HiveConnector

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -219,14 +219,14 @@ void HiveDataSink::appendWriter(
       writerParameters.writeFileName();
   writerInfo_.push_back(
       std::make_shared<HiveWriterInfo>(std::move(writerParameters)));
-  auto sink = dwio::common::DataSink::create(writePath);
 
   auto writerFactory =
       dwio::common::getWriterFactory(insertTableHandle_->tableStorageFormat());
   dwio::common::WriterOptions options;
   options.schema = inputType_;
   options.memoryPool = connectorQueryCtx_->connectorMemoryPool();
-  writers_.push_back(writerFactory->createWriter(std::move(sink), options));
+  writers_.push_back(writerFactory->createWriter(
+      dwio::common::DataSink::create(writePath), options));
 }
 
 void HiveDataSink::computePartitionRowCountsAndIndices() {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -20,15 +20,10 @@
 #include "velox/common/base/Fs.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/HivePartitionUtil.h"
-#include "velox/dwio/dwrf/writer/Writer.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-
-using namespace facebook::velox::dwrf;
-using WriterConfig = facebook::velox::dwrf::Config;
 
 namespace facebook::velox::connector::hive {
 
@@ -217,21 +212,21 @@ void HiveDataSink::ensurePartitionWriters() {
 
 void HiveDataSink::appendWriter(
     const std::optional<std::string>& partitionName) {
-  // TODO: Wire up serde properties to writer configs.
-  facebook::velox::dwrf::WriterOptions options;
-  options.config = std::make_shared<WriterConfig>();
-  options.schema = inputType_;
   // Without explicitly setting flush policy, the default memory based flush
   // policy is used.
   auto writerParameters = getWriterParameters(partitionName);
   const auto writePath = fs::path(writerParameters.writeDirectory()) /
       writerParameters.writeFileName();
-
-  auto sink = dwio::common::DataSink::create(writePath);
-  writers_.push_back(std::make_unique<Writer>(
-      options, std::move(sink), *connectorQueryCtx_->connectorMemoryPool()));
   writerInfo_.push_back(
       std::make_shared<HiveWriterInfo>(std::move(writerParameters)));
+  auto sink = dwio::common::DataSink::create(writePath);
+
+  auto writerFactory =
+      dwio::common::getWriterFactory(insertTableHandle_->tableStorageFormat());
+  dwio::common::WriterOptions options;
+  options.schema = inputType_;
+  options.memoryPool = connectorQueryCtx_->connectorMemoryPool();
+  writers_.push_back(writerFactory->createWriter(std::move(sink), options));
 }
 
 void HiveDataSink::computePartitionRowCountsAndIndices() {

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -17,6 +17,8 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Writer.h"
 
 namespace facebook::velox::dwrf {
 class Writer;
@@ -87,9 +89,11 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
  public:
   HiveInsertTableHandle(
       std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
-      std::shared_ptr<const LocationHandle> locationHandle)
+      std::shared_ptr<const LocationHandle> locationHandle,
+      const dwio::common::FileFormat tableStorageFormat)
       : inputColumns_(std::move(inputColumns)),
-        locationHandle_(std::move(locationHandle)) {}
+        locationHandle_(std::move(locationHandle)),
+        tableStorageFormat_(tableStorageFormat) {}
 
   virtual ~HiveInsertTableHandle() = default;
 
@@ -100,6 +104,10 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
 
   const std::shared_ptr<const LocationHandle>& locationHandle() const {
     return locationHandle_;
+  }
+
+  const dwio::common::FileFormat tableStorageFormat() const {
+    return tableStorageFormat_;
   }
 
   bool isPartitioned() const;
@@ -117,6 +125,7 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
  private:
   const std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns_;
   const std::shared_ptr<const LocationHandle> locationHandle_;
+  const dwio::common::FileFormat tableStorageFormat_;
 };
 
 /// Parameters for Hive writers.
@@ -254,7 +263,7 @@ class HiveDataSink : public DataSink {
   // Below are structures for partitions from all inputs. writerInfo_ and
   // writers_ are both indexed by partitionId.
   std::vector<std::shared_ptr<HiveWriterInfo>> writerInfo_;
-  std::vector<std::unique_ptr<dwrf::Writer>> writers_;
+  std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
 
   // Below are structures updated when processing current input. partitionIds_
   // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -90,7 +90,8 @@ class HiveInsertTableHandle : public ConnectorInsertTableHandle {
   HiveInsertTableHandle(
       std::vector<std::shared_ptr<const HiveColumnHandle>> inputColumns,
       std::shared_ptr<const LocationHandle> locationHandle,
-      const dwio::common::FileFormat tableStorageFormat)
+      const dwio::common::FileFormat tableStorageFormat =
+          dwio::common::FileFormat::DWRF)
       : inputColumns_(std::move(inputColumns)),
         locationHandle_(std::move(locationHandle)),
         tableStorageFormat_(tableStorageFormat) {}

--- a/velox/core/CMakeLists.txt
+++ b/velox/core/CMakeLists.txt
@@ -18,14 +18,8 @@ endif()
 add_library(velox_config Config.cpp)
 target_link_libraries(velox_config velox_exception Folly::folly)
 
-add_library(
-  velox_core
-  Expressions.cpp
-  PlanFragment.cpp
-  PlanNode.cpp
-  QueryConfig.cpp
-  QueryCtx.cpp
-  SimpleFunctionMetadata.cpp)
+add_library(velox_core Expressions.cpp PlanFragment.cpp PlanNode.cpp
+                       QueryConfig.cpp QueryCtx.cpp SimpleFunctionMetadata.cpp)
 
 target_link_libraries(
   velox_core

--- a/velox/dwio/CMakeLists.txt
+++ b/velox/dwio/CMakeLists.txt
@@ -30,9 +30,5 @@ target_link_libraries(
 
 add_subdirectory(common)
 add_subdirectory(dwrf)
-
-if(VELOX_ENABLE_PARQUET)
-  add_subdirectory(parquet)
-endif()
-
+add_subdirectory(parquet)
 add_subdirectory(type)

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -50,7 +50,8 @@ add_library(
   SelectiveStructColumnReader.cpp
   SeekableInputStream.cpp
   TypeUtils.cpp
-  TypeWithId.cpp)
+  TypeWithId.cpp
+  WriterFactory.cpp)
 
 target_link_libraries(
   velox_dwio_common

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -24,6 +24,7 @@
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
 #include "velox/dwio/common/FlatMapHelper.h"
+#include "velox/dwio/common/FlushPolicy.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
@@ -558,6 +559,11 @@ class ReaderOptions {
   uint64_t getFilePreloadThreshold() const {
     return filePreloadThreshold;
   }
+};
+
+struct WriterOptions {
+  TypePtr schema;
+  velox::memory::MemoryPool* memoryPool;
 };
 
 } // namespace common

--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::dwio::common {
+
+/**
+ * Abstract writer class.
+ *
+ * Writer object is used to write a single file.
+ *
+ * Writer objects are created through factories implementing
+ * WriterFactory interface.
+ */
+class Writer {
+ public:
+  virtual ~Writer() = default;
+
+  /**
+   * Appends 'data' to writer. Data might still be in memory and not
+   * yet written to the file.
+   */
+  virtual void write(const VectorPtr& data) = 0;
+
+  /*
+   * Forces the writer to flush data to the file.
+   * Does not close the writer.
+   */
+  virtual void flush() = 0;
+
+  /**
+   *  Invokes flush and closes the writer.
+   *  Data can no longer be written.
+   */
+  virtual void close() = 0;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/WriterFactory.cpp
+++ b/velox/dwio/common/WriterFactory.cpp
@@ -31,7 +31,8 @@ WriterFactoriesMap& writerFactories() {
 } // namespace
 
 bool registerWriterFactory(std::shared_ptr<WriterFactory> factory) {
-  bool ok = writerFactories().insert({factory->fileFormat(), factory}).second;
+  const bool ok =
+      writerFactories().insert({factory->fileFormat(), factory}).second;
   VELOX_CHECK(
       ok,
       "WriterFactory is already registered for format {}",
@@ -40,8 +41,7 @@ bool registerWriterFactory(std::shared_ptr<WriterFactory> factory) {
 }
 
 bool unregisterWriterFactory(FileFormat format) {
-  auto count = writerFactories().erase(format);
-  return count == 1;
+  return (writerFactories().erase(format) == 1);
 }
 
 std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format) {
@@ -55,7 +55,7 @@ std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format) {
 
 bool hasWriterFactory(FileFormat format) {
   auto it = writerFactories().find(format);
-  return it != writerFactories().end();
+  return (writerFactories().count(format) == 1);
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/WriterFactory.cpp
+++ b/velox/dwio/common/WriterFactory.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/WriterFactory.h"
+
+namespace facebook::velox::dwio::common {
+
+namespace {
+
+using WriterFactoriesMap =
+    std::unordered_map<FileFormat, std::shared_ptr<WriterFactory>>;
+
+WriterFactoriesMap& writerFactories() {
+  static WriterFactoriesMap factories;
+  return factories;
+}
+
+} // namespace
+
+bool registerWriterFactory(std::shared_ptr<WriterFactory> factory) {
+  bool ok = writerFactories().insert({factory->fileFormat(), factory}).second;
+  VELOX_CHECK(
+      ok,
+      "WriterFactory is already registered for format {}",
+      toString(factory->fileFormat()));
+  return true;
+}
+
+bool unregisterWriterFactory(FileFormat format) {
+  auto count = writerFactories().erase(format);
+  return count == 1;
+}
+
+std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format) {
+  auto it = writerFactories().find(format);
+  VELOX_CHECK(
+      it != writerFactories().end(),
+      "WriterFactory is not registered for format {}",
+      toString(format));
+  return it->second;
+}
+
+bool hasWriterFactory(FileFormat format) {
+  auto it = writerFactories().find(format);
+  return it != writerFactories().end();
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/WriterFactory.h
+++ b/velox/dwio/common/WriterFactory.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "velox/dwio/common/DataSink.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Writer.h"
+
+namespace facebook::velox::dwio::common {
+
+/**
+ * Writer factory interface.
+ *
+ * Implement this interface to provide a factory of writers
+ * for a particular file format. Factory objects should be
+ * registered using registerWriteFactory method to become
+ * available for connectors. Only a single writer factory
+ * per file format is allowed.
+ */
+class WriterFactory {
+ public:
+  /**
+   * Constructor.
+   * @param format File format this factory is designated to.
+   */
+  explicit WriterFactory(FileFormat format) : format_(format) {}
+
+  virtual ~WriterFactory() = default;
+
+  /**
+   * Get the file format ths factory is designated to.
+   */
+  FileFormat fileFormat() const {
+    return format_;
+  }
+
+  /**
+   * Create a writer object.
+   * @param sink output sink
+   * @param options writer options
+   * @return writer object
+   */
+  virtual std::unique_ptr<Writer> createWriter(
+      std::unique_ptr<dwio::common::DataSink> sink,
+      const dwio::common::WriterOptions& options) = 0;
+
+ private:
+  const FileFormat format_;
+};
+
+/**
+ * Register a writer factory. Only a single factory can be registered
+ * for each file format. An attempt to register multiple factories for
+ * a single file format would cause a failure.
+ * @return true
+ */
+bool registerWriterFactory(std::shared_ptr<WriterFactory> factory);
+
+/**
+ * Unregister a writer factory for a specified file format.
+ * @return true for unregistered factory and false for a
+ * missing factory for the specified format.
+ */
+bool unregisterWriterFactory(FileFormat format);
+
+/**
+ * Get writer factory object for a specified file format. Results in
+ * a failure if there is no registered factory for this format.
+ * @return WriterFactory object
+ */
+std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format);
+
+bool hasWriterFactory(FileFormat format);
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -160,7 +160,7 @@ class ColumnWriterStatsTest : public ::testing::Test {
       config->set(Config::FLATTEN_MAP, true);
       config->set(Config::MAP_FLAT_COLS, {folly::to<uint32_t>(flatMapColId)});
     }
-    WriterOptions options;
+    dwrf::WriterOptions options;
     options.config = config;
     options.schema = type;
     options.flushPolicyFactory = [&]() {
@@ -169,7 +169,7 @@ class ColumnWriterStatsTest : public ::testing::Test {
       });
     };
 
-    Writer writer{options, std::move(sink), rootPool_};
+    dwrf::Writer writer{std::move(sink), options, rootPool_};
 
     for (size_t i = 0; i < repeat; ++i) {
       writer.write(batch);

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -1488,7 +1488,7 @@ std::unique_ptr<DwrfReader> getDwrfReader(
   auto sink = std::make_unique<MemorySink>(leafPool, 2 * 1024 * 1024);
   auto sinkPtr = sink.get();
 
-  WriterOptions options;
+  dwrf::WriterOptions options;
   options.config = config;
   options.schema = type;
   options.flushPolicyFactory = [&]() {
@@ -1496,7 +1496,8 @@ std::unique_ptr<DwrfReader> getDwrfReader(
       return true; // Flushes every batch.
     });
   };
-  Writer writer{options, std::move(sink), rootPool};
+  options.memoryPool = &rootPool;
+  dwrf::Writer writer{std::move(sink), options};
   writer.write(batch);
   writer.close();
 

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -75,7 +75,8 @@ class E2EFilterTest : public E2EFilterTestBase {
     };
     auto sink = std::make_unique<MemorySink>(*leafPool_, 200 * 1024 * 1024);
     sinkPtr_ = sink.get();
-    writer_ = std::make_unique<Writer>(options, std::move(sink), *rootPool_);
+    options.memoryPool = rootPool_.get();
+    writer_ = std::make_unique<dwrf::Writer>(std::move(sink), options);
     for (auto& batch : batches) {
       writer_->write(batch);
     }
@@ -100,7 +101,7 @@ class E2EFilterTest : public E2EFilterTestBase {
   std::unordered_set<std::string> flatMapColumns_;
 
  private:
-  WriterOptions createWriterOptions(const TypePtr& type) {
+  dwrf::WriterOptions createWriterOptions(const TypePtr& type) {
     auto config = std::make_shared<dwrf::Config>();
     config->set(dwrf::Config::COMPRESSION, CompressionKind_NONE);
     config->set(dwrf::Config::USE_VINTS, useVInts_);
@@ -141,13 +142,13 @@ class E2EFilterTest : public E2EFilterTestBase {
       config->set<const std::vector<std::vector<std::string>>>(
           dwrf::Config::MAP_FLAT_COLS_STRUCT_KEYS, mapFlatColsStructKeys);
     }
-    WriterOptions options;
+    dwrf::WriterOptions options;
     options.config = config;
     options.schema = writerSchema;
     return options;
   }
 
-  std::unique_ptr<Writer> writer_;
+  std::unique_ptr<dwrf::Writer> writer_;
   std::unordered_map<uint32_t, std::vector<std::string>>
       flatmapNodeIdsAsStruct_;
 };

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -83,10 +83,11 @@ class E2EWriterTests : public Test {
     auto sink = std::make_unique<MemorySink>(*leafPool_, 200 * 1024 * 1024);
     auto sinkPtr = sink.get();
 
-    WriterOptions options;
+    dwrf::WriterOptions options;
     options.config = config;
     options.schema = type;
-    Writer writer{options, std::move(sink), *rootPool_};
+    options.memoryPool = rootPool_.get();
+    dwrf::Writer writer{std::move(sink), options};
 
     for (size_t i = 0; i < stripes; ++i) {
       writer.write(BatchMaker::createBatch(type, size, *leafPool_, nullptr, i));
@@ -134,10 +135,11 @@ class E2EWriterTests : public Test {
     auto sink = std::make_unique<MemorySink>(*leafPool_, 400 * 1024 * 1024);
     auto sinkPtr = sink.get();
 
-    WriterOptions options;
+    dwrf::WriterOptions options;
     options.config = config;
     options.schema = type;
-    Writer writer{options, std::move(sink), *rootPool_};
+    options.memoryPool = rootPool_.get();
+    dwrf::Writer writer{std::move(sink), options};
 
     const size_t seed = std::time(nullptr);
     LOG(INFO) << "seed: " << seed;
@@ -753,10 +755,11 @@ TEST_F(E2EWriterTests, PartialStride) {
   auto sink = std::make_unique<MemorySink>(*leafPool_, 2 * 1024 * 1024);
   auto sinkPtr = sink.get();
 
-  WriterOptions options;
+  dwrf::WriterOptions options;
   options.config = config;
   options.schema = type;
-  Writer writer{options, std::move(sink), *rootPool_};
+  options.memoryPool = rootPool_.get();
+  dwrf::Writer writer{std::move(sink), options};
 
   auto nulls = allocateNulls(size, leafPool_.get());
   auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -964,12 +967,12 @@ class E2EEncryptionTest : public E2EWriterTests {
     config->set(Config::ENTROPY_KEY_STRING_SIZE_THRESHOLD, 0.0f);
     auto sink = std::make_unique<MemorySink>(*leafPool_, 16 * 1024 * 1024);
     sink_ = sink.get();
-    WriterOptions options;
+    dwrf::WriterOptions options;
     options.config = config;
     options.schema = type;
     options.encryptionSpec = spec;
     options.encrypterFactory = std::make_shared<TestEncrypterFactory>();
-    writer_ = std::make_unique<Writer>(options, std::move(sink), rootPool_);
+    writer_ = std::make_unique<Writer>(std::move(sink), options, rootPool_);
 
     for (size_t i = 0; i < batchCount_; ++i) {
       auto batch =

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1718,7 +1718,7 @@ void verifyRowNumbers(
   ASSERT_EQ(numRows, expectedNumRows);
 }
 
-std::pair<std::unique_ptr<Writer>, std::unique_ptr<DwrfReader>>
+std::pair<std::unique_ptr<dwrf::Writer>, std::unique_ptr<DwrfReader>>
 createWriterReader(
     const std::vector<VectorPtr>& batches,
     memory::MemoryPool& pool) {

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -203,7 +203,7 @@ class DummyWriter : public velox::dwrf::Writer {
       WriterOptions& options,
       std::unique_ptr<dwio::common::DataSink> sink,
       std::shared_ptr<memory::MemoryPool> pool)
-      : Writer{options, std::move(sink), std::move(pool)} {}
+      : Writer{std::move(sink), options, std::move(pool)} {}
 
   MOCK_METHOD1(
       flushImpl,
@@ -331,7 +331,7 @@ class WriterFlushTestHelper {
             memory::MemoryPool::Kind::kAggregate,
             nullptr,
             writerMemoryBudget));
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
     zeroOutMemoryUsage(context);
     return writer;
   }
@@ -371,7 +371,7 @@ class WriterFlushTestHelper {
       int64_t numStripes,
       const std::vector<SimulatedWrite>& writeSequence,
       std::mt19937& gen) {
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
     for (const auto& write : writeSequence) {
       if (writer->shouldFlush(context, write.numRows)) {
         ASSERT_EQ(
@@ -438,7 +438,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   auto pool = MockMemoryPool::create();
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     SimulatedWrite simWrite{10, 500, 300};
     simWrite.apply(context);
@@ -451,7 +451,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   }
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     SimulatedWrite simWrite{10, 500, 300};
     simWrite.apply(context);
@@ -475,7 +475,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   }
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     SimulatedWrite{10, 500, 300}.apply(context);
     SimulatedFlush simFlush{
@@ -497,7 +497,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   }
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     // 0 overhead flush but with raw size per row variance.
     SimulatedWrite{10, 500, 300}.apply(context);
@@ -528,7 +528,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   }
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     // 0 overhead flush but with raw size per row variance.
     SimulatedWrite{10, 500, 300}.apply(context);
@@ -551,7 +551,7 @@ TEST(TestWriterFlush, CheckAgainstMemoryBudget) {
   }
   {
     auto writer = WriterFlushTestHelper::prepWriter(pool, 1024);
-    auto& context = writer->getContext();
+    auto& context = writer->writerBase_->getContext();
 
     // 0 overhead flush but with flush overhead variance.
     SimulatedWrite{10, 500, 300}.apply(context);

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -39,16 +39,16 @@ namespace facebook::velox::dwrf {
         layoutPlannerFactory,
     const int64_t writerMemoryCap) {
   // write file to memory
-  WriterOptions options;
+  dwrf::WriterOptions options;
   options.config = config;
   options.schema = type;
   options.memoryBudget = writerMemoryCap;
   options.flushPolicyFactory = flushPolicyFactory;
   options.layoutPlannerFactory = layoutPlannerFactory;
 
-  auto writer = std::make_unique<Writer>(
-      options,
+  auto writer = std::make_unique<dwrf::Writer>(
       std::move(sink),
+      options,
       velox::memory::defaultMemoryManager().addRootPool());
 
   for (size_t i = 0; i < batches.size(); ++i) {

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -19,6 +19,8 @@
 #include <iterator>
 #include <limits>
 
+#include "velox/dwio/common/Writer.h"
+#include "velox/dwio/common/WriterFactory.h"
 #include "velox/dwio/dwrf/common/Encryption.h"
 #include "velox/dwio/dwrf/writer/ColumnWriter.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -30,6 +32,7 @@ namespace facebook::velox::dwrf {
 struct WriterOptions {
   std::shared_ptr<const Config> config = std::make_shared<Config>();
   std::shared_ptr<const Type> schema;
+  velox::memory::MemoryPool* memoryPool;
   // The default factory allows the writer to construct the default flush
   // policy with the configs in its ctor.
   std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory;
@@ -45,13 +48,13 @@ struct WriterOptions {
       columnWriterFactory;
 };
 
-class Writer : public WriterBase {
+class Writer : public dwio::common::Writer {
  public:
   Writer(
-      const WriterOptions& options,
       std::unique_ptr<dwio::common::DataSink> sink,
+      const WriterOptions& options,
       std::shared_ptr<memory::MemoryPool> pool)
-      : WriterBase{std::move(sink)},
+      : writerBase_(std::make_unique<WriterBase>(std::move(sink))),
         schema_{dwio::common::TypeWithId::create(options.schema)} {
     auto handler =
         (options.encryptionSpec ? encryption::EncryptionHandler::create(
@@ -59,8 +62,9 @@ class Writer : public WriterBase {
                                       *options.encryptionSpec,
                                       options.encrypterFactory.get())
                                 : nullptr);
-    initContext(options.config, std::move(pool), std::move(handler));
-    auto& context = getContext();
+    writerBase_->initContext(
+        options.config, std::move(pool), std::move(handler));
+    auto& context = writerBase_->getContext();
     context.buildPhysicalSizeAggregators(*schema_);
     if (!options.flushPolicyFactory) {
       flushPolicy_ = std::make_unique<DefaultFlushPolicy>(
@@ -77,31 +81,31 @@ class Writer : public WriterBase {
     }
 
     if (!options.columnWriterFactory) {
-      writer_ = BaseColumnWriter::create(getContext(), *schema_);
+      writer_ = BaseColumnWriter::create(writerBase_->getContext(), *schema_);
     } else {
-      writer_ = options.columnWriterFactory(getContext(), *schema_);
+      writer_ =
+          options.columnWriterFactory(writerBase_->getContext(), *schema_);
     }
   }
 
   Writer(
-      const WriterOptions& options,
       std::unique_ptr<dwio::common::DataSink> sink,
-      memory::MemoryPool& parentPool)
+      const WriterOptions& options)
       : Writer{
-            options,
             std::move(sink),
-            parentPool.addAggregateChild(fmt::format(
+            options,
+            options.memoryPool->addAggregateChild(fmt::format(
                 "writer_node_{}",
                 folly::to<std::string>(folly::Random::rand64())))} {}
 
   ~Writer() override = default;
 
-  void write(const VectorPtr& slice);
+  virtual void write(const VectorPtr& slice) override;
 
   // Forces the writer to flush, does not close the writer.
-  void flush();
+  virtual void flush() override;
 
-  void close() override;
+  virtual void close() override;
 
   void setLowMemoryMode();
 
@@ -120,6 +124,9 @@ class Writer : public WriterBase {
     writer_->tryAbandonDictionaries(true);
   }
 
+ protected:
+  std::shared_ptr<WriterBase> writerBase_;
+
  private:
   // Create a new stripe. No-op if there is no data written.
   void flushInternal(bool close = false);
@@ -128,7 +135,7 @@ class Writer : public WriterBase {
 
   void createRowIndexEntry() {
     writer_->createIndexEntry();
-    getContext().indexRowCount = 0;
+    writerBase_->getContext().indexRowCount = 0;
   }
 
   const std::shared_ptr<const dwio::common::TypeWithId> schema_;
@@ -138,5 +145,18 @@ class Writer : public WriterBase {
 
   friend class WriterTestHelper;
 };
+
+class DwrfWriterFactory : public dwio::common::WriterFactory {
+ public:
+  DwrfWriterFactory() : WriterFactory(dwio::common::FileFormat::DWRF) {}
+
+  std::unique_ptr<dwio::common::Writer> createWriter(
+      std::unique_ptr<dwio::common::DataSink> sink,
+      const dwio::common::WriterOptions& options) override;
+};
+
+void registerDwrfWriterFactory();
+
+void unregisterDwrfWriterFactory();
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/parquet/CMakeLists.txt
+++ b/velox/dwio/parquet/CMakeLists.txt
@@ -12,16 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(duckdb_reader)
-add_subdirectory(thrift)
-add_subdirectory(reader)
-add_subdirectory(writer)
+if(VELOX_ENABLE_PARQUET)
+  add_subdirectory(duckdb_reader)
+  add_subdirectory(thrift)
+  add_subdirectory(reader)
+  add_subdirectory(writer)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
+  if(${VELOX_BUILD_TESTING})
+    add_subdirectory(tests)
+  endif()
 endif()
 
 add_library(velox_dwio_parquet_reader RegisterParquetReader.cpp)
-target_link_libraries(
-  velox_dwio_parquet_reader velox_dwio_duckdb_parquet_reader
-  velox_dwio_native_parquet_reader xsimd)
+add_library(velox_dwio_parquet_writer RegisterParquetWriter.cpp)
+
+if(VELOX_ENABLE_PARQUET)
+  target_link_libraries(
+    velox_dwio_parquet_reader velox_dwio_duckdb_parquet_reader
+    velox_dwio_native_parquet_reader xsimd)
+  target_link_libraries(velox_dwio_parquet_writer
+                        velox_dwio_arrow_parquet_writer)
+endif()

--- a/velox/dwio/parquet/RegisterParquetReader.cpp
+++ b/velox/dwio/parquet/RegisterParquetReader.cpp
@@ -16,12 +16,15 @@
 
 #include "velox/dwio/parquet/RegisterParquetReader.h"
 
+#ifdef VELOX_ENABLE_PARQUET
 #include "velox/dwio/parquet/duckdb_reader/ParquetReader.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
+#endif
 
 namespace facebook::velox::parquet {
 
 void registerParquetReaderFactory(ParquetReaderType parquetReaderType) {
+#ifdef VELOX_ENABLE_PARQUET
   switch (parquetReaderType) {
     case ParquetReaderType::DUCKDB:
       dwio::common::registerReaderFactory(
@@ -35,10 +38,13 @@ void registerParquetReaderFactory(ParquetReaderType parquetReaderType) {
       VELOX_UNSUPPORTED(
           "Velox does not support ParquetReaderType ", parquetReaderType);
   }
+#endif
 }
 
 void unregisterParquetReaderFactory() {
+#ifdef VELOX_ENABLE_PARQUET
   dwio::common::unregisterReaderFactory(dwio::common::FileFormat::PARQUET);
+#endif
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetWriter.cpp
+++ b/velox/dwio/parquet/RegisterParquetWriter.cpp
@@ -14,28 +14,24 @@
  * limitations under the License.
  */
 
-#pragma once
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 
-#include <string>
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/writer/Writer.h"
+#endif
 
-namespace facebook::velox::dwio::common {
+namespace facebook::velox::parquet {
 
-enum CompressionKind {
-  CompressionKind_NONE = 0,
-  CompressionKind_ZLIB = 1,
-  CompressionKind_SNAPPY = 2,
-  CompressionKind_LZO = 3,
-  CompressionKind_ZSTD = 4,
-  CompressionKind_LZ4 = 5,
-  CompressionKind_GZIP = 6,
-  CompressionKind_MAX = INT64_MAX
-};
+void registerParquetWriterFactory() {
+#ifdef VELOX_ENABLE_PARQUET
+  dwio::common::registerWriterFactory(std::make_shared<ParquetWriterFactory>());
+#endif
+}
 
-/**
- * Get the name of the CompressionKind.
- */
-std::string compressionKindToString(CompressionKind kind);
+void unregisterParquetWriterFactory() {
+#ifdef VELOX_ENABLE_PARQUET
+  dwio::common::unregisterWriterFactory(dwio::common::FileFormat::PARQUET);
+#endif
+}
 
-constexpr uint64_t DEFAULT_COMPRESSION_BLOCK_SIZE = 256 * 1024;
-
-} // namespace facebook::velox::dwio::common
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/RegisterParquetWriter.h
+++ b/velox/dwio/parquet/RegisterParquetWriter.h
@@ -16,26 +16,10 @@
 
 #pragma once
 
-#include <string>
+namespace facebook::velox::parquet {
 
-namespace facebook::velox::dwio::common {
+void registerParquetWriterFactory();
 
-enum CompressionKind {
-  CompressionKind_NONE = 0,
-  CompressionKind_ZLIB = 1,
-  CompressionKind_SNAPPY = 2,
-  CompressionKind_LZO = 3,
-  CompressionKind_ZSTD = 4,
-  CompressionKind_LZ4 = 5,
-  CompressionKind_GZIP = 6,
-  CompressionKind_MAX = INT64_MAX
-};
+void unregisterParquetWriterFactory();
 
-/**
- * Get the name of the CompressionKind.
- */
-std::string compressionKindToString(CompressionKind kind);
-
-constexpr uint64_t DEFAULT_COMPRESSION_BLOCK_SIZE = 256 * 1024;
-
-} // namespace facebook::velox::dwio::common
+} // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -31,9 +31,9 @@ target_link_libraries(
   velox_dwio_parquet_thrift
   velox_type
   velox_dwio_common
-  arrow
   fmt::fmt
   parquet
+  arrow
   Snappy::snappy
   thrift
   zstd::zstd)

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTableScanTest.cpp
@@ -35,6 +35,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
 
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
+    unregisterParquetReaderFactory();
     registerParquetReaderFactory();
   }
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -31,7 +31,6 @@ class E2EFilterTest : public E2EFilterTestBase {
  protected:
   void SetUp() override {
     E2EFilterTestBase::SetUp();
-    writerProperties_ = ::parquet::WriterProperties::Builder().build();
   }
 
   void testWithTypes(
@@ -59,9 +58,10 @@ class E2EFilterTest : public E2EFilterTestBase {
       bool /*forRowGroupSkip*/) override {
     auto sink = std::make_unique<MemorySink>(*leafPool_, 200 * 1024 * 1024);
     sinkPtr_ = sink.get();
+    options_.memoryPool = rootPool_.get();
 
     writer_ = std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), *leafPool_, rowGroupSize_, writerProperties_);
+        std::move(sink), options_);
     for (auto& batch : batches) {
       writer_->write(batch);
     }
@@ -75,8 +75,7 @@ class E2EFilterTest : public E2EFilterTestBase {
   }
 
   std::unique_ptr<facebook::velox::parquet::Writer> writer_;
-  std::shared_ptr<::parquet::WriterProperties> writerProperties_;
-  int32_t rowGroupSize_{10000};
+  facebook::velox::parquet::WriterOptions options_;
 };
 
 TEST_F(E2EFilterTest, writerMagic) {
@@ -102,10 +101,9 @@ TEST_F(E2EFilterTest, boolean) {
 }
 
 TEST_F(E2EFilterTest, integerDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
+
   testWithTypes(
       "short_val:smallint,"
       "int_val:int,"
@@ -118,18 +116,16 @@ TEST_F(E2EFilterTest, integerDirect) {
 }
 TEST_F(E2EFilterTest, compression) {
   for (const auto compression :
-       {::parquet::Compression::SNAPPY,
-        ::parquet::Compression::ZSTD,
-        ::parquet::Compression::GZIP,
-        ::parquet::Compression::UNCOMPRESSED}) {
-    if (!arrow::util::Codec::IsAvailable(compression)) {
+       {dwio::common::CompressionKind_SNAPPY,
+        dwio::common::CompressionKind_ZSTD,
+        dwio::common::CompressionKind_GZIP,
+        dwio::common::CompressionKind_NONE}) {
+    if (!facebook::velox::parquet::Writer::isArrowCodecAvailable(compression)) {
       continue;
     }
 
-    writerProperties_ = ::parquet::WriterProperties::Builder()
-                            .data_pagesize(4 * 1024)
-                            ->compression(compression)
-                            ->build();
+    options_.dataPageSize = 4 * 1024;
+    options_.compression = compression;
 
     testWithTypes(
         "short_val:smallint,"
@@ -173,8 +169,7 @@ TEST_F(E2EFilterTest, compression) {
 }
 
 TEST_F(E2EFilterTest, integerDictionary) {
-  writerProperties_ =
-      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  options_.dataPageSize = 4 * 1024;
 
   testWithTypes(
       "short_val:smallint,"
@@ -217,10 +212,8 @@ TEST_F(E2EFilterTest, integerDictionary) {
 }
 
 TEST_F(E2EFilterTest, floatAndDoubleDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
 
   testWithTypes(
       "float_val:float,"
@@ -291,10 +284,9 @@ TEST_F(E2EFilterTest, shortDecimalDictionary) {
 }
 
 TEST_F(E2EFilterTest, shortDecimalDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
+
   // decimal(10, 5) maps to 5 bytes FLBA in Parquet.
   // decimal(17, 5) maps to 8 bytes FLBA in Parquet.
   for (const auto& type : {
@@ -356,10 +348,9 @@ TEST_F(E2EFilterTest, longDecimalDictionary) {
 }
 
 TEST_F(E2EFilterTest, longDecimalDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
+
   // decimal(30, 10) maps to 13 bytes FLBA in Parquet.
   // decimal(37, 15) maps to 16 bytes FLBA in Parquet.
   for (const auto& type : {
@@ -398,10 +389,8 @@ TEST_F(E2EFilterTest, longDecimalDirect) {
 }
 
 TEST_F(E2EFilterTest, stringDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
 
   testWithTypes(
       "string_val:string,"
@@ -431,10 +420,8 @@ TEST_F(E2EFilterTest, stringDictionary) {
 }
 
 TEST_F(E2EFilterTest, dedictionarize) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .max_row_group_length(10000000)
-                          ->dictionary_pagesize_limit(20000)
-                          ->build();
+  options_.maxRowGroupLength = 10'000'000;
+  options_.dictionaryPageSizeLimit = 20'000;
 
   testWithTypes(
       "long_val: bigint,"
@@ -469,8 +456,8 @@ TEST_F(E2EFilterTest, filterStruct) {
 
 TEST_F(E2EFilterTest, list) {
   // Break up the leaf data in small pages to cover coalescing repdefs.
-  writerProperties_ =
-      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  options_.dataPageSize = 4 * 1024;
+
   batchCount_ = 2;
   batchSize_ = 12000;
   testWithTypes(
@@ -496,8 +483,8 @@ TEST_F(E2EFilterTest, mutationCornerCases) {
 
 TEST_F(E2EFilterTest, map) {
   // Break up the leaf data in small pages to cover coalescing repdefs.
-  writerProperties_ =
-      ::parquet::WriterProperties::Builder().data_pagesize(4 * 1024)->build();
+  options_.dataPageSize = 4 * 1024;
+
   batchCount_ = 2;
   batchSize_ = 12000;
   testWithTypes(
@@ -512,10 +499,8 @@ TEST_F(E2EFilterTest, map) {
 }
 
 TEST_F(E2EFilterTest, varbinaryDirect) {
-  writerProperties_ = ::parquet::WriterProperties::Builder()
-                          .disable_dictionary()
-                          ->data_pagesize(4 * 1024)
-                          ->build();
+  options_.enableDictionary = false;
+  options_.dataPageSize = 4 * 1024;
 
   testWithTypes(
       "varbinary_val:varbinary,"
@@ -545,8 +530,8 @@ TEST_F(E2EFilterTest, varbinaryDictionary) {
 }
 
 TEST_F(E2EFilterTest, largeMetadata) {
-  writerProperties_ =
-      ::parquet::WriterProperties::Builder().max_row_group_length(1)->build();
+  options_.maxRowGroupLength = 1;
+
   rowType_ = ROW({INTEGER()});
   std::vector<RowVectorPtr> batches;
   batches.push_back(std::static_pointer_cast<RowVector>(

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -46,17 +46,14 @@ class ParquetReaderBenchmark {
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_.get(), 0);
     auto sink =
         std::make_unique<LocalFileSink>(fileFolder_->path + "/" + fileName_);
-    std::shared_ptr<::parquet::WriterProperties> writerProperties;
+    facebook::velox::parquet::WriterOptions options;
     if (disableDictionary_) {
       // The parquet file is in plain encoding format.
-      writerProperties =
-          ::parquet::WriterProperties::Builder().disable_dictionary()->build();
-    } else {
-      // The parquet file is in dictionary encoding format.
-      writerProperties = ::parquet::WriterProperties::Builder().build();
+      options.enableDictionary = false;
     }
+    options.memoryPool = pool_.get();
     writer_ = std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), *pool_, 10000, writerProperties);
+        std::move(sink), options);
   }
 
   ~ParquetReaderBenchmark() {

--- a/velox/dwio/parquet/writer/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_dwio_parquet_writer Writer.cpp)
+add_library(velox_dwio_arrow_parquet_writer Writer.cpp)
 
-target_link_libraries(velox_dwio_parquet_writer velox_dwio_common
+target_link_libraries(velox_dwio_arrow_parquet_writer velox_dwio_common
                       velox_arrow_bridge parquet arrow fmt::fmt)

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -14,52 +14,170 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/vector/arrow/Bridge.h"
+
 #include <arrow/c/bridge.h> // @manual
 #include <arrow/table.h> // @manual
-#include "velox/vector/arrow/Bridge.h"
+#include <parquet/arrow/writer.h> // @manual
+#include "velox/dwio/parquet/writer/Writer.h"
 
 namespace facebook::velox::parquet {
 
-void Writer::write(const RowVectorPtr& data) {
+// Utility for capturing Arrow output into a DataBuffer.
+class ArrowDataBufferSink : public arrow::io::OutputStream {
+ public:
+  explicit ArrowDataBufferSink(memory::MemoryPool& pool) : buffer_(pool) {}
+
+  arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
+    buffer_.append(
+        buffer_.size(),
+        reinterpret_cast<const char*>(data->data()),
+        data->size());
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Write(const void* data, int64_t nbytes) override {
+    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes);
+    return arrow::Status::OK();
+  }
+
+  arrow::Status Flush() override {
+    return arrow::Status::OK();
+  }
+
+  arrow::Result<int64_t> Tell() const override {
+    return buffer_.size();
+  }
+
+  arrow::Status Close() override {
+    return arrow::Status::OK();
+  }
+
+  bool closed() const override {
+    return false;
+  }
+
+  dwio::common::DataBuffer<char>& dataBuffer() {
+    return buffer_;
+  }
+
+ private:
+  dwio::common::DataBuffer<char> buffer_;
+};
+
+struct ArrowContext {
+  std::unique_ptr<::parquet::arrow::FileWriter> writer;
+  std::shared_ptr<::parquet::WriterProperties> properties;
+};
+
+::parquet::Compression::type getArrowParquetCompression(
+    dwio::common::CompressionKind compression) {
+  if (compression == dwio::common::CompressionKind_SNAPPY) {
+    return ::parquet::Compression::SNAPPY;
+  } else if (compression == dwio::common::CompressionKind_GZIP) {
+    return ::parquet::Compression::GZIP;
+  } else if (compression == dwio::common::CompressionKind_ZSTD) {
+    return ::parquet::Compression::ZSTD;
+  } else if (compression == dwio::common::CompressionKind_NONE) {
+    return ::parquet::Compression::UNCOMPRESSED;
+  } else {
+    VELOX_FAIL("Unsupported compression {}", compression);
+  }
+}
+
+std::shared_ptr<::parquet::WriterProperties> getArrowParquetWriterOptions(
+    const parquet::WriterOptions& options) {
+  auto builder = ::parquet::WriterProperties::Builder();
+  ::parquet::WriterProperties::Builder* properties = &builder;
+  if (!options.enableDictionary) {
+    properties = properties->disable_dictionary();
+  }
+  properties =
+      properties->compression(getArrowParquetCompression(options.compression));
+  properties = properties->data_pagesize(options.dataPageSize);
+  return properties->build();
+}
+
+Writer::Writer(
+    std::unique_ptr<dwio::common::DataSink> sink,
+    const WriterOptions& options,
+    std::shared_ptr<memory::MemoryPool> pool)
+    : rowsInRowGroup_(options.rowsInRowGroup),
+      pool_(std::move(pool)),
+      generalPool_{pool_->addLeafChild(".general")},
+      finalSink_(std::move(sink)) {
+  arrowContext_ = std::make_shared<ArrowContext>();
+  arrowContext_->properties = std::move(getArrowParquetWriterOptions(options));
+}
+
+Writer::Writer(
+    std::unique_ptr<dwio::common::DataSink> sink,
+    const WriterOptions& options)
+    : Writer{
+          std::move(sink),
+          options,
+          options.memoryPool->addAggregateChild(fmt::format(
+              "writer_node_{}",
+              folly::to<std::string>(folly::Random::rand64())))} {}
+
+void Writer::write(const VectorPtr& data) {
   ArrowArray array;
   ArrowSchema schema;
-  exportToArrow(data, array, &pool_);
+  exportToArrow(data, array, generalPool_.get());
   exportToArrow(data, schema);
   PARQUET_ASSIGN_OR_THROW(
       auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
   auto table = arrow::Table::Make(
       recordBatch->schema(), recordBatch->columns(), data->size());
-  if (!arrowWriter_) {
-    stream_ = std::make_shared<DataBufferSink>(pool_);
+  if (!arrowContext_->writer) {
+    stream_ = std::make_shared<ArrowDataBufferSink>(*generalPool_);
     auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
     PARQUET_THROW_NOT_OK(::parquet::arrow::FileWriter::Open(
         *recordBatch->schema(),
         arrow::default_memory_pool(),
         stream_,
-        properties_,
+        arrowContext_->properties,
         arrowProperties,
-        &arrowWriter_));
+        &arrowContext_->writer));
   }
 
-  PARQUET_THROW_NOT_OK(arrowWriter_->WriteTable(*table, 10000));
+  PARQUET_THROW_NOT_OK(arrowContext_->writer->WriteTable(*table, 10000));
+}
+
+bool Writer::isArrowCodecAvailable(dwio::common::CompressionKind compression) {
+  return arrow::util::Codec::IsAvailable(
+      getArrowParquetCompression(compression));
 }
 
 void Writer::flush() {
-  if (arrowWriter_) {
-    PARQUET_THROW_NOT_OK(arrowWriter_->Close());
-    arrowWriter_.reset();
+  if (arrowContext_->writer) {
+    PARQUET_THROW_NOT_OK(arrowContext_->writer->Close());
+    arrowContext_->writer.reset();
     finalSink_->write(std::move(stream_->dataBuffer()));
   }
 }
 
 void Writer::newRowGroup(int32_t numRows) {
-  PARQUET_THROW_NOT_OK(arrowWriter_->NewRowGroup(numRows));
+  PARQUET_THROW_NOT_OK(arrowContext_->writer->NewRowGroup(numRows));
 }
 
 void Writer::close() {
   flush();
   finalSink_->close();
+}
+
+parquet::WriterOptions getParquetOptions(
+    const dwio::common::WriterOptions& options) {
+  parquet::WriterOptions parquetOptions;
+  parquetOptions.memoryPool = options.memoryPool;
+  return parquetOptions;
+}
+
+std::unique_ptr<dwio::common::Writer> ParquetWriterFactory::createWriter(
+    std::unique_ptr<dwio::common::DataSink> sink,
+    const dwio::common::WriterOptions& options) {
+  auto parquetOptions = getParquetOptions(options);
+  return std::make_unique<Writer>(std::move(sink), parquetOptions);
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -16,77 +16,51 @@
 
 #pragma once
 
+#include "velox/dwio/common/Common.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/DataSink.h"
-
+#include "velox/dwio/common/Options.h"
+#include "velox/dwio/common/Writer.h"
+#include "velox/dwio/common/WriterFactory.h"
 #include "velox/vector/ComplexVector.h"
-
-#include <parquet/arrow/writer.h> // @manual
 
 namespace facebook::velox::parquet {
 
-// Utility for capturing Arrow output into a DataBuffer.
-class DataBufferSink : public arrow::io::OutputStream {
- public:
-  explicit DataBufferSink(memory::MemoryPool& pool) : buffer_(pool) {}
+class ArrowDataBufferSink;
 
-  arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
-    buffer_.append(
-        buffer_.size(),
-        reinterpret_cast<const char*>(data->data()),
-        data->size());
-    return arrow::Status::OK();
-  }
+struct ArrowContext;
 
-  arrow::Status Write(const void* data, int64_t nbytes) override {
-    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes);
-    return arrow::Status::OK();
-  }
-
-  arrow::Status Flush() override {
-    return arrow::Status::OK();
-  }
-
-  arrow::Result<int64_t> Tell() const override {
-    return buffer_.size();
-  }
-
-  arrow::Status Close() override {
-    return arrow::Status::OK();
-  }
-
-  bool closed() const override {
-    return false;
-  }
-
-  dwio::common::DataBuffer<char>& dataBuffer() {
-    return buffer_;
-  }
-
- private:
-  dwio::common::DataBuffer<char> buffer_;
+struct WriterOptions {
+  bool enableDictionary = true;
+  int64_t dataPageSize = 1'024 * 1'024;
+  int32_t rowsInRowGroup = 10'000;
+  int64_t maxRowGroupLength = 1'024 * 1'024;
+  int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
+  dwio::common::CompressionKind compression =
+      dwio::common::CompressionKind_NONE;
+  velox::memory::MemoryPool* memoryPool;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.
-class Writer {
+class Writer : public dwio::common::Writer {
  public:
-  // Constructts a writer with output to 'sink'. A new row group is
+  // Constructs a writer with output to 'sink'. A new row group is
   // started every 'rowsInRowGroup' top level rows. 'pool' is used for
   // temporary memory. 'properties' specifies Parquet-specific
   // options.
   Writer(
       std::unique_ptr<dwio::common::DataSink> sink,
-      memory::MemoryPool& pool,
-      int32_t rowsInRowGroup,
-      std::shared_ptr<::parquet::WriterProperties> properties =
-          ::parquet::WriterProperties::Builder().build())
-      : rowsInRowGroup_(rowsInRowGroup),
-        pool_(pool),
-        finalSink_(std::move(sink)),
-        properties_(std::move(properties)) {}
+      const WriterOptions& options,
+      std::shared_ptr<memory::MemoryPool> pool);
+
+  Writer(
+      std::unique_ptr<dwio::common::DataSink> sink,
+      const WriterOptions& options);
+
+  static bool isArrowCodecAvailable(dwio::common::CompressionKind compression);
 
   // Appends 'data' into the writer.
-  void write(const RowVectorPtr& data);
+  void write(const VectorPtr& data);
 
   void flush();
 
@@ -102,17 +76,25 @@ class Writer {
   const int32_t rowsInRowGroup_;
 
   // Pool for 'stream_'.
-  memory::MemoryPool& pool_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::shared_ptr<memory::MemoryPool> generalPool_;
 
   // Final destination of output.
   std::unique_ptr<dwio::common::DataSink> finalSink_;
 
   // Temporary Arrow stream for capturing the output.
-  std::shared_ptr<DataBufferSink> stream_;
+  std::shared_ptr<ArrowDataBufferSink> stream_;
 
-  std::unique_ptr<::parquet::arrow::FileWriter> arrowWriter_;
+  std::shared_ptr<ArrowContext> arrowContext_;
+};
 
-  std::shared_ptr<::parquet::WriterProperties> properties_;
+class ParquetWriterFactory : public dwio::common::WriterFactory {
+ public:
+  ParquetWriterFactory() : WriterFactory(dwio::common::FileFormat::PARQUET) {}
+
+  std::unique_ptr<dwio::common::Writer> createWriter(
+      std::unique_ptr<dwio::common::DataSink> sink,
+      const dwio::common::WriterOptions& options) override;
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -41,6 +41,8 @@ target_link_libraries(
   velox_dwio_type_fbhive
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_dwio_common_test_utils
   velox_hive_connector
   velox_tpch_connector

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -21,6 +21,8 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/tests/utils/QueryAssertions.h"
 
 namespace facebook::velox::exec::test {
@@ -37,6 +39,9 @@ void HiveConnectorTestBase::SetUp() {
           ->newConnector(kHiveConnectorId, nullptr, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
   dwrf::registerDwrfReaderFactory();
+  dwrf::registerDwrfWriterFactory();
+  parquet::registerParquetReaderFactory(parquet::ParquetReaderType::NATIVE);
+  parquet::registerParquetWriterFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
@@ -44,6 +49,9 @@ void HiveConnectorTestBase::TearDown() {
   // connector.
   ioExecutor_.reset();
   dwrf::unregisterDwrfReaderFactory();
+  dwrf::unregisterDwrfWriterFactory();
+  parquet::unregisterParquetReaderFactory();
+  parquet::unregisterParquetWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }
@@ -58,13 +66,14 @@ void HiveConnectorTestBase::writeToFile(
     const std::string& filePath,
     const std::vector<RowVectorPtr>& vectors,
     std::shared_ptr<dwrf::Config> config) {
-  facebook::velox::dwrf::WriterOptions options;
+  velox::dwrf::WriterOptions options;
   options.config = config;
   options.schema = vectors[0]->type();
   auto sink =
       std::make_unique<facebook::velox::dwio::common::LocalFileSink>(filePath);
   auto childPool = rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
-  facebook::velox::dwrf::Writer writer{options, std::move(sink), *childPool};
+  options.memoryPool = childPool.get();
+  facebook::velox::dwrf::Writer writer{std::move(sink), options};
   for (size_t i = 0; i < vectors.size(); ++i) {
     writer.write(vectors[i]);
   }
@@ -172,7 +181,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const std::vector<std::string>& tableColumnNames,
     const std::vector<TypePtr>& tableColumnTypes,
     const std::vector<std::string>& partitionedBy,
-    std::shared_ptr<connector::hive::LocationHandle> locationHandle) {
+    std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+    const dwio::common::FileFormat tableStorageFormat) {
   std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
       columnHandles;
   for (int i = 0; i < tableColumnNames.size(); ++i) {
@@ -195,7 +205,7 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
   }
 
   return std::make_shared<connector::hive::HiveInsertTableHandle>(
-      columnHandles, locationHandle);
+      columnHandles, locationHandle, tableStorageFormat);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -119,7 +119,9 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::vector<std::string>& tableColumnNames,
       const std::vector<TypePtr>& tableColumnTypes,
       const std::vector<std::string>& partitionedBy,
-      std::shared_ptr<connector::hive::LocationHandle> locationHandle);
+      std::shared_ptr<connector::hive::LocationHandle> locationHandle,
+      const dwio::common::FileFormat tableStorageFormat =
+          dwio::common::FileFormat::DWRF);
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,


### PR DESCRIPTION
HiveConnector today only supports the DWRF file format. 
This PR generalizes it to other file formats such as Parquet.
Add `dwio::common::Writer` API and extend it to DWRF and Parquet file formats.
Add support for Writer Factories.
Extend HiveDataSink to utilize writer factories.

The `WriterOptions` for DWRF and parquet have nothing in common.
The `dwrf::WriterOptions` is also strongly coupled with DWRF structures.
`dwio::common::WriterOptions` API has been created to store some common fields.
The current implementation specializes `WriterOptions` for DWRF and Parquet.

Resolves: https://github.com/facebookincubator/velox/issues/4874