### PR TITLE
Add data structures for bucket table writer support

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -79,6 +79,104 @@ class LocationHandle : public ISerializable {
   const TableType tableType_;
 };
 
+class HiveSortingColumn : public ISerializable {
+ public:
+  HiveSortingColumn(
+      const std::string& sortColumn,
+      const core::SortOrder& sortOrder);
+
+  const std::string& sortColumn() const {
+    return sortColumn_;
+  }
+
+  core::SortOrder sortOrder() const {
+    return sortOrder_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<HiveSortingColumn> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  std::string toString() const;
+
+  static void registerSerDe();
+
+ private:
+  const std::string sortColumn_;
+  const core::SortOrder sortOrder_;
+};
+
+class HiveBucketProperty : public ISerializable {
+ public:
+  enum class Kind { kHiveCompatible, kPrestoNative };
+
+  HiveBucketProperty(
+      Kind kind,
+      int32_t bucketCount,
+      const std::vector<std::string>& bucketedBy,
+      const std::vector<TypePtr>& bucketedTypes,
+      const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy);
+
+  Kind kind() const {
+    return kind_;
+  }
+
+  static std::string kindString(Kind kind);
+
+  /// Returns the number of bucket count.
+  int32_t bucketCount() const {
+    return bucketCount_;
+  }
+
+  /// Returns the bucketed by column names.
+  const std::vector<std::string>& bucketedBy() const {
+    return bucketedBy_;
+  }
+
+  /// Returns the bucketed by column types.
+  const std::vector<TypePtr>& bucketedTypes() const {
+    return bucketTypes_;
+  }
+
+  /// Returns the hive sorting columns if not empty.
+  const std::vector<std::shared_ptr<const HiveSortingColumn>>& sortedBy()
+      const {
+    return sortedBy_;
+  }
+
+  folly::dynamic serialize() const override;
+
+  static std::shared_ptr<HiveBucketProperty> deserialize(
+      const folly::dynamic& obj,
+      void* context);
+
+  bool operator==(const HiveBucketProperty& other) const {
+    return true;
+  }
+
+  static void registerSerDe();
+
+  std::string toString() const;
+
+ private:
+  void validate() const;
+
+  const Kind kind_;
+  const int32_t bucketCount_;
+  const std::vector<std::string> bucketedBy_;
+  const std::vector<TypePtr> bucketTypes_;
+  const std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy_;
+};
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    const HiveBucketProperty::Kind& kind) {
+  os << HiveBucketProperty::kindString(kind);
+  return os;
+}
+
 class HiveInsertTableHandle;
 using HiveInsertTableHandlePtr = std::shared_ptr<HiveInsertTableHandle>;
 

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -13,8 +13,13 @@
 # limitations under the License.
 add_executable(
   velox_hive_connector_test
-  HivePartitionFunctionTest.cpp FileHandleTest.cpp HivePartitionUtilTest.cpp
-  PartitionIdGeneratorTest.cpp HiveConnectorTest.cpp HiveConnectorSerDeTest.cpp)
+  HiveDataSinkTest.cpp
+  HivePartitionFunctionTest.cpp
+  FileHandleTest.cpp
+  HivePartitionUtilTest.cpp
+  PartitionIdGeneratorTest.cpp
+  HiveConnectorTest.cpp
+  HiveConnectorSerDeTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::velox::connector::hive {
+namespace {
+
+using namespace facebook::velox::common;
+using namespace facebook::velox::exec::test;
+
+class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
+ protected:
+  void SetUp() override {
+    Type::registerSerDe();
+    HiveSortingColumn::registerSerDe();
+    HiveBucketProperty::registerSerDe();
+  }
+  std::shared_ptr<memory::MemoryPool> pool_ =
+      memory::addDefaultLeafMemoryPool();
+};
+
+TEST_F(HiveDataSinkTest, hiveSortingColumn) {
+  struct {
+    std::string sortColumn;
+    core::SortOrder sortOrder;
+    bool badColumn;
+    std::string exceptionString;
+    std::string expectedToString;
+
+    std::string debugString() const {
+      return fmt::format(
+          "sortColumn {} sortOrder {} badColumn {} exceptionString {} expectedToString {}",
+          sortColumn,
+          sortOrder.toString(),
+          badColumn,
+          exceptionString,
+          expectedToString);
+    }
+  } testSettings[] = {
+      {"a",
+       core::SortOrder{true, true},
+       false,
+       "",
+       "[COLUMN[a] ORDER[ASC NULLS FIRST]]"},
+      {"a",
+       core::SortOrder{false, false},
+       false,
+       "",
+       "[COLUMN[a] ORDER[DESC NULLS LAST]]"},
+      {"",
+       core::SortOrder{true, true},
+       true,
+       "hive sort column must be set",
+       ""},
+      {"a",
+       core::SortOrder{true, false},
+       true,
+       "Bad hive sort order: [COLUMN[a] ORDER[ASC NULLS LAST]]",
+       ""},
+      {"a",
+       core::SortOrder{false, true},
+       true,
+       "Bad hive sort order: [COLUMN[a] ORDER[DESC NULLS FIRST]]",
+       ""}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    if (testData.badColumn) {
+      VELOX_ASSERT_THROW(
+          HiveSortingColumn(testData.sortColumn, testData.sortOrder),
+          testData.exceptionString);
+      continue;
+    }
+    const HiveSortingColumn column(testData.sortColumn, testData.sortOrder);
+    ASSERT_EQ(column.sortOrder(), testData.sortOrder);
+    ASSERT_EQ(column.sortColumn(), testData.sortColumn);
+    ASSERT_EQ(column.toString(), testData.expectedToString);
+    auto obj = column.serialize();
+    const auto deserializedColumn = HiveSortingColumn::deserialize(obj, pool());
+    ASSERT_EQ(obj, deserializedColumn->serialize());
+  }
+}
+
+TEST_F(HiveDataSinkTest, hiveBucketProperty) {
+  const std::vector<std::string> columns = {"a", "b", "c"};
+  const std::vector<TypePtr> types = {INTEGER(), VARCHAR(), BIGINT()};
+  const std::vector<std::shared_ptr<const HiveSortingColumn>> sortedColumns = {
+      std::make_shared<HiveSortingColumn>("d", core::SortOrder{false, false}),
+      std::make_shared<HiveSortingColumn>("e", core::SortOrder{false, false}),
+      std::make_shared<HiveSortingColumn>("f", core::SortOrder{true, true})};
+  struct {
+    HiveBucketProperty::Kind kind;
+    std::vector<std::string> bucketedBy;
+    std::vector<TypePtr> bucketedTypes;
+    uint32_t bucketCount;
+    std::vector<std::shared_ptr<const HiveSortingColumn>> sortedBy;
+    bool badProperty;
+    std::string exceptionString;
+    std::string expectedToString;
+  } testSettings[] = {
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0]},
+       {types[0], types[1]},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0], columns[1]},
+       {types[0]},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0], columns[1]},
+       {},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {},
+       {types[0]},
+       4,
+       {},
+       true,
+       "Hive bucket columns must be set",
+       ""},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       0,
+       {},
+       true,
+       "Hive bucket count can't be zero",
+       ""},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       4,
+       {},
+       false,
+       "",
+       "\nHiveBucketProperty[<PRESTO_NATIVE 4>\n"
+       "\tBucket Columns:\n"
+       "\t\ta\n"
+       "\t\tb\n"
+       "\tBucket Types:\n"
+       "\t\tINTEGER\n"
+       "\t\tVARCHAR\n"
+       "]\n"},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0]},
+       {types[0]},
+       4,
+       {},
+       false,
+       "",
+       "\nHiveBucketProperty[<PRESTO_NATIVE 4>\n\tBucket Columns:\n\t\ta\n\tBucket Types:\n\t\tINTEGER\n]\n"},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       4,
+       {{sortedColumns[0]}},
+       false,
+       "",
+       "\nHiveBucketProperty[<PRESTO_NATIVE 4>\n\tBucket Columns:\n\t\ta\n\t\tb\n\tBucket Types:\n\t\tINTEGER\n\t\tVARCHAR\n\tSortedBy Columns:\n\t\t[COLUMN[d] ORDER[DESC NULLS LAST]]\n]\n"},
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0]},
+       {types[0]},
+       4,
+       {{sortedColumns[0], sortedColumns[2]}},
+       false,
+       "",
+       "\nHiveBucketProperty[<PRESTO_NATIVE 4>\n\tBucket Columns:\n\t\ta\n\tBucket Types:\n\t\tINTEGER\n\tSortedBy Columns:\n\t\t[COLUMN[d] ORDER[DESC NULLS LAST]]\n\t\t[COLUMN[f] ORDER[ASC NULLS FIRST]]\n]\n"},
+
+      {HiveBucketProperty::Kind::kPrestoNative,
+       {columns[0]},
+       {types[0], types[1]},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0], columns[1]},
+       {types[0]},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0], columns[1]},
+       {},
+       4,
+       {},
+       true,
+       "The number of hive bucket columns and types do not match",
+       ""},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {},
+       {types[0]},
+       4,
+       {},
+       true,
+       "Hive bucket columns must be set",
+       ""},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       0,
+       {},
+       true,
+       "Hive bucket count can't be zero",
+       ""},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       4,
+       {},
+       false,
+       "",
+       "\nHiveBucketProperty[<HIVE_COMPATIBLE 4>\n"
+       "\tBucket Columns:\n"
+       "\t\ta\n"
+       "\t\tb\n"
+       "\tBucket Types:\n"
+       "\t\tINTEGER\n"
+       "\t\tVARCHAR\n"
+       "]\n"},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0]},
+       {types[0]},
+       4,
+       {},
+       false,
+       "",
+       "\nHiveBucketProperty[<HIVE_COMPATIBLE 4>\n\tBucket Columns:\n\t\ta\n\tBucket Types:\n\t\tINTEGER\n]\n"},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0], columns[1]},
+       {types[0], types[1]},
+       4,
+       {{sortedColumns[0]}},
+       false,
+       "",
+       "\nHiveBucketProperty[<HIVE_COMPATIBLE 4>\n\tBucket Columns:\n\t\ta\n\t\tb\n\tBucket Types:\n\t\tINTEGER\n\t\tVARCHAR\n\tSortedBy Columns:\n\t\t[COLUMN[d] ORDER[DESC NULLS LAST]]\n]\n"},
+      {HiveBucketProperty::Kind::kHiveCompatible,
+       {columns[0]},
+       {types[0]},
+       4,
+       {{sortedColumns[0], sortedColumns[2]}},
+       false,
+       "",
+       "\nHiveBucketProperty[<HIVE_COMPATIBLE 4>\n\tBucket Columns:\n\t\ta\n\tBucket Types:\n\t\tINTEGER\n\tSortedBy Columns:\n\t\t[COLUMN[d] ORDER[DESC NULLS LAST]]\n\t\t[COLUMN[f] ORDER[ASC NULLS FIRST]]\n]\n"},
+  };
+  for (const auto& testData : testSettings) {
+    if (testData.badProperty) {
+      VELOX_ASSERT_THROW(
+          HiveBucketProperty(
+              testData.kind,
+              testData.bucketCount,
+              testData.bucketedBy,
+              testData.bucketedTypes,
+              testData.sortedBy),
+          testData.exceptionString);
+      continue;
+    }
+    HiveBucketProperty hiveProperty(
+        testData.kind,
+        testData.bucketCount,
+        testData.bucketedBy,
+        testData.bucketedTypes,
+        testData.sortedBy);
+    ASSERT_EQ(hiveProperty.kind(), testData.kind);
+    ASSERT_EQ(hiveProperty.sortedBy(), testData.sortedBy);
+    ASSERT_EQ(hiveProperty.bucketedBy(), testData.bucketedBy);
+    ASSERT_EQ(hiveProperty.bucketedTypes(), testData.bucketedTypes);
+    ASSERT_EQ(hiveProperty.toString(), testData.expectedToString);
+
+    auto obj = hiveProperty.serialize();
+    const auto deserializedProperty =
+        HiveBucketProperty::deserialize(obj, pool());
+    ASSERT_EQ(obj, deserializedProperty->serialize());
+  }
+}
+} // namespace
+} // namespace facebook::velox::connector::hive

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -69,6 +69,15 @@ class SortOrder {
     return nullsFirst_;
   }
 
+  bool operator==(const SortOrder& other) const {
+    return std::tie(ascending_, nullsFirst_) ==
+        std::tie(other.ascending_, other.nullsFirst_);
+  }
+
+  bool operator!=(const SortOrder& other) const {
+    return !(*this == other);
+  }
+
   std::string toString() const {
     return fmt::format(
         "{} NULLS {}",
@@ -84,6 +93,13 @@ class SortOrder {
   bool ascending_;
   bool nullsFirst_;
 };
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& os,
+    const SortOrder& order) {
+  os << order.toString();
+  return os;
+}
 
 extern const SortOrder kAscNullsFirst;
 extern const SortOrder kAscNullsLast;

--- a/velox/core/tests/PlanNodeTest.cpp
+++ b/velox/core/tests/PlanNodeTest.cpp
@@ -63,3 +63,37 @@ TEST(TestPlanNode, findFirstNode) {
         return node->name() == "Unknown";
       }));
 }
+
+TEST(TestPlanNode, sortOrder) {
+  struct {
+    SortOrder order1;
+    SortOrder order2;
+    int expectedEqual;
+
+    std::string debugString() const {
+      return fmt::format(
+          "order1 {} order2 {} expectedEqual {}",
+          order1.toString(),
+          order2.toString(),
+          expectedEqual);
+    }
+  } testSettings[] = {
+      {{true, true}, {true, true}, true},
+      {{true, false}, {true, false}, true},
+      {{false, true}, {false, true}, true},
+      {{false, false}, {false, false}, true},
+      {{true, true}, {true, false}, false},
+      {{true, true}, {false, false}, false},
+      {{true, true}, {false, true}, false},
+      {{true, false}, {false, false}, false},
+      {{true, false}, {false, true}, false},
+      {{false, true}, {false, false}, false}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    if (testData.expectedEqual) {
+      ASSERT_EQ(testData.order1, testData.order2);
+    } else {
+      ASSERT_NE(testData.order1, testData.order2);
+    }
+  }
+}


### PR DESCRIPTION
Add HiveBucketProperty and HiveSortingColumn and data structures
to support table bucket write. HiveBucketProperty specifies the bucket
function and bucket columns. HiveSortingColumn specifies the sorting
column and orders if required.