### PR TITLE
Fix size reporting in WriteFileDataSink

### DIFF
--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,7 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file Folly::folly)
+target_link_libraries(velox_file velox_common_base Folly::folly)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/File.h
+++ b/velox/common/file/File.h
@@ -289,8 +289,12 @@ class LocalReadFile final : public ReadFile {
 
 class LocalWriteFile final : public WriteFile {
  public:
-  // An error is thrown is a file already exists at |path|.
-  explicit LocalWriteFile(std::string_view path);
+  // An error is thrown is a file already exists at |path|,
+  // unless flag shouldThrowOnFileAlreadyExists is false
+  explicit LocalWriteFile(
+      std::string_view path,
+      bool shouldCreateParentDirectories = false,
+      bool shouldThrowOnFileAlreadyExists = true);
   ~LocalWriteFile();
 
   void append(std::string_view data) final;

--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -155,14 +155,6 @@ class WriteFileDataSink final : public DataSink {
 
   static void registerFactory();
 
-  uint64_t size() const override {
-    DWIO_ENSURE_EQ(
-        size_,
-        writeFile_->size(),
-        "Size mismatch between WriteFile and DataSink.");
-    return size_;
-  }
-
   using DataSink::write;
 
   void write(std::vector<DataBuffer<char>>& buffers) override;


### PR DESCRIPTION
Summary:
We can run into an issue where tests fail due to size mismatch between LocalWriteFile and the wrapping WriteFileDataSink. This is because:

1. We write to a file
2. We open a new WriteFileDataSink on that file
3. We check the file's size. WriteFileDataSink uses DataSink's built in size, based on total appended data (0) LocalWriteFile uses the size of the underlying file itself (however many bytes we wrote in step 1).

This fixes this by using semantics from `DataSink`- report 0 if file has not been written to.

Differential Revision: D46996258

