### PR TITLE
Add query id to hive connector to build bucket file name

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -219,6 +219,7 @@ class ConnectorQueryCtx {
       const Config* connectorConfig,
       std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator,
       memory::MemoryAllocator* FOLLY_NONNULL allocator,
+      const std::string& queryId,
       const std::string& taskId,
       const std::string& planNodeId,
       int driverId)
@@ -228,6 +229,7 @@ class ConnectorQueryCtx {
         expressionEvaluator_(std::move(expressionEvaluator)),
         allocator_(allocator),
         scanId_(fmt::format("{}.{}", taskId, planNodeId)),
+        queryId_(queryId),
         taskId_(taskId),
         driverId_(driverId) {}
 
@@ -266,6 +268,10 @@ class ConnectorQueryCtx {
     return scanId_;
   }
 
+  const std::string queryId() const {
+    return queryId_;
+  }
+
   const std::string& taskId() const {
     return taskId_;
   }
@@ -281,6 +287,7 @@ class ConnectorQueryCtx {
   std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
   memory::MemoryAllocator* FOLLY_NONNULL allocator_;
   const std::string scanId_;
+  const std::string queryId_;
   const std::string taskId_;
   const int driverId_;
 };

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -500,8 +500,8 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
   std::string targetFileName;
   if (bucketId.has_value()) {
     // TODO: add hive.file_renaming_enabled support.
-    targetFileName =
-        computeBucketedFileName(connectorQueryCtx_->taskId(), bucketId.value());
+    targetFileName = computeBucketedFileName(
+        connectorQueryCtx_->queryId(), bucketId.value());
   } else {
     targetFileName = fmt::format(
         "{}_{}_{}",

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -18,19 +18,19 @@
 namespace facebook::velox::core {
 
 QueryCtx::QueryCtx(
-    folly::Executor* FOLLY_NULLABLE executor,
+    folly::Executor* executor,
     std::unordered_map<std::string, std::string> queryConfigValues,
     std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
-    memory::MemoryAllocator* FOLLY_NONNULL allocator,
+    memory::MemoryAllocator* allocator,
     std::shared_ptr<memory::MemoryPool> pool,
     std::shared_ptr<folly::Executor> spillExecutor,
     const std::string& queryId)
-    : connectorConfigs_(connectorConfigs),
+    : queryId_(queryId),
+      connectorConfigs_(connectorConfigs),
       allocator_(allocator),
       pool_(std::move(pool)),
       executor_(executor),
       queryConfig_{std::move(queryConfigValues)},
-      queryId_(queryId),
       spillExecutor_(std::move(spillExecutor)) {
   initPool(queryId);
 }
@@ -39,15 +39,15 @@ QueryCtx::QueryCtx(
     folly::Executor::KeepAlive<> executorKeepalive,
     std::unordered_map<std::string, std::string> queryConfigValues,
     std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
-    memory::MemoryAllocator* FOLLY_NONNULL allocator,
+    memory::MemoryAllocator* allocator,
     std::shared_ptr<memory::MemoryPool> pool,
     const std::string& queryId)
-    : connectorConfigs_(connectorConfigs),
+    : queryId_(queryId),
+      connectorConfigs_(connectorConfigs),
       allocator_(allocator),
       pool_(std::move(pool)),
       executorKeepalive_(std::move(executorKeepalive)),
-      queryConfig_{std::move(queryConfigValues)},
-      queryId_(queryId) {
+      queryConfig_{std::move(queryConfigValues)} {
   initPool(queryId);
 }
 

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -35,11 +35,11 @@ class QueryCtx {
   /// be passed in here, but instead, ensure that executor exists when actually
   /// being used.
   QueryCtx(
-      folly::Executor* FOLLY_NULLABLE executor = nullptr,
+      folly::Executor* executor = nullptr,
       std::unordered_map<std::string, std::string> queryConfigValues = {},
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MemoryAllocator* FOLLY_NONNULL allocator =
+      memory::MemoryAllocator* allocator =
           memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       std::shared_ptr<folly::Executor> spillExecutor = nullptr,
@@ -54,22 +54,22 @@ class QueryCtx {
       std::unordered_map<std::string, std::string> queryConfigValues = {},
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
-      memory::MemoryAllocator* FOLLY_NONNULL allocator =
+      memory::MemoryAllocator* allocator =
           memory::MemoryAllocator::getInstance(),
       std::shared_ptr<memory::MemoryPool> pool = nullptr,
       const std::string& queryId = "");
 
   static std::string generatePoolName(const std::string& queryId);
 
-  memory::MemoryPool* FOLLY_NONNULL pool() const {
+  memory::MemoryPool* pool() const {
     return pool_.get();
   }
 
-  memory::MemoryAllocator* FOLLY_NONNULL allocator() const {
+  memory::MemoryAllocator* allocator() const {
     return allocator_;
   }
 
-  folly::Executor* FOLLY_NONNULL executor() const {
+  folly::Executor* executor() const {
     if (executor_ != nullptr) {
       return executor_;
     }
@@ -82,8 +82,7 @@ class QueryCtx {
     return queryConfig_;
   }
 
-  Config* FOLLY_NONNULL
-  getConnectorConfig(const std::string& connectorId) const {
+  Config* getConnectorConfig(const std::string& connectorId) const {
     auto it = connectorConfigs_.find(connectorId);
     if (it == connectorConfigs_.end()) {
       return getEmptyConfig();
@@ -107,7 +106,7 @@ class QueryCtx {
         std::make_shared<MemConfig>(std::move(configOverrides));
   }
 
-  folly::Executor* FOLLY_NULLABLE spillExecutor() const {
+  folly::Executor* spillExecutor() const {
     return spillExecutor_.get();
   }
 
@@ -120,7 +119,7 @@ class QueryCtx {
   }
 
  private:
-  static Config* FOLLY_NONNULL getEmptyConfig() {
+  static Config* getEmptyConfig() {
     static const std::unique_ptr<Config> kEmptyConfig =
         std::make_unique<MemConfig>();
     return kEmptyConfig.get();
@@ -133,29 +132,28 @@ class QueryCtx {
     }
   }
 
+  const std::string queryId_;
+
   std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs_;
-  memory::MemoryAllocator* FOLLY_NONNULL allocator_;
+  memory::MemoryAllocator* allocator_;
   std::shared_ptr<memory::MemoryPool> pool_;
-  folly::Executor* FOLLY_NULLABLE executor_;
+  folly::Executor* executor_;
   folly::Executor::KeepAlive<> executorKeepalive_;
   QueryConfig queryConfig_;
-  const std::string queryId_;
   std::shared_ptr<folly::Executor> spillExecutor_;
 };
 
 // Represents the state of one thread of query execution.
 class ExecCtx {
  public:
-  ExecCtx(
-      memory::MemoryPool* FOLLY_NONNULL pool,
-      QueryCtx* FOLLY_NULLABLE queryCtx)
+  ExecCtx(memory::MemoryPool* pool, QueryCtx* queryCtx)
       : pool_(pool), queryCtx_(queryCtx), vectorPool_{pool} {}
 
-  velox::memory::MemoryPool* FOLLY_NONNULL pool() const {
+  velox::memory::MemoryPool* pool() const {
     return pool_;
   }
 
-  QueryCtx* FOLLY_NONNULL queryCtx() const {
+  QueryCtx* queryCtx() const {
     return queryCtx_;
   }
 
@@ -228,8 +226,8 @@ class ExecCtx {
 
  private:
   // Pool for all Buffers for this thread.
-  memory::MemoryPool* FOLLY_NONNULL pool_;
-  QueryCtx* FOLLY_NULLABLE queryCtx_;
+  memory::MemoryPool* pool_;
+  QueryCtx* queryCtx_;
   // A pool of preallocated DecodedVectors for use by expressions and operators.
   std::vector<std::unique_ptr<DecodedVector>> decodedVectorPool_;
   // A pool of preallocated SelectivityVectors for use by expressions

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -55,6 +55,7 @@ OperatorCtx::createConnectorQueryCtx(
       std::make_unique<SimpleExpressionEvaluator>(
           execCtx()->queryCtx(), execCtx()->pool()),
       driverCtx_->task->queryCtx()->allocator(),
+      driverCtx_->task->queryCtx()->queryId(),
       taskId(),
       planNodeId,
       driverCtx_->driverId);

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -440,25 +440,6 @@ class TableWriteTest : public HiveConnectorTestBase {
     }
   }
 
-#if 0
-  // Verifies if the given partitioned table directory (names) are encoded
-  // properly based on the used partitioned keys.
-  void verifyPartitionFileDirectory(
-      const std::filesystem::path& filePath,
-      const std::string& targetDir) {
-    auto parentPath = filePath.parent_path();
-    for (int i = partitionedBy_.size() - 1; i >= 0; --i) {
-      const auto& partitionColumn = partitionedBy_[i];
-      ASSERT_TRUE(RE2::FullMatch(
-          parentPath.filename().string(),
-          fmt::format("{}=.+", partitionColumn)))
-          << parentPath.filename().string() << " " << partitionColumn << " "
-          << i << " " << parentPath.string();
-      parentPath = parentPath.parent_path();
-    }
-  }
-#endif
-
   // Verifies if a partitioned file path (directory and file name) is encoded
   // properly.
   void verifyPartitionedFilePath(
@@ -476,12 +457,12 @@ class TableWriteTest : public HiveConnectorTestBase {
     verifyPartitionedDirPath(filePath, targetDir);
     if (commitStrategy_ == CommitStrategy::kNoCommit) {
       ASSERT_TRUE(RE2::FullMatch(
-          filePath.filename().string(), "0[0-9]+_0_test_cursor.+"))
+          filePath.filename().string(), "0[0-9]+_0_TaskCursorQuery_[0-9]+"))
           << filePath.filename().string();
     } else {
       ASSERT_TRUE(RE2::FullMatch(
           filePath.filename().string(),
-          ".tmp.velox.0[0-9]+_0_test_cursor.+_.+"))
+          ".tmp.velox.0[0-9]+_0_TaskCursorQuery_[0-9]+_.+"))
           << filePath.filename().string();
     }
   }

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -118,7 +118,15 @@ TaskCursor::TaskCursor(const CursorParameters& params)
     // activities to finish on TaskCursor destruction.
     executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(
         std::thread::hardware_concurrency());
-    queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    static std::atomic<uint64_t> cursorQueryId{0};
+    queryCtx = std::make_shared<core::QueryCtx>(
+        executor_.get(),
+        std::unordered_map<std::string, std::string>{},
+        std::unordered_map<std::string, std::shared_ptr<Config>>{},
+        memory::MemoryAllocator::getInstance(),
+        nullptr,
+        nullptr,
+        fmt::format("TaskCursorQuery_{}", cursorQueryId++));
   }
 
   queue_ = std::make_shared<TaskQueue>(params.bufferedBytes);


### PR DESCRIPTION
In Presto e2e test, we found the bucket file name is not compatible
with one generated by Presto java if some bucket file is missing
(computeFileNamesForMissingBuckets). The difference is that java
use query id to build bucket file name but velox use the task id.
We can just use query id which is unique under a particular partition
dir so no need to use task id.