### PR TITLE
Register Presto between function with Timestamp arguments

### DIFF
--- a/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ComparisonFunctionsRegistration.cpp
@@ -64,6 +64,8 @@ void registerComparisonFunctions(const std::string& prefix) {
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, Date, Date, Date>(
       {prefix + "between"});
+  registerFunction<BetweenFunction, bool, Timestamp, Timestamp, Timestamp>(
+      {prefix + "between"});
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_between, prefix + "between");
 }

--- a/velox/functions/prestosql/tests/ComparisonsTest.cpp
+++ b/velox/functions/prestosql/tests/ComparisonsTest.cpp
@@ -111,6 +111,27 @@ TEST_F(ComparisonsTest, betweenDate) {
   }
 }
 
+TEST_F(ComparisonsTest, betweenTimestamp) {
+  using util::fromTimestampString;
+
+  const auto between = [&](std::optional<std::string> s) {
+    auto expr =
+        "c0 between cast(\'2019-02-28 10:00:00.500\' as timestamp) and"
+        " cast(\'2019-02-28 10:00:00.600\' as timestamp)";
+    if (s.has_value()) {
+      return evaluateOnce<bool>(
+          expr, std::optional(fromTimestampString((StringView)s.value())));
+    }
+    return evaluateOnce<bool>(expr, std::optional<Timestamp>());
+  };
+
+  EXPECT_EQ(std::nullopt, between(std::nullopt));
+  EXPECT_FALSE(between("2019-02-28 10:00:00.000").value());
+  EXPECT_TRUE(between("2019-02-28 10:00:00.500").value());
+  EXPECT_TRUE(between("2019-02-28 10:00:00.600").value());
+  EXPECT_FALSE(between("2019-02-28 10:00:00.650").value());
+}
+
 TEST_F(ComparisonsTest, betweenDecimal) {
   auto runAndCompare = [&](const std::string& exprStr,
                            VectorPtr input,


### PR DESCRIPTION
Presto function `between` is not registered with arguments:
(TIMESTAMP, TIMESTAMP, TIMESTAMP). Since the gte and lte is already registered
with Timestamp type, scalar function registration is the only missing part.