### PR TITLE
Skip probe input from non-spilled source when build is empty

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -192,6 +192,11 @@ class QueryConfig {
   static constexpr const char* kSparkLegacySizeOfNull =
       "spark.legacy_size_of_null";
 
+  /// If true, finish the hash probe on an empty build table for a specific set
+  /// of hash joins.
+  static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
+      "hash_probe_finish_early_on_empty_build";
+
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
@@ -382,6 +387,10 @@ class QueryConfig {
 
   bool operatorTrackCpuUsage() const {
     return get<bool>(kOperatorTrackCpuUsage, true);
+  }
+
+  bool hashProbeFinishEarlyOnEmptyBuild() const {
+    return get<bool>(kHashProbeFinishEarlyOnEmptyBuild, true);
   }
 
   template <typename T>

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -296,6 +296,14 @@ class HashProbe : public Operator {
   // Indicates whether there was no input. Used for right semi join project.
   bool noInput_{true};
 
+  // Indicates whether to skip probe input data processing or not. It only
+  // applies for a specific set of join types (see skipProbeOnEmptyBuild()), and
+  // the build table is empty and the probe input is read from non-spilled
+  // source. This ensures the hash probe operator keeps running until all the
+  // probe input from the sources have been processed. It prevents the exchange
+  // hanging problem at the producer side caused by the early query finish.
+  bool skipInput_{false};
+
   // Indicates whether there are rows with null join keys on the build
   // side. Used by anti and left semi project join.
   bool buildSideHasNullKeys_{false};


### PR DESCRIPTION
Hash probe adds to skip probe input data processing logic for a specific
join types (see skipProbeOnEmptyBuild()), and the build table is empty
and the probe input is read from non-spilled source. This ensures the
hash probe operator keeps running until all the probe input from the sources
have been processed. It prevents the exchange hanging problem at the
producer side caused by the early query finish. Here is event sequence that
can lead into this hanging situation:
1. Hash probe in exchange consumer detects the build side is empty and
    mark the operator to finish
2. Hash probe query finishes which don't receive any new splits (exchange
    producer and no more splits signal) from the coordinator as the query has
    finished
3. Exchange producer still keeps generating data until full and then block there
    as there is no completion (abort) signal from the consumer.