### PR TITLE
Use Hugepages to back AllocationPool/HashStringAllocator

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -623,13 +623,23 @@ bool AsyncDataCache::allocateNonContiguous(
 }
 
 bool AsyncDataCache::allocateContiguous(
-    MachinePageCount numPages,
+    memory::MachinePageCount numPages,
     memory::Allocation* collateral,
     memory::ContiguousAllocation& allocation,
-    ReservationCallback reservationCB) {
+    ReservationCallback reservationCB,
+    memory::MachinePageCount maxPages) {
   return makeSpace(numPages, [&]() {
     return allocator_->allocateContiguous(
-        numPages, collateral, allocation, reservationCB);
+        numPages, collateral, allocation, reservationCB, maxPages);
+  });
+}
+
+bool AsyncDataCache::growContiguous(
+    MachinePageCount increment,
+    memory::ContiguousAllocation& allocation,
+    ReservationCallback reservationCB) {
+  return makeSpace(increment, [&]() {
+    return allocator_->growContiguous(increment, allocation, reservationCB);
   });
 }
 

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -663,11 +663,17 @@ class AsyncDataCache : public memory::MemoryAllocator {
       memory::MachinePageCount numPages,
       memory::Allocation* FOLLY_NULLABLE collateral,
       memory::ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) override;
+      ReservationCallback reservationCB = nullptr,
+      memory::MachinePageCount maxPages = 0) override;
 
   void freeContiguous(memory::ContiguousAllocation& allocation) override {
     allocator_->freeContiguous(allocation);
   }
+
+  bool growContiguous(
+      memory::MachinePageCount increment,
+      memory::ContiguousAllocation& allocation,
+      ReservationCallback reservationCB = nullptr) override;
 
   void* allocateBytes(uint64_t bytes, uint16_t alignment) override;
 

--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -21,38 +21,47 @@
 
 namespace facebook::velox {
 
+folly::Range<char*> AllocationPool::rangeAt(int32_t index) const {
+  if (index < allocations_.size()) {
+    auto run = allocations_[index].runAt(0);
+    return folly::Range<char*>(
+        run.data<char>(),
+        run.data<char>() == startOfRun_ ? currentOffset_ : run.numBytes());
+  }
+  const auto largeIndex = index - allocations_.size();
+  if (largeIndex < largeAllocations_.size()) {
+    auto range = largeAllocations_[largeIndex].hugePageRange().value();
+    if (range.data() == startOfRun_) {
+      return folly::Range<char*>(range.data(), currentOffset_);
+    }
+    return range;
+  }
+  VELOX_FAIL("Out of range index for rangeAt(): {}", index);
+}
+
 void AllocationPool::clear() {
-  // Trigger Allocation's destructor to free allocated memory
-  auto copy = std::move(allocation_);
   allocations_.clear();
-  auto copyLarge = std::move(largeAllocations_);
   largeAllocations_.clear();
+  startOfRun_ = nullptr;
+  bytesInRun_ = 0;
+  currentOffset_ = 0;
+  usedBytes_ = 0;
 }
 
 char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
   VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
   if (availableInRun() >= bytes && alignment == 1) {
-    auto* result = currentRun().data<char>() + currentOffset_;
+    auto* result = startOfRun_ + currentOffset_;
     currentOffset_ += bytes;
+    if (currentOffset_ > endOfReservedRun()) {
+      growLastAllocation();
+    }
     return result;
   }
   VELOX_CHECK_EQ(
       __builtin_popcount(alignment), 1, "Alignment can only be power of 2");
 
   auto numPages = memory::AllocationTraits::numPages(bytes + alignment - 1);
-
-  // Use contiguous allocations from mapped memory if allocation size is large
-  if (numPages > pool_->largestSizeClass()) {
-    auto largeAlloc = std::make_unique<memory::ContiguousAllocation>();
-    pool_->allocateContiguous(numPages, *largeAlloc);
-    largeAllocations_.emplace_back(std::move(largeAlloc));
-    auto result = largeAllocations_.back()->data<char>();
-    VELOX_CHECK_NOT_NULL(
-        result, "Unexpected nullptr for large contiguous allocation");
-    // Should be at page boundary and always aligned.
-    VELOX_CHECK_EQ(reinterpret_cast<uintptr_t>(result) % alignment, 0);
-    return result;
-  }
 
   if (availableInRun() == 0) {
     newRunImpl(numPages);
@@ -63,31 +72,68 @@ char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
       newRunImpl(numPages);
     }
   }
-  auto run = currentRun();
   currentOffset_ += memory::alignmentPadding(firstFreeInRun(), alignment);
-  uint64_t size = run.numBytes();
-  VELOX_CHECK_LE(bytes + currentOffset_, size);
-  auto* result = run.data<char>() + currentOffset_;
+  VELOX_CHECK_LE(bytes + currentOffset_, bytesInRun_);
+  auto* result = startOfRun_ + currentOffset_;
   VELOX_CHECK_EQ(reinterpret_cast<uintptr_t>(result) % alignment, 0);
   currentOffset_ += bytes;
+  if (currentOffset_ > endOfReservedRun()) {
+    growLastAllocation();
+  }
   return result;
 }
 
-void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
-  ++currentRun_;
-  if (currentRun_ >= allocation_.numRuns()) {
-    if (allocation_.numRuns() > 0) {
-      allocations_.push_back(
-          std::make_unique<memory::Allocation>(std::move(allocation_)));
-    }
-    pool_->allocateNonContiguous(
-        std::max<int32_t>(kMinPages, numPages), allocation_, numPages);
-    currentRun_ = 0;
-  }
-  currentOffset_ = 0;
+void AllocationPool::growLastAllocation() {
+  VELOX_CHECK_GT(bytesInRun_, kHugePageSize);
+  auto bytesToReserve =
+      bits::roundUp(currentOffset_ - endOfReservedRun(), kHugePageSize);
+  largeAllocations_.back().grow(bytesToReserve / kPageSize);
+  usedBytes_ += bytesToReserve;
 }
 
-void AllocationPool::newRun(int32_t preferredSize) {
+void AllocationPool::newRunImpl(memory::MachinePageCount numPages) {
+  if (usedBytes_ >= hugePageThreshold_ ||
+      numPages > pool_->sizeClasses().back()) {
+    // At least 16 huge pages, no more than kMaxMmapBytes. The next is
+    // double the previous. Because the previous is a hair under the
+    // power of two because of fractional pages at ends of allocation,
+    // add an extra huge page size.
+    int64_t nextSize = std::min(
+        kMaxMmapBytes,
+        std::max<int64_t>(
+            16 * kHugePageSize,
+            bits::nextPowerOfTwo(usedBytes_ + kHugePageSize)));
+    // Round 'numPages' to no of pages in huge page. Allocating this plus an
+    // extra huge page guarantees that 'numPages' worth of contiguous aligned
+    // huge pages will be founfd in the allocation.
+    numPages = bits::roundUp(numPages, kHugePageSize / kPageSize);
+    if (numPages * kPageSize + kHugePageSize > nextSize) {
+      // Extra large single request.
+      nextSize = numPages * kPageSize + kHugePageSize;
+    }
+    memory::ContiguousAllocation largeAlloc;
+    pool_->allocateContiguous(
+        kHugePageSize / kPageSize, largeAlloc, nextSize / kPageSize);
+    auto range = largeAlloc.hugePageRange().value();
+    startOfRun_ = range.data();
+    bytesInRun_ = range.size();
+    largeAllocations_.emplace_back(std::move(largeAlloc));
+    currentOffset_ = 0;
+    usedBytes_ += kHugePageSize;
+    return;
+  }
+  memory::Allocation allocation;
+  auto roundedPages = std::max<int32_t>(kMinPages, numPages);
+  pool_->allocateNonContiguous(roundedPages, allocation, roundedPages);
+  VELOX_CHECK_EQ(allocation.numRuns(), 1);
+  startOfRun_ = allocation.runAt(0).data<char>();
+  bytesInRun_ = allocation.runAt(0).numBytes();
+  currentOffset_ = 0;
+  allocations_.push_back(std::move(allocation));
+  usedBytes_ += bytesInRun_;
+}
+
+void AllocationPool::newRun(int64_t preferredSize) {
   newRunImpl(memory::AllocationTraits::numPages(preferredSize));
 }
 

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -113,7 +113,13 @@ bool MallocAllocator::allocateContiguousImpl(
     MachinePageCount numPages,
     Allocation* collateral,
     ContiguousAllocation& allocation,
-    ReservationCallback reservationCB) {
+    ReservationCallback reservationCB,
+    MachinePageCount maxPages) {
+  if (maxPages == 0) {
+    maxPages = numPages;
+  } else {
+    VELOX_CHECK_LE(numPages, maxPages);
+  }
   MachinePageCount numCollateralPages = 0;
   if (collateral != nullptr) {
     numCollateralPages =
@@ -166,13 +172,16 @@ bool MallocAllocator::allocateContiguousImpl(
   numMapped_.fetch_add(numPages);
   void* data = ::mmap(
       nullptr,
-      AllocationTraits::pageBytes(numPages),
+      AllocationTraits::pageBytes(maxPages),
       PROT_READ | PROT_WRITE,
       MAP_PRIVATE | MAP_ANONYMOUS,
       -1,
       0);
   // TODO: add handling of MAP_FAILED.
-  allocation.set(data, AllocationTraits::pageBytes(numPages));
+  allocation.set(
+      data,
+      AllocationTraits::pageBytes(numPages),
+      AllocationTraits::pageBytes(maxPages));
   useHugePages(allocation, true);
   return true;
 }
@@ -222,6 +231,32 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   numAllocated_.fetch_sub(numPages);
   decrementUsage(bytes);
   allocation.clear();
+}
+
+bool MallocAllocator::growContiguous(
+    MachinePageCount increment,
+    ContiguousAllocation& allocation,
+    ReservationCallback reservationCB) {
+  VELOX_CHECK_LE(
+      allocation.size() + increment * AllocationTraits::kPageSize,
+      allocation.maxSize());
+  if (reservationCB != nullptr) {
+    // May throw. If does, there is nothing to revert.
+    reservationCB(AllocationTraits::pageBytes(increment), true);
+  }
+  if (!incrementUsage(AllocationTraits::pageBytes(increment))) {
+    if (reservationCB != nullptr) {
+      reservationCB(AllocationTraits::pageBytes(increment), false);
+    }
+    return false;
+  }
+  numAllocated_ += increment;
+  numMapped_ += increment;
+  allocation.set(
+      allocation.data(),
+      allocation.size() + AllocationTraits::kPageSize * increment,
+      allocation.maxSize());
+  return true;
 }
 
 void* MallocAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {

--- a/velox/common/memory/MallocAllocator.h
+++ b/velox/common/memory/MallocAllocator.h
@@ -57,11 +57,12 @@ class MallocAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) override {
+      ReservationCallback reservationCB = nullptr,
+      MachinePageCount maxPages = 0) override {
     bool result;
     stats_.recordAllocate(AllocationTraits::pageBytes(numPages), 1, [&]() {
       result = allocateContiguousImpl(
-          numPages, collateral, allocation, reservationCB);
+          numPages, collateral, allocation, reservationCB, maxPages);
     });
     return result;
   }
@@ -70,6 +71,11 @@ class MallocAllocator : public MemoryAllocator {
     stats_.recordFree(
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
+
+  bool growContiguous(
+      MachinePageCount increment,
+      ContiguousAllocation& allocation,
+      ReservationCallback reservationCB = nullptr) override;
 
   void* allocateBytes(uint64_t bytes, uint16_t alignment) override;
 
@@ -102,7 +108,8 @@ class MallocAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* FOLLY_NULLABLE collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB);
+      ReservationCallback reservationCB,
+      MachinePageCount maxPages);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -227,29 +227,46 @@ class MemoryAllocator : public std::enable_shared_from_this<MemoryAllocator> {
   /// function returns the actual freed bytes.
   virtual int64_t freeNonContiguous(Allocation& allocation) = 0;
 
-  /// Makes a contiguous mmap of 'numPages'. Advises away the required number of
-  /// free pages so as not to have resident size exceed the capacity if capacity
-  /// is bounded. Returns false if sufficient free pages do not exist.
-  /// 'collateral' and 'allocation' are freed and unmapped or advised away to
-  /// provide pages to back the new 'allocation'. This will always succeed if
-  /// collateral and allocation together cover the new size of allocation.
-  /// 'allocation' is newly mapped and hence zeroed. The contents of
-  /// 'allocation' and 'collateral' are freed in all cases, also if the
-  /// allocation fails. 'reservationCB' is used in the same way as allocate
-  /// does. It may throw and the end state will be consistent, with no new
-  /// allocation and 'allocation' and 'collateral' cleared.
+  /// Makes a contiguous mmap of 'numPages' or 'maxPages'. 'maxPages' defaults
+  /// to 'numPages'.  Advises away the required number of free pages so as not
+  /// to have resident size exceed the capacity if capacity is bounded. Returns
+  /// false if sufficient free pages do not exist. 'collateral' and 'allocation'
+  /// are freed and unmapped or advised away to provide pages to back the new
+  /// 'allocation'. This will always succeed if collateral and allocation
+  /// together cover the new size of allocation. 'allocation' is newly mapped
+  /// and hence zeroed. The contents of 'allocation' and 'collateral' are freed
+  /// in all cases, also if the allocation fails. 'reservationCB' is used in the
+  /// same way as allocate does. It may throw and the end state will be
+  /// consistent, with no new allocation and 'allocation' and 'collateral'
+  /// cleared.
   ///
-  /// NOTE:
-  /// - 'collateral' and passed in 'allocation' are guaranteed to be freed.
-  /// - Throws if allocation exceeds capacity
+  /// NOTE: - 'collateral' and passed in 'allocation' are guaranteed
+  /// to be freed.  If 'maxPages' is non-0, 'maxPages' worth of
+  /// address space is mapped but the utilization in the allocator and
+  /// pool is incremented by 'numPages'. This allows reserving
+  /// a large range of addresses for use with huge pages without
+  /// declaring the whole range as held by the query. The reservation
+  /// will be increased as and if addresses in the range are used. See
+  /// growContiguous().
   virtual bool allocateContiguous(
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) = 0;
+      ReservationCallback reservationCB = nullptr,
+      MachinePageCount maxPages = 0) = 0;
 
   /// Frees contiguous 'allocation'. 'allocation' is empty on return.
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
+
+  /// Increments the reserved part of 'allocation' by
+  /// 'increment'. false if would exceed capacity, Throws if size
+  /// would exceed maxSize given in allocateContiguous(). Calls reservationCB
+  /// before increasing the utilization and returns false with no effect if this
+  /// fails.
+  virtual bool growContiguous(
+      MachinePageCount increment,
+      ContiguousAllocation& allocation,
+      ReservationCallback reservationCB = nullptr) = 0;
 
   /// Allocates contiguous 'bytes' and return the first byte. Returns nullptr if
   /// there is no space.

--- a/velox/common/memory/MmapAllocator.h
+++ b/velox/common/memory/MmapAllocator.h
@@ -101,11 +101,12 @@ class MmapAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB = nullptr) override {
+      ReservationCallback reservationCB = nullptr,
+      MachinePageCount maxPages = 0) override {
     bool result;
     stats_.recordAllocate(numPages * AllocationTraits::kPageSize, 1, [&]() {
       result = allocateContiguousImpl(
-          numPages, collateral, allocation, reservationCB);
+          numPages, collateral, allocation, reservationCB, maxPages);
     });
     return result;
   }
@@ -114,6 +115,11 @@ class MmapAllocator : public MemoryAllocator {
     stats_.recordFree(
         allocation.size(), [&]() { freeContiguousImpl(allocation); });
   }
+
+  bool growContiguous(
+      MachinePageCount increment,
+      ContiguousAllocation& allocation,
+      ReservationCallback reservationCB = nullptr) override;
 
   /// Allocates 'bytes' contiguous bytes and returns the pointer to the first
   /// byte. If 'bytes' is less than 'maxMallocBytes_', delegates the allocation
@@ -337,7 +343,8 @@ class MmapAllocator : public MemoryAllocator {
       MachinePageCount numPages,
       Allocation* collateral,
       ContiguousAllocation& allocation,
-      ReservationCallback reservationCB);
+      ReservationCallback reservationCB,
+      MachinePageCount maxPages);
 
   void freeContiguousImpl(ContiguousAllocation& allocation);
 

--- a/velox/common/memory/tests/AllocationPoolTest.cpp
+++ b/velox/common/memory/tests/AllocationPoolTest.cpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/memory/AllocationPool.h"
+
+#include <folly/container/F14Map.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+class AllocationPoolTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    auto root_ = memory::MemoryManager::getInstance().addRootPool(
+        "allocationPoolTestRoot");
+    pool_ = root_->addLeafChild("leaf");
+  }
+
+  // Writes a byte at pointer so we see RSS change.
+  void setByte(void* ptr) {
+    *reinterpret_cast<char*>(ptr) = 1;
+  }
+
+  std::shared_ptr<memory::MemoryPool> root_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(AllocationPoolTest, hugePages) {
+  constexpr int64_t kHugePageSize = memory::AllocationTraits::kHugePageSize;
+  auto allocationPool = std::make_unique<AllocationPool>(pool_.get());
+  allocationPool->setHugePageThreshold(128 << 10);
+  int32_t counter = 0;
+  for (;;) {
+    int32_t usedKB = 0;
+    allocationPool->newRun(32 << 10);
+    // Initial allocations round up to 64K
+    EXPECT_EQ(1, allocationPool->numRanges());
+    EXPECT_EQ(allocationPool->availableInRun(), 64 << 10);
+    allocationPool->newRun(64 << 10);
+    EXPECT_LE(128 << 10, pool_->currentBytes());
+    allocationPool->allocateFixed(64 << 10);
+    // Now at end of second 64K range, next will go to huge pages.
+    setByte(allocationPool->allocateFixed(11));
+    EXPECT_LE((2 << 20) - 11, allocationPool->availableInRun());
+    // The first 2MB of the hugepage run are marked reserved.
+    EXPECT_LE((2048 + 128) << 10, pool_->currentBytes());
+
+    // The next allocation starts reserves the next 2MB of the mmapped range.
+    setByte(allocationPool->allocateFixed(2 << 20));
+    EXPECT_LE((4096 + 128) << 10, pool_->currentBytes());
+
+    // Allocate the rest.
+    allocationPool->allocateFixed(allocationPool->availableInRun());
+
+    // We expect 3 ranges, 2 small and one large.
+    EXPECT_EQ(3, allocationPool->numRanges());
+
+    // We allocate more, expect a larger mmap.
+    allocationPool->allocateFixed(1);
+
+    // The first is at least 15 huge pages. The next is at least 31. The mmaps
+    // may have unused addresses at either end, so count one huge page less than
+    // the nominal size.
+    EXPECT_LE((62 << 20) - 1, allocationPool->availableInRun());
+
+    // We make a 5GB extra large allocation.
+    allocationPool->allocateFixed(5UL << 30);
+    EXPECT_EQ(5, allocationPool->numRanges());
+
+    // 5G is an even multiple of huge page, no free space at end. But it can be
+    // the mmap happens to start at 2MB boundary so we get another 2MB.
+    EXPECT_GE(kHugePageSize, allocationPool->availableInRun());
+
+    EXPECT_LE(
+        (5UL << 30) + (31 << 20) + (128 << 10),
+        allocationPool->allocatedBytes());
+    EXPECT_LE((5UL << 30) + (31 << 20) + (128 << 10), pool_->currentBytes());
+
+    if (counter++ >= 1) {
+      break;
+    }
+
+    // Repeat the above after a clear().
+    allocationPool->clear();
+    // Should be empty after clear().
+    EXPECT_EQ(0, pool_->currentBytes());
+  }
+  allocationPool.reset();
+  // Should be empty after destruction.
+  EXPECT_EQ(0, pool_->currentBytes());
+}

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   ByteStreamTest.cpp
   CompactDoubleListTest.cpp
   HashStringAllocatorTest.cpp
+  AllocationPoolTest.cpp
   MemoryAllocatorTest.cpp
   MemoryArbitratorTest.cpp
   MemoryCapExceededTest.cpp

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -111,7 +111,7 @@ TEST_F(HashStringAllocatorTest, allocate) {
     }
   }
   // We allow for some free overhead for free lists after all is freed.
-  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 200);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 250);
 }
 
 TEST_F(HashStringAllocatorTest, allocateLarge) {
@@ -343,7 +343,7 @@ TEST_F(HashStringAllocatorTest, stlAllocatorWithSet) {
   allocator_->checkConsistency();
 
   // We allow for some overhead for free lists after all is freed.
-  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 100);
+  EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 180);
 }
 
 TEST_F(HashStringAllocatorTest, alignedStlAllocatorWithF14Map) {

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -138,13 +138,20 @@ class MockMemoryPool : public velox::memory::MemoryPool {
 
   void allocateContiguous(
       velox::memory::MachinePageCount /*unused*/,
-      velox::memory::ContiguousAllocation& /*unused*/) override {
+      velox::memory::ContiguousAllocation& /*unused*/,
+      velox::memory::MachinePageCount /*unused*/ = 0) override {
     VELOX_UNSUPPORTED("allocateContiguous unsupported");
   }
 
   void freeContiguous(velox::memory::ContiguousAllocation&
                       /*unused*/) override {
     VELOX_UNSUPPORTED("freeContiguous unsupported");
+  }
+
+  void growContiguous(
+      velox::memory::MachinePageCount /*unused*/,
+      velox::memory::ContiguousAllocation& /*unused*/) override {
+    VELOX_UNSUPPORTED("growContiguous unsupported");
   }
 
   int64_t currentBytes() const override {

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -683,10 +683,12 @@ void GroupingSet::ensureInputFits(const RowVectorPtr& input) {
     // spill protected section instead.
     return;
   }
-  // If there is variable length data we take the flat size of the
-  // input as a cap on the new variable length data needed.
+  // If there is variable length data we take double the flat size of
+  // the input as a cap on the new variable length data needed. Same
+  // condition as in first check. Completely arbitrary. Allow growth
+  // in spill protected area instead.
   auto increment =
-      rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes : 0) +
+      rows->sizeIncrement(input->size(), outOfLineBytes ? flatBytes * 2 : 0) +
       tableIncrement;
   // There must be at least 2x the increment in reservation.
   if (pool_.availableReservation() > 2 * increment) {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -67,7 +67,6 @@ using normalized_key_t = uint64_t;
 
 struct RowContainerIterator {
   int32_t allocationIndex = 0;
-  int32_t runIndex = 0;
   int32_t rowOffset = 0;
   // Number of unvisited entries that are prefixed by an uint64_t for
   // normalized key. Set in listRows() on first call.
@@ -77,7 +76,7 @@ struct RowContainerIterator {
   // Ordinal position of 'currentRow' in RowContainer.
   int32_t rowNumber{0};
   char* FOLLY_NULLABLE rowBegin{nullptr};
-  // First byte after the end of the PageRun containing 'currentRow'.
+  // First byte after the end of the range containing 'currentRow'.
   char* FOLLY_NULLABLE endOfRun{nullptr};
 
   // Returns the current row, skipping a possible normalized key below the first
@@ -406,69 +405,56 @@ class RowContainer {
       char* FOLLY_NONNULL* FOLLY_NONNULL rows) {
     int32_t count = 0;
     uint64_t totalBytes = 0;
-    VELOX_CHECK_EQ(rows_.numLargeAllocations(), 0);
-    auto numAllocations = rows_.numSmallAllocations();
-    if (iter->allocationIndex == 0 && iter->runIndex == 0 &&
-        iter->rowOffset == 0) {
+    auto numAllocations = rows_.numRanges();
+    if (iter->allocationIndex == 0 && iter->rowOffset == 0) {
       iter->normalizedKeysLeft = numRowsWithNormalizedKey_;
       iter->normalizedKeySize = originalNormalizedKeySize_;
     }
     int32_t rowSize = fixedRowSize_ +
         (iter->normalizedKeysLeft > 0 ? originalNormalizedKeySize_ : 0);
     for (auto i = iter->allocationIndex; i < numAllocations; ++i) {
-      auto allocation = rows_.allocationAt(i);
-      auto numRuns = allocation->numRuns();
-      for (auto runIndex = iter->runIndex; runIndex < numRuns; ++runIndex) {
-        memory::Allocation::PageRun run = allocation->runAt(runIndex);
-        auto* data =
-            run.data<char>() + memory::alignmentPadding(run.data(), alignment_);
-        int64_t limit;
-        if (i == numAllocations - 1 && runIndex == rows_.currentRunIndex()) {
-          limit = rows_.currentOffset();
-        } else {
-          limit = run.numPages() * memory::AllocationTraits::kPageSize;
+      auto range = rows_.rangeAt(i);
+      auto* data =
+          range.data() + memory::alignmentPadding(range.data(), alignment_);
+      auto limit = range.size();
+      auto row = iter->rowOffset;
+      while (row + rowSize <= limit) {
+        rows[count++] = data + row +
+            (iter->normalizedKeysLeft > 0 ? originalNormalizedKeySize_ : 0);
+        VELOX_DCHECK_EQ(
+            reinterpret_cast<uintptr_t>(rows[count - 1]) % alignment_, 0);
+        row += rowSize;
+        auto newTotalBytes = totalBytes + rowSize;
+        if (--iter->normalizedKeysLeft == 0) {
+          rowSize -= originalNormalizedKeySize_;
         }
-        auto row = iter->rowOffset;
-        while (row + rowSize <= limit) {
-          rows[count++] = data + row +
-              (iter->normalizedKeysLeft > 0 ? originalNormalizedKeySize_ : 0);
-          VELOX_DCHECK_EQ(
-              reinterpret_cast<uintptr_t>(rows[count - 1]) % alignment_, 0);
-          row += rowSize;
-          auto newTotalBytes = totalBytes + rowSize;
-          if (--iter->normalizedKeysLeft == 0) {
-            rowSize -= originalNormalizedKeySize_;
-          }
-          if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+        if (bits::isBitSet(rows[count - 1], freeFlagOffset_)) {
+          --count;
+          continue;
+        }
+        if constexpr (probeType == ProbeType::kNotProbed) {
+          if (bits::isBitSet(rows[count - 1], probedFlagOffset_)) {
             --count;
             continue;
           }
-          if constexpr (probeType == ProbeType::kNotProbed) {
-            if (bits::isBitSet(rows[count - 1], probedFlagOffset_)) {
-              --count;
-              continue;
-            }
-          }
-          if constexpr (probeType == ProbeType::kProbed) {
-            if (not(bits::isBitSet(rows[count - 1], probedFlagOffset_))) {
-              --count;
-              continue;
-            }
-          }
-          totalBytes = newTotalBytes;
-          if (rowSizeOffset_) {
-            totalBytes += variableRowSize(rows[count - 1]);
-          }
-          if (count == maxRows || totalBytes > maxBytes) {
-            iter->rowOffset = row;
-            iter->runIndex = runIndex;
-            iter->allocationIndex = i;
-            return count;
+        }
+        if constexpr (probeType == ProbeType::kProbed) {
+          if (not(bits::isBitSet(rows[count - 1], probedFlagOffset_))) {
+            --count;
+            continue;
           }
         }
-        iter->rowOffset = 0;
+        totalBytes = newTotalBytes;
+        if (rowSizeOffset_) {
+          totalBytes += variableRowSize(rows[count - 1]);
+        }
+        if (count == maxRows || totalBytes > maxBytes) {
+          iter->rowOffset = row;
+          iter->allocationIndex = i;
+          return count;
+        }
       }
-      iter->runIndex = 0;
+      iter->rowOffset = 0;
     }
     iter->allocationIndex = std::numeric_limits<int32_t>::max();
     return count;
@@ -599,7 +585,7 @@ class RowContainer {
   // reserved storage for variable length data.
   std::pair<uint64_t, uint64_t> freeSpace() const {
     return std::make_pair<uint64_t, uint64_t>(
-        rows_.availableInRun() / fixedRowSize_ + numFreeRows_,
+        rows_.availableInReservedRun() / fixedRowSize_ + numFreeRows_,
         stringAllocator_.freeSpace());
   }
 

--- a/velox/functions/lib/tests/KllSketchTest.cpp
+++ b/velox/functions/lib/tests/KllSketchTest.cpp
@@ -377,9 +377,9 @@ TEST(KllSketchTest, memoryUsage) {
   HashStringAllocator alloc(pool.get());
   KllSketch<int64_t, StlAllocator<int64_t>> kll(
       1024, StlAllocator<int64_t>(&alloc));
-  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);
+  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 84);
   kll.insert(0);
-  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 64);
+  EXPECT_LE(alloc.retainedSize() - alloc.freeSpace(), 84);
   for (int i = 1; i < 1024; ++i) {
     kll.insert(i);
   }


### PR DESCRIPTION
Use Hugepages to back AllocationPool/HashStringAllocator

Simplifies AllocationPool to consider a mix of small and large
allocations. We present a single set of allocated ranges to the user,
e.g. RowContainer or HashStringAllocator. We do not export
memory::Allocations.

Adaptively starts using huge pages in Allocationpool after passing a
threshold size. We allocate large chunks, 32MB - 512MB and request
huge pages for the range. We do not give these out as a unit
however. Instead we increase the reservation one 2MB huge page at a
time as and when these so far unbacked addresses are given out. The OS
will at some point migrate the ranges to huge pages.

This is seen to speed up hash tables by some 20% over just having the hash table arrays as huge pages.

Adds a SIMD word wide tail to address ranges in HashStringAllocator. This means that any byte in content, also at end of allocations, is safe to access with full width.

Changes the iterators in RowContainer to use the simplified AllocationPool range API.
