### PR TITLE
Fix assertReadExpected to account for the number of actual rows read in ParquetReaderTestBase

### DIFF
--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -90,10 +90,9 @@ class ParquetReaderTestBase : public testing::Test {
 
     while (total < expected->size()) {
       auto part = reader.next(1000, result);
-      EXPECT_GT(part, 0);
       if (part > 0) {
         assertEqualVectorPart(expected, result, total);
-        total += part;
+        total += result->size();
       } else {
         break;
       }


### PR DESCRIPTION
This PR fixes a small bug in `assertReadExpected` in ParquetReaderTestBase where we
would count the total rows read, i.e. actual rows that match the filter as well as the rows
that were filtered out, thus inflating the final row count. This works fine when the reader
scans all data in the file but breaks once only a subset of rows is requested.