### PR TITLE
Add array_remove Presto scalar function

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -127,6 +127,13 @@ Array Functions
 
     If ``instance > 0``, returns the position of the ``instance``-th occurrence of the ``element`` in array ``x``. If ``instance < 0``, returns the position of the ``instance``-to-last occurrence of the ``element`` in array ``x``. If no matching element instance is found, 0 is returned.
 
+.. function:: array_remove(x, element) -> array
+
+    Remove all elements that equal ``element`` from array ``x``.
+
+        SELECT array_remove(ARRAY [1, 2, 3], 3); -- [1, 2]
+        SELECT array_remove(ARRAY [2, 1, NULL], 1); -- [2, NULL]
+
 .. function:: array_sort(array(E)) -> array(E)
 
      Returns an array which has the sorted order of the input array x. The elements of x must

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -77,6 +77,12 @@ inline void registerArrayNormalizeFunctions(const std::string& prefix) {
 }
 
 template <typename T>
+inline void registerArrayRemoveFunctions(const std::string& prefix) {
+  registerFunction<ArrayRemoveFunction, Array<T>, Array<T>, T>(
+      {prefix + "array_remove"});
+}
+
+template <typename T>
 inline void registerArrayTrimFunctions(const std::string& prefix) {
   registerFunction<ArrayTrimFunction, Array<T>, Array<T>, int64_t>(
       {prefix + "trim_array"});
@@ -198,6 +204,27 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayHasDuplicatesFunctions<int128_t>(prefix);
   registerArrayHasDuplicatesFunctions<Varchar>(prefix);
 
+  registerArrayRemoveFunctions<int8_t>(prefix);
+  registerArrayRemoveFunctions<int16_t>(prefix);
+  registerArrayRemoveFunctions<int32_t>(prefix);
+  registerArrayRemoveFunctions<int64_t>(prefix);
+  registerArrayRemoveFunctions<int128_t>(prefix);
+  registerArrayRemoveFunctions<float>(prefix);
+  registerArrayRemoveFunctions<double>(prefix);
+  registerArrayRemoveFunctions<bool>(prefix);
+  registerArrayRemoveFunctions<Timestamp>(prefix);
+  registerArrayRemoveFunctions<Date>(prefix);
+  registerArrayRemoveFunctions<Varbinary>(prefix);
+  registerFunction<
+      ArrayRemoveFunctionString,
+      Array<Varchar>,
+      Array<Varchar>,
+      Varchar>({prefix + "array_remove"});
+  registerFunction<
+      ArrayRemoveFunction,
+      Array<Generic<T1>>,
+      Array<Generic<T1>>,
+      Generic<T1>>({prefix + "array_remove"});
   registerArrayFrequencyFunctions<int64_t>(prefix);
   registerArrayFrequencyFunctions<int128_t>(prefix);
   registerArrayFrequencyFunctions<Varchar>(prefix);

--- a/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayRemoveTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::test;
+
+namespace {
+
+class ArrayRemoveTest : public FunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+};
+
+/// Remove all elements that equal element from array
+TEST_F(ArrayRemoveTest, removeArray) {
+  const auto arrayVector = makeArrayVector<std::string>(
+      {{"1", "2", "3", "4"},
+       {"3", "4", "5"},
+       {"7", "8", "9"},
+       {"10", "20", "30"}});
+  const auto elementVector = makeFlatVector<std::string>({"2", "3", "9", "20"});
+  VectorPtr expected;
+
+  expected = makeArrayVector<std::string>({
+      {"1", "3", "4"},
+      {"4", "5"},
+      {"7", "8"},
+      {"10", "30"},
+  });
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+/// Remove all elements that equal element from array with null
+TEST_F(ArrayRemoveTest, removeArrayWithNull) {
+  const auto arrayVector = makeNullableArrayVector<int64_t>(
+      {{1, 2, std::nullopt, 4},
+       {3, 4, 5},
+       {7, 8, 9},
+       {10, 20, 30, std::nullopt}});
+  const auto elementVector = makeFlatVector<int64_t>({2, 3, 9, 20});
+  VectorPtr expected;
+
+  expected = makeNullableArrayVector<int64_t>({
+      {1, std::nullopt, 4},
+      {4, 5},
+      {7, 8},
+      {10, 30, std::nullopt},
+  });
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+/// Remove all elements that equal element from char array with/without NULL
+TEST_F(ArrayRemoveTest, removeCharArray) {
+  const auto arrayVector = makeNullableArrayVector<StringView>(
+      {{"aa"_sv, "bb"_sv, std::nullopt, "cc"_sv},
+       {"aa"_sv, "cc"_sv, "dd"_sv},
+       {"aa"_sv, "ee"_sv, "ff"_sv},
+       {"aa"_sv, "dd"_sv, "ff"_sv, std::nullopt}});
+  const auto elementVector =
+      makeFlatVector<StringView>({"aa"_sv, "cc"_sv, "ff"_sv, "ff"_sv});
+  VectorPtr expected;
+
+  expected = makeNullableArrayVector<StringView>({
+      {"bb"_sv, std::nullopt, "cc"_sv},
+      {"aa"_sv, "dd"_sv},
+      {"aa"_sv, "ee"_sv},
+      {"aa"_sv, "dd"_sv, std::nullopt},
+  });
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+/// Remove complex type.
+TEST_F(ArrayRemoveTest, complexTypes) {
+  // [[1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6]]
+  auto baseVector = makeArrayVector<int64_t>(
+      {{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}});
+
+  // [[1, 1], [2, 2], [3, 3], [4, 4]]
+  // [[5, 5], [6, 6]]
+  auto arrayVector = makeArrayVector({0, 4}, baseVector);
+
+  // [[2, 2]]
+  // [[5, 5]]
+  auto elementVector = makeArrayVector<int64_t>({{2, 2}, {5, 5}});
+
+  // [[1, 1], [3, 3], [4, 4]]
+  // [[6, 6]]
+  auto expected = makeArrayVector(
+      {0, 3}, makeArrayVector<int64_t>({{1, 1}, {3, 3}, {4, 4}, {6, 6}}));
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+/// Remove complex type with NULL.
+TEST_F(ArrayRemoveTest, complexTypesWithNull) {
+  // Make a vector with a NULL.
+  // [[1, 2], null, [3, 2], [2, 2, 3], [2, 1, 5]]
+  auto baseVectorWithNull = makeNullableArrayVector<int64_t>(
+      {{1, 2}, {std::nullopt}, {3, 2}, {2, 2, 3}, {2, 1, 5}});
+
+  // [[1, 2], null, [3, 2]]
+  // [[2, 2, 3], [2, 1, 5]]
+  auto arrayVector = makeArrayVector({0, 3}, baseVectorWithNull);
+
+  // [[1, 9]]
+  // [[2, 1, 5]]
+  auto elementVector = makeNullableArrayVector<int64_t>({{1, 9}, {2, 1, 5}});
+
+  // [[1, 2], null, [3, 2]]
+  // [[2, 2, 3]]
+  auto expected = makeArrayVector(
+      {0, 3},
+      makeNullableArrayVector<int64_t>(
+          {{1, 2}, {std::nullopt}, {3, 2}, {2, 2, 3}}));
+
+  testExpression(
+      "array_remove(c0, c1)", {arrayVector, elementVector}, expected);
+}
+
+//  Remove array when element is null
+TEST_F(ArrayRemoveTest, removeArrayNullElement) {
+  auto input = makeNullableArrayVector<std::int64_t>(
+      {{1, 2, 3}, {1, std::nullopt, std::nullopt, 4}});
+  auto elementVector =
+      makeNullableFlatVector<std::int64_t>({std::nullopt, std::nullopt});
+  auto expected =
+      makeNullableArrayVector<std::int64_t>({std::nullopt, std::nullopt});
+  testExpression("array_remove(c0, c1)", {input, elementVector}, expected);
+}
+} // namespace

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_executable(
   ArrayNoneMatchTest.cpp
   ArrayNormalizeTest.cpp
   ArrayPositionTest.cpp
+  ArrayRemoveTest.cpp
   ArraySortTest.cpp
   ArrayShuffleTest.cpp
   ArraysOverlapTest.cpp


### PR DESCRIPTION
# Description
Presto support [array_remove](https://prestodb.io/docs/current/functions/array.html#:~:text=0%20is%20returned.-,array_remove,-(x%2C ) 
and 
Spark support [array_remove](https://spark.apache.org/docs/latest/api/sql/#array_remove) since 2.4.0</br>
let's add it to Velox.</br>
### array_remove(x, element) → array
* Not Implemented for Presto and Spark.
* Remove all elements that equal element from array x.
### For example:
```
> SELECT array_remove(array(1, 2, 3, null, 3), 3);
 [1,2,null]
```