### PR TITLE
Make LocalWriteFile optionally create parent directory

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,7 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file Folly::folly)
+target_link_libraries(velox_file velox_common_base Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -289,8 +289,12 @@ class LocalReadFile final : public ReadFile {
 
 class LocalWriteFile final : public WriteFile {
  public:
-  // An error is thrown is a file already exists at |path|.
-  explicit LocalWriteFile(std::string_view path);
+  // An error is thrown is a file already exists at |path|,
+  // unless flag shouldThrowOnFileAlreadyExists is false
+  explicit LocalWriteFile(
+      std::string_view path,
+      bool shouldCreateParentDirectories = false,
+      bool shouldThrowOnFileAlreadyExists = true);
   ~LocalWriteFile();
 
   void append(std::string_view data) final;


### PR DESCRIPTION
Summary: `LocalFileSink` creates parent directory if not exists. Pass flag to `LocalWriteFile` so it can do the same.

Differential Revision: D46993078

