### PR TITLE
Pass StreamLabels to SelectiveReaders

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -542,7 +542,8 @@ IntegerDictionaryColumnReader<ReqT>::IntegerDictionaryColumnReader(
       stripe.getStream(data, true), vers, memoryPool_, dataVInts, numBytes);
 
   // make a lazy dictionary initializer
-  dictInit = stripe.getIntDictionaryInitializerForNode(encodingKey, numBytes);
+  dictInit = stripe.getIntDictionaryInitializerForNode(
+      encodingKey, numBytes, streamLabels);
 
   auto inDictStream = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_IN_DICTIONARY), false);

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -23,6 +23,7 @@
 #include "velox/dwio/dwrf/common/Compression.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/reader/EncodingContext.h"
+#include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/dwio/dwrf/reader/StripeStream.h"
 #include "velox/vector/BaseVector.h"
 
@@ -67,6 +68,7 @@ class ColumnReader {
   ColumnReader(
       std::shared_ptr<const dwio::common::TypeWithId> nodeId,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext = {});
 
   virtual ~ColumnReader() = default;
@@ -111,6 +113,7 @@ class ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext = {});
 };
 
@@ -121,9 +124,14 @@ class ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext = {}) {
     return ColumnReader::build(
-        requestedType, dataType, stripe, std::move(flatMapContext));
+        requestedType,
+        dataType,
+        stripe,
+        streamLabels,
+        std::move(flatMapContext));
   }
 
   static ColumnReaderFactory* baseFactory();

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -115,10 +115,14 @@ class DwrfData : public dwio::common::FormatData {
 // DWRF specific initialization.
 class DwrfParams : public dwio::common::FormatParams {
  public:
-  explicit DwrfParams(StripeStreams& stripeStreams, FlatMapContext context = {})
+  explicit DwrfParams(
+      StripeStreams& stripeStreams,
+      const StreamLabels& streamLabels,
+      FlatMapContext context = {})
       : FormatParams(stripeStreams.getMemoryPool()),
         stripeStreams_(stripeStreams),
-        flatMapContext_(context) {}
+        flatMapContext_(context),
+        streamLabels_(streamLabels) {}
 
   std::unique_ptr<dwio::common::FormatData> toFormatData(
       const std::shared_ptr<const dwio::common::TypeWithId>& type,
@@ -134,9 +138,14 @@ class DwrfParams : public dwio::common::FormatParams {
     return flatMapContext_;
   }
 
+  const StreamLabels& streamLabels() const {
+    return streamLabels_;
+  }
+
  private:
   StripeStreams& stripeStreams_;
   FlatMapContext flatMapContext_;
+  const StreamLabels& streamLabels_;
 };
 
 inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::dwrf {
@@ -405,6 +406,8 @@ void DwrfRowReader::startNextStripe() {
   auto dataType = getReader().getSchemaWithId();
   FlatMapContext flatMapContext;
   flatMapContext.keySelectionCallback = options_.getKeySelectionCallback();
+  AllocationPool pool(&getReader().getMemoryPool());
+  StreamLabels streamLabels(pool);
 
   if (scanSpec) {
     selectiveColumnReader_ = SelectiveDwrfReader::build(
@@ -412,7 +415,7 @@ void DwrfRowReader::startNextStripe() {
     selectiveColumnReader_->setIsTopLevel();
   } else {
     columnReader_ = ColumnReader::build(
-        requestedType, dataType, stripeStreams, flatMapContext);
+        requestedType, dataType, stripeStreams, streamLabels, flatMapContext);
   }
   DWIO_ENSURE(
       (columnReader_ != nullptr) != (selectiveColumnReader_ != nullptr),

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -411,7 +411,12 @@ void DwrfRowReader::startNextStripe() {
 
   if (scanSpec) {
     selectiveColumnReader_ = SelectiveDwrfReader::build(
-        requestedType, dataType, stripeStreams, scanSpec, flatMapContext);
+        requestedType,
+        dataType,
+        stripeStreams,
+        streamLabels,
+        scanSpec,
+        flatMapContext);
     selectiveColumnReader_->setIsTopLevel();
   } else {
     columnReader_ = ColumnReader::build(

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -22,6 +22,7 @@
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/ConstantColumnReader.h"
+#include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/dwio/dwrf/utils/BitIterator.h"
 
 namespace facebook::velox::dwrf {
@@ -145,6 +146,7 @@ class FlatMapColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext);
   ~FlatMapColumnReader() override = default;
 
@@ -173,6 +175,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext);
   ~FlatMapStructEncodingColumnReader() override = default;
 
@@ -196,6 +199,7 @@ class FlatMapColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext);
 };
 

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -37,9 +37,10 @@ class SelectiveDwrfReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       common::ScanSpec* FOLLY_NONNULL scanSpec,
       FlatMapContext flatMapContext = {}) {
-    auto params = DwrfParams(stripe, flatMapContext);
+    auto params = DwrfParams(stripe, streamLabels, flatMapContext);
     return build(requestedType, dataType, params, *scanSpec);
   }
 };
@@ -54,8 +55,9 @@ class SelectiveColumnReaderFactory : public ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       StripeStreams& stripe,
+      const StreamLabels& streamLabels,
       FlatMapContext flatMapContext = {}) {
-    auto params = DwrfParams(stripe, std::move(flatMapContext));
+    auto params = DwrfParams(stripe, streamLabels, std::move(flatMapContext));
     auto reader =
         SelectiveDwrfReader::build(requestedType, dataType, params, *scanSpec_);
     reader->setIsTopLevel();

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -159,6 +159,7 @@ std::vector<KeyNode<T>> getKeyNodes(
         auto inMapDecoder = createBooleanRleDecoder(std::move(inMap), seqEk);
         DwrfParams childParams(
             stripe,
+            params.streamLabels(),
             FlatMapContext{
                 .sequence = sequence,
                 .inMapDecoder = inMapDecoder.get(),

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -48,7 +48,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
 
   // make a lazy dictionary initializer
   dictInit_ = stripe.getIntDictionaryInitializerForNode(
-      encodingKey, numBytes, numBytes);
+      encodingKey, numBytes, params.streamLabels(), numBytes);
 
   auto inDictStream = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_IN_DICTIONARY), false);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -71,8 +71,10 @@ SelectiveListColumnReader::SelectiveListColumnReader(
   scanSpec_->children()[0]->setProjectOut(true);
   scanSpec_->children()[0]->setExtractValues(true);
 
-  auto childParams =
-      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
+  auto childParams = DwrfParams(
+      stripe,
+      params.streamLabels(),
+      flatMapContextFromEncodingKey(encodingKey));
   child_ = SelectiveDwrfReader::build(
       childType, nodeType_->childAt(0), childParams, *scanSpec_->children()[0]);
   children_ = {child_.get()};
@@ -108,8 +110,10 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   VELOX_CHECK(
       cs.shouldReadNode(keyType->id),
       "Map key must be selected in SelectiveMapColumnReader");
-  auto keyParams =
-      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
+  auto keyParams = DwrfParams(
+      stripe,
+      params.streamLabels(),
+      flatMapContextFromEncodingKey(encodingKey));
   keyReader_ = SelectiveDwrfReader::build(
       keyType,
       nodeType_->childAt(0),
@@ -120,8 +124,10 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
   VELOX_CHECK(
       cs.shouldReadNode(valueType->id),
       "Map Values must be selected in SelectiveMapColumnReader");
-  auto elementParams =
-      DwrfParams(stripe, flatMapContextFromEncodingKey(encodingKey));
+  auto elementParams = DwrfParams(
+      stripe,
+      params.streamLabels(),
+      flatMapContextFromEncodingKey(encodingKey));
   elementReader_ = SelectiveDwrfReader::build(
       valueType,
       nodeType_->childAt(1),

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -55,6 +55,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
         requestedType_->childByName(childSpec->fieldName());
     auto childParams = DwrfParams(
         stripe,
+        params.streamLabels(),
         FlatMapContext{
             .sequence = encodingKey.sequence,
             .inMapDecoder = nullptr,

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -107,6 +107,7 @@ std::function<BufferPtr()>
 StripeStreamsBase::getIntDictionaryInitializerForNode(
     const EncodingKey& ek,
     uint64_t elementWidth,
+    const StreamLabels& streamLabels,
     uint64_t dictionaryWidth) {
   // Create local copy for manipulation
   EncodingKey localEk{ek};

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -20,6 +20,7 @@
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SeekableInputStream.h"
 #include "velox/dwio/dwrf/common/Common.h"
+#include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/dwio/dwrf/reader/StripeDictionaryCache.h"
 #include "velox/dwio/dwrf/reader/StripeReaderBase.h"
 
@@ -131,6 +132,7 @@ class StripeStreams {
   virtual std::function<BufferPtr()> getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t elementWidth,
+      const StreamLabels& streamLabels,
       uint64_t dictionaryWidth = sizeof(int64_t)) = 0;
 
   virtual std::shared_ptr<StripeDictionaryCache> getStripeDictionaryCache() = 0;
@@ -185,6 +187,7 @@ class StripeStreamsBase : public StripeStreams {
   std::function<BufferPtr()> getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t elementWidth,
+      const StreamLabels& streamLabels,
       uint64_t dictionaryWidth = sizeof(int64_t)) override;
 
   std::shared_ptr<StripeDictionaryCache> getStripeDictionaryCache() override {

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -54,6 +54,7 @@ class MockStripeStreams : public StripeStreams {
   std::function<BufferPtr()> getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t /* unused */,
+      const StreamLabels& /* streamLabels */,
       uint64_t /* unused */) override {
     return [this, nodeId = ek.node, sequenceId = ek.sequence]() {
       BufferPtr dictionaryData;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1081,8 +1081,13 @@ TEST(TestReader, testUpcastBoolean) {
           HiveTypeParser().parse("struct<col0:int>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
+  AllocationPool allocPool(defaultPool.get());
+  StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      labels);
 
   VectorPtr batch;
   reader->next(104, batch);
@@ -1125,8 +1130,13 @@ TEST(TestReader, testUpcastIntDirect) {
 
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
+  AllocationPool allocPool(defaultPool.get());
+  StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      labels);
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1186,8 +1196,13 @@ TEST(TestReader, testUpcastIntDict) {
           HiveTypeParser().parse("struct<col0:bigint>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
+  AllocationPool allocPool(defaultPool.get());
+  StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      labels);
 
   VectorPtr batch;
   reader->next(100, batch);
@@ -1235,8 +1250,13 @@ TEST(TestReader, testUpcastFloat) {
           HiveTypeParser().parse("struct<col0:double>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
+  AllocationPool allocPool(defaultPool.get());
+  StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
-      TypeWithId::create(reqType), TypeWithId::create(rowType), streams);
+      TypeWithId::create(reqType),
+      TypeWithId::create(rowType),
+      streams,
+      labels);
 
   VectorPtr batch;
   reader->next(100, batch);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -143,6 +143,7 @@ class ColumnReaderTestBase {
           cs.getSchemaWithId(),
           dataTypeWithId,
           streams_,
+          labels_,
           scanSpec,
           FlatMapContext{});
       selectiveColumnReader_->setIsTopLevel();

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -20,6 +20,7 @@
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 #include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
+#include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/dwio/dwrf/test/OrcTest.h"
 #include "velox/dwio/type/fbhive/HiveTypeParser.h"
 #include "velox/vector/ComplexVector.h"
@@ -108,6 +109,8 @@ std::shared_ptr<T> getChild(std::shared_ptr<F>& batch, size_t index) {
 
 class ColumnReaderTestBase {
  protected:
+  ColumnReaderTestBase() : pool_{&streams_.getMemoryPool()}, labels_{pool_} {}
+
   virtual ~ColumnReaderTestBase() = default;
 
   void buildReader(
@@ -145,8 +148,8 @@ class ColumnReaderTestBase {
       selectiveColumnReader_->setIsTopLevel();
       columnReader_ = nullptr;
     } else {
-      columnReader_ =
-          ColumnReader::build(cs.getSchemaWithId(), dataTypeWithId, streams_);
+      columnReader_ = ColumnReader::build(
+          cs.getSchemaWithId(), dataTypeWithId, streams_, labels_);
       selectiveColumnReader_ = nullptr;
     }
   }
@@ -203,6 +206,8 @@ class ColumnReaderTestBase {
   virtual bool returnFlatVector() const = 0;
 
   MockStripeStreams streams_;
+  AllocationPool pool_;
+  StreamLabels labels_;
   std::unique_ptr<ColumnReader> columnReader_;
   std::unique_ptr<SelectiveColumnReader> selectiveColumnReader_;
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -635,21 +635,23 @@ TEST(StripeStream, shareDictionary) {
       ss, getStreamProxy(2, Not(0), proto::Stream_Kind_DICTIONARY_DATA, _))
       .WillRepeatedly(Return(nullptr));
 
+  facebook::velox::AllocationPool allocPool(pool.get());
+  StreamLabels labels(allocPool);
   std::vector<std::function<facebook::velox::BufferPtr()>> dictInits{};
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{1, 0}, 8));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{1, 0}, 8, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 2}, 16));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 2}, 16, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 3}, 4));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 3}, 4, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 5}, 16));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 5}, 16, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 8}, 8));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 8}, 8, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 13}, 4));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 13}, 4, labels));
   dictInits.push_back(
-      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 21}, 16));
+      ss.getIntDictionaryInitializerForNode(EncodingKey{2, 21}, 16, labels));
 
   auto dictCache = ss.getStripeDictionaryCache();
   // Maybe verify range is useful here.


### PR DESCRIPTION
Summary: We'll create the label hierarchy during the column readers creation. For now we'll just pass the root to everywhere. In a follow up diff (for clarity) we'll add columns and flatmaps in the path.

Differential Revision: D46506950

