### PR TITLE
Fix potential concurrency bug in SsdFile::updateStats

### DIFF
--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -214,7 +214,7 @@ class SsdFile {
   // Asserts that the region of 'offset' is pinned. This is called by
   // the pin holder. The pin count can be read without mutex.
   void checkPinned(uint64_t offset) const {
-    tsan_lock_guard<std::mutex> l(mutex_);
+    tsan_lock_guard<std::shared_mutex> l(mutex_);
     VELOX_CHECK_LT(0, regionPins_[regionIndex(offset)]);
   }
 
@@ -318,7 +318,7 @@ class SsdFile {
   void logEviction(const std::vector<int32_t>& regions);
 
   // Serializes access to all private data members.
-  mutable std::mutex mutex_;
+  mutable std::shared_mutex mutex_;
   // Name of cache file, used as prefix for checkpoint files.
   std::string fileName_;
   static constexpr const char* FOLLY_NONNULL kLogExtension = ".log";


### PR DESCRIPTION
Summary:
The test AsyncDataCacheTest.ssd is currently flaky.  When it fails it reports that numPins in the stats from
the SsdCache is more than 0 when it's expected to be 0.

My theory (I'm having trouble consistently reproducing it) is that this is due to cache incoherence between
the threads that are pinning/unpinning regions and the main thread.

The numPins stats is gotten by summing up all the pins across all regions across all SsdFiles in the
SsdCache.  Each SsdFile has an std::vector, counting all the pins across all regions.  Multiple threads update
this std::vector as regions are pinned/unpinned each taking a lock as they do so.  When we call updateStats
on the SsdFile, we don't take a lock (except, somewhat tellingly, in TSAN mode which would complain
otherwise) when we read from that std::vector.

According to the description of the C++ memory model as I understand it, without something to synchronize
threads A and B, if they run on separate cores, B may not see all updates made by A due to cache
incoherence. https://en.cppreference.com/w/cpp/atomic/memory_order (and is also why TSAN is
complaining)

Acquiring a mutex is one way to synchronize threads, so we just need to make that mutex lock happen
across all modes, not just TSAN.

In terms of performance, other than tests
* SsdFile::updateStats() is only called from SsdCache::stats()
* SsdCache::stats() is only called from SsdCache::toString() (which I assume is only used for debugging
purposes) and AsyncDataCache::refreshStats()
* AsyncDataCache::refreshStats() is only called from AsyncDataCache::toString() (which I again assume is
only used for debugging)

So it shouldn't have any impact on production.

Differential Revision: D46953325

