### PR TITLE
Add 3-argument version of min_by and max_by Presto aggregates

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -71,9 +71,17 @@ General Aggregate Functions
 
     Returns the value of ``x`` associated with the maximum value of ``y`` over all input values.
 
+.. function:: max_by(x, y, n) -> array([same as x])
+
+    Returns n values of ``x`` associated with the n largest values of ``y`` in descending order of ``y``.
+
 .. function:: min_by(x, y) -> [same as x]
 
     Returns the value of ``x`` associated with the minimum value of ``y`` over all input values.
+
+.. function:: min_by(x, y, n) -> array([same as x])
+
+    Returns n values of ``x`` associated with the n smallest values of ``y`` in ascending order of ``y``.
 
 .. function:: max(x) -> [same as input]
 

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -26,6 +26,20 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
+void resizeRowVectorAndChildren(RowVector& rowVector, vector_size_t size) {
+  rowVector.resize(size);
+  for (auto& child : rowVector.children()) {
+    child->resize(size);
+  }
+}
+
+std::pair<vector_size_t*, vector_size_t*> rawOffsetAndSizes(
+    ArrayVector& arrayVector) {
+  return {
+      arrayVector.offsets()->asMutable<vector_size_t>(),
+      arrayVector.sizes()->asMutable<vector_size_t>()};
+}
+
 template <typename T>
 constexpr bool isNumericOrDate() {
   return std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t> ||
@@ -210,9 +224,7 @@ class MinMaxByAggregate : public exec::Aggregate {
     auto valueVector = rowVector->childAt(0);
     auto comparisonVector = rowVector->childAt(1);
 
-    rowVector->resize(numGroups);
-    valueVector->resize(numGroups);
-    comparisonVector->resize(numGroups);
+    resizeRowVectorAndChildren(*rowVector, numGroups);
     uint64_t* rawNulls = getRawNulls(rowVector);
 
     T* rawValues = nullptr;
@@ -628,6 +640,454 @@ class MinByAggregate : public MinMaxByAggregate<T, U> {
   }
 };
 
+/// @tparam V Type of value.
+/// @tparam C Type of compare.
+/// @tparam Compare Type of comparator of std::pair<C, std::optional<V>>.
+template <typename V, typename C, typename Compare>
+struct MinMaxByNAccumulator {
+  int64_t n{0};
+
+  using Pair = std::pair<C, std::optional<V>>;
+  std::priority_queue<Pair, std::vector<Pair, StlAllocator<Pair>>, Compare>
+      topPairs;
+
+  explicit MinMaxByNAccumulator(HashStringAllocator* allocator)
+      : topPairs{Compare{}, StlAllocator<Pair>(allocator)} {}
+
+  void
+  compareAndAdd(C comparison, std::optional<V> value, Compare& comparator) {
+    if (topPairs.size() < n) {
+      topPairs.push({comparison, value});
+    } else {
+      const auto& topPair = topPairs.top();
+      if (comparator.compare(comparison, topPair)) {
+        topPairs.pop();
+        topPairs.push({comparison, value});
+      }
+    }
+  }
+
+  /// Moves all values from 'topPairs' into 'rawValues' and 'rawValueNulls'
+  /// buffers. The queue of 'topPairs' will be empty after this call.
+  void
+  extractValues(V* rawValues, uint64_t* rawValueNulls, vector_size_t offset) {
+    const vector_size_t size = topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = topPairs.top();
+      const auto index = offset + i;
+
+      const bool valueIsNull = !topPair.second.has_value();
+      bits::setNull(rawValueNulls, index, valueIsNull);
+      if (!valueIsNull) {
+        rawValues[index] = topPair.second.value();
+      }
+
+      topPairs.pop();
+    }
+  }
+
+  /// Moves all pairs of (comparison, value) from 'topPairs' into
+  /// 'rawComparisons', 'rawValues' and 'rawValueNulls' buffers. The queue of
+  /// 'topPairs' will be empty after this call.
+  void extractPairs(
+      C* rawComparisons,
+      V* rawValues,
+      uint64_t* rawValueNulls,
+      vector_size_t offset) {
+    const vector_size_t size = topPairs.size();
+    for (auto i = size - 1; i >= 0; --i) {
+      const auto& topPair = topPairs.top();
+      const auto index = offset + i;
+
+      rawComparisons[index] = topPair.first;
+
+      const bool valueIsNull = !topPair.second.has_value();
+      bits::setNull(rawValueNulls, index, valueIsNull);
+      if (!valueIsNull) {
+        rawValues[index] = topPair.second.value();
+      }
+
+      topPairs.pop();
+    }
+  }
+};
+
+template <typename V, typename C>
+struct Less {
+  using Pair = std::pair<C, std::optional<V>>;
+  bool operator()(const Pair& lhs, const Pair& rhs) {
+    return lhs.first < rhs.first;
+  }
+
+  bool compare(C lhs, const Pair& rhs) {
+    return lhs < rhs.first;
+  }
+};
+
+template <typename V, typename C>
+struct Greater {
+  using Pair = std::pair<C, std::optional<V>>;
+  bool operator()(const Pair& lhs, const Pair& rhs) {
+    return lhs.first > rhs.first;
+  }
+
+  bool compare(C lhs, const Pair& rhs) {
+    return lhs > rhs.first;
+  }
+};
+
+template <typename V, typename C, typename Compare>
+class MinMaxByNAggregate : public exec::Aggregate {
+ public:
+  explicit MinMaxByNAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  using AccumulatorType = MinMaxByNAccumulator<V, C, Compare>;
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(AccumulatorType);
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    exec::Aggregate::setAllNulls(groups, indices);
+    for (const vector_size_t i : indices) {
+      auto group = groups[i];
+      new (group + offset_) AccumulatorType(allocator_);
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto valuesArray = (*result)->as<ArrayVector>();
+    valuesArray->resize(numGroups);
+
+    const auto numValues =
+        countValuesAndSetResultNulls(groups, numGroups, *result);
+
+    auto values = valuesArray->elements();
+    values->resize(numValues);
+
+    auto rawValues = values->as<FlatVector<V>>()->mutableRawValues();
+    uint64_t* rawValueNulls = values->mutableRawNulls();
+
+    auto [rawOffsets, rawSizes] = rawOffsetAndSizes(*valuesArray);
+
+    vector_size_t offset = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      auto* group = groups[i];
+
+      if (!isNull(group)) {
+        auto* accumulator = value(group);
+        const vector_size_t size = accumulator->topPairs.size();
+
+        rawOffsets[i] = offset;
+        rawSizes[i] = size;
+
+        accumulator->extractValues(rawValues, rawValueNulls, offset);
+
+        offset += size;
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    auto nVector = rowVector->childAt(0);
+    auto valueArray = rowVector->childAt(1)->as<ArrayVector>();
+    auto comparisonArray = rowVector->childAt(2)->as<ArrayVector>();
+
+    resizeRowVectorAndChildren(*rowVector, numGroups);
+
+    auto* rawNs = nVector->as<FlatVector<int64_t>>()->mutableRawValues();
+
+    const auto numValues =
+        countValuesAndSetResultNulls(groups, numGroups, *result);
+
+    auto values = valueArray->elements();
+    auto comparisons = comparisonArray->elements();
+
+    values->resize(numValues);
+    comparisons->resize(numValues);
+
+    auto rawValues = values->as<FlatVector<V>>()->mutableRawValues();
+    uint64_t* rawValueNulls = values->mutableRawNulls();
+    auto rawComparisons = comparisons->as<FlatVector<C>>()->mutableRawValues();
+
+    auto [rawValueOffsets, rawValueSizes] = rawOffsetAndSizes(*valueArray);
+    auto [rawComparisonOffsets, rawComparisonSizes] =
+        rawOffsetAndSizes(*comparisonArray);
+
+    vector_size_t offset = 0;
+    for (auto i = 0; i < numGroups; ++i) {
+      auto* group = groups[i];
+
+      if (!isNull(group)) {
+        auto* accumulator = value(group);
+        const auto size = accumulator->topPairs.size();
+
+        rawNs[i] = accumulator->n;
+
+        rawValueOffsets[i] = offset;
+        rawValueSizes[i] = size;
+
+        rawComparisonOffsets[i] = offset;
+        rawComparisonSizes[i] = size;
+
+        accumulator->extractPairs(
+            rawComparisons, rawValues, rawValueNulls, offset);
+
+        offset += size;
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*unused*/) override {
+    decodedValue_.decode(*args[0], rows);
+    decodedComparison_.decode(*args[1], rows);
+    decodedN_.decode(*args[2], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (decodedComparison_.isNullAt(i)) {
+        return;
+      }
+
+      auto* group = groups[i];
+
+      auto* accumulator = value(group);
+      const auto n = validateN(decodedN_, i, accumulator->n);
+
+      addRawInput(group, n, i);
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto results = decodeIntermediateResults(args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (!decodedIntermediates_.isNullAt(i)) {
+        addIntermediateResults(groups[i], i, results);
+      }
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*unused*/) override {
+    decodedValue_.decode(*args[0], rows);
+    decodedComparison_.decode(*args[1], rows);
+
+    auto* accumulator = value(group);
+    const auto n = extractN(args[2], rows, accumulator->n);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (!decodedComparison_.isNullAt(i)) {
+        addRawInput(group, n, i);
+      }
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /*mayPushdown*/) override {
+    auto results = decodeIntermediateResults(args[0], rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      if (!decodedIntermediates_.isNullAt(i)) {
+        addIntermediateResults(group, i, results);
+      }
+    });
+  }
+
+ private:
+  inline AccumulatorType* value(char* group) {
+    return reinterpret_cast<AccumulatorType*>(group + Aggregate::offset_);
+  }
+
+  static std::optional<V> optionalValue(
+      const DecodedVector& decoded,
+      vector_size_t index) {
+    std::optional<V> value;
+    if (!decoded.isNullAt(index)) {
+      value = decoded.valueAt<V>(index);
+    }
+
+    return value;
+  }
+
+  static std::optional<V> optionalValue(
+      const FlatVector<V>& vector,
+      vector_size_t index) {
+    std::optional<V> value;
+    if (!vector.isNullAt(index)) {
+      value = vector.valueAt(index);
+    }
+
+    return value;
+  }
+
+  void addRawInput(char* group, int64_t n, vector_size_t index) {
+    clearNull(group);
+
+    auto* accumulator = value(group);
+    accumulator->n = n;
+
+    const auto comparison = decodedComparison_.valueAt<C>(index);
+    const auto value = optionalValue(decodedValue_, index);
+    accumulator->compareAndAdd(comparison, value, comparator_);
+  }
+
+  struct IntermediateResult {
+    const ArrayVector* valueArray;
+    const FlatVector<V>* values;
+    const ArrayVector* comparisonArray;
+    const FlatVector<C>* comparisons;
+  };
+
+  void addIntermediateResults(
+      char* group,
+      vector_size_t index,
+      const IntermediateResult& result) {
+    clearNull(group);
+
+    auto* accumulator = value(group);
+
+    const auto decodedIndex = decodedIntermediates_.index(index);
+
+    const auto n = validateN(decodedN_, decodedIndex, accumulator->n);
+    accumulator->n = n;
+
+    const auto* valueArray = result.valueArray;
+    const auto* values = result.values;
+    const auto* comparisonArray = result.comparisonArray;
+    const auto* comparisons = result.comparisons;
+
+    const auto numValues = valueArray->sizeAt(decodedIndex);
+    const auto valueOffset = valueArray->offsetAt(decodedIndex);
+    const auto comparisonOffset = comparisonArray->offsetAt(decodedIndex);
+    for (auto i = 0; i < numValues; ++i) {
+      const auto comparison = comparisons->valueAt(comparisonOffset + i);
+      const auto value = optionalValue(*values, valueOffset + i);
+      accumulator->compareAndAdd(comparison, value, comparator_);
+    }
+  }
+
+  IntermediateResult decodeIntermediateResults(
+      const VectorPtr& arg,
+      const SelectivityVector& rows) {
+    decodedIntermediates_.decode(*arg, rows);
+
+    auto baseRowVector =
+        dynamic_cast<const RowVector*>(decodedIntermediates_.base());
+
+    decodedN_.decode(*baseRowVector->childAt(0), rows);
+    decodedValue_.decode(*baseRowVector->childAt(1), rows);
+    decodedComparison_.decode(*baseRowVector->childAt(2), rows);
+
+    IntermediateResult result;
+    result.valueArray = decodedValue_.base()->template as<ArrayVector>();
+    result.comparisonArray =
+        decodedComparison_.base()->template as<ArrayVector>();
+
+    result.values = result.valueArray->elements()->template as<FlatVector<V>>();
+    result.comparisons =
+        result.comparisonArray->elements()->template as<FlatVector<C>>();
+
+    return result;
+  }
+
+  /// Return total number of values in all accumulators of specified 'groups'.
+  /// Set null flags in 'result'.
+  vector_size_t countValuesAndSetResultNulls(
+      char** groups,
+      int32_t numGroups,
+      VectorPtr& result) {
+    vector_size_t numValues = 0;
+
+    uint64_t* rawNulls = getRawNulls(result.get());
+
+    for (auto i = 0; i < numGroups; ++i) {
+      auto* group = groups[i];
+      auto* accumulator = value(group);
+
+      if (isNull(group)) {
+        result->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        numValues += accumulator->topPairs.size();
+      }
+    }
+
+    return numValues;
+  }
+
+  int64_t
+  validateN(DecodedVector& decodedN, vector_size_t row, int64_t currentN) {
+    VELOX_USER_CHECK(
+        !decodedN.isNullAt(row),
+        "third argument of max_by/min_by must be a positive integer");
+    const auto n = decodedN.valueAt<int64_t>(row);
+    VELOX_USER_CHECK_GT(
+        n, 0, "third argument of max_by/min_by must be a positive integer");
+
+    if (currentN) {
+      VELOX_USER_CHECK_EQ(
+          n,
+          currentN,
+          "third argument of max_by/min_by must be a constant for all rows in a group");
+    }
+    return n;
+  }
+
+  int64_t extractN(
+      const VectorPtr& arg,
+      const SelectivityVector& rows,
+      int64_t currentN) {
+    decodedN_.decode(*arg, rows);
+    if (decodedN_.isConstantMapping()) {
+      return validateN(decodedN_, rows.begin(), currentN);
+    }
+
+    const auto n = validateN(decodedN_, rows.begin(), currentN);
+    rows.applyToSelected([&](auto row) { validateN(decodedN_, row, n); });
+    return n;
+  }
+
+  Compare comparator_;
+  DecodedVector decodedValue_;
+  DecodedVector decodedComparison_;
+  DecodedVector decodedN_;
+  DecodedVector decodedIntermediates_;
+};
+
+template <typename C, typename V>
+class MinByNAggregate : public MinMaxByNAggregate<C, V, Less<C, V>> {
+ public:
+  explicit MinByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<C, V, Less<C, V>>(resultType) {}
+};
+
+template <typename C, typename V>
+class MaxByNAggregate : public MinMaxByNAggregate<C, V, Greater<C, V>> {
+ public:
+  explicit MaxByNAggregate(TypePtr resultType)
+      : MinMaxByNAggregate<C, V, Greater<C, V>>(resultType) {}
+};
+
 template <template <typename U, typename V> class Aggregate, typename W>
 std::unique_ptr<exec::Aggregate> create(
     TypePtr resultType,
@@ -659,19 +1119,78 @@ std::unique_ptr<exec::Aggregate> create(
 }
 
 template <template <typename U, typename V> class Aggregate>
+std::unique_ptr<exec::Aggregate> create(
+    TypePtr resultType,
+    TypePtr valueType,
+    TypePtr compareType,
+    const std::string& errorMessage) {
+  switch (valueType->kind()) {
+    case TypeKind::BOOLEAN:
+      return create<Aggregate, bool>(resultType, compareType, errorMessage);
+    case TypeKind::TINYINT:
+      return create<Aggregate, int8_t>(resultType, compareType, errorMessage);
+    case TypeKind::SMALLINT:
+      return create<Aggregate, int16_t>(resultType, compareType, errorMessage);
+    case TypeKind::INTEGER:
+      return create<Aggregate, int32_t>(resultType, compareType, errorMessage);
+    case TypeKind::BIGINT:
+      return create<Aggregate, int64_t>(resultType, compareType, errorMessage);
+    case TypeKind::REAL:
+      return create<Aggregate, float>(resultType, compareType, errorMessage);
+    case TypeKind::DOUBLE:
+      return create<Aggregate, double>(resultType, compareType, errorMessage);
+    case TypeKind::VARCHAR:
+      return create<Aggregate, StringView>(
+          resultType, compareType, errorMessage);
+    case TypeKind::DATE:
+      return create<Aggregate, Date>(resultType, compareType, errorMessage);
+    case TypeKind::TIMESTAMP:
+      return create<Aggregate, Timestamp>(
+          resultType, compareType, errorMessage);
+    case TypeKind::ARRAY:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::MAP:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::ROW:
+      return create<Aggregate, ComplexType>(
+          resultType, compareType, errorMessage);
+    default:
+      VELOX_FAIL(errorMessage);
+  }
+}
+
+std::string toString(const std::vector<TypePtr>& types) {
+  std::ostringstream out;
+  for (auto i = 0; i < types.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << types[i]->toString();
+  }
+  return out.str();
+}
+
+template <
+    template <typename U, typename V>
+    class Aggregate,
+    template <typename U, typename V>
+    class NAggregate>
 exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   // TODO Add support for boolean 'compare' types.
-  for (const auto& compareType :
-       {"tinyint",
-        "smallint",
-        "integer",
-        "bigint",
-        "real",
-        "double",
-        "varchar",
-        "date",
-        "timestamp"}) {
+  const std::vector<std::string> supportedCompareTypes = {
+      "tinyint",
+      "smallint",
+      "integer",
+      "bigint",
+      "real",
+      "double",
+      "varchar",
+      "date",
+      "timestamp"};
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  for (const auto& compareType : supportedCompareTypes) {
+    // V, C -> V.
     signatures.push_back(
         exec::AggregateFunctionSignatureBuilder()
             .typeVariable("T")
@@ -682,6 +1201,22 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
             .build());
   }
 
+  // Add support for all value types to 3-arg version of the aggregate.
+  for (const auto& compareType : supportedCompareTypes) {
+    for (const auto& valueType : supportedCompareTypes) {
+      // V, C, bigint -> array(V).
+      signatures.push_back(
+          exec::AggregateFunctionSignatureBuilder()
+              .returnType(fmt::format("array({})", valueType))
+              .intermediateType(fmt::format(
+                  "row(bigint,array({}),array({}))", valueType, compareType))
+              .argumentType(valueType)
+              .argumentType(compareType)
+              .argumentType("bigint")
+              .build());
+    }
+  }
+
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -689,76 +1224,42 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
           core::AggregationNode::Step step,
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType) -> std::unique_ptr<exec::Aggregate> {
-        auto isRawInput = exec::isRawInput(step);
-        if (isRawInput) {
-          VELOX_CHECK_EQ(
-              argTypes.size(),
-              2,
-              "{} partial aggregation takes 2 arguments",
-              name);
-        } else {
-          VELOX_CHECK_EQ(
-              argTypes.size(),
-              1,
-              "{} final aggregation takes one argument",
-              name);
-          VELOX_CHECK_EQ(
-              argTypes[0]->kind(),
-              TypeKind::ROW,
-              "{} final aggregation takes ROW({NUMERIC,NUMERIC}) structs as input",
-              name);
-        }
-        const auto valueType =
-            isRawInput ? argTypes[0] : argTypes[0]->childAt(0);
-        const auto compareType =
-            isRawInput ? argTypes[1] : argTypes[0]->childAt(1);
+        const auto isRawInput = exec::isRawInput(step);
         const std::string errorMessage = fmt::format(
-            "Unknown input types for {} ({}) aggregation: {}, {}",
+            "Unknown input types for {} ({}) aggregation: {}",
             name,
             mapAggregationStepToName(step),
-            valueType->kindName(),
-            compareType->kindName());
+            toString(argTypes));
 
-        switch (valueType->kind()) {
-          case TypeKind::BOOLEAN:
-            return create<Aggregate, bool>(
-                resultType, compareType, errorMessage);
-          case TypeKind::TINYINT:
-            return create<Aggregate, int8_t>(
-                resultType, compareType, errorMessage);
-          case TypeKind::SMALLINT:
-            return create<Aggregate, int16_t>(
-                resultType, compareType, errorMessage);
-          case TypeKind::INTEGER:
-            return create<Aggregate, int32_t>(
-                resultType, compareType, errorMessage);
-          case TypeKind::BIGINT:
-            return create<Aggregate, int64_t>(
-                resultType, compareType, errorMessage);
-          case TypeKind::REAL:
-            return create<Aggregate, float>(
-                resultType, compareType, errorMessage);
-          case TypeKind::DOUBLE:
-            return create<Aggregate, double>(
-                resultType, compareType, errorMessage);
-          case TypeKind::VARCHAR:
-            return create<Aggregate, StringView>(
-                resultType, compareType, errorMessage);
-          case TypeKind::DATE:
-            return create<Aggregate, Date>(
-                resultType, compareType, errorMessage);
-          case TypeKind::TIMESTAMP:
-            return create<Aggregate, Timestamp>(
-                resultType, compareType, errorMessage);
-          case TypeKind::ARRAY:
-            FOLLY_FALLTHROUGH;
-          case TypeKind::MAP:
-            FOLLY_FALLTHROUGH;
-          case TypeKind::ROW:
-            return create<Aggregate, ComplexType>(
-                resultType, compareType, errorMessage);
-          default:
-            VELOX_FAIL(errorMessage);
+        const bool nAgg = (argTypes.size() == 3) ||
+            (argTypes.size() == 1 && argTypes[0]->size() == 3);
+
+        if (nAgg) {
+          if (isRawInput) {
+            // Input is: V, C, BIGINT.
+            return create<NAggregate>(
+                resultType, argTypes[0], argTypes[1], errorMessage);
+          } else {
+            // Input is: ROW(BIGINT, ARRAY(V), ARRAY(C)).
+            const auto& rowType = argTypes[0];
+            const auto& valueType = rowType->childAt(1)->childAt(0);
+            const auto& compareType = rowType->childAt(2)->childAt(0);
+            return create<NAggregate>(
+                resultType, valueType, compareType, errorMessage);
+          }
+        } else {
+          if (isRawInput) {
+            // Input is: V, C.
+            return create<Aggregate>(
+                resultType, argTypes[0], argTypes[1], errorMessage);
+          } else {
+            // Input is: ROW(V, C).
+            const auto& rowType = argTypes[0];
+            const auto& valueType = rowType->childAt(0);
+            const auto& compareType = rowType->childAt(1);
+            return create<Aggregate>(
+                resultType, valueType, compareType, errorMessage);
+          }
         }
       });
 }
@@ -766,8 +1267,8 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
 } // namespace
 
 void registerMinMaxByAggregates(const std::string& prefix) {
-  registerMinMaxBy<MaxByAggregate>(prefix + kMaxBy);
-  registerMinMaxBy<MinByAggregate>(prefix + kMinBy);
+  registerMinMaxBy<MaxByAggregate, MaxByNAggregate>(prefix + kMaxBy);
+  registerMinMaxBy<MinByAggregate, MinByNAggregate>(prefix + kMinBy);
 }
 
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Add versions of min_by and max_by Presto aggregates that return n smallest or largest values. 

```
max_by(x, y, n) → array<[same as x]>[#](https://prestodb.io/docs/current/functions/aggregate.html#id2)

   Returns n values of x associated with the n largest of all input values of y in descending order of y.

min_by(x, y, n) → array<[same as x]>[#](https://prestodb.io/docs/current/functions/aggregate.html#id3)

   Returns n values of x associated with the n smallest of all input values of y in ascending order of y.
```

Only fixed-width types are currently supported for 'x' and 'y' arguments. 