### PR TITLE
Add support in HiveParser to identify Date logical type

### DIFF
--- a/velox/type/fbhive/HiveTypeParser.cpp
+++ b/velox/type/fbhive/HiveTypeParser.cpp
@@ -102,6 +102,8 @@ Result HiveTypeParser::parseType() {
       eatToken(TokenType::RightRoundBracket);
       return Result{DECIMAL(
           std::atoi(precision.value.data()), std::atoi(scale.value.data()))};
+    } else if (nt.metadata->tokenString[0] == "date") {
+      return Result{DATE()};
     }
     auto scalarType = createScalarType(nt.typeKind());
     VELOX_CHECK_NOT_NULL(

--- a/velox/type/fbhive/tests/HiveTypeParserTests.cpp
+++ b/velox/type/fbhive/tests/HiveTypeParserTests.cpp
@@ -46,7 +46,6 @@ TEST(FbHive, typeParserPrimitive) {
   validate<TypeKind::VARCHAR>("string");
   validate<TypeKind::VARCHAR>("varchar");
   validate<TypeKind::VARCHAR>("varchar(16)");
-  validate<TypeKind::INTEGER>("date");
   validate<TypeKind::INTEGER>("   int  ");
 }
 
@@ -74,6 +73,13 @@ TEST(FbHive, decimal) {
   ASSERT_EQ(longType.precision(), 21);
   ASSERT_EQ(longType.scale(), 3);
   ASSERT_EQ(t->toString(), "DECIMAL(21,3)");
+}
+
+TEST(FbHive, date) {
+  HiveTypeParser parser;
+  auto t = parser.parse("date");
+  ASSERT_EQ(t, DATE());
+  ASSERT_EQ(t->kind(), TypeKind::INTEGER);
 }
 
 TEST(FbHive, list) {


### PR DESCRIPTION
Summary: Date was recently transitions to being a logical type instead of a TypeKind. This meant that HiveParser would translate 'date' hive type to an INTEGER velox type which corresponds to DATE's physical type. However this violated a check in TableHandler which compared velox and hive types. This change ensures that 'date' hive type is correctly converted to it DATE velox type.

Reviewed By: xiaoxmeng, amitkdutta

Differential Revision: D47301882

