### PR TITLE
Add inverse_beta_cdf scalar function

### DIFF
--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -47,6 +47,26 @@ struct BetaCDFFunction {
 };
 
 template <typename T>
+struct InverseBetaCDFFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(double& result, double a, double b, double p) {
+    VELOX_USER_CHECK_GT(a, 0, "a must be > 0");
+    VELOX_USER_CHECK_GT(b, 0, "b must be > 0");
+    VELOX_USER_CHECK_GE(p, 0, "p must be in the interval [0, 1]");
+    VELOX_USER_CHECK_LE(p, 1, "p must be in the interval [0, 1]");
+
+    constexpr double kInf = std::numeric_limits<double>::infinity();
+    if ((a == kInf) || (b == kInf)) {
+      result = 0.0;
+    } else {
+      boost::math::beta_distribution<> dist(a, b);
+      result = boost::math::quantile(dist, p);
+    }
+  }
+};
+
+template <typename T>
 struct NormalCDFFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -103,6 +103,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "truncate"});
   registerFunction<BetaCDFFunction, double, double, double, double>(
       {prefix + "beta_cdf"});
+  registerFunction<InverseBetaCDFFunction, double, double, double, double>(
+      {prefix + "inverse_beta_cdf"});
   registerFunction<NormalCDFFunction, double, double, double, double>(
       {prefix + "normal_cdf"});
   registerFunction<BinomialCDFFunction, double, int64_t, double, int64_t>(

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -71,6 +71,30 @@ TEST_F(ProbabilityTest, betaCDF) {
       betaCDF(3, 3, kNan), "value must be in the interval [0, 1]");
 }
 
+TEST_F(ProbabilityTest, inverseBetaCDF) {
+  const auto inverseBetaCDF = [&](std::optional<double> a,
+                                  std::optional<double> b,
+                                  std::optional<double> p) {
+    return evaluateOnce<double>("inverse_beta_cdf(c0, c1, c2)", a, b, p);
+  };
+
+  constexpr double kInf = std::numeric_limits<double>::infinity();
+
+  EXPECT_EQ(0.0, inverseBetaCDF(3, 3.6, 0.0));
+  EXPECT_EQ(1.0, inverseBetaCDF(3, 3.6, 1.0));
+  EXPECT_EQ(0.34696754854406159, inverseBetaCDF(3, 3.6, 0.3));
+  EXPECT_EQ(0.76002724631002683, inverseBetaCDF(3, 3.6, 0.95));
+
+  EXPECT_EQ(0.0, inverseBetaCDF(3, kInf, 0.3));
+  EXPECT_EQ(0.0, inverseBetaCDF(kInf, 3.6, 0.3));
+  VELOX_ASSERT_THROW(inverseBetaCDF(0, 3, 0.5), "a must be > 0");
+  VELOX_ASSERT_THROW(inverseBetaCDF(3, 0, 0.5), "b must be > 0");
+  VELOX_ASSERT_THROW(
+      inverseBetaCDF(3, 3.6, -0.005), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      inverseBetaCDF(3, 3.6, 1.0005), "p must be in the interval [0, 1]");
+}
+
 TEST_F(ProbabilityTest, normalCDF) {
   const auto normal_cdf = [&](std::optional<double> mean,
                               std::optional<double> sd,


### PR DESCRIPTION
Add scalar function inverse_beta_cdf mapped to presto inverse_beta_cdf. 
The underlying math library being used is different from Presto, `boost::math::quantile` calculates inversed cdf for C++.

Presto wiki reference: https://prestodb.io/docs/current/functions/math.html#probability-functions-inverse-cdf
Presto code implementation reference: 
* https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java#L826
* https://github.com/prestodb/presto/blob/master/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java#L1389