### PR TITLE
RFC: simplify benchmark creation using ExpressionBenchmarkBuilder

### DIFF
--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -13,6 +13,24 @@
 # limitations under the License.
 add_subdirectory(basic)
 
+set(velox_benchmark_deps
+    velox_type
+    velox_vector
+    velox_vector_fuzzer
+    velox_expression
+    velox_parse_parser
+    velox_parse_utils
+    velox_parse_expression
+    velox_serialization
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    ${DOUBLE_CONVERSION}
+    gflags::gflags
+    glog::glog)
+
+add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
+target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
+
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)
 endif()

--- a/velox/benchmarks/ExpressionBenchmarkBuilder.cpp
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.cpp
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include <folly/Benchmark.h>
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox {
+
+ExpressionBenchmarkSet& ExpressionBenchmarkSet::addExpression(
+    const std::string& name,
+    const std::string& expression) {
+  VELOX_CHECK(!expressions_.count(name), "expression name already used");
+  expressions_.emplace(
+      name, builder_.compileExpression(expression, inputType_));
+  return *this;
+}
+
+ExpressionBenchmarkSet& ExpressionBenchmarkSet::addExpressions(
+    const std::vector<std::pair<std::string, std::string>>& expressions) {
+  for (auto& [name, expression] : expressions) {
+    addExpression(name, expression);
+  }
+  return *this;
+}
+
+// Make sure all input vectors are generated.
+void ExpressionBenchmarkBuilder::ensureInputVectors() {
+  for (auto& [_, benchmarkSet] : benchmarkSets_) {
+    if (!benchmarkSet.inputRowVetor_) {
+      VectorFuzzer fuzzer(benchmarkSet.fuzzerOptions_, pool());
+      benchmarkSet.inputRowVetor_ = std::dynamic_pointer_cast<RowVector>(
+          fuzzer.fuzzFlat(benchmarkSet.inputType_));
+    }
+  }
+}
+
+void ExpressionBenchmarkBuilder::testBenchmarks() {
+  ensureInputVectors();
+
+  auto evalExpression = [&](auto& exprSet, auto& inputVector) {
+    exec::EvalCtx evalCtx(&this->execCtx_, &exprSet, inputVector.get());
+    SelectivityVector rows(inputVector->size());
+    std::vector<VectorPtr> results(1);
+    exprSet.eval(rows, evalCtx, results);
+    return results[0];
+  };
+
+  auto testBenchmarkSet = [&](auto& benchmarkSet) {
+    if (benchmarkSet.expressions_.size() == 0) {
+      return;
+    }
+    // Evaluate the first expression.
+    auto it = benchmarkSet.expressions_.begin();
+    auto refResult = evalExpression(it->second, benchmarkSet.inputRowVetor_);
+    it++;
+    while (it != benchmarkSet.expressions_.end()) {
+      auto result = evalExpression(it->second, benchmarkSet.inputRowVetor_);
+      test::assertEqualVectors(refResult, result);
+      it++;
+    }
+  };
+
+  for (auto& [_, benchmarkSet] : benchmarkSets_) {
+    if (!benchmarkSet.disableTesting_) {
+      testBenchmarkSet(benchmarkSet);
+    }
+  }
+}
+
+void ExpressionBenchmarkBuilder::registerBenchmarks() {
+  ensureInputVectors();
+  // Generate input vectors if needed.
+  for (auto& [setName, benchmarkSet] : benchmarkSets_) {
+    for (auto& [exprName, exprSet] : benchmarkSet.expressions_) {
+      auto name = fmt::format("{}##{}", setName, exprName);
+      auto& inputVector = benchmarkSet.inputRowVetor_;
+      auto times = benchmarkSet.itterations_;
+      // The compiler does not allow capturing exprSet int the lambda
+      auto& exprSetLocal = exprSet;
+      folly::addBenchmark(
+          __FILE__, name, [this, &inputVector, &exprSetLocal, times]() {
+            int cnt = 0;
+            folly::BenchmarkSuspender suspender;
+            // TODO: shall we cache those.
+            exec::EvalCtx evalCtx(
+                &this->execCtx_, &exprSetLocal, inputVector.get());
+            SelectivityVector rows(inputVector->size());
+            suspender.dismiss();
+
+            std::vector<VectorPtr> results(1);
+            for (auto i = 0; i < times; i++) {
+              exprSetLocal.eval(rows, evalCtx, results);
+
+              // TODO: add flag to enable/disable flatenning.
+              BaseVector::flattenVector(results[0]);
+
+              // TODO: add flag to enable/disable reuse.
+              results[0]->prepareForReuse();
+
+              cnt += results[0]->size();
+            }
+            folly::doNotOptimizeAway(cnt);
+            return 1;
+          });
+    }
+    BENCHMARK_DRAW_LINE();
+    BENCHMARK_DRAW_LINE();
+  }
+}
+} // namespace facebook::velox

--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+namespace facebook::velox {
+
+class ExpressionBenchmarkBuilder;
+
+// This class represents a set of expressions to benchmark those expressions
+// uses the same input vector type, and are expected to have the same result
+// if testing is not disabled for the set.
+// Users can pass the inputVector explicitly, if not passed a flat vector will
+// be fuzzed with some default fuzzer options. Users can also pass fuzzer
+// config to be used.
+class ExpressionBenchmarkSet {
+ public:
+  ExpressionBenchmarkSet& addExpression(
+      const std::string& name,
+      const std::string& expression);
+
+  ExpressionBenchmarkSet& addExpressions(
+      const std::vector<std::pair<std::string, std::string>>& expressions);
+
+  ExpressionBenchmarkSet& disableTesting() {
+    disableTesting_ = true;
+    return *this;
+  }
+
+  ExpressionBenchmarkSet& withFuzzerOptions(
+      const VectorFuzzer::Options& options) {
+    VELOX_CHECK(
+        !inputRowVetor_,
+        "input row vector is already passed, fuzzer wont be used");
+    fuzzerOptions_ = options;
+    return *this;
+  }
+
+  ExpressionBenchmarkSet& withIterations(int itterations) {
+    itterations_ = itterations;
+    return *this;
+  }
+
+ private:
+  ExpressionBenchmarkSet(
+      ExpressionBenchmarkBuilder& builder,
+      const RowVectorPtr& inputRowVetor)
+      : inputRowVetor_(inputRowVetor),
+        inputType_(inputRowVetor_->type()),
+        builder_(builder) {}
+
+  ExpressionBenchmarkSet(
+      ExpressionBenchmarkBuilder& builder,
+      const TypePtr& inputType)
+      : inputType_(inputType), builder_(builder) {}
+
+  // All the expressions that belongs to this set.
+  std::map<std::string, exec::ExprSet> expressions_;
+
+  // The input that will be used for for benchmarking expressions. If not set,
+  // a flat input vector is fuzzed using fuzzerOptions_.
+  RowVectorPtr inputRowVetor_;
+
+  // The type of the input that will be used for all the expressions
+  // benchmarked.
+  TypePtr inputType_;
+
+  // User can provide fuzzer options for the input row vector used for this
+  // benchmark. Note that the fuzzer will be used to generate a flat input row
+  // vector if inputRowVetor_ is nullptr.
+  VectorFuzzer::Options fuzzerOptions_{.vectorSize = 10000, .nullRatio = 0};
+
+  // Number of times to run each benchmark.
+  int itterations_ = 1000;
+
+  bool disableTesting_ = false;
+
+  // The builder that this expression set belongs to.
+  ExpressionBenchmarkBuilder& builder_;
+  friend class ExpressionBenchmarkBuilder;
+};
+
+// A utility class to simplify creating expression's benchmarks.
+class ExpressionBenchmarkBuilder
+    : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit ExpressionBenchmarkBuilder() : FunctionBenchmarkBase() {}
+
+  // Register all the benchmarks, so that they would run when
+  // folly::runBenchmarks() is called.
+  void registerBenchmarks();
+
+  // All benchmarks within one group set are expected to have the same results.
+  // If disbleTesting=true for a group set, testing is skipped.
+  void testBenchmarks();
+
+  ExpressionBenchmarkSet& addBenchmarkSet(
+      const std::string& name,
+      const RowVectorPtr& inputRowVetor) {
+    VELOX_CHECK(!benchmarkSets_.count(name));
+    benchmarkSets_.emplace(name, ExpressionBenchmarkSet(*this, inputRowVetor));
+    return benchmarkSets_.at(name);
+  }
+
+  ExpressionBenchmarkSet& addBenchmarkSet(
+      const std::string& name,
+      const TypePtr& inputType) {
+    VELOX_CHECK(!benchmarkSets_.count(name));
+    benchmarkSets_.emplace(name, ExpressionBenchmarkSet(*this, inputType));
+    return benchmarkSets_.at(name);
+  }
+
+ private:
+  void ensureInputVectors();
+
+  std::map<std::string, ExpressionBenchmarkSet> benchmarkSets_;
+};
+} // namespace facebook::velox

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -15,6 +15,7 @@
  */
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/Registerer.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
@@ -63,92 +64,33 @@ FOLLY_ALWAYS_INLINE bool call(
 }
 VELOX_UDF_END();
 
-class ArrayContainsBenchmark : public functions::test::FunctionBenchmarkBase {
- public:
-  ArrayContainsBenchmark() : FunctionBenchmarkBase() {
-    functions::prestosql::registerArrayFunctions();
-    functions::prestosql::registerGeneralFunctions();
-
-    registerFunction<
-        udf_contains<int32_t>,
-        bool,
-        facebook::velox::Array<int32_t>,
-        int32_t>({"contains_alt"});
-  }
-
-  void runInteger(const std::string& functionName) {
-    folly::BenchmarkSuspender suspender;
-    vector_size_t size = 1'000;
-    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
-        size,
-        [](auto row) { return row % 5; },
-        [](auto row) { return row % 23; });
-
-    auto elementVector =
-        BaseVector::createConstant(INTEGER(), 7, size, execCtx_.pool());
-
-    auto rowVector = vectorMaker_.rowVector({arrayVector, elementVector});
-    auto exprSet = compileExpression(
-        fmt::format("{}(c0, c1)", functionName), rowVector->type());
-    suspender.dismiss();
-
-    doRun(exprSet, rowVector);
-  }
-
-  void runVarchar(const std::string& functionName) {
-    folly::BenchmarkSuspender suspender;
-    vector_size_t size = 1'000;
-
-    std::vector<std::string> colors = {
-        "red",
-        "blue",
-        "green",
-        "yellow",
-        "orange",
-        "purple",
-        "crimson red",
-        "cerulean blue"};
-
-    auto arrayVector = vectorMaker_.arrayVector<StringView>(
-        size,
-        [](auto row) { return row % 5; },
-        [&](auto row) { return StringView(colors[row % colors.size()]); });
-
-    auto elementVector = BaseVector::createConstant(
-        VARCHAR(), "crimson red", size, execCtx_.pool());
-
-    auto rowVector = vectorMaker_.rowVector({arrayVector, elementVector});
-    auto exprSet = compileExpression(
-        fmt::format("{}(c0, c1)", functionName), rowVector->type());
-    suspender.dismiss();
-
-    doRun(exprSet, rowVector);
-  }
-
-  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
-    int cnt = 0;
-    for (auto i = 0; i < 100; i++) {
-      cnt += evaluate(exprSet, rowVector)->size();
-    }
-    folly::doNotOptimizeAway(cnt);
-  }
-};
-
-BENCHMARK(vectorSimpleFunction) {
-  ArrayContainsBenchmark benchmark;
-  benchmark.runInteger("contains_alt");
-}
-
-BENCHMARK_RELATIVE(vectorFunctionInteger) {
-  ArrayContainsBenchmark benchmark;
-  benchmark.runInteger("contains");
-}
-
 } // namespace
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  functions::prestosql::registerArrayFunctions();
 
+  registerFunction<
+      udf_contains<int32_t>,
+      bool,
+      facebook::velox::Array<int32_t>,
+      int32_t>({"contains_alt"});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ROW({"c0", "c1"}, {ARRAY(INTEGER()), INTEGER()});
+
+  benchmarkBuilder.addBenchmarkSet("contains_benchmark", inputType)
+      .addExpression("vector", "contains(c0,  c1)")
+      .addExpression("simple", "contains_alt(c0, c1)");
+
+  benchmarkBuilder.addBenchmarkSet("contains_benchmark_with_nulls", inputType)
+      .withFuzzerOptions({.vectorSize = 1000, .nullRatio = 0})
+      .addExpression("vector", "contains(c0,  c1)")
+      .addExpression("simple", "contains_alt(c0, c1)");
+
+  benchmarkBuilder.registerBenchmarks();
+  // Make sure all expressions within benchmarkSets have the same results.
+  benchmarkBuilder.testBenchmarks();
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -17,22 +17,22 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
-#include <velox/common/base/VeloxException.h>
-#include "velox/functions/Registerer.h"
-#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.h"
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/common/base/VeloxException.h"
+#include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 
 namespace facebook::velox::functions {
 
-void registerVectorFunctionBasic() {
+void registerTestVectorFunctionBasic() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_min_basic, "vector_basic");
 }
 
-void registerSimpleFunctions() {
+void registerTestSimpleFunctions() {
   registerFunction<ArrayMinSimpleFunction, int32_t, Array<int32_t>>(
       {"array_min_simple"});
-
   registerFunction<ArrayMinSimpleFunctionIterator, int32_t, Array<int32_t>>(
       {"array_min_simple_iterator"});
 
@@ -41,98 +41,36 @@ void registerSimpleFunctions() {
       int32_t,
       Array<int32_t>>({"array_min_simple_skip_null_iterator"});
 }
-
-namespace {
-
-class ArrayMinMaxBenchmark : public functions::test::FunctionBenchmarkBase {
- public:
-  ArrayMinMaxBenchmark() : FunctionBenchmarkBase() {
-    functions::prestosql::registerArrayFunctions();
-    registerVectorFunctionBasic();
-    registerSimpleFunctions();
-  }
-
-  RowVectorPtr makeData() {
-    const vector_size_t size = 1'000;
-    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
-        size,
-        [](auto row) { return row % 5; },
-        [](auto row) { return row % 23; });
-
-    return vectorMaker_.rowVector({arrayVector});
-  }
-
-  size_t runInteger(const std::string& functionName) {
-    folly::BenchmarkSuspender suspender;
-    auto arrayVector = makeData()->childAt(0);
-    auto rowVector = vectorMaker_.rowVector({arrayVector});
-    auto exprSet = compileExpression(
-        fmt::format("{}(c0)", functionName), rowVector->type());
-    suspender.dismiss();
-
-    return doRun(exprSet, rowVector);
-  }
-
-  size_t doRun(exec::ExprSet& exprSet, const RowVectorPtr& rowVector) {
-    int cnt = 0;
-    for (auto i = 0; i < 100; i++) {
-      cnt += evaluate(exprSet, rowVector)->size();
-    }
-    return cnt;
-  }
-
-  template <typename F>
-  size_t runFastInteger(F function) {
-    folly::BenchmarkSuspender suspender;
-    auto arrayVector = makeData()->childAt(0);
-    suspender.dismiss();
-
-    int cnt = 0;
-    for (auto i = 0; i < 100; i++) {
-      cnt += function(arrayVector)->size();
-    }
-    folly::doNotOptimizeAway(cnt);
-    return cnt;
-  }
-};
-
-BENCHMARK_MULTI(fastMinInteger) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runFastInteger(fastMin<int32_t>);
-}
-
-BENCHMARK_MULTI(vectorNoFastPath) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runInteger("vector_basic");
-}
-
-BENCHMARK_MULTI(simpleMinIntegerSkipNullIterator) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runInteger("array_min_simple_skip_null_iterator");
-}
-
-BENCHMARK_MULTI(simpleMinIntegerIterator) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runInteger("array_min_simple_iterator");
-}
-
-BENCHMARK_MULTI(simpleMinInteger) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runInteger("array_min_simple");
-}
-
-// The function registred in prestoSQL.
-BENCHMARK_MULTI(prestoSQLArrayMin) {
-  ArrayMinMaxBenchmark benchmark;
-  return benchmark.runInteger("array_min");
-}
-
-} // namespace
 } // namespace facebook::velox::functions
+
+using namespace facebook::velox;
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  functions::prestosql::registerArrayFunctions();
+
+  functions::registerTestVectorFunctionBasic();
+
+  functions::registerTestSimpleFunctions();
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ROW({"c0"}, {ARRAY(INTEGER())});
+
+  benchmarkBuilder.addBenchmarkSet("array_min_max", inputType)
+      .withIterations(1000)
+      .addExpression("vector_basic", "vector_basic(c0)")
+      .addExpression(
+          "simple_skip_null_iterator",
+          "array_min_simple_skip_null_iterator(c0)")
+      .addExpression("simple_iterator", "array_min_simple_iterator(c0)")
+      .addExpression("simple", "array_min_simple(c0)")
+      .addExpression("prestoSQLArrayMin", "array_min(c0)");
+
+  benchmarkBuilder.registerBenchmarks();
+
+  // Make sure all expressions within benchmarkSets have the same results.
+  benchmarkBuilder.testBenchmarks();
 
   folly::runBenchmarks();
+
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
@@ -16,6 +16,7 @@
 #include <folly/Benchmark.h>
 #include <folly/init/Init.h>
 
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
 #include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
@@ -25,83 +26,34 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions;
 
-namespace {
-
-class ArraySumBenchmark : public functions::test::FunctionBenchmarkBase {
- public:
-  ArraySumBenchmark() : FunctionBenchmarkBase() {
-    functions::prestosql::registerArrayFunctions();
-    registerFunction<ArraySumFunction, int64_t, Array<int32_t>>(
-        {"array_sum_alt"});
-  }
-
-  void runInteger(const std::string& functionName) {
-    folly::BenchmarkSuspender suspender;
-    vector_size_t size = 10'000;
-    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
-        size,
-        [](auto row) { return row % 5; },
-        [](auto row) { return row % 23; });
-
-    auto rowVector = vectorMaker_.rowVector({arrayVector});
-    auto exprSet = compileExpression(
-        fmt::format("{}(c0)", functionName), rowVector->type());
-    suspender.dismiss();
-
-    doRun(exprSet, rowVector);
-  }
-
-  void runIntegerNulls(const std::string& functionName) {
-    folly::BenchmarkSuspender suspender;
-    vector_size_t size = 10'000;
-    auto arrayVector = vectorMaker_.arrayVector<int32_t>(
-        size,
-        [](auto row) { return row % 5; },
-        [](auto row) { return row % 23; },
-        [](auto row) { return (row % 513) == 0; },
-        [](auto row) { return (row % 13) == 0; });
-
-    auto rowVector = vectorMaker_.rowVector({arrayVector});
-    auto exprSet = compileExpression(
-        fmt::format("{}(c0)", functionName), rowVector->type());
-    suspender.dismiss();
-
-    doRun(exprSet, rowVector);
-  }
-
-  void doRun(ExprSet& exprSet, const RowVectorPtr& rowVector) {
-    int cnt = 0;
-    for (auto i = 0; i < 100; i++) {
-      cnt += evaluate(exprSet, rowVector)->size();
-    }
-    folly::doNotOptimizeAway(cnt);
-  }
-};
-
-BENCHMARK(SimpleFunction) {
-  ArraySumBenchmark benchmark;
-  benchmark.runInteger("array_sum_alt");
-}
-
-BENCHMARK_RELATIVE(VectorFunction) {
-  ArraySumBenchmark benchmark;
-  benchmark.runInteger("array_sum");
-}
-
-BENCHMARK(SimpleFunctionNulls) {
-  ArraySumBenchmark benchmark;
-  benchmark.runIntegerNulls("array_sum_alt");
-}
-
-BENCHMARK_RELATIVE(VectorFunctionNulls) {
-  ArraySumBenchmark benchmark;
-  benchmark.runIntegerNulls("array_sum");
-}
-
-} // namespace
-
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+
+  functions::prestosql::registerArrayFunctions();
+  registerFunction<ArraySumFunction, int64_t, Array<int32_t>>(
+      {"array_sum_alt"});
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  auto inputType = ROW({"c0"}, {ARRAY(INTEGER())});
+
+  auto createSet = [&](bool withNulls) {
+    benchmarkBuilder
+        .addBenchmarkSet(
+            fmt::format("array_sum_{}", withNulls ? "nulls" : "nullfree"),
+            inputType)
+        .withFuzzerOptions(
+            {.vectorSize = 1000, .nullRatio = withNulls ? 0.2 : 0})
+        .addExpression("vector", "array_sum(c0)")
+        .addExpression("simple", "array_sum_alt(c0)");
+  };
+
+  createSet(true);
+  createSet(false);
+
+  benchmarkBuilder.registerBenchmarks();
+
+  // Make sure all expressions within benchmarkSets have the same results.
+  benchmarkBuilder.testBenchmarks();
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -13,8 +13,13 @@
 # limitations under the License.
 
 set(BENCHMARK_DEPENDENCIES_NO_FUNC
-    velox_functions_test_lib velox_exec velox_exec_test_lib gflags::gflags
-    Folly::folly ${FOLLY_BENCHMARK})
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_lib
+    gflags::gflags
+    Folly::folly
+    ${FOLLY_BENCHMARK}
+    velox_benchmark_builder)
 
 set(BENCHMARK_DEPENDENCIES
     velox_functions_prestosql velox_functions_lib velox_vector_fuzzer


### PR DESCRIPTION
Summary:
There is so much code repetition each time a new benchmarks is added. And so much pitfalls that people can make that makes the benchmarks not accurate.

This diff introduce ExpressionBenchmarkBuilder to significantly simply adding benchmarks and tests associated with them.

For example existing array_contains benchmarks can be written as
```
  ExpressionBenchmarkBuilder benchmarkBuilder;
  auto inputType = ROW({"c0", "c1"}, {ARRAY(INTEGER()), INTEGER()});

  benchmarkBuilder.addBenchmarkSet("contains_benchmark", inputType)
      .addExpression("vector", "contains(c0,  c1)")
      .addExpression("simple", "contains_alt(c0, c1)");

  benchmarkBuilder.registerBenchmarks();

 // Make sure all expressions within benchmarkSets have the same
 // results (unless testing disabled for that benchmarkSet using `withTestingDisabled()`.
  benchmarkBuilder.testBenchmarks();

  folly::runBenchmarks();
  folly::runBenchmarks();
```
Some on can also pass input vectors or alternatively pass fuzzer options.

for example:
```
  ExpressionBenchmarkBuilder benchmarkBuilder;
  auto inputType = ROW({"c0", "c1"}, {ARRAY(INTEGER()), INTEGER()});

  benchmarkBuilder.addBenchmarkSet("contains_benchmark", inputType)
      .addExpression("vector", "contains(c0,  c1)")
      .addExpression("simple", "contains_alt(c0, c1)");

// add another set with fuzzer options overriden.
  benchmarkBuilder.addBenchmarkSet("contains_benchmark_with_nulls", inputType)
      .withFuzzerOptions({.vectorSize = 1000, .nullRatio = 0})
      .addExpression("vector", "contains(c0,  c1)")
      .addExpression("simple", "contains_alt(c0, c1)");

  benchmarkBuilder.registerBenchmarks();
  folly::runBenchmarks();
```

Result for the above are:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
contains_benchmark##simple                                107.27ms      9.32
contains_benchmark##vector                                177.13ms      5.65
contains_benchmark_with_nulls##simple                      26.96ms     37.10
contains_benchmark_with_nulls##vector                      28.54ms     35.04
```

Differential Revision: D46962146

