### PR TITLE
Refactor S3FileSystem Registration

### DIFF
--- a/velox/connectors/hive/storage_adapters/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/CMakeLists.txt
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if(VELOX_ENABLE_S3)
-  add_subdirectory(s3fs)
-endif()
+add_subdirectory(s3fs)
+
 if(VELOX_ENABLE_HDFS)
   add_subdirectory(hdfs)
 endif()

--- a/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/CMakeLists.txt
@@ -14,11 +14,17 @@
 
 # for generated headers
 
-add_library(velox_s3fs S3FileSystem.cpp S3Util.cpp)
-target_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
-target_link_libraries(velox_s3fs Folly::folly ${AWSSDK_LIBRARIES})
+add_library(velox_s3fs RegisterS3FileSystem.cpp)
+if(VELOX_ENABLE_S3)
+  target_sources(velox_s3fs PRIVATE S3FileSystem.cpp S3Util.cpp)
 
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-  add_subdirectory(benchmark)
+  target_include_directories(velox_s3fs PUBLIC ${AWSSDK_INCLUDE_DIRS})
+  target_link_libraries(velox_s3fs Folly::folly ${AWSSDK_LIBRARIES})
+
+  if(${VELOX_BUILD_TESTING})
+    add_subdirectory(tests)
+  endif()
+  if(${VELOX_ENABLE_BENCHMARKS})
+    add_subdirectory(benchmark)
+  endif()
 endif()

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef VELOX_ENABLE_S3
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
+#include "velox/core/Config.h"
+#endif
+
+namespace facebook::velox::filesystems {
+
+#ifdef VELOX_ENABLE_S3
+folly::once_flag S3FSInstantiationFlag;
+
+std::function<std::shared_ptr<
+    FileSystem>(std::shared_ptr<const Config>, std::string_view)>
+fileSystemGenerator() {
+  static auto filesystemGenerator = [](std::shared_ptr<const Config> properties,
+                                       std::string_view filePath) {
+    // Only one instance of S3FileSystem is supported for now.
+    // TODO: Support multiple S3FileSystem instances using a cache
+    // Initialize on first access and reuse after that.
+    static std::shared_ptr<FileSystem> s3fs;
+    folly::call_once(S3FSInstantiationFlag, [&properties]() {
+      std::shared_ptr<S3FileSystem> fs;
+      if (properties != nullptr) {
+        fs = std::make_shared<S3FileSystem>(properties);
+      } else {
+        fs =
+            std::make_shared<S3FileSystem>(std::make_shared<core::MemConfig>());
+      }
+      fs->initializeClient();
+      s3fs = fs;
+    });
+    return s3fs;
+  };
+  return filesystemGenerator;
+}
+#endif
+
+void registerS3FileSystem() {
+#ifdef VELOX_ENABLE_S3
+  registerFileSystem(isS3File, fileSystemGenerator());
+#endif
+}
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace facebook::velox::filesystems {
+
+// Register the S3 filesystem.
+void registerS3FileSystem();
+
+} // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -75,6 +75,4 @@ class S3FileSystem : public FileSystem {
   std::shared_ptr<Impl> impl_;
 };
 
-// Register the S3 filesystem.
-void registerS3FileSystem();
 } // namespace facebook::velox::filesystems

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmark.h
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/file/benchmark/ReadBenchmark.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
 
 DECLARE_string(s3_config);

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.h"
 #include "connectors/hive/storage_adapters/s3fs/S3Util.h"
 #include "connectors/hive/storage_adapters/s3fs/tests/MinioServer.h"
 #include "velox/common/file/File.h"


### PR DESCRIPTION
Move S3FileSystem registration to a separate header `RegisterS3FileSystem.h`.
Push optional checks inside the registration such that disabling S3 will cause
`registerS3FileSystem()` to be a no-op. The S3 dependencies are also linked to `s3fs` when S3 is 
enabled.
This helps the clients avoid the optional checks.