### PR TITLE
Extend hive partition function and spec to support multi table writer drivers

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -137,6 +137,24 @@ class HivePartitionFunctionSpec : public core::PartitionFunctionSpec {
         channels_(std::move(channels)),
         constValues_(std::move(constValues)) {}
 
+  /// The constructor without 'bucketToPartition' input is used in case that
+  /// we don't know the actual number of partitions until we create the
+  /// partition function instance. The hive partition function spec then builds
+  /// a bucket to partition map based on the actual number of partitions with
+  /// round-robin partitioning scheme to create the function instance. For
+  /// instance, when we create the local partition node with hive bucket
+  /// function to support multiple table writer drivers, we don't know the the
+  /// actual number of table writer drivers until start the task.
+  HivePartitionFunctionSpec(
+      int numBuckets,
+      std::vector<column_index_t> channels,
+      std::vector<VectorPtr> constValues)
+      : HivePartitionFunctionSpec(
+            numBuckets,
+            {},
+            std::move(channels),
+            std::move(constValues)) {}
+
   std::unique_ptr<core::PartitionFunction> create(
       int numPartitions) const override;
 

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -19,10 +19,9 @@
 #include "velox/common/base/Fs.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/core/ITypedExpr.h"
 #include "velox/dwio/dwrf/writer/Writer.h"
-#include "velox/exec/HashPartitionFunction.h"
-#include "velox/exec/Operator.h"
 
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/uuid_generators.hpp>
@@ -97,8 +96,8 @@ std::unique_ptr<core::PartitionFunction> createBucketFunction(
     }
     bucketedByChannels.push_back(inputChannel);
   }
-  return std::make_unique<exec::HashPartitionFunction>(
-      bucketProperty.bucketCount(), inputType, bucketedByChannels);
+  return std::make_unique<HivePartitionFunction>(
+      bucketProperty.bucketCount(), bucketedByChannels);
 }
 
 std::string computeBucketedFileName(

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -246,9 +246,17 @@ void HivePartitionFunction::partition(
 
   static const int32_t kInt32Max = std::numeric_limits<int32_t>::max();
 
-  for (auto i = 0; i < numRows; ++i) {
-    partitions[i] =
-        bucketToPartition_[((hashes_[i] & kInt32Max) % numBuckets_)];
+  if (bucketToPartition_.empty()) {
+    // NOTE: if bucket to partition mapping is empty, then we do identical
+    // mapping.
+    for (auto i = 0; i < numRows; ++i) {
+      partitions[i] = (hashes_[i] & kInt32Max) % numBuckets_;
+    }
+  } else {
+    for (auto i = 0; i < numRows; ++i) {
+      partitions[i] =
+          bucketToPartition_[((hashes_[i] & kInt32Max) % numBuckets_)];
+    }
   }
 }
 

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -28,6 +28,16 @@ class HivePartitionFunction : public core::PartitionFunction {
       std::vector<column_index_t> keyChannels,
       const std::vector<VectorPtr>& constValues = {});
 
+  HivePartitionFunction(
+      int numBuckets,
+      std::vector<column_index_t> keyChannels,
+      const std::vector<VectorPtr>& constValues = {})
+      : HivePartitionFunction(
+            numBuckets,
+            {},
+            std::move(keyChannels),
+            constValues) {}
+
   ~HivePartitionFunction() override = default;
 
   void partition(const RowVector& input, std::vector<uint32_t>& partitions)

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ target_link_libraries(
   velox_hive_connector
   velox_hive_partition_function
   velox_dwio_common_exception
+  velox_vector_fuzzer
   velox_vector_test_lib
   velox_exec
   velox_exec_test_lib

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -18,8 +18,8 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
+#include "velox/connectors/hive/HivePartitionFunction.h"
 #include "velox/dwio/common/WriterFactory.h"
-#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -541,8 +541,8 @@ class TableWriteTest : public HiveConnectorTestBase {
     }
     VELOX_USER_CHECK_EQ(bucketedByChannels.size(), bucketedBy.size());
 
-    return std::make_unique<exec::HashPartitionFunction>(
-        bucketProperty_->bucketCount(), tableSchema_, bucketedByChannels);
+    return std::make_unique<HivePartitionFunction>(
+        bucketProperty_->bucketCount(), bucketedByChannels);
   }
 
   // Verifies the bucketed file data by checking if the bucket id of each read


### PR DESCRIPTION
For bucketed table write, we need a local partition between remote exchange
and table writers. The local partition needs to repartition data based on the
bucket id to ensure the data with the same bucket id go to the same table writer.
The partition function should use the hive partition function but the bucket to
partition map is unknown when we convert the query plan (from presto to velox).
So can only create hive partition spec with the number of buckets. When task
instantiates the drivers, the local planner will pass the actual number of table
writer drivers as the number of partitions to create the hive partition function used
by the local partition operator. The hive partition function can use round robin to
map from bucket to partition as extended by this PR.
This PR also changes the hive data sink to use hive partition function instead of
hash partition function be consistent with hive partition function used by local
partition operator. Since hive data sink doesn't need any mapping on the bucket
id, so we extend a hive function to handle the case without the bucket to partition
map. But the alternative is to let the hive data sink to build an identical map and 
pass to the hive partition function.

Details see [multi driver support](https://github.com/facebookincubator/velox/issues/5546)