### PR TITLE
FIX: Refactor computeMetaData and separate propagateNull() from computePropagateNulls() API.

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -453,4 +453,3 @@ SWITCH expression evaluation goes through the following steps:
 SWITCH expression sets EvalCtx::isFinalSelection flag to false. The expressions
 are expected to use this flag to decide whether the partially populated result
 vector must be preserved or can be overwritten.
-

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -34,11 +34,11 @@ class CoalesceExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return false;
+ private:
+  void computePropagatesNulls() override {
+    propagatesNulls_ = false;
   }
 
- private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 
   friend class CoalesceCallToSpecialForm;

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -56,10 +56,6 @@ class ConjunctExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return false;
-  }
-
   bool isConditional() const override {
     return true;
   }
@@ -74,7 +70,12 @@ class ConjunctExpr : public SpecialForm {
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 
+  void computePropagatesNulls() override {
+    propagatesNulls_ = false;
+  }
+
   void maybeReorderInputs();
+
   void updateResult(
       BaseVector* inputResult,
       EvalCtx& context,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -282,9 +282,24 @@ class Expr {
     isMultiplyReferenced_ = true;
   }
 
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  template <typename T>
+  T* as() {
+    return dynamic_cast<T*>(this);
+  }
+
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
   // True if 'this' Expr tree is null for a null in any of the columns
   // this depends on.
-  virtual bool propagatesNulls() const {
+  bool propagatesNulls() const {
     return propagatesNulls_;
   }
 

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -57,11 +57,6 @@ class LambdaExpr : public SpecialForm {
   std::string toSql(
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
-  bool propagatesNulls() const override {
-    // A null capture does not result in a null function.
-    return false;
-  }
-
   void evalSpecialForm(
       const SelectivityVector& rows,
       EvalCtx& context,
@@ -70,6 +65,11 @@ class LambdaExpr : public SpecialForm {
  private:
   /// Used to initialize captureChannels_ and typeWithCapture_ on first use.
   void makeTypeWithCapture(EvalCtx& context);
+
+  void computePropagatesNulls() override {
+    // A null capture does not result in a null function.
+    propagatesNulls_ = false;
+  }
 
   RowTypePtr signature_;
 

--- a/velox/expression/SpecialForm.h
+++ b/velox/expression/SpecialForm.h
@@ -34,5 +34,11 @@ class SpecialForm : public Expr {
             true /* specialForm */,
             supportsFlatNoNullsFastPath,
             trackCpuUsage) {}
+
+  // This is safe to call only after all metadata is computed for input
+  // expressions.
+  virtual void computePropagatesNulls() {
+    VELOX_NYI();
+  }
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -48,14 +48,14 @@ class SwitchExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override;
-
   bool isConditional() const override {
     return true;
   }
 
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
+
+  void computePropagatesNulls() override;
 
   const size_t numCases_;
   const bool hasElseClause_;

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -41,14 +41,17 @@ class TryExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return inputs_[0]->propagatesNulls();
-  }
-
   void nullOutErrors(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result);
+
+ private:
+  // This is safe to call only after all metadata is computed for input
+  // expressions.
+  void computePropagatesNulls() override {
+    propagatesNulls_ = inputs_[0]->propagatesNulls();
+  }
 };
 
 class TryCallToSpecialForm : public FunctionCallToSpecialForm {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3734,6 +3734,14 @@ TEST_F(ExprTest, nullPropagation) {
       ROW({"c0", "c1"}, {VARCHAR(), VARCHAR()}));
   EXPECT_TRUE(propagatesNulls(singleString));
   EXPECT_FALSE(propagatesNulls(twoStrings));
+
+  // Try will call propagateNulls on its child, that should not
+  // redo the computation.
+  auto switchInTry = parseExpression(
+      "try(switch(subscript(c0, array_min(c1)), FALSE, FALSE,"
+      "FALSE, is_null('6338838335202944843'::BIGINT)))",
+      ROW({"c0", "c1"}, {ARRAY({BOOLEAN()}), ARRAY({BIGINT()})}));
+  EXPECT_FALSE(propagatesNulls(switchInTry));
 }
 
 TEST_F(ExprTest, peelingWithSmallerConstantInput) {


### PR DESCRIPTION
Summary:
This fix a set of expression fuzzer failures such as https://github.com/facebookincubator/velox/issues/5059.

The diff split propagateNull() and computePropagateNulls() API. previously propagateNull()
used to retrieve the propagateNull property for some expressions and re-compute it for others.

with this change propagateNull() only accesses the pre-computed property. And
computePropagateNulls() is called from computeMetaData to compute the property
for some expressions.

The diff also refactor computeMetaData for better readability, it used to interleave computations
of different properties and combine things in a hard to track manner.

Following diffs will address two remaining issues:
- The re-compute that happens over and over during query compilations.
- Avoid emptying distinct fields if shared with parents and simplify the API.

Differential Revision: D46457021

