### PR TITLE
Reduce linker threads in nightly fuzzer build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ commands:
       - run:
           name: Build
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=8
+            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
Similar to the fix for linux-build in https://github.com/facebookincubator/velox/pull/4582

Calling make debug OOM's the CircleCI container unless we drop the number of linker threads to 6.

This fixes the nightly fuzzer runs so they no longer OOM during the build phase.

In https://github.com/facebookincubator/velox/pull/5381 I modified the CircleCI config so that the fuzzer jobs run on PRs.  All the build phases succeeded (a couple of the fuzzer tests failed at runtime which is why we need them running).