### PR TITLE
Allow integer values for k rows frame bound

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1992,6 +1992,12 @@ class WindowNode : public PlanNode {
 
   static BoundType boundTypeFromName(const std::string& name);
 
+  /// Window frames can be ROW or RANGE type.
+  /// Frame bounds can be CURRENT ROW, UNBOUNDED PRECEDING(FOLLOWING)
+  /// and k PRECEDING(FOLLOWING). K could be a constant or column.
+  ///
+  /// k PRECEDING(FOLLOWING) is only supported for ROW frames now.
+  /// k has to be of integer or bigint type.
   struct Frame {
     WindowType type;
     BoundType startType;

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -88,6 +88,20 @@ Window::Window(
 Window::WindowFrame Window::createWindowFrame(
     core::WindowNode::Frame frame,
     const RowTypePtr& inputType) {
+  if (frame.type == core::WindowNode::WindowType::kRows) {
+    auto frameBoundCheck = [&](const core::TypedExprPtr& frame) -> void {
+      if (frame == nullptr) {
+        return;
+      }
+
+      VELOX_USER_CHECK(
+          frame->type() == INTEGER() || frame->type() == BIGINT(),
+          "k frame bound must be INTEGER or BIGINT type");
+    };
+    frameBoundCheck(frame.startValue);
+    frameBoundCheck(frame.endValue);
+  }
+
   auto createFrameChannelArg =
       [&](const core::TypedExprPtr& frame) -> std::optional<FrameChannelArg> {
     // frame is nullptr for non (kPreceding or kFollowing) frames.
@@ -100,13 +114,16 @@ Window::WindowFrame Window::createWindowFrame(
           std::dynamic_pointer_cast<const core::ConstantTypedExpr>(frame)
               ->value();
       VELOX_CHECK(!constant.isNull(), "k in frame bounds must not be null");
-      VELOX_USER_CHECK_GE(
-          constant.value<int64_t>(), 1, "k in frame bounds must be at least 1");
-      return std::make_optional(FrameChannelArg{
-          kConstantChannel, nullptr, constant.value<int64_t>()});
+      auto value = VariantConverter::convert(constant, TypeKind::BIGINT)
+                       .value<int64_t>();
+      VELOX_USER_CHECK_GE(value, 1, "k in frame bounds must be at least 1");
+      return std::make_optional(
+          FrameChannelArg{kConstantChannel, nullptr, value});
     } else {
       return std::make_optional(FrameChannelArg{
-          frameChannel, BaseVector::create(BIGINT(), 0, pool()), std::nullopt});
+          frameChannel,
+          BaseVector::create(frame->type(), 0, pool()),
+          std::nullopt});
     }
   };
 
@@ -290,6 +307,33 @@ void Window::callResetPartition(vector_size_t partitionNumber) {
   }
 }
 
+namespace {
+
+template <typename T>
+void updateKRowsOffsetsColumn(
+    bool isKPreceding,
+    const VectorPtr& value,
+    vector_size_t firstPartitionRow,
+    vector_size_t startRow,
+    vector_size_t numRows,
+    vector_size_t* rawFrameBounds) {
+  auto offsets = value->values()->as<T>();
+  for (auto i = 0; i < numRows; i++) {
+    VELOX_USER_CHECK(!value->isNullAt(i), "k in frame bounds cannot be null");
+    VELOX_USER_CHECK_GE(offsets[i], 1, "k in frame bounds must be at least 1");
+  }
+
+  // Preceding involves subtracting from the current position, while following
+  // moves ahead.
+  int precedingFactor = isKPreceding ? -1 : 1;
+  for (auto i = 0; i < numRows; i++) {
+    rawFrameBounds[i] = (startRow + i) +
+        vector_size_t(precedingFactor * offsets[i]) - firstPartitionRow;
+  }
+}
+
+}; // namespace
+
 void Window::updateKRowsFrameBounds(
     bool isKPreceding,
     const FrameChannelArg& frameArg,
@@ -306,20 +350,22 @@ void Window::updateKRowsFrameBounds(
   } else {
     windowPartition_->extractColumn(
         frameArg.index, partitionOffset_, numRows, 0, frameArg.value);
-    auto offsets = frameArg.value->values()->as<int64_t>();
-    for (auto i = 0; i < numRows; i++) {
-      VELOX_USER_CHECK(
-          !frameArg.value->isNullAt(i), "k in frame bounds cannot be null");
-      VELOX_USER_CHECK_GE(
-          offsets[i], 1, "k in frame bounds must be at least 1");
-    }
-
-    // Preceding involves subtracting from the current position, while following
-    // moves ahead.
-    int precedingFactor = isKPreceding ? -1 : 1;
-    for (auto i = 0; i < numRows; i++) {
-      rawFrameBounds[i] = (startRow + i) +
-          vector_size_t(precedingFactor * offsets[i]) - firstPartitionRow;
+    if (frameArg.value->typeKind() == TypeKind::INTEGER) {
+      updateKRowsOffsetsColumn<int32_t>(
+          isKPreceding,
+          frameArg.value,
+          firstPartitionRow,
+          startRow,
+          numRows,
+          rawFrameBounds);
+    } else {
+      updateKRowsOffsetsColumn<int64_t>(
+          isKPreceding,
+          frameArg.value,
+          firstPartitionRow,
+          startRow,
+          numRows,
+          rawFrameBounds);
     }
   }
 }

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -54,7 +54,7 @@ RowVectorPtr WindowTestBase::makeSimpleVector(vector_size_t size) {
       makeFlatVector<int32_t>(
           size, [](auto row) { return row % 7; }, nullEvery(15)),
       makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 13 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
   });
 }
 
@@ -64,7 +64,7 @@ RowVectorPtr WindowTestBase::makeSinglePartitionVector(vector_size_t size) {
       makeFlatVector<int32_t>(
           size, [](auto row) { return row; }, nullEvery(7)),
       makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 13 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
   });
 }
 
@@ -73,7 +73,7 @@ RowVectorPtr WindowTestBase::makeSingleRowPartitionsVector(vector_size_t size) {
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
       makeFlatVector<int32_t>(size, [](auto row) { return row; }),
       makeFlatVector<int64_t>(size, [](auto row) { return row % 11 + 1; }),
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 13 + 1; }),
+      makeFlatVector<int32_t>(size, [](auto row) { return row % 13 + 1; }),
   });
 }
 


### PR DESCRIPTION
Presto could use both integer and bigint columns for row frame bounds with a k preceding or following bound. 

The old code expected only int64 column for frame bound. 

Fixes #5490