### PR TITLE
Add more context to std::exceptions thrown by operators

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -150,6 +150,11 @@ void Operator::registerOperator(
   translators().emplace_back(std::move(translator));
 }
 
+// static
+void Operator::unregisterAllOperators() {
+  translators().clear();
+}
+
 std::optional<uint32_t> Operator::maxDrivers(
     const core::PlanNodePtr& planNode) {
   for (auto& translator : translators()) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -452,6 +452,10 @@ class Operator : public BaseRuntimeStatWriter {
   /// instances to user-defined Operators.
   static void registerOperator(std::unique_ptr<PlanNodeTranslator> translator);
 
+  /// Removes all translators registered earlier via calls to
+  /// 'registerOperator'.
+  static void unregisterAllOperators();
+
   /// Calls all the registered PlanNodeTranslators on 'planNode' and returns the
   /// result of the first one that returns non-nullptr or nullptr if all return
   /// nullptr. exchangeClient is not-null only when


### PR DESCRIPTION
When an operator throws std::exception, there is not much context available to
investigate. For example, we may get only "std::exception: bad_function_call"
with no stack trace and no indication of which operator failed.

This change wraps Operator::addInput, noMoreInput and getOutput calls in
try-catch and converts std::exception into VeloxRuntimeError with error message
that include operator type and plan node ID.