### PR TITLE
Add new RowContainer::compare API

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -467,15 +467,25 @@ int32_t RowContainer::compareComplexType(
     const char* left,
     const char* right,
     const Type* type,
-    int32_t offset,
+    int32_t leftOffset,
+    int32_t rightOffset,
     CompareFlags flags) {
   VELOX_DCHECK(!flags.stopAtNull, "not supported compare flag");
 
   ByteStream leftStream;
   ByteStream rightStream;
-  prepareRead(left, offset, leftStream);
-  prepareRead(right, offset, rightStream);
+  prepareRead(left, leftOffset, leftStream);
+  prepareRead(right, rightOffset, rightStream);
   return serde_.compare(leftStream, rightStream, type, flags);
+}
+
+int32_t RowContainer::compareComplexType(
+    const char* left,
+    const char* right,
+    const Type* type,
+    int32_t offset,
+    CompareFlags flags) {
+  return compareComplexType(left, right, type, offset, offset, flags);
 }
 
 template <TypeKind Kind>


### PR DESCRIPTION
This variation of RowContainer::compare supports comparing values in 2 different rows in 2 different columns of the same type.

This is used for range value checks in the Window operator. (ref https://github.com/facebookincubator/velox/pull/4510)