### PR TITLE
Use C++17 [[fallthrough]] in velox/expression/CastExpr.cpp

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -497,6 +497,7 @@ VectorPtr CastExpr::applyDecimal(
         break;
       }
     }
+      [[fallthrough]];
     default:
       VELOX_UNSUPPORTED(
           "Cast from {} to {} is not supported",


### PR DESCRIPTION
Differential Revision: D46603513

