### PR TITLE
Add support for map_union(map(unknown, unknown))

### DIFF
--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -45,7 +45,7 @@ class MapUnionAggregate : public aggregate::MapAggregateBase {
 exec::AggregateRegistrationResult registerMapUnion(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
-          .knownTypeVariable("K")
+          .typeVariable("K")
           .typeVariable("V")
           .returnType("map(K,V)")
           .intermediateType("map(K,V)")


### PR DESCRIPTION
Presto supports map_union(map(unknown, unknown)) when input maps are all empty.

```
WITH t as (SELECT map(array[], array[]) as m)
SELECT map_union(m) FROM t
```