### PR TITLE
Fix use-after-free of MetadataFilter::LeafNode

### DIFF
--- a/velox/dwio/common/FormatData.h
+++ b/velox/dwio/common/FormatData.h
@@ -92,7 +92,7 @@ class FormatData {
   struct FilterRowGroupsResult {
     std::vector<uint64_t> filterResult;
     std::vector<std::pair<
-        velox::common::MetadataFilter::LeafNode*,
+        const velox::common::MetadataFilter::LeafNode*,
         std::vector<uint64_t>>>
         metadataFilterResults;
     int totalCount = 0;

--- a/velox/dwio/common/MetadataFilter.h
+++ b/velox/dwio/common/MetadataFilter.h
@@ -42,8 +42,11 @@ class MetadataFilter {
   /// existing bitmask in `finalResult` will be ANDed with the result we get
   /// from evaluation and stored back.
   void eval(
-      std::vector<std::pair<LeafNode*, std::vector<uint64_t>>>& leafNodeResults,
+      std::vector<std::pair<const LeafNode*, std::vector<uint64_t>>>&
+          leafNodeResults,
       std::vector<uint64_t>& finalResult);
+
+  std::string toString() const;
 
  private:
   class Node;

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -391,6 +391,9 @@ std::string ScanSpec::toString() const {
     if (isConstant()) {
       out << " constant";
     }
+    if (!metadataFilters_.empty()) {
+      out << " metadata_filters(" << metadataFilters_.size() << ")";
+    }
   }
   if (!children_.empty()) {
     out << " (";

--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -86,21 +86,21 @@ class ScanSpec {
   }
 
   void addMetadataFilter(
-      MetadataFilter::LeafNode* leaf,
-      std::unique_ptr<common::Filter> filter) {
-    metadataFilters_.emplace_back(leaf, std::move(filter));
+      const MetadataFilter::LeafNode* leaf,
+      common::Filter* filter) {
+    metadataFilters_.emplace_back(leaf, filter);
   }
 
   int numMetadataFilters() const {
     return metadataFilters_.size();
   }
 
-  MetadataFilter::LeafNode* metadataFilterNodeAt(int i) const {
+  const MetadataFilter::LeafNode* metadataFilterNodeAt(int i) const {
     return metadataFilters_[i].first;
   }
 
   common::Filter* metadataFilterAt(int i) const {
-    return metadataFilters_[i].second.get();
+    return metadataFilters_[i].second;
   }
 
   // Returns a constant vector if 'this' corresponds to a partitioning
@@ -382,8 +382,7 @@ class ScanSpec {
   // the pointers to LeafNodes are stored here.  We need to keep these pointers
   // so that we can match the leaf node filter results and apply logical
   // conjunctions later properly.
-  std::vector<
-      std::pair<MetadataFilter::LeafNode*, std::shared_ptr<common::Filter>>>
+  std::vector<std::pair<const MetadataFilter::LeafNode*, common::Filter*>>
       metadataFilters_;
 
   SelectivityInfo selectivity_;

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -224,6 +224,9 @@ class Subfield {
   }
 
   std::string toString() const {
+    if (!valid()) {
+      return "";
+    }
     std::ostringstream out;
     out << static_cast<const NestedField*>(path_[0].get())->name();
     for (int i = 1; i < path_.size(); i++) {
@@ -254,6 +257,10 @@ class Subfield {
       result = result * 31 + path_[i]->hash();
     }
     return result;
+  }
+
+  bool valid() const {
+    return !path_.empty() && path_[0]->kind() == kNestedField;
   }
 
  private:

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -78,6 +78,7 @@ std::vector<std::unique_ptr<Subfield::PathElement>> createElements() {
 
 void testRoundTrip(const Subfield& path) {
   auto actual = Subfield(tokenize(path.toString()));
+  ASSERT_TRUE(actual.valid());
   EXPECT_EQ(actual, path) << "at " << path.toString() << ", "
                           << actual.toString();
 }
@@ -113,6 +114,9 @@ TEST(SubfieldTest, basic) {
       }
     }
   }
+
+  ASSERT_FALSE(Subfield().valid());
+  ASSERT_EQ(Subfield().toString(), "");
 }
 
 TEST(SubfieldTest, prefix) {


### PR DESCRIPTION
Summary:
In an `OR` node of remaining filter, if either side of the expression
cannot be converted to metadata filter, we drop both sides.  In this case we
should not add the metadata filter to `ScanSpec` for the other side that can be
converted.

Differential Revision: D46648422

