### PR TITLE
Remove old fuzzer compatibility code

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -119,11 +119,7 @@ int128_t rand(FuzzerGenerator& rng) {
 }
 
 Timestamp randTimestamp(FuzzerGenerator& rng, VectorFuzzer::Options opts) {
-  auto precision = opts.useMicrosecondPrecisionTimestamp
-      ? VectorFuzzer::Options::TimestampPrecision::kMicroSeconds
-      : opts.timestampPrecision;
-
-  switch (precision) {
+  switch (opts.timestampPrecision) {
     case VectorFuzzer::Options::TimestampPrecision::kNanoSeconds:
       return Timestamp(rand<int32_t>(rng), (rand<int64_t>(rng) % MAX_NANOS));
     case VectorFuzzer::Options::TimestampPrecision::kMicroSeconds:

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -135,10 +135,6 @@ class VectorFuzzer {
     };
     TimestampPrecision timestampPrecision{TimestampPrecision::kNanoSeconds};
 
-    /// TODO: keeping the deprecated option for backwards compatibility. Will be
-    /// removed soon. For new code the option above.
-    bool useMicrosecondPrecisionTimestamp{false};
-
     /// If true, fuzz() will randomly generate lazy vectors and fuzzInputRow()
     /// will generate a raw vector with children that can randomly be lazy
     /// vectors. The generated lazy vectors can also have any number of


### PR DESCRIPTION
Summary:
Remove old fuzzer compatibility code leftover to maintain backwards
compatibility. Not needed anymore.

Reviewed By: amitkdutta

Differential Revision: D46780599

