### PR TITLE
Fix decodedVector's state when re-used

### DIFF
--- a/velox/vector/DecodedVector.cpp
+++ b/velox/vector/DecodedVector.cpp
@@ -106,6 +106,10 @@ void DecodedVector::makeIndices(
 }
 
 void DecodedVector::reset(vector_size_t size) {
+  if (!indicesNotCopied()) {
+    // Init with default value to avoid invalid indices for unselected rows)
+    std::fill(copiedIndices_.begin(), copiedIndices_.end(), 0);
+  }
   size_ = size;
   indices_ = nullptr;
   data_ = nullptr;


### PR DESCRIPTION
Summary:
Expression evaluation re-used decoded vectors as an optimization. A decoded vector has a member variable that stores a vector of indices merged across all encoding layers while decoding a vector. This is currently only resized when used so if a decodedVector ends up being re-used with a different set of selected rows, then the unselected rows might have indices from a previous usage. This can be a problem for instance where nulls and indices are generated after decoding and do not have access to the original set of selected rows which were used for decoding, because it tried to create a copy and can end up using old/ garbage indices that can result in a segfault (see nulls()).
This fix makes sure that the internal member variable keeping track of indices is reset to a default value whenever it is used.

Reviewed By: Yuhta

Differential Revision: D46767207

