### PR TITLE
Creating one event base per remote function

### DIFF
--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/functions/remote/client/Remote.h"
+
+#include <folly/io/async/EventBase.h>
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/remote/client/ThriftClient.h"
@@ -39,7 +41,7 @@ class RemoteFunction : public exec::VectorFunction {
       const RemoteVectorFunctionMetadata& metadata)
       : functionName_(functionName),
         location_(metadata.location),
-        thriftClient_(getThriftClient(location_)),
+        thriftClient_(getThriftClient(location_, &eventBase_)),
         serdeFormat_(metadata.serdeFormat),
         serde_(getSerde(serdeFormat_)) {
     std::vector<TypePtr> types;
@@ -120,6 +122,8 @@ class RemoteFunction : public exec::VectorFunction {
 
   const std::string functionName_;
   folly::SocketAddress location_;
+
+  folly::EventBase eventBase_;
   std::unique_ptr<RemoteFunctionClient> thriftClient_;
   remote::PageFormat serdeFormat_;
   std::unique_ptr<VectorSerde> serde_;

--- a/velox/functions/remote/client/ThriftClient.cpp
+++ b/velox/functions/remote/client/ThriftClient.cpp
@@ -15,14 +15,13 @@
  */
 
 #include "velox/functions/remote/client/ThriftClient.h"
-#include <folly/io/async/EventBaseManager.h>
 
 namespace facebook::velox::functions {
 
 std::unique_ptr<RemoteFunctionClient> getThriftClient(
-    folly::SocketAddress location) {
-  return newHeaderClient<RemoteFunctionClient>(
-      folly::EventBaseManager::get()->getEventBase(), location);
+    folly::SocketAddress location,
+    folly::EventBase* eventBase) {
+  return newHeaderClient<RemoteFunctionClient>(eventBase, location);
 }
 
 } // namespace facebook::velox::functions

--- a/velox/functions/remote/client/ThriftClient.h
+++ b/velox/functions/remote/client/ThriftClient.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/io/async/EventBase.h>
 #include <thrift/perf/cpp2/util/Util.h>
 #include "velox/functions/remote/if/gen-cpp2/RemoteFunctionServiceAsyncClient.h"
 
@@ -25,6 +26,7 @@ using RemoteFunctionClient =
     apache::thrift::Client<remote::RemoteFunctionService>;
 
 std::unique_ptr<RemoteFunctionClient> getThriftClient(
-    folly::SocketAddress location);
+    folly::SocketAddress location,
+    folly::EventBase* eventBase);
 
 } // namespace facebook::velox::functions


### PR DESCRIPTION
Summary:
Event base manager is not setup correctly in Velox integrations like
Prestissimo. For now just creating one event base to drive the loop per
function instance (per Expr instance). In the future we can look into using a
pool of available event bases, but it doesn't seem to affect performance for
now.

Reviewed By: mbasmanova

Differential Revision: D46917299

