### PR TITLE
Ignore empty frames in window rank functions

### DIFF
--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -56,8 +56,6 @@ class CumeDistFunction : public exec::WindowFunction {
       rawValues[resultOffset + i] = cumeDist_;
     }
 
-    // Set NULL values for rows with empty frames.
-    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -79,9 +79,6 @@ class NtileFunction : public exec::WindowFunction {
     }
 
     partitionOffset_ += numRows;
-
-    // Set NULL values for rows with empty frames.
-    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -79,8 +79,6 @@ class RankFunction : public exec::WindowFunction {
       previousPeerCount_ += 1;
     }
 
-    // Set NULL values for rows with empty frames.
-    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/RowNumber.cpp
+++ b/velox/functions/prestosql/window/RowNumber.cpp
@@ -44,9 +44,6 @@ class RowNumberFunction : public exec::WindowFunction {
     for (int i = 0; i < numRows; i++) {
       rawValues[resultOffset + i] = rowNumber_++;
     }
-
-    // Set NULL values for rows with empty frames.
-    setNullEmptyFramesResults(validRows, resultOffset, result);
   }
 
  private:

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -26,8 +26,7 @@ class NtileTest : public WindowTestBase {
  protected:
   void testNtile(const std::vector<RowVectorPtr>& vectors) {
     // Tests ntile with a column.
-    WindowTestBase::testWindowFunction(
-        vectors, "ntile(c2)", kOverClauses, kFrameClauses);
+    WindowTestBase::testWindowFunction(vectors, "ntile(c2)", kOverClauses);
     // Tests ntile with constant value arguments.
     testNtileWithConstants(vectors, kOverClauses);
   }
@@ -57,7 +56,7 @@ class NtileTest : public WindowTestBase {
     // Note: The DuckDB table has been previously created.
     for (auto function : kNtileInvocations) {
       WindowTestBase::testWindowFunction(
-          vectors, function, overClauses, kFrameClauses, false);
+          vectors, function, overClauses, {}, false);
     }
   }
 };

--- a/velox/functions/prestosql/window/tests/NtileTest.cpp
+++ b/velox/functions/prestosql/window/tests/NtileTest.cpp
@@ -56,7 +56,7 @@ class NtileTest : public WindowTestBase {
     // Note: The DuckDB table has been previously created.
     for (auto function : kNtileInvocations) {
       WindowTestBase::testWindowFunction(
-          vectors, function, overClauses, {}, false);
+          vectors, function, overClauses, {""}, false);
     }
   }
 };

--- a/velox/functions/prestosql/window/tests/RankTest.cpp
+++ b/velox/functions/prestosql/window/tests/RankTest.cpp
@@ -47,8 +47,7 @@ class RankTestBase : public WindowTestBase {
       : function_(testParam.function), overClause_(testParam.overClause) {}
 
   void testWindowFunction(const std::vector<RowVectorPtr>& vectors) {
-    WindowTestBase::testWindowFunction(
-        vectors, function_, {overClause_}, kFrameClauses);
+    WindowTestBase::testWindowFunction(vectors, function_, {overClause_});
   }
 
   void SetUp() override {


### PR DESCRIPTION
Previously NULL values were returned for empty frames in window rank functions. This behavior was consistent with DuckDB, but inconsistent with Presto that ignored empty frames.

DuckDB has fixed the behavior in 0.8.0. And Velox is being migrated to it.

Removing the logic to set NULL values for empty frames in rank window functions.
