### PR TITLE
Fix velox_aggregates_test memory leaks

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -144,7 +144,11 @@ TEST_F(ApproxMostFrequentTestInt, invalidBuckets) {
     auto elem1 = makeConstant<int64_t>(buckets, buckets);
     auto elem2 = makeFlatVector<int>(buckets, folly::identity);
     auto elem3 = makeConstant<int64_t>(buckets, buckets);
-    auto rows = makeRowVector({elem1, elem2, elem3, });
+    auto rows = makeRowVector({
+        elem1,
+        elem2,
+        elem3,
+    });
     auto plan = exec::test::PlanBuilder()
                     .values({rows})
                     .singleAggregation({}, {"approx_most_frequent(c0, c1, c2)"})

--- a/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp
@@ -139,11 +139,12 @@ using ApproxMostFrequentTestInt = ApproxMostFrequentTest<int>;
 TEST_F(ApproxMostFrequentTestInt, invalidBuckets) {
   static_cast<memory::MemoryPoolImpl*>(pool())->testingSetCapacity(1 << 21);
   auto run = [&](int64_t buckets) {
-    auto rows = makeRowVector({
-        makeConstant<int64_t>(buckets, buckets),
-        makeFlatVector<int>(buckets, folly::identity),
-        makeConstant<int64_t>(buckets, buckets),
-    });
+    // expression-list uses explicit generated elements to avoid memory leak.
+    // sse https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0400r0.html
+    auto elem1 = makeConstant<int64_t>(buckets, buckets);
+    auto elem2 = makeFlatVector<int>(buckets, folly::identity);
+    auto elem3 = makeConstant<int64_t>(buckets, buckets);
+    auto rows = makeRowVector({elem1, elem2, elem3, });
     auto plan = exec::test::PlanBuilder()
                     .values({rows})
                     .singleAggregation({}, {"approx_most_frequent(c0, c1, c2)"})


### PR DESCRIPTION
We found memory leaks when we run tests on enabling VELOX_ENABLE_ADDRESS_SANITIZER, this small fix is for fixing this issue.

145: =================================================================
145: ==11813==ERROR: LeakSanitizer: detected memory leaks
145: 
145: Direct leak of 288 byte(s) in 1 object(s) allocated from:
145:     #0 0x7fcfb181fb2f in operator new(unsigned long, std::align_val_t) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:111
145:     #1 0x555e53f00d24 in __gnu_cxx::new_allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> >::allocate(unsigned long, void const*) /usr/include/c++/10/ext/new_allocator.h:112
145:     #2 0x555e53efdd06 in std::allocator_traits<std::allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> > >::allocate(std::allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> >&, unsigned long) /usr/include/c++/10/bits/alloc_traits.h:460
145:     #3 0x555e53efb933 in std::__allocated_ptr<std::allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> > > std::__allocate_guarded<std::allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> > >(std::allocator<std::_Sp_counted_ptr_inplace<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, (__gnu_cxx::_Lock_policy)2> >&) /usr/include/c++/10/bits/allocated_ptr.h:97
145:     #4 0x555e5fbc3d53 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::__shared_count<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const>&, long, facebook::velox::SimpleVectorStats<long>, unsigned long>(facebook::velox::ConstantVector<long>*&, std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::ConstantVector<long> > >, facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const>&, long&&, facebook::velox::SimpleVectorStats<long>&&, unsigned long&&) /usr/include/c++/10/bits/shared_ptr_base.h:680
145:     #5 0x555e5fbac88d in std::__shared_ptr<facebook::velox::ConstantVector<long>, (__gnu_cxx::_Lock_policy)2>::__shared_ptr<std::allocator<facebook::velox::ConstantVector<long> >, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const>&, long, facebook::velox::SimpleVectorStats<long>, unsigned long>(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::ConstantVector<long> > >, facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const>&, long&&, facebook::velox::SimpleVectorStats<long>&&, unsigned long&&) /usr/include/c++/10/bits/shared_ptr_base.h:1371
145:     #6 0x555e5fb9f50d in std::shared_ptr<facebook::velox::ConstantVector<long> >::shared_ptr<std::allocator<facebook::velox::ConstantVector<long> >, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const>&, long, facebook::velox::SimpleVectorStats<long>, unsigned long>(std::_Sp_alloc_shared_tag<std::allocator<facebook::velox::ConstantVector<long> > >, facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const>&, long&&, facebook::velox::SimpleVectorStats<long>&&, unsigned long&&) /usr/include/c++/10/bits/shared_ptr.h:408
145:     #7 0x555e5fb94ce0 in std::shared_ptr<facebook::velox::ConstantVector<long> > std::allocate_shared<facebook::velox::ConstantVector<long>, std::allocator<facebook::velox::ConstantVector<long> >, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const>&, long, facebook::velox::SimpleVectorStats<long>, unsigned long>(std::allocator<facebook::velox::ConstantVector<long> > const&, facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const>&, long&&, facebook::velox::SimpleVectorStats<long>&&, unsigned long&&) /usr/include/c++/10/bits/shared_ptr.h:860
145:     #8 0x555e5fb8ba58 in std::shared_ptr<facebook::velox::ConstantVector<long> > std::make_shared<facebook::velox::ConstantVector<long>, facebook::velox::memory::MemoryPool*&, int&, bool, std::shared_ptr<facebook::velox::Type const>&, long, facebook::velox::SimpleVectorStats<long>, unsigned long>(facebook::velox::memory::MemoryPool*&, int&, bool&&, std::shared_ptr<facebook::velox::Type const>&, long&&, facebook::velox::SimpleVectorStats<long>&&, unsigned long&&) /usr/include/c++/10/bits/shared_ptr.h:876
145:     #9 0x555e5fb7bb4e in std::shared_ptr<facebook::velox::BaseVector> facebook::velox::newConstant<(facebook::velox::TypeKind)4>(facebook::velox::variant&, int, facebook::velox::memory::MemoryPool*) ../../velox/vector/BaseVector.cpp:650
145:     #10 0x555e5fb5861f in operator() ../../velox/vector/BaseVector.cpp:683
145:     #11 0x555e5fb599b0 in operator() ../../velox/vector/BaseVector.cpp:683
145:     #12 0x555e5fb59ba0 in facebook::velox::BaseVector::createConstant(facebook::velox::variant, int, facebook::velox::memory::MemoryPool*) ../../velox/vector/BaseVector.cpp:683
145:     #13 0x555e53e9c3ac in std::shared_ptr<facebook::velox::BaseVector> facebook::velox::test::VectorTestBase::makeConstant<long>(long, int, std::shared_ptr<facebook::velox::Type const> const&) ../.././velox/vector/tests/utils/VectorTestBase.h:615
145:     #14 0x555e53e84905 in operator() ../../velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp:144
145:     #15 0x555e53e85d46 in TestBody ../../velox/functions/prestosql/aggregates/tests/ApproxMostFrequentTest.cpp:153
145:     #16 0x555e5afc50a3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../../third_party/googletest/googletest/src/gtest.cc:2607
145:     #17 0x555e5afb6f40 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) ../../third_party/googletest/googletest/src/gtest.cc:2643
145:     #18 0x555e5af57233 in testing::Test::Run() ../../third_party/googletest/googletest/src/gtest.cc:2682
145:     #19 0x555e5af586c6 in testing::TestInfo::Run() ../../third_party/googletest/googletest/src/gtest.cc:2861
145:     #20 0x555e5af597b4 in testing::TestSuite::Run() ../../third_party/googletest/googletest/src/gtest.cc:3015
145:     #21 0x555e5af7de7a in testing::internal::UnitTestImpl::RunAllTests() ../../third_party/googletest/googletest/src/gtest.cc:5855
145:     #22 0x555e5afc7665 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../../third_party/googletest/googletest/src/gtest.cc:2607
145:     #23 0x555e5afb93ed in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) ../../third_party/googletest/googletest/src/gtest.cc:2643
145:     #24 0x555e5af7aba1 in testing::UnitTest::Run() ../../third_party/googletest/googletest/src/gtest.cc:5438
145:     #25 0x555e540fedbb in RUN_ALL_TESTS() ../../third_party/googletest/googletest/include/gtest/gtest.h:2490
145:     #26 0x555e540feca6 in main ../../velox/functions/prestosql/aggregates/tests/Main.cpp:22
145:     #27 0x7fcfb0bbfd09 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x26d09)
145: 
145: SUMMARY: AddressSanitizer: 288 byte(s) leaked in 1 allocation(s).
155/157 Test #145: velox_aggregates_test ......................................................***Failed  595.78 sec