### PR TITLE
Add log2/log10 in Sparksql functions

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -74,11 +74,11 @@ Mathematical Functions
 
 .. spark:function:: log2(x) -> double
 
-    Returns the logarithm of ``x`` with base 2. Return null for zero input.
+    Returns the logarithm of ``x`` with base 2. Return null for zero and non-positive input.
 
 .. spark:function:: log10(x) -> double
 
-    Returns the logarithm of ``x`` with base 10. Return null for zero input.
+    Returns the logarithm of ``x`` with base 10. Return null for zero and non-positive input.
 
 .. spark:function:: multiply(x, y) -> [same as x]
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -74,11 +74,11 @@ Mathematical Functions
 
 .. spark:function:: log2(x) -> double
 
-    Returns the logarithm of ``x`` with base 2.
+    Returns the logarithm of ``x`` with base 2. Return null for zero input.
 
 .. spark:function:: log10(x) -> double
 
-    Returns the logarithm of ``x`` with base 10.
+    Returns the logarithm of ``x`` with base 10. Return null for zero input.
 
 .. spark:function:: multiply(x, y) -> [same as x]
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -71,6 +71,15 @@ Mathematical Functions
 
     Returns the natural logarithm of the “given value ``x`` plus one”.
     Return NULL if x is less than or equal to -1.
+
+.. spark:function:: log2(x) -> double
+
+    Returns the logarithm of ``x`` with base 2.
+
+.. spark:function:: log10(x) -> double
+
+    Returns the logarithm of ``x`` with base 10.
+
 .. spark:function:: multiply(x, y) -> [same as x]
 
     Returns the result of multiplying x by y. The types of x and y must be the same.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -228,6 +228,18 @@ struct HypotFunction {
 };
 
 template <typename T>
+struct Log2Function {
+  FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
+    double yAsymptote = 0.0;
+    if (a <= yAsymptote) {
+      return false;
+    }
+    result = std::log2(a);
+    return true;
+  }
+};
+
+template <typename T>
 struct Log1pFunction {
   FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
     if (a <= -1) {
@@ -237,4 +249,18 @@ struct Log1pFunction {
     return true;
   }
 };
+
+template <typename T>
+struct Log10Function {
+  FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
+    double yAsymptote = 0.0;
+    if (a <= yAsymptote) {
+      return false;
+    }
+    result = std::log10(a);
+    return true;
+  }
+};
+
+>>>>>>> add log2/log10 function
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -261,6 +261,4 @@ struct Log10Function {
     return true;
   }
 };
-
->>>>>>> add log2/log10 function
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -230,8 +230,7 @@ struct HypotFunction {
 template <typename T>
 struct Log2Function {
   FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
-    double yAsymptote = 0.0;
-    if (a <= yAsymptote) {
+    if (a <= 0.0) {
       return false;
     }
     result = std::log2(a);
@@ -253,8 +252,7 @@ struct Log1pFunction {
 template <typename T>
 struct Log10Function {
   FOLLY_ALWAYS_INLINE bool call(double& result, double a) {
-    double yAsymptote = 0.0;
-    if (a <= yAsymptote) {
+    if (a <= 0.0) {
       return false;
     }
     result = std::log10(a);

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -62,6 +62,8 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<sparksql::FloorFunction, int64_t, double>(
       {prefix + "floor"});
   registerFunction<HypotFunction, double, double, double>({prefix + "hypot"});
+  registerFunction<sparksql::Log2Function, double, double>({prefix + "log2"});
+  registerFunction<sparksql::Log10Function, double, double>({prefix + "log10"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -361,12 +361,21 @@ class LogNTest : public SparkFunctionBaseTest {
   }
 };
 
-TEST_F(LogNTest, logN) {
+TEST_F(LogNTest, log2) {
+  const auto log2 = [&](std::optional<double> a) {
+    return evaluateOnce<double>("log2(c0)", a);
+  };
   EXPECT_EQ(log2(8), 3.0);
-  EXPECT_EQ(log2(std::nullopt), std::nullopt);
   EXPECT_EQ(log2(-1.0), std::nullopt);
+  EXPECT_EQ(log2(0.0), std::nullopt);
+}
+
+TEST_F(LogNTest, log10) {
+  const auto log10 = [&](std::optional<double> a) {
+    return evaluateOnce<double>("log10(c0)", a);
+  };
   EXPECT_EQ(log10(100), 2.0);
-  EXPECT_EQ(log10(std::nullopt), std::nullopt);
+  EXPECT_EQ(log2(0.0), std::nullopt);
   EXPECT_EQ(log10(-1.0), std::nullopt);
 }
 

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -350,5 +350,25 @@ TEST_F(ArithmeticTest, hypot) {
   EXPECT_DOUBLE_EQ(5.70087712549569, hypot(3.5, -4.5).value());
 }
 
+class LogNTest : public SparkFunctionBaseTest {
+ protected:
+  std::optional<double> log2(std::optional<double> arg) {
+    return evaluateOnce<double>("log2(c0)", arg);
+  }
+
+  std::optional<double> log10(std::optional<double> arg) {
+    return evaluateOnce<double>("log10(c0)", arg);
+  }
+};
+
+TEST_F(LogNTest, logN) {
+  EXPECT_EQ(log2(8), 3.0);
+  EXPECT_EQ(log2(std::nullopt), std::nullopt);
+  EXPECT_EQ(log2(-1.0), std::nullopt);
+  EXPECT_EQ(log10(100), 2.0);
+  EXPECT_EQ(log10(std::nullopt), std::nullopt);
+  EXPECT_EQ(log10(-1.0), std::nullopt);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -352,14 +352,6 @@ TEST_F(ArithmeticTest, hypot) {
 
 class LogNTest : public SparkFunctionBaseTest {
  protected:
-  std::optional<double> log2(std::optional<double> arg) {
-    return evaluateOnce<double>("log2(c0)", arg);
-  }
-
-  std::optional<double> log10(std::optional<double> arg) {
-    return evaluateOnce<double>("log10(c0)", arg);
-  }
-
   static constexpr float kInf = std::numeric_limits<double>::infinity();
 };
 

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -359,6 +359,8 @@ class LogNTest : public SparkFunctionBaseTest {
   std::optional<double> log10(std::optional<double> arg) {
     return evaluateOnce<double>("log10(c0)", arg);
   }
+
+  static constexpr float kInf = std::numeric_limits<double>::infinity();
 };
 
 TEST_F(LogNTest, log2) {
@@ -368,6 +370,7 @@ TEST_F(LogNTest, log2) {
   EXPECT_EQ(log2(8), 3.0);
   EXPECT_EQ(log2(-1.0), std::nullopt);
   EXPECT_EQ(log2(0.0), std::nullopt);
+  EXPECT_EQ(log2(kInf), kInf);
 }
 
 TEST_F(LogNTest, log10) {
@@ -375,8 +378,9 @@ TEST_F(LogNTest, log10) {
     return evaluateOnce<double>("log10(c0)", a);
   };
   EXPECT_EQ(log10(100), 2.0);
-  EXPECT_EQ(log2(0.0), std::nullopt);
+  EXPECT_EQ(log10(0.0), std::nullopt);
   EXPECT_EQ(log10(-1.0), std::nullopt);
+  EXPECT_EQ(log10(kInf), kInf);
 }
 
 } // namespace


### PR DESCRIPTION
```
log2/log10: 
Returns the natural logarithm (base 2/10) of a double value. Special cases:
If the argument is NaN or less than zero, then the result is NaN.
If the argument is positive infinity, then the result is positive infinity.
If the argument is positive zero or negative zero, then the result is negative infinity.
```
Here is the [link](https://github.com/apache/spark/blob/branch-3.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L568-L580) of spark implementation.
