### PR TITLE
Support setup script when homebrew installed at home directory

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -57,11 +57,12 @@ function prompt {
 }
 
 function update_brew {
-  BREW_PATH=/usr/local/bin/brew
+  DEFAULT_BREW_PATH=/usr/local/bin/brew
   if [ `arch` == "arm64" ] ;
-     then
-       BREW_PATH=/opt/homebrew/bin/brew ;
- fi
+    then
+      DEFAULT_BREW_PATH=$(which brew) ;
+  fi
+  BREW_PATH=${BREW_PATH:-$DEFAULT_BREW_PATH}
   $BREW_PATH update --auto-update --verbose
   $BREW_PATH developer off
 }


### PR DESCRIPTION
For M1 machines, Homebrew can be installed at home directory instead of `opt/homebrew`. 
Adding a check for the file directory existence during the mac os setup and use corresponding directories.

