### PR TITLE
Temporarily comment out the velox check.

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -209,11 +209,7 @@ void HashAggregation::addInput(RowVectorPtr input) {
     if (newDistincts_) {
       // Save input to use for output in getOutput().
       input_ = input;
-    } else {
-      // In case of 'no new distinct groups' the only reason we can have
-      // 'partial full' true is due to 'abandoning partial aggregation early'
-      // being true. If that's not the case, then it is a bug.
-      VELOX_CHECK_EQ(partialFull_, abandonPartialEarly);
+    } else if (abandonPartialEarly) {
       // If no new distinct groups (meaning we don't have anything to output)
       // and we are abandoning the partial aggregation, then we need to ensure
       // we 'need input'. For that we need to reset the 'partial full' flag.


### PR DESCRIPTION
Summary:
Some queries are fialing with this check.
It can be a sign of a legit problem or might be not.
To avoid some query failure we disable this check and
will investigate this further.

Differential Revision: D46298705

