### PR TITLE
Add support for TIMESTAMP input to min_by and max_by Presto aggregates

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -188,6 +188,8 @@ variant duckValueToVariant(const Value& val) {
       return variant(val.GetValue<float>());
     case LogicalTypeId::DOUBLE:
       return variant(val.GetValue<double>());
+    case LogicalTypeId::TIMESTAMP:
+      return variant(duckdbTimestampToVelox(val.GetValue<timestamp_t>()));
     case LogicalTypeId::DECIMAL:
       return decimalVariant(val);
     case LogicalTypeId::VARCHAR:

--- a/velox/duckdb/conversion/DuckConversion.h
+++ b/velox/duckdb/conversion/DuckConversion.h
@@ -39,7 +39,18 @@ static ::duckdb::timestamp_t veloxTimestampToDuckDB(
 static Timestamp duckdbTimestampToVelox(
     const ::duckdb::timestamp_t& timestamp) {
   auto micros = ::duckdb::Timestamp::GetEpochMicroSeconds(timestamp);
-  return Timestamp(micros / 1000000, (micros % 1000000) * 1000);
+
+  auto seconds = micros / 1'000'000;
+  auto nanoSeconds = (micros % 1'000'000) * 1'000;
+
+  // Make sure nanoseconds are >= 0 even if timestamp represents time before
+  // epoch.
+  if (nanoSeconds < 0) {
+    seconds--;
+    nanoSeconds += 1'000'000'000;
+  }
+
+  return Timestamp(seconds, nanoSeconds);
 }
 
 // Converts a duckDB Value (class that holds an arbitrary data type) into

--- a/velox/duckdb/conversion/tests/DuckConversionTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckConversionTest.cpp
@@ -63,6 +63,21 @@ TEST(DuckConversionTest, duckValueToVariant) {
     EXPECT_NO_THROW(duckValueToVariant(Value::FLOAT(i)));
   }
 
+  // Timestamp.
+  for (const auto ts : {
+           Timestamp::fromMillis(123),
+           Timestamp::fromMillis(-123),
+           Timestamp::fromMillis(0),
+           Timestamp::fromMillis(123'456'789),
+           Timestamp::fromMillis(-123'456'789),
+       }) {
+    SCOPED_TRACE(ts.toString());
+    EXPECT_EQ(
+        variant(ts),
+        duckValueToVariant(
+            Value::TIMESTAMP(::duckdb::Timestamp::FromEpochMs(ts.toMillis()))));
+  }
+
   // Strings.
   std::vector<std::string> vec = {"", "asdf", "aS$!#^*HFD"};
   for (const auto& i : vec) {
@@ -73,7 +88,6 @@ TEST(DuckConversionTest, duckValueToVariant) {
 TEST(DuckConversionTest, duckValueToVariantUnsupported) {
   std::vector<LogicalType> unsupported = {
       LogicalType::TIME,
-      LogicalType::TIMESTAMP,
       LogicalType::INTERVAL,
       LogicalType::LIST({LogicalType::INTEGER}),
       LogicalType::STRUCT(

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -122,6 +122,17 @@ struct MinMaxTrait<Date> {
   }
 };
 
+template <>
+struct MinMaxTrait<Timestamp> {
+  static constexpr Timestamp lowest() {
+    return Timestamp(std::numeric_limits<int64_t>::min(), 0);
+  }
+
+  static constexpr Timestamp max() {
+    return Timestamp(std::numeric_limits<int64_t>::max(), 999'999);
+  }
+};
+
 /// MinMaxByAggregate is the base class for min_by and max_by functions
 /// with numeric value and comparison types. These functions return the value of
 /// X associated with the minimum/maximum value of Y over all input values.
@@ -639,6 +650,8 @@ std::unique_ptr<exec::Aggregate> create(
       return std::make_unique<Aggregate<W, StringView>>(resultType);
     case TypeKind::DATE:
       return std::make_unique<Aggregate<W, Date>>(resultType);
+    case TypeKind::TIMESTAMP:
+      return std::make_unique<Aggregate<W, Timestamp>>(resultType);
     default:
       VELOX_FAIL("{}", errorMessage);
       return nullptr;
@@ -648,7 +661,7 @@ std::unique_ptr<exec::Aggregate> create(
 template <template <typename U, typename V> class Aggregate>
 bool registerMinMaxBy(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  // TODO Add support for boolean and timestamp 'compare' types.
+  // TODO Add support for boolean 'compare' types.
   for (const auto& compareType :
        {"tinyint",
         "smallint",
@@ -657,7 +670,8 @@ bool registerMinMaxBy(const std::string& name) {
         "real",
         "double",
         "varchar",
-        "date"}) {
+        "date",
+        "timestamp"}) {
     signatures.push_back(
         exec::AggregateFunctionSignatureBuilder()
             .typeVariable("T")


### PR DESCRIPTION
Allow TIMESTAMP values for the second argument (compare) of min_by and max_by.

Also, fix duckdbTimestampToVelox for timestamps that represent time before epoch.