### PR TITLE
Fix out-of-range condition buffer access in SwitchExpr

### DIFF
--- a/velox/expression/BooleanMix.cpp
+++ b/velox/expression/BooleanMix.cpp
@@ -34,6 +34,11 @@ BooleanMix refineBooleanMixNonNull(
 }
 } // namespace
 
+// Return a BooleanMix representing the status of boolean values in vector. If
+// vector contains a mix of true and false, extract the boolean values to a raw
+// buffer valuesOut. valuesOut may point to a raw buffer possessed by vector.
+// nullsOut remain unchanged if there is no null in vector. tempValues and
+// tempNulls may or may not be set by this function.
 BooleanMix getFlatBool(
     BaseVector* vector,
     const SelectivityVector& activeRows,

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -105,7 +105,6 @@ void SwitchExpr::evalSpecialForm(
         true,
         &values,
         nullptr);
-    context.releaseVector(condition);
     switch (booleanMix) {
       case BooleanMix::kAllTrue:
         inputs_[2 * i + 1]->eval(*remainingRows.get(), context, result);
@@ -115,12 +114,13 @@ void SwitchExpr::evalSpecialForm(
       case BooleanMix::kAllFalse:
         continue;
       default: {
+        thenRows.get(remainingRows->end(), false);
         bits::andBits(
-            thenRows.get(rows.end(), false)->asMutableRange().bits(),
+            thenRows.get()->asMutableRange().bits(),
             remainingRows.get()->asRange().bits(),
             values,
             0,
-            rows.end());
+            remainingRows->end());
         thenRows.get()->updateBounds();
 
         if (thenRows.get()->hasSelections()) {
@@ -129,6 +129,7 @@ void SwitchExpr::evalSpecialForm(
         }
       }
     }
+    context.releaseVector(condition);
   }
 
   // Evaluate the "else" clause.


### PR DESCRIPTION
Summary: When evaluating a branch, SwitchExpr first evaluates the condition sub-expression into a `condition` vector. getFlatBool() is then called to extract a  uint64_t* buffer of values in `condition` to participate the subsequent bit operation that computes a SelectivityVector of rows that pass the condition. However, `condition` is guaranteed to be at least of the size `remainingRows->end()` while the bit operaiton is performed from bit 0 to rows.end() that may be larger than remainingRows->end(), hence causing out-of-range access error. This diff fixes this bug by making the bit operation performed from bit 0 to remainingRows->end().

Differential Revision: D46920659

