### PR TITLE
Add function to register WriteFileDataSink factory wrapping LocalWriteFile

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,7 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file Folly::folly)
+target_link_libraries(velox_file velox_common_base Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -289,8 +289,12 @@ class LocalReadFile final : public ReadFile {
 
 class LocalWriteFile final : public WriteFile {
  public:
-  // An error is thrown is a file already exists at |path|.
-  explicit LocalWriteFile(std::string_view path);
+  // An error is thrown is a file already exists at |path|,
+  // unless flag shouldThrowOnFileAlreadyExists is false
+  explicit LocalWriteFile(
+      std::string_view path,
+      bool shouldCreateParentDirectories = false,
+      bool shouldThrowOnFileAlreadyExists = true);
   ~LocalWriteFile();
 
   void append(std::string_view data) final;

--- a/velox/dwio/common/DataSink.cpp
+++ b/velox/dwio/common/DataSink.cpp
@@ -40,6 +40,25 @@ void WriteFileDataSink::doClose() {
   }
 }
 
+std::unique_ptr<DataSink> localWriteFileSink(
+    const std::string& filename,
+    MetricsLogPtr metricsLog,
+    IoStatistics* stats = nullptr) {
+  if (strncmp(filename.c_str(), "file:", 5) == 0) {
+    auto pathSuffix = filename.substr(5);
+    return std::make_unique<WriteFileDataSink>(
+        std::make_unique<LocalWriteFile>(pathSuffix, true, false),
+        pathSuffix,
+        metricsLog,
+        stats);
+  }
+  return nullptr;
+}
+
+void WriteFileDataSink::registerLocalFileFactory() {
+  DataSink::registerFactory(localWriteFileSink);
+}
+
 LocalFileSink::LocalFileSink(
     const std::string& name,
     const MetricsLogPtr& metricLogger,

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -145,6 +145,8 @@ class WriteFileDataSink final : public DataSink {
       : DataSink(std::move(name), std::move(metricLogger), stats),
         writeFile_{std::move(writeFile)} {}
 
+  static void registerLocalFileFactory();
+
   ~WriteFileDataSink() override {
     destroy();
   }

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -155,14 +155,6 @@ class WriteFileDataSink final : public DataSink {
 
   static void registerFactory();
 
-  uint64_t size() const override {
-    DWIO_ENSURE_EQ(
-        size_,
-        writeFile_->size(),
-        "Size mismatch between WriteFile and DataSink.");
-    return size_;
-  }
-
   using DataSink::write;
 
   void write(std::vector<DataBuffer<char>>& buffers) override;


### PR DESCRIPTION
Summary: We need to be able to register factory for a DataSink wrapped LocalWriteFile. This does that without using the soon-to-be-deprecated `VELOX_REGISTER_DATA_SINK_METHOD_DEFINITION` macro.

Differential Revision: D46953912

