### PR TITLE
Add support for aggregations over sorted inputs to AggregationNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -66,7 +66,7 @@ const std::vector<PlanNodePtr> kEmptySources;
 RowTypePtr getAggregationOutputType(
     const std::vector<FieldAccessTypedExprPtr>& groupingKeys,
     const std::vector<std::string>& aggregateNames,
-    const std::vector<CallTypedExprPtr>& aggregates) {
+    const std::vector<AggregationNode::Aggregate>& aggregates) {
   VELOX_CHECK_EQ(
       aggregateNames.size(),
       aggregates.size(),
@@ -85,7 +85,7 @@ RowTypePtr getAggregationOutputType(
 
   for (int32_t i = 0; i < aggregateNames.size(); i++) {
     names.push_back(aggregateNames[i]);
-    types.push_back(aggregates[i]->type());
+    types.push_back(aggregates[i].call->type());
   }
 
   return std::make_shared<RowType>(std::move(names), std::move(types));
@@ -98,8 +98,7 @@ AggregationNode::AggregationNode(
     const std::vector<FieldAccessTypedExprPtr>& groupingKeys,
     const std::vector<FieldAccessTypedExprPtr>& preGroupedKeys,
     const std::vector<std::string>& aggregateNames,
-    const std::vector<CallTypedExprPtr>& aggregates,
-    const std::vector<FieldAccessTypedExprPtr>& aggregateMasks,
+    const std::vector<Aggregate>& aggregates,
     bool ignoreNullKeys,
     PlanNodePtr source)
     : PlanNode(id),
@@ -108,7 +107,6 @@ AggregationNode::AggregationNode(
       preGroupedKeys_(preGroupedKeys),
       aggregateNames_(aggregateNames),
       aggregates_(aggregates),
-      aggregateMasks_(aggregateMasks),
       ignoreNullKeys_(ignoreNullKeys),
       sources_{source},
       outputType_(getAggregationOutputType(
@@ -168,6 +166,18 @@ void addKeys(std::stringstream& stream, const std::vector<TypedExprPtr>& keys) {
     }
   }
 }
+
+void addSortingKeys(
+    const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
+    const std::vector<SortOrder>& sortingOrders,
+    std::stringstream& stream) {
+  for (auto i = 0; i < sortingKeys.size(); ++i) {
+    if (i > 0) {
+      stream << ", ";
+    }
+    stream << sortingKeys[i]->name() << " " << sortingOrders[i].toString();
+  }
+}
 } // namespace
 
 void AggregationNode::addDetails(std::stringstream& stream) const {
@@ -183,9 +193,15 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
     if (i > 0) {
       stream << ", ";
     }
-    stream << aggregateNames_[i] << " := " << aggregates_[i]->toString();
-    if (aggregateMasks_.size() > i && aggregateMasks_[i]) {
-      stream << " mask: " << aggregateMasks_[i]->name();
+    const auto& aggregate = aggregates_[i];
+    stream << aggregateNames_[i] << " := " << aggregate.call->toString();
+    if (aggregate.mask) {
+      stream << " mask: " << aggregate.mask->name();
+    }
+
+    if (!aggregate.sortingKeys.empty()) {
+      stream << " ORDER BY ";
+      addSortingKeys(aggregate.sortingKeys, aggregate.sortingOrders, stream);
     }
   }
 }
@@ -228,15 +244,9 @@ folly::dynamic AggregationNode::serialize() const {
   obj["groupingKeys"] = ISerializable::serialize(groupingKeys_);
   obj["preGroupedKeys"] = ISerializable::serialize(preGroupedKeys_);
   obj["aggregateNames"] = ISerializable::serialize(aggregateNames_);
-  obj["aggregates"] = ISerializable::serialize(aggregates_);
-
-  obj["masks"] = folly::dynamic::array;
-  for (const auto& mask : aggregateMasks_) {
-    if (mask) {
-      obj["masks"].push_back(mask->serialize());
-    } else {
-      obj["masks"].push_back(nullptr);
-    }
+  obj["aggregates"] = folly::dynamic::array;
+  for (const auto& aggregate : aggregates_) {
+    obj["aggregates"].push_back(aggregate.serialize());
   }
 
   obj["ignoreNullKeys"] = ignoreNullKeys_;
@@ -258,7 +268,51 @@ std::vector<std::string> deserializeStrings(const folly::dynamic& array) {
 RowTypePtr deserializeRowType(const folly::dynamic& obj) {
   return ISerializable::deserialize<RowType>(obj);
 }
+
+folly::dynamic serializeSortingOrders(
+    const std::vector<SortOrder>& sortingOrders) {
+  auto array = folly::dynamic::array();
+  for (const auto& order : sortingOrders) {
+    array.push_back(order.serialize());
+  }
+
+  return array;
+}
+
+std::vector<SortOrder> deserializeSortingOrders(const folly::dynamic& array) {
+  std::vector<SortOrder> sortingOrders;
+  sortingOrders.reserve(array.size());
+  for (const auto& order : array) {
+    sortingOrders.push_back(SortOrder::deserialize(order));
+  }
+  return sortingOrders;
+}
 } // namespace
+
+folly::dynamic AggregationNode::Aggregate::serialize() const {
+  folly::dynamic obj = folly::dynamic::object();
+  obj["call"] = call->serialize();
+  if (mask) {
+    obj["mask"] = mask->serialize();
+  }
+  obj["sortingKeys"] = ISerializable::serialize(sortingKeys);
+  obj["sortingOrders"] = serializeSortingOrders(sortingOrders);
+  return obj;
+}
+
+// static
+AggregationNode::Aggregate AggregationNode::Aggregate::deserialize(
+    const folly::dynamic& obj,
+    void* context) {
+  auto call = ISerializable::deserialize<CallTypedExpr>(obj["call"]);
+  FieldAccessTypedExprPtr mask;
+  if (obj.count("mask")) {
+    mask = ISerializable::deserialize<FieldAccessTypedExpr>(obj["mask"]);
+  }
+  auto sortingKeys = deserializeFields(obj["sortingKeys"], context);
+  auto sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
+  return {call, mask, std::move(sortingKeys), std::move(sortingOrders)};
+}
 
 // static
 PlanNodePtr AggregationNode::create(const folly::dynamic& obj, void* context) {
@@ -267,17 +321,10 @@ PlanNodePtr AggregationNode::create(const folly::dynamic& obj, void* context) {
   auto groupingKeys = deserializeFields(obj["groupingKeys"], context);
   auto preGroupedKeys = deserializeFields(obj["preGroupedKeys"], context);
   auto aggregateNames = deserializeStrings(obj["aggregateNames"]);
-  auto aggregates = ISerializable::deserialize<std::vector<CallTypedExpr>>(
-      obj["aggregates"], context);
 
-  std::vector<FieldAccessTypedExprPtr> masks;
-  for (const auto& mask : obj["masks"]) {
-    if (mask.isNull()) {
-      masks.push_back(nullptr);
-    } else {
-      masks.push_back(
-          ISerializable::deserialize<FieldAccessTypedExpr>(mask, context));
-    }
+  std::vector<Aggregate> aggregates;
+  for (const auto& aggregate : obj["aggregates"]) {
+    aggregates.push_back(Aggregate::deserialize(aggregate, context));
   }
 
   return std::make_shared<AggregationNode>(
@@ -287,7 +334,6 @@ PlanNodePtr AggregationNode::create(const folly::dynamic& obj, void* context) {
       preGroupedKeys,
       aggregateNames,
       aggregates,
-      masks,
       obj["ignoreNullKeys"].asBool(),
       deserializeSingleSource(obj, context));
 }
@@ -1073,20 +1119,6 @@ WindowNode::WindowNode(
       "Number of sorting keys must be equal to the number of sorting orders");
 }
 
-namespace {
-void addSortingKeys(
-    std::stringstream& stream,
-    const std::vector<FieldAccessTypedExprPtr>& sortingKeys,
-    const std::vector<SortOrder>& sortingOrders) {
-  for (auto i = 0; i < sortingKeys.size(); ++i) {
-    if (i > 0) {
-      stream << ", ";
-    }
-    stream << sortingKeys[i]->name() << " " << sortingOrders[i].toString();
-  }
-}
-} // namespace
-
 void WindowNode::addDetails(std::stringstream& stream) const {
   stream << "partition by [";
   if (!partitionKeys_.empty()) {
@@ -1095,7 +1127,7 @@ void WindowNode::addDetails(std::stringstream& stream) const {
   stream << "] ";
 
   stream << "order by [";
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
   stream << "] ";
 
   auto numInputCols = sources_[0]->outputType()->size();
@@ -1204,26 +1236,6 @@ WindowNode::Function WindowNode::Function::deserialize(
       WindowNode::Frame::deserialize(obj["frame"]),
       obj["ignoreNulls"].asBool()};
 }
-
-namespace {
-folly::dynamic serializeSortingOrders(
-    const std::vector<SortOrder>& sortingOrders) {
-  auto array = folly::dynamic::array();
-  for (const auto& order : sortingOrders) {
-    array.push_back(order.serialize());
-  }
-
-  return array;
-}
-
-std::vector<SortOrder> deserializeSortingOrders(const folly::dynamic& array) {
-  std::vector<SortOrder> sortingOrders;
-  for (const auto& order : array) {
-    sortingOrders.push_back(SortOrder::deserialize(order));
-  }
-  return sortingOrders;
-}
-} // namespace
 
 folly::dynamic WindowNode::serialize() const {
   auto obj = PlanNode::serialize();
@@ -1435,7 +1447,7 @@ void TopNRowNumberNode::addDetails(std::stringstream& stream) const {
   }
 
   stream << "order by (";
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
   stream << ") ";
 
   stream << "limit " << limit_;
@@ -1479,7 +1491,7 @@ PlanNodePtr TopNRowNumberNode::create(
 }
 
 void LocalMergeNode::addDetails(std::stringstream& stream) const {
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
 }
 
 folly::dynamic LocalMergeNode::serialize() const {
@@ -1546,7 +1558,7 @@ PlanNodePtr TableWriteNode::create(const folly::dynamic& obj, void* context) {
 }
 
 void MergeExchangeNode::addDetails(std::stringstream& stream) const {
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
 }
 
 folly::dynamic MergeExchangeNode::serialize() const {
@@ -1686,7 +1698,7 @@ void TopNNode::addDetails(std::stringstream& stream) const {
   }
   stream << count_ << " ";
 
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
 }
 
 folly::dynamic TopNNode::serialize() const {
@@ -1747,7 +1759,7 @@ void OrderByNode::addDetails(std::stringstream& stream) const {
   if (isPartial_) {
     stream << "PARTIAL ";
   }
-  addSortingKeys(stream, sortingKeys_, sortingOrders_);
+  addSortingKeys(sortingKeys_, sortingOrders_, stream);
 }
 
 folly::dynamic OrderByNode::serialize() const {

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -125,10 +125,12 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
   std::vector<std::string> emptyAggregateNames{};
   std::vector<TypedExprPtr> aggregateInputs{
       std::make_shared<InputTypedExpr>(BIGINT())};
-  const std::vector<CallTypedExprPtr> aggregates{
-      std::make_shared<core::CallTypedExpr>(BIGINT(), aggregateInputs, "sum")};
-  const std::vector<CallTypedExprPtr> emptyAggregates{};
-  const std::vector<FieldAccessTypedExprPtr> emptyAggregateMasks;
+  const std::vector<AggregationNode::Aggregate> aggregates{
+      {std::make_shared<core::CallTypedExpr>(BIGINT(), aggregateInputs, "sum"),
+       nullptr,
+       {},
+       {}}};
+  const std::vector<AggregationNode::Aggregate> emptyAggregates{};
 
   struct {
     AggregationNode::Step aggregationStep;
@@ -179,7 +181,6 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
         testData.hasPreAggregation ? preGroupingKeys : emptyPreGroupingKeys,
         testData.isDistinct ? emptyAggregateNames : aggregateNames,
         testData.isDistinct ? emptyAggregates : aggregates,
-        emptyAggregateMasks,
         false,
         valueNode_);
     auto queryCtx = getSpillQueryCtx(

--- a/velox/exec/tests/AggregationFuzzer.cpp
+++ b/velox/exec/tests/AggregationFuzzer.cpp
@@ -750,7 +750,7 @@ AggregationFuzzer::computeDuckAggregation(
       projections.empty() ? plan.get() : plan->sources()[0].get());
   VELOX_CHECK_NOT_NULL(aggregationNode);
   for (const auto& agg : aggregationNode->aggregates()) {
-    if (duckFunctionNames_.count(agg->name()) == 0) {
+    if (duckFunctionNames_.count(agg.call->name()) == 0) {
       return std::nullopt;
     }
   }
@@ -1102,13 +1102,12 @@ void AggregationFuzzer::verifyAggregation(
   }
 
   // Get masks.
-  auto masks = node->aggregateMasks();
   std::vector<std::string> maskNames;
-  maskNames.reserve(masks.size());
+  maskNames.reserve(node->aggregates().size());
 
-  for (auto maskName : masks) {
-    if (maskName) {
-      maskNames.push_back(maskName->name());
+  for (auto aggregate : node->aggregates()) {
+    if (aggregate.mask) {
+      maskNames.push_back(aggregate.mask->name());
     }
   }
 
@@ -1138,9 +1137,9 @@ void AggregationFuzzer::verifyAggregation(
 
   bool customVerification = false;
   for (auto aggregate : node->aggregates()) {
-    aggregateStrings.push_back(aggregate->toString());
+    aggregateStrings.push_back(aggregate.call->toString());
     customVerification |=
-        customVerificationFunctions_.count(aggregate->name()) != 0;
+        customVerificationFunctions_.count(aggregate.call->name()) != 0;
   }
 
   const bool verifyResults = !customVerification || !projections.empty();

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -410,14 +410,16 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
     return PlanBuilder()
         .values({data})
         .addNode([&](auto nodeId, auto source) -> core::PlanNodePtr {
+          std::vector<core::AggregationNode::Aggregate> aggregates{
+              {aggExpr, nullptr, {}, {}}};
+
           return std::make_shared<core::AggregationNode>(
               nodeId,
               core::AggregationNode::Step::kSingle,
               std::vector<core::FieldAccessTypedExprPtr>{},
               std::vector<core::FieldAccessTypedExprPtr>{},
               std::vector<std::string>{"agg"},
-              std::vector<core::CallTypedExprPtr>{aggExpr},
-              std::vector<core::FieldAccessTypedExprPtr>{},
+              aggregates,
               false,
               std::move(source));
         })

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -70,6 +70,15 @@ TEST_F(PlanNodeSerdeTest, aggregation) {
                   .planNode();
 
   testSerde(plan);
+
+  // Aggregation over sorted inputs.
+  plan = PlanBuilder()
+             .values({data_})
+             .singleAggregation(
+                 {"c0"}, {"array_agg(c1 ORDER BY c2 DESC)", "sum(c1)"})
+             .planNode();
+
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, assignUniqueId) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -231,6 +231,17 @@ TEST_F(PlanNodeToStringTest, aggregation) {
   ASSERT_EQ(
       "-- Aggregation[SINGLE [c0] a := sum(ROW[\"c1\"]) mask: m1, b := avg(ROW[\"c2\"]) mask: m2] -> c0:BIGINT, a:BIGINT, b:DOUBLE\n",
       plan->toString(true, false));
+
+  // Aggregation over sorted inputs.
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({"c0"}, {"array_agg(c1 ORDER BY c2 DESC)"})
+             .planNode();
+
+  ASSERT_EQ("-- Aggregation\n", plan->toString());
+  ASSERT_EQ(
+      "-- Aggregation[SINGLE [c0] a0 := array_agg(ROW[\"c1\"]) ORDER BY c2 DESC NULLS LAST] -> c0:BIGINT, a0:ARRAY<INTEGER>\n",
+      plan->toString(true, false));
 }
 
 TEST_F(PlanNodeToStringTest, groupId) {

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -427,26 +427,26 @@ core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
   auto numAggregates = partialAggregates.size();
   auto numGroupingKeys = groupingKeys.size();
 
-  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> masks(
-      numAggregates);
-
-  std::vector<std::shared_ptr<const core::CallTypedExpr>> aggregates;
+  std::vector<core::AggregationNode::Aggregate> aggregates;
   aggregates.reserve(numAggregates);
   for (auto i = 0; i < numAggregates; i++) {
     // Resolve final or intermediate aggregation result type using raw input
     // types for the partial aggregation.
-    auto name = partialAggregates[i]->name();
-    auto rawInputs = partialAggregates[i]->inputs();
+    auto name = partialAggregates[i].call->name();
+    auto rawInputs = partialAggregates[i].call->inputs();
 
     std::vector<TypePtr> rawInputTypes;
     for (auto& rawInput : rawInputs) {
       rawInputTypes.push_back(rawInput->type());
     }
 
+    core::AggregationNode::Aggregate aggregate;
+
     auto type = resolveAggregateType(name, step, rawInputTypes, false);
     std::vector<core::TypedExprPtr> inputs = {field(numGroupingKeys + i)};
-    aggregates.emplace_back(
-        std::make_shared<core::CallTypedExpr>(type, std::move(inputs), name));
+    aggregate.call =
+        std::make_shared<core::CallTypedExpr>(type, std::move(inputs), name);
+    aggregates.emplace_back(aggregate);
   }
 
   return std::make_shared<core::AggregationNode>(
@@ -456,7 +456,6 @@ core::PlanNodePtr PlanBuilder::createIntermediateOrFinalAggregation(
       partialAggNode->preGroupedKeys(),
       partialAggNode->aggregateNames(),
       aggregates,
-      masks,
       partialAggNode->ignoreNullKeys(),
       planNode_);
 }
@@ -517,56 +516,66 @@ PlanBuilder& PlanBuilder::finalAggregation() {
   return *this;
 }
 
-PlanBuilder::ExpressionsAndNames
-PlanBuilder::createAggregateExpressionsAndNames(
+PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
     const std::vector<std::string>& aggregates,
+    const std::vector<std::string>& masks,
     core::AggregationNode::Step step,
     const std::vector<TypePtr>& resultTypes) {
+  std::vector<core::AggregationNode::Aggregate> aggs;
+
   AggregateTypeResolver resolver(step);
-  std::vector<std::shared_ptr<const core::CallTypedExpr>> exprs;
   std::vector<std::string> names;
-  exprs.reserve(aggregates.size());
+  aggs.reserve(aggregates.size());
   names.reserve(aggregates.size());
+
+  duckdb::ParseOptions options;
+  options.parseIntegerAsBigint = options_.parseIntegerAsBigint;
+
   for (auto i = 0; i < aggregates.size(); i++) {
-    auto& agg = aggregates[i];
+    auto& aggregate = aggregates[i];
     if (i < resultTypes.size()) {
       resolver.setResultType(resultTypes[i]);
     }
 
-    auto untypedExpr = parse::parseExpr(agg, options_);
+    auto untypedExpr = duckdb::parseAggregateExpr(aggregate, options);
 
-    auto expr = std::dynamic_pointer_cast<const core::CallTypedExpr>(
-        inferTypes(untypedExpr));
-    exprs.emplace_back(expr);
+    core::AggregationNode::Aggregate agg;
+    agg.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
+        inferTypes(untypedExpr.expr));
+    if (i < masks.size() && !masks[i].empty()) {
+      agg.mask = field(masks[i]);
+    }
 
-    if (untypedExpr->alias().has_value()) {
-      names.push_back(untypedExpr->alias().value());
+    if (!untypedExpr.orderBy.empty()) {
+      VELOX_CHECK(
+          step == core::AggregationNode::Step::kSingle,
+          "Aggregations over sorted inputs cannot be split into partial and final: {}.",
+          aggregate)
+    }
+
+    for (const auto& [keyExpr, order] : untypedExpr.orderBy) {
+      auto sortingKey =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+              inferTypes(keyExpr));
+      VELOX_CHECK_NOT_NULL(
+          sortingKey,
+          "ORDER BY clause must use a column name, not an expression: {}",
+          aggregate);
+
+      agg.sortingKeys.push_back(sortingKey);
+      agg.sortingOrders.push_back(order);
+    }
+
+    aggs.emplace_back(agg);
+
+    if (untypedExpr.expr->alias().has_value()) {
+      names.push_back(untypedExpr.expr->alias().value());
     } else {
       names.push_back(fmt::format("a{}", i));
     }
   }
 
-  return {exprs, names};
-}
-
-std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
-PlanBuilder::createAggregateMasks(
-    size_t numAggregates,
-    const std::vector<std::string>& masks) {
-  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>> maskExprs(
-      numAggregates);
-  if (masks.empty()) {
-    return maskExprs;
-  }
-
-  VELOX_CHECK_EQ(numAggregates, masks.size());
-  for (auto i = 0; i < numAggregates; ++i) {
-    if (!masks[i].empty()) {
-      maskExprs[i] = field(masks[i]);
-    }
-  }
-
-  return maskExprs;
+  return {aggs, names};
 }
 
 PlanBuilder& PlanBuilder::aggregation(
@@ -577,17 +586,15 @@ PlanBuilder& PlanBuilder::aggregation(
     core::AggregationNode::Step step,
     bool ignoreNullKeys,
     const std::vector<TypePtr>& resultTypes) {
-  auto numAggregates = aggregates.size();
   auto aggregatesAndNames =
-      createAggregateExpressionsAndNames(aggregates, step, resultTypes);
+      createAggregateExpressionsAndNames(aggregates, masks, step, resultTypes);
   planNode_ = std::make_shared<core::AggregationNode>(
       nextPlanNodeId(),
       step,
       fields(groupingKeys),
       fields(preGroupedKeys),
       aggregatesAndNames.names,
-      aggregatesAndNames.expressions,
-      createAggregateMasks(numAggregates, masks),
+      aggregatesAndNames.aggregates,
       ignoreNullKeys,
       planNode_);
   return *this;
@@ -600,17 +607,15 @@ PlanBuilder& PlanBuilder::streamingAggregation(
     core::AggregationNode::Step step,
     bool ignoreNullKeys,
     const std::vector<TypePtr>& resultTypes) {
-  auto numAggregates = aggregates.size();
   auto aggregatesAndNames =
-      createAggregateExpressionsAndNames(aggregates, step, resultTypes);
+      createAggregateExpressionsAndNames(aggregates, masks, step, resultTypes);
   planNode_ = std::make_shared<core::AggregationNode>(
       nextPlanNodeId(),
       step,
       fields(groupingKeys),
       fields(groupingKeys),
       aggregatesAndNames.names,
-      aggregatesAndNames.expressions,
-      createAggregateMasks(numAggregates, masks),
+      aggregatesAndNames.aggregates,
       ignoreNullKeys,
       planNode_);
   return *this;

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -801,20 +801,16 @@ class PlanBuilder {
       core::AggregationNode::Step step,
       const core::AggregationNode* partialAggNode);
 
-  struct ExpressionsAndNames {
-    std::vector<std::shared_ptr<const core::CallTypedExpr>> expressions;
+  struct AggregatesAndNames {
+    std::vector<core::AggregationNode::Aggregate> aggregates;
     std::vector<std::string> names;
   };
 
-  ExpressionsAndNames createAggregateExpressionsAndNames(
+  AggregatesAndNames createAggregateExpressionsAndNames(
       const std::vector<std::string>& aggregates,
+      const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& resultTypes);
-
-  std::vector<std::shared_ptr<const core::FieldAccessTypedExpr>>
-  createAggregateMasks(
-      size_t numAggregates,
-      const std::vector<std::string>& masks);
 
  protected:
   core::PlanNodePtr planNode_;

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -493,7 +493,7 @@ RowVectorPtr AggregationTestBase::validateStreamingInTestAggregations(
       static_cast<const core::AggregationNode&>(*builder.planNode());
   EXPECT_EQ(expected->childrenSize(), aggregationNode.aggregates().size());
   for (int i = 0; i < aggregationNode.aggregates().size(); ++i) {
-    auto& aggregate = aggregationNode.aggregates()[i];
+    auto& aggregate = aggregationNode.aggregates()[i].call;
     SCOPED_TRACE(aggregate->name());
     std::vector<VectorPtr> rawInput1, rawInput2;
     for (auto& arg : aggregate->inputs()) {

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -291,7 +291,7 @@ PlanNodePtr toVeloxPlan(
     memory::MemoryPool* pool,
     std::vector<PlanNodePtr> sources,
     QueryContext& queryContext) {
-  std::vector<CallTypedExprPtr> aggregates;
+  std::vector<AggregationNode::Aggregate> aggregates;
 
   std::vector<std::string> projectNames;
   std::vector<TypedExprPtr> projections;
@@ -317,8 +317,12 @@ PlanNodePtr toVeloxPlan(
       }
     }
 
-    aggregates.push_back(std::make_shared<CallTypedExpr>(
-        call->type(), fieldInputs, call->name()));
+    aggregates.push_back(
+        {std::make_shared<CallTypedExpr>(
+             call->type(), fieldInputs, call->name()),
+         nullptr,
+         {},
+         {}});
   }
 
   std::vector<FieldAccessTypedExprPtr> groupingKeys;
@@ -359,8 +363,7 @@ PlanNodePtr toVeloxPlan(
       groupingKeys,
       std::vector<FieldAccessTypedExprPtr>{}, // preGroupedKeys
       names,
-      aggregates,
-      std::vector<FieldAccessTypedExprPtr>{}, // aggregateMasks
+      std::move(aggregates),
       false, // ignoreNullKeys
       source);
 }


### PR DESCRIPTION
Extend AggregationNode to allow specifying sorting of inputs for individual aggregations.

Part of #5223 
Depends on #5246