### PR TITLE
Add to respect max capacity in arbitration

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -65,6 +65,19 @@ class SharedArbitrator : public MemoryArbitrator {
     const std::chrono::steady_clock::time_point startTime_;
   };
 
+  // Invoked to check if the memory growth will exceed the memory pool's max
+  // capacity limit or the arbitrator's node capacity limit.
+  bool checkCapacityGrowth(const MemoryPool& pool, uint64_t targetBytes) const;
+
+  // Invoked to ensure the memory growth request won't exceed the requestor's
+  // max capacity as well as the arbitrator's node capacity. If it does, then we
+  // first need to reclaim the used memory from the requestor itself to ensure
+  // the memory growth won't exceed the capacity limit, and then proceed with
+  // the memory arbitration process. The reclaimed memory capacity returns to
+  // the arbitrator, and let the memory arbitration process to grow the
+  // requestor capacity accordingly.
+  bool ensureCapacity(MemoryPool* requestor, uint64_t targetBytes);
+
   // Invoked to capture the candidate memory pools stats for arbitration.
   static std::vector<Candidate> getCandidateStats(
       const std::vector<std::shared_ptr<MemoryPool>>& pools);

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -50,7 +50,7 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   // We look for these lines separately, since their order can change (not sure
   // why).
   std::vector<std::string> expectedTexts = {
-      "Exceeded memory pool cap of 5.00MB when requesting 2.00MB"};
+      "Exceeded memory pool cap of 5.00MB with max 5.00MB when requesting 2.00MB, memory manager cap is UNLIMITED"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -115,7 +115,7 @@ TEST(MemoryManagerTest, addPoolWithArbitrator) {
   // The arbitrator capacity will be overridden by the memory manager's
   // capacity.
   options.arbitratorConfig.capacity = options.capacity;
-  const uint64_t initialPoolCapacity = options.arbitratorConfig.capacity / 8;
+  const uint64_t initialPoolCapacity = options.arbitratorConfig.capacity / 32;
   options.arbitratorConfig.initMemoryPoolCapacity = initialPoolCapacity;
   MemoryManager manager{options};
 

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -192,6 +192,10 @@ TEST_P(MemoryPoolTest, Ctor) {
     ASSERT_EQ(grandChild->root(), root.get());
     ASSERT_EQ(grandChild->capacity(), capacity);
   }
+  // Check we can't create a memory pool with zero max capacity.
+  VELOX_ASSERT_THROW(
+      manager.addRootPool("rootWithZeroMaxCapacity", 0),
+      "Memory pool rootWithZeroMaxCapacity max capacity can't be zero");
 }
 
 TEST_P(MemoryPoolTest, AddChild) {
@@ -374,8 +378,9 @@ TEST_P(MemoryPoolTest, AllocTest) {
   ASSERT_EQ(4 * kChunkSize, child->stats().peakBytes);
 }
 
-TEST_P(MemoryPoolTest, DISABLED_memoryLeakCheck) {
+TEST_P(MemoryPoolTest, memoryLeakCheck) {
   gflags::FlagSaver flagSaver;
+  testing::FLAGS_gtest_death_test_style = "fast";
   auto manager = getMemoryManager(8 * GB);
   auto root = manager->addRootPool();
 
@@ -385,6 +390,27 @@ TEST_P(MemoryPoolTest, DISABLED_memoryLeakCheck) {
   FLAGS_velox_memory_leak_check_enabled = true;
   ASSERT_DEATH(child.reset(), "");
   child->free(oneChunk, kChunkSize);
+}
+
+TEST_P(MemoryPoolTest, growBeyondMaxCapacity) {
+  gflags::FlagSaver flagSaver;
+  testing::FLAGS_gtest_death_test_style = "fast";
+  auto manager = getMemoryManager(8 * GB);
+  {
+    auto poolWithoutLimit = manager->addRootPool("poolWithoutLimit");
+    ASSERT_EQ(poolWithoutLimit->capacity(), kMaxMemory);
+    ASSERT_DEATH(
+        poolWithoutLimit->grow(1), "Can't grow with unlimited capacity");
+  }
+  {
+    const int64_t capacity = 4 * GB;
+    auto poolWithLimit = manager->addRootPool("poolWithLimit", capacity);
+    ASSERT_EQ(poolWithLimit->capacity(), capacity);
+    ASSERT_EQ(poolWithLimit->shrink(poolWithLimit->currentBytes()), capacity);
+    ASSERT_EQ(poolWithLimit->grow(capacity / 2), capacity / 2);
+    ASSERT_DEATH(
+        poolWithLimit->grow(capacity), "Can't grow beyond the max capacity");
+  }
 }
 
 TEST_P(MemoryPoolTest, ReallocTestSameSize) {
@@ -525,7 +551,7 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         ASSERT_EQ(error_code::kMemCapExceeded.c_str(), ex.errorCode());
         ASSERT_TRUE(ex.isRetriable());
         ASSERT_EQ(
-            "\nExceeded memory pool cap of 127.00MB when requesting 128.00MB, memory manager cap is 127.00MB\nMemoryCapExceptions usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
+            "\nExceeded memory pool cap of 127.00MB with max 127.00MB when requesting 128.00MB, memory manager cap is 127.00MB\nMemoryCapExceptions usage 0B peak 0B\n\nFailed memory pool: static_quota: 0B\n",
             ex.message());
       }
     }
@@ -2154,7 +2180,7 @@ TEST(MemoryPoolTest, debugMode) {
 
 TEST_P(MemoryPoolTest, shrinkAndGrowAPIs) {
   MemoryManager manager;
-  std::vector<uint64_t> capacities = {kMaxMemory, 0, 128 * MB};
+  std::vector<uint64_t> capacities = {kMaxMemory, 128 * MB};
   const int allocationSize = 8 * MB;
   for (const auto& capacity : capacities) {
     SCOPED_TRACE(fmt::format("capacity {}", succinctBytes(capacity)));
@@ -2913,7 +2939,7 @@ class MockMemoryReclaimer : public MemoryReclaimer {
 
 TEST_P(MemoryPoolTest, abortAPI) {
   MemoryManager manager;
-  std::vector<uint64_t> capacities = {kMaxMemory, 0, 128 * MB};
+  std::vector<uint64_t> capacities = {kMaxMemory, 128 * MB};
   for (const auto& capacity : capacities) {
     SCOPED_TRACE(fmt::format("capacity {}", succinctBytes(capacity)));
     {


### PR DESCRIPTION
Add to respect max capacity in arbitration. Before we start memory
arbitration, we make sure that the memory growth won't exceed the
max capacity. If it does, then we reclaim used memory from this
memory pool first. And if the growth still exceeds the limit, then we
fails the memory grow request without running arbitration.