### PR TITLE
Add context to std::exception thrown by Operator::{isBlocked,needsInput}

### DIFF
--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -814,6 +814,8 @@ namespace {
 class ThrowNode : public core::PlanNode {
  public:
   enum class OperatorMethod {
+    kIsBlocked,
+    kNeedsInput,
     kAddInput,
     kNoMoreInput,
     kGetOutput,
@@ -859,6 +861,14 @@ class ThrowOperator : public Operator {
         throwingMethod_{node->throwingMethod()} {}
 
   bool needsInput() const override {
+    if (throwingMethod_ == ThrowNode::OperatorMethod::kNeedsInput) {
+      // Trigger a std::bad_function_call exception.
+      std::function<bool(vector_size_t)> nullFunction = nullptr;
+
+      if (nullFunction(123)) {
+        return false;
+      }
+    }
     return !noMoreInput_ && !input_;
   }
 
@@ -901,6 +911,14 @@ class ThrowOperator : public Operator {
   }
 
   BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    if (throwingMethod_ == ThrowNode::OperatorMethod::kIsBlocked) {
+      // Trigger a std::bad_function_call exception.
+      std::function<bool()> nullFunction = nullptr;
+
+      if (nullFunction()) {
+        return BlockingReason::kWaitForMemory;
+      }
+    }
     return BlockingReason::kNotBlocked;
   }
 
@@ -979,6 +997,16 @@ TEST_F(DriverTest, nonVeloxOperatorException) {
         })
         .planNode();
   };
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(ThrowNode::OperatorMethod::kIsBlocked))
+          .copyResults(pool()),
+      "Operator::isBlocked failed for [operator: Throw, plan node ID: 1]");
+
+  VELOX_ASSERT_THROW(
+      AssertQueryBuilder(makePlan(ThrowNode::OperatorMethod::kNeedsInput))
+          .copyResults(pool()),
+      "Operator::needsInput failed for [operator: Throw, plan node ID: 1]");
 
   VELOX_ASSERT_THROW(
       AssertQueryBuilder(makePlan(ThrowNode::OperatorMethod::kAddInput))


### PR DESCRIPTION
A follow-up to #5159.

Wrap calls to Operator::isBlocked and Operator::needsInput in CALL_OPERATOR
macro to add context (operator type and plan node ID) to std::exception thrown
by these methods.