### PR TITLE
Skip flattening of an expression if inputs are of different types

### DIFF
--- a/velox/docs/develop/expression-evaluation.rst
+++ b/velox/docs/develop/expression-evaluation.rst
@@ -194,7 +194,9 @@ compiler to convert concat(a, concat(b, concat(c, d))) expression to
 concat(a, b, c, d).
 
 Other functions that can leverage this optimization include concat(array,..) and
-map_concat(map,..).
+map_concat(map,..). However, only signatures that have the same input type for
+all inputs are currently supported. For eg, concat(array<T>, concat(array<T>, array<T>))
+will be flattened but concat(T, concat(array<T>, array<T>)) will not.
 
 A function declaring support for flattening must have a signature with variadic
 arguments of the same type and return type must be the same as input type.

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -61,10 +61,6 @@ int main(int argc, char** argv) {
       "in",
       "element_at",
       "width_bucket",
-      // Skip concat as it triggers a test failure due to an incorrect
-      // expression generation from fuzzer:
-      // https://github.com/facebookincubator/velox/issues/5398
-      "concat",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(

--- a/velox/functions/prestosql/tests/ArrayConcatTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayConcatTest.cpp
@@ -201,4 +201,23 @@ TEST_F(ArrayConcatTest, arrayWithElement) {
   });
   testExpression("concat(c0, c1)", {elementVector, arrayVector}, expected);
 }
+
+TEST_F(ArrayConcatTest, nestedConcat) {
+  const auto elementVector = makeFlatVector<int64_t>({11, 22, 33, 44});
+  const auto arrayVector = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4}, {3, 4, 5}, {7, 8, 9}, {10, 20, 30}});
+  VectorPtr expected;
+
+  // concat(intVal, concat(array, intVal))
+  expected = makeArrayVector<int64_t>({
+      {11, 1, 2, 3, 4, 11},
+      {22, 3, 4, 5, 22},
+      {33, 7, 8, 9, 33},
+      {44, 10, 20, 30, 44},
+  });
+  testExpression(
+      "concat(c0, concat(c1, c2))",
+      {elementVector, arrayVector, elementVector},
+      expected);
+}
 } // namespace


### PR DESCRIPTION
Existing expression compilation attempt to flatten based on function
names. However, if a function has signatures that do not allow
flattening then this can fail compilation. This is a stopgap
solution that ensures only the most common case is supported where
inputs of the function are of the same type.

Fixes #5398

Test Plan:
- Added a unit test to ExprCompilerTest
- Will run expression fuzzer for 1 hour with assign_function_tickets
startup flag set to 'concat=10'