### PR TITLE
Fix MapFromEntries corner case.

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -453,4 +453,3 @@ SWITCH expression evaluation goes through the following steps:
 SWITCH expression sets EvalCtx::isFinalSelection flag to false. The expressions
 are expected to use this flag to decide whether the partially populated result
 vector must be preserved or can be overwritten.
-

--- a/velox/expression/CoalesceExpr.h
+++ b/velox/expression/CoalesceExpr.h
@@ -34,11 +34,11 @@ class CoalesceExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return false;
+ private:
+  void computePropagatesNulls() override {
+    propagatesNulls_ = false;
   }
 
- private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 
   friend class CoalesceCallToSpecialForm;

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -56,10 +56,6 @@ class ConjunctExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return false;
-  }
-
   bool isConditional() const override {
     return true;
   }
@@ -74,7 +70,12 @@ class ConjunctExpr : public SpecialForm {
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
 
+  void computePropagatesNulls() override {
+    propagatesNulls_ = false;
+  }
+
   void maybeReorderInputs();
+
   void updateResult(
       BaseVector* inputResult,
       EvalCtx& context,

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -282,9 +282,24 @@ class Expr {
     isMultiplyReferenced_ = true;
   }
 
+  template <typename T>
+  const T* as() const {
+    return dynamic_cast<const T*>(this);
+  }
+
+  template <typename T>
+  T* as() {
+    return dynamic_cast<T*>(this);
+  }
+
+  template <typename T>
+  bool is() const {
+    return as<T>() != nullptr;
+  }
+
   // True if 'this' Expr tree is null for a null in any of the columns
   // this depends on.
-  virtual bool propagatesNulls() const {
+  bool propagatesNulls() const {
     return propagatesNulls_;
   }
 

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -57,11 +57,6 @@ class LambdaExpr : public SpecialForm {
   std::string toSql(
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
-  bool propagatesNulls() const override {
-    // A null capture does not result in a null function.
-    return false;
-  }
-
   void evalSpecialForm(
       const SelectivityVector& rows,
       EvalCtx& context,
@@ -70,6 +65,11 @@ class LambdaExpr : public SpecialForm {
  private:
   /// Used to initialize captureChannels_ and typeWithCapture_ on first use.
   void makeTypeWithCapture(EvalCtx& context);
+
+  void computePropagatesNulls() override {
+    // A null capture does not result in a null function.
+    propagatesNulls_ = false;
+  }
 
   RowTypePtr signature_;
 

--- a/velox/expression/SpecialForm.h
+++ b/velox/expression/SpecialForm.h
@@ -34,5 +34,11 @@ class SpecialForm : public Expr {
             true /* specialForm */,
             supportsFlatNoNullsFastPath,
             trackCpuUsage) {}
+
+  // This is safe to call only after all metadata is computed for input
+  // expressions.
+  virtual void computePropagatesNulls() {
+    VELOX_NYI();
+  }
 };
 } // namespace facebook::velox::exec

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -48,14 +48,14 @@ class SwitchExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override;
-
   bool isConditional() const override {
     return true;
   }
 
  private:
   static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
+
+  void computePropagatesNulls() override;
 
   const size_t numCases_;
   const bool hasElseClause_;

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -41,14 +41,17 @@ class TryExpr : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
-  bool propagatesNulls() const override {
-    return inputs_[0]->propagatesNulls();
-  }
-
   void nullOutErrors(
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result);
+
+ private:
+  // This is safe to call only after all metadata is computed for input
+  // expressions.
+  void computePropagatesNulls() override {
+    propagatesNulls_ = inputs_[0]->propagatesNulls();
+  }
 };
 
 class TryCallToSpecialForm : public FunctionCallToSpecialForm {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3734,6 +3734,14 @@ TEST_F(ExprTest, nullPropagation) {
       ROW({"c0", "c1"}, {VARCHAR(), VARCHAR()}));
   EXPECT_TRUE(propagatesNulls(singleString));
   EXPECT_FALSE(propagatesNulls(twoStrings));
+
+  // Try will call propagateNulls on its child, that should not
+  // redo the computation.
+  auto switchInTry = parseExpression(
+      "try(switch(subscript(c0, array_min(c1)), FALSE, FALSE,"
+      "FALSE, is_null('6338838335202944843'::BIGINT)))",
+      ROW({"c0", "c1"}, {ARRAY({BOOLEAN()}), ARRAY({BIGINT()})}));
+  EXPECT_FALSE(propagatesNulls(switchInTry));
 }
 
 TEST_F(ExprTest, peelingWithSmallerConstantInput) {


### PR DESCRIPTION
Summary:
For an input of type array(row(int, int)) and values array(null, null, null).
Children of the row can have size 0. map_from_entries throws
error in this case.

But when in a try, those errors are silenced this leads to the construction of
a map vector  that reference elements that do not exist in keys and values.

This diff fix the issue by setting sizes of those indices to 0, this is a fuzzer found issue.
fix the issue: https://github.com/facebookincubator/velox/issues/5342

Differential Revision: D46907195

