### PR TITLE
[ORC] Support RLEv2 decoding when do column read

### DIFF
--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -413,6 +413,10 @@ class ColumnVisitor {
     }
   }
 
+  ExtractValues extractValues() const {
+    return values_;
+  }
+
   HookType& hook() {
     return values_.hook();
   }

--- a/velox/dwio/common/IntDecoder.h
+++ b/velox/dwio/common/IntDecoder.h
@@ -31,6 +31,7 @@ template <bool isSigned>
 class IntDecoder {
  public:
   static constexpr int32_t kMinDenseBatch = 8;
+  static constexpr bool kIsSigned = isSigned;
 
   IntDecoder(
       std::unique_ptr<dwio::common::SeekableInputStream> input,

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -26,6 +26,13 @@
 
 namespace facebook::velox::dwio::common {
 
+#define VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor) \
+  if (nulls) {                                             \
+    decoder->readWithVisitor<true>(nulls, visitor);        \
+  } else {                                                 \
+    decoder->readWithVisitor<false>(nulls, visitor);       \
+  }
+
 // Generalized representation of a set of distinct values for dictionary
 // encodings.
 struct DictionaryValues {

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -155,6 +155,9 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
     case proto::ColumnEncoding_Kind_DIRECT:
     case proto::ColumnEncoding_Kind_DICTIONARY:
       return RleVersion_1;
+    case proto::ColumnEncoding_Kind_DIRECT_V2:
+    case proto::ColumnEncoding_Kind_DICTIONARY_V2:
+      return RleVersion_2;
     default:
       DWIO_RAISE("Unknown encoding in convertRleVersion");
   }

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -42,9 +42,11 @@ std::unique_ptr<SelectiveColumnReader> buildIntegerReader(
   auto& stripe = params.stripeStreams();
   switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
     case proto::ColumnEncoding_Kind_DICTIONARY:
+    case proto::ColumnEncoding_Kind_DICTIONARY_V2:
       return std::make_unique<SelectiveIntegerDictionaryColumnReader>(
           requestedType, dataType, params, scanSpec, numBytes);
     case proto::ColumnEncoding_Kind_DIRECT:
+    case proto::ColumnEncoding_Kind_DIRECT_V2:
       return std::make_unique<SelectiveIntegerDirectColumnReader>(
           requestedType, dataType, params, numBytes, scanSpec);
     default:
@@ -110,9 +112,11 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     case TypeKind::VARCHAR:
       switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
         case proto::ColumnEncoding_Kind_DIRECT:
+        case proto::ColumnEncoding_Kind_DIRECT_V2:
           return std::make_unique<SelectiveStringDirectColumnReader>(
               requestedType, params, scanSpec);
         case proto::ColumnEncoding_Kind_DICTIONARY:
+        case proto::ColumnEncoding_Kind_DICTIONARY_V2:
           return std::make_unique<SelectiveStringDictionaryColumnReader>(
               requestedType, params, scanSpec);
         default:

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -71,14 +71,12 @@ void SelectiveIntegerDictionaryColumnReader::readWithVisitor(
     ColumnVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
   auto dictVisitor = visitor.toDictionaryColumnVisitor();
-  const uint64_t* nulls =
-      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
   if (rleVersion_ == RleVersion_1) {
-    auto decoder = reinterpret_cast<RleDecoderV1<false>*>(dataReader_.get());
-    VELOX_DECODE_WITH_VISITOR(decoder, nulls, dictVisitor);
+    decodeWithVisitor<velox::dwrf::RleDecoderV1<false>>(
+        dataReader_.get(), dictVisitor);
   } else {
-    auto decoder = reinterpret_cast<RleDecoderV2<false>*>(dataReader_.get());
-    VELOX_DECODE_WITH_VISITOR(decoder, nulls, dictVisitor);
+    decodeWithVisitor<velox::dwrf::RleDecoderV2<false>>(
+        dataReader_.get(), dictVisitor);
   }
   readOffset_ += numRows;
 }

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -42,14 +42,24 @@ class SelectiveIntegerDirectColumnReader
     auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
     auto& stripe = params.stripeStreams();
     bool dataVInts = stripe.getUseVInts(data);
-    auto decoder = createDirectDecoder</*isSigned*/ true>(
-        stripe.getStream(data, params.streamLabels().label(), true),
-        dataVInts,
-        numBytes);
-    auto rawDecoder = decoder.release();
-    auto directDecoder =
-        dynamic_cast<dwio::common::DirectDecoder<true>*>(rawDecoder);
-    ints.reset(directDecoder);
+
+    format = stripe.format();
+    if (format == velox::dwrf::DwrfFormat::kDwrf) {
+      ints = createDirectDecoder</*isSigned*/ true>(
+          stripe.getStream(data, params.streamLabels().label(), true),
+          dataVInts,
+          numBytes);
+    } else if (format == velox::dwrf::DwrfFormat::kOrc) {
+      version = convertRleVersion(stripe.getEncoding(encodingKey).kind());
+      ints = createRleDecoder</*isSigned*/ true>(
+          stripe.getStream(data, params.streamLabels().label(), true),
+          version,
+          params.pool(),
+          dataVInts,
+          numBytes);
+    } else {
+      VELOX_FAIL("invalid stripe format");
+    }
   }
 
   bool hasBulkPath() const override {
@@ -73,7 +83,9 @@ class SelectiveIntegerDirectColumnReader
   void readWithVisitor(RowSet rows, ColumnVisitor visitor);
 
  private:
-  std::unique_ptr<dwio::common::DirectDecoder</*isSigned*/ true>> ints;
+  dwrf::DwrfFormat format;
+  RleVersion version;
+  std::unique_ptr<dwio::common::IntDecoder<true>> ints;
 };
 
 template <typename ColumnVisitor>
@@ -81,11 +93,41 @@ void SelectiveIntegerDirectColumnReader::readWithVisitor(
     RowSet rows,
     ColumnVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
-  if (nullsInReadRange_) {
-    ints->readWithVisitor<true>(nullsInReadRange_->as<uint64_t>(), visitor);
+  const uint64_t* nulls =
+      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+
+  if (format == velox::dwrf::DwrfFormat::kDwrf) {
+    auto decoder = dynamic_cast<dwio::common::DirectDecoder<true>*>(ints.get());
+    VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor);
   } else {
-    ints->readWithVisitor<false>(nullptr, visitor);
+    // orc format does not use int128
+    if constexpr (!std::is_same_v<typename ColumnVisitor::DataType, int128_t>) {
+      velox::dwio::common::DirectRleColumnVisitor<
+          typename ColumnVisitor::DataType,
+          typename ColumnVisitor::FilterType,
+          typename ColumnVisitor::Extract,
+          ColumnVisitor::dense>
+          drVisitor(
+              visitor.filter(),
+              &visitor.reader(),
+              rows,
+              visitor.extractValues());
+      if (version == velox::dwrf::RleVersion_1) {
+        auto decoder =
+            dynamic_cast<velox::dwrf::RleDecoderV1<true>*>(ints.get());
+        VELOX_DECODE_WITH_VISITOR(decoder, nulls, drVisitor);
+      } else {
+        VELOX_CHECK(version == velox::dwrf::RleVersion_2);
+        auto decoder =
+            dynamic_cast<velox::dwrf::RleDecoderV2<true>*>(ints.get());
+        VELOX_DECODE_WITH_VISITOR(decoder, nulls, drVisitor);
+      }
+    } else {
+      VELOX_UNREACHABLE(
+          "SelectiveIntegerDirectColumnReader::readWithVisitor get int128_t");
+    }
   }
   readOffset_ += numRows;
 }
+
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -31,8 +31,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
       provider_(params.stripeStreams().getStrideIndexProvider()) {
   auto& stripe = params.stripeStreams();
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
-  RleVersion rleVersion =
-      convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   scanState_.dictionary.numValues =
       stripe.getEncoding(encodingKey).dictionarysize();
 
@@ -40,7 +39,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
   bool dictVInts = stripe.getUseVInts(dataId);
   dictIndex_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, params.streamLabels().label(), true),
-      rleVersion,
+      version_,
       memoryPool_,
       dictVInts,
       dwio::common::INT_BYTE_SIZE);
@@ -49,7 +48,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
   bool lenVInts = stripe.getUseVInts(lenId);
   lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, params.streamLabels().label(), false),
-      rleVersion,
+      version_,
       memoryPool_,
       lenVInts,
       dwio::common::INT_BYTE_SIZE);
@@ -82,7 +81,7 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
     strideDictLengthDecoder_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, params.streamLabels().label(), true),
-        rleVersion,
+        version_,
         memoryPool_,
         strideLenVInt,
         dwio::common::INT_BYTE_SIZE);

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -107,16 +107,12 @@ void SelectiveStringDictionaryColumnReader::readWithVisitor(
     RowSet rows,
     TVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
-  const uint64_t* nulls =
-      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
   if (version_ == velox::dwrf::RleVersion_1) {
-    auto decoder =
-        dynamic_cast<velox::dwrf::RleDecoderV1<false>*>(dictIndex_.get());
-    VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor);
+    decodeWithVisitor<velox::dwrf::RleDecoderV1<false>>(
+        dictIndex_.get(), visitor);
   } else {
-    auto decoder =
-        dynamic_cast<velox::dwrf::RleDecoderV2<false>*>(dictIndex_.get());
-    VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor);
+    decodeWithVisitor<velox::dwrf::RleDecoderV2<false>>(
+        dictIndex_.get(), visitor);
   }
   readOffset_ += numRows;
 }

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
 
 namespace facebook::velox::dwrf {
@@ -91,6 +92,7 @@ class SelectiveStringDictionaryColumnReader
   int64_t lastStrideIndex_;
   size_t positionOffset_;
   size_t strideDictSizeOffset_;
+  RleVersion version_;
 
   const StrideIndexProvider& provider_;
 
@@ -105,13 +107,16 @@ void SelectiveStringDictionaryColumnReader::readWithVisitor(
     RowSet rows,
     TVisitor visitor) {
   vector_size_t numRows = rows.back() + 1;
-  auto decoder = dynamic_cast<RleDecoderV1<false>*>(dictIndex_.get());
-  VELOX_CHECK(decoder, "Only RLEv1 is supported");
-  if (nullsInReadRange_) {
-    decoder->readWithVisitor<true, TVisitor>(
-        nullsInReadRange_->as<uint64_t>(), visitor);
+  const uint64_t* nulls =
+      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  if (version_ == velox::dwrf::RleVersion_1) {
+    auto decoder =
+        dynamic_cast<velox::dwrf::RleDecoderV1<false>*>(dictIndex_.get());
+    VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor);
   } else {
-    decoder->readWithVisitor<false, TVisitor>(nullptr, visitor);
+    auto decoder =
+        dynamic_cast<velox::dwrf::RleDecoderV2<false>*>(dictIndex_.get());
+    VELOX_DECODE_WITH_VISITOR(decoder, nulls, visitor);
   }
   readOffset_ += numRows;
 }

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -29,12 +29,12 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
     : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  RleVersion vers = convertRleVersion(stripe.getEncoding(encodingKey).kind());
+  version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool vints = stripe.getUseVInts(data);
   seconds_ = createRleDecoder</*isSigned*/ true>(
       stripe.getStream(data, params.streamLabels().label(), true),
-      vers,
+      version_,
       memoryPool_,
       vints,
       LONG_BYTE_SIZE);
@@ -42,7 +42,7 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
   bool nanoVInts = stripe.getUseVInts(nanoData);
   nano_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(nanoData, params.streamLabels().label(), true),
-      vers,
+      version_,
       memoryPool_,
       nanoVInts,
       LONG_BYTE_SIZE);
@@ -68,24 +68,21 @@ void SelectiveTimestampColumnReader::readHelper(RowSet rows) {
   vector_size_t numRows = rows.back() + 1;
   ExtractToReader extractValues(this);
   common::AlwaysTrue filter;
-  auto secondsV1 = dynamic_cast<RleDecoderV1<true>*>(seconds_.get());
-  VELOX_CHECK(secondsV1, "Only RLEv1 is supported");
-  if (nullsInReadRange_) {
-    secondsV1->readWithVisitor<true>(
-        nullsInReadRange_->as<uint64_t>(),
-        DirectRleColumnVisitor<
-            int64_t,
-            common::AlwaysTrue,
-            decltype(extractValues),
-            dense>(filter, this, rows, extractValues));
+  const uint64_t* nulls =
+      nullsInReadRange_ ? nullsInReadRange_->as<uint64_t>() : nullptr;
+  DirectRleColumnVisitor<
+      int64_t,
+      common::AlwaysTrue,
+      decltype(extractValues),
+      dense>
+      visitor(filter, this, rows, extractValues);
+
+  if (version_ == velox::dwrf::RleVersion_1) {
+    auto secondsV1 = dynamic_cast<RleDecoderV1<true>*>(seconds_.get());
+    VELOX_DECODE_WITH_VISITOR(secondsV1, nulls, visitor);
   } else {
-    secondsV1->readWithVisitor<false>(
-        nullptr,
-        DirectRleColumnVisitor<
-            int64_t,
-            common::AlwaysTrue,
-            decltype(extractValues),
-            dense>(filter, this, rows, extractValues));
+    auto secondsV2 = dynamic_cast<RleDecoderV2<true>*>(seconds_.get());
+    VELOX_DECODE_WITH_VISITOR(secondsV2, nulls, visitor);
   }
 
   // Save the seconds into their own buffer before reading nanos into
@@ -100,24 +97,12 @@ void SelectiveTimestampColumnReader::readHelper(RowSet rows) {
 
   // We read the nanos into 'values_' starting at index 0.
   numValues_ = 0;
-  auto nanosV1 = dynamic_cast<RleDecoderV1<false>*>(nano_.get());
-  VELOX_CHECK(nanosV1, "Only RLEv1 is supported");
-  if (nullsInReadRange_) {
-    nanosV1->readWithVisitor<true>(
-        nullsInReadRange_->as<uint64_t>(),
-        DirectRleColumnVisitor<
-            int64_t,
-            common::AlwaysTrue,
-            decltype(extractValues),
-            dense>(filter, this, rows, extractValues));
+  if (version_ == velox::dwrf::RleVersion_1) {
+    auto nanosV1 = dynamic_cast<RleDecoderV1<false>*>(nano_.get());
+    VELOX_DECODE_WITH_VISITOR(nanosV1, nulls, visitor);
   } else {
-    nanosV1->readWithVisitor<false>(
-        nullptr,
-        DirectRleColumnVisitor<
-            int64_t,
-            common::AlwaysTrue,
-            decltype(extractValues),
-            dense>(filter, this, rows, extractValues));
+    auto nanosV2 = dynamic_cast<RleDecoderV2<false>*>(nano_.get());
+    VELOX_DECODE_WITH_VISITOR(nanosV2, nulls, visitor);
   }
   readOffset_ += numRows;
 }

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
+#include "velox/dwio/dwrf/common/DecoderUtil.h"
 #include "velox/dwio/dwrf/reader/DwrfData.h"
 
 namespace facebook::velox::dwrf {
@@ -48,6 +49,7 @@ class SelectiveTimestampColumnReader
 
   // Values from copied from 'seconds_'. Nanos are in 'values_'.
   BufferPtr secondsValues_;
+  RleVersion version_;
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -71,7 +71,11 @@ class MockStripeStreams : public StripeStreams {
   }
 
   DwrfFormat format() const override {
-    return DwrfFormat::kDwrf;
+    return this->format_;
+  }
+
+  void setFormat(DwrfFormat format) {
+    this->format_ = format;
   }
 
   MOCK_METHOD2(
@@ -122,6 +126,7 @@ class MockStripeStreams : public StripeStreams {
  private:
   std::shared_ptr<memory::MemoryPool> pool_;
   dwio::common::RowReaderOptions options_;
+  DwrfFormat format_ = DwrfFormat::kDwrf;
 };
 
 inline uint64_t zigZagEncode(int64_t val) {

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -729,15 +729,38 @@ TEST_P(TestColumnReader, testByteSkipsWithNulls) {
 }
 
 TEST_P(TestColumnReader, testIntegerRLEv2) {
-  int32_t expects[] = {2030, 2000, 2020, 1000000, 2040, 2050, 2060,
-                       2070, 2080, 2090, 2100,    2110, 2120, 2130,
-                       2140, 2150, 2160, 2170,    2180, 2190};
-  // RLEv2 with PATCHED_BASE
-  const unsigned char buffer[] = {0x8e, 0x13, 0x2b, 0x21, 0x07, 0xd0, 0x1e,
-                                  0x00, 0x14, 0x70, 0x28, 0x32, 0x3c, 0x46,
-                                  0x50, 0x5a, 0x64, 0x6e, 0x78, 0x82, 0x8c,
-                                  0x96, 0xa0, 0xaa, 0xb4, 0xbe, 0xfc, 0xe8};
-  int32_t size = VELOX_ARRAY_SIZE(expects);
+  // col_0's data (RLEv2 with PATCHED_BASE)
+  int32_t col0[] = {2030, 2000, 2020, 1000000, 2040, 2050, 2060,
+                    2070, 2080, 2090, 2100,    2110, 2120, 2130,
+                    2140, 2150, 2160, 2170,    2180, 2190};
+  const unsigned char buffer0[] = {0x8e, 0x13, 0x2b, 0x21, 0x07, 0xd0, 0x1e,
+                                   0x00, 0x14, 0x70, 0x28, 0x32, 0x3c, 0x46,
+                                   0x50, 0x5a, 0x64, 0x6e, 0x78, 0x82, 0x8c,
+                                   0x96, 0xa0, 0xaa, 0xb4, 0xbe, 0xfc, 0xe8};
+  // col_2's data (RLEv2 with Delta)
+  int32_t col2[] = {1,  2,  4,  6,  10, 12, 16, 18, 22, 28,
+                    30, 32, 34, 36, 38, 40, 42, 44, 46, 48};
+  const unsigned char buffer2[] = {
+      0xc6,
+      0x13,
+      0x02,
+      0x02,
+      0x22,
+      0x42,
+      0x42,
+      0x46,
+      0x22,
+      0x22,
+      0x22,
+      0x22,
+      0x22};
+
+  // expects that with Filter
+  int32_t expects_col0[] = {2110, 2120, 2130, 2140};
+  int32_t expects_col1[] = {11, 12, 13, 14};
+  int32_t expects_col2[] = {32, 34, 36, 38};
+  int32_t size = VELOX_ARRAY_SIZE(col0);
+
   // set format
   streams_.setFormat(DwrfFormat::kOrc);
   // set getEncoding
@@ -748,24 +771,84 @@ TEST_P(TestColumnReader, testIntegerRLEv2) {
   EXPECT_CALL(streams_, getEncodingProxy(0))
       .WillRepeatedly(Return(&directEncoding)); // row type use direct only
   EXPECT_CALL(streams_, getEncodingProxy(1))
-      .WillRepeatedly(Return(&directv2Encoding));
+      .WillRepeatedly(Return(&directv2Encoding)); // col_0 use RLEv2
+  EXPECT_CALL(streams_, getEncodingProxy(2))
+      .WillRepeatedly(Return(&directEncoding)); // col_1 use RLEv1
+  EXPECT_CALL(streams_, getEncodingProxy(3))
+      .WillRepeatedly(Return(&directv2Encoding)); // col_2 use RLEv2
+
   // set getStream
   EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_PRESENT, false))
       .WillRepeatedly(Return(nullptr));
   EXPECT_CALL(streams_, getStreamProxy(_, proto::Stream_Kind_ROW_INDEX, false))
       .WillRepeatedly(Return(nullptr));
+  // col_0's DATA stream
   EXPECT_CALL(streams_, getStreamProxy(1, proto::Stream_Kind_DATA, true))
       .WillRepeatedly(Return(
-          new SeekableArrayInputStream(buffer, VELOX_ARRAY_SIZE(buffer))));
+          new SeekableArrayInputStream(buffer0, VELOX_ARRAY_SIZE(buffer0))));
+  // col_1's DATA stream
+  std::array<char, 1024> data;
+  std::vector<int64_t> v;
+  data[0] = 0x9c; // rle literal, -100
+  for (int64_t i = 0; i < size; ++i) {
+    v.push_back(i);
+  }
+  auto count = writeVsLongs(data.data() + 1, v);
+  EXPECT_CALL(streams_, getStreamProxy(2, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(
+          Invoke([&](auto /* unused */, auto /* unused */, auto /* unused */) {
+            return new SeekableArrayInputStream(data.data(), count + 1);
+          }));
+  // col_2's DATA stream
+  EXPECT_CALL(streams_, getStreamProxy(3, proto::Stream_Kind_DATA, true))
+      .WillRepeatedly(Return(
+          new SeekableArrayInputStream(buffer2, VELOX_ARRAY_SIZE(buffer2))));
+
   // create the row type
-  auto rowType = HiveTypeParser().parse("struct<myInt:int>");
-  buildReader(rowType);
+  auto rowType =
+      HiveTypeParser().parse("struct<col_0:int,col_1:int,col_2:int>");
+  auto dataType = TypeWithId::create(rowType)->type;
   VectorPtr batch = newBatch(rowType);
-  skipAndRead(batch, /* read */ size);
-  auto intBatch = getOnlyChild<FlatVector<int32_t>>(batch);
-  ASSERT_EQ(size, intBatch->size());
-  for (size_t i = 0; i < batch->size(); ++i) {
-    ASSERT_EQ(expects[i], intBatch->valueAt(i));
+  if (useSelectiveReader()) {
+    auto scanSpec = std::make_unique<common::ScanSpec>("root");
+    scanSpec->addAllChildFields(*dataType);
+    scanSpec->childByName("col_0")->setFilter(
+        std::make_unique<common::BigintRange>(2100, 2140, false));
+    scanSpec->childByName("col_1")->setFilter(
+        std::make_unique<common::BigintRange>(11, 20, false));
+    buildReader(rowType, {}, nullptr, scanSpec.get());
+    selectiveColumnReader_->next(size, batch, nullptr);
+
+    auto rowVector = std::dynamic_pointer_cast<RowVector>(batch);
+    ASSERT_NE(rowVector->childAt(0)->encoding(), VectorEncoding::Simple::LAZY);
+    ASSERT_NE(rowVector->childAt(1)->encoding(), VectorEncoding::Simple::LAZY);
+    ASSERT_EQ(rowVector->childAt(2)->encoding(), VectorEncoding::Simple::LAZY);
+
+    auto colBatch = getChild<FlatVector<int32_t>>(batch, 0);
+    auto colBatch2 = getChild<FlatVector<int32_t>>(batch, 1);
+    auto colBatch3 = getChild<FlatVector<int32_t>>(batch, 2);
+    ASSERT_EQ(VELOX_ARRAY_SIZE(expects_col0), colBatch->size());
+    ASSERT_EQ(colBatch->size(), colBatch2->size());
+    ASSERT_EQ(colBatch2->size(), colBatch3->size());
+    for (size_t i = 0; i < batch->size(); ++i) {
+      ASSERT_EQ(expects_col0[i], colBatch->valueAt(i));
+      ASSERT_EQ(expects_col1[i], colBatch2->valueAt(i));
+      ASSERT_EQ(expects_col2[i], colBatch3->valueAt(i));
+    }
+  } else {
+    buildReader(rowType);
+    skipAndRead(batch, /* read */ size);
+    auto colBatch = getChild<FlatVector<int32_t>>(batch, 0);
+    auto colBatch2 = getChild<FlatVector<int32_t>>(batch, 1);
+    auto colBatch3 = getChild<FlatVector<int32_t>>(batch, 2);
+    ASSERT_EQ(size, colBatch->size());
+    ASSERT_EQ(colBatch->size(), colBatch2->size());
+    ASSERT_EQ(colBatch2->size(), colBatch3->size());
+    for (size_t i = 0; i < batch->size(); ++i) {
+      ASSERT_EQ(col0[i], colBatch->valueAt(i));
+      ASSERT_EQ(i, colBatch2->valueAt(i));
+      ASSERT_EQ(col2[i], colBatch3->valueAt(i));
+    }
   }
   // reset format
   streams_.setFormat(DwrfFormat::kDwrf);


### PR DESCRIPTION
Currently, only RleDecoderV1 was used during column reading, If the ORC file was encoded with RLEv2, It can not be read correctly.