### PR TITLE
Optimize row vector reusing in table scan

### DIFF
--- a/velox/common/testutil/TestValue.cpp
+++ b/velox/common/testutil/TestValue.cpp
@@ -61,7 +61,6 @@ bool TestValue::enabled() {
   return false;
 }
 void TestValue::clear(const std::string& injectionPoint) {}
-void TestValue::adjust(const std::string& injectionPoint, void* testData) {}
 #endif
 
 } // namespace facebook::velox::common::testutil

--- a/velox/common/testutil/TestValue.h
+++ b/velox/common/testutil/TestValue.h
@@ -102,10 +102,18 @@ void TestValue::set(
     std::function<void(T*)> injectionCb) {}
 #endif
 
+#ifdef NDEBUG
+// Keep the definition in header so that it can be inlined (elided).
+inline void TestValue::adjust(
+    const std::string& injectionPoint,
+    void* testData) {}
+#endif
+
 #define VELOX_CONCAT(x, y) __##x##y
 #define VELOX_VARNAME(x) VELOX_CONCAT(x, Obj)
 
-#define SCOPED_TESTVALUE_SET(point, ...) \
-  ScopedTestValue VELOX_VARNAME(__LINE__)(point, ##__VA_ARGS__)
+#define SCOPED_TESTVALUE_SET(point, ...)                              \
+  ::facebook::velox::common::testutil::ScopedTestValue VELOX_VARNAME( \
+      __LINE__)(point, ##__VA_ARGS__)
 
 } // namespace facebook::velox::common::testutil

--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -32,8 +32,10 @@ static void scatter(RowSet rows, VectorPtr* result) {
   for (int32_t i = 0; i < rows.size(); ++i) {
     rawIndices[rows[i]] = i;
   }
-  *result =
-      BaseVector::wrapInDictionary(BufferPtr(nullptr), indices, end, *result);
+  // Disable dictionary values caching in expression eval so that we don't need
+  // to reallocate the result for every batch.
+  result->get()->disableMemo();
+  *result = BaseVector::wrapInDictionary(nullptr, indices, end, *result);
 }
 } // namespace
 

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/SuccinctPrinter.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/core/Expressions.h"
 #include "velox/expression/CastExpr.h"
 #include "velox/expression/ConstantExpr.h"
@@ -969,8 +970,11 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
 
   // If the expression depends on one dictionary, results are cacheable.
   bool mayCache = distinctFields_.size() == 1 &&
-      VectorEncoding::isDictionary(context.wrapEncoding());
+      VectorEncoding::isDictionary(context.wrapEncoding()) &&
+      !peeledVectors[0]->memoDisabled();
 
+  common::testutil::TestValue::adjust(
+      "facebook::velox::exec::Expr::peelEncodings::mayCache", &mayCache);
   return {newRows, finalRowsHolder.get(), mayCache};
 }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -752,7 +752,7 @@ void BaseVector::prepareForReuse(VectorPtr& vector, vector_size_t size) {
   vector->resize(size);
 }
 
-void BaseVector::prepareForReuse() {
+void BaseVector::reuseNulls() {
   // Check nulls buffer. Keep the buffer if singly-referenced and mutable and
   // there is at least one null bit set. Reset otherwise.
   if (nulls_) {
@@ -766,6 +766,10 @@ void BaseVector::prepareForReuse() {
       rawNulls_ = nullptr;
     }
   }
+}
+
+void BaseVector::prepareForReuse() {
+  reuseNulls();
   this->resetDataDependentFlags(nullptr);
 }
 

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -245,7 +245,7 @@ class ConstantVector final : public SimpleVector<T> {
 
   // Base vector if isScalar() is false (e.g. complex type vector) or if base
   // vector is a lazy vector that hasn't been loaded yet.
-  VectorPtr valueVector() const override {
+  const VectorPtr& valueVector() const override {
     return valueVector_;
   }
 

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -109,7 +109,7 @@ class DictionaryVector : public SimpleVector<T> {
     return indices_;
   }
 
-  VectorPtr valueVector() const override {
+  const VectorPtr& valueVector() const override {
     return dictionaryValues_;
   }
 

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -128,6 +128,7 @@ class LazyVector : public BaseVector {
     BaseVector::length_ = size;
     loader_ = std::move(loader);
     allLoaded_ = false;
+    containsLazyAndIsWrapped_ = false;
   }
 
   inline bool isLoaded() const {

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -108,7 +108,7 @@ class SequenceVector : public SimpleVector<T> {
     return const_cast<SequenceVector<T>*>(this)->loadedVector();
   }
 
-  VectorPtr valueVector() const override {
+  const VectorPtr& valueVector() const override {
     return sequenceValues_;
   }
 

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1252,8 +1252,7 @@ TEST_F(VectorTest, wrapInConstantWithCopy) {
       std::dynamic_pointer_cast<ConstantVector<ComplexType>>(
           BaseVector::wrapInConstant(size, 22, constBaseVector, true));
   EXPECT_NE(constArrayVector->valueVector(), nullptr);
-  // This is 2 because valueVector() doesn't return a reference.
-  EXPECT_EQ(constArrayVector->valueVector().use_count(), 2);
+  EXPECT_TRUE(constArrayVector->valueVector().unique());
   for (auto i = 0; i < size; i++) {
     ASSERT_FALSE(constArrayVector->isNullAt(i));
     ASSERT_TRUE(constArrayVector->equalValueAt(arrayVector.get(), i, 3));
@@ -1265,8 +1264,7 @@ TEST_F(VectorTest, wrapInConstantWithCopy) {
   constArrayVector = std::dynamic_pointer_cast<ConstantVector<ComplexType>>(
       BaseVector::wrapInConstant(size, 22, constBaseVector, true));
   EXPECT_NE(constArrayVector->valueVector(), nullptr);
-  // This is 2 because valueVector() doesn't return a reference.
-  EXPECT_EQ(constArrayVector->valueVector().use_count(), 2);
+  EXPECT_TRUE(constArrayVector->valueVector().unique());
   for (auto i = 0; i < size; i++) {
     ASSERT_TRUE(constArrayVector->isNullAt(i));
   }


### PR DESCRIPTION
Summary:
We see performance regression comparing to Presto Java when reading large struct values with most of the subfields pruned.  The cause is that although pruning is done correctly, the result `RowVector` is not reused properly for several reasons listed below, and large overhead occurs while recreating the vector on each batch.

`RowVector` result is not reused due to the following reasons:
1. When the column is created lazily, we create a new `LazyVector` for each batch, thus the materialized `RowVector` cannot be reused.  Instead we should use `LazyVector::reset` whenever possible.
2. The constant children of `RowVector` are recreated on each batch.  Should reuse the previous one if it is compatible.
3. When a remaining filter exists, the column is wrapped in a dictionary.  With domain tuples, there is a second layer of dictionary inside, possibly with a lazy layer in-between the two.  In `Expr::evalWithMemo`, we cache the innermost base vector (`RowVector` in this case) and prevent us from reusing it in the reader.  In these cases, the base vector is not likely to be shared across different batches (because it is rewritten by reader on each batch), thus there is no point to cache it.  We add a flag to indicate such situation and inform `FilterProject` not to cache such vectors, so that they can be reused by reader.
4. When the encoding of result switching between batches (could happen for example if one row group has nulls and the following one without nulls), we are not reusing result.  We should try to reuse the materialized vector of `LazyVector` and base vector of dictionary in this case.

Differential Revision: D47249077

