### PR TITLE
More flexible serializer support in remote functions

### DIFF
--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -18,7 +18,9 @@
 
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/remote/client/Remote.h"
 #include "velox/functions/remote/client/ThriftClient.h"
+#include "velox/functions/remote/if/GetSerde.h"
 #include "velox/functions/remote/if/gen-cpp2/RemoteFunctionServiceAsyncClient.h"
 #include "velox/vector/VectorStream.h"
 
@@ -29,11 +31,13 @@ class RemoteFunction : public exec::VectorFunction {
  public:
   RemoteFunction(
       const std::string& functionName,
-      folly::SocketAddress location,
-      const std::vector<exec::VectorFunctionArg>& inputArgs)
+      const std::vector<exec::VectorFunctionArg>& inputArgs,
+      const RemoteVectorFunctionMetadata& metadata)
       : functionName_(functionName),
-        location_(location),
-        thriftClient_(getThriftClient(location_)) {
+        location_(metadata.location),
+        thriftClient_(getThriftClient(location_)),
+        serdeFormat_(metadata.serdeFormat),
+        serde_(getSerde(serdeFormat_)) {
     std::vector<TypePtr> types;
     types.reserve(inputArgs.size());
     serializedInputTypes_.reserve(inputArgs.size());
@@ -95,23 +99,26 @@ class RemoteFunction : public exec::VectorFunction {
 
     auto requestInputs = request.inputs_ref();
     requestInputs->rowCount_ref() = remoteRowVector->size();
-    requestInputs->pageFormat_ref() = remote::PageFormat::PRESTO_PAGE;
+    requestInputs->pageFormat_ref() = serdeFormat_;
 
     // TODO: serialize only active rows.
-    requestInputs->payload_ref() =
-        rowVectorToIOBuf(remoteRowVector, rows.end(), *context.pool());
+    requestInputs->payload_ref() = rowVectorToIOBuf(
+        remoteRowVector, rows.end(), *context.pool(), serde_.get());
 
     thriftClient_->sync_invokeFunction(remoteResponse, request);
     auto outputRowVector = IOBufToRowVector(
         remoteResponse.get_result().get_payload(),
         ROW({outputType}),
-        *context.pool());
+        *context.pool(),
+        serde_.get());
     result = outputRowVector->childAt(0);
   }
 
   const std::string functionName_;
   folly::SocketAddress location_;
   std::unique_ptr<RemoteFunctionClient> thriftClient_;
+  remote::PageFormat serdeFormat_;
+  std::unique_ptr<VectorSerde> serde_;
 
   // Structures we construct once to cache:
   RowTypePtr remoteInputType_;
@@ -121,8 +128,8 @@ class RemoteFunction : public exec::VectorFunction {
 std::shared_ptr<exec::VectorFunction> createRemoteFunction(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
-    folly::SocketAddress location) {
-  return std::make_unique<RemoteFunction>(name, location, inputArgs);
+    const RemoteVectorFunctionMetadata& metadata) {
+  return std::make_unique<RemoteFunction>(name, inputArgs, metadata);
 }
 
 } // namespace
@@ -130,8 +137,7 @@ std::shared_ptr<exec::VectorFunction> createRemoteFunction(
 void registerRemoteFunction(
     const std::string& name,
     std::vector<exec::FunctionSignaturePtr> signatures,
-    folly::SocketAddress location,
-    exec::VectorFunctionMetadata metadata,
+    const RemoteVectorFunctionMetadata& metadata,
     bool overwrite) {
   exec::registerStatefulVectorFunction(
       name,
@@ -140,7 +146,7 @@ void registerRemoteFunction(
           createRemoteFunction,
           std::placeholders::_1,
           std::placeholders::_2,
-          location),
+          metadata),
       metadata,
       overwrite);
 }

--- a/velox/functions/remote/client/Remote.h
+++ b/velox/functions/remote/client/Remote.h
@@ -18,11 +18,21 @@
 
 #include <folly/SocketAddress.h>
 #include "velox/expression/VectorFunction.h"
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunction_types.h"
 
 namespace facebook::velox::functions {
 
-/// Registers a new remote function that will serialize input data and
-/// communicate with a server at `location`.
+struct RemoteVectorFunctionMetadata : public exec::VectorFunctionMetadata {
+  /// Network address of the server to communicate with.
+  folly::SocketAddress location;
+
+  /// The serialization format to be used
+  remote::PageFormat serdeFormat{remote::PageFormat::PRESTO_PAGE};
+};
+
+/// Registers a new remote function. It will use the meatadata defined in
+/// `RemoteVectorFunctionMetadata` to control the serialization format and
+/// remote server address.
 //
 /// Remote functions are registered as regular statufull functions (using the
 /// same internal catalog), and hence conflict if there already exists a
@@ -31,8 +41,7 @@ namespace facebook::velox::functions {
 void registerRemoteFunction(
     const std::string& name,
     std::vector<exec::FunctionSignaturePtr> signatures,
-    folly::SocketAddress location,
-    exec::VectorFunctionMetadata metadata = {},
+    const RemoteVectorFunctionMetadata& metadata = {},
     bool overwrite = true);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/remote/if/GetSerde.cpp
+++ b/velox/functions/remote/if/GetSerde.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/remote/if/GetSerde.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/serializers/UnsafeRowSerializer.h"
+
+namespace facebook::velox::functions {
+
+std::unique_ptr<VectorSerde> getSerde(const remote::PageFormat& format) {
+  switch (format) {
+    case remote::PageFormat::PRESTO_PAGE:
+      return std::make_unique<serializer::presto::PrestoVectorSerde>();
+
+    case remote::PageFormat::SPARK_UNSAFE_ROW:
+      return std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
+  }
+}
+
+} // namespace facebook::velox::functions

--- a/velox/functions/remote/if/GetSerde.h
+++ b/velox/functions/remote/if/GetSerde.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/remote/if/gen-cpp2/RemoteFunction_types.h"
+
+namespace facebook::velox {
+class VectorSerde;
+}
+
+namespace facebook::velox::functions {
+
+std::unique_ptr<VectorSerde> getSerde(const remote::PageFormat& format);
+
+} // namespace facebook::velox::functions

--- a/velox/vector/VectorStream.h
+++ b/velox/vector/VectorStream.h
@@ -102,8 +102,12 @@ VectorSerde* getNamedVectorSerde(std::string_view serdeName);
 
 class VectorStreamGroup : public StreamArena {
  public:
-  explicit VectorStreamGroup(memory::MemoryPool* FOLLY_NONNULL pool)
-      : StreamArena(pool) {}
+  /// If `serde` is not specified, fallback to the default registered.
+  explicit VectorStreamGroup(
+      memory::MemoryPool* FOLLY_NONNULL pool,
+      VectorSerde* serde = nullptr)
+      : StreamArena(pool),
+        serde_(serde != nullptr ? serde : getVectorSerde()) {}
 
   void createStreamTree(
       RowTypePtr type,
@@ -134,25 +138,29 @@ class VectorStreamGroup : public StreamArena {
 
  private:
   std::unique_ptr<VectorSerializer> serializer_;
+  VectorSerde* serde_{nullptr};
 };
 
 /// Convenience function to serialize a single rowVector into an IOBuf using the
 /// registered serde object.
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
-    memory::MemoryPool& pool);
+    memory::MemoryPool& pool,
+    VectorSerde* serde = nullptr);
 
 /// Same as above but serializes up until row `rangeEnd`.
 folly::IOBuf rowVectorToIOBuf(
     const RowVectorPtr& rowVector,
     vector_size_t rangeEnd,
-    memory::MemoryPool& pool);
+    memory::MemoryPool& pool,
+    VectorSerde* serde = nullptr);
 
-/// Convenience function to deserialize an IOBuf into a rowVector using the
-/// registered serde object.
+/// Convenience function to deserialize an IOBuf into a rowVector. If `serde` is
+/// nullptr, use the default installed serializer.
 RowVectorPtr IOBufToRowVector(
     const folly::IOBuf& ioBuf,
     const RowTypePtr& outputType,
-    memory::MemoryPool& pool);
+    memory::MemoryPool& pool,
+    VectorSerde* serde = nullptr);
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
Make remote functions able to specify serializer based on a serde
format in a more flexible manner, without relying on the default serializer
installed in the process. This is needed because different remote functions
might need to communicate with different remote services, using distinct serialization
formats.
Now the serialization format can be defined when registering the function, as
part of the metadata.

Differential Revision: D46960082

