### PR TITLE
Allow varchar input in json_xxx functions

### DIFF
--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -24,6 +24,8 @@ void registerJsonFunctions(const std::string& prefix) {
 
   registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
+  registerFunction<SIMDIsJsonScalarFunction, bool, Varchar>(
+      {prefix + "is_json_scalar"});
 
   registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});
@@ -37,17 +39,29 @@ void registerJsonFunctions(const std::string& prefix) {
 
   registerFunction<SIMDJsonArrayLengthFunction, int64_t, Json>(
       {prefix + "json_array_length"});
+  registerFunction<SIMDJsonArrayLengthFunction, int64_t, Varchar>(
+      {prefix + "json_array_length"});
 
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, bool>(
       {prefix + "json_array_contains"});
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, bool>(
+      {prefix + "json_array_contains"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, int64_t>(
+      {prefix + "json_array_contains"});
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, int64_t>(
       {prefix + "json_array_contains"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, double>(
       {prefix + "json_array_contains"});
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, double>(
+      {prefix + "json_array_contains"});
   registerFunction<SIMDJsonArrayContainsFunction, bool, Json, Varchar>(
+      {prefix + "json_array_contains"});
+  registerFunction<SIMDJsonArrayContainsFunction, bool, Varchar, Varchar>(
       {prefix + "json_array_contains"});
 
   registerFunction<JsonSizeFunction, int64_t, Json, Varchar>(
+      {prefix + "json_size"});
+  registerFunction<JsonSizeFunction, int64_t, Varchar, Varchar>(
       {prefix + "json_size"});
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_json_format, prefix + "json_format");


### PR DESCRIPTION
Presto allows both JSON and VARCHAR values in json_xxx functions.

```
presto:di> show functions like '%json_%';
      Function       | Return Type |     Argument Types     | Function Type | Deterministic | Description | Variable Arity | Built In | Temporary | Language
---------------------+-------------+------------------------+---------------+---------------+-------------+----------------+----------+-----------+----------
 is_json_scalar      | boolean     | json                   | scalar        | true          |             | false          | true     | false     |
 is_json_scalar      | boolean     | varchar(x)             | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | json, bigint           | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | json, boolean          | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | json, double           | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | json, varchar(x)       | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | varchar(x), bigint     | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | varchar(x), boolean    | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | varchar(x), double     | scalar        | true          |             | false          | true     | false     |
 json_array_contains | boolean     | varchar(x), varchar(y) | scalar        | true          |             | false          | true     | false     |
 json_array_get      | json        | json, bigint           | scalar        | true          |             | false          | true     | false     |
 json_array_get      | json        | varchar(x), bigint     | scalar        | true          |             | false          | true     | false     |
 json_array_length   | bigint      | json                   | scalar        | true          |             | false          | true     | false     |
 json_array_length   | bigint      | varchar(x)             | scalar        | true          |             | false          | true     | false     |
 json_extract        | json        | json, JsonPath         | scalar        | true          |             | false          | true     | false     |
 json_extract        | json        | varchar(x), JsonPath   | scalar        | true          |             | false          | true     | false     |
 json_extract_scalar | varchar     | json, JsonPath         | scalar        | true          |             | false          | true     | false     |
 json_extract_scalar | varchar(x)  | varchar(x), JsonPath   | scalar        | true          |             | false          | true     | false     |
 json_format         | varchar     | json                   | scalar        | true          |             | false          | true     | false     |
 json_parse          | json        | varchar(x)             | scalar        | true          |             | false          | true     | false     |
 json_size           | bigint      | json, JsonPath         | scalar        | true          |             | false          | true     | false     |
 json_size           | bigint      | varchar(x), JsonPath   | scalar        | true          |             | false          | true     | false     |
(22 rows)
```