### PR TITLE
Reject window functions with ignore nulls flag

### DIFF
--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -122,6 +122,9 @@ void Window::createWindowFunctions(
     const std::shared_ptr<const core::WindowNode>& windowNode,
     const RowTypePtr& inputType) {
   for (const auto& windowNodeFunction : windowNode->windowFunctions()) {
+    VELOX_USER_CHECK(
+        !windowNodeFunction.ignoreNulls,
+        "Ignore nulls for window functions is not supported yet");
     std::vector<WindowFunctionArg> functionArgs;
     functionArgs.reserve(windowNodeFunction.functionCall->inputs().size());
     for (auto& arg : windowNodeFunction.functionCall->inputs()) {


### PR DESCRIPTION
Ignore nulls flag for window functions is not supported yet. Fail fast instead
of returning incorrect results.