### PR TITLE
Differentiate taskCompletionFuture and stateChangeFuture.

### DIFF
--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -103,7 +103,7 @@ class TpchSpeedTest {
 
     // Wait for the task to finish.
     auto& inlineExecutor = folly::QueuedImmediateExecutor::instance();
-    task->stateChangeFuture(0).via(&inlineExecutor).wait();
+    task->taskCompletionFuture(0).via(&inlineExecutor).wait();
 
     std::chrono::duration<double> elapsed = system_clock::now() - startTime;
     LOG(INFO) << "Summary:";

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -39,6 +39,49 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::exec {
 
 namespace {
+// RAII helper class to satisfy given promises and notify listeners of an event
+// connected to the promises outside of the mutex that guards the promises.
+// Inactive on creation. Must be activated explicitly by calling 'activate'.
+class EventCompletionNotifier {
+ public:
+  /// Calls notify() if it hasn't been called yet.
+  ~EventCompletionNotifier() {
+    notify();
+  }
+
+  // Activates the notifier and provides a callback to invoke and promises to
+  // satisfy on destruction or a call to 'notify'.
+  void activate(
+      std::vector<ContinuePromise> promises,
+      std::function<void()> callback = nullptr) {
+    active_ = true;
+    callback_ = callback;
+    promises_ = std::move(promises);
+  }
+
+  // Satisfies the promises passed to 'activate' and invokes the callback.
+  // Does nothing if 'activate' hasn't been called or 'notify' has been
+  // called already.
+  void notify() {
+    if (active_) {
+      for (auto& promise : promises_) {
+        promise.setValue();
+      }
+      promises_.clear();
+
+      if (callback_) {
+        callback_();
+      }
+
+      active_ = false;
+    }
+  }
+
+ private:
+  bool active_{false};
+  std::function<void()> callback_{nullptr};
+  std::vector<ContinuePromise> promises_;
+};
 
 folly::Synchronized<std::vector<std::shared_ptr<TaskListener>>>& listeners() {
   static folly::Synchronized<std::vector<std::shared_ptr<TaskListener>>>
@@ -828,6 +871,7 @@ void Task::createDriversLocked(
 void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
   bool foundDriver = false;
   bool allFinished = true;
+  EventCompletionNotifier stateChangeNotifier;
   {
     std::lock_guard<std::mutex> taskLock(self->mutex_);
     for (auto& driverPtr : self->drivers_) {
@@ -858,6 +902,7 @@ void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
         if (splitGroupId != kUngroupedGroupId) {
           --self->numRunningSplitGroups_;
           self->taskStats_.completedSplitGroups.emplace(splitGroupId);
+          stateChangeNotifier.activate(std::move(self->stateChangePromises_));
           splitGroupState.clear();
           self->ensureSplitGroupsAreBeingProcessedLocked(self);
         } else {
@@ -875,6 +920,7 @@ void Task::removeDriver(std::shared_ptr<Task> self, Driver* driver) {
                 << " ms.";
     }
   }
+  stateChangeNotifier.notify();
 
   if (!foundDriver) {
     LOG(WARNING) << "Trying to remove a Driver twice from its Task";
@@ -1048,6 +1094,7 @@ void Task::noMoreSplitsForGroup(
     const core::PlanNodeId& planNodeId,
     int32_t splitGroupId) {
   std::vector<ContinuePromise> promises;
+  EventCompletionNotifier stateChangeNotifier;
   {
     std::lock_guard<std::mutex> l(mutex_);
 
@@ -1060,8 +1107,10 @@ void Task::noMoreSplitsForGroup(
     // group complete.
     if (seenSplitGroups_.count(splitGroupId) == 0) {
       taskStats_.completedSplitGroups.insert(splitGroupId);
+      stateChangeNotifier.activate(std::move(stateChangePromises_));
     }
   }
+  stateChangeNotifier.notify();
   for (auto& promise : promises) {
     promise.setValue();
   }
@@ -1526,7 +1575,8 @@ static void movePromisesOut(
 
 ContinueFuture Task::terminate(TaskState terminalState) {
   std::vector<std::shared_ptr<Driver>> offThreadDrivers;
-  TaskCompletionNotifier completionNotifier;
+  EventCompletionNotifier taskCompletionNotifier;
+  EventCompletionNotifier stateChangeNotifier;
   std::vector<std::shared_ptr<ExchangeClient>> exchangeClients;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -1551,7 +1601,9 @@ ContinueFuture Task::terminate(TaskState terminalState) {
               << taskStateString(state_) << " after running for "
               << timeSinceStartMsLocked() << " ms.";
 
-    activateTaskCompletionNotifier(completionNotifier);
+    taskCompletionNotifier.activate(
+        std::move(taskCompletionPromises_), [&]() { onTaskCompletion(); });
+    stateChangeNotifier.activate(std::move(stateChangePromises_));
 
     // Update the total number of drivers if we were cancelled.
     numTotalDrivers_ = seenSplitGroups_.size() * numDriversPerSplitGroup_ +
@@ -1575,7 +1627,8 @@ ContinueFuture Task::terminate(TaskState terminalState) {
     exchangeClients.swap(exchangeClients_);
   }
 
-  completionNotifier.notify();
+  taskCompletionNotifier.notify();
+  stateChangeNotifier.notify();
 
   // Get the stats and free the resources of Drivers that were not on
   // thread.
@@ -1779,6 +1832,22 @@ ContinueFuture Task::stateChangeFuture(uint64_t maxWaitMicros) {
   auto [promise, future] = makeVeloxContinuePromiseContract(
       fmt::format("Task::stateChangeFuture {}", taskId_));
   stateChangePromises_.emplace_back(std::move(promise));
+  if (maxWaitMicros > 0) {
+    return std::move(future).within(std::chrono::microseconds(maxWaitMicros));
+  }
+  return std::move(future);
+}
+
+ContinueFuture Task::taskCompletionFuture(uint64_t maxWaitMicros) {
+  std::lock_guard<std::mutex> l(mutex_);
+  // If 'this' is running, the future is realized on timeout or when
+  // this no longer is running.
+  if (not isRunningLocked()) {
+    return ContinueFuture();
+  }
+  auto [promise, future] = makeVeloxContinuePromiseContract(
+      fmt::format("Task::taskCompletionFuture {}", taskId_));
+  taskCompletionPromises_.emplace_back(std::move(promise));
   if (maxWaitMicros > 0) {
     return std::move(future).within(std::chrono::microseconds(maxWaitMicros));
   }
@@ -2147,31 +2216,6 @@ ContinueFuture Task::requestPause() {
   TestValue::adjust("facebook::velox::exec::Task::requestPauseLocked", this);
   pauseRequested_ = true;
   return makeFinishFutureLocked("Task::requestPause");
-}
-
-Task::TaskCompletionNotifier::~TaskCompletionNotifier() {
-  notify();
-}
-
-void Task::TaskCompletionNotifier::activate(
-    std::function<void()> callback,
-    std::vector<ContinuePromise> promises) {
-  active_ = true;
-  callback_ = callback;
-  promises_ = std::move(promises);
-}
-
-void Task::TaskCompletionNotifier::notify() {
-  if (active_) {
-    for (auto& promise : promises_) {
-      promise.setValue();
-    }
-    promises_.clear();
-
-    callback_();
-
-    active_ = false;
-  }
 }
 
 void Task::createExchangeClient(

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -219,12 +219,20 @@ class Task : public std::enable_shared_from_this<Task> {
     return state_;
   }
 
-  /// Returns a future which is realized when 'this' is no longer in
-  /// running state. If 'this' is not in running state at the time of
-  /// call, the future is immediately realized. The future is realized
-  /// with an exception after maxWaitMicros. A zero max wait means no
-  /// timeout.
+  /// Returns a future which is realized when the task's state has changed and
+  /// the Task is ready to report some progress (such as split group finished or
+  /// task is completed).
+  /// If the task is not in running state at the time of call, the future is
+  /// immediately realized. The future is realized with an exception after
+  /// maxWaitMicros. A zero max wait means no timeout.
   ContinueFuture stateChangeFuture(uint64_t maxWaitMicros);
+
+  /// Returns a future which is realized when the task is no longer in
+  /// running state.
+  /// If the task is not in running state at the time of call, the future is
+  /// immediately realized. The future is realized with an exception after
+  /// maxWaitMicros. A zero max wait means no timeout.
+  ContinueFuture taskCompletionFuture(uint64_t maxWaitMicros);
 
   /// Returns task execution error or nullptr if no error occurred.
   std::exception_ptr error() const {
@@ -820,36 +828,6 @@ class Task : public std::enable_shared_from_this<Task> {
   std::shared_ptr<ExchangeClient> getExchangeClientLocked(
       int32_t pipelineId) const;
 
-  // RAII helper class to satisfy 'stateChangePromises_' and notify listeners
-  // that task is complete outside of the mutex. Inactive on creation. Must be
-  // activated explicitly by calling 'activate'.
-  class TaskCompletionNotifier {
-   public:
-    /// Calls notify() if it hasn't been called yet.
-    ~TaskCompletionNotifier();
-
-    /// Activates the notifier and provides a callback to invoke and promises to
-    /// satisfy on destruction or a call to 'notify'.
-    void activate(
-        std::function<void()> callback,
-        std::vector<ContinuePromise> promises);
-
-    /// Satisfies the promises passed to 'activate' and invokes the callback.
-    /// Does nothing if 'activate' hasn't been called or 'notify' has been
-    /// called already.
-    void notify();
-
-   private:
-    bool active_{false};
-    std::function<void()> callback_;
-    std::vector<ContinuePromise> promises_;
-  };
-
-  void activateTaskCompletionNotifier(TaskCompletionNotifier& notifier) {
-    notifier.activate(
-        [&]() { onTaskCompletion(); }, std::move(stateChangePromises_));
-  }
-
   // The helper class used to maintain 'numCreatedTasks_' and 'numDeletedTasks_'
   // on task construction and destruction.
   class TaskCounter {
@@ -990,6 +968,11 @@ class Task : public std::enable_shared_from_this<Task> {
   /// manage splits of the plan nodes that expect splits.
   std::unordered_map<core::PlanNodeId, SplitsState> splitsStates_;
 
+  // Promises that are fulfilled when the task is completed (terminated).
+  std::vector<ContinuePromise> taskCompletionPromises_;
+
+  // Promises that are fulfilled when the task's state has changed and ready to
+  // report some progress (such as split group finished or task is completed).
   std::vector<ContinuePromise> stateChangePromises_;
 
   TaskStats taskStats_;

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -171,7 +171,8 @@ class DriverTest : public OperatorTestBase {
       // To be realized either after 1s wall time or when the corresponding Task
       // is no longer running.
       auto& executor = folly::QueuedImmediateExecutor::instance();
-      auto future = tasks_.back()->stateChangeFuture(1'000'000).via(&executor);
+      auto future =
+          tasks_.back()->taskCompletionFuture(1'000'000).via(&executor);
       stateFutures_.emplace(threadId, std::move(future));
 
       EXPECT_FALSE(stateFutures_.at(threadId).isReady());
@@ -446,7 +447,7 @@ TEST_F(DriverTest, error) {
   EXPECT_EQ(numRead, 0);
   EXPECT_TRUE(stateFutures_.at(0).isReady());
   // Realized immediately since task not running.
-  EXPECT_TRUE(tasks_[0]->stateChangeFuture(1'000'000).isReady());
+  EXPECT_TRUE(tasks_[0]->taskCompletionFuture(1'000'000).isReady());
   EXPECT_EQ(tasks_[0]->state(), TaskState::kFailed);
 }
 
@@ -468,7 +469,7 @@ TEST_F(DriverTest, cancel) {
   }
   EXPECT_GE(numRead, 1'000'000);
   auto& executor = folly::QueuedImmediateExecutor::instance();
-  auto future = tasks_[0]->stateChangeFuture(1'000'000).via(&executor);
+  auto future = tasks_[0]->taskCompletionFuture(1'000'000).via(&executor);
   future.wait();
   EXPECT_TRUE(stateFutures_.at(0).isReady());
 
@@ -521,7 +522,7 @@ TEST_F(DriverTest, slow) {
   // are updated some tens of instructions after this. Determinism
   // requires a barrier.
   auto& executor = folly::QueuedImmediateExecutor::instance();
-  auto future = tasks_[0]->stateChangeFuture(1'000'000).via(&executor);
+  auto future = tasks_[0]->taskCompletionFuture(1'000'000).via(&executor);
   future.wait();
   // Note that the driver count drops after the last thread stops and
   // realizes the future.
@@ -557,7 +558,7 @@ TEST_F(DriverTest, pause) {
   readResults(params, ResultOperation::kPause, 370'000'000, &numRead);
   // Each thread will fully read the 1M rows in values.
   EXPECT_EQ(numRead, 10 * hits);
-  auto stateFuture = tasks_[0]->stateChangeFuture(100'000'000);
+  auto stateFuture = tasks_[0]->taskCompletionFuture(100'000'000);
   auto& executor = folly::QueuedImmediateExecutor::instance();
   auto state = std::move(stateFuture).via(&executor);
   state.wait();

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -1247,7 +1247,7 @@ bool waitForTaskStateChange(
   // Wait for task to transition to finished state.
   if (task->state() != state) {
     auto& executor = folly::QueuedImmediateExecutor::instance();
-    auto future = task->stateChangeFuture(maxWaitMicros).via(&executor);
+    auto future = task->taskCompletionFuture(maxWaitMicros).via(&executor);
     future.wait();
   }
 

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -132,7 +132,7 @@ class SimpleAggregatesBenchmark : public HiveConnectorTestBase {
 
     exec::Task::start(task, 1);
     auto& executor = folly::QueuedImmediateExecutor::instance();
-    auto future = task->stateChangeFuture(60'000'000).via(&executor);
+    auto future = task->taskCompletionFuture(60'000'000).via(&executor);
     future.wait();
 
     folly::doNotOptimizeAway(numResultRows);


### PR DESCRIPTION
Summary:
stateChangeFuture was returning futures realized when the Task is finished,
not when the state was changed, per se.
We've been using this method to wait for Task state change when replying to
getTaskStatus() and getTaskInfo() messages.
This created the delay for up to 1 second in the Tasks with grouped execution,
when we completed splits, but report them only when 1 second timeout in
the message reply code is expired, not immediately.
This change introduces the new taskCompletionFuture method that realizes
futures when the Task is completed, like stateChangeFuture did before.
stateChangeFuture on the other hand now realizes futures upon the Task
completion as well as upon a split group completion.
This improves the grouped execution query timing in the following way:
  1st run (clear cache): 1:22 - 1:27 -> 0:59
  Subsequent runs (warm cache): 0:38 - 0:42 -> 0:16 - 0:29

Also refactored TaskCompletionNotifier by moving it from the h to cpp and renaming.

Changed unit tests and benchmarks to use the new taskCompletionFuture.

Differential Revision: D46411874

