### PR TITLE
Load vector before serializing

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -87,7 +87,7 @@ void serializeOne<TypeKind::ROW>(
   out.append<uint64_t>(nulls);
   for (auto i = 0; i < children.size(); ++i) {
     if (!bits ::isBitSet(nulls.data(), i)) {
-      serializeSwitch(*children[i], wrappedIndex, out);
+      serializeSwitch(*children[i]->loadedVector(), wrappedIndex, out);
     }
   }
 }

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(
   ArrowStreamTest.cpp
   AssignUniqueIdTest.cpp
   AsyncConnectorTest.cpp
+  ContainerRowSerdeTest.cpp
   CustomJoinTest.cpp
   EnforceSingleRowTest.cpp
   ExchangeClientTest.cpp

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/memory/ByteStream.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/exec/ContainerRowSerde.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/LazyVector.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox;
+using facebook::velox::exec::ContainerRowSerde;
+using facebook::velox::test::TestingLoader;
+
+class ContainerRowSerdeTest : public testing::Test,
+                              public test::VectorTestBase {};
+
+TEST_F(ContainerRowSerdeTest, nestedSerde) {
+  auto data = makeFlatVector<int32_t>(10, [](auto row) { return row; });
+  auto columnType = ROW({"a", "b"}, {INTEGER(), INTEGER()});
+
+  auto loaderA = std::make_unique<TestingLoader>(data);
+  auto loaderB = std::make_unique<TestingLoader>(data);
+  auto lazyVectorA = std::make_shared<LazyVector>(
+      pool_.get(), INTEGER(), 10, std::move(loaderA));
+  auto lazyVectorB = std::make_shared<LazyVector>(
+      pool_.get(), INTEGER(), 10, std::move(loaderB));
+  std::vector<VectorPtr> children{lazyVectorA, lazyVectorB};
+  auto rowVector = std::make_shared<RowVector>(
+      pool_.get(), columnType, BufferPtr(nullptr), 10, children);
+
+  HashStringAllocator allocator(pool_.get());
+
+  auto begin = allocator.allocate(1024);
+  ByteStream stream(&allocator);
+  allocator.extendWrite({begin, begin->begin()}, stream);
+  ContainerRowSerde::instance().serialize(*rowVector, 0, stream);
+
+  HashStringAllocator::prepareRead(begin, stream);
+  VectorPtr result = BaseVector::create(columnType, 1, pool());
+  exec::ContainerRowSerde::instance().deserialize(stream, 0, result.get());
+  ASSERT_TRUE(result->equalValueAt(rowVector.get(), 0, 0));
+}

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -33,48 +33,7 @@
 
 using namespace facebook::velox;
 using facebook::velox::ComplexType;
-
-// LazyVector loader for testing. Minimal implementation that documents the API
-// contract.
-class TestingLoader : public VectorLoader {
- public:
-  explicit TestingLoader(VectorPtr data) : data_(data), rowCounter_(0) {}
-
-  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
-    if (hook) {
-      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-          applyHook, data_->typeKind(), rows, hook);
-      return;
-    }
-    *result = data_;
-    rowCounter_ += rows.size();
-  }
-
-  int32_t rowCount() const {
-    return rowCounter_;
-  }
-
- private:
-  template <TypeKind Kind>
-  void applyHook(RowSet rows, ValueHook* hook) {
-    using T = typename TypeTraits<Kind>::NativeType;
-    auto values = data_->as<SimpleVector<T>>();
-    bool acceptsNulls = hook->acceptsNulls();
-    for (auto i = 0; i < rows.size(); ++i) {
-      auto row = rows[i];
-      if (values->isNullAt(row)) {
-        if (acceptsNulls) {
-          hook->addNull(i);
-        }
-      } else {
-        T value = values->valueAt(row);
-        hook->addValue(i, &value);
-      }
-    }
-  }
-  VectorPtr data_;
-  int32_t rowCounter_;
-};
+using facebook::velox::test::TestingLoader;
 
 struct NonPOD {
   static int alive;

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -39,6 +39,48 @@ class SimpleVectorLoader : public VectorLoader {
   std::function<VectorPtr(RowSet)> loader_;
 };
 
+// LazyVector loader for testing. Minimal implementation that documents the API
+// contract.
+class TestingLoader : public VectorLoader {
+ public:
+  explicit TestingLoader(VectorPtr data) : data_(data), rowCounter_(0) {}
+
+  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
+    if (hook) {
+      VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          applyHook, data_->typeKind(), rows, hook);
+      return;
+    }
+    *result = data_;
+    rowCounter_ += rows.size();
+  }
+
+  int32_t rowCount() const {
+    return rowCounter_;
+  }
+
+ private:
+  template <TypeKind Kind>
+  void applyHook(RowSet rows, ValueHook* hook) {
+    using T = typename TypeTraits<Kind>::NativeType;
+    auto values = data_->as<SimpleVector<T>>();
+    bool acceptsNulls = hook->acceptsNulls();
+    for (auto i = 0; i < rows.size(); ++i) {
+      auto row = rows[i];
+      if (values->isNullAt(row)) {
+        if (acceptsNulls) {
+          hook->addNull(i);
+        }
+      } else {
+        T value = values->valueAt(row);
+        hook->addValue(i, &value);
+      }
+    }
+  }
+  VectorPtr data_;
+  int32_t rowCounter_;
+};
+
 class VectorMaker {
  public:
   explicit VectorMaker(memory::MemoryPool* pool) : pool_(pool) {}


### PR DESCRIPTION
Summary:
For github issue:
https://github.com/facebookincubator/velox/issues/5065

Read the issue for more details about the problem.

If we don't load the lazy vector, we get a SEGV due to asUnchecked().

This approach is hacky. We probably shouldn't pay the cost of checking whether vector is loaded per-row. Also there may be other code paths where this is not checked. But this helps unblock a lot of queries

Differential Revision: D46415593

