### PR TITLE
Add to handle memory arbitration failure by aborting query with largest capacity

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -35,7 +35,8 @@ MemoryManager::MemoryManager(const Options& options)
               options.arbitratorConfig.initMemoryPoolCapacity,
           .minMemoryPoolCapacityTransferSize =
               options.arbitratorConfig.minMemoryPoolCapacityTransferSize,
-      })),
+          .retryArbitrationFailure =
+              options.arbitratorConfig.retryArbitrationFailure})),
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
       checkUsageLeak_(options.checkUsageLeak),
       poolDestructionCb_([&](MemoryPool* pool) { dropPool(pool); }),

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -77,6 +77,14 @@ class MemoryArbitrator {
     /// The minimal memory capacity to transfer out of or into a memory pool
     /// during the memory arbitration.
     uint64_t minMemoryPoolCapacityTransferSize{32 << 20};
+
+    /// If true, handle the memory arbitration failure by aborting the memory
+    /// pool with most capacity and retry the memory arbitration, otherwise we
+    /// simply fails the memory arbitration requestor itself. This helps the
+    /// distributed query execution use case such as Prestissimo that fail the
+    /// same query on all the workers instead of a random victim query which
+    /// happens to trigger the failed memory arbitration.
+    bool retryArbitrationFailure{true};
   };
   static std::unique_ptr<MemoryArbitrator> create(const Config& config);
 
@@ -154,12 +162,14 @@ class MemoryArbitrator {
         capacity_(config.capacity),
         initMemoryPoolCapacity_(config.initMemoryPoolCapacity),
         minMemoryPoolCapacityTransferSize_(
-            config.minMemoryPoolCapacityTransferSize) {}
+            config.minMemoryPoolCapacityTransferSize),
+        retryArbitrationFailure_(config.retryArbitrationFailure) {}
 
   const Kind kind_;
   const uint64_t capacity_;
   const uint64_t initMemoryPoolCapacity_;
   const uint64_t minMemoryPoolCapacityTransferSize_;
+  const bool retryArbitrationFailure_;
 };
 
 std::ostream& operator<<(std::ostream& out, const MemoryArbitrator::Kind& kind);

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -69,9 +69,18 @@ class SharedArbitrator : public MemoryArbitrator {
   static std::vector<Candidate> getCandidateStats(
       const std::vector<std::shared_ptr<MemoryPool>>& pools);
 
-  void sortCandidatesByReclaimableMemory(std::vector<Candidate>& candidates);
+  void sortCandidatesByReclaimableMemory(
+      std::vector<Candidate>& candidates) const;
 
-  void sortCandidatesByFreeCapacity(std::vector<Candidate>& candidates);
+  void sortCandidatesByFreeCapacity(std::vector<Candidate>& candidates) const;
+
+  // Finds the candidate with the largest capacity. For 'requestor', the
+  // capacity for comparison including its current capacity and the capacity to
+  // grow.
+  const Candidate& findCandidateWithLargestCapacity(
+      MemoryPool* requestor,
+      uint64_t targetBytes,
+      const std::vector<Candidate>& candidates) const;
 
   bool arbitrateMemory(
       MemoryPool* requestor,
@@ -111,6 +120,13 @@ class SharedArbitrator : public MemoryArbitrator {
 
   // Invoked to abort memory 'pool'.
   void abort(MemoryPool* pool);
+
+  // Invoked to handle the memory arbitration failure to abort the memory pool
+  // with the largest capacity to free up memory.
+  void handleOOM(
+      MemoryPool* requestor,
+      uint64_t targetBytes,
+      std::vector<Candidate>& candidates);
 
   // Decrement free capacity from the arbitrator with up to 'bytes'. The
   // arbitrator might have less free available capacity. The function returns

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -268,7 +268,8 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
   void setupMemory(
       int64_t memoryCapacity = 0,
       uint64_t initMemoryPoolCapacity = 0,
-      uint64_t minMemoryPoolCapacityTransferSize = 0) {
+      uint64_t minMemoryPoolCapacityTransferSize = 0,
+      bool retryArbitrationFailure = true) {
     if (initMemoryPoolCapacity == 0) {
       initMemoryPoolCapacity = kInitMemoryPoolCapacity;
     }
@@ -281,7 +282,8 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
         .kind = MemoryArbitrator::Kind::kShared,
         .capacity = options.capacity,
         .initMemoryPoolCapacity = initMemoryPoolCapacity,
-        .minMemoryPoolCapacityTransferSize = minMemoryPoolCapacityTransferSize};
+        .minMemoryPoolCapacityTransferSize = minMemoryPoolCapacityTransferSize,
+        .retryArbitrationFailure = retryArbitrationFailure};
     options.checkUsageLeak = true;
     memoryManager_ = std::make_unique<MemoryManager>(options);
     ASSERT_EQ(
@@ -1249,6 +1251,8 @@ DEBUG_ONLY_TEST_F(
 DEBUG_ONLY_TEST_F(
     SharedArbitrationTest,
     failedToReclaimFromHashJoinBuildersInNonReclaimableSection) {
+  // Disable the memory arbitration failure retry to ease testing.
+  setupMemory(0, 0, 0, false);
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
   fuzzerOpts_.vectorSize = 128;
@@ -1416,6 +1420,8 @@ DEBUG_ONLY_TEST_F(
 DEBUG_ONLY_TEST_F(
     SharedArbitrationTest,
     failedToReclaimFromHashJoinBuildersInNotRunningState) {
+  // Disable the memory arbitration failure retry to ease testing.
+  setupMemory(0, 0, 0, false);
   const int numVectors = 32;
   std::vector<RowVectorPtr> vectors;
   fuzzerOpts_.vectorSize = 128;


### PR DESCRIPTION
Add to handle memory arbitration failure by aborting the query with
the largest capacity instead of simply failing the requestor. This helps
preventing to fail a random victim query which happens to trigger the
failed the memory arbitration. This is helps the distributed query execution
use case such as prestissimo to fail the same query on all the workers.
Here we assume the query use the most memory on all its shards in the
cluster.