### PR TITLE
Avoid resizing child through ensureWritable in FieldReference

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -278,4 +278,19 @@ VectorPtr PeeledEncoding::wrap(
   }
   return wrappedResult;
 }
+
+void PeeledEncoding::zeroOutNullRows(
+    const SelectivityVector& allRows,
+    const SelectivityVector& nonNullRows) {
+  if (wrapEncoding_ != VectorEncoding::Simple::DICTIONARY) {
+    return;
+  }
+
+  auto* rawIndices = wrap_->asMutable<vector_size_t>();
+  allRows.applyToSelected([&](auto row) {
+    if (!nonNullRows.isValid(row)) {
+      rawIndices[row] = 0;
+    }
+  });
+}
 } // namespace facebook::velox::exec

--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -148,6 +148,10 @@ class PeeledEncoding {
       VectorPtr peeledResult,
       const SelectivityVector& rows) const;
 
+  void zeroOutNullRows(
+      const SelectivityVector& allRows,
+      const SelectivityVector& nonNullRows);
+
   /// Takes a set of outer rows (rows defined over the peel) and a functor that
   /// is executed for each outer row which does not map to a null row.
   /// The outer and its corresponding inner row is passed to the functor.


### PR DESCRIPTION
Summary: FieldReference used to resize the child vector through BaseVector::ensureWritable when the child size is smaller than its parent size. This resizing was necessary to avoid errors during wrapping, because we wrap the parent's encoding over the child. This leads to increased memory usage in an internal engine. This diff avoid resizing the child vector by zeroing out indices to NULL rows in the parent's encoding before wrapping it to the child.

Differential Revision: D47045705

