### PR TITLE
Add hypot SparkSql function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -58,6 +58,10 @@ Mathematical Functions
     Returns ``x`` rounded down to the nearest integer.
     Supported types are: BIGINT and DOUBLE.
 
+.. spark:function:: hypot(a, b) -> double
+
+    Returns the square root of `a` squared plus `b` squared.
+
 .. spark:function:: multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -212,4 +212,10 @@ struct SinhFunction {
   }
 };
 
+template <typename T>
+struct HypotFunction {
+  FOLLY_ALWAYS_INLINE void call(double& result, double a, double b) {
+    result = std::hypot(a, b);
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -59,6 +59,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
       {prefix + "floor"});
   registerFunction<sparksql::FloorFunction, int64_t, double>(
       {prefix + "floor"});
+  registerFunction<HypotFunction, double, double, double>({prefix + "hypot"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -313,5 +313,17 @@ TEST_F(BinTest, bin) {
   EXPECT_EQ(bin(0), "0");
 }
 
+TEST_F(ArithmeticTest, hypot) {
+  const auto hypot = [&](std::optional<double> a, std::optional<double> b) {
+    return evaluateOnce<double>("hypot(c0, c1)", a, b);
+  };
+
+  EXPECT_EQ(hypot(3, 4), 5);
+  EXPECT_EQ(hypot(-3, -4), 5);
+  EXPECT_EQ(hypot(3.0, -4.0), 5.0);
+  EXPECT_DOUBLE_EQ(5.70087712549569, hypot(3.5, 4.5).value());
+  EXPECT_DOUBLE_EQ(5.70087712549569, hypot(3.5, -4.5).value());
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
# Description
Spark support [hypot](https://spark.apache.org/docs/latest/api/sql/#hypot) since 1.4.0, let's add it to Velox.</br>
### hypot(double a, double b)
* Not supported in Presto.
* Returns sqrt(a² + b²).
### For example:
```
> SELECT hypot(3, 4);
 5.0
```