### PR TITLE
Rename ColumnSelector test

### DIFF
--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(
   BitConcatenationTest.cpp
   BitPackDecoderTest.cpp
   ChainedBufferTests.cpp
+  ColumnSelectorTests.cpp
   DataBufferTests.cpp
   DecoderUtilTest.cpp
   LocalFileSinkTest.cpp
@@ -27,7 +28,6 @@ add_executable(
   ReadFileInputStreamTests.cpp
   RetryTests.cpp
   TestBufferedInput.cpp
-  TestColumnSelector.cpp
   TypeTests.cpp)
 add_test(velox_dwio_common_test velox_dwio_common_test)
 target_link_libraries(

--- a/velox/dwio/common/tests/ColumnSelectorTests.cpp
+++ b/velox/dwio/common/tests/ColumnSelectorTests.cpp
@@ -23,7 +23,7 @@ using namespace facebook::velox::dwio::common;
 using facebook::velox::RowType;
 using facebook::velox::dwio::type::fbhive::HiveTypeParser;
 
-TEST(TestColumnSelector, testBasicFilterTree) {
+TEST(ColumnSelectorTests, testBasicFilterTree) {
   const auto schema =
       "struct<"
       "id:bigint"
@@ -194,7 +194,7 @@ TEST(TestColumnSelector, testBasicFilterTree) {
   }
 }
 
-TEST(TestColumnSelector, testGetColumnFilter) {
+TEST(ColumnSelectorTests, testGetColumnFilter) {
   const auto schema =
       "struct<"
       "id:bigint"
@@ -229,7 +229,7 @@ TEST(TestColumnSelector, testGetColumnFilter) {
   EXPECT_EQ(emptyFilter.getProjection().size(), 5);
 }
 
-TEST(TestColumnSelector, testSearchInColumnFilter) {
+TEST(ColumnSelectorTests, testSearchInColumnFilter) {
   const auto schema =
       "struct<"
       "id:bigint"
@@ -256,7 +256,7 @@ TEST(TestColumnSelector, testSearchInColumnFilter) {
   EXPECT_TRUE(FilterNode(4).in(filter) == filter.cend());
 }
 
-TEST(TestColumnSelector, testSchemaMismatchHandling) {
+TEST(ColumnSelectorTests, testSchemaMismatchHandling) {
   const auto strSchema =
       "struct<"
       "id:bigint"
@@ -320,7 +320,7 @@ TEST(TestColumnSelector, testSchemaMismatchHandling) {
   }
 }
 
-TEST(TestColumnSelector, testMapKeyFilterSyntax) {
+TEST(ColumnSelectorTests, testMapKeyFilterSyntax) {
   const auto schema =
       "struct<"
       "id:bigint"
@@ -366,7 +366,7 @@ TEST(TestColumnSelector, testMapKeyFilterSyntax) {
   EXPECT_TRUE(tags2->valid());
 }
 
-TEST(TestColumnSelector, testPartitionKeysMark) {
+TEST(ColumnSelectorTests, testPartitionKeysMark) {
   const auto schema = std::dynamic_pointer_cast<const RowType>(
       HiveTypeParser().parse("struct<"
                              "id:bigint"
@@ -482,7 +482,7 @@ TEST(TestColumnSelector, testPartitionKeysMark) {
   }
 }
 
-TEST(TestColumnSelector, testProjectionUnchangedWhenReadSetChanged) {
+TEST(ColumnSelectorTests, testProjectionUnchangedWhenReadSetChanged) {
   const auto schema = std::dynamic_pointer_cast<const RowType>(
       HiveTypeParser().parse("struct<"
                              "id:bigint"
@@ -531,7 +531,7 @@ TEST(TestColumnSelector, testProjectionUnchangedWhenReadSetChanged) {
   }
 }
 
-TEST(TestColumnSelector, testProjectOrder) {
+TEST(ColumnSelectorTests, testProjectOrder) {
   const auto schema = std::dynamic_pointer_cast<const RowType>(
       HiveTypeParser().parse("struct<"
                              "id:bigint"
@@ -614,7 +614,7 @@ TEST(TestColumnSelector, testProjectOrder) {
   }
 }
 
-TEST(TestColumnSelector, testNonexistingColFilters) {
+TEST(ColumnSelectorTests, testNonexistingColFilters) {
   const auto schema = std::dynamic_pointer_cast<const RowType>(
       HiveTypeParser().parse("struct<"
                              "id:bigint"


### PR DESCRIPTION
Summary: Rename TestColumnSelector to ColumnSelectorTests to harmonize its name with other tests in that folder and make finding this test easier.

Reviewed By: Magoja

Differential Revision: D46363682

