### PR TITLE
Parquet Writer: Update buffer grow factor to 1.5 (from 1)

### DIFF
--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -59,7 +59,6 @@ class E2EFilterTest : public E2EFilterTestBase {
     auto sink = std::make_unique<MemorySink>(*leafPool_, 200 * 1024 * 1024);
     sinkPtr_ = sink.get();
     options_.memoryPool = rootPool_.get();
-    options_.bufferGrowRatio = 2;
     int32_t flushCounter = 0;
     options_.flushPolicyFactory = [&]() {
       return std::make_unique<LambdaFlushPolicy>(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -29,7 +29,7 @@ class ArrowDataBufferSink : public arrow::io::OutputStream {
   ArrowDataBufferSink(
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool,
-      double growRatio = 1)
+      double growRatio)
       : sink_(std::move(sink)), growRatio_(growRatio), buffer_(pool) {}
 
   arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
@@ -75,6 +75,9 @@ class ArrowDataBufferSink : public arrow::io::OutputStream {
 
  private:
   std::unique_ptr<dwio::common::DataSink> sink_;
+  // growRatio_ parameter determines the growth factor used when invoking
+  // the reserve method of DataSink, thereby helping to minimize frequent memcpy
+  // operations.
   const double growRatio_;
   dwio::common::DataBuffer<char> buffer_;
   int64_t bytesFlushed_ = 0;

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -26,6 +26,9 @@ namespace facebook::velox::parquet {
 // Utility for buffering Arrow output with a DataBuffer.
 class ArrowDataBufferSink : public arrow::io::OutputStream {
  public:
+  /// @param growRatio Determines the growth factor used when invoking
+  /// the reserve method of DataSink, thereby helping to minimize frequent
+  /// memcpy operations.
   ArrowDataBufferSink(
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool,
@@ -75,9 +78,6 @@ class ArrowDataBufferSink : public arrow::io::OutputStream {
 
  private:
   std::unique_ptr<dwio::common::DataSink> sink_;
-  // growRatio_ parameter determines the growth factor used when invoking
-  // the reserve method of DataSink, thereby helping to minimize frequent memcpy
-  // operations.
   const double growRatio_;
   dwio::common::DataBuffer<char> buffer_;
   int64_t bytesFlushed_ = 0;

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -26,9 +26,8 @@ namespace facebook::velox::parquet {
 // Utility for buffering Arrow output with a DataBuffer.
 class ArrowDataBufferSink : public arrow::io::OutputStream {
  public:
-  /// @param growRatio Determines the growth factor used when invoking
-  /// the reserve method of DataSink, thereby helping to minimize frequent
-  /// memcpy operations.
+  /// @param growRatio Growth factor used when invoking the reserve() method of
+  /// DataSink, thereby helping to minimize frequent memcpy operations.
   ArrowDataBufferSink(
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool,

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -85,7 +85,10 @@ struct WriterOptions {
   bool enableDictionary = true;
   int64_t dataPageSize = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
-  double bufferGrowRatio = 1;
+  // Growth ratio passed to ArrowDataBufferSink. The default value is a
+  // heuristic borrowed from
+  // folly/FBVector(https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md#memory-handling).
+  double bufferGrowRatio = 1.5;
   common::CompressionKind compression = common::CompressionKind_NONE;
   velox::memory::MemoryPool* memoryPool;
   // The default factory allows the writer to construct the default flush


### PR DESCRIPTION
When we call the velox parquet write API in Gluten, the execution time can be
800s when writing 1GB TPC-DS store_sales. And we found that the performance
bottleneck is the constant reallocating of the memory pool. The reason is that
DataBuffer is directly reallocated in [reserve()]
(https://github.com/facebookincubator/velox/blob/4a2baa70ecb887e778eaf47b6f63a7590a26a37c/velox/dwio/common/DataBuffer.h#L99)
method , and `memcpy`  must be called every time, resulting in performance
degradation. 

We adjust the size of each reallocate to 1.5  times in this PR.
The execution time can be 3s with this PR. We add configurable parameter for
parquet writer to control the buffer grow ratio in
https://github.com/facebookincubator/velox/pull/4854. If users utilize the
default value 1, they will still encounter performance degradation issues. This
PR change the default value to 1.5 and refer the [folly/FBVector]
(https://github.com/facebook/folly/blob/main/folly/docs/FBVector.md#memory-handling).
