### PR TITLE
Add support for lead and lag window functions in DuckParser

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -755,6 +755,15 @@ const IExprWindowFunction parseWindowExpr(const std::string& windowString) {
   for (const auto& c : windowExpr.children) {
     params.emplace_back(parseExpr(*c, options));
   }
+
+  // Lead and Lag functions have extra offset and default_value arguments.
+  if (windowExpr.offset_expr) {
+    params.emplace_back(parseExpr(*windowExpr.offset_expr, options));
+  }
+  if (windowExpr.default_expr) {
+    params.emplace_back(parseExpr(*windowExpr.default_expr, options));
+  }
+
   auto func = normalizeFuncName(windowExpr.function_name);
   windowIExpr.functionCall =
       callExpr(func, std::move(params), getAlias(windowExpr));

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -515,6 +515,16 @@ TEST(DuckParserTest, window) {
       parseWindow(
           "row_number() over (partition by a order by b desc nulls first "
           "rows between a + 10 preceding and 10 following)"));
+
+  EXPECT_EQ(
+      "lead(\"x\",\"y\",\"z\") OVER (  "
+      "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+      parseWindow("lead(x, y, z) over ()"));
+
+  EXPECT_EQ(
+      "lag(\"x\",3,\"z\") OVER (  "
+      "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)",
+      parseWindow("lag(x, 3, z) over ()"));
 }
 
 TEST(DuckParserTest, invalidExpression) {


### PR DESCRIPTION
DuckDB parser puts offset and default_value arguments of lead and lag functions
into separate fields.
