### PR TITLE
Add sanity check on state transition to NestedLoopJoinProbe.

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -467,4 +467,24 @@ RowVectorPtr NestedLoopJoinProbe::doMatch(vector_size_t probeCnt) {
   return output;
 }
 
+void NestedLoopJoinProbe::setState(ProbeOperatorState state) {
+  checkStateTransition(state);
+  state_ = state;
+}
+
+void NestedLoopJoinProbe::checkStateTransition(ProbeOperatorState state) const {
+  VELOX_CHECK_NE(state_, state);
+  switch (state) {
+    case ProbeOperatorState::kRunning:
+      VELOX_CHECK_EQ(state_, ProbeOperatorState::kWaitForBuild);
+      break;
+    case ProbeOperatorState::kFinish:
+      VELOX_CHECK_EQ(state_, ProbeOperatorState::kRunning);
+      break;
+    default:
+      VELOX_UNREACHABLE(probeOperatorStateName(state_));
+      break;
+  }
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -113,10 +113,9 @@ class NestedLoopJoinProbe : public Operator {
         noMoreInput_;
   }
 
-  // TODO: Add state transition check.
-  void setState(ProbeOperatorState state) {
-    state_ = state;
-  }
+  void setState(ProbeOperatorState state);
+
+  void checkStateTransition(ProbeOperatorState state) const;
 
  private:
   // Maximum number of rows in the output batch.


### PR DESCRIPTION
NestedLoopJoinProbe has a simple state transition as: kWaitForBuild -> kRunning -> kFinish. 
Add sanity check on the state transition.