### PR TITLE
Add function prefix as an option in DuckParser.cpp

### DIFF
--- a/velox/duckdb/conversion/DuckParser.h
+++ b/velox/duckdb/conversion/DuckParser.h
@@ -30,6 +30,11 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Velox expression.
+  std::string functionPrefix = "";
 };
 
 // Parses an input expression using DuckDB's internal postgresql-based parser,

--- a/velox/duckdb/conversion/tests/DuckParserTest.cpp
+++ b/velox/duckdb/conversion/tests/DuckParserTest.cpp
@@ -617,6 +617,83 @@ TEST(DuckParserTest, parseInteger) {
   }
 }
 
+TEST(DuckParserTest, parseWithPrefix) {
+  ParseOptions options;
+  options.functionPrefix = "prefix.";
+  EXPECT_EQ(
+      "prefix.in(\"col1\",[1,2,3])",
+      parseExpr("col1 in (1, 2, 3)", options)->toString());
+  EXPECT_EQ(
+      "prefix.like(\"name\",\"%b%\")",
+      parseExpr("name LIKE '%b%'", options)->toString());
+  EXPECT_EQ(
+      "prefix.not(prefix.like(\"name\",\"%b%\"))",
+      parseExpr("name NOT LIKE '%b%'", options)->toString());
+
+  // Arithmetic operators.
+  EXPECT_EQ("prefix.plus(1,0)", parseExpr("1 + 0", options)->toString());
+  EXPECT_EQ("prefix.minus(1,0)", parseExpr("1 - 0", options)->toString());
+  EXPECT_EQ("prefix.multiply(1,0)", parseExpr("1 * 0", options)->toString());
+  EXPECT_EQ("prefix.divide(1,0)", parseExpr("1 / 0", options)->toString());
+  EXPECT_EQ("prefix.mod(1,0)", parseExpr("1 % 0", options)->toString());
+
+  // Comparisons.
+  EXPECT_EQ("prefix.eq(1,0)", parseExpr("1 = 0", options)->toString());
+  EXPECT_EQ("prefix.neq(1,0)", parseExpr("1 != 0", options)->toString());
+  EXPECT_EQ("prefix.neq(1,0)", parseExpr("1 <> 0", options)->toString());
+  EXPECT_EQ("prefix.not(1)", parseExpr("!1", options)->toString());
+  EXPECT_EQ("prefix.gt(1,0)", parseExpr("1 > 0", options)->toString());
+  EXPECT_EQ("prefix.gte(1,0)", parseExpr("1 >= 0", options)->toString());
+  EXPECT_EQ("prefix.lt(1,0)", parseExpr("1 < 0", options)->toString());
+  EXPECT_EQ("prefix.lte(1,0)", parseExpr("1 <= 0", options)->toString());
+  EXPECT_EQ(
+      "prefix.distinct_from(1,0)",
+      parseExpr("1 IS DISTINCT FROM 0", options)->toString());
+  EXPECT_EQ(
+      "prefix.between(\"c0\",0,1)",
+      parseExpr("c0 between 0 and 1", options)->toString());
+
+  EXPECT_EQ("prefix.not(1)", parseExpr("not 1", options)->toString());
+  EXPECT_EQ("prefix.count()", parseExpr("count()", options)->toString());
+  EXPECT_EQ(
+      "prefix.array_constructor(1,2,3,4,5)",
+      parseExpr("array_constructor(1, 2, 3, 4, 5)", options)->toString());
+  EXPECT_EQ(
+      "prefix.is_null(\"a\")", parseExpr("a IS NULL", options)->toString());
+  EXPECT_EQ(
+      "prefix.not(prefix.is_null(\"a\"))",
+      parseExpr("a IS NOT NULL", options)->toString());
+  EXPECT_EQ(
+      "prefix.avg(\"col1\")", parseExpr("avg(col1)", options)->toString());
+  EXPECT_EQ(
+      "prefix.f(100,prefix.g(prefix.h(3.6)),99)",
+      parseExpr("f(100, g(h(3.6)), 99)", options)->toString());
+  EXPECT_EQ(
+      "prefix.subscript(\"c\",0)", parseExpr("c[0]", options)->toString());
+
+  // Functions which prefix should not be applied to.
+  EXPECT_EQ("and(1,0)", parseExpr("1 and 0", options)->toString());
+  EXPECT_EQ("or(1,0)", parseExpr("1 or 0", options)->toString());
+  EXPECT_EQ("dot(\"a\",\"b\")", parseExpr("(a).b", options)->toString());
+  EXPECT_EQ("if(99,1,0)", parseExpr("if(99, 1, 0)", options)->toString());
+  EXPECT_EQ(
+      "switch(prefix.gt(\"a\",0),1,prefix.lt(\"a\",0),-1,0)",
+      parseExpr("case when a > 0 then 1 when a < 0 then -1 else 0 end", options)
+          ->toString());
+  EXPECT_EQ(
+      "coalesce(null,0)", parseExpr("coalesce(NULL, 0)", options)->toString());
+  EXPECT_EQ(
+      "cast(\"1\", BIGINT)",
+      parseExpr("cast('1' as bigint)", options)->toString());
+  EXPECT_EQ(
+      "try(prefix.plus(\"c0\",\"c1\"))",
+      parseExpr("try(c0 + c1)", options)->toString());
+  // Alias.
+  EXPECT_EQ(
+      "prefix.plus(\"a\",\"b\") AS sum",
+      parseExpr("a + b AS sum", options)->toString());
+}
+
 TEST(DuckParserTest, lambda) {
   // There is a bug in DuckDB in parsing lambda expressions that use
   // comparisons. This doesn't work: filter(a, x -> x = 10). This does:

--- a/velox/parse/ExpressionsParser.cpp
+++ b/velox/parse/ExpressionsParser.cpp
@@ -24,7 +24,7 @@ std::shared_ptr<const core::IExpr> parseExpr(
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
-
+  duckConversionOptions.functionPrefix = options.functionPrefix;
   return facebook::velox::duckdb::parseExpr(expr, duckConversionOptions);
 }
 
@@ -34,6 +34,7 @@ std::vector<std::shared_ptr<const core::IExpr>> parseMultipleExpressions(
   facebook::velox::duckdb::ParseOptions duckConversionOptions;
   duckConversionOptions.parseDecimalAsDouble = options.parseDecimalAsDouble;
   duckConversionOptions.parseIntegerAsBigint = options.parseIntegerAsBigint;
+  duckConversionOptions.functionPrefix = options.functionPrefix;
   return facebook::velox::duckdb::parseMultipleExpressions(
       expr, duckConversionOptions);
 }

--- a/velox/parse/ExpressionsParser.h
+++ b/velox/parse/ExpressionsParser.h
@@ -27,6 +27,11 @@ struct ParseOptions {
   // Retain legacy behavior by default.
   bool parseDecimalAsDouble = true;
   bool parseIntegerAsBigint = true;
+
+  /// SQL functions could be registered with different prefixes by the user.
+  /// This parameter is the registered prefix of presto or spark functions,
+  /// which helps generate the correct Velox expression.
+  std::string functionPrefix = "";
 };
 
 std::shared_ptr<const core::IExpr> parseExpr(


### PR DESCRIPTION
Before this change DuckParser created a CallExpr using function without the
prefix. This change adds the prefix to ParseOptions and uses it to generate
fully-qualified function names.