### PR TITLE
Add presto element_at scalar function with boolean args

### DIFF
--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -85,7 +85,8 @@ class SubscriptImpl : public exec::VectorFunction {
         "bigint",
         "real",
         "double",
-        "varchar"};
+        "varchar",
+        "boolean"};
     for (const auto& keyType : keyTypes) {
       signatures.push_back(exec::FunctionSignatureBuilder()
                                .typeVariable("V")
@@ -149,6 +150,8 @@ class SubscriptImpl : public exec::VectorFunction {
         return applyMapTyped<double>(rows, mapArg, indexArg, context);
       case TypeKind::VARCHAR:
         return applyMapTyped<StringView>(rows, mapArg, indexArg, context);
+      case TypeKind::BOOLEAN:
+        return applyMapTyped<bool>(rows, mapArg, indexArg, context);
       default:
         VELOX_UNSUPPORTED(
             "Unsupported map key type for element_at: {}",

--- a/velox/functions/prestosql/tests/ElementAtTest.cpp
+++ b/velox/functions/prestosql/tests/ElementAtTest.cpp
@@ -661,6 +661,7 @@ TEST_F(ElementAtTest, variableInputMap) {
   testVariableInputMap<int8_t>(); // TINYINT
   testVariableInputMap<float>(); // REAL
   testVariableInputMap<double>(); // DOUBLE
+  testVariableInputMap<bool>(); // BOOLEAN
 
   testVariableInputMap<StringView>(); // VARCHAR
 }


### PR DESCRIPTION
Add missing argument type `boolean` for presto function `element_at`. 

Presto reference: https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapElementAtFunction.java#L54 