### PR TITLE
Add Type::isIntervalDayTime() API

### DIFF
--- a/velox/duckdb/conversion/DuckConversion.cpp
+++ b/velox/duckdb/conversion/DuckConversion.cpp
@@ -69,7 +69,7 @@ LogicalType fromVeloxType(const TypePtr& type) {
     case TypeKind::INTEGER:
       return LogicalType::INTEGER;
     case TypeKind::BIGINT:
-      if (isIntervalDayTimeType(type)) {
+      if (type->isIntervalDayTime()) {
         return LogicalType::INTERVAL;
       }
       return LogicalType::BIGINT;

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -371,7 +371,7 @@ std::vector<MaterializedRow> materialize(
         row.push_back(rowVariantAt(dataChunk->GetValue(j, i), type));
       } else if (type->isDecimal()) {
         row.push_back(duckdb::decimalVariant(dataChunk->GetValue(j, i)));
-      } else if (isIntervalDayTimeType(type)) {
+      } else if (type->isIntervalDayTime()) {
         auto value = variant(::duckdb::Interval::GetMicro(
             dataChunk->GetValue(j, i).GetValue<::duckdb::interval_t>()));
         row.push_back(value);
@@ -823,7 +823,7 @@ void DuckDbQueryRunner::createTable(
           appender.Append(duckValueAt<TypeKind::BIGINT>(columnVector, row));
         } else if (rowType.childAt(column)->isLongDecimal()) {
           appender.Append(duckValueAt<TypeKind::HUGEINT>(columnVector, row));
-        } else if (isIntervalDayTimeType(type)) {
+        } else if (type->isIntervalDayTime()) {
           auto value = ::duckdb::Value::INTERVAL(
               0, 0, columnVector->as<SimpleVector<int64_t>>()->valueAt(row));
           appender.Append(value);

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -195,7 +195,7 @@ TEST_F(FunctionTest, setVectorFromVariants) {
 
   resultVec = setVectorFromVariants(
       INTERVAL_DAY_TIME(), {variant(9020LL), variant(8875LL)}, pool_.get());
-  ASSERT_TRUE(isIntervalDayTimeType(resultVec->type()));
+  ASSERT_TRUE(resultVec->type()->isIntervalDayTime());
   ASSERT_EQ(9020, resultVec->asFlatVector<int64_t>()->valueAt(0));
   ASSERT_EQ(8875, resultVec->asFlatVector<int64_t>()->valueAt(1));
 }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -552,6 +552,8 @@ class Type : public Tree<const std::shared_ptr<const Type>>,
   bool isLongDecimal() const;
   bool isDecimal() const;
 
+  bool isIntervalDayTime() const;
+
   bool containsUnknown() const;
 
  protected:
@@ -1109,14 +1111,14 @@ class IntervalDayTimeType : public BigintType {
   }
 };
 
-FOLLY_ALWAYS_INLINE bool isIntervalDayTimeType(const TypePtr& type) {
-  // Pointer comparison works since this type is a singleton.
-  return IntervalDayTimeType::get() == type;
-}
-
 FOLLY_ALWAYS_INLINE std::shared_ptr<const IntervalDayTimeType>
 INTERVAL_DAY_TIME() {
   return IntervalDayTimeType::get();
+}
+
+FOLLY_ALWAYS_INLINE bool Type::isIntervalDayTime() const {
+  // Pointer comparison works since this type is a singleton.
+  return (this == INTERVAL_DAY_TIME().get());
 }
 
 /// Used as T for SimpleVector subclasses that wrap another vector when


### PR DESCRIPTION
Add `Type::isIntervalDayTime()` API for IntervalDayTimeType.
This is consistent with other Velox Types.