### PR TITLE
Make Timestamp constructor throw VeloxUserError instead of VeloxRuntimeError

### DIFF
--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -53,9 +53,11 @@ struct Timestamp {
 
   Timestamp(int64_t seconds, uint64_t nanos)
       : seconds_(seconds), nanos_(nanos) {
-    VELOX_DCHECK_GE(seconds, kMinSeconds, "Timestamp seconds out of range");
-    VELOX_DCHECK_LE(seconds, kMaxSeconds, "Timestamp seconds out of range");
-    VELOX_DCHECK_LE(nanos, kMaxNanos, "Timestamp nanos out of range");
+    VELOX_USER_DCHECK_GE(
+        seconds, kMinSeconds, "Timestamp seconds out of range");
+    VELOX_USER_DCHECK_LE(
+        seconds, kMaxSeconds, "Timestamp seconds out of range");
+    VELOX_USER_DCHECK_LE(nanos, kMaxNanos, "Timestamp nanos out of range");
   }
 
   // Returns the current unix timestamp (ms precision).


### PR DESCRIPTION
Summary:
A recent diff introduced VELOX_DCHECK in Timestamp constructor. But there
are UDFs, such as from_unixtime, that construct Timestamp objects from input
values. As the result, these UDFs may throw VeloxRuntimeError during fuzzer
test and fail the test. This diff changes these checks to VELOX_USER_DCHECK.

This diff fixes https://github.com/facebookincubator/velox/issues/5424.

Differential Revision: D47063148

