### PR TITLE
Add IGNORE NULLs support in Window value functions

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -391,6 +391,7 @@ void registerAggregateWindowFunction(const std::string& name) {
         [name](
             const std::vector<exec::WindowFunctionArg>& args,
             const TypePtr& resultType,
+            bool /*ignoreNulls*/,
             velox::memory::MemoryPool* pool,
             HashStringAllocator* stringAllocator,
             const core::QueryConfig& config)

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -141,9 +141,6 @@ void Window::createWindowFunctions(
     const RowTypePtr& inputType,
     const core::QueryConfig& config) {
   for (const auto& windowNodeFunction : windowNode->windowFunctions()) {
-    VELOX_USER_CHECK(
-        !windowNodeFunction.ignoreNulls,
-        "Ignore nulls for window functions is not supported yet");
     std::vector<WindowFunctionArg> functionArgs;
     functionArgs.reserve(windowNodeFunction.functionCall->inputs().size());
     for (auto& arg : windowNodeFunction.functionCall->inputs()) {
@@ -162,6 +159,7 @@ void Window::createWindowFunctions(
         windowNodeFunction.functionCall->name(),
         functionArgs,
         windowNodeFunction.functionCall->type(),
+        windowNodeFunction.ignoreNulls,
         operatorCtx_->pool(),
         &stringAllocator_,
         config));

--- a/velox/exec/WindowFunction.cpp
+++ b/velox/exec/WindowFunction.cpp
@@ -60,13 +60,14 @@ std::unique_ptr<WindowFunction> WindowFunction::create(
     const std::string& name,
     const std::vector<WindowFunctionArg>& args,
     const TypePtr& resultType,
+    bool ignoreNulls,
     memory::MemoryPool* pool,
     HashStringAllocator* stringAllocator,
     const core::QueryConfig& config) {
   // Lookup the function in the new registry first.
   if (auto func = getWindowFunctionEntry(name)) {
     return func.value()->factory(
-        args, resultType, pool, stringAllocator, config);
+        args, resultType, ignoreNulls, pool, stringAllocator, config);
   }
 
   VELOX_USER_FAIL("Window function not registered: {}", name);

--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -105,13 +105,13 @@ class WindowFunction {
       const std::string& name,
       const std::vector<WindowFunctionArg>& args,
       const TypePtr& resultType,
+      bool ignoreNulls,
       memory::MemoryPool* pool,
       HashStringAllocator* stringAllocator,
       const core::QueryConfig& config);
 
  protected:
-  // This utility function can be used across WindowFunctions to set NULL for
-  // rows with invalid frames in the input.
+  // Set result NULL for rows with invalid frames in the input.
   void setNullEmptyFramesResults(
       const SelectivityVector& validRows,
       vector_size_t resultOffset,
@@ -134,6 +134,7 @@ class WindowFunction {
 using WindowFunctionFactory = std::function<std::unique_ptr<WindowFunction>(
     const std::vector<WindowFunctionArg>& args,
     const TypePtr& resultType,
+    bool ignoreNulls,
     memory::MemoryPool* pool,
     HashStringAllocator* stringAllocator,
     const core::QueryConfig& config)>;

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -53,4 +53,59 @@ void WindowPartition::extractColumn(
       result);
 }
 
+void WindowPartition::extractNulls(
+    int32_t columnIndex,
+    vector_size_t partitionOffset,
+    vector_size_t numRows,
+    const BufferPtr& nullsBuffer) const {
+  RowContainer::extractNulls(
+      partition_.data() + partitionOffset,
+      numRows,
+      columns_[columnIndex],
+      nullsBuffer);
+}
+
+namespace {
+
+std::pair<vector_size_t, vector_size_t> findMinMaxFrameBounds(
+    const SelectivityVector& validRows,
+    const BufferPtr& frameStarts,
+    const BufferPtr& frameEnds) {
+  auto rawFrameStarts = frameStarts->as<vector_size_t>();
+  auto rawFrameEnds = frameEnds->as<vector_size_t>();
+
+  auto firstValidRow = validRows.begin();
+  vector_size_t minFrame = rawFrameStarts[firstValidRow];
+  vector_size_t maxFrame = rawFrameEnds[firstValidRow];
+  validRows.applyToSelected([&](auto i) {
+    minFrame = std::min(minFrame, rawFrameStarts[i]);
+    maxFrame = std::max(maxFrame, rawFrameEnds[i]);
+  });
+  return {minFrame, maxFrame};
+}
+
+}; // namespace
+
+std::optional<std::pair<vector_size_t, vector_size_t>>
+WindowPartition::extractNulls(
+    column_index_t col,
+    const SelectivityVector& validRows,
+    const BufferPtr& frameStarts,
+    const BufferPtr& frameEnds,
+    BufferPtr* nulls) const {
+  VELOX_CHECK(validRows.hasSelections(), "Buffer has no active rows");
+  auto [minFrame, maxFrame] =
+      findMinMaxFrameBounds(validRows, frameStarts, frameEnds);
+
+  // Add 1 since maxFrame is the index of the frame end row.
+  auto framesSize = maxFrame - minFrame + 1;
+  AlignedBuffer::reallocate<bool>(nulls, framesSize);
+
+  extractNulls(col, minFrame, framesSize, *nulls);
+  auto foundNull =
+      bits::findFirstBit((*nulls)->as<uint64_t>(), 0, framesSize) >= 0;
+  return foundNull ? std::make_optional(std::make_pair(minFrame, framesSize))
+                   : std::nullopt;
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/WindowPartition.h
+++ b/velox/exec/WindowPartition.h
@@ -55,6 +55,30 @@ class WindowPartition {
       vector_size_t resultOffset,
       const VectorPtr& result) const;
 
+  /// Extracts null positions at 'columnIndex' into 'nullsBuffer' for
+  /// 'numRows' starting at positions 'partitionOffset' in the partition
+  /// input data.
+  void extractNulls(
+      int32_t columnIndex,
+      vector_size_t partitionOffset,
+      vector_size_t numRows,
+      const BufferPtr& nullsBuffer) const;
+
+  /// Extracts null positions at 'col' into 'nulls'. The null positions
+  /// are from the smallest 'frameStarts' value to the greatest 'frameEnds'
+  /// value for 'validRows'. Both 'frameStarts' and 'frameEnds' are buffers
+  /// of type vector_size_t.
+  /// The returned value is an optional pair of vector_size_t.
+  /// The pair is returned only if null values are found in the nulls
+  /// extracted. The first value of the pair is the smallest frameStart for
+  /// nulls. The second is the number of frames extracted.
+  std::optional<std::pair<vector_size_t, vector_size_t>> extractNulls(
+      column_index_t col,
+      const SelectivityVector& validRows,
+      const BufferPtr& frameStarts,
+      const BufferPtr& frameEnds,
+      BufferPtr* nulls) const;
+
  private:
   // This is a copy of the input RowColumn objects that are used for
   // accessing the partition row columns. These RowColumn objects

--- a/velox/functions/lib/window/NthValue.cpp
+++ b/velox/functions/lib/window/NthValue.cpp
@@ -27,8 +27,9 @@ class NthValueFunction : public exec::WindowFunction {
   explicit NthValueFunction(
       const std::vector<exec::WindowFunctionArg>& args,
       const TypePtr& resultType,
+      bool ignoreNulls,
       velox::memory::MemoryPool* pool)
-      : WindowFunction(resultType, pool, nullptr) {
+      : WindowFunction(resultType, pool, nullptr), ignoreNulls_(ignoreNulls) {
     VELOX_CHECK_EQ(args.size(), 2);
     VELOX_CHECK_NULL(args[0].constantValue);
     valueIndex_ = args[0].index.value();
@@ -57,12 +58,13 @@ class NthValueFunction : public exec::WindowFunction {
                 ->valueAt(0);
         VELOX_USER_CHECK_GE(
             constantOffset_.value(), 1, "Offset must be at least 1");
-        return;
+      } else {
+        offsetIndex_ = args[1].index.value();
+        offsets_ = BaseVector::create<FlatVector<int64_t>>(BIGINT(), 0, pool);
       }
-
-      offsetIndex_ = args[1].index.value();
-      offsets_ = BaseVector::create<FlatVector<int64_t>>(BIGINT(), 0, pool);
     }
+
+    nulls_ = allocateNulls(0, pool);
   }
 
   void resetPartition(const exec::WindowPartition* partition) override {
@@ -79,15 +81,17 @@ class NthValueFunction : public exec::WindowFunction {
       int32_t resultOffset,
       const VectorPtr& result) override {
     auto numRows = frameStarts->size() / sizeof(vector_size_t);
-    auto rawFrameStarts = frameStarts->as<vector_size_t>();
-    auto rawFrameEnds = frameEnds->as<vector_size_t>();
-
     rowNumbers_.resize(numRows);
-    if (constantOffset_.has_value() || isConstantOffsetNull_) {
-      setRowNumbersForConstantOffset(validRows, rawFrameStarts, rawFrameEnds);
+
+    if (isConstantOffsetNull_) {
+      std::fill(rowNumbers_.begin(), rowNumbers_.end(), kNullRow);
     } else {
-      setRowNumbers(numRows, validRows, rawFrameStarts, rawFrameEnds);
+      if (validRows.hasSelections()) {
+        setRowNumbers(validRows, frameStarts, frameEnds, numRows);
+      }
     }
+
+    setRowNumbersForEmptyFrames(validRows);
 
     auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
     partition_->extractColumn(
@@ -97,49 +101,118 @@ class NthValueFunction : public exec::WindowFunction {
   }
 
  private:
-  // The below 2 functions build the rowNumbers for column extraction.
+  // The below functions build the rowNumbers for column extraction.
   // The rowNumbers map for each output row, as per nth_value function
   // semantics, the rowNumber (relative to the start of the partition) from
   // which the input value should be copied.
   // A rowNumber of kNullRow is for nullptr in the result.
-  void setRowNumbersForConstantOffset(
+  void setRowNumbers(
       const SelectivityVector& validRows,
-      const vector_size_t* frameStarts,
-      const vector_size_t* frameEnds) {
-    if (isConstantOffsetNull_) {
-      std::fill(rowNumbers_.begin(), rowNumbers_.end(), kNullRow);
-      return;
+      const BufferPtr& frameStarts,
+      const BufferPtr& frameEnds,
+      vector_size_t numRows) {
+    auto rawFrameStarts = frameStarts->as<vector_size_t>();
+    auto rawFrameEnds = frameEnds->as<vector_size_t>();
+    bool ignoreNullsForBlock = false;
+    vector_size_t leastFrame = 0;
+    if (ignoreNulls_) {
+      auto extractNullsResult = partition_->extractNulls(
+          valueIndex_, validRows, frameStarts, frameEnds, &nulls_);
+      // Perform ignoreNulls processing only if there are null values in the
+      // current output block. Otherwise continue processing with the logic
+      // without as it is more efficient.
+      ignoreNullsForBlock = extractNullsResult.has_value();
+      leastFrame = ignoreNullsForBlock ? extractNullsResult->first : leastFrame;
     }
 
-    vector_size_t constantOffsetValue =
-        static_cast<vector_size_t>(constantOffset_.value());
-    validRows.applyToSelected([&](auto i) {
-      setRowNumber(i, frameStarts, frameEnds, constantOffsetValue);
-    });
-
-    setRowNumbersForEmptyFrames(validRows);
+    if (constantOffset_.has_value()) {
+      setRowNumbersForConstantOffset(
+          ignoreNullsForBlock,
+          validRows,
+          rawFrameStarts,
+          rawFrameEnds,
+          leastFrame);
+    } else {
+      setRowNumbersForColumnOffset(
+          ignoreNullsForBlock,
+          numRows,
+          validRows,
+          rawFrameStarts,
+          rawFrameEnds,
+          leastFrame);
+    }
   }
 
-  void setRowNumbers(
-      vector_size_t numRows,
+  void setRowNumbersForConstantOffset(
+      bool ignoreNulls,
       const SelectivityVector& validRows,
       const vector_size_t* frameStarts,
-      const vector_size_t* frameEnds) {
-    offsets_->resize(numRows);
-    partition_->extractColumn(
-        offsetIndex_, partitionOffset_, numRows, 0, offsets_);
+      const vector_size_t* frameEnds,
+      vector_size_t leastFrame) {
+    vector_size_t constantOffsetValue =
+        static_cast<vector_size_t>(constantOffset_.value());
+    if (ignoreNulls) {
+      auto rawNulls = nulls_->as<uint64_t>();
+      validRows.applyToSelected([&](auto i) {
+        setRowNumberIgnoreNulls(
+            i,
+            rawNulls,
+            leastFrame,
+            frameStarts,
+            frameEnds,
+            constantOffsetValue);
+      });
+    } else {
+      validRows.applyToSelected([&](auto i) {
+        setRowNumber(i, frameStarts, frameEnds, constantOffsetValue);
+      });
+    }
+  }
 
+  template <bool ignoreNulls>
+  void setRowNumbersApplyLoop(
+      const SelectivityVector& validRows,
+      const vector_size_t* frameStarts,
+      const vector_size_t* frameEnds,
+      const uint64_t* rawNulls = nullptr,
+      vector_size_t leastFrame = 0) {
     validRows.applyToSelected([&](auto i) {
       if (offsets_->isNullAt(i)) {
         rowNumbers_[i] = kNullRow;
       } else {
         vector_size_t offset = offsets_->valueAt(i);
         VELOX_USER_CHECK_GE(offset, 1, "Offset must be at least 1");
-        setRowNumber(i, frameStarts, frameEnds, offset);
+        if constexpr (ignoreNulls) {
+          setRowNumberIgnoreNulls(
+              i, rawNulls, leastFrame, frameStarts, frameEnds, offset);
+        } else {
+          setRowNumber(i, frameStarts, frameEnds, offset);
+        }
       }
     });
+  }
 
-    setRowNumbersForEmptyFrames(validRows);
+  void setRowNumbersForColumnOffset(
+      bool ignoreNulls,
+      vector_size_t numRows,
+      const SelectivityVector& validRows,
+      const vector_size_t* frameStarts,
+      const vector_size_t* frameEnds,
+      vector_size_t leastFrame) {
+    offsets_->resize(numRows);
+    partition_->extractColumn(
+        offsetIndex_, partitionOffset_, numRows, 0, offsets_);
+
+    if (ignoreNulls) {
+      setRowNumbersApplyLoop<true>(
+          validRows,
+          frameStarts,
+          frameEnds,
+          nulls_->as<uint64_t>(),
+          leastFrame);
+    } else {
+      setRowNumbersApplyLoop<false>(validRows, frameStarts, frameEnds);
+    }
   }
 
   void setRowNumbersForEmptyFrames(const SelectivityVector& validRows) {
@@ -164,6 +237,30 @@ class NthValueFunction : public exec::WindowFunction {
     rowNumbers_[i] = rowNumber <= frameEnd ? rowNumber : kNullRow;
   }
 
+  inline void setRowNumberIgnoreNulls(
+      vector_size_t i,
+      const uint64_t* rawNulls,
+      vector_size_t leastFrame,
+      const vector_size_t* frameStarts,
+      const vector_size_t* frameEnds,
+      vector_size_t offset) {
+    auto frameStart = frameStarts[i];
+    auto frameEnd = frameEnds[i];
+    vector_size_t nonNullCount = 0;
+    for (auto j = frameStart; j <= frameEnd; j++) {
+      if (!bits::isBitSet(rawNulls, j - leastFrame)) {
+        ++nonNullCount;
+        if (nonNullCount == offset) {
+          rowNumbers_[i] = j;
+          return;
+        }
+      }
+    }
+    rowNumbers_[i] = kNullRow;
+  }
+
+  const bool ignoreNulls_;
+
   // These are the argument indices of the nth_value value and offset columns
   // in the input row vector. These are needed to retrieve column values
   // from the partition data.
@@ -185,7 +282,10 @@ class NthValueFunction : public exec::WindowFunction {
   // to the present row set in getOutput.
   vector_size_t partitionOffset_;
 
-  // The NthValue function directly writes from the input column to the
+  // Used to read the null positions of the value column for ignoreNulls.
+  BufferPtr nulls_;
+
+  // The function directly writes from the input column to the
   // resultVector using the extractColumn API specifying the rowNumber mapping
   // to copy between the 2 vectors. This variable is used for the rowNumber
   // vector across getOutput calls.
@@ -212,11 +312,13 @@ void registerNthValue(const std::string& name, const TypeKind& offsetTypeKind) {
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,
+          bool ignoreNulls,
           velox::memory::MemoryPool* pool,
           HashStringAllocator* /*stringAllocator*/,
           const core::QueryConfig& /*queryConfig*/)
           -> std::unique_ptr<exec::WindowFunction> {
-        return std::make_unique<NthValueFunction>(args, resultType, pool);
+        return std::make_unique<NthValueFunction>(
+            args, resultType, ignoreNulls, pool);
       });
 }
 

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -52,9 +52,9 @@ RowVectorPtr WindowTestBase::makeSimpleVector(vector_size_t size) {
   return makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row % 5; }),
       makeFlatVector<int32_t>(
-          size, [](auto row) { return row % 7; }, nullEvery(15)),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
+          size, [](auto row) { return row % 7; }, nullEvery(11)),
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 6 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 4 + 1; }),
   });
 }
 
@@ -63,8 +63,8 @@ RowVectorPtr WindowTestBase::makeSinglePartitionVector(vector_size_t size) {
       makeFlatVector<int32_t>(size, [](auto /* row */) { return 1; }),
       makeFlatVector<int32_t>(
           size, [](auto row) { return row; }, nullEvery(7)),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 6 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 4 + 1; }),
   });
 }
 
@@ -72,8 +72,8 @@ RowVectorPtr WindowTestBase::makeSingleRowPartitionsVector(vector_size_t size) {
   return makeRowVector({
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
+      makeFlatVector<int64_t>(size, [](auto row) { return row % 6 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 4 + 1; }),
   });
 }
 

--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -77,6 +77,7 @@ void registerCumeDist(const std::string& name) {
       [name](
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& /*resultType*/,
+          bool /*ignoreNulls*/,
           velox::memory::MemoryPool* /*pool*/,
           HashStringAllocator* /*stringAllocator*/,
           const velox::core::QueryConfig& /*queryConfig*/)

--- a/velox/functions/prestosql/window/LeadLag.cpp
+++ b/velox/functions/prestosql/window/LeadLag.cpp
@@ -27,17 +27,32 @@ class LeadLagFunction : public exec::WindowFunction {
   explicit LeadLagFunction(
       const std::vector<exec::WindowFunctionArg>& args,
       const TypePtr& resultType,
+      bool ignoreNulls,
       velox::memory::MemoryPool* pool)
-      : WindowFunction(resultType, pool, nullptr) {
+      : WindowFunction(resultType, pool, nullptr), ignoreNulls_(ignoreNulls) {
     valueIndex_ = args[0].index.value();
 
     initializeOffset(args);
     initializeDefaultValue(args);
+
+    nulls_ = allocateNulls(0, pool);
   }
 
   void resetPartition(const exec::WindowPartition* partition) override {
     partition_ = partition;
     partitionOffset_ = 0;
+    ignoreNullsForPartition_ = false;
+
+    if (ignoreNulls_) {
+      auto partitionSize = partition_->numRows();
+      AlignedBuffer::reallocate<bool>(&nulls_, partitionSize);
+
+      partition_->extractNulls(valueIndex_, 0, partitionSize, nulls_);
+      // There are null bits so the special ignoreNulls processing is required
+      // for this partition.
+      ignoreNullsForPartition_ =
+          bits::countBits(nulls_->as<uint64_t>(), 0, partitionSize) > 0;
+    }
   }
 
   void apply(
@@ -55,7 +70,11 @@ class LeadLagFunction : public exec::WindowFunction {
     if (constantOffset_.has_value() || isConstantOffsetNull_) {
       setRowNumbersForConstantOffset();
     } else {
-      setRowNumbers(numRows);
+      if (ignoreNullsForPartition_) {
+        setRowNumbers<true>(numRows, nulls_->as<uint64_t>());
+      } else {
+        setRowNumbers<false>(numRows);
+      }
     }
 
     auto rowNumbersRange = folly::Range(rowNumbers_.data(), numRows);
@@ -110,12 +129,13 @@ class LeadLagFunction : public exec::WindowFunction {
 
   void setRowNumbersForConstantOffset();
 
-  void setRowNumbers(vector_size_t numRows) {
+  template <bool ignoreNulls>
+  void setRowNumbers(
+      vector_size_t numRows,
+      const uint64_t* rawNulls = nullptr) {
     offsets_->resize(numRows);
     partition_->extractColumn(
         offsetIndex_, partitionOffset_, numRows, 0, offsets_);
-
-    const auto maxRowNumber = partition_->numRows() - 1;
 
     for (auto i = 0; i < numRows; ++i) {
       if (offsets_->isNullAt(i)) {
@@ -125,14 +145,48 @@ class LeadLagFunction : public exec::WindowFunction {
         VELOX_USER_CHECK_GE(offset, 0, "Offset must be at least 0");
 
         if constexpr (isLag) {
-          auto rowNumber = partitionOffset_ + i - offset;
-          rowNumbers_[i] = rowNumber >= 0 ? rowNumber : kNullRow;
+          if constexpr (ignoreNulls) {
+            rowNumbers_[i] = rowNumberIgnoreNull(
+                rawNulls, offset, partitionOffset_ + i - 1, -1, -1);
+          } else {
+            auto rowNumber = partitionOffset_ + i - offset;
+            rowNumbers_[i] = rowNumber >= 0 ? rowNumber : kNullRow;
+          }
         } else {
-          auto rowNumber = partitionOffset_ + i + offset;
-          rowNumbers_[i] = rowNumber <= maxRowNumber ? rowNumber : kNullRow;
+          if constexpr (ignoreNulls) {
+            rowNumbers_[i] = rowNumberIgnoreNull(
+                rawNulls,
+                offset,
+                partitionOffset_ + i + 1,
+                partition_->numRows(),
+                1);
+          } else {
+            auto rowNumber = partitionOffset_ + i + offset;
+            rowNumbers_[i] =
+                rowNumber < partition_->numRows() ? rowNumber : kNullRow;
+          }
         }
       }
     }
+  }
+
+  vector_size_t rowNumberIgnoreNull(
+      const uint64_t* rawNulls,
+      vector_size_t offset,
+      vector_size_t start,
+      vector_size_t end,
+      vector_size_t step) {
+    auto nonNullCount = 0;
+    for (auto j = start; j != end; j += step) {
+      if (!bits::isBitSet(rawNulls, j)) {
+        nonNullCount++;
+        if (nonNullCount == offset) {
+          return j;
+        }
+      }
+    }
+
+    return kNullRow;
   }
 
   void setDefaultValue(const VectorPtr& result, int32_t resultOffset) {
@@ -179,6 +233,12 @@ class LeadLagFunction : public exec::WindowFunction {
     }
   }
 
+  const bool ignoreNulls_;
+
+  // Certain partitions may not have null values. So ignore nulls processing can
+  // be skipped for them. Used for tracking this at the partition level.
+  bool ignoreNullsForPartition_;
+
   // Index of the 'value' argument.
   column_index_t valueIndex_;
 
@@ -203,6 +263,9 @@ class LeadLagFunction : public exec::WindowFunction {
 
   // Reusable vector of default values if these are not cosntant.
   VectorPtr defaultValues_;
+
+  // Null positions buffer to use for ignoreNulls.
+  BufferPtr nulls_;
 
   // This offset tracks how far along the partition rows have been output.
   // This can be used to optimize reading offset column values corresponding
@@ -235,11 +298,19 @@ void LeadLagFunction<true>::setRowNumbersForConstantOffset() {
     }
   }
 
-  // Populate sequential values for non-NULL rows.
-  std::iota(
-      rowNumbers_.begin() + nullCnt,
-      rowNumbers_.end(),
-      partitionOffset_ + nullCnt - constantOffsetValue);
+  if (ignoreNullsForPartition_) {
+    auto rawNulls = nulls_->as<uint64_t>();
+    for (auto i = nullCnt; i < rowNumbers_.size(); i++) {
+      rowNumbers_[i] = rowNumberIgnoreNull(
+          rawNulls, constantOffsetValue, partitionOffset_ + i - 1, -1, -1);
+    }
+  } else {
+    // Populate sequential values for non-NULL rows.
+    std::iota(
+        rowNumbers_.begin() + nullCnt,
+        rowNumbers_.end(),
+        partitionOffset_ + nullCnt - constantOffsetValue);
+  }
 }
 
 template <>
@@ -263,10 +334,22 @@ void LeadLagFunction<false>::setRowNumbersForConstantOffset() {
 
   // Populate sequential values for non-NULL rows.
   if (nonNullCnt > 0) {
-    std::iota(
-        rowNumbers_.begin(),
-        rowNumbers_.begin() + nonNullCnt,
-        partitionOffset_ + constantOffsetValue);
+    if (ignoreNullsForPartition_) {
+      auto rawNulls = nulls_->as<uint64_t>();
+      for (auto i = 0; i < nonNullCnt; i++) {
+        rowNumbers_[i] = rowNumberIgnoreNull(
+            rawNulls,
+            constantOffsetValue,
+            partitionOffset_ + i + 1,
+            partition_->numRows(),
+            1);
+      }
+    } else {
+      std::iota(
+          rowNumbers_.begin(),
+          rowNumbers_.begin() + nonNullCnt,
+          partitionOffset_ + constantOffsetValue);
+    }
   }
 }
 
@@ -305,11 +388,13 @@ void registerLag(const std::string& name) {
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,
+          bool ignoreNulls,
           velox::memory::MemoryPool* pool,
           HashStringAllocator* /*stringAllocator*/,
           const velox::core::QueryConfig& /*queryConfig*/)
           -> std::unique_ptr<exec::WindowFunction> {
-        return std::make_unique<LeadLagFunction<true>>(args, resultType, pool);
+        return std::make_unique<LeadLagFunction<true>>(
+            args, resultType, ignoreNulls, pool);
       });
 }
 
@@ -320,11 +405,13 @@ void registerLead(const std::string& name) {
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& resultType,
+          bool ignoreNulls,
           velox::memory::MemoryPool* pool,
           HashStringAllocator* /*stringAllocator*/,
           const velox::core::QueryConfig& /*queryConfig*/)
           -> std::unique_ptr<exec::WindowFunction> {
-        return std::make_unique<LeadLagFunction<false>>(args, resultType, pool);
+        return std::make_unique<LeadLagFunction<false>>(
+            args, resultType, ignoreNulls, pool);
       });
 }
 } // namespace facebook::velox::window::prestosql

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -241,6 +241,7 @@ void registerNtile(const std::string& name) {
       [name](
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& /*resultType*/,
+          bool /*ignoreNulls*/,
           velox::memory::MemoryPool* pool,
           HashStringAllocator* /*stringAllocator*/,
           const core::QueryConfig& /*queryConfig*/)

--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -103,6 +103,7 @@ void registerRankInternal(
       [name](
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& resultType,
+          bool /*ignoreNulls*/,
           velox::memory::MemoryPool* /*pool*/,
           HashStringAllocator* /*stringAllocator*/,
           const core::QueryConfig& /*queryConfig*/)

--- a/velox/functions/prestosql/window/RowNumber.cpp
+++ b/velox/functions/prestosql/window/RowNumber.cpp
@@ -64,6 +64,7 @@ void registerRowNumber(const std::string& name) {
       [name](
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& /*resultType*/,
+          bool /*ignoreNulls*/,
           velox::memory::MemoryPool* /*pool*/,
           HashStringAllocator* /*stringAllocator*/,
           const core::QueryConfig& /*queryConfig*/)


### PR DESCRIPTION
Value functions can have IGNORE NULL semantics.
i) first_value IGNORE NULLS gives the first non-null value of the frame. last_value IGNORE NULLs gives the last non-null value.
ii) nth_value IGNORE NULLS gives the nth non-null value of the frame.
iii) lead(lag) IGNORE NULLS gives the row at offsets (of non-null values only) from the current row.

This PR is only for IGNORE NULLS in value functions. There will be a subsequent PR IGNORE NULL in aggregate window functions.