### PR TITLE
Forward declare Dwrf ColumnReader inside DwrfReader.h

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exception.h"
+#include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/StreamLabels.h"
 #include "velox/vector/FlatVector.h"
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/common/TypeUtils.h"
 #include "velox/dwio/common/exception/Exception.h"

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -17,10 +17,11 @@
 #pragma once
 
 #include "velox/dwio/common/ReaderFactory.h"
-#include "velox/dwio/dwrf/reader/ColumnReader.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 
 namespace facebook::velox::dwrf {
+
+class ColumnReader;
 
 class DwrfRowReader : public StrideIndexProvider,
                       public StripeReaderBase,


### PR DESCRIPTION
Including `velox/dwio/dwrf/reader/ColumnReader.h` inside `DwrfReader.h` is causing
protobuf headers to be pulled into Prestissimo causing build failure in bundled Velox install.
We should forward declare always where possible.