### PR TITLE
Add seed parameter to hash and xxhash64 Spark functions

### DIFF
--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -6,6 +6,10 @@ Binary Functions
 
     Computes the hash of x.
 
+.. spark:function:: hash_with_seed(seed, x) -> integer
+
+    Computes the hash of x with seed.
+
 .. spark:function:: md5(x) -> varbinary
 
     Computes the md5 of x.
@@ -34,3 +38,7 @@ Binary Functions
 .. spark:function:: xxhash64(x) -> integer
 
     Computes the xxhash64 of x.
+
+.. spark:function:: xxhash64_with_seed(seed, x) -> integer
+
+    Computes the xxhash64 of x with seed.

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -2,13 +2,21 @@
 Binary Functions
 ================
 
-.. spark:function:: hash(x) -> integer
+.. spark:function:: hash(x, x1, ..., xn) -> integer
 
-    Computes the hash of x.
+    Computes the hash of one or more number of input arguments based on the default seed value of 42.
 
-.. spark:function:: hash_with_seed(seed, x) -> integer
+.. spark:function:: hash_with_seed(seed, x, x1, ..., xn) -> integer
 
-    Computes the hash of x with seed.
+    Computes the hash of one or more number of input arguments based on a given seed.
+
+.. spark:function:: xxhash64(x, x1, ..., xn) -> bigint
+
+    Computes the xxhash64 of one or more number of input arguments based on the default seed value of 42.
+
+.. spark:function:: xxhash64_with_seed(seed, x) -> bigint
+
+    Computes the xxhash64 of one or more number of input arguments based on a given seed.
 
 .. spark:function:: md5(x) -> varbinary
 
@@ -34,11 +42,3 @@ Binary Functions
     have a value of 224, 256, 384, 512, or 0 (which is equivalent to 256). If asking
     for an unsupported bitLength, the return value is NULL.
     Note: x can only be varbinary type.
-
-.. spark:function:: xxhash64(x) -> integer
-
-    Computes the xxhash64 of x.
-
-.. spark:function:: xxhash64_with_seed(seed, x) -> integer
-
-    Computes the xxhash64 of x with seed.

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -2,21 +2,21 @@
 Binary Functions
 ================
 
-.. spark:function:: hash(x, x1, ..., xn) -> integer
+.. spark:function:: hash(x, ...) -> integer
 
-    Computes the hash of one or more number of input arguments based on the default seed value of 42.
+    Computes the hash of one or more input values using seed value of 42.
 
-.. spark:function:: hash_with_seed(seed, x, x1, ..., xn) -> integer
+.. spark:function:: hash_with_seed(seed, x, ...) -> integer
 
-    Computes the hash of one or more number of input arguments based on a given seed.
+    Computes the hash of one or more input values using specified seed.
 
-.. spark:function:: xxhash64(x, x1, ..., xn) -> bigint
+.. spark:function:: xxhash64(x, ...) -> bigint
 
-    Computes the xxhash64 of one or more number of input arguments based on the default seed value of 42.
+    Computes the xxhash64 of one or more input values using seed value of 42.
 
-.. spark:function:: xxhash64_with_seed(seed, x) -> bigint
+.. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
 
-    Computes the xxhash64 of one or more number of input arguments based on a given seed.
+    Computes the xxhash64 of one or more input values using specified seed.
 
 .. spark:function:: md5(x) -> varbinary
 

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -370,7 +370,7 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const core::QueryConfig& /*config*/) {
   const auto& constantSeed = inputArgs[0].constantValue;
   if (!constantSeed || constantSeed->isNullAt(0)) {
-    VELOX_USER_FAIL("{} requires a constant seed argument.", name);
+    VELOX_USER_FAIL("{} requires a constant non-null seed argument.", name);
   }
   auto seed = constantSeed->as<ConstantVector<int32_t>>()->valueAt(0);
   return std::make_shared<Murmur3HashFunction>(seed);
@@ -417,7 +417,7 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const core::QueryConfig& /*config*/) {
   const auto& constantSeed = inputArgs[0].constantValue;
   if (!constantSeed || constantSeed->isNullAt(0)) {
-    VELOX_USER_FAIL("{} requires a constant seed argument.", name);
+    VELOX_USER_FAIL("{} requires a constant non-null seed argument.", name);
   }
   auto seed = constantSeed->as<ConstantVector<int64_t>>()->valueAt(0);
   return std::make_shared<XxHash64Function>(seed);

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -369,7 +369,9 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
   const auto& constantSeed = inputArgs[0].constantValue;
-  VELOX_USER_CHECK_NOT_NULL(constantSeed, "Hash seed cannot be null");
+  if (!constantSeed || constantSeed->isNullAt(0)) {
+    VELOX_USER_FAIL("{} requires a constant seed argument.", name);
+  }
   auto seed = constantSeed->as<ConstantVector<int32_t>>()->valueAt(0);
   return std::make_shared<Murmur3HashFunction>(seed);
 }
@@ -414,7 +416,9 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
   const auto& constantSeed = inputArgs[0].constantValue;
-  VELOX_USER_CHECK_NOT_NULL(constantSeed, "Hash seed cannot be null");
+  if (!constantSeed || constantSeed->isNullAt(0)) {
+    VELOX_USER_FAIL("{} requires a constant seed argument.", name);
+  }
   auto seed = constantSeed->as<ConstantVector<int64_t>>()->valueAt(0);
   return std::make_shared<XxHash64Function>(seed);
 }

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -362,7 +362,8 @@ std::shared_ptr<exec::VectorFunction> makeHash(
 
 std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
   BaseVector* constantSeed = inputArgs[0].constantValue.get();
   auto seed = constantSeed->as<ConstantVector<int32_t>>()->valueAt(0);
   static const auto kHashFunction = std::make_shared<Murmur3HashFunction>(seed);
@@ -406,7 +407,8 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64(
 
 std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
   BaseVector* constantSeed = inputArgs[0].constantValue.get();
   auto seed = constantSeed->as<ConstantVector<int64_t>>()->valueAt(0);
   static const auto kXxHash64Function =

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -186,7 +186,7 @@ class Murmur3HashFunction final : public exec::VectorFunction {
   }
 
  private:
-  std::optional<int32_t> seed_;
+  const std::optional<int32_t> seed_;
 };
 
 class XxHash64 final {
@@ -343,7 +343,7 @@ class XxHash64Function final : public exec::VectorFunction {
   }
 
  private:
-  std::optional<int64_t> seed_;
+  const std::optional<int64_t> seed_;
 };
 
 } // namespace
@@ -368,7 +368,8 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  BaseVector* constantSeed = inputArgs[0].constantValue.get();
+  const auto& constantSeed = inputArgs[0].constantValue;
+  VELOX_USER_CHECK_NOT_NULL(constantSeed, "Hash seed cannot be null");
   auto seed = constantSeed->as<ConstantVector<int32_t>>()->valueAt(0);
   return std::make_shared<Murmur3HashFunction>(seed);
 }
@@ -384,7 +385,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> hashWithSeedSignatures() {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> xxhash64Signatures() {
   return {exec::FunctionSignatureBuilder()
-              .returnType("integer")
+              .returnType("bigint")
               .argumentType("any")
               .variableArity()
               .build()};
@@ -393,7 +394,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> xxhash64Signatures() {
 std::vector<std::shared_ptr<exec::FunctionSignature>>
 xxhash64WithSeedSignatures() {
   return {exec::FunctionSignatureBuilder()
-              .returnType("integer")
+              .returnType("bigint")
               .constantArgumentType("bigint")
               .argumentType("any")
               .variableArity()
@@ -412,7 +413,8 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  BaseVector* constantSeed = inputArgs[0].constantValue.get();
+  const auto& constantSeed = inputArgs[0].constantValue;
+  VELOX_USER_CHECK_NOT_NULL(constantSeed, "Hash seed cannot be null");
   auto seed = constantSeed->as<ConstantVector<int64_t>>()->valueAt(0);
   return std::make_shared<XxHash64Function>(seed);
 }

--- a/velox/functions/sparksql/Hash.h
+++ b/velox/functions/sparksql/Hash.h
@@ -39,6 +39,12 @@ std::shared_ptr<exec::VectorFunction> makeHash(
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
 
+std::vector<std::shared_ptr<exec::FunctionSignature>> hashWithSeedSignatures();
+
+std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
+
 // Supported types:
 //   - Bools
 //   - Integer types (byte, short, int, long)
@@ -55,9 +61,16 @@ std::shared_ptr<exec::VectorFunction> makeHash(
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> xxhash64Signatures();
 
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+xxhash64WithSeedSignatures();
+
 std::shared_ptr<exec::VectorFunction> makeXxHash64(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
+
+std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Hash.h
+++ b/velox/functions/sparksql/Hash.h
@@ -34,16 +34,17 @@ namespace facebook::velox::functions::sparksql {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> hashSignatures();
 
+std::vector<std::shared_ptr<exec::FunctionSignature>> hashWithSeedSignatures();
+
 std::shared_ptr<exec::VectorFunction> makeHash(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& config);
 
-std::vector<std::shared_ptr<exec::FunctionSignature>> hashWithSeedSignatures();
-
 std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs);
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
 
 // Supported types:
 //   - Bools
@@ -71,6 +72,7 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64(
 
 std::shared_ptr<exec::VectorFunction> makeXxHash64WithSeed(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs);
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& config);
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -139,7 +139,13 @@ void registerFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "hash", hashSignatures(), makeHash);
   exec::registerStatefulVectorFunction(
+      prefix + "hash_with_seed", hashWithSeedSignatures(), makeHashWithSeed);
+  exec::registerStatefulVectorFunction(
       prefix + "xxhash64", xxhash64Signatures(), makeXxHash64);
+  exec::registerStatefulVectorFunction(
+      prefix + "xxhash64_with_seed",
+      xxhash64WithSeedSignatures(),
+      makeXxHash64WithSeed);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
 
   // Register 'in' functions.

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -29,7 +29,8 @@ class XxHash64Test : public SparkFunctionBaseTest {
 
   template <typename T>
   std::optional<int64_t> xxhash64WithSeed(int64_t seed, std::optional<T> arg) {
-    return evaluateOnce<int64_t>(fmt::format("xxhash64({}, c0)", seed), arg);
+    return evaluateOnce<int64_t>(
+        fmt::format("xxhash64_with_seed({}, c0)", seed), arg);
   }
 };
 

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -27,8 +27,8 @@ class XxHash64Test : public SparkFunctionBaseTest {
     return evaluateOnce<int64_t>("xxhash64(c0)", arg);
   }
 
-  template <typename T, typename Seed>
-  std::optional<int64_t> xxhash64WithSeed(Seed seed, std::optional<T> arg) {
+  template <typename T>
+  std::optional<int64_t> xxhash64WithSeed(int64_t seed, std::optional<T> arg) {
     return evaluateOnce<int64_t>(fmt::format("xxhash64({}, c0)", seed), arg);
   }
 };


### PR DESCRIPTION
Spark Hash function supports specifying  parameter `seed` https://github.com/apache/spark/blob/3a9185964a0de3c720a6b77d38a446258b73468e/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/hash.scala#L658
Currently the hash seed in Velox's sparksql functions is fixed to 42, so the result will be wrong when using other values for the seed. This patch adds `hash_with_seed` and `xxhash64_with_seed` functions to allow calling hash functions with a specified seed.