### PR TITLE
Add benchmark

### DIFF
--- a/build/fbcode_builder/manifests/benchmark
+++ b/build/fbcode_builder/manifests/benchmark
@@ -1,0 +1,13 @@
+[manifest]
+name = benchmark
+
+[download]
+url = https://github.com/google/benchmark/archive/refs/tags/v1.8.0.tar.gz
+sha256 = ea2e94c24ddf6594d15c711c06ccd4486434d9cf3eca954e2af8a20c88f9f172
+
+[build]
+builder = cmake
+subdir = benchmark-1.8.0/
+
+[cmake.defines]
+BENCHMARK_ENABLE_TESTING=OFF


### PR DESCRIPTION
Summary:
Adds the latest google benchmark version (v1.8.0) to the manifests.

This is required by Zstrong, which I'm adding in a stacked diff.

bypass-github-export-checks

Differential Revision: D46747196

