### PR TITLE
Add lpad/rpad Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -49,6 +49,18 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT lower('SparkSql'); -- sparksql
 
+.. spark:function:: lpad(string, len, pad) -> string
+    
+    Returns ``string``, left-padded with pad to a length of ``len``. If ``string`` is
+    longer than ``len``, the return value is shortened to ``len`` characters or bytes.
+    If ``pad`` is not specified, ``string`` will be padded to the left with space characters
+    if it is a character string, and with zeros if it is a byte sequence. ::
+
+        SELECT lpad('hi', 5, '??'); -- ???hi
+        SELECT lpad('hi', 1, '??'); -- h
+        SELECT hex(lpad(unhex('aabb'), 5)); -- 000000AABB
+        SELECT hex(lpad(unhex('aabb'), 5, unhex('1122'))); -- 112211AABB
+
 .. spark:function:: ltrim(string) -> varchar
 
     Removes leading 0x20(space) characters from ``string``. ::
@@ -89,6 +101,18 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Replaces all occurrences of `search` with `replace`. ::
 
         SELECT replace('ABCabc', 'abc', 'DEF'); -- ABCDEF
+
+.. spark:function:: rpad(string, len, pad) -> string
+    
+    Returns ``string``, right-padded with ``pad`` to a length of ``len``. 
+    If ``string`` is longer than ``len``, the return value is shortened to ``len`` characters.
+    If ``pad`` is not specified, ``string`` will be padded to the right with space characters
+    if it is a character string, and with zeros if it is a binary string. ::
+
+        SELECT lpad('hi', 5, '??'); -- ???hi
+        SELECT lpad('hi', 1, '??'); -- h
+        SELECT hex(lpad(unhex('aabb'), 5)); -- 000000AABB
+        SELECT hex(lpad(unhex('aabb'), 5, unhex('1122'))); -- 112211AABB
 
 .. spark:function:: rtrim(string) -> varchar
 

--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -58,8 +58,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT lpad('hi', 5, '??'); -- ???hi
         SELECT lpad('hi', 1, '??'); -- h
-        SELECT hex(lpad(unhex('aabb'), 5)); -- 000000AABB
-        SELECT hex(lpad(unhex('aabb'), 5, unhex('1122'))); -- 112211AABB
+        SELECT lpad('hi', 4); --   hi
 
 .. spark:function:: ltrim(string) -> varchar
 
@@ -111,8 +110,7 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
 
         SELECT lpad('hi', 5, '??'); -- ???hi
         SELECT lpad('hi', 1, '??'); -- h
-        SELECT hex(lpad(unhex('aabb'), 5)); -- 000000AABB
-        SELECT hex(lpad(unhex('aabb'), 5, unhex('1122'))); -- 112211AABB
+        SELECT lpad('hi', 4); -- hi  
 
 .. spark:function:: rtrim(string) -> varchar
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -81,9 +81,13 @@ void registerFunctions(const std::string& prefix) {
   // Register string functions.
   registerFunction<sparksql::ChrFunction, Varchar, int64_t>({prefix + "chr"});
   registerFunction<AsciiFunction, int32_t, Varchar>({prefix + "ascii"});
-  registerFunction<LPadFunction, Varchar, Varchar, int32_t, Varchar>(
+  registerFunction<sparksql::LPadFunction, Varchar, Varchar, int32_t, Varchar>(
       {prefix + "lpad"});
-  registerFunction<RPadFunction, Varchar, Varchar, int32_t, Varchar>(
+  registerFunction<sparksql::RPadFunction, Varchar, Varchar, int32_t, Varchar>(
+      {prefix + "rpad"});
+  registerFunction<sparksql::LPadFunction, Varchar, Varchar, int32_t>(
+      {prefix + "lpad"});
+  registerFunction<sparksql::RPadFunction, Varchar, Varchar, int32_t>(
       {prefix + "rpad"});
   registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -81,7 +81,10 @@ void registerFunctions(const std::string& prefix) {
   // Register string functions.
   registerFunction<sparksql::ChrFunction, Varchar, int64_t>({prefix + "chr"});
   registerFunction<AsciiFunction, int32_t, Varchar>({prefix + "ascii"});
-
+  registerFunction<LPadFunction, Varchar, Varchar, int32_t, Varchar>(
+      {prefix + "lpad"});
+  registerFunction<RPadFunction, Varchar, Varchar, int32_t, Varchar>(
+      {prefix + "rpad"});
   registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});
   registerFunction<

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -27,6 +27,50 @@
 
 namespace facebook::velox::functions::sparksql {
 
+template <typename T, bool lpad>
+struct PadFunctionBase {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& string,
+      const arg_type<int64_t>& size,
+      const arg_type<Varchar>& padString) {
+    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, padString);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& string,
+      const arg_type<int64_t>& size) {
+    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, " ");
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& string,
+      const arg_type<int64_t>& size,
+      const arg_type<Varchar>& padString) {
+    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, padString);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& string,
+      const arg_type<int64_t>& size) {
+    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, " ");
+  }
+};
+
+template <typename T>
+struct LPadFunction : public PadFunctionBase<T, true> {};
+
+template <typename T>
+struct RPadFunction : public PadFunctionBase<T, false> {};
+
 template <typename T>
 struct AsciiFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -46,7 +46,7 @@ struct PadFunctionBase {
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size) {
-    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, " ");
+    stringImpl::pad<lpad, false /*isAscii*/>(result, string, size, {" "});
   }
 
   FOLLY_ALWAYS_INLINE void callAscii(
@@ -61,7 +61,7 @@ struct PadFunctionBase {
       out_type<Varchar>& result,
       const arg_type<Varchar>& string,
       const arg_type<int64_t>& size) {
-    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, " ");
+    stringImpl::pad<lpad, true /*isAscii*/>(result, string, size, {" "});
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -163,6 +163,21 @@ class StringTest : public SparkFunctionBaseTest {
         pos,
         len);
   }
+  std::optional<std::string> rpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size,
+      std::optional<std::string> padString) {
+    return evaluateOnce<std::string>(
+        "rpad(c0, c1, c2)", string, size, padString);
+  };
+
+  std::optional<std::string> lpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size,
+      std::optional<std::string> padString) {
+    return evaluateOnce<std::string>(
+        "lpad(c0, c1, c2)", string, size, padString);
+  };
 };
 
 TEST_F(StringTest, Ascii) {
@@ -483,6 +498,85 @@ TEST_F(StringTest, overlayVarbinary) {
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", 0, 4), "##rk SQL");
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, -1), "##park SQL");
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, 4), "##rk SQL");
+}
+TEST_F(StringTest, rpad) {
+  const std::string invalidString = "Ψ\xFF\xFFΣΓΔA";
+  const std::string invalidPadString = "\xFFΨ\xFF";
+
+  // ASCII strings with various values for size and padString
+  EXPECT_EQ("textx", rpad("text", 5, "x"));
+  EXPECT_EQ("text", rpad("text", 4, "x"));
+  EXPECT_EQ("textxy", rpad("text", 6, "xy"));
+  EXPECT_EQ("textxyx", rpad("text", 7, "xy"));
+  EXPECT_EQ("textxyzxy", rpad("text", 9, "xyz"));
+
+  // Non-ASCII strings with various values for size and padString
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u671B",
+      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 10, "\u671B"));
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u671B\u671B",
+      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 11, "\u671B"));
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u5E0C\u671B\u5E0C",
+      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 12, "\u5E0C\u671B"));
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u5E0C\u671B\u5E0C\u671B",
+      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 13, "\u5E0C\u671B"));
+
+  // Empty string
+  EXPECT_EQ("aaa", rpad("", 3, "a"));
+
+  // Truncating string
+  EXPECT_EQ("", rpad("abc", 0, "e"));
+  EXPECT_EQ("tex", rpad("text", 3, "xy"));
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 ",
+      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 5, "\u671B"));
+
+  // Invalid UTF-8 chars
+  EXPECT_EQ(invalidString + "x", rpad(invalidString, 8, "x"));
+  EXPECT_EQ("abc" + invalidPadString, rpad("abc", 6, invalidPadString));
+}
+
+TEST_F(StringTest, lpad) {
+  std::string invalidString = "Ψ\xFF\xFFΣΓΔA";
+  std::string invalidPadString = "\xFFΨ\xFF";
+
+  // ASCII strings with various values for size and padString
+  EXPECT_EQ("xtext", lpad("text", 5, "x"));
+  EXPECT_EQ("text", lpad("text", 4, "x"));
+  EXPECT_EQ("xytext", lpad("text", 6, "xy"));
+  EXPECT_EQ("xyxtext", lpad("text", 7, "xy"));
+  EXPECT_EQ("xyzxytext", lpad("text", 9, "xyz"));
+
+  // Non-ASCII strings with various values for size and padString
+  EXPECT_EQ(
+      "\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
+      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 10, "\u671B"));
+  EXPECT_EQ(
+      "\u671B\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
+      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 11, "\u671B"));
+  EXPECT_EQ(
+      "\u5E0C\u671B\u5E0C\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
+      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 12, "\u5E0C\u671B"));
+  EXPECT_EQ(
+      "\u5E0C\u671B\u5E0C\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
+      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 13, "\u5E0C\u671B"));
+
+  // Empty string
+  EXPECT_EQ("aaa", lpad("", 3, "a"));
+
+  // Truncating string
+  EXPECT_EQ("", lpad("abc", 0, "e"));
+  EXPECT_EQ("tex", lpad("text", 3, "xy"));
+  EXPECT_EQ(
+      "\u4FE1\u5FF5 \u7231 ",
+      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 5, "\u671B"));
+
+  // Invalid UTF-8 chars
+  EXPECT_EQ("x" + invalidString, lpad(invalidString, 8, "x"));
+  EXPECT_EQ(invalidPadString + "abc", lpad("abc", 6, invalidPadString));
 }
 
 TEST_F(StringTest, left) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -169,7 +169,7 @@ class StringTest : public SparkFunctionBaseTest {
       std::optional<std::string> padString) {
     return evaluateOnce<std::string>(
         "rpad(c0, c1, c2)", string, size, padString);
-  };
+  }
 
   std::optional<std::string> lpad(
       std::optional<std::string> string,
@@ -177,19 +177,19 @@ class StringTest : public SparkFunctionBaseTest {
       std::optional<std::string> padString) {
     return evaluateOnce<std::string>(
         "lpad(c0, c1, c2)", string, size, padString);
-  };
+  }
 
   std::optional<std::string> rpad(
       std::optional<std::string> string,
       std::optional<int32_t> size) {
     return evaluateOnce<std::string>("rpad(c0, c1)", string, size);
-  };
+  }
 
   std::optional<std::string> lpad(
       std::optional<std::string> string,
       std::optional<int32_t> size) {
     return evaluateOnce<std::string>("lpad(c0, c1)", string, size);
-  };
+  }
 };
 
 TEST_F(StringTest, Ascii) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -178,6 +178,18 @@ class StringTest : public SparkFunctionBaseTest {
     return evaluateOnce<std::string>(
         "lpad(c0, c1, c2)", string, size, padString);
   };
+
+  std::optional<std::string> rpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size) {
+    return evaluateOnce<std::string>("rpad(c0, c1)", string, size);
+  };
+
+  std::optional<std::string> lpad(
+      std::optional<std::string> string,
+      std::optional<int32_t> size) {
+    return evaluateOnce<std::string>("lpad(c0, c1)", string, size);
+  };
 };
 
 TEST_F(StringTest, Ascii) {
@@ -499,6 +511,7 @@ TEST_F(StringTest, overlayVarbinary) {
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, -1), "##park SQL");
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, 4), "##rk SQL");
 }
+
 TEST_F(StringTest, rpad) {
   const std::string invalidString = "Ψ\xFF\xFFΣΓΔA";
   const std::string invalidPadString = "\xFFΨ\xFF";
@@ -506,23 +519,16 @@ TEST_F(StringTest, rpad) {
   // ASCII strings with various values for size and padString
   EXPECT_EQ("textx", rpad("text", 5, "x"));
   EXPECT_EQ("text", rpad("text", 4, "x"));
-  EXPECT_EQ("textxy", rpad("text", 6, "xy"));
   EXPECT_EQ("textxyx", rpad("text", 7, "xy"));
-  EXPECT_EQ("textxyzxy", rpad("text", 9, "xyz"));
+  EXPECT_EQ("text  ", rpad("text", 6));
 
   // Non-ASCII strings with various values for size and padString
-  EXPECT_EQ(
-      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u671B",
-      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 10, "\u671B"));
   EXPECT_EQ(
       "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u671B\u671B",
       rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 11, "\u671B"));
   EXPECT_EQ(
       "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u5E0C\u671B\u5E0C",
       rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 12, "\u5E0C\u671B"));
-  EXPECT_EQ(
-      "\u4FE1\u5FF5 \u7231 \u5E0C\u671B  \u5E0C\u671B\u5E0C\u671B",
-      rpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 13, "\u5E0C\u671B"));
 
   // Empty string
   EXPECT_EQ("aaa", rpad("", 3, "a"));
@@ -546,23 +552,16 @@ TEST_F(StringTest, lpad) {
   // ASCII strings with various values for size and padString
   EXPECT_EQ("xtext", lpad("text", 5, "x"));
   EXPECT_EQ("text", lpad("text", 4, "x"));
-  EXPECT_EQ("xytext", lpad("text", 6, "xy"));
   EXPECT_EQ("xyxtext", lpad("text", 7, "xy"));
-  EXPECT_EQ("xyzxytext", lpad("text", 9, "xyz"));
+  EXPECT_EQ("  text", lpad("text", 6));
 
   // Non-ASCII strings with various values for size and padString
-  EXPECT_EQ(
-      "\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
-      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 10, "\u671B"));
   EXPECT_EQ(
       "\u671B\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
       lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 11, "\u671B"));
   EXPECT_EQ(
       "\u5E0C\u671B\u5E0C\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
       lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 12, "\u5E0C\u671B"));
-  EXPECT_EQ(
-      "\u5E0C\u671B\u5E0C\u671B\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ",
-      lpad("\u4FE1\u5FF5 \u7231 \u5E0C\u671B  ", 13, "\u5E0C\u671B"));
 
   // Empty string
   EXPECT_EQ("aaa", lpad("", 3, "a"));


### PR DESCRIPTION
The input type of spark's lpad/rpad function is different with presto.  [defined here](https://github.com/apache/spark/blob/branch-3.2/sql/core/src/main/scala/org/apache/spark/sql/functions.scala#L2678)  So this pr change int64 to int32.

presto and spark have different semantics.

Here is presto lpad() description:

lpad(string, size, padstring) → varchar  [link](https://prestodb.io/docs/current/functions/string.html#lpad)
Left pads string to size characters with padstring. If size is less than the length of string, the result is truncated to size characters. size must not be negative and padstring must be non-empty.


Here is spark lpad() description:

[lpad](https://spark.apache.org/docs/latest/api/sql/index.html#lpad)
lpad(str, len[, pad]) - Returns str, left-padded with pad to a length of len. If str is longer than len, the return value is shortened to len characters or bytes. If pad is not specified, str will be padded to the left with space characters if it is a character string.
