### PR TITLE
Do not enforce capacity at AsyncDataCache

### DIFF
--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -568,9 +568,10 @@ TEST_F(AsyncDataCacheTest, replace) {
 }
 
 TEST_F(AsyncDataCacheTest, outOfCapacity) {
-  constexpr int64_t kMaxBytes = 16 << 20;
-  constexpr int32_t kSize = 16 << 10;
-  constexpr int32_t kSizeInPages = kSize / memory::AllocationTraits::kPageSize;
+  const int64_t kMaxBytes = 64
+      << 20; // 64MB as MmapAllocator's min size is 64MB
+  const int32_t kSize = 16 << 10;
+  const int32_t kSizeInPages = memory::AllocationTraits::numPages(kSize);
   std::deque<CachePin> pins;
   std::deque<memory::Allocation> allocations;
   initializeCache(kMaxBytes);
@@ -590,8 +591,8 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
   ASSERT_FALSE(cache_->allocateNonContiguous(kSizeInPages, allocation));
   // One 4 page entry below the max size of 4K 4 page entries in 16MB of
   // capacity.
-  ASSERT_EQ(4092, cache_->incrementCachedPages(0));
-  ASSERT_EQ(4092, cache_->incrementPrefetchPages(0));
+  ASSERT_EQ(16384, cache_->incrementCachedPages(0));
+  ASSERT_EQ(16384, cache_->incrementPrefetchPages(0));
   pins.clear();
 
   // We allocate the full capacity and expect the cache entries to go.
@@ -603,7 +604,7 @@ TEST_F(AsyncDataCacheTest, outOfCapacity) {
   }
   EXPECT_EQ(0, cache_->incrementCachedPages(0));
   EXPECT_EQ(0, cache_->incrementPrefetchPages(0));
-  EXPECT_EQ(4092, cache_->numAllocated());
+  EXPECT_EQ(16384, cache_->numAllocated());
   clearAllocations(allocations);
 }
 

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -41,6 +41,10 @@ class MallocAllocator : public MemoryAllocator {
     return kind_;
   }
 
+  size_t capacity() const override {
+    return capacity_;
+  }
+
   bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -195,6 +195,9 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
 
   using ReservationCallback = std::function<void(int64_t, bool)>;
 
+  /// Returns the capacity of the allocator in bytes.
+  virtual size_t capacity() const = 0;
+
   /// Allocates one or more runs that add up to at least 'numPages', with the
   /// smallest run being at least 'minSizeClass' pages. 'minSizeClass' must be
   /// <= the size of the largest size class. The new memory is returned in 'out'

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -85,6 +85,10 @@ class MmapAllocator : public MemoryAllocator {
     return kind_;
   }
 
+  size_t capacity() const override {
+    return AllocationTraits::pageBytes(capacity_);
+  }
+
   bool allocateNonContiguous(
       MachinePageCount numPages,
       Allocation& out,
@@ -135,10 +139,6 @@ class MmapAllocator : public MemoryAllocator {
   /// Checks that the totals of mapped free and mapped and allocated pages match
   /// the data in the bitmaps in the size classes.
   bool checkConsistency() const override;
-
-  MachinePageCount capacity() const {
-    return capacity_;
-  }
 
   int32_t maxMallocBytes() const {
     return maxMallocBytes_;

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -62,7 +62,7 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
       allocator_ = std::make_shared<MmapAllocator>(options);
       auto mmapAllocator = std::dynamic_pointer_cast<MmapAllocator>(allocator_);
       ASSERT_EQ(
-          mmapAllocator->capacity(),
+          AllocationTraits::numPages(mmapAllocator->capacity()),
           bits::roundUp(
               kCapacityBytes * (100 - options.smallAllocationReservePct) / 100 /
                   AllocationTraits::kPageSize,
@@ -369,7 +369,7 @@ TEST_P(MemoryAllocatorTest, mmapAllocatorInit) {
         bits::roundUp(
             AllocationTraits::numPages(options.capacity - smallAllocationBytes),
             64 * mmapAllocator->sizeClasses().back()),
-        mmapAllocator->capacity());
+        AllocationTraits::numPages(mmapAllocator->capacity()));
     EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
     EXPECT_EQ(smallAllocationBytes, mmapAllocator->mallocReservedBytes());
   }
@@ -383,7 +383,7 @@ TEST_P(MemoryAllocatorTest, mmapAllocatorInit) {
         bits::roundUp(
             AllocationTraits::numPages(kCapacityBytes),
             64 * mmapAllocator->sizeClasses().back()),
-        mmapAllocator->capacity());
+        AllocationTraits::numPages(mmapAllocator->capacity()));
     EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
     EXPECT_EQ(0, mmapAllocator->mallocReservedBytes());
   }
@@ -399,7 +399,7 @@ TEST_P(MemoryAllocatorTest, mmapAllocatorInit) {
         bits::roundUp(
             AllocationTraits::numPages(options.capacity),
             64 * mmapAllocator->sizeClasses().back()),
-        mmapAllocator->capacity());
+        AllocationTraits::numPages(mmapAllocator->capacity()));
     EXPECT_EQ(options.maxMallocBytes, mmapAllocator->maxMallocBytes());
     EXPECT_EQ(smallAllocationBytes, mmapAllocator->mallocReservedBytes());
   }

--- a/velox/dwio/common/CachedBufferedInput.cpp
+++ b/velox/dwio/common/CachedBufferedInput.cpp
@@ -92,7 +92,7 @@ bool CachedBufferedInput::shouldPreload(int32_t numPages) {
         memory::AllocationTraits::kPageSize;
   }
   auto cachePages = cache_->incrementCachedPages(0);
-  auto maxPages = cache_->maxBytes() / memory::AllocationTraits::kPageSize;
+  auto maxPages = memory::AllocationTraits::numPages(cache_->capacity());
   auto allocatedPages = cache_->numAllocated();
   if (numPages < maxPages - allocatedPages) {
     // There is free space for the read-ahead.


### PR DESCRIPTION
After capacity enforcement in MallocAllocator, all allocators now have capacity enforcement. We now do not want to rely on AsyncDataCache for capacity enforcement as this work is:
1. duplicate
2. introducing an API inconsistency by enforcing the capacity check before calling allocate() lambda in makeSpace(). Note that some allocate() calls (e.g. allocateNonContiguous/allocateContiguous in order to free the collateral) must be called at least once but here it might have a chance that it's never called.