### PR TITLE
Add to release more memory resources in hash probe close

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -36,6 +36,15 @@ uint64_t capacityAfterGrowth(const MemoryPool& pool, uint64_t targetBytes) {
 }
 } // namespace
 
+std::string SharedArbitrator::Candidate::toString() const {
+  return fmt::format(
+      "CANDIDATE[{} RECLAIMABLE[{}] RECLAIMABLE_BYTES[{}] FREE_BYTES[{}]]",
+      pool->root()->name(),
+      reclaimable,
+      succinctBytes(reclaimableBytes),
+      succinctBytes(freeBytes));
+}
+
 void SharedArbitrator::sortCandidatesByFreeCapacity(
     std::vector<Candidate>& candidates) const {
   std::sort(

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -50,6 +50,8 @@ class SharedArbitrator : public MemoryArbitrator {
     uint64_t reclaimableBytes{0};
     uint64_t freeBytes{0};
     MemoryPool* pool;
+
+    std::string toString() const;
   };
 
  private:

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1402,6 +1402,10 @@ void HashProbe::close() {
   joinBridge_.reset();
   spiller_.reset();
   table_.reset();
+  outputRowMapping_.reset();
+  output_.reset();
+  nonSpillInputIndicesBuffer_.reset();
+  spillInputIndicesBuffers_.clear();
 }
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Currently hash probe close only free major memory resources
and this caused  a flaky unit test #5240: which expect all the memory
has been freed. This PR adds to fix more memory resource and the
flaky test passed 1000 times in meta internal test.