### PR TITLE
Simplify serialization of whole vectors

### DIFF
--- a/velox/vector/VectorStream.cpp
+++ b/velox/vector/VectorStream.cpp
@@ -17,6 +17,12 @@
 #include <memory>
 
 namespace facebook::velox {
+
+void VectorSerializer::append(const RowVectorPtr& vector) {
+  const IndexRange allRows{0, vector->size()};
+  append(vector, folly::Range(&allRows, 1));
+}
+
 namespace {
 
 std::unique_ptr<VectorSerde>& getVectorSerdeImpl() {
@@ -96,9 +102,13 @@ void VectorStreamGroup::createStreamTree(
 }
 
 void VectorStreamGroup::append(
-    RowVectorPtr vector,
+    const RowVectorPtr& vector,
     const folly::Range<const IndexRange*>& ranges) {
   serializer_->append(vector, ranges);
+}
+
+void VectorStreamGroup::append(const RowVectorPtr& vector) {
+  serializer_->append(vector);
 }
 
 void VectorStreamGroup::flush(OutputStream* out) {

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -35,17 +35,22 @@ class VectorSerializer {
  public:
   virtual ~VectorSerializer() = default;
 
+  /// Serialize a subset of rows in a vector.
   virtual void append(
       const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges) = 0;
 
-  // Writes the contents to 'stream' in wire format
+  /// Serialize all rows in a vector.
+  void append(const RowVectorPtr& vector);
+
+  /// Write serialized data to 'stream'.
   virtual void flush(OutputStream* stream) = 0;
 };
 
 class VectorSerde {
  public:
   virtual ~VectorSerde() = default;
+
   // Lets the caller pass options to the Serde. This can be extended to add
   // custom options by each of its extended classes.
   struct Options {
@@ -111,8 +116,10 @@ class VectorStreamGroup : public StreamArena {
       vector_size_t** sizes);
 
   void append(
-      RowVectorPtr vector,
+      const RowVectorPtr& vector,
       const folly::Range<const IndexRange*>& ranges);
+
+  void append(const RowVectorPtr& vector);
 
   // Writes the contents to 'stream' in wire format.
   void flush(OutputStream* stream);


### PR DESCRIPTION
Make it easier to serialize whole vectors via VectorSerializer::append(vector).