### PR TITLE
Buckify simdjson and use it everywhere

### DIFF
--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -27,6 +27,16 @@ message(STATUS "Building simdjson from source")
 FetchContent_Declare(
   simdjson
   URL ${VELOX_SIMDJSON_SOURCE_URL}
-  URL_HASH ${VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM})
+  URL_HASH ${VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM}
+  SOURCE_DIR ${CMAKE_BINARY_DIR}/_deps/simdjson-src/simdjson)
 
-FetchContent_MakeAvailable(simdjson)
+# When simdjson is built with cmake it places simdjson/singleheader/simdjson.h
+# at the root so files simply depend on simdjson.h.  This breaks building with
+# systems other than cmake. This hack makes it so that simdjson.h can
+# consistently be found at simdjson/singleheader/simdjson.h.
+FetchContent_Populate(simdjson)
+
+add_library(simdjson INTERFACE)
+target_sources(simdjson
+               INTERFACE ${simdjson_SOURCE_DIR}/singleheader/simdjson.cpp)
+target_include_directories(simdjson INTERFACE ${simdjson_SOURCE_DIR}/..)

--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "simdjson.h"
+#include "simdjson/singleheader/simdjson.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/UDFOutputString.h"
 #include "velox/functions/prestosql/json/JsonPathTokenizer.h"


### PR DESCRIPTION
Summary:
Added a `BUCK` entry in `third-party`.

Explicitly using this in `JsonParseBenchmark.cpp` (otherwise `#include <simdjson.h>` uses the `third-party2/simdjson/1.0.2` version). It seems to work, but I'm not sure if this is the most elegant version.

Reviewed By: DenisYaroshevskiy

Differential Revision: D46759844

