### PR TITLE
Allow loading of nested lazy RowVector

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -673,6 +673,12 @@ bool isLazyNotLoaded(const BaseVector& vector) {
     case VectorEncoding::Simple::CONSTANT:
       return vector.valueVector() ? isLazyNotLoaded(*vector.valueVector())
                                   : false;
+    case VectorEncoding::Simple::ROW: {
+      const auto& children = vector.as<RowVector>()->children();
+      return std::any_of(children.begin(), children.end(), [](auto it) {
+        return it != nullptr && isLazyNotLoaded(*it);
+      });
+    }
     default:
       return false;
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -546,7 +546,7 @@ class BaseVector {
     return this;
   }
 
-  static VectorPtr loadedVectorShared(VectorPtr);
+  static VectorPtr loadedVectorShared(VectorPtr vector);
 
   virtual const BufferPtr& values() const {
     VELOX_UNSUPPORTED("Only flat vectors have a values buffer");

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -93,6 +93,23 @@ class RowVector : public BaseVector {
 
   uint64_t hashValueAt(vector_size_t index) const override;
 
+  BaseVector* loadedVector() override {
+    for (auto i = 0; i < childrenSize_; ++i) {
+      if (!children_[i]) {
+        continue;
+      }
+      auto newChild = BaseVector::loadedVectorShared(children_[i]);
+      if (children_[i].get() != newChild.get()) {
+        children_[i] = newChild;
+      }
+    }
+    return this;
+  }
+
+  const BaseVector* loadedVector() const override {
+    return const_cast<RowVector*>(this)->loadedVector();
+  }
+
   std::unique_ptr<SimpleVector<uint64_t>> hashAll() const override;
 
   /// Return the number of child vectors.


### PR DESCRIPTION
Followup of: https://github.com/facebookincubator/velox/pull/5140

For cases when we have nested lazies in row vector, we should load them appropriately when decoding, or calling loadedvector(). This PR addresses this loading for lazies in row type.

I'm not sure if its safe to mutate the RowVector when loading.