### PR TITLE
Remove sequence and bias support from DecodedVector

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -328,7 +328,7 @@ void mergeOrThrowArgumentErrors(
 }
 
 // Returns true if vector is a LazyVector that hasn't been loaded yet or
-// is not dictionary, sequence or constant encoded.
+// is not dictionary or constant encoded.
 bool isFlat(const BaseVector& vector) {
   auto encoding = vector.encoding();
   if (encoding == VectorEncoding::Simple::LAZY) {
@@ -339,7 +339,6 @@ bool isFlat(const BaseVector& vector) {
     encoding = vector.loadedVector()->encoding();
   }
   return !(
-      encoding == VectorEncoding::Simple::SEQUENCE ||
       encoding == VectorEncoding::Simple::DICTIONARY ||
       encoding == VectorEncoding::Simple::CONSTANT);
 }
@@ -1312,7 +1311,6 @@ inline bool isPeelable(VectorEncoding::Simple encoding) {
   switch (encoding) {
     case VectorEncoding::Simple::CONSTANT:
     case VectorEncoding::Simple::DICTIONARY:
-    case VectorEncoding::Simple::SEQUENCE:
       return true;
     default:
       return false;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -1748,7 +1748,7 @@ TEST_F(ExprTest, ifWithConstant) {
 namespace {
 // Testing functions for generating intermediate results in different
 // encodings. The test case passes vectors to these and these
-// functions make constant/dictionary/sequence vectors from their arguments
+// functions make constant/dictionary vectors from their arguments
 
 // Returns the first value of the argument vector wrapped as a constant.
 class TestingConstantFunction : public exec::VectorFunction {
@@ -1808,37 +1808,6 @@ class TestingDictionaryFunction : public exec::VectorFunction {
   }
 };
 
-// Takes a vector  of values and a vector of integer run lengths.
-// Wraps the values in a SequenceVector with the run lengths.
-
-class TestingSequenceFunction : public exec::VectorFunction {
- public:
-  bool isDefaultNullBehavior() const override {
-    return false;
-  }
-
-  void apply(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      const TypePtr& /* outputType */,
-      exec::EvalCtx& context,
-      VectorPtr& result) const override {
-    VELOX_CHECK(rows.isAllSelected());
-    auto lengths = args[1]->as<FlatVector<int32_t>>()->values();
-    result = BaseVector::wrapInSequence(lengths, rows.size(), args[0]);
-  }
-
-  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
-    // T, integer -> T
-    return {exec::FunctionSignatureBuilder()
-                .typeVariable("T")
-                .returnType("T")
-                .argumentType("T")
-                .argumentType("integer")
-                .build()};
-  }
-};
-
 // Single-argument deterministic functions always receive their argument
 // vector as flat or constant.
 class TestingSingleArgDeterministicFunction : public exec::VectorFunction {
@@ -1877,11 +1846,6 @@ VELOX_DECLARE_VECTOR_FUNCTION(
     std::make_unique<TestingDictionaryFunction>());
 
 VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_testing_sequence,
-    TestingSequenceFunction::signatures(),
-    std::make_unique<TestingSequenceFunction>());
-
-VELOX_DECLARE_VECTOR_FUNCTION(
     udf_testing_single_arg_deterministic,
     TestingSingleArgDeterministicFunction::signatures(),
     std::make_unique<TestingSingleArgDeterministicFunction>());
@@ -1891,7 +1855,6 @@ TEST_F(ExprTest, peelArgs) {
   constexpr int32_t kDistinct = 10;
   VELOX_REGISTER_VECTOR_FUNCTION(udf_testing_constant, "testing_constant");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_testing_dictionary, "testing_dictionary");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_testing_sequence, "testing_sequence");
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_testing_single_arg_deterministic, "testing_single_arg_deterministic");
 
@@ -1926,16 +1889,6 @@ TEST_F(ExprTest, peelArgs) {
   expected32 = makeFlatVector<int32_t>(kSize, [&](int32_t row) {
     return 1 + distinctSource[indicesSource[row]];
   });
-  assertEqualVectors(expected32, result);
-
-  auto lengths = makeFlatVector<int32_t>(lengthSource);
-  result = evaluate(
-      "testing_constant(c0) + testing_sequence(c1, c2)",
-      makeRowVector({allOnes, distincts, lengths}));
-  expected32 = makeFlatVector<int32_t>(kSize, [&](int32_t row) {
-    return 1 + distinctSource[row / (kSize / kDistinct)];
-  });
-
   assertEqualVectors(expected32, result);
 
   // dictionary and single-argument deterministic

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -324,9 +324,6 @@ class DecodedVector {
 
   void setFlatNulls(const BaseVector& vector, const SelectivityVector* rows);
 
-  template <TypeKind kind>
-  void decodeBiased(const BaseVector& vector, const SelectivityVector* rows);
-
   void makeIndicesMutable();
 
   void combineWrappers(
@@ -338,10 +335,6 @@ class DecodedVector {
       const BaseVector& dictionaryVector,
       const SelectivityVector* rows);
 
-  void applySequenceWrapper(
-      const BaseVector& sequenceVector,
-      const SelectivityVector* rows);
-
   void copyNulls(vector_size_t size);
 
   void fillInIndices();
@@ -349,10 +342,6 @@ class DecodedVector {
   void setBaseData(const BaseVector& vector, const SelectivityVector* rows);
 
   void setBaseDataForConstant(
-      const BaseVector& vector,
-      const SelectivityVector* rows);
-
-  void setBaseDataForBias(
       const BaseVector& vector,
       const SelectivityVector* rows);
 
@@ -399,8 +388,7 @@ class DecodedVector {
   std::optional<const uint64_t*> allNulls_ = nullptr;
 
   // The base vector of 'vector' given to decode(). This is the data
-  // after sequence, constant and dictionary vectors have been peeled
-  // off.
+  // after constant and dictionary vectors have been peeled off.
   const BaseVector* baseVector_ = nullptr;
 
   // True if either the leaf vector has nulls or if nulls were added
@@ -420,10 +408,6 @@ class DecodedVector {
   // complex type. Applies only when isConstantMapping_ is true and baseVector_
   // is of complex type (array, map, row).
   vector_size_t constantIndex_{0};
-
-  // Holds data that needs to be copied out from the base vector,
-  // e.g. exploded BiasVector values.
-  std::vector<uint64_t> tempSpace_;
 
   // Holds indices if an array of indices needs to be materialized,
   // e.g. when combining nested dictionaries.


### PR DESCRIPTION
Sequence and bias encodings are not being used, but the logic for processing
these in DecodedVector is complex and not well tested.