### PR TITLE
Remove incorrect and confusing code from ValueList

### DIFF
--- a/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
+++ b/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
@@ -45,11 +45,9 @@ HashStringAllocator::Position AddressableNonNullValueList::append(
   exec::ContainerRowSerde::instance().serialize(
       *decoded.base(), decoded.index(index), stream);
 
-  totalBytes_ += stream.size();
   ++size_;
-  const auto reserve =
-      std::max<int32_t>(1024, std::min<int64_t>(128, totalBytes_));
-  currentPosition_ = allocator->finishWrite(stream, reserve);
+
+  currentPosition_ = allocator->finishWrite(stream, 1024);
   return position;
 }
 

--- a/velox/functions/prestosql/aggregates/AddressableNonNullValueList.h
+++ b/velox/functions/prestosql/aggregates/AddressableNonNullValueList.h
@@ -91,9 +91,6 @@ class AddressableNonNullValueList {
   HashStringAllocator::Header* firstHeader_{nullptr};
   HashStringAllocator::Position currentPosition_{nullptr, nullptr};
 
-  // Total bytes written.
-  uint64_t totalBytes_{0};
-
   // Number of values added.
   uint32_t size_{0};
 };

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -48,8 +48,6 @@ void ValueList::writeLastNulls(HashStringAllocator* allocator) {
   }
   stream.appendOne(lastNulls_);
   nullsCurrent_ = allocator->finishWrite(stream, kInitialSize);
-
-  totalBytes_ += sizeof(uint64_t);
 }
 
 void ValueList::appendNull(HashStringAllocator* allocator) {
@@ -66,10 +64,9 @@ void ValueList::appendNonNull(
   ByteStream stream(allocator);
   allocator->extendWrite(dataCurrent_, stream);
   exec::ContainerRowSerde::instance().serialize(values, index, stream);
-  totalBytes_ += stream.size();
   ++size_;
-  auto reserve = std::max<int32_t>(1024, std::min<int64_t>(128, totalBytes_));
-  dataCurrent_ = allocator->finishWrite(stream, reserve);
+
+  dataCurrent_ = allocator->finishWrite(stream, 1024);
 }
 
 void ValueList::appendValue(

--- a/velox/functions/prestosql/aggregates/ValueList.h
+++ b/velox/functions/prestosql/aggregates/ValueList.h
@@ -92,9 +92,6 @@ class ValueList {
   HashStringAllocator::Header* dataBegin_{nullptr};
   HashStringAllocator::Position dataCurrent_{nullptr, nullptr};
 
-  // Total bytes written.
-  uint64_t totalBytes_{0};
-
   // Number of values added, including nulls.
   uint32_t size_{0};
 


### PR DESCRIPTION
Summary:
> totalBytes_ += stream.size();

This code is incorrect because stream.size() returns total capacity of the stream, not how many bytes have been written.

> auto reserve = std::max<int32_t>(1024, std::min<int64_t>(128, totalBytes_));

This is confusing because the result is always 1024.

The min and max need to be swapped above, but doing this runs in to memory management bug. Hence, just replace with 1024 for now.

Differential Revision: D47135739

