### PR TITLE
Fix string life cycle issue in approx_most_frequent

### DIFF
--- a/velox/functions/lib/ApproxMostFrequentStreamSummary.h
+++ b/velox/functions/lib/ApproxMostFrequentStreamSummary.h
@@ -78,6 +78,10 @@ struct ApproxMostFrequentStreamSummary {
     return counts_.data();
   }
 
+  bool contains(T value) const {
+    return indices_.count(value) > 0;
+  }
+
  private:
   template <typename U>
   using RebindAlloc =

--- a/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/BloomFilterAggAggregateTest.cpp
@@ -25,7 +25,7 @@ namespace {
 class BloomFilterAggAggregateTest
     : public aggregate::test::AggregationTestBase {
  public:
-  BloomFilterAggAggregateTest() {
+  void SetUp() override {
     AggregationTestBase::SetUp();
     registerAggregateFunctions("");
     allowInputShuffle();

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ target_link_libraries(
   velox_vector_test_lib
   velox_functions_aggregates_test_lib
   velox_functions_spark_aggregates
+  velox_hive_connector
   gflags::gflags
   gtest
   gtest_main)


### PR DESCRIPTION
Summary: `approx_most_frequent` incorrectly assumes that the `StringView` data in the input is always pointing to valid memory.  Fix this by using `Strings` helper class that we use in other functions.

Differential Revision: D47375076

