### PR TITLE
Make flow control for exchange

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -100,6 +100,8 @@ class QueryConfig {
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "max_page_partitioning_buffer_size";
 
+  static constexpr const char* kExchangeBufferSize = "exchange.max_buffer_size";
+
   /// Preferred size of batches in bytes to be returned by operators from
   /// Operator::getOutput. It is used when an estimate of average row size is
   /// known. Otherwise kPreferredOutputBatchRows is used.
@@ -245,6 +247,11 @@ class QueryConfig {
   uint64_t maxPartitionedOutputBufferSize() const {
     static constexpr uint64_t kDefault = 32UL << 20;
     return get<uint64_t>(kMaxPartitionedOutputBufferSize, kDefault);
+  }
+
+  uint64_t exchangeBufferSize() const {
+    static constexpr uint64_t kDefault = 32UL << 20;
+    return get<uint64_t>(kExchangeBufferSize, kDefault);
   }
 
   uint64_t maxLocalExchangeBufferSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -69,6 +69,12 @@ Generic Configuration
      - 32MB
      - The target size for a Task's buffered output. The producer Drivers are blocked when the buffered size exceeds this.
        The Drivers are resumed when the buffered size goes below PartitionedOutputBufferManager::kContinuePct (90)% of this.
+   * - exchange.max_buffer_size
+     - integer
+     - 32MB
+     - Size of buffer in the exchange client that holds data fetched from other nodes before it is processed.
+     - A larger buffer can increase network throughput for larger clusters and thus decrease query processing time,
+     - but will reduce the amount of memory available for other usages.
 
 Expression Evaluation Configuration
 -----------------------------------
@@ -280,7 +286,7 @@ Hive Connector
      - bool
      - false
      - True if reading the source file column names as lower case, and planner should guarantee
-     - the input column name and filter is also lower case to achive case-insensitive read..    
+     - the input column name and filter is also lower case to achive case-insensitive read..
    * - max-coalesced-bytes
      - integer
      - 512KB

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -122,7 +122,7 @@ class MergeExchangeSource : public MergeSource {
       int destination,
       memory::MemoryPool* FOLLY_NONNULL pool)
       : mergeExchange_(mergeExchange),
-        client_(std::make_unique<ExchangeClient>(destination, pool)) {
+        client_(ExchangeClient::create(destination, pool)) {
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
   }
@@ -181,7 +181,7 @@ class MergeExchangeSource : public MergeSource {
 
  private:
   MergeExchange* const mergeExchange_;
-  std::unique_ptr<ExchangeClient> client_;
+  std::shared_ptr<ExchangeClient> client_;
   std::unique_ptr<ByteStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -188,6 +188,11 @@ class PartitionedOutputBuffer {
   // producer task has an error or cancellation.
   void terminate();
 
+  /// Removes any DataAvailable callbacks that may have been added to
+  /// destination buffers. Calls the callback of each with no data. Used for
+  /// simulating a 'no data' response from a remote source.
+  void testingClearNotifys();
+
   std::string toString();
 
  private:
@@ -360,6 +365,11 @@ class PartitionedOutputBufferManager {
       std::function<std::unique_ptr<OutputStreamListener>()> factory) {
     listenerFactory_ = factory;
   }
+
+  /// Removes any DataAvailable callbacks that may have been added to
+  /// destination buffers. Calls the callback of each with no data. Used for
+  /// simulating a 'no data' response from a remote source.
+  void testingClearNotifys();
 
   std::string toString();
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2245,10 +2245,10 @@ void Task::createExchangeClient(
       planNodeId);
   // Low-water mark for filling the exchange queue is 1/2 of the per worker
   // buffer size of the producers.
-  exchangeClients_[pipelineId] = std::make_shared<ExchangeClient>(
+  exchangeClients_[pipelineId] = ExchangeClient::create(
       destination_,
       addExchangeClientPool(planNodeId, pipelineId),
-      queryCtx()->queryConfig().maxPartitionedOutputBufferSize() / 2);
+      queryCtx()->queryConfig().exchangeBufferSize());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -583,6 +583,12 @@ class Task : public std::enable_shared_from_this<Task> {
   /// Invoked to run provided 'callback' on each alive driver of the task.
   void testingVisitDrivers(const std::function<void(Driver*)>& callback);
 
+  std::vector<std::shared_ptr<ExchangeClient>> exchangeClients() const {
+    std::lock_guard<std::mutex> l(mutex_);
+    auto copy = exchangeClients_;
+    return copy;
+  }
+
  private:
   Task(
       const std::string& taskId,

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -32,14 +32,15 @@ TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
         throw std::runtime_error("Testing error");
       });
 
-  ExchangeClient client(1, pool.get());
+  auto client =
+      ExchangeClient::create(1, pool.get(), ExchangeClient::kDefaultBufferSize);
   VELOX_ASSERT_THROW(
-      client.addRemoteTaskId("task.1.2.3"),
+      client->addRemoteTaskId("task.1.2.3"),
       "Failed to create ExchangeSource: Testing error. Task ID: task.1.2.3.");
 
   // Test with a very long task ID. Make sure it is truncated.
   VELOX_ASSERT_THROW(
-      client.addRemoteTaskId(std::string(1024, 'x')),
+      client->addRemoteTaskId(std::string(1024, 'x')),
       "Failed to create ExchangeSource: Testing error. "
       "Task ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.");
 }

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -37,8 +38,46 @@ using namespace facebook::velox::memory;
 using facebook::velox::common::testutil::TestValue;
 using facebook::velox::test::BatchMaker;
 
+class PartitionedOutputBufferTimeout {
+ public:
+  PartitionedOutputBufferTimeout(const int32_t* intervalMillis)
+      : intervalMillis_(intervalMillis) {
+    thread = std::thread([&]() {
+      while (!stopping_) {
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds(*intervalMillis_));
+        auto mgr = PartitionedOutputBufferManager::getInstance().lock();
+        if (mgr) {
+          mgr->testingClearNotifys();
+        }
+      }
+    });
+  }
+
+  ~PartitionedOutputBufferTimeout() {
+    stopping_ = true;
+    thread.join();
+  }
+
+ private:
+  const int32_t* intervalMillis_;
+  std::atomic<bool> stopping_{false};
+  std::thread thread;
+};
+
 class MultiFragmentTest : public HiveConnectorTestBase {
  protected:
+  void SetUp() override {
+    HiveConnectorTestBase::SetUp();
+    periodicTimeout_ =
+        std::make_unique<PartitionedOutputBufferTimeout>(&clearInterval_);
+  }
+
+  void TearDown() override {
+    periodicTimeout_.reset();
+    HiveConnectorTestBase::TearDown();
+  }
+
   static std::string makeTaskId(const std::string& prefix, int num) {
     return fmt::format("local://{}-{}", prefix, num);
   }
@@ -140,11 +179,155 @@ class MultiFragmentTest : public HiveConnectorTestBase {
         expectedCount, exchangeStats.at("localExchangeSource.numPages").count);
   }
 
+  // Returns a power law distributed pseudorandom size as a function of counter.
+  int32_t randomSize(int32_t counter, int32_t max) {
+    int32_t range = 30;
+    auto hash = folly::hasher<uint64_t>()(counter) >> 15;
+    int32_t low = (hash >> 10) & 1023;
+    if (low > 1010) {
+      range = 30;
+    } else if (low > 990) {
+      range = 20;
+    } else if (low > 950) {
+      range = 12;
+    } else {
+      range = 10;
+    }
+    auto size = 1 << (hash % range);
+    return size % max;
+  }
+
+  // Parameters for aggregationFlow test.
+  struct FlowTestParams {
+    // number of partitions in the shuffle.
+    int32_t numPartitions{11};
+
+    // Drivers in each of the Tasks
+    int32_t taskWidth{5};
+
+    // Number of bytes produced by each of 'numPartitions * taskWidth' drivers.
+    int64_t bytesPerSource{10000000};
+
+    // Minimum payload row size.
+    int32_t minRowBytes{100};
+
+    // Maximum payload row size.
+    int32_t maxRowBytes{1000};
+
+    // PartitionedOutputBufferManager capacity. Each task divides these bytes
+    // across its producers.
+    int32_t partitionBufferSize{20000};
+    // Maximum size of exchange queue for each consumer task. Determines request
+    // sizes.
+    int32_t exchangeBufferSize{10000};
+  };
+
+  /// Tests a shuffle with parameters in 'params'. Returns the aggregated stats
+  /// of Exchanges and PartitionedOutputs from the plan.
+  std::pair<OperatorStats, OperatorStats> aggregationFlow(
+      FlowTestParams params) {
+    configSettings_[core::QueryConfig::kMaxPartitionedOutputBufferSize] =
+        fmt::format("{}", params.partitionBufferSize);
+    configSettings_[core::QueryConfig::kExchangeBufferSize] =
+        fmt::format("{}", params.exchangeBufferSize);
+    std::vector<std::shared_ptr<Task>> tasks;
+    int32_t taskWidth = 5;
+    constexpr int32_t kVectorSize = 1000;
+    std::vector<RowVectorPtr> vectors;
+    int64_t bytes = 0;
+    int32_t counter = 0;
+    do {
+      std::string temp;
+      auto row = makeRowVector(
+          {makeFlatVector<int64_t>(kVectorSize, [](auto row) { return row; }),
+           makeFlatVector<StringView>(kVectorSize, [&](auto row) {
+             auto stringBytes = params.minRowBytes +
+                 randomSize(++counter, params.maxRowBytes - params.minRowBytes);
+             temp.resize(stringBytes);
+             return StringView(temp.data(), temp.size());
+           })});
+      bytes += row->retainedSize();
+      vectors.push_back(row);
+    } while (bytes < params.bytesPerSource);
+
+    RowTypePtr leafType;
+    std::vector<std::string> leafTaskIds;
+    for (int32_t i = 0; i < params.numPartitions; ++i) {
+      auto leafTaskId = makeTaskId("leaf", i);
+      leafTaskIds.push_back(leafTaskId);
+      core::PlanNodePtr leafPlan;
+      leafPlan = PlanBuilder()
+                     .values(vectors, true)
+                     .partitionedOutput({"c0"}, params.numPartitions)
+                     .planNode();
+      auto leafTask = makeTask(leafTaskId, leafPlan, 0);
+      leafType = leafPlan->outputType();
+      tasks.push_back(leafTask);
+      Task::start(leafTask, taskWidth);
+    }
+
+    core::PlanNodePtr finalAggPlan;
+    std::vector<Split> finalAggSplits;
+    for (int i = 0; i < params.numPartitions; i++) {
+      finalAggPlan = PlanBuilder()
+                         .exchange(leafType)
+                         .singleAggregation({"c0"}, {"count(1)"})
+                         .partitionedOutput({}, 1)
+                         .planNode();
+
+      auto taskId = makeTaskId("final-agg", i);
+      finalAggSplits.push_back(
+          exec::Split(std::make_shared<RemoteConnectorSplit>(taskId), -1));
+      auto task = makeTask(taskId, finalAggPlan, i);
+      tasks.push_back(task);
+      Task::start(task, taskWidth);
+      addRemoteSplits(task, leafTaskIds);
+    }
+
+    auto expected =
+        makeRowVector({makeFlatVector<int64_t>(1, [&](auto /*row*/) {
+          return vectors.size() * kVectorSize * params.numPartitions *
+              params.taskWidth;
+        })});
+
+    auto op = PlanBuilder()
+                  .exchange(finalAggPlan->outputType())
+                  .singleAggregation({}, {"sum(a0)"})
+                  .planNode();
+
+    AssertQueryBuilder(op)
+        .config(core::QueryConfig::kExchangeBufferSize, "10000")
+        .splits(finalAggSplits)
+        .assertResults(expected);
+
+    OperatorStats allExchanges(0, 0, "0", "Exchange");
+    OperatorStats allRepartitions(0, 0, "0", "PartitionedOutput");
+    for (auto& task : tasks) {
+      auto stats = task->taskStats();
+      for (auto& pipeline : stats.pipelineStats) {
+        for (auto& op : pipeline.operatorStats) {
+          if (op.operatorType == "Exchange") {
+            allExchanges.add(op);
+          } else if (op.operatorType == "PartitionedOutput") {
+            allRepartitions.add(op);
+          }
+        }
+      }
+    }
+    return std::make_pair(allExchanges, allRepartitions);
+  }
+
   RowTypePtr rowType_{
       ROW({"c0", "c1", "c2", "c3", "c4", "c5"},
           {BIGINT(), INTEGER(), SMALLINT(), REAL(), DOUBLE(), VARCHAR()})};
   std::unordered_map<std::string, std::string> configSettings_;
   std::vector<std::shared_ptr<TempFilePath>> filePaths_;
+
+  std::unique_ptr<PartitionedOutputBufferTimeout> periodicTimeout_;
+
+  // Millisecond interval for clearing notifications for data that has not
+  // arrived from PartitionedOutputBufferManager.
+  int32_t clearInterval_{10};
   std::vector<RowVectorPtr> vectors_;
 };
 
@@ -1288,6 +1471,28 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   receivedIobufs.clear();
   ASSERT_EQ(task.use_count(), 1);
   task.reset();
+}
+
+TEST_F(MultiFragmentTest, flowControl) {
+  FlowTestParams params;
+
+  {
+    auto [exchange, partition] = aggregationFlow(params);
+    auto& stats = exchange.runtimeStats;
+    EXPECT_LT(stats["peakBytes"].max, 124000);
+  }
+
+  params.numPartitions = 21;
+  params.bytesPerSource = 100000000;
+  params.minRowBytes = 100;
+  params.maxRowBytes = 100000;
+  params.partitionBufferSize = 16000000;
+  int32_t exchangeBufferSize = 9000000;
+  {
+    auto [exchange, partition] = aggregationFlow(params);
+    auto& stats = exchange.runtimeStats;
+    EXPECT_LT(stats["peakBytes"].max, 10000000);
+  }
 }
 
 DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -899,7 +899,8 @@ TEST_F(PartitionedOutputBufferManagerTest, outOfOrderAcks) {
 }
 
 TEST_F(PartitionedOutputBufferManagerTest, errorInQueue) {
-  auto queue = std::make_shared<ExchangeQueue>(1 << 20);
+  std::weak_ptr<ExchangeClient> ignore;
+  auto queue = std::make_shared<ExchangeQueue>(1 << 20, 1 << 20, ignore);
   auto page = std::make_unique<SerializedPage>(folly::IOBuf::copyBuffer("", 0));
   std::vector<ContinuePromise> promises;
   { queue->setError("error"); }
@@ -922,7 +923,8 @@ TEST_F(PartitionedOutputBufferManagerTest, setQueueErrorWithPendingPages) {
 
   auto page = std::make_unique<SerializedPage>(std::move(iobuf));
 
-  auto queue = std::make_shared<ExchangeQueue>(1 << 20);
+  std::weak_ptr<ExchangeClient> ignore;
+  auto queue = std::make_shared<ExchangeQueue>(1 << 20, 1 << 20, ignore);
   std::vector<ContinuePromise> promises;
   {
     std::lock_guard<std::mutex> l(queue->mutex());


### PR DESCRIPTION
Make flow control for exchange

Adds a request size parameter to ExchangeClient::request(). Adds
counters tracking the history and current state of ExchangeSources,
ExchangeQueue and ExchangeClient.

The flo control of Exchange seeks to work within a maximum queue size
given by, Presto-compatible config name 'exchangeBufferSize()
exchange.max_buffer_size'.

All operations that either consume or process or add sources for
exchange call ExchangeClient::requestIfDue(). This checks if there are
requestable sources and space in the buffer and issues a suitable
number of requests. If this is called from enqueueing a reply from an
exchange source, the source is passed as an argument. requestIfDue
will first request other sources in a round robin fashion. If, after
requesting ther sources, there is space to also request the source
that just arrived, we send a direct request for more. If there is no
space in the queue, we acknowledge the data that may have arrived in
the reply and leave the just arrived source as non-pending. This will
be requested eventually after other sources produce data or time out.


ExchangeQueue tracks the average size of exchange response
pages. Requests are sized to multiples of these. When a request is
started, ExchangeQueue::expectedBytes_ is updated to reflect the
expected data. When a response arrives, the expectedBytes is updated
pro rata, i.e. if there are 3 pending, one response removes at least
1/3 of expectedBytes_.

This mechanism relies on request always producing a possibly empty
response within a relatively short time. This is the case in
Presto/Prestissimo. This is simulated in the test by periodically
timing out all pending callbacks in PartitionedoutputBufferManager.

The test runs exchanges of different widths with different buffer
sizes and variation of data sizes. It checks that the queue peak size
stays within limits.


Requires corresponding changes in Prestissimo PrestoExchangeSource.*.

