### PR TITLE
Add CAST(varchar as decimal)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -764,6 +764,7 @@ Valid example
   SELECT cast('9.' as decimal(12, 2)); -- decimal '9.00'
   SELECT cast('.9' as decimal(12, 2)); -- decimal '0.90'
   SELECT cast('3E+2' as decimal(12, 2)); -- decimal '300.00'
+  SELECT cast('3E+00002' as decimal(12, 2)); -- decimal '300.00'
   SELECT cast('3e+2' as decimal(12, 2)); -- decimal '300.00'
   SELECT cast('31.423e+2' as decimal(12, 2)); -- decimal '3142.30'
   SELECT cast('1.2e-2' as decimal(12, 2)); -- decimal '0.01'
@@ -779,3 +780,7 @@ Invalid example
   SELECT cast('0.0446a' as decimal(9, 1)); -- Value is not a number
   SELECT cast('' as decimal(9, 1)); -- Value is not a number
   SELECT cast('23e-5d' as decimal(9, 1)); -- Value is not a number
+  SELECT cast('1.23 ' as decimal(38, 0)); -- Value is not a number
+  SELECT cast(' -3E+2' as decimal(12, 2)); -- Value is not a number
+  SELECT cast('-3E+2.1' as decimal(12, 2)); -- Value is not a number
+  SELECT cast('3E+' as decimal(12, 2)); -- Value is not a number

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -149,7 +149,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      -
      - Y
-     -
+     - Y
    * - timestamp
      -
      -
@@ -744,3 +744,38 @@ Invalid example
 
   SELECT cast(decimal '-1000.000' as decimal(6, 4)); -- Out of range
   SELECT cast(decimal '123456789' as decimal(9, 1)); -- Out of range
+
+From varchar
+^^^^^^^^^^^^
+
+Casting varchar to a decimal of given precision and scale is allowed
+if the input value can be represented by the precision and scale. When casting from
+a larger scale to a smaller one, the fraction part is rounded. Casting from invalid input value throws.
+
+Valid example
+
+::
+
+  SELECT cast('9999999999.99' as decimal(12, 2)); -- decimal '9999999999.99'
+  SELECT cast('1.556' as decimal(12, 2)); -- decimal '1.56'
+  SELECT cast('1.554' as decimal(12, 2)); -- decimal '1.55'
+  SELECT cast('-1.554' as decimal(12, 2)); -- decimal '-1.55'
+  SELECT cast('+09' as decimal(12, 2)); -- decimal '9.00'
+  SELECT cast('9.' as decimal(12, 2)); -- decimal '9.00'
+  SELECT cast('.9' as decimal(12, 2)); -- decimal '0.90'
+  SELECT cast('3E+2' as decimal(12, 2)); -- decimal '300.00'
+  SELECT cast('3e+2' as decimal(12, 2)); -- decimal '300.00'
+  SELECT cast('31.423e+2' as decimal(12, 2)); -- decimal '3142.30'
+  SELECT cast('1.2e-2' as decimal(12, 2)); -- decimal '0.01'
+  SELECT cast('1.2e-5' as decimal(12, 2)); -- decimal '0.00'
+  SELECT cast('0000.123' as decimal(12, 2)); -- decimal '0.12'
+  SELECT cast('.123000000' as decimal(12, 2)); -- decimal '0.12'
+
+Invalid example
+
+::
+
+  SELECT cast('1.23e67' as decimal(38, 0)); -- Value too large
+  SELECT cast('0.0446a' as decimal(9, 1)); -- Value is not a number
+  SELECT cast('' as decimal(9, 1)); -- Value is not a number
+  SELECT cast('23e-5d' as decimal(9, 1)); -- Value is not a number

--- a/velox/docs/functions/spark/conversion.rst
+++ b/velox/docs/functions/spark/conversion.rst
@@ -162,3 +162,23 @@ Invalid examples
   SELECT cast('2012-Oct-23' as date); -- Invalid argument
   SELECT cast('2012/10/23' as date); -- Invalid argument
   SELECT cast('2012.10.23' as date); -- Invalid argument
+
+Cast to Decimal
+---------------
+
+From varchar
+^^^^^^^^^^^^
+
+Casting varchar to a decimal of given precision and scale is allowed.
+The behavior is similar with Presto except Spark allows leading and trailing white-spaces in input varchars.
+
+Valid example
+
+::
+
+  SELECT cast(' 1.23' as decimal(38, 0)); -- 1
+  SELECT cast('1.23 ' as decimal(38, 0)); -- 1
+  SELECT cast('  1.23  ' as decimal(38, 0)); -- 1
+  SELECT cast(' -3E+2' as decimal(12, 2)); -- -300.00
+  SELECT cast('-3E+2 ' as decimal(12, 2)); -- -300.00
+  SELECT cast('  -3E+2  ' as decimal(12, 2)); -- -300.00

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -52,43 +52,6 @@ inline std::exception_ptr makeBadCastException(
       false));
 }
 
-/// Represent the varchar fragment.
-///
-/// For example:
-/// | value | wholeDigits | fractionalDigits | exponent | sign
-/// | 9999999999.99 | 9999999999 | 99 | nullopt | 1
-/// | 15 | 15 |  | nullopt | 1
-/// | 1.5 | 1 | 5 | nullopt | 1
-/// | -1.5 | 1 | 5 | nullopt | -1
-/// | 31.523e-2 | 31 | 523 | -2 | 1
-struct DecimalComponents {
-  std::string_view wholeDigits;
-  std::string_view fractionalDigits;
-  std::optional<int32_t> exponent = std::nullopt;
-  int8_t sign = 1;
-};
-
-// Copied from format.h of fmt.
-inline int countDigits(uint128_t n) {
-  int count = 1;
-  for (;;) {
-    if (n < 10) {
-      return count;
-    }
-    if (n < 100) {
-      return count + 1;
-    }
-    if (n < 1000) {
-      return count + 2;
-    }
-    if (n < 10000) {
-      return count + 3;
-    }
-    n /= 10000u;
-    count += 4;
-  }
-}
-
 /// @brief Convert the unscaled value of a decimal to varchar and write to raw
 /// string buffer from start position.
 /// @tparam T The type of input value.
@@ -149,121 +112,64 @@ StringView convertToStringView(
   return StringView(startPosition, writePosition - startPosition);
 }
 
-size_t parseDigitsRun(
-    const char* s,
-    size_t start,
-    size_t size,
-    std::string_view& out) {
-  size_t pos = start;
-  for (; pos < size; ++pos) {
-    if (!std::isdigit(s[pos])) {
-      break;
-    }
-  }
-  out = std::string_view(s + start, pos - start);
-  return pos;
-}
+} // namespace
 
-std::optional<DecimalComponents> parseDecimalComponents(
-    const char* s,
-    size_t size) {
-  if (size == 0) {
-    return std::nullopt;
-  }
-  DecimalComponents out;
-  size_t pos = 0;
-  // Sign of the number.
-  if (s[pos] == '-') {
-    out.sign = -1;
-    ++pos;
-  } else if (s[pos] == '+') {
-    out.sign = 1;
-    ++pos;
-  }
-  // First run of digits.
-  pos = parseDigitsRun(s, pos, size, out.wholeDigits);
-  if (pos == size) {
-    return out.wholeDigits.empty() ? std::nullopt
-                                   : std::optional<DecimalComponents>(out);
-  }
-  // Optional dot (if given in fractional form).
-  if (s[pos] == '.') {
-    // Second run of digits.
-    ++pos;
-    pos = parseDigitsRun(s, pos, size, out.fractionalDigits);
-  }
-  if (out.wholeDigits.empty() && out.fractionalDigits.empty()) {
-    // Need at least some digits (whole or fractional).
-    return std::nullopt;
-  }
-  if (pos == size) {
-    return out;
-  }
-  // Optional exponent.
-  if (s[pos] == 'e' || s[pos] == 'E') {
-    ++pos;
-    if (pos != size && s[pos] == '+') {
-      ++pos;
-    }
-    folly::StringPiece p = {s + pos, size - pos};
-    auto tryExp =
-        folly::tryTo<int32_t>(folly::StringPiece(s + pos, size - pos));
-    if (tryExp.hasError()) {
-      return std::nullopt;
-    }
-    out.exponent = tryExp.value();
-    return out;
-  }
-  return pos == size ? std::optional<DecimalComponents>(out) : std::nullopt;
-}
+namespace detail {
 
-/// Multiple out by the appropriate power of 10 necessary to add source parsed
-/// as int128_t and then adds the parsed value of source.
-bool shiftAndAdd(std::string_view input, int128_t& out) {
-  auto length = input.size();
-  if (length == 0) {
-    return true;
-  }
-
-  bool overflow =
-      __builtin_mul_overflow(out, DecimalUtil::kPowersOfTen[length], &out);
-  if (overflow) {
-    return false;
-  }
-  auto tryValue =
-      folly::tryTo<int128_t>(folly::StringPiece(input.data(), length));
-  if (tryValue.hasError()) {
-    return false;
-  }
-
-  overflow = __builtin_add_overflow(out, tryValue.value(), &out);
-  VELOX_DCHECK(!overflow)
-  return true;
-}
-
-/// Derives from Arrow function DecimalFromString.
-/// Arrow implementation:
-/// https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/decimal.cc#L637
+/// Represent the varchar fragment.
 ///
-/// Firstly, it will parse the varchar to DecimalComponents which contains the
-/// message that can represent a value. Secondly, process the exponent to get
-/// the value parsedScale. Thirdly, compute the rescaled value.
-/// The caller should test if `error` is empty
+/// For example:
+/// | value | wholeDigits | fractionalDigits | exponent | sign |
+/// | 9999999999.99 | 9999999999 | 99 | nullopt | 1 |
+/// | 15 | 15 |  | nullopt | 1 |
+/// | 1.5 | 1 | 5 | nullopt | 1 |
+/// | -1.5 | 1 | 5 | nullopt | -1 |
+/// | 31.523e-2 | 31 | 523 | -2 | 1 |
+struct DecimalComponents {
+  std::string_view wholeDigits;
+  std::string_view fractionalDigits;
+  std::optional<int32_t> exponent = std::nullopt;
+  int8_t sign = 1;
+};
+
+// Extract a string view of continuous digits.
+std::string_view extractDigits(const char* s, size_t start, size_t size);
+
+/// Parse decimal components, including whole digits, fractional digits,
+/// exponent and sign, from input chars. Returns error status if input chars
+/// do not represent a valid value.
+Status
+parseDecimalComponents(const char* s, size_t size, DecimalComponents& out);
+
+/// Parse huge int from decimal components. The fractional part is scaled up by
+/// required power of 10, and added with the whole part. Returns error status if
+/// overflows.
+Status parseHugeInt(const DecimalComponents& decimalComponents, int128_t& out);
+
+/// Converts string view to decimal value of given precision and scale.
+/// Derives from Arrow function DecimalFromString. Arrow implementation:
+/// https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/decimal.cc#L637.
+///
+/// Firstly, it parses the varchar to DecimalComponents which contains the
+/// message that can represent a decimal value. Secondly, processes the exponent
+/// to get the scale. Thirdly, compute the rescaled value. Returns status for
+/// the outcome of computing.
 template <typename T>
-std::optional<T> rescaleVarchar(
+Status toDecimalValue(
     const StringView s,
     int toPrecision,
     int toScale,
-    std::string& error) {
-  auto decimalComponentsOpt = parseDecimalComponents(s.data(), s.size());
-  if (!decimalComponentsOpt.has_value()) {
-    error = "Value is not a number.";
-    return std::nullopt;
+    T& decimalValue) {
+  DecimalComponents decimalComponents;
+  if (auto status =
+          parseDecimalComponents(s.data(), s.size(), decimalComponents);
+      !status.ok()) {
+    return Status::UserError("Value is not a number. " + status.message());
   }
-  auto decimalComponents = decimalComponentsOpt.value();
 
   // Count number of significant digits (without leading zeros).
-  size_t firstNonZero = decimalComponents.wholeDigits.find_first_not_of('0');
+  const size_t firstNonZero =
+      decimalComponents.wholeDigits.find_first_not_of('0');
   size_t significantDigits = decimalComponents.fractionalDigits.size();
   if (firstNonZero != std::string::npos) {
     significantDigits += decimalComponents.wholeDigits.size() - firstNonZero;
@@ -271,94 +177,86 @@ std::optional<T> rescaleVarchar(
   int32_t parsedPrecision = static_cast<int32_t>(significantDigits);
 
   int32_t parsedScale = 0;
-  bool addOne = false;
-  int32_t fractionalDigitsSize = decimalComponents.fractionalDigits.size();
-  if (decimalComponents.exponent.has_value()) {
-    auto adjustedExponent = decimalComponents.exponent.value();
-    parsedScale = -adjustedExponent + fractionalDigitsSize;
-    // Truncate the fractionalDigits.
-    if (parsedScale > toScale) {
-      // adjustedExponent is negative, fractionalDigits only consider the last
-      // digit to round up.
-      if (-adjustedExponent >= toScale) {
-        if (fractionalDigitsSize > 0 &&
-            decimalComponents.fractionalDigits[0] >= '5') {
-          addOne = true;
-        }
-        decimalComponents.fractionalDigits = "";
-        parsedScale -= fractionalDigitsSize;
-      } else {
-        auto reduceDigits = adjustedExponent + toScale;
-        if (fractionalDigitsSize > reduceDigits &&
-            decimalComponents.fractionalDigits[reduceDigits] >= '5') {
-          addOne = true;
-        }
-        decimalComponents.fractionalDigits = std::string_view(
-            decimalComponents.fractionalDigits.data(),
-            std::min(reduceDigits, fractionalDigitsSize));
-        parsedScale -=
-            fractionalDigitsSize - decimalComponents.fractionalDigits.size();
-      }
-    }
-  } else {
-    if (fractionalDigitsSize > toScale) {
+  bool roundUp = false;
+  const int32_t fractionSize = decimalComponents.fractionalDigits.size();
+  if (!decimalComponents.exponent.has_value()) {
+    if (fractionSize > toScale) {
       if (decimalComponents.fractionalDigits[toScale] >= '5') {
-        addOne = true;
+        roundUp = true;
       }
       parsedScale = toScale;
       decimalComponents.fractionalDigits =
           std::string_view(decimalComponents.fractionalDigits.data(), toScale);
     } else {
-      parsedScale = fractionalDigitsSize;
+      parsedScale = fractionSize;
+    }
+  } else {
+    const auto exponent = decimalComponents.exponent.value();
+    parsedScale = -exponent + fractionSize;
+    // Truncate the fractionalDigits.
+    if (parsedScale > toScale) {
+      if (-exponent >= toScale) {
+        // The fractional digits could be dropped.
+        if (fractionSize > 0 && decimalComponents.fractionalDigits[0] >= '5') {
+          roundUp = true;
+        }
+        decimalComponents.fractionalDigits = "";
+        parsedScale -= fractionSize;
+      } else {
+        const auto reduceDigits = exponent + toScale;
+        if (fractionSize > reduceDigits &&
+            decimalComponents.fractionalDigits[reduceDigits] >= '5') {
+          roundUp = true;
+        }
+        decimalComponents.fractionalDigits = std::string_view(
+            decimalComponents.fractionalDigits.data(),
+            std::min(reduceDigits, fractionSize));
+        parsedScale -= fractionSize - decimalComponents.fractionalDigits.size();
+      }
     }
   }
 
   int128_t out = 0;
-  if (!shiftAndAdd(decimalComponents.wholeDigits, out)) {
-    error = "Value too large.";
-    return std::nullopt;
+  if (auto status = parseHugeInt(decimalComponents, out); !status.ok()) {
+    return status;
   }
 
-  if (!shiftAndAdd(decimalComponents.fractionalDigits, out)) {
-    error = "Value too large.";
-    return std::nullopt;
-  }
-  if (addOne) {
+  if (roundUp) {
     bool overflow = __builtin_add_overflow(out, 1, &out);
     if (UNLIKELY(overflow)) {
-      error = "Value too large.";
-      return std::nullopt;
+      return Status::UserError("Value too large.");
     }
   }
-  out = out * decimalComponents.sign;
+  out *= decimalComponents.sign;
 
   if (parsedScale < 0) {
-    /// Force the scale to zero, to avoid negative scales (due to
+    /// Force the scale to be zero, to avoid negative scales (due to
     /// compatibility issues with external systems such as databases).
-    if (-parsedScale + toScale > LongDecimalType::kMaxScale) {
-      error = "Value too large.";
-      return std::nullopt;
+    if (-parsedScale + toScale > LongDecimalType::kMaxPrecision) {
+      return Status::UserError("Value too large.");
     }
 
     bool overflow = __builtin_mul_overflow(
         out, DecimalUtil::kPowersOfTen[-parsedScale + toScale], &out);
     if (UNLIKELY(overflow)) {
-      error = "Value too large.";
-      return std::nullopt;
+      return Status::UserError("Value too large.");
     }
     parsedPrecision -= parsedScale;
     parsedScale = toScale;
   }
-  bool overflow = false;
-  auto rescaledValue = DecimalUtil::rescaleWithRoundUp<int128_t, T>(
-      out, parsedPrecision, parsedScale, toPrecision, toScale, overflow, false);
-  if (overflow) {
-    error = "Value too large.";
-    return std::nullopt;
+  const auto status = DecimalUtil::rescaleWithRoundUp<int128_t, T>(
+      out,
+      std::min((uint8_t)parsedPrecision, LongDecimalType::kMaxPrecision),
+      parsedScale,
+      toPrecision,
+      toScale,
+      decimalValue);
+  if (!status.ok()) {
+    return Status::UserError("Value too large.");
   }
-  return rescaledValue;
+  return status;
 }
-} // namespace
+} // namespace detail
 
 template <bool adjustForTimeZone>
 void CastExpr::castTimestampToDate(
@@ -565,28 +463,23 @@ void CastExpr::applyVarcharToDecimalCastKernel(
   auto sourceVector = input.as<SimpleVector<StringView>>();
   auto rawBuffer = result->asUnchecked<FlatVector<T>>()->mutableRawValues();
   const auto toPrecisionScale = getDecimalPrecisionScale(*toType);
-  auto setError = [&](vector_size_t row, const std::string& details) {
-    if (setNullInResultAtError()) {
-      result->setNull(row, true);
-    } else {
-      context.setVeloxExceptionError(
-          row, makeBadCastException(toType, input, row, details));
-    }
-  };
 
   rows.applyToSelected([&](auto row) {
-    std::string error;
-    auto rescaledValue = rescaleVarchar<T>(
-        sourceVector->valueAt(row),
+    T decimalValue;
+    const auto status = detail::toDecimalValue<T>(
+        hooks_->removeWhiteSpaces(sourceVector->valueAt(row)),
         toPrecisionScale.first,
         toPrecisionScale.second,
-        error);
-    if (!error.empty()) {
-      setError(row, error);
-    } else if (rescaledValue.has_value()) {
-      rawBuffer[row] = rescaledValue.value();
+        decimalValue);
+    if (status.ok()) {
+      rawBuffer[row] = decimalValue;
     } else {
-      result->setNull(row, true);
+      if (setNullInResultAtError()) {
+        result->setNull(row, true);
+      } else {
+        context.setVeloxExceptionError(
+            row, makeBadCastException(toType, input, row, status.message()));
+      }
     }
   });
 }

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -52,6 +52,43 @@ inline std::exception_ptr makeBadCastException(
       false));
 }
 
+/// Represent the varchar fragment.
+///
+/// For example:
+/// | value | wholeDigits | fractionalDigits | exponent | sign
+/// | 9999999999.99 | 9999999999 | 99 | nullopt | 1
+/// | 15 | 15 |  | nullopt | 1
+/// | 1.5 | 1 | 5 | nullopt | 1
+/// | -1.5 | 1 | 5 | nullopt | -1
+/// | 31.523e-2 | 31 | 523 | -2 | 1
+struct DecimalComponents {
+  std::string_view wholeDigits;
+  std::string_view fractionalDigits;
+  std::optional<int32_t> exponent = std::nullopt;
+  int8_t sign = 1;
+};
+
+// Copied from format.h of fmt.
+inline int countDigits(uint128_t n) {
+  int count = 1;
+  for (;;) {
+    if (n < 10) {
+      return count;
+    }
+    if (n < 100) {
+      return count + 1;
+    }
+    if (n < 1000) {
+      return count + 2;
+    }
+    if (n < 10000) {
+      return count + 3;
+    }
+    n /= 10000u;
+    count += 4;
+  }
+}
+
 /// @brief Convert the unscaled value of a decimal to varchar and write to raw
 /// string buffer from start position.
 /// @tparam T The type of input value.
@@ -112,6 +149,215 @@ StringView convertToStringView(
   return StringView(startPosition, writePosition - startPosition);
 }
 
+size_t parseDigitsRun(
+    const char* s,
+    size_t start,
+    size_t size,
+    std::string_view& out) {
+  size_t pos = start;
+  for (; pos < size; ++pos) {
+    if (!std::isdigit(s[pos])) {
+      break;
+    }
+  }
+  out = std::string_view(s + start, pos - start);
+  return pos;
+}
+
+std::optional<DecimalComponents> parseDecimalComponents(
+    const char* s,
+    size_t size) {
+  if (size == 0) {
+    return std::nullopt;
+  }
+  DecimalComponents out;
+  size_t pos = 0;
+  // Sign of the number.
+  if (s[pos] == '-') {
+    out.sign = -1;
+    ++pos;
+  } else if (s[pos] == '+') {
+    out.sign = 1;
+    ++pos;
+  }
+  // First run of digits.
+  pos = parseDigitsRun(s, pos, size, out.wholeDigits);
+  if (pos == size) {
+    return out.wholeDigits.empty() ? std::nullopt
+                                   : std::optional<DecimalComponents>(out);
+  }
+  // Optional dot (if given in fractional form).
+  if (s[pos] == '.') {
+    // Second run of digits.
+    ++pos;
+    pos = parseDigitsRun(s, pos, size, out.fractionalDigits);
+  }
+  if (out.wholeDigits.empty() && out.fractionalDigits.empty()) {
+    // Need at least some digits (whole or fractional).
+    return std::nullopt;
+  }
+  if (pos == size) {
+    return out;
+  }
+  // Optional exponent.
+  if (s[pos] == 'e' || s[pos] == 'E') {
+    ++pos;
+    if (pos != size && s[pos] == '+') {
+      ++pos;
+    }
+    folly::StringPiece p = {s + pos, size - pos};
+    auto tryExp =
+        folly::tryTo<int32_t>(folly::StringPiece(s + pos, size - pos));
+    if (tryExp.hasError()) {
+      return std::nullopt;
+    }
+    out.exponent = tryExp.value();
+    return out;
+  }
+  return pos == size ? std::optional<DecimalComponents>(out) : std::nullopt;
+}
+
+/// Multiple out by the appropriate power of 10 necessary to add source parsed
+/// as int128_t and then adds the parsed value of source.
+bool shiftAndAdd(std::string_view input, int128_t& out) {
+  auto length = input.size();
+  if (length == 0) {
+    return true;
+  }
+
+  bool overflow =
+      __builtin_mul_overflow(out, DecimalUtil::kPowersOfTen[length], &out);
+  if (overflow) {
+    return false;
+  }
+  auto tryValue =
+      folly::tryTo<int128_t>(folly::StringPiece(input.data(), length));
+  if (tryValue.hasError()) {
+    return false;
+  }
+
+  overflow = __builtin_add_overflow(out, tryValue.value(), &out);
+  VELOX_DCHECK(!overflow)
+  return true;
+}
+
+/// Derives from Arrow function DecimalFromString.
+/// Arrow implementation:
+/// https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/decimal.cc#L637
+///
+/// Firstly, it will parse the varchar to DecimalComponents which contains the
+/// message that can represent a value. Secondly, process the exponent to get
+/// the value parsedScale. Thirdly, compute the rescaled value.
+/// The caller should test if `error` is empty
+template <typename T>
+std::optional<T> rescaleVarchar(
+    const StringView s,
+    int toPrecision,
+    int toScale,
+    std::string& error) {
+  auto decimalComponentsOpt = parseDecimalComponents(s.data(), s.size());
+  if (!decimalComponentsOpt.has_value()) {
+    error = "Value is not a number.";
+    return std::nullopt;
+  }
+  auto decimalComponents = decimalComponentsOpt.value();
+
+  // Count number of significant digits (without leading zeros).
+  size_t firstNonZero = decimalComponents.wholeDigits.find_first_not_of('0');
+  size_t significantDigits = decimalComponents.fractionalDigits.size();
+  if (firstNonZero != std::string::npos) {
+    significantDigits += decimalComponents.wholeDigits.size() - firstNonZero;
+  }
+  int32_t parsedPrecision = static_cast<int32_t>(significantDigits);
+
+  int32_t parsedScale = 0;
+  bool addOne = false;
+  int32_t fractionalDigitsSize = decimalComponents.fractionalDigits.size();
+  if (decimalComponents.exponent.has_value()) {
+    auto adjustedExponent = decimalComponents.exponent.value();
+    parsedScale = -adjustedExponent + fractionalDigitsSize;
+    // Truncate the fractionalDigits.
+    if (parsedScale > toScale) {
+      // adjustedExponent is negative, fractionalDigits only consider the last
+      // digit to round up.
+      if (-adjustedExponent >= toScale) {
+        if (fractionalDigitsSize > 0 &&
+            decimalComponents.fractionalDigits[0] >= '5') {
+          addOne = true;
+        }
+        decimalComponents.fractionalDigits = "";
+        parsedScale -= fractionalDigitsSize;
+      } else {
+        auto reduceDigits = adjustedExponent + toScale;
+        if (fractionalDigitsSize > reduceDigits &&
+            decimalComponents.fractionalDigits[reduceDigits] >= '5') {
+          addOne = true;
+        }
+        decimalComponents.fractionalDigits = std::string_view(
+            decimalComponents.fractionalDigits.data(),
+            std::min(reduceDigits, fractionalDigitsSize));
+        parsedScale -=
+            fractionalDigitsSize - decimalComponents.fractionalDigits.size();
+      }
+    }
+  } else {
+    if (fractionalDigitsSize > toScale) {
+      if (decimalComponents.fractionalDigits[toScale] >= '5') {
+        addOne = true;
+      }
+      parsedScale = toScale;
+      decimalComponents.fractionalDigits =
+          std::string_view(decimalComponents.fractionalDigits.data(), toScale);
+    } else {
+      parsedScale = fractionalDigitsSize;
+    }
+  }
+
+  int128_t out = 0;
+  if (!shiftAndAdd(decimalComponents.wholeDigits, out)) {
+    error = "Value too large.";
+    return std::nullopt;
+  }
+
+  if (!shiftAndAdd(decimalComponents.fractionalDigits, out)) {
+    error = "Value too large.";
+    return std::nullopt;
+  }
+  if (addOne) {
+    bool overflow = __builtin_add_overflow(out, 1, &out);
+    if (UNLIKELY(overflow)) {
+      error = "Value too large.";
+      return std::nullopt;
+    }
+  }
+  out = out * decimalComponents.sign;
+
+  if (parsedScale < 0) {
+    /// Force the scale to zero, to avoid negative scales (due to
+    /// compatibility issues with external systems such as databases).
+    if (-parsedScale + toScale > LongDecimalType::kMaxScale) {
+      error = "Value too large.";
+      return std::nullopt;
+    }
+
+    bool overflow = __builtin_mul_overflow(
+        out, DecimalUtil::kPowersOfTen[-parsedScale + toScale], &out);
+    if (UNLIKELY(overflow)) {
+      error = "Value too large.";
+      return std::nullopt;
+    }
+    parsedPrecision -= parsedScale;
+    parsedScale = toScale;
+  }
+  bool overflow = false;
+  auto rescaledValue = DecimalUtil::rescaleWithRoundUp<int128_t, T>(
+      out, parsedPrecision, parsedScale, toPrecision, toScale, overflow, false);
+  if (overflow) {
+    error = "Value too large.";
+    return std::nullopt;
+  }
+  return rescaledValue;
+}
 } // namespace
 
 template <bool adjustForTimeZone>
@@ -307,6 +553,42 @@ void CastExpr::applyIntToDecimalCastKernel(
           castResult->setNull(row, true);
         }
       });
+}
+
+template <typename T>
+void CastExpr::applyVarcharToDecimalCastKernel(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& toType,
+    VectorPtr& result) {
+  auto sourceVector = input.as<SimpleVector<StringView>>();
+  auto rawBuffer = result->asUnchecked<FlatVector<T>>()->mutableRawValues();
+  const auto toPrecisionScale = getDecimalPrecisionScale(*toType);
+  auto setError = [&](vector_size_t row, const std::string& details) {
+    if (setNullInResultAtError()) {
+      result->setNull(row, true);
+    } else {
+      context.setVeloxExceptionError(
+          row, makeBadCastException(toType, input, row, details));
+    }
+  };
+
+  rows.applyToSelected([&](auto row) {
+    std::string error;
+    auto rescaledValue = rescaleVarchar<T>(
+        sourceVector->valueAt(row),
+        toPrecisionScale.first,
+        toPrecisionScale.second,
+        error);
+    if (!error.empty()) {
+      setError(row, error);
+    } else if (rescaledValue.has_value()) {
+      rawBuffer[row] = rescaledValue.value();
+    } else {
+      result->setNull(row, true);
+    }
+  });
 }
 
 template <typename FromNativeType, TypeKind ToKind>

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -483,6 +483,10 @@ VectorPtr CastExpr::applyDecimal(
       }
       [[fallthrough]];
     }
+    case TypeKind::VARCHAR:
+      applyVarcharToDecimalCastKernel<toDecimalType>(
+          rows, input, context, toType, castResult);
+      break;
     default:
       VELOX_UNSUPPORTED(
           "Cast from {} to {} is not supported",

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -33,6 +33,117 @@
 
 namespace facebook::velox::exec {
 
+std::string_view
+detail::extractDigits(const char* s, size_t start, size_t size) {
+  size_t pos = start;
+  for (; pos < size; ++pos) {
+    if (!std::isdigit(s[pos])) {
+      break;
+    }
+  }
+  return std::string_view(s + start, pos - start);
+}
+
+Status detail::parseDecimalComponents(
+    const char* s,
+    size_t size,
+    detail::DecimalComponents& out) {
+  if (size == 0) {
+    return Status::UserError("Input is empty.");
+  }
+
+  size_t pos = 0;
+
+  // Sign of the number.
+  if (s[pos] == '-') {
+    out.sign = -1;
+    ++pos;
+  } else if (s[pos] == '+') {
+    out.sign = 1;
+    ++pos;
+  }
+
+  // Extract the whole digits.
+  out.wholeDigits = detail::extractDigits(s, pos, size);
+  pos += out.wholeDigits.size();
+  if (pos == size) {
+    return out.wholeDigits.empty()
+        ? Status::UserError("Extracted digits are empty.")
+        : Status::OK();
+  }
+
+  // Optional dot (if given in fractional form).
+  if (s[pos] == '.') {
+    // Extract the fractional digits.
+    ++pos;
+    out.fractionalDigits = detail::extractDigits(s, pos, size);
+    pos += out.fractionalDigits.size();
+  }
+
+  if (out.wholeDigits.empty() && out.fractionalDigits.empty()) {
+    return Status::UserError("Extracted digits are empty.");
+  }
+  if (pos == size) {
+    return Status::OK();
+  }
+  // Optional exponent.
+  if (s[pos] == 'e' || s[pos] == 'E') {
+    ++pos;
+    bool withSign = pos < size && (s[pos] == '+' || s[pos] == '-');
+    if (withSign && pos == size - 1) {
+      return Status::UserError("The exponent part only contains sign.");
+    }
+    // Make sure all chars after sign are digits, as as folly::tryTo allows
+    // leading and trailing whitespaces.
+    for (auto i = (size_t)withSign; i < size - pos; ++i) {
+      if (!std::isdigit(s[pos + i])) {
+        return Status::UserError(
+            "Non-digit character '{}' is not allowed in the exponent part.",
+            s[pos + i]);
+      }
+    }
+    out.exponent = folly::to<int32_t>(folly::StringPiece(s + pos, size - pos));
+    return Status::OK();
+  }
+  return pos == size
+      ? Status::OK()
+      : Status::UserError(
+            "Chars '{}' are invalid.", std::string(s + pos, size - pos));
+}
+
+Status detail::parseHugeInt(
+    const DecimalComponents& decimalComponents,
+    int128_t& out) {
+  // Parse the whole digits.
+  if (decimalComponents.wholeDigits.size() > 0) {
+    const auto tryValue = folly::tryTo<int128_t>(folly::StringPiece(
+        decimalComponents.wholeDigits.data(),
+        decimalComponents.wholeDigits.size()));
+    if (tryValue.hasError()) {
+      return Status::UserError("Value too large.");
+    }
+    out = tryValue.value();
+  }
+
+  // Parse the fractional digits.
+  if (decimalComponents.fractionalDigits.size() > 0) {
+    const auto length = decimalComponents.fractionalDigits.size();
+    bool overflow =
+        __builtin_mul_overflow(out, DecimalUtil::kPowersOfTen[length], &out);
+    if (overflow) {
+      return Status::UserError("Value too large.");
+    }
+    const auto tryValue = folly::tryTo<int128_t>(
+        folly::StringPiece(decimalComponents.fractionalDigits.data(), length));
+    if (tryValue.hasError()) {
+      return Status::UserError("Value too large.");
+    }
+    overflow = __builtin_add_overflow(out, tryValue.value(), &out);
+    VELOX_DCHECK(!overflow);
+  }
+  return Status::OK();
+}
+
 VectorPtr CastExpr::castFromDate(
     const SelectivityVector& rows,
     const BaseVector& input,

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -206,6 +206,14 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& castResult);
 
+  template <typename T>
+  void applyVarcharToDecimalCastKernel(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType,
+      VectorPtr& castResult);
+
   template <typename FromNativeType, TypeKind ToKind>
   VectorPtr applyDecimalToFloatCast(
       const SelectivityVector& rows,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1692,6 +1692,230 @@ TEST_F(CastExprTest, boolToDecimal) {
           DECIMAL(20, 10)));
 }
 
+// The result is obtained by select cast('31.4e-2' as decimal(12, 2)).
+TEST_F(CastExprTest, varcharToDecimal) {
+  auto input = makeFlatVector<StringView>(
+      {"9999999999.99",
+       "15",
+       "1.5",
+       "-1.5",
+       "1.556",
+       "1.554",
+       ("1.556" + std::string(32, '1')).data(),
+       ("1.556" + std::string(32, '9')).data(),
+       "0000.123",
+       ".12300000000",
+       "+09",
+       "9.",
+       ".9",
+       "3E2",
+       "-3E+2",
+       "3E+2",
+       "3E-2",
+       "3e+2",
+       "3e-2",
+       "3.5E-2",
+       "3.4E-2",
+       "3.5E+2",
+       "3.4E+2",
+       "31.423e+2",
+       "31.423e-2",
+       "31.523e-2"});
+  testComplexCast(
+      "c0",
+      input,
+      makeFlatVector<int64_t>(
+          {999'999'999'999,
+           1500,
+           150,
+           -150,
+           156,
+           155,
+           156,
+           156,
+           12,
+           12,
+           900,
+           900,
+           90,
+           30000,
+           -30000,
+           30000,
+           3,
+           30000,
+           3,
+           4,
+           3,
+           35000,
+           34000,
+           314230,
+           31,
+           32},
+          DECIMAL(12, 2)));
+
+  // Truncate the fractional digits with exponent.
+  testComplexCast(
+      "c0",
+      makeFlatVector<StringView>(
+          {"112345612.23e-6",
+           "112345662.23e-6",
+           "1.23e-6",
+           "1.23e-3",
+           "1.26e-3",
+           "1.23456781e3",
+           "1.23456789e3",
+           "1.23456789123451789123456789e9",
+           "1.23456789123456789123456789e9"}),
+      makeFlatVector<int128_t>(
+          {1123456,
+           1123457,
+           0,
+           12,
+           13,
+           12345678,
+           12345679,
+           12345678912345,
+           12345678912346},
+          DECIMAL(20, 4)));
+
+  auto minDecimalStr = '-' + std::string(36, '9') + '.' + "99";
+  auto maxDecimalStr = std::string(36, '9') + '.' + "99";
+  testComplexCast(
+      "c0",
+      makeFlatVector<StringView>(
+          {StringView(minDecimalStr),
+           StringView(maxDecimalStr),
+           "123456789012345678901234.567"}),
+      makeFlatVector<int128_t>(
+          {
+              DecimalUtil::kLongDecimalMin,
+              DecimalUtil::kLongDecimalMax,
+              HugeInt::build(
+                  669260, 10962463713375599297U), // 12345678901234567890123457
+          },
+          DECIMAL(38, 2)));
+
+  std::string fractionLarge = "1.9" + std::string(67, '9');
+  std::string fractionLargeExp = "1.9" + std::string(67, '9') + "e2";
+  std::string fractionLargeNegExp = "1000.9" + std::string(67, '9') + "e-2";
+  testComplexCast(
+      "c0",
+      makeFlatVector<StringView>(
+          {StringView(('-' + std::string(38, '9')).data()),
+           StringView(std::string(38, '9').data()),
+           StringView(fractionLarge.data()),
+           StringView(fractionLargeExp.data()),
+           StringView(fractionLargeNegExp.data())}),
+      makeFlatVector<int128_t>(
+          {DecimalUtil::kLongDecimalMin,
+           DecimalUtil::kLongDecimalMax,
+           2,
+           200,
+           10},
+          DECIMAL(38, 0)));
+  std::string fractionRoundDown = "0." + std::string(38, '9') + "2";
+  std::string fractionRoundDownExp = "99." + std::string(36, '9') + "2e-2";
+  testComplexCast(
+      "c0",
+      makeFlatVector<StringView>(
+          {StringView(fractionRoundDown), StringView(fractionRoundDownExp)}),
+      makeConstant<int128_t>(DecimalUtil::kLongDecimalMax, 2, DECIMAL(38, 38)));
+
+  // WholeDigits shiftAndAdd overflow.
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>(std::string(280, '9').data(), 1),
+          makeConstant<int128_t>(1, 1, DECIMAL(38, 0))),
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 0). Value too large.",
+          std::string(280, '9')))
+  // Function shiftAndAdd shift fractionalDigits overflow.
+  std::string shiftFractionOverflow = std::string(36, '9') + '.' + "23456";
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>(shiftFractionOverflow.data(), 1),
+          makeConstant<int128_t>(2, 1, DECIMAL(38, 10))),
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 10). Value too large.",
+          shiftFractionOverflow))
+  std::string fractionRoundUp = "0." + std::string(38, '9') + "6";
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>(fractionRoundUp.data(), 1),
+          makeConstant<int128_t>(3, 1, DECIMAL(38, 38))),
+      fmt::format(
+          "Cannot cast VARCHAR '{}' to DECIMAL(38, 38). Value too large.",
+          fractionRoundUp))
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("0.0444a", 1),
+          makeConstant<int128_t>(4, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '0.0444a' to DECIMAL(38, 0). Value is not a number")
+
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("", 1),
+          makeConstant<int128_t>(5, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '' to DECIMAL(38, 0). Value is not a number")
+
+  // exponent parsedScale > LongDecimalType::kMaxScale.
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("1.23e67", 1),
+          makeConstant<int128_t>(6, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '1.23e67' to DECIMAL(38, 0). Value too large.")
+
+  // Out * DecimalUtil::kPowersOfTen[-parsedScale] overflow.
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("20908.23e35", 1),
+          makeConstant<int128_t>(7, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '20908.23e35' to DECIMAL(38, 0). Value too large.")
+
+  // Rescale overflow.
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("111111111111111111.23", 1),
+          makeConstant<int128_t>(8, 1, DECIMAL(38, 38))),
+      "Cannot cast VARCHAR '111111111111111111.23' to DECIMAL(38, 38). Value too large.")
+
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("23e-5d", 1),
+          makeConstant<int128_t>(9, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '23e-5d' to DECIMAL(38, 0). Value is not a number")
+
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("1. 23", 1),
+          makeConstant<int128_t>(10, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '1. 23' to DECIMAL(38, 0). Value is not a number")
+
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>("1.23 ", 1),
+          makeConstant<int128_t>(11, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR '1.23 ' to DECIMAL(38, 0). Value is not a number")
+
+  VELOX_ASSERT_THROW(
+      testComplexCast(
+          "c0",
+          makeConstant<StringView>(" 1.23 ", 1),
+          makeConstant<int128_t>(12, 1, DECIMAL(38, 0))),
+      "Cannot cast VARCHAR ' 1.23 ' to DECIMAL(38, 0). Value is not a number")
+}
+
 TEST_F(CastExprTest, castInTry) {
   // Test try(cast(array(varchar) as array(bigint))) whose input vector is
   // wrapped in dictinary encoding. The row of ["2a"] should trigger an error

--- a/velox/functions/sparksql/tests/SparkCastExprTest.cpp
+++ b/velox/functions/sparksql/tests/SparkCastExprTest.cpp
@@ -504,6 +504,7 @@ TEST_F(SparkCastExprTest, timestampToString) {
 }
 
 TEST_F(SparkCastExprTest, fromString) {
+  // String with leading and trailing whitespaces.
   testCast<std::string, int8_t>(
       "tinyint", {"\n\f\r\t\n\u001F 123\u000B\u001C\u001D\u001E"}, {123});
   testCast<std::string, int32_t>(
@@ -524,6 +525,23 @@ TEST_F(SparkCastExprTest, fromString) {
       "timestamp",
       {"\n\f\r\t\n\u001F 2000-01-01 12:21:56\u000B\u001C\u001D\u001E"},
       {Timestamp(946729316, 0)});
+  testComplexCast(
+      "c0",
+      makeFlatVector<StringView>(
+          {" 9999999999.99",
+           "9999999999.99 ",
+           "\n\f\r\t\n\u001F 9999999999.99\u000B\u001C\u001D\u001E",
+           " -3E+2",
+           "-3E+2 ",
+           "\u000B\u001C\u001D-3E+2\u001E\n\f\r\t\n\u001F "}),
+      makeFlatVector<int64_t>(
+          {999'999'999'999,
+           999'999'999'999,
+           999'999'999'999,
+           -30000,
+           -30000,
+           -30000},
+          DECIMAL(12, 2)));
 }
 } // namespace
 } // namespace facebook::velox::test

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -668,7 +668,6 @@ class DecimalType : public ScalarType<KIND> {
   static_assert(KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT);
   static constexpr uint8_t kMaxPrecision = KIND == TypeKind::BIGINT ? 18 : 38;
   static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 0 : 19;
-  static constexpr uint8_t kMaxScale = kMaxPrecision;
 
   inline bool equivalent(const Type& other) const override {
     if (!Type::hasSameTypeId(other)) {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -668,6 +668,7 @@ class DecimalType : public ScalarType<KIND> {
   static_assert(KIND == TypeKind::BIGINT || KIND == TypeKind::HUGEINT);
   static constexpr uint8_t kMaxPrecision = KIND == TypeKind::BIGINT ? 18 : 38;
   static constexpr uint8_t kMinPrecision = KIND == TypeKind::BIGINT ? 0 : 19;
+  static constexpr uint8_t kMaxScale = kMaxPrecision;
 
   inline bool equivalent(const Type& other) const override {
     if (!Type::hasSameTypeId(other)) {


### PR DESCRIPTION
Spark implementation: https://github.com/apache/spark/blob/branch-3.3/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L822

Derives from Arrow function `DecimalFromString`.
Arrow implementation: https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/decimal.cc#L637