### PR TITLE
Add filter support to flatmap column

### DIFF
--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -387,7 +387,12 @@ TEST_F(E2EFilterTest, flatMap) {
 #endif
 #endif
   testWithTypes(
-      kColumns, customize, false, {"long_val"}, numCombinations, true);
+      kColumns,
+      customize,
+      false,
+      {"long_val", "long_vals"},
+      numCombinations,
+      true);
 }
 
 TEST_F(E2EFilterTest, metadataFilter) {


### PR DESCRIPTION
Summary: Add null filter support (which is the only filter supported on map/flatmap type) to selective flatmap reader.

Differential Revision: D46546604

