### PR TITLE
Fix flaky concurrent arbitration test

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -179,7 +179,7 @@ class FakeMemoryOperator : public Operator {
 
   const bool canReclaim_;
   const AllocationCallback allocationCb_;
-  const ReclaimInjectionCallback reclaimCb_;
+  const ReclaimInjectionCallback reclaimCb_{nullptr};
 
   std::atomic<size_t> totalBytes_{0};
   std::vector<Allocation> allocations_;
@@ -1632,6 +1632,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
   std::vector<std::thread> queryThreads;
   for (int i = 0; i < numThreads; ++i) {
     queryThreads.emplace_back([&, i]() {
+      DuckDbQueryRunner duckDbQueryRunner;
       folly::Random::DefaultGenerator rng;
       rng.seed(i);
       while (!stopped) {
@@ -1646,7 +1647,7 @@ TEST_F(SharedArbitrationTest, concurrentArbitration) {
         }
         std::shared_ptr<Task> task;
         try {
-          task = AssertQueryBuilder(duckDbQueryRunner_)
+          task = AssertQueryBuilder(duckDbQueryRunner)
                      .queryCtx(query)
                      .plan(PlanBuilder()
                                .values(vectors)

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -40,8 +40,14 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, kind, parent, nullptr, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
+      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
         capacity_(cap) {}
+
+  ~MockMemoryPool() override {
+    if (parent_ != nullptr) {
+      static_cast<MockMemoryPool*>(parent_.get())->dropChild(this);
+    }
+  }
 
   int64_t capacity() const override {
     return parent_ != nullptr ? parent_->capacity() : capacity_;
@@ -163,6 +169,31 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   MOCK_CONST_METHOD0(alignment, uint16_t());
 
   uint64_t freeBytes() const override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  void setReclaimer(
+      std::unique_ptr<memory::MemoryReclaimer> reclaimer) override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  memory::MemoryReclaimer* reclaimer() const override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  void enterArbitration() override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  void leaveArbitration() noexcept override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  bool reclaimableBytes(uint64_t& reclaimableBytes) const override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  uint64_t reclaim(uint64_t targetBytes) override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 


### PR DESCRIPTION
Fix a couple tsan detected race condition in concurrent arbitration
test:
(1) protect the reclaimer set using mutex lock in MemoryPoolImpl and use
tsan lock for access
(2) fix capacity access race in out of memory exception message generation
(3) fix concurrent duckdb access under tsan
(4) fix fake memory operator initialization race with reclaimer

Verified with meta internal tsan tests