### PR TITLE
Pin Protobuf version to 21.12 on MacOS

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_DEPS="ninja flex bison cmake ccache protobuf icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
+MACOS_DEPS="ninja flex bison cmake ccache protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
 
 function run_and_time {
   time "$@" || (echo "Failed to run $* ." ; exit 1 )


### PR DESCRIPTION
The latest Protobuf version 23.2 is causing the following link failure
0  0x101725649  __assert_rtn + 139
1  0x1015b0746  ld::tool::InputFiles::findDylib(char const*, ld::dylib::File const*, bool) + 1110
2  0x1016a8362  generic::dylib::File::processIndirectLibraries(ld::dylib::File::DylibHandler*, bool) + 82
3  0x1015b223c  ld::tool::InputFiles::createIndirectDylibs() + 556
4  0x1015b31b2  ld::tool::InputFiles::forEachInitialAtom(ld::File::AtomHandler&, ld::Internal&) + 1026
5  0x1015c96f9  ld::tool::Resolver::resolve() + 137
6  0x101522e67  main + 887

Resolves https://github.com/facebookincubator/velox/issues/5218