### PR TITLE
Remove LocalFileSink from open source

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,7 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file Folly::folly)
+target_link_libraries(velox_file velox_common_base Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -289,8 +289,12 @@ class LocalReadFile final : public ReadFile {
 
 class LocalWriteFile final : public WriteFile {
  public:
-  // An error is thrown is a file already exists at |path|.
-  explicit LocalWriteFile(std::string_view path);
+  // An error is thrown is a file already exists at |path|,
+  // unless flag shouldThrowOnFileAlreadyExists is false
+  explicit LocalWriteFile(
+      std::string_view path,
+      bool shouldCreateParentDirectories = false,
+      bool shouldThrowOnFileAlreadyExists = true);
   ~LocalWriteFile();
 
   void append(std::string_view data) final;

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -98,12 +98,12 @@ class HiveConnectorFactory : public ConnectorFactory {
       "hive-hadoop2";
 
   HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {
-    dwio::common::LocalFileSink::registerFactory();
+    dwio::common::WriteFileDataSink::registerLocalFileFactory();
   }
 
   HiveConnectorFactory(const char* FOLLY_NONNULL connectorName)
       : ConnectorFactory(connectorName) {
-    dwio::common::LocalFileSink::registerFactory();
+    dwio::common::WriteFileDataSink::registerLocalFileFactory();
   }
 
   std::shared_ptr<Connector> newConnector(

--- a/velox/dwio/common/DataSink.cpp
+++ b/velox/dwio/common/DataSink.cpp
@@ -40,6 +40,25 @@ void WriteFileDataSink::doClose() {
   }
 }
 
+std::unique_ptr<DataSink> localWriteFileSink(
+    const std::string& filename,
+    MetricsLogPtr metricsLog,
+    IoStatistics* stats = nullptr) {
+  if (strncmp(filename.c_str(), "file:", 5) == 0) {
+    auto pathSuffix = filename.substr(5);
+    return std::make_unique<WriteFileDataSink>(
+        std::make_unique<LocalWriteFile>(pathSuffix, true, false),
+        pathSuffix,
+        metricsLog,
+        stats);
+  }
+  return nullptr;
+}
+
+void WriteFileDataSink::registerLocalFileFactory() {
+  DataSink::registerFactory(localWriteFileSink);
+}
+
 LocalFileSink::LocalFileSink(
     const std::string& name,
     const MetricsLogPtr& metricLogger,

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -145,6 +145,8 @@ class WriteFileDataSink final : public DataSink {
       : DataSink(std::move(name), std::move(metricLogger), stats),
         writeFile_{std::move(writeFile)} {}
 
+  static void registerLocalFileFactory();
+
   ~WriteFileDataSink() override {
     destroy();
   }

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -155,14 +155,6 @@ class WriteFileDataSink final : public DataSink {
 
   static void registerFactory();
 
-  uint64_t size() const override {
-    DWIO_ENSURE_EQ(
-        size_,
-        writeFile_->size(),
-        "Size mismatch between WriteFile and DataSink.");
-    return size_;
-  }
-
   using DataSink::write;
 
   void write(std::vector<DataBuffer<char>>& buffers) override;

--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -25,9 +25,7 @@ using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::dwio::common {
 
-TEST(LocalFileSinkTest, create) {
-  LocalFileSink::registerFactory();
-
+void runTest() {
   auto root = TempDirectoryPath::create();
   auto filePath = fs::path(root->path) / "xxx/yyy/zzz/test_file.ext";
 
@@ -38,6 +36,16 @@ TEST(LocalFileSinkTest, create) {
   localFileSink->close();
 
   EXPECT_TRUE(fs::exists(filePath.string()));
+}
+
+TEST(LocalFileSinkTest, create) {
+  LocalFileSink::registerFactory();
+  runTest();
+}
+
+TEST(LocalFileSinkTest, writeFileSink) {
+  WriteFileDataSink::registerLocalFileFactory();
+  runTest();
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -270,7 +270,10 @@ TEST_F(E2EWriterTests, DISABLED_TestFileCreation) {
         BatchMaker::createBatch(type, size, *leafPool_, nullptr, i));
   }
 
-  auto sink = std::make_unique<LocalFileSink>("/tmp/e2e_generated_file.orc");
+  auto path = "/tmp/e2e_generated_file.orc";
+  auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
+  auto sink =
+      std::make_unique<WriteFileDataSink>(std::move(localWriteFile), path);
   E2EWriterTestUtil::writeData(
       std::move(sink),
       type,

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -44,8 +44,10 @@ class ParquetReaderBenchmark {
       : disableDictionary_(disableDictionary) {
     pool_ = memory::addDefaultLeafMemoryPool();
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*pool_.get(), 0);
+    auto path = fileFolder_->path + "/" + fileName_;
+    auto localWriteFile = std::make_unique<LocalWriteFile>(path, true, false);
     auto sink =
-        std::make_unique<LocalFileSink>(fileFolder_->path + "/" + fileName_);
+        std::make_unique<WriteFileDataSink>(std::move(localWriteFile), path);
     facebook::velox::parquet::WriterOptions options;
     if (disableDictionary_) {
       // The parquet file is in plain encoding format.

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -62,8 +62,9 @@ void HiveConnectorTestBase::writeToFile(
   velox::dwrf::WriterOptions options;
   options.config = config;
   options.schema = vectors[0]->type();
-  auto sink =
-      std::make_unique<facebook::velox::dwio::common::LocalFileSink>(filePath);
+  auto localWriteFile = std::make_unique<LocalWriteFile>(filePath, true, false);
+  auto sink = std::make_unique<dwio::common::WriteFileDataSink>(
+      std::move(localWriteFile), filePath);
   auto childPool = rootPool_->addAggregateChild("HiveConnectorTestBase.Writer");
   options.memoryPool = childPool.get();
   facebook::velox::dwrf::Writer writer{std::move(sink), options};


### PR DESCRIPTION
Summary: Removes `LocalFileSink` usages from velox, replacing with `WriteFileDataSink`.

Differential Revision: D46951742

