### PR TITLE
Parquet write support combine batches to big row group

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.h
+++ b/velox/dwio/parquet/reader/ParquetReader.h
@@ -214,6 +214,10 @@ class ParquetReader : public dwio::common::Reader {
     return readerBase_->schemaWithId();
   }
 
+  size_t numberOfRowGroups() const {
+    return readerBase_->fileMetaData().row_groups.size();
+  }
+
   std::unique_ptr<dwio::common::RowReader> createRowReader(
       const dwio::common::RowReaderOptions& options = {}) const override;
 

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -55,18 +55,27 @@ class E2EFilterTest : public E2EFilterTestBase {
   void writeToMemory(
       const TypePtr&,
       const std::vector<RowVectorPtr>& batches,
-      bool /*forRowGroupSkip*/) override {
+      bool forRowGroupSkip = false) override {
     auto sink = std::make_unique<MemorySink>(*leafPool_, 200 * 1024 * 1024);
     sinkPtr_ = sink.get();
     options_.memoryPool = rootPool_.get();
-
     options_.bufferGrowRatio = 2;
+    int32_t flushCounter = 0;
+    options_.flushPolicyFactory = [&]() {
+      return std::make_unique<LambdaFlushPolicy>(
+          rowsInRowGroup_, bytesInRowGroup_, [&]() {
+            return forRowGroupSkip
+                ? false
+                : (++flushCounter % flushEveryNBatches_ == 0);
+          });
+    };
+
     writer_ = std::make_unique<facebook::velox::parquet::Writer>(
         std::move(sink), options_);
     for (auto& batch : batches) {
       writer_->write(batch);
-      writer_->flush();
     }
+    writer_->flush();
     writer_->close();
   }
 
@@ -78,6 +87,8 @@ class E2EFilterTest : public E2EFilterTestBase {
 
   std::unique_ptr<facebook::velox::parquet::Writer> writer_;
   facebook::velox::parquet::WriterOptions options_;
+  uint64_t rowsInRowGroup_ = 10'000;
+  int64_t bytesInRowGroup_ = 128 * 1'024 * 1'024;
 };
 
 TEST_F(E2EFilterTest, writerMagic) {
@@ -422,7 +433,7 @@ TEST_F(E2EFilterTest, stringDictionary) {
 }
 
 TEST_F(E2EFilterTest, dedictionarize) {
-  options_.maxRowGroupLength = 10'000'000;
+  rowsInRowGroup_ = 10'000;
   options_.dictionaryPageSizeLimit = 20'000;
 
   testWithTypes(
@@ -472,6 +483,9 @@ TEST_F(E2EFilterTest, list) {
 }
 
 TEST_F(E2EFilterTest, metadataFilter) {
+  // Follow the batch size in `E2EFiltersTestBase`,
+  // so that each batch can produce a row group.
+  rowsInRowGroup_ = 10;
   testMetadataFilter();
 }
 
@@ -532,7 +546,7 @@ TEST_F(E2EFilterTest, varbinaryDictionary) {
 }
 
 TEST_F(E2EFilterTest, largeMetadata) {
-  options_.maxRowGroupLength = 1;
+  rowsInRowGroup_ = 1;
 
   rowType_ = ROW({INTEGER()});
   std::vector<RowVectorPtr> batches;
@@ -567,6 +581,25 @@ TEST_F(E2EFilterTest, date) {
       false,
       {"date_val"},
       20);
+}
+
+TEST_F(E2EFilterTest, combineRowGroup) {
+  rowsInRowGroup_ = 5;
+  rowType_ = ROW({INTEGER()});
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 5; i++) {
+    batches.push_back(std::static_pointer_cast<RowVector>(
+        test::BatchMaker::createBatch(rowType_, 1, *leafPool_, nullptr, 0)));
+  }
+  writeToMemory(rowType_, batches, false);
+  std::string_view data(sinkPtr_->getData(), sinkPtr_->size());
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
+  EXPECT_EQ(parquetReader.numberOfRowGroups(), 1);
+  EXPECT_EQ(parquetReader.numberOfRows(), 5);
 }
 
 // Define main so that gflags get processed.

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -229,8 +229,7 @@ void Writer::write(const VectorPtr& data) {
   }
 
   for (int colIdx = 0; colIdx < recordBatch->num_columns(); colIdx++) {
-    auto array = recordBatch->column(colIdx);
-    arrowContext_->stagingChunks.at(colIdx).push_back(array);
+    arrowContext_->stagingChunks.at(colIdx).push_back(recordBatch->column(colIdx));
   }
   arrowContext_->stagingRows += numRows;
   arrowContext_->stagingBytes += bytes;

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -229,7 +229,8 @@ void Writer::write(const VectorPtr& data) {
   }
 
   for (int colIdx = 0; colIdx < recordBatch->num_columns(); colIdx++) {
-    arrowContext_->stagingChunks.at(colIdx).push_back(recordBatch->column(colIdx));
+    arrowContext_->stagingChunks.at(colIdx).push_back(
+        recordBatch->column(colIdx));
   }
   arrowContext_->stagingRows += numRows;
   arrowContext_->stagingBytes += bytes;

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -82,7 +82,12 @@ class ArrowDataBufferSink : public arrow::io::OutputStream {
 
 struct ArrowContext {
   std::unique_ptr<::parquet::arrow::FileWriter> writer;
+  std::shared_ptr<arrow::Schema> schema;
   std::shared_ptr<::parquet::WriterProperties> properties;
+  uint64_t stagingRows = 0;
+  int64_t stagingBytes = 0;
+  // columns, Arrays
+  std::vector<std::vector<std::shared_ptr<arrow::Array>>> stagingChunks;
 };
 
 ::parquet::Compression::type getArrowParquetCompression(
@@ -101,7 +106,8 @@ struct ArrowContext {
 }
 
 std::shared_ptr<::parquet::WriterProperties> getArrowParquetWriterOptions(
-    const parquet::WriterOptions& options) {
+    const parquet::WriterOptions& options,
+    const std::unique_ptr<DefaultFlushPolicy>& flushPolicy) {
   auto builder = ::parquet::WriterProperties::Builder();
   ::parquet::WriterProperties::Builder* properties = &builder;
   if (!options.enableDictionary) {
@@ -110,6 +116,8 @@ std::shared_ptr<::parquet::WriterProperties> getArrowParquetWriterOptions(
   properties =
       properties->compression(getArrowParquetCompression(options.compression));
   properties = properties->data_pagesize(options.dataPageSize);
+  properties = properties->max_row_group_length(
+      static_cast<int64_t>(flushPolicy->rowsInRowGroup()));
   return properties->build();
 }
 
@@ -117,15 +125,20 @@ Writer::Writer(
     std::unique_ptr<dwio::common::DataSink> sink,
     const WriterOptions& options,
     std::shared_ptr<memory::MemoryPool> pool)
-    : rowsInRowGroup_(options.rowsInRowGroup),
-      pool_(std::move(pool)),
+    : pool_(std::move(pool)),
       generalPool_{pool_->addLeafChild(".general")},
       stream_(std::make_shared<ArrowDataBufferSink>(
           std::move(sink),
           *generalPool_,
           options.bufferGrowRatio)),
       arrowContext_(std::make_shared<ArrowContext>()) {
-  arrowContext_->properties = getArrowParquetWriterOptions(options);
+  if (options.flushPolicyFactory) {
+    flushPolicy_ = options.flushPolicyFactory();
+  } else {
+    flushPolicy_ = std::make_unique<DefaultFlushPolicy>();
+  }
+  arrowContext_->properties =
+      getArrowParquetWriterOptions(options, flushPolicy_);
 }
 
 Writer::Writer(
@@ -138,6 +151,60 @@ Writer::Writer(
               "writer_node_{}",
               folly::to<std::string>(folly::Random::rand64())))} {}
 
+void Writer::flush() {
+  if (arrowContext_->stagingRows > 0) {
+    if (!arrowContext_->writer) {
+      auto arrowProperties =
+          ::parquet::ArrowWriterProperties::Builder().build();
+      PARQUET_THROW_NOT_OK(::parquet::arrow::FileWriter::Open(
+          *arrowContext_->schema.get(),
+          arrow::default_memory_pool(),
+          stream_,
+          arrowContext_->properties,
+          arrowProperties,
+          &arrowContext_->writer));
+    }
+
+    auto fields = arrowContext_->schema->fields();
+    std::vector<std::shared_ptr<arrow::ChunkedArray>> chunks;
+    for (int colIdx = 0; colIdx < fields.size(); colIdx++) {
+      auto dataType = fields.at(colIdx)->type();
+      auto chunk =
+          arrow::ChunkedArray::Make(
+              std::move(arrowContext_->stagingChunks.at(colIdx)), dataType)
+              .ValueOrDie();
+      chunks.push_back(chunk);
+    }
+    auto table = arrow::Table::Make(
+        arrowContext_->schema,
+        std::move(chunks),
+        static_cast<int64_t>(arrowContext_->stagingRows));
+    PARQUET_THROW_NOT_OK(arrowContext_->writer->WriteTable(
+        *table, static_cast<int64_t>(flushPolicy_->rowsInRowGroup())));
+    PARQUET_THROW_NOT_OK(stream_->Flush());
+    for (auto& chunk : arrowContext_->stagingChunks) {
+      chunk.clear();
+    }
+    arrowContext_->stagingRows = 0;
+    arrowContext_->stagingBytes = 0;
+  }
+}
+
+dwio::common::StripeProgress getStripeProgress(
+    uint64_t stagingRows,
+    int64_t stagingBytes) {
+  return dwio::common::StripeProgress{
+      .stripeRowCount = stagingRows, .stripeSizeEstimate = stagingBytes};
+}
+
+/**
+ * This method would cache input `ColumnarBatch` to make the size of row group
+ * big. It would flush when:
+ * - the cached numRows bigger than `rowsInRowGroup_`
+ * - the cached bytes bigger than `bytesInRowGroup_`
+ *
+ * This method assumes each input `ColumnarBatch` have same schema.
+ */
 void Writer::write(const VectorPtr& data) {
   ArrowArray array;
   ArrowSchema schema;
@@ -145,21 +212,28 @@ void Writer::write(const VectorPtr& data) {
   exportToArrow(data, schema);
   PARQUET_ASSIGN_OR_THROW(
       auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
-  auto table = arrow::Table::Make(
-      recordBatch->schema(), recordBatch->columns(), data->size());
-  if (!arrowContext_->writer) {
-    auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
-    PARQUET_THROW_NOT_OK(::parquet::arrow::FileWriter::Open(
-        *recordBatch->schema(),
-        arrow::default_memory_pool(),
-        stream_,
-        arrowContext_->properties,
-        arrowProperties,
-        &arrowContext_->writer));
+  if (!arrowContext_->schema) {
+    arrowContext_->schema = recordBatch->schema();
+    for (int colIdx = 0; colIdx < arrowContext_->schema->num_fields();
+         colIdx++) {
+      arrowContext_->stagingChunks.push_back(
+          std::vector<std::shared_ptr<arrow::Array>>());
+    }
   }
 
-  PARQUET_THROW_NOT_OK(
-      arrowContext_->writer->WriteTable(*table, rowsInRowGroup_));
+  auto bytes = data->estimateFlatSize();
+  auto numRows = data->size();
+  if (flushPolicy_->shouldFlush(getStripeProgress(
+          arrowContext_->stagingRows, arrowContext_->stagingBytes))) {
+    flush();
+  }
+
+  for (int colIdx = 0; colIdx < recordBatch->num_columns(); colIdx++) {
+    auto array = recordBatch->column(colIdx);
+    arrowContext_->stagingChunks.at(colIdx).push_back(array);
+  }
+  arrowContext_->stagingRows += numRows;
+  arrowContext_->stagingBytes += bytes;
 }
 
 bool Writer::isCodecAvailable(common::CompressionKind compression) {
@@ -167,20 +241,20 @@ bool Writer::isCodecAvailable(common::CompressionKind compression) {
       getArrowParquetCompression(compression));
 }
 
-void Writer::flush() {
-  PARQUET_THROW_NOT_OK(stream_->Flush());
-}
-
 void Writer::newRowGroup(int32_t numRows) {
   PARQUET_THROW_NOT_OK(arrowContext_->writer->NewRowGroup(numRows));
 }
 
 void Writer::close() {
+  flush();
+
   if (arrowContext_->writer) {
     PARQUET_THROW_NOT_OK(arrowContext_->writer->Close());
     arrowContext_->writer.reset();
   }
   PARQUET_THROW_NOT_OK(stream_->Close());
+
+  arrowContext_->stagingChunks.clear();
 }
 
 parquet::WriterOptions getParquetOptions(

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -19,6 +19,7 @@
 #include "velox/common/compression/Compression.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/DataSink.h"
+#include "velox/dwio/common/FlushPolicy.h"
 #include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/Writer.h"
 #include "velox/dwio/common/WriterFactory.h"
@@ -30,15 +31,66 @@ class ArrowDataBufferSink;
 
 struct ArrowContext;
 
+class DefaultFlushPolicy : public dwio::common::FlushPolicy {
+ public:
+  DefaultFlushPolicy()
+      : rowsInRowGroup_(1'024 * 1'024), bytesInRowGroup_(128 * 1'024 * 1'024) {}
+  DefaultFlushPolicy(uint64_t rowsInRowGroup, int64_t bytesInRowGroup)
+      : rowsInRowGroup_(rowsInRowGroup), bytesInRowGroup_(bytesInRowGroup) {}
+
+  bool shouldFlush(
+      const dwio::common::StripeProgress& stripeProgress) override {
+    return stripeProgress.stripeRowCount >= rowsInRowGroup_ ||
+        stripeProgress.stripeSizeEstimate >= bytesInRowGroup_;
+  }
+
+  void onClose() override {
+    // No-op
+  }
+
+  uint64_t rowsInRowGroup() const {
+    return rowsInRowGroup_;
+  }
+
+  int64_t bytesInRowGroup() const {
+    return bytesInRowGroup_;
+  }
+
+ private:
+  const uint64_t rowsInRowGroup_;
+  const int64_t bytesInRowGroup_;
+};
+
+class LambdaFlushPolicy : public DefaultFlushPolicy {
+ public:
+  explicit LambdaFlushPolicy(
+      uint64_t rowsInRowGroup,
+      int64_t bytesInRowGroup,
+      std::function<bool()> lambda)
+      : DefaultFlushPolicy(rowsInRowGroup, bytesInRowGroup) {
+    lambda_ = lambda;
+  }
+  virtual ~LambdaFlushPolicy() override = default;
+
+  bool shouldFlush(
+      const dwio::common::StripeProgress& stripeProgress) override {
+    return lambda_() || DefaultFlushPolicy::shouldFlush(stripeProgress);
+  }
+
+ private:
+  std::function<bool()> lambda_;
+};
+
 struct WriterOptions {
   bool enableDictionary = true;
   int64_t dataPageSize = 1'024 * 1'024;
-  int32_t rowsInRowGroup = 10'000;
-  int64_t maxRowGroupLength = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
   double bufferGrowRatio = 1;
   common::CompressionKind compression = common::CompressionKind_NONE;
   velox::memory::MemoryPool* memoryPool;
+  // The default factory allows the writer to construct the default flush
+  // policy with the configs in its ctor.
+  std::function<std::unique_ptr<DefaultFlushPolicy>()> flushPolicyFactory;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.
@@ -75,8 +127,6 @@ class Writer : public dwio::common::Writer {
   void close() override;
 
  private:
-  const int32_t rowsInRowGroup_;
-
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;
   std::shared_ptr<memory::MemoryPool> generalPool_;
@@ -85,6 +135,8 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<ArrowDataBufferSink> stream_;
 
   std::shared_ptr<ArrowContext> arrowContext_;
+
+  std::unique_ptr<DefaultFlushPolicy> flushPolicy_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -68,7 +68,7 @@ class LambdaFlushPolicy : public DefaultFlushPolicy {
       int64_t bytesInRowGroup,
       std::function<bool()> lambda)
       : DefaultFlushPolicy(rowsInRowGroup, bytesInRowGroup) {
-    lambda_ = lambda;
+    lambda_ = std::move(lambda);
   }
   virtual ~LambdaFlushPolicy() override = default;
 


### PR DESCRIPTION
Parquet write would build row groups for each columnar batch, which causes a lot of small row groups.  It's due to each call on arrow WriteTable would build new row group.

This pr caches the input columnar batch and flush to arrow when:
- the cached numRows bigger than `rowsInRowGroup`
- the cached bytes bigger than `bytesInRowGroup`

Note, `bytesInRowGroup` is a new added option which is commonly used at java side.

