### PR TITLE
Add data columns to HiveTableHandle

### DIFF
--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -101,9 +101,8 @@ class HiveTableHandle : public ConnectorTableHandle {
       const std::string& tableName,
       bool filterPushdownEnabled,
       SubfieldFilters subfieldFilters,
-      const core::TypedExprPtr& remainingFilter);
-
-  ~HiveTableHandle() override;
+      const core::TypedExprPtr& remainingFilter,
+      const RowTypePtr& dataColumns = nullptr);
 
   bool isFilterPushdownEnabled() const {
     return filterPushdownEnabled_;
@@ -115,6 +114,11 @@ class HiveTableHandle : public ConnectorTableHandle {
 
   const core::TypedExprPtr& remainingFilter() const {
     return remainingFilter_;
+  }
+
+  // Schema of the table.  Need this for reading TEXTFILE.
+  const RowTypePtr& dataColumns() const {
+    return dataColumns_;
   }
 
   std::string toString() const override;
@@ -132,6 +136,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const bool filterPushdownEnabled_;
   const SubfieldFilters subfieldFilters_;
   const core::TypedExprPtr remainingFilter_;
+  const RowTypePtr dataColumns_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorSerDeTest.cpp
@@ -80,7 +80,9 @@ TEST_F(HiveConnectorSerDeTest, hiveTableHandle) {
               "c5",
               orFilter(between("abc", "efg"), greaterThanOrEqual("dragon")))
           .build(),
-      parseExpr("c1 > c4 and c3 = true", rowType));
+      parseExpr("c1 > c4 and c3 = true", rowType),
+      "hive_table",
+      ROW({"c0", "c1"}, {BIGINT(), VARCHAR()}));
   testSerde(*tableHandle);
 }
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -79,13 +79,15 @@ class HiveConnectorTestBase : public OperatorTestBase {
   static std::shared_ptr<connector::hive::HiveTableHandle> makeTableHandle(
       common::test::SubfieldFilters subfieldFilters = {},
       const core::TypedExprPtr& remainingFilter = nullptr,
-      const std::string& tableName = "hive_table") {
+      const std::string& tableName = "hive_table",
+      const RowTypePtr& dataColumns = nullptr) {
     return std::make_shared<connector::hive::HiveTableHandle>(
         kHiveConnectorId,
         tableName,
         true,
         std::move(subfieldFilters),
-        remainingFilter);
+        remainingFilter,
+        dataColumns);
   }
 
   /// @param name Column name.

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -126,7 +126,8 @@ PlanBuilder& PlanBuilder::tableScan(
       tableName,
       true,
       std::move(filters),
-      remainingFilterExpr);
+      remainingFilterExpr,
+      nullptr);
   return tableScan(outputType, tableHandle, assignments);
 }
 

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -415,6 +415,7 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
         "hive_table",
         filterPushdownEnabled,
         connector::hive::SubfieldFilters{},
+        nullptr,
         nullptr);
   } else {
     connector::hive::SubfieldFilters filters =
@@ -424,6 +425,7 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
         "hive_table",
         filterPushdownEnabled,
         std::move(filters),
+        nullptr,
         nullptr);
   }
 


### PR DESCRIPTION
Summary:
For TEXTFILE, we cannot infer the file schema from the file content
itself, and must receive the schema via data columns from the coordinator.

Differential Revision: D46840957

