### PR TITLE
Add range checks for seconds and nanos to Timestamp's constructor

### DIFF
--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -244,16 +244,16 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
       {std::nullopt,
        Timestamp(100'000, 900'000),
        Timestamp(
-           std::numeric_limits<int64_t>::min(),
+           dwio::common::MIN_SECONDS,
            std::numeric_limits<uint64_t>::min()),
        Timestamp(
            std::numeric_limits<int64_t>::max(),
-           std::numeric_limits<uint64_t>::max())});
+           dwio::common::MAX_NANOS)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 0});
-  assertPartitions(values, 500, {0, 284, 0, 0});
-  assertPartitions(values, 997, {0, 514, 0, 0});
+  assertPartitions(values, 500, {0, 284, 123, 324});
+  assertPartitions(values, 997, {0, 514, 818, 713});
 
   assertPartitionsWithConstChannel(values, 1);
   assertPartitionsWithConstChannel(values, 2);

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -248,8 +248,8 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 0});
-  assertPartitions(values, 500, {0, 284, 446, 450});
-  assertPartitions(values, 997, {0, 514, 147, 733});
+  assertPartitions(values, 500, {0, 284, 122, 450});
+  assertPartitions(values, 997, {0, 514, 404, 733});
 
   assertPartitionsWithConstChannel(values, 1);
   assertPartitionsWithConstChannel(values, 2);

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -251,7 +251,7 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
            dwio::common::MAX_NANOS)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
-  assertPartitions(values, 2, {0, 0, 0, 0});
+  assertPartitions(values, 2, {0, 0, 1, 0});
   assertPartitions(values, 500, {0, 284, 123, 324});
   assertPartitions(values, 997, {0, 514, 818, 713});
 

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -243,15 +243,13 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
   auto values = makeNullableFlatVector<Timestamp>(
       {std::nullopt,
        Timestamp(100'000, 900'000),
-       Timestamp(
-           std::numeric_limits<int64_t>::min(),
-           std::numeric_limits<uint64_t>::min()),
-       Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos)});
+       Timestamp(Timestamp::kMinSeconds, std::numeric_limits<uint64_t>::min()),
+       Timestamp(Timestamp::kMaxSeconds, Timestamp::kMaxNanos)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 0});
-  assertPartitions(values, 500, {0, 284, 0, 324});
-  assertPartitions(values, 997, {0, 514, 0, 713});
+  assertPartitions(values, 500, {0, 284, 446, 450});
+  assertPartitions(values, 997, {0, 514, 147, 733});
 
   assertPartitionsWithConstChannel(values, 1);
   assertPartitionsWithConstChannel(values, 2);

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -246,7 +246,7 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
        Timestamp(
            std::numeric_limits<int64_t>::min(),
            std::numeric_limits<uint64_t>::min()),
-       Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::MAX_NANOS)});
+       Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 0});

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -244,14 +244,14 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
       {std::nullopt,
        Timestamp(100'000, 900'000),
        Timestamp(
-           dwio::common::MIN_SECONDS, std::numeric_limits<uint64_t>::min()),
-       Timestamp(
-           std::numeric_limits<int64_t>::max(), dwio::common::MAX_NANOS)});
+           std::numeric_limits<int64_t>::min(),
+           std::numeric_limits<uint64_t>::min()),
+       Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::MAX_NANOS)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
-  assertPartitions(values, 2, {0, 0, 1, 0});
-  assertPartitions(values, 500, {0, 284, 123, 324});
-  assertPartitions(values, 997, {0, 514, 818, 713});
+  assertPartitions(values, 2, {0, 0, 0, 0});
+  assertPartitions(values, 500, {0, 284, 0, 324});
+  assertPartitions(values, 997, {0, 514, 0, 713});
 
   assertPartitionsWithConstChannel(values, 1);
   assertPartitionsWithConstChannel(values, 2);

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -244,11 +244,9 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
       {std::nullopt,
        Timestamp(100'000, 900'000),
        Timestamp(
-           dwio::common::MIN_SECONDS,
-           std::numeric_limits<uint64_t>::min()),
+           dwio::common::MIN_SECONDS, std::numeric_limits<uint64_t>::min()),
        Timestamp(
-           std::numeric_limits<int64_t>::max(),
-           dwio::common::MAX_NANOS)});
+           std::numeric_limits<int64_t>::max(), dwio::common::MAX_NANOS)});
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 1, 0});

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -65,9 +65,13 @@ unsigned integer for nanoseconds. Nanoseconds represent the high-precision part 
 the timestamp, which is less than 1 second. Valid range of nanoseconds is [0, 10^9).
 Timestamps before the epoch are specified using negative values for the seconds.
 Examples:
-* Timestamp(0, 0) represents 1970-01-01T00:00:00 (epoch).
-* Timestamp(10*24*60*60 + 125, 0) represents 1970-01-11T00:02:05 (10 days 125 seconds after epoch).
-* Timestamp(-10*24*60*60 - 125, 0) represents 1969-12-21T23:57:55 (10 days 125 seconds before epoch).
+* Timestamp(0, 0) represents 1970-01-0 T00:00:00 (epoch).
+* Timestamp(10*24*60*60 + 125, 0) represents 1970-01-11 00:02:05 (10 days 125 seconds after epoch).
+* Timestamp(19524*24*60*60 + 500, 38726411) represents 2023-06-16 08:08:20.038726411
+  (19524 days 500 seconds 38726411 nanoseconds after epoch).
+* Timestamp(-10*24*60*60 - 125, 0) represents 1969-12-21 23:57:55 (10 days 125 seconds before epoch).
+* Timestamp(-5000*24*60*60 - 1000, 123456) represents 1956-04-24 07:43:20.000123456
+  (5000 days 1000 seconds before epoch plus 123456 nanoseconds).
 
 Logical Types
 ~~~~~~~~~~~~~
@@ -138,4 +142,4 @@ TIMESTAMP WITH TIME ZONE  ROW<BIGINT, SMALLINT>
 TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
 from UNIX epoch with timezone information. Its physical type contains one 64-bit
 signed integer for milliseconds and another 16-bit signed integer for timezone ID.
-Valid range of timezone ID is [1, 1680].
+Valid range of timezone ID is [1, 1680], its definition can be found in ``TimeZoneDatabase.cpp``.

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -60,14 +60,14 @@ to determine the type of the elements. This works because there are no elements.
 
 TIMESTAMP type is used to represent a specific point in time.
 A TIMESTAMP is defined as the sum of seconds and nanoseconds since UNIX epoch.
-`struct Timestamp` uses a 64-bit integers to store seconds and a 64-bit unsigned integer
-to store nanoseconds. Nanoseconds in Timestamp is used to represent the high-precision
-part of Timestamp less than 1 second, so the value range of nanoseconds is [0, 10^9).
-For example, `Timestamp(0, 0)` represents `1970-01-01 00:00:00` and
-`Timestamp(10*24*60*60 + 125, 0)` represents `1970-01-11 00:02:05`.
-The seconds in Timestamp can be a negative value, which is used to represent a time point
-that is less than UNIX epoch. For example, `Timestamp(-(10*24*60*60 + 125), 0)` represents
-`1969-12-21 23:57:55`.
+`struct Timestamp` contains one 64-bit signed integer for seconds and another 64-bit
+unsigned integer for nanoseconds. Nanoseconds represent the high-precision part of
+the timestamp, which is less than 1 second. Valid range of nanoseconds is [0, 10^9).
+Timestamps before the epoch are specified using negative values for the seconds.
+Examples:
+* Timestamp(0, 0) represents 1970-01-01T00:00:00 (epoch).
+* Timestamp(10*24*60*60 + 125, 0) represents 1970-01-11T00:02:05 (10 days 125 seconds after epoch).
+* Timestamp(-10*24*60*60 - 125, 0) represents 1969-12-21T23:57:55 (10 days 125 seconds before epoch).
 
 Logical Types
 ~~~~~~~~~~~~~
@@ -135,3 +135,7 @@ JSON                      VARCHAR
 TIMESTAMP WITH TIME ZONE  ROW<BIGINT, SMALLINT>
 ========================  =====================
 
+TIMESTAMP WITH TIME ZONE represents a time point in milliseconds precision
+from UNIX epoch with timezone information. Its physical type contains one 64-bit
+signed integer for milliseconds and another 16-bit signed integer for timezone ID.
+Valid range of timezone ID is [1, 1680].

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -59,15 +59,14 @@ For example, SELECT array() returns an ARRAY(UNKNOWN()) because it is not possib
 to determine the type of the elements. This works because there are no elements.
 
 TIMESTAMP type is used to represent a specific point in time.
-In Velox, a TIMESTAMP is defined as the sum of seconds and nanoseconds since UNIX epoch.
+A TIMESTAMP is defined as the sum of seconds and nanoseconds since UNIX epoch.
 `struct Timestamp` uses a 64-bit integers to store seconds and a 64-bit unsigned integer
-to store nanoseconds, and the nanoseconds value must be less than 10^9.
-Nanoseconds in Timestamp is used to represent the high-precision part of Timestamp
-less than 1 second, so the value range of nanoseconds is [0, 10^9).
+to store nanoseconds. Nanoseconds in Timestamp is used to represent the high-precision
+part of Timestamp less than 1 second, so the value range of nanoseconds is [0, 10^9).
 For example, `Timestamp(0, 0)` represents `1970-01-01 00:00:00` and
 `Timestamp(10*24*60*60 + 125, 0)` represents `1970-01-11 00:02:05`.
-The seconds in Timestamp can be a negative value, which is used to indicate a time point
-that is less than UNIX epoch. For example, `Timestamp(-(10*24*60*60 + 125), 0)` represent
+The seconds in Timestamp can be a negative value, which is used to represent a time point
+that is less than UNIX epoch. For example, `Timestamp(-(10*24*60*60 + 125), 0)` represents
 `1969-12-21 23:57:55`.
 
 Logical Types

--- a/velox/docs/develop/types.rst
+++ b/velox/docs/develop/types.rst
@@ -58,6 +58,18 @@ UNKNOWN type is used to represent an empty or all nulls vector of unknown type.
 For example, SELECT array() returns an ARRAY(UNKNOWN()) because it is not possible
 to determine the type of the elements. This works because there are no elements.
 
+TIMESTAMP type is used to represent a specific point in time.
+In Velox, a TIMESTAMP is defined as the sum of seconds and nanoseconds since UNIX epoch.
+`struct Timestamp` uses a 64-bit integers to store seconds and a 64-bit unsigned integer
+to store nanoseconds, and the nanoseconds value must be less than 10^9.
+Nanoseconds in Timestamp is used to represent the high-precision part of Timestamp
+less than 1 second, so the value range of nanoseconds is [0, 10^9).
+For example, `Timestamp(0, 0)` represents `1970-01-01 00:00:00` and
+`Timestamp(10*24*60*60 + 125, 0)` represents `1970-01-11 00:02:05`.
+The seconds in Timestamp can be a negative value, which is used to indicate a time point
+that is less than UNIX epoch. For example, `Timestamp(-(10*24*60*60 + 125), 0)` represent
+`1969-12-21 23:57:55`.
+
 Logical Types
 ~~~~~~~~~~~~~
 Logical types are backed by a physical type and include additional semantics.

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -152,8 +152,8 @@ Convenience Extraction Functions
 These functions support TIMESTAMP, DATE, and TIMESTAMP WITH TIME ZONE input types.
 
 For these functions, the input timestamp has range limitations on seconds and nanoseconds.
-Seconds should be in range [INT64_MIN/1000 - 1, INT64_MAX/1000], nanoseconds needs
-to be in range [0, 999999999]. This behavior is different from Presto Java that allows
+Seconds should be in the range [INT64_MIN/1000 - 1, INT64_MAX/1000], nanoseconds should
+be in the range [0, 999999999]. This behavior is different from Presto Java that allows
 arbitrary large timestamps.
 
 .. function:: day(x) -> bigint

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -152,7 +152,9 @@ Convenience Extraction Functions
 These functions support TIMESTAMP, DATE, and TIMESTAMP WITH TIME ZONE input types.
 
 For these functions, the input timestamp has range limitations on seconds and nanoseconds.
-This behavior is different from Presto Java that allows arbitrary large timestamps.
+Seconds should be in range [INT64_MIN/1000 - 1, INT64_MAX/1000], nanoseconds needs
+to be in range [0, 999999999]. This behavior is different from Presto Java that allows
+arbitrary large timestamps.
 
 .. function:: day(x) -> bigint
 

--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -151,9 +151,7 @@ Convenience Extraction Functions
 
 These functions support TIMESTAMP, DATE, and TIMESTAMP WITH TIME ZONE input types.
 
-These functions are implemented using
-`std::gmtime <https://en.cppreference.com/w/c/chrono/gmtime>`_ which raises an
-error when input timestamp is too large (for example, > 100'000'000'000'000'000).
+For these functions, the input timestamp has range limitations on seconds and nanoseconds.
 This behavior is different from Presto Java that allows arbitrary large timestamps.
 
 .. function:: day(x) -> bigint

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -451,6 +451,24 @@ TEST(ColumnWriterTests, TestTimestampMixedWriter) {
   testDataTypeWriter(TIMESTAMP(), data);
 }
 
+void verifyInvalidTimestamp(int64_t seconds, int64_t nanos) {
+  std::vector<std::optional<Timestamp>> data;
+  for (int64_t i = 1; i < ITERATIONS; ++i) {
+    Timestamp ts(i, i);
+    data.emplace_back(ts);
+  }
+  Timestamp ts(seconds, nanos);
+  data.emplace_back(ts);
+  EXPECT_THROW(
+      testDataTypeWriter(TIMESTAMP(), data), exception::LoggedException);
+}
+
+TEST(ColumnWriterTests, TestTimestampInvalidWriter) {
+  // Seconds invalid range.
+  verifyInvalidTimestamp(INT64_MIN, 0);
+  verifyInvalidTimestamp(MIN_SECONDS - 1, MAX_NANOS);
+}
+
 TEST(ColumnWriterTests, TestTimestampNullWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -424,10 +424,10 @@ TEST(ColumnWriterTests, TestTimestampBoundaryValuesWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
     if (i & 1) {
-      Timestamp ts(INT64_MAX, MAX_NANOS);
+      Timestamp ts(Timestamp::kMaxSeconds, MAX_NANOS);
       data.emplace_back(ts);
     } else {
-      Timestamp ts(MIN_SECONDS, MAX_NANOS);
+      Timestamp ts(Timestamp::kMinSeconds, MAX_NANOS);
       data.emplace_back(ts);
     }
     data.emplace_back();

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -465,7 +465,6 @@ void verifyInvalidTimestamp(int64_t seconds, int64_t nanos) {
 
 TEST(ColumnWriterTests, TestTimestampInvalidWriter) {
   // Seconds invalid range.
-  verifyInvalidTimestamp(INT64_MIN, 0);
   verifyInvalidTimestamp(MIN_SECONDS - 1, MAX_NANOS);
 }
 

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -438,7 +438,8 @@ TEST(ColumnWriterTests, TestTimestampBoundaryValuesWriter) {
 TEST(ColumnWriterTests, TestTimestampMixedWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {
-    int64_t seconds = static_cast<int64_t>(Random::rand64());
+    int64_t seconds = static_cast<int64_t>(
+        Random::rand64(Timestamp::kMinSeconds, Timestamp::kMaxSeconds));
     if (seconds < MIN_SECONDS) {
       seconds = MIN_SECONDS;
     }
@@ -461,11 +462,6 @@ void verifyInvalidTimestamp(int64_t seconds, int64_t nanos) {
   data.emplace_back(ts);
   EXPECT_THROW(
       testDataTypeWriter(TIMESTAMP(), data), exception::LoggedException);
-}
-
-TEST(ColumnWriterTests, TestTimestampInvalidWriter) {
-  // Seconds invalid range.
-  verifyInvalidTimestamp(MIN_SECONDS - 1, MAX_NANOS);
 }
 
 TEST(ColumnWriterTests, TestTimestampNullWriter) {

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -451,28 +451,6 @@ TEST(ColumnWriterTests, TestTimestampMixedWriter) {
   testDataTypeWriter(TIMESTAMP(), data);
 }
 
-void verifyInvalidTimestamp(int64_t seconds, int64_t nanos) {
-  std::vector<std::optional<Timestamp>> data;
-  for (int64_t i = 1; i < ITERATIONS; ++i) {
-    Timestamp ts(i, i);
-    data.emplace_back(ts);
-  }
-  Timestamp ts(seconds, nanos);
-  data.emplace_back(ts);
-  EXPECT_THROW(
-      testDataTypeWriter(TIMESTAMP(), data), exception::LoggedException);
-}
-
-TEST(ColumnWriterTests, TestTimestampInvalidWriter) {
-  // Nanos invalid range.
-  verifyInvalidTimestamp(ITERATIONS, UINT64_MAX);
-  verifyInvalidTimestamp(ITERATIONS, MAX_NANOS + 1);
-
-  // Seconds invalid range.
-  verifyInvalidTimestamp(INT64_MIN, 0);
-  verifyInvalidTimestamp(MIN_SECONDS - 1, MAX_NANOS);
-}
-
 TEST(ColumnWriterTests, TestTimestampNullWriter) {
   std::vector<std::optional<Timestamp>> data;
   for (int64_t i = 0; i < ITERATIONS; ++i) {

--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -43,25 +43,20 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
   static const int64_t kMax = std::numeric_limits<int64_t>::max();
   static const int64_t kMin = std::numeric_limits<int64_t>::min();
 
-  static const Timestamp kMaxTimestamp(
-      kMax / 1000, kMax % 1000 * kNanosecondsInMillisecond);
-  static const Timestamp kMinTimestamp(
-      kMin / 1000 - 1, (kMin % 1000 + 1000) * kNanosecondsInMillisecond);
-
   // On some compilers if we cast kMax to a double, we can get a number larger
   // than 'kMax'. This will allow 'unixtime' values > 'kMax'. The workaround
   // here is to use uint64_t to represent ('kMax' + 1), which can be represented
   // exactly as double. We then check if the difference with 'unixtime' <= 1.
   if (UNLIKELY((static_cast<uint64_t>(kMax) + 1) - unixtime <= 1)) {
-    return kMaxTimestamp;
+    return Timestamp::maxMillis();
   }
 
   if (UNLIKELY(unixtime <= kMin)) {
-    return kMinTimestamp;
+    return Timestamp::minMillis();
   }
 
   if (UNLIKELY(std::isinf(unixtime))) {
-    return unixtime < 0 ? kMinTimestamp : kMaxTimestamp;
+    return unixtime < 0 ? Timestamp::minMillis() : Timestamp::maxMillis();
   }
 
   auto seconds = std::floor(unixtime);

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -35,12 +35,11 @@ template <>
 struct MinMaxTrait<Timestamp> {
   static Timestamp lowest() {
     return Timestamp(
-        std::numeric_limits<int64_t>::lowest(),
-        std::numeric_limits<uint64_t>::lowest());
+        Timestamp::kMinSeconds, std::numeric_limits<uint64_t>::lowest());
   }
 
   static Timestamp max() {
-    return Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos);
+    return Timestamp(Timestamp::kMaxSeconds, Timestamp::kMaxNanos);
   }
 };
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -35,12 +35,12 @@ template <>
 struct MinMaxTrait<Timestamp> {
   static Timestamp lowest() {
     return Timestamp(
-        dwio::common::MIN_SECONDS, std::numeric_limits<uint64_t>::lowest());
+        std::numeric_limits<int64_t>::lowest(),
+        std::numeric_limits<uint64_t>::lowest());
   }
 
   static Timestamp max() {
-    return Timestamp(
-        std::numeric_limits<int64_t>::max(), dwio::common::MAX_NANOS);
+    return Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::MAX_NANOS);
   }
 };
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -33,13 +33,14 @@ struct MinMaxTrait : public std::numeric_limits<T> {};
 
 template <>
 struct MinMaxTrait<Timestamp> {
-  static constexpr Timestamp lowest() {
+  static Timestamp lowest() {
     return Timestamp(
-        MinMaxTrait<int64_t>::lowest(), MinMaxTrait<uint64_t>::lowest());
+        dwio::common::MIN_SECONDS, std::numeric_limits<uint64_t>::lowest());
   }
 
-  static constexpr Timestamp max() {
-    return Timestamp(MinMaxTrait<int64_t>::max(), MinMaxTrait<uint64_t>::max());
+  static Timestamp max() {
+    return Timestamp(
+        std::numeric_limits<int64_t>::max(), dwio::common::MAX_NANOS);
   }
 };
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -40,7 +40,7 @@ struct MinMaxTrait<Timestamp> {
   }
 
   static Timestamp max() {
-    return Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::MAX_NANOS);
+    return Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos);
   }
 };
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -32,18 +32,6 @@ template <typename T>
 struct MinMaxTrait : public std::numeric_limits<T> {};
 
 template <>
-struct MinMaxTrait<Timestamp> {
-  static Timestamp lowest() {
-    return Timestamp(
-        Timestamp::kMinSeconds, std::numeric_limits<uint64_t>::lowest());
-  }
-
-  static Timestamp max() {
-    return Timestamp(Timestamp::kMaxSeconds, Timestamp::kMaxNanos);
-  }
-};
-
-template <>
 struct MinMaxTrait<Date> {
   static constexpr Date lowest() {
     return Date(std::numeric_limits<int32_t>::lowest());

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -136,17 +136,6 @@ struct MinMaxTrait<Date> {
   }
 };
 
-template <>
-struct MinMaxTrait<Timestamp> {
-  static constexpr Timestamp lowest() {
-    return Timestamp(std::numeric_limits<int64_t>::min(), 0);
-  }
-
-  static constexpr Timestamp max() {
-    return Timestamp(std::numeric_limits<int64_t>::max(), 999'999);
-  }
-};
-
 /// MinMaxByAggregate is the base class for min_by and max_by functions
 /// with numeric value and comparison types. These functions return the value of
 /// X associated with the minimum/maximum value of Y over all input values.

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -434,7 +434,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::MAX_NANOS)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));
@@ -595,7 +595,7 @@ TEST_F(DateTimeFunctionsTest, quarter) {
 
   EXPECT_EQ(std::nullopt, quarter(std::nullopt));
   EXPECT_EQ(4, quarter(Timestamp(0, 0)));
-  EXPECT_EQ(4, quarter(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(4, quarter(Timestamp(-1, Timestamp::MAX_NANOS)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 0)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2, quarter(Timestamp(990000000, 321000000)));
@@ -661,7 +661,7 @@ TEST_F(DateTimeFunctionsTest, month) {
 
   EXPECT_EQ(std::nullopt, month(std::nullopt));
   EXPECT_EQ(12, month(Timestamp(0, 0)));
-  EXPECT_EQ(12, month(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(12, month(Timestamp(-1, Timestamp::MAX_NANOS)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 0)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(8, month(Timestamp(998474645, 321000000)));
@@ -724,7 +724,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
 
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(13, hour(Timestamp(0, 0)));
-  EXPECT_EQ(12, hour(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::MAX_NANOS)));
   // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
   // systems.
   // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
@@ -1191,7 +1191,7 @@ TEST_F(DateTimeFunctionsTest, second) {
   EXPECT_EQ(0, second(Timestamp(0, 0)));
   EXPECT_EQ(40, second(Timestamp(4000000000, 0)));
   EXPECT_EQ(59, second(Timestamp(-1, 123000000)));
-  EXPECT_EQ(59, second(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(59, second(Timestamp(-1, Timestamp::MAX_NANOS)));
 }
 
 TEST_F(DateTimeFunctionsTest, secondDate) {
@@ -1246,7 +1246,7 @@ TEST_F(DateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(0, millisecond(Timestamp(0, 0)));
   EXPECT_EQ(0, millisecond(Timestamp(4000000000, 0)));
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
-  EXPECT_EQ(999, millisecond(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(999, millisecond(Timestamp(-1, Timestamp::MAX_NANOS)));
 }
 
 TEST_F(DateTimeFunctionsTest, millisecondDate) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -434,7 +434,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(1969, year(Timestamp(-1, dwio::common::MAX_NANOS)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));
@@ -595,7 +595,7 @@ TEST_F(DateTimeFunctionsTest, quarter) {
 
   EXPECT_EQ(std::nullopt, quarter(std::nullopt));
   EXPECT_EQ(4, quarter(Timestamp(0, 0)));
-  EXPECT_EQ(4, quarter(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(4, quarter(Timestamp(-1, dwio::common::MAX_NANOS)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 0)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2, quarter(Timestamp(990000000, 321000000)));
@@ -661,7 +661,7 @@ TEST_F(DateTimeFunctionsTest, month) {
 
   EXPECT_EQ(std::nullopt, month(std::nullopt));
   EXPECT_EQ(12, month(Timestamp(0, 0)));
-  EXPECT_EQ(12, month(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(12, month(Timestamp(-1, dwio::common::MAX_NANOS)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 0)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(8, month(Timestamp(998474645, 321000000)));
@@ -724,7 +724,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
 
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(13, hour(Timestamp(0, 0)));
-  EXPECT_EQ(12, hour(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(12, hour(Timestamp(-1, dwio::common::MAX_NANOS)));
   // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
   // systems.
   // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
@@ -1191,7 +1191,7 @@ TEST_F(DateTimeFunctionsTest, second) {
   EXPECT_EQ(0, second(Timestamp(0, 0)));
   EXPECT_EQ(40, second(Timestamp(4000000000, 0)));
   EXPECT_EQ(59, second(Timestamp(-1, 123000000)));
-  EXPECT_EQ(59, second(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(59, second(Timestamp(-1, dwio::common::MAX_NANOS)));
 }
 
 TEST_F(DateTimeFunctionsTest, secondDate) {
@@ -1246,7 +1246,7 @@ TEST_F(DateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(0, millisecond(Timestamp(0, 0)));
   EXPECT_EQ(0, millisecond(Timestamp(4000000000, 0)));
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
-  EXPECT_EQ(12300, millisecond(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(999, millisecond(Timestamp(-1, dwio::common::MAX_NANOS)));
 }
 
 TEST_F(DateTimeFunctionsTest, millisecondDate) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -434,7 +434,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::kMaxNanos)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));
@@ -595,7 +595,7 @@ TEST_F(DateTimeFunctionsTest, quarter) {
 
   EXPECT_EQ(std::nullopt, quarter(std::nullopt));
   EXPECT_EQ(4, quarter(Timestamp(0, 0)));
-  EXPECT_EQ(4, quarter(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(4, quarter(Timestamp(-1, Timestamp::kMaxNanos)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 0)));
   EXPECT_EQ(4, quarter(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2, quarter(Timestamp(990000000, 321000000)));
@@ -661,7 +661,7 @@ TEST_F(DateTimeFunctionsTest, month) {
 
   EXPECT_EQ(std::nullopt, month(std::nullopt));
   EXPECT_EQ(12, month(Timestamp(0, 0)));
-  EXPECT_EQ(12, month(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(12, month(Timestamp(-1, Timestamp::kMaxNanos)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 0)));
   EXPECT_EQ(10, month(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(8, month(Timestamp(998474645, 321000000)));
@@ -724,7 +724,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
 
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(13, hour(Timestamp(0, 0)));
-  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::kMaxNanos)));
   // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
   // systems.
   // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
@@ -1191,7 +1191,7 @@ TEST_F(DateTimeFunctionsTest, second) {
   EXPECT_EQ(0, second(Timestamp(0, 0)));
   EXPECT_EQ(40, second(Timestamp(4000000000, 0)));
   EXPECT_EQ(59, second(Timestamp(-1, 123000000)));
-  EXPECT_EQ(59, second(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(59, second(Timestamp(-1, Timestamp::kMaxNanos)));
 }
 
 TEST_F(DateTimeFunctionsTest, secondDate) {
@@ -1246,7 +1246,7 @@ TEST_F(DateTimeFunctionsTest, millisecond) {
   EXPECT_EQ(0, millisecond(Timestamp(0, 0)));
   EXPECT_EQ(0, millisecond(Timestamp(4000000000, 0)));
   EXPECT_EQ(123, millisecond(Timestamp(-1, 123000000)));
-  EXPECT_EQ(999, millisecond(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(999, millisecond(Timestamp(-1, Timestamp::kMaxNanos)));
 }
 
 TEST_F(DateTimeFunctionsTest, millisecondDate) {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -481,34 +481,6 @@ TEST_F(DateTimeFunctionsTest, yearTimestampWithTimezone) {
           "year(c0)", std::nullopt, std::nullopt));
 }
 
-TEST_F(DateTimeFunctionsTest, timestampTooLarge) {
-  std::vector<std::string> functions = {
-      "year",
-      "quarter",
-      "month",
-      "week",
-      "day",
-      "dow",
-      "doy",
-      "yow",
-      "hour",
-      "minute",
-      "second",
-  };
-
-  Timestamp ts(100'000'000'000'000'000, 0);
-  for (const auto& function : functions) {
-    VELOX_ASSERT_THROW(
-        evaluateOnce<int64_t>(
-            fmt::format("{}(c0)", function), std::make_optional(ts)),
-        "Timestamp is too large: 100000000000000000 seconds since epoch");
-  }
-
-  VELOX_ASSERT_THROW(
-      evaluateOnce<int64_t>("date_trunc('hour', c0)", std::make_optional(ts)),
-      "Timestamp is too large: 100000000000000000 seconds since epoch");
-}
-
 TEST_F(DateTimeFunctionsTest, weekDate) {
   const auto weekDate = [&](const char* dateString) {
     auto date = std::make_optional(parseDate(dateString));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -48,7 +48,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::MAX_NANOS)));
+  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::kMaxNanos)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -48,7 +48,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, 12300000000)));
+  EXPECT_EQ(1969, year(Timestamp(-1, dwio::common::MAX_NANOS)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -48,7 +48,7 @@ TEST_F(DateTimeFunctionsTest, year) {
 
   EXPECT_EQ(std::nullopt, year(std::nullopt));
   EXPECT_EQ(1969, year(Timestamp(0, 0)));
-  EXPECT_EQ(1969, year(Timestamp(-1, dwio::common::MAX_NANOS)));
+  EXPECT_EQ(1969, year(Timestamp(-1, Timestamp::MAX_NANOS)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 0)));
   EXPECT_EQ(2096, year(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(2001, year(Timestamp(998474645, 321000000)));

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -36,8 +36,8 @@ struct Timestamp {
   static constexpr int64_t kMillisecondsInSecond = 1'000;
   static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
 
-  // Limit the range of seconds to avoid some problems. Seconds in
-  // Timestamp need to be in range [INT64_MIN/1000 - 1, INT64_MAX/1000].
+  // Limit the range of seconds to avoid some problems. Seconds should be
+  // in the range [INT64_MIN/1000 - 1, INT64_MAX/1000].
   // Presto's Timestamp is stored in one 64-bit signed integer for
   // milliseconds, this range ensures that Timestamp's range in Velox will not
   // be smaller than Presto, and can make Timestamp::toString work correctly.
@@ -78,7 +78,10 @@ struct Timestamp {
           checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
     } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to nanoseconds, {}", e.what());
+          "Could not convert Timestamp({}, {}) to nanoseconds, {}",
+          seconds_,
+          nanos_,
+          e.what());
     }
   }
 
@@ -91,7 +94,10 @@ struct Timestamp {
           (int64_t)(nanos_ / 1'000'000));
     } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, {}", e.what());
+          "Could not convert Timestamp({}, {}) to microseconds, {}",
+          seconds_,
+          nanos_,
+          e.what());
     }
   }
 
@@ -104,7 +110,10 @@ struct Timestamp {
           (int64_t)(nanos_ / 1'000));
     } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, {}", e.what());
+          "Could not convert Timestamp({}, {}) to microseconds, {}",
+          seconds_,
+          nanos_,
+          e.what());
     }
   }
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -22,6 +22,7 @@
 #include <folly/dynamic.h>
 
 #include "velox/common/base/CheckedArithmetic.h"
+#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/type/StringView.h"
 
 namespace date {
@@ -34,8 +35,20 @@ struct Timestamp {
  public:
   enum class Precision : int { kMilliseconds = 3, kNanoseconds = 9 };
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
-  constexpr Timestamp(int64_t seconds, uint64_t nanos)
-      : seconds_(seconds), nanos_(nanos) {}
+  Timestamp(int64_t seconds, uint64_t nanos) {
+    VELOX_CHECK_GE(
+        seconds,
+        dwio::common::MIN_SECONDS,
+        "Expect seconds >= {} in Timestamp",
+        dwio::common::MIN_SECONDS);
+    VELOX_CHECK_LE(
+        nanos,
+        dwio::common::MAX_NANOS,
+        "Expect nanos <= {} in Timestamp",
+        dwio::common::MAX_NANOS);
+    seconds_ = seconds;
+    nanos_ = nanos;
+  }
 
   // Returns the current unix timestamp (ms precision).
   static Timestamp now();

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -36,21 +36,21 @@ struct Timestamp {
   static constexpr int64_t kMillisecondsInSecond = 1'000;
   static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
 
-  // We need to limit the range of seconds to avoid some problems.
-  // Seconds in Timestamp need to be in range
-  // [INT64_MIN/1000 - 1, INT64_MAX/1000]. Presto's Timestamp is stored
-  // in one 64-bit signed integer for milliseconds, this range ensures
-  // that Timestamp's range in Velox will not be smaller than Presto,
-  // and can make Timestamp::toString work correctly.
+  // Limit the range of seconds to avoid some problems. Seconds in
+  // Timestamp need to be in range [INT64_MIN/1000 - 1, INT64_MAX/1000].
+  // Presto's Timestamp is stored in one 64-bit signed integer for
+  // milliseconds, this range ensures that Timestamp's range in Velox will not
+  // be smaller than Presto, and can make Timestamp::toString work correctly.
   static constexpr int64_t kMaxSeconds =
       std::numeric_limits<int64_t>::max() / kMillisecondsInSecond;
   static constexpr int64_t kMinSeconds =
       std::numeric_limits<int64_t>::min() / kMillisecondsInSecond - 1;
 
-  // Nanos in Timestamp need to be less than 1 second.
+  // Nanoseconds should be less than 1 second.
   static constexpr uint64_t kMaxNanos = 999'999'999;
 
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
+
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
     VELOX_DCHECK_GE(seconds, kMinSeconds, "Timestamp seconds out of range");
@@ -76,9 +76,9 @@ struct Timestamp {
     try {
       return checkedPlus(
           checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
-    } catch (...) {
+    } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to nanoseconds, integer overflow");
+          "Could not convert Timestamp({}, {}) to nanoseconds, {}", e.what());
     }
   }
 
@@ -89,9 +89,9 @@ struct Timestamp {
       return checkedPlus(
           checkedMultiply(seconds_, (int64_t)1'000),
           (int64_t)(nanos_ / 1'000'000));
-    } catch (...) {
+    } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, integer overflow");
+          "Could not convert Timestamp({}, {}) to microseconds, {}", e.what());
     }
   }
 
@@ -102,9 +102,9 @@ struct Timestamp {
       return checkedPlus(
           checkedMultiply(seconds_, (int64_t)1'000'000),
           (int64_t)(nanos_ / 1'000));
-    } catch (...) {
+    } catch (const std::exception& e) {
       VELOX_USER_FAIL(
-          "Could not convert Timestamp({}, {}) to microseconds, integer overflow");
+          "Could not convert Timestamp({}, {}) to microseconds, {}", e.what());
     }
   }
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -33,15 +33,19 @@ namespace facebook::velox {
 struct Timestamp {
  public:
   enum class Precision : int { kMilliseconds = 3, kNanoseconds = 9 };
+  static constexpr int64_t kMillisecondsInSecond = 1'000;
+  static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
+
   // We need to limit the range of seconds to avoid some problems.
-  // Seconds in Timestamp need to be in range [INT64_MIN/1000, INT64_MAX/1000].
-  // Presto's Timestamp is stored in milliseconds, this range ensures that
-  // Timestamp's range in Velox will not be smaller than Presto, and can make
-  // Timestamp::toString work correctly.
+  // Seconds in Timestamp need to be in range
+  // [INT64_MIN/1000 - 1, INT64_MAX/1000]. Presto's Timestamp is stored
+  // in one 64-bit signed integer for milliseconds, this range ensures
+  // that Timestamp's range in Velox will not be smaller than Presto,
+  // and can make Timestamp::toString work correctly.
   static constexpr int64_t kMaxSeconds =
-      std::numeric_limits<int64_t>::max() / 1000;
+      std::numeric_limits<int64_t>::max() / kMillisecondsInSecond;
   static constexpr int64_t kMinSeconds =
-      std::numeric_limits<int64_t>::min() / 1000;
+      std::numeric_limits<int64_t>::min() / kMillisecondsInSecond - 1;
 
   // Nanos in Timestamp need to be less than 1 second.
   static constexpr uint64_t kMaxNanos = 999'999'999;
@@ -49,9 +53,9 @@ struct Timestamp {
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
-    VELOX_CHECK_GE(seconds, kMinSeconds);
-    VELOX_DCHECK_LE(seconds, kMaxSeconds);
-    VELOX_DCHECK_LE(nanos, kMaxNanos);
+    VELOX_DCHECK_GE(seconds, kMinSeconds, "Timestamp seconds out of range");
+    VELOX_DCHECK_LE(seconds, kMaxSeconds, "Timestamp seconds out of range");
+    VELOX_DCHECK_LE(nanos, kMaxNanos, "Timestamp nanos out of range");
   }
 
   // Returns the current unix timestamp (ms precision).
@@ -66,13 +70,12 @@ struct Timestamp {
   }
 
   int64_t toNanos() const {
-    // int64 can store around 292 years in nanos ~ till 2262-04-12
-    // The addition cannot overflow because the product will be promoted to
-    // uint64_t first and its value is at most UINT64_MAX / 2. However, too
-    // large seconds_ will cause checkedMultiply overflow, we should make
-    // sure the product is less than INT64_MAX.
+    // int64 can store around 292 years in nanos ~ till 2262-04-12.
+    // When an integer overflow occurs in the calculation,
+    // an exception will be thrown.
     try {
-      return checkedMultiply(seconds_, (int64_t)1'000'000'000) + nanos_;
+      return checkedPlus(
+          checkedMultiply(seconds_, (int64_t)1'000'000'000), (int64_t)nanos_);
     } catch (...) {
       VELOX_USER_FAIL(
           "Could not convert Timestamp({}, {}) to nanoseconds, integer overflow");
@@ -80,18 +83,25 @@ struct Timestamp {
   }
 
   int64_t toMillis() const {
-    // The addition cannot overflow because the product will be promoted to
-    // uint64_t first and its value is at most UINT64_MAX / 2. We should make
-    // sure the product is less than INT64_MAX.
-    return checkedMultiply(seconds_, (int64_t)1'000) + nanos_ / 1'000'000;
+    // When an integer overflow occurs in the calculation,
+    // an exception will be thrown.
+    try {
+      return checkedPlus(
+          checkedMultiply(seconds_, (int64_t)1'000),
+          (int64_t)(nanos_ / 1'000'000));
+    } catch (...) {
+      VELOX_USER_FAIL(
+          "Could not convert Timestamp({}, {}) to microseconds, integer overflow");
+    }
   }
 
   int64_t toMicros() const {
-    // The addition cannot overflow because the product will be promoted to
-    // uint64_t first and its value is at most UINT64_MAX / 2. We should make
-    // sure the product is less than INT64_MAX.
+    // When an integer overflow occurs in the calculation,
+    // an exception will be thrown.
     try {
-      return checkedMultiply(seconds_, (int64_t)1'000'000) + nanos_ / 1'000;
+      return checkedPlus(
+          checkedMultiply(seconds_, (int64_t)1'000'000),
+          (int64_t)(nanos_ / 1'000));
     } catch (...) {
       VELOX_USER_FAIL(
           "Could not convert Timestamp({}, {}) to microseconds, integer overflow");
@@ -123,6 +133,32 @@ struct Timestamp {
     auto second = nanos / 1'000'000'000 - 1;
     auto nano = (nanos - second * 1'000'000'000) % 1'000'000'000;
     return Timestamp(second, nano);
+  }
+
+  static const Timestamp minMillis() {
+    // The minimum Timestamp that toMillis() method will not overflow.
+    // Used to calculate the minimum value of the Presto timestamp.
+    constexpr int64_t kMin = std::numeric_limits<int64_t>::min();
+    return Timestamp(
+        kMinSeconds,
+        (kMin % kMillisecondsInSecond + kMillisecondsInSecond) *
+            kNanosecondsInMillisecond);
+  }
+
+  static const Timestamp maxMillis() {
+    // The maximum Timestamp that toMillis() method will not overflow.
+    // Used to calculate the maximum value of the Presto timestamp.
+    constexpr int64_t kMax = std::numeric_limits<int64_t>::max();
+    return Timestamp(
+        kMaxSeconds, kMax % kMillisecondsInSecond * kNanosecondsInMillisecond);
+  }
+
+  static const Timestamp min() {
+    return Timestamp(kMinSeconds, 0);
+  }
+
+  static const Timestamp max() {
+    return Timestamp(kMaxSeconds, kMaxNanos);
   }
 
   // Assuming the timestamp represents a time at zone, converts it to the GMT
@@ -240,6 +276,21 @@ struct hash<::facebook::velox::Timestamp> {
 };
 
 std::string to_string(const ::facebook::velox::Timestamp& ts);
+
+template <>
+class numeric_limits<facebook::velox::Timestamp> {
+ public:
+  static facebook::velox::Timestamp min() {
+    return facebook::velox::Timestamp::min();
+  }
+  static facebook::velox::Timestamp max() {
+    return facebook::velox::Timestamp::max();
+  }
+
+  static facebook::velox::Timestamp lowest() {
+    return facebook::velox::Timestamp::min();
+  }
+};
 
 } // namespace std
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -22,7 +22,6 @@
 #include <folly/dynamic.h>
 
 #include "velox/common/base/CheckedArithmetic.h"
-#include "velox/dwio/common/IntCodecCommon.h"
 #include "velox/type/StringView.h"
 
 namespace date {
@@ -34,20 +33,13 @@ namespace facebook::velox {
 struct Timestamp {
  public:
   enum class Precision : int { kMilliseconds = 3, kNanoseconds = 9 };
+  // nanos in Timestamp should not greater than 1 second.
+  static constexpr uint64_t MAX_NANOS = 999'999'999;
+
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
-  Timestamp(int64_t seconds, uint64_t nanos) {
-    VELOX_CHECK_GE(
-        seconds,
-        dwio::common::MIN_SECONDS,
-        "Expect seconds >= {} in Timestamp",
-        dwio::common::MIN_SECONDS);
-    VELOX_CHECK_LE(
-        nanos,
-        dwio::common::MAX_NANOS,
-        "Expect nanos <= {} in Timestamp",
-        dwio::common::MAX_NANOS);
-    seconds_ = seconds;
-    nanos_ = nanos;
+  Timestamp(int64_t seconds, uint64_t nanos)
+      : seconds_(seconds), nanos_(nanos) {
+    VELOX_CHECK_LE(nanos, MAX_NANOS);
   }
 
   // Returns the current unix timestamp (ms precision).

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -39,7 +39,7 @@ struct Timestamp {
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
-    VELOX_CHECK_LE(nanos, kMaxNanos);
+    VELOX_DCHECK_LE(nanos, kMaxNanos);
   }
 
   // Returns the current unix timestamp (ms precision).

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -33,13 +33,13 @@ namespace facebook::velox {
 struct Timestamp {
  public:
   enum class Precision : int { kMilliseconds = 3, kNanoseconds = 9 };
-  // nanos in Timestamp should not greater than 1 second.
-  static constexpr uint64_t MAX_NANOS = 999'999'999;
+  // Nanos in Timestamp need to be less than 1 second.
+  static constexpr uint64_t kMaxNanos = 999'999'999;
 
   constexpr Timestamp() : seconds_(0), nanos_(0) {}
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
-    VELOX_CHECK_LE(nanos, MAX_NANOS);
+    VELOX_CHECK_LE(nanos, kMaxNanos);
   }
 
   // Returns the current unix timestamp (ms precision).

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -137,5 +137,25 @@ TEST(TimestampTest, now) {
   EXPECT_GE(expectedEpochMs, now.toMillis());
 }
 
+TEST(TimestampTest, invalidInput) {
+  // Nanos invalid range.
+  VELOX_ASSERT_THROW(
+      Timestamp(1, std::numeric_limits<uint64_t>::max()),
+      fmt::format("Expect nanos <= {} in Timestamp", dwio::common::MAX_NANOS));
+  VELOX_ASSERT_THROW(
+      Timestamp(1, dwio::common::MAX_NANOS + 1),
+      fmt::format("Expect nanos <= {} in Timestamp", dwio::common::MAX_NANOS));
+
+  // Seconds invalid range.
+  VELOX_ASSERT_THROW(
+      Timestamp(std::numeric_limits<int64_t>::min(), 0),
+      fmt::format(
+          "Expect seconds >= {} in Timestamp", dwio::common::MIN_SECONDS));
+  VELOX_ASSERT_THROW(
+      Timestamp(dwio::common::MIN_SECONDS - 1, dwio::common::MAX_NANOS),
+      fmt::format(
+          "Expect seconds >= {} in Timestamp", dwio::common::MIN_SECONDS));
+}
+
 } // namespace
 } // namespace facebook::velox

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -139,9 +139,6 @@ TEST(TimestampTest, now) {
 
 DEBUG_ONLY_TEST(TimestampTest, invalidInput) {
   constexpr uint64_t kMax = std::numeric_limits<uint64_t>::max();
-  auto ts = Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos);
-  FLAGS_logtostderr = true;
-  LOG(INFO) << ts.toMillis();
   // Nanos invalid range.
   VELOX_ASSERT_THROW(
       Timestamp(1, kMax),

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -142,11 +142,11 @@ TEST(TimestampTest, invalidInput) {
   // Nanos invalid range.
   VELOX_ASSERT_THROW(
       Timestamp(1, kMax),
-      fmt::format("({} vs. {})", kMax, Timestamp::MAX_NANOS));
+      fmt::format("({} vs. {})", kMax, Timestamp::kMaxNanos));
   VELOX_ASSERT_THROW(
-      Timestamp(1, Timestamp::MAX_NANOS + 1),
+      Timestamp(1, Timestamp::kMaxNanos + 1),
       fmt::format(
-          "({} vs. {})", Timestamp::MAX_NANOS + 1, Timestamp::MAX_NANOS));
+          "({} vs. {})", Timestamp::kMaxNanos + 1, Timestamp::kMaxNanos));
 }
 
 } // namespace

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -138,23 +138,15 @@ TEST(TimestampTest, now) {
 }
 
 TEST(TimestampTest, invalidInput) {
+  constexpr uint64_t kMax = std::numeric_limits<uint64_t>::max();
   // Nanos invalid range.
   VELOX_ASSERT_THROW(
-      Timestamp(1, std::numeric_limits<uint64_t>::max()),
-      fmt::format("Expect nanos <= {} in Timestamp", dwio::common::MAX_NANOS));
+      Timestamp(1, kMax),
+      fmt::format("({} vs. {})", kMax, Timestamp::MAX_NANOS));
   VELOX_ASSERT_THROW(
-      Timestamp(1, dwio::common::MAX_NANOS + 1),
-      fmt::format("Expect nanos <= {} in Timestamp", dwio::common::MAX_NANOS));
-
-  // Seconds invalid range.
-  VELOX_ASSERT_THROW(
-      Timestamp(std::numeric_limits<int64_t>::min(), 0),
+      Timestamp(1, Timestamp::MAX_NANOS + 1),
       fmt::format(
-          "Expect seconds >= {} in Timestamp", dwio::common::MIN_SECONDS));
-  VELOX_ASSERT_THROW(
-      Timestamp(dwio::common::MIN_SECONDS - 1, dwio::common::MAX_NANOS),
-      fmt::format(
-          "Expect seconds >= {} in Timestamp", dwio::common::MIN_SECONDS));
+          "({} vs. {})", Timestamp::MAX_NANOS + 1, Timestamp::MAX_NANOS));
 }
 
 } // namespace

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -137,8 +137,11 @@ TEST(TimestampTest, now) {
   EXPECT_GE(expectedEpochMs, now.toMillis());
 }
 
-TEST(TimestampTest, invalidInput) {
+DEBUG_ONLY_TEST(TimestampTest, invalidInput) {
   constexpr uint64_t kMax = std::numeric_limits<uint64_t>::max();
+  auto ts = Timestamp(std::numeric_limits<int64_t>::max(), Timestamp::kMaxNanos);
+  FLAGS_logtostderr = true;
+  LOG(INFO) << ts.toMillis();
   // Nanos invalid range.
   VELOX_ASSERT_THROW(
       Timestamp(1, kMax),


### PR DESCRIPTION
See https://github.com/facebookincubator/velox/discussions/5060