### PR TITLE
Add DynamicRowView and its reader

### DIFF
--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -702,6 +702,51 @@ struct VectorReader<Generic<T>> {
   mutable std::optional<const std::type_info*> castType_ = std::nullopt;
 };
 
+template <>
+struct VectorReader<DynamicRow> {
+  using in_vector_t = RowVector;
+  using exec_in_t = DynamicRowView<true>;
+  using exec_null_free_in_t = DynamicRowView<false>;
+
+  explicit VectorReader(const DecodedVector* decoded)
+      : decoded_(*decoded),
+        vector_(detail::getDecoded<in_vector_t>(decoded_)),
+        childrenDecoders_{vector_.childrenSize()} {
+    for (int i = 0; i < vector_.childrenSize(); i++) {
+      childReaders_.push_back(std::make_unique<VectorReader<Any>>(
+          detail::decode(childrenDecoders_[i], *vector_.childAt(i))));
+    }
+  }
+
+  exec_in_t operator[](size_t offset) const {
+    auto index = decoded_.index(offset);
+    return {&childReaders_, index};
+  }
+
+  exec_null_free_in_t readNullFree(size_t offset) const {
+    auto index = decoded_.index(offset);
+    return {&childReaders_, index};
+  }
+
+  bool isSet(size_t offset) const {
+    return !decoded_.isNullAt(offset);
+  }
+
+  bool mayHaveNulls() const {
+    return decoded_.mayHaveNulls();
+  }
+
+  const BaseVector* baseVector() const {
+    return decoded_.base();
+  }
+
+ private:
+  const DecodedVector& decoded_;
+  const in_vector_t& vector_;
+  std::vector<DecodedVector> childrenDecoders_;
+  std::vector<std::unique_ptr<VectorReader<Any>>> childReaders_;
+};
+
 template <typename T>
 struct VectorReader<CustomType<T>> : public VectorReader<typename T::type> {
   explicit VectorReader(const DecodedVector* decoded)


### PR DESCRIPTION
Summary:
A DynamicRowView can represent a row vector of any width of any types, without having to be typed.
It has two functions:
1. size() : width of the struct.
2. at(int i) : return generic view for the field i.

This simplify and enable writing functions with rows of unknown
or unlimited types. This is also needed  to support row types
in the GenericWriter copy_from operation.

next diff will plug DynamicRowView and DynamicRowWriter in the
simple function interface and then row support for generic writer
copy_from operation will be added.

Differential Revision: D46299159

