### PR TITLE
FIX: Make ascii computation thread safe.

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -57,6 +57,9 @@ using VectorPtr = std::shared_ptr<BaseVector>;
  */
 class BaseVector {
  public:
+  BaseVector(const BaseVector&) = delete;
+  BaseVector& operator=(const BaseVector&) = delete;
+
   static constexpr uint64_t kNullHash = 1;
 
   BaseVector(

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -37,6 +37,9 @@ constexpr column_index_t kConstantChannel =
 
 class RowVector : public BaseVector {
  public:
+  RowVector(const RowVector&) = delete;
+  RowVector& operator=(const RowVector&) = delete;
+
   RowVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,
@@ -205,6 +208,7 @@ class RowVector : public BaseVector {
 // Common parent class for ARRAY and MAP vectors.  Contains 'offsets' and
 // 'sizes' data and provide manipulations on them.
 struct ArrayVectorBase : BaseVector {
+  ArrayVectorBase(const ArrayVectorBase&) = delete;
   const BufferPtr& offsets() const {
     return offsets_;
   }
@@ -316,6 +320,9 @@ struct ArrayVectorBase : BaseVector {
 
 class ArrayVector : public ArrayVectorBase {
  public:
+  ArrayVector(const ArrayVector&) = delete;
+  ArrayVector& operator=(const ArrayVector&) = delete;
+
   ArrayVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,
@@ -420,6 +427,9 @@ class ArrayVector : public ArrayVectorBase {
 
 class MapVector : public ArrayVectorBase {
  public:
+  MapVector(const MapVector&) = delete;
+  MapVector& operator=(const MapVector&) = delete;
+
   MapVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -36,6 +36,9 @@ struct DummyReleaser {
 template <typename T>
 class ConstantVector final : public SimpleVector<T> {
  public:
+  ConstantVector(const ConstantVector&) = delete;
+  ConstantVector& operator=(const ConstantVector&) = delete;
+
   static constexpr bool can_simd =
       (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
        std::is_same_v<T, int16_t> || std::is_same_v<T, int8_t> ||

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -31,6 +31,9 @@ namespace velox {
 template <typename T>
 class DictionaryVector : public SimpleVector<T> {
  public:
+  DictionaryVector(const DictionaryVector&) = delete;
+  DictionaryVector& operator=(const DictionaryVector&) = delete;
+
   static constexpr bool can_simd = std::is_same_v<T, int64_t>;
 
   // Creates dictionary vector using base vector (dictionaryValues) and a set

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -452,10 +452,10 @@ void FlatVector<StringView>::copy(
       ensureIsAsciiCapacity(rows.end());
       // If we arent All ascii, then invalidate
       // because the remaining selected rows might be ascii
-      if (!isAllAscii_) {
+      if (!*isAllAscii_) {
         invalidateIsAscii();
       } else {
-        asciiSetRows_.deselect(rows);
+        asciiSetRows_->deselect(rows);
       }
     }
   }

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -35,6 +35,8 @@ template <typename T>
 class FlatVector final : public SimpleVector<T> {
  public:
   using value_type = T;
+  FlatVector(const FlatVector&) = delete;
+  FlatVector& operator=(const FlatVector&) = delete;
 
   static constexpr bool can_simd =
       (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -57,6 +57,9 @@ struct SimpleVectorStats {
 template <typename T>
 class SimpleVector : public BaseVector {
  public:
+  SimpleVector(const SimpleVector&) = delete;
+  SimpleVector& operator=(const SimpleVector&) = delete;
+
   SimpleVector(
       velox::memory::MemoryPool* pool,
       TypePtr type,

--- a/velox/vector/tests/SimpleVectorTest.cpp
+++ b/velox/vector/tests/SimpleVectorTest.cpp
@@ -128,6 +128,32 @@ TEST_F(SimpleVectorNonParameterizedTest, BasicRoundTrip) {
   assertVectorAndProperties<int64_t>(expected.data(), vector);
 }
 
+TEST_F(SimpleVectorNonParameterizedTest, ThreadSafeAsciiCompute) {
+  std::vector<std::thread> tasks;
+  SelectivityVector rows(10000);
+  VectorPtr vectorBase;
+  BaseVector::ensureWritable(rows, VARCHAR(), pool_.get(), vectorBase);
+  auto vector = vectorBase->as<FlatVector<StringView>>();
+  for (int i = 0; i < 10000; i++) {
+    vector->set(i, "dsfdsfsdfdsfds"_sv); // set first element
+  }
+
+  for (int i = 0; i < 100; i++) {
+    tasks.emplace_back([&]() {
+      for (int j = 0; j < 100; j++) {
+        vector->invalidateIsAscii();
+        vector->computeAndSetIsAscii(rows);
+        for (int k = 0; k < vector->size(); k++) {
+          ASSERT_TRUE(vector->isAscii(k));
+        }
+      }
+    });
+  }
+  for (auto& thread : tasks) {
+    thread.join();
+  }
+}
+
 // Only signed types are supported.
 using SimpleTypes = ::testing::
     Types<int8_t, int16_t, int32_t, int64_t, double, StringView, bool>;


### PR DESCRIPTION
Summary:
Input vector for expression eval can be shared across threads,
this makes it unsafe to do lock-free mutations to the vectors.

This diff makes the ascii compute thread safe, a following diff,
will mark those input vectors recursively and add checks that
 guarantee that we do not call any vector mutating function on them.

Differential Revision: D46605902

