### PR TITLE
Remove GTEST_SKIP

### DIFF
--- a/velox/dwio/common/DataSink.h
+++ b/velox/dwio/common/DataSink.h
@@ -163,8 +163,13 @@ class WriteFileDataSink final : public DataSink {
 
   void doClose() override;
 
+  std::unique_ptr<WriteFile> toWriteFile() {
+    markClosed();
+    return std::move(writeFile_);
+  }
+
  private:
-  std::shared_ptr<WriteFile> writeFile_;
+  std::unique_ptr<WriteFile> writeFile_;
 };
 
 class LocalFileSink : public DataSink {

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -551,7 +551,7 @@ TEST_P(MinMaxByGlobalByAggregationTest, randomMinByGlobalBy) {
   // DuckDB).
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   testGlobalAggregation(
@@ -564,7 +564,7 @@ TEST_P(MinMaxByGlobalByAggregationTest, randomMinByGlobalBy) {
 TEST_P(MinMaxByGlobalByAggregationTest, randomMaxByGlobalBy) {
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   testGlobalAggregation(
@@ -579,7 +579,7 @@ TEST_P(
     randomMaxByGlobalByWithDistinctCompareValue) {
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   // Enable disk spilling test with distinct comparison values.
@@ -979,7 +979,7 @@ TEST_P(MinMaxByGroupByAggregationTest, maxByFinalGroupBy) {
 TEST_P(MinMaxByGroupByAggregationTest, randomMinByGroupBy) {
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   testGroupByAggregation(
@@ -993,7 +993,7 @@ TEST_P(MinMaxByGroupByAggregationTest, randomMinByGroupBy) {
 TEST_P(MinMaxByGroupByAggregationTest, randomMaxByGroupBy) {
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   testGroupByAggregation(
@@ -1009,7 +1009,7 @@ TEST_P(
     randomMinMaxByGroupByWithDistinctCompareValue) {
   if (GetParam().comparisonType == TypeKind::TIMESTAMP ||
       GetParam().valueType == TypeKind::TIMESTAMP) {
-    GTEST_SKIP() << "Fuzzer test for timestamps is not supported yet.";
+    return;
   }
 
   // Enable disk spilling test with distinct comparison values.


### PR DESCRIPTION
Summary: In Meta internal system, skipped tests are marked as red flags and should be avoided.

Reviewed By: kgpai

Differential Revision: D47335484

