### PR TITLE
Add support for sorted aggregations with masks

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -118,12 +118,6 @@ HashAggregation::HashAggregation(
       info.sortingKeys.push_back(exprToChannel(key.get(), inputType));
     }
 
-    if (numSortingKeys > 0) {
-      VELOX_USER_CHECK_NULL(
-          aggregate.mask,
-          "Aggregations over sorted inputs with masks are not supported yet");
-    }
-
     aggregateInfos.emplace_back(std::move(info));
   }
 

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -83,6 +83,10 @@ SortedAggregations::SortedAggregations(
       VELOX_USER_CHECK_NE(sortingKey, kConstantChannel);
       allInputs.insert(sortingKey);
     }
+
+    if (aggregate->mask) {
+      allInputs.insert(aggregate->mask.value());
+    }
   }
 
   inputMapping_.resize(inputType->size());
@@ -210,6 +214,30 @@ void SortedAggregations::sortSingleGroup(
 std::vector<VectorPtr> SortedAggregations::extractSingleGroup(
     std::vector<char*>& groupRows,
     const AggregateInfo& aggregate) {
+  const auto numGroups = groupRows.size();
+
+  std::vector<vector_size_t> rowNumbers;
+  if (aggregate.mask) {
+    FlatVectorPtr<bool> mask = BaseVector::create<FlatVector<bool>>(
+        BOOLEAN(), numGroups, inputData_->pool());
+    inputData_->extractColumn(
+        groupRows.data(),
+        numGroups,
+        inputMapping_[aggregate.mask.value()],
+        mask);
+
+    rowNumbers.reserve(numGroups);
+    for (auto i = 0; i < numGroups; ++i) {
+      if (!mask->isNullAt(i) && mask->valueAt(i)) {
+        rowNumbers.push_back(i);
+      }
+    }
+
+    if (rowNumbers.empty()) {
+      return {};
+    }
+  }
+
   const auto numInputs = aggregate.inputs.size();
   std::vector<VectorPtr> inputVectors(numInputs);
   for (auto i = 0; i < numInputs; ++i) {
@@ -217,12 +245,20 @@ std::vector<VectorPtr> SortedAggregations::extractSingleGroup(
       inputVectors[i] = aggregate.constantInputs[i];
     } else {
       const auto columnIndex = inputMapping_[aggregate.inputs[i]];
+      const auto numRows = aggregate.mask ? rowNumbers.size() : numGroups;
       inputVectors[i] = BaseVector::create(
-          inputData_->keyTypes()[columnIndex],
-          groupRows.size(),
-          inputData_->pool());
-      inputData_->extractColumn(
-          groupRows.data(), groupRows.size(), columnIndex, inputVectors[i]);
+          inputData_->keyTypes()[columnIndex], numRows, inputData_->pool());
+      if (aggregate.mask) {
+        inputData_->extractColumn(
+            groupRows.data(),
+            folly::Range(rowNumbers.data(), rowNumbers.size()),
+            columnIndex,
+            0, // resultOffset
+            inputVectors[i]);
+      } else {
+        inputData_->extractColumn(
+            groupRows.data(), numGroups, columnIndex, inputVectors[i]);
+      }
     }
   }
 
@@ -248,8 +284,12 @@ void SortedAggregations::extractValues(
       // TODO Process group rows in batches to avoid creating very large input
       // vectors.
       auto inputVectors = extractSingleGroup(groupRows, aggregate);
+      if (inputVectors.empty()) {
+        // Mask must be false for all 'groupRows'.
+        continue;
+      }
 
-      rows.resize(groupRows.size());
+      rows.resize(inputVectors[0]->size());
       aggregate.function->addSingleGroupRawInput(
           group, rows, inputVectors, false);
     }


### PR DESCRIPTION
Add support for queries like `SELECT agg(x ORDER BY y) FILTER (WHERE z) FROM t`