### PR TITLE
Optimize Generic Writer for maps

### DIFF
--- a/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
@@ -166,6 +166,9 @@ class SimpleSubscriptBenchmark : public functions::test::FunctionBenchmarkBase {
     testArraySubscript(ARRAY(INTEGER()));
     testArraySubscript(ARRAY(ARRAY(INTEGER())));
     testArraySubscript(MAP(INTEGER(), INTEGER()));
+    testArraySubscript(MAP(VARCHAR(), INTEGER()));
+    testArraySubscript(MAP(INTEGER(), ARRAY(BIGINT())));
+    testArraySubscript(MAP(ARRAY(INTEGER()), BIGINT()));
   }
 
  private:
@@ -260,8 +263,41 @@ BENCHMARK(ArraySubscriptSimple_ArrayString) {
 BENCHMARK(ArraySubscript_NestedArrayString) {
   benchmark->run("subscript(c0, c1)", ARRAY(VARCHAR()));
 }
+
 BENCHMARK(ArraySubscriptSimple_NestedArrayString) {
   benchmark->run("subscript_simple(c0, c1)", ARRAY(VARCHAR()));
+}
+
+BENCHMARK(ArraySubscriptSimple_MapIntInt) {
+  benchmark->run("subscript_simple(c0, c1)", MAP(BIGINT(), BIGINT()));
+}
+
+BENCHMARK(ArraySubscript_MapIntInt) {
+  benchmark->run("subscript(c0, c1)", MAP(BIGINT(), BIGINT()));
+}
+
+BENCHMARK(ArraySubscriptSimple_MapStringInt) {
+  benchmark->run("subscript_simple(c0, c1)", MAP(VARCHAR(), BIGINT()));
+}
+
+BENCHMARK(ArraySubscript_MapStringInt) {
+  benchmark->run("subscript(c0, c1)", MAP(VARCHAR(), BIGINT()));
+}
+
+BENCHMARK(ArraySubscriptSimple_MapIntArray) {
+  benchmark->run("subscript_simple(c0, c1)", MAP(BIGINT(), ARRAY(BIGINT())));
+}
+
+BENCHMARK(ArraySubscript_MapIntArray) {
+  benchmark->run("subscript(c0, c1)", MAP(BIGINT(), ARRAY(BIGINT())));
+}
+
+BENCHMARK(ArraySubscriptSimple_MapArrayInt) {
+  benchmark->run("subscript_simple(c0, c1)", MAP(ARRAY(BIGINT()), BIGINT()));
+}
+
+BENCHMARK(ArraySubscript_MapArrayInt) {
+  benchmark->run("subscript(c0, c1)", MAP(ARRAY(BIGINT()), BIGINT()));
 }
 
 int main(int argc, char** argv) {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1267,6 +1267,10 @@ std::shared_ptr<const OpaqueType> OPAQUE() {
         return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::BIGINT>(    \
             __VA_ARGS__);                                                \
       }                                                                  \
+      case ::facebook::velox::TypeKind::HUGEINT: {                       \
+        return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::HUGEINT>(   \
+            __VA_ARGS__);                                                \
+      }                                                                  \
       case ::facebook::velox::TypeKind::REAL: {                          \
         return TEMPLATE_FUNC<T, ::facebook::velox::TypeKind::REAL>(      \
             __VA_ARGS__);                                                \
@@ -1754,6 +1758,9 @@ struct SimpleTypeTrait<CustomType<T>>
   // This is different than the physical type name.
   static constexpr char* name = T::typeName;
 };
+
+template <>
+struct SimpleTypeTrait<UnknownValue> : public TypeTraits<TypeKind::UNKNOWN> {};
 
 // TODO: move cppToType testing utilities.
 template <typename T>


### PR DESCRIPTION
Summary:
Add fast path when keys and values are primitives.
The effect is not much when not both keys and values is supported in fast path. We can optimize that in the future also though.

Differential Revision: D46282619

