### PR TITLE
Add left SparkSQL function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -34,6 +34,11 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Returns the starting position of the first instance of ``substring`` in
     ``string``. Positions start with ``1``. Returns 0 if 'substring' is not found.
 
+.. spark:function:: left(string, length) -> string
+
+    Returns the leftmost length characters from the ``string``.
+    If ``length`` is less or equal than 0 the result is an empty string.
+
 .. spark:function:: length(string) -> integer
 
     Returns the length of ``string`` in characters.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -104,6 +104,10 @@ void registerFunctions(const std::string& prefix) {
       Varbinary,
       int32_t,
       int32_t>({prefix + "overlay"});
+
+  registerFunction<sparksql::LeftFunction, Varchar, Varchar, int32_t>(
+      {prefix + "left"});
+
   exec::registerStatefulVectorFunction(
       prefix + "instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -485,7 +485,6 @@ TEST_F(StringTest, overlayVarbinary) {
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, 4), "##rk SQL");
 }
 
-
 TEST_F(StringTest, left) {
   EXPECT_EQ(left("example", -2), "");
   EXPECT_EQ(left("example", 0), "");

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -134,6 +134,12 @@ class StringTest : public SparkFunctionBaseTest {
         "substring(c0, c1, c2)", str, start, length);
   }
 
+  std::optional<std::string> left(
+      std::optional<std::string> str,
+      std::optional<int32_t> length) {
+    return evaluateOnce<std::string>("left(c0, c1)", str, length);
+  }
+
   std::optional<std::string> overlay(
       std::optional<std::string> input,
       std::optional<std::string> replace,
@@ -477,6 +483,19 @@ TEST_F(StringTest, overlayVarbinary) {
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", 0, 4), "##rk SQL");
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, -1), "##park SQL");
   EXPECT_EQ(overlayVarbinary("Spark SQL", "##", -10, 4), "##rk SQL");
+}
+
+
+TEST_F(StringTest, left) {
+  EXPECT_EQ(left("example", -2), "");
+  EXPECT_EQ(left("example", 0), "");
+  EXPECT_EQ(left("example", 2), "ex");
+  EXPECT_EQ(left("example", 7), "example");
+  EXPECT_EQ(left("example", 20), "example");
+
+  EXPECT_EQ(left("da\u6570\u636Eta", 2), "da");
+  EXPECT_EQ(left("da\u6570\u636Eta", 3), "da\u6570");
+  EXPECT_EQ(left("da\u6570\u636Eta", 30), "da\u6570\u636Eta");
 }
 
 } // namespace


### PR DESCRIPTION
# Description
Spark support [left](https://spark.apache.org/docs/latest/api/sql/#left) since 2.3.0, let's add it to Velox.</br>
### For example:
```
> SELECT left('Spark SQL', 3);
 Spa
```
### left(string, length)
* Not supported in Presto.
* Returns the leftmost len characters from the string str.
* Return an empty string if len is less or equal than 0.