### PR TITLE
Add arbitrary output buffer to support scaled write for presto batch

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -579,7 +579,11 @@ void Task::start(
           : factory->numDrivers;
       bufferManager->initializeTask(
           self,
-          partitionedOutputNode->isBroadcast(),
+          // TODO: change PartitionedOutputNode to pass partition output type
+          // which include arbitrary.
+          partitionedOutputNode->isBroadcast()
+              ? PartitionedOutputBuffer::Kind::kBroadcast
+              : PartitionedOutputBuffer::Kind::kPartitioned,
           partitionedOutputNode->numPartitions(),
           totalOutputDrivers);
     }

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -16,6 +16,8 @@
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include <gtest/gtest.h>
 #include <velox/common/memory/MemoryAllocator.h>
+#include "folly/experimental/EventCount.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -28,6 +30,12 @@ using facebook::velox::test::BatchMaker;
 
 class PartitionedOutputBufferManagerTest : public testing::Test {
  protected:
+  PartitionedOutputBufferManagerTest() {
+    std::vector<std::string> names = {"c0", "c1"};
+    std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
+    rowType_ = ROW(std::move(names), std::move(types));
+  }
+
   void SetUp() override {
     pool_ = facebook::velox::memory::addDefaultLeafMemoryPool();
     bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
@@ -44,21 +52,28 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
   std::shared_ptr<Task> initializeTask(
       const std::string& taskId,
       const RowTypePtr& rowType,
+      PartitionedOutputBuffer::Kind kind,
       int numDestinations,
-      int numDrivers) {
+      int numDrivers,
+      int maxPartitionedOutputBufferSize = 0) {
     bufferManager_->removeTask(taskId);
 
     auto planFragment = exec::test::PlanBuilder()
                             .values({std::dynamic_pointer_cast<RowVector>(
                                 BatchMaker::createBatch(rowType, 100, *pool_))})
                             .planFragment();
-    auto task = Task::create(
-        taskId,
-        std::move(planFragment),
-        0,
-        std::make_shared<core::QueryCtx>(executor_.get()));
+    std::unordered_map<std::string, std::string> configSettings;
+    if (maxPartitionedOutputBufferSize != 0) {
+      configSettings[core::QueryConfig::kMaxPartitionedOutputBufferSize] =
+          std::to_string(maxPartitionedOutputBufferSize);
+    }
+    auto queryCtx = std::make_shared<core::QueryCtx>(
+        executor_.get(), std::move(configSettings));
 
-    bufferManager_->initializeTask(task, false, numDestinations, numDrivers);
+    auto task =
+        Task::create(taskId, std::move(planFragment), 0, std::move(queryCtx));
+
+    bufferManager_->initializeTask(task, kind, numDestinations, numDrivers);
     return task;
   }
 
@@ -86,13 +101,27 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
 
   void enqueue(
       const std::string& taskId,
+      std::shared_ptr<const RowType> rowType,
+      vector_size_t size,
+      bool expectedBlock = false) {
+    enqueue(taskId, 0, std::move(rowType), size);
+  }
+
+  void enqueue(
+      const std::string& taskId,
       int destination,
       std::shared_ptr<const RowType> rowType,
-      vector_size_t size) {
+      vector_size_t size,
+      bool expectedBlock = false) {
     ContinueFuture future;
     auto blockingReason = bufferManager_->enqueue(
         taskId, destination, makeSerializedPage(rowType, size), &future);
-    ASSERT_EQ(blockingReason, BlockingReason::kNotBlocked);
+    if (!expectedBlock) {
+      ASSERT_EQ(blockingReason, BlockingReason::kNotBlocked);
+    }
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      future.wait();
+    }
   }
 
   void noMoreData(const std::string& taskId) {
@@ -104,21 +133,32 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
       int destination,
       int64_t sequence,
       uint64_t maxBytes = 1024,
-      int expectedGroups = 1) {
+      int expectedGroups = 1,
+      bool expectedEndMarker = false) {
     bool receivedData = false;
     ASSERT_TRUE(bufferManager_->getData(
         taskId,
         destination,
         maxBytes,
         sequence,
-        [destination, sequence, expectedGroups, &receivedData](
+        [destination,
+         sequence,
+         expectedGroups,
+         expectedEndMarker,
+         &receivedData](
             std::vector<std::unique_ptr<folly::IOBuf>> pages,
             int64_t inSequence) {
           EXPECT_FALSE(receivedData) << "for destination " << destination;
           EXPECT_EQ(pages.size(), expectedGroups)
               << "for destination " << destination;
-          for (const auto& page : pages) {
-            EXPECT_TRUE(page != nullptr) << "for destination " << destination;
+          for (int i = 0; i < pages.size(); ++i) {
+            if (i == pages.size() - 1) {
+              EXPECT_EQ(expectedEndMarker, pages[i] == nullptr)
+                  << "for destination " << destination;
+            } else {
+              EXPECT_TRUE(pages[i] != nullptr)
+                  << "for destination " << destination;
+            }
           }
           EXPECT_EQ(inSequence, sequence) << "for destination " << destination;
           receivedData = true;
@@ -186,7 +226,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
         destination,
         std::numeric_limits<uint64_t>::max(),
         sequence,
-        receiveEndMarker(destination, 1, receivedEndMarker)));
+        receiveEndMarker(destination, sequence, receivedEndMarker)));
     EXPECT_FALSE(receivedEndMarker) << "for destination " << destination;
   }
 
@@ -226,21 +266,276 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
     EXPECT_FALSE(receivedData) << "for destination " << destination;
   }
 
+  void dataFetcher(
+      const std::string& taskId,
+      int destination,
+      int64_t& fetchedPages,
+      bool earlyTermination) {
+    folly::Random::DefaultGenerator rng;
+    rng.seed(destination);
+    int64_t nextSequence{0};
+    while (true) {
+      if (earlyTermination && folly::Random().oneIn(200)) {
+        bufferManager_->deleteResults(taskId, destination);
+        return;
+      }
+      const int64_t maxBytes = folly::Random().oneIn(4, rng) ? 32'000'000 : 1;
+      int64_t receivedSequence;
+      bool atEnd{false};
+      folly::EventCount dataWait;
+      auto dataWaitKey = dataWait.prepareWait();
+      bufferManager_->getData(
+          taskId,
+          destination,
+          maxBytes,
+          nextSequence,
+          [&](std::vector<std::unique_ptr<folly::IOBuf>> pages,
+              int64_t inSequence) {
+            ASSERT_EQ(inSequence, nextSequence);
+            for (int i = 0; i < pages.size(); ++i) {
+              if (pages[i] != nullptr) {
+                ++nextSequence;
+              } else {
+                ASSERT_EQ(i, pages.size() - 1);
+                atEnd = true;
+              }
+            }
+            dataWait.notify();
+          });
+      dataWait.wait(dataWaitKey);
+      if (atEnd) {
+        break;
+      }
+    }
+    bufferManager_->deleteResults(taskId, destination);
+    fetchedPages = nextSequence;
+  }
+
   std::shared_ptr<folly::Executor> executor_{
       std::make_shared<folly::CPUThreadPoolExecutor>(
           std::thread::hardware_concurrency())};
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_;
   std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
+  RowTypePtr rowType_;
 };
 
-TEST_F(PartitionedOutputBufferManagerTest, basic) {
-  std::vector<std::string> names = {"c0", "c1"};
-  std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
-  auto rowType = ROW(std::move(names), std::move(types));
+struct TestParam {
+  PartitionedOutputBuffer::Kind kind;
+};
+
+class AllPartitionedOutputBufferManagerTest
+    : public PartitionedOutputBufferManagerTest,
+      public testing::WithParamInterface<PartitionedOutputBuffer::Kind> {
+ public:
+  AllPartitionedOutputBufferManagerTest() : kind_(GetParam()) {}
+
+  static std::vector<PartitionedOutputBuffer::Kind> getTestParams() {
+    static std::vector<PartitionedOutputBuffer::Kind> params = {
+        PartitionedOutputBuffer::Kind::kBroadcast,
+        PartitionedOutputBuffer::Kind::kPartitioned,
+        PartitionedOutputBuffer::Kind::kArbitrary};
+    return params;
+  }
+
+ protected:
+  PartitionedOutputBuffer::Kind kind_;
+};
+
+TEST_F(PartitionedOutputBufferManagerTest, arbitrayBuffer) {
+  {
+    ArbitraryBuffer buffer;
+    ASSERT_TRUE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[false]]");
+    VELOX_ASSERT_THROW(buffer.enqueue(nullptr), "Unexpected null page");
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[false]]");
+    buffer.noMoreData();
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[true]]");
+  }
+
+  {
+    ArbitraryBuffer buffer;
+    ASSERT_TRUE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    auto page1 = makeSerializedPage(rowType_, 100);
+    auto* rawPage1 = page1.get();
+    buffer.enqueue(std::move(page1));
+    ASSERT_FALSE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[1] NO MORE DATA[false]]");
+    auto page2 = makeSerializedPage(rowType_, 100);
+    auto* rawPage2 = page2.get();
+    buffer.enqueue(std::move(page2));
+    ASSERT_FALSE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[false]]");
+
+    auto pages = buffer.getPages(1);
+    ASSERT_EQ(pages.size(), 1);
+    ASSERT_EQ(pages[0].get(), rawPage1);
+    auto page3 = makeSerializedPage(rowType_, 100);
+    auto* rawPage3 = page3.get();
+    buffer.enqueue(std::move(page3));
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[false]]");
+    buffer.noMoreData();
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[true]]");
+    pages = buffer.getPages(1'000'000'000);
+    ASSERT_EQ(pages.size(), 3);
+    ASSERT_EQ(pages[0].get(), rawPage2);
+    ASSERT_EQ(pages[1].get(), rawPage3);
+    ASSERT_EQ(pages[2].get(), nullptr);
+    ASSERT_TRUE(buffer.empty());
+    ASSERT_TRUE(buffer.hasNoMoreData());
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[true]]");
+    auto page4 = makeSerializedPage(rowType_, 100);
+    VELOX_ASSERT_THROW(
+        buffer.enqueue(std::move(page4)),
+        "Arbitrary buffer has set no more data marker");
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[0] NO MORE DATA[true]]");
+    buffer.noMoreData();
+    VELOX_ASSERT_THROW(buffer.getPages(0), "maxBytes can't be zero");
+    // Verify the end marker is persistent.
+    for (int i = 0; i < 3; ++i) {
+      pages = buffer.getPages(100);
+      ASSERT_EQ(pages.size(), 1);
+      ASSERT_EQ(pages[0].get(), nullptr);
+    }
+  }
+}
+
+TEST_F(PartitionedOutputBufferManagerTest, outputType) {
+  ASSERT_EQ(
+      PartitionedOutputBuffer::kindString(
+          PartitionedOutputBuffer::Kind::kPartitioned),
+      "PARTITIONED");
+  ASSERT_EQ(
+      PartitionedOutputBuffer::kindString(
+          PartitionedOutputBuffer::Kind::kArbitrary),
+      "ARBITRARY");
+  ASSERT_EQ(
+      PartitionedOutputBuffer::kindString(
+          PartitionedOutputBuffer::Kind::kBroadcast),
+      "BROADCAST");
+  ASSERT_EQ(
+      PartitionedOutputBuffer::kindString(
+          static_cast<PartitionedOutputBuffer::Kind>(100)),
+      "INVALID OUTPUT KIND 100");
+}
+
+TEST_F(PartitionedOutputBufferManagerTest, destinationBuffer) {
+  {
+    ArbitraryBuffer buffer;
+    DestinationBuffer destinationBuffer;
+    VELOX_ASSERT_THROW(
+        destinationBuffer.loadData(&buffer, 0), "maxBytes can't be zero");
+    destinationBuffer.loadData(&buffer, 100);
+    std::atomic<bool> notified{false};
+    destinationBuffer.getData(
+        1'000'000,
+        0,
+        [&](std::vector<std::unique_ptr<folly::IOBuf>> buffers,
+            int64_t sequence) {
+          ASSERT_EQ(buffers.size(), 1);
+          ASSERT_TRUE(buffers[0].get() == nullptr);
+          notified = true;
+        });
+    ASSERT_TRUE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    ASSERT_FALSE(notified);
+    VELOX_ASSERT_THROW(destinationBuffer.maybeLoadData(&buffer), "");
+    buffer.noMoreData();
+    destinationBuffer.maybeLoadData(&buffer);
+    destinationBuffer.getAndClearNotify().notify();
+    ASSERT_TRUE(notified);
+  }
+
+  {
+    ArbitraryBuffer buffer;
+    int64_t expectedNumBytes{0};
+    for (int i = 0; i < 10; ++i) {
+      auto page = makeSerializedPage(rowType_, 100);
+      expectedNumBytes += page->size();
+      buffer.enqueue(std::move(page));
+    }
+    DestinationBuffer destinationBuffer;
+    destinationBuffer.loadData(&buffer, 1);
+    ASSERT_EQ(
+        buffer.toString(), "[ARBITRARY_BUFFER PAGES[9] NO MORE DATA[false]]");
+    std::atomic<bool> notified{false};
+    int64_t numBytes{0};
+    auto buffers = destinationBuffer.getData(
+        1'000'000'000,
+        0,
+        [&](std::vector<std::unique_ptr<folly::IOBuf>> /*unused*/,
+            int64_t /*unused*/) { notified = true; });
+    for (const auto& buffer : buffers) {
+      numBytes += buffer->length();
+    }
+    ASSERT_GT(numBytes, 0);
+    ASSERT_FALSE(notified);
+    {
+      auto result = destinationBuffer.getAndClearNotify();
+      ASSERT_EQ(result.callback, nullptr);
+      ASSERT_TRUE(result.data.empty());
+      ASSERT_EQ(result.sequence, 0);
+    }
+    auto pages = destinationBuffer.acknowledge(1, false);
+    ASSERT_EQ(pages.size(), 1);
+
+    buffers = destinationBuffer.getData(
+        1'000'000,
+        1,
+        [&](std::vector<std::unique_ptr<folly::IOBuf>> buffers,
+            int64_t sequence) {
+          ASSERT_EQ(sequence, 1);
+          ASSERT_EQ(buffers.size(), 9);
+          for (const auto& buffer : buffers) {
+            numBytes += buffer->length();
+          }
+          notified = true;
+        });
+    ASSERT_TRUE(buffers.empty());
+    ASSERT_FALSE(notified);
+
+    destinationBuffer.maybeLoadData(&buffer);
+    destinationBuffer.getAndClearNotify().notify();
+    ASSERT_TRUE(notified);
+    ASSERT_TRUE(buffer.empty());
+    ASSERT_FALSE(buffer.hasNoMoreData());
+    ASSERT_EQ(numBytes, expectedNumBytes);
+  }
+}
+
+TEST_F(PartitionedOutputBufferManagerTest, basicPartitioned) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  auto task = initializeTask(taskId, rowType, 5, 1);
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kPartitioned, 5, 1);
+
+  // Partitioned output buffer doesn't allow to update output buffers once
+  // created.
+  VELOX_ASSERT_THROW(
+      bufferManager_->updateOutputBuffers(taskId, 5 + 1, true),
+      "updateOutputBuffers is not supported on PARTITIONED output buffer");
+  VELOX_ASSERT_THROW(
+      bufferManager_->updateOutputBuffers(taskId, 5 + 1, false),
+      "updateOutputBuffers is not supported on PARTITIONED output buffer");
+  VELOX_ASSERT_THROW(
+      bufferManager_->updateOutputBuffers(taskId, 5 - 1, true),
+      "updateOutputBuffers is not supported on PARTITIONED output buffer");
+  VELOX_ASSERT_THROW(
+      bufferManager_->updateOutputBuffers(taskId, 5 - 1, false),
+      "updateOutputBuffers is not supported on PARTITIONED output buffer");
 
   // - enqueue one group per destination
   // - fetch and ask one group per destination
@@ -252,8 +547,8 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   // - assert callback was called for destination 3
   // - fetch end markers for destinations 0-2 and 4
 
-  for (int destination = 0; destination < 5; destination++) {
-    enqueue(taskId, destination, rowType, size);
+  for (int destination = 0; destination < 5; ++destination) {
+    enqueue(taskId, destination, rowType_, size);
   }
   EXPECT_FALSE(bufferManager_->isFinished(taskId));
 
@@ -265,7 +560,7 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   EXPECT_FALSE(bufferManager_->isFinished(taskId));
 
   for (int destination = 0; destination < 3; destination++) {
-    enqueue(taskId, destination, rowType, size);
+    enqueue(taskId, destination, rowType_, size);
   }
 
   for (int destination = 0; destination < 3; destination++) {
@@ -281,7 +576,7 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   bool receivedData4;
   registerForData(taskId, 4, 1, 1, receivedData4);
 
-  enqueue(taskId, 4, rowType, size);
+  enqueue(taskId, 4, rowType_, size);
   EXPECT_TRUE(receivedData4);
 
   noMoreData(taskId);
@@ -298,50 +593,289 @@ TEST_F(PartitionedOutputBufferManagerTest, basic) {
   EXPECT_TRUE(task->isFinished());
 }
 
-TEST_F(PartitionedOutputBufferManagerTest, maxBytes) {
-  std::vector<std::string> names = {"c0", "c1"};
-  std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
-  auto rowType = ROW(std::move(names), std::move(types));
+TEST_F(PartitionedOutputBufferManagerTest, basicBroadcast) {
   vector_size_t size = 100;
 
   std::string taskId = "t0";
-  initializeTask(taskId, rowType, 5, 1);
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kBroadcast, 5, 1);
+  VELOX_ASSERT_THROW(enqueue(taskId, 1, rowType_, size), "Bad destination 1");
 
-  enqueue(taskId, 0, rowType, size);
-  enqueue(taskId, 1, rowType, size);
-  enqueue(taskId, 1, rowType, size);
+  enqueue(taskId, rowType_, size);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
 
-  fetchOneAndAck(taskId, 0, 0);
+  for (int destination = 0; destination < 5; destination++) {
+    fetchOneAndAck(taskId, destination, 0);
+    // Try to re-fetch already ack-ed data - should fail
+    EXPECT_THROW(fetchOne(taskId, destination, 0), std::exception);
+  }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
 
-  // fetch up to 1Kb - 1 group
-  fetchOne(taskId, 1, 0);
-  // re-fetch with larger size limit - 2 groups
-  fetch(taskId, 1, 0, std::numeric_limits<int64_t>::max(), 2);
-  // re-fetch with 1Kb limit - 1 group
-  fetchOneAndAck(taskId, 1, 0);
-  fetchOneAndAck(taskId, 1, 1);
+  enqueue(taskId, rowType_, size);
+
+  for (int destination = 0; destination < 5; destination++) {
+    fetchOneAndAck(taskId, destination, 1);
+  }
+
+  bool receivedEndMarker3;
+  registerForEndMarker(taskId, 3, 2, receivedEndMarker3);
 
   noMoreData(taskId);
-  fetchEndMarker(taskId, 0, 1);
-  fetchEndMarker(taskId, 1, 2);
-  for (int destination = 2; destination < 5; destination++) {
-    fetchEndMarker(taskId, destination, 0);
+  EXPECT_TRUE(receivedEndMarker3);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  for (int destination = 0; destination < 5; ++destination) {
+    if (destination != 3) {
+      fetchEndMarker(taskId, destination, 2);
+    }
   }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+  bufferManager_->updateOutputBuffers(taskId, 5, false);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+  bufferManager_->updateOutputBuffers(taskId, 6, false);
+
+  // Fetch all for the new added destinations.
+  fetch(taskId, 5, 0, 1'000'000'000, 3, true);
+  VELOX_ASSERT_THROW(
+      acknowledge(taskId, 5, 4),
+      "(4 vs. 3) Ack received for a not yet produced item");
+  acknowledge(taskId, 5, 0);
+  acknowledge(taskId, 5, 1);
+  acknowledge(taskId, 5, 2);
+  acknowledge(taskId, 5, 3);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+  deleteResults(taskId, 5);
+  VELOX_ASSERT_THROW(
+      fetch(taskId, 5, 0, 1'000'000'000, 2),
+      "getData received after its buffer is deleted. Destination: 5, sequence: 0");
+
+  bufferManager_->updateOutputBuffers(taskId, 7, true);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+  fetch(taskId, 6, 0, 1'000'000'000, 3, true);
+  acknowledge(taskId, 6, 2);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+  deleteResults(taskId, 6);
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  EXPECT_TRUE(task->isRunning());
+  deleteResults(taskId, 3);
+  EXPECT_TRUE(bufferManager_->isFinished(taskId));
+  bufferManager_->removeTask(taskId);
+  EXPECT_TRUE(task->isFinished());
+}
+
+TEST_F(PartitionedOutputBufferManagerTest, basicArbitrary) {
+  const vector_size_t size = 100;
+  int numDestinations = 5;
+  const std::string taskId = "t0";
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kArbitrary, 5, 1);
+  VELOX_ASSERT_THROW(
+      enqueue(taskId, 1, rowType_, size), "(1 vs. 0) Bad destination 1");
+
+  for (int i = 0; i < numDestinations; ++i) {
+    enqueue(taskId, rowType_, size);
+  }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  std::unordered_map<int, int> ackedSeqbyDestination;
+
+  for (int destination = 0; destination < numDestinations; destination++) {
+    fetchOne(taskId, destination, 0, 1);
+    acknowledge(taskId, destination, 1);
+    ackedSeqbyDestination[destination] = 1;
+    // Try to re-fetch already ack-ed data - should fail
+    VELOX_ASSERT_THROW(fetchOne(taskId, destination, 0), "");
+  }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  bool receivedData0{false};
+  bool receivedData1{false};
+  registerForData(taskId, 0, 1, 1, receivedData0);
+  registerForData(taskId, 1, 1, 1, receivedData1);
+  enqueue(taskId, rowType_, size);
+  enqueue(taskId, rowType_, size);
+  ASSERT_TRUE(receivedData0);
+  ASSERT_TRUE(receivedData1);
+  acknowledge(taskId, 0, 2);
+  ackedSeqbyDestination[0] = 2;
+  acknowledge(taskId, 1, 2);
+  ackedSeqbyDestination[1] = 2;
+  bool receivedData{false};
+  registerForData(taskId, 4, 1, 1, receivedData);
+  enqueue(taskId, rowType_, size);
+  enqueue(taskId, rowType_, size);
+  ASSERT_TRUE(receivedData);
+  acknowledge(taskId, 4, 2);
+  ackedSeqbyDestination[4] = 2;
+
+  bufferManager_->updateOutputBuffers(taskId, ++numDestinations, false);
+  bufferManager_->updateOutputBuffers(taskId, ++numDestinations, false);
+  fetchOneAndAck(taskId, numDestinations - 1, 0);
+  ackedSeqbyDestination[numDestinations - 1] = 1;
+
+  bufferManager_->updateOutputBuffers(taskId, numDestinations, true);
+  VELOX_ASSERT_THROW(fetchOneAndAck(taskId, numDestinations, 0), "");
+
+  receivedData = false;
+  registerForData(taskId, numDestinations - 2, 0, 1, receivedData);
+  enqueue(taskId, rowType_, size);
+  ASSERT_TRUE(receivedData);
+  acknowledge(taskId, numDestinations - 2, 1);
+  ackedSeqbyDestination[numDestinations - 2] = 1;
+
+  noMoreData(taskId);
+  EXPECT_TRUE(task->isRunning());
+  for (int i = 0; i < numDestinations; ++i) {
+    fetchEndMarker(taskId, i, ackedSeqbyDestination[i]);
+  }
+  EXPECT_TRUE(bufferManager_->isFinished(taskId));
+
+  EXPECT_FALSE(task->isRunning());
+  EXPECT_TRUE(bufferManager_->isFinished(taskId));
+  bufferManager_->removeTask(taskId);
+  EXPECT_TRUE(task->isFinished());
+}
+
+TEST_F(
+    PartitionedOutputBufferManagerTest,
+    broadcastWithDynamicAddedDestination) {
+  vector_size_t size = 100;
+
+  std::string taskId = "t0";
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kBroadcast, 5, 1);
+
+  const int numPages = 10;
+  for (int i = 0; i < numPages; ++i) {
+    enqueue(taskId, rowType_, size);
+  }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  for (int i = 0; i < numPages; ++i) {
+    for (int destination = 0; destination < 5; ++destination) {
+      fetchOneAndAck(taskId, destination, i);
+    }
+  }
+
+  // Dynamic added destination.
+  fetch(taskId, 5, 0, 1'000'000'000, 10);
+  bufferManager_->updateOutputBuffers(taskId, 4, false);
+  bufferManager_->updateOutputBuffers(taskId, 6, false);
+  bufferManager_->updateOutputBuffers(taskId, 7, false);
+
+  fetch(taskId, 6, 0, 1'000'000'000, 10);
+  fetch(taskId, 7, 0, 1'000'000'000, 10);
+  fetch(taskId, 8, 0, 1'000'000'000, 10);
+
+  bufferManager_->updateOutputBuffers(taskId, 7, true);
+
+  VELOX_ASSERT_THROW(fetch(taskId, 10, 0, 1'000'000'000, 10), "");
+
+  ASSERT_FALSE(bufferManager_->isFinished(taskId));
+  noMoreData(taskId);
+  for (int i = 0; i < 9; ++i) {
+    fetchEndMarker(taskId, i, numPages);
+  }
+  ASSERT_TRUE(bufferManager_->isFinished(taskId));
+
+  bufferManager_->removeTask(taskId);
+  EXPECT_TRUE(task->isFinished());
+}
+
+TEST_F(
+    PartitionedOutputBufferManagerTest,
+    arbitraryWithDynamicAddedDestination) {
+  const vector_size_t size = 100;
+  int numDestinations = 5;
+  const std::string taskId = "t0";
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kArbitrary, 5, 1);
+
+  for (int i = 0; i < numDestinations; ++i) {
+    enqueue(taskId, rowType_, size);
+  }
+  std::unordered_map<int, int> ackedSeqbyDestination;
+
+  for (int destination = 0; destination < 5; destination++) {
+    fetchOne(taskId, destination, 0, 1);
+    acknowledge(taskId, destination, 1);
+    ackedSeqbyDestination[destination] = 1;
+  }
+  EXPECT_FALSE(bufferManager_->isFinished(taskId));
+
+  // Dynamic added destination.
+  enqueue(taskId, rowType_, size);
+  fetchOneAndAck(taskId, numDestinations, 0);
+  ackedSeqbyDestination[numDestinations] = 1;
+
+  bufferManager_->updateOutputBuffers(taskId, numDestinations - 1, false);
+  bufferManager_->updateOutputBuffers(taskId, numDestinations, false);
+  bufferManager_->updateOutputBuffers(taskId, numDestinations + 1, false);
+
+  enqueue(taskId, rowType_, size);
+  fetchOneAndAck(taskId, numDestinations + 10, 0);
+  ackedSeqbyDestination[numDestinations + 10] = 1;
+
+  bufferManager_->updateOutputBuffers(taskId, numDestinations, true);
+
+  enqueue(taskId, rowType_, size);
+  fetchOneAndAck(taskId, numDestinations + 9, 0);
+  ackedSeqbyDestination[numDestinations + 9] = 1;
+
+  VELOX_ASSERT_THROW(
+      fetch(taskId, numDestinations + 20, 0, 1'000'000'000, 1), "");
+
+  ASSERT_FALSE(bufferManager_->isFinished(taskId));
+
+  noMoreData(taskId);
+  EXPECT_TRUE(task->isRunning());
+  for (int i = 0; i <= numDestinations + 10; ++i) {
+    fetchEndMarker(taskId, i, ackedSeqbyDestination[i]);
+  }
+  EXPECT_TRUE(bufferManager_->isFinished(taskId));
+
+  EXPECT_FALSE(task->isRunning());
+  EXPECT_TRUE(bufferManager_->isFinished(taskId));
+  bufferManager_->removeTask(taskId);
+  EXPECT_TRUE(task->isFinished());
+}
+
+TEST_P(AllPartitionedOutputBufferManagerTest, maxBytes) {
+  const vector_size_t size = 100;
+  const std::string taskId = "t0";
+  initializeTask(taskId, rowType_, kind_, 1, 1);
+
+  enqueue(taskId, 0, rowType_, size);
+  enqueue(taskId, 0, rowType_, size);
+  enqueue(taskId, 0, rowType_, size);
+
+  // fetch up to 1Kb - 1 group
+  fetchOne(taskId, 0, 0);
+  // re-fetch with larger size limit - 2 groups
+  fetch(taskId, 0, 0, std::numeric_limits<int64_t>::max(), 3);
+  // re-fetch with 1Kb limit - 1 group
+  fetchOneAndAck(taskId, 0, 0);
+  fetchOneAndAck(taskId, 0, 1);
+  fetchOneAndAck(taskId, 0, 2);
+
+  if (kind_ != PartitionedOutputBuffer::Kind::kPartitioned) {
+    bufferManager_->updateOutputBuffers(taskId, 0, true);
+  }
+  noMoreData(taskId);
+  fetchEndMarker(taskId, 0, 3);
   bufferManager_->removeTask(taskId);
 }
 
 TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
-  std::vector<std::string> names = {"c0", "c1"};
-  std::vector<TypePtr> types = {BIGINT(), VARCHAR()};
-  auto rowType = ROW(std::move(names), std::move(types));
-  vector_size_t size = 100;
+  const vector_size_t size = 100;
+  const std::string taskId = "t0";
+  auto task = initializeTask(
+      taskId, rowType_, PartitionedOutputBuffer::Kind::kPartitioned, 5, 1);
 
-  std::string taskId = "t0";
-  auto task = initializeTask(taskId, rowType, 5, 1);
-
-  enqueue(taskId, 0, rowType, size);
+  enqueue(taskId, 0, rowType_, size);
   for (int i = 0; i < 10; i++) {
-    enqueue(taskId, 1, rowType, size);
+    enqueue(taskId, 1, rowType_, size);
   }
 
   // fetch first 3 groups
@@ -426,3 +960,97 @@ TEST_F(PartitionedOutputBufferManagerTest, updateBrodcastBufferOnFailedTask) {
       10,
       false));
 }
+
+TEST_P(AllPartitionedOutputBufferManagerTest, multiFetchers) {
+  const std::vector<bool> earlyTerminations = {false, true};
+  for (const auto earlyTermination : earlyTerminations) {
+    SCOPED_TRACE(fmt::format("earlyTermination {}", earlyTermination));
+
+    const vector_size_t size = 10;
+    const std::string taskId = "t0";
+    int numPartitions = 10;
+    int extendedNumPartitions = numPartitions / 2;
+    initializeTask(
+        taskId,
+        rowType_,
+        kind_,
+        numPartitions,
+        1,
+        kind_ == PartitionedOutputBuffer::Kind::kBroadcast ? 256 << 20 : 0);
+
+    std::vector<std::thread> threads;
+    std::vector<int64_t> fetchedPages(numPartitions + extendedNumPartitions, 0);
+    for (size_t i = 0; i < numPartitions; ++i) {
+      threads.emplace_back([&, i]() {
+        dataFetcher(taskId, i, fetchedPages.at(i), earlyTermination);
+      });
+    }
+    folly::Random::DefaultGenerator rng;
+    rng.seed(1234);
+    const int totalPages = 10'000;
+    std::vector<int64_t> producedPages(
+        numPartitions + extendedNumPartitions, 0);
+    for (int i = 0; i < totalPages; ++i) {
+      const int partition = kind_ == PartitionedOutputBuffer::Kind::kPartitioned
+          ? folly::Random().rand32(rng) % numPartitions
+          : 0;
+      try {
+        enqueue(taskId, partition, rowType_, size, true);
+      } catch (...) {
+        // Early termination might cause the task to fail early.
+        ASSERT_TRUE(earlyTermination);
+        break;
+      }
+      ++producedPages[partition];
+      if (folly::Random().oneIn(4)) {
+        std::this_thread::sleep_for(std::chrono::microseconds(5)); // NOLINT
+      }
+      if (i == 1000 && (kind_ != PartitionedOutputBuffer::Kind::kPartitioned)) {
+        bufferManager_->updateOutputBuffers(
+            taskId, numPartitions + extendedNumPartitions, false);
+        for (size_t i = numPartitions;
+             i < numPartitions + extendedNumPartitions;
+             ++i) {
+          threads.emplace_back([&, i]() {
+            dataFetcher(taskId, i, fetchedPages.at(i), earlyTermination);
+          });
+          fetchedPages[i] = 0;
+        }
+        bufferManager_->updateOutputBuffers(taskId, 0, true);
+      }
+    }
+    noMoreData(taskId);
+
+    for (int i = 0; i < threads.size(); ++i) {
+      threads[i].join();
+    }
+
+    if (!earlyTermination) {
+      if (kind_ == PartitionedOutputBuffer::Kind::kPartitioned) {
+        for (int i = 0; i < numPartitions; ++i) {
+          ASSERT_EQ(fetchedPages[i], producedPages[i]);
+        }
+      } else if (kind_ == PartitionedOutputBuffer::Kind::kBroadcast) {
+        int64_t totalFetchedPages{0};
+        for (const auto& pages : fetchedPages) {
+          totalFetchedPages += pages;
+        }
+        ASSERT_EQ(
+            totalPages * (numPartitions + extendedNumPartitions),
+            totalFetchedPages);
+      } else {
+        int64_t totalFetchedPages{0};
+        for (const auto& pages : fetchedPages) {
+          totalFetchedPages += pages;
+        }
+        ASSERT_EQ(totalPages, totalFetchedPages);
+      }
+    }
+    bufferManager_->removeTask(taskId);
+  }
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    AllPartitionedOutputBufferManagerTestSuite,
+    AllPartitionedOutputBufferManagerTest,
+    testing::ValuesIn(AllPartitionedOutputBufferManagerTest::getTestParams()));


### PR DESCRIPTION
Add arbitrary output buffer type to support scaled writer for presto batch.
The arbitrary output buffer enables to distribute produced data to any one
of the destinations which could be dynamically added during a query running.
The arbitrary output buffer guarantees each produced buffer to be delivered
to any one of the destination exactly once. It mainly works as follows:

An arbitrary output buffer contains a single arbitrary buffer object (introduced
in this pr) to receive and store the incoming data from enqueue() interface.
The incoming data has no destination, and the arbitrary buffer will dispatch them
to any destination buffer on demand:
(1) data enqueue path: first enqueue the new data into the single arbitrary buffer
which is shared among destinations. Then loop over all the destinations to see
if any destination has pending fetch to wait for data and dispatch the required
amount of data to the corresponding destination buffer in FIFO manner. The
destination buffer will handle the actual data transfer and acknowledge with
the data fetcher (the downstream stage task)
(2) data fetch path: first tries to load the required amount of data from the shared
arbitrary buffer given the max request bytes to the corresponding destination buffer
(here we assume most of time the data fetch is to request new data except some
transient network retries). Then it tries to fetch data from the destination buffer
and if there is no available data, then it sets notification to wake for the new incoming
data from data enqueue path (1).

This PR also improves the output buffer manager testing.