### PR TITLE
Bump benchalerts version for benchmark alerting

### DIFF
--- a/scripts/benchmark-requirements.txt
+++ b/scripts/benchmark-requirements.txt
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-benchadapt@git+https://github.com/conbench/conbench.git@16d0243#subdirectory=benchadapt/python
-benchalerts@git+https://github.com/conbench/conbench.git@16d0243#subdirectory=benchalerts
-benchclients@git+https://github.com/conbench/conbench.git@16d0243#subdirectory=benchclients/python
+benchadapt@git+https://github.com/conbench/conbench.git@86b8b12#subdirectory=benchadapt/python
+benchalerts@git+https://github.com/conbench/conbench.git@86b8b12#subdirectory=benchalerts
+benchclients@git+https://github.com/conbench/conbench.git@86b8b12#subdirectory=benchclients/python


### PR DESCRIPTION
This PR bumps the dependency version of `benchalerts`, the library that will alert on Conbench benchmark results. It updates the usage of that library to comply with the new API.