### PR TITLE
Add IOBufs=preadv(Regions) support

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -59,6 +59,17 @@ void ReadFile::preadv(const std::vector<ReadFile::Segment>& segments) const {
   }
 }
 
+void ReadFile::preadv(
+    const std::vector<common::Region>& regions,
+    folly::IOBuf* output) const {
+  for (const auto& region : regions) {
+    *output = folly::IOBuf(folly::IOBuf::CREATE, region.length);
+    pread(region.offset, region.length, output->writableData());
+    output->append(region.length);
+    ++output;
+  }
+}
+
 std::string_view
 InMemoryReadFile::pread(uint64_t offset, uint64_t length, void* buf) const {
   bytesRead_ += length;

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -37,6 +37,7 @@
 #include <folly/futures/Future.h>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/file/Region.h"
 
 namespace facebook::velox {
 
@@ -85,10 +86,20 @@ class ReadFile {
   // Vectorized read API. Implementations can coalesce and parallelize.
   // It is different to the preadv above because we can add a label to the
   // segment and because the offsets don't need to be sorted.
-  // In the preadv above offsets of buffers are always
   //
   // This method should be thread safe.
   virtual void preadv(const std::vector<Segment>& segments) const;
+
+  // Vectorized read API. Implementations can coalesce and parallelize.
+  // The offsets don't need to be sorted.
+  // `output` is a pointer to an array of IOBufs to store the read data. They
+  // will be stored in the same order as the input `regions` vector. So the
+  // array must be pre-allocated by the caller, with the same size as `regions`.
+  //
+  // This method should be thread safe.
+  virtual void preadv(
+      const std::vector<common::Region>& regions,
+      folly::IOBuf* output) const;
 
   // Like preadv but may execute asynchronously and returns the read
   // size or exception via SemiFuture. Use hasPreadvAsync() to check

--- a/velox/common/file/Utils.cpp
+++ b/velox/common/file/Utils.cpp
@@ -31,4 +31,16 @@ bool CoalesceIfDistanceLE::operator()(
   return gap <= maxCoalescingDistance_;
 }
 
+bool CoalesceIfDistanceLE::operator()(
+    const velox::common::Region& a,
+    const velox::common::Region& b) const {
+  VELOX_CHECK_LE(a.offset, b.offset, "Regions to combine must be sorted.");
+  const uint64_t beginGap = a.offset + a.length, endGap = b.offset;
+
+  VELOX_CHECK_LE(beginGap, endGap, "Regions to combine can't overlap.");
+  const uint64_t gap = endGap - beginGap;
+
+  return gap <= maxCoalescingDistance_;
+}
+
 } // namespace facebook::velox::file::utils

--- a/velox/common/file/Utils.h
+++ b/velox/common/file/Utils.h
@@ -20,6 +20,7 @@
 
 #include "folly/io/Cursor.h"
 #include "velox/common/file/File.h"
+#include "velox/common/file/Region.h"
 
 namespace facebook::velox::file::utils {
 
@@ -109,6 +110,10 @@ class CoalesceIfDistanceLE {
       : maxCoalescingDistance_(maxCoalescingDistance) {}
 
   bool operator()(const ReadFile::Segment& a, const ReadFile::Segment& b) const;
+
+  bool operator()(
+      const velox::common::Region& a,
+      const velox::common::Region& b) const;
 
  private:
   uint64_t maxCoalescingDistance_;

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 
 using namespace facebook::velox;
+using facebook::velox::common::Region;
 
 constexpr int kOneMB = 1 << 20;
 
@@ -95,16 +96,43 @@ TEST(InMemoryFile, preadv) {
   // aaaaa bbbbb c*1MB ddddd
   InMemoryReadFile readFile(buf);
   std::vector<std::string> buffers = {"1234", "567", "something else", "890"};
-  std::vector<std::string> expected = {"1ab4", "567", "scccdding else", "ddd"};
+  std::vector<std::string> expected = {"1ab4", "5b7", "scccdding else", "ddd"};
   std::vector<ReadFile::Segment> readSegments = std::vector<ReadFile::Segment>{
       {4, folly::Range<char*>{&buffers[0][1], 2UL}, {}},
-      {0, folly::Range<char*>{&buffers[1][1], 0UL}, {}},
+      {5, folly::Range<char*>{&buffers[1][1], 1UL}, {}},
       {5 + 5 + kOneMB - 3, {&buffers[2][1], 5UL}, {}},
       {5 + 5 + kOneMB + 2, {&buffers[3][0], 3UL}, {}}};
 
   readFile.preadv(readSegments);
 
   EXPECT_EQ(expected, buffers);
+}
+
+TEST(InMemoryFile, preadv2) {
+  std::string buf;
+  {
+    InMemoryWriteFile writeFile(&buf);
+    writeData(&writeFile);
+  }
+  // aaaaa bbbbb c*1MB ddddd
+  InMemoryReadFile readFile(buf);
+  std::vector<std::string> expected = {"ab", "a", "cccdd", "ddd"};
+  std::vector<Region> readRegions = std::vector<Region>{
+      {4, 2UL, {}},
+      {0, 1UL, {}},
+      {5 + 5 + kOneMB - 3, 5UL, {}},
+      {5 + 5 + kOneMB + 2, 3UL, {}}};
+
+  std::vector<folly::IOBuf> iobufs(readRegions.size());
+  readFile.preadv(readRegions, iobufs.data());
+  std::vector<std::string> values;
+  values.reserve(iobufs.size());
+  for (auto& iobuf : iobufs) {
+    values.push_back(std::string{
+        reinterpret_cast<const char*>(iobuf.data()), iobuf.length()});
+  }
+
+  EXPECT_EQ(expected, values);
 }
 
 TEST(LocalFile, writeAndRead) {

--- a/velox/common/file/tests/UtilsTest.cpp
+++ b/velox/common/file/tests/UtilsTest.cpp
@@ -24,6 +24,7 @@ using namespace ::testing;
 using namespace ::facebook::velox;
 using namespace ::facebook::velox::file::utils;
 using namespace ::facebook::velox::tests::utils;
+using ::facebook::velox::common::Region;
 
 namespace {
 
@@ -33,8 +34,14 @@ class MockShouldCoalesce {
 
   MOCK_METHOD(
       bool,
-      shouldCoalesce,
+      shouldCoalesceSegments,
       (const ReadFile::Segment& a, const ReadFile::Segment& b),
+      (const));
+
+  MOCK_METHOD(
+      bool,
+      shouldCoalesceRegions,
+      (const Region& a, const Region& b),
       (const));
 };
 
@@ -45,7 +52,11 @@ class ShouldCoalesceWrapper {
 
   bool operator()(const ReadFile::Segment& a, const ReadFile::Segment& b)
       const {
-    return shouldCoalesce_.shouldCoalesce(a, b);
+    return shouldCoalesce_.shouldCoalesceSegments(a, b);
+  }
+
+  bool operator()(const Region& a, const Region& b) const {
+    return shouldCoalesce_.shouldCoalesceRegions(a, b);
   }
 
  private:
@@ -66,17 +77,29 @@ coalescedIndices(Iter begin, Iter end, ShouldCoalesce& shouldCoalesce) {
   return result;
 }
 
+enum class ComparisonType { SEGMENT, REGION };
+
 bool willCoalesceIfDistanceLE(
     uint64_t distance,
-    const std::pair<uint64_t, uint64_t>& segA,
-    const std::pair<uint64_t, uint64_t>& segB) {
-  std::string bufA(segA.second /* size */, '-');
-  std::string bufB(segB.second /* size */, '-');
-  ReadFile::Segment a{
-      segA.first, folly::Range<char*>(bufA.data(), bufA.size()), {}};
-  ReadFile::Segment b{
-      segB.first, folly::Range<char*>(bufB.data(), bufB.size()), {}};
-  return CoalesceIfDistanceLE(distance)(a, b);
+    const std::pair<uint64_t, uint64_t>& rangeA,
+    const std::pair<uint64_t, uint64_t>& rangeB,
+    ComparisonType type) {
+  if (type == ComparisonType::SEGMENT) {
+    std::string bufA(rangeA.second /* size */, '-');
+    std::string bufB(rangeB.second /* size */, '-');
+
+    ReadFile::Segment segA{
+        rangeA.first, folly::Range<char*>(bufA.data(), bufA.size()), {}};
+    ReadFile::Segment segB{
+        rangeB.first, folly::Range<char*>(bufB.data(), bufB.size()), {}};
+
+    return CoalesceIfDistanceLE(distance)(segA, segB);
+  } else {
+    Region regA{rangeA.first, rangeA.second, {}};
+    Region regB{rangeB.first, rangeB.second, {}};
+
+    return CoalesceIfDistanceLE(distance)(regA, regB);
+  }
 }
 
 auto getReader(
@@ -90,152 +113,221 @@ auto getReader(
   };
 }
 
+std::vector<Region> toRegions(const std::vector<ReadFile::Segment>& segments) {
+  std::vector<Region> regions;
+  regions.reserve(segments.size());
+  std::transform(
+      segments.cbegin(),
+      segments.cend(),
+      std::back_inserter(regions),
+      [](const auto& segment) {
+        return Region(segment.offset, segment.buffer.size(), segment.label);
+      });
+  return regions;
+}
+
 } // namespace
 
 TEST(CoalesceSegmentsTest, EmptyCase) {
   const auto testData = getSegments({});
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
+  const auto r = toRegions(s);
 
   MockShouldCoalesce shouldCoalesce;
-  EXPECT_CALL(shouldCoalesce, shouldCoalesce(_, _)).Times(0);
+  EXPECT_CALL(shouldCoalesce, shouldCoalesceSegments(_, _)).Times(0);
+  EXPECT_CALL(shouldCoalesce, shouldCoalesceRegions(_, _)).Times(0);
+
+  std::vector<std::pair<size_t, size_t>> resultSegments =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
+
+  std::vector<std::pair<size_t, size_t>> resultRegions =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
 
   std::vector<std::pair<size_t, size_t>> expected = {};
-  std::vector<std::pair<size_t, size_t>> result =
-      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(resultSegments, expected);
+  EXPECT_EQ(resultRegions, expected);
 }
 
 TEST(CoalesceSegmentsTest, MergeAll) {
   const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
+  const auto r = toRegions(s);
 
   MockShouldCoalesce shouldCoalesce;
-  for (size_t i = 1; i < p.size(); ++i) {
-    EXPECT_CALL(shouldCoalesce, shouldCoalesce(Ref(p[i - 1]), Ref(p[i])))
+  for (size_t i = 1; i < s.size(); ++i) {
+    EXPECT_CALL(
+        shouldCoalesce, shouldCoalesceSegments(Ref(s[i - 1]), Ref(s[i])))
+        .Times(1)
+        .WillOnce(Return(true));
+    EXPECT_CALL(shouldCoalesce, shouldCoalesceRegions(Ref(r[i - 1]), Ref(r[i])))
         .Times(1)
         .WillOnce(Return(true));
   }
 
+  std::vector<std::pair<size_t, size_t>> resultSegments =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
+
+  std::vector<std::pair<size_t, size_t>> resultRegions =
+      coalescedIndices(r.cbegin(), r.cend(), shouldCoalesce);
+
   std::vector<std::pair<size_t, size_t>> expected = {{0UL, 5UL}};
-  std::vector<std::pair<size_t, size_t>> result =
-      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(resultSegments, expected);
+  EXPECT_EQ(resultRegions, expected);
 }
 
 TEST(CoalesceSegmentsTest, MergeNone) {
   const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
+  const auto r = toRegions(s);
 
   MockShouldCoalesce shouldCoalesce;
-  for (size_t i = 1; i < p.size(); ++i) {
-    EXPECT_CALL(shouldCoalesce, shouldCoalesce(Ref(p[i - 1]), Ref(p[i])))
+  for (size_t i = 1; i < s.size(); ++i) {
+    EXPECT_CALL(
+        shouldCoalesce, shouldCoalesceSegments(Ref(s[i - 1]), Ref(s[i])))
+        .Times(1)
+        .WillOnce(Return(false));
+    EXPECT_CALL(shouldCoalesce, shouldCoalesceRegions(Ref(r[i - 1]), Ref(r[i])))
         .Times(1)
         .WillOnce(Return(false));
   }
 
+  std::vector<std::pair<size_t, size_t>> resultSegments =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
+
+  std::vector<std::pair<size_t, size_t>> resultRegions =
+      coalescedIndices(r.cbegin(), r.cend(), shouldCoalesce);
+
   std::vector<std::pair<size_t, size_t>> expected = {
       {0UL, 1UL}, {1UL, 2UL}, {2UL, 3UL}, {3UL, 4UL}, {4UL, 5UL}};
-  std::vector<std::pair<size_t, size_t>> result =
-      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(resultSegments, expected);
+  EXPECT_EQ(resultRegions, expected);
 }
 
 TEST(CoalesceSegmentsTest, MergeOdd) {
   const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
+  const auto r = toRegions(s);
 
   auto isOdd = [](size_t i) { return i % 2 == 1; };
 
   MockShouldCoalesce shouldCoalesce;
-  for (size_t i = 1; i < p.size(); ++i) {
-    EXPECT_CALL(shouldCoalesce, shouldCoalesce(Ref(p[i - 1]), Ref(p[i])))
+  for (size_t i = 1; i < s.size(); ++i) {
+    EXPECT_CALL(
+        shouldCoalesce, shouldCoalesceSegments(Ref(s[i - 1]), Ref(s[i])))
+        .Times(1)
+        .WillOnce(Return(isOdd(i)));
+    EXPECT_CALL(shouldCoalesce, shouldCoalesceRegions(Ref(r[i - 1]), Ref(r[i])))
         .Times(1)
         .WillOnce(Return(isOdd(i)));
   }
 
+  std::vector<std::pair<size_t, size_t>> resultSegments =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
+
+  std::vector<std::pair<size_t, size_t>> resultRegions =
+      coalescedIndices(r.cbegin(), r.cend(), shouldCoalesce);
+
   std::vector<std::pair<size_t, size_t>> expected = {
       {0UL, 2UL}, {2UL, 4UL}, {4UL, 5UL}};
-  std::vector<std::pair<size_t, size_t>> result =
-      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(resultSegments, expected);
+  EXPECT_EQ(resultRegions, expected);
 }
 
 TEST(CoalesceSegmentsTest, MergeEven) {
   const auto testData = getSegments({"aaaa", "bbbb", "c", "dd", "eee"});
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
+  const auto r = toRegions(s);
   auto isEven = [](size_t i) { return i % 2 == 0; };
 
   MockShouldCoalesce shouldCoalesce;
-  for (size_t i = 1; i < p.size(); ++i) {
-    EXPECT_CALL(shouldCoalesce, shouldCoalesce(Ref(p[i - 1]), Ref(p[i])))
+  for (size_t i = 1; i < s.size(); ++i) {
+    EXPECT_CALL(
+        shouldCoalesce, shouldCoalesceSegments(Ref(s[i - 1]), Ref(s[i])))
+        .Times(1)
+        .WillOnce(Return(isEven(i)));
+    EXPECT_CALL(shouldCoalesce, shouldCoalesceRegions(Ref(r[i - 1]), Ref(r[i])))
         .Times(1)
         .WillOnce(Return(isEven(i)));
   }
 
+  std::vector<std::pair<size_t, size_t>> resultSegments =
+      coalescedIndices(s.cbegin(), s.cend(), shouldCoalesce);
+
+  std::vector<std::pair<size_t, size_t>> resultRegions =
+      coalescedIndices(r.cbegin(), r.cend(), shouldCoalesce);
+
   std::vector<std::pair<size_t, size_t>> expected = {
       {0UL, 1UL}, {1UL, 3UL}, {3UL, 5UL}};
-  std::vector<std::pair<size_t, size_t>> result =
-      coalescedIndices(p.cbegin(), p.cend(), shouldCoalesce);
-  EXPECT_EQ(result, expected);
+  EXPECT_EQ(resultSegments, expected);
+  EXPECT_EQ(resultRegions, expected);
 }
 
-TEST(CoalesceIfDistanceLETest, MultipleCases) {
-  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 1}, {1, 1}));
-  EXPECT_FALSE(willCoalesceIfDistanceLE(0, {0, 1}, {2, 1}));
+class CoalesceIfDistanceLETest : public testing::TestWithParam<ComparisonType> {
+};
 
-  EXPECT_TRUE(willCoalesceIfDistanceLE(1, {0, 1}, {2, 1}));
+TEST_P(CoalesceIfDistanceLETest, MultipleCases) {
+  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 1}, {1, 1}, GetParam()));
+  EXPECT_FALSE(willCoalesceIfDistanceLE(0, {0, 1}, {2, 1}, GetParam()));
 
-  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 1}, {1, 1}));
-  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {10, 1}, {11, 1}));
-  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {19, 5}));
-  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {20, 5}));
-  EXPECT_FALSE(willCoalesceIfDistanceLE(10, {0, 10}, {21, 5}));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(1, {0, 1}, {2, 1}, GetParam()));
 
-  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 0}, {0, 1}));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 1}, {1, 1}, GetParam()));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {10, 1}, {11, 1}, GetParam()));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {19, 5}, GetParam()));
+  EXPECT_TRUE(willCoalesceIfDistanceLE(10, {0, 10}, {20, 5}, GetParam()));
+  EXPECT_FALSE(willCoalesceIfDistanceLE(10, {0, 10}, {21, 5}, GetParam()));
+
+  EXPECT_TRUE(willCoalesceIfDistanceLE(0, {0, 0}, {0, 1}, GetParam()));
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
+TEST_P(CoalesceIfDistanceLETest, SegmentsMustBeSorted) {
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(0, {1, 1}, {0, 1}),
+      willCoalesceIfDistanceLE(0, {1, 1}, {0, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(10, {1, 1}, {0, 1}),
+      willCoalesceIfDistanceLE(10, {1, 1}, {0, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(0, {1000, 1}, {2, 1}),
+      willCoalesceIfDistanceLE(0, {1000, 1}, {2, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(10, {1000, 1}, {2, 1}),
+      willCoalesceIfDistanceLE(10, {1000, 1}, {2, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
 }
 
-TEST(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
+TEST_P(CoalesceIfDistanceLETest, SegmentsCantOverlap) {
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(0, {0, 1}, {0, 1}),
+      willCoalesceIfDistanceLE(0, {0, 1}, {0, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(10, {0, 1}, {0, 1}),
+      willCoalesceIfDistanceLE(10, {0, 1}, {0, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(0, {0, 2}, {1, 1}),
+      willCoalesceIfDistanceLE(0, {0, 2}, {1, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(10, {0, 2}, {1, 1}),
+      willCoalesceIfDistanceLE(10, {0, 2}, {1, 1}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(0, {0, 2}, {1, 2}),
+      willCoalesceIfDistanceLE(0, {0, 2}, {1, 2}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
   EXPECT_THROW(
-      willCoalesceIfDistanceLE(10, {0, 2}, {1, 2}),
+      willCoalesceIfDistanceLE(10, {0, 2}, {1, 2}, GetParam()),
       ::facebook::velox::VeloxRuntimeError);
 }
+
+INSTANTIATE_TEST_SUITE_P(
+    CoalesceIfDistanceLESuite,
+    CoalesceIfDistanceLETest,
+    ValuesIn(std::vector<ComparisonType>(
+        {ComparisonType::SEGMENT, ComparisonType::REGION})));
 
 TEST(ReadToSegmentsTest, CanReadToContiguousSegments) {
   auto testData = getSegments({"this", "is", "an", "awesome", "test"});
   ASSERT_EQ(testData.segments.size(), 5);
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
 
-  auto readToSegments = ReadToSegments(p.begin(), p.end(), getReader());
+  auto readToSegments = ReadToSegments(s.begin(), s.end(), getReader());
 
   EXPECT_EQ(
       testData.buffers,
@@ -251,9 +343,9 @@ TEST(ReadToSegmentsTest, CanReadToContiguousSegments) {
 TEST(ReadToSegmentsTest, CanReadToNonContiguousSegments) {
   auto testData = getSegments({"this", "is", "an", "awesome", "test"}, {1, 3});
   ASSERT_EQ(testData.segments.size(), 3);
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
 
-  auto readToSegments = ReadToSegments(p.begin(), p.end(), getReader());
+  auto readToSegments = ReadToSegments(s.begin(), s.end(), getReader());
 
   EXPECT_EQ(
       testData.buffers,
@@ -269,14 +361,14 @@ TEST(ReadToSegmentsTest, CanReadToNonContiguousSegments) {
 TEST(ReadToSegmentsTest, NoSegmentsIsNoOp) {
   auto testData = getSegments({"a", "b"});
   ASSERT_EQ(testData.segments.size(), 2);
-  const auto& p = testData.segments;
+  const auto& s = testData.segments;
 
   // Set the desired read size to 0, but point to buffer to check that we don't
   // override
   testData.segments[0].buffer.reset(testData.buffers[0].data(), 0);
   testData.segments[1].buffer.reset(testData.buffers[1].data(), 0);
 
-  auto readToSegments = ReadToSegments(p.begin(), p.end(), getReader());
+  auto readToSegments = ReadToSegments(s.begin(), s.end(), getReader());
 
   EXPECT_EQ(testData.buffers, (std::vector<std::string>{"a", "b"}));
 


### PR DESCRIPTION
Summary: We'll use this new preadv(Regions) API instead of the preadv(Segments) one. We'll remove the Segments version, that nobody should be using, once we switch our code to call the new version.

Differential Revision: D46815918

