### PR TITLE
Fix return type of 'size' SparkSQL function

### DIFF
--- a/velox/functions/sparksql/Size.cpp
+++ b/velox/functions/sparksql/Size.cpp
@@ -35,7 +35,7 @@ struct Size {
   }
 
   template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool callNullable(int64_t& out, const TInput* input) {
+  FOLLY_ALWAYS_INLINE bool callNullable(int32_t& out, const TInput* input) {
     if (input == nullptr) {
       if (legacySizeOfNull_) {
         out = -1;
@@ -54,8 +54,8 @@ struct Size {
 } // namespace
 
 void registerSize(const std::string& prefix) {
-  registerFunction<Size, int64_t, Array<Any>>({prefix});
-  registerFunction<Size, int64_t, Map<Any, Any>>({prefix});
+  registerFunction<Size, int32_t, Array<Any>>({prefix});
+  registerFunction<Size, int32_t, Map<Any, Any>>({prefix});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/SizeTest.cpp
+++ b/velox/functions/sparksql/tests/SizeTest.cpp
@@ -30,7 +30,7 @@ class SizeTest : public SparkFunctionBaseTest {
 
   void testSize(VectorPtr vector, vector_size_t numRows) {
     auto result =
-        evaluate<SimpleVector<int64_t>>("size(c0)", makeRowVector({vector}));
+        evaluate<SimpleVector<int32_t>>("size(c0)", makeRowVector({vector}));
     for (vector_size_t i = 0; i < numRows; ++i) {
       if (vector->isNullAt(i)) {
         EXPECT_EQ(result->valueAt(i), -1) << "at " << i;
@@ -42,7 +42,7 @@ class SizeTest : public SparkFunctionBaseTest {
 
   void testSizeLegacyNull(VectorPtr vector, vector_size_t numRows) {
     auto result =
-        evaluate<SimpleVector<int64_t>>("size(c0)", makeRowVector({vector}));
+        evaluate<SimpleVector<int32_t>>("size(c0)", makeRowVector({vector}));
     for (vector_size_t i = 0; i < numRows; ++i) {
       EXPECT_EQ(result->isNullAt(i), vector->isNullAt(i)) << "at " << i;
     }


### PR DESCRIPTION
In Spark 'size' function returns Integer result.

```scala
case class Size(child: Expression, legacySizeOfNull: Boolean)
  extends UnaryExpression with ExpectsInputTypes {

  def this(child: Expression) = this(child, SQLConf.get.legacySizeOfNull)

  override def dataType: DataType = IntegerType
```