### PR TITLE
Make 'function not registered' a user error

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -435,12 +435,12 @@ ExprPtr compileExpression(
       }
 
       if (signatures.empty()) {
-        VELOX_FAIL(
+        VELOX_USER_FAIL(
             "Scalar function name not registered: {}, called with arguments: ({}).",
             call->name(),
             folly::join(", ", inputTypes));
       } else {
-        VELOX_FAIL(
+        VELOX_USER_FAIL(
             "Scalar function {} not registered with arguments: ({}). "
             "Found function registered with the following signatures:\n{}",
             call->name(),


### PR DESCRIPTION
Summary:
Missing features should be reported as user errors, not system errors.

```
VeloxRuntimeError:  Scalar function name not registered: presto.default.at_timezone
```

After this change, the message about would use VeloxUserError.

Differential Revision: D46391342

