### PR TITLE
Add array_sort lambda Presto function 

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -138,6 +138,13 @@ Array Functions
         SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
 
+.. function:: array_sort(array(T), function(T,U)) -> array(T)
+
+    Returns the array sorted by values computed using specified lambda in ascending
+    order. Null elements will be placed at the end of the returned array. ::
+
+        SELECT array_sort(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['cat', 'mouse', 'leopard']
+
 .. function:: array_sort_desc(array(E)) -> array(E)
 
     Returns the array sorted in the descending order. The elements of the array must
@@ -148,6 +155,13 @@ Array Functions
         SELECT array_sort_desc(ARRAY [2, 1, NULL]; -- [2, 1, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 2, 1]); -- [2, 1, NULL]
+
+.. function:: array_sort_desc(array(T), function(T,U)) -> array(T)
+
+    Returns the array sorted by values computed using specified lambda in descending
+    order. Null elements will be placed at the end of the returned array. ::
+
+        SELECT array_sort_desc(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['leopard', 'mouse', 'cat']
 
 .. function:: array_sum(array(T)) -> bigint/double
 

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -532,6 +532,45 @@ TEST_F(ArraySortTest, wellFormedVectors) {
       arrayVec->elements()->size());
 }
 
+TEST_F(ArraySortTest, lambda) {
+  auto data = makeRowVector({makeNullableArrayVector<std::string>({
+      {"abc123", "abc", std::nullopt, "abcd"},
+      {std::nullopt, "x", "xyz123", "xyz"},
+  })});
+
+  auto sortedAsc = makeNullableArrayVector<std::string>({
+      {"abc", "abcd", "abc123", std::nullopt},
+      {"x", "xyz", "xyz123", std::nullopt},
+  });
+
+  auto sortedDesc = makeNullableArrayVector<std::string>({
+      {"abc123", "abcd", "abc", std::nullopt},
+      {"xyz123", "xyz", "x", std::nullopt},
+  });
+
+  auto testAsc = [&](const std::string& name, const std::string& lambdaExpr) {
+    SCOPED_TRACE(name);
+    SCOPED_TRACE(lambdaExpr);
+    auto result = evaluate(fmt::format("{}(c0, {})", name, lambdaExpr), data);
+    assertEqualVectors(sortedAsc, result);
+  };
+
+  auto testDesc = [&](const std::string& name, const std::string& lambdaExpr) {
+    SCOPED_TRACE(name);
+    SCOPED_TRACE(lambdaExpr);
+    auto result = evaluate(fmt::format("{}(c0, {})", name, lambdaExpr), data);
+    assertEqualVectors(sortedDesc, result);
+  };
+
+  // Different ways to sort by length ascending.
+  testAsc("array_sort", "x -> length(x)");
+  testAsc("array_sort_desc", "x -> length(x) * -1");
+
+  // Different ways to sort by length descending.
+  testDesc("array_sort", "x -> length(x) * -1");
+  testDesc("array_sort_desc", "x -> length(x)");
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ArraySortTest,
     ArraySortTest,


### PR DESCRIPTION
Add a version of array_sort function that takes a lambda to compute sorting
keys. For example, this allows to sort an array of strings by string lengths.

```
SELECT array_sort(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['cat', 'mouse', 'leopard']
```

This will be used to implement most common cases of a more generic array_sort
function which takes a comparator lambda:
https://prestodb.io/docs/current/functions/array.html#id2

In most cases, the comparator is a simple < or > comparison on values derived
from the array elements, e.g. a subfield of a struct.

Partial fix for #5545