### PR TITLE
No need for computeMetaData to be virtual.

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -238,7 +238,9 @@ Executable expressions include a set of metadata that’s used during evaluation
 This is calculated by Expr::computeMetadata() virtual methods and stored in
 member variables of the exec::Expr class.
 
-* *distinctFields_* - List of distinct input columns if different from the parent expression. This list is empty if the list of distinct input columns is the same as for the parent expression.
+* *distinctFields_* - List of distinct input columns.
+* *multiplyReferencedFields_* - Subset of distinctFields_ that are used as inputs by multiple subexpressions.
+* *sameAsParentDistinctFields_* - True if distinctFields_ matches one of the parent's distinctFields_ (parents to refer expressions that have this expression as input).
 * *propagatesNulls_* - Boolean indicating whether a null in any of the input columns causes this expression to always return null for the row.
 * *deterministic_* - Boolean indicating whether this expression and all its children are deterministic.
 * *hasConditionals_* - Boolean indicating whether this expression or any of its children is an IF, SWITCH, AND or OR expression.

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -205,6 +205,7 @@ void Expr::computeMetadata() {
   if (metaDataComputed_) {
     return;
   }
+
   // Compute metadata for all the inputs.
   for (auto& input : inputs_) {
     input->computeMetadata();
@@ -230,10 +231,14 @@ void Expr::computeMetadata() {
         distinctFields_, multiplyReferencedFields_, input->distinctFields_);
   }
 
+  if (is<FieldReference>() && inputs_.empty()) {
+    distinctFields_.resize(1);
+    distinctFields_[0] = this->as<FieldReference>();
+  }
+
   // (3) Compute propagatesNulls_.
   // propagatesNulls_ is true iff a null in any of the columns this
   // depends on makes the Expr null.
-
   if (isSpecialForm() && !is<ConstantExpr>() && !is<FieldReference>() &&
       !is<CastExpr>()) {
     as<SpecialForm>()->computePropagatesNulls();

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -235,7 +235,7 @@ class Expr {
   // Compute the following properties: deterministic_, propagatesNulls_,
   // distinctFields_, multiplyReferencedFields_, hasConditionals_ and
   // sameAsParentDistinctFields_.
-  virtual void computeMetadata();
+  void computeMetadata();
 
   virtual void reset() {
     sharedSubexprResults_.clear();

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -61,18 +61,6 @@ class FieldReference : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
- protected:
-  void computeMetadata() override {
-    propagatesNulls_ = true;
-    if (inputs_.empty()) {
-      distinctFields_.resize(1);
-      distinctFields_[0] = this;
-      metaDataComputed_ = true;
-    } else {
-      Expr::computeMetadata();
-    }
-  }
-
  private:
   const std::string field_;
   int32_t index_ = -1;

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -70,7 +70,7 @@ void SwitchExpr::evalSpecialForm(
     // else load access the same vectors, so there is no extra loading.
     DecodedVector decoded;
     auto& remaining = *remainingRows.get();
-    for (const auto& field : distinctFields_) {
+    for (auto* field : distinctFields_) {
       context.ensureFieldLoaded(field->index(context), remaining);
       const auto& vector = context.getField(field->index(context));
       if (vector->mayHaveNulls()) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -37,9 +37,8 @@
 #include "velox/vector/tests/TestingAlwaysThrowsFunction.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
-using namespace facebook::velox;
-using namespace facebook::velox::test;
-
+namespace facebook::velox::test {
+namespace {
 class ExprTest : public testing::Test, public VectorTestBase {
  protected:
   void SetUp() override {
@@ -4012,3 +4011,15 @@ TEST_F(ExprTest, dereference) {
   auto expected = makeNullConstant(TypeKind::BIGINT, 6);
   assertEqualVectors(expected, result);
 }
+
+TEST_F(ExprTest, inputFreeFieldReferenceMetaData) {
+  auto exprSet = compileExpression("c0", {ROW({"c0"}, {INTEGER()})});
+  auto expr = exprSet->expr(0);
+  EXPECT_EQ(expr->distinctFields().size(), 1);
+  EXPECT_EQ((void*)expr->distinctFields()[0], expr.get());
+
+  EXPECT_TRUE(expr->propagatesNulls());
+  EXPECT_TRUE(expr->isDeterministic());
+}
+} // namespace
+} // namespace facebook::velox::test


### PR DESCRIPTION
Summary:
computeMetaData was virtual, however only one expression names FieldReference
override it. The FieldReference computeMetaData calls back the base
computeMetaData when there is inputs.

Moreover, meta data for field reference is computed in the same way as other special
form expect for distinct fields when there is no inputs.

This diff remove the virtual and handles field reference in computeMetaData

Differential Revision: D46916994

