### PR TITLE
Remove nullOutput flag from converter.

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -230,11 +230,8 @@ velox::variant convertFromString(const std::optional<std::string>& value) {
     if constexpr (ToKind == TypeKind::VARCHAR) {
       return velox::variant(value.value());
     }
-    bool nullOutput = false;
-    auto result =
-        velox::util::Converter<ToKind>::cast(value.value(), nullOutput);
-    VELOX_CHECK(
-        not nullOutput, "Failed to cast {} to {}", value.value(), ToKind)
+    auto result = velox::util::Converter<ToKind>::cast(value.value());
+
     return velox::variant(result);
   }
   return velox::variant(ToKind);

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -52,9 +52,7 @@ core::TypedExprPtr parseExpr(
 
 template <TypeKind FromKind, TypeKind ToKind>
 typename TypeTraits<ToKind>::NativeType cast(const variant& v) {
-  bool nullOutput;
-  return util::Converter<ToKind, void, false>::cast(
-      v.value<FromKind>(), nullOutput);
+  return util::Converter<ToKind, void, false>::cast(v.value<FromKind>());
 }
 } // namespace
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -41,18 +41,13 @@ namespace {
 /// @param row The index of the current row
 /// @param input The input vector (of type FromKind)
 /// @param result The output vector (of type ToKind)
-/// @return False if the result is null
 template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
 void applyCastKernel(
     vector_size_t row,
     const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
-    FlatVector<typename TypeTraits<ToKind>::NativeType>* result,
-    bool& nullOutput) {
-  auto output = util::Converter<ToKind, void, Truncate>::cast(
-      input->valueAt(row), nullOutput);
-  if (nullOutput) {
-    return;
-  }
+    FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
+  auto output =
+      util::Converter<ToKind, void, Truncate>::cast(input->valueAt(row));
 
   if constexpr (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
     // Write the result output to the output vector
@@ -142,11 +137,10 @@ void applyCastPrimitives(
 
   if (!queryConfig.isCastToIntByTruncate()) {
     context.applyToSelectedNoThrow(rows, [&](int row) {
-      bool nullOutput = false;
       try {
         // Passing a false truncate flag
         applyCastKernel<ToKind, FromKind, false>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+            row, inputSimpleVector, resultFlatVector);
       } catch (const VeloxRuntimeError& re) {
         VELOX_FAIL(
             makeErrorMessage(input, row, resultFlatVector->type()) + " " +
@@ -159,19 +153,14 @@ void applyCastPrimitives(
         VELOX_USER_FAIL(
             makeErrorMessage(input, row, resultFlatVector->type()) + " " +
             e.what());
-      }
-
-      if (nullOutput) {
-        VELOX_USER_FAIL(makeErrorMessage(input, row, resultFlatVector->type()));
       }
     });
   } else {
     context.applyToSelectedNoThrow(rows, [&](int row) {
-      bool nullOutput = false;
       try {
         // Passing a true truncate flag
         applyCastKernel<ToKind, FromKind, true>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+            row, inputSimpleVector, resultFlatVector);
       } catch (const VeloxRuntimeError& re) {
         VELOX_FAIL(
             makeErrorMessage(input, row, resultFlatVector->type()) + " " +
@@ -184,10 +173,6 @@ void applyCastPrimitives(
         VELOX_USER_FAIL(
             makeErrorMessage(input, row, resultFlatVector->type()) + " " +
             e.what());
-      }
-
-      if (nullOutput) {
-        VELOX_USER_FAIL(makeErrorMessage(input, row, resultFlatVector->type()));
       }
     });
   }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -933,8 +933,8 @@ TEST_F(CastExprTest, integerToDecimal) {
 TEST_F(CastExprTest, castInTry) {
   // Test try(cast(array(varchar) as array(bigint))) whose input vector is
   // wrapped in dictinary encoding. The row of ["2a"] should trigger an error
-  // during casting and the try expression should turn this error into a null at
-  // this row.
+  // during casting and the try expression should turn this error into a null
+  // at this row.
   auto input = makeRowVector({makeNullableArrayVector<StringView>(
       {{{"1"_sv}}, {{"2a"_sv}}, std::nullopt, std::nullopt})});
   auto expected = makeNullableArrayVector<int64_t>(
@@ -1056,8 +1056,8 @@ TEST_F(CastExprTest, castAsCall) {
 }
 
 namespace {
-/// Wraps input in a constant encoding that repeats the first element and then
-/// in dictionary that reverses the order of rows.
+/// Wraps input in a constant encoding that repeats the first element and
+/// then in dictionary that reverses the order of rows.
 class TestingDictionaryOverConstFunction : public exec::VectorFunction {
  public:
   TestingDictionaryOverConstFunction() {}

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -101,9 +101,7 @@ struct ArrayJoinFunction {
 
   template <typename C>
   void writeValue(out_type<velox::Varchar>& result, const C& value) {
-    bool nullOutput = false;
-    result += util::Converter<TypeKind::VARCHAR, void, false>::cast(
-        value, nullOutput);
+    result += util::Converter<TypeKind::VARCHAR, void, false>::cast(value);
   }
 
   template <typename C>

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -106,23 +106,20 @@ struct DateFunction : public TimestampWithTimezoneSupport<T> {
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<Varchar>& date) {
-    bool nullOutput;
-    result = util::Converter<TypeKind::DATE>::cast(date, nullOutput);
+    result = util::Converter<TypeKind::DATE>::cast(date);
   }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<Timestamp>& timestamp) {
-    bool nullOutput;
-    result = util::Converter<TypeKind::DATE>::cast(timestamp, nullOutput);
+    result = util::Converter<TypeKind::DATE>::cast(timestamp);
   }
 
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
-    bool nullOutput;
     result = util::Converter<TypeKind::DATE>::cast(
-        this->toTimestamp(timestampWithTimezone), nullOutput);
+        this->toTimestamp(timestampWithTimezone));
   }
 };
 

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -29,11 +29,7 @@ namespace facebook::velox::util {
 template <TypeKind KIND, typename = void, bool TRUNCATE = false>
 struct Converter {
   template <typename T>
-  // nullOutput API requires that the user has already set nullOutput to
-  // false as default to avoid having to reset it in each cast function for now
-  // If in the future we change nullOutput in many functions we can revisit that
-  // contract.
-  static typename TypeTraits<KIND>::NativeType cast(T val, bool& nullOutput) {
+  static typename TypeTraits<KIND>::NativeType cast(T) {
     VELOX_UNSUPPORTED(
         "Conversion to {} is not supported", TypeTraits<KIND>::name);
   }
@@ -44,27 +40,27 @@ struct Converter<TypeKind::BOOLEAN> {
   using T = bool;
 
   template <typename From>
-  static T cast(const From& v, bool& nullOutput) {
+  static T cast(const From& v) {
     return folly::to<T>(v);
   }
 
-  static T cast(const folly::StringPiece& v, bool& nullOutput) {
+  static T cast(folly::StringPiece v) {
     return folly::to<T>(v);
   }
 
-  static T cast(const StringView& v, bool& nullOutput) {
+  static T cast(const StringView& v) {
     return folly::to<T>(folly::StringPiece(v));
   }
 
-  static T cast(const std::string& v, bool& nullOutput) {
+  static T cast(const std::string& v) {
     return folly::to<T>(v);
   }
 
-  static T cast(const Date& d, bool& nullOutput) {
+  static T cast(const Date&) {
     VELOX_UNSUPPORTED("Conversion of Date to Boolean is not supported");
   }
 
-  static T cast(const Timestamp& d, bool& nullOutput) {
+  static T cast(const Timestamp&) {
     VELOX_UNSUPPORTED("Conversion of Timestamp to Boolean is not supported");
   }
 };
@@ -81,29 +77,29 @@ struct Converter<
   using T = typename TypeTraits<KIND>::NativeType;
 
   template <typename From>
-  static T cast(const From& v, bool& nullOutput) {
+  static T cast(const From&) {
     VELOX_UNSUPPORTED(
         "Conversion to {} is not supported", TypeTraits<KIND>::name);
   }
 
-  static T convertStringToInt(const folly::StringPiece& v, bool& nullOutput) {
+  static T convertStringToInt(const folly::StringPiece v) {
     // Handling boolean target case fist because it is in this scope
     if constexpr (std::is_same_v<T, bool>) {
       return folly::to<T>(v);
     } else {
       // Handling integer target cases
-      nullOutput = true;
-      bool negative = false;
       T result = 0;
       int index = 0;
       int len = v.size();
       if (len == 0) {
-        return -1;
+        VELOX_USER_FAIL("Cannot cast an empty string to an integral value.");
       }
+
       // Setting negative flag
+      bool negative = false;
       if (v[0] == '-') {
         if (len == 1) {
-          return -1;
+          VELOX_USER_FAIL("Cannot cast an '-' string to an integral value.");
         }
         negative = true;
         index = 1;
@@ -111,36 +107,35 @@ struct Converter<
       if (negative) {
         for (; index < len; index++) {
           if (!std::isdigit(v[index])) {
-            return -1;
+            VELOX_USER_FAIL("Encountered a non-digit character");
           }
           result = result * 10 - (v[index] - '0');
           // Overflow check
           if (result > 0) {
-            return -1;
+            VELOX_USER_FAIL("Value is too large for type");
           }
         }
       } else {
         for (; index < len; index++) {
           if (!std::isdigit(v[index])) {
-            return -1;
+            VELOX_USER_FAIL("Encountered a non-digit character");
           }
           result = result * 10 + (v[index] - '0');
           // Overflow check
           if (result < 0) {
-            return -1;
+            VELOX_USER_FAIL("Value is too large for type");
           }
         }
       }
       // Final result
-      nullOutput = false;
       return result;
     }
   }
 
-  static T cast(const folly::StringPiece& v, bool& nullOutput) {
+  static T cast(folly::StringPiece v) {
     try {
       if constexpr (TRUNCATE) {
-        return convertStringToInt(v, nullOutput);
+        return convertStringToInt(v);
       } else {
         return folly::to<T>(v);
       }
@@ -149,10 +144,10 @@ struct Converter<
     }
   }
 
-  static T cast(const StringView& v, bool& nullOutput) {
+  static T cast(const StringView& v) {
     try {
       if constexpr (TRUNCATE) {
-        return convertStringToInt(folly::StringPiece(v), nullOutput);
+        return convertStringToInt(folly::StringPiece(v));
       } else {
         return folly::to<T>(folly::StringPiece(v));
       }
@@ -161,10 +156,10 @@ struct Converter<
     }
   }
 
-  static T cast(const std::string& v, bool& nullOutput) {
+  static T cast(const std::string& v) {
     try {
       if constexpr (TRUNCATE) {
-        return convertStringToInt(v, nullOutput);
+        return convertStringToInt(v);
       } else {
         return folly::to<T>(v);
       }
@@ -173,7 +168,7 @@ struct Converter<
     }
   }
 
-  static T cast(const bool& v, bool& nullOutput) {
+  static T cast(const bool& v) {
     return folly::to<T>(v);
   }
 
@@ -213,7 +208,7 @@ struct Converter<
     }
   };
 
-  static T cast(const float& v, bool& nullOutput) {
+  static T cast(const float& v) {
     if constexpr (TRUNCATE) {
       if (std::isnan(v)) {
         return 0;
@@ -237,7 +232,7 @@ struct Converter<
     }
   }
 
-  static T cast(const double& v, bool& nullOutput) {
+  static T cast(const double& v) {
     if constexpr (TRUNCATE) {
       if (std::isnan(v)) {
         return 0;
@@ -261,7 +256,7 @@ struct Converter<
     }
   }
 
-  static T cast(const int8_t& v, bool& nullOutput) {
+  static T cast(const int8_t& v) {
     if constexpr (TRUNCATE) {
       return T(v);
     } else {
@@ -269,7 +264,7 @@ struct Converter<
     }
   }
 
-  static T cast(const int16_t& v, bool& nullOutput) {
+  static T cast(const int16_t& v) {
     if constexpr (TRUNCATE) {
       return T(v);
     } else {
@@ -277,7 +272,7 @@ struct Converter<
     }
   }
 
-  static T cast(const int32_t& v, bool& nullOutput) {
+  static T cast(const int32_t& v) {
     if constexpr (TRUNCATE) {
       return T(v);
     } else {
@@ -285,7 +280,7 @@ struct Converter<
     }
   }
 
-  static T cast(const int64_t& v, bool& nullOutput) {
+  static T cast(const int64_t& v) {
     if constexpr (TRUNCATE) {
       return T(v);
     } else {
@@ -302,7 +297,7 @@ struct Converter<
   using T = typename TypeTraits<KIND>::NativeType;
 
   template <typename From>
-  static T cast(const From& v, bool& nullOutput) {
+  static T cast(const From& v) {
     try {
       return folly::to<T>(v);
     } catch (const std::exception& e) {
@@ -310,59 +305,59 @@ struct Converter<
     }
   }
 
-  static T cast(const folly::StringPiece& v, bool& nullOutput) {
-    return cast<folly::StringPiece>(v, nullOutput);
+  static T cast(folly::StringPiece v) {
+    return cast<folly::StringPiece>(v);
   }
 
-  static T cast(const StringView& v, bool& nullOutput) {
-    return cast<folly::StringPiece>(folly::StringPiece(v), nullOutput);
+  static T cast(const StringView& v) {
+    return cast<folly::StringPiece>(folly::StringPiece(v));
   }
 
-  static T cast(const std::string& v, bool& nullOutput) {
-    return cast<std::string>(v, nullOutput);
+  static T cast(const std::string& v) {
+    return cast<std::string>(v);
   }
 
-  static T cast(const bool& v, bool& nullOutput) {
-    return cast<bool>(v, nullOutput);
+  static T cast(const bool& v) {
+    return cast<bool>(v);
   }
 
-  static T cast(const float& v, bool& nullOutput) {
-    return cast<float>(v, nullOutput);
+  static T cast(const float& v) {
+    return cast<float>(v);
   }
 
-  static T cast(const double& v, bool& nullOutput) {
+  static T cast(const double& v) {
     if constexpr (TRUNCATE) {
       return T(v);
     } else {
-      return cast<double>(v, nullOutput);
+      return cast<double>(v);
     }
   }
 
-  static T cast(const int8_t& v, bool& nullOutput) {
-    return cast<int8_t>(v, nullOutput);
+  static T cast(const int8_t& v) {
+    return cast<int8_t>(v);
   }
 
-  static T cast(const int16_t& v, bool& nullOutput) {
-    return cast<int16_t>(v, nullOutput);
+  static T cast(const int16_t& v) {
+    return cast<int16_t>(v);
   }
 
   // Convert integer to double or float directly, not using folly, as it
   // might throw 'loss of precision' error.
-  static T cast(const int32_t& v, bool& nullOutput) {
+  static T cast(const int32_t& v) {
     return static_cast<T>(v);
   }
 
   // Convert large integer to double or float directly, not using folly, as it
   // might throw 'loss of precision' error.
-  static T cast(const int64_t& v, bool& nullOutput) {
+  static T cast(const int64_t& v) {
     return static_cast<T>(v);
   }
 
-  static T cast(const Date& d, bool& nullOutput) {
+  static T cast(const Date&) {
     VELOX_UNSUPPORTED("Conversion of Date to Real or Double is not supported");
   }
 
-  static T cast(const Timestamp& d, bool& nullOutput) {
+  static T cast(const Timestamp&) {
     VELOX_UNSUPPORTED(
         "Conversion of Timestamp to Real or Double is not supported");
   }
@@ -372,15 +367,15 @@ template <bool TRUNCATE>
 struct Converter<TypeKind::VARBINARY, void, TRUNCATE> {
   // Same semantics of TypeKind::VARCHAR converter.
   template <typename T>
-  static std::string cast(const T& val, bool& nullOutput) {
-    return Converter<TypeKind::VARCHAR, void, TRUNCATE>::cast(val, nullOutput);
+  static std::string cast(const T& val) {
+    return Converter<TypeKind::VARCHAR, void, TRUNCATE>::cast(val);
   }
 };
 
 template <bool TRUNCATE>
 struct Converter<TypeKind::VARCHAR, void, TRUNCATE> {
   template <typename T>
-  static std::string cast(const T& val, bool& nullOutput) {
+  static std::string cast(const T& val) {
     if constexpr (
         TRUNCATE && (std::is_same_v<T, double> || std::is_same_v<T, double>)) {
       auto stringValue = folly::to<std::string>(val);
@@ -393,11 +388,11 @@ struct Converter<TypeKind::VARCHAR, void, TRUNCATE> {
     return folly::to<std::string>(val);
   }
 
-  static std::string cast(const Timestamp& val, bool& nullOutput) {
+  static std::string cast(const Timestamp& val) {
     return val.toString(Timestamp::Precision::kMilliseconds);
   }
 
-  static std::string cast(const bool& val, bool& nullOutput) {
+  static std::string cast(const bool& val) {
     return val ? "true" : "false";
   }
 };
@@ -408,24 +403,24 @@ struct Converter<TypeKind::TIMESTAMP> {
   using T = typename TypeTraits<TypeKind::TIMESTAMP>::NativeType;
 
   template <typename From>
-  static T cast(const From& /* v */, bool& nullOutput) {
+  static T cast(const From& /* v */) {
     VELOX_UNSUPPORTED("Conversion to Timestamp is not supported");
     return T();
   }
 
-  static T cast(folly::StringPiece v, bool& nullOutput) {
+  static T cast(folly::StringPiece v) {
     return fromTimestampString(v.data(), v.size());
   }
 
-  static T cast(const StringView& v, bool& nullOutput) {
+  static T cast(const StringView& v) {
     return fromTimestampString(v.data(), v.size());
   }
 
-  static T cast(const std::string& v, bool& nullOutput) {
+  static T cast(const std::string& v) {
     return fromTimestampString(v.data(), v.size());
   }
 
-  static T cast(const Date& d, bool& nullOutput) {
+  static T cast(const Date& d) {
     static const int64_t kMillisPerDay{86'400'000};
     return Timestamp::fromMillis(d.days() * kMillisPerDay);
   }
@@ -436,24 +431,24 @@ template <bool TRUNCATE>
 struct Converter<TypeKind::DATE, void, TRUNCATE> {
   using T = typename TypeTraits<TypeKind::DATE>::NativeType;
   template <typename From>
-  static T cast(const From& /* v */, bool& nullOutput) {
+  static T cast(const From& /* v */) {
     VELOX_UNSUPPORTED("Conversion to Date is not supported");
     return T();
   }
 
-  static T cast(folly::StringPiece v, bool& nullOutput) {
+  static T cast(folly::StringPiece v) {
     return fromDateString(v.data(), v.size());
   }
 
-  static T cast(const StringView& v, bool& nullOutput) {
+  static T cast(const StringView& v) {
     return fromDateString(v.data(), v.size());
   }
 
-  static T cast(const std::string& v, bool& nullOutput) {
+  static T cast(const std::string& v) {
     return fromDateString(v.data(), v.size());
   }
 
-  static T cast(const Timestamp& t, bool& nullOutput) {
+  static T cast(const Timestamp& t) {
     static const int32_t kSecsPerDay{86'400};
     auto seconds = t.getSeconds();
     if (seconds >= 0 || seconds % kSecsPerDay == 0) {

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -582,12 +582,7 @@ struct VariantConverter {
     if (value.isNull()) {
       return variant{value.kind()};
     }
-    bool nullOutput = false;
-    auto converted =
-        util::Converter<ToKind>::cast(value.value<FromKind>(), nullOutput);
-    if (nullOutput) {
-      throw std::invalid_argument("Velox cast error");
-    }
+    auto converted = util::Converter<ToKind>::cast(value.value<FromKind>());
     return {converted};
   }
 


### PR DESCRIPTION
Summary:
The flag nullOutput was introduced by https://github.com/facebookincubator/velox/pull/476
as performance optimization.

However its problematic in different ways:
1. It was introduced to remove the cost of the throw, however callers still throw after reading
that nullOutput is true, so moving the throw inside the cast function should be ok.
2. It is only enabled in truncate mode! and only in convertStringToInt conversion, but not elsewhere!.
The flag is passed to 10 of functions without any change.
3. The original diff did not provide evidence of performance.
4. If we want to optimize throw/catch we can pass context and call setError as an alternative that would avoid the throw
we are inside a try.
5. The flag spams the converter code since it's not used in almost all cast functions.

Differential Revision: D46506557

