### PR TITLE
Add configs for SparkSql function bloom_filter_agg

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -192,15 +192,15 @@ class QueryConfig {
   static constexpr const char* kSparkLegacySizeOfNull =
       "spark.legacy_size_of_null";
 
-  // The default number of expected items for the runtime bloomfilter.
+  // The default number of expected items for the bloomfilter.
   static constexpr const char* kSparkBloomFilterExpectedNumItems =
       "spark.bloom_filter.expected_num_items";
 
-  // The default number of bits to use for the runtime bloom filter.
+  // The default number of bits to use for the bloom filter.
   static constexpr const char* kSparkBloomFilterNumBits =
       "spark.bloom_filter.num_bits";
 
-  // The max number of bits to use for the runtime bloom filter.
+  // The max number of bits to use for the bloom filter.
   static constexpr const char* kSparkBloomFilterMaxNumBits =
       "spark.bloom_filter.max_num_bits";
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -421,12 +421,11 @@ class QueryConfig {
   int64_t sparkBloomFilterMaxNumBits() const {
     constexpr int64_t kDefault = 4'096 * 1024;
     auto value = get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
-    VELOX_CHECK_LE(
+    VELOX_USER_CHECK_LE(
         value,
         kDefault,
-        "{} cannot exceed the default value {} in case of memory limit",
-        kSparkBloomFilterMaxNumBits,
-        kDefault);
+        "{} cannot exceed the default value",
+        kSparkBloomFilterMaxNumBits);
     return value;
   }
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -420,7 +420,14 @@ class QueryConfig {
   // 256, so decrease it to not over memory limit.
   int64_t sparkRuntimeBloomFilterMaxNumBits() const {
     constexpr int64_t kDefault = 4'096 * 1024;
-    return get<int64_t>(kSparkRuntimeBloomFilterMaxNumBits, kDefault);
+    auto value = get<int64_t>(kSparkRuntimeBloomFilterMaxNumBits, kDefault);
+    VELOX_CHECK_LE(
+        value,
+        kDefault,
+        "{} cannot exceed the default value {} in case of memory limit",
+        kSparkRuntimeBloomFilterMaxNumBits,
+        kDefault);
+    return value;
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -193,16 +193,16 @@ class QueryConfig {
       "spark.legacy_size_of_null";
 
   // The default number of expected items for the runtime bloomfilter.
-  static constexpr const char* kSparkRuntimeBloomFilterExpectedNumItems =
-      "spark.runtime.bloom_filter.expected_num_items";
+  static constexpr const char* kSparkBloomFilterExpectedNumItems =
+      "spark.bloom_filter.expected_num_items";
 
   // The default number of bits to use for the runtime bloom filter.
-  static constexpr const char* kSparkRuntimeBloomFilterNumBits =
-      "spark.runtime.bloom_filter.num_bits";
+  static constexpr const char* kSparkBloomFilterNumBits =
+      "spark.bloom_filter.num_bits";
 
   // The max number of bits to use for the runtime bloom filter.
-  static constexpr const char* kSparkRuntimeBloomFilterMaxNumBits =
-      "spark.runtime.bloom_filter.max_num_bits";
+  static constexpr const char* kSparkBloomFilterMaxNumBits =
+      "spark.bloom_filter.max_num_bits";
 
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
@@ -406,26 +406,26 @@ class QueryConfig {
     return get<bool>(kSparkLegacySizeOfNull, kDefault);
   }
 
-  int64_t sparkRuntimeBloomFilterExpectedNumItems() const {
+  int64_t sparkBloomFilterExpectedNumItems() const {
     constexpr int64_t kDefault = 1'000'000L;
-    return get<int64_t>(kSparkRuntimeBloomFilterExpectedNumItems, kDefault);
+    return get<int64_t>(kSparkBloomFilterExpectedNumItems, kDefault);
   }
 
-  int64_t sparkRuntimeBloomFilterNumBits() const {
+  int64_t sparkBloomFilterNumBits() const {
     constexpr int64_t kDefault = 8'388'608L;
-    return get<int64_t>(kSparkRuntimeBloomFilterNumBits, kDefault);
+    return get<int64_t>(kSparkBloomFilterNumBits, kDefault);
   }
 
   // Spark kMaxNumBits is 67'108'864, but velox has memory limit sizeClassSizes
   // 256, so decrease it to not over memory limit.
-  int64_t sparkRuntimeBloomFilterMaxNumBits() const {
+  int64_t sparkBloomFilterMaxNumBits() const {
     constexpr int64_t kDefault = 4'096 * 1024;
-    auto value = get<int64_t>(kSparkRuntimeBloomFilterMaxNumBits, kDefault);
+    auto value = get<int64_t>(kSparkBloomFilterMaxNumBits, kDefault);
     VELOX_CHECK_LE(
         value,
         kDefault,
         "{} cannot exceed the default value {} in case of memory limit",
-        kSparkRuntimeBloomFilterMaxNumBits,
+        kSparkBloomFilterMaxNumBits,
         kDefault);
     return value;
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -192,6 +192,18 @@ class QueryConfig {
   static constexpr const char* kSparkLegacySizeOfNull =
       "spark.legacy_size_of_null";
 
+  // The default number of expected items for the runtime bloomfilter.
+  static constexpr const char* kSparkRuntimeBloomFilterExpectedNumItems =
+      "spark.runtime.bloom_filter.expected_num_items";
+
+  // The default number of bits to use for the runtime bloom filter.
+  static constexpr const char* kSparkRuntimeBloomFilterNumBits =
+      "spark.runtime.bloom_filter.num_bits";
+
+  // The max number of bits to use for the runtime bloom filter.
+  static constexpr const char* kSparkRuntimeBloomFilterMaxNumBits =
+      "spark.runtime.bloom_filter.max_num_bits";
+
   /// The number of local parallel table writer operators per task.
   static constexpr const char* kTaskWriterCount = "task_writer_count";
 
@@ -392,6 +404,23 @@ class QueryConfig {
   bool sparkLegacySizeOfNull() const {
     constexpr bool kDefault{true};
     return get<bool>(kSparkLegacySizeOfNull, kDefault);
+  }
+
+  int64_t sparkRuntimeBloomFilterExpectedNumItems() const {
+    constexpr int64_t kDefault = 1'000'000L;
+    return get<int64_t>(kSparkRuntimeBloomFilterExpectedNumItems, kDefault);
+  }
+
+  int64_t sparkRuntimeBloomFilterNumBits() const {
+    constexpr int64_t kDefault = 8'388'608L;
+    return get<int64_t>(kSparkRuntimeBloomFilterNumBits, kDefault);
+  }
+
+  // Spark kMaxNumBits is 67'108'864, but velox has memory limit sizeClassSizes
+  // 256, so decrease it to not over memory limit.
+  int64_t sparkRuntimeBloomFilterMaxNumBits() const {
+    constexpr int64_t kDefault = 4'096 * 1024;
+    return get<int64_t>(kSparkRuntimeBloomFilterMaxNumBits, kDefault);
   }
 
   bool exprTrackCpuUsage() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -386,12 +386,12 @@ Spark-specific Configuration
    * - spark.runtime.bloom_filter.expected_num_items
      - integer
      - 1000000
-     - The default number of expected items for the runtime bloom filter in ``bloom_filter_agg`` function.
+     - The default number of expected items for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.
    * - spark.runtime.bloom_filter.num_bits
      - integer
      - 8388608
-     - The default number of bits to use for the runtime bloom filter in ``bloom_filter_agg`` function.
+     - The default number of bits to use for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.
    * - spark.runtime.bloom_filter.max_num_bits
      - integer
      - 4194304
-     - The maximum number of bits to use for the runtime bloom filter in ``bloom_filter_agg`` function.
+     - The maximum number of bits to use for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -383,15 +383,16 @@ Spark-specific Configuration
      - bool
      - true
      - If false, ``size`` function returns null for null input.
-   * - spark.runtime.bloom_filter.expected_num_items
+   * - spark.bloom_filter.expected_num_items
      - integer
      - 1000000
-     - The default number of expected items for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.
-   * - spark.runtime.bloom_filter.num_bits
+     - The default number of expected items for the bloom filter in :spark:func:`bloom_filter_agg` function.
+   * - spark.bloom_filter.num_bits
      - integer
      - 8388608
-     - The default number of bits to use for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.
-   * - spark.runtime.bloom_filter.max_num_bits
+     - The default number of bits to use for the bloom filter in :spark:func:`bloom_filter_agg` function.
+   * - spark.bloom_filter.max_num_bits
      - integer
      - 4194304
-     - The maximum number of bits to use for the runtime bloom filter in :spark:func:`bloom_filter_agg` function.
+     - The maximum number of bits to use for the bloom filter in :spark:func:`bloom_filter_agg` function,
+       the value of this config can not exceed the default value.

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -383,3 +383,15 @@ Spark-specific Configuration
      - bool
      - true
      - If false, ``size`` function returns null for null input.
+   * - spark.runtime.bloom_filter.expected_num_items
+     - integer
+     - 1000000
+     - The default number of expected items for the runtime bloom filter in ``bloom_filter_agg`` function.
+   * - spark.runtime.bloom_filter.num_bits
+     - integer
+     - 8388608
+     - The default number of bits to use for the runtime bloom filter in ``bloom_filter_agg`` function.
+   * - spark.runtime.bloom_filter.max_num_bits
+     - integer
+     - 4194304
+     - The maximum number of bits to use for the runtime bloom filter in ``bloom_filter_agg`` function.

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -24,7 +24,7 @@ General Aggregate Functions
     ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
     In Spark, the value of ``numBits`` is automatically capped at config value 67,108,864.
-    In Velox, the value of ``numBits`` is automatically capped at the value of spark.runtime.bloom_filter.max_num_bits configuration property.
+    In Velox, the value of ``numBits`` is automatically capped at the value of spark.bloom_filter.max_num_bits configuration property.
 
     ``hash``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
@@ -39,7 +39,7 @@ General Aggregate Functions
 
 .. spark:function:: bloom_filter_agg(hash) -> varbinary
     
-    A version of ``bloom_filter_agg`` that use the value of spark.runtime.bloom_filter.max_num_bits configuration property as ``numBits``.
+    A version of ``bloom_filter_agg`` that use the value of spark.bloom_filter.max_num_bits configuration property as ``numBits``.
 
     ``hash`` cannot be null.
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -24,7 +24,7 @@ General Aggregate Functions
     ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
     In Spark, the value of ``numBits`` is automatically capped at config value 67,108,864.
-    In Velox, the value of ``numBits`` is automatically capped at fixed value 4,194,304.
+    In Velox, the value of ``numBits`` is automatically capped at config value 4,194,304.
 
     ``hash``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
@@ -39,7 +39,7 @@ General Aggregate Functions
 
 .. spark:function:: bloom_filter_agg(hash) -> varbinary
     
-    A version of ``bloom_filter_agg`` that use 4,194,304 as ``numBits``.
+    A version of ``bloom_filter_agg`` that use config default value 4,194,304 as ``numBits``.
 
     ``hash`` cannot be null.
 

--- a/velox/docs/functions/spark/aggregate.rst
+++ b/velox/docs/functions/spark/aggregate.rst
@@ -24,7 +24,7 @@ General Aggregate Functions
     ``hash`` cannot be null.
     ``numBits`` specifies max capacity of the bloom filter, which allows to trade accuracy for memory.
     In Spark, the value of ``numBits`` is automatically capped at config value 67,108,864.
-    In Velox, the value of ``numBits`` is automatically capped at config value 4,194,304.
+    In Velox, the value of ``numBits`` is automatically capped at the value of spark.runtime.bloom_filter.max_num_bits configuration property.
 
     ``hash``, ``estimatedNumItems`` and ``numBits`` must be ``BIGINT``.
 
@@ -39,7 +39,7 @@ General Aggregate Functions
 
 .. spark:function:: bloom_filter_agg(hash) -> varbinary
     
-    A version of ``bloom_filter_agg`` that use config default value 4,194,304 as ``numBits``.
+    A version of ``bloom_filter_agg`` that use the value of spark.runtime.bloom_filter.max_num_bits configuration property as ``numBits``.
 
     ``hash`` cannot be null.
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -64,6 +64,14 @@ AssertQueryBuilder& AssertQueryBuilder::config(
   return *this;
 }
 
+AssertQueryBuilder& AssertQueryBuilder::configs(
+    const std::unordered_map<std::string, std::string>& values) {
+  for (auto& entry : values) {
+    configs_[entry.first] = entry.second;
+  }
+  return *this;
+}
+
 AssertQueryBuilder& AssertQueryBuilder::connectorConfig(
     const std::string& connectorId,
     const std::string& key,

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,7 +39,7 @@ class AssertQueryBuilder {
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);
 
-  /// Set multiple configuration properties
+  /// Set multiple configuration properties.
   AssertQueryBuilder& configs(
       const std::unordered_map<std::string, std::string>& values);
 

--- a/velox/exec/tests/utils/AssertQueryBuilder.h
+++ b/velox/exec/tests/utils/AssertQueryBuilder.h
@@ -39,6 +39,10 @@ class AssertQueryBuilder {
   /// properties.
   AssertQueryBuilder& config(const std::string& key, const std::string& value);
 
+  /// Set multiple configuration properties
+  AssertQueryBuilder& configs(
+      const std::unordered_map<std::string, std::string>& values);
+
   /// Set connector-specific configuration property. May be called multiple
   /// times to set multiple properties for one or multiple connectors.
   AssertQueryBuilder& connectorConfig(

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -595,18 +595,18 @@ RowVectorPtr AggregationTestBase::validateStreamingInTestAggregations(
     const std::unordered_map<std::string, std::string>& config) {
   PlanBuilder builder(pool());
   makeSource(builder);
-  auto inputQueryBuilder = AssertQueryBuilder(builder.planNode());
-  inputQueryBuilder.configs(config);
-  auto input = inputQueryBuilder.copyResults(pool());
+  auto input = AssertQueryBuilder(builder.planNode())
+                   .configs(config)
+                   .copyResults(pool());
   if (input->size() < 2) {
     return nullptr;
   }
   auto size1 = input->size() / 2;
   auto size2 = input->size() - size1;
   builder.singleAggregation({}, aggregates);
-  auto expectedQueryBuilder = AssertQueryBuilder(builder.planNode());
-  expectedQueryBuilder.configs(config);
-  auto expected = expectedQueryBuilder.copyResults(pool());
+  auto expected = AssertQueryBuilder(builder.planNode())
+                      .configs(config)
+                      .copyResults(pool());
   EXPECT_EQ(expected->size(), 1);
   auto& aggregationNode =
       static_cast<const core::AggregationNode&>(*builder.planNode());

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -71,17 +71,19 @@ void AggregationTestBase::testAggregations(
     const std::vector<RowVectorPtr>& data,
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
-    const std::string& duckDbSql) {
+    const std::string& duckDbSql,
+    const std::unordered_map<std::string, std::string>& config) {
   SCOPED_TRACE(duckDbSql);
-  testAggregations(data, groupingKeys, aggregates, {}, duckDbSql);
+  testAggregations(data, groupingKeys, aggregates, {}, duckDbSql, config);
 }
 
 void AggregationTestBase::testAggregations(
     const std::vector<RowVectorPtr>& data,
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
-    const std::vector<RowVectorPtr>& expectedResult) {
-  testAggregations(data, groupingKeys, aggregates, {}, expectedResult);
+    const std::vector<RowVectorPtr>& expectedResult,
+    const std::unordered_map<std::string, std::string>& config) {
+  testAggregations(data, groupingKeys, aggregates, {}, expectedResult, config);
 }
 
 void AggregationTestBase::testAggregations(
@@ -89,14 +91,16 @@ void AggregationTestBase::testAggregations(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& postAggregationProjections,
-    const std::string& duckDbSql) {
+    const std::string& duckDbSql,
+    const std::unordered_map<std::string, std::string>& config) {
   SCOPED_TRACE(duckDbSql);
   testAggregations(
       [&](PlanBuilder& builder) { builder.values(data); },
       groupingKeys,
       aggregates,
       postAggregationProjections,
-      [&](auto& builder) { return builder.assertResults(duckDbSql); });
+      [&](auto& builder) { return builder.assertResults(duckDbSql); },
+      config);
 }
 
 namespace {
@@ -230,7 +234,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
     const std::vector<std::string>& aggregates,
     const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
     const std::vector<std::string>& postAggregationProjections,
-    const std::string& duckDbSql) {
+    const std::string& duckDbSql,
+    const std::unordered_map<std::string, std::string>& config) {
   testAggregationsWithCompanion(
       data,
       preAggregationProcessing,
@@ -238,7 +243,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
       aggregates,
       aggregatesArgTypes,
       postAggregationProjections,
-      [&](auto& builder) { return builder.assertResults(duckDbSql); });
+      [&](auto& builder) { return builder.assertResults(duckDbSql); },
+      config);
 }
 
 void AggregationTestBase::testAggregationsWithCompanion(
@@ -248,7 +254,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
     const std::vector<std::string>& aggregates,
     const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
     const std::vector<std::string>& postAggregationProjections,
-    const std::vector<RowVectorPtr>& expectedResult) {
+    const std::vector<RowVectorPtr>& expectedResult,
+    const std::unordered_map<std::string, std::string>& config) {
   testAggregationsWithCompanion(
       data,
       preAggregationProcessing,
@@ -256,7 +263,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
       aggregates,
       aggregatesArgTypes,
       postAggregationProjections,
-      [&](auto& builder) { return builder.assertResults(expectedResult); });
+      [&](auto& builder) { return builder.assertResults(expectedResult); },
+      config);
 }
 
 void AggregationTestBase::testAggregationsWithCompanion(
@@ -267,7 +275,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
     const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
     const std::vector<std::string>& postAggregationProjections,
     std::function<std::shared_ptr<exec::Task>(exec::test::AssertQueryBuilder&)>
-        assertResults) {
+        assertResults,
+    const std::unordered_map<std::string, std::string>& config) {
   auto dataWithExtraGroupingKey = addExtraGroupingKey(data, "k0");
   auto groupingKeysWithPartialKey = groupingKeys;
   groupingKeysWithPartialKey.push_back("k0");
@@ -312,6 +321,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -342,7 +352,8 @@ void AggregationTestBase::testAggregationsWithCompanion(
     auto spillDirectory = exec::test::TempDirectoryPath::create();
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
+    queryBuilder.configs(config)
+        .config(core::QueryConfig::kTestingSpillPct, "100")
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .spillDirectory(spillDirectory->path)
@@ -373,6 +384,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -394,6 +406,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -415,7 +428,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.maxDrivers(4);
+    queryBuilder.configs(config).maxDrivers(4);
     assertResults(queryBuilder);
   }
 
@@ -448,7 +461,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.maxDrivers(2);
+    queryBuilder.configs(config).maxDrivers(2);
     assertResults(queryBuilder);
   }
 
@@ -458,11 +471,13 @@ void AggregationTestBase::testAggregationsWithCompanion(
       SCOPED_TRACE("Streaming partial");
       auto partialResult = validateStreamingInTestAggregations(
           [&](auto& builder) { builder.values(dataWithExtraGroupingKey); },
-          paritialAggregates);
+          paritialAggregates,
+          config);
 
       validateStreamingInTestAggregations(
           [&](auto& builder) { builder.values({partialResult}); },
-          mergeAggregates);
+          mergeAggregates,
+          config);
     }
   }
 }
@@ -548,39 +563,50 @@ void AggregationTestBase::testAggregations(
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& postAggregationProjections,
-    const std::vector<RowVectorPtr>& expectedResult) {
+    const std::vector<RowVectorPtr>& expectedResult,
+    const std::unordered_map<std::string, std::string>& config) {
   testAggregations(
       [&](PlanBuilder& builder) { builder.values(data); },
       groupingKeys,
       aggregates,
       postAggregationProjections,
-      [&](auto& builder) { return builder.assertResults(expectedResult); });
+      [&](auto& builder) { return builder.assertResults(expectedResult); },
+      config);
 }
 
 void AggregationTestBase::testAggregations(
     std::function<void(PlanBuilder&)> makeSource,
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
-    const std::string& duckDbSql) {
+    const std::string& duckDbSql,
+    const std::unordered_map<std::string, std::string>& config) {
   testAggregations(
-      makeSource, groupingKeys, aggregates, {}, [&](auto& builder) {
-        return builder.assertResults(duckDbSql);
-      });
+      makeSource,
+      groupingKeys,
+      aggregates,
+      {},
+      [&](auto& builder) { return builder.assertResults(duckDbSql); },
+      config);
 }
 
 RowVectorPtr AggregationTestBase::validateStreamingInTestAggregations(
     const std::function<void(PlanBuilder&)>& makeSource,
-    const std::vector<std::string>& aggregates) {
+    const std::vector<std::string>& aggregates,
+    const std::unordered_map<std::string, std::string>& config) {
   PlanBuilder builder(pool());
   makeSource(builder);
-  auto input = AssertQueryBuilder(builder.planNode()).copyResults(pool());
+  auto inputQueryBuilder = AssertQueryBuilder(builder.planNode());
+  inputQueryBuilder.configs(config);
+  auto input = inputQueryBuilder.copyResults(pool());
   if (input->size() < 2) {
     return nullptr;
   }
   auto size1 = input->size() / 2;
   auto size2 = input->size() - size1;
   builder.singleAggregation({}, aggregates);
-  auto expected = AssertQueryBuilder(builder.planNode()).copyResults(pool());
+  auto expectedQueryBuilder = AssertQueryBuilder(builder.planNode());
+  expectedQueryBuilder.configs(config);
+  auto expected = expectedQueryBuilder.copyResults(pool());
   EXPECT_EQ(expected->size(), 1);
   auto& aggregationNode =
       static_cast<const core::AggregationNode&>(*builder.planNode());
@@ -612,12 +638,12 @@ RowVectorPtr AggregationTestBase::validateStreamingInTestAggregations(
     }
 
     auto actualResult1 =
-        testStreaming(name, true, rawInput1, size1, rawInput2, size2);
+        testStreaming(name, true, rawInput1, size1, rawInput2, size2, config);
     velox::exec::test::assertEqualResults(
         {makeRowVector({expected->childAt(i)})},
         {makeRowVector({actualResult1})});
     auto actualResult2 =
-        testStreaming(name, false, rawInput1, size1, rawInput2, size2);
+        testStreaming(name, false, rawInput1, size1, rawInput2, size2, config);
     velox::exec::test::assertEqualResults(
         {makeRowVector({expected->childAt(i)})},
         {makeRowVector({actualResult2})});
@@ -631,7 +657,8 @@ void AggregationTestBase::testAggregations(
     const std::vector<std::string>& aggregates,
     const std::vector<std::string>& postAggregationProjections,
     std::function<std::shared_ptr<exec::Task>(AssertQueryBuilder&)>
-        assertResults) {
+        assertResults,
+    const std::unordered_map<std::string, std::string>& config) {
   {
     SCOPED_TRACE("Run partial + final");
     PlanBuilder builder(pool());
@@ -642,6 +669,7 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -666,7 +694,8 @@ void AggregationTestBase::testAggregations(
     auto spillDirectory = exec::test::TempDirectoryPath::create();
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
+    queryBuilder.configs(config)
+        .config(core::QueryConfig::kTestingSpillPct, "100")
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .spillDirectory(spillDirectory->path)
@@ -701,7 +730,7 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder
+    queryBuilder.configs(config)
         .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
         .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
         .config(core::QueryConfig::kMaxPartialAggregationMemory, "0")
@@ -732,6 +761,7 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -751,7 +781,7 @@ void AggregationTestBase::testAggregations(
     auto spillDirectory = exec::test::TempDirectoryPath::create();
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.config(core::QueryConfig::kTestingSpillPct, "100")
+    queryBuilder.configs(config).config(core::QueryConfig::kTestingSpillPct, "100")
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kAggregationSpillEnabled, "true")
         .spillDirectory(spillDirectory->path);
@@ -783,6 +813,7 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder);
   }
 
@@ -800,6 +831,7 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder.maxDrivers(4));
   }
 
@@ -826,13 +858,14 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
+    queryBuilder.configs(config);
     assertResults(queryBuilder.maxDrivers(2));
   }
 
   if (testStreaming_ && groupingKeys.empty() &&
       postAggregationProjections.empty()) {
     SCOPED_TRACE("Streaming");
-    validateStreamingInTestAggregations(makeSource, aggregates);
+    validateStreamingInTestAggregations(makeSource, aggregates, config);
   }
 }
 
@@ -864,7 +897,8 @@ VectorPtr AggregationTestBase::testStreaming(
     const std::string& functionName,
     bool testGlobal,
     const std::vector<VectorPtr>& rawInput1,
-    const std::vector<VectorPtr>& rawInput2) {
+    const std::vector<VectorPtr>& rawInput2,
+    const std::unordered_map<std::string, std::string>& config) {
   VELOX_CHECK(!rawInput1.empty());
   VELOX_CHECK(!rawInput2.empty());
   return testStreaming(
@@ -873,7 +907,8 @@ VectorPtr AggregationTestBase::testStreaming(
       rawInput1,
       rawInput1[0]->size(),
       rawInput2,
-      rawInput2[0]->size());
+      rawInput2[0]->size(),
+      config);
 }
 
 VectorPtr AggregationTestBase::testStreaming(
@@ -882,7 +917,8 @@ VectorPtr AggregationTestBase::testStreaming(
     const std::vector<VectorPtr>& rawInput1,
     vector_size_t rawInput1Size,
     const std::vector<VectorPtr>& rawInput2,
-    vector_size_t rawInput2Size) {
+    vector_size_t rawInput2Size,
+    const std::unordered_map<std::string, std::string>& config) {
   constexpr int kRowSizeOffset = 8;
   constexpr int kOffset = kRowSizeOffset + 8;
   HashStringAllocator allocator(pool());

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -929,13 +929,13 @@ VectorPtr AggregationTestBase::testStreaming(
   auto [intermediateType, finalType] =
       getResultTypes(functionName, rawInputTypes);
   auto createFunction = [&, &finalType = finalType] {
-    core::QueryConfig config({});
+    core::QueryConfig queryConfig({config});
     auto func = exec::Aggregate::create(
         functionName,
         core::AggregationNode::Step::kSingle,
         rawInputTypes,
         finalType,
-        config);
+        queryConfig);
     func->setAllocator(&allocator);
     func->setOffsets(kOffset, 0, 1, kRowSizeOffset);
     return func;

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -65,7 +65,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       std::function<void(exec::test::PlanBuilder&)> makeSource,
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::string& duckDbSql);
+      const std::string& duckDbSql,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Same as above, but allows to specify a set of projections to apply after
   /// the aggregation.
@@ -75,7 +76,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& postAggregationProjections,
       std::function<std::shared_ptr<exec::Task>(
-          exec::test::AssertQueryBuilder& builder)> assertResults);
+          exec::test::AssertQueryBuilder& builder)> assertResults,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node.
@@ -83,7 +85,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<RowVectorPtr>& data,
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::string& duckDbSql);
+      const std::string& duckDbSql,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node.
@@ -92,7 +95,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& postAggregationProjections,
-      const std::string& duckDbSql);
+      const std::string& duckDbSql,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node, and the expected result instead of a
@@ -101,7 +105,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<RowVectorPtr>& data,
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
-      const std::vector<RowVectorPtr>& expectedResult);
+      const std::vector<RowVectorPtr>& expectedResult,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Convenience version that allows to specify input data instead of a
   /// function to build Values plan node, and the expected result instead of a
@@ -111,7 +116,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
       const std::vector<std::string>& postAggregationProjections,
-      const std::vector<RowVectorPtr>& expectedResult);
+      const std::vector<RowVectorPtr>& expectedResult,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   /// Ensure the function is working in streaming use case.  Create a first
   /// aggregation function, add the rawInput1, then extract the accumulator,
@@ -121,7 +127,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::string& functionName,
       bool testGlobal,
       const std::vector<VectorPtr>& rawInput1,
-      const std::vector<VectorPtr>& rawInput2);
+      const std::vector<VectorPtr>& rawInput2,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   // Given a list of aggregation expressions, test their equivalent plans using
   // companion functions. For example, suppose we have the following arguments
@@ -137,6 +144,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   // Note that we intentionally add an additional grouping key k1 at the
   // avg_partial operation so that the following avg_merge operation will have
   // multiple values to merge for each g0 group.
+  // config is used in Aggregate.core::QueryConfig
   void testAggregationsWithCompanion(
       const std::vector<RowVectorPtr>& data,
       const std::function<void(exec::test::PlanBuilder&)>&
@@ -145,7 +153,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& aggregates,
       const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
       const std::vector<std::string>& postAggregationProjections,
-      const std::string& duckDbSql);
+      const std::string& duckDbSql,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   void testAggregationsWithCompanion(
       const std::vector<RowVectorPtr>& data,
@@ -155,7 +164,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::string>& aggregates,
       const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
       const std::vector<std::string>& postAggregationProjections,
-      const std::vector<RowVectorPtr>& expectedResult);
+      const std::vector<RowVectorPtr>& expectedResult,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   void testAggregationsWithCompanion(
       const std::vector<RowVectorPtr>& data,
@@ -166,7 +176,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<std::vector<TypePtr>>& aggregatesArgTypes,
       const std::vector<std::string>& postAggregationProjections,
       std::function<std::shared_ptr<exec::Task>(
-          exec::test::AssertQueryBuilder&)> assertResults);
+          exec::test::AssertQueryBuilder&)> assertResults,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   // Split the input into 2 files then read the input from files.  Can reveal
   // bugs in string life cycle management.
@@ -220,7 +231,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   // results. Return the result of aggregates if successful.
   RowVectorPtr validateStreamingInTestAggregations(
       const std::function<void(exec::test::PlanBuilder&)>& makeSource,
-      const std::vector<std::string>& aggregates);
+      const std::vector<std::string>& aggregates,
+      const std::unordered_map<std::string, std::string>& config);
 
   VectorPtr testStreaming(
       const std::string& functionName,
@@ -228,7 +240,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
       const std::vector<VectorPtr>& rawInput1,
       vector_size_t rawInput1Size,
       const std::vector<VectorPtr>& rawInput2,
-      vector_size_t rawInput2Size);
+      vector_size_t rawInput2Size,
+      const std::unordered_map<std::string, std::string>& config = {});
 
   bool allowInputShuffle_{false};
 };

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -61,7 +61,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   /// @param groupingKeys A list of grouping keys. May be empty.
   /// @param aggregates A list of aggregates to compute.
   /// @param duckDbSql An equivalent DuckDB SQL query.
-  /// @param config The config to build core::QueryConfig in Aggregate.
+  /// @param config Optional configuration properties to use when evaluating aggregations.
   void testAggregations(
       std::function<void(exec::test::PlanBuilder&)> makeSource,
       const std::vector<std::string>& groupingKeys,

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -61,7 +61,8 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   /// @param groupingKeys A list of grouping keys. May be empty.
   /// @param aggregates A list of aggregates to compute.
   /// @param duckDbSql An equivalent DuckDB SQL query.
-  /// @param config Optional configuration properties to use when evaluating aggregations.
+  /// @param config Optional configuration properties to use when evaluating
+  /// aggregations.
   void testAggregations(
       std::function<void(exec::test::PlanBuilder&)> makeSource,
       const std::vector<std::string>& groupingKeys,

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -61,6 +61,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   /// @param groupingKeys A list of grouping keys. May be empty.
   /// @param aggregates A list of aggregates to compute.
   /// @param duckDbSql An equivalent DuckDB SQL query.
+  /// @param config The config to build core::QueryConfig in Aggregate.
   void testAggregations(
       std::function<void(exec::test::PlanBuilder&)> makeSource,
       const std::vector<std::string>& groupingKeys,
@@ -144,7 +145,7 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
   // Note that we intentionally add an additional grouping key k1 at the
   // avg_partial operation so that the following avg_merge operation will have
   // multiple values to merge for each g0 group.
-  // config is used in Aggregate.core::QueryConfig
+  // This config is used in Aggregate parameter core::QueryConfig.
   void testAggregationsWithCompanion(
       const std::vector<RowVectorPtr>& data,
       const std::function<void(exec::test::PlanBuilder&)>&

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -262,16 +262,16 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   }
 
   static constexpr int64_t kMissingArgument = -1;
+  const int64_t defaultExpectedNumItems_;
+  const int64_t defaultNumBits_;
+  const int64_t maxNumBits_;
+  
   // Reusable instance of DecodedVector for decoding input vectors.
   DecodedVector decodedRaw_;
   DecodedVector decodedIntermediate_;
   int64_t estimatedNumItems_ = kMissingArgument;
   int64_t numBits_ = kMissingArgument;
   int32_t capacity_ = kMissingArgument;
-
-  const int64_t defaultExpectedNumItems_;
-  const int64_t defaultNumBits_;
-  const int64_t maxNumBits_;
 };
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -64,10 +64,9 @@ class BloomFilterAggAggregate : public exec::Aggregate {
       const TypePtr& resultType,
       const core::QueryConfig& config)
       : Aggregate(resultType),
-        defaultExpectedNumItems_(
-            config.sparkRuntimeBloomFilterExpectedNumItems()),
-        defaultNumBits_(config.sparkRuntimeBloomFilterNumBits()),
-        maxNumBits_(config.sparkRuntimeBloomFilterMaxNumBits()) {}
+        defaultExpectedNumItems_(config.sparkBloomFilterExpectedNumItems()),
+        defaultNumBits_(config.sparkBloomFilterNumBits()),
+        maxNumBits_(config.sparkBloomFilterMaxNumBits()) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(BloomFilterAccumulator);

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -265,7 +265,7 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   const int64_t defaultExpectedNumItems_;
   const int64_t defaultNumBits_;
   const int64_t maxNumBits_;
-  
+
   // Reusable instance of DecodedVector for decoding input vectors.
   DecodedVector decodedRaw_;
   DecodedVector decodedIntermediate_;

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -60,8 +60,14 @@ struct BloomFilterAccumulator {
 
 class BloomFilterAggAggregate : public exec::Aggregate {
  public:
-  explicit BloomFilterAggAggregate(const TypePtr& resultType)
-      : Aggregate(resultType) {}
+  explicit BloomFilterAggAggregate(
+      const TypePtr& resultType,
+      const core::QueryConfig& config)
+      : Aggregate(resultType) {
+    defaultExpectedNumItems_ = config.sparkRuntimeBloomFilterExpectedNumItems();
+    defaultNumBits_ = config.sparkRuntimeBloomFilterNumBits();
+    maxNumBits_ = config.sparkRuntimeBloomFilterMaxNumBits();
+  }
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(BloomFilterAccumulator);
@@ -190,12 +196,6 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   }
 
  private:
-  const int64_t kDefaultExpectedNumItems = 1'000'000;
-  const int64_t kDefaultNumBits = 8'388'608;
-  // Spark kMaxNumBits is 67108864, but velox has memory limit sizeClassSizes
-  // 256, so decrease it to not over memory limit.
-  const int64_t kMaxNumBits = 4'096 * 1024;
-
   void decodeArguments(
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args) {
@@ -213,14 +213,14 @@ class BloomFilterAggAggregate : public exec::Aggregate {
         numBits_ = estimatedNumItems_ * 8;
       }
     } else {
-      estimatedNumItems_ = kDefaultExpectedNumItems;
-      numBits_ = kDefaultNumBits;
+      estimatedNumItems_ = defaultExpectedNumItems_;
+      numBits_ = defaultNumBits_;
     }
   }
 
   void computeCapacity() {
     if (capacity_ == kMissingArgument) {
-      int64_t numBits = std::min(numBits_, kMaxNumBits);
+      int64_t numBits = std::min(numBits_, maxNumBits_);
       capacity_ = numBits / 16;
     }
   }
@@ -269,6 +269,10 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   int64_t estimatedNumItems_ = kMissingArgument;
   int64_t numBits_ = kMissingArgument;
   int32_t capacity_ = kMissingArgument;
+
+  int64_t defaultExpectedNumItems_;
+  int64_t defaultNumBits_;
+  int64_t maxNumBits_;
 };
 
 } // namespace
@@ -302,9 +306,8 @@ exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
           core::AggregationNode::Step /* step */,
           const std::vector<TypePtr>& /* argTypes */,
           const TypePtr& resultType,
-          const core::QueryConfig& /*config*/)
-          -> std::unique_ptr<exec::Aggregate> {
-        return std::make_unique<BloomFilterAggAggregate>(resultType);
+          const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
+        return std::make_unique<BloomFilterAggAggregate>(resultType, config);
       });
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -63,11 +63,11 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   explicit BloomFilterAggAggregate(
       const TypePtr& resultType,
       const core::QueryConfig& config)
-      : Aggregate(resultType) {
-    defaultExpectedNumItems_ = config.sparkRuntimeBloomFilterExpectedNumItems();
-    defaultNumBits_ = config.sparkRuntimeBloomFilterNumBits();
-    maxNumBits_ = config.sparkRuntimeBloomFilterMaxNumBits();
-  }
+      : Aggregate(resultType),
+        defaultExpectedNumItems_(
+            config.sparkRuntimeBloomFilterExpectedNumItems()),
+        defaultNumBits_(config.sparkRuntimeBloomFilterNumBits()),
+        maxNumBits_(config.sparkRuntimeBloomFilterMaxNumBits()) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(BloomFilterAccumulator);
@@ -270,9 +270,9 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   int64_t numBits_ = kMissingArgument;
   int32_t capacity_ = kMissingArgument;
 
-  int64_t defaultExpectedNumItems_;
-  int64_t defaultNumBits_;
-  int64_t maxNumBits_;
+  const int64_t defaultExpectedNumItems_;
+  const int64_t defaultNumBits_;
+  const int64_t maxNumBits_;
 };
 
 } // namespace

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -86,4 +86,19 @@ TEST_F(BloomFilterAggAggregateTest, nullBloomFilter) {
           vectors, {}, {"bloom_filter_agg(c0, 5, 64)"}, expectedFake),
       "First argument of bloom_filter_agg cannot be null");
 }
+
+TEST_F(BloomFilterAggAggregateTest, config) {
+  auto vector = {makeRowVector({makeFlatVector<int64_t>(
+      100, [](vector_size_t row) { return row % 9; })})};
+  auto bloomFilter = getSerializedBloomFilter(100);
+  auto expected = {
+      makeRowVector({makeConstant<StringView>(StringView(bloomFilter), 1)})};
+
+  testAggregations(
+      vector,
+      {},
+      {"bloom_filter_agg(c0)"},
+      expected,
+      {{core::QueryConfig::kSparkRuntimeBloomFilterMaxNumBits, "1600"}});
+}
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -104,13 +104,13 @@ TEST_F(BloomFilterAggAggregateTest, config) {
       expected,
       {{core::QueryConfig::kSparkBloomFilterMaxNumBits, "1600"}});
 
-  exec::test::PlanBuilder builder(pool());
-  builder.values(vector)
-      .partialAggregation({}, {"bloom_filter_agg(c0)"})
-      .finalAggregation();
-  exec::test::AssertQueryBuilder queryBuilder(
-      builder.planNode(), duckDbQueryRunner_);
-  auto actual = queryBuilder.copyResults(pool());
+  // Test fails without setting the config.
+  auto planNode = exec::test::PlanBuilder(pool())
+                      .values(vector)
+                      .partialAggregation({}, {"bloom_filter_agg(c0)"})
+                      .finalAggregation()
+                      .planNode();
+  auto actual = exec::test::AssertQueryBuilder(planNode).copyResults(pool());
   EXPECT_FALSE(
       expected[0]->childAt(0)->equalValueAt(actual->childAt(0).get(), 0, 0));
 }


### PR DESCRIPTION
Add the QueryConfig `spark.bloom_filter.expected_num_items`, `spark.bloom_filter.expected_num_bits`, `spark.bloom_filter.expected_max_num_bits`.