### PR TITLE
Add buck support to map_from_entries Presto function

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -27,16 +27,16 @@ Map Functions
 
     See also :func:`map_agg` for creating a map as an aggregation.
 
+.. function:: map_concat(map1(K,V), map2(K,V), ..., mapN(K,V)) -> map(K,V)
+
+   Returns the union of all the given maps. If a key is found in multiple given maps,
+   that key's value in the resulting map comes from the last one of those maps.
+
 .. function:: map_entries(map(K,V)) -> array(row(K,V))
 
     Returns an array of all entries in the given map. ::
 
         SELECT map_entries(MAP(ARRAY[1, 2], ARRAY['x', 'y'])); -- [ROW(1, 'x'), ROW(2, 'y')]
-
-.. function:: map_concat(map1(K,V), map2(K,V), ..., mapN(K,V)) -> map(K,V)
-
-   Returns the union of all the given maps. If a key is found in multiple given maps,
-   that key's value in the resulting map comes from the last one of those maps.
 
 .. function:: map_filter(map(K,V), function(K,V,boolean)) -> map(K,V)
 
@@ -46,6 +46,12 @@ Map Functions
         SELECT map_filter(MAP(ARRAY[10, 20, 30], ARRAY['a', NULL, 'c']), (k, v) -> v IS NOT NULL); -- {10 -> a, 30 -> c}
         SELECT map_filter(MAP(ARRAY['k1', 'k2', 'k3'], ARRAY[20, 3, 15]), (k, v) -> v > 10); -- {k1 -> 20, k3 -> 15}
 
+.. function:: map_from_entries(array(row(K, V))) -> map(K, V)
+
+    Returns a map created from the given array of entries. ::
+
+        SELECT map_from_entries(ARRAY[(1, 'x'), (2, 'y')]); -- {1 -> 'x', 2 -> 'y'}
+
 .. function:: map_keys(x(K,V)) -> array(K)
 
     Returns all the keys in the map ``x``.
@@ -53,14 +59,6 @@ Map Functions
 .. function:: map_values(x(K,V)) -> array(V)
 
     Returns all the values in the map ``x``.
-
-.. function:: subscript(map(K, V), key) -> V
-   :noindex:
-
-    Returns value for given ``key``. Throws if the key is not contained in the map.
-    Corresponds to SQL subscript operator [].
-
-    SELECT name_to_age_map['Bob'] AS bob_age;
 
 .. function:: map_zip_with(map(K,V1), map(K,V2), function(K,V1,V2,V3)) -> map(K,V3)
 
@@ -76,6 +74,14 @@ Map Functions
         SELECT map_zip_with(MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 8, 27]), -- {a -> a1, b -> b4, c -> c9}
                             MAP(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]),
                             (k, v1, v2) -> k || CAST(v1/v2 AS VARCHAR));
+
+.. function:: subscript(map(K, V), key) -> V
+   :noindex:
+
+    Returns value for given ``key``. Throws if the key is not contained in the map.
+    Corresponds to SQL subscript operator [].
+
+    SELECT name_to_age_map['Bob'] AS bob_age;
 
 .. function:: transform_keys(map(K1,V), function(K1,V,K2)) -> map(K2,V)
 

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   JsonFunctions.cpp
   Map.cpp
   MapEntries.cpp
+  MapFromEntries.cpp
   MapKeysAndValues.cpp
   MapZipWith.cpp
   Not.cpp

--- a/velox/functions/prestosql/MapFromEntries.cpp
+++ b/velox/functions/prestosql/MapFromEntries.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/expression/EvalCtx.h"
+#include "velox/expression/Expr.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/lib/CheckDuplicateKeys.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
+
+namespace facebook::velox::functions {
+namespace {
+// See documentation at https://prestodb.io/docs/current/functions/map.html
+class MapFromEntriesFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_CHECK_EQ(args.size(), 1);
+    auto& arg = args[0];
+    VectorPtr localResult;
+
+    // Input can be constant or flat.
+    if (arg->isConstantEncoding()) {
+      auto* constantArray = arg->as<ConstantVector<ComplexType>>();
+      const auto& flatArray = constantArray->valueVector();
+      const auto flatIndex = constantArray->index();
+
+      exec::LocalSelectivityVector singleRow(context, flatIndex + 1);
+      singleRow->clearAll();
+      singleRow->setValid(flatIndex, true);
+      singleRow->updateBounds();
+
+      localResult = applyFlat(
+          *singleRow.get(), flatArray->as<ArrayVector>(), outputType, context);
+      localResult =
+          BaseVector::wrapInConstant(rows.size(), flatIndex, localResult);
+    } else {
+      localResult =
+          applyFlat(rows, arg->as<ArrayVector>(), outputType, context);
+    }
+
+    context.moveOrCopyResult(localResult, rows, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {// array(unknown) -> map(unknown, unknown)
+            exec::FunctionSignatureBuilder()
+                .returnType("map(unknown, unknown)")
+                .argumentType("array(unknown)")
+                .build(),
+            // array(row(K,V)) -> map(K,V)
+            exec::FunctionSignatureBuilder()
+                .knownTypeVariable("K")
+                .typeVariable("V")
+                .returnType("map(K,V)")
+                .argumentType("array(row(K,V))")
+                .build()};
+  }
+
+ private:
+  VectorPtr applyFlat(
+      const SelectivityVector& rows,
+      const ArrayVector* inputArray,
+      const TypePtr& outputType,
+      exec::EvalCtx& context) const {
+    auto& inputValueVector = inputArray->elements();
+    exec::LocalDecodedVector decodedValueVector(context);
+    decodedValueVector.get()->decode(*inputValueVector);
+    auto valueRowVector = decodedValueVector->base()->as<RowVector>();
+    auto keyValueVector = valueRowVector->childAt(0);
+
+    // Validate all map entries and map keys are not null.
+    if (decodedValueVector->mayHaveNulls() || keyValueVector->mayHaveNulls()) {
+      context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
+        const auto size = inputArray->sizeAt(row);
+        const auto offset = inputArray->offsetAt(row);
+        for (auto i = 0; i < size; ++i) {
+          const bool isMapEntryNull = decodedValueVector->isNullAt(offset + i);
+          VELOX_USER_CHECK(!isMapEntryNull, "map entry cannot be null");
+          const bool isMapKeyNull =
+              keyValueVector->isNullAt(decodedValueVector->index(offset + i));
+          VELOX_USER_CHECK(!isMapKeyNull, "map key cannot be null");
+        }
+      });
+    }
+
+    VectorPtr wrappedKeys;
+    VectorPtr wrappedValues;
+    if (decodedValueVector->isIdentityMapping()) {
+      wrappedKeys = valueRowVector->childAt(0);
+      wrappedValues = valueRowVector->childAt(1);
+    } else {
+      wrappedKeys = decodedValueVector->wrap(
+          valueRowVector->childAt(0),
+          *inputValueVector,
+          inputValueVector->size());
+      wrappedValues = decodedValueVector->wrap(
+          valueRowVector->childAt(1),
+          *inputValueVector,
+          inputValueVector->size());
+    }
+
+    // To avoid creating new buffers, we try to reuse the input's buffers
+    // as many as possible.
+    auto mapVector = std::make_shared<MapVector>(
+        context.pool(),
+        outputType,
+        inputArray->nulls(),
+        rows.end(),
+        inputArray->offsets(),
+        inputArray->sizes(),
+        wrappedKeys,
+        wrappedValues);
+
+    checkDuplicateKeys(mapVector, rows, context);
+    return mapVector;
+  }
+};
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_map_from_entries,
+    MapFromEntriesFunction::signatures(),
+    std::make_unique<MapFromEntriesFunction>());
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/MapFunctionsRegistration.cpp
@@ -26,6 +26,8 @@ void registerMapFunctions(const std::string& prefix) {
       udf_transform_values, prefix + "transform_values");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_entries, prefix + "map_entries");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_map_from_entries, prefix + "map_from_entries");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_keys, prefix + "map_keys");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_values, prefix + "map_values");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map_zip_with, prefix + "map_zip_with");

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -58,6 +58,7 @@ add_executable(
   JsonFunctionsTest.cpp
   MapEntriesTest.cpp
   MapFilterTest.cpp
+  MapFromEntriesTest.cpp
   MapKeysAndValuesTest.cpp
   MapTest.cpp
   MapZipWithTest.cpp

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+#include "velox/vector/tests/TestingDictionaryArrayElementsFunction.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace {
+std::optional<std::vector<std::pair<int32_t, std::optional<int32_t>>>> O(
+    const std::vector<std::pair<int32_t, std::optional<int32_t>>>& vector) {
+  return std::make_optional(vector);
+}
+} // namespace
+
+namespace {
+class MapFromEntriesTest : public FunctionBaseTest {
+ protected:
+  /// Create an MAP vector of size 1 using specified 'keys' and 'values' vector.
+  VectorPtr makeSingleRowMapVector(
+      const VectorPtr& keys,
+      const VectorPtr& values) {
+    BufferPtr offsets = allocateOffsets(1, pool());
+    BufferPtr sizes = allocateSizes(1, pool());
+    sizes->asMutable<vector_size_t>()[0] = keys->size();
+
+    return std::make_shared<MapVector>(
+        pool(),
+        MAP(keys->type(), values->type()),
+        nullptr,
+        1,
+        offsets,
+        sizes,
+        keys,
+        values);
+  }
+
+  void verifyMapFromEntries(
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected,
+      const std::string& funcArg = "C0",
+      bool wrappedWithTry = false) {
+    const std::string expr = wrappedWithTry
+        ? fmt::format("try(map_from_entries({}))", funcArg)
+        : fmt::format("map_from_entries({})", funcArg);
+    auto result = evaluate<MapVector>(expr, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  // Evaluate an expression only, usually expect error thrown.
+  void evaluateExpr(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    evaluate(expression, makeRowVector(input));
+  }
+};
+} // namespace
+
+TEST_F(MapFromEntriesTest, intKeyAndVarcharValue) {
+  auto rowType = ROW({INTEGER(), VARCHAR()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, "red"}),
+       variant::row({2, "blue"}),
+       variant::row({3, "green"})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected = makeMapVector<int32_t, StringView>(
+      {{{1, "red"_sv}, {2, "blue"_sv}, {3, "green"_sv}}});
+  verifyMapFromEntries({input}, expected);
+}
+
+TEST_F(MapFromEntriesTest, nullMapEntries) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant(TypeKind::ROW)}, {variant::row({1, 11})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  VELOX_ASSERT_THROW(
+      evaluateExpr("map_from_entries(C0)", {input}),
+      "map entry cannot be null");
+  auto expected =
+      makeNullableMapVector<int32_t, int32_t>({std::nullopt, O({{1, 11}})});
+  verifyMapFromEntries({input}, expected, "C0", true);
+}
+
+TEST_F(MapFromEntriesTest, nullKeys) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({variant::null(TypeKind::INTEGER), 0})},
+      {variant::row({1, 11})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  VELOX_ASSERT_THROW(
+      evaluateExpr("map_from_entries(C0)", {input}), "map key cannot be null");
+  auto expected =
+      makeNullableMapVector<int32_t, int32_t>({std::nullopt, O({{1, 11}})});
+  verifyMapFromEntries({input}, expected, "C0", true);
+}
+
+TEST_F(MapFromEntriesTest, duplicateKeys) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, 10}), variant::row({1, 11})}, {variant::row({2, 22})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  VELOX_ASSERT_THROW(
+      evaluateExpr("map_from_entries(C0)", {input}),
+      "Duplicate map keys (1) are not allowed");
+  auto expected =
+      makeNullableMapVector<int32_t, int32_t>({std::nullopt, O({{2, 22}})});
+  verifyMapFromEntries({input}, expected, "C0", true);
+}
+
+TEST_F(MapFromEntriesTest, nullValues) {
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, variant::null(TypeKind::INTEGER)}),
+       variant::row({2, 22}),
+       variant::row({3, 33})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected =
+      makeMapVector<int32_t, int32_t>({{{1, std::nullopt}, {2, 22}, {3, 33}}});
+  verifyMapFromEntries({input}, expected);
+}
+
+TEST_F(MapFromEntriesTest, constant) {
+  const vector_size_t kConstantSize = 1'000;
+  auto rowType = ROW({VARCHAR(), INTEGER()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({"red", 1}),
+       variant::row({"blue", 2}),
+       variant::row({"green", 3})},
+      {variant::row({"red shiny car ahead", 4}),
+       variant::row({"blue clear sky above", 5})},
+      {variant::row({"r", 11}),
+       variant::row({"g", 22}),
+       variant::row({"b", 33})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+
+  auto evaluateConstant = [&](vector_size_t row, const VectorPtr& vector) {
+    return evaluate(
+        "map_from_entries(C0)",
+        makeRowVector(
+            {BaseVector::wrapInConstant(kConstantSize, row, vector)}));
+  };
+
+  auto result = evaluateConstant(0, input);
+  auto expected = BaseVector::wrapInConstant(
+      kConstantSize,
+      0,
+      makeSingleRowMapVector(
+          makeFlatVector<StringView>({"red"_sv, "blue"_sv, "green"_sv}),
+          makeFlatVector<int32_t>({1, 2, 3})));
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(1, input);
+  expected = BaseVector::wrapInConstant(
+      kConstantSize,
+      0,
+      makeSingleRowMapVector(
+          makeFlatVector<StringView>(
+              {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
+          makeFlatVector<int32_t>({4, 5})));
+  test::assertEqualVectors(expected, result);
+
+  result = evaluateConstant(2, input);
+  expected = BaseVector::wrapInConstant(
+      kConstantSize,
+      0,
+      makeSingleRowMapVector(
+          makeFlatVector<StringView>({"r"_sv, "g"_sv, "b"_sv}),
+          makeFlatVector<int32_t>({11, 22, 33})));
+  test::assertEqualVectors(expected, result);
+}
+
+TEST_F(MapFromEntriesTest, dictionaryEncodedElementsInFlat) {
+  exec::registerVectorFunction(
+      "testing_dictionary_array_elements",
+      test::TestingDictionaryArrayElementsFunction::signatures(),
+      std::make_unique<test::TestingDictionaryArrayElementsFunction>());
+
+  auto rowType = ROW({INTEGER(), VARCHAR()});
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, "red"}),
+       variant::row({2, "blue"}),
+       variant::row({3, "green"})}};
+  auto input = makeArrayOfRowVector(rowType, data);
+  auto expected = makeMapVector<int32_t, StringView>(
+      {{{1, "red"_sv}, {2, "blue"_sv}, {3, "green"_sv}}});
+  verifyMapFromEntries(
+      {input}, expected, "testing_dictionary_array_elements(C0)");
+}
+
+TEST_F(MapFromEntriesTest, outputSizeIsBoundBySelectedRows) {
+  // This test makes sure that map_from_entries output vector size is
+  // `rows.end()` instead of `rows.size()`.
+
+  auto rowType = ROW({INTEGER(), INTEGER()});
+  auto function =
+      exec::getVectorFunction("map_from_entries", {ARRAY(rowType)}, {});
+
+  std::vector<std::vector<variant>> data = {
+      {variant::row({1, 11}), variant::row({2, 22}), variant::row({3, 33})},
+      {variant::row({4, 44}), variant::row({5, 55})},
+      {variant::row({6, 66})}};
+  auto array = makeArrayOfRowVector(rowType, data);
+
+  auto rowVector = makeRowVector({array});
+
+  // Only the first 2 rows selected.
+  SelectivityVector rows(2);
+  // This is larger than input array size but rows beyond the input vector size
+  // are not selected.
+  rows.resize(1000, false);
+
+  ASSERT_EQ(rows.size(), 1000);
+  ASSERT_EQ(rows.end(), 2);
+  ASSERT_EQ(array->size(), 3);
+
+  auto typedExpr =
+      makeTypedExpr("map_from_entries(c0)", asRowType(rowVector->type()));
+  std::vector<VectorPtr> results(1);
+
+  exec::ExprSet exprSet({typedExpr}, &execCtx_);
+  exec::EvalCtx evalCtx(&execCtx_, &exprSet, rowVector.get());
+  exprSet.eval(rows, evalCtx, results);
+
+  ASSERT_EQ(results[0]->size(), 2);
+}

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -244,9 +244,7 @@ class VectorTestBase {
 
   // Create an ArrayVector<ROW> from nested std::vectors of variants.
   // Example:
-  //   auto arrayVector = makeArrayOfRowVector(
-  //     ROW({INTEGER(), VARCHAR()}),
-  //     {
+  //   auto arrayVector = makeArrayOfRowVector({
   //       {variant::row({1, "red"}), variant::row({1, "blue"})},
   //       {},
   //       {variant::row({3, "green"})},


### PR DESCRIPTION
Summary:
In previous PR: https://github.com/facebookincubator/velox/pull/3417 (D46169043), the buck TARGETS file changes are overlooked. Thus it causes many internal build failures.

This change is to amend those BUCK changes.

Differential Revision: D46700832

