### PR TITLE
Remove default CPU_TARGET avx from cmake_install function in setup-helper-functions.sh

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,7 +127,6 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  CPU_TARGET="${CPU_TARGET:-avx}"
   COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,7 +127,6 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  COMPILER_FLAGS=$(get_cxx_flags)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev -B"${BINARY_DIR}" \

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -127,7 +127,7 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
+  COMPILER_FLAGS=$(get_cxx_flags)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev -B"${BINARY_DIR}" \

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -15,6 +15,43 @@
 
 # github_checkout $REPO $VERSION $GIT_CLONE_PARAMS clones or re-uses an existing clone of the
 # specified repo, checking out the requested version.
+function github_checkout {
+  local REPO=$1
+  shift
+  local VERSION=$1
+  shift
+  local GIT_CLONE_PARAMS=$@
+  local DIRNAME=$(basename "$REPO")
+  cd "$DEPENDENCY_DIR"
+  if [ -z "$DIRNAME" ]; then
+    echo "Failed to get repo name from $REPO"
+    exit 1
+  fi
+  if [ -d "$DIRNAME" ] && prompt "$DIRNAME already exists. Delete?"; then
+    rm -rf "$DIRNAME"
+  fi
+  if [ ! -d "$DIRNAME" ]; then
+    git clone -q -b "$VERSION" $GIT_CLONE_PARAMS "https://github.com/$REPO.git"
+  fi
+  cd "$DIRNAME"
+}
+
+
+# get_cxx_flags [$CPU_ARCH]
+# Sets and exports the variable VELOX_CXX_FLAGS with appropriate compiler flags.
+# If $CPU_ARCH is set then we use that else we determine best possible set of flags
+# to use based on current cpu architecture.
+# The goal of this function is to consolidate all architecture specific flags to one
+# location.
+# The values that CPU_ARCH can take are as follows:
+#   arm64  : Target Apple silicon.
+#   aarch64: Target general 64 bit arm cpus.
+#   avx:     Target Intel CPUs with AVX.
+#   sse:     Target Intel CPUs with sse.
+# Echo's the appropriate compiler flags which can be captured as so
+# CXX_FLAGS=$(get_cxx_flags) or
+# CXX_FLAGS=$(get_cxx_flags "avx")
+
 function get_cxx_flags {
   local OS
   OS=$(uname)

--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -15,109 +15,41 @@
 
 # github_checkout $REPO $VERSION $GIT_CLONE_PARAMS clones or re-uses an existing clone of the
 # specified repo, checking out the requested version.
-function github_checkout {
-  local REPO=$1
-  shift
-  local VERSION=$1
-  shift
-  local GIT_CLONE_PARAMS=$@
-  local DIRNAME=$(basename $REPO)
-  cd "${DEPENDENCY_DIR}"
-  if [ -z "${DIRNAME}" ]; then
-    echo "Failed to get repo name from ${REPO}"
-    exit 1
-  fi
-  if [ -d "${DIRNAME}" ] && prompt "${DIRNAME} already exists. Delete?"; then
-    rm -rf "${DIRNAME}"
-  fi
-  if [ ! -d "${DIRNAME}" ]; then
-    git clone -q -b $VERSION $GIT_CLONE_PARAMS "https://github.com/${REPO}.git"
-  fi
-  cd "${DIRNAME}"
-}
-
-
-# get_cxx_flags [$CPU_ARCH]
-# Sets and exports the variable VELOX_CXX_FLAGS with appropriate compiler flags.
-# If $CPU_ARCH is set then we use that else we determine best possible set of flags
-# to use based on current cpu architecture.
-# The goal of this function is to consolidate all architecture specific flags to one
-# location.
-# The values that CPU_ARCH can take are as follows:
-#   arm64  : Target Apple silicon.
-#   aarch64: Target general 64 bit arm cpus.
-#   avx:     Target Intel CPUs with AVX.
-#   sse:     Target Intel CPUs with sse.
-# Echo's the appropriate compiler flags which can be captured as so
-# CXX_FLAGS=$(get_cxx_flags) or
-# CXX_FLAGS=$(get_cxx_flags "avx")
-
 function get_cxx_flags {
-  local CPU_ARCH=$1
-
   local OS
   OS=$(uname)
   local MACHINE
   MACHINE=$(uname -m)
   ADDITIONAL_FLAGS=""
 
-  if [ -z "$CPU_ARCH" ]; then
-
-    if [ "$OS" = "Darwin" ]; then
-
-      if [ "$MACHINE" = "x86_64" ]; then
-        local CPU_CAPABILITIES
-        CPU_CAPABILITIES=$(sysctl -a | grep machdep.cpu.features | awk '{print tolower($0)}')
-
-        if [[ $CPU_CAPABILITIES =~ "avx" ]]; then
-          CPU_ARCH="avx"
-        else
-          CPU_ARCH="sse"
-        fi
-
-      elif [[ $(sysctl -a | grep machdep.cpu.brand_string) =~ "Apple" ]]; then
-        # Apple silicon.
-        CPU_ARCH="arm64"
-      fi
-
-    # On MacOs prevent the flood of translation visibility settings warnings.
-    ADDITIONAL_FLAGS="-fvisibility=hidden -fvisibility-inlines-hidden"
-    else [ "$OS" = "Linux" ];
-
+  if [ "$OS" = "Darwin" ]; then
+    if [ "$MACHINE" = "x86_64" ]; then
       local CPU_CAPABILITIES
-      CPU_CAPABILITIES=$(cat /proc/cpuinfo | grep flags | head -n 1| awk '{print tolower($0)}')
+      CPU_CAPABILITIES=$(sysctl -a | grep machdep.cpu.features | awk '{print tolower($0)}')
 
-      if [[ "$CPU_CAPABILITIES" =~ "avx" ]]; then
-            CPU_ARCH="avx"
-      elif [[ "$CPU_CAPABILITIES" =~ "sse" ]]; then
-            CPU_ARCH="sse"
-      elif [ "$MACHINE" = "aarch64" ]; then
-            CPU_ARCH="aarch64"
+      if [[ $CPU_CAPABILITIES =~ "avx" ]]; then
+        echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 $ADDITIONAL_FLAGS"
+      else
+        echo -n "-msse4.2 -std=c++17 $ADDITIONAL_FLAGS"
       fi
-    fi
-  fi
-
-  case $CPU_ARCH in
-
-    "arm64")
+    elif [[ $(sysctl -a | grep machdep.cpu.brand_string) =~ "Apple" ]]; then
+      # Apple silicon.
       echo -n "-mcpu=apple-m1+crc -std=c++17 -fvisibility=hidden $ADDITIONAL_FLAGS"
-    ;;
+    fi
+  elif [ "$OS" = "Linux" ]; then
+    local CPU_CAPABILITIES
+    CPU_CAPABILITIES=$(cat /proc/cpuinfo | grep flags | head -n 1 | awk '{print tolower($0)}')
 
-    "avx")
+    if [[ "$CPU_CAPABILITIES" =~ "avx" ]]; then
       echo -n "-mavx2 -mfma -mavx -mf16c -mlzcnt -std=c++17 -mbmi2 $ADDITIONAL_FLAGS"
-    ;;
-
-    "sse")
+    elif [[ "$CPU_CAPABILITIES" =~ "sse" ]]; then
       echo -n "-msse4.2 -std=c++17 $ADDITIONAL_FLAGS"
-    ;;
-
-    "aarch64")
+    elif [ "$MACHINE" = "aarch64" ]; then
       echo -n "-mcpu=neoverse-n1 -std=c++17 $ADDITIONAL_FLAGS"
-    ;;
-  *)
+    fi
+  else
     echo -n "Architecture not supported!"
-  esac
-
+  fi
 }
 
 function cmake_install {
@@ -127,6 +59,7 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
+  COMPILER_FLAGS=$(get_cxx_flags)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev -B"${BINARY_DIR}" \
@@ -140,4 +73,3 @@ function cmake_install {
     "$@"
   ninja -C "${BINARY_DIR}" install
 }
-


### PR DESCRIPTION
The default CPU_TARGET avx does not work on Mac M1 machines.
We can remove CPU_TARGET default since get_cxx_flags automatically infers the target if not specified.

Resolves: https://github.com/facebookincubator/velox/issues/5204