### PR TITLE
Fix race condition in Task abort

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -454,7 +454,9 @@ uint64_t Operator::MemoryReclaimer::reclaim(
     return 0;
   }
   VELOX_CHECK_EQ(pool->name(), op_->pool()->name());
-  VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
+  VELOX_CHECK(
+      !driver->state().isOnThread() || driver->state().isSuspended ||
+      driver->state().isTerminated);
   VELOX_CHECK(driver->task()->pauseRequested());
 
   op_->reclaim(targetBytes);
@@ -467,7 +469,9 @@ void Operator::MemoryReclaimer::abort(memory::MemoryPool* pool) {
     return;
   }
   VELOX_CHECK_EQ(pool->name(), op_->pool()->name());
-  VELOX_CHECK(!driver->state().isOnThread() || driver->state().isSuspended);
+  VELOX_CHECK(
+      !driver->state().isOnThread() || driver->state().isSuspended ||
+      driver->state().isTerminated);
   VELOX_CHECK(driver->task()->isCancelled());
 
   // Calls operator close to free up major memory usage.


### PR DESCRIPTION
Summary:
HashJoinTest.hashBuildAbortDuringInputgProcessing exposes a potential race condition when aborting a Task.

The test creates a Task for a Join query, which has 2 Drivers, one for the HashProbe and one for the HashBuild.  The Driver for the HashBuild will get suspended at which point the Task will be aborted.

It's possible that the Driver for the HashProbe has been enqueued on the Task's executor but hasn't been executed yet and isn't executed until after abort is called on its operators.

In this case:
* when the Task's terminate function is called as part of abort, it calls enterForTerminateLocked on the Driver's state and sees that this Driver is not "onThread", it sets its state to terminated and calls setThread
* when abort is called on any operator from the Driver, the MemoryReclaimer sees that the Driver is now "onThread" and the Driver is not suspended, so it fails this check https://www.internalfb.com/code/fbsource/[80b90c8613db0fc6a4f44778b41a236a4b4d92a4]/fbcode/velox/exec/Operator.cpp?lines=470

In this case it is still safe to close the Operator.  As soon as the Driver is run, it will see that it is terminated and cease to run.  In general this is the case because a Driver can only be in state terminated if it is not actively running.

I believe this is also an issue for the reclaim function.

Differential Revision: D46983765

