### PR TITLE
make buildPartitionBounds_ a vector int64 instead of int32 to avoid integer overflow when the hashtable has billions of records

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,10 @@ option(VELOX_ENABLE_CCACHE "Use ccache if installed." ON)
 option(VELOX_BUILD_TEST_UTILS "Builds Velox test utilities" OFF)
 option(VELOX_BUILD_PYTHON_PACKAGE "Builds Velox Python bindings" OFF)
 option(VELOX_BUILD_BENCHMARKS "Builds Velox benchmarks" OFF)
+option(
+  VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND
+  "make buildPartitionBounds_ a vector int64 instead of int32 to avoid integer overflow when the hashtable has billions of records"
+  OFF)
 
 if(${VELOX_BUILD_MINIMAL})
   # Enable and disable components for velox base build
@@ -222,6 +226,12 @@ endif()
 # define processor variable for conditional compilation
 if(${VELOX_CODEGEN_SUPPORT})
   add_compile_definitions(CODEGEN_ENABLED=1)
+endif()
+
+# make buildPartitionBounds_ a vector int64 instead of int32 to avoid integer
+# overflow
+if(${VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND})
+  add_compile_definitions(VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND)
 endif()
 
 # MacOSX enables two-level namespace by default:

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -779,12 +779,17 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
   std::fill(
       buildPartitionBounds_.begin(),
       buildPartitionBounds_.begin() + buildPartitionBounds_.capacity(),
-      std::numeric_limits<int32_t>::max());
+      std::numeric_limits<PartitionBoundIndexType>::max());
   for (auto i = 0; i < numPartitions; ++i) {
     // The bounds are rounded up to cache line size.
     buildPartitionBounds_[i] = bits::roundUp(
         (capacity_ / numPartitions) * i,
         folly::hardware_destructive_interference_size);
+    // Bounds must always be positive
+    VELOX_CHECK_GE(
+        buildPartitionBounds_[i],
+        0,
+        "Turn on VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND to avoid integer overflow in buildPartitionBounds_");
   }
   buildPartitionBounds_.back() = capacity_;
   std::vector<std::shared_ptr<AsyncSource<bool>>> partitionSteps;
@@ -849,14 +854,17 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
 namespace {
 // Returns an index into 'buildPartitionBounds_' given an index into tags of the
 // HashTable.
-int32_t
-findPartition(int32_t index, const int32_t* bounds, int32_t numPartitions) {
+int32_t findPartition(
+    PartitionBoundIndexType index,
+    const PartitionBoundIndexType* bounds,
+    int32_t numPartitions) {
   // The partition bounds are padded to batch size.
-  constexpr int32_t kBatch = xsimd::batch<int32_t>::size;
-  auto indexVector = xsimd::batch<int32_t>::broadcast(index);
+  constexpr int32_t kBatch = xsimd::batch<PartitionBoundIndexType>::size;
+  auto indexVector = xsimd::batch<PartitionBoundIndexType>::broadcast(index);
   for (auto i = 1; i < numPartitions; i += kBatch) {
-    uint8_t bits = simd::toBitMask(
-        indexVector < xsimd::batch<int32_t>::load_unaligned(bounds + i));
+    auto bits = simd::toBitMask(
+        indexVector <
+        xsimd::batch<PartitionBoundIndexType>::load_unaligned(bounds + i));
     if (bits) {
       return i + __builtin_ctz(bits) - 1;
     }
@@ -878,7 +886,8 @@ void HashTable<ignoreNullKeys>::partitionRows(
     hashRows(folly::Range<char**>(rows.data(), numRows), true, hashes);
     VELOX_DCHECK_EQ(
         0,
-        buildPartitionBounds_.capacity() % xsimd::batch<int32_t>::size,
+        buildPartitionBounds_.capacity() %
+            xsimd::batch<PartitionBoundIndexType>::size,
         "partition bounds must be padded to SIMD width");
     for (auto i = 0; i < numRows; ++i) {
       auto index = ProbeState::tagsByteOffset(hashes[i], sizeMask_);
@@ -998,10 +1007,10 @@ FOLLY_ALWAYS_INLINE void HashTable<ignoreNullKeys>::buildFullProbe(
     uint64_t hash,
     char* inserted,
     bool extraCheck,
-    int32_t partitionBegin,
-    int32_t partitionEnd,
+    PartitionBoundIndexType partitionBegin,
+    PartitionBoundIndexType partitionEnd,
     std::vector<char*>* FOLLY_NULLABLE overflows) {
-  auto insertFn = [&](int32_t /*row*/, int32_t index) {
+  auto insertFn = [&](int32_t /*row*/, PartitionBoundIndexType index) {
     if (index < partitionBegin || index >= partitionEnd) {
       overflows->push_back(inserted);
       return nullptr;
@@ -1056,8 +1065,8 @@ void HashTable<ignoreNullKeys>::insertForJoin(
     char** groups,
     uint64_t* hashes,
     int32_t numGroups,
-    int32_t partitionBegin,
-    int32_t partitionEnd,
+    PartitionBoundIndexType partitionBegin,
+    PartitionBoundIndexType partitionEnd,
     std::vector<char*>* overflow) {
   // The insertable rows are in the table, all get put in the hash
   // table or array.

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -22,6 +22,12 @@
 
 namespace facebook::velox::exec {
 
+#ifdef VELOX_ENABLE_INT64_BUILD_PARTITION_BOUND
+using PartitionBoundIndexType = int64_t;
+#else
+using PartitionBoundIndexType = int32_t;
+#endif
+
 struct HashLookup {
   explicit HashLookup(const std::vector<std::unique_ptr<VectorHasher>>& h)
       : hashers(h) {}
@@ -556,8 +562,9 @@ class HashTable : public BaseHashTable {
       char* FOLLY_NULLABLE* FOLLY_NULLABLE groups,
       uint64_t* FOLLY_NULLABLE hashes,
       int32_t numGroups,
-      int32_t partitionBegin = 0,
-      int32_t partitionEnd = std::numeric_limits<int32_t>::max(),
+      PartitionBoundIndexType partitionBegin = 0,
+      PartitionBoundIndexType partitionEnd =
+          std::numeric_limits<PartitionBoundIndexType>::max(),
       std::vector<char*>* FOLLY_NULLABLE overflows = nullptr);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
@@ -645,8 +652,8 @@ class HashTable : public BaseHashTable {
       uint64_t hash,
       char* FOLLY_NULLABLE row,
       bool extraCheck,
-      int32_t partitionBegin,
-      int32_t partitionEnd,
+      PartitionBoundIndexType partitionBegin,
+      PartitionBoundIndexType partitionEnd,
       std::vector<char*>* FOLLY_NULLABLE overflows);
 
   // Updates 'hashers_' to correspond to the keys in the
@@ -695,7 +702,7 @@ class HashTable : public BaseHashTable {
   // Bounds of independently buildable index ranges in the table. The
   // range of partition i starts at [i] and ends at [i +1]. Bounds are multiple
   // of cache line  size.
-  raw_vector<int32_t> buildPartitionBounds_;
+  raw_vector<PartitionBoundIndexType> buildPartitionBounds_;
 
   // Executor for parallelizing hash join build. This may be the
   // executor for Drivers. If this executor is indefinitely taken by


### PR DESCRIPTION
## Problem Description
Testing Q95 from TPC-DS SF1000 failed with the error "std::exception".
Here is one root cause of the exception I discovered.
```
E0630 08:10:46.968391 1318667 HashTable.cpp:746] Error in async hash build: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: UNREACHABLE_CODE
Reason: Partition index out of range
Retriable: False
Function: findPartition
File: /root/xinxianyin/build/prestissimo/presto-native-execution/velox/velox/exec/HashTable.cpp
Line: 866
Stack trace:
# 0  
# 1  
# 2  
# 3  
# 4  
# 5  
# 6  
# 7  
# 8  
# 9  
# 10 
# 11 
```

## Root Cause
"Partition index out of range" error was reported here.
https://github.com/facebookincubator/velox/blob/main/velox/exec/HashTable.cpp#L864

The root cause was that buildPartitionBounds_ has negative values in it. This is the buildPartitionBounds_ values we captured when throwing the ""Partition index out of range"" error.
```
I0701 02:26:13.077515 2294324 HashTable.cpp:868] bounds i=1 val=(268435456, 536870912, 805306368, 1073741824, 1342177280, 1610612736, 1879048192, -2147483648)
I0701 02:26:13.077518 2294324 HashTable.cpp:868] bounds i=9 val=(-1879048192, -1610612736, -1342177280, -1073741824, -805306368, -536870912, -268435456, 0)
```

This is obviously caused by integer overflow. In fact, partition bound index can be larger than int32_t.max when the size of the table has billions of rows. 

## Solution
Therefore, we need to make [`HashTable.buildPartitionBounds_`](https://code.byted.org/dp/velox/blob/bd_main/velox/exec/HashTable.h#L687) a vector of int64_t values instead of int32_t values (consistent with [`HashTable.capacity_`](https://github.com/facebookincubator/velox/blob/main/velox/exec/HashTable.h#L683)).