### PR TITLE
Improve Decimal to Double cast performance

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -135,13 +135,13 @@ VectorPtr applyDecimalToDoubleCast(
   auto sourceVector = input.as<SimpleVector<TInput>>();
   auto resultBuffer =
       result->asUnchecked<FlatVector<double>>()->mutableRawValues();
-  auto toPrecisionScale = getDecimalPrecisionScale(*fromType);
+  auto [precision, scale] = getDecimalPrecisionScale(*fromType);
+  const auto simpleInput = input.as<SimpleVector<TInput>>();
+  const auto kDenominator = (double)DecimalUtil::kPowersOfTen[scale];
   context.applyToSelectedNoThrow(rows, [&](int row) {
-    auto output =
-        util::Converter<CppToType<double>::typeKind, void, false>::cast(
-            input.as<SimpleVector<TInput>>()->valueAt(row));
-    resultBuffer[row] =
-        output / (double)DecimalUtil::kPowersOfTen[toPrecisionScale.second];
+    auto output = util::Converter<TypeKind::DOUBLE, void, false>::cast(
+        simpleInput->valueAt(row));
+    resultBuffer[row] = output / kDenominator;
   });
   return result;
 }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -137,11 +137,11 @@ VectorPtr applyDecimalToDoubleCast(
       result->asUnchecked<FlatVector<double>>()->mutableRawValues();
   auto [precision, scale] = getDecimalPrecisionScale(*fromType);
   const auto simpleInput = input.as<SimpleVector<TInput>>();
-  const auto kDenominator = (double)DecimalUtil::kPowersOfTen[scale];
+  const auto denominator = (double)DecimalUtil::kPowersOfTen[scale];
   context.applyToSelectedNoThrow(rows, [&](int row) {
     auto output = util::Converter<TypeKind::DOUBLE, void, false>::cast(
         simpleInput->valueAt(row));
-    resultBuffer[row] = output / kDenominator;
+    resultBuffer[row] = output / denominator;
   });
   return result;
 }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -135,13 +135,13 @@ VectorPtr applyDecimalToDoubleCast(
   auto sourceVector = input.as<SimpleVector<TInput>>();
   auto resultBuffer =
       result->asUnchecked<FlatVector<double>>()->mutableRawValues();
-  auto [precision, scale] = getDecimalPrecisionScale(*fromType);
+  const auto precisionScale = getDecimalPrecisionScale(*fromType);
   const auto simpleInput = input.as<SimpleVector<TInput>>();
-  const auto denominator = (double)DecimalUtil::kPowersOfTen[scale];
   context.applyToSelectedNoThrow(rows, [&](int row) {
     auto output = util::Converter<TypeKind::DOUBLE, void, false>::cast(
         simpleInput->valueAt(row));
-    resultBuffer[row] = output / denominator;
+    resultBuffer[row] =
+        output / DecimalUtil::kPowersOfTen[precisionScale.second];
   });
   return result;
 }


### PR DESCRIPTION
Apply Decimal to Double cast at the batch level instead of row-level.
This also improves performance of cast between primitive types.