### PR TITLE
Support row type in generic writer copy_from operation.

### DIFF
--- a/velox/expression/tests/GenericWriterTest.cpp
+++ b/velox/expression/tests/GenericWriterTest.cpp
@@ -704,8 +704,9 @@ TEST_F(GenericWriterTest, copyFromGeneric) {
   test(VARCHAR());
   test(MAP(INTEGER(), INTEGER()));
   test(MAP(INTEGER(), ARRAY(INTEGER())));
-  // Rows not supported yet.
-  EXPECT_ANY_THROW(test(ROW({INTEGER()})));
+  test(ROW({INTEGER()}));
+  test(ROW({INTEGER(), ARRAY(INTEGER())}));
+  test(ROW({}));
 }
 
 } // namespace

--- a/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
@@ -169,6 +169,10 @@ class SimpleSubscriptBenchmark : public functions::test::FunctionBenchmarkBase {
     testArraySubscript(MAP(VARCHAR(), INTEGER()));
     testArraySubscript(MAP(INTEGER(), ARRAY(BIGINT())));
     testArraySubscript(MAP(ARRAY(INTEGER()), BIGINT()));
+    testArraySubscript(ROW({INTEGER()}));
+    testArraySubscript(ROW({INTEGER(), ARRAY(INTEGER())}));
+    testArraySubscript(ROW({MAP(INTEGER(), INTEGER()), ARRAY(INTEGER())}));
+    testArraySubscript(ARRAY(ROW({INTEGER(), ARRAY(INTEGER())})));
   }
 
  private:
@@ -298,6 +302,53 @@ BENCHMARK(ArraySubscriptSimple_MapArrayInt) {
 
 BENCHMARK(ArraySubscript_MapArrayInt) {
   benchmark->run("subscript(c0, c1)", MAP(ARRAY(BIGINT()), BIGINT()));
+}
+
+BENCHMARK(ArraySubscriptSimple_RowInt) {
+  benchmark->run("subscript_simple(c0, c1)", ROW({INTEGER()}));
+}
+
+BENCHMARK(ArraySubscript_RowInt) {
+  benchmark->run("subscript(c0, c1)", ROW({INTEGER()}));
+}
+
+BENCHMARK(ArraySubscriptSimple_RowIntArray) {
+  benchmark->run(
+      "subscript_simple(c0, c1)", ROW({INTEGER(), ARRAY(INTEGER())}));
+}
+
+BENCHMARK(ArraySubscript_RowIntArray) {
+  benchmark->run("subscript(c0, c1)", ROW({INTEGER(), ARRAY(INTEGER())}));
+}
+
+BENCHMARK(ArraySubscriptSimple_RowMapArray) {
+  benchmark->run(
+      "subscript_simple(c0, c1)",
+      ROW({MAP(INTEGER(), INTEGER()), ARRAY(INTEGER())}));
+}
+
+BENCHMARK(ArraySubscript_RowMapArray) {
+  benchmark->run(
+      "subscript(c0, c1)", ROW({MAP(INTEGER(), INTEGER()), ARRAY(INTEGER())}));
+}
+
+BENCHMARK(ArraySubscriptSimple_ArrayRowIntArray) {
+  benchmark->run(
+      "subscript_simple(c0, c1)", ARRAY(ROW({INTEGER(), ARRAY(INTEGER())})));
+}
+
+BENCHMARK(ArraySubscript_ArrayRowIntArray) {
+  benchmark->run(
+      "subscript(c0, c1)", ARRAY(ROW({INTEGER(), ARRAY(INTEGER())})));
+}
+
+BENCHMARK(ArraySubscriptSimple_ArrayRowIntInt) {
+  benchmark->run(
+      "subscript_simple(c0, c1)", ARRAY(ROW({INTEGER(), INTEGER()})));
+}
+
+BENCHMARK(ArraySubscript_ArrayRowIntInt) {
+  benchmark->run("subscript(c0, c1)", ARRAY(ROW({INTEGER(), INTEGER()})));
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Summary:
The copy_from in the generic writer need to support all types to be
useful. This diff adds the support for the row type.

Benchmarks results are good when the elements of the row are
complex. For Row with primitive fields, users might want to add fast
paths. We can potentially also add fast path  copy_from_internal<TypeKind::ROW> for primitive fields that avoid
the cast per row in a following diff.
```
ArraySubscriptSimple_RowInt                                 7.60ms    131.55
ArraySubscript_RowInt                                       1.79ms    559.80
ArraySubscriptSimple_RowIntArray                           20.04ms     49.91
ArraySubscript_RowIntArray                                 11.72ms     85.30
ArraySubscriptSimple_RowMapArray                           32.50ms     30.76
ArraySubscript_RowMapArray                                 24.35ms     41.06                          25.09ms     39.85
```

Differential Revision: D46322762

