### PR TITLE
Optimize WindowOperator for pre-sorted input

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2039,6 +2039,7 @@ class WindowNode : public PlanNode {
       std::vector<SortOrder> sortingOrders,
       std::vector<std::string> windowColumnNames,
       std::vector<Function> windowFunctions,
+      bool inputsSorted,
       PlanNodePtr source);
 
   const std::vector<PlanNodePtr>& sources() const override {
@@ -2067,6 +2068,10 @@ class WindowNode : public PlanNode {
     return windowFunctions_;
   }
 
+  bool inputsSorted() const {
+    return inputsSorted_;
+  }
+
   std::string_view name() const override {
     return "Window";
   }
@@ -2084,6 +2089,8 @@ class WindowNode : public PlanNode {
   const std::vector<SortOrder> sortingOrders_;
 
   const std::vector<Function> windowFunctions_;
+
+  const bool inputsSorted_;
 
   const std::vector<PlanNodePtr> sources_;
 

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -619,6 +619,8 @@ If no sorting columns are specified then the order of the results is unspecified
     - Output column names for each window function invocation in windowFunctions list below.
   * - windowFunctions
     - Window function calls with the frame clause. e.g row_number(), first_value(name) between range 10 preceding and current row. The default frame is between range unbounded preceding and current row.
+  * - inputsSorted
+    - If true, the Window operator assumes that the inputs are clustered on partition keys and sorted on sorting keys in sorting orders. In this case, the operator splits the window partition and begins processing it as soon as it receives the data. If false, the Window operator accumulates all inputs first, then sorts the data, splits the window partition based on the defined criteria, and then processes each window partition sequentially.
 
 RowNumberNode
 ~~~~~~~~~~~~~

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(
   SpillOperatorGroup.cpp
   Spiller.cpp
   StreamingAggregation.cpp
+  StreamingWindowBuild.cpp
   Strings.cpp
   TableScan.cpp
   TableWriteMerge.cpp

--- a/velox/exec/StreamingWindowBuild.cpp
+++ b/velox/exec/StreamingWindowBuild.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/StreamingWindowBuild.h"
+
+namespace facebook::velox::exec {
+
+StreamingWindowBuild::StreamingWindowBuild(
+    const std::shared_ptr<const core::WindowNode>& windowNode,
+    velox::memory::MemoryPool* pool)
+    : WindowBuild(windowNode, pool) {}
+
+void StreamingWindowBuild::buildNextPartition() {
+  partitionStartRows_.push_back(sortedRows_.size());
+  sortedRows_.insert(sortedRows_.end(), inputRows_.begin(), inputRows_.end());
+  inputRows_.clear();
+}
+
+void StreamingWindowBuild::addInput(RowVectorPtr input) {
+  for (auto col = 0; col < input->childrenSize(); ++col) {
+    decodedInputVectors_[col].decode(*input->childAt(col));
+  }
+
+  for (auto row = 0; row < input->size(); ++row) {
+    char* newRow = data_->newRow();
+
+    for (auto col = 0; col < input->childrenSize(); ++col) {
+      data_->store(decodedInputVectors_[col], row, newRow, col);
+    }
+
+    if (previousRow_ != nullptr &&
+        compareRowsWithKeys(previousRow_, newRow, partitionKeyInfo_)) {
+      buildNextPartition();
+    }
+
+    inputRows_.push_back(newRow);
+    previousRow_ = newRow;
+  }
+}
+
+void StreamingWindowBuild::noMoreInput() {
+  buildNextPartition();
+
+  // Help for last partition related calculations.
+  partitionStartRows_.push_back(sortedRows_.size());
+}
+
+std::unique_ptr<WindowPartition> StreamingWindowBuild::nextPartition() {
+  VELOX_CHECK_GT(
+      partitionStartRows_.size(), 0, "No window partitions available")
+
+  currentPartition_++;
+  VELOX_CHECK_LE(
+      currentPartition_,
+      partitionStartRows_.size() - 2,
+      "All window partitions consumed");
+
+  // Erase previous partition.
+  if (currentPartition_ > 0) {
+    auto numPreviousPartitionRows = partitionStartRows_[currentPartition_];
+    data_->eraseRows(
+        folly::Range<char**>(sortedRows_.data(), numPreviousPartitionRows));
+    sortedRows_.erase(
+        sortedRows_.begin(), sortedRows_.begin() + numPreviousPartitionRows);
+    for (int i = currentPartition_; i < partitionStartRows_.size(); i++) {
+      partitionStartRows_[i] =
+          partitionStartRows_[i] - numPreviousPartitionRows;
+    }
+  }
+
+  auto windowPartition = std::make_unique<WindowPartition>(
+      data_.get(), inputColumns_, sortKeyInfo_);
+  auto partitionSize = partitionStartRows_[currentPartition_ + 1] -
+      partitionStartRows_[currentPartition_];
+  auto partition = folly::Range(
+      sortedRows_.data() + partitionStartRows_[currentPartition_],
+      partitionSize);
+  windowPartition->resetPartition(partition);
+
+  return windowPartition;
+}
+
+bool StreamingWindowBuild::hasNextPartition() {
+  return partitionStartRows_.size() > 0 &&
+      currentPartition_ < int(partitionStartRows_.size() - 2);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/StreamingWindowBuild.h
+++ b/velox/exec/StreamingWindowBuild.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/WindowBuild.h"
+
+namespace facebook::velox::exec {
+
+/// The StreamingWindowBuild is used when the input data is already sorted by
+/// {partition keys + order by keys}. The logic identifies partition changes
+/// when receiving input rows and splits out WindowPartitions for the Window
+/// operator to process.
+class StreamingWindowBuild : public WindowBuild {
+ public:
+  StreamingWindowBuild(
+      const std::shared_ptr<const core::WindowNode>& windowNode,
+      velox::memory::MemoryPool* pool);
+
+  void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
+
+  bool hasNextPartition() override;
+
+  std::unique_ptr<WindowPartition> nextPartition() override;
+
+  bool needsInput() override {
+    // No partitions are available or the currentPartition is the last available
+    // one, so can consume input rows.
+    return partitionStartRows_.size() == 0 ||
+        currentPartition_ == partitionStartRows_.size() - 2;
+  }
+
+ private:
+  void buildNextPartition();
+
+  // Vector of pointers to each input row in the data_ RowContainer.
+  // Rows are erased from data_ when they are output from the
+  // Window operator.
+  std::vector<char*> sortedRows_;
+
+  // Holds input rows within the current partition.
+  std::vector<char*> inputRows_;
+
+  // Indices of  the start row (in sortedRows_) of each partition in
+  // the RowContainer data_. This auxiliary structure helps demarcate
+  // partitions.
+  std::vector<vector_size_t> partitionStartRows_;
+
+  // Used to compare rows based on partitionKeys.
+  char* previousRow_ = nullptr;
+
+  // Current partition being output. Used to construct WindowPartitions
+  // during resetPartition.
+  vector_size_t currentPartition_ = -1;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -153,7 +153,7 @@ class Window : public Operator {
 
   // WindowBuild is used to store input rows and return WindowPartitions
   // for the processing.
-  const std::unique_ptr<WindowBuild> windowBuild_;
+  std::unique_ptr<WindowBuild> windowBuild_;
 
   // The cached window plan node used for window function initialization. It is
   // reset after the initialization.

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -106,7 +106,7 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .planNode()
           ->toString(true, false),
       "-- Window[partition by [a] order by [b ASC NULLS LAST] "
-      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
+      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n");
 
   VELOX_CHECK_EQ(
@@ -116,7 +116,7 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .planNode()
           ->toString(true, false),
       "-- Window[partition by [a] order by [] "
-      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
+      "d := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n");
 
   VELOX_CHECK_EQ(
@@ -126,7 +126,7 @@ TEST_F(PlanBuilderTest, windowFunctionCall) {
           .planNode()
           ->toString(true, false),
       "-- Window[partition by [] order by [] "
-      "w0 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW] "
+      "w0 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and CURRENT ROW inputsSorted [0]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, w0:BIGINT\n");
 
   VELOX_ASSERT_THROW(
@@ -175,7 +175,7 @@ TEST_F(PlanBuilderTest, windowFrame) {
       "d7 := window1(ROW[\"c\"]) ROWS between CURRENT ROW and UNBOUNDED FOLLOWING, "
       "d8 := window1(ROW[\"c\"]) RANGE between CURRENT ROW and UNBOUNDED FOLLOWING, "
       "d9 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING, "
-      "d10 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING] "
+      "d10 := window1(ROW[\"c\"]) RANGE between UNBOUNDED PRECEDING and UNBOUNDED FOLLOWING inputsSorted [0]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d1:BIGINT, d2:BIGINT, d3:BIGINT, d4:BIGINT, "
       "d5:BIGINT, d6:BIGINT, d7:BIGINT, d8:BIGINT, d9:BIGINT, d10:BIGINT\n");
 

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -410,6 +410,23 @@ TEST_F(PlanNodeSerdeTest, window) {
              .planNode();
 
   testSerde(plan);
+
+  // Test StreamingWindow serde.
+  plan =
+      PlanBuilder()
+          .values({data_})
+          .streamingWindow(
+              {"sum(c0) over (partition by c1 order by c2 rows between 10 preceding and 5 following)"})
+          .planNode();
+
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .streamingWindow({"sum(c0) over (partition by c1 order by c2)"})
+             .planNode();
+
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, rowNumber) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -683,7 +683,7 @@ TEST_F(PlanNodeToStringTest, window) {
   ASSERT_EQ("-- Window\n", plan->toString());
   ASSERT_EQ(
       "-- Window[partition by [a] order by [b ASC NULLS LAST] "
-      "d := window1(ROW[\"c\"]) RANGE between 10 PRECEDING and UNBOUNDED FOLLOWING] "
+      "d := window1(ROW[\"c\"]) RANGE between 10 PRECEDING and UNBOUNDED FOLLOWING inputsSorted [0]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n",
       plan->toString(true, false));
 
@@ -695,7 +695,32 @@ TEST_F(PlanNodeToStringTest, window) {
   ASSERT_EQ("-- Window\n", plan->toString());
   ASSERT_EQ(
       "-- Window[partition by [a] order by [] "
-      "w0 := window1(ROW[\"c\"]) RANGE between CURRENT ROW and b FOLLOWING] "
+      "w0 := window1(ROW[\"c\"]) RANGE between CURRENT ROW and b FOLLOWING inputsSorted [0]] "
+      "-> a:VARCHAR, b:BIGINT, c:BIGINT, w0:BIGINT\n",
+      plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .tableScan(ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), BIGINT()}))
+             .streamingWindow(
+                 {"window1(c) over (partition by a order by b "
+                  "range between 10 preceding and unbounded following) AS d"})
+             .planNode();
+  ASSERT_EQ("-- Window\n", plan->toString());
+  ASSERT_EQ(
+      "-- Window[partition by [a] order by [b ASC NULLS LAST] "
+      "d := window1(ROW[\"c\"]) RANGE between 10 PRECEDING and UNBOUNDED FOLLOWING inputsSorted [1]] "
+      "-> a:VARCHAR, b:BIGINT, c:BIGINT, d:BIGINT\n",
+      plan->toString(true, false));
+
+  plan = PlanBuilder()
+             .tableScan(ROW({"a", "b", "c"}, {VARCHAR(), BIGINT(), BIGINT()}))
+             .streamingWindow({"window1(c) over (partition by a "
+                               "range between current row and b following)"})
+             .planNode();
+  ASSERT_EQ("-- Window\n", plan->toString());
+  ASSERT_EQ(
+      "-- Window[partition by [a] order by [] "
+      "w0 := window1(ROW[\"c\"]) RANGE between CURRENT ROW and b FOLLOWING inputsSorted [1]] "
       "-> a:VARCHAR, b:BIGINT, c:BIGINT, w0:BIGINT\n",
       plan->toString(true, false));
 }

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1429,7 +1429,8 @@ bool equalSortOrderList(
 } // namespace
 
 PlanBuilder& PlanBuilder::window(
-    const std::vector<std::string>& windowFunctions) {
+    const std::vector<std::string>& windowFunctions,
+    bool inputSorted) {
   VELOX_CHECK_GT(
       windowFunctions.size(),
       0,
@@ -1510,8 +1511,19 @@ PlanBuilder& PlanBuilder::window(
       sortingOrders,
       windowNames,
       windowNodeFunctions,
+      inputSorted,
       planNode_);
   return *this;
+}
+
+PlanBuilder& PlanBuilder::window(
+    const std::vector<std::string>& windowFunctions) {
+  return window(windowFunctions, false);
+}
+
+PlanBuilder& PlanBuilder::streamingWindow(
+    const std::vector<std::string>& windowFunctions) {
+  return window(windowFunctions, true);
 }
 
 PlanBuilder& PlanBuilder::rowNumber(

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -721,6 +721,11 @@ class PlanBuilder {
   ///  rows between a + 10 preceding and 10 following)"
   PlanBuilder& window(const std::vector<std::string>& windowFunctions);
 
+  /// Adds WindowNode to compute window functions over pre-sorted inputs.
+  /// All functions must use same partition by and sorting keys and input must
+  /// be already sorted on these.
+  PlanBuilder& streamingWindow(const std::vector<std::string>& windowFunctions);
+
   /// Add a RowNumberNode to compute single row_number window function with an
   /// optional limit and no sorting.
   PlanBuilder& rowNumber(
@@ -840,6 +845,12 @@ class PlanBuilder {
       const std::vector<std::string>& masks,
       core::AggregationNode::Step step,
       const std::vector<TypePtr>& resultTypes);
+
+  /// Create WindowNode based on whether input is sorted and then compute the
+  /// window functions.
+  PlanBuilder& window(
+      const std::vector<std::string>& windowFunctions,
+      bool inputSorted);
 
  protected:
   core::PlanNodePtr planNode_;

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -18,7 +18,9 @@
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int_distribution.hpp>
 
+#include <iostream>
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
@@ -46,6 +48,44 @@ WindowTestBase::QueryInfo WindowTestBase::buildWindowQuery(
       fmt::format("SELECT {}, {} FROM tmp", columnsString, functionSql);
 
   return {op, functionSql, querySql};
+}
+
+WindowTestBase::QueryInfo WindowTestBase::buildStreamingWindowQuery(
+    const std::vector<RowVectorPtr>& input,
+    const std::string& function,
+    const std::string& overClause,
+    const std::string& frameClause) {
+  std::string functionSql =
+      fmt::format("{} over ({} {})", function, overClause, frameClause);
+  std::vector<std::string> orderByClauses;
+  auto windowExpr = duckdb::parseWindowExpr(functionSql, {});
+
+  // Extract the partition by keys.
+  for (const auto& partition : windowExpr.partitionBy) {
+    orderByClauses.push_back(partition->toString() + " NULLS FIRST");
+  }
+
+  // Extract the order by keys.
+  const auto& orderBy = windowExpr.orderBy;
+  for (auto i = 0; i < orderBy.size(); ++i) {
+    orderByClauses.push_back(
+        orderBy[i].first->toString() + " " + orderBy[i].second.toString());
+  }
+
+  // Sort the input data before streaming window.
+  auto plan = PlanBuilder()
+                  .setParseOptions(options_)
+                  .values(input)
+                  .orderBy(orderByClauses, false)
+                  .streamingWindow({functionSql})
+                  .planNode();
+
+  auto rowType = asRowType(input[0]->type());
+  std::string columnsString = folly::join(", ", rowType->names());
+  std::string querySql =
+      fmt::format("SELECT {}, {} FROM tmp", columnsString, functionSql);
+
+  return {plan, functionSql, querySql};
 }
 
 RowVectorPtr WindowTestBase::makeSimpleVector(vector_size_t size) {
@@ -108,14 +148,30 @@ void WindowTestBase::testWindowFunction(
     const std::string& function,
     const std::vector<std::string>& overClauses,
     const std::vector<std::string>& frameClauses,
-    bool createTable) {
+    bool createTable,
+    WindowStyle windowStyle) {
   if (createTable) {
     createDuckDbTable(input);
   }
+
+  // Generate a random boolean to determine the window style
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<int> dis(0, 1);
+
   for (const auto& overClause : overClauses) {
-    for (auto& frameClause : frameClauses) {
-      auto queryInfo =
-          buildWindowQuery(input, function, overClause, frameClause);
+    WindowTestBase::QueryInfo queryInfo;
+    for (const auto& frameClause : frameClauses) {
+      auto resolvedWindowStyle = windowStyle == WindowStyle::kRandom
+          ? static_cast<int>(dis(gen))
+          : static_cast<int>(windowStyle);
+      if (resolvedWindowStyle == static_cast<int>(WindowStyle::kSort)) {
+        queryInfo = buildWindowQuery(input, function, overClause, frameClause);
+      } else {
+        queryInfo =
+            buildStreamingWindowQuery(input, function, overClause, frameClause);
+      }
+
       SCOPED_TRACE(queryInfo.functionSql);
       assertQuery(queryInfo.planNode, queryInfo.querySql);
     }

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -19,6 +19,8 @@
 
 namespace facebook::velox::window::test {
 
+enum class WindowStyle { kSort, kStreaming, kRandom };
+
 /// Exhaustive set of window function over clauses using a combination of four
 /// columns. Columns c0 and c1 have input data meant to test partitioning
 /// and sorting behavior of the operator. Columns c2 and c3 are used with
@@ -90,6 +92,9 @@ inline const std::vector<std::string> kEmptyFrameClauses = {
 
 };
 
+static const std::string kPartitionByStr = "partition by";
+static const std::string kOrderByStr = "order by";
+
 class WindowTestBase : public exec::test::OperatorTestBase {
  protected:
   void SetUp() override {
@@ -132,6 +137,14 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const std::string& overClause,
       const std::string& frameClause);
 
+  // This function is used to test the StreamingWindow. It will add the order by
+  // action to ensure the data is ordered.
+  QueryInfo buildStreamingWindowQuery(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& function,
+      const std::string& overClause,
+      const std::string& frameClause);
+
   /// This function tests SQL queries for the window function and
   /// the specified overClauses and frameClauses with the input RowVectors.
   /// Note : 'function' should be a full window function invocation string
@@ -144,7 +157,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       const std::string& function,
       const std::vector<std::string>& overClauses,
       const std::vector<std::string>& frameClauses = {""},
-      bool createTable = true);
+      bool createTable = true,
+      WindowStyle windowStyle = WindowStyle::kRandom);
 
   /// This function tests the SQL query for the window function and overClause
   /// combination with the input RowVectors. It is expected that query execution


### PR DESCRIPTION
Spark planner inserts a Sort operator before a Window operator to sort the data.
Hence, there is no need to sort the data again in the window operator. 

Add an option to WindowOperator to skip sorting if inputs are already sorted.
This allow WindowOperator to process data in streaming manner without
accumulating all input in memory.
