### PR TITLE
Revert D46494517: Multisect successfully blamed D46494517 for test or build failures

### DIFF
--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -257,20 +257,19 @@ std::string variant::toJson(const TypePtr& type) const {
       folly::json::escapeString(str, target, getOpts());
       return target;
     }
-    case TypeKind::HUGEINT:
-      VELOX_CHECK(type && type->isLongDecimal());
-      return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
     case TypeKind::TINYINT:
-      FOLLY_FALLTHROUGH;
     case TypeKind::SMALLINT:
-      FOLLY_FALLTHROUGH;
     case TypeKind::INTEGER:
-      FOLLY_FALLTHROUGH;
-    case TypeKind::BIGINT:
+    case TypeKind::BIGINT: {
       if (type && type->isShortDecimal()) {
         return DecimalUtil::toString(value<TypeKind::BIGINT>(), type);
       }
-      FOLLY_FALLTHROUGH;
+    }
+    case TypeKind::HUGEINT: {
+      if (type && type->isLongDecimal()) {
+        return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      }
+    }
     case TypeKind::BOOLEAN: {
       auto converted = VariantConverter::convert<TypeKind::VARCHAR>(*this);
       if (converted.isNull()) {


### PR DESCRIPTION
Summary:
This diff is reverting D46494517
D46494517: [velox] Add fallthrough to variant::toJson by Yuhta has been identified to be causing the following test or build failures:

Tests affected:
- [hpc/torchrec/models/feed/gpu_tests:ifr_combined_mtml_launcher_test - test_packaging (hpc.torchrec.models.feed.gpu_tests.ifr_combined_mtml_launcher_test.IFRCombinedMTMLLauncherTest)](https://www.internalfb.com/intern/test/562950043789773/)

Here's the Multisect link:
https://www.internalfb.com/multisect/2217013
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Differential Revision: D46558239

