### PR TITLE
Implement JsonExtractor with simdjson

### DIFF
--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -11,9 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp)
+add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp
+                                 SIMDJsonExtractor.cpp)
 
-target_link_libraries(velox_functions_json velox_exception Folly::folly)
+target_link_libraries(velox_functions_json velox_exception Folly::folly
+                      simdjson)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
+
+namespace facebook::velox::functions::detail {
+/* static */ SIMDJsonExtractor& SIMDJsonExtractor::getInstance(
+    folly::StringPiece path) {
+  // Cache tokenize operations in JsonExtractor across invocations in the same
+  // thread for the same JsonPath.
+  thread_local static std::
+      unordered_map<std::string, std::shared_ptr<SIMDJsonExtractor>>
+          extractorCache;
+  // Pre-process
+  auto trimmedPath = folly::trimWhitespace(path).str();
+
+  std::shared_ptr<SIMDJsonExtractor> op;
+  if (extractorCache.count(trimmedPath)) {
+    return *extractorCache.at(trimmedPath);
+  }
+
+  if (extractorCache.size() == kMaxCacheSize) {
+    // TODO: Blindly evict the first one, use better policy
+    extractorCache.erase(extractorCache.begin());
+  }
+
+  auto it =
+      extractorCache.emplace(trimmedPath, new SIMDJsonExtractor(trimmedPath));
+  return *it.first->second;
+}
+
+simdjson::ondemand::document SIMDJsonExtractor::parse(
+    const simdjson::padded_string& json) {
+  thread_local static simdjson::ondemand::parser parser;
+  return parser.iterate(json);
+}
+
+bool SIMDJsonExtractor::tokenize(const std::string& path) {
+  thread_local static JsonPathTokenizer tokenizer;
+
+  if (path.empty()) {
+    return false;
+  }
+
+  if (!tokenizer.reset(path)) {
+    return false;
+  }
+
+  while (tokenizer.hasNext()) {
+    if (auto token = tokenizer.getNext()) {
+      tokens_.push_back(token.value());
+    } else {
+      tokens_.clear();
+      return false;
+    }
+  }
+
+  return true;
+}
+
+void extractObject(
+    simdjson::ondemand::value& jsonObj,
+    const std::string& key,
+    std::optional<simdjson::ondemand::value>& ret) {
+  for (auto field : jsonObj.get_object()) {
+    if (field.unescaped_key().value() == key) {
+      ret.emplace(field.value());
+      return;
+    }
+  }
+}
+
+void extractArray(
+    simdjson::ondemand::value& jsonValue,
+    const std::string& index,
+    std::optional<simdjson::ondemand::value>& ret) {
+  auto jsonArray = jsonValue.get_array();
+  auto rv = folly::tryTo<int32_t>(index);
+  if (rv.hasValue()) {
+    auto val = jsonArray.at(rv.value());
+    if (!val.error()) {
+      ret.emplace(std::move(val));
+    }
+  }
+}
+} // namespace facebook::velox::functions::detail

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.h
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.h
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#include "folly/Range.h"
+#include "folly/dynamic.h"
+#include "simdjson/singleheader/simdjson.h"
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/functions/prestosql/json/JsonPathTokenizer.h"
+#include "velox/type/StringView.h"
+
+namespace facebook::velox::functions {
+
+template <typename TConsumer>
+bool simdJsonExtract(
+    const velox::StringView& json,
+    const velox::StringView& path,
+    TConsumer&& consumer);
+
+namespace detail {
+
+using JsonVector = std::vector<simdjson::ondemand::value>;
+
+class SIMDJsonExtractor {
+ public:
+  template <typename TConsumer>
+  void extract(
+      simdjson::ondemand::value& json,
+      TConsumer& consumer,
+      size_t tokenStartIndex = 0);
+
+  // Returns true if this extractor was initialized with the trivial path "$".
+  bool isRootOnlyPath() {
+    return tokens_.empty();
+  }
+
+  simdjson::ondemand::document parse(const simdjson::padded_string& json);
+
+ private:
+  // Use this method to get an instance of SIMDJsonExtractor given a JSON path.
+  // Given the nature of the cache, it's important this is only used by
+  // simdJsonExtract.
+  static SIMDJsonExtractor& getInstance(folly::StringPiece path);
+
+  // Shouldn't instantiate directly - use getInstance().
+  explicit SIMDJsonExtractor(const std::string& path) {
+    if (!tokenize(path)) {
+      VELOX_USER_FAIL("Invalid JSON path: {}", path);
+    }
+  }
+
+  bool tokenize(const std::string& path);
+
+  // Max number of extractors cached in extractorCache.
+  static const uint32_t kMaxCacheSize{32};
+
+  std::vector<std::string> tokens_;
+
+  template <typename TConsumer>
+  friend bool facebook::velox::functions::simdJsonExtract(
+      const velox::StringView& json,
+      const velox::StringView& path,
+      TConsumer&& consumer);
+};
+
+void extractObject(
+    simdjson::ondemand::value& jsonObj,
+    const std::string& key,
+    std::optional<simdjson::ondemand::value>& ret);
+
+void extractArray(
+    simdjson::ondemand::value& jsonValue,
+    const std::string& index,
+    std::optional<simdjson::ondemand::value>& ret);
+
+template <typename TConsumer>
+void SIMDJsonExtractor::extract(
+    simdjson::ondemand::value& json,
+    TConsumer& consumer,
+    size_t tokenStartIndex) {
+  simdjson::ondemand::value input = json;
+  // Temporary extraction result holder.
+  std::optional<simdjson::ondemand::value> result;
+
+  for (int tokenIndex = tokenStartIndex; tokenIndex < tokens_.size();
+       tokenIndex++) {
+    auto& token = tokens_[tokenIndex];
+    if (input.type() == simdjson::ondemand::json_type::object) {
+      extractObject(input, token, result);
+    } else if (input.type() == simdjson::ondemand::json_type::array) {
+      if (token == "*") {
+        for (auto child : input.get_array()) {
+          if (tokenIndex == tokens_.size() - 1) {
+            // If this is the last token in the path, consume each element in
+            // the array.
+            consumer(child.value());
+          } else {
+            // If not, then recursively call the extract function on each
+            // element in the array.
+            extract(child.value(), consumer, tokenIndex + 1);
+          }
+        }
+
+        return;
+      } else {
+        extractArray(input, token, result);
+      }
+    }
+    if (!result) {
+      return;
+    }
+
+    input = result.value();
+    result.reset();
+  }
+
+  consumer(input);
+}
+} // namespace detail
+
+/**
+ * Extract element(s) from a JSON object using the given path.
+ * @param json: A JSON object
+ * @param path: Path to locate a JSON object. Following operators are supported.
+ *              "$"      Root member of a JSON structure no matter if it's an
+ *                       object, an array, or a scalar.
+ *              "."      Child operator to get a child object.
+ *              "[]"     Subscript operator for array.
+ *              "*"      Wildcard for [], get all the elements of an array.
+ * @param consumer: Function to consume the extracted elements. Should be able
+ *                  to take an argument that can either be a
+ *                  simdjson::ondemand::document or a simdjson::ondemand::value.
+ *                  Note that once consumer returns, it should be assumed that
+ *                  the argument passed in is no longer valid, so do not attempt
+ *                  to store it as is in the consumer.
+ * @return Return true on success.
+ *         If any errors are encountered parsing the JSON, returns false.
+ */
+
+template <typename TConsumer>
+bool simdJsonExtract(
+    const velox::StringView& json,
+    const velox::StringView& path,
+    TConsumer&& consumer) {
+  try {
+    // If extractor fails to parse the path, this will throw a VeloxUserError,
+    // and we want to let this exception bubble up to the client. We only catch
+    // JSON parsing failures (in which cases we return folly::none instead of
+    // throw).
+    auto& extractor = detail::SIMDJsonExtractor::getInstance(path);
+    simdjson::padded_string paddedJson(json.data(), json.size());
+    simdjson::ondemand::document jsonDoc = extractor.parse(paddedJson);
+
+    if (extractor.isRootOnlyPath()) {
+      // If the path is just to return the original object, call consumer on the
+      // document.  Note, we cannot convert this to a value as this is not
+      // supported if the object is a scalar.
+      consumer(jsonDoc);
+    } else {
+      auto value = jsonDoc.get_value().value();
+      extractor.extract(value, std::forward<TConsumer>(consumer));
+    }
+  } catch (const simdjson::simdjson_error&) {
+    // simdjson might throw a conversion error while parsing the input JSON.
+    return false;
+  }
+
+  return true;
+}
+
+template <typename TConsumer>
+bool simdJsonExtract(
+    const std::string& json,
+    const std::string& path,
+    TConsumer&& consumer) {
+  return simdJsonExtract(
+      velox::StringView(json),
+      velox::StringView(path),
+      std::forward<TConsumer>(consumer));
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/json/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/json/tests/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_executable(velox_functions_json_test JsonExtractorTest.cpp
-                                         JsonPathTokenizerTest.cpp)
+add_executable(
+  velox_functions_json_test JsonExtractorTest.cpp JsonPathTokenizerTest.cpp
+                            SIMDJsonExtractorTest.cpp)
 
 add_test(velox_functions_json_test velox_functions_json_test)
 

--- a/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
+++ b/velox/functions/prestosql/json/tests/SIMDJsonExtractorTest.cpp
@@ -1,0 +1,529 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/json/SIMDJsonExtractor.h"
+#include <optional>
+#include <string>
+
+#include "folly/json.h"
+#include "gtest/gtest.h"
+#include "velox/common/base/VeloxException.h"
+
+namespace {
+using facebook::velox::VeloxUserError;
+using facebook::velox::functions::simdJsonExtract;
+
+class SIMDJsonExtractorTest : public testing::Test {
+ public:
+  void expectThrowInvalidArgument(
+      const std::string& json,
+      const std::string& path) {
+    EXPECT_THROW(testExtract(json, path, std::nullopt), VeloxUserError);
+  }
+
+  void testExtract(
+      const std::string& json,
+      const std::string& path,
+      const std::string& expected) {
+    testExtract(json, path, std::vector<std::string>{expected});
+  }
+
+  void testExtract(
+      const std::string& json,
+      const std::string& path,
+      const std::optional<std::vector<std::string>>& expected) {
+    std::vector<std::string> res;
+    auto consumer = [&res](auto& v) {
+      res.push_back(std::string(simdjson::to_json_string(v).value()));
+    };
+
+    EXPECT_TRUE(simdJsonExtract(json, path, consumer))
+        << "with json " << json << " and path " << path;
+
+    if (!expected) {
+      EXPECT_EQ(0, res.size());
+      return;
+    }
+
+    EXPECT_EQ(expected->size(), res.size())
+        << "with json " << json << " and path " << path;
+    for (int i = 0; i < res.size(); i++) {
+      EXPECT_EQ(folly::parseJson(expected->at(i)), folly::parseJson(res.at(i)))
+          << "Encountered different values at position " << i << " with json "
+          << json << " and path " << path;
+    }
+  }
+
+  void testExtractScalar(
+      const std::string& json,
+      const std::string& path,
+      const std::optional<std::string>& expected) {
+    bool resultPopulated = false;
+    std::optional<std::string> actual;
+    auto consumer = [&actual, &resultPopulated](auto& v) {
+      if (resultPopulated) {
+        // We expect a single value, if consumer gets called multiple times,
+        // e.g. the path contains [*], return null.
+        actual = std::nullopt;
+        return;
+      }
+
+      resultPopulated = true;
+
+      switch (v.type()) {
+        case simdjson::ondemand::json_type::boolean:
+          actual = v.get_bool().value() ? "true" : "false";
+          break;
+        case simdjson::ondemand::json_type::string:
+          actual = v.get_string().value();
+          break;
+        case simdjson::ondemand::json_type::object:
+        case simdjson::ondemand::json_type::array:
+        case simdjson::ondemand::json_type::null:
+          // Do nothing.
+          break;
+        default:
+          actual = simdjson::to_json_string(v).value();
+      }
+    };
+
+    EXPECT_TRUE(simdJsonExtract(json, path, consumer))
+        << "with json " << json << " and path " << path;
+
+    EXPECT_EQ(expected, actual) << "with json " << json << " and path " << path;
+  }
+
+ private:
+  simdjson::ondemand::parser parser_;
+};
+
+TEST_F(SIMDJsonExtractorTest, generalJsonTest) {
+  std::string json = R"DELIM(
+      {"store":
+          {"fruit":[
+          {"weight":8, "type":"apple"},
+          {"weight":9, "type":"pear"}],
+          "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
+          "book":[
+              {"author":"Nigel Rees",
+              "title":"ayings of the Century",
+              "category":"reference",
+              "price":8.95},
+              {"author":"Herman Melville",
+              "title":"Moby Dick",
+              "category":"fiction",
+              "price":8.99,
+              "isbn":"0-553-21311-3"},
+              {"author":"J. R. R. Tolkien",
+              "title":"The Lord of the Rings",
+              "category":"fiction",
+              "reader":[
+                  {"age":25,
+                  "name":"bob"},
+                  {"age":26,
+                  "name":"jack"}],
+              "price":22.99,
+              "isbn":"0-395-19395-8"}],
+          "bicycle":{"price":19.95, "color":"red"}},
+          "e mail":"amy@only_for_json_udf_test.net",
+          "owner":"amy"})DELIM";
+  std::replace(json.begin(), json.end(), '\'', '\"');
+  testExtract(json, "$.store.fruit[0].weight", "8");
+  testExtract(json, "$.store.fruit[1].weight", "9");
+  testExtract(json, "$.store.fruit[2].weight", std::nullopt);
+  testExtract(
+      json, "$.store.fruit[*].weight", std::vector<std::string>{"8", "9"});
+  testExtract(
+      json,
+      "$.store.fruit[*].type",
+      std::vector<std::string>{"\"apple\"", "\"pear\""});
+  testExtract(json, "$.store.book[0].price", "8.95");
+  testExtract(json, "$.store.book[2].category", "\"fiction\"");
+  testExtract(json, "$.store.basket[1]", "[3,4]");
+  testExtract(json, "$.store.basket[0]", "[1,2,{\"a\":\"x\",\"b\":\"y\"}]");
+  testExtract(json, "$.store.baskets[1]", std::nullopt);
+  testExtract(json, "$[\"e mail\"]", "\"amy@only_for_json_udf_test.net\"");
+  testExtract(json, "$.owner", "\"amy\"");
+
+  testExtract("[[1.1,[2.1,2.2]],2,{\"a\":\"b\"}]", "$[0][1][1]", "2.2");
+
+  json = "[1,2,{\"a\":\"b\"}]";
+  testExtract(json, "$[1]", "2");
+  testExtract(json, "$[2]", "{\"a\":\"b\"}");
+  testExtract(json, "$[3]", std::nullopt);
+
+  json = "[{\"a\":\"b\"}]";
+  testExtract(json, "$[0]", "{\"a\":\"b\"}");
+  testExtract(json, "$[2]", std::nullopt);
+
+  testExtract("{\"a\":\"b\"}", " $ ", "{\"a\":\"b\"}");
+
+  json =
+      "[[{\"key\": 1, \"value\": 2},"
+      "{\"key\": 2, \"value\": 4}],"
+      "[{\"key\": 3, \"value\": 6},"
+      "{\"key\": 4, \"value\": 8},"
+      "{\"key\": 5, \"value\": 10}]]";
+  testExtract(
+      json,
+      "$[*]",
+      std::vector<std::string>{
+          "[{\"key\": 1, \"value\": 2},"
+          "{\"key\": 2, \"value\": 4}]",
+          "[{\"key\": 3, \"value\": 6},"
+          "{\"key\": 4, \"value\": 8},"
+          "{\"key\": 5, \"value\": 10}]"});
+  testExtract(
+      json,
+      "$[*][*]",
+      std::vector<std::string>{
+          "{\"key\": 1, \"value\": 2}",
+          "{\"key\": 2, \"value\": 4}",
+          "{\"key\": 3, \"value\": 6}",
+          "{\"key\": 4, \"value\": 8}",
+          "{\"key\": 5, \"value\": 10}"});
+  testExtract(
+      json, "$[*][*].key", std::vector<std::string>{"1", "2", "3", "4", "5"});
+  testExtract(
+      json,
+      "$[*][0]",
+      std::vector<std::string>{
+          "{\"key\":1,\"value\":2}", "{\"key\":3,\"value\":6}"});
+  testExtract(json, "$[*][2]", "{\"key\":5,\"value\":10}");
+
+  json = " [ [1.1,[2.1,2.2]],2, {\"a\": \"b\"}]";
+  testExtract(json, " $[0][1][1]", "2.2");
+  expectThrowInvalidArgument(json, "  \t\n ");
+}
+
+// Test compatibility with Presto
+// Reference: from https://github.com/prestodb/presto
+// presto-main/src/test/java/com/facebook/presto/operator/scalar/TestJsonExtract.java
+TEST_F(SIMDJsonExtractorTest, scalarValueTest) {
+  testExtractScalar("123", "$", "123");
+  testExtractScalar("-1", "$", "-1");
+  testExtractScalar("\"abc\"", "$", "abc");
+  testExtractScalar("\"\"", "$", "");
+  testExtractScalar("null", "$", std::nullopt);
+
+  // Test character escaped values
+  testExtractScalar("\"ab\\u0001c\"", "$", "ab\001c");
+  testExtractScalar("\"ab\\u0002c\"", "$", "ab\002c");
+
+  // Complex types should return null
+  testExtractScalar("[1, 2, 3]", "$", std::nullopt);
+  testExtractScalar("{\"a\": 1}", "$", std::nullopt);
+}
+
+TEST_F(SIMDJsonExtractorTest, jsonValueTest) {
+  // Check scalar values
+  testExtract("123", "$", "123");
+  testExtract("-1", "$", "-1");
+  testExtract("0.01", "$", "0.01");
+  testExtract("\"abc\"", "$", "\"abc\"");
+  testExtract("\"\"", "$", "\"\"");
+  testExtract("null", "$", "null");
+
+  // Test character escaped values
+  testExtract("\"ab\\u0001c\"", "$", "\"ab\\u0001c\"");
+  testExtract("\"ab\\u0002c\"", "$", "\"ab\\u0002c\"");
+
+  // Complex types should return json values
+  testExtract("[1, 2, 3]", "$", "[1,2,3]");
+  testExtract("{\"a\": 1}", "$", "{\"a\":1}");
+}
+
+TEST_F(SIMDJsonExtractorTest, arrayJsonValueTest) {
+  testExtract("[]", "$[0]", std::nullopt);
+  testExtract("[1, 2, 3]", "$[0]", "1");
+  testExtract("[1, 2]", "$[1]", "2");
+  testExtract("[1, null]", "$[1]", "null");
+  // Out of bounds
+  testExtract("[1]", "$[1]", std::nullopt);
+  // Check skipping complex structures
+  testExtract("[{\"a\": 1}, 2, 3]", "$[1]", "2");
+}
+
+TEST_F(SIMDJsonExtractorTest, objectJsonValueTest) {
+  testExtractScalar("{}", "$.fuu", std::nullopt);
+  testExtractScalar("{\"a\": 1}", "$.fuu", std::nullopt);
+  testExtractScalar("{\"fuu\": 1}", "$.fuu", "1");
+  testExtractScalar("{\"a\": 0, \"fuu\": 1}", "$.fuu", "1");
+  // Check skipping complex structures
+  testExtractScalar("{\"a\": [1, 2, 3], \"fuu\": 1}", "$.fuu", "1");
+}
+
+TEST_F(SIMDJsonExtractorTest, fullScalarTest) {
+  testExtractScalar("{}", "$", std::nullopt);
+  testExtractScalar(
+      "{\"fuu\": {\"bar\": 1}}",
+      "$.fuu",
+      std::nullopt); // Null b/c value is complex
+  testExtractScalar("{\"fuu\": 1}", "$.fuu", "1");
+  testExtractScalar("{\"fuu\": 1}", "$[fuu]", "1");
+  testExtractScalar("{\"fuu\": 1}", "$[\"fuu\"]", "1");
+  testExtractScalar("{\"ab\\\"cd\\\"ef\": 2}", "$[\"ab\\\"cd\\\"ef\"]", "2");
+  testExtractScalar("{\"fuu\": null}", "$.fuu", std::nullopt);
+  testExtractScalar("{\"fuu\": 1}", "$.bar", std::nullopt);
+  testExtractScalar(
+      "{\"fuu\": [\"\\u0001\"]}",
+      "$.fuu[0]",
+      "\001"); // Test escaped characters
+  testExtractScalar("{\"fuu\": 1, \"bar\": \"abc\"}", "$.bar", "abc");
+  testExtractScalar("{\"fuu\": [0.1, 1, 2]}", "$.fuu[0]", "0.1");
+  testExtractScalar(
+      "{\"fuu\": [0, [100, 101], 2]}",
+      "$.fuu[1]",
+      std::nullopt); // Null b/c value is complex type
+  testExtractScalar("{\"fuu\": [0, [100, 101], 2]}", "$.fuu[1][1]", "101");
+  testExtractScalar(
+      "{\"fuu\": [0, {\"bar\": {\"key\" : [\"value\"]}}, 2]}",
+      "$.fuu[1].bar.key[0]",
+      "value");
+
+  // Test non-object extraction
+  testExtractScalar("[0, 1, 2]", "$[0]", "0");
+  testExtractScalar("\"abc\"", "$", "abc");
+  testExtractScalar("123", "$", "123");
+  testExtractScalar("null", "$", std::nullopt);
+
+  // Test numeric path expression matches arrays and objects
+  testExtractScalar("[0, 1, 2]", "$.1", "1");
+  testExtractScalar("[0, 1, 2]", "$[1]", "1");
+  testExtractScalar("[0, 1, 2]", "$[\"1\"]", "1");
+  testExtractScalar("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$.1", "1");
+  testExtractScalar("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$[1]", "1");
+  testExtractScalar("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$[\"1\"]", "1");
+
+  // Test fields starting with a digit
+  testExtractScalar(
+      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$.30day", "1");
+  testExtractScalar(
+      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$[30day]", "1");
+  testExtractScalar(
+      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$[\"30day\"]", "1");
+}
+
+TEST_F(SIMDJsonExtractorTest, fullJsonValueTest) {
+  testExtract("{}", "$", "{}");
+  testExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu", "{\"bar\":1}");
+  testExtract("{\"fuu\": 1}", "$.fuu", "1");
+  testExtract("{\"fuu\": 1}", "$[fuu]", "1");
+  testExtract("{\"fuu\": 1}", "$[\"fuu\"]", "1");
+  testExtract("{\"fuu\": null}", "$.fuu", "null");
+  testExtract("{\"fuu\": 1}", "$.bar", std::nullopt);
+  testExtract(
+      "{\"fuu\": [\"\\u0001\"]}",
+      "$.fuu[0]",
+      "\"\\u0001\""); // Test escaped characters
+  testExtract("{\"fuu\": 1, \"bar\": \"abc\"}", "$.bar", "\"abc\"");
+  testExtract("{\"fuu\": [0.1, 1, 2]}", "$.fuu[0]", "0.1");
+  testExtract("{\"fuu\": [0, [100, 101], 2]}", "$.fuu[1]", "[100,101]");
+  testExtract("{\"fuu\": [0, [100, 101], 2]}", "$.fuu[1][1]", "101");
+
+  // Test non-object extraction
+  testExtract("[0, 1, 2]", "$[0]", "0");
+  testExtract("\"abc\"", "$", "\"abc\"");
+  testExtract("123", "$", "123");
+  testExtract("null", "$", "null");
+
+  // Test extraction using bracket json path
+  testExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"]", "{\"bar\":1}");
+  testExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"][\"bar\"]", "1");
+  testExtract("{\"fuu\": 1}", "$[\"fuu\"]", "1");
+  testExtract("{\"fuu\": null}", "$[\"fuu\"]", "null");
+  testExtract("{\"fuu\": 1}", "$[\"bar\"]", std::nullopt);
+  testExtract(
+      "{\"fuu\": [\"\\u0001\"]}",
+      "$[\"fuu\"][0]",
+      "\"\\u0001\""); // Test escaped characters
+  testExtract("{\"fuu\": 1, \"bar\": \"abc\"}", "$[\"bar\"]", "\"abc\"");
+  testExtract("{\"fuu\": [0.1, 1, 2]}", "$[\"fuu\"][0]", "0.1");
+  testExtract("{\"fuu\": [0, [100, 101], 2]}", "$[\"fuu\"][1]", "[100,101]");
+  testExtract("{\"fuu\": [0, [100, 101], 2]}", "$[\"fuu\"][1][1]", "101");
+
+  // Test extraction using bracket json path with special json characters in
+  // path
+  testExtract("{\"@$fuu\": {\".b.ar\": 1}}", "$[\"@$fuu\"]", "{\".b.ar\":1}");
+  testExtract("{\"fuu..\": 1}", "$[\"fuu..\"]", "1");
+  testExtract("{\"fu*u\": null}", "$[\"fu*u\"]", "null");
+  testExtract("{\",fuu\": 1}", "$[\"bar\"]", std::nullopt);
+  testExtract(
+      "{\",fuu\": [\"\\u0001\"]}",
+      "$[\",fuu\"][0]",
+      "\"\\u0001\""); // Test escaped characters
+  testExtract(
+      "{\":fu:u:\": 1, \":b:ar:\": \"abc\"}", "$[\":b:ar:\"]", "\"abc\"");
+  testExtract("{\"?()fuu\": [0.1, 1, 2]}", "$[\"?()fuu\"][0]", "0.1");
+  testExtract("{\"f?uu\": [0, [100, 101], 2]}", "$[\"f?uu\"][1]", "[100,101]");
+  testExtract("{\"fuu()\": [0, [100, 101], 2]}", "$[\"fuu()\"][1][1]", "101");
+
+  // Test extraction using mix of bracket and dot notation json path
+  testExtract("{\"fuu\": {\"bar\": 1}}", "$[\"fuu\"].bar", "1");
+  testExtract("{\"fuu\": {\"bar\": 1}}", "$.fuu[\"bar\"]", "1");
+  testExtract(
+      "{\"fuu\": [\"\\u0001\"]}",
+      "$[\"fuu\"][0]",
+      "\"\\u0001\""); // Test escaped characters
+  testExtract(
+      "{\"fuu\": [\"\\u0001\"]}",
+      "$.fuu[0]",
+      "\"\\u0001\""); // Test escaped characters
+
+  // Test extraction using  mix of bracket and dot notation json path with
+  // special json characters in path
+  testExtract("{\"@$fuu\": {\"bar\": 1}}", "$[\"@$fuu\"].bar", "1");
+  testExtract(
+      "{\",fuu\": {\"bar\": [\"\\u0001\"]}}",
+      "$[\",fuu\"].bar[0]",
+      "\"\\u0001\""); // Test escaped characters
+
+  // Test numeric path expression matches arrays and objects
+  testExtract("[0, 1, 2]", "$.1", "1");
+  testExtract("[0, 1, 2]", "$[1]", "1");
+  testExtract("[0, 1, 2]", "$[\"1\"]", "1");
+  testExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$.1", "1");
+  testExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$[1]", "1");
+  testExtract("{\"0\" : 0, \"1\" : 1, \"2\" : 2 }", "$[\"1\"]", "1");
+
+  // Test fields starting with a digit
+  testExtract("{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$.30day", "1");
+  testExtract(
+      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$[30day]", "1");
+  testExtract(
+      "{\"15day\" : 0, \"30day\" : 1, \"90day\" : 2 }", "$[\"30day\"]", "1");
+  testExtract("{\"a\\\\b\": 4}", "$[\"a\\\\b\"]", "4");
+  testExtract("{\"fuu\" : null}", "$.a.b", std::nullopt);
+}
+
+TEST_F(SIMDJsonExtractorTest, invalidJsonPathTest) {
+  expectThrowInvalidArgument("", "");
+  expectThrowInvalidArgument("{}", "$.bar[2][-1]");
+  expectThrowInvalidArgument("{}", "$.fuu..bar");
+  expectThrowInvalidArgument("{}", "$.");
+  expectThrowInvalidArgument("", "$$");
+  expectThrowInvalidArgument("", " ");
+  expectThrowInvalidArgument("", ".");
+  expectThrowInvalidArgument(
+      "{ \"store\": { \"book\": [{ \"title\": \"title\" }] } }",
+      "$.store.book[");
+}
+
+TEST_F(SIMDJsonExtractorTest, reextractJsonTest) {
+  std::string json = R"DELIM(
+      {"store":
+        {"fruit":[
+          {"weight":8, "type":"apple"},
+          {"weight":9, "type":"pear"}],
+         "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
+         "book":[
+            {"author":"Nigel Rees",
+             "title":"ayings of the Century",
+             "category":"reference",
+             "price":8.95},
+            {"author":"Herman Melville",
+             "title":"Moby Dick",
+             "category":"fiction",
+             "price":8.99,
+             "isbn":"0-553-21311-3"},
+            {"author":"J. R. R. Tolkien",
+             "title":"The Lord of the Rings",
+             "category":"fiction",
+             "reader":[
+                {"age":25,
+                 "name":"bob"},
+                {"age":26,
+                 "name":"jack"}],
+             "price":22.99,
+             "isbn":"0-395-19395-8"}],
+          "bicycle":{"price":19.95, "color":"red"}},
+        "e mail":"amy@only_for_json_udf_test.net",
+        "owner":"amy"})DELIM";
+  std::string extract;
+  std::string ret;
+  auto consumer = [&ret](auto& v) {
+    ret = simdjson::to_json_string(v).value();
+  };
+
+  simdJsonExtract(json, "$", consumer);
+  // extract the same json json by giving the root path
+  extract.swap(ret);
+  simdJsonExtract(extract, "$", consumer);
+  // expect the re-extracted json object to be the same as the original
+  EXPECT_EQ(ret, extract);
+}
+
+TEST_F(SIMDJsonExtractorTest, jsonMultipleExtractsTest) {
+  std::string json = R"DELIM(
+      {"store":
+        {"fruit":[
+          {"weight":8, "type":"apple"},
+          {"weight":9, "type":"pear"}],
+         "basket":[[1,2,{"b":"y","a":"x"}],[3,4],[5,6]],
+         "book":[
+            {"author":"Nigel Rees",
+             "title":"ayings of the Century",
+             "category":"reference",
+             "price":8.95},
+            {"author":"Herman Melville",
+             "title":"Moby Dick",
+             "category":"fiction",
+             "price":8.99,
+             "isbn":"0-553-21311-3"},
+            {"author":"J. R. R. Tolkien",
+             "title":"The Lord of the Rings",
+             "category":"fiction",
+             "reader":[
+                {"age":25,
+                 "name":"bob"},
+                {"age":26,
+                 "name":"jack"}],
+             "price":22.99,
+             "isbn":"0-395-19395-8"}],
+          "bicycle":{"price":19.95, "color":"red"}},
+        "e mail":"amy@only_for_json_udf_test.net",
+        "owner":"amy"})DELIM";
+  std::string extract1;
+  std::string extract2;
+  std::string ret;
+  auto consumer = [&ret](auto& v) {
+    ret = simdjson::to_json_string(v).value();
+  };
+
+  simdJsonExtract(json, "$.store", consumer);
+  extract1.swap(ret);
+  simdJsonExtract(extract1, "$.fruit", consumer);
+  extract2.swap(ret);
+  simdJsonExtract(json, "$.store.fruit", consumer);
+  EXPECT_EQ(ret, extract2);
+}
+
+TEST_F(SIMDJsonExtractorTest, invalidJson) {
+  // No-op consumer.
+  auto consumer = [](auto& /* unused */) {};
+
+  // Object key is invalid.
+  std::string json = "{\"foo: \"bar\"}";
+  EXPECT_FALSE(simdJsonExtract(json, "$.foo", consumer));
+  // Object value is invalid.
+  json = "{\"foo\": \"bar}";
+  EXPECT_FALSE(simdJsonExtract(json, "$.foo", consumer));
+  // Value in array is invalid.
+  // Inner object is invalid.
+  json = "{\"foo\": [\"bar\", \"baz]}";
+  EXPECT_FALSE(simdJsonExtract(json, "$.foo[0]", consumer));
+}
+} // namespace


### PR DESCRIPTION
Summary:
This adds a new implementation of the JsonExtractor, called SIMDJsonExtractor, that provides similar
functionality, but using the more performant simdjson library in place of folly.

One key difference with simdjson that I had to work around is that it uses a cursor so values have a "use it or
lose it" ephemeral quality.  To handle this, I allow the user to pass in a consumer function that gets called on
final values (what would be returned by the original JsonExractor) while they're still valid.  I also had to make
the extract call recursive to handle the "*" operator on arrays.

I will update the json_extract and json_extract_scalar functions to use the new extractor in forthcoming diffs,
and include benchmark results there, but from what I've seen, the performance benefits are in line with what
we've seen from using simdjson in other JSON UDFs.

Ultimately, the plan is that this should entirely replace the JsonExtractor so we can remove it from the
codebase.

Differential Revision: D47235020

