### PR TITLE
Add timestamp - timestamp -> interval day time Presto function (minus)

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -334,6 +334,18 @@ struct DatePlusIntervalDayTime {
 };
 
 template <typename T>
+struct TimestampMinusIntervalDayTime {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<IntervalDayTime>& result,
+      const arg_type<Timestamp>& a,
+      const arg_type<Timestamp>& b) {
+    result = a.toMillis() - b.toMillis();
+  }
+};
+
+template <typename T>
 struct DayOfWeekFunction : public InitSessionTimezone<T>,
                            public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -63,6 +63,11 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "minus"});
   registerFunction<DatePlusIntervalDayTime, Date, Date, IntervalDayTime>(
       {prefix + "plus"});
+  registerFunction<
+      TimestampMinusIntervalDayTime,
+      IntervalDayTime,
+      Timestamp,
+      Timestamp>({prefix + "minus"});
   registerFunction<DayFunction, int64_t, TimestampWithTimezone>(
       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int64_t, Timestamp>(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -835,6 +835,30 @@ TEST_F(DateTimeFunctionsTest, plusMinusDateIntervalDayTime) {
   EXPECT_THROW(minus(baseDate, partDay), VeloxUserError);
 }
 
+TEST_F(DateTimeFunctionsTest, minusTimestampIntervalDayTime) {
+  const auto minus = [&](std::optional<int64_t> t1, std::optional<int64_t> t2) {
+    const auto timestamp1 = (t1.has_value()) ? Timestamp(t1.value(), 0)
+                                             : std::optional<Timestamp>();
+    const auto timestamp2 = (t2.has_value()) ? Timestamp(t2.value(), 0)
+                                             : std::optional<Timestamp>();
+    return evaluateOnce<int64_t>(
+        "c0 - c1",
+        makeRowVector({
+            makeNullableFlatVector<Timestamp>({timestamp1}),
+            makeNullableFlatVector<Timestamp>({timestamp2}),
+        }));
+  };
+
+  EXPECT_EQ(std::nullopt, minus(std::nullopt, std::nullopt));
+  EXPECT_EQ(std::nullopt, minus(1, std::nullopt));
+  EXPECT_EQ(std::nullopt, minus(std::nullopt, 1));
+  EXPECT_EQ(1000, minus(1, 0));
+  EXPECT_EQ(-1000, minus(1, 2));
+  VELOX_ASSERT_THROW(
+      minus(Timestamp::kMinSeconds, Timestamp::kMaxSeconds),
+      "integer overflow");
+}
+
 TEST_F(DateTimeFunctionsTest, dayOfMonthTimestampWithTimezone) {
   EXPECT_EQ(
       31,


### PR DESCRIPTION
Presto Timestamp subtract scalar function is missing, adding this function with the same implementation in Presto by comparing Timestamp milli seconds and return in interval day time.
https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/type/TimestampOperators.java#L64 
