### PR TITLE
Create directory for SSD cache

### DIFF
--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -18,6 +18,7 @@
 #include <folly/container/F14Map.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "velox/common/caching/FileIds.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/common/Common.h"
@@ -103,6 +104,7 @@ class CacheTest : public testing::Test {
     executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
     rng_.seed(1);
     ioStats_ = std::make_shared<IoStatistics>();
+    filesystems::registerLocalFileSystem();
   }
 
   void TearDown() override {


### PR DESCRIPTION
Explicitly create the directory for SSD cache files, which is the parent directory of  async-cache-ssd-path. Then we do not need to assume the existence of the SSD cache directory.

If the directory already exists, do nothing and existing files under the directory are kept.