### PR TITLE
Fix recoding of wall and cpu time spent in Operator::noMoreInput() 

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -479,9 +479,17 @@ StopReason Driver::runInternal(
               }
               RuntimeStatWriterScopeGuard statsWriterGuard(op);
               if (op->isFinished()) {
+                // This branch is to update the finishTiming of op.
                 auto timer =
                     createDeltaCpuWallTimer([op](const CpuWallTiming& timing) {
                       op->stats().wlock()->finishTiming.add(timing);
+                    });
+              }
+
+              if (op->isFinished()) {
+                auto timer = createDeltaCpuWallTimer(
+                    [nextOp](const CpuWallTiming& timing) {
+                      nextOp->stats().wlock()->finishTiming.add(timing);
                     });
                 RuntimeStatWriterScopeGuard statsWriterGuard(nextOp);
                 TestValue::adjust(

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 
 namespace facebook::velox::window::test {
@@ -124,6 +125,8 @@ class WindowTestBase : public exec::test::OperatorTestBase {
     core::PlanNodePtr planNode;
     std::string functionSql;
     std::string querySql;
+    core::PlanNodeId windowId;
+    core::PlanNodeId valuesId;
   };
 
   QueryInfo buildWindowQuery(


### PR DESCRIPTION
Wall and CPU time spent in Operator::noMoreInput() used to be attributed to the 
wrong operator (the one downstream of current).