### PR TITLE
Add support for all types to set_agg and set_union

### DIFF
--- a/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
+++ b/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/AddressableNonNullValueList.h"
+#include "velox/exec/ContainerRowSerde.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+HashStringAllocator::Position AddressableNonNullValueList::append(
+    const DecodedVector& decoded,
+    vector_size_t index,
+    HashStringAllocator* allocator) {
+  ByteStream stream(allocator);
+  if (!firstHeader_) {
+    // An array_agg or related begins with an allocation of 5 words and
+    // 4 bytes for header. This is compact for small arrays (up to 5
+    // bigints) and efficient if needs to be extended (stores 4 bigints
+    // and a next pointer. This could be adaptive, with smaller initial
+    // sizes for lots of small arrays.
+    static constexpr int kInitialSize = 44;
+
+    currentPosition_ = allocator->newWrite(stream, kInitialSize);
+    firstHeader_ = currentPosition_.header;
+  } else {
+    allocator->extendWrite(currentPosition_, stream);
+  }
+
+  const auto position = currentPosition_;
+
+  // Write hash.
+  stream.appendOne(decoded.base()->hashValueAt(decoded.index(index)));
+  // Write value.
+  exec::ContainerRowSerde::instance().serialize(
+      *decoded.base(), decoded.index(index), stream);
+
+  totalBytes_ += stream.size();
+  ++size_;
+  const auto reserve =
+      std::max<int32_t>(1024, std::min<int64_t>(128, totalBytes_));
+  currentPosition_ = allocator->finishWrite(stream, reserve);
+  return position;
+}
+
+namespace {
+
+void prepareRead(
+    HashStringAllocator::Position position,
+    ByteStream& stream,
+    bool skipHash) {
+  auto header = position.header;
+  auto seek = static_cast<int32_t>(position.position - header->begin());
+
+  HashStringAllocator::prepareRead(header, stream);
+  stream.seekp(seek);
+  if (skipHash) {
+    stream.skip(sizeof(uint64_t));
+  }
+}
+} // namespace
+
+// static
+bool AddressableNonNullValueList::equalTo(
+    HashStringAllocator::Position left,
+    HashStringAllocator::Position right,
+    const TypePtr& type) {
+  ByteStream leftStream;
+  prepareRead(left, leftStream, true /*skipHash*/);
+
+  ByteStream rightStream;
+  prepareRead(right, rightStream, true /*skipHash*/);
+
+  CompareFlags compareFlags;
+  compareFlags.equalsOnly = true;
+  return exec::ContainerRowSerde::instance().compare(
+             leftStream, rightStream, type.get(), compareFlags) == 0;
+}
+
+// static
+uint64_t AddressableNonNullValueList::readHash(
+    HashStringAllocator::Position position) {
+  ByteStream stream;
+  prepareRead(position, stream, false /*skipHash*/);
+
+  return stream.read<uint64_t>();
+}
+
+// static
+void AddressableNonNullValueList::read(
+    HashStringAllocator::Position position,
+    BaseVector& result,
+    vector_size_t index) {
+  ByteStream stream;
+  prepareRead(position, stream, true /*skipHash*/);
+
+  exec::ContainerRowSerde::instance().deserialize(stream, index, &result);
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AddressableNonNullValueList.h
+++ b/velox/functions/prestosql/aggregates/AddressableNonNullValueList.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+/// A list of non-null values of complex type stored in possibly non-contiguous
+/// memory allocated via HashStringAllocator. Provides index-based access to
+/// individual elements. Allows removing elements from the end of the list.
+///
+/// Designed to be used together with F14FastSet or F14FastMap.
+///
+/// Used in aggregations that deduplicate complex values, e.g. set_agg and
+/// set_union.
+class AddressableNonNullValueList {
+ public:
+  struct Hash {
+    size_t operator()(HashStringAllocator::Position position) const {
+      return AddressableNonNullValueList::readHash(position);
+    }
+  };
+
+  struct EqualTo {
+    const TypePtr& type;
+
+    bool operator()(
+        HashStringAllocator::Position left,
+        HashStringAllocator::Position right) const {
+      return AddressableNonNullValueList::equalTo(left, right, type);
+    }
+  };
+
+  /// Append a non-null value to the end of the list. Returns 'index' that can
+  /// be used to access the value later.
+  HashStringAllocator::Position append(
+      const DecodedVector& decoded,
+      vector_size_t index,
+      HashStringAllocator* allocator);
+
+  /// Removes last element. 'position' must be a value returned from the latest
+  /// call to 'append'.
+  void removeLast(HashStringAllocator::Position position) {
+    currentPosition_ = position;
+    --size_;
+  }
+
+  /// Returns number of elements in the list.
+  int32_t size() const {
+    return size_;
+  }
+
+  /// Returns true if elements at 'left' and 'right' are equal.
+  static bool equalTo(
+      HashStringAllocator::Position left,
+      HashStringAllocator::Position right,
+      const TypePtr& type);
+
+  /// Returns the hash of the specified element.
+  static uint64_t readHash(HashStringAllocator::Position position);
+
+  /// Copies the specified element to 'result[index]'.
+  static void read(
+      HashStringAllocator::Position position,
+      BaseVector& result,
+      vector_size_t index);
+
+  void free(HashStringAllocator& allocator) {
+    if (size_ > 0) {
+      allocator.free(firstHeader_);
+    }
+  }
+
+ private:
+  // Memory allocation (potentially multi-part).
+  HashStringAllocator::Header* firstHeader_{nullptr};
+  HashStringAllocator::Position currentPosition_{nullptr, nullptr};
+
+  // Total bytes written.
+  uint64_t totalBytes_{0};
+
+  // Number of values added.
+  uint32_t size_{0};
+};
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(
   velox_aggregates
+  AddressableNonNullValueList.cpp
   ApproxDistinctAggregate.cpp
   ApproxMostFrequentAggregate.cpp
   ApproxPercentileAggregate.cpp

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/Aggregate.h"
+#include "velox/functions/prestosql/aggregates/AddressableNonNullValueList.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
 #include "velox/functions/prestosql/aggregates/Strings.h"
 #include "velox/vector/FlatVector.h"
@@ -22,17 +23,21 @@ namespace facebook::velox::aggregate::prestosql {
 
 namespace {
 
-/// Maintains a set of unique values of fixed-width type (integers). Also
-/// maintains a flag indicating whether there was a null value.
-template <typename T>
+/// Maintains a set of unique values. Non-null values are stored in F14FastSet.
+/// A separate flag tracks presence of the null value.
+template <
+    typename T,
+    typename Hash = std::hash<T>,
+    typename EqualTo = std::equal_to<T>>
 struct Accumulator {
   bool hasNull{false};
-  folly::
-      F14FastSet<T, std::hash<T>, std::equal_to<T>, AlignedStlAllocator<T, 16>>
-          uniqueValues;
+  folly::F14FastSet<T, Hash, EqualTo, AlignedStlAllocator<T, 16>> uniqueValues;
 
-  explicit Accumulator(HashStringAllocator* allocator)
+  Accumulator(const TypePtr& /*type*/, HashStringAllocator* allocator)
       : uniqueValues{AlignedStlAllocator<T, 16>(allocator)} {}
+
+  Accumulator(Hash hash, EqualTo equalTo, HashStringAllocator* allocator)
+      : uniqueValues{0, hash, equalTo, AlignedStlAllocator<T, 16>(allocator)} {}
 
   /// Adds value if new. No-op if the value was added before.
   void addValue(
@@ -89,8 +94,8 @@ struct StringViewAccumulator {
   /// Stores unique non-null non-inline strings.
   Strings strings;
 
-  explicit StringViewAccumulator(HashStringAllocator* allocator)
-      : base{allocator} {}
+  StringViewAccumulator(const TypePtr& type, HashStringAllocator* allocator)
+      : base{type, allocator} {}
 
   void addValue(
       const DecodedVector& decoded,
@@ -134,6 +139,70 @@ struct StringViewAccumulator {
   }
 };
 
+/// Maintains a set of unique arrays, maps or structs.
+struct ComplexTypeAccumulator {
+  /// A set of pointers to values stored in AddressableNonNullValueList.
+  Accumulator<
+      HashStringAllocator::Position,
+      AddressableNonNullValueList::Hash,
+      AddressableNonNullValueList::EqualTo>
+      base;
+
+  /// Stores unique non-null values.
+  AddressableNonNullValueList values;
+
+  ComplexTypeAccumulator(const TypePtr& type, HashStringAllocator* allocator)
+      : base{
+            AddressableNonNullValueList::Hash{},
+            AddressableNonNullValueList::EqualTo{type},
+            allocator} {}
+
+  void addValue(
+      const DecodedVector& decoded,
+      vector_size_t index,
+      HashStringAllocator* allocator) {
+    if (decoded.isNullAt(index)) {
+      base.hasNull = true;
+    } else {
+      auto position = values.append(decoded, index, allocator);
+
+      if (!base.uniqueValues.insert(position).second) {
+        values.removeLast(position);
+      }
+    }
+  }
+
+  void addValues(
+      const ArrayVector& arrayVector,
+      vector_size_t index,
+      const DecodedVector& values,
+      HashStringAllocator* allocator) {
+    const auto size = arrayVector.sizeAt(index);
+    const auto offset = arrayVector.offsetAt(index);
+
+    for (auto i = 0; i < size; ++i) {
+      addValue(values, offset + i, allocator);
+    }
+  }
+
+  size_t size() const {
+    return base.size();
+  }
+
+  vector_size_t extractValues(BaseVector& values, vector_size_t offset) {
+    vector_size_t index = offset;
+    for (const auto& position : base.uniqueValues) {
+      AddressableNonNullValueList::read(position, values, index++);
+    }
+
+    if (base.hasNull) {
+      values.setNull(index++, true);
+    }
+
+    return index - offset;
+  }
+};
+
 template <typename T>
 struct AccumulatorTypeTraits {
   using AccumulatorType = Accumulator<T>;
@@ -142,6 +211,11 @@ struct AccumulatorTypeTraits {
 template <>
 struct AccumulatorTypeTraits<StringView> {
   using AccumulatorType = StringViewAccumulator;
+};
+
+template <>
+struct AccumulatorTypeTraits<ComplexType> {
+  using AccumulatorType = ComplexTypeAccumulator;
 };
 
 template <typename T>
@@ -163,9 +237,10 @@ class SetBaseAggregate : public exec::Aggregate {
   void initializeNewGroups(
       char** groups,
       folly::Range<const vector_size_t*> indices) override {
+    const auto& type = resultType()->childAt(0);
     exec::Aggregate::setAllNulls(groups, indices);
     for (auto i : indices) {
-      new (groups[i] + offset_) AccumulatorType(allocator_);
+      new (groups[i] + offset_) AccumulatorType(type, allocator_);
     }
   }
 
@@ -195,14 +270,27 @@ class SetBaseAggregate : public exec::Aggregate {
       }
     }
 
-    auto values = arrayVector->elements()->as<FlatVector<T>>();
-    values->resize(numValues);
+    if constexpr (std::is_same_v<T, ComplexType>) {
+      auto values = arrayVector->elements();
+      values->resize(numValues);
 
-    vector_size_t offset = 0;
-    for (auto i = 0; i < numGroups; ++i) {
-      auto* group = groups[i];
-      if (!isNull(group)) {
-        offset += value(group)->extractValues(*values, offset);
+      vector_size_t offset = 0;
+      for (auto i = 0; i < numGroups; ++i) {
+        auto* group = groups[i];
+        if (!isNull(group)) {
+          offset += value(group)->extractValues(*values, offset);
+        }
+      }
+    } else {
+      auto values = arrayVector->elements()->as<FlatVector<T>>();
+      values->resize(numValues);
+
+      vector_size_t offset = 0;
+      for (auto i = 0; i < numGroups; ++i) {
+        auto* group = groups[i];
+        if (!isNull(group)) {
+          offset += value(group)->extractValues(*values, offset);
+        }
       }
     }
   }
@@ -270,6 +358,14 @@ class SetBaseAggregate : public exec::Aggregate {
       for (auto* group : groups) {
         if (!isNull(group)) {
           value(group)->strings.free(*allocator_);
+        }
+      }
+    }
+
+    if constexpr (std::is_same_v<T, ComplexType>) {
+      for (auto* group : groups) {
+        if (!isNull(group)) {
+          value(group)->values.free(*allocator_);
         }
       }
     }
@@ -355,6 +451,8 @@ std::unique_ptr<exec::Aggregate> create(
     TypeKind typeKind,
     const TypePtr& resultType) {
   switch (typeKind) {
+    case TypeKind::BOOLEAN:
+      return std::make_unique<Aggregate<bool>>(resultType);
     case TypeKind::TINYINT:
       return std::make_unique<Aggregate<int8_t>>(resultType);
     case TypeKind::SMALLINT:
@@ -363,27 +461,33 @@ std::unique_ptr<exec::Aggregate> create(
       return std::make_unique<Aggregate<int32_t>>(resultType);
     case TypeKind::BIGINT:
       return std::make_unique<Aggregate<int64_t>>(resultType);
+    case TypeKind::REAL:
+      return std::make_unique<Aggregate<float>>(resultType);
+    case TypeKind::DOUBLE:
+      return std::make_unique<Aggregate<double>>(resultType);
+    case TypeKind::TIMESTAMP:
+      return std::make_unique<Aggregate<Timestamp>>(resultType);
+    case TypeKind::DATE:
+      return std::make_unique<Aggregate<Date>>(resultType);
     case TypeKind::VARCHAR:
       return std::make_unique<Aggregate<StringView>>(resultType);
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+    case TypeKind::ROW:
+      return std::make_unique<Aggregate<ComplexType>>(resultType);
     default:
-      VELOX_UNREACHABLE();
+      VELOX_UNREACHABLE("Unexpected type {}", mapTypeKindToName(typeKind));
   }
-}
-
-std::vector<std::string> supportedTypes() {
-  return {"tinyint", "smallint", "integer", "bigint", "varchar"};
 }
 
 exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  for (const auto& inputType : supportedTypes()) {
-    const std::string arrayType = fmt::format("array({})", inputType);
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .returnType(arrayType)
-                             .intermediateType(arrayType)
-                             .argumentType(inputType)
-                             .build());
-  }
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("array(T)")
+          .intermediateType("array(T)")
+          .argumentType("T")
+          .build()};
 
   return exec::registerAggregateFunction(
       name,
@@ -403,15 +507,13 @@ exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
 }
 
 exec::AggregateRegistrationResult registerSetUnion(const std::string& name) {
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  for (const auto& type : supportedTypes()) {
-    const std::string arrayType = fmt::format("array({})", type);
-    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                             .returnType(arrayType)
-                             .intermediateType(arrayType)
-                             .argumentType(arrayType)
-                             .build());
-  }
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("T")
+          .returnType("array(T)")
+          .intermediateType("array(T)")
+          .argumentType("array(T)")
+          .build()};
 
   return exec::registerAggregateFunction(
       name,

--- a/velox/functions/prestosql/aggregates/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/AddressableNonNullValueListTest.cpp
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/prestosql/aggregates/AddressableNonNullValueList.h"
+#include <gtest/gtest.h>
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+namespace {
+
+class AddressableNonNullValueListTest : public testing::Test,
+                                        public test::VectorTestBase {
+ protected:
+  void test(const VectorPtr& data, const VectorPtr& uniqueData) {
+    using T = HashStringAllocator::Position;
+    using Set = folly::F14FastSet<
+        T,
+        AddressableNonNullValueList::Hash,
+        AddressableNonNullValueList::EqualTo,
+        AlignedStlAllocator<T, 16>>;
+
+    Set uniqueValues{
+        0,
+        AddressableNonNullValueList::Hash{},
+        AddressableNonNullValueList::EqualTo{data->type()},
+        AlignedStlAllocator<T, 16>(allocator())};
+
+    AddressableNonNullValueList values;
+
+    std::vector<HashStringAllocator::Position> positions;
+
+    DecodedVector decodedVector(*data);
+    for (auto i = 0; i < data->size(); ++i) {
+      auto position = values.append(decodedVector, i, allocator());
+
+      if (uniqueValues.contains(position)) {
+        values.removeLast(position);
+        continue;
+      }
+
+      positions.push_back(position);
+
+      ASSERT_TRUE(uniqueValues.insert(position).second);
+      ASSERT_TRUE(uniqueValues.contains(position));
+      ASSERT_FALSE(uniqueValues.insert(position).second);
+    }
+
+    ASSERT_EQ(uniqueData->size(), values.size());
+    ASSERT_EQ(uniqueData->size(), uniqueValues.size());
+
+    auto copy = BaseVector::create(data->type(), uniqueData->size(), pool());
+    for (auto i = 0; i < positions.size(); ++i) {
+      auto position = positions[i];
+      ASSERT_TRUE(uniqueValues.contains(position));
+      AddressableNonNullValueList::read(position, *copy, i);
+    }
+
+    test::assertEqualVectors(uniqueData, copy);
+  }
+
+  HashStringAllocator* allocator() {
+    return allocator_.get();
+  }
+
+  std::unique_ptr<HashStringAllocator> allocator_{
+      std::make_unique<HashStringAllocator>(pool())};
+};
+
+TEST_F(AddressableNonNullValueListTest, array) {
+  auto data = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {4, 5},
+      {6, 7, 8, 9},
+      {},
+  });
+
+  test(data, data);
+
+  auto dataWithDuplicates = makeArrayVector<int32_t>({
+      {1, 2, 3},
+      {1, 2, 3},
+      {4, 5},
+      {6, 7, 8, 9},
+      {},
+      {4, 5},
+      {1, 2, 3},
+      {},
+  });
+
+  test(dataWithDuplicates, data);
+}
+
+TEST_F(AddressableNonNullValueListTest, map) {
+  auto data = makeMapVector<int16_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
+      {},
+  });
+
+  test(data, data);
+
+  auto dataWithDuplicates = makeMapVector<int16_t, int64_t>({
+      {{1, 10}, {2, 20}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{3, 30}, {4, 40}, {5, 50}},
+      {{1, 10}, {2, 20}},
+      {{1, 10}, {3, 30}, {4, 40}, {6, 60}},
+      {},
+      {{1, 10}, {2, 20}},
+      {},
+      {{3, 30}, {4, 40}, {5, 50}},
+  });
+
+  test(dataWithDuplicates, data);
+}
+
+TEST_F(AddressableNonNullValueListTest, row) {
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 3, 4, 5}),
+      makeFlatVector<int32_t>({10, 20, 30, 40, 50}),
+      makeFlatVector<int64_t>({11, 22, 33, 44, 55}),
+  });
+
+  test(data, data);
+
+  auto dataWithDuplicates = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 3, 4, 2, 5, 3}),
+      makeFlatVector<int32_t>({10, 20, 30, 40, 20, 50, 30}),
+      makeFlatVector<int64_t>({11, 22, 33, 44, 22, 55, 33}),
+  });
+
+  test(dataWithDuplicates, data);
+
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 1, 1, 1}),
+      makeFlatVector<int32_t>({10, 20, 30, 30, 40}),
+      makeFlatVector<int64_t>({11, 22, 33, 44, 55}),
+  });
+
+  dataWithDuplicates = makeRowVector({
+      makeFlatVector<int16_t>({1, 1, 1, 1, 1, 1, 1}),
+      makeFlatVector<int32_t>({10, 10, 20, 20, 30, 30, 40}),
+      makeFlatVector<int64_t>({11, 11, 22, 22, 33, 44, 55}),
+  });
+
+  test(dataWithDuplicates, data);
+
+  data = makeRowVector({
+      makeNullableFlatVector<int16_t>({1, 2, std::nullopt, 4, 5}),
+      makeNullableFlatVector<int32_t>({10, 20, 30, std::nullopt, 50}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 22, 33, std::nullopt, 55}),
+  });
+
+  test(data, data);
+
+  dataWithDuplicates = makeRowVector({
+      makeNullableFlatVector<int16_t>(
+          {1, 2, 2, std::nullopt, 4, 5, std::nullopt}),
+      makeNullableFlatVector<int32_t>({10, 20, 20, 30, std::nullopt, 50, 30}),
+      makeNullableFlatVector<int64_t>(
+          {std::nullopt, 22, 22, 33, std::nullopt, 55, 33}),
+  });
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   velox_aggregates_test
+  AddressableNonNullValueListTest.cpp
   AggregationFunctionRegTest.cpp
   ApproxDistinctTest.cpp
   ApproxMostFrequentTest.cpp


### PR DESCRIPTION
Add support for complex types (arrays, maps and structs) and missing scalar
types (boolean, real, double, timestamp and date).