### PR TITLE
Fix argument type in NthValueFunction::setRowNumber

### DIFF
--- a/velox/functions/prestosql/window/NthValue.cpp
+++ b/velox/functions/prestosql/window/NthValue.cpp
@@ -138,7 +138,7 @@ class NthValueFunction : public exec::WindowFunction {
   }
 
   inline void setRowNumber(
-      column_index_t i,
+      vector_size_t i,
       const vector_size_t* frameStarts,
       const vector_size_t* frameEnds,
       vector_size_t offset) {


### PR DESCRIPTION
Row numbers should use vector_size_t type, not column_index_t.