### PR TITLE
Change spark MakeDateFunction and LastDayFunction to throw user errors

### DIFF
--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -162,7 +162,7 @@ struct MakeDateFunction {
       const int32_t month,
       const int32_t day) {
     auto daysSinceEpoch = util::daysSinceEpochFromDate(year, month, day);
-    VELOX_CHECK_EQ(
+    VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
         "Integer overflow in make_date({}, {}, {})",
@@ -198,7 +198,7 @@ struct LastDayFunction {
     int32_t day = getMonth(dateTime);
     auto lastDay = util::getMaxDayOfMonth(year, month);
     auto daysSinceEpoch = util::daysSinceEpochFromDate(year, month, lastDay);
-    VELOX_CHECK_EQ(
+    VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
         "Integer overflow in last_day({}-{}-{})",


### PR DESCRIPTION
Summary:
Throwing VeloxRuntimeError causes fuzzer test failure. This diff changes spark MakeDateFunction and LastDayFunction to throw VeloxUserError.

This diff fixes https://github.com/facebookincubator/velox/issues/5488.

Differential Revision: D47142137

