### PR TITLE
Add Hdfs support in DataSink

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
@@ -14,8 +14,8 @@
 
 # for generated headers
 
-add_library(velox_hdfs HdfsFileSystem.cpp HdfsReadFile.cpp HdfsWriteFile.cpp)
-target_link_libraries(velox_hdfs Folly::folly ${LIBHDFS3})
+add_library(velox_hdfs HdfsFileSystem.cpp HdfsReadFile.cpp HdfsWriteFile.cpp HdfsFileSink.cpp)
+target_link_libraries(velox_hdfs Folly::folly ${LIBHDFS3} xsimd gtest)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 # for generated headers
 
-add_library(velox_hdfs HdfsFileSystem.cpp HdfsReadFile.cpp HdfsWriteFile.cpp HdfsFileSink.cpp)
+add_library(velox_hdfs HdfsFileSystem.cpp HdfsReadFile.cpp HdfsWriteFile.cpp
+                       HdfsFileSink.cpp)
 target_link_libraries(velox_hdfs Folly::folly ${LIBHDFS3} xsimd gtest)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSink.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSink.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSink.h"
+#include <hdfs/hdfs.h>
+
+namespace facebook::velox {
+
+void HdfsFileSink::write(
+    std::vector<facebook::velox::dwio::common::DataBuffer<char>>& buffers) {
+  writeImpl(buffers, [&](auto& buffer) {
+    size_t size = buffer.size();
+    std::string str(buffer.data(), size);
+    file_->append(str);
+    return size;
+  });
+}
+} // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSink.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSink.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/file/FileSystems.h"
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h"
+#include "velox/dwio/common/DataSink.h"
+
+namespace facebook::velox {
+
+class HdfsFileSink : public facebook::velox::dwio::common::DataSink {
+ public:
+  explicit HdfsFileSink(
+      const std::string& fullDestinationPath,
+      const facebook::velox::dwio::common::MetricsLogPtr& metricLogger =
+          facebook::velox::dwio::common::MetricsLog::voidLog(),
+      facebook::velox::dwio::common::IoStatistics* stats = nullptr)
+      : facebook::velox::dwio::common::DataSink{
+            "HdfsFileSink",
+            metricLogger,
+            stats} {
+    auto destinationPathStartPos = fullDestinationPath.substr(7).find("/", 0);
+    std::string destinationPath =
+        fullDestinationPath.substr(destinationPathStartPos + 7);
+    auto hdfsFileSystem =
+        filesystems::getFileSystem(fullDestinationPath, nullptr);
+    file_ = hdfsFileSystem->openFileForWrite(destinationPath);
+  }
+
+  ~HdfsFileSink() override {
+    destroy();
+  }
+
+  using facebook::velox::dwio::common::DataSink::write;
+
+  void write(std::vector<facebook::velox::dwio::common::DataBuffer<char>>&
+                 buffers) override;
+
+  static void registerFactory();
+
+ protected:
+  void doClose() override {
+    file_->close();
+  }
+
+ private:
+  std::unique_ptr<WriteFile> file_;
+};
+} // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -15,10 +15,12 @@
  */
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
 #include <boost/format.hpp>
+#include <connectors/hive/storage_adapters/hdfs/HdfsFileSink.h>
 #include <connectors/hive/storage_adapters/hdfs/HdfsReadFile.h>
 #include <connectors/hive/storage_adapters/hdfs/HdfsWriteFile.h>
 #include <gmock/gmock-matchers.h>
 #include <hdfs/hdfs.h>
+#include <velox/dwio/common/DataBuffer.h>
 #include <atomic>
 #include <random>
 #include "HdfsMiniCluster.h"
@@ -28,8 +30,6 @@
 #include "velox/common/file/FileSystems.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
-#include <connectors/hive/storage_adapters/hdfs/HdfsFileSink.h>
-#include <velox/dwio/common/DataBuffer.h>
 using namespace facebook::velox;
 
 constexpr int kOneMB = 1 << 20;
@@ -452,7 +452,8 @@ TEST_F(HdfsFileSystemTest, readFailures) {
 
 TEST_F(HdfsFileSystemTest, hdfsFileSinkTest) {
   filesystems::registerHdfsFileSystem();
-  auto sink = std::make_shared<facebook::velox::HdfsFileSink>(fullDestinationPath);
+  auto sink =
+      std::make_shared<facebook::velox::HdfsFileSink>(fullDestinationPath);
 
   auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   facebook::velox::dwio::common::DataBuffer<char> buffer{*pool};


### PR DESCRIPTION
When we support the native parquet write function in Gluten, we found that Velox Parquet Writer only support write the data into local file system. And this PR add the  HDFS file system writing support. And then Gluten can write the data into HDFS path when calling velox parquet writer.