### PR TITLE
Allow (varchar, varchar) inputs in json_extract_scalar

### DIFF
--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -24,10 +24,15 @@ void registerJsonFunctions(const std::string& prefix) {
 
   registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
+
   registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
+  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
+      {prefix + "json_extract_scalar"});
+
   registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
+
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
       {prefix + "json_array_contains"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, int64_t>(
@@ -36,9 +41,12 @@ void registerJsonFunctions(const std::string& prefix) {
       {prefix + "json_array_contains"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, Varchar>(
       {prefix + "json_array_contains"});
+
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
       {prefix + "json_size"});
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_parse, prefix + "json_parse");
 }
 

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -194,9 +194,10 @@ TEST_F(JsonFunctionsTest, jsonArrayLengthSignatures) {
 
 TEST_F(JsonFunctionsTest, jsonExtractScalarSignatures) {
   auto signatures = getSignatureStrings("json_extract_scalar");
-  ASSERT_EQ(1, signatures.size());
+  ASSERT_EQ(2, signatures.size());
 
   ASSERT_EQ(1, signatures.count("(json,varchar) -> varchar"));
+  ASSERT_EQ(1, signatures.count("(varchar,varchar) -> varchar"));
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsSignatures) {


### PR DESCRIPTION
Presto allows both JSON and VARCHAR values as first argument of json_extract_scalar.