### PR TITLE
Bundled folly installation needs to link with openssl@1.1

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -25,6 +25,23 @@ resolve_dependency_url(FOLLY)
 
 message(STATUS "Building Folly from source")
 
+if(APPLE AND NOT DEFINED OPENSSL_ROOT_DIR)
+  find_program(BREW brew)
+  if(BREW)
+    execute_process(
+      COMMAND brew --prefix openssl@1.1
+      OUTPUT_VARIABLE OPENSSL_ROOT_DIR
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    set(ENV{OPENSSL_ROOT_DIR} ${OPENSSL_ROOT_DIR})
+  endif()
+  if(NOT OPENSSL_ROOT_DIR)
+    message(
+      FATAL_ERROR
+        "Unable to locate brew prefix for OpenSSL 1.1. Please install with `brew install openssl@1.1` or set OPENSSL_ROOT_DIR"
+    )
+  endif()
+endif()
+
 if(gflags_SOURCE STREQUAL "BUNDLED")
   set(glog_patch && git apply ${CMAKE_CURRENT_LIST_DIR}/folly-gflags-glog.patch)
 endif()


### PR DESCRIPTION
Summary:
Folly needs OpenSSL 1.1 version to function. In the presence of other OpenSSL versions,
 it is possible that folly in bundled mode can pick up other incompatible versions causing the build to fail.

Currently, in the `setup-macos.sh` script, we set
OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1).

We require a similar change for the bundled folly installs as well. To achieve this goal, we now set the `OPENSSL_ROOT_DIR` environment variable via the CMake file to set the path to the correct version of OpenSSL.

Resolves #5309