### PR TITLE
Add support for S3 FileSystem compatible schemes 'cos' and 'cosn'

### DIFF
--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -40,6 +40,9 @@ constexpr std::string_view kS3aScheme{"s3a://"};
 constexpr std::string_view kS3nScheme{"s3n://"};
 // OSS Alibaba support S3 format, usage only with SSL.
 constexpr std::string_view kOssScheme{"oss://"};
+// Tencent COS support S3 format.
+constexpr std::string_view kCosScheme{"cos://"};
+constexpr std::string_view kCosNScheme{"cosn://"};
 // From AWS documentation
 constexpr int kS3MaxKeySize{1024};
 } // namespace
@@ -60,10 +63,18 @@ inline bool isOssFile(const std::string_view filename) {
   return filename.substr(0, kOssScheme.size()) == kOssScheme;
 }
 
+inline bool isCosFile(const std::string_view filename) {
+  return filename.substr(0, kCosScheme.size()) == kCosScheme;
+}
+
+inline bool isCosNFile(const std::string_view filename) {
+  return filename.substr(0, kCosNScheme.size()) == kCosNScheme;
+}
+
 inline bool isS3File(const std::string_view filename) {
   // TODO: Each prefix should be implemented as its own filesystem.
   return isS3AwsFile(filename) || isS3aFile(filename) || isS3nFile(filename) ||
-      isOssFile(filename);
+      isOssFile(filename) || isCosFile(filename) || isCosNFile(filename);
 }
 
 inline void bucketAndKeyFromS3Path(
@@ -102,6 +113,10 @@ inline std::string s3Path(const std::string_view& path) {
     return std::string(path.substr(kS3nScheme.length()));
   } else if (isOssFile(path)) {
     return std::string(path.substr(kOssScheme.length()));
+  } else if (isCosFile(path)) {
+    return std::string(path.substr(kCosScheme.length()));
+  } else if (isCosNFile(path)) {
+    return std::string(path.substr(kCosNScheme.length()));
   }
   return std::string(path);
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -25,8 +25,11 @@ TEST(S3UtilTest, isS3File) {
   EXPECT_FALSE(isS3File("ss3://"));
   EXPECT_FALSE(isS3File("s3:/"));
   EXPECT_FALSE(isS3File("oss:"));
+  EXPECT_FALSE(isS3File("cos:"));
+  EXPECT_FALSE(isS3File("cosn:"));
   EXPECT_FALSE(isS3File("S3A://bucket/some/file.txt"));
   EXPECT_FALSE(isS3File("OSS://other-bucket/some/file.txt"));
+  EXPECT_FALSE(isS3File("COS://other-bucket/some/file.txt"));
   EXPECT_FALSE(isS3File("s3::/bucket"));
   EXPECT_FALSE(isS3File("s3:/bucket"));
   EXPECT_FALSE(isS3File("file://bucket"));
@@ -65,16 +68,37 @@ TEST(S3UtilTest, isOssFile) {
   EXPECT_TRUE(isOssFile("oss://bucket/file.txt"));
 }
 
+TEST(S3UtilTest, isCosFile) {
+  EXPECT_FALSE(isCosFile("cos:"));
+  EXPECT_FALSE(isCosFile("cos::/bucket"));
+  EXPECT_FALSE(isCosFile("cos:/bucket"));
+  EXPECT_FALSE(isCosFile("COS://BUCKET/sub-key/file.txt"));
+  EXPECT_TRUE(isCosFile("cos://bucket/file.txt"));
+}
+
+TEST(S3UtilTest, isCosNFile) {
+  EXPECT_FALSE(isCosNFile("cosn:"));
+  EXPECT_FALSE(isCosNFile("cosn::/bucket"));
+  EXPECT_FALSE(isCosNFile("cosn:/bucket"));
+  EXPECT_FALSE(isCosNFile("COSN://BUCKET/sub-key/file.txt"));
+  EXPECT_TRUE(isCosNFile("cosn://bucket/file.txt"));
+}
+
 // TODO: Each prefix should be implemented as its own filesystem.
 TEST(S3UtilTest, s3Path) {
   auto path_0 = s3Path("s3://bucket/file.txt");
   auto path_1 = s3Path("oss://bucket-name/file.txt");
   auto path_2 = s3Path("S3A://bucket-NAME/sub-PATH/my-file.txt");
   auto path_3 = s3Path("s3N://bucket-NAME/sub-PATH/my-file.txt");
+  auto path_4 = s3Path("cos://bucket-name/file.txt");
+  auto path_5 = s3Path("cosn://bucket-name/file.txt");
+
   EXPECT_EQ(path_0, "bucket/file.txt");
   EXPECT_EQ(path_1, "bucket-name/file.txt");
   EXPECT_NE(path_2, "bucket-NAME/sub-PATH/my-file.txt");
   EXPECT_NE(path_3, "bucket-NAME/sub-PATH/my-file.txt");
+  EXPECT_EQ(path_4, "bucket-name/file.txt");
+  EXPECT_EQ(path_5, "bucket-name/file.txt");
 }
 
 TEST(S3UtilTest, bucketAndKeyFromS3Path) {


### PR DESCRIPTION
## Description
[Tencent COS](https://intl.cloud.tencent.com/product/cos) is a famous object storage system provided by Tencent Corp. From [this document](https://www.tencentcloud.com/document/product/436/32537) COS offers AWS S3-compatible APIs, and we can use the APIs of S3 SDK to access files in COS. This pull request introduce acceptance of `cos://` and `cosn://` prefixes as supported and compatible `S3` implementations.

## Usage
With this pull request, We set the following parameters in the `hive.properties` file to access cos
```
hive.s3.endpoint=https://cos.ap-beijing.myqcloud.com
hive.s3.aws-access-key=xxxxx
hive.s3.aws-secret-key=xxxx
```



