### PR TITLE
Add totalUsedBytes API for MemoryAllocator

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -683,6 +683,10 @@ class AsyncDataCache : public memory::MemoryAllocator {
     return allocator_->sizeClasses();
   }
 
+  size_t totalUsedBytes() const override {
+    return allocator_->totalUsedBytes();
+  }
+
   memory::MachinePageCount numAllocated() const override {
     return allocator_->numAllocated();
   }

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -77,6 +77,10 @@ class MallocAllocator : public MemoryAllocator {
 
   void freeBytes(void* p, uint64_t bytes) noexcept override;
 
+  size_t totalUsedBytes() const override {
+    return allocatedBytes_;
+  }
+
   MachinePageCount numAllocated() const override {
     return numAllocated_;
   }

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -281,6 +281,9 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
     return sizeClassSizes_;
   }
 
+  /// Returns the total number of used bytes by this allocator
+  virtual size_t totalUsedBytes() const = 0;
+
   virtual MachinePageCount numAllocated() const = 0;
 
   virtual MachinePageCount numMapped() const = 0;

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -148,6 +148,10 @@ class MmapAllocator : public MemoryAllocator {
     return mallocReservedBytes_;
   }
 
+  size_t totalUsedBytes() const override {
+    return numMallocBytes_ + AllocationTraits::pageBytes(numAllocated_);
+  }
+
   MachinePageCount numAllocated() const override {
     return numAllocated_;
   }


### PR DESCRIPTION
Add a common interface to MemoryAllocator to retrieve the currently used bytes for the allocator. This will be used for exposing global memory usage to MemoryManager