### PR TITLE
Make assci computation thread safe.

### DIFF
--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -452,10 +452,10 @@ void FlatVector<StringView>::copy(
       ensureIsAsciiCapacity(rows.end());
       // If we arent All ascii, then invalidate
       // because the remaining selected rows might be ascii
-      if (!isAllAscii_) {
+      if (!asciiInfo.isAllAscii()) {
         invalidateIsAscii();
       } else {
-        asciiSetRows_.deselect(rows);
+        asciiInfo.asciiSetRows().deselect(rows);
       }
     }
   }


### PR DESCRIPTION
Summary:
Input vector for expression eval can be shared across threads,
this makes it unsafe to do lock-free mutations to the vectors.

This diff makes the ascii compute thread safe, a following diff,
will mark those input vectors recursively and add checks that
guarantee that we do not call any vector mutating function on them.

Reviewed By: kevinwilfong, focus913

Differential Revision: D46878482

