### PR TITLE
Cleanup after making DATE a logical type

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -141,23 +141,26 @@ void appendSqlLiteral(
     return;
   }
 
-  if (vector.type()->isDate()) {
-    auto dateVector = vector.wrappedVector()->as<SimpleVector<int32_t>>();
-    out << "'"
-        << DATE()->toString(dateVector->valueAt(vector.wrappedIndex(row)))
-        << "'::" << vector.type()->toString();
-    return;
-  }
-
   switch (vector.typeKind()) {
     case TypeKind::BOOLEAN: {
       auto value = vector.as<SimpleVector<bool>>()->valueAt(row);
       out << (value ? "TRUE" : "FALSE");
       break;
     }
+    case TypeKind::INTEGER: {
+      if (vector.type()->isDate()) {
+        auto dateVector = vector.wrappedVector()->as<SimpleVector<int32_t>>();
+        out << "'"
+            << DATE()->toString(dateVector->valueAt(vector.wrappedIndex(row)))
+            << "'::" << vector.type()->toString();
+      } else {
+        out << "'" << vector.wrappedVector()->toString(vector.wrappedIndex(row))
+            << "'::" << vector.type()->toString();
+      }
+      break;
+    }
     case TypeKind::TINYINT:
     case TypeKind::SMALLINT:
-    case TypeKind::INTEGER:
     case TypeKind::BIGINT:
     case TypeKind::TIMESTAMP:
     case TypeKind::REAL:

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -97,10 +97,6 @@ bool isChecksumBitSet(int8_t codec) {
 }
 
 std::string typeToEncodingName(const TypePtr& type) {
-  if (type->isDate()) {
-    return "INT_ARRAY";
-  }
-
   switch (type->kind()) {
     case TypeKind::BOOLEAN:
       return "BYTE_ARRAY";

--- a/velox/substrait/VeloxSubstraitSignature.cpp
+++ b/velox/substrait/VeloxSubstraitSignature.cpp
@@ -20,10 +20,6 @@
 namespace facebook::velox::substrait {
 
 std::string VeloxSubstraitSignature::toSubstraitSignature(const TypePtr& type) {
-  if (type->isDate()) {
-    return "date";
-  }
-
   switch (type->kind()) {
     case TypeKind::BOOLEAN:
       return "bool";
@@ -32,6 +28,9 @@ std::string VeloxSubstraitSignature::toSubstraitSignature(const TypePtr& type) {
     case TypeKind::SMALLINT:
       return "i16";
     case TypeKind::INTEGER:
+      if (type->isDate()) {
+        return "date";
+      }
       return "i32";
     case TypeKind::BIGINT:
       return "i64";

--- a/velox/substrait/VeloxToSubstraitType.cpp
+++ b/velox/substrait/VeloxToSubstraitType.cpp
@@ -26,15 +26,6 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
   ::substrait::Type* substraitType =
       google::protobuf::Arena::CreateMessage<::substrait::Type>(&arena);
 
-  if (type->isDate()) {
-    auto substraitDate =
-        google::protobuf::Arena::CreateMessage<::substrait::Type_Date>(&arena);
-    substraitDate->set_nullability(
-        ::substrait::Type_Nullability_NULLABILITY_NULLABLE);
-    substraitType->set_allocated_date(substraitDate);
-    return *substraitType;
-  }
-
   switch (type->kind()) {
     case velox::TypeKind::BOOLEAN: {
       auto substraitBool =
@@ -63,6 +54,16 @@ const ::substrait::Type& VeloxToSubstraitTypeConvertor::toSubstraitType(
       break;
     }
     case velox::TypeKind::INTEGER: {
+      if (type->isDate()) {
+        auto substraitDate =
+            google::protobuf::Arena::CreateMessage<::substrait::Type_Date>(
+                &arena);
+        substraitDate->set_nullability(
+            ::substrait::Type_Nullability_NULLABILITY_NULLABLE);
+        substraitType->set_allocated_date(substraitDate);
+        return *substraitType;
+      }
+
       auto substraitI32 =
           google::protobuf::Arena::CreateMessage<::substrait::Type_I32>(&arena);
       substraitI32->set_nullability(

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -183,10 +183,6 @@ std::string variant::toJson(const TypePtr& type) const {
     return "null";
   }
 
-  if (type->isDate()) {
-    return '"' + DATE()->toString(value<TypeKind::INTEGER>()) + '"';
-  }
-
   switch (kind_) {
     case TypeKind::MAP: {
       auto& map = value<TypeKind::MAP>();
@@ -256,6 +252,9 @@ std::string variant::toJson(const TypePtr& type) const {
     case TypeKind::SMALLINT:
       [[fallthrough]];
     case TypeKind::INTEGER:
+      if (type->isDate()) {
+        return '"' + DATE()->toString(value<TypeKind::INTEGER>()) + '"';
+      }
       [[fallthrough]];
     case TypeKind::BIGINT:
       if (type && type->isShortDecimal()) {

--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -217,10 +217,6 @@ const char* exportArrowFormatStr(
     return formatBuffer.c_str();
   }
 
-  if (type->isDate()) {
-    return "tdD";
-  }
-
   switch (type->kind()) {
     // Scalar types.
     case TypeKind::BOOLEAN:
@@ -230,6 +226,9 @@ const char* exportArrowFormatStr(
     case TypeKind::SMALLINT:
       return "s"; // int16
     case TypeKind::INTEGER:
+      if (type->isDate()) {
+        return "tdD";
+      }
       return "i"; // int32
     case TypeKind::BIGINT:
       return "l"; // int64


### PR DESCRIPTION
The changes do the date type checks only if TypeKind::INTEGER is matched. That avoids the check to run for all types.