### PR TITLE
Re-enable distinct aggregations in the fuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -555,7 +555,7 @@ void AggregationFuzzer::go() {
               << iteration << " (seed: " << currentSeed_ << ")";
 
     // 10% of times test distinct aggregation.
-    if (vectorFuzzer_.coinToss(0.0)) {
+    if (vectorFuzzer_.coinToss(0.1)) {
       ++stats_.numDistinct;
 
       std::vector<TypePtr> types;


### PR DESCRIPTION
I noticed that Aggregation fuzzer doesn't run distinct aggregations:

```
Total distinct aggregations: 0 (0.00%)
```

Turns it this is because of the typo that chooses distinct aggregation 0% of the time instead of 10%.