### PR TITLE
Add convenience functions to serde to/from IOBufs

### DIFF
--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -136,4 +136,23 @@ class VectorStreamGroup : public StreamArena {
   std::unique_ptr<VectorSerializer> serializer_;
 };
 
+/// Convenience function to serialize a single rowVector into an IOBuf using the
+/// registered serde object.
+folly::IOBuf rowVectorToIOBuf(
+    const RowVectorPtr& rowVector,
+    memory::MemoryPool& pool);
+
+/// Same as above but serializes up until row `rangeEnd`.
+folly::IOBuf rowVectorToIOBuf(
+    const RowVectorPtr& rowVector,
+    vector_size_t rangeEnd,
+    memory::MemoryPool& pool);
+
+/// Convenience function to deserialize an IOBuf into a rowVector using the
+/// registered serde object.
+RowVectorPtr IOBufToRowVector(
+    const folly::IOBuf& ioBuf,
+    const RowTypePtr& outputType,
+    memory::MemoryPool& pool);
+
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Adding convenience functions to serialize and deserialize between
RowVectors and IOBufs. They only cover the simple case of a single vector and
range, but remove boilerplace from callsites. Will be used in the next PR.

Differential Revision: D46753242

