### PR TITLE
redefine distinctFields and make skipPeeling optimization explicit.

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -238,7 +238,9 @@ Executable expressions include a set of metadata that’s used during evaluation
 This is calculated by Expr::computeMetadata() virtual methods and stored in
 member variables of the exec::Expr class.
 
-* *distinctFields_* - List of distinct input columns if different from the parent expression. This list is empty if the list of distinct input columns is the same as for the parent expression.
+* *distinctFields_* - List of distinct input columns.
+* *multiplyReferencedFields_* - Subset of distinctFields_ that are used as inputs by multiple subexpressions.
+* *sameAsParentDistinctFields_* - True if distinctFields_ matches one of the parent's distinctFields_ (parents to refer expressions that have this expression as input).
 * *propagatesNulls_* - Boolean indicating whether a null in any of the input columns causes this expression to always return null for the row.
 * *deterministic_* - Boolean indicating whether this expression and all its children are deterministic.
 * *hasConditionals_* - Boolean indicating whether this expression or any of its children is an IF, SWITCH, AND or OR expression.

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -70,7 +70,7 @@ void SwitchExpr::evalSpecialForm(
     // else load access the same vectors, so there is no extra loading.
     DecodedVector decoded;
     auto& remaining = *remainingRows.get();
-    for (const auto& field : distinctFields_) {
+    for (auto* field : distinctFields_) {
       context.ensureFieldLoaded(field->index(context), remaining);
       const auto& vector = context.getField(field->index(context));
       if (vector->mayHaveNulls()) {


### PR DESCRIPTION
Summary:
distinctFields was defined as
1. the distinct fields of the expression.
2. or empty list if the expression is singe referenced and have the
same as its parent distinct fields.

(2) was added to optimize peeling (avoiding it) when fields are known
to be shared with parents.
This diff splits the optimization from the definition of the  distinct fields
and makes it explicit using skipPeeling() function.
With this users of the library can always trust that  distinct fields refers to the
expression's distinct fields.

Differential Revision: D46915886

