### PR TITLE
Add -DFOLLY_HAVE_INT128_T=ON to setup scripts

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -42,6 +42,8 @@ if(ON_APPLE_M1)
 endif()
 # Suppress all warnings
 set(FOLLY_CXX_FLAGS -w)
+# Enable INT128 support
+set(FOLLY_HAVE_INT128_T ON)
 FetchContent_MakeAvailable(folly)
 
 # Folly::folly is not valid for FC but we want to match FindFolly

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -106,7 +106,7 @@ cmake_install gflags -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflag
 cmake_install glog -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX:PATH=/usr
 cmake_install snappy -DSNAPPY_BUILD_TESTS=OFF
 cmake_install fmt -DFMT_TEST=OFF
-cmake_install folly
+cmake_install folly -DFOLLY_HAVE_INT128_T=ON
 # cmake_install ranges-v3
 
 dnf clean all

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -94,7 +94,7 @@ function install_fmt {
 function install_folly {
   github_checkout facebook/folly "v2022.11.14.00"
   OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
-    cmake_install -DBUILD_TESTS=OFF
+  cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_double_conversion {

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -90,7 +90,7 @@ function install_fmt {
 
 function install_folly {
   github_checkout facebook/folly "${FB_OS_VERSION}"
-  cmake_install -DBUILD_TESTS=OFF
+  cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 
 function install_fizz {

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -99,4 +99,4 @@ wait
 
 cmake_install gflags -DBUILD_SHARED_LIBS=ON
 cmake_install fmt -DFMT_TEST=OFF
-cmake_install folly
+cmake_install folly -DFOLLY_HAVE_INT128_T=ON


### PR DESCRIPTION
To support HUGEINT(int128_t) natively in Velox, we need to build Folly with FOLLY_HAVE_INT128_T=ON.
