### PR TITLE
Fix signatures for histogram Presto aggregate function

### DIFF
--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -222,13 +222,25 @@ class HistogramAggregate : public exec::Aggregate {
 };
 
 exec::AggregateRegistrationResult registerHistogram(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
-      exec::AggregateFunctionSignatureBuilder()
-          .typeVariable("T")
-          .returnType("map(T,bigint)")
-          .intermediateType("map(T,bigint)")
-          .argumentType("T")
-          .build()};
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  for (const auto inputType :
+       {"boolean",
+        "tinyint",
+        "smallint",
+        "integer",
+        "bigint",
+        "real",
+        "double",
+        "timestamp",
+        "date",
+        "interval day to second"}) {
+    signatures.push_back(
+        exec::AggregateFunctionSignatureBuilder()
+            .returnType(fmt::format("map({},bigint)", inputType))
+            .intermediateType(fmt::format("map({},bigint)", inputType))
+            .argumentType(inputType)
+            .build());
+  }
 
   return exec::registerAggregateFunction(
       name,


### PR DESCRIPTION
The histogram Presto aggregate function used to declare support for any input
type, but supported only a subset of primitive types. This caused SYSTEM errors
like `VeloxRuntimeError:  Unknown input type for presto.default.histogram
aggregation VARCHAR`. This change is to report supported signatures accurately.
Unsupported inputs will not report USER errors.