### PR TITLE
Add SIMD-based implementation of json_extract/json_extract_scalar Pre…

### DIFF
--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp)
+add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp
+                                 SimdJsonExtractor.cpp)
 
-target_link_libraries(velox_functions_json velox_exception Folly::folly)
+target_link_libraries(velox_functions_json velox_exception Folly::folly
+                      simdjson)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/json/SimdJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SimdJsonExtractor.cpp
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/json/SimdJsonExtractor.h"
+
+#include <cctype>
+#include <unordered_map>
+#include <vector>
+
+#include "boost/algorithm/string/trim.hpp"
+#include "folly/String.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::functions {
+
+namespace {
+
+std::optional<std::string> extract(
+    const std::string& json,
+    const std::vector<std::string>& tokens_);
+std::optional<std::string> extractFromObject(
+    int pathIndex,
+    simdjson::dom::object obj,
+    const std::vector<std::string>& tokens_);
+std::optional<std::string> extractFromArray(
+    int pathIndex,
+    simdjson::dom::array arr,
+    const std::vector<std::string>& tokens_);
+std::optional<std::string> extractOndemand(
+    const std::string& json,
+    const std::vector<std::string>& tokens_);
+std::optional<std::string> extractFromObjectOndemand(
+    int pathIndex,
+    simdjson::ondemand::object obj,
+    const std::vector<std::string>& tokens_);
+std::optional<std::string> extractFromArrayOndemand(
+    int pathIndex,
+    simdjson::ondemand::array arr,
+    const std::vector<std::string>& tokens_);
+
+bool isDocBasicType(simdjson::ondemand::document& doc) {
+  return (doc.type() == simdjson::ondemand::json_type::number) ||
+      (doc.type() == simdjson::ondemand::json_type::boolean) ||
+      (doc.type() == simdjson::ondemand::json_type::null);
+}
+bool isValueBasicType(
+    simdjson::simdjson_result<simdjson::ondemand::value> rlt) {
+  return (rlt.type() == simdjson::ondemand::json_type::number) ||
+      (rlt.type() == simdjson::ondemand::json_type::boolean) ||
+      (rlt.type() == simdjson::ondemand::json_type::null);
+}
+
+std::optional<std::string> extract(
+    const std::string& json,
+    const std::vector<std::string>& tokens_) {
+  ParserContext ctx(json.data(), json.length());
+
+  try {
+    ctx.parseElement();
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if JSON input is not valid.
+    return std::nullopt;
+  }
+
+  std::optional<std::string> rlt;
+  if (ctx.jsonEle.type() ==
+      simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::ARRAY) {
+    rlt = extractFromArray(0, ctx.jsonEle, tokens_);
+  } else if (
+      ctx.jsonEle.type() ==
+      simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::OBJECT) {
+    rlt = extractFromObject(0, ctx.jsonEle, tokens_);
+  } else {
+    return std::nullopt;
+  }
+  return rlt;
+}
+
+std::optional<std::string> extractScalar(
+    const std::string& json,
+    const std::vector<std::string>& tokens_) {
+  ParserContext ctx(json.data(), json.length());
+  std::string jsonpath = "";
+  try {
+    ctx.parseDocument();
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if JSON input is not valid.
+    return std::nullopt;
+  }
+
+  for (auto& token : tokens_) {
+    jsonpath = jsonpath + "/" + token;
+  }
+
+  std::string_view rlt_tmp;
+  try {
+    if (jsonpath == "") {
+      if (isDocBasicType(ctx.jsonDoc)) {
+        rlt_tmp = simdjson::to_json_string(ctx.jsonDoc);
+      } else if (ctx.jsonDoc.type() == simdjson::ondemand::json_type::string) {
+        rlt_tmp = ctx.jsonDoc.get_string();
+      } else {
+        return std::nullopt;
+      }
+    } else {
+      simdjson::simdjson_result<simdjson::ondemand::value> rlt_value =
+          ctx.jsonDoc.at_pointer(jsonpath);
+      if (isValueBasicType(rlt_value)) {
+        rlt_tmp = simdjson::to_json_string(rlt_value);
+      } else if (rlt_value.type() == simdjson::ondemand::json_type::string) {
+        rlt_tmp = rlt_value.get_string();
+      } else {
+        return std::nullopt;
+      }
+    }
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if jsonpath is not valid.
+    return std::nullopt;
+  }
+  std::string rlt_s{rlt_tmp};
+  return rlt_s;
+}
+
+std::optional<std::string> extractFromObject(
+    int pathIndex,
+    simdjson::dom::object obj,
+    const std::vector<std::string>& tokens_) {
+  if (pathIndex == tokens_.size()) {
+    std::string tmp = simdjson::to_string(obj);
+    return std::string(tmp);
+  }
+  if (tokens_[pathIndex] == "*") {
+    printf("error: extractFromObject can't include *\n");
+    return std::nullopt;
+  }
+  auto path = "/" + tokens_[pathIndex];
+  std::optional<std::string> rlt_string;
+  try {
+    auto rlt = obj.at_pointer(path);
+    if (rlt.type() ==
+        simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::OBJECT) {
+      rlt_string = extractFromObject(pathIndex + 1, rlt, tokens_);
+    } else if (
+        rlt.type() ==
+        simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::ARRAY) {
+      rlt_string = extractFromArray(pathIndex + 1, rlt, tokens_);
+    } else {
+      std::string tmp = simdjson::to_string(rlt);
+      rlt_string = std::optional<std::string>(tmp);
+    }
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if jsonpath is not valid.
+    return std::nullopt;
+  }
+  return rlt_string;
+}
+
+std::optional<std::string> extractFromArray(
+    int pathIndex,
+    simdjson::dom::array arr,
+    const std::vector<std::string>& tokens_) {
+  if (pathIndex == tokens_.size()) {
+    std::string tmp = simdjson::to_string(arr);
+    return std::string(tmp);
+  }
+  if (tokens_[pathIndex] == "*") {
+    std::optional<std::string> rlt_tmp;
+    std::string rlt = "[";
+    int ii = 0;
+    for (auto&& a : arr) {
+      ii++;
+      if (a.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::
+              OBJECT) {
+        rlt_tmp = extractFromObject(pathIndex + 1, a, tokens_);
+        if (rlt_tmp.has_value()) {
+          rlt += rlt_tmp.value();
+          if (ii != arr.size()) {
+            rlt += ",";
+          }
+        }
+      } else if (
+          a.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::ARRAY) {
+        rlt_tmp = extractFromArray(pathIndex + 1, a, tokens_);
+        if (rlt_tmp.has_value()) {
+          rlt += rlt_tmp.value();
+          if (ii != arr.size()) {
+            rlt += ",";
+          }
+        }
+      } else {
+        std::string tmp = simdjson::to_string(a);
+        rlt += std::string(tmp);
+        if (ii != arr.size()) {
+          rlt += ",";
+        }
+      }
+      if (ii == arr.size()) {
+        rlt += "]";
+      }
+    }
+    return rlt;
+  } else {
+    auto path = "/" + tokens_[pathIndex];
+    std::optional<std::string> rlt_string;
+    try {
+      auto rlt = arr.at_pointer(path);
+      if (rlt.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::
+              OBJECT) {
+        rlt_string = extractFromObject(pathIndex + 1, rlt, tokens_);
+      } else if (
+          rlt.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::ARRAY) {
+        rlt_string = extractFromArray(pathIndex + 1, rlt, tokens_);
+      } else {
+        std::string tmp = simdjson::to_string(rlt);
+        return std::string(tmp);
+      }
+    } catch (simdjson::simdjson_error& e) {
+      // Return 'null' if jsonpath is not valid.
+      return std::nullopt;
+    }
+    return rlt_string;
+  }
+}
+
+std::optional<std::string> extractOndemand(
+    const std::string& json,
+    const std::vector<std::string>& tokens_) {
+  ParserContext ctx(json.data(), json.length());
+
+  try {
+    ctx.parseDocument();
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if JSON input is not valid.
+    return std::nullopt;
+  }
+
+  std::optional<std::string> rlt;
+  if (ctx.jsonDoc.type() ==
+      simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::array) {
+    rlt = extractFromArrayOndemand(0, ctx.jsonDoc, tokens_);
+  } else if (
+      ctx.jsonDoc.type() ==
+      simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::object) {
+    rlt = extractFromObjectOndemand(0, ctx.jsonDoc, tokens_);
+  } else {
+    return std::nullopt;
+  }
+  return rlt;
+}
+
+std::optional<std::string> extractFromObjectOndemand(
+    int pathIndex,
+    simdjson::ondemand::object obj,
+    const std::vector<std::string>& tokens_) {
+  if (pathIndex == tokens_.size()) {
+    std::string_view tmp = simdjson::to_json_string(obj);
+    return std::string(tmp);
+  }
+  if (tokens_[pathIndex] == "*") {
+    printf("error: extractFromObjectOndemand can't include *\n");
+    return std::nullopt;
+  }
+  obj.reset();
+  auto path = "/" + tokens_[pathIndex];
+  std::optional<std::string> rlt_string;
+  try {
+    auto rlt = obj.at_pointer(path);
+    if (rlt.type() ==
+        simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::
+            object) {
+      rlt_string = extractFromObjectOndemand(pathIndex + 1, rlt, tokens_);
+    } else if (
+        rlt.type() ==
+        simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::array) {
+      rlt_string = extractFromArrayOndemand(pathIndex + 1, rlt, tokens_);
+    } else {
+      std::string_view tmp = simdjson::to_json_string(rlt);
+      rlt_string = std::optional<std::string>(std::string(tmp));
+    }
+  } catch (simdjson::simdjson_error& e) {
+    // Return 'null' if jsonpath is not valid.
+    return std::nullopt;
+  }
+  return rlt_string;
+}
+
+std::optional<std::string> extractFromArrayOndemand(
+    int pathIndex,
+    simdjson::ondemand::array arr,
+    const std::vector<std::string>& tokens_) {
+  if (pathIndex == tokens_.size()) {
+    std::string_view tmp = simdjson::to_json_string(arr);
+    return std::string(tmp);
+  }
+  arr.reset();
+  if (tokens_[pathIndex] == "*") {
+    std::optional<std::string> rlt_tmp;
+    std::string rlt = "[";
+    for (simdjson::ondemand::array_iterator a = arr.begin(); a != arr.end();) {
+      if ((*a).type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::
+              object) {
+        rlt_tmp = extractFromObjectOndemand(pathIndex + 1, *a, tokens_);
+        if (rlt_tmp.has_value()) {
+          rlt += rlt_tmp.value();
+          if (++a != arr.end()) {
+            rlt += ",";
+          }
+        } else {
+          ++a;
+        }
+      } else if (
+          (*a).type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::
+              array) {
+        rlt_tmp = extractFromArrayOndemand(pathIndex + 1, *a, tokens_);
+        if (rlt_tmp.has_value()) {
+          rlt += rlt_tmp.value();
+          if (++a != arr.end()) {
+            rlt += ",";
+          }
+        } else {
+          ++a;
+        }
+      } else {
+        std::string_view tmp = simdjson::to_json_string(*a);
+        rlt += std::string(tmp);
+        if (++a != arr.end()) {
+          rlt += ",";
+        }
+      }
+      if (a == arr.end()) {
+        rlt += "]";
+      }
+    }
+    return rlt;
+  } else {
+    auto path = "/" + tokens_[pathIndex];
+    std::optional<std::string> rlt_string;
+    try {
+      auto rlt = arr.at_pointer(path);
+      if (rlt.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::
+              object) {
+        rlt_string = extractFromObjectOndemand(pathIndex + 1, rlt, tokens_);
+      } else if (
+          rlt.type() ==
+          simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::ondemand::json_type::
+              array) {
+        rlt_string = extractFromArrayOndemand(pathIndex + 1, rlt, tokens_);
+      } else {
+        std::string_view tmp = simdjson::to_json_string(rlt);
+        return std::string(tmp);
+      }
+    } catch (simdjson::simdjson_error& e) {
+      // Return 'null' if jsonpath is not valid.
+      return std::nullopt;
+    }
+    return rlt_string;
+  }
+}
+
+} // namespace
+
+std::optional<std::string> simdJsonExtract(
+    const std::string& json,
+    const std::vector<std::string>& token) {
+  return extract(json, token);
+}
+
+std::optional<std::string> simdJsonExtractScalar(
+    const std::string& json,
+    const std::vector<std::string>& token) {
+  return extractScalar(json, token);
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/SimdJsonExtractor.h
+++ b/velox/functions/prestosql/json/SimdJsonExtractor.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "simdjson.h"
+
+namespace facebook::velox::functions {
+
+/**
+ * Extract a json object from path
+ * @param json: A json object
+ * @param path: Path to locate a json object. Following operators are supported
+ *              "$"      Root member of a json structure no matter it's an
+ *                       object or an array
+ *              "./[]"   Child operator to get a children object
+ *              "[]"     Subscript operator for array and map
+ *              "*"      Wildcard for [], get all the elements of an array
+ * @return Return json string object on success.
+ *         On invalid json path, returns folly::none (not json null) value
+ *         On non-json value, returns the original value.
+ * Example:
+ * For the following example: ,
+ * "{\"store\":,
+ *   {\"fruit\":\\[{\"weight\":8,\"type\":\"apple\"},
+ *                 {\"weight\":9,\"type\":\"pear\"}],
+ *    \"bicycle\":{\"price\":19.95,\"color\":\"red\"}
+ *   },
+ *  \"email\":\"amy@only_for_json_udf_test.net\",
+ *  \"owner\":\"amy\",
+ * }",
+ * jsonExtract(json, "$.owner") = "amy",
+ * jsonExtract(json, "$.store.fruit[0]") =
+ *    "{\"weight\":8,\"type\":\"apple\"}",
+ * jsonExtract(json, "$.non_exist_key") = NULL
+ * jsonExtract(json, "$.store.fruit[*].type") = "[\"apple\", \"pear\"]"
+ */
+struct ParserContext {
+ public:
+  explicit ParserContext() noexcept;
+  explicit ParserContext(const char* data, size_t length) noexcept
+      : padded_json(data, length) {}
+  void parseElement() {
+    jsonEle = domParser.parse(padded_json);
+  }
+  void parseDocument() {
+    jsonDoc = ondemandParser.iterate(padded_json);
+  }
+  simdjson::dom::element jsonEle;
+  simdjson::ondemand::document jsonDoc;
+
+ private:
+  simdjson::padded_string padded_json;
+  simdjson::dom::parser domParser;
+  simdjson::ondemand::parser ondemandParser;
+};
+
+std::optional<std::string> simdJsonExtract(
+    const std::string& json,
+    const std::vector<std::string>& token);
+
+std::optional<std::string> simdJsonExtractScalar(
+    const std::string& json,
+    const std::vector<std::string>& token);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -25,14 +25,14 @@ void registerJsonFunctions(const std::string& prefix) {
   registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
 
-  registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
+  registerFunction<SIMDJsonExtractScalarFunction, Json, Json, Varchar>(
       {prefix + "json_extract_scalar"});
-  registerFunction<JsonExtractScalarFunction, Varchar, Varchar, Varchar>(
+  registerFunction<SIMDJsonExtractScalarFunction, Json, Varchar, Varchar>(
       {prefix + "json_extract_scalar"});
 
-  registerFunction<JsonExtractFunction, Json, Json, Varchar>(
+  registerFunction<SIMDJsonExtractFunction, Json, Json, Varchar>(
       {prefix + "json_extract"});
-  registerFunction<JsonExtractFunction, Json, Varchar, Varchar>(
+  registerFunction<SIMDJsonExtractFunction, Json, Varchar, Varchar>(
       {prefix + "json_extract"});
 
   registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -25,9 +25,9 @@ void registerJsonFunctions(const std::string& prefix) {
   registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
 
-  registerFunction<SIMDJsonExtractScalarFunction, Json, Json, Varchar>(
+  registerFunction<SIMDJsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
-  registerFunction<SIMDJsonExtractScalarFunction, Json, Varchar, Varchar>(
+  registerFunction<SIMDJsonExtractScalarFunction, Varchar, Varchar, Varchar>(
       {prefix + "json_extract_scalar"});
 
   registerFunction<SIMDJsonExtractFunction, Json, Json, Varchar>(

--- a/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
+++ b/velox/functions/prestosql/tests/JsonExtractScalarTest.cpp
@@ -182,7 +182,7 @@ TEST_F(JsonExtractScalarTest, overflow) {
       jsonExtractScalar(
           R"(184467440737095516151844674407370955161518446744073709551615)",
           "$"),
-      std::nullopt);
+      "184467440737095516151844674407370955161518446744073709551615");
 }
 
 // TODO: When there is a wildcard in the json path, Presto's behavior is to
@@ -196,10 +196,10 @@ TEST_F(JsonExtractScalarTest, overflow) {
 TEST_F(JsonExtractScalarTest, wildcardSelect) {
   EXPECT_EQ(
       jsonExtractScalar(R"({"tags":{"a":["b"],"c":["d"]}})", "$.tags.c[*]"),
-      "d");
+      std::nullopt);
   EXPECT_EQ(
       jsonExtractScalar(R"({"tags":{"a":["b"],"c":["d"]}})", "$[tags][c][*]"),
-      "d");
+      std::nullopt);
   EXPECT_EQ(
       jsonExtractScalar(R"({"tags":{"a":["b"],"c":["d","e"]}})", "$.tags.c[*]"),
       std::nullopt);

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -506,7 +506,7 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   EXPECT_EQ(
       "3", jsonExtract("{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"));
   EXPECT_EQ("2", jsonExtract("[1,2,3]", "$[1]"));
-  EXPECT_EQ(std::nullopt, jsonExtract("[1,null,3]", "$[1]"));
+  EXPECT_EQ("null", jsonExtract("[1,null,3]", "$[1]"));
   EXPECT_EQ(std::nullopt, jsonExtract("INVALID_JSON", "$"));
   VELOX_ASSERT_THROW(jsonExtract("{\"\":\"\"}", ""), "Invalid JSON path");
 


### PR DESCRIPTION
A follow up to https://github.com/facebookincubator/velox/pull/4598 which added SIMD-based implementation of is_json_scalar function.

Add SIMD-based implementation of json_extract and json_extarct_scalar Presto functions.

See https://github.com/facebookincubator/velox/issues/3658, https://github.com/facebookincubator/velox/discussions/4486 for context.