### PR TITLE
Change preadv signature to use folly::Ranges

### DIFF
--- a/velox/common/file/File.cpp
+++ b/velox/common/file/File.cpp
@@ -60,13 +60,15 @@ void ReadFile::preadv(const std::vector<ReadFile::Segment>& segments) const {
 }
 
 void ReadFile::preadv(
-    const std::vector<common::Region>& regions,
-    folly::IOBuf* output) const {
-  for (const auto& region : regions) {
-    *output = folly::IOBuf(folly::IOBuf::CREATE, region.length);
-    pread(region.offset, region.length, output->writableData());
-    output->append(region.length);
-    ++output;
+    folly::Range<const common::Region*> regions,
+    folly::Range<folly::IOBuf*> iobufs) const {
+  VELOX_CHECK_EQ(regions.size(), iobufs.size());
+  for (size_t i = 0; i < regions.size(); ++i) {
+    const auto& region = regions[i];
+    auto& output = iobufs[i];
+    output = folly::IOBuf(folly::IOBuf::CREATE, region.length);
+    pread(region.offset, region.length, output.writableData());
+    output.append(region.length);
   }
 }
 

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -92,14 +92,16 @@ class ReadFile {
 
   // Vectorized read API. Implementations can coalesce and parallelize.
   // The offsets don't need to be sorted.
-  // `output` is a pointer to an array of IOBufs to store the read data. They
+  // `iobufs` is a range of IOBufs to store the read data. They
   // will be stored in the same order as the input `regions` vector. So the
-  // array must be pre-allocated by the caller, with the same size as `regions`.
+  // array must be pre-allocated by the caller, with the same size as `regions`,
+  // but don't need to be initialized, since each iobuf will be copy-constructed
+  // by the preadv.
   //
   // This method should be thread safe.
   virtual void preadv(
-      const std::vector<common::Region>& regions,
-      folly::IOBuf* output) const;
+      folly::Range<const common::Region*> regions,
+      folly::Range<folly::IOBuf*> iobufs) const;
 
   // Like preadv but may execute asynchronously and returns the read
   // size or exception via SemiFuture. Use hasPreadvAsync() to check

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -124,7 +124,7 @@ TEST(InMemoryFile, preadv2) {
       {5 + 5 + kOneMB + 2, 3UL, {}}};
 
   std::vector<folly::IOBuf> iobufs(readRegions.size());
-  readFile.preadv(readRegions, iobufs.data());
+  readFile.preadv(readRegions, {iobufs.data(), iobufs.size()});
   std::vector<std::string> values;
   values.reserve(iobufs.size());
   for (auto& iobuf : iobufs) {

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -131,8 +131,8 @@ bool ReadFileInputStream::hasReadAsync() const {
 }
 
 void ReadFileInputStream::vread(
-    const std::vector<velox::common::Region>& regions,
-    folly::IOBuf* output,
+    folly::Range<const velox::common::Region*> regions,
+    folly::Range<folly::IOBuf*> iobufs,
     const LogType purpose) {
   DWIO_ENSURE_GT(regions.size(), 0, "regions to read can't be empty");
   const size_t length = std::accumulate(
@@ -142,7 +142,7 @@ void ReadFileInputStream::vread(
       [&](size_t acc, const auto& r) { return acc + r.length; });
   logRead(regions[0].offset, length, purpose);
   auto readStartMs = getCurrentTimeMs();
-  readFile_->preadv(regions, output);
+  readFile_->preadv(regions, iobufs);
   if (stats_) {
     stats_->incRawBytesRead(length);
     stats_->incTotalScanTime(getCurrentTimeMs() - readStartMs);

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -119,11 +119,11 @@ class InputStream {
    * Take advantage of vectorized read API provided by some file system.
    * Allow file system to do optimzied reading plan to disk to minimize
    * total bytes transferred through network. Stores the result in an IOBuf
-   * array starting at `output`, which must have the same size as `regions`.
+   * range named at `iobufs`, which must have the same size as `regions`.
    */
   virtual void vread(
-      const std::vector<velox::common::Region>& regions,
-      folly::IOBuf* output,
+      folly::Range<const velox::common::Region*> regions,
+      folly::Range<folly::IOBuf*> iobufs,
       const LogType purpose) = 0;
 
   // case insensitive find
@@ -173,8 +173,8 @@ class ReadFileInputStream final : public InputStream {
   bool hasReadAsync() const override;
 
   void vread(
-      const std::vector<velox::common::Region>& regions,
-      folly::IOBuf* output,
+      folly::Range<const velox::common::Region*> regions,
+      folly::Range<folly::IOBuf*> iobufs,
       const LogType purpose) override;
 
   const std::shared_ptr<velox::ReadFile>& getReadFile() const {

--- a/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
+++ b/velox/dwio/common/tests/ReadFileInputStreamTests.cpp
@@ -60,7 +60,7 @@ TEST(ReadFileInputStream, VReadIOBufs) {
   ASSERT_EQ(inputStream.getLength(), 15);
   std::vector<Region> regions = {{0, 6}, {9, 5}};
   std::vector<folly::IOBuf> iobufs(regions.size());
-  inputStream.vread(regions, iobufs.data(), LogType::STREAM);
+  inputStream.vread(regions, {iobufs.data(), iobufs.size()}, LogType::STREAM);
   std::vector<std::string> result;
   std::transform(
       iobufs.cbegin(),


### PR DESCRIPTION
Summary: To address concerns of using raw pointers.

Differential Revision: D46958136

