### PR TITLE
Add support for sum(decimal) Spark aggregate function

### DIFF
--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -277,8 +277,8 @@ The author defines an optional flag `is_fixed_size_` indicating whether the
 every accumulator takes fixed amount of memory. This flag is true by default.
 Next, the author defines another optional flag `use_external_memory_`
 indicating whether the accumulator uses memory that is not tracked by Velox.
-This flag is false by default. Then, the author can define optional flag
-`aligned_accumulator_` indicationg whether the accumulator requires aligned
+This flag is false by default. Then, the author can define an optional flag
+`aligned_accumulator_` indicating whether the accumulator requires aligned
 access. This flag is false by default.
 
 The author defines a constructor that takes a single argument of
@@ -370,7 +370,7 @@ For aggregaiton functions of non-default-null behavior, the author defines an
   };
 
 The definition of `is_fixed_size_`, `use_external_memory_`,
-`aligned_accumulator_` the constructor, and the `destroy` method are exactly
+`aligned_accumulator_`, the constructor, and the `destroy` method are exactly
 the same as those for default-null behavior.
 
 On the other hand, the C++ function signatures of `addInput`, `combine`,

--- a/velox/docs/develop/aggregate-functions.rst
+++ b/velox/docs/develop/aggregate-functions.rst
@@ -254,6 +254,9 @@ For aggregaiton functions of default-null behavior, the author defines an
     // Optional. Default is false.
     static constexpr bool use_external_memory_ = true;
 
+    // Optional. Default is false.
+    static constexpr bool aligned_accumulator_ = true;
+
     explicit AccumulatorType(HashStringAllocator* allocator);
 
     void addInput(HashStringAllocator* allocator, exec::arg_type<T1> value1, ...);
@@ -274,7 +277,9 @@ The author defines an optional flag `is_fixed_size_` indicating whether the
 every accumulator takes fixed amount of memory. This flag is true by default.
 Next, the author defines another optional flag `use_external_memory_`
 indicating whether the accumulator uses memory that is not tracked by Velox.
-This flag is false by default.
+This flag is false by default. Then, the author can define optional flag
+`aligned_accumulator_` indicationg whether the accumulator requires aligned
+access. This flag is false by default.
 
 The author defines a constructor that takes a single argument of
 `HashStringAllocator*`. This constructor is called before aggregation starts to
@@ -345,6 +350,9 @@ For aggregaiton functions of non-default-null behavior, the author defines an
     // Optional. Default is false.
     static constexpr bool use_external_memory_ = true;
 
+    // Optional. Default is false.
+    static constexpr bool aligned_accumulator_ = true;
+
     explicit AccumulatorType(HashStringAllocator* allocator);
 
     bool addInput(HashStringAllocator* allocator, exec::optional_arg_type<T1> value1, ...);
@@ -361,9 +369,9 @@ For aggregaiton functions of non-default-null behavior, the author defines an
     void destroy(HashStringAllocator* allocator);
   };
 
-The definition of `is_fixed_size_`, `use_external_memory_`, the constructor,
-and the `destroy` method are exactly the same as those for default-null
-behavior.
+The definition of `is_fixed_size_`, `use_external_memory_`,
+`aligned_accumulator_` the constructor, and the `destroy` method are exactly
+the same as those for default-null behavior.
 
 On the other hand, the C++ function signatures of `addInput`, `combine`,
 `writeIntermediateResult`, and `writeFinalResult` are different.

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -116,9 +116,9 @@ General Aggregate Functions
     For all other input types, the result type is BIGINT.
 
     Note:
-    When all input values is NULL, for all input types, the result of sum(x) is NULL.
+    When all input values is NULL, for all input types, the result is NULL.
 
-    For DECIMAL type, when an overflow occurs in the accumulation, it returns null. For REAL and DOUBLE type, it
+    For DECIMAL type, when an overflow occurs in the accumulation, it returns NULL. For REAL and DOUBLE type, it
     returns Infinity. For all other input types, when the sum of input values exceeds its limit, it cycles to the
     overflowed value rather than raising an error.
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -111,15 +111,13 @@ General Aggregate Functions
 
     When x is of type DOUBLE, the result type is DOUBLE.
     When x is of type REAL, the result type is REAL.
-
-    When x is of type DECIMAL(p, s), the result type is DECIMAL(p + 10, s), and p + 10 will not exceed 38.
-    For DECIMAL type, the initial value of sum is 0. We need to keep sum unchanged if the input is null, as sum
-    function ignores null input. Currently, only non-ANSI mode is supported, and the sum can only be null if
-    overflow happens.
+    When x is of type DECIMAL(p, s), the result type is DECIMAL(p + 10, s), where (p + 10) is capped at 38.
 
     For all other input types, the result type is BIGINT.
 
-    Note: When the sum of BIGINT values exceeds its limit, it cycles to the overflowed value rather than raising an error.
+    Note:
+    For DECIMAL type, when an overflow occurs in the accumulation, it returns null. For all other input types,
+    when the sum of input values exceeds its limit, it cycles to the overflowed value rather than raising an error.
 
     Example::
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -116,8 +116,11 @@ General Aggregate Functions
     For all other input types, the result type is BIGINT.
 
     Note:
-    For DECIMAL type, when an overflow occurs in the accumulation, it returns null. For all other input types,
-    when the sum of input values exceeds its limit, it cycles to the overflowed value rather than raising an error.
+    When all input values is NULL, for all input types, the result of sum(x) is NULL.
+
+    For DECIMAL type, when an overflow occurs in the accumulation, it returns null. For REAL and DOUBLE type, it
+    returns Infinity. For all other input types, when the sum of input values exceeds its limit, it cycles to the
+    overflowed value rather than raising an error.
 
     Example::
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -107,10 +107,16 @@ General Aggregate Functions
 
     Returns the sum of `x`.
 
-    Supported types are TINYINT, SMALLINT, INTEGER, BIGINT, REAL and DOUBLE.
+    Supported types are TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE and DECIMAL.
 
     When x is of type DOUBLE, the result type is DOUBLE.
     When x is of type REAL, the result type is REAL.
+
+    When x is of type DECIMAL(p, s), the result type is DECIMAL(p + 10, s), and p + 10 will not exceed 38.
+    For DECIMAL type, the initial value of sum is 0. We need to keep sum unchanged if the input is null, as sum
+    function ignores null input. Currently, only non-ANSI mode is supported, and the sum can only be null if
+    overflow happens.
+
     For all other input types, the result type is BIGINT.
 
     Note: When the sum of BIGINT values exceeds its limit, it cycles to the overflowed value rather than raising an error.

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -172,6 +172,10 @@ class SimpleAggregateAdapter : public Aggregate {
     return sizeof(typename FUNC::AccumulatorType);
   }
 
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(typename FUNC::AccumulatorType);
+  }
+
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -145,6 +145,18 @@ class SimpleAggregateAdapter : public Aggregate {
   struct support_to_intermediate<T, std::void_t<decltype(&T::toIntermediate)>>
       : std::true_type {};
 
+  // Whether the accumulator requires aligned access. If it is defined,
+  // SimpleAggregateAdapter::accumulatorAlignmentSize() returns
+  // alignof(typename FUNC::AccumulatorType).
+  // Otherwise, SimpleAggregateAdapter::accumulatorAlignmentSize() returns
+  // Aggregate::accumulatorAlignmentSize(), with a default value of 1.
+  template <typename T, typename = void>
+  struct aligned_accumulator : std::false_type {};
+
+  template <typename T>
+  struct aligned_accumulator<T, std::void_t<decltype(T::aligned_accumulator_)>>
+      : std::integral_constant<bool, T::aligned_accumulator_> {};
+
   static constexpr bool aggregate_default_null_behavior_ =
       aggregate_default_null_behavior<FUNC>::value;
 
@@ -160,6 +172,8 @@ class SimpleAggregateAdapter : public Aggregate {
   static constexpr bool support_to_intermediate_ =
       support_to_intermediate<FUNC>::value;
 
+  static constexpr bool aligned_accumulator_ = aligned_accumulator<FUNC>::value;
+
   bool isFixedSize() const override {
     return accumulator_is_fixed_size_;
   }
@@ -173,7 +187,10 @@ class SimpleAggregateAdapter : public Aggregate {
   }
 
   int32_t accumulatorAlignmentSize() const override {
-    return alignof(typename FUNC::AccumulatorType);
+    if constexpr (aligned_accumulator_) {
+      return alignof(typename FUNC::AccumulatorType);
+    }
+    return Aggregate::accumulatorAlignmentSize();
   }
 
   void initializeNewGroups(

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -14,336 +14,135 @@
  * limitations under the License.
  */
 #pragma once
-#include "velox/exec/Aggregate.h"
-#include "velox/vector/FlatVector.h"
+
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/type/DecimalUtil.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-/// This struct stores the sum of input values, overflow during accumulation,
-/// and a bool value isEmpty used to indicate whether all inputs are null. The
-/// initial value of sum is 0. We need to keep sum unchanged if the input is
-/// null, as sum function ignores null input. If the isEmpty is true, then it
-/// means there were no values to begin with or all the values were null, so the
-/// result will be null. If the isEmpty is false, then if sum is null that means
-/// an overflow has happened, it returns null.
-struct DecimalSum {
-  int128_t sum{0};
-  int64_t overflow{0};
-  bool isEmpty{true};
-
-  std::optional<int128_t> computeFinalValue(const TypePtr& sumType) const {
-    auto adjustedSum = DecimalUtil::adjustSumForOverflow(sum, overflow);
-    auto [rPrecision, rScale] = getDecimalPrecisionScale(*sumType);
-    if (adjustedSum.has_value() &&
-        DecimalUtil::valueInPrecisionRange(adjustedSum, rPrecision)) {
-      return adjustedSum;
-    } else {
-      // Find overflow during computing adjusted sum.
-      return std::nullopt;
-    }
-  }
-};
-
-template <typename TInputType, typename TResultType>
-class DecimalSumAggregate : public exec::Aggregate {
+/// TInputType refer to the raw input data type. TSumType refer to the type of
+/// sum in the output of partial aggregation or the final output type of final
+/// aggregation.
+template <typename TInputType, typename TSumType>
+class DecimalSumAggregate {
  public:
-  // resultType refers to the output type of the aggregate function. For partial
-  // aggregation, the resultType is ROW(DECIMAL, BOOLEAN), and for final
-  // aggregation, the resultType is DECIMAL. sumType refers to the type of
-  // DECIMAL in ROW(DECIMAL, BOOLEAN) used to store the accumulated sum in the
-  // output of partial aggregation or the input of final aggregation.
-  DecimalSumAggregate(TypePtr resultType, TypePtr sumType)
-      : exec::Aggregate(resultType), sumType_(sumType) {}
+  using InputType = Row<TInputType>;
 
-  int32_t accumulatorFixedWidthSize() const override {
-    return sizeof(DecimalSum);
+  using IntermediateType =
+      Row</*sum*/ TSumType,
+          /*isEmpty*/ bool>;
+
+  using OutputType = TSumType;
+
+  static constexpr bool default_null_behavior_ = true;
+
+  static bool toIntermediate(
+      exec::out_type<Row<TSumType, bool>>& out,
+      exec::arg_type<TInputType> in) {
+    out.copy_from(std::make_tuple(static_cast<TSumType>(in), false));
+    return true;
   }
 
-  int32_t accumulatorAlignmentSize() const override {
-    return alignof(DecimalSum);
-  }
+  // This struct stores the sum of input values, overflow during accumulation,
+  // and a bool value isEmpty used to indicate whether all inputs are null. The
+  // initial value of sum is 0. We need to keep sum unchanged if the input is
+  // null, as sum function ignores null input. If the isEmpty is true, then it
+  // means there were no values to begin with or all the values were null, so
+  // the result will be null. If the isEmpty is false, then if sum is nullopt
+  // that means an overflow has happened, it returns null.
+  struct AccumulatorType {
+    std::optional<int128_t> sum_;
+    int64_t overflow_;
+    bool isEmpty_;
 
-  void initializeNewGroups(
-      char** groups,
-      folly::Range<const vector_size_t*> indices) override {
-    setAllNulls(groups, indices);
-    for (auto i : indices) {
-      new (groups[i] + offset_) DecimalSum();
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(HashStringAllocator* /*allocator*/) {
+      sum_ = 0;
+      overflow_ = 0;
+      isEmpty_ = true;
     }
-  }
 
-  void addRawInput(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /* mayPushdown */) override {
-    decodedRaw_.decode(*args[0], rows);
-    if (decodedRaw_.isConstantMapping()) {
-      if (!decodedRaw_.isNullAt(0)) {
-        auto value = decodedRaw_.valueAt<TInputType>(0);
-        rows.applyToSelected([&](vector_size_t i) {
-          updateNonNullValue(groups[i], value, false);
-        });
+    std::optional<int128_t> computeFinalResult() const {
+      if (!sum_.has_value()) {
+        return std::nullopt;
       }
-    } else if (decodedRaw_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (!decodedRaw_.isNullAt(i)) {
-          updateNonNullValue(
-              groups[i], decodedRaw_.valueAt<TInputType>(i), false);
-        }
-      });
-    } else if (!numNulls_ && decodedRaw_.isIdentityMapping()) {
-      auto data = decodedRaw_.data<TInputType>();
-      rows.applyToSelected([&](vector_size_t i) {
-        updateNonNullValue<false>(groups[i], data[i], false);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        updateNonNullValue(
-            groups[i], decodedRaw_.valueAt<TInputType>(i), false);
-      });
-    }
-  }
-
-  void addSingleGroupRawInput(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /* mayPushdown */) override {
-    decodedRaw_.decode(*args[0], rows);
-    if (decodedRaw_.isConstantMapping()) {
-      if (!decodedRaw_.isNullAt(0)) {
-        auto value = decodedRaw_.valueAt<TInputType>(0);
-        rows.applyToSelected(
-            [&](vector_size_t i) { updateNonNullValue(group, value, false); });
-      }
-    } else if (decodedRaw_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (!decodedRaw_.isNullAt(i)) {
-          updateNonNullValue(group, decodedRaw_.valueAt<TInputType>(i), false);
-        }
-      });
-    } else if (!numNulls_ && decodedRaw_.isIdentityMapping()) {
-      auto data = decodedRaw_.data<TInputType>();
-      rows.applyToSelected([&](vector_size_t i) {
-        updateNonNullValue<false>(group, data[i], false);
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        updateNonNullValue(group, decodedRaw_.valueAt<TInputType>(i), false);
-      });
-    }
-  }
-
-  void addIntermediateResults(
-      char** groups,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /* mayPushdown */) override {
-    decodedPartial_.decode(*args[0], rows);
-    VELOX_CHECK_EQ(
-        decodedPartial_.base()->encoding(), VectorEncoding::Simple::ROW);
-    auto baseRowVector = decodedPartial_.base()->as<RowVector>();
-    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TResultType>>();
-    auto isEmptyVector = baseRowVector->childAt(1)->as<SimpleVector<bool>>();
-
-    if (decodedPartial_.isConstantMapping()) {
-      if (!decodedPartial_.isNullAt(0)) {
-        auto decodedIndex = decodedPartial_.index(0);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          rows.applyToSelected([&](vector_size_t i) { setNull(groups[i]); });
-        } else {
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          rows.applyToSelected([&](vector_size_t i) {
-            updateNonNullValue(groups[i], sum, isEmpty);
-          });
-        }
-      }
-    } else if (decodedPartial_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (!decodedPartial_.isNullAt(i)) {
-          auto decodedIndex = decodedPartial_.index(i);
-          if (isIntermediateResultOverflow(
-                  isEmptyVector, sumVector, decodedIndex)) {
-            setNull(groups[i]);
-          } else {
-            auto sum = sumVector->valueAt(decodedIndex);
-            auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-            updateNonNullValue(groups[i], sum, isEmpty);
-          }
-        }
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        auto decodedIndex = decodedPartial_.index(i);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          setNull(groups[i]);
-        } else {
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          updateNonNullValue(groups[i], sum, isEmpty);
-        }
-      });
-    }
-  }
-
-  void addSingleGroupIntermediateResults(
-      char* group,
-      const SelectivityVector& rows,
-      const std::vector<VectorPtr>& args,
-      bool /* mayPushdown */) override {
-    decodedPartial_.decode(*args[0], rows);
-    VELOX_CHECK_EQ(
-        decodedPartial_.base()->encoding(), VectorEncoding::Simple::ROW);
-    auto baseRowVector = decodedPartial_.base()->as<RowVector>();
-    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TResultType>>();
-    auto isEmptyVector = baseRowVector->childAt(1)->as<SimpleVector<bool>>();
-    if (decodedPartial_.isConstantMapping()) {
-      if (!decodedPartial_.isNullAt(0)) {
-        auto decodedIndex = decodedPartial_.index(0);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          setNull(group);
-        } else {
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          rows.applyToSelected([&](vector_size_t i) {
-            updateNonNullValue(group, sum, isEmpty);
-          });
-        }
-      }
-    } else if (decodedPartial_.mayHaveNulls()) {
-      rows.applyToSelected([&](vector_size_t i) {
-        if (!decodedPartial_.isNullAt(i)) {
-          auto decodedIndex = decodedPartial_.index(i);
-          if (isIntermediateResultOverflow(
-                  isEmptyVector, sumVector, decodedIndex)) {
-            setNull(group);
-          } else {
-            auto sum = sumVector->valueAt(decodedIndex);
-            auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-            updateNonNullValue(group, sum, isEmpty);
-          }
-        }
-      });
-    } else {
-      rows.applyToSelected([&](vector_size_t i) {
-        auto decodedIndex = decodedPartial_.index(i);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          setNull(group);
-        } else {
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          updateNonNullValue(group, sum, isEmpty);
-        }
-      });
-    }
-  }
-
-  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
-      override {
-    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::ROW);
-    auto rowVector = (*result)->as<RowVector>();
-    auto sumVector = rowVector->childAt(0)->asFlatVector<TResultType>();
-    auto isEmptyVector = rowVector->childAt(1)->asFlatVector<bool>();
-
-    rowVector->resize(numGroups);
-    sumVector->resize(numGroups);
-    isEmptyVector->resize(numGroups);
-
-    TResultType* rawSums = sumVector->mutableRawValues();
-    // Bool uses compact representation, use mutableRawValues<uint64_t>
-    // and bits::setBit instead.
-    auto* rawIsEmpty = isEmptyVector->mutableRawValues<uint64_t>();
-    uint64_t* rawNulls = getRawNulls(rowVector);
-
-    for (auto i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      clearNull(rawNulls, i);
-      if (isNull(group)) {
-        rawSums[i] = 0;
-        bits::setBit(rawIsEmpty, i, true);
+      auto adjustedSum =
+          DecimalUtil::adjustSumForOverflow(sum_.value(), overflow_);
+      uint8_t maxPrecision = std::is_same_v<TSumType, int128_t>
+          ? LongDecimalType::kMaxPrecision
+          : ShortDecimalType::kMaxPrecision;
+      if (adjustedSum.has_value() &&
+          DecimalUtil::valueInPrecisionRange(adjustedSum, maxPrecision)) {
+        return adjustedSum;
       } else {
-        auto* decimalSum = accumulator(group);
-        auto finalResult = decimalSum->computeFinalValue(sumType_);
-        if (!finalResult.has_value()) {
-          // Sum should be set to null on overflow, and
-          // isEmpty should be set to false.
-          sumVector->setNull(i, true);
-          bits::setBit(rawIsEmpty, i, false);
-        } else {
-          rawSums[i] = (TResultType)finalResult.value();
-          bits::setBit(rawIsEmpty, i, decimalSum->isEmpty);
-        }
+        // Find overflow during computing adjusted sum.
+        return std::nullopt;
       }
     }
-  }
 
-  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
-      override {
-    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::FLAT);
-    auto vector = (*result)->as<FlatVector<TResultType>>();
-    VELOX_CHECK(vector);
-    vector->resize(numGroups);
-    uint64_t* rawNulls = getRawNulls(vector);
+    static bool isIntermediateResultOverflow(
+        std::optional<TSumType> sum,
+        std::optional<bool> isEmpty) {
+      return !sum.has_value() && isEmpty.has_value();
+    }
 
-    TResultType* rawValues = vector->mutableRawValues();
-    for (auto i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      if (isNull(group)) {
-        vector->setNull(i, true);
+    void addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<TInputType> data) {
+      int128_t result;
+      overflow_ += DecimalUtil::addWithOverflow(result, data, sum_.value());
+      sum_ = result;
+      isEmpty_ = false;
+    }
+
+    void combine(
+        HashStringAllocator* /*allocator*/,
+        exec::arg_type<Row<TSumType, bool>> other) {
+      auto otherSum = other.template at<0>();
+      auto otherIsEmpty = other.template at<1>();
+      bool bufferOverflow = !isEmpty_ && !sum_.has_value();
+      bool inputOverflow = isIntermediateResultOverflow(otherSum, otherIsEmpty);
+      if (bufferOverflow || inputOverflow) {
+        sum_ = std::nullopt;
       } else {
-        clearNull(rawNulls, i);
-        auto* decimalSum = accumulator(group);
-        if (decimalSum->isEmpty) {
-          // If isEmpty is true, we should set null.
-          vector->setNull(i, true);
-        } else {
-          auto finalResult = decimalSum->computeFinalValue(sumType_);
-          if (!finalResult.has_value()) {
-            // Sum should be set to null on overflow.
-            vector->setNull(i, true);
-          } else {
-            rawValues[i] = (TResultType)finalResult.value();
-          }
-        }
+        int128_t result;
+        overflow_ += DecimalUtil::addWithOverflow(
+            result, otherSum.value(), sum_.value());
+        sum_ = result;
+        isEmpty_ &= otherIsEmpty.value();
       }
     }
-  }
 
- private:
-  template <bool tableHasNulls = true>
-  inline void updateNonNullValue(char* group, TResultType value, bool isEmpty) {
-    if constexpr (tableHasNulls) {
-      clearNull(group);
+    bool writeIntermediateResult(exec::out_type<IntermediateType>& out) {
+      auto finalResult = computeFinalResult();
+      if (finalResult.has_value()) {
+        out = std::make_tuple(
+            static_cast<TSumType>(finalResult.value()), isEmpty_);
+      } else {
+        // Sum should be set to null on overflow, and
+        // isEmpty should be set to false.
+        out.template set_null_at<0>();
+        out.template get_writer_at<1>() = false;
+      }
+      return true;
     }
-    auto decimalSum = accumulator(group);
-    decimalSum->overflow +=
-        DecimalUtil::addWithOverflow(decimalSum->sum, value, decimalSum->sum);
-    decimalSum->isEmpty &= isEmpty;
-  }
 
-  inline DecimalSum* accumulator(char* group) {
-    return value<DecimalSum>(group);
-  }
-
-  inline bool isIntermediateResultOverflow(
-      const SimpleVector<bool>* isEmptyVector,
-      const SimpleVector<TResultType>* sumVector,
-      vector_size_t index) {
-    // If isEmpty is false and sum is null, it means this intermediate
-    // result has an overflow. The final accumulator of this group will
-    // be null.
-    return !isEmptyVector->valueAt(index) && sumVector->isNullAt(index);
-  }
-
-  DecodedVector decodedRaw_;
-  DecodedVector decodedPartial_;
-  TypePtr sumType_;
+    bool writeFinalResult(exec::out_type<OutputType>& out) {
+      if (isEmpty_) {
+        // If isEmpty is true, we should set null.
+        return false;
+      }
+      auto finalResult = computeFinalResult();
+      if (finalResult.has_value()) {
+        out = static_cast<TSumType>(finalResult.value());
+        return true;
+      } else {
+        // Sum should be set to null on overflow.
+        return false;
+      }
+    }
+  };
 };
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 #include "velox/exec/Aggregate.h"
-#include "velox/expression/FunctionSignature.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
@@ -24,13 +23,6 @@ struct DecimalSum {
   int128_t sum{0};
   int64_t overflow{0};
   bool isEmpty{true};
-
-  void mergeWith(const DecimalSum& other) {
-    this->overflow += other.overflow;
-    this->overflow +=
-        DecimalUtil::addWithOverflow(this->sum, other.sum, this->sum);
-    this->isEmpty &= other.isEmpty;
-  }
 };
 
 template <typename TInputType, typename TResultType>
@@ -57,103 +49,22 @@ class DecimalSumAggregate : public exec::Aggregate {
   }
 
   int128_t computeFinalValue(DecimalSum* decimalSum, bool& overflow) {
-    int128_t sum = decimalSum->sum;
-    if ((decimalSum->overflow == 1 && decimalSum->sum < 0) ||
-        (decimalSum->overflow == -1 && decimalSum->sum > 0)) {
-      sum = static_cast<int128_t>(
-          DecimalUtil::kOverflowMultiplier * decimalSum->overflow +
-          decimalSum->sum);
+    auto sum = DecimalUtil::adjustSumForOverflow(
+        decimalSum->sum, decimalSum->overflow);
+    if (!sum.has_value()) {
+      // Find overflow during computing adjusted sum.
+      overflow = true;
+      return 0;
     } else {
-      if (decimalSum->overflow != 0) {
-        overflow = true;
-        return 0;
-      }
-    }
-
-    auto [resultPrecision, resultScale] =
-        getDecimalPrecisionScale(*sumType_.get());
-    overflow = !DecimalUtil::valueInPrecisionRange(sum, resultPrecision);
-    return sum;
-  }
-
-  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
-      override {
-    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::FLAT);
-    auto vector = (*result)->as<FlatVector<TResultType>>();
-    VELOX_CHECK(vector);
-    vector->resize(numGroups);
-    uint64_t* rawNulls = getRawNulls(vector);
-
-    TResultType* rawValues = vector->mutableRawValues();
-    for (auto i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      if (isNull(group)) {
-        vector->setNull(i, true);
-      } else {
-        clearNull(rawNulls, i);
-        auto* decimalSum = accumulator(group);
-        if (decimalSum->isEmpty) {
-          // If isEmpty is true, we should set null.
-          vector->setNull(i, true);
-        } else {
-          bool overflow = false;
-          auto result = (TResultType)computeFinalValue(decimalSum, overflow);
-          if (overflow) {
-            // Sum should be set to null on overflow.
-            vector->setNull(i, true);
-          } else {
-            rawValues[i] = result;
-          }
-        }
-      }
-    }
-  }
-
-  void extractAccumulators(
-      char** groups,
-      int32_t numGroups,
-      facebook::velox::VectorPtr* result) override {
-    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::ROW);
-    auto rowVector = (*result)->as<RowVector>();
-    auto sumVector = rowVector->childAt(0)->asFlatVector<TResultType>();
-    auto isEmptyVector = rowVector->childAt(1)->asFlatVector<bool>();
-
-    rowVector->resize(numGroups);
-    sumVector->resize(numGroups);
-    isEmptyVector->resize(numGroups);
-
-    TResultType* rawSums = sumVector->mutableRawValues();
-    // Bool uses compact representation, use mutableRawValues<uint64_t>
-    // and bits::setBit instead.
-    auto* rawIsEmpty = isEmptyVector->mutableRawValues<uint64_t>();
-    uint64_t* rawNulls = getRawNulls(rowVector);
-
-    for (auto i = 0; i < numGroups; ++i) {
-      char* group = groups[i];
-      clearNull(rawNulls, i);
-      if (isNull(group)) {
-        rawSums[i] = 0;
-        bits::setBit(rawIsEmpty, i, true);
-      } else {
-        auto* decimalSum = accumulator(group);
-        bool overflow = false;
-        auto result = (TResultType)computeFinalValue(decimalSum, overflow);
-        if (overflow) {
-          // Sum should be set to null on overflow, and
-          // isEmpty should be set to false.
-          sumVector->setNull(i, true);
-          bits::setBit(rawIsEmpty, i, false);
-        } else {
-          rawSums[i] = result;
-          bits::setBit(rawIsEmpty, i, decimalSum->isEmpty);
-        }
-      }
+      auto [rPrecision, rScale] = getDecimalPrecisionScale(*sumType_);
+      overflow = !DecimalUtil::valueInPrecisionRange(sum, rPrecision);
+      return sum.value();
     }
   }
 
   void addRawInput(
       char** groups,
-      const facebook::velox::SelectivityVector& rows,
+      const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /* mayPushdown */) override {
     decodedRaw_.decode(*args[0], rows);
@@ -166,13 +77,12 @@ class DecimalSumAggregate : public exec::Aggregate {
       }
     } else if (decodedRaw_.mayHaveNulls()) {
       rows.applyToSelected([&](vector_size_t i) {
-        if (decodedRaw_.isNullAt(i)) {
-          return;
+        if (!decodedRaw_.isNullAt(i)) {
+          updateNonNullValue(
+              groups[i], decodedRaw_.valueAt<TInputType>(i), false);
         }
-        updateNonNullValue(
-            groups[i], decodedRaw_.valueAt<TInputType>(i), false);
       });
-    } else if (!exec::Aggregate::numNulls_ && decodedRaw_.isIdentityMapping()) {
+    } else if (!numNulls_ && decodedRaw_.isIdentityMapping()) {
       auto data = decodedRaw_.data<TInputType>();
       rows.applyToSelected([&](vector_size_t i) {
         updateNonNullValue<false>(groups[i], data[i], false);
@@ -194,7 +104,7 @@ class DecimalSumAggregate : public exec::Aggregate {
     if (decodedRaw_.isConstantMapping()) {
       if (!decodedRaw_.isNullAt(0)) {
         auto value = decodedRaw_.valueAt<TInputType>(0);
-        rows.template applyToSelected(
+        rows.applyToSelected(
             [&](vector_size_t i) { updateNonNullValue(group, value, false); });
       }
     } else if (decodedRaw_.mayHaveNulls()) {
@@ -203,23 +113,15 @@ class DecimalSumAggregate : public exec::Aggregate {
           updateNonNullValue(group, decodedRaw_.valueAt<TInputType>(i), false);
         }
       });
-    } else if (!exec::Aggregate::numNulls_ && decodedRaw_.isIdentityMapping()) {
+    } else if (!numNulls_ && decodedRaw_.isIdentityMapping()) {
       auto data = decodedRaw_.data<TInputType>();
-      DecimalSum decimalSum;
       rows.applyToSelected([&](vector_size_t i) {
-        decimalSum.overflow += DecimalUtil::addWithOverflow(
-            decimalSum.sum, data[i], decimalSum.sum);
-        decimalSum.isEmpty = false;
+        updateNonNullValue<false>(group, data[i], false);
       });
-      mergeAccumulators(group, decimalSum);
     } else {
-      DecimalSum decimalSum;
       rows.applyToSelected([&](vector_size_t i) {
-        decimalSum.overflow += DecimalUtil::addWithOverflow(
-            decimalSum.sum, decodedRaw_.valueAt<TInputType>(i), decimalSum.sum);
-        decimalSum.isEmpty = false;
+        updateNonNullValue(group, decodedRaw_.valueAt<TInputType>(i), false);
       });
-      mergeAccumulators(group, decimalSum);
     }
   }
 
@@ -245,29 +147,26 @@ class DecimalSumAggregate : public exec::Aggregate {
           auto sum = sumVector->valueAt(decodedIndex);
           auto isEmpty = isEmptyVector->valueAt(decodedIndex);
           rows.applyToSelected([&](vector_size_t i) {
-            clearNull(groups[i]);
             updateNonNullValue(groups[i], sum, isEmpty);
           });
         }
       }
     } else if (decodedPartial_.mayHaveNulls()) {
       rows.applyToSelected([&](vector_size_t i) {
-        if (decodedPartial_.isNullAt(i)) {
-          return;
-        }
-        auto decodedIndex = decodedPartial_.index(i);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          setNull(groups[i]);
-        } else {
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          updateNonNullValue(groups[i], sum, isEmpty);
+        if (!decodedPartial_.isNullAt(i)) {
+          auto decodedIndex = decodedPartial_.index(i);
+          if (isIntermediateResultOverflow(
+                  isEmptyVector, sumVector, decodedIndex)) {
+            setNull(groups[i]);
+          } else {
+            auto sum = sumVector->valueAt(decodedIndex);
+            auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+            updateNonNullValue(groups[i], sum, isEmpty);
+          }
         }
       });
     } else {
       rows.applyToSelected([&](vector_size_t i) {
-        clearNull(groups[i]);
         auto decodedIndex = decodedPartial_.index(i);
         if (isIntermediateResultOverflow(
                 isEmptyVector, sumVector, decodedIndex)) {
@@ -301,9 +200,6 @@ class DecimalSumAggregate : public exec::Aggregate {
         } else {
           auto sum = sumVector->valueAt(decodedIndex);
           auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          if (rows.hasSelections()) {
-            clearNull(group);
-          }
           rows.applyToSelected([&](vector_size_t i) {
             updateNonNullValue(group, sum, isEmpty);
           });
@@ -311,37 +207,104 @@ class DecimalSumAggregate : public exec::Aggregate {
       }
     } else if (decodedPartial_.mayHaveNulls()) {
       rows.applyToSelected([&](vector_size_t i) {
-        if (decodedPartial_.isNullAt(i)) {
-          return;
-        }
-        auto decodedIndex = decodedPartial_.index(i);
-        if (isIntermediateResultOverflow(
-                isEmptyVector, sumVector, decodedIndex)) {
-          setNull(group);
-          return;
-        } else {
-          clearNull(group);
-          auto sum = sumVector->valueAt(decodedIndex);
-          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
-          updateNonNullValue(group, sum, isEmpty);
+        if (!decodedPartial_.isNullAt(i)) {
+          auto decodedIndex = decodedPartial_.index(i);
+          if (isIntermediateResultOverflow(
+                  isEmptyVector, sumVector, decodedIndex)) {
+            setNull(group);
+          } else {
+            auto sum = sumVector->valueAt(decodedIndex);
+            auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+            updateNonNullValue(group, sum, isEmpty);
+          }
         }
       });
     } else {
-      if (rows.hasSelections()) {
-        clearNull(group);
-      }
       rows.applyToSelected([&](vector_size_t i) {
         auto decodedIndex = decodedPartial_.index(i);
         if (isIntermediateResultOverflow(
                 isEmptyVector, sumVector, decodedIndex)) {
           setNull(group);
-          return;
         } else {
           auto sum = sumVector->valueAt(decodedIndex);
           auto isEmpty = isEmptyVector->valueAt(decodedIndex);
           updateNonNullValue(group, sum, isEmpty);
         }
       });
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::ROW);
+    auto rowVector = (*result)->as<RowVector>();
+    auto sumVector = rowVector->childAt(0)->asFlatVector<TResultType>();
+    auto isEmptyVector = rowVector->childAt(1)->asFlatVector<bool>();
+
+    rowVector->resize(numGroups);
+    sumVector->resize(numGroups);
+    isEmptyVector->resize(numGroups);
+
+    TResultType* rawSums = sumVector->mutableRawValues();
+    // Bool uses compact representation, use mutableRawValues<uint64_t>
+    // and bits::setBit instead.
+    auto* rawIsEmpty = isEmptyVector->mutableRawValues<uint64_t>();
+    uint64_t* rawNulls = getRawNulls(rowVector);
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      clearNull(rawNulls, i);
+      if (isNull(group)) {
+        rawSums[i] = 0;
+        bits::setBit(rawIsEmpty, i, true);
+      } else {
+        auto* decimalSum = accumulator(group);
+        bool overflow = false;
+        auto finalResult = (TResultType)computeFinalValue(decimalSum, overflow);
+        if (overflow) {
+          // Sum should be set to null on overflow, and
+          // isEmpty should be set to false.
+          sumVector->setNull(i, true);
+          bits::setBit(rawIsEmpty, i, false);
+        } else {
+          rawSums[i] = finalResult;
+          bits::setBit(rawIsEmpty, i, decimalSum->isEmpty);
+        }
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::FLAT);
+    auto vector = (*result)->as<FlatVector<TResultType>>();
+    VELOX_CHECK(vector);
+    vector->resize(numGroups);
+    uint64_t* rawNulls = getRawNulls(vector);
+
+    TResultType* rawValues = vector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        vector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        auto* decimalSum = accumulator(group);
+        if (decimalSum->isEmpty) {
+          // If isEmpty is true, we should set null.
+          vector->setNull(i, true);
+        } else {
+          bool overflow = false;
+          auto finalResult =
+              (TResultType)computeFinalValue(decimalSum, overflow);
+          if (overflow) {
+            // Sum should be set to null on overflow.
+            vector->setNull(i, true);
+          } else {
+            rawValues[i] = finalResult;
+          }
+        }
+      }
     }
   }
 
@@ -349,7 +312,7 @@ class DecimalSumAggregate : public exec::Aggregate {
   template <bool tableHasNulls = true>
   inline void updateNonNullValue(char* group, TResultType value, bool isEmpty) {
     if constexpr (tableHasNulls) {
-      exec::Aggregate::clearNull(group);
+      clearNull(group);
     }
     auto decimalSum = accumulator(group);
     decimalSum->overflow +=
@@ -357,17 +320,8 @@ class DecimalSumAggregate : public exec::Aggregate {
     decimalSum->isEmpty &= isEmpty;
   }
 
-  template <bool tableHasNulls = true>
-  inline void mergeAccumulators(char* group, DecimalSum other) {
-    if constexpr (tableHasNulls) {
-      exec::Aggregate::clearNull(group);
-    }
-    auto decimalSum = accumulator(group);
-    decimalSum->mergeWith(other);
-  }
-
   inline DecimalSum* accumulator(char* group) {
-    return exec::Aggregate::value<DecimalSum>(group);
+    return value<DecimalSum>(group);
   }
 
   inline bool isIntermediateResultOverflow(

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/exec/Aggregate.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::functions::aggregate::sparksql {
+
+struct DecimalSum {
+  int128_t sum{0};
+  int64_t overflow{0};
+  bool isEmpty{true};
+
+  void mergeWith(const DecimalSum& other) {
+    this->overflow += other.overflow;
+    this->overflow +=
+        DecimalUtil::addWithOverflow(this->sum, other.sum, this->sum);
+    this->isEmpty &= other.isEmpty;
+  }
+};
+
+template <typename TInputType, typename TResultType>
+class DecimalSumAggregate : public exec::Aggregate {
+ public:
+  explicit DecimalSumAggregate(TypePtr resultType, TypePtr sumType)
+      : exec::Aggregate(resultType), sumType_(sumType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(DecimalSum);
+  }
+
+  int32_t accumulatorAlignmentSize() const override {
+    return alignof(DecimalSum);
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) DecimalSum();
+    }
+  }
+
+  int128_t computeFinalValue(DecimalSum* decimalSum, bool& overflow) {
+    int128_t sum = decimalSum->sum;
+    if ((decimalSum->overflow == 1 && decimalSum->sum < 0) ||
+        (decimalSum->overflow == -1 && decimalSum->sum > 0)) {
+      sum = static_cast<int128_t>(
+          DecimalUtil::kOverflowMultiplier * decimalSum->overflow +
+          decimalSum->sum);
+    } else {
+      if (decimalSum->overflow != 0) {
+        overflow = true;
+        return 0;
+      }
+    }
+
+    auto [resultPrecision, resultScale] =
+        getDecimalPrecisionScale(*sumType_.get());
+    overflow = !DecimalUtil::valueInPrecisionRange(sum, resultPrecision);
+    return sum;
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::FLAT);
+    auto vector = (*result)->as<FlatVector<TResultType>>();
+    VELOX_CHECK(vector);
+    vector->resize(numGroups);
+    uint64_t* rawNulls = getRawNulls(vector);
+
+    TResultType* rawValues = vector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        vector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        auto* decimalSum = accumulator(group);
+        if (decimalSum->isEmpty) {
+          // If isEmpty is true, we should set null.
+          vector->setNull(i, true);
+        } else {
+          bool overflow = false;
+          auto result = (TResultType)computeFinalValue(decimalSum, overflow);
+          if (overflow) {
+            // Sum should be set to null on overflow.
+            vector->setNull(i, true);
+          } else {
+            rawValues[i] = result;
+          }
+        }
+      }
+    }
+  }
+
+  void extractAccumulators(
+      char** groups,
+      int32_t numGroups,
+      facebook::velox::VectorPtr* result) override {
+    VELOX_CHECK_EQ((*result)->encoding(), VectorEncoding::Simple::ROW);
+    auto rowVector = (*result)->as<RowVector>();
+    auto sumVector = rowVector->childAt(0)->asFlatVector<TResultType>();
+    auto isEmptyVector = rowVector->childAt(1)->asFlatVector<bool>();
+
+    rowVector->resize(numGroups);
+    sumVector->resize(numGroups);
+    isEmptyVector->resize(numGroups);
+
+    TResultType* rawSums = sumVector->mutableRawValues();
+    // Bool uses compact representation, use mutableRawValues<uint64_t>
+    // and bits::setBit instead.
+    auto* rawIsEmpty = isEmptyVector->mutableRawValues<uint64_t>();
+    uint64_t* rawNulls = getRawNulls(rowVector);
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      clearNull(rawNulls, i);
+      if (isNull(group)) {
+        rawSums[i] = 0;
+        bits::setBit(rawIsEmpty, i, true);
+      } else {
+        auto* decimalSum = accumulator(group);
+        bool overflow = false;
+        auto result = (TResultType)computeFinalValue(decimalSum, overflow);
+        if (overflow) {
+          // Sum should be set to null on overflow, and
+          // isEmpty should be set to false.
+          sumVector->setNull(i, true);
+          bits::setBit(rawIsEmpty, i, false);
+        } else {
+          rawSums[i] = result;
+          bits::setBit(rawIsEmpty, i, decimalSum->isEmpty);
+        }
+      }
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const facebook::velox::SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedRaw_.decode(*args[0], rows);
+    if (decodedRaw_.isConstantMapping()) {
+      if (!decodedRaw_.isNullAt(0)) {
+        auto value = decodedRaw_.valueAt<TInputType>(0);
+        rows.applyToSelected([&](vector_size_t i) {
+          updateNonNullValue(groups[i], value, false);
+        });
+      }
+    } else if (decodedRaw_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedRaw_.isNullAt(i)) {
+          return;
+        }
+        updateNonNullValue(
+            groups[i], decodedRaw_.valueAt<TInputType>(i), false);
+      });
+    } else if (!exec::Aggregate::numNulls_ && decodedRaw_.isIdentityMapping()) {
+      auto data = decodedRaw_.data<TInputType>();
+      rows.applyToSelected([&](vector_size_t i) {
+        updateNonNullValue<false>(groups[i], data[i], false);
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        updateNonNullValue(
+            groups[i], decodedRaw_.valueAt<TInputType>(i), false);
+      });
+    }
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedRaw_.decode(*args[0], rows);
+    if (decodedRaw_.isConstantMapping()) {
+      if (!decodedRaw_.isNullAt(0)) {
+        auto value = decodedRaw_.valueAt<TInputType>(0);
+        rows.template applyToSelected(
+            [&](vector_size_t i) { updateNonNullValue(group, value, false); });
+      }
+    } else if (decodedRaw_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!decodedRaw_.isNullAt(i)) {
+          updateNonNullValue(group, decodedRaw_.valueAt<TInputType>(i), false);
+        }
+      });
+    } else if (!exec::Aggregate::numNulls_ && decodedRaw_.isIdentityMapping()) {
+      auto data = decodedRaw_.data<TInputType>();
+      DecimalSum decimalSum;
+      rows.applyToSelected([&](vector_size_t i) {
+        decimalSum.overflow += DecimalUtil::addWithOverflow(
+            decimalSum.sum, data[i], decimalSum.sum);
+        decimalSum.isEmpty = false;
+      });
+      mergeAccumulators(group, decimalSum);
+    } else {
+      DecimalSum decimalSum;
+      rows.applyToSelected([&](vector_size_t i) {
+        decimalSum.overflow += DecimalUtil::addWithOverflow(
+            decimalSum.sum, decodedRaw_.valueAt<TInputType>(i), decimalSum.sum);
+        decimalSum.isEmpty = false;
+      });
+      mergeAccumulators(group, decimalSum);
+    }
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+    VELOX_CHECK_EQ(
+        decodedPartial_.base()->encoding(), VectorEncoding::Simple::ROW);
+    auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TResultType>>();
+    auto isEmptyVector = baseRowVector->childAt(1)->as<SimpleVector<bool>>();
+
+    if (decodedPartial_.isConstantMapping()) {
+      if (!decodedPartial_.isNullAt(0)) {
+        auto decodedIndex = decodedPartial_.index(0);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          rows.applyToSelected([&](vector_size_t i) { setNull(groups[i]); });
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          rows.applyToSelected([&](vector_size_t i) {
+            clearNull(groups[i]);
+            updateNonNullValue(groups[i], sum, isEmpty);
+          });
+        }
+      }
+    } else if (decodedPartial_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedPartial_.isNullAt(i)) {
+          return;
+        }
+        auto decodedIndex = decodedPartial_.index(i);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          setNull(groups[i]);
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          updateNonNullValue(groups[i], sum, isEmpty);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        clearNull(groups[i]);
+        auto decodedIndex = decodedPartial_.index(i);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          setNull(groups[i]);
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          updateNonNullValue(groups[i], sum, isEmpty);
+        }
+      });
+    }
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+    VELOX_CHECK_EQ(
+        decodedPartial_.base()->encoding(), VectorEncoding::Simple::ROW);
+    auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TResultType>>();
+    auto isEmptyVector = baseRowVector->childAt(1)->as<SimpleVector<bool>>();
+    if (decodedPartial_.isConstantMapping()) {
+      if (!decodedPartial_.isNullAt(0)) {
+        auto decodedIndex = decodedPartial_.index(0);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          setNull(group);
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          if (rows.hasSelections()) {
+            clearNull(group);
+          }
+          rows.applyToSelected([&](vector_size_t i) {
+            updateNonNullValue(group, sum, isEmpty);
+          });
+        }
+      }
+    } else if (decodedPartial_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedPartial_.isNullAt(i)) {
+          return;
+        }
+        auto decodedIndex = decodedPartial_.index(i);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          setNull(group);
+          return;
+        } else {
+          clearNull(group);
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          updateNonNullValue(group, sum, isEmpty);
+        }
+      });
+    } else {
+      if (rows.hasSelections()) {
+        clearNull(group);
+      }
+      rows.applyToSelected([&](vector_size_t i) {
+        auto decodedIndex = decodedPartial_.index(i);
+        if (isIntermediateResultOverflow(
+                isEmptyVector, sumVector, decodedIndex)) {
+          setNull(group);
+          return;
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto isEmpty = isEmptyVector->valueAt(decodedIndex);
+          updateNonNullValue(group, sum, isEmpty);
+        }
+      });
+    }
+  }
+
+ private:
+  template <bool tableHasNulls = true>
+  inline void updateNonNullValue(char* group, TResultType value, bool isEmpty) {
+    if constexpr (tableHasNulls) {
+      exec::Aggregate::clearNull(group);
+    }
+    auto decimalSum = accumulator(group);
+    decimalSum->overflow +=
+        DecimalUtil::addWithOverflow(decimalSum->sum, value, decimalSum->sum);
+    decimalSum->isEmpty &= isEmpty;
+  }
+
+  template <bool tableHasNulls = true>
+  inline void mergeAccumulators(char* group, DecimalSum other) {
+    if constexpr (tableHasNulls) {
+      exec::Aggregate::clearNull(group);
+    }
+    auto decimalSum = accumulator(group);
+    decimalSum->mergeWith(other);
+  }
+
+  inline DecimalSum* accumulator(char* group) {
+    return exec::Aggregate::value<DecimalSum>(group);
+  }
+
+  inline bool isIntermediateResultOverflow(
+      const SimpleVector<bool>* isEmptyVector,
+      const SimpleVector<TResultType>* sumVector,
+      vector_size_t index) {
+    // If isEmpty is false and sum is null, it means this intermediate
+    // result has an overflow. The final accumulator of this group will
+    // be null.
+    return !isEmptyVector->valueAt(index) && sumVector->isNullAt(index);
+  }
+
+  DecodedVector decodedRaw_;
+  DecodedVector decodedPartial_;
+  TypePtr sumType_;
+};
+
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -34,13 +34,13 @@ class DecimalSumAggregate {
 
   using OutputType = TSumType;
 
-  // Spark's decimal sum doesn't have the concept of a null group, each group is
-  // initialized with an initial value, where sum = 0 and isEmpty = true. The
-  // final agg may fallback to being executed in Spark, so the meaning of the
-  // intermediate data should be consistent with Spark. Therefore, we need to
-  // use the parameter nonNullGroup in writeIntermediateResult to output a null
-  // group as sum = 0, isEmpty = true. nonNullGroup is only available when
-  // default-null behavior is disabled.
+  /// Spark's decimal sum doesn't have the concept of a null group, each group
+  /// is initialized with an initial value, where sum = 0 and isEmpty = true.
+  /// The final agg may fallback to being executed in Spark, so the meaning of
+  /// the intermediate data should be consistent with Spark. Therefore, we need
+  /// to use the parameter nonNullGroup in writeIntermediateResult to output a
+  /// null group as sum = 0, isEmpty = true. nonNullGroup is only available when
+  /// default-null behavior is disabled.
   static constexpr bool default_null_behavior_ = false;
 
   static bool toIntermediate(
@@ -54,13 +54,13 @@ class DecimalSumAggregate {
     return true;
   }
 
-  // This struct stores the sum of input values, overflow during accumulation,
-  // and a bool value isEmpty used to indicate whether all inputs are null. The
-  // initial value of sum is 0. We need to keep sum unchanged if the input is
-  // null, as sum function ignores null input. If the isEmpty is true, then it
-  // means there were no values to begin with or all the values were null, so
-  // the result will be null. If the isEmpty is false, then if sum is nullopt
-  // that means an overflow has happened, it returns null.
+  /// This struct stores the sum of input values, overflow during accumulation,
+  /// and a bool value isEmpty used to indicate whether all inputs are null. The
+  /// initial value of sum is 0. We need to keep sum unchanged if the input is
+  /// null, as sum function ignores null input. If the isEmpty is true, then it
+  /// means there were no values to begin with or all the values were null, so
+  /// the result will be null. If the isEmpty is false, then if sum is nullopt
+  /// that means an overflow has happened, it returns null.
   struct AccumulatorType {
     std::optional<int128_t> sum{0};
     int64_t overflow{0};
@@ -74,7 +74,7 @@ class DecimalSumAggregate {
       if (!sum.has_value()) {
         return std::nullopt;
       }
-      auto adjustedSum =
+      auto const adjustedSum =
           DecimalUtil::adjustSumForOverflow(sum.value(), overflow);
       constexpr uint8_t maxPrecision = std::is_same_v<TSumType, int128_t>
           ? LongDecimalType::kMaxPrecision
@@ -108,8 +108,8 @@ class DecimalSumAggregate {
       if (!other.has_value()) {
         return false;
       }
-      auto otherSum = other.value().template at<0>();
-      auto otherIsEmpty = other.value().template at<1>();
+      auto const otherSum = other.value().template at<0>();
+      auto const otherIsEmpty = other.value().template at<1>();
 
       // isEmpty is never null.
       VELOX_CHECK(otherIsEmpty.has_value());
@@ -143,7 +143,7 @@ class DecimalSumAggregate {
               static_cast<TSumType>(finalResult.value()), isEmpty);
         } else {
           // Sum should be set to null on overflow,
-          // and isEmptyshould be set to false.
+          // and isEmpty should be set to false.
           out.template set_null_at<0>();
           out.template get_writer_at<1>() = false;
         }

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -121,6 +121,10 @@ class DecimalSumAggregate {
 
       // isEmpty is never null.
       VELOX_CHECK(otherIsEmpty.has_value());
+      if (isEmpty && otherIsEmpty.value()) {
+        // Both accumulators are empty, no need to do the combination.
+        return false;
+      }
 
       bool currentOverflow = !isEmpty && !sum.has_value();
       bool otherOverflow = !otherIsEmpty.value() && !otherSum.has_value();

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -43,6 +43,8 @@ class DecimalSumAggregate {
   /// default-null behavior is disabled.
   static constexpr bool default_null_behavior_ = false;
 
+  static constexpr bool aligned_accumulator_ = true;
+
   static bool toIntermediate(
       exec::out_type<Row<TSumType, bool>>& out,
       exec::optional_arg_type<TInputType> in) {
@@ -93,6 +95,12 @@ class DecimalSumAggregate {
         exec::optional_arg_type<TInputType> data) {
       if (!data.has_value()) {
         return false;
+      }
+      if (!sum.has_value()) {
+        // sum is initialized to 0. When it is nullopt, it implies that the
+        // input data must not be empty.
+        VELOX_CHECK(!isEmpty)
+        return true;
       }
       int128_t result;
       overflow +=

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -34,6 +34,6 @@ void registerAggregateFunctions(
   registerBitwiseXorAggregate(prefix);
   registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
   registerAverage(prefix + "avg", withCompanionFunctions);
-  registerSum(prefix + "sum");
+  registerSum(prefix + "sum", withCompanionFunctions);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -29,7 +29,13 @@ using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, true>;
 TypePtr getDecimalSumType(
     const TypePtr& resultType,
     core::AggregationNode::Step step) {
-  return exec::isPartialOutput(step) ? resultType->childAt(0) : resultType;
+  if (exec::isPartialOutput(step)) {
+    return resultType->childAt(0);
+  }
+  if (step == core::AggregationNode::Step::kSingle && resultType->isRow()) {
+    return resultType->childAt(0);
+  }
+  return resultType;
 }
 } // namespace
 

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -46,7 +46,9 @@ void checkAccumulatorRowType(const TypePtr& type) {
 }
 } // namespace
 
-exec::AggregateRegistrationResult registerSum(const std::string& name) {
+exec::AggregateRegistrationResult registerSum(
+    const std::string& name,
+    bool withCompanionFunctions) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")
@@ -100,7 +102,7 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
                 BIGINT());
           case TypeKind::BIGINT: {
             if (inputType->isShortDecimal()) {
-              auto sumType = getDecimalSumType(resultType, step);
+              auto const sumType = getDecimalSumType(resultType, step);
               if (sumType->isShortDecimal()) {
                 return std::make_unique<DecimalSumAggregate<int64_t, int64_t>>(
                     resultType, sumType);
@@ -114,9 +116,9 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
           }
           case TypeKind::HUGEINT: {
             if (inputType->isLongDecimal()) {
-              auto sumType = getDecimalSumType(resultType, step);
+              auto const sumType = getDecimalSumType(resultType, step);
               // If inputType is long decimal,
-              // its output type always be long decimal.
+              // its output type is always long decimal.
               return std::make_unique<DecimalSumAggregate<int128_t, int128_t>>(
                   resultType, sumType);
             }
@@ -138,7 +140,7 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
           case TypeKind::ROW: {
             VELOX_DCHECK(!exec::isRawInput(step));
             checkAccumulatorRowType(inputType);
-            auto sumType = getDecimalSumType(resultType, step);
+            auto const sumType = getDecimalSumType(resultType, step);
             // For intermediate input agg, input intermediate sum type
             // is equal to final result sum type.
             if (inputType->childAt(0)->isShortDecimal()) {
@@ -156,7 +158,8 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
                 name,
                 inputType->kindName());
         }
-      });
+      },
+      withCompanionFunctions);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -16,6 +16,7 @@
 #include "velox/functions/sparksql/aggregates/SumAggregate.h"
 
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"
+#include "velox/functions/sparksql/aggregates/DecimalSumAggregate.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -24,7 +25,13 @@ namespace facebook::velox::functions::aggregate::sparksql {
 namespace {
 template <typename TInput, typename TAccumulator, typename ResultType>
 using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, true>;
+
+TypePtr getDecimalSumType(
+    const TypePtr& resultType,
+    core::AggregationNode::Step step) {
+  return exec::isPartialOutput(step) ? resultType->childAt(0) : resultType;
 }
+} // namespace
 
 exec::AggregateRegistrationResult registerSum(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
@@ -37,6 +44,15 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
           .returnType("double")
           .intermediateType("double")
           .argumentType("double")
+          .build(),
+      exec::AggregateFunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable("r_precision", "min(38, a_precision + 10)")
+          .integerVariable("r_scale", "min(38, a_scale)")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .intermediateType("ROW(DECIMAL(r_precision, r_scale), boolean)")
+          .returnType("DECIMAL(r_precision, r_scale)")
           .build(),
   };
 
@@ -71,13 +87,26 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
                 BIGINT());
           case TypeKind::BIGINT: {
             if (inputType->isShortDecimal()) {
-              VELOX_NYI();
+              auto sumType = getDecimalSumType(resultType, step);
+              if (sumType->isShortDecimal()) {
+                return std::make_unique<DecimalSumAggregate<int64_t, int64_t>>(
+                    resultType, sumType);
+              } else if (sumType->isLongDecimal()) {
+                return std::make_unique<DecimalSumAggregate<int64_t, int128_t>>(
+                    resultType, sumType);
+              }
             }
             return std::make_unique<SumAggregate<int64_t, int64_t, int64_t>>(
                 BIGINT());
           }
           case TypeKind::HUGEINT: {
-            VELOX_NYI();
+            if (inputType->isLongDecimal()) {
+              auto sumType = getDecimalSumType(resultType, step);
+              // If inputType is long decimal,
+              // its output type always be long decimal.
+              return std::make_unique<DecimalSumAggregate<int128_t, int128_t>>(
+                  resultType, sumType);
+            }
           }
           case TypeKind::REAL:
             if (resultType->kind() == TypeKind::REAL) {
@@ -93,6 +122,19 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
             }
             return std::make_unique<SumAggregate<double, double, double>>(
                 DOUBLE());
+          case TypeKind::ROW: {
+            VELOX_DCHECK(!exec::isRawInput(step));
+            auto sumType = getDecimalSumType(resultType, step);
+            // For intermediate input agg, input intermediate sum type
+            // is equal to final result sum type.
+            if (inputType->childAt(0)->isShortDecimal()) {
+              return std::make_unique<DecimalSumAggregate<int64_t, int64_t>>(
+                  resultType, sumType);
+            } else if (inputType->childAt(0)->isLongDecimal()) {
+              return std::make_unique<DecimalSumAggregate<int128_t, int128_t>>(
+                  resultType, sumType);
+            }
+          }
           default:
             VELOX_CHECK(
                 false,

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -37,6 +37,12 @@ TypePtr getDecimalSumType(
   }
   return resultType;
 }
+
+void checkAccumulatorRowType(const TypePtr& type) {
+  VELOX_CHECK_EQ(type->kind(), TypeKind::ROW);
+  VELOX_CHECK(type->childAt(0)->isShortDecimal() || type->childAt(0)->isLongDecimal());
+  VELOX_CHECK_EQ(type->childAt(1)->kind(), TypeKind::BOOLEAN);
+}
 } // namespace
 
 exec::AggregateRegistrationResult registerSum(const std::string& name) {
@@ -130,6 +136,7 @@ exec::AggregateRegistrationResult registerSum(const std::string& name) {
                 DOUBLE());
           case TypeKind::ROW: {
             VELOX_DCHECK(!exec::isRawInput(step));
+            checkAccumulatorRowType(inputType);
             auto sumType = getDecimalSumType(resultType, step);
             // For intermediate input agg, input intermediate sum type
             // is equal to final result sum type.

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -40,7 +40,8 @@ TypePtr getDecimalSumType(
 
 void checkAccumulatorRowType(const TypePtr& type) {
   VELOX_CHECK_EQ(type->kind(), TypeKind::ROW);
-  VELOX_CHECK(type->childAt(0)->isShortDecimal() || type->childAt(0)->isLongDecimal());
+  VELOX_CHECK(
+      type->childAt(0)->isShortDecimal() || type->childAt(0)->isLongDecimal());
   VELOX_CHECK_EQ(type->childAt(1)->kind(), TypeKind::BOOLEAN);
 }
 } // namespace

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -119,7 +119,6 @@ exec::AggregateRegistrationResult registerSum(
           }
           case TypeKind::HUGEINT: {
             if (inputType->isLongDecimal()) {
-              auto const sumType = getDecimalSumType(resultType, step);
               // If inputType is long decimal,
               // its output type is always long decimal.
               return std::make_unique<exec::SimpleAggregateAdapter<

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -142,8 +142,8 @@ exec::AggregateRegistrationResult registerSum(
           case TypeKind::ROW: {
             VELOX_DCHECK(!exec::isRawInput(step));
             checkAccumulatorRowType(inputType);
-            // For intermediate input agg, input intermediate sum type
-            // is equal to final result sum type.
+            // For the intermediate aggregation step, input intermediate sum
+            // type is equal to final result sum type.
             if (inputType->childAt(0)->isShortDecimal()) {
               return std::make_unique<exec::SimpleAggregateAdapter<
                   DecimalSumAggregate<int64_t, int64_t>>>(resultType);

--- a/velox/functions/sparksql/aggregates/SumAggregate.h
+++ b/velox/functions/sparksql/aggregates/SumAggregate.h
@@ -22,6 +22,8 @@
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
-exec::AggregateRegistrationResult registerSum(const std::string& name);
+exec::AggregateRegistrationResult registerSum(
+    const std::string& name,
+    bool withCompanionFunctions);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -78,7 +78,7 @@ class SumAggregationTest : public SumTestBase {
       const std::vector<std::optional<TOut>>& output,
       const TypePtr& outputType) {
     std::vector<RowVectorPtr> vectors;
-    FlatVectorPtr<TIn> inputDecimalVector;
+    VectorPtr inputDecimalVector;
     if constexpr (std::is_same_v<int64_t, TIn>) {
       inputDecimalVector = makeNullableFlatVector<int64_t>(input, inputType);
     } else {
@@ -90,7 +90,7 @@ class SumAggregationTest : public SumTestBase {
            inputDecimalVector}));
     }
 
-    FlatVectorPtr<TOut> outputDecimalVector;
+    VectorPtr outputDecimalVector;
     if constexpr (std::is_same_v<int64_t, TOut>) {
       outputDecimalVector = makeNullableFlatVector<int64_t>(output, outputType);
     } else {
@@ -137,9 +137,7 @@ TEST_F(SumAggregationTest, decimalSumCompanionPartial) {
   auto expected = makeRowVector({makeRowVector(
       {makeFlatVector<int128_t>(sumVector, DECIMAL(20, 1)),
        makeFlatVector<bool>(isEmptyVector)})});
-  AssertQueryBuilder assertQueryBuilder(plan);
-  auto result = assertQueryBuilder.copyResults(pool());
-  assertEqualResults({expected}, {result});
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
 TEST_F(SumAggregationTest, decimalSumCompanionMerge) {
@@ -155,9 +153,7 @@ TEST_F(SumAggregationTest, decimalSumCompanionMerge) {
   auto expected = makeRowVector({makeRowVector(
       {makeFlatVector<int128_t>(std::vector<int128_t>{6000}, DECIMAL(20, 1)),
        makeFlatVector<bool>(std::vector<bool>{false})})});
-  AssertQueryBuilder assertQueryBuilder(plan);
-  auto result = assertQueryBuilder.copyResults(pool());
-  assertEqualResults({expected}, {result});
+  AssertQueryBuilder(plan).assertResults(expected);
 }
 
 TEST_F(SumAggregationTest, decimalSum) {

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/lib/aggregates/tests/SumTestBase.h"
 #include "velox/functions/sparksql/aggregates/Register.h"
 
+using facebook::velox::exec::test::PlanBuilder;
+using namespace facebook::velox::exec::test;
 using namespace facebook::velox::functions::aggregate::test;
 
 namespace facebook::velox::functions::aggregate::sparksql::test {
@@ -28,6 +32,82 @@ class SumAggregationTest : public SumTestBase {
     SumTestBase::SetUp();
     registerAggregateFunctions("spark_");
   }
+
+ protected:
+  // check global partial agg overflow, and final agg output null
+  void decimalGlobalSumOverflow(
+      const std::vector<std::optional<int128_t>>& input,
+      const std::vector<std::optional<int128_t>>& output) {
+    const TypePtr type = DECIMAL(38, 0);
+    auto in = makeRowVector({makeNullableFlatVector<int128_t>({input}, type)});
+    auto expected =
+        makeRowVector({makeNullableFlatVector<int128_t>({output}, type)});
+    testAggregations(
+        {in},
+        {},
+        {"spark_sum(c0)"},
+        {expected},
+        /*config*/ {},
+        /*testWithTableScan*/ false);
+  }
+
+  // check group by partial agg overflow, and final agg output null
+  void decimalGroupBySumOverflow(
+      const std::vector<std::optional<int128_t>>& input) {
+    const TypePtr type = DECIMAL(38, 0);
+    auto in = makeRowVector(
+        {makeFlatVector<int32_t>(20, [](auto row) { return row % 10; }),
+         makeNullableFlatVector<int128_t>(input, type)});
+    auto expected = makeRowVector(
+        {makeFlatVector<int32_t>(10, [](auto row) { return row; }),
+         makeNullableFlatVector<int128_t>(
+             std::vector<std::optional<int128_t>>(10, std::nullopt), type)});
+    testAggregations(
+        {in},
+        {"c0"},
+        {"spark_sum(c1)"},
+        {expected},
+        /*config*/ {},
+        /*testWithTableScan*/ false);
+  }
+
+  template <typename TIn, typename TOut>
+  void decimalSumAllNulls(
+      const std::vector<std::optional<TIn>>& input,
+      const TypePtr& inputType,
+      const std::vector<std::optional<TOut>>& output,
+      const TypePtr& outputType) {
+    std::vector<RowVectorPtr> vectors;
+    FlatVectorPtr<TIn> inputDecimalVector;
+    if constexpr (std::is_same_v<int64_t, TIn>) {
+      inputDecimalVector = makeNullableFlatVector<int64_t>(input, inputType);
+    } else {
+      inputDecimalVector = makeNullableFlatVector<int128_t>(input, inputType);
+    }
+    for (int i = 0; i < 5; ++i) {
+      vectors.emplace_back(makeRowVector(
+          {makeFlatVector<int32_t>(20, [](auto row) { return row % 4; }),
+           inputDecimalVector}));
+    }
+
+    FlatVectorPtr<TOut> outputDecimalVector;
+    if constexpr (std::is_same_v<int64_t, TOut>) {
+      outputDecimalVector = makeNullableFlatVector<int64_t>(output, outputType);
+    } else {
+      outputDecimalVector =
+          makeNullableFlatVector<int128_t>(output, outputType);
+    }
+    auto expected = makeRowVector(
+        {makeFlatVector<int32_t>(std::vector<int32_t>{0, 1, 2, 3}),
+         outputDecimalVector});
+    testAggregations(
+        {vectors},
+        {"c0"},
+        {"spark_sum(c1)"},
+        {expected},
+        /*config*/ {},
+        /*testWithTableScan*/ false);
+  }
 };
 
 TEST_F(SumAggregationTest, overflow) {
@@ -38,5 +118,231 @@ TEST_F(SumAggregationTest, hookLimits) {
   testHookLimits<int64_t, int64_t, true>();
 }
 
+TEST_F(SumAggregationTest, decimalSum) {
+  std::vector<std::optional<int64_t>> shortDecimalRawVector;
+  std::vector<std::optional<int128_t>> longDecimalRawVector;
+  for (int i = 0; i < 1000; ++i) {
+    shortDecimalRawVector.emplace_back(i * 1000);
+    longDecimalRawVector.emplace_back(HugeInt::build(i * 10, i * 100));
+  }
+  shortDecimalRawVector.emplace_back(std::nullopt);
+  longDecimalRawVector.emplace_back(std::nullopt);
+  auto input = makeRowVector(
+      {makeNullableFlatVector<int64_t>(shortDecimalRawVector, DECIMAL(10, 1)),
+       makeNullableFlatVector<int128_t>(longDecimalRawVector, DECIMAL(23, 4))});
+  createDuckDbTable({input});
+  testAggregations(
+      {input},
+      {},
+      {"spark_sum(c0)", "spark_sum(c1)"},
+      "SELECT sum(c0), sum(c1) FROM tmp",
+      /*config*/ {},
+      /*testWithTableScan*/ false);
+
+  // Short decimal sum aggregation with multiple groups.
+  auto inputShortDecimalRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{37220, 53450}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{10410, 9250}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{-12783, 0}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{23178, 41093}, DECIMAL(5, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{-10023, 5290}, DECIMAL(5, 2))}),
+  };
+
+  auto expectedShortDecimalResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{113848}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{50730}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeFlatVector<int64_t>(
+               std::vector<int64_t>{-7493}, DECIMAL(15, 2))})};
+
+  testAggregations(
+      inputShortDecimalRows,
+      {"c0"},
+      {"spark_sum(c1)"},
+      expectedShortDecimalResult,
+      /*config*/ {},
+      /*testWithTableScan*/ false);
+
+  // Long decimal sum aggregation with multiple groups.
+  auto inputLongDecimalRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeFlatVector<int128_t>(
+               {HugeInt::build(13, 113848), HugeInt::build(12, 53450)},
+               DECIMAL(20, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeFlatVector<int128_t>(
+               {HugeInt::build(21, 10410), HugeInt::build(17, 9250)},
+               DECIMAL(20, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeFlatVector<int128_t>(
+               {HugeInt::build(25, 12783), HugeInt::build(19, 0)},
+               DECIMAL(20, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int128_t>(
+               {HugeInt::build(31, 23178), HugeInt::build(82, 41093)},
+               DECIMAL(20, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeFlatVector<int128_t>(
+               {HugeInt::build(25, 10023), HugeInt::build(43, 5290)},
+               DECIMAL(20, 2))}),
+  };
+
+  auto expectedLongDecimalResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeFlatVector<int128_t>(
+               std::vector<int128_t>{HugeInt::build(56, 190476)},
+               DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeFlatVector<int128_t>(
+               std::vector<int128_t>{HugeInt::build(145, 70776)},
+               DECIMAL(38, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeFlatVector<int128_t>(
+               std::vector<int128_t>{HugeInt::build(87, 18073)},
+               DECIMAL(38, 2))})};
+
+  testAggregations(
+      inputLongDecimalRows,
+      {"c0"},
+      {"spark_sum(c1)"},
+      expectedLongDecimalResult,
+      /*config*/ {},
+      /*testWithTableScan*/ false);
+}
+
+TEST_F(SumAggregationTest, decimalGlobalSumOverflow) {
+  // Test Positive Overflow.
+  std::vector<std::optional<int128_t>> longDecimalInput;
+  std::vector<std::optional<int128_t>> longDecimalOutput;
+  // Create input with 2 kLongDecimalMax.
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMax);
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMax);
+  // The sum must overflow, and will return null
+  decimalGlobalSumOverflow(longDecimalInput, {std::nullopt});
+
+  // Now add kLongDecimalMin.
+  // The sum now must not overflow.
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMin);
+  longDecimalOutput.emplace_back(DecimalUtil::kLongDecimalMax);
+  decimalGlobalSumOverflow(longDecimalInput, longDecimalOutput);
+
+  // Test Negative Overflow.
+  longDecimalInput.clear();
+  longDecimalOutput.clear();
+
+  // Create input with 2 kLongDecimalMin.
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMin);
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMin);
+
+  // The sum must overflow, and will return null
+  decimalGlobalSumOverflow(longDecimalInput, {std::nullopt});
+
+  // Now add kLongDecimalMax.
+  // The sum now must not overflow.
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMax);
+  longDecimalOutput.emplace_back(DecimalUtil::kLongDecimalMin);
+  decimalGlobalSumOverflow(longDecimalInput, longDecimalOutput);
+
+  // Check value in range.
+  longDecimalInput.clear();
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMax);
+  longDecimalInput.emplace_back(1);
+  decimalGlobalSumOverflow(longDecimalInput, {std::nullopt});
+
+  longDecimalInput.clear();
+  longDecimalInput.emplace_back(DecimalUtil::kLongDecimalMin);
+  longDecimalInput.emplace_back(-1);
+  decimalGlobalSumOverflow(longDecimalInput, {std::nullopt});
+}
+
+TEST_F(SumAggregationTest, decimalGroupBySumOverflow) {
+  // Test Positive Overflow.
+  decimalGroupBySumOverflow(
+      std::vector<std::optional<int128_t>>(20, DecimalUtil::kLongDecimalMax));
+
+  // Test Negative Overflow.
+  decimalGroupBySumOverflow(
+      std::vector<std::optional<int128_t>>(20, DecimalUtil::kLongDecimalMin));
+
+  // Check value in range.
+  auto decimalVector =
+      std::vector<std::optional<int128_t>>(10, DecimalUtil::kLongDecimalMax);
+  auto oneValueVector = std::vector<std::optional<int128_t>>(10, 1);
+  decimalVector.insert(
+      decimalVector.end(), oneValueVector.begin(), oneValueVector.end());
+  decimalGroupBySumOverflow(decimalVector);
+
+  decimalVector =
+      std::vector<std::optional<int128_t>>(10, DecimalUtil::kLongDecimalMin);
+  oneValueVector = std::vector<std::optional<int128_t>>(10, -1);
+  decimalVector.insert(
+      decimalVector.end(), oneValueVector.begin(), oneValueVector.end());
+  decimalGroupBySumOverflow(decimalVector);
+}
+
+// Test if all values in some groups are null, the final sum of this group
+// should be null.
+TEST_F(SumAggregationTest, decimalSomeGroupsAllnullValues) {
+  std::vector<std::optional<int64_t>> shortDecimalNulls(20);
+  std::vector<std::optional<int128_t>> longDecimalNulls(20);
+  for (int i = 0; i < 20; i++) {
+    if (i % 4 == 1 || i % 4 == 3) {
+      // not all groups are null
+      shortDecimalNulls[i] = 1;
+      longDecimalNulls[i] = 1;
+    }
+  }
+
+  // Test short decimal inputs and the output sum is short decimal.
+  decimalSumAllNulls<int64_t, int64_t>(
+      shortDecimalNulls,
+      DECIMAL(7, 2),
+      std::vector<std::optional<int64_t>>{std::nullopt, 25, std::nullopt, 25},
+      DECIMAL(17, 2));
+
+  // Test short decimal inputs and the output sum is long decimal.
+  decimalSumAllNulls<int64_t, int128_t>(
+      shortDecimalNulls,
+      DECIMAL(17, 2),
+      std::vector<std::optional<int128_t>>{std::nullopt, 25, std::nullopt, 25},
+      DECIMAL(27, 2));
+
+  // Test long decimal inputs and the output sum is long decimal.
+  decimalSumAllNulls<int128_t, int128_t>(
+      longDecimalNulls,
+      DECIMAL(25, 2),
+      std::vector<std::optional<int128_t>>{std::nullopt, 25, std::nullopt, 25},
+      DECIMAL(35, 2));
+}
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -51,7 +51,7 @@ class SumAggregationTest : public SumTestBase {
         /*testWithTableScan*/ false);
   }
 
-  // check group by partial agg overflow, and final agg output null
+  // Check group by partial agg overflow, and final agg output null.
   void decimalGroupBySumOverflow(
       const std::vector<std::optional<int128_t>>& input) {
     const TypePtr type = DECIMAL(38, 0);

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -49,6 +49,15 @@ class SumAggregationTest : public SumTestBase {
         {expected},
         /*config*/ {},
         /*testWithTableScan*/ false);
+    testAggregationsWithCompanion(
+        {in},
+        [](auto& /*builder*/) {},
+        {},
+        {"spark_sum(c0)"},
+        {{type}},
+        {},
+        {expected},
+        {});
   }
 
   // Check group by partial agg overflow, and final agg output null.
@@ -69,6 +78,15 @@ class SumAggregationTest : public SumTestBase {
         {expected},
         /*config*/ {},
         /*testWithTableScan*/ false);
+    testAggregationsWithCompanion(
+        {in},
+        [](auto& /*builder*/) {},
+        {"c0"},
+        {"spark_sum(c1)"},
+        {{type}},
+        {"c0", "a0"},
+        {expected},
+        {});
   }
 
   template <typename TIn, typename TOut>
@@ -107,6 +125,15 @@ class SumAggregationTest : public SumTestBase {
         {expected},
         /*config*/ {},
         /*testWithTableScan*/ false);
+    testAggregationsWithCompanion(
+        {vectors},
+        [](auto& /*builder*/) {},
+        {"c0"},
+        {"spark_sum(c1)"},
+        {{inputType}},
+        {"c0", "a0"},
+        {expected},
+        {});
   }
 };
 
@@ -176,6 +203,15 @@ TEST_F(SumAggregationTest, decimalSum) {
       "SELECT sum(c0), sum(c1) FROM tmp",
       /*config*/ {},
       /*testWithTableScan*/ false);
+  testAggregationsWithCompanion(
+      {input},
+      [](auto& /*builder*/) {},
+      {},
+      {"spark_sum(c0)", "spark_sum(c1)"},
+      {{DECIMAL(10, 1)}, {DECIMAL(23, 4)}},
+      {},
+      "SELECT sum(c0), sum(c1) FROM tmp",
+      {});
 
   // Short decimal sum aggregation with multiple groups.
   auto inputShortDecimalRows = {
@@ -222,6 +258,15 @@ TEST_F(SumAggregationTest, decimalSum) {
       expectedShortDecimalResult,
       /*config*/ {},
       /*testWithTableScan*/ false);
+  testAggregationsWithCompanion(
+      {inputShortDecimalRows},
+      [](auto& /*builder*/) {},
+      {"c0"},
+      {"spark_sum(c1)"},
+      {{DECIMAL(5, 2)}},
+      {"c0", "a0"},
+      expectedShortDecimalResult,
+      {});
 
   // Long decimal sum aggregation with multiple groups.
   auto inputLongDecimalRows = {
@@ -276,6 +321,15 @@ TEST_F(SumAggregationTest, decimalSum) {
       expectedLongDecimalResult,
       /*config*/ {},
       /*testWithTableScan*/ false);
+  testAggregationsWithCompanion(
+      {inputShortDecimalRows},
+      [](auto& /*builder*/) {},
+      {"c0"},
+      {"spark_sum(c1)"},
+      {{DECIMAL(20, 2)}},
+      {"c0", "a0"},
+      expectedShortDecimalResult,
+      {});
 }
 
 TEST_F(SumAggregationTest, decimalGlobalSumOverflow) {
@@ -362,6 +416,15 @@ TEST_F(SumAggregationTest, decimalAllNullValues) {
       {expected},
       /*config*/ {},
       /*testWithTableScan*/ false);
+  testAggregationsWithCompanion(
+      {input},
+      [](auto& /*builder*/) {},
+      {},
+      {"spark_sum(c0)"},
+      {{DECIMAL(20, 2)}},
+      {},
+      {expected},
+      {});
 }
 
 // Test if all values in some groups are null, the final sum of this group
@@ -420,6 +483,15 @@ TEST_F(SumAggregationTest, decimalRangeOverflow) {
       {expected},
       /*config*/ {},
       /*testWithTableScan*/ false);
+  testAggregationsWithCompanion(
+      {firstInput, secondInput},
+      [](auto& /*builder*/) {},
+      {},
+      {"spark_sum(c0)"},
+      {{DECIMAL(38, 18)}},
+      {},
+      {expected},
+      {});
 }
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/SumAggregationTest.cpp
@@ -96,25 +96,16 @@ class SumAggregationTest : public SumTestBase {
       const std::vector<std::optional<TOut>>& output,
       const TypePtr& outputType) {
     std::vector<RowVectorPtr> vectors;
-    VectorPtr inputDecimalVector;
-    if constexpr (std::is_same_v<int64_t, TIn>) {
-      inputDecimalVector = makeNullableFlatVector<int64_t>(input, inputType);
-    } else {
-      inputDecimalVector = makeNullableFlatVector<int128_t>(input, inputType);
-    }
+    VectorPtr inputDecimalVector =
+        makeNullableFlatVector<TIn>(input, inputType);
     for (int i = 0; i < 5; ++i) {
       vectors.emplace_back(makeRowVector(
           {makeFlatVector<int32_t>(20, [](auto row) { return row % 4; }),
            inputDecimalVector}));
     }
 
-    VectorPtr outputDecimalVector;
-    if constexpr (std::is_same_v<int64_t, TOut>) {
-      outputDecimalVector = makeNullableFlatVector<int64_t>(output, outputType);
-    } else {
-      outputDecimalVector =
-          makeNullableFlatVector<int128_t>(output, outputType);
-    }
+    VectorPtr outputDecimalVector =
+        makeNullableFlatVector<TOut>(output, outputType);
     auto expected = makeRowVector(
         {makeFlatVector<int32_t>(std::vector<int32_t>{0, 1, 2, 3}),
          outputDecimalVector});


### PR DESCRIPTION
resolve https://github.com/facebookincubator/velox/issues/5226.
spark sql needs an isEmpty attribute in decimal sum agg. We need to implement
a new decimal sum agg and add isEmpty semantics.
Currently, gluten only support no ansi mode, so we need to return null when
overflow. Spark judges whether overflow occurs by using isEmpty=false, but
sum is null. isEmpty can cooperate with sum to express there is overflow in
the intermediate result.
Spark's implement
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Sum.scala