### PR TITLE
Optimize SelectiveFlatMapColumnReader memory footprint

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -115,18 +115,20 @@ class DwrfData : public dwio::common::FormatData {
 // DWRF specific initialization.
 class DwrfParams : public dwio::common::FormatParams {
  public:
-  explicit DwrfParams(StripeStreams& stripeStreams, FlatMapContext context = {})
-      : FormatParams(stripeStreams.getMemoryPool()),
+  explicit DwrfParams(
+      const std::shared_ptr<StripeStreams>& stripeStreams,
+      FlatMapContext context = {})
+      : FormatParams(stripeStreams->getMemoryPool()),
         stripeStreams_(stripeStreams),
         flatMapContext_(context) {}
 
   std::unique_ptr<dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
       const common::ScanSpec& /*scanSpec*/) override {
-    return std::make_unique<DwrfData>(type, stripeStreams_, flatMapContext_);
+    return std::make_unique<DwrfData>(type, *stripeStreams_, flatMapContext_);
   }
 
-  StripeStreams& stripeStreams() {
+  const std::shared_ptr<StripeStreams>& stripeStreams() {
     return stripeStreams_;
   }
 
@@ -135,7 +137,7 @@ class DwrfParams : public dwio::common::FormatParams {
   }
 
  private:
-  StripeStreams& stripeStreams_;
+  std::shared_ptr<StripeStreams> stripeStreams_;
   FlatMapContext flatMapContext_;
 };
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -389,7 +389,7 @@ void DwrfRowReader::startNextStripe() {
   auto currentStripeInfo = loadStripe(currentStripe, preload);
   rowsInCurrentStripe = currentStripeInfo.numberOfRows();
 
-  StripeStreamsImpl stripeStreams(
+  auto stripeStreams = std::make_shared<StripeStreamsImpl>(
       *this,
       getColumnSelector(),
       options_,
@@ -412,7 +412,7 @@ void DwrfRowReader::startNextStripe() {
     selectiveColumnReader_->setIsTopLevel();
   } else {
     columnReader_ = ColumnReader::build(
-        requestedType, dataType, stripeStreams, flatMapContext);
+        requestedType, dataType, *stripeStreams, flatMapContext);
   }
   DWIO_ENSURE(
       (columnReader_ != nullptr) != (selectiveColumnReader_ != nullptr),
@@ -423,10 +423,10 @@ void DwrfRowReader::startNextStripe() {
   // if planReads is off which means stripe data loaded as whole
   if (!preload) {
     VLOG(1) << "[DWRF] Load read plan for stripe " << currentStripe;
-    stripeStreams.loadReadPlan();
+    stripeStreams->loadReadPlan();
   }
 
-  stripeDictionaryCache_ = stripeStreams.getStripeDictionaryCache();
+  stripeDictionaryCache_ = stripeStreams->getStripeDictionaryCache();
   newStripeLoaded = true;
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -40,11 +40,11 @@ class SelectiveByteRleColumnReader
     auto& stripe = params.stripeStreams();
     if (isBool) {
       boolRle_ = createBooleanRleDecoder(
-          stripe.getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true),
+          stripe->getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true),
           encodingKey);
     } else {
       byteRle_ = createByteRleDecoder(
-          stripe.getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true),
+          stripe->getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true),
           encodingKey);
     }
   }

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -40,7 +40,7 @@ std::unique_ptr<SelectiveColumnReader> buildIntegerReader(
     common::ScanSpec& scanSpec) {
   EncodingKey ek{requestedType->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
+  switch (static_cast<int64_t>(stripe->getEncoding(ek).kind())) {
     case proto::ColumnEncoding_Kind_DICTIONARY:
       return std::make_unique<SelectiveIntegerDictionaryColumnReader>(
           requestedType, dataType, params, scanSpec, numBytes);
@@ -76,7 +76,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
       return std::make_unique<SelectiveListColumnReader>(
           requestedType, dataType, params, scanSpec);
     case TypeKind::MAP:
-      if (stripe.getEncoding(ek).kind() ==
+      if (stripe->getEncoding(ek).kind() ==
           proto::ColumnEncoding_Kind_MAP_FLAT) {
         return createSelectiveFlatMapColumnReader(
             requestedType, dataType, params, scanSpec);
@@ -108,7 +108,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
           requestedType, dataType, params, scanSpec, false);
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
-      switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
+      switch (static_cast<int64_t>(stripe->getEncoding(ek).kind())) {
         case proto::ColumnEncoding_Kind_DIRECT:
           return std::make_unique<SelectiveStringDirectColumnReader>(
               requestedType, params, scanSpec);

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -36,7 +36,7 @@ class SelectiveDwrfReader {
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe,
+      const std::shared_ptr<StripeStreams>& stripe,
       common::ScanSpec* FOLLY_NONNULL scanSpec,
       FlatMapContext flatMapContext = {}) {
     auto params = DwrfParams(stripe, flatMapContext);
@@ -53,7 +53,7 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
   std::unique_ptr<dwio::common::SelectiveColumnReader> buildSelective(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
-      StripeStreams& stripe,
+      const std::shared_ptr<StripeStreams>& stripe,
       FlatMapContext flatMapContext = {}) {
     auto params = DwrfParams(stripe, std::move(flatMapContext));
     auto reader =

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -70,7 +70,7 @@ SelectiveFloatingPointColumnReader<TData, TRequested>::
           dataType,
           params,
           scanSpec),
-      decoder_(params.stripeStreams().getStream(
+      decoder_(params.stripeStreams()->getStream(
           EncodingKey{root::nodeType_->id, params.flatMapContext().sequence}
               .forKind(proto::Stream_Kind_DATA),
           true)) {}

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -34,23 +34,23 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
           dataType->type) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  auto encoding = stripe.getEncoding(encodingKey);
+  auto encoding = stripe->getEncoding(encodingKey);
   scanState_.dictionary.numValues = encoding.dictionarysize();
   rleVersion_ = convertRleVersion(encoding.kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
-  bool dataVInts = stripe.getUseVInts(data);
+  bool dataVInts = stripe->getUseVInts(data);
   dataReader_ = createRleDecoder</* isSigned = */ false>(
-      stripe.getStream(data, true),
+      stripe->getStream(data, true),
       rleVersion_,
       memoryPool_,
       dataVInts,
       numBytes);
 
   // make a lazy dictionary initializer
-  dictInit_ = stripe.getIntDictionaryInitializerForNode(
+  dictInit_ = stripe->getIntDictionaryInitializerForNode(
       encodingKey, numBytes, numBytes);
 
-  auto inDictStream = stripe.getStream(
+  auto inDictStream = stripe->getStream(
       encodingKey.forKind(proto::Stream_Kind_IN_DICTIONARY), false);
   if (inDictStream) {
     inDictionaryReader_ =

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -41,9 +41,9 @@ class SelectiveIntegerDirectColumnReader
     EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
     auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
     auto& stripe = params.stripeStreams();
-    bool dataVInts = stripe.getUseVInts(data);
+    bool dataVInts = stripe->getUseVInts(data);
     auto decoder = createDirectDecoder</*isSigned*/ true>(
-        stripe.getStream(data, true), dataVInts, numBytes);
+        stripe->getStream(data, true), dataVInts, numBytes);
     auto rawDecoder = decoder.release();
     auto directDecoder =
         dynamic_cast<dwio::common::DirectDecoder<true>*>(rawDecoder);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -25,11 +25,11 @@ std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> makeLengthDecoder(
     memory::MemoryPool& pool) {
   EncodingKey encodingKey{nodeType.id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  auto rleVersion = convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  auto rleVersion = convertRleVersion(stripe->getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
-  bool lenVints = stripe.getUseVInts(lenId);
+  bool lenVints = stripe->getUseVInts(lenId);
   return createRleDecoder</*isSigned*/ false>(
-      stripe.getStream(lenId, true),
+      stripe->getStream(lenId, true),
       rleVersion,
       pool,
       lenVints,
@@ -59,7 +59,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   // count the number of selected sub-columns
-  const auto& cs = stripe.getColumnSelector();
+  const auto& cs = stripe->getColumnSelector();
   auto& childType = requestedType_->childAt(0);
   VELOX_CHECK(
       cs.shouldReadNode(childType->id),
@@ -103,7 +103,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   scanSpec_->children()[1]->setProjectOut(true);
   scanSpec_->children()[1]->setExtractValues(true);
 
-  const auto& cs = stripe.getColumnSelector();
+  const auto& cs = stripe->getColumnSelector();
   auto& keyType = requestedType_->childAt(0);
   VELOX_CHECK(
       cs.shouldReadNode(keyType->id),

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -28,17 +28,17 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
   EncodingKey encodingKey{nodeType->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   RleVersion rleVersion =
-      convertRleVersion(stripe.getEncoding(encodingKey).kind());
+      convertRleVersion(stripe->getEncoding(encodingKey).kind());
   auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
-  bool lenVInts = stripe.getUseVInts(lenId);
+  bool lenVInts = stripe->getUseVInts(lenId);
   lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
-      stripe.getStream(lenId, true),
+      stripe->getStream(lenId, true),
       rleVersion,
       memoryPool_,
       lenVInts,
       dwio::common::INT_BYTE_SIZE);
   blobStream_ =
-      stripe.getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true);
+      stripe->getStream(encodingKey.forKind(proto::Stream_Kind_DATA), true);
 }
 
 uint64_t SelectiveStringDirectColumnReader::skip(uint64_t numValues) {

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -34,13 +34,13 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
           scanSpec) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  auto encoding = static_cast<int64_t>(stripe.getEncoding(encodingKey).kind());
+  auto encoding = static_cast<int64_t>(stripe->getEncoding(encodingKey).kind());
   DWIO_ENSURE_EQ(
       encoding,
       proto::ColumnEncoding_Kind_DIRECT,
       "Unknown encoding for StructColumnReader");
 
-  const auto& cs = stripe.getColumnSelector();
+  const auto& cs = stripe->getColumnSelector();
   // A reader tree may be constructed while the ScanSpec is being used
   // for another read. This happens when the next stripe is being
   // prepared while the previous one is reading.

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -29,15 +29,15 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
     : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  RleVersion vers = convertRleVersion(stripe->getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
-  bool vints = stripe.getUseVInts(data);
+  bool vints = stripe->getUseVInts(data);
   seconds_ = createRleDecoder</*isSigned*/ true>(
-      stripe.getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
+      stripe->getStream(data, true), vers, memoryPool_, vints, LONG_BYTE_SIZE);
   auto nanoData = encodingKey.forKind(proto::Stream_Kind_NANO_DATA);
-  bool nanoVInts = stripe.getUseVInts(nanoData);
+  bool nanoVInts = stripe->getUseVInts(nanoData);
   nano_ = createRleDecoder</*isSigned*/ false>(
-      stripe.getStream(nanoData, true),
+      stripe->getStream(nanoData, true),
       vers,
       memoryPool_,
       nanoVInts,

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -386,7 +386,12 @@ TEST_F(E2EFilterTest, flatMap) {
 #endif
 #endif
   testWithTypes(
-      kColumns, customize, false, {"long_val"}, numCombinations, true);
+      kColumns,
+      customize,
+      false,
+      {"long_val", "long_vals"},
+      numCombinations,
+      true);
 }
 
 TEST_F(E2EFilterTest, metadataFilter) {


### PR DESCRIPTION
Summary: `SelectiveFlatMapColumnReader` is having memory issue when we read data that has many columns (e.g. 20000).  Instead of keeping all child readers in memory, we create one single reader at a time and drop the reader after the reading.  In next read we create a new child reader and seek to the right row group and offset for the child reader.

Differential Revision: D46489132

