### PR TITLE
Fix capture vectors size in ExprCallable::apply[NoThrow]

### DIFF
--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -49,7 +49,9 @@ class ExprCallable : public Callable {
       const std::vector<VectorPtr>& args,
       const BufferPtr& elementToTopLevelRows,
       VectorPtr* result) override {
-    auto row = createRowVector(context, wrapCapture, args, rows.end());
+    auto captureSize =
+        context->isFinalSelection() ? rows.end() : finalSelection.end();
+    auto row = createRowVector(context, wrapCapture, args, captureSize);
     EvalCtx lambdaCtx = createLambdaCtx(context, row, finalSelection);
     ScopedVarSetter throwOnError(
         lambdaCtx.mutableThrowOnError(), context->throwOnError());
@@ -65,7 +67,10 @@ class ExprCallable : public Callable {
       const std::vector<VectorPtr>& args,
       ErrorVectorPtr& elementErrors,
       VectorPtr* result) override {
-    auto row = createRowVector(context, wrapCapture, args, rows.end());
+    // Make sure to size capture vectors to cover 'final selection' rows.
+    auto captureSize =
+        context->isFinalSelection() ? rows.end() : finalSelection.end();
+    auto row = createRowVector(context, wrapCapture, args, captureSize);
     EvalCtx lambdaCtx = createLambdaCtx(context, row, finalSelection);
     ScopedVarSetter throwOnError(lambdaCtx.mutableThrowOnError(), false);
     body_->eval(rows, lambdaCtx, *result);


### PR DESCRIPTION
ExprCallable::apply[NoThrow] must ensure that 'capture' vectors cover all rows in 'final selection'. Otherwise, peeling dictionary encoding from capture vectors fails.

```
VeloxRuntimeError: rows->end() <= vector.size() (1889 vs. 1887) presto.default.concat(item_category, //:VARCHAR)
	at Unknown.# 0  facebook::velox::VeloxException::VeloxException(char const*, unsigned long, char const*, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, std::basic_string_view<char, std::char_traits<char> >, bool, facebook::velox::VeloxException::Type, std::basic_string_view<char, std::char_traits<char> >)(Unknown Source)
	at Unknown.# 1  void facebook::velox::detail::veloxCheckFail<facebook::velox::VeloxRuntimeError, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(facebook::velox::detail::VeloxCheckFailArgs const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)(Unknown Source)
	at Unknown.# 2  facebook::velox::DecodedVector::makeIndices(facebook::velox::BaseVector const&, facebook::velox::SelectivityVector const*, int)(Unknown Source)
	at Unknown.# 3  facebook::velox::exec::PeeledEncoding::peelInternal(std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > > const&, facebook::velox::SelectivityVector const&, facebook::velox::exec::LocalDecodedVector&, bool, std::vector<std::shared_ptr<facebook::velox::BaseVector>, std::allocator<std::shared_ptr<facebook::velox::BaseVector> > >&)(Unknown Source)
```