### PR TITLE
Share filterCache memory when the dictionary is shared

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -38,7 +38,7 @@ void ScanState::updateRawState() {
       dictionary2.values ? dictionary2.values->as<void*>() : nullptr;
   rawState.dictionary2.numValues = dictionary2.numValues;
   rawState.inDictionary = inDictionary ? inDictionary->as<uint64_t>() : nullptr;
-  rawState.filterCache = filterCache.data();
+  rawState.filterCache = filterCache ? filterCache->data() : nullptr;
 }
 
 SelectiveColumnReader::SelectiveColumnReader(
@@ -336,11 +336,11 @@ void SelectiveColumnReader::setNulls(BufferPtr resultNulls) {
 }
 
 void SelectiveColumnReader::resetFilterCaches() {
-  if (!scanState_.filterCache.empty()) {
+  if (scanState_.filterCache) {
     simd::memset(
-        scanState_.filterCache.data(),
+        scanState_.filterCache->data(),
         FilterResult::kUnknown,
-        scanState_.filterCache.size());
+        scanState_.filterCache->size());
   }
 }
 

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -111,7 +111,7 @@ struct ScanState {
   // Cached results of filter application subscripted by dictionary
   // index. The visitor needs to reset this if the dictionary changes
   // in mid scan.
-  raw_vector<uint8_t> filterCache;
+  std::shared_ptr<raw_vector<uint8_t>> filterCache;
 
   // The above as raw pointers.
   RawScanState rawState;

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -500,7 +500,7 @@ class IntegerDictionaryColumnReader : public ColumnReader {
   std::unique_ptr<ByteRleDecoder> inDictionaryReader;
   std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ false>> dataReader;
   uint64_t dictionarySize;
-  std::function<BufferPtr()> dictInit;
+  std::function<StripeDictionaryCache::Entry()> dictInit;
   bool initialized_{false};
 };
 
@@ -599,7 +599,7 @@ void IntegerDictionaryColumnReader<ReqT>::ensureInitialized() {
     return;
   }
 
-  dictionary = dictInit();
+  dictionary = dictInit().buffer;
   initialized_ = true;
 }
 

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -108,16 +108,9 @@ void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {
   }
 
   Timer timer;
-  scanState_.dictionary.values = dictInit_();
-  // Make sure there is a cache even for an empty dictionary because
-  // of asan failure when preparing a gather with all lanes masked
-  // out.
-  scanState_.filterCache.resize(
-      std::max<int32_t>(1, scanState_.dictionary.numValues));
-  simd::memset(
-      scanState_.filterCache.data(),
-      FilterResult::kUnknown,
-      scanState_.filterCache.size());
+  auto dict = dictInit_();
+  scanState_.dictionary.values = std::move(dict.buffer);
+  scanState_.filterCache = std::move(dict.filterCache);
   initialized_ = true;
   initTimeClocks_ = timer.elapsedClocks();
   scanState_.updateRawState();

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -59,7 +59,7 @@ class SelectiveIntegerDictionaryColumnReader
   std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
   std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ false>> dataReader_;
   std::unique_ptr<dwio::common::IntDecoder</* isSigned = */ true>> dictReader_;
-  std::function<BufferPtr()> dictInit_;
+  std::function<StripeDictionaryCache::Entry()> dictInit_;
   RleVersion rleVersion_;
   bool initialized_{false};
 };

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -81,6 +81,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
         strideLenVInt,
         dwio::common::INT_BYTE_SIZE);
   }
+  scanState_.filterCache = std::make_shared<raw_vector<uint8_t>>();
   scanState_.updateRawState();
 }
 
@@ -148,11 +149,11 @@ void SelectiveStringDictionaryColumnReader::loadStrideDictionary() {
   lastStrideIndex_ = nextStride;
   dictionaryValues_ = nullptr;
 
-  scanState_.filterCache.resize(
+  scanState_.filterCache->resize(
       scanState_.dictionary.numValues + scanState_.dictionary2.numValues);
   scanState_.updateRawState();
   simd::memset(
-      scanState_.filterCache.data() + scanState_.dictionary.numValues,
+      scanState_.filterCache->data() + scanState_.dictionary.numValues,
       FilterResult::kUnknown,
       scanState_.dictionary2.numValues);
 }
@@ -287,9 +288,9 @@ void SelectiveStringDictionaryColumnReader::ensureInitialized() {
 
   loadDictionary(*blobStream_, *lengthDecoder_, scanState_.dictionary);
 
-  scanState_.filterCache.resize(scanState_.dictionary.numValues);
+  scanState_.filterCache->resize(scanState_.dictionary.numValues);
   simd::memset(
-      scanState_.filterCache.data(),
+      scanState_.filterCache->data(),
       FilterResult::kUnknown,
       scanState_.dictionary.numValues);
 

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.cpp
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.cpp
@@ -15,19 +15,29 @@
  */
 
 #include "velox/dwio/dwrf/reader/StripeDictionaryCache.h"
+#include "velox/dwio/common/ColumnVisitors.h"
 
 namespace facebook::velox::dwrf {
 StripeDictionaryCache::DictionaryEntry::DictionaryEntry(
+    int32_t dictionarySize,
     folly::Function<BufferPtr(velox::memory::MemoryPool*)>&& dictGen)
-    : dictGen_{std::move(dictGen)} {}
+    : dictionarySize_{dictionarySize}, dictGen_{std::move(dictGen)} {}
 
-BufferPtr StripeDictionaryCache::DictionaryEntry::getDictionaryBuffer(
+StripeDictionaryCache::Entry StripeDictionaryCache::DictionaryEntry::get(
     velox::memory::MemoryPool* pool) {
   if (!dictionaryBuffer_) {
     dictionaryBuffer_ = dictGen_(pool);
     dictGen_ = nullptr;
+    // Make sure there is a cache even for an empty dictionary because of asan
+    // failure when preparing a gather with all lanes masked out.
+    filterCache_ =
+        std::make_shared<raw_vector<uint8_t>>(std::max(1, dictionarySize_));
+    std::fill(
+        filterCache_->begin(),
+        filterCache_->end(),
+        dwio::common::FilterResult::kUnknown);
   }
-  return dictionaryBuffer_;
+  return {dictionaryBuffer_, filterCache_};
 }
 
 StripeDictionaryCache::StripeDictionaryCache(velox::memory::MemoryPool* pool)
@@ -36,13 +46,16 @@ StripeDictionaryCache::StripeDictionaryCache(velox::memory::MemoryPool* pool)
 // It might be more elegant to pass in a StripeStream here instead.
 void StripeDictionaryCache::registerIntDictionary(
     const EncodingKey& ek,
+    int32_t dictionarySize,
     folly::Function<BufferPtr(velox::memory::MemoryPool*)>&& dictGen) {
   intDictionaryFactories_.emplace(
-      ek, std::make_unique<DictionaryEntry>(std::move(dictGen)));
+      ek,
+      std::make_unique<DictionaryEntry>(dictionarySize, std::move(dictGen)));
 }
 
-BufferPtr StripeDictionaryCache::getIntDictionary(const EncodingKey& ek) {
-  return intDictionaryFactories_.at(ek)->getDictionaryBuffer(pool_);
+StripeDictionaryCache::Entry StripeDictionaryCache::getIntDictionary(
+    const EncodingKey& ek) {
+  return intDictionaryFactories_.at(ek)->get(pool_);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/StripeStream.cpp
+++ b/velox/dwio/dwrf/reader/StripeStream.cpp
@@ -103,7 +103,7 @@ BufferPtr readDict(
 }
 } // namespace
 
-std::function<BufferPtr()>
+std::function<StripeDictionaryCache::Entry()>
 StripeStreamsBase::getIntDictionaryInitializerForNode(
     const EncodingKey& ek,
     uint64_t elementWidth,
@@ -123,6 +123,7 @@ StripeStreamsBase::getIntDictionaryInitializerForNode(
   DWIO_ENSURE(dataStream.get());
   stripeDictionaryCache_->registerIntDictionary(
       localEk,
+      dictionarySize,
       [dictReader = createDirectDecoder</* isSigned = */ true>(
            std::move(dataStream), dictVInts, elementWidth),
        dictionaryWidth,

--- a/velox/dwio/dwrf/reader/StripeStream.h
+++ b/velox/dwio/dwrf/reader/StripeStream.h
@@ -128,7 +128,8 @@ class StripeStreams {
   /// 'dictionaryWidth' is *the width at which this is stored  in the reader.
   /// The non - selective path stores this always as int64, the selective path
   /// stores this at column width.
-  virtual std::function<BufferPtr()> getIntDictionaryInitializerForNode(
+  virtual std::function<StripeDictionaryCache::Entry()>
+  getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t elementWidth,
       uint64_t dictionaryWidth = sizeof(int64_t)) = 0;
@@ -182,7 +183,8 @@ class StripeStreamsBase : public StripeStreams {
     return DwrfFormat::kDwrf;
   }
 
-  std::function<BufferPtr()> getIntDictionaryInitializerForNode(
+  std::function<StripeDictionaryCache::Entry()>
+  getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t elementWidth,
       uint64_t dictionaryWidth = sizeof(int64_t)) override;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -51,7 +51,8 @@ class MockStripeStreams : public StripeStreams {
         throwIfNotFound));
   }
 
-  std::function<BufferPtr()> getIntDictionaryInitializerForNode(
+  std::function<StripeDictionaryCache::Entry()>
+  getIntDictionaryInitializerForNode(
       const EncodingKey& ek,
       uint64_t /* unused */,
       uint64_t /* unused */) override {
@@ -59,7 +60,7 @@ class MockStripeStreams : public StripeStreams {
       BufferPtr dictionaryData;
       genMockDictDataSetter(nodeId, sequenceId)(
           dictionaryData, &getMemoryPool());
-      return dictionaryData;
+      return StripeDictionaryCache::Entry{dictionaryData, nullptr};
     };
   }
 

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -635,7 +635,7 @@ TEST(StripeStream, shareDictionary) {
       ss, getStreamProxy(2, Not(0), proto::Stream_Kind_DICTIONARY_DATA, _))
       .WillRepeatedly(Return(nullptr));
 
-  std::vector<std::function<facebook::velox::BufferPtr()>> dictInits{};
+  std::vector<std::function<StripeDictionaryCache::Entry()>> dictInits{};
   dictInits.push_back(
       ss.getIntDictionaryInitializerForNode(EncodingKey{1, 0}, 8));
   dictInits.push_back(

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -513,12 +513,17 @@ void PageReader::prepareDictionary(const PageHeader& pageHeader) {
 void PageReader::makeFilterCache(dwio::common::ScanState& state) {
   VELOX_CHECK(
       !state.dictionary2.values, "Parquet supports only one dictionary");
-  state.filterCache.resize(state.dictionary.numValues);
+  if (!state.filterCache) {
+    state.filterCache =
+        std::make_shared<raw_vector<uint8_t>>(state.dictionary.numValues);
+  } else {
+    state.filterCache->resize(state.dictionary.numValues);
+  }
   simd::memset(
-      state.filterCache.data(),
+      state.filterCache->data(),
       dwio::common::FilterResult::kUnknown,
-      state.filterCache.size());
-  state.rawState.filterCache = state.filterCache.data();
+      state.filterCache->size());
+  state.rawState.filterCache = state.filterCache->data();
 }
 
 namespace {


### PR DESCRIPTION
Summary: The integer dictionary used by flatmap values are usually shared, but in our code we are instantiating different filter cache for them and wasted memory as well as CPU to reallocate and recalculate same data.  This change makes the filter cache shared among child readers of flatmap if the dictionary is shared.

Differential Revision: D46560720

