### PR TITLE
Use unix domain sockets for remote function local tests

### DIFF
--- a/velox/functions/remote/client/Remote.h
+++ b/velox/functions/remote/client/Remote.h
@@ -23,7 +23,9 @@
 namespace facebook::velox::functions {
 
 struct RemoteVectorFunctionMetadata : public exec::VectorFunctionMetadata {
-  /// Network address of the server to communicate with.
+  /// Network address of the servr to communicate with. Note that this can hold
+  /// a network location (ip/port pair) or a unix domain socket path (see
+  /// SocketAddress::makeFromPath()).
   folly::SocketAddress location;
 
   /// The serialization format to be used


### PR DESCRIPTION
Summary:
Using unix domain sockets for remote function local tests since
finding an empty port to run tests is error prone and unreliable when
running stress runs.

Differential Revision: D47155789

