### PR TITLE
Support Timestamp in spark hash function

### DIFF
--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -69,6 +69,7 @@ void applyWithType(
       CASE(VARBINARY, hash.hashBytes, StringView);
       CASE(REAL, hash.hashFloat, float);
       CASE(DOUBLE, hash.hashDouble, double);
+      CASE(TIMESTAMP, hash.hashTimestamp, Timestamp);
 #undef CASE
       default:
         VELOX_NYI(
@@ -133,6 +134,10 @@ class Murmur3Hash final {
       h1 = mixH1(h1, mixK1(*i));
     }
     return fmix(h1, input.size());
+  }
+
+  uint32_t hashTimestamp(Timestamp input, uint32_t seed) {
+    return hashInt64(input.toMicros(), seed);
   }
 
  private:
@@ -233,6 +238,10 @@ class XxHash64 final {
       offset++;
     }
     return fmix(hash);
+  }
+
+  uint32_t hashTimestamp(Timestamp input, uint32_t seed) {
+    return hashInt64(input.toMicros(), seed);
   }
 
  private:

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -113,5 +113,17 @@ TEST_F(HashTest, Float) {
   EXPECT_EQ(hash<float>(-limits::infinity()), 427440766);
 }
 
+TEST_F(HashTest, Int64) {
+  EXPECT_EQ(
+      hash<Timestamp>(Timestamp::fromMicros(0xcafecafedeadbeef)), -256235155);
+  EXPECT_EQ(
+      hash<Timestamp>(Timestamp::fromMillis(0xdeadbeefcafecafe)), 673261790);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(INT64_MAX)), -1604625029);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(INT64_MIN)), -853646085);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(1)), -1712319331);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(0)), -1670924195);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(-1)), -939490007);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(std::nullopt)), 42);
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/HashTest.cpp
+++ b/velox/functions/sparksql/tests/HashTest.cpp
@@ -113,17 +113,17 @@ TEST_F(HashTest, Float) {
   EXPECT_EQ(hash<float>(-limits::infinity()), 427440766);
 }
 
-TEST_F(HashTest, Int64) {
+TEST_F(HashTest, timestamp) {
   EXPECT_EQ(
       hash<Timestamp>(Timestamp::fromMicros(0xcafecafedeadbeef)), -256235155);
   EXPECT_EQ(
-      hash<Timestamp>(Timestamp::fromMillis(0xdeadbeefcafecafe)), 673261790);
+      hash<Timestamp>(Timestamp::fromMicros(0xdeadbeefcafecafe)), 673261790);
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(INT64_MAX)), -1604625029);
-  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(INT64_MIN)), -853646085);
+  EXPECT_EQ(hash<Timestamp>(Timestamp::fromNanos(INT64_MIN)), -296049171);
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(1)), -1712319331);
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(0)), -1670924195);
   EXPECT_EQ(hash<Timestamp>(Timestamp::fromMicros(-1)), -939490007);
-  EXPECT_EQ(hash<Timestamp>(Timestamp::fromMillis(std::nullopt)), 42);
+  EXPECT_EQ(hash<Timestamp>(std::nullopt), 42);
 }
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -118,5 +118,28 @@ TEST_F(XxHash64Test, float) {
   EXPECT_EQ(xxhash64<float>(limits::infinity()), -5940311692336719973);
   EXPECT_EQ(xxhash64<float>(-limits::infinity()), -7580553461823983095);
 }
+
+TEST_F(XxHash64Test, int64) {
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMicros(0xcafecafedeadbeef)),
+      -6259772178006417012);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMillis(0xdeadbeefcafecafe)),
+      -1700188678616701932);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMicros(INT64_MAX)),
+      -3246596055638297850);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMillis(INT64_MIN)),
+      -8619748838626508300);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMicros(1)), -7001672635703045582);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMillis(0)), -5252525462095825812);
+  EXPECT_EQ(
+      xxhash64<Timestamp>(Timestamp::fromMicros(-1)), 3858142552250413010);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMillis(std::nullopt)), 42);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/XxHash64Test.cpp
+++ b/velox/functions/sparksql/tests/XxHash64Test.cpp
@@ -119,26 +119,19 @@ TEST_F(XxHash64Test, float) {
   EXPECT_EQ(xxhash64<float>(-limits::infinity()), -7580553461823983095);
 }
 
-TEST_F(XxHash64Test, int64) {
+TEST_F(XxHash64Test, timestamp) {
   EXPECT_EQ(
       xxhash64<Timestamp>(Timestamp::fromMicros(0xcafecafedeadbeef)),
-      -6259772178006417012);
+      2869813644);
   EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMillis(0xdeadbeefcafecafe)),
-      -1700188678616701932);
-  EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMicros(INT64_MAX)),
-      -3246596055638297850);
-  EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMillis(INT64_MIN)),
-      -8619748838626508300);
-  EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMicros(1)), -7001672635703045582);
-  EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMillis(0)), -5252525462095825812);
-  EXPECT_EQ(
-      xxhash64<Timestamp>(Timestamp::fromMicros(-1)), 3858142552250413010);
-  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMillis(std::nullopt)), 42);
+      xxhash64<Timestamp>(Timestamp::fromMicros(0xdeadbeefcafecafe)),
+      2682856468);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMicros(INT64_MAX)), 2927538950);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromNanos(INT64_MIN)), 2932133398);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMicros(1)), 2472071730);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMillis(0)), 3658839148);
+  EXPECT_EQ(xxhash64<Timestamp>(Timestamp::fromMicros(-1)), 3216273362);
+  EXPECT_EQ(xxhash64<Timestamp>(std::nullopt), 42);
 }
 
 } // namespace


### PR DESCRIPTION
Enable TIMESTAMP type in spark hash function.