### PR TITLE
Add support for UNKNOWN type to UnsafeRow serializer

### DIFF
--- a/velox/docs/develop/unsaferow.rst
+++ b/velox/docs/develop/unsaferow.rst
@@ -64,6 +64,12 @@ map size. These are duplicated in the serialized data.
 Structs are stored as 'null bits' for struct fields, followed by
 fixed-width field values and variable-width field values.
 
+Values of Velox type UNKNOWN (only null values) are treated as fixed-width
+types. UNKNOWN values in the top-level columns and as struct fields use 1 bit
+in the nulls section and 8 bytes in the fixed-width section. UNKNOWN value
+serialized as an array element or map value uses 1 bit for null flag and zero
+bytes for the value.
+
 Examples
 --------
 

--- a/velox/row/UnsafeRow.h
+++ b/velox/row/UnsafeRow.h
@@ -419,8 +419,11 @@ FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes<TypeKind::VARBINARY>() {
 }
 
 /// Returns the number of bytes needed to serialized fixed-width type. Throws if
-/// 'type' is ot fixed-width.
+/// 'type' is not fixed-width.
 FOLLY_ALWAYS_INLINE size_t serializedSizeInBytes(const TypePtr& type) {
+  if (type->isUnKnown()) {
+    return 0;
+  }
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
       serializedSizeInBytes, type->kind());
 }

--- a/velox/row/UnsafeRowFast.cpp
+++ b/velox/row/UnsafeRowFast.cpp
@@ -99,6 +99,7 @@ void UnsafeRowFast::initialize(const TypePtr& type) {
     case TypeKind::DOUBLE:
       FOLLY_FALLTHROUGH;
     case TypeKind::DATE:
+    case TypeKind::UNKNOWN:
       valueBytes_ = type->cppSizeInBytes();
       fixedWidthTypeKind_ = true;
       supportsBulkCopy_ = decoded_.isIdentityMapping();
@@ -172,10 +173,13 @@ void UnsafeRowFast::serializeFixedWidth(
     vector_size_t size,
     char* buffer) {
   VELOX_DCHECK(supportsBulkCopy_);
-  memcpy(
-      buffer,
-      decoded_.data<char>() + decoded_.index(offset) * valueBytes_,
-      valueBytes_ * size);
+  // decoded_.data<char>() can be null if all values are null.
+  if (decoded_.data<char>()) {
+    memcpy(
+        buffer,
+        decoded_.data<char>() + decoded_.index(offset) * valueBytes_,
+        valueBytes_ * size);
+  }
 }
 
 int32_t UnsafeRowFast::serializeVariableWidth(

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -106,6 +106,7 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       DOUBLE(),
       VARCHAR(),
       VARBINARY(),
+      UNKNOWN(),
       // Arrays.
       ARRAY(BOOLEAN()),
       ARRAY(TINYINT()),
@@ -116,10 +117,12 @@ TEST_F(UnsafeRowFuzzTests, fast) {
       ARRAY(DOUBLE()),
       ARRAY(VARCHAR()),
       ARRAY(VARBINARY()),
+      ARRAY(UNKNOWN()),
       // Nested arrays.
       ARRAY(ARRAY(INTEGER())),
       ARRAY(ARRAY(BIGINT())),
       ARRAY(ARRAY(VARCHAR())),
+      ARRAY(ARRAY(UNKNOWN())),
       // Maps.
       MAP(BIGINT(), REAL()),
       MAP(BIGINT(), BIGINT()),

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -217,3 +217,41 @@ TEST_F(UnsafeRowSerializerTest, date) {
 
   testRoundTrip(rowVector);
 }
+
+TEST_F(UnsafeRowSerializerTest, unknown) {
+  // UNKNOWN type.
+  auto rowVector = makeRowVector({
+      BaseVector::createNullConstant(UNKNOWN(), 10, pool()),
+  });
+
+  testRoundTrip(rowVector);
+
+  // ARRAY(UNKNOWN) type.
+  rowVector = makeRowVector({
+      makeArrayVector(
+          {0, 3, 10, 15},
+          BaseVector::createNullConstant(UNKNOWN(), 30, pool())),
+  });
+
+  testRoundTrip(rowVector);
+
+  // MAP(BIGINT, UNKNOWN) type.
+  rowVector = makeRowVector({
+      makeMapVector(
+          {0, 3, 7},
+          makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7, 8, 9}),
+          BaseVector::createNullConstant(UNKNOWN(), 9, pool())),
+  });
+
+  testRoundTrip(rowVector);
+
+  // Mix of INTEGER, UNKNOWN and DOUBLE.
+  rowVector = makeRowVector({
+      makeNullableFlatVector<int32_t>({1, std::nullopt, 3, 4, 5}),
+      BaseVector::createNullConstant(UNKNOWN(), 5, pool()),
+      makeNullableFlatVector<double>(
+          {1.1, 2.2, std::nullopt, 4.4, std::nullopt}),
+  });
+
+  testRoundTrip(rowVector);
+}


### PR DESCRIPTION
Extends UnsafeRow serde to support values of UNKNOWN types. These are always nulls.