### PR TITLE
Register components for Dwrf, Parquet, S3 FileSystem during HiveConnector registration

### DIFF
--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -31,8 +31,6 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/Options.h"
-#include "velox/dwio/dwrf/reader/DwrfReader.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/Split.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -242,12 +240,7 @@ class TpchBenchmark {
     aggregate::prestosql::registerAllAggregateFunctions();
     parse::registerTypeResolver();
     filesystems::registerLocalFileSystem();
-    if (FLAGS_use_native_parquet_reader) {
-      parquet::registerParquetReaderFactory(parquet::ParquetReaderType::NATIVE);
-    } else {
-      parquet::registerParquetReaderFactory(parquet::ParquetReaderType::DUCKDB);
-    }
-    dwrf::registerDwrfReaderFactory();
+
     ioExecutor_ =
         std::make_unique<folly::IOThreadPoolExecutor>(FLAGS_num_io_threads);
 

--- a/velox/connectors/Connector.cpp
+++ b/velox/connectors/Connector.cpp
@@ -32,6 +32,7 @@ std::unordered_map<std::string, std::shared_ptr<Connector>>& connectors() {
 } // namespace
 
 bool registerConnectorFactory(std::shared_ptr<ConnectorFactory> factory) {
+  factory->initialize();
   bool ok =
       connectorFactories().insert({factory->connectorName(), factory}).second;
   VELOX_CHECK(

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -373,7 +373,7 @@ class ConnectorFactory {
 
   virtual ~ConnectorFactory() = default;
 
-  /// Initialize is called during the factory registration.
+  // Initialize is called during the factory registration.
   virtual void initialize() {}
 
   const std::string& connectorName() const {

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -373,6 +373,9 @@ class ConnectorFactory {
 
   virtual ~ConnectorFactory() = default;
 
+  /// Initialize is called during the factory registration.
+  virtual void initialize() {}
+
   const std::string& connectorName() const {
     return name_;
   }

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -26,11 +26,14 @@ add_library(
 target_link_libraries(
   velox_hive_connector
   velox_connector
+  velox_dwio_catalog_fbhive
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_file
   velox_hive_partition_function
-  velox_dwio_catalog_fbhive)
+  velox_s3fs)
 
 add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -18,6 +18,17 @@
 
 #include "velox/common/base/Fs.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
+// Meta's buck build system needs this check.
+#ifdef VELOX_ENABLE_S3
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
+#endif
+#include "velox/dwio/dwrf/reader/DwrfReader.h"
+#include "velox/dwio/dwrf/writer/Writer.h"
+// Meta's buck build system needs this check.
+#ifdef VELOX_ENABLE_PARQUET
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
+#endif
 #include "velox/expression/FieldReference.h"
 
 #include <boost/lexical_cast.hpp>
@@ -63,6 +74,24 @@ std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(
                                  : bucketToPartition_,
       channels_,
       constValues_);
+}
+
+void HiveConnectorFactory::initialize() {
+  static bool once = []() {
+    dwio::common::WriteFileDataSink::registerLocalFileFactory();
+    dwrf::registerDwrfReaderFactory();
+    dwrf::registerDwrfWriterFactory();
+// Meta's buck build system needs this check.
+#ifdef VELOX_ENABLE_PARQUET
+    parquet::registerParquetReaderFactory();
+    parquet::registerParquetWriterFactory();
+#endif
+// Meta's buck build system needs this check.
+#ifdef VELOX_ENABLE_S3
+    filesystems::registerS3FileSystem();
+#endif
+    return true;
+  }();
 }
 
 std::string HivePartitionFunctionSpec::toString() const {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -102,14 +102,14 @@ class HiveConnectorFactory : public ConnectorFactory {
   static constexpr const char* FOLLY_NONNULL kHiveHadoop2ConnectorName =
       "hive-hadoop2";
 
-  HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {
-    dwio::common::WriteFileDataSink::registerLocalFileFactory();
-  }
+  HiveConnectorFactory() : ConnectorFactory(kHiveConnectorName) {}
 
   HiveConnectorFactory(const char* FOLLY_NONNULL connectorName)
-      : ConnectorFactory(connectorName) {
-    dwio::common::WriteFileDataSink::registerLocalFileFactory();
-  }
+      : ConnectorFactory(connectorName) {}
+
+  /// Register HiveConnector components such as Dwrf, Parquet readers and
+  /// writers and FileSystems.
+  void initialize() override;
 
   std::shared_ptr<Connector> newConnector(
       const std::string& id,

--- a/velox/connectors/hive/storage_adapters/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/CMakeLists.txt
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(VELOX_ENABLE_S3)
-  add_subdirectory(s3fs)
-endif()
+add_subdirectory(s3fs)
+
 if(VELOX_ENABLE_HDFS)
   add_subdirectory(hdfs)
 endif()

--- a/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
@@ -14,11 +14,17 @@
 
 # for generated headers
 
-add_library(velox_s3fs S3FileSystem.cpp S3Util.cpp)
-target_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
-target_link_libraries(velox_s3fs Folly::folly ${AWSSDK_LIBRARIES})
+add_library(velox_s3fs RegisterS3FileSystem.cpp)
+if(VELOX_ENABLE_S3)
+  target_sources(velox_s3fs PRIVATE S3FileSystem.cpp S3Util.cpp)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-  add_subdirectory(benchmark)
+  target_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
+  target_link_libraries(velox_s3fs Folly::folly ${AWSSDK_LIBRARIES})
+
+  if(${VELOX_BUILD_TESTING})
+    add_subdirectory(tests)
+  endif()
+  if(${VELOX_ENABLE_BENCHMARKS})
+    add_subdirectory(benchmark)
+  endif()
 endif()

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef VELOX_ENABLE_S3
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
+#include "velox/core/Config.h"
+#endif
+
+namespace facebook::velox::filesystems {
+
+#ifdef VELOX_ENABLE_S3
+folly::once_flag S3FSInstantiationFlag;
+
+std::function<std::shared_ptr<
+    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+fileSystemGenerator() {
+  static auto filesystemGenerator = [](std::shared_ptr<const Config> properties,
+                                       std::string_view filePath) {
+    // Only one instance of S3FileSystem is supported for now.
+    // TODO: Support multiple S3FileSystem instances using a cache
+    // Initialize on first access and reuse after that.
+    static std::shared_ptr<FileSystem> s3fs;
+    folly::call_once(S3FSInstantiationFlag, [&properties]() {
+      std::shared_ptr<S3FileSystem> fs;
+      if (properties != nullptr) {
+        fs = std::make_shared<S3FileSystem>(properties);
+      } else {
+        fs =
+            std::make_shared<S3FileSystem>(std::make_shared<core::MemConfig>());
+      }
+      fs->initializeClient();
+      s3fs = fs;
+    });
+    return s3fs;
+  };
+  return filesystemGenerator;
+}
+#endif
+
+void registerS3FileSystem() {
+#ifdef VELOX_ENABLE_S3
+  registerFileSystem(isS3File, fileSystemGenerator());
+#endif
+}
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::filesystems {
+
+// Register the S3 filesystem.
+void registerS3FileSystem();
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -75,6 +75,4 @@ class S3FileSystem : public FileSystem {
   std::shared_ptr<Impl> impl_;
 };
 
-// Register the S3 filesystem.
-void registerS3FileSystem();
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/file/benchmark/ReadBenchmark.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
 DECLARE_string(s3_config);

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "connectors/hive/storage_adapters/s3fs/S3Util.h"
 #include "connectors/hive/storage_adapters/s3fs/tests/MinioServer.h"
 #include "velox/common/file/File.h"
@@ -34,7 +35,6 @@ class S3FileSystemTest : public testing::Test {
       minioServer_ = std::make_shared<MinioServer>();
       minioServer_->start();
     }
-    filesystems::registerS3FileSystem();
   }
 
   static void TearDownTestSuite() {

--- a/velox/dwio/common/WriterFactory.h
+++ b/velox/dwio/common/WriterFactory.h
@@ -86,6 +86,12 @@ bool unregisterWriterFactory(FileFormat format);
  */
 std::shared_ptr<WriterFactory> getWriterFactory(FileFormat format);
 
+/**
+ * Check if a writer factory object exists for a specified file format.
+ * Returns true if there is a registered factory for this format, false
+ * otherwise.
+ * @return true
+ */
 bool hasWriterFactory(FileFormat format);
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/parquet/tests/ParquetTpchTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTpchTestBase.h
@@ -60,6 +60,7 @@ class ParquetTpchTestBase : public testing::Test {
     if (parquetReaderType_ == ParquetReaderType::DUCKDB) {
       FLAGS_split_preload_per_driver = 0;
     }
+    unregisterParquetReaderFactory();
     registerParquetReaderFactory(parquetReaderType_);
 
     auto hiveConnector =

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -841,12 +841,8 @@ class PartitionedTableWriterTest
   static std::vector<uint64_t> getTestParams() {
     std::vector<uint64_t> testParams;
     const std::vector<bool> multiDriverOptions = {false, true};
-    std::vector<FileFormat> fileFormats;
-    if (hasWriterFactory(FileFormat::PARQUET)) {
-      fileFormats = {FileFormat::DWRF, FileFormat::PARQUET};
-    } else {
-      fileFormats = {FileFormat::DWRF};
-    }
+    // Add Parquet with https://github.com/facebookincubator/velox/issues/5560
+    std::vector<FileFormat> fileFormats = {FileFormat::DWRF};
     for (bool multiDrivers : multiDriverOptions) {
       for (FileFormat fileFormat : fileFormats) {
         testParams.push_back(TestParam{
@@ -951,12 +947,8 @@ class BucketedTableOnlyWriteTest
   static std::vector<uint64_t> getTestParams() {
     std::vector<uint64_t> testParams;
     const std::vector<bool> multiDriverOptions = {false, true};
-    std::vector<FileFormat> fileFormats;
-    if (hasWriterFactory(FileFormat::PARQUET)) {
-      fileFormats = {FileFormat::DWRF, FileFormat::PARQUET};
-    } else {
-      fileFormats = {FileFormat::DWRF};
-    }
+    // Add Parquet with https://github.com/facebookincubator/velox/issues/5560
+    std::vector<FileFormat> fileFormats = {FileFormat::DWRF};
     for (bool multiDrivers : multiDriverOptions) {
       for (FileFormat fileFormat : fileFormats) {
         testParams.push_back(TestParam{
@@ -1006,12 +998,8 @@ class PartitionedWithoutBucketTableWriterTest
   static std::vector<uint64_t> getTestParams() {
     std::vector<uint64_t> testParams;
     const std::vector<bool> multiDriverOptions = {false, true};
-    std::vector<FileFormat> fileFormats;
-    if (hasWriterFactory(FileFormat::PARQUET)) {
-      fileFormats = {FileFormat::DWRF, FileFormat::PARQUET};
-    } else {
-      fileFormats = {FileFormat::DWRF};
-    }
+    // Add Parquet with https://github.com/facebookincubator/velox/issues/5560
+    std::vector<FileFormat> fileFormats = {FileFormat::DWRF};
     for (bool multiDrivers : multiDriverOptions) {
       for (FileFormat fileFormat : fileFormats) {
         testParams.push_back(TestParam{
@@ -1044,12 +1032,8 @@ class AllTableWriterTest : public TableWriteTest,
   static std::vector<uint64_t> getTestParams() {
     std::vector<uint64_t> testParams;
     const std::vector<bool> multiDriverOptions = {false, true};
-    std::vector<FileFormat> fileFormats;
-    if (hasWriterFactory(FileFormat::PARQUET)) {
-      fileFormats = {FileFormat::DWRF, FileFormat::PARQUET};
-    } else {
-      fileFormats = {FileFormat::DWRF};
-    }
+    // Add Parquet with https://github.com/facebookincubator/velox/issues/5560
+    std::vector<FileFormat> fileFormats = {FileFormat::DWRF};
     for (bool multiDrivers : multiDriverOptions) {
       for (FileFormat fileFormat : fileFormats) {
         testParams.push_back(TestParam{

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -20,14 +20,11 @@
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/dwio/common/WriterFactory.h"
-#include "velox/dwio/parquet/RegisterParquetReader.h"
-#include "velox/dwio/parquet/RegisterParquetWriter.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
-#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 #include <re2/re2.h>
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -35,16 +35,12 @@ void HiveConnectorTestBase::SetUp() {
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(kHiveConnectorId, nullptr, ioExecutor_.get());
   connector::registerConnector(hiveConnector);
-  dwrf::registerDwrfReaderFactory();
-  dwrf::registerDwrfWriterFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
   // Make sure all pending loads are finished or cancelled before unregister
   // connector.
   ioExecutor_.reset();
-  dwrf::unregisterDwrfReaderFactory();
-  dwrf::unregisterDwrfWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -60,11 +60,9 @@ void AggregationTestBase::SetUp() {
           connector::hive::HiveConnectorFactory::kHiveConnectorName)
           ->newConnector(kHiveConnectorId, nullptr);
   connector::registerConnector(hiveConnector);
-  dwrf::registerDwrfReaderFactory();
 }
 
 void AggregationTestBase::TearDown() {
-  dwrf::unregisterDwrfReaderFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }


### PR DESCRIPTION
Velox formats such as Dwrf Reader, Dwrf Writer, Parquet Reader, Parquet Writer and 
file-systems such as S3 FileSystem are tied to the HiveConnector. 
In the current setup, these components are registered independent of the HiveConnector.
This introduces duplication at each call site.
Some components such as Parquet, S3 FileSystem are optional. These introduce additional checks at
each of the consumer.
This PR adds a `initialize()` method in the ConnectorFactory that can be used to register 
components related to the ConnectorFactory.
S3FileSystem is also refactored such that the checks are moved into the S3FileSystem.
Disabling S3 now builds an velox_s3fs library without the S3 implementation.
This removes need for checks at the consumer.