### PR TITLE
Fix HSA::finishWrite API

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -242,7 +242,7 @@ class ByteStream {
     }
   }
 
-  StreamArena* arena_;
+  StreamArena* arena_{nullptr};
 
   // Indicates that position in ranges_ is in bits, not bytes.
   const bool isBits_;
@@ -256,7 +256,7 @@ class ByteStream {
   std::vector<ByteRange> ranges_;
 
   // Pointer to the current element of 'ranges_'.
-  ByteRange* current_ = nullptr;
+  ByteRange* current_{nullptr};
 
   // Number of bits/bytes that have been written in the last element
   // of 'ranges_'. In a write situation, all non-last ranges are full

--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -89,11 +89,10 @@ void HashStringAllocator::prepareRead(const Header* begin, ByteStream& stream) {
   auto header = const_cast<Header*>(begin);
   for (;;) {
     ranges.push_back(ByteRange{
-        reinterpret_cast<uint8_t*>(header->begin()), header->size(), 0});
+        reinterpret_cast<uint8_t*>(header->begin()), header->usableSize(), 0});
     if (!header->isContinued()) {
       break;
     }
-    ranges.back().size -= sizeof(void*);
     header = header->nextContinued();
   }
   stream.resetInput(std::move(ranges));
@@ -113,18 +112,19 @@ HashStringAllocator::Position HashStringAllocator::newWrite(
       currentHeader_->size(),
       0});
 
-  return Position{currentHeader_, currentHeader_->begin()};
+  startPosition_ = Position::atOffset(currentHeader_, 0);
+
+  return startPosition_;
 }
 
 void HashStringAllocator::extendWrite(Position position, ByteStream& stream) {
   auto header = position.header;
+  const auto offset = position.offset();
+  VELOX_CHECK_GE(
+      offset, 0, "Starting extendWrite outside of the current range");
   VELOX_CHECK_LE(
-      header->begin(),
-      position.position,
-      "Starting extendWrite outside of the current range");
-  VELOX_CHECK_LE(
-      position.position,
-      header->end(),
+      offset,
+      header->usableSize(),
       "Starting extendWrite outside of the current range");
 
   if (header->isContinued()) {
@@ -137,25 +137,24 @@ void HashStringAllocator::extendWrite(Position position, ByteStream& stream) {
       static_cast<int32_t>(header->end() - position.position),
       0});
   currentHeader_ = header;
+  startPosition_ = position;
 }
 
-HashStringAllocator::Position HashStringAllocator::finishWrite(
-    ByteStream& stream,
-    int32_t numReserveBytes) {
+std::pair<HashStringAllocator::Position, HashStringAllocator::Position>
+HashStringAllocator::finishWrite(ByteStream& stream, int32_t numReserveBytes) {
   VELOX_CHECK(
       currentHeader_, "Must call newWrite or extendWrite before finishWrite");
   auto writePosition = stream.writePosition();
+  const auto offset = writePosition - currentHeader_->begin();
 
+  VELOX_CHECK_GE(
+      offset, 0, "finishWrite called with writePosition out of range");
   VELOX_CHECK_LE(
-      currentHeader_->begin(),
-      writePosition,
-      "finishWrite called with writePosition out of range");
-  VELOX_CHECK_LE(
-      writePosition,
-      currentHeader_->end(),
+      offset,
+      currentHeader_->usableSize(),
       "finishWrite called with writePosition out of range");
 
-  Position currentPos{currentHeader_, writePosition};
+  Position currentPosition = Position::atOffset(currentHeader_, offset);
   if (currentHeader_->isContinued()) {
     free(currentHeader_->nextContinued());
     currentHeader_->clearContinued();
@@ -165,7 +164,20 @@ HashStringAllocator::Position HashStringAllocator::finishWrite(
       currentHeader_,
       writePosition - currentHeader_->begin() + numReserveBytes);
   currentHeader_ = nullptr;
-  return currentPos;
+
+  // The starting position may have shifted if it was at the end of the block
+  // and the block was extended. Calculate the new position.
+  if (startPosition_.header->isContinued()) {
+    auto header = startPosition_.header;
+    const auto offset = startPosition_.offset();
+    const auto extra = offset - header->usableSize();
+    if (extra > 0) {
+      auto newHeader = header->nextContinued();
+      auto newPosition = newHeader->begin() + extra;
+      startPosition_ = {newHeader, newPosition};
+    }
+  }
+  return {startPosition_, currentPosition};
 }
 
 void HashStringAllocator::newSlab(int32_t size) {
@@ -211,8 +223,8 @@ void HashStringAllocator::newRange(
       "Must have called newWrite or extendWrite before newRange");
   auto newHeader = allocate(bytes, contiguous);
 
-  auto lastWordPtr =
-      reinterpret_cast<void**>(currentHeader_->end() - sizeof(void*));
+  auto lastWordPtr = reinterpret_cast<void**>(
+      currentHeader_->end() - Header::kContinuedPtrSize);
   *reinterpret_cast<void**>(newHeader->begin()) = *lastWordPtr;
   *lastWordPtr = newHeader;
   currentHeader_->setContinued();
@@ -220,7 +232,7 @@ void HashStringAllocator::newRange(
   *range = ByteRange{
       reinterpret_cast<uint8_t*>(currentHeader_->begin()),
       currentHeader_->size(),
-      sizeof(void*)};
+      Header::kContinuedPtrSize};
 }
 
 void HashStringAllocator::newRange(int32_t bytes, ByteRange* range) {
@@ -431,42 +443,44 @@ void HashStringAllocator::free(Header* _header) {
   } while (header);
 }
 
-//  static
+// static
 int64_t HashStringAllocator::offset(
     Header* FOLLY_NONNULL header,
     Position position) {
+  static const int64_t kOutOfRange = -1;
+  if (!position.isSet()) {
+    return kOutOfRange;
+  }
+
   int64_t size = 0;
   for (;;) {
     assert(header);
-    bool continued = header->isContinued();
-    auto length = header->size() - (continued ? sizeof(void*) : 0);
-    auto begin = header->begin();
-    if (position.position >= begin && position.position <= begin + length) {
-      return size + (position.position - begin);
+    const auto length = header->usableSize();
+    const auto offset = position.position - header->begin();
+    if (offset >= 0 && offset <= length) {
+      return size + offset;
     }
-    if (!continued) {
-      return -1;
+    if (!header->isContinued()) {
+      return kOutOfRange;
     }
     size += length;
     header = header->nextContinued();
   }
 }
 
-//  static
+// static
 HashStringAllocator::Position HashStringAllocator::seek(
     Header* FOLLY_NONNULL header,
     int64_t offset) {
   int64_t size = 0;
   for (;;) {
     assert(header);
-    bool continued = header->isContinued();
-    auto length = header->size() - (continued ? sizeof(void*) : 0);
-    auto begin = header->begin();
+    auto length = header->usableSize();
     if (offset <= size + length) {
-      return Position{header, begin + (offset - size)};
+      return Position::atOffset(header, offset - size);
     }
-    if (!continued) {
-      return {nullptr, nullptr};
+    if (!header->isContinued()) {
+      return Position::null();
     }
     size += length;
     header = header->nextContinued();
@@ -476,19 +490,16 @@ HashStringAllocator::Position HashStringAllocator::seek(
 // static
 int64_t HashStringAllocator::available(const Position& position) {
   auto header = position.header;
-  auto startOffset = position.position - position.header->begin();
+  const auto startOffset = position.offset();
   // startOffset bytes from the first block are already used.
   int64_t size = -startOffset;
   for (;;) {
     assert(header);
-    auto continued = header->isContinued();
-    auto length = header->size() - (continued ? sizeof(void*) : 0);
-    size += length;
-    if (!continued) {
+    size += header->usableSize();
+    if (!header->isContinued()) {
       return size;
     }
     header = header->nextContinued();
-    startOffset = 0;
   }
 }
 
@@ -496,8 +507,8 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
   if (available(position) >= bytes) {
     return;
   }
+
   ByteStream stream(this);
-  auto fromHeader = offset(position.header, position);
   extendWrite(position, stream);
   static char data[128];
   while (bytes) {
@@ -505,8 +516,7 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
     stream.append(folly::StringPiece(data, written));
     bytes -= written;
   }
-  finishWrite(stream, 0);
-  position = seek(position.header, fromHeader);
+  position = finishWrite(stream, 0).first;
 }
 
 void HashStringAllocator::checkConsistency() const {

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -110,6 +110,10 @@ class HashStringAllocator : public StreamArena {
       return data_ & kSizeMask;
     }
 
+    int32_t usableSize() const {
+      return isContinued() ? (size() - kContinuedPtrSize) : size();
+    }
+
     void setSize(int32_t size) {
       VELOX_CHECK(size <= kSizeMask);
       data_ = size | (data_ & ~kSizeMask);
@@ -145,6 +149,27 @@ class HashStringAllocator : public StreamArena {
   struct Position {
     Header* FOLLY_NULLABLE header{nullptr};
     char* FOLLY_NULLABLE position{nullptr};
+
+    int32_t offset() const {
+      VELOX_DCHECK_NOT_NULL(header);
+      VELOX_DCHECK_NOT_NULL(position);
+      return position - header->begin();
+    }
+
+    bool isSet() const {
+      return header != nullptr && position != nullptr;
+    }
+
+    static Position atOffset(Header* header, int32_t offset) {
+      VELOX_DCHECK_NOT_NULL(header);
+      VELOX_DCHECK_GE(offset, 0);
+      VELOX_DCHECK_LE(offset, header->usableSize());
+      return {header, header->begin() + offset};
+    }
+
+    static Position null() {
+      return {nullptr, nullptr};
+    }
   };
 
   explicit HashStringAllocator(memory::MemoryPool* FOLLY_NONNULL pool)
@@ -256,9 +281,12 @@ class HashStringAllocator : public StreamArena {
 
   // Completes a write prepared with newWrite or
   // extendWrite. Up to 'numReserveBytes' unused bytes, if available, are left
-  // after the end of the write to accommodate another write. Returns the
-  // position immediately after the last written byte.
-  Position finishWrite(ByteStream& stream, int32_t numReserveBytes);
+  // after the end of the write to accommodate another write. Returns a pair of
+  // positions: (1) position at the start of this 'write', (2) position
+  // immediately after the last written byte.
+  std::pair<Position, Position> finishWrite(
+      ByteStream& stream,
+      int32_t numReserveBytes);
 
   /// Allocates a new range for a stream writing to 'this'. Sets the last word
   /// of the previous range to point to the new range and copies the overwritten
@@ -401,6 +429,7 @@ class HashStringAllocator : public StreamArena {
 
   // Pointer to Header for the range being written. nullptr if a write is not in
   // progress.
+  Position startPosition_;
   Header* FOLLY_NULLABLE currentHeader_ = nullptr;
 
   // Pool for getting new slabs.

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 #include <folly/Random.h>
 
@@ -21,11 +22,14 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-using namespace facebook::velox;
+namespace facebook::velox {
+namespace {
+
+using HSA = HashStringAllocator;
 
 struct Multipart {
-  HashStringAllocator::Position start{nullptr, nullptr};
-  HashStringAllocator::Position current{nullptr, nullptr};
+  HSA::Position start;
+  HSA::Position current;
   uint64_t size = 0;
   std::string reference;
 };
@@ -34,18 +38,18 @@ class HashStringAllocatorTest : public testing::Test {
  protected:
   void SetUp() override {
     pool_ = memory::addDefaultLeafMemoryPool();
-    instance_ = std::make_unique<HashStringAllocator>(pool_.get());
+    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }
 
-  HashStringAllocator::Header* allocate(int32_t numBytes) {
-    auto result = instance_->allocate(numBytes);
+  HSA::Header* allocate(int32_t numBytes) {
+    auto result = allocator_->allocate(numBytes);
     EXPECT_GE(result->size(), numBytes);
     initializeContents(result);
     return result;
   }
 
-  void initializeContents(HashStringAllocator::Header* header) {
+  void initializeContents(HSA::Header* header) {
     auto sequence = ++sequence_;
     int32_t numWords = header->size() / sizeof(void*);
     void** ptr = reinterpret_cast<void**>(header->begin());
@@ -55,9 +59,9 @@ class HashStringAllocatorTest : public testing::Test {
     }
   }
 
-  void checkMultipart(Multipart& data) {
+  static void checkMultipart(const Multipart& data) {
     std::string storage;
-    auto contiguous = HashStringAllocator::contiguousString(
+    auto contiguous = HSA::contiguousString(
         StringView(data.start.position, data.reference.size()), storage);
     EXPECT_EQ(StringView(data.reference), contiguous);
   }
@@ -65,48 +69,49 @@ class HashStringAllocatorTest : public testing::Test {
   void checkAndFree(Multipart& data) {
     checkMultipart(data);
     data.reference.clear();
-    instance_->free(data.start.header);
-    data.start = {nullptr, nullptr};
+    allocator_->free(data.start.header);
+    data.start = HSA::Position::null();
+  }
+
+  uint32_t rand32() {
+    return folly::Random::rand32(rng_);
   }
 
   std::string randomString() {
     std::string result;
     result.resize(
-        20 +
-        (folly::Random::rand32(rng_) % 10 > 8
-             ? folly::Random::rand32(rng_) % 200
-             : 1000 + folly::Random::rand32(rng_) % 1000));
+        20 + (rand32() % 10 > 8 ? rand32() % 200 : 1000 + rand32() % 1000));
     for (auto i = 0; i < result.size(); ++i) {
-      result[i] = 32 + (folly::Random::rand32(rng_) % 96);
+      result[i] = 32 + (rand32() % 96);
     }
     return result;
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
-  std::unique_ptr<HashStringAllocator> instance_;
+  std::unique_ptr<HashStringAllocator> allocator_;
   int32_t sequence_ = 0;
   folly::Random::DefaultGenerator rng_;
 };
 
 TEST_F(HashStringAllocatorTest, allocate) {
   for (auto count = 0; count < 3; ++count) {
-    std::vector<HashStringAllocator::Header*> headers;
+    std::vector<HSA::Header*> headers;
     for (auto i = 0; i < 10'000; ++i) {
       headers.push_back(allocate((i % 10) * 10));
     }
-    instance_->checkConsistency();
+    allocator_->checkConsistency();
     for (int32_t step = 7; step >= 1; --step) {
       for (auto i = 0; i < headers.size(); i += step) {
         if (headers[i]) {
-          instance_->free(headers[i]);
+          allocator_->free(headers[i]);
           headers[i] = nullptr;
         }
       }
-      instance_->checkConsistency();
+      allocator_->checkConsistency();
     }
   }
   // We allow for some free overhead for free lists after all is freed.
-  EXPECT_LE(instance_->retainedSize() - instance_->freeSpace(), 200);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 200);
 }
 
 TEST_F(HashStringAllocatorTest, allocateLarge) {
@@ -115,8 +120,62 @@ TEST_F(HashStringAllocatorTest, allocateLarge) {
   auto size =
       memory::AllocationTraits::pageBytes(pool_->largestSizeClass() + 1);
   auto header = allocate(size);
-  instance_->free(header);
-  EXPECT_EQ(0, instance_->retainedSize());
+  allocator_->free(header);
+  EXPECT_EQ(0, allocator_->retainedSize());
+}
+
+TEST_F(HashStringAllocatorTest, finishWrite) {
+  ByteStream stream(allocator_.get());
+  auto start = allocator_->newWrite(stream);
+
+  // Write a short string.
+  stream.appendStringPiece(folly::StringPiece("abc"));
+  auto [firstStart, firstFinish] = allocator_->finishWrite(stream, 0);
+
+  ASSERT_EQ(start.header, firstStart.header);
+  ASSERT_EQ(HSA::offset(firstStart.header, firstFinish), 3);
+
+  // Replace short string with a long string that uses two bytes short of
+  // available space.
+  allocator_->extendWrite(start, stream);
+  auto longString = std::string(start.header->size() - 2, 'x');
+  stream.appendStringPiece(folly::StringPiece(longString));
+  auto [longStart, longFinish] = allocator_->finishWrite(stream, 0);
+
+  ASSERT_EQ(start.header, longStart.header);
+  ASSERT_EQ(HSA::offset(longStart.header, longFinish), longString.size());
+
+  // Append another string after the long string.
+  allocator_->extendWrite(longFinish, stream);
+  stream.appendStringPiece(folly::StringPiece("abc"));
+  auto [appendStart, appendFinish] = allocator_->finishWrite(stream, 0);
+
+  ASSERT_NE(appendStart.header, longFinish.header);
+  ASSERT_EQ(HSA::offset(longStart.header, appendStart), longString.size());
+  ASSERT_EQ(
+      HSA::offset(appendStart.header, appendFinish), appendStart.offset() + 3);
+
+  // Replace last string.
+  allocator_->extendWrite(appendStart, stream);
+  stream.appendStringPiece(folly::StringPiece("abcd"));
+  auto [replaceStart, replaceFinish] = allocator_->finishWrite(stream, 0);
+
+  ASSERT_EQ(appendStart.header, replaceStart.header);
+  ASSERT_EQ(
+      HSA::offset(replaceStart.header, replaceFinish),
+      replaceStart.offset() + 4);
+
+  // Read back long and short strings.
+  HSA::prepareRead(longStart.header, stream);
+
+  std::string copy;
+  copy.resize(longString.size());
+  stream.readBytes(copy.data(), copy.size());
+  ASSERT_EQ(copy, longString);
+
+  copy.resize(4);
+  stream.readBytes(copy.data(), 4);
+  ASSERT_EQ(copy, "abcd");
 }
 
 TEST_F(HashStringAllocatorTest, multipart) {
@@ -124,96 +183,94 @@ TEST_F(HashStringAllocatorTest, multipart) {
   std::vector<Multipart> data(kNumSamples);
   for (auto count = 0; count < 3; ++count) {
     for (auto i = 0; i < kNumSamples; ++i) {
-      if (data[i].start.header && folly::Random::rand32(rng_) % 10 > 7) {
+      if (data[i].start.header && rand32() % 10 > 7) {
         checkAndFree(data[i]);
         continue;
       }
       auto chars = randomString();
-      ByteStream stream(instance_.get(), false, false);
+      ByteStream stream(allocator_.get());
       if (data[i].start.header) {
-        if (folly::Random::rand32(rng_) % 5) {
+        if (rand32() % 5) {
           // 4/5 of cases append to the end.
-          instance_->extendWrite(data[i].current, stream);
+          allocator_->extendWrite(data[i].current, stream);
         } else {
           // 1/5 of cases rewrite from the start.
-          instance_->extendWrite(data[i].start, stream);
+          allocator_->extendWrite(data[i].start, stream);
           data[i].current = data[i].start;
           data[i].reference.clear();
         }
       } else {
-        data[i].start = instance_->newWrite(stream, chars.size());
+        data[i].start = allocator_->newWrite(stream, chars.size());
         data[i].current = data[i].start;
         EXPECT_EQ(
-            data[i].start.header,
-            HashStringAllocator::headerOf(stream.ranges()[0].buffer));
+            data[i].start.header, HSA::headerOf(stream.ranges()[0].buffer));
       }
       stream.appendStringPiece(folly::StringPiece(chars.data(), chars.size()));
-      auto reserve = folly::Random::rand32(rng_) % 100;
-      data[i].current = instance_->finishWrite(stream, reserve);
+      auto reserve = rand32() % 100;
+      data[i].current = allocator_->finishWrite(stream, reserve).second;
       data[i].reference.insert(
           data[i].reference.end(), chars.begin(), chars.end());
     }
-    instance_->checkConsistency();
+    allocator_->checkConsistency();
   }
-  for (auto i = 0; i < data.size(); ++i) {
-    if (data[i].start.header) {
-      checkMultipart(data[i]);
+  for (const auto& d : data) {
+    if (d.start.isSet()) {
+      checkMultipart(d);
     }
   }
-  for (auto i = 0; i < data.size(); ++i) {
-    if (data[i].start.header) {
-      checkAndFree(data[i]);
-      instance_->checkConsistency();
+  for (auto& d : data) {
+    if (d.start.isSet()) {
+      checkAndFree(d);
+      allocator_->checkConsistency();
     }
   }
-  instance_->checkConsistency();
+  allocator_->checkConsistency();
 }
 
 TEST_F(HashStringAllocatorTest, rewrite) {
-  ByteStream stream(instance_.get());
-  auto header = instance_->allocate(5);
+  ByteStream stream(allocator_.get());
+  auto header = allocator_->allocate(5);
   EXPECT_EQ(16, header->size()); // Rounds up to kMinAlloc.
-  HashStringAllocator::Position current{header, header->begin()};
+  HSA::Position current = HSA::Position::atOffset(header, 0);
   for (auto i = 0; i < 10; ++i) {
-    instance_->extendWrite(current, stream);
+    allocator_->extendWrite(current, stream);
     stream.appendOne(123456789012345LL);
-    current = instance_->finishWrite(stream, 0);
-    auto offset = HashStringAllocator::offset(header, current);
+    current = allocator_->finishWrite(stream, 0).second;
+    auto offset = HSA::offset(header, current);
     EXPECT_EQ((i + 1) * sizeof(int64_t), offset);
     // The allocated writable space from 'header' is at least the amount
     // written.
-    auto avail = HashStringAllocator::available({header, header->begin()});
-    EXPECT_LE((i + 1) * sizeof(int64_t), avail);
+    auto available = HSA::available(HSA::Position::atOffset(header, 0));
+    EXPECT_LE((i + 1) * sizeof(int64_t), available);
   }
-  EXPECT_EQ(-1, HashStringAllocator::offset(header, {nullptr, nullptr}));
+  EXPECT_EQ(-1, HSA::offset(header, HSA::Position::null()));
   for (auto repeat = 0; repeat < 2; ++repeat) {
-    auto position = HashStringAllocator::seek(header, sizeof(int64_t));
+    auto position = HSA::seek(header, sizeof(int64_t));
     // We write the words at index 1 and 2.
-    instance_->extendWrite(position, stream);
+    allocator_->extendWrite(position, stream);
     stream.appendOne(12345LL);
     stream.appendOne(67890LL);
-    position = instance_->finishWrite(stream, 0);
-    EXPECT_EQ(
-        3 * sizeof(int64_t), HashStringAllocator::offset(header, position));
-    HashStringAllocator::prepareRead(header, stream);
+    position = allocator_->finishWrite(stream, 0).second;
+    EXPECT_EQ(3 * sizeof(int64_t), HSA::offset(header, position));
+    HSA::prepareRead(header, stream);
     EXPECT_EQ(123456789012345LL, stream.read<int64_t>());
     EXPECT_EQ(12345LL, stream.read<int64_t>());
     EXPECT_EQ(67890LL, stream.read<int64_t>());
   }
   // The stream contains 3 int64_t's.
-  auto end = HashStringAllocator::seek(header, 3 * sizeof(int64_t));
-  EXPECT_EQ(0, HashStringAllocator::available(end));
-  instance_->ensureAvailable(32, end);
-  EXPECT_EQ(32, HashStringAllocator::available(end));
+  auto end = HSA::seek(header, 3 * sizeof(int64_t));
+  EXPECT_EQ(0, HSA::available(end));
+  allocator_->ensureAvailable(32, end);
+  EXPECT_EQ(32, HSA::available(end));
 }
 
 TEST_F(HashStringAllocatorTest, stlAllocator) {
   {
     std::vector<double, StlAllocator<double>> data(
-        StlAllocator<double>(instance_.get()));
+        StlAllocator<double>(allocator_.get()));
     uint32_t counter{0};
     {
-      RowSizeTracker trackSize(counter, *instance_);
+      RowSizeTracker trackSize(counter, *allocator_);
 
       // The contiguous size goes to 80K, rounded to 128K by
       // std::vector. This covers making an extra-large slab in the
@@ -248,10 +305,10 @@ TEST_F(HashStringAllocatorTest, stlAllocator) {
     }
   }
 
-  instance_->checkConsistency();
+  allocator_->checkConsistency();
 
   // We allow for some overhead for free lists after all is freed.
-  EXPECT_LE(instance_->retainedSize() - instance_->freeSpace(), 100);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 100);
 }
 
 TEST_F(HashStringAllocatorTest, stlAllocatorWithSet) {
@@ -261,7 +318,7 @@ TEST_F(HashStringAllocatorTest, stlAllocatorWithSet) {
         std::hash<double>,
         std::equal_to<double>,
         StlAllocator<double>>
-        set(StlAllocator<double>(instance_.get()));
+        set(StlAllocator<double>(allocator_.get()));
 
     for (auto i = 0; i < 10'000; i++) {
       set.insert(i);
@@ -283,10 +340,10 @@ TEST_F(HashStringAllocatorTest, stlAllocatorWithSet) {
     }
   }
 
-  instance_->checkConsistency();
+  allocator_->checkConsistency();
 
   // We allow for some overhead for free lists after all is freed.
-  EXPECT_LE(instance_->retainedSize() - instance_->freeSpace(), 100);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 100);
 }
 
 TEST_F(HashStringAllocatorTest, alignedStlAllocatorWithF14Map) {
@@ -298,7 +355,7 @@ TEST_F(HashStringAllocatorTest, alignedStlAllocatorWithF14Map) {
         std::equal_to<int32_t>,
         AlignedStlAllocator<std::pair<const int32_t, double>, 16>>
         map(AlignedStlAllocator<std::pair<const int32_t, double>, 16>(
-            instance_.get()));
+            allocator_.get()));
 
     for (auto i = 0; i < 10'000; i++) {
       map.try_emplace(i, i + 0.05);
@@ -320,16 +377,19 @@ TEST_F(HashStringAllocatorTest, alignedStlAllocatorWithF14Map) {
     }
   }
 
-  instance_->checkConsistency();
+  allocator_->checkConsistency();
 
   // We allow for some overhead for free lists after all is freed. Map tends to
   // generate more free blocks at the end, so we loosen the upper bound a bit.
-  EXPECT_LE(instance_->retainedSize() - instance_->freeSpace(), 130);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 130);
 }
 
 TEST_F(HashStringAllocatorTest, stlAllocatorOverflow) {
-  StlAllocator<int64_t> alloc(instance_.get());
-  EXPECT_THROW(alloc.allocate(1ULL << 62), VeloxException);
-  AlignedStlAllocator<int64_t, 16> alignedAlloc(instance_.get());
-  EXPECT_THROW(alignedAlloc.allocate(1ULL << 62), VeloxException);
+  StlAllocator<int64_t> alloc(allocator_.get());
+  VELOX_ASSERT_THROW(alloc.allocate(1ULL << 62), "integer overflow");
+  AlignedStlAllocator<int64_t, 16> alignedAlloc(allocator_.get());
+  VELOX_ASSERT_THROW(alignedAlloc.allocate(1ULL << 62), "integer overflow");
 }
+
+} // namespace
+} // namespace facebook::velox

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -36,7 +36,7 @@ struct RowPointers {
     }
 
     stream.appendOne(reinterpret_cast<uintptr_t>(row));
-    currentBlock = allocator.finishWrite(stream, 1024);
+    currentBlock = allocator.finishWrite(stream, 1024).second;
 
     ++size;
   }

--- a/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
+++ b/velox/functions/prestosql/aggregates/AddressableNonNullValueList.cpp
@@ -37,8 +37,6 @@ HashStringAllocator::Position AddressableNonNullValueList::append(
     allocator->extendWrite(currentPosition_, stream);
   }
 
-  const auto position = currentPosition_;
-
   // Write hash.
   stream.appendOne(decoded.base()->hashValueAt(decoded.index(index)));
   // Write value.
@@ -47,8 +45,9 @@ HashStringAllocator::Position AddressableNonNullValueList::append(
 
   ++size_;
 
-  currentPosition_ = allocator->finishWrite(stream, 1024);
-  return position;
+  auto startAndFinish = allocator->finishWrite(stream, 1024);
+  currentPosition_ = startAndFinish.second;
+  return startAndFinish.first;
 }
 
 namespace {

--- a/velox/functions/prestosql/aggregates/Strings.cpp
+++ b/velox/functions/prestosql/aggregates/Strings.cpp
@@ -52,7 +52,7 @@ StringView Strings::append(StringView value, HashStringAllocator& allocator) {
   // Copy the string and return a StringView over the copy.
   char* start = stream.writePosition();
   stream.appendStringPiece(folly::StringPiece(value.data(), value.size()));
-  currentBlock = allocator.finishWrite(stream, maxStringSize * 4);
+  currentBlock = allocator.finishWrite(stream, maxStringSize * 4).second;
   return StringView(start, value.size());
 }
 

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -47,7 +47,7 @@ void ValueList::writeLastNulls(HashStringAllocator* allocator) {
     nullsBegin_ = position.header;
   }
   stream.appendOne(lastNulls_);
-  nullsCurrent_ = allocator->finishWrite(stream, kInitialSize);
+  nullsCurrent_ = allocator->finishWrite(stream, kInitialSize).second;
 }
 
 void ValueList::appendNull(HashStringAllocator* allocator) {
@@ -66,7 +66,7 @@ void ValueList::appendNonNull(
   exec::ContainerRowSerde::instance().serialize(values, index, stream);
   ++size_;
 
-  dataCurrent_ = allocator->finishWrite(stream, 1024);
+  dataCurrent_ = allocator->finishWrite(stream, 1024).second;
 }
 
 void ValueList::appendValue(


### PR DESCRIPTION
Start position specified in a call to HSA::extendWrite may shift if it points
somewhere in the last 8 bytes of the block and that block gets extended during
the write. When this happens, the original 'start position' ends up pointing
somewhere inside the data written earlier. Using this position to call
extendWrite again ends up corrupting previous entry.

This happens in set_agg aggregation function that uses
AddressableNonNullValueList to accumulate a list of unique values. I this case,
values are appended one by one and occasionally last entry is replaced. If last
entry happened to start a the very end of the block, replacing that entry
corrupts the previous entry.

Also, refactor HSA and HSATest for readability.  

Fixes #5513