### PR TITLE
fix jsonArrayLength return and add a test

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -130,17 +130,20 @@ struct SIMDJsonArrayLengthFunction {
     ParserContext ctx(json.data(), json.size());
 
     try {
-      ctx.parseDocument();
+      ctx.parseElement();
     } catch (const simdjson::simdjson_error&) {
       return false;
     }
 
-    if (ctx.jsonDoc.type() != simdjson::ondemand::json_type::array) {
+    if (ctx.jsonEle.type() !=
+        simdjson::SIMDJSON_BUILTIN_IMPLEMENTATION::dom::element_type::ARRAY) {
       return false;
     }
 
     try {
-      len = ctx.jsonDoc.count_elements();
+      for (auto&& v : ctx.jsonEle) {
+        len++;
+      }
     } catch (const simdjson::simdjson_error&) {
       return false;
     }

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -275,6 +275,7 @@ TEST_F(JsonFunctionsTest, isJsonScalar) {
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayLength) {
+  EXPECT_EQ(jsonArrayLength(R"([)"), std::nullopt);
   EXPECT_EQ(jsonArrayLength(R"([])"), 0);
   EXPECT_EQ(jsonArrayLength(R"([1])"), 1);
   EXPECT_EQ(jsonArrayLength(R"([1, 2, 3])"), 3);


### PR DESCRIPTION
In the current implementation of jsonArrayLength, the results differ from Presto in some cases.
jsonArrayLength(R"([)") should return std::nullopt, instead of 1. fix this bug.
