### PR TITLE
Migrate TopNFrequencyHistogram aggregate function to Velox

### DIFF
--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -217,6 +217,10 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
   localResult = BaseVector::wrapInDictionary(
       nullptr, rowsToGroupsIndices, rows.end(), localResult);
   context.moveOrCopyResult(localResult, rows, result);
+
+  if (fn_->accumulatorUsesExternalMemory()) {
+    fn_->destroy(folly::Range(groups, groupCount));
+  }
 }
 
 bool CompanionFunctionsRegistrar::registerPartialFunction(


### PR DESCRIPTION
Summary: Migrate the F3 TopNFrequencyHistogram aggregate function to Velox and test the original and companion functions. Besides, this diff also fixes a memory leak in the Velox AggregateCompaionAdapter. The added unit test failed without this fix.

Differential Revision: D46382571

