### PR TITLE
Size-specific free list in HashStringAllocator

### DIFF
--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -48,7 +48,7 @@ class AllocationPool {
   }
 
   int32_t numSmallAllocations() const {
-    return 1 + allocations_.size();
+    return (allocation_.numPages() == 0 ? 0 : 1) + allocations_.size();
   }
 
   int32_t numLargeAllocations() const {
@@ -109,6 +109,13 @@ class AllocationPool {
 
   memory::MemoryPool* pool() const {
     return pool_;
+  }
+
+  /// true if 'ptr' is inside the active allocation.
+  bool isInCurrentAllocation(void* ptr) const {
+    return allocation_.numPages() && ptr >= allocation_.runAt(0).data<void>() &&
+        ptr <
+        allocation_.runAt(0).data<char>() + allocation_.runAt(0).numBytes();
   }
 
  private:

--- a/velox/common/memory/CompactDoubleList.h
+++ b/velox/common/memory/CompactDoubleList.h
@@ -31,6 +31,11 @@ class CompactDoubleList {
     setPrevious(this);
   }
 
+  CompactDoubleList(const CompactDoubleList& other) = delete;
+  CompactDoubleList(CompactDoubleList&& other) = delete;
+  void operator=(const CompactDoubleList& other) = delete;
+  void operator=(CompactDoubleList&& other) = delete;
+
   // Return true if 'this' is the only element.
   bool empty() const {
     return next() == this;

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -13,14 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/base/Portability.h"
+#include "velox/common/base/SimdUtil.h"
 
 namespace facebook::velox {
 
 namespace {
-/// Returns the size of the previous free block. The size is stored in the last
-/// 4 bytes of the free block, e.g. 4 bytes just before the current header.
+/// Returns the size of the previous free block. The size is stored in the
+/// last 4 bytes of the free block, e.g. 4 bytes just before the current
+/// header.
 uint32_t* previousFreeSize(HashStringAllocator::Header* header) {
   return reinterpret_cast<uint32_t*>(header) - 1;
 }
@@ -41,8 +43,9 @@ getPreviousFree(HashStringAllocator::Header* FOLLY_NONNULL header) {
   return previous;
 }
 
-/// Sets kFree flag in the 'header' and writes the size of the block to the last
-/// 4 bytes of the block. Sets kPreviousFree flag in the next block's 'header'.
+/// Sets kFree flag in the 'header' and writes the size of the block to the
+/// last 4 bytes of the block. Sets kPreviousFree flag in the next block's
+/// 'header'.
 void markAsFree(HashStringAllocator::Header* FOLLY_NONNULL header) {
   header->setFree();
   auto nextHeader = header->next();
@@ -52,6 +55,33 @@ void markAsFree(HashStringAllocator::Header* FOLLY_NONNULL header) {
   }
 }
 } // namespace
+
+HashStringAllocator::~HashStringAllocator() {
+  for (auto& pair : allocationsFromPool_) {
+    pool()->free(pair.first, pair.second);
+  }
+}
+
+void* HashStringAllocator::allocateFromPool(size_t size) {
+  auto ptr = pool()->allocate(size);
+  cumulativeBytes_ += size;
+  allocationsFromPool_[ptr] = size;
+  sizeFromPool_ += size;
+  return ptr;
+}
+
+void HashStringAllocator::freeToPool(void* ptr, size_t size) {
+  auto it = allocationsFromPool_.find(ptr);
+  VELOX_CHECK(
+      it != allocationsFromPool_.end(),
+      "freeToPool for block not allocated from pool of HashStringAllocator");
+  VELOX_CHECK_EQ(
+      size, it->second, "Bad size in HashStringAllocator::freeToPool()");
+  allocationsFromPool_.erase(it);
+  sizeFromPool_ -= size;
+  cumulativeBytes_ -= size;
+  pool()->free(ptr, size);
+}
 
 // static
 void HashStringAllocator::prepareRead(const Header* begin, ByteStream& stream) {
@@ -232,12 +262,40 @@ void HashStringAllocator::freeRestOfBlock(Header* header, int32_t keepBytes) {
   free(newHeader);
 }
 
+// Free list sizes align with size of containers. + 20 allows for padding for an
+// alignment of 16 bytes.
+int32_t HashStringAllocator::freeListSizes_[kNumFreeLists + 1] = {
+    72,
+    8 * 16 + 20,
+    16 * 16 + 20,
+    32 * 16 + 20,
+    64 * 16 + 20,
+    128 * 16 + 20,
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max()};
+
+int32_t HashStringAllocator::freeListIndex(int32_t size, uint32_t mask) {
+  static_assert(sizeof(freeListSizes_) == sizeof(xsimd::batch<int32_t>));
+  int32_t bits =
+      simd::toBitMask(
+          xsimd::broadcast(size) < xsimd::load_unaligned(freeListSizes_)) &
+      mask;
+  return count_trailing_zeros(bits);
+}
+
 HashStringAllocator::Header* FOLLY_NULLABLE
 HashStringAllocator::allocate(int32_t size, bool exactSize) {
-  auto header = allocateFromFreeList(size, exactSize, exactSize);
+  if (size > kMaxAlloc && exactSize) {
+    VELOX_CHECK(size <= Header::kSizeMask);
+    auto header =
+        reinterpret_cast<Header*>(allocateFromPool(size + sizeof(Header)));
+    new (header) Header(size);
+    return header;
+  }
+  auto header = allocateFromFreeLists(size, exactSize, exactSize);
   if (!header) {
     newSlab(size);
-    header = allocateFromFreeList(size, exactSize, exactSize);
+    header = allocateFromFreeLists(size, exactSize, exactSize);
     VELOX_CHECK(header != nullptr);
     VELOX_CHECK_GT(header->size(), 0);
   }
@@ -246,20 +304,48 @@ HashStringAllocator::allocate(int32_t size, bool exactSize) {
 }
 
 HashStringAllocator::Header* FOLLY_NULLABLE
-HashStringAllocator::allocateFromFreeList(
+HashStringAllocator::allocateFromFreeLists(
     int32_t preferredSize,
     bool mustHaveSize,
     bool isFinalSize) {
-  constexpr int32_t kMaxCheckedForFit = 5;
+  preferredSize = std::max(kMinAlloc, preferredSize);
   if (!numFree_) {
     return nullptr;
   }
-  VELOX_CHECK(!free_.empty());
-  preferredSize = std::max(kMinAlloc, preferredSize);
+  auto index = freeListIndex(preferredSize, freeNonEmpty_);
+  while (index < kNumFreeLists) {
+    if (auto header = allocateFromFreeList(
+            preferredSize, mustHaveSize, isFinalSize, index)) {
+      return header;
+    }
+    // Go to the next larger size non-empty free list.
+    index = count_trailing_zeros(freeNonEmpty_ & ~bits::lowMask(index + 1));
+  }
+  if (mustHaveSize) {
+    return nullptr;
+  }
+  index = freeListIndex(preferredSize) - 1;
+  for (; index >= 0; --index) {
+    if (auto header =
+            allocateFromFreeList(preferredSize, false, isFinalSize, index)) {
+      return header;
+    }
+  }
+  return nullptr;
+}
+
+HashStringAllocator::Header* FOLLY_NULLABLE
+HashStringAllocator::allocateFromFreeList(
+    int32_t preferredSize,
+    bool mustHaveSize,
+    bool isFinalSize,
+    int32_t freeListIndex) {
+  constexpr int32_t kMaxCheckedForFit = 5;
   int32_t counter = 0;
   Header* largest = nullptr;
   Header* found = nullptr;
-  for (auto* item = free_.next(); item != &free_; item = item->next()) {
+  for (auto* item = free_[freeListIndex].next(); item != &free_[freeListIndex];
+       item = item->next()) {
     auto header = headerOf(item);
     VELOX_CHECK(header->isFree());
     auto size = header->size();
@@ -298,6 +384,14 @@ HashStringAllocator::allocateFromFreeList(
 
 void HashStringAllocator::free(Header* _header) {
   Header* header = _header;
+  if (header->size() > kMaxAlloc && !pool_.isInCurrentAllocation(header) &&
+      allocationsFromPool_.find(header) != allocationsFromPool_.end()) {
+    // A large free can either be a rest of block or a standalone allocation.
+    VELOX_CHECK(!header->isContinued());
+    freeToPool(header, header->size() + sizeof(Header));
+    return;
+  }
+
   do {
     Header* continued = nullptr;
     if (header->isContinued()) {
@@ -320,13 +414,18 @@ void HashStringAllocator::free(Header* _header) {
     }
     if (header->isPreviousFree()) {
       auto previousFree = getPreviousFree(header);
+      removeFromFreeList(previousFree);
       previousFree->setSize(
           previousFree->size() + header->size() + sizeof(Header));
+
       header = previousFree;
     } else {
       ++numFree_;
-      free_.insert(reinterpret_cast<CompactDoubleList*>(header->begin()));
     }
+    auto freeIndex = freeListIndex(header->size());
+    freeNonEmpty_ |= 1 << freeIndex;
+    free_[freeIndex].insert(
+        reinterpret_cast<CompactDoubleList*>(header->begin()));
     markAsFree(header);
     header = continued;
   } while (header);
@@ -455,10 +554,21 @@ void HashStringAllocator::checkConsistency() const {
   VELOX_CHECK_EQ(freeBytes, freeBytes_);
   uint64_t numInFreeList = 0;
   uint64_t bytesInFreeList = 0;
-  for (auto free = free_.next(); free != &free_; free = free->next()) {
-    ++numInFreeList;
-    bytesInFreeList += headerOf(free)->size() + sizeof(Header);
+  for (auto i = 0; i < kNumFreeLists; ++i) {
+    bool hasData = freeNonEmpty_ & (1 << i);
+    bool listNonEmpty = !free_[i].empty();
+    VELOX_CHECK_EQ(hasData, listNonEmpty);
+    for (auto free = free_[i].next(); free != &free_[i]; free = free->next()) {
+      ++numInFreeList;
+      auto size = headerOf(free)->size();
+      if (i > 0) {
+        VELOX_CHECK_GE(size, freeListSizes_[i - 1]);
+      }
+      VELOX_CHECK_LT(size, freeListSizes_[i]);
+      bytesInFreeList += size + sizeof(Header);
+    }
   }
+
   VELOX_CHECK_EQ(numInFreeList, numFree_);
   VELOX_CHECK_EQ(bytesInFreeList, freeBytes_);
 }

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -116,8 +116,7 @@ TEST_F(HashStringAllocatorTest, allocateLarge) {
       memory::AllocationTraits::pageBytes(pool_->largestSizeClass() + 1);
   auto header = allocate(size);
   instance_->free(header);
-  // We allow for some free overhead for free lists after all is freed.
-  EXPECT_LE(instance_->retainedSize() - instance_->freeSpace(), 200);
+  EXPECT_EQ(0, instance_->retainedSize());
 }
 
 TEST_F(HashStringAllocatorTest, multipart) {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -673,10 +673,14 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
   }
 
   if (!tableIncrement && freeRows > input->size() &&
-      (outOfLineBytes == 0 || outOfLineFreeBytes >= flatBytes)) {
+      (outOfLineBytes == 0 || outOfLineFreeBytes >= flatBytes * 2)) {
     // Enough free rows for input rows and enough variable length free
-    // space for the flat size of the whole vector. If outOfLineBytes
-    // is 0 there is no need for variable length space.
+    // space for double the flat size of the whole vector. If
+    // outOfLineBytes is 0 there is no need for variable length
+    // space. Double the flat size is a stopgap because the real
+    // increase can be higher, specially with aggregates that have stl
+    // or folly containers. Make a way to raise the reservation in the
+    // spill protected section instead.
     return;
   }
   // If there is variable length data we take the flat size of the

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -634,7 +634,7 @@ int64_t RowContainer::sizeIncrement(
       AllocationPool::kMinPages * memory::AllocationTraits::kPageSize;
   int32_t needRows = std::max<int64_t>(0, numRows - numFreeRows_);
   int64_t needBytes =
-      std::min<int64_t>(0, variableLengthBytes - stringAllocator_.freeSpace());
+      std::max<int64_t>(0, variableLengthBytes - stringAllocator_.freeSpace());
   return bits::roundUp(needRows * fixedRowSize_, kAllocUnit) +
       bits::roundUp(needBytes, kAllocUnit);
 }


### PR DESCRIPTION
We maintain size specific free lists for faster allocation. When splitting or merging blocks we may move from one free list to another. For allocations that do not have to be contiguous, we check the size specific or larger lists first, then consume from the smaller ones before growing the HashStringAllocator.

For allocations in the MmapAllocator size classes size range, we go directly to the allocator of the pool and do not use the HashStringAllocator arenas. In this way, when such a block is freed it will become available to the rest of the system, which would not happen if this were embedded in an extra large HashStringAllocator arena.