### PR TITLE
Refactor SingleValueAccumulator

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -137,8 +137,8 @@ class HashStringAllocator : public StreamArena {
   };
 
   struct Position {
-    Header* FOLLY_NULLABLE header;
-    char* FOLLY_NULLABLE position;
+    Header* FOLLY_NULLABLE header{nullptr};
+    char* FOLLY_NULLABLE position{nullptr};
   };
 
   explicit HashStringAllocator(memory::MemoryPool* FOLLY_NONNULL pool)

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -17,12 +17,12 @@
 #pragma once
 
 #include "velox/common/memory/HashStringAllocator.h"
-#include "velox/exec/ContainerRowSerde.h"
+#include "velox/vector/DecodedVector.h"
 
 namespace facebook::velox::functions::aggregate {
 
-// An accumulator for a single variable-width value (a string, a map, an array
-// or a struct).
+/// An accumulator for a single variable-width value (a string, a map, an array
+/// or a struct).
 struct SingleValueAccumulator {
   void write(
       const BaseVector* vector,
@@ -33,16 +33,18 @@ struct SingleValueAccumulator {
 
   bool hasValue() const;
 
-  // Returns 0 if stored and new values are equal; <0 if stored value is less
-  // then new value; >0 if stored value is greated than new value
+  /// Returns 0 if stored and new values are equal; <0 if stored value is less
+  /// then new value; >0 if stored value is greater than new value.
+  ///
+  /// The caller needs to ensure that hasValue() is true before calling this
+  /// method.
   int32_t compare(const DecodedVector& decoded, vector_size_t index) const;
 
+  /// Returns memory back to HashStringAllocator.
   void destroy(HashStringAllocator* allocator);
 
  private:
-  static constexpr int kInitialBytes{20};
-
-  HashStringAllocator::Header* begin_{nullptr};
+  HashStringAllocator::Position start_;
 };
 
 } // namespace facebook::velox::functions::aggregate


### PR DESCRIPTION
Use newWrite + extendWrite instead of allocate + extendWrite.

SingleValueAccumulator is used by arbitrary, min, max, min_by and max_by aggregate 
functions to store variable-width values.