### PR TITLE
Add cast benchmark.

### DIFF
--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -111,6 +111,10 @@ class ExpressionBenchmarkBuilder
   // If disbleTesting=true for a group set, testing is skipped.
   void testBenchmarks();
 
+  test::VectorMaker& vectorMaker() {
+    return vectorMaker_;
+  }
+
   ExpressionBenchmarkSet& addBenchmarkSet(
       const std::string& name,
       const RowVectorPtr& inputRowVetor) {

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ set(velox_benchmark_deps
     velox_parse_utils
     velox_parse_expression
     velox_serialization
+    velox_benchmark_builder
     Folly::folly
     ${FOLLY_BENCHMARK}
     ${DOUBLE_CONVERSION}
@@ -65,3 +66,7 @@ target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
 add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
 target_link_libraries(velox_benchmark_basic_vector_fuzzer
                       ${velox_benchmark_deps} velox_vector_test_lib)
+
+add_executable(velox_cast_benchmark CastBenchmark.cpp)
+target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps}
+                      velox_vector_test_lib)

--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto invalidInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+
+  auto validInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+  invalidInput->resize(1000);
+  validInput->resize(1000);
+
+  for (int i = 0; i < 1000; i++) {
+    invalidInput->set(i, ""_sv);
+    validInput->set(i, StringView::makeInline(std::to_string(i)));
+  }
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_int",
+          vectorMaker.rowVector(
+              {"valid", "invalid"}, {validInput, invalidInput}))
+      .addExpression("try_invalid", "try_cast (invalid as int)")
+      .addExpression("try_valid", "try_cast (valid as int)")
+      .addExpression("valid", "cast(valid as int)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}


### PR DESCRIPTION
Summary:
```
without error logging
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_int##try_invalid                                        3.25s   307.91m
cast_int##try_valid                                         2.15ms    465.69
cast_int##valid                                             2.19ms    456.76
----------------------------------------------------------------------------
----------------------------------------------------------------------------
```
```
with error logging
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_int##try_invalid                                        4.88s   204.83m
cast_int##try_valid                                         2.15ms    465.22
cast_int##valid                                             2.20ms    453.96
----------------------------------------------------------------------------
----------------------------------------------------------------------------
```

Differential Revision: D47295115

