### PR TITLE
Allow case insensitive units in date_diff Presto function

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -540,28 +540,30 @@ inline std::optional<DateTimeUnit> fromDateTimeUnitString(
   static const StringView kQuarter("quarter");
   static const StringView kYear("year");
 
-  if (unitString == kMillisecond) {
+  const auto unit = boost::algorithm::to_lower_copy(unitString.str());
+
+  if (unit == kMillisecond) {
     return DateTimeUnit::kMillisecond;
   }
-  if (unitString == kSecond) {
+  if (unit == kSecond) {
     return DateTimeUnit::kSecond;
   }
-  if (unitString == kMinute) {
+  if (unit == kMinute) {
     return DateTimeUnit::kMinute;
   }
-  if (unitString == kHour) {
+  if (unit == kHour) {
     return DateTimeUnit::kHour;
   }
-  if (unitString == kDay) {
+  if (unit == kDay) {
     return DateTimeUnit::kDay;
   }
-  if (unitString == kMonth) {
+  if (unit == kMonth) {
     return DateTimeUnit::kMonth;
   }
-  if (unitString == kQuarter) {
+  if (unit == kQuarter) {
     return DateTimeUnit::kQuarter;
   }
-  if (unitString == kYear) {
+  if (unit == kYear) {
     return DateTimeUnit::kYear;
   }
   // TODO Add support for "week".

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -1833,11 +1833,18 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
   EXPECT_EQ(std::nullopt, dateDiff("month", std::nullopt, Date(0)));
 
   // Check invalid units
-  EXPECT_THROW(dateDiff("millisecond", Date(1), Date(0)), VeloxUserError);
-  EXPECT_THROW(dateDiff("second", Date(1), Date(0)), VeloxUserError);
-  EXPECT_THROW(dateDiff("minute", Date(1), Date(0)), VeloxUserError);
-  EXPECT_THROW(dateDiff("hour", Date(1), Date(0)), VeloxUserError);
-  EXPECT_THROW(dateDiff("invalid_unit", Date(1), Date(0)), VeloxUserError);
+  VELOX_ASSERT_THROW(
+      dateDiff("millisecond", Date(1), Date(0)),
+      "millisecond is not a valid DATE field");
+  VELOX_ASSERT_THROW(
+      dateDiff("second", Date(1), Date(0)), "second is not a valid DATE field");
+  VELOX_ASSERT_THROW(
+      dateDiff("minute", Date(1), Date(0)), "minute is not a valid DATE field");
+  VELOX_ASSERT_THROW(
+      dateDiff("hour", Date(1), Date(0)), "hour is not a valid DATE field");
+  VELOX_ASSERT_THROW(
+      dateDiff("invalid_unit", Date(1), Date(0)),
+      "Unsupported datetime unit: invalid_unit");
 
   // Simple tests
   EXPECT_EQ(
@@ -1848,6 +1855,14 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
       4, dateDiff("quarter", parseDate("2019-02-28"), parseDate("2020-02-28")));
   EXPECT_EQ(
       1, dateDiff("year", parseDate("2019-02-28"), parseDate("2020-02-28")));
+
+  // Verify that units are not case sensitive.
+  EXPECT_EQ(
+      1, dateDiff("DAY", parseDate("2019-02-28"), parseDate("2019-03-01")));
+  EXPECT_EQ(
+      1, dateDiff("dAY", parseDate("2019-02-28"), parseDate("2019-03-01")));
+  EXPECT_EQ(
+      1, dateDiff("Day", parseDate("2019-02-28"), parseDate("2019-03-01")));
 
   // Account for the last day of a year-month
   EXPECT_EQ(


### PR DESCRIPTION
Presto allow case insensitive units.

Fixes errors like `Unsupported datetime unit: DAY`.