### PR TITLE
Add log1p SparkSql function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -62,6 +62,11 @@ Mathematical Functions
 
     Returns the square root of `a` squared plus `b` squared.
 
+
+.. function:: log1p(x) -> double
+
+    Returns the natural logarithm of the “given value ``x`` plus one”.
+    Return NULL if x is less than or equal to -1.
 .. spark:function:: multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -218,4 +218,15 @@ struct HypotFunction {
     result = std::hypot(a, b);
   }
 };
+
+template <typename T>
+struct Log1pFunction {
+  FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
+    if (a <= -1) {
+      return false;
+    }
+    result = std::log1p(a);
+    return true;
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -38,6 +38,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<SecFunction, double, double>({prefix + "sec"});
   registerFunction<CscFunction, double, double>({prefix + "csc"});
   registerFunction<SinhFunction, double, double>({prefix + "sinh"});
+  registerFunction<Log1pFunction, double, double>({prefix + "log1p"});
   registerFunction<ToBinaryStringFunction, Varchar, int64_t>({prefix + "bin"});
   registerFunction<ExpFunction, double, double>({prefix + "exp"});
   registerBinaryIntegral<PModFunction>({prefix + "pmod"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -294,6 +294,19 @@ TEST_F(ArithmeticTest, sinh) {
   EXPECT_TRUE(std::isnan(sinh(kNan).value_or(0)));
 }
 
+TEST_F(ArithmeticTest, log1p) {
+  const double kE = std::exp(1);
+
+  static const auto log1p = [&](std::optional<double> a) {
+    return evaluateOnce<double>("log1p(c0)", a);
+  };
+
+  EXPECT_EQ(log1p(0), 0);
+  EXPECT_EQ(log1p(kE - 1), 1);
+  EXPECT_EQ(log1p(kInf), kInf);
+  EXPECT_TRUE(std::isnan(log1p(kNan).value_or(0)));
+}
+
 class BinTest : public SparkFunctionBaseTest {
  protected:
   std::optional<std::string> bin(std::optional<std::int64_t> arg) {


### PR DESCRIPTION
# Description
Spark support [log1p](https://spark.apache.org/docs/latest/api/sql/#log1p) since 1.4.0, let's add it to Velox.</br>
### For example:
```
> SELECT log1p(0);
 0.0
```
### log1p(double x)
* Not supported in Presto.
* Returns the natural logarithm of the “given value x plus one”. (log(1 + x))