### PR TITLE
Fix: Add Unit test for Array<Any> as output.

### DIFF
--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -91,7 +91,7 @@ struct PrimitiveWriter {
 
 template <typename V>
 bool constexpr provide_std_interface =
-    CppToType<V>::isPrimitiveType && !std::is_same_v<Varchar, V> &&
+    SimpleTypeTrait<V>::isPrimitiveType && !std::is_same_v<Varchar, V> &&
     !std::is_same_v<Varbinary, V> && !std::is_same_v<Any, V>;
 
 // bool is an exception, it requires commit but also provides std::interface.


### PR DESCRIPTION
Summary: Use SimpleTypeTrait instead of CppToType fix a bug that made generic appears as primitive. Add Unit tests.

Reviewed By: Yuhta

Differential Revision: D46562616

