### PR TITLE
Enable huge pages for large contiguous allocations

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -121,6 +121,7 @@ bool MallocAllocator::allocateContiguousImpl(
   }
   auto numContiguousCollateralPages = allocation.numPages();
   if (numContiguousCollateralPages > 0) {
+    useHugePages(allocation, false);
     if (::munmap(allocation.data(), allocation.size()) < 0) {
       VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << "for "
                            << allocation.data() << ", " << allocation.size();
@@ -172,6 +173,7 @@ bool MallocAllocator::allocateContiguousImpl(
       0);
   // TODO: add handling of MAP_FAILED.
   allocation.set(data, AllocationTraits::pageBytes(numPages));
+  useHugePages(allocation, true);
   return true;
 }
 
@@ -209,7 +211,7 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   if (allocation.empty()) {
     return;
   }
-
+  useHugePages(allocation, false);
   const auto bytes = allocation.size();
   const auto numPages = allocation.numPages();
   if (::munmap(allocation.data(), bytes) < 0) {

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -374,6 +374,10 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     return true;
   }
 
+  // If 'data' is sufficiently large, enables/disables adaptive  huge pages for
+  // the address raneg.
+  void useHugePages(const ContiguousAllocation& data, bool enable);
+
   // The machine page counts corresponding to different sizes in order
   // of increasing size.
   const std::vector<MachinePageCount>

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -236,6 +236,7 @@ bool MmapAllocator::allocateContiguousImpl(
   }
   const auto numLargeCollateralPages = allocation.numPages();
   if (numLargeCollateralPages > 0) {
+    useHugePages(allocation, false);
     if (useMmapArena_) {
       std::lock_guard<std::mutex> l(arenaMutex_);
       managedArenas_->free(allocation.data(), allocation.size());
@@ -349,6 +350,7 @@ bool MmapAllocator::allocateContiguousImpl(
     return false;
   }
   allocation.set(data, AllocationTraits::pageBytes(numPages));
+  useHugePages(allocation, true);
   return true;
 }
 
@@ -356,6 +358,7 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   if (allocation.empty()) {
     return;
   }
+  useHugePages(allocation, false);
   if (useMmapArena_) {
     std::lock_guard<std::mutex> l(arenaMutex_);
     managedArenas_->free(allocation.data(), allocation.size());

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -118,3 +118,5 @@ DEFINE_bool(
     false,
     "If true, suppress the verbose error message in memory capacity exceeded "
     "exception. This is only used by test to control the test error output size");
+
+DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");


### PR DESCRIPTION
Hash tables of tens of MB or more benefit from huge pages because of fewer TLB misses. Savings can be ~30% of CPU time.  We enable huge pages for allocations over 2MB (huge page is 2MB). Since this is an advice to the OS that does not change semantics, we do not fail even if the madvise fails.