### PR TITLE
Fix: double decoded index lookup in generic view cast.

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1072,19 +1072,23 @@ class GenericView {
         index_(index) {}
 
   uint64_t hash() const {
-    return decoded_.base()->hashValueAt(index_);
+    return decoded_.base()->hashValueAt(decodedIndex());
   }
 
   bool operator==(const GenericView& other) const {
     return decoded_.base()->equalValueAt(
-        other.decoded_.base(), index_, other.index_);
+        other.decoded_.base(), decodedIndex(), other.decodedIndex());
+  }
+
+  vector_size_t decodedIndex() const {
+    return decoded_.index(index_);
   }
 
   std::optional<int64_t> compare(
       const GenericView& other,
       const CompareFlags flags) const {
     return decoded_.base()->compare(
-        other.decoded_.base(), index_, other.index_, flags);
+        other.decoded_.base(), decodedIndex(), other.decodedIndex(), flags);
   }
 
   TypeKind kind() const {
@@ -1108,7 +1112,8 @@ class GenericView {
     // TODO: We can distinguish if this is a null-free or not null-free
     // generic. And based on that determine if we want to call operator[] or
     // readNullFree. For now we always return nullable.
-    return ensureReader<ToType>()->operator[](index_);
+    return ensureReader<ToType>()->operator[](
+        index_); // We pass the non-decoded index.
   }
 
   template <typename ToType>
@@ -1117,7 +1122,8 @@ class GenericView {
       return std::nullopt;
     }
 
-    return ensureReader<ToType>()->operator[](index_);
+    return ensureReader<ToType>()->operator[](
+        index_); // We pass the non-decoded index.
   }
 
  private:

--- a/velox/expression/GenericWriter.cpp
+++ b/velox/expression/GenericWriter.cpp
@@ -17,7 +17,6 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/expression/VectorWriters.h"
-
 namespace facebook::velox::exec {
 
 namespace {

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -643,13 +643,13 @@ struct VectorReader<Generic<T>> {
 
   VectorReader<Generic<T>>& operator=(const VectorReader<Generic<T>>&) = delete;
 
-  bool isSet(size_t offset) const {
+  bool isSet(vector_size_t offset) const {
     return !decoded_.isNullAt(offset);
   }
 
-  exec_in_t operator[](size_t offset) const {
-    auto index = decoded_.index(offset);
-    return GenericView{decoded_, castReaders_, castType_, index};
+  exec_in_t operator[](vector_size_t offset) const {
+    // We pass the non-decoded index.
+    return GenericView{decoded_, castReaders_, castType_, offset};
   }
 
   exec_null_free_in_t readNullFree(vector_size_t offset) const {


### PR DESCRIPTION
Summary:
fixes https://github.com/facebookincubator/velox/issues/5228.
GenericView used to store the decoded index, when casted we call
the accessor on the vector reader by passing the decoded index.
The accessor will re-decode the index resulting in wrong index

This diff change the genericView to store the non-decoded index instead.

Differential Revision: D46634632

