### PR TITLE
Add hiveType to HiveColumnHandle

### DIFF
--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -56,6 +56,7 @@ folly::dynamic HiveColumnHandle::serialize() const {
   obj["hiveColumnHandleName"] = name_;
   obj["columnType"] = columnTypeName(columnType_);
   obj["dataType"] = dataType_->serialize();
+  obj["hiveType"] = hiveType_->serialize();
   folly::dynamic requiredSubfields = folly::dynamic::array;
   for (const auto& subfield : requiredSubfields_) {
     requiredSubfields.push_back(subfield.toString());
@@ -83,6 +84,7 @@ ColumnHandlePtr HiveColumnHandle::create(const folly::dynamic& obj) {
   auto name = obj["hiveColumnHandleName"].asString();
   auto columnType = columnTypeFromName(obj["columnType"].asString());
   auto dataType = ISerializable::deserialize<Type>(obj["dataType"]);
+  auto hiveType = ISerializable::deserialize<Type>(obj["hiveType"]);
 
   const auto& arr = obj["requiredSubfields"];
   std::vector<common::Subfield> requiredSubfields;
@@ -92,7 +94,7 @@ ColumnHandlePtr HiveColumnHandle::create(const folly::dynamic& obj) {
   }
 
   return std::make_shared<HiveColumnHandle>(
-      name, columnType, dataType, std::move(requiredSubfields));
+      name, columnType, dataType, hiveType, std::move(requiredSubfields));
 }
 
 void HiveColumnHandle::registerSerDe() {

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -30,15 +30,42 @@ class HiveColumnHandle : public ColumnHandle {
  public:
   enum class ColumnType { kPartitionKey, kRegular, kSynthesized };
 
+  /// NOTE: 'dataType' is the column type in target write table. 'hiveType' is
+  /// converted type of the corresponding column in source table which might not
+  /// be the same type, and the table scan needs to do data coercion if needs.
+  /// The table writer also needs to respect the type difference when processing
+  /// input data such as bucket id calculation.
+  HiveColumnHandle(
+      const std::string& name,
+      ColumnType columnType,
+      TypePtr dataType,
+      TypePtr hiveType,
+      std::vector<common::Subfield> requiredSubfields = {})
+      : name_(name),
+        columnType_(columnType),
+        dataType_(std::move(dataType)),
+        hiveType_(std::move(hiveType)),
+        requiredSubfields_(std::move(requiredSubfields)) {
+    VELOX_USER_CHECK(
+        dataType_->equivalent(*hiveType_),
+        "data type {} and hive type {} do not match",
+        dataType_->toString(),
+        hiveType_->toString());
+  }
+
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   HiveColumnHandle(
       const std::string& name,
       ColumnType columnType,
       TypePtr dataType,
       std::vector<common::Subfield> requiredSubfields = {})
-      : name_(name),
-        columnType_(columnType),
-        dataType_(std::move(dataType)),
-        requiredSubfields_(std::move(requiredSubfields)) {}
+      : HiveColumnHandle(
+            name,
+            columnType,
+            dataType,
+            dataType,
+            std::move(requiredSubfields)) {}
+#endif
 
   const std::string& name() const {
     return name_;
@@ -50,6 +77,10 @@ class HiveColumnHandle : public ColumnHandle {
 
   const TypePtr& dataType() const {
     return dataType_;
+  }
+
+  const TypePtr& hiveType() const {
+    return hiveType_;
   }
 
   // Applies to columns of complex types: arrays, maps and structs.  When a
@@ -91,6 +122,7 @@ class HiveColumnHandle : public ColumnHandle {
   const std::string name_;
   const ColumnType columnType_;
   const TypePtr dataType_;
+  const TypePtr hiveType_;
   const std::vector<common::Subfield> requiredSubfields_;
 };
 

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -17,9 +17,10 @@ add_executable(
   HivePartitionFunctionTest.cpp
   FileHandleTest.cpp
   HivePartitionUtilTest.cpp
-  PartitionIdGeneratorTest.cpp
   HiveConnectorTest.cpp
-  HiveConnectorSerDeTest.cpp)
+  HiveConnectorSerDeTest.cpp
+  PartitionIdGeneratorTest.cpp
+  TableHandleTest.cpp)
 add_test(velox_hive_connector_test velox_hive_connector_test)
 
 target_link_libraries(

--- a/velox/connectors/hive/tests/TableHandleTest.cpp
+++ b/velox/connectors/hive/tests/TableHandleTest.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/TableHandle.h"
+
+#include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+
+using namespace facebook::velox;
+
+TEST(FileHandleTest, hiveColumnHandle) {
+  Type::registerSerDe();
+  connector::hive::HiveColumnHandle::registerSerDe();
+  auto columnType = ROW(
+      {{"c0c0", BIGINT()},
+       {"c0c1",
+        ARRAY(MAP(
+            VARCHAR(), ROW({{"c0c1c0", BIGINT()}, {"c0c1c1", BIGINT()}})))}});
+  auto columnHandle = exec::test::HiveConnectorTestBase::makeColumnHandle(
+      "columnHandle", columnType, columnType, {"c0.c0c1[3][\"foo\"].c0c1c0"});
+  ASSERT_EQ(columnHandle->name(), "columnHandle");
+  ASSERT_EQ(
+      columnHandle->columnType(),
+      connector::hive::HiveColumnHandle::ColumnType::kRegular);
+  ASSERT_EQ(columnHandle->dataType(), columnType);
+  ASSERT_EQ(columnHandle->hiveType(), columnType);
+  ASSERT_FALSE(columnHandle->isPartitionKey());
+
+  auto str = columnHandle->toString();
+  auto obj = columnHandle->serialize();
+  auto clone =
+      ISerializable::deserialize<connector::hive::HiveColumnHandle>(obj);
+  ASSERT_EQ(clone->toString(), str);
+
+  auto incompatibleHiveType = ROW({{"c0c0", BIGINT()}, {"c0c1", BIGINT()}});
+  VELOX_ASSERT_THROW(
+      exec::test::HiveConnectorTestBase::makeColumnHandle(
+          "columnHandle",
+          columnType,
+          incompatibleHiveType,
+          {"c0.c0c1[3][\"foo\"].c0c1c0"}),
+      "data type ROW<c0c0:BIGINT,c0c1:ARRAY<MAP<VARCHAR,ROW<c0c1c0:BIGINT,c0c1c1:BIGINT>>>> and hive type ROW<c0c0:BIGINT,c0c1:BIGINT> do not match");
+}

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -329,6 +329,7 @@ TEST_F(TableScanTest, subfieldPruningRowType) {
       "e",
       HiveColumnHandle::ColumnType::kRegular,
       columnType,
+      columnType,
       std::move(requiredSubfields));
   auto op = PlanBuilder()
                 .tableScan(rowType, makeTableHandle(), assignments)
@@ -380,6 +381,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterSubfieldsMissing) {
       "e",
       HiveColumnHandle::ColumnType::kRegular,
       columnType,
+      columnType,
       std::move(requiredSubfields));
 
   auto op = PlanBuilder()
@@ -413,7 +415,7 @@ TEST_F(TableScanTest, subfieldPruningRemainingFilterRootFieldMissing) {
   std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
       assignments;
   assignments["d"] = std::make_shared<HiveColumnHandle>(
-      "d", HiveColumnHandle::ColumnType::kRegular, BIGINT());
+      "d", HiveColumnHandle::ColumnType::kRegular, BIGINT(), BIGINT());
   auto op = PlanBuilder()
                 .tableScan(
                     ROW({{"d", BIGINT()}}),
@@ -477,6 +479,7 @@ TEST_F(TableScanTest, subfieldPruningMapType) {
   assignments["c"] = std::make_shared<HiveColumnHandle>(
       "c",
       HiveColumnHandle::ColumnType::kRegular,
+      mapType,
       mapType,
       std::move(requiredSubfields));
   auto op = PlanBuilder()
@@ -546,6 +549,7 @@ TEST_F(TableScanTest, subfieldPruningArrayType) {
   assignments["c"] = std::make_shared<HiveColumnHandle>(
       "c",
       HiveColumnHandle::ColumnType::kRegular,
+      arrayType,
       arrayType,
       std::move(requiredSubfields));
   auto op = PlanBuilder()

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -134,6 +134,15 @@ HiveConnectorTestBase::makeColumnHandle(
     const std::string& name,
     const TypePtr& type,
     const std::vector<std::string>& requiredSubfields) {
+  return makeColumnHandle(name, type, type, requiredSubfields);
+}
+
+std::shared_ptr<connector::hive::HiveColumnHandle>
+HiveConnectorTestBase::makeColumnHandle(
+    const std::string& name,
+    const TypePtr& dataType,
+    const TypePtr& hiveType,
+    const std::vector<std::string>& requiredSubfields) {
   std::vector<common::Subfield> subfields;
   subfields.reserve(requiredSubfields.size());
   for (auto& path : requiredSubfields) {
@@ -143,7 +152,8 @@ HiveConnectorTestBase::makeColumnHandle(
   return std::make_shared<connector::hive::HiveColumnHandle>(
       name,
       connector::hive::HiveColumnHandle::ColumnType::kRegular,
-      type,
+      dataType,
+      hiveType,
       std::move(subfields));
 }
 
@@ -228,12 +238,14 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
           std::make_shared<connector::hive::HiveColumnHandle>(
               tableColumnNames.at(i),
               connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+              tableColumnTypes.at(i),
               tableColumnTypes.at(i)));
     } else {
       columnHandles.push_back(
           std::make_shared<connector::hive::HiveColumnHandle>(
               tableColumnNames.at(i),
               connector::hive::HiveColumnHandle::ColumnType::kRegular,
+              tableColumnTypes.at(i),
               tableColumnTypes.at(i)));
     }
   }
@@ -249,7 +261,10 @@ HiveConnectorTestBase::regularColumn(
     const std::string& name,
     const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kRegular, type);
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kRegular,
+      type,
+      type);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>
@@ -257,7 +272,10 @@ HiveConnectorTestBase::synthesizedColumn(
     const std::string& name,
     const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kSynthesized, type);
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kSynthesized,
+      type,
+      type);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>
@@ -265,7 +283,10 @@ HiveConnectorTestBase::partitionKey(
     const std::string& name,
     const TypePtr& type) {
   return std::make_shared<connector::hive::HiveColumnHandle>(
-      name, connector::hive::HiveColumnHandle::ColumnType::kPartitionKey, type);
+      name,
+      connector::hive::HiveColumnHandle::ColumnType::kPartitionKey,
+      type,
+      type);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -98,6 +98,16 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const TypePtr& type,
       const std::vector<std::string>& requiredSubfields);
 
+  /// @param name Column name.
+  /// @param type Column type.
+  /// @param type Hive type.
+  /// @param Required subfields of this column.
+  static std::shared_ptr<connector::hive::HiveColumnHandle> makeColumnHandle(
+      const std::string& name,
+      const TypePtr& dataType,
+      const TypePtr& hiveType,
+      const std::vector<std::string>& requiredSubfields);
+
   /// @param targetDirectory Final directory of the target table after commit.
   /// @param writeDirectory Write directory of the target table before commit.
   /// @param tableType Whether to create a new table, insert into an existing

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -89,7 +89,10 @@ PlanBuilder& PlanBuilder::tableScan(
     assignments.insert(
         {name,
          std::make_shared<HiveColumnHandle>(
-             hiveColumnName, HiveColumnHandle::ColumnType::kRegular, type)});
+             hiveColumnName,
+             HiveColumnHandle::ColumnType::kRegular,
+             type,
+             type)});
   }
   SubfieldFilters filters;
   filters.reserve(subfieldFilters.size());

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -439,6 +439,7 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     assignments[outName] = std::make_shared<connector::hive::HiveColumnHandle>(
         colNameList[idx],
         connector::hive::HiveColumnHandle::ColumnType::kRegular,
+        veloxTypeList[idx],
         veloxTypeList[idx]);
     outNames.emplace_back(outName);
   }


### PR DESCRIPTION
Add hiveType to HiveColumnHandle which is a velox type parsed
from hive type set in corresponding presto proto. The hiveType
might be different than the dataType in HiveColumnHandle. The
dataType is column type in target write table while hiveType is
column type in source read table. They might not be the same and
table scan need to do the data conversion before sending data to
table writer, and the writer might need to respect the type discrepancy
in data processing such as bucket id calculation. We will add the required
table scan/table writer support later and enforce a check in HiveColumnHandle
to require the two types to be the same.