### PR TITLE
Reduce window tests timing

### DIFF
--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -107,8 +107,11 @@ void WindowTestBase::testWindowFunction(
     const std::vector<RowVectorPtr>& input,
     const std::string& function,
     const std::vector<std::string>& overClauses,
-    const std::vector<std::string>& frameClauses) {
-  createDuckDbTable(input);
+    const std::vector<std::string>& frameClauses,
+    bool createTable) {
+  if (createTable) {
+    createDuckDbTable(input);
+  }
   for (const auto& overClause : overClauses) {
     for (auto& frameClause : frameClauses) {
       auto queryInfo =

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -32,26 +32,20 @@ inline const std::vector<std::string> kOverClauses = {
     "partition by c0 order by c1 desc, c2, c3",
     "partition by c1 order by c0, c2 desc, c3",
     "partition by c0 order by c2, c1, c3",
-    "partition by c1 order by c2, c0 desc, c3",
 
     // Order by with asc/desc and nulls first/last.
     "partition by c0 order by c1 nulls first, c2, c3",
     "partition by c0, c2 order by c1 nulls first, c3",
-    "partition by c1 order by c0 nulls first, c2, c3",
-    "partition by c1, c2 order by c0 nulls first, c3",
     "partition by c0 order by c1 desc nulls first, c2, c3",
     "partition by c0, c2 order by c1 desc nulls first, c3",
-    "partition by c1 order by c0 desc nulls first, c2, c3",
-    "partition by c1, c2 order by c0 desc nulls first, c3",
 
     // No partition by clause.
     "order by c0 asc nulls first, c1 desc, c2, c3",
     "order by c1 asc, c0 desc nulls last, c2 desc, c3",
     "order by c0 asc, c2 desc, c1 asc nulls last, c3",
     "order by c2 asc, c1 desc nulls first, c0, c3",
+
     "order by c0 asc nulls first, c1 desc nulls first, c2, c3",
-    "order by c1 asc nulls first, c0 desc nulls first, c2, c3",
-    "order by c0 desc nulls first, c1 asc nulls first, c2, c3",
     "order by c1 desc nulls first, c0 asc nulls first, c2, c3",
 
     // No order by clause.
@@ -76,19 +70,12 @@ inline const std::vector<std::string> kFrameClauses = {
 
     // Frame clauses in ROWS mode with k preceding and k following frame bounds,
     // where k is a constant integer.
-    "rows between 1 preceding and current row",
     "rows between 5 preceding and current row",
-    "rows between 1 preceding and unbounded following",
     "rows between 5 preceding and unbounded following",
-
-    "rows between current row and 1 following",
     "rows between current row and 5 following",
-    "rows between unbounded preceding and 1 following",
     "rows between unbounded preceding and 5 following",
 
     "rows between 1 preceding and 5 following",
-    "rows between 5 preceding and 1 following",
-    "rows between 1 preceding and 1 following",
     "rows between 5 preceding and 5 following",
 
     // Frame clauses in ROWS mode with k preceding and k following frame bounds,
@@ -104,9 +91,7 @@ inline const std::vector<std::string> kFrameClauses = {
     // Frame clauses with invalid frames.
     "rows between unbounded preceding and 1 preceding",
     "rows between 1 preceding and 4 preceding",
-    "rows between 4 preceding and 1 preceding",
     "rows between 1 following and unbounded following",
-    "rows between 1 following and 4 following",
     "rows between 4 following and 1 following",
     "rows between c2 preceding and c3 preceding",
     "rows between c2 following and c3 following",
@@ -165,7 +150,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const std::vector<RowVectorPtr>& input,
       const std::string& function,
       const std::vector<std::string>& overClauses,
-      const std::vector<std::string>& frameClauses = {""});
+      const std::vector<std::string>& frameClauses = {""},
+      bool createTable = true);
 
   /// This function tests the SQL query for the window function and overClause
   /// combination with the input RowVectors. It is expected that query execution

--- a/velox/functions/prestosql/window/tests/NthValueTest.cpp
+++ b/velox/functions/prestosql/window/tests/NthValueTest.cpp
@@ -55,22 +55,22 @@ class NthValueTest : public WindowTestBase {
     // This function invocation gets the column value of the 10th
     // frame row. Many tests have < 10 rows per partition. so the function
     // is expected to return null for such offsets.
-    testWindowFunction(input, "nth_value(c0, 10)");
+    testWindowFunction(input, "nth_value(c0, 10)", false);
 
     // This test gets the nth_value offset from a column c2. The offsets could
     // be outside the partition also. The error cases for -ve offset values
     // are tested separately.
-    testWindowFunction(input, "nth_value(c3, c2)");
+    testWindowFunction(input, "nth_value(c3, c2)", false);
 
     // The first_value, last_value functions are tested for columns c0, c1, and
     // c2, which contain data with different distributions.
-    testWindowFunction(input, "first_value(c0)");
-    testWindowFunction(input, "first_value(c1)");
-    testWindowFunction(input, "first_value(c2)");
+    testWindowFunction(input, "first_value(c0)", false);
+    testWindowFunction(input, "first_value(c1)", false);
+    testWindowFunction(input, "first_value(c2)", false);
 
-    testWindowFunction(input, "last_value(c0)");
-    testWindowFunction(input, "last_value(c1)");
-    testWindowFunction(input, "last_value(c2)");
+    testWindowFunction(input, "last_value(c0)", false);
+    testWindowFunction(input, "last_value(c1)", false);
+    testWindowFunction(input, "last_value(c2)", false);
   }
 
   // This is for testing different output column types in the
@@ -96,22 +96,23 @@ class NthValueTest : public WindowTestBase {
     WindowTestBase::testWindowFunction(
         {vectors}, "nth_value(c4, 1)", {newOverClause}, kFrameClauses);
     WindowTestBase::testWindowFunction(
-        {vectors}, "nth_value(c4, 7)", {newOverClause}, kFrameClauses);
+        {vectors}, "nth_value(c4, 7)", {newOverClause}, kFrameClauses, false);
     WindowTestBase::testWindowFunction(
-        {vectors}, "nth_value(c4, c2)", {newOverClause}, kFrameClauses);
+        {vectors}, "nth_value(c4, c2)", {newOverClause}, kFrameClauses, false);
 
     WindowTestBase::testWindowFunction(
-        {vectors}, "first_value(c4)", {newOverClause}, kFrameClauses);
+        {vectors}, "first_value(c4)", {newOverClause}, kFrameClauses, false);
     WindowTestBase::testWindowFunction(
-        {vectors}, "last_value(c4)", {newOverClause}, kFrameClauses);
+        {vectors}, "last_value(c4)", {newOverClause}, kFrameClauses, false);
   }
 
  private:
   void testWindowFunction(
       const std::vector<RowVectorPtr>& input,
-      const std::string& function) {
+      const std::string& function,
+      bool createDuckDBTable = true) {
     WindowTestBase::testWindowFunction(
-        input, function, {overClause_}, kFrameClauses);
+        input, function, {overClause_}, kFrameClauses, createDuckDBTable);
   }
 
   const std::string overClause_;
@@ -124,24 +125,20 @@ class MultiNthValueTest : public NthValueTest,
 };
 
 TEST_P(MultiNthValueTest, basic) {
-  testValueFunctions({makeSimpleVector(50)});
+  testValueFunctions({makeSimpleVector(40)});
 }
 
 TEST_P(MultiNthValueTest, singlePartition) {
-  testValueFunctions({makeSinglePartitionVector(50)});
-}
-
-TEST_P(MultiNthValueTest, multiInput) {
   testValueFunctions(
-      {makeSinglePartitionVector(50), makeSinglePartitionVector(75)});
+      {makeSinglePartitionVector(40), makeSinglePartitionVector(50)});
 }
 
 TEST_P(MultiNthValueTest, singleRowPartitions) {
-  testValueFunctions({makeSingleRowPartitionsVector((50))});
+  testValueFunctions({makeSingleRowPartitionsVector((30))});
 }
 
 TEST_P(MultiNthValueTest, randomInput) {
-  testValueFunctions({makeRandomInputVector((50))});
+  testValueFunctions({makeRandomInputVector((25))});
 }
 
 TEST_P(MultiNthValueTest, integerValues) {

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -25,11 +25,11 @@ namespace {
 class NtileTest : public WindowTestBase {
  protected:
   void testNtile(const std::vector<RowVectorPtr>& vectors) {
-    // Tests ntile with constant value arguments.
-    testNtileWithConstants(vectors, kOverClauses);
     // Tests ntile with a column.
     WindowTestBase::testWindowFunction(
         vectors, "ntile(c2)", kOverClauses, kFrameClauses);
+    // Tests ntile with constant value arguments.
+    testNtileWithConstants(vectors, kOverClauses);
   }
 
   void SetUp() override {
@@ -38,6 +38,8 @@ class NtileTest : public WindowTestBase {
   }
 
  private:
+  // Note: This function assumes that the DuckDB table has been previously
+  // constructed from the data.
   void testNtileWithConstants(
       const std::vector<RowVectorPtr>& vectors,
       const std::vector<std::string>& overClauses) {
@@ -51,9 +53,11 @@ class NtileTest : public WindowTestBase {
         "ntile(10)",
         "ntile(16)",
     };
+
+    // Note: The DuckDB table has been previously created.
     for (auto function : kNtileInvocations) {
       WindowTestBase::testWindowFunction(
-          vectors, function, overClauses, kFrameClauses);
+          vectors, function, overClauses, kFrameClauses, false);
     }
   }
 };
@@ -63,14 +67,9 @@ TEST_F(NtileTest, basic) {
   testNtile({makeSimpleVector(30)});
 }
 
-// Tests ntile with a dataset with all rows in a single partition.
-TEST_F(NtileTest, singlePartition) {
-  testNtile({makeSinglePartitionVector(25)});
-}
-
 // Test ntile with a dataset with all rows in a single partition but in
 // 2 input vectors.
-TEST_F(NtileTest, multiInput) {
+TEST_F(NtileTest, singlePartition) {
   testNtile({makeSinglePartitionVector(25), makeSinglePartitionVector(30)});
 }
 

--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -78,29 +78,24 @@ class RankTest : public RankTestBase,
 
 // Tests all functions with a dataset with uniform distribution of partitions.
 TEST_P(RankTest, basic) {
-  testWindowFunction({makeSimpleVector(50)});
-}
-
-// Tests all functions with a dataset with all rows in a single partition.
-TEST_P(RankTest, singlePartition) {
-  testWindowFunction({makeSinglePartitionVector(50)});
+  testWindowFunction({makeSimpleVector(40)});
 }
 
 // Tests all functions with a dataset with all rows in a single partition,
 // but in 2 input vectors.
-TEST_P(RankTest, multiInput) {
+TEST_P(RankTest, singlePartition) {
   testWindowFunction(
-      {makeSinglePartitionVector(50), makeSinglePartitionVector(75)});
+      {makeSinglePartitionVector(40), makeSinglePartitionVector(50)});
 }
 
 // Tests all functions with a dataset in which all partitions have a single row.
 TEST_P(RankTest, singleRowPartitions) {
-  testWindowFunction({makeSingleRowPartitionsVector(50)});
+  testWindowFunction({makeSingleRowPartitionsVector(40)});
 }
 
 // Tests all functions with a dataset with randomly generated data.
 TEST_P(RankTest, randomInput) {
-  testWindowFunction({makeRandomInputVector(20), makeRandomInputVector(30)});
+  testWindowFunction({makeRandomInputVector(30)});
 }
 
 // Run above tests for all combinations of rank function and over clauses.

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -82,27 +82,21 @@ TEST_P(SimpleAggregatesTest, basic) {
   testWindowFunction({makeSimpleVector(10)});
 }
 
-// Tests function with a dataset with a single partition containing all the
-// rows.
-TEST_P(SimpleAggregatesTest, singlePartition) {
-  testWindowFunction({makeSinglePartitionVector(100)});
-}
-
 // Tests function with a dataset with a single partition but 2 input row
 // vectors.
-TEST_P(SimpleAggregatesTest, multiInput) {
+TEST_P(SimpleAggregatesTest, singlePartition) {
   testWindowFunction(
-      {makeSinglePartitionVector(250), makeSinglePartitionVector(50)});
+      {makeSinglePartitionVector(50), makeSinglePartitionVector(40)});
 }
 
 // Tests function with a dataset where all partitions have a single row.
 TEST_P(SimpleAggregatesTest, singleRowPartitions) {
-  testWindowFunction({makeSingleRowPartitionsVector(50)});
+  testWindowFunction({makeSingleRowPartitionsVector(40)});
 }
 
 // Tests function with a randomly generated input dataset.
 TEST_P(SimpleAggregatesTest, randomInput) {
-  testWindowFunction({makeRandomInputVector(50)});
+  testWindowFunction({makeRandomInputVector(25)});
 }
 
 // Instantiate all the above tests for each combination of aggregate function


### PR DESCRIPTION
This changes reduces the runtime on my laptop to almost 1/2 of current time.
i) Remove some redundant partition clauses and frame clauses.
ii) Optimize duckdb table creation for multiple function calls using the same data.
iii) Remove singlePartition test variation which was also tested in multiInput.
iv) Reduce data sizes