### PR TITLE
Add S3/OSS RequestID in VELOX_CHECK_AWS_OUTCOME

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -137,22 +137,38 @@ inline std::string getS3BackendService(
   }
   return "Unknown";
 }
+
+inline std::string getRequestID(
+    const Aws::Http::HeaderValueCollection& headers) {
+  static const std::vector<std::string> kRequestIds{
+      "x-amz-request-id", "x-oss-request-id"};
+
+  for (const auto& kRequestId : kRequestIds) {
+    const auto it = headers.find(kRequestId);
+    if (it != headers.end()) {
+      return it->second;
+    }
+  }
+  return "";
+}
 } // namespace
 
-#define VELOX_CHECK_AWS_OUTCOME(outcome, errorMsgPrefix, bucket, key)                                          \
-  {                                                                                                            \
-    if (!outcome.IsSuccess()) {                                                                                \
-      auto error = outcome.GetError();                                                                         \
-      VELOX_FAIL(                                                                                              \
-          "{} due to: '{}'. Path:'{}', SDK Error Type:{}, HTTP Status Code:{}, S3 Service:'{}', Message:'{}'", \
-          errorMsgPrefix,                                                                                      \
-          getErrorStringFromS3Error(error),                                                                    \
-          s3URI(bucket, key),                                                                                  \
-          error.GetErrorType(),                                                                                \
-          error.GetResponseCode(),                                                                             \
-          getS3BackendService(error.GetResponseHeaders()),                                                     \
-          error.GetMessage());                                                                                 \
-    }                                                                                                          \
+/// Only Amazon (amz) and Alibaba (oss) request IDs are supported.
+#define VELOX_CHECK_AWS_OUTCOME(outcome, errorMsgPrefix, bucket, key)                                                          \
+  {                                                                                                                            \
+    if (!outcome.IsSuccess()) {                                                                                                \
+      auto error = outcome.GetError();                                                                                         \
+      VELOX_FAIL(                                                                                                              \
+          "{} due to: '{}'. Path:'{}', SDK Error Type:{}, HTTP Status Code:{}, S3 Service:'{}', Message:'{}', RequestID:'{}'", \
+          errorMsgPrefix,                                                                                                      \
+          getErrorStringFromS3Error(error),                                                                                    \
+          s3URI(bucket, key),                                                                                                  \
+          error.GetErrorType(),                                                                                                \
+          error.GetResponseCode(),                                                                                             \
+          getS3BackendService(error.GetResponseHeaders()),                                                                     \
+          error.GetMessage(),                                                                                                  \
+          getRequestID(error.GetResponseHeaders()))                                                                            \
+    }                                                                                                                          \
   }
 
 } // namespace facebook::velox


### PR DESCRIPTION
Add aws/oss request id to VELOX_CHECK_AWS_OUTCOME.
Refer: https://docs.aws.amazon.com/AmazonS3/latest/userguide/get-request-ids.html#http-request-id

