### PR TITLE
Add support for aggregations over sorted inputs

### DIFF
--- a/velox/exec/AggregateInfo.h
+++ b/velox/exec/AggregateInfo.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/PlanNode.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+
+class Aggregate;
+
+/// Information needed to evaluate an aggregate function.
+struct AggregateInfo {
+  /// Instance of the Aggregate class.
+  std::unique_ptr<Aggregate> function;
+
+  /// Indices of the input columns in the input RowVector.
+  std::vector<column_index_t> inputs;
+
+  /// Optional constant inputs. The size of this vector matches the size of
+  /// 'inputs'. Non-constant inputs have null entries.
+  std::vector<VectorPtr> constantInputs;
+
+  /// Optional index of an input boolean column that should be used as a mask.
+  std::optional<column_index_t> mask;
+
+  /// Optional list of input columns that should be used to sort input rows
+  /// before aggregating. Thes column may or may not overlap with 'inputs'.
+  std::vector<column_index_t> sortingKeys;
+
+  /// Optional list of sorting orders that goes with 'sortingKeys'.
+  std::vector<core::SortOrder> sortingOrders;
+
+  /// Index of the result column in the output RowVector.
+  column_index_t output;
+
+  /// Type of intermediate results. Used for spilling.
+  TypePtr intermediateType;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(
   ProbeOperatorState.cpp
   RowContainer.cpp
   RowNumber.cpp
+  SortedAggregations.cpp
   Spill.cpp
   SpillOperatorGroup.cpp
   Spiller.cpp

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -63,13 +63,11 @@ HashAggregation::HashAggregation(
   }
 
   auto numAggregates = aggregationNode->aggregates().size();
+  std::vector<AggregateInfo> aggregateInfos;
+  aggregateInfos.reserve(numAggregates);
+
   std::vector<std::unique_ptr<Aggregate>> aggregates;
   aggregates.reserve(numAggregates);
-  std::vector<std::optional<column_index_t>> aggrMaskChannels;
-  aggrMaskChannels.reserve(numAggregates);
-  std::vector<std::vector<column_index_t>> args;
-  std::vector<std::vector<VectorPtr>> constantLists;
-  std::vector<TypePtr> intermediateTypes;
   for (auto i = 0; i < numAggregates; i++) {
     const auto& aggregate = aggregationNode->aggregates()[i];
 
@@ -77,8 +75,10 @@ HashAggregation::HashAggregation(
         aggregate.sortingKeys.empty(),
         "Aggregations over sorted input is not supported yet");
 
-    std::vector<column_index_t> channels;
-    std::vector<VectorPtr> constants;
+    AggregateInfo info;
+
+    auto& channels = info.inputs;
+    auto& constants = info.constantInputs;
     std::vector<TypePtr> argTypes;
     for (const auto& arg : aggregate.call->inputs()) {
       argTypes.push_back(arg->type());
@@ -91,31 +91,39 @@ HashAggregation::HashAggregation(
       }
     }
     if (isRawInput(aggregationNode->step())) {
-      intermediateTypes.push_back(
-          Aggregate::intermediateType(aggregate.call->name(), argTypes));
+      info.intermediateType =
+          Aggregate::intermediateType(aggregate.call->name(), argTypes);
     } else {
-      VELOX_DCHECK(!argTypes.empty());
-      intermediateTypes.push_back(argTypes[0]);
       VELOX_CHECK_EQ(
           argTypes.size(),
           1,
           "Intermediate aggregates must have a single argument");
+      info.intermediateType = argTypes[0];
     }
     // Setup aggregation mask: convert the Variable Reference name to the
     // channel (projection) index, if there is a mask.
-    const auto& aggrMask = aggregate.mask;
-    if (aggrMask == nullptr) {
-      aggrMaskChannels.emplace_back(std::nullopt);
-    } else {
-      aggrMaskChannels.emplace_back(
-          inputType->asRow().getChildIdx(aggrMask->name()));
+    if (const auto& mask = aggregate.mask) {
+      if (mask != nullptr) {
+        info.mask = inputType->asRow().getChildIdx(mask->name());
+      }
     }
 
     const auto& resultType = outputType_->childAt(numHashers + i);
-    aggregates.push_back(Aggregate::create(
-        aggregate.call->name(), aggregationNode->step(), argTypes, resultType));
-    args.push_back(channels);
-    constantLists.push_back(constants);
+    info.function = Aggregate::create(
+        aggregate.call->name(), aggregationNode->step(), argTypes, resultType);
+    info.output = numHashers + i;
+
+    // Sorting keys and orders.
+    const auto numSortingKeys = aggregate.sortingKeys.size();
+    VELOX_CHECK_EQ(numSortingKeys, aggregate.sortingOrders.size());
+    info.sortingOrders = aggregate.sortingOrders;
+
+    info.sortingKeys.reserve(numSortingKeys);
+    for (const auto& key : aggregate.sortingKeys) {
+      info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
+    }
+
+    aggregateInfos.emplace_back(std::move(info));
   }
 
   // Check that aggregate result type match the output type
@@ -137,13 +145,10 @@ HashAggregation::HashAggregation(
   }
 
   groupingSet_ = std::make_unique<GroupingSet>(
+      inputType,
       std::move(hashers),
       std::move(preGroupedChannels),
-      std::move(aggregates),
-      std::move(aggrMaskChannels),
-      std::move(args),
-      std::move(constantLists),
-      std::move(intermediateTypes),
+      std::move(aggregateInfos),
       aggregationNode->ignoreNullKeys(),
       isPartialOutput_,
       isRawInput(aggregationNode->step()),

--- a/velox/exec/MarkDistinct.cpp
+++ b/velox/exec/MarkDistinct.cpp
@@ -44,6 +44,7 @@ MarkDistinct::MarkDistinct(
   resultProjections_.emplace_back(0, inputType->size());
 
   groupingSet_ = GroupingSet::createForMarkDistinct(
+      inputType,
       createVectorHashers(inputType, planNode->distinctKeys()),
       operatorCtx_.get(),
       &nonReclaimableSection_);

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/SortedAggregations.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+/// Stores a list of char* pointers to rows in RowContainer.
+struct RowPointers {
+  HashStringAllocator::Header* firstBlock{nullptr};
+  HashStringAllocator::Position currentBlock{nullptr, nullptr};
+  size_t size{0};
+
+  void append(char* row, HashStringAllocator& allocator) {
+    ByteStream stream(&allocator);
+    if (firstBlock == nullptr) {
+      // Allocate first block.
+      currentBlock = allocator.newWrite(stream);
+      firstBlock = currentBlock.header;
+    } else {
+      allocator.extendWrite(currentBlock, stream);
+    }
+
+    stream.appendOne(reinterpret_cast<uintptr_t>(row));
+    currentBlock = allocator.finishWrite(stream, 1024);
+
+    ++size;
+  }
+
+  void free(HashStringAllocator& allocator) {
+    if (firstBlock != nullptr) {
+      allocator.free(firstBlock);
+      firstBlock = nullptr;
+      currentBlock = {nullptr, nullptr};
+    }
+  }
+
+  std::vector<char*> read(HashStringAllocator& allocator) {
+    ByteStream stream(&allocator);
+    HashStringAllocator::prepareRead(firstBlock, stream);
+
+    std::vector<char*> rows(size);
+    for (auto i = 0; i < size; ++i) {
+      rows[i] = reinterpret_cast<char*>(stream.read<uintptr_t>());
+    }
+    return rows;
+  }
+};
+} // namespace
+
+SortedAggregations::SortedAggregations(
+    std::vector<AggregateInfo*> aggregates,
+    const RowTypePtr& inputType,
+    memory::MemoryPool* pool)
+    : aggregates_{std::move(aggregates)} {
+  // Collect inputs and sorting keys from all aggregates.
+  std::unordered_set<column_index_t> allInputs;
+  for (const auto* aggregate : aggregates_) {
+    for (auto i = 0; i < aggregate->inputs.size(); ++i) {
+      auto input = aggregate->inputs[i];
+      if (input != kConstantChannel) {
+        allInputs.insert(input);
+      } else {
+        VELOX_USER_CHECK_NOT_NULL(aggregate->constantInputs[i]);
+      }
+    }
+
+    for (auto sortingKey : aggregate->sortingKeys) {
+      VELOX_USER_CHECK_NE(sortingKey, kConstantChannel);
+      allInputs.insert(sortingKey);
+    }
+  }
+
+  inputMapping_.resize(inputType->size());
+
+  std::vector<TypePtr> types;
+  for (auto input : allInputs) {
+    types.push_back(inputType->childAt(input));
+
+    inputMapping_[input] = inputs_.size();
+    inputs_.push_back(input);
+  }
+
+  inputData_ = std::make_unique<RowContainer>(types, pool);
+  decodedInputs_.resize(inputs_.size());
+}
+
+Accumulator SortedAggregations::accumulator() const {
+  return {
+      false,
+      sizeof(RowPointers),
+      false,
+      1,
+      [this](folly::Range<char**> groups) {
+        for (auto* group : groups) {
+          auto* accumulator = reinterpret_cast<RowPointers*>(group + offset_);
+          accumulator->free(*allocator_);
+        }
+      }};
+}
+
+void SortedAggregations::initializeNewGroups(
+    char** groups,
+    folly::Range<const vector_size_t*> indices) {
+  for (auto i : indices) {
+    groups[i][nullByte_] |= nullMask_;
+    new (groups[i] + offset_) RowPointers();
+  }
+
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    const auto& aggregate = *aggregates_[i];
+    aggregate.function->initializeNewGroups(groups, indices);
+  }
+}
+
+void SortedAggregations::addInput(char** groups, const RowVectorPtr& input) {
+  for (auto i = 0; i < inputs_.size(); ++i) {
+    decodedInputs_[i].decode(*input->childAt(inputs_[i]));
+  }
+
+  // Add all the rows into the RowContainer.
+  for (auto row = 0; row < input->size(); ++row) {
+    char* newRow = inputData_->newRow();
+
+    for (auto i = 0; i < inputs_.size(); ++i) {
+      inputData_->store(decodedInputs_[i], row, newRow, i);
+    }
+
+    addNewRow(groups[row], newRow);
+  }
+}
+
+void SortedAggregations::addNewRow(char* group, char* newRow) {
+  auto* accumulator = reinterpret_cast<RowPointers*>(group + offset_);
+  RowSizeTracker<char, uint32_t> tracker(group[rowSizeOffset_], *allocator_);
+  accumulator->append(newRow, *allocator_);
+}
+
+void SortedAggregations::addSingleGroupInput(
+    char* group,
+    const RowVectorPtr& input) {
+  for (auto i = 0; i < inputs_.size(); ++i) {
+    decodedInputs_[i].decode(*input->childAt(inputs_[i]));
+  }
+
+  // Add all the rows into the RowContainer.
+  for (auto row = 0; row < input->size(); ++row) {
+    char* newRow = inputData_->newRow();
+
+    for (auto i = 0; i < inputs_.size(); ++i) {
+      inputData_->store(decodedInputs_[i], row, newRow, i);
+    }
+
+    addNewRow(group, newRow);
+  }
+}
+
+bool SortedAggregations::compareRowsWithKeys(
+    const char* lhs,
+    const char* rhs,
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& keys) {
+  if (lhs == rhs) {
+    return false;
+  }
+  for (auto& key : keys) {
+    if (auto result = inputData_->compare(
+            lhs,
+            rhs,
+            key.first,
+            {key.second.isNullsFirst(), key.second.isAscending(), false})) {
+      return result < 0;
+    }
+  }
+  return false;
+}
+
+void SortedAggregations::noMoreInput() {}
+
+void SortedAggregations::sortSingleGroup(
+    std::vector<char*>& groupRows,
+    const AggregateInfo& aggregate) {
+  std::vector<std::pair<column_index_t, core::SortOrder>> keys;
+  for (auto i = 0; i < aggregate.sortingKeys.size(); ++i) {
+    keys.push_back(
+        {inputMapping_[aggregate.sortingKeys[i]], aggregate.sortingOrders[i]});
+  }
+
+  std::sort(
+      groupRows.begin(),
+      groupRows.end(),
+      [&](const char* leftRow, const char* rightRow) {
+        return compareRowsWithKeys(leftRow, rightRow, keys);
+      });
+}
+
+std::vector<VectorPtr> SortedAggregations::extractSingleGroup(
+    std::vector<char*>& groupRows,
+    const AggregateInfo& aggregate) {
+  const auto numInputs = aggregate.inputs.size();
+  std::vector<VectorPtr> inputVectors(numInputs);
+  for (auto i = 0; i < numInputs; ++i) {
+    if (aggregate.inputs[i] == kConstantChannel) {
+      inputVectors[i] = aggregate.constantInputs[i];
+    } else {
+      const auto columnIndex = inputMapping_[aggregate.inputs[i]];
+      inputVectors[i] = BaseVector::create(
+          inputData_->keyTypes()[columnIndex],
+          groupRows.size(),
+          inputData_->pool());
+      inputData_->extractColumn(
+          groupRows.data(), groupRows.size(), columnIndex, inputVectors[i]);
+    }
+  }
+
+  return inputVectors;
+}
+
+void SortedAggregations::extractValues(
+    folly::Range<char**> groups,
+    const RowVectorPtr& result) {
+  // TODO Identify aggregates with same order by and sort once.
+
+  SelectivityVector rows;
+  for (auto i = 0; i < aggregates_.size(); ++i) {
+    const auto& aggregate = *aggregates_[i];
+
+    // For each group, sort inputs, add them to aggregate.
+    for (auto* group : groups) {
+      auto groupRows =
+          reinterpret_cast<RowPointers*>(group + offset_)->read(*allocator_);
+
+      sortSingleGroup(groupRows, aggregate);
+
+      // TODO Process group rows in batches to avoid creating very large input
+      // vectors.
+      auto inputVectors = extractSingleGroup(groupRows, aggregate);
+
+      rows.resize(groupRows.size());
+      aggregate.function->addSingleGroupRawInput(
+          group, rows, inputVectors, false);
+    }
+
+    aggregate.function->extractValues(
+        groups.data(), groups.size(), &result->childAt(aggregate.output));
+
+    // Release memory back to HashStringAllocator to allow next aggregate to
+    // re-use it.
+    aggregate.function->destroy(groups);
+  }
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SortedAggregations.h
+++ b/velox/exec/SortedAggregations.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateInfo.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+
+/// Accumulates inputs for aggregations over sorted input, sorts these inputs
+/// and computes aggregates.
+class SortedAggregations {
+ public:
+  /// @param aggregates Non-empty list of aggregates that require inputs to be
+  /// sorted.
+  /// @param inputType Input row type for the aggregation operator.
+  /// @param pool Memory pool.
+  SortedAggregations(
+      std::vector<AggregateInfo*> aggregates,
+      const RowTypePtr& inputType,
+      memory::MemoryPool* pool);
+
+  /// Returns metadata about the accumulator used to store lists of input rows.
+  Accumulator accumulator() const;
+
+  /// Aggregate-like APIs to aggregate input rows per group.
+  void setAllocator(HashStringAllocator* allocator) {
+    allocator_ = allocator;
+  }
+
+  void setOffsets(
+      int32_t offset,
+      int32_t nullByte,
+      uint8_t nullMask,
+      int32_t rowSizeOffset) {
+    offset_ = offset;
+    nullByte_ = nullByte;
+    nullMask_ = nullMask;
+    rowSizeOffset_ = rowSizeOffset;
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices);
+
+  void addInput(char** groups, const RowVectorPtr& input);
+
+  void addSingleGroupInput(char* group, const RowVectorPtr& input);
+
+  void noMoreInput();
+
+  /// Sorts input row for the specified groups, computes aggregations and stores
+  /// results in the specified 'result' vector.
+  void extractValues(folly::Range<char**> groups, const RowVectorPtr& result);
+
+ private:
+  void addNewRow(char* group, char* newRow);
+
+  bool compareRowsWithKeys(
+      const char* lhs,
+      const char* rhs,
+      const std::vector<std::pair<column_index_t, core::SortOrder>>& keys);
+
+  void sortSingleGroup(
+      std::vector<char*>& groupRows,
+      const AggregateInfo& aggregate);
+
+  std::vector<VectorPtr> extractSingleGroup(
+      std::vector<char*>& groupRows,
+      const AggregateInfo& aggregate);
+
+  const std::vector<AggregateInfo*> aggregates_;
+
+  /// Indices of all inputs for all aggregates.
+  std::vector<column_index_t> inputs_;
+  /// Stores all input rows for all groups.
+  std::unique_ptr<RowContainer> inputData_;
+  /// Mapping from the input column index to an index into 'inputs_'.
+  std::vector<column_index_t> inputMapping_;
+
+  std::vector<DecodedVector> decodedInputs_;
+
+  HashStringAllocator* allocator_;
+  int32_t offset_;
+  int32_t nullByte_;
+  uint8_t nullMask_;
+  int32_t rowSizeOffset_;
+};
+
+} // namespace facebook::velox::exec


### PR DESCRIPTION
Enhance HashAggregation operator to support aggregations over sorted inputs.

```
SELECT a, array_agg(x ORDER BY y) FROM t GROUP BY 1
```

Support global and group-by aggregations, but not masked aggregations. No
spilling support.

Introduce a new class, SortedAggregations, to handle aggregations over sorted
inputs. SortedAggregations accumulates all inputs and order-by keys into a
RowContainer. Once all input has been received, SortedAggregations sorts input
rows for each group, evaluates aggregations and returns the results.

Fixes #5243