### PR TITLE
Register max_data_size_for_stats and sum_data_size as internal agg functions

### DIFF
--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -61,14 +61,18 @@ void registerAllAggregateFunctions(const std::string& prefix) {
   registerMapAggAggregate(prefix);
   registerMapUnionAggregate(prefix);
   registerMapUnionSumAggregate(prefix);
-  registerMaxDataSizeForStatsAggregate(prefix);
-  registerSumDataSizeForStatsAggregate(prefix);
   registerMinMaxAggregates(prefix);
   registerMinMaxByAggregates(prefix);
   registerSetAggAggregate(prefix);
   registerSetUnionAggregate(prefix);
   registerSumAggregate(prefix);
   registerVarianceAggregates(prefix);
+
+  // Register internal aggregate functions. Presto doesn't expose
+  // these functions to users.
+  static const std::string kInternalPrefix = prefix + "$internal$";
+  registerMaxDataSizeForStatsAggregate(kInternalPrefix);
+  registerSumDataSizeForStatsAggregate(kInternalPrefix);
 }
 
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
Resolves this https://github.com/facebookincubator/velox/issues/5447 and https://github.com/facebookincubator/velox/issues/5484