### PR TITLE
Extract row filter from remaining filter

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -78,6 +78,14 @@ class HiveDataSource : public DataSource {
       const std::vector<common::Subfield>& remainingFilterInputs,
       memory::MemoryPool* pool);
 
+  // Internal API, made public to be accessible in unit tests.  Do not use in
+  // other places.
+  static core::TypedExprPtr extractFiltersFromRemainingFilter(
+      const core::TypedExprPtr& expr,
+      core::ExpressionEvaluator* evaluator,
+      bool negated,
+      SubfieldFilters& filters);
+
  protected:
   virtual uint64_t readNext(uint64_t size) {
     return rowReader_->next(size, output_);

--- a/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/duckdb_reader/ParquetReader.cpp
@@ -274,8 +274,8 @@ uint64_t ParquetRowReader::next(
   reader_->Scan(state_, output);
 
   if (output.size() > 0) {
-    std::vector<VectorPtr> columns;
-    columns.resize(output.data.size());
+    VELOX_CHECK(result);
+    std::vector<VectorPtr> columns(result->type()->size());
     for (auto& spec : scanSpec_->children()) {
       if (spec->isConstant()) {
         columns[spec->channel()] =
@@ -292,7 +292,7 @@ uint64_t ParquetRowReader::next(
 
     result = std::make_shared<RowVector>(
         &pool_,
-        rowType_,
+        result->type(),
         BufferPtr(nullptr),
         output.size(),
         columns,

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -24,7 +24,7 @@ StructColumnReader::StructColumnReader(
     ParquetParams& params,
     common::ScanSpec& scanSpec)
     : SelectiveStructColumnReader(dataType, dataType, params, scanSpec) {
-  auto& childSpecs = scanSpec_->children();
+  auto& childSpecs = scanSpec_->stableChildren();
   for (auto i = 0; i < childSpecs.size(); ++i) {
     if (childSpecs[i]->isConstant()) {
       continue;
@@ -116,10 +116,6 @@ void StructColumnReader::seekToRowGroup(uint32_t index) {
   for (auto& child : children_) {
     child->seekToRowGroup(index);
   }
-}
-
-bool StructColumnReader::filterMatches(const thrift::RowGroup& /*rowGroup*/) {
-  return true;
 }
 
 void StructColumnReader::seekToEndOfPresetNulls() {

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -63,7 +63,6 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
       dwio::common::FormatData::FilterRowGroupsResult&) const override;
 
  private:
-  bool filterMatches(const thrift::RowGroup& rowGroup);
   dwio::common::SelectiveColumnReader* findBestLeaf();
 
   // Leaf column reader used for getting nullability information for

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -93,25 +93,6 @@ class ParquetReaderTestBase : public testing::Test {
     EXPECT_EQ(reader.next(1000, result), 0);
   }
 
-  void assertReadExpected(
-      dwio::common::RowReader& reader,
-      RowVectorPtr expected) {
-    uint64_t total = 0;
-    VectorPtr result;
-    while (total < expected->size()) {
-      auto part = reader.next(1000, result);
-      EXPECT_GT(part, 0);
-      if (part > 0) {
-        assertEqualVectorPart(expected, result, total);
-        total += part;
-      } else {
-        break;
-      }
-    }
-    EXPECT_EQ(total, expected->size());
-    EXPECT_EQ(reader.next(1000, result), 0);
-  }
-
   std::shared_ptr<velox::common::ScanSpec> makeScanSpec(
       const RowTypePtr& rowType) {
     auto scanSpec = std::make_shared<velox::common::ScanSpec>("");
@@ -137,7 +118,7 @@ class ParquetReaderTestBase : public testing::Test {
     auto rowReaderOpts = getReaderOpts(fileSchema);
     rowReaderOpts.setScanSpec(scanSpec);
     auto rowReader = reader->createRowReader(rowReaderOpts);
-    assertReadExpected(*rowReader, expected);
+    assertReadExpected(fileSchema, *rowReader, expected, *pool_);
   }
 
   std::string getExampleFilePath(const std::string& fileName) {

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
@@ -93,7 +93,7 @@ TEST_F(ParquetReaderTest, readSampleFull) {
   auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(20, 1), rangeVector<double>(20, 1)});
-  assertReadExpected(*rowReader, expected);
+  assertReadExpected(sampleSchema(), *rowReader, expected, *pool_);
 }
 
 TEST_F(ParquetReaderTest, readSampleRange1) {
@@ -109,7 +109,7 @@ TEST_F(ParquetReaderTest, readSampleRange1) {
   auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(10, 1), rangeVector<double>(10, 1)});
-  assertReadExpected(*rowReader, expected);
+  assertReadExpected(sampleSchema(), *rowReader, expected, *pool_);
 }
 
 TEST_F(ParquetReaderTest, readSampleRange2) {
@@ -125,7 +125,7 @@ TEST_F(ParquetReaderTest, readSampleRange2) {
   auto rowReader = reader->createRowReader(rowReaderOpts);
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int64_t>(10, 11), rangeVector<double>(10, 11)});
-  assertReadExpected(*rowReader, expected);
+  assertReadExpected(sampleSchema(), *rowReader, expected, *pool_);
 }
 
 TEST_F(ParquetReaderTest, readSampleEmptyRange) {
@@ -207,7 +207,7 @@ TEST_F(ParquetReaderTest, dateRead) {
   auto rowReader = reader->createRowReader(rowReaderOpts);
 
   auto expected = vectorMaker_->rowVector({rangeVector<Date>(25, -5)});
-  assertReadExpected(*rowReader, expected);
+  assertReadExpected(dateSchema(), *rowReader, expected, *pool_);
 }
 
 TEST_F(ParquetReaderTest, dateFilter) {
@@ -248,7 +248,7 @@ TEST_F(ParquetReaderTest, intRead) {
 
   auto expected = vectorMaker_->rowVector(
       {rangeVector<int32_t>(10, 100), rangeVector<int64_t>(10, 1000)});
-  assertReadExpected(*rowReader, expected);
+  assertReadExpected(intSchema(), *rowReader, expected, *pool_);
 }
 
 TEST_F(ParquetReaderTest, intMultipleFilters) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "velox/exec/TableScan.h"
-#include <velox/type/Timestamp.h>
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -27,6 +26,7 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/type/Timestamp.h"
 #include "velox/type/Type.h"
 #include "velox/type/tests/SubfieldFiltersBuilder.h"
 
@@ -2070,6 +2070,20 @@ TEST_F(TableScanTest, remainingFilter) {
           .planNode(),
       filePaths,
       "SELECT c1, c2 FROM tmp WHERE c1 > c0");
+
+  // Remaining filter converted into tuple domain.
+  assertQuery(
+      PlanBuilder(pool_.get())
+          .tableScan(rowType, {}, "not (c0 > 0::INTEGER or c1 > 0::INTEGER)")
+          .planNode(),
+      filePaths,
+      "SELECT * FROM tmp WHERE not (c0 > 0 or c1 > 0)");
+  assertQuery(
+      PlanBuilder(pool_.get())
+          .tableScan(rowType, {}, "not (c0 > 0::INTEGER or c1 > c0)")
+          .planNode(),
+      filePaths,
+      "SELECT * FROM tmp WHERE not (c0 > 0 or c1 > c0)");
 }
 
 TEST_F(TableScanTest, remainingFilterSkippedStrides) {

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -151,6 +151,8 @@ std::unique_ptr<common::Filter> makeLessThanOrEqualFilter(
       return lessThanOrEqual(singleValue<int32_t>(upper));
     case TypeKind::BIGINT:
       return lessThanOrEqual(singleValue<int64_t>(upper));
+    case TypeKind::HUGEINT:
+      return lessThanOrEqualHugeint(singleValue<int128_t>(upper));
     case TypeKind::DOUBLE:
       return lessThanOrEqualDouble(singleValue<double>(upper));
     case TypeKind::REAL:
@@ -180,6 +182,8 @@ std::unique_ptr<common::Filter> makeLessThanFilter(
       return lessThan(singleValue<int32_t>(upper));
     case TypeKind::BIGINT:
       return lessThan(singleValue<int64_t>(upper));
+    case TypeKind::HUGEINT:
+      return lessThanHugeint(singleValue<int128_t>(upper));
     case TypeKind::DOUBLE:
       return lessThanDouble(singleValue<double>(upper));
     case TypeKind::REAL:
@@ -209,6 +213,8 @@ std::unique_ptr<common::Filter> makeGreaterThanOrEqualFilter(
       return greaterThanOrEqual(singleValue<int32_t>(lower));
     case TypeKind::BIGINT:
       return greaterThanOrEqual(singleValue<int64_t>(lower));
+    case TypeKind::HUGEINT:
+      return greaterThanOrEqualHugeint(singleValue<int128_t>(lower));
     case TypeKind::DOUBLE:
       return greaterThanOrEqualDouble(singleValue<double>(lower));
     case TypeKind::REAL:
@@ -238,6 +244,8 @@ std::unique_ptr<common::Filter> makeGreaterThanFilter(
       return greaterThan(singleValue<int32_t>(lower));
     case TypeKind::BIGINT:
       return greaterThan(singleValue<int64_t>(lower));
+    case TypeKind::HUGEINT:
+      return greaterThanHugeint(singleValue<int128_t>(lower));
     case TypeKind::DOUBLE:
       return greaterThanDouble(singleValue<double>(lower));
     case TypeKind::REAL:
@@ -269,6 +277,8 @@ std::unique_ptr<common::Filter> makeEqualFilter(
       return equal(singleValue<int32_t>(value));
     case TypeKind::BIGINT:
       return equal(singleValue<int64_t>(value));
+    case TypeKind::HUGEINT:
+      return equalHugeint(singleValue<int128_t>(value));
     case TypeKind::VARCHAR:
       return equal(singleValue<StringView>(value));
     case TypeKind::DATE:
@@ -315,6 +325,8 @@ std::unique_ptr<common::Filter> makeNotEqualFilter(
     ranges.emplace_back(std::unique_ptr<common::BigintRange>(greaterRange));
 
     return std::make_unique<common::BigintMultiRange>(std::move(ranges), false);
+  } else if (value->typeKind() == TypeKind::HUGEINT) {
+    VELOX_NYI();
   } else {
     std::vector<std::unique_ptr<common::Filter>> filters;
     filters.emplace_back(std::move(lessThanFilter));

--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -39,4 +39,14 @@ Subfield::Subfield(std::vector<std::unique_ptr<Subfield::PathElement>>&& path)
     : path_(std::move(path)) {
   VELOX_CHECK_GE(path_.size(), 1);
 };
+
+Subfield Subfield::clone() const {
+  Subfield subfield;
+  subfield.path_.reserve(path_.size());
+  for (auto& element : path_) {
+    subfield.path_.push_back(element->clone());
+  }
+  return subfield;
+}
+
 } // namespace facebook::velox::common

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -263,6 +263,8 @@ class Subfield {
     return !path_.empty() && path_[0]->kind() == kNestedField;
   }
 
+  Subfield clone() const;
+
  private:
   std::vector<std::unique_ptr<PathElement>> path_;
 };


### PR DESCRIPTION
Summary:
Currently if the remaining filter container clauses that are `AND` but
the field is a subfield of struct, or the clause is not `AND` but can be
converted into `AND` (e.g. `NOT (A = 1 OR B = 1)`), Presto optimizer is not able
to identify them.  We do this extraction in Velox so that we don't read more
than necessary.

Differential Revision: D46648421

