### PR TITLE
Fix subfields that only exists in remaining filter (#5132)

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -191,6 +191,7 @@ class HiveDataSource : public DataSource {
       const SubfieldFilters& filters,
       const RowTypePtr& rowType,
       const std::vector<const HiveColumnHandle*>& columnHandles,
+      const std::vector<common::Subfield>& remainingFilterInputs,
       memory::MemoryPool* pool);
 
  protected:

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -65,7 +65,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_multilevel) {
   auto columnHandle =
       makeColumnHandle("c0", columnType, {"c0.c0c1[3][\"foo\"].c0c1c0"});
   auto scanSpec = HiveDataSource::makeScanSpec(
-      {}, rowType, {columnHandle.get()}, pool_.get());
+      {}, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0c0 = scanSpec->childByName("c0")->childByName("c0c0");
   validateNullConstant(*c0c0, *BIGINT());
   auto* c0c1 = scanSpec->childByName("c0")->childByName("c0c1");
@@ -98,7 +98,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeFields) {
       columnType,
       {"c0.c0c0.c0c0c0", "c0.c0c0.c0c0c2", "c0.c0c1", "c0.c0c1.c0c1c0"});
   auto scanSpec = HiveDataSource::makeScanSpec(
-      {}, rowType, {columnHandle.get()}, pool_.get());
+      {}, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0c0 = scanSpec->childByName("c0")->childByName("c0c0");
   ASSERT_FALSE(c0c0->childByName("c0c0c0")->isConstant());
   ASSERT_FALSE(c0c0->childByName("c0c0c2")->isConstant());
@@ -117,7 +117,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeArray) {
   auto columnHandle =
       makeColumnHandle("c0", columnType, {"c0[1].c0c0", "c0[2].c0c2"});
   auto scanSpec = HiveDataSource::makeScanSpec(
-      {}, rowType, {columnHandle.get()}, pool_.get());
+      {}, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0 = scanSpec->childByName("c0");
   ASSERT_EQ(c0->maxArrayElementsCount(), 2);
   auto* elements = c0->childByName(ScanSpec::kArrayElementsFieldName);
@@ -134,7 +134,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_mergeMap) {
   auto columnHandle =
       makeColumnHandle("c0", columnType, {"c0[10].c0c0", "c0[20].c0c2"});
   auto scanSpec = HiveDataSource::makeScanSpec(
-      {}, rowType, {columnHandle.get()}, pool_.get());
+      {}, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0 = scanSpec->childByName("c0");
   auto* keysFilter = c0->childByName(ScanSpec::kMapKeysFieldName)->filter();
   ASSERT_TRUE(keysFilter);
@@ -155,7 +155,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
     SCOPED_TRACE(path);
     auto columnHandle = makeColumnHandle("c0", columnType, {path});
     auto scanSpec = HiveDataSource::makeScanSpec(
-        {}, rowType, {columnHandle.get()}, pool_.get());
+        {}, rowType, {columnHandle.get()}, {}, pool_.get());
     auto* c0 = scanSpec->childByName("c0");
     ASSERT_FALSE(c0->childByName(ScanSpec::kMapKeysFieldName)->filter());
     auto* values = c0->childByName(ScanSpec::kMapValuesFieldName);
@@ -169,7 +169,7 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
   }
   auto columnHandle = makeColumnHandle("c0", columnType, {"c0[*][*].c0c0"});
   auto scanSpec = HiveDataSource::makeScanSpec(
-      {}, rowType, {columnHandle.get()}, pool_.get());
+      {}, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0 = scanSpec->childByName("c0");
   ASSERT_FALSE(c0->childByName(ScanSpec::kMapKeysFieldName)->filter());
   auto* values = c0->childByName(ScanSpec::kMapValuesFieldName);

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -388,6 +388,9 @@ std::string ScanSpec::toString() const {
     if (filter_) {
       out << " filter " << filter_->toString();
     }
+    if (isConstant()) {
+      out << " constant";
+    }
   }
   if (!children_.empty()) {
     out << " (";

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -128,7 +128,7 @@ void SelectiveStructColumnReaderBase::read(
     activeRows = outputRows_;
   }
 
-  assert(!children_.empty());
+  VELOX_CHECK(!children_.empty());
   auto& childSpecs = scanSpec_->children();
   for (size_t i = 0; i < childSpecs.size(); ++i) {
     auto& childSpec = childSpecs[i];
@@ -221,7 +221,7 @@ void fillRowVectorChildren(
 void SelectiveStructColumnReaderBase::getValues(
     RowSet rows,
     VectorPtr* result) {
-  assert(!children_.empty());
+  VELOX_CHECK(!children_.empty());
   VELOX_CHECK(
       *result != nullptr,
       "SelectiveStructColumnReaderBase expects a non-null result");


### PR DESCRIPTION
Summary:
When some fields or subfields appear only in remaining filter (i.e. not in output type or domain tuple), the Presto planner does not add these to either column handles or the corresponding required subfields.  In these cases we need to extract these fields in Velox and add them to `ScanSpec` properly.

We add all subfields recursively in such cases for now.  Future optimization could look at remaining filter and includes only those subfields really needed.


Reviewed By: pranjalssh

Differential Revision: D46399338

