### PR TITLE
Add array_sort with generic comparator

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -138,6 +138,13 @@ Array Functions
         SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
 
+.. function:: array_sort(array(T), function(T,U)) -> array(T)
+
+    Returns the array sorted by values computed using specified lambda in ascending
+    order. Null elements will be placed at the end of the returned array. ::
+
+        SELECT array_sort(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['cat', 'mouse', 'leopard']
+
 .. function:: array_sort_desc(array(E)) -> array(E)
 
     Returns the array sorted in the descending order. The elements of the array must
@@ -148,6 +155,13 @@ Array Functions
         SELECT array_sort_desc(ARRAY [2, 1, NULL]; -- [2, 1, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort_desc(ARRAY [NULL, 2, 1]); -- [2, 1, NULL]
+
+.. function:: array_sort_desc(array(T), function(T,U)) -> array(T)
+
+    Returns the array sorted by values computed using specified lambda in descending
+    order. Null elements will be placed at the end of the returned array. ::
+
+        SELECT array_sort_desc(ARRAY ['cat', 'leopard', 'mouse'], x -> length(x)); -- ['leopard', 'mouse', 'cat']
 
 .. function:: array_sum(array(T)) -> bigint/double
 

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -133,4 +133,13 @@ bool registerVectorFunction(
       name, signatures, factory, metadata, overwrite);
 }
 
+std::vector<ExpressionRewrite>& expressionRewrites() {
+  static std::vector<ExpressionRewrite> rewrites;
+  return rewrites;
+}
+
+void registerExpressionRewrite(ExpressionRewrite rewrite) {
+  expressionRewrites().emplace_back(rewrite);
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -17,12 +17,14 @@
 #pragma once
 
 #include <vector>
+#include "velox/core/Expressions.h"
 #include "velox/expression/EvalCtx.h"
 #include "velox/expression/FunctionSignature.h"
 #include "velox/vector/SelectivityVector.h"
 #include "velox/vector/SimpleVector.h"
 
 #include <folly/Synchronized.h>
+
 namespace facebook::velox::exec {
 
 class Expr;
@@ -262,6 +264,22 @@ bool registerStatefulVectorFunction(
     VectorFunctionFactory factory,
     VectorFunctionMetadata metadata = {},
     bool overwrite = true);
+
+/// An expression re-writer that takes an expression and returns an equivalent
+/// expression or nullptr if re-write is not possible.
+using ExpressionRewrite = std::function<core::TypedExprPtr(core::TypedExprPtr)>;
+
+/// Returns a list of registered re-writes.
+std::vector<ExpressionRewrite>& expressionRewrites();
+
+/// Appends a 'rewrite' to 'expressionRewrites'.
+///
+/// The logic that applies re-writes is very simple and assumes that all
+/// rewrites are independent. Re-writes are applied to all expressions starting
+/// at the root and going down the hierarchy. For each expression, rewrites are
+/// applied in the order they were registered. The first rewrite that returns
+/// non-null result terminates the re-write for this particular expression.
+void registerExpressionRewrite(ExpressionRewrite rewrite);
 
 } // namespace facebook::velox::exec
 

--- a/velox/functions/prestosql/ArraySort.h
+++ b/velox/functions/prestosql/ArraySort.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::functions {
+
+/// Analyzes array_sort(array, lambda) call to determine whether it can be
+/// re-written into a simpler call that specifies sort-by expression.
+///
+/// For example, rewrites
+///     array_sort(a, (x, y) -> if(length(x) < length(y), -1, if(length(x) >
+///     length(y), 1, 0))
+/// into
+///     array_sort(a, x -> length(x))
+///
+/// Returns new expression or nullptr if rewrite is not possible.
+core::TypedExprPtr rewriteArraySortCall(const core::TypedExprPtr& expr);
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/ArrayConstructor.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
+#include "velox/functions/prestosql/ArraySort.h"
 #include "velox/functions/prestosql/WidthBucketArray.h"
 
 namespace facebook::velox::functions {
@@ -100,9 +101,13 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_zip_with, prefix + "zip_with");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_position, prefix + "array_position");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_shuffle, prefix + "shuffle");
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sort, prefix + "array_sort");
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_sort_desc, prefix + "array_sort_desc");
+
+  exec::registerExpressionRewrite(rewriteArraySortCall);
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, prefix + "repeat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_sequence, prefix + "sequence");

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -565,10 +565,22 @@ TEST_F(ArraySortTest, lambda) {
   // Different ways to sort by length ascending.
   testAsc("array_sort", "x -> length(x)");
   testAsc("array_sort_desc", "x -> length(x) * -1");
+  testAsc(
+      "array_sort",
+      "(x, y) -> if(length(x) < length(y), -1, if(length(x) > length(y), 1, 0))");
+  testAsc(
+      "array_sort",
+      "(x, y) -> if(length(x) < length(y), -1, if(length(x) = length(y), 0, 1))");
 
   // Different ways to sort by length descending.
   testDesc("array_sort", "x -> length(x) * -1");
   testDesc("array_sort_desc", "x -> length(x)");
+  testDesc(
+      "array_sort",
+      "(x, y) -> if(length(x) < length(y), 1, if(length(x) > length(y), -1, 0))");
+  testDesc(
+      "array_sort",
+      "(x, y) -> if(length(x) < length(y), 1, if(length(x) = length(y), 0, -1))");
 }
 
 VELOX_INSTANTIATE_TEST_SUITE_P(

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -532,6 +532,45 @@ TEST_F(ArraySortTest, wellFormedVectors) {
       arrayVec->elements()->size());
 }
 
+TEST_F(ArraySortTest, lambda) {
+  auto data = makeRowVector({makeNullableArrayVector<std::string>({
+      {"abc123", "abc", std::nullopt, "abcd"},
+      {std::nullopt, "x", "xyz123", "xyz"},
+  })});
+
+  auto sortedAsc = makeNullableArrayVector<std::string>({
+      {"abc", "abcd", "abc123", std::nullopt},
+      {"x", "xyz", "xyz123", std::nullopt},
+  });
+
+  auto sortedDesc = makeNullableArrayVector<std::string>({
+      {"abc123", "abcd", "abc", std::nullopt},
+      {"xyz123", "xyz", "x", std::nullopt},
+  });
+
+  auto testAsc = [&](const std::string& name, const std::string& lambdaExpr) {
+    SCOPED_TRACE(name);
+    SCOPED_TRACE(lambdaExpr);
+    auto result = evaluate(fmt::format("{}(c0, {})", name, lambdaExpr), data);
+    assertEqualVectors(sortedAsc, result);
+  };
+
+  auto testDesc = [&](const std::string& name, const std::string& lambdaExpr) {
+    SCOPED_TRACE(name);
+    SCOPED_TRACE(lambdaExpr);
+    auto result = evaluate(fmt::format("{}(c0, {})", name, lambdaExpr), data);
+    assertEqualVectors(sortedDesc, result);
+  };
+
+  // Different ways to sort by length ascending.
+  testAsc("array_sort", "x -> length(x)");
+  testAsc("array_sort_desc", "x -> length(x) * -1");
+
+  // Different ways to sort by length descending.
+  testDesc("array_sort", "x -> length(x) * -1");
+  testDesc("array_sort_desc", "x -> length(x)");
+}
+
 VELOX_INSTANTIATE_TEST_SUITE_P(
     ArraySortTest,
     ArraySortTest,


### PR DESCRIPTION
Add array_sort Presto function that takes an array and a comparator lambda. 

Implement most common scenario where comparator is a simple less-than or
great-than over a value derived from array element. For example, sort array of
struct using one of the struct fields as a sorting key.

```
array_sort(a, (x, y) -> if(x.p < y.p, -1, if(x.p > y.p, 1, 0)))
```

Re-write such calls into array_sort call with a lambda that specifies how to compute sorting key:

```
array_sort(a, x -> x.p)
```

Fail the query if comparator cannot be re-written this way.

A follow-up PR will add support for generic comparator, but it won't be as efficient as this re-write.

Part of #5545