### PR TITLE
Enable typed null constants in DuckParser

### DIFF
--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -46,6 +46,7 @@ TEST(DuckParserTest, constants) {
 
   // Nulls
   EXPECT_EQ("null", parseExpr("NULL")->toString());
+  EXPECT_EQ("null", parseExpr("NULL::double")->toString());
 
   // Booleans
   EXPECT_EQ("true", parseExpr("TRUE")->toString());


### PR DESCRIPTION
Modify DuckParser to parse `null::<type>` as a constant expression as opposed to
cast over constant expression.