### PR TITLE
Fix flush for parquet writer

### DIFF
--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -65,6 +65,7 @@ class E2EFilterTest : public E2EFilterTestBase {
         std::move(sink), options_);
     for (auto& batch : batches) {
       writer_->write(batch);
+      writer_->flush();
     }
     writer_->close();
   }

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -77,14 +77,10 @@ class Writer : public dwio::common::Writer {
 
  private:
   const int32_t rowsInRowGroup_;
-  const double bufferGrowRatio_;
 
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> generalPool_;
-
-  // Final destination of output.
-  std::unique_ptr<dwio::common::DataSink> finalSink_;
 
   // Temporary Arrow stream for capturing the output.
   std::shared_ptr<ArrowDataBufferSink> stream_;


### PR DESCRIPTION
Summary:
Parquet writer was not able to write a second row group after flush.

Fix https://github.com/facebookincubator/velox/issues/5314

Differential Revision: D46878122

