### PR TITLE
Delete copy constructors of velox vectors.

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -57,6 +57,9 @@ using VectorPtr = std::shared_ptr<BaseVector>;
  */
 class BaseVector {
  public:
+  BaseVector(const BaseVector&) = delete;
+  BaseVector& operator=(const BaseVector&) = delete;
+
   static constexpr uint64_t kNullHash = 1;
 
   BaseVector(

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -37,6 +37,9 @@ constexpr column_index_t kConstantChannel =
 
 class RowVector : public BaseVector {
  public:
+  RowVector(const RowVector&) = delete;
+  RowVector& operator=(const RowVector&) = delete;
+
   RowVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,
@@ -205,6 +208,7 @@ class RowVector : public BaseVector {
 // Common parent class for ARRAY and MAP vectors.  Contains 'offsets' and
 // 'sizes' data and provide manipulations on them.
 struct ArrayVectorBase : BaseVector {
+  ArrayVectorBase(const ArrayVectorBase&) = delete;
   const BufferPtr& offsets() const {
     return offsets_;
   }
@@ -316,6 +320,9 @@ struct ArrayVectorBase : BaseVector {
 
 class ArrayVector : public ArrayVectorBase {
  public:
+  ArrayVector(const ArrayVector&) = delete;
+  ArrayVector& operator=(const ArrayVector&) = delete;
+
   ArrayVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,
@@ -420,6 +427,9 @@ class ArrayVector : public ArrayVectorBase {
 
 class MapVector : public ArrayVectorBase {
  public:
+  MapVector(const MapVector&) = delete;
+  MapVector& operator=(const MapVector&) = delete;
+
   MapVector(
       velox::memory::MemoryPool* pool,
       std::shared_ptr<const Type> type,

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -36,6 +36,9 @@ struct DummyReleaser {
 template <typename T>
 class ConstantVector final : public SimpleVector<T> {
  public:
+  ConstantVector(const ConstantVector&) = delete;
+  ConstantVector& operator=(const ConstantVector&) = delete;
+
   static constexpr bool can_simd =
       (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||
        std::is_same_v<T, int16_t> || std::is_same_v<T, int8_t> ||

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -31,6 +31,9 @@ namespace velox {
 template <typename T>
 class DictionaryVector : public SimpleVector<T> {
  public:
+  DictionaryVector(const DictionaryVector&) = delete;
+  DictionaryVector& operator=(const DictionaryVector&) = delete;
+
   static constexpr bool can_simd = std::is_same_v<T, int64_t>;
 
   // Creates dictionary vector using base vector (dictionaryValues) and a set

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -35,6 +35,8 @@ template <typename T>
 class FlatVector final : public SimpleVector<T> {
  public:
   using value_type = T;
+  FlatVector(const FlatVector&) = delete;
+  FlatVector& operator=(const FlatVector&) = delete;
 
   static constexpr bool can_simd =
       (std::is_same_v<T, int64_t> || std::is_same_v<T, int32_t> ||

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -57,6 +57,9 @@ struct SimpleVectorStats {
 template <typename T>
 class SimpleVector : public BaseVector {
  public:
+  SimpleVector(const SimpleVector&) = delete;
+  SimpleVector& operator=(const SimpleVector&) = delete;
+
   SimpleVector(
       velox::memory::MemoryPool* pool,
       TypePtr type,


### PR DESCRIPTION
Summary: Found internal usages in Meta that does copy.

Differential Revision: D46599380

