### PR TITLE
Enable Parquet Writer test in AllTableWriterTest

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -1588,6 +1588,7 @@ TEST_P(UnpartitionedTableWriterTest, appendToAnExistingUnpartitionedTable) {
   //
   // The test inserts data vector by vector and checks the intermediate results
   // as well as the final result.
+
   auto kRowsPerVector = 100;
   auto input = makeVectors(10, kRowsPerVector);
 
@@ -1605,8 +1606,7 @@ TEST_P(UnpartitionedTableWriterTest, appendToAnExistingUnpartitionedTable) {
           outputDirectory->path,
           {},
           nullptr,
-          tableType,
-          commitStrategy_);
+          tableType);
       assertQuery(plan, fmt::format("SELECT {}", kRowsPerVector));
       assertQuery(
           PlanBuilder()
@@ -1805,6 +1805,7 @@ TEST_P(AllTableWriterTest, tableWriteOutputCheck) {
       << "\nwrite files: " << folly::join(",", writeFiles)
       << "\ndisk files: " << folly::join(",", diskFiles);
 }
+
 // TODO: add partitioned table write update mode tests and more failure tests.
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -40,6 +40,8 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
   velox_dwio_common_test_utils
   velox_type_fbhive
   velox_hive_connector

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -21,6 +21,8 @@
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
+#include "velox/dwio/parquet/RegisterParquetReader.h"
+#include "velox/dwio/parquet/RegisterParquetWriter.h"
 
 namespace facebook::velox::exec::test {
 
@@ -37,6 +39,8 @@ void HiveConnectorTestBase::SetUp() {
   connector::registerConnector(hiveConnector);
   dwrf::registerDwrfReaderFactory();
   dwrf::registerDwrfWriterFactory();
+  parquet::registerParquetReaderFactory();
+  parquet::registerParquetWriterFactory();
 }
 
 void HiveConnectorTestBase::TearDown() {
@@ -45,6 +49,8 @@ void HiveConnectorTestBase::TearDown() {
   ioExecutor_.reset();
   dwrf::unregisterDwrfReaderFactory();
   dwrf::unregisterDwrfWriterFactory();
+  parquet::unregisterParquetReaderFactory();
+  parquet::unregisterParquetWriterFactory();
   connector::unregisterConnector(kHiveConnectorId);
   OperatorTestBase::TearDown();
 }


### PR DESCRIPTION
The PR that introduced https://github.com/facebookincubator/velox/pull/5055 missed some changes
after being imported. This resulted in the Parquet writer test AllTableWriterTest.directReadWrite being disabled.
A subsequent PR #5299 improved the AllTableWriterTest.directReadWrite test by adding bucketed and 
partitioned modes.
Parquet writer in these modes now fails with 
`NotImplemented: Writing DictionaryArray with null encoded in dictionary type not yet supported`
Only unpartitioned test mode works for the Parquet writer. The test has been modified for the same.