### PR TITLE
Generalize the setup-macos.sh to get BREW_PATH dynamically

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -59,7 +59,7 @@ function prompt {
 function update_brew {
   BREW_PATH="$(which brew)"
   "${BREW_PATH}" update --auto-update --verbose
-  "{$BREW_PATH}" developer off
+  "${BREW_PATH}" developer off
 }
 
 function install_build_prerequisites {

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -57,11 +57,7 @@ function prompt {
 }
 
 function update_brew {
-  BREW_PATH=/usr/local/bin/brew
-  if [ `arch` == "arm64" ] ;
-     then
-       BREW_PATH=/opt/homebrew/bin/brew ;
- fi
+  BREW_PATH="$(which brew)"
   $BREW_PATH update --auto-update --verbose
   $BREW_PATH developer off
 }

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -58,8 +58,8 @@ function prompt {
 
 function update_brew {
   BREW_PATH="$(which brew)"
-  $BREW_PATH update --auto-update --verbose
-  $BREW_PATH developer off
+  "${BREW_PATH}" update --auto-update --verbose
+  "{$BREW_PATH}" developer off
 }
 
 function install_build_prerequisites {


### PR DESCRIPTION
The current code has a hard coded arch check for where the brew is located, which may be changed at anytime in the future. This change use the which to locate the brew binary location.