### PR TITLE
Do not allocate dictionary filter cache if there is no filter

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -594,6 +594,9 @@ void HiveDataSource::addDynamicFilter(
   auto& fieldSpec = scanSpec_->getChildByChannel(outputChannel);
   fieldSpec.addFilter(*filter);
   scanSpec_->resetCachedValues(true);
+  if (rowReader_) {
+    rowReader_->resetFilterCaches();
+  }
 }
 
 std::unique_ptr<dwio::common::BufferedInput>

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -336,6 +336,11 @@ void SelectiveColumnReader::setNulls(BufferPtr resultNulls) {
 }
 
 void SelectiveColumnReader::resetFilterCaches() {
+  if (scanState_.filterCache.empty() && scanSpec_->hasFilter()) {
+    scanState_.filterCache.resize(std::max<int32_t>(
+        1, scanState_.dictionary.numValues + scanState_.dictionary2.numValues));
+    scanState_.updateRawState();
+  }
   if (!scanState_.filterCache.empty()) {
     simd::memset(
         scanState_.filterCache.data(),

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -111,15 +111,16 @@ void SelectiveIntegerDictionaryColumnReader::ensureInitialized() {
 
   Timer timer;
   scanState_.dictionary.values = dictInit_();
-  // Make sure there is a cache even for an empty dictionary because
-  // of asan failure when preparing a gather with all lanes masked
-  // out.
-  scanState_.filterCache.resize(
-      std::max<int32_t>(1, scanState_.dictionary.numValues));
-  simd::memset(
-      scanState_.filterCache.data(),
-      FilterResult::kUnknown,
-      scanState_.filterCache.size());
+  if (scanSpec_->hasFilter()) {
+    // Make sure there is a cache even for an empty dictionary because of asan
+    // failure when preparing a gather with all lanes masked out.
+    scanState_.filterCache.resize(
+        std::max<int32_t>(1, scanState_.dictionary.numValues));
+    simd::memset(
+        scanState_.filterCache.data(),
+        FilterResult::kUnknown,
+        scanState_.filterCache.size());
+  }
   initialized_ = true;
   initTimeClocks_ = timer.elapsedClocks();
   scanState_.updateRawState();

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -387,7 +387,12 @@ TEST_F(E2EFilterTest, flatMap) {
 #endif
 #endif
   testWithTypes(
-      kColumns, customize, false, {"long_val"}, numCombinations, true);
+      kColumns,
+      customize,
+      false,
+      {"long_val", "long_vals"},
+      numCombinations,
+      true);
 }
 
 TEST_F(E2EFilterTest, metadataFilter) {


### PR DESCRIPTION
Summary: Dictionary filter cache occupies huge amount of memory for flatmap column when the number of children is large.  We can reduce the memory as well as CPU usage by skipping allocating and initializing the filter cache when there is no filter on children (which is always the case for flatmap read as map).

Differential Revision: D46567619

