### PR TITLE
Add acos SparkSQL function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -6,6 +6,10 @@ Mathematical Functions
 
     Returns the absolute value of ``x``.
 
+.. spark:function:: acos(x) -> double
+
+    Returns the inverse cosine (a.k.a. arc cosine) of ``x``.
+
 .. spark:function:: acosh(x) -> double
 
     Returns inverse hyperbolic cosine of ``x``.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -153,6 +153,14 @@ struct FloorFunction {
 };
 
 template <typename T>
+struct AcosFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {
+    result = std::acos(a);
+  }
+};
+
+template <typename T>
 struct AcoshFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(TInput& result, TInput a) {

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -31,6 +31,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerUnaryNumeric<UnaryMinusFunction>({prefix + "unaryminus"});
   // Math functions.
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});
+  registerFunction<AcosFunction, double, double>({prefix + "acos"});
   registerFunction<AcoshFunction, double, double>({prefix + "acosh"});
   registerFunction<AsinhFunction, double, double>({prefix + "asinh"});
   registerFunction<AtanhFunction, double, double>({prefix + "atanh"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -183,6 +183,19 @@ TEST_F(ArithmeticTest, Divide) {
   EXPECT_TRUE(std::isnan(divide(kInf, -kInf).value_or(0)));
 }
 
+TEST_F(ArithmeticTest, acos) {
+  const auto acos = [&](std::optional<double> a) {
+    return evaluateOnce<double>("acos(c0)", a);
+  };
+
+  EXPECT_EQ(acos(1), 0);
+  EXPECT_TRUE(std::isnan(acos(2).value_or(0)));
+  EXPECT_TRUE(std::isnan(acos(kInf).value_or(0)));
+  EXPECT_TRUE(std::isnan(acos(-kInf).value_or(0)));
+  EXPECT_EQ(acos(std::nullopt), std::nullopt);
+  EXPECT_TRUE(std::isnan(acos(kNan).value_or(0)));
+}
+
 TEST_F(ArithmeticTest, acosh) {
   const auto acosh = [&](std::optional<double> a) {
     return evaluateOnce<double>("acosh(c0)", a);


### PR DESCRIPTION
Spark support [acos](https://spark.apache.org/docs/latest/api/sql/#acos) since 1.4.0, this pull request add it to Velox.