### PR TITLE
Allow DWRF writer to write map with unaligned keys and values

### DIFF
--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -1875,6 +1875,8 @@ uint64_t MapColumnWriter::write(
     auto begin = offsets[pos];
     auto end = begin + lengths[pos];
     if (end > begin) {
+      DWIO_ENSURE_LE(end, mapSlice->mapKeys()->size());
+      DWIO_ENSURE_LE(end, mapSlice->mapValues()->size());
       childRanges.add(begin, end);
     }
     nonNullLengths.unsafeAppend(end - begin);
@@ -1936,7 +1938,6 @@ uint64_t MapColumnWriter::write(
 
   uint64_t rawSize = 0;
   if (childRanges.size()) {
-    DWIO_ENSURE_EQ(mapSlice->mapKeys()->size(), mapSlice->mapValues()->size());
     rawSize += children_.at(0)->write(mapSlice->mapKeys(), childRanges);
     rawSize += children_.at(1)->write(mapSlice->mapValues(), childRanges);
   }

--- a/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/FlatMapColumnWriter.cpp
@@ -377,9 +377,13 @@ uint64_t FlatMapColumnWriter<K>::writeMap(
 
   // Lambda that iterates keys of a map and records the offsets to write to
   // particular value node.
-  auto processMap = [&](uint64_t offsetIndex, const auto& keysVector) {
+  auto processMap = [&](const MapVector* mapSlice,
+                        const uint64_t offsetIndex,
+                        const auto& keysVector) {
     auto begin = offsets[offsetIndex];
     auto end = begin + lengths[offsetIndex];
+    DWIO_ENSURE_LE(end, mapSlice->mapKeys()->size());
+    DWIO_ENSURE_LE(end, mapSlice->mapValues()->size());
 
     for (auto i = begin; i < end; ++i) {
       auto key = keysVector.valueAt(i);
@@ -406,16 +410,18 @@ uint64_t FlatMapColumnWriter<K>::writeMap(
     if (keysFlat) {
       // Keys are flat
       Flat<KeyType> keysVector{mapKeys};
-      return iterateMaps(
-          ranges, map, [&](auto offset) { processMap(offset, keysVector); });
+      return iterateMaps(ranges, map, [&](auto offset) {
+        processMap(mapSlice, offset, keysVector);
+      });
     } else {
       // Keys are encoded. Decode.
       iterateMaps(ranges, map, computeKeyRanges);
       auto localDecodedKeys = decode(mapKeys, keyRanges);
       auto& decodedKeys = localDecodedKeys.get();
       Decoded<KeyType> keysVector{decodedKeys};
-      return iterateMaps(
-          ranges, map, [&](auto offset) { processMap(offset, keysVector); });
+      return iterateMaps(ranges, map, [&](auto offset) {
+        processMap(mapSlice, offset, keysVector);
+      });
     }
   };
 


### PR DESCRIPTION
Summary: As long as all the valid offsets and sizes are in the range, this is ok.

Differential Revision: D46846162

