### PR TITLE
Perf+BE: (CLANGTIDY) facebook-hte-MissingStdForward

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -331,7 +331,7 @@ class Driver : public std::enable_shared_from_this<Driver> {
   template <typename F>
   std::unique_ptr<DeltaCpuWallTimer<F>> createDeltaCpuWallTimer(F&& func) {
     return trackOperatorCpuUsage_
-        ? std::make_unique<DeltaCpuWallTimer<F>>(std::move(func))
+        ? std::make_unique<DeltaCpuWallTimer<F>>(std::forward<F>(func))
         : nullptr;
   }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1041,7 +1041,7 @@ std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
   std::vector<StringView> views;
   views.reserve(values.size());
   for (const auto& value : values) {
-    views.emplace_back(StringView(value));
+    views.emplace_back(value);
   }
   return views;
 }


### PR DESCRIPTION
Summary:
Warning  (CLANGTIDY) facebook-hte-MissingStdForward
    Universal reference parameters should always be forwarded via
    `std::forward<T>`.

             331   template <typename F>
             332   std::unique_ptr<DeltaCpuWallTimer<F>> createDeltaCpuWallTimer(F&& func) {
             333     return trackOperatorCpuUsage_
        -    334         ? std::make_unique<DeltaCpuWallTimer<F>>(std::move(func))
        +                ? std::make_unique<DeltaCpuWallTimer<F>>(std::forward<F>(func))
             335         : nullptr;
             336   }
             337

   Warning  (CLANGTIDY) facebook-use-proper-emplace
    unnecessary temporary object created while calling emplace_back

            1037   std::vector<StringView> views;
            1038   views.reserve(values.size());
            1039   for (const auto& value : values) {
        -   1040     views.emplace_back(StringView(value));
        +            views.emplace_back(value);
            1041   }
            1042   return views;
            1043 }

Differential Revision: D46759138

