### PR TITLE
Close the data sink before returning the output

### DIFF
--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -100,6 +100,10 @@ RowVectorPtr TableWriter::getOutput() {
   }
   finished_ = true;
 
+  // Close the data sink to flush all the buffered data and metadata to storage
+  // and close the files.
+  auto freeGuard = folly::makeGuard([&]() { close(); });
+
   if (outputType_->size() == 0) {
     return nullptr;
   }


### PR DESCRIPTION
The hive data sink might fail on driver close after returning the
output. We shall first close data sink and throw any error before
returning the output