### PR TITLE
Install folly in setup script.

### DIFF
--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -116,6 +116,7 @@ function install_velox_deps {
   if [ "${INSTALL_PREREQUISITES:-Y}" == "Y" ]; then
     run_and_time install_build_prerequisites
   fi
+  run_and_time install_folly
   run_and_time install_ranges_v3
   run_and_time install_fmt
   run_and_time install_double_conversion


### PR DESCRIPTION
When we build velox with folly dependencies, its required to have folly in system path. Setup script does not call folly build method. As a result, when a change in folly is needed to build velox from main (e.g. https://github.com/facebookincubator/velox/pull/4828), running setup does not make build work because folly is not built with new options (here huge int `-DFOLLY_HAVE_INT128_T=ON`). Making sure we call folly installation from setup script. In this particular case, folly installation had the huge int flag on, but the function itself was never called.  