### PR TITLE
Add missing override specifier and fix name in Parquet writer

### DIFF
--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -121,7 +121,7 @@ TEST_F(E2EFilterTest, compression) {
         dwio::common::CompressionKind_ZSTD,
         dwio::common::CompressionKind_GZIP,
         dwio::common::CompressionKind_NONE}) {
-    if (!facebook::velox::parquet::Writer::isArrowCodecAvailable(compression)) {
+    if (!facebook::velox::parquet::Writer::isCodecAvailable(compression)) {
       continue;
     }
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -156,7 +156,7 @@ void Writer::write(const VectorPtr& data) {
   PARQUET_THROW_NOT_OK(arrowContext_->writer->WriteTable(*table, 10000));
 }
 
-bool Writer::isArrowCodecAvailable(dwio::common::CompressionKind compression) {
+bool Writer::isCodecAvailable(dwio::common::CompressionKind compression) {
   return arrow::util::Codec::IsAvailable(
       getArrowParquetCompression(compression));
 }

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -58,12 +58,14 @@ class Writer : public dwio::common::Writer {
       std::unique_ptr<dwio::common::DataSink> sink,
       const WriterOptions& options);
 
-  static bool isArrowCodecAvailable(dwio::common::CompressionKind compression);
+  ~Writer() override = default;
+
+  static bool isCodecAvailable(dwio::common::CompressionKind compression);
 
   // Appends 'data' into the writer.
   void write(const VectorPtr& data) override;
 
-  void flush();
+  void flush() override;
 
   // Forces a row group boundary before the data added by next write().
   void newRowGroup(int32_t numRows);
@@ -71,7 +73,7 @@ class Writer : public dwio::common::Writer {
   // Closes 'this', After close, data can no longer be added and the completed
   // Parquet file is flushed into 'sink' provided at construction. 'sink' stays
   // live until destruction of 'this'.
-  void close();
+  void close() override;
 
  private:
   const int32_t rowsInRowGroup_;


### PR DESCRIPTION
Rename isArrowCodecAvailable to isCodecAvailable