### PR TITLE
Modify default CPU_TARGET in setup-helper-functions.sh

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -61,8 +61,7 @@ function get_cxx_flags {
   MACHINE=$(uname -m)
   ADDITIONAL_FLAGS=""
 
-  if [ -z "$CPU_ARCH" ]; then
-
+  if [[ -z "$CPU_ARCH" ]] || [[ $CPU_ARCH == "unknown" ]]; then
     if [ "$OS" = "Darwin" ]; then
 
       if [ "$MACHINE" = "x86_64" ]; then
@@ -127,7 +126,7 @@ function cmake_install {
     rm -rf "${BINARY_DIR}"
   fi
   mkdir -p "${BINARY_DIR}"
-  CPU_TARGET="${CPU_TARGET:-avx}"
+  CPU_TARGET="${CPU_TARGET:-unknown}"
   COMPILER_FLAGS=$(get_cxx_flags $CPU_TARGET)
 
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \


### PR DESCRIPTION
The default CPU_TARGET avx does not work on Mac M1 machines.
Change CPU_TARGET default to unknown.
Modify get_cxx_flags to infer the target if CPU_ARCH/CPU_TARGET is unknown.

Resolves: https://github.com/facebookincubator/velox/issues/5204