### PR TITLE
Refactor Operator::fillOutput

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -177,7 +177,9 @@ static bool isSequence(
   return true;
 }
 
-RowVectorPtr Operator::fillOutput(vector_size_t size, BufferPtr mapping) {
+RowVectorPtr Operator::fillOutput(
+    vector_size_t size,
+    const BufferPtr& mapping) {
   bool wrapResults = true;
   if (size == input_->size() &&
       (!mapping || isSequence(mapping->as<vector_size_t>(), 0, size))) {
@@ -187,27 +189,26 @@ RowVectorPtr Operator::fillOutput(vector_size_t size, BufferPtr mapping) {
     wrapResults = false;
   }
 
-  std::vector<VectorPtr> columns(outputType_->size());
-  if (!identityProjections_.empty()) {
-    auto input = input_->children();
-    for (auto& projection : identityProjections_) {
-      columns[projection.outputChannel] = wrapResults
-          ? wrapChild(size, mapping, input[projection.inputChannel])
-          : input[projection.inputChannel];
-    }
-  }
-  for (auto& projection : resultProjections_) {
-    columns[projection.outputChannel] = wrapResults
-        ? wrapChild(size, mapping, results_[projection.inputChannel])
-        : results_[projection.inputChannel];
-  }
-
-  return std::make_shared<RowVector>(
+  auto output{std::make_shared<RowVector>(
       operatorCtx_->pool(),
       outputType_,
-      BufferPtr(nullptr),
+      nullptr,
       size,
-      std::move(columns));
+      std::vector<VectorPtr>(outputType_->size(), nullptr))};
+  output->resize(size);
+  projectChildren(
+      output,
+      input_,
+      identityProjections_,
+      size,
+      wrapResults ? mapping : nullptr);
+  projectChildren(
+      output,
+      results_,
+      resultProjections_,
+      size,
+      wrapResults ? mapping : nullptr);
+  return output;
 }
 
 OperatorStats Operator::stats(bool clear) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -555,7 +555,7 @@ class Operator : public BaseRuntimeStatWriter {
 
   /// Creates output vector from 'input_' and 'results_' according to
   /// 'identityProjections_' and 'resultProjections_'.
-  RowVectorPtr fillOutput(vector_size_t size, BufferPtr mapping);
+  RowVectorPtr fillOutput(vector_size_t size, const BufferPtr& mapping);
 
   /// Returns the number of rows for the output batch. This uses averageRowSize
   /// to calculate how many rows fit in preferredOutputBatchBytes. It caps the

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -554,7 +554,11 @@ class Operator : public BaseRuntimeStatWriter {
   }
 
   /// Creates output vector from 'input_' and 'results_' according to
-  /// 'identityProjections_' and 'resultProjections_'.
+  /// 'identityProjections_' and 'resultProjections_'. If 'mapping' is set to
+  /// nullptr, the children of the output vector will be identical to their
+  /// respective sources from 'input_' or 'results_'. However, if 'mapping' is
+  /// provided, the children of the output vector will be generated as
+  /// dictionary of the sources using the specified 'mapping'.
   RowVectorPtr fillOutput(vector_size_t size, const BufferPtr& mapping);
 
   /// Returns the number of rows for the output batch. This uses averageRowSize

--- a/velox/exec/OperatorUtils.cpp
+++ b/velox/exec/OperatorUtils.cpp
@@ -402,9 +402,18 @@ void projectChildren(
     const std::vector<IdentityProjection>& projections,
     int32_t size,
     const BufferPtr& mapping) {
+  projectChildren(dest, src->children(), projections, size, mapping);
+}
+
+void projectChildren(
+    const RowVectorPtr& dest,
+    const std::vector<VectorPtr>& src,
+    const std::vector<IdentityProjection>& projections,
+    int32_t size,
+    const BufferPtr& mapping) {
   for (const auto& projection : projections) {
     dest->childAt(projection.outputChannel) =
-        wrapChild(size, mapping, src->childAt(projection.inputChannel));
+        wrapChild(size, mapping, src[projection.inputChannel]);
   }
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -146,4 +146,13 @@ void projectChildren(
     int32_t size,
     const BufferPtr& mapping);
 
+/// Overload of the above function that takes reference to const vector of
+/// VectorPtr as 'src' argument, instead of row vector.
+void projectChildren(
+    const RowVectorPtr& dest,
+    const std::vector<VectorPtr>& src,
+    const std::vector<IdentityProjection>& projections,
+    int32_t size,
+    const BufferPtr& mapping);
+
 } // namespace facebook::velox::exec


### PR DESCRIPTION
1. Update `fillOutput` to make use of `projectChildren`.
2. `fillOutput` takes `mapping` by reference to `const BufferPtr`, instead of by value.
3. Add an overload to `projectChildren` that takes 'src' as `const vector<VectorPtr>&`.