### PR TITLE
Decouple RowContainer and HashTable from Aggregate

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -239,17 +239,6 @@ TypePtr Aggregate::intermediateType(
   VELOX_USER_FAIL(error.str());
 }
 
-int32_t Aggregate::combineAlignmentInternal(int32_t otherAlignment) const {
-  auto thisAlignment = accumulatorAlignmentSize();
-  VELOX_CHECK_EQ(
-      __builtin_popcount(thisAlignment), 1, "Alignment can only be power of 2");
-  VELOX_CHECK_EQ(
-      __builtin_popcount(otherAlignment),
-      1,
-      "Alignment can only be power of 2");
-  return std::max(thisAlignment, otherAlignment);
-}
-
 void Aggregate::setAllocatorInternal(HashStringAllocator* allocator) {
   allocator_ = allocator;
 }

--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -54,12 +54,6 @@ class Aggregate {
     return 1;
   }
 
-  /// Return an alignment that satisfies both the accumulator alignment
-  /// requirement of this function and the alignment passed in.
-  int32_t combineAlignment(int32_t alignment) const {
-    return combineAlignmentInternal(alignment);
-  }
-
   // Return true if accumulator is allocated from external memory, e.g. memory
   // not managed by Velox.
   virtual bool accumulatorUsesExternalMemory() const {
@@ -246,11 +240,6 @@ class Aggregate {
       const std::vector<TypePtr>& argTypes);
 
  protected:
-  // The following internal function should not be overriden by any user-defined
-  // aggregation function. They shall only be overridden by
-  // AggregateCompanionAdapter.
-  virtual int32_t combineAlignmentInternal(int32_t otherAlignment) const;
-
   virtual void setAllocatorInternal(HashStringAllocator* allocator);
 
   virtual void setOffsetsInternal(

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -39,11 +39,6 @@ int32_t AggregateCompanionFunctionBase::accumulatorAlignmentSize() const {
   return fn_->accumulatorAlignmentSize();
 }
 
-int32_t AggregateCompanionFunctionBase::combineAlignmentInternal(
-    int32_t otherAlignment) const {
-  return fn_->combineAlignment(otherAlignment);
-}
-
 bool AggregateCompanionFunctionBase::accumulatorUsesExternalMemory() const {
   return fn_->accumulatorUsesExternalMemory();
 }

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -76,8 +76,6 @@ class AggregateCompanionFunctionBase : public Aggregate {
       uint8_t nullMask,
       int32_t rowSizeOffset) override final;
 
-  int32_t combineAlignmentInternal(int32_t otherAlignment) const override final;
-
   void setAllocatorInternal(HashStringAllocator* allocator) override final;
 
   void clearInternal() override final;

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -49,7 +49,7 @@ std::string BaseHashTable::modeString(HashMode mode) {
 template <bool ignoreNullKeys>
 HashTable<ignoreNullKeys>::HashTable(
     std::vector<std::unique_ptr<VectorHasher>>&& hashers,
-    const std::vector<std::unique_ptr<Aggregate>>& aggregates,
+    const std::vector<Accumulator>& accumulators,
     const std::vector<TypePtr>& dependentTypes,
     bool allowDuplicates,
     bool isJoinBuild,
@@ -63,10 +63,11 @@ HashTable<ignoreNullKeys>::HashTable(
       hashMode_ = HashMode::kHash;
     }
   }
+
   rows_ = std::make_unique<RowContainer>(
       keys,
       !ignoreNullKeys,
-      aggregates,
+      accumulators,
       dependentTypes,
       allowDuplicates,
       isJoinBuild,

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -16,7 +16,6 @@
 #pragma once
 
 #include "velox/common/memory/MemoryAllocator.h"
-#include "velox/exec/Aggregate.h"
 #include "velox/exec/Operator.h"
 #include "velox/exec/RowContainer.h"
 #include "velox/exec/VectorHasher.h"
@@ -326,7 +325,7 @@ class HashTable : public BaseHashTable {
   // that matches join condition for right and full outer joins.
   HashTable(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
-      const std::vector<std::unique_ptr<Aggregate>>& aggregates,
+      const std::vector<Accumulator>& accumulators,
       const std::vector<TypePtr>& dependentTypes,
       bool allowDuplicates,
       bool isJoinBuild,
@@ -335,11 +334,11 @@ class HashTable : public BaseHashTable {
 
   static std::unique_ptr<HashTable> createForAggregation(
       std::vector<std::unique_ptr<VectorHasher>>&& hashers,
-      const std::vector<std::unique_ptr<Aggregate>>& aggregates,
+      const std::vector<Accumulator>& accumulators,
       memory::MemoryPool* FOLLY_NULLABLE pool) {
     return std::make_unique<HashTable>(
         std::move(hashers),
-        aggregates,
+        accumulators,
         std::vector<TypePtr>{},
         false, // allowDuplicates
         false, // isJoinBuild
@@ -353,10 +352,9 @@ class HashTable : public BaseHashTable {
       bool allowDuplicates,
       bool hasProbedFlag,
       memory::MemoryPool* FOLLY_NULLABLE pool) {
-    static const std::vector<std::unique_ptr<Aggregate>> kNoAggregates;
     return std::make_unique<HashTable>(
         std::move(hashers),
-        kNoAggregates,
+        std::vector<Accumulator>{},
         dependentTypes,
         allowDuplicates,
         true, // isJoinBuild

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/exec/RowNumber.h"
-#include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::exec {
 
@@ -36,7 +35,7 @@ RowNumber::RowNumber(
   if (numKeys > 0) {
     table_ = std::make_unique<HashTable<false>>(
         createVectorHashers(inputType, keys),
-        std::vector<std::unique_ptr<Aggregate>>{},
+        std::vector<Accumulator>{},
         std::vector<TypePtr>{BIGINT()},
         false, // allowDuplicates
         false, // isJoinBuild

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -18,6 +18,7 @@
 #include <folly/ScopeGuard.h>
 #include "velox/common/base/AsyncSource.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/exec/Aggregate.h"
 
 using facebook::velox::common::testutil::TestValue;
 
@@ -132,10 +133,12 @@ void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
   for (auto i = 0; i < types.size(); ++i) {
     container_->extractColumn(rows.data(), rows.size(), i, result->childAt(i));
   }
-  auto& aggregates = container_->aggregates();
+
+  auto& accumulators = container_->accumulators();
+
   auto numKeys = types.size();
-  for (auto i = 0; i < aggregates.size(); ++i) {
-    aggregates[i]->extractAccumulators(
+  for (auto i = 0; i < accumulators.size(); ++i) {
+    accumulators[i].aggregateForSpill()->extractAccumulators(
         rows.data(), rows.size(), &result->childAt(i + numKeys));
   }
 }

--- a/velox/exec/StreamingAggregation.h
+++ b/velox/exec/StreamingAggregation.h
@@ -15,12 +15,12 @@
  */
 #pragma once
 
+#include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregationMasks.h"
 #include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {
 
-class Aggregate;
 class RowContainer;
 
 class StreamingAggregation : public Operator {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -329,11 +329,10 @@ class AggregationTest : public OperatorTestBase {
   std::unique_ptr<RowContainer> makeRowContainer(
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes) {
-    static const std::vector<std::unique_ptr<Aggregate>> kEmptyAggregates;
     return std::make_unique<RowContainer>(
         keyTypes,
         false,
-        kEmptyAggregates,
+        std::vector<Accumulator>{},
         dependentTypes,
         false,
         false,

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -57,11 +57,10 @@ class RowContainerTestBase : public testing::Test,
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes,
       bool isJoinBuild = true) {
-    static const std::vector<std::unique_ptr<Aggregate>> kEmptyAggregates;
     return std::make_unique<RowContainer>(
         keyTypes,
         !isJoinBuild,
-        kEmptyAggregates,
+        std::vector<Accumulator>{},
         dependentTypes,
         isJoinBuild,
         isJoinBuild,


### PR DESCRIPTION
Tight coupling of RowContainer and HashTable to executable aggregate function
makes it difficult to use these data structures in window operators (Window and
TopNRowNumber). The only information RowContainer needs from an aggregate
function is metadata about how much memory is needed for the accumulator and
whether it has any specific alignment requirements. In addition, RowContainer
needs a way to call aggregate function to release out-of-line memory
allocations.

This change introduces an Accumulator class that specifies memory requirements
of an aggregate function and provides a 'destroy' method to release out-of-line
memory. RowContainer and HashTable are modified to use Accumulator instead 
of Aggregate.

A slight wrinkle is that Spiller needs access to executable aggregations to
spill intermediate results. It calls Aggregate::extractAccumulators to convert
results into vectors so these can be serialized to disk. To accommodate this
use case, Accumulator class provides access to Aggregate instance. In the
future, we could generalize this interface to allow for spilling non-Aggregate
accumulators as well (e.g. window states).