### PR TITLE
VeloxExpressionListener to populate ClientTagId onError()

### DIFF
--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -748,7 +748,8 @@ class ExprSetListener {
   /// @param errors Error vector produced inside the try expression.
   virtual void onError(
       const SelectivityVector& rows,
-      const ErrorVector& errors) = 0;
+      const ErrorVector& errors,
+      const std::string& queryId) = 0;
 };
 
 /// Return the ExprSetListeners having been registered.

--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -82,7 +82,8 @@ void applyListenersOnError(
   exprSetListeners().withRLock([&](auto& listeners) {
     if (!listeners.empty()) {
       for (auto& listener : listeners) {
-        listener->onError(*errorRows, *errors);
+        listener->onError(
+            *errorRows, *errors, context.execCtx()->queryCtx()->queryId());
       }
     }
   });

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -171,7 +171,8 @@ class TestListener : public exec::ExprSetListener {
 
   void onError(
       const SelectivityVector& rows,
-      const ::facebook::velox::ErrorVector& errors) override {
+      const ::facebook::velox::ErrorVector& errors,
+      const std::string& /*queryId*/) override {
     rows.applyToSelected([&](auto row) {
       exceptionCount_++;
 

--- a/velox/expression/tests/ExpressionFuzzer.h
+++ b/velox/expression/tests/ExpressionFuzzer.h
@@ -132,7 +132,8 @@ class ExpressionFuzzer {
     // occurred.
     void onError(
         const SelectivityVector& /*rows*/,
-        const ::facebook::velox::ErrorVector& /*errors*/) override {}
+        const ::facebook::velox::ErrorVector& /*errors*/,
+        const std::string& /*queryId*/) override {}
 
    private:
     std::unordered_map<std::string, ExprUsageStats>& exprNameToStats_;


### PR DESCRIPTION
Summary: 
- onError doesn't report the query id. This appears to be a feature gap since query id would allow us to pull error metrics grouped by query id.

Differential Revision: D46524709

