### PR TITLE
Add matcher for simple comparison lambdas

### DIFF
--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(
   Reverse.cpp
   RowFunction.cpp
   Sequence.cpp
+  SimpleComparisonMatcher.cpp
   Slice.cpp
   Split.cpp
   StringFunctions.cpp

--- a/velox/functions/prestosql/SimpleComparisonMatcher.cpp
+++ b/velox/functions/prestosql/SimpleComparisonMatcher.cpp
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/SimpleComparisonMatcher.h"
+#include "velox/vector/ConstantVector.h"
+
+namespace facebook::velox::functions::prestosql {
+
+namespace {
+
+class Matcher {
+ public:
+  virtual bool match(const core::TypedExprPtr& expr) = 0;
+
+  virtual ~Matcher() = default;
+
+  static bool allMatch(
+      const std::vector<core::TypedExprPtr>& exprs,
+      std::vector<std::shared_ptr<Matcher>>& matchers) {
+    for (auto i = 0; i < exprs.size(); ++i) {
+      if (!matchers[i]->match(exprs[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+using MatcherPtr = std::shared_ptr<Matcher>;
+
+class IfMatcher : public Matcher {
+ public:
+  explicit IfMatcher(std::vector<MatcherPtr> inputMatchers)
+      : inputMatchers_{std::move(inputMatchers)} {
+    VELOX_CHECK_EQ(3, inputMatchers_.size());
+  }
+
+  bool match(const core::TypedExprPtr& expr) override {
+    if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
+      if (call->name() == "if" && allMatch(call->inputs(), inputMatchers_)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  std::vector<MatcherPtr> inputMatchers_;
+};
+
+using IfMatcherPtr = std::shared_ptr<IfMatcher>;
+
+class ComparisonMatcher : public Matcher {
+ public:
+  ComparisonMatcher(std::vector<MatcherPtr> inputMatchers, std::string* op)
+      : inputMatchers_{std::move(inputMatchers)}, op_{op} {
+    VELOX_CHECK_EQ(2, inputMatchers_.size());
+  }
+
+  bool match(const core::TypedExprPtr& expr) override {
+    if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
+      const auto& name = call->name();
+      if (name == "eq" || name == "lt" || name == "gt") {
+        if (allMatch(call->inputs(), inputMatchers_)) {
+          *op_ = name;
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+ private:
+  std::vector<MatcherPtr> inputMatchers_;
+  std::string* op_;
+};
+
+using ComparisonMatcherPtr = std::shared_ptr<ComparisonMatcher>;
+
+class AnySingleInputMatcher : public Matcher {
+ public:
+  AnySingleInputMatcher(
+      core::TypedExprPtr* expr,
+      core::FieldAccessTypedExprPtr* input)
+      : expr_{expr}, input_{input} {}
+
+  bool match(const core::TypedExprPtr& expr) override {
+    // Check if 'expr' depends on a single column.
+    std::unordered_set<core::FieldAccessTypedExprPtr> inputs;
+    collectInputs(expr, inputs);
+
+    if (inputs.size() == 1) {
+      *expr_ = expr;
+      *input_ = *inputs.begin();
+      return true;
+    }
+
+    return false;
+  }
+
+ private:
+  static void collectInputs(
+      const core::TypedExprPtr& expr,
+      std::unordered_set<core::FieldAccessTypedExprPtr>& inputs) {
+    if (auto field =
+            std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(expr)) {
+      if (field->isInputColumn()) {
+        inputs.insert(field);
+        return;
+      }
+    }
+
+    for (const auto& input : expr->inputs()) {
+      collectInputs(input, inputs);
+    }
+  }
+
+  core::TypedExprPtr* const expr_;
+  core::FieldAccessTypedExprPtr* const input_;
+};
+
+/// Matches constant expression that represents values 1, 0, or -1 of type
+/// BIGINT.
+class ComparisonConstantMatcher : public Matcher {
+ public:
+  explicit ComparisonConstantMatcher(int64_t* value) : value_{value} {}
+
+  bool match(const core::TypedExprPtr& expr) override {
+    if (auto constant = asConstant(expr.get())) {
+      auto v = constant.value();
+      if (v == 0 || v == 1 || v == -1) {
+        *value_ = v;
+        return true;
+      }
+    }
+    return false;
+  }
+
+ private:
+  static std::optional<int64_t> asConstant(const core::ITypedExpr* expr) {
+    if (auto constant = dynamic_cast<const core::ConstantTypedExpr*>(expr)) {
+      if (constant->hasValueVector()) {
+        auto constantVector =
+            constant->valueVector()->as<SimpleVector<int64_t>>();
+        if (!constantVector->isNullAt(0)) {
+          return constantVector->valueAt(0);
+        }
+      } else {
+        if (!constant->value().isNull()) {
+          return constant->value().value<int64_t>();
+        }
+      }
+    }
+
+    return std::nullopt;
+  }
+
+  int64_t* const value_;
+};
+
+using ComparisonConstantMatcherPtr = std::shared_ptr<ComparisonConstantMatcher>;
+
+MatcherPtr ifelse(
+    const MatcherPtr& condition,
+    const MatcherPtr& thenClause,
+    const MatcherPtr& elseClause) {
+  return std::make_shared<IfMatcher>(
+      std::vector<MatcherPtr>{condition, thenClause, elseClause});
+}
+
+MatcherPtr
+comparison(const MatcherPtr& left, const MatcherPtr& right, std::string* op) {
+  return std::make_shared<ComparisonMatcher>(
+      std::vector<MatcherPtr>{left, right}, op);
+}
+
+MatcherPtr anySingleInput(
+    core::TypedExprPtr* expr,
+    core::FieldAccessTypedExprPtr* input) {
+  return std::make_shared<AnySingleInputMatcher>(expr, input);
+}
+
+MatcherPtr comparisonConstant(int64_t* value) {
+  return std::make_shared<ComparisonConstantMatcher>(value);
+}
+
+std::string invert(const std::string& op) {
+  return op == "lt" ? "gt" : "lt";
+}
+
+/// Returns true for a < b -> -1.
+bool isLessThen(
+    const std::string& operation,
+    const core::FieldAccessTypedExprPtr& left,
+    const core::FieldAccessTypedExprPtr& right,
+    int64_t result,
+    const std::string& inputLeft) {
+  std::string op = (left->name() == inputLeft) ? operation : invert(operation);
+
+  if (op == "lt") {
+    return result < 0;
+  }
+
+  return result > 0;
+}
+
+} // namespace
+
+std::optional<SimpleComparison> isSimpleComparison(
+    const core::LambdaTypedExpr& expr) {
+  // First, check the shape of the expression.
+  // if (x(a) < y(b), c1, if (u(c) > v(d), c2, c3))
+  core::FieldAccessTypedExprPtr a, b, c, d;
+  core::TypedExprPtr x, y, u, v;
+  std::string op1, op2;
+  int64_t c1, c2, c3;
+
+  auto matcher = ifelse(
+      comparison(anySingleInput(&x, &a), anySingleInput(&y, &b), &op1),
+      comparisonConstant(&c1),
+      ifelse(
+          comparison(anySingleInput(&u, &c), anySingleInput(&v, &d), &op2),
+          comparisonConstant(&c2),
+          comparisonConstant(&c3)));
+
+  if (!matcher->match(expr.body())) {
+    return std::nullopt;
+  }
+
+  // Verify that a != b, c != d.
+  if (a == b || c == d) {
+    return std::nullopt;
+  }
+
+  // Verify that x, y, u, v are the same (except for input column).
+  std::unordered_map<std::string, core::TypedExprPtr> inputMapping;
+  inputMapping.emplace(
+      a->name(),
+      std::make_shared<core::FieldAccessTypedExpr>(a->type(), b->name()));
+
+  // Verify all constants are different.
+  if (c1 == c2 || c2 == c3 || c1 == c3) {
+    return std::nullopt;
+  }
+
+  // Verify that equality comparisons return zero.
+  // if (x(a) = y(a), 0,..) is good. if (x(a) = y(a), 1,..) is not good.
+  // Also, verify that non-equality comparisons return non-zerp.
+  // if (x(a) < y(a), 1,..) is good. if (x(a) < y(a), 0,..) is not good.
+  if ((op1 == "eq" && c1 != 0) || (op1 != "eq" && c1 == 0)) {
+    return std::nullopt;
+  }
+
+  if ((op2 == "eq" && c2 != 0) || (op2 != "eq" && c2 == 0)) {
+    return std::nullopt;
+  }
+
+  const auto left = expr.signature()->nameOf(0);
+
+  const auto transform = a->name() == left ? x : y;
+
+  if (op1 == "eq") {
+    // if (x(a) = y(b), 0,...)
+    return {{transform, isLessThen(op2, c, d, c2, left)}};
+  }
+
+  if (op2 == "eq") {
+    return {{transform, isLessThen(op1, a, b, c1, left)}};
+  }
+
+  // Make sure op1 and op2 are aligned.
+  auto b1 = isLessThen(op1, a, b, c1, left);
+  auto b2 = isLessThen(op2, c, d, c2, left);
+  if (b1 != b2) {
+    return std::nullopt;
+  }
+
+  return {{transform, b1}};
+}
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/SimpleComparisonMatcher.h
+++ b/velox/functions/prestosql/SimpleComparisonMatcher.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::functions::prestosql {
+
+struct SimpleComparison {
+  core::TypedExprPtr expr;
+  bool isLessThen;
+};
+
+/// Given a lambda expression, checks it if represents a simple comparator and
+/// returns the summary of the same.
+///
+/// For example, identifies
+///     (x, y) -> if(length(x) < length(y), -1, if(length(x) > length(y), 1, 0))
+/// expression as a "less than" comparison over length(x).
+///
+/// Recognizes different variations of this expression, e.g.
+///
+///     (x, y) -> if(expr(x) = expr(y), 0, if(expr(x) < expr(y), -1, 1))
+///     (x, y) -> if(expr(x) = expr(y), 0, if(expr(y) > expr(x), -1, 1))
+///
+/// Returns std::nullopt if expression is not recognized as a simple comparator.
+///
+/// Can be used to re-write generic lambda expressions passed to array_sort into
+/// simpler ones that can be evaluated more efficiently.
+std::optional<SimpleComparison> isSimpleComparison(
+    const core::LambdaTypedExpr& expr);
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -72,6 +72,7 @@ add_executable(
   ReverseTest.cpp
   RoundTest.cpp
   ScalarFunctionRegTest.cpp
+  SimpleComparisonMatcherTest.cpp
   SliceTest.cpp
   SequenceTest.cpp
   SplitTest.cpp

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gtest/gtest.h>
+
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/prestosql/SimpleComparisonMatcher.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/parse/Expressions.h"
+#include "velox/parse/ExpressionsParser.h"
+#include "velox/parse/TypeResolver.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::functions::prestosql {
+namespace {
+
+class SimpleComparisonMatcherTest : public testing::Test,
+                                    public test::VectorTestBase {
+ protected:
+  void SetUp() override {
+    functions::prestosql::registerAllScalarFunctions();
+    parse::registerTypeResolver();
+  }
+
+  core::TypedExprPtr parseExpression(
+      const std::string& text,
+      const RowTypePtr& rowType) {
+    parse::ParseOptions options;
+    auto untyped = parse::parseExpr(text, options);
+    return core::Expressions::inferTypes(untyped, rowType, execCtx_->pool());
+  }
+
+  std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
+  std::unique_ptr<core::ExecCtx> execCtx_{
+      std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get())};
+};
+
+class TestFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& /* outputType */,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    VELOX_UNSUPPORTED();
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {exec::FunctionSignatureBuilder()
+                .typeVariable("T")
+                .returnType("array(T)")
+                .argumentType("array(T)")
+                .argumentType("function(T,T,bigint)")
+                .build()};
+  }
+};
+
+TEST_F(SimpleComparisonMatcherTest, basic) {
+  exec::registerVectorFunction(
+      "test_array_sort",
+      TestFunction::signatures(),
+      std::make_unique<TestFunction>());
+
+  const auto inputType =
+      ROW({"a"}, {ARRAY(ROW({"f", "g"}, {BIGINT(), BIGINT()}))});
+
+  auto testMatcher = [&](const std::string& expr,
+                         std::optional<bool> lessThan) {
+    SCOPED_TRACE(expr);
+    auto parsedExpr = parseExpression(
+        fmt::format("test_array_sort(a, (x, y) -> {})", expr), inputType);
+
+    auto lambdaExpr = std::dynamic_pointer_cast<const core::LambdaTypedExpr>(
+        parsedExpr->inputs()[1]);
+
+    auto comparison = functions::prestosql::isSimpleComparison(*lambdaExpr);
+
+    ASSERT_EQ(lessThan.has_value(), comparison.has_value());
+    if (lessThan.has_value()) {
+      ASSERT_EQ(lessThan.value(), comparison->isLessThen);
+
+      auto field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+          comparison->expr.get());
+      ASSERT_TRUE(field != nullptr);
+      ASSERT_EQ("f", field->name());
+    }
+  };
+
+  // Different ways to define x < y (asc) sort order.
+  testMatcher("if(x.f > y.f, 1, if(x.f < y.f, -1, 0))", true);
+  testMatcher("if(x.f > y.f, 1, if(y.f > x.f, -1, 0))", true);
+  testMatcher("if(x.f > y.f, 1, if(x.f = y.f, 0, -1))", true);
+
+  testMatcher("if(x.f < y.f, -1, if(x.f > y.f, 1, 0))", true);
+  testMatcher("if(x.f < y.f, -1, if(y.f < x.f, 1, 0))", true);
+  testMatcher("if(x.f < y.f, -1, if(x.f = y.f, 0, 1))", true);
+
+  testMatcher("if(x.f = y.f, 0, if(x.f < y.f, -1, 1))", true);
+  testMatcher("if(x.f = y.f, 0, if(y.f > x.f, -1, 1))", true);
+  testMatcher("if(x.f = y.f, 0, if(x.f > y.f, 1, -1))", true);
+  testMatcher("if(x.f = y.f, 0, if(y.f < x.f, 1, -1))", true);
+
+  // Different ways to define x > y (desc) sort order.
+  testMatcher("if (x.f < y.f, 1, if (x.f > y.f, -1, 0))", false);
+  testMatcher("if (x.f < y.f, 1, if (y.f < x.f, -1, 0))", false);
+  testMatcher("if (x.f < y.f, 1, if (y.f = x.f, 0, -1))", false);
+
+  testMatcher("if (x.f > y.f, -1, if (x.f < y.f, 1, 0))", false);
+  testMatcher("if (x.f > y.f, -1, if (y.f > x.f, 1, 0))", false);
+  testMatcher("if (x.f > y.f, -1, if (y.f = x.f, 0, 1))", false);
+
+  testMatcher("if(x.f = y.f, 0, if(x.f < y.f, 1, -1))", false);
+  testMatcher("if(x.f = y.f, 0, if(y.f > x.f, 1, -1))", false);
+  testMatcher("if(x.f = y.f, 0, if(x.f > y.f, -1, 1))", false);
+  testMatcher("if(x.f = y.f, 0, if(y.f < x.f, -1, 1))", false);
+
+  // Non-matching expressions.
+  testMatcher("if(x.f + y.f > 0, 1, -1)", std::nullopt);
+  testMatcher("if(x.f < y.f, 1, -1)", std::nullopt);
+}
+
+} // namespace
+} // namespace facebook::velox::functions::prestosql


### PR DESCRIPTION
Add matcher to identify lambda expression as a simple comparison.

For example, identify

```
     (x, y) -> if(length(x) < length(y), -1, if(length(x) > length(y), 1, 0))
```

as a "less than" comparison over length(x).

Recognizes different variations of this expression, e.g.

```
     (x, y) -> if(expr(x) = expr(y), 0, if(expr(x) < expr(y), -1, 1))
     (x, y) -> if(expr(x) = expr(y), 0, if(expr(y) > expr(x), -1, 1))
```

Will be used to re-write generic lambda expressions passed to array_sort into
simpler ones that can be evaluated more efficiently.

Part of #5545