### PR TITLE
Remove updateBroadcastBuffers from broadcast output buffer manager

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -283,14 +283,6 @@ void PartitionedOutputBuffer::updateOutputBuffers(
   }
 }
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-void PartitionedOutputBuffer::updateBroadcastOutputBuffers(
-    int numBuffers,
-    bool noMoreBuffers) {
-  updateOutputBuffers(numBuffers, noMoreBuffers);
-}
-#endif
-
 void PartitionedOutputBuffer::updateNumDrivers(uint32_t newNumDrivers) {
   bool isNoMoreDrivers{false};
   {

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -153,10 +153,6 @@ class PartitionedOutputBuffer {
   /// output buffer type.
   void updateOutputBuffers(int numBuffers, bool noMoreBuffers);
 
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  void updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
-#endif
-
   /// When we understand the final number of split groups (for grouped
   /// execution only), we need to update the number of producing drivers here.
   void updateNumDrivers(uint32_t newNumDrivers);

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1261,6 +1261,10 @@ bool Task::isFinishedLocked() const {
 }
 
 bool Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
+  return updateOutputBuffers(numBuffers, noMoreBuffers);
+}
+
+bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
       bufferManager,
@@ -1268,16 +1272,15 @@ bool Task::updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers) {
       "PartitionedOutputBufferManager was already destructed");
   {
     std::lock_guard<std::mutex> l(mutex_);
-    if (noMoreBroadcastBuffers_) {
+    if (noMoreOutputBuffers_) {
       // Ignore messages received after no-more-buffers message.
       return false;
     }
     if (noMoreBuffers) {
-      noMoreBroadcastBuffers_ = true;
+      noMoreOutputBuffers_ = true;
     }
   }
-  return bufferManager->updateBroadcastOutputBuffers(
-      taskId_, numBuffers, noMoreBuffers);
+  return bufferManager->updateOutputBuffers(taskId_, numBuffers, noMoreBuffers);
 }
 
 int Task::getOutputPipelineId() const {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -193,9 +193,9 @@ class Task : public std::enable_shared_from_this<Task> {
   /// corresponding to plan node with specified ID.
   void noMoreSplits(const core::PlanNodeId& planNodeId);
 
-  /// Updates the total number of output buffers to broadcast the results of the
-  /// execution to. Used when plan tree ends with a PartitionedOutputNode with
-  /// broadcast flag set to true.
+  /// Updates the total number of output buffers to broadcast or arbitrarily
+  /// distribute the results of the execution to. Used when plan tree ends with
+  /// a PartitionedOutputNode with broadcast of arbitrary output type.
   /// @param numBuffers Number of output buffers. Must not decrease on
   /// subsequent calls.
   /// @param noMoreBuffers A flag indicating that numBuffers is the final number
@@ -205,6 +205,10 @@ class Task : public std::enable_shared_from_this<Task> {
   /// @return true if update was successful.
   ///         false if noMoreBuffers was previously set to true.
   ///         false if buffer was not found for a given task.
+  bool updateOutputBuffers(int numBuffers, bool noMoreBuffers);
+
+  /// TODO: deprecate this API after Prestissimo switches to use
+  /// updateOutputBuffers.
   bool updateBroadcastOutputBuffers(int numBuffers, bool noMoreBuffers);
 
   /// Returns true if state is 'running'.
@@ -1000,9 +1004,9 @@ class Task : public std::enable_shared_from_this<Task> {
 
   std::weak_ptr<PartitionedOutputBufferManager> bufferManager_;
 
-  /// Boolean indicating that we have already received no-more-broadcast-buffers
+  /// Boolean indicating that we have already received no-more-output-buffers
   /// message. Subsequent messages will be ignored.
-  bool noMoreBroadcastBuffers_{false};
+  bool noMoreOutputBuffers_{false};
 
   // Thread counts and cancellation -related state.
   //

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -845,10 +845,10 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
 
     task->start(task, 1, 1);
 
-    ASSERT_TRUE(task->updateBroadcastOutputBuffers(10, true /*noMoreBuffers*/));
+    ASSERT_TRUE(task->updateOutputBuffers(10, true /*noMoreBuffers*/));
 
     // Calls after no-more-buffers are ignored.
-    ASSERT_FALSE(task->updateBroadcastOutputBuffers(11, false));
+    ASSERT_FALSE(task->updateOutputBuffers(11, false));
 
     task->requestCancel();
   }
@@ -859,14 +859,14 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
 
     task->start(task, 1, 1);
 
-    ASSERT_TRUE(task->updateBroadcastOutputBuffers(5, false));
-    ASSERT_TRUE(task->updateBroadcastOutputBuffers(10, false));
+    ASSERT_TRUE(task->updateOutputBuffers(5, false));
+    ASSERT_TRUE(task->updateOutputBuffers(10, false));
 
     task->requestAbort();
 
     // Calls after task has been removed from the buffer manager (via abort) are
     // ignored.
-    ASSERT_FALSE(task->updateBroadcastOutputBuffers(15, true));
+    ASSERT_FALSE(task->updateOutputBuffers(15, true));
   }
 }
 


### PR DESCRIPTION
The followup will update partitioned output plan node to use
partition output type instead of broadcast flag.