### PR TITLE
Avoid quadratic calls to computeMetaData

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -188,7 +188,22 @@ bool Expr::allSupportFlatNoNullsFastPath(
   return true;
 }
 
+void Expr::clearMetaData() {
+  metaDataComputed_ = false;
+  for (auto child : inputs_) {
+    child->clearMetaData();
+  }
+  propagatesNulls_ = false;
+  distinctFields_.clear();
+  multiplyReferencedFields_.clear();
+  hasConditionals_ = false;
+  deterministic_ = true;
+}
+
 void Expr::computeMetadata() {
+  if (metaDataComputed_) {
+    return;
+  }
   // Compute metadata for all the inputs.
   for (auto& input : inputs_) {
     input->computeMetadata();
@@ -264,6 +279,8 @@ void Expr::computeMetadata() {
 
   // (5) Compute hasConditionals_.
   hasConditionals_ = hasConditionals(this);
+
+  metaDataComputed_ = true;
 }
 
 namespace {

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -232,6 +232,8 @@ class Expr {
     evalSpecialForm(rows, context, result);
   }
 
+  // Compute the following properties: deterministic_, propagatesNulls_,
+  // distinctFields_, multiplyReferencedFields_ and hasConditionals_.
   virtual void computeMetadata();
 
   virtual void reset() {
@@ -367,6 +369,8 @@ class Expr {
       const SelectivityVector& rows,
       EvalCtx& context,
       VectorPtr& result) const;
+
+  void clearMetaData();
 
  private:
   struct PeelEncodingsResult {
@@ -586,6 +590,10 @@ class Expr {
 
   /// Runtime statistics. CPU time, wall time and number of processed rows.
   ExprStats stats_;
+
+  // If true computeMetaData returns, otherwise meta data is computed and the
+  // flag is set to true.
+  bool metaDataComputed_ = false;
 };
 
 /// Generate a selectivity vector of a single row.

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -357,6 +357,7 @@ ExprPtr compileExpression(
       alreadyCompiled->setMultiplyReferenced();
       // A property of this expression changed, namely isMultiplyReferenced_,
       // that affects metadata, so we re-compute it.
+      alreadyCompiled->clearMetaData();
       alreadyCompiled->computeMetadata();
     }
     return alreadyCompiled;

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -67,6 +67,7 @@ class FieldReference : public SpecialForm {
     if (inputs_.empty()) {
       distinctFields_.resize(1);
       distinctFields_[0] = this;
+      metaDataComputed_ = true;
     } else {
       Expr::computeMetadata();
     }


### PR DESCRIPTION
Summary:
computeMetaData is called from  the expression compiler.
Input expressions are compiled from leaf to root, calling
computeMetaData on leafs then root.

We need to call computeMetaData in that manner, because
we do constant folding. This diff avoid recompilation when not
needed by adding a flag metaDataComputed_

Differential Revision: D46909748

