### PR TITLE
Add query configs to support multi table writer drivers

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -192,6 +192,14 @@ class QueryConfig {
   static constexpr const char* kSparkLegacySizeOfNull =
       "spark.legacy_size_of_null";
 
+  /// The number of local parallel table writer operators per task.
+  static constexpr const char* kTaskWriterCount = "task_writer_count";
+
+  /// The number of local parallel table writer operators per task for
+  /// partitioned writes. If not set, use "task_writer_count".
+  static constexpr const char* kTaskPartitionedWriterCount =
+      "task_partitioned_writer_count";
+
   /// If true, finish the hash probe on an empty build table for a specific set
   /// of hash joins.
   static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
@@ -387,6 +395,15 @@ class QueryConfig {
 
   bool operatorTrackCpuUsage() const {
     return get<bool>(kOperatorTrackCpuUsage, true);
+  }
+
+  uint32_t taskWriterCount() const {
+    return get<uint32_t>(kTaskWriterCount, 1);
+  }
+
+  uint32_t taskPartitionedWriterCount() const {
+    return get<uint32_t>(kTaskPartitionedWriterCount)
+        .value_or(taskWriterCount());
   }
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -208,6 +208,25 @@ Spilling
      - 0
      - Percentage of aggregation or join input batches that will be forced to spill for testing. 0 means no extra spilling.
 
+Table Writer
+------------
+.. list-table::
+   :widths: 20 10 10 70
+   :header-rows: 1
+
+   * - Property Name
+     - Type
+     - Default Value
+     - Description
+   * - task_writer_count
+     - integer
+     - 1
+     - The number of parallel table writer threads per task.
+   * - task_partitioned_writer_count
+     - integer
+     - task_writer_count
+     - The number of parallel table writer threads per task for bucketed table writes. If not set, use 'task_writer_count' as default.
+
 Codegen Configuration
 ---------------------
 .. list-table::


### PR DESCRIPTION
Add the following two query configs to support multi table writer drivers:
'task_writer_count': the number of table writer drivers for non-bucketed
table writes
'task_partitioned_writer_count': the number of table writer drivers for
bucketed table writes
If 'task_partitioned_writer_count' is not set, then we fall back to use
'task_writer_count' which align with Presto java implementation
Details see [multi driver support](https://github.com/facebookincubator/velox/issues/5546)