### PR TITLE
Enhance array_sort rewrite to support registration prefix

### DIFF
--- a/velox/duckdb/conversion/DuckParser.cpp
+++ b/velox/duckdb/conversion/DuckParser.cpp
@@ -569,7 +569,9 @@ std::shared_ptr<const core::IExpr> parseLambdaExpr(
   } else if (
       auto callExpr =
           std::dynamic_pointer_cast<const core::CallExpr>(capture)) {
-    VELOX_CHECK_EQ("row", callExpr->getFunctionName());
+    VELOX_CHECK_EQ(
+        toFullFunctionName("row", options.functionPrefix),
+        callExpr->getFunctionName());
     for (auto& input : callExpr->getInputs()) {
       auto fieldExpr =
           std::dynamic_pointer_cast<const core::FieldAccessExpr>(input);

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -401,9 +401,11 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> signatures(
   return signatures;
 }
 
-core::CallTypedExprPtr asArraySortCall(const core::TypedExprPtr& expr) {
+core::CallTypedExprPtr asArraySortCall(
+    const std::string& prefix,
+    const core::TypedExprPtr& expr) {
   if (auto call = std::dynamic_pointer_cast<const core::CallTypedExpr>(expr)) {
-    if (call->name() == "array_sort") {
+    if (call->name() == prefix + "array_sort") {
       return call;
     }
   }
@@ -412,8 +414,10 @@ core::CallTypedExprPtr asArraySortCall(const core::TypedExprPtr& expr) {
 
 } // namespace
 
-core::TypedExprPtr rewriteArraySortCall(const core::TypedExprPtr& expr) {
-  auto call = asArraySortCall(expr);
+core::TypedExprPtr rewriteArraySortCall(
+    const std::string& prefix,
+    const core::TypedExprPtr& expr) {
+  auto call = asArraySortCall(prefix, expr);
   if (call == nullptr || call->inputs().size() != 2) {
     return nullptr;
   }
@@ -428,9 +432,10 @@ core::TypedExprPtr rewriteArraySortCall(const core::TypedExprPtr& expr) {
     return nullptr;
   }
 
-  if (auto comparison = functions::prestosql::isSimpleComparison(*lambda)) {
-    std::string name =
-        comparison->isLessThen ? "array_sort" : "array_sort_desc";
+  if (auto comparison =
+          functions::prestosql::isSimpleComparison(prefix, *lambda)) {
+    std::string name = comparison->isLessThen ? prefix + "array_sort"
+                                              : prefix + "array_sort_desc";
     auto rewritten = std::make_shared<core::CallTypedExpr>(
         call->type(),
         std::vector<core::TypedExprPtr>{

--- a/velox/functions/prestosql/ArraySort.h
+++ b/velox/functions/prestosql/ArraySort.h
@@ -29,6 +29,8 @@ namespace facebook::velox::functions {
 ///     array_sort(a, x -> length(x))
 ///
 /// Returns new expression or nullptr if rewrite is not possible.
-core::TypedExprPtr rewriteArraySortCall(const core::TypedExprPtr& expr);
+core::TypedExprPtr rewriteArraySortCall(
+    const std::string& prefix,
+    const core::TypedExprPtr& expr);
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/SimpleComparisonMatcher.h
+++ b/velox/functions/prestosql/SimpleComparisonMatcher.h
@@ -41,6 +41,7 @@ struct SimpleComparison {
 /// Can be used to re-write generic lambda expressions passed to array_sort into
 /// simpler ones that can be evaluated more efficiently.
 std::optional<SimpleComparison> isSimpleComparison(
+    const std::string& prefix,
     const core::LambdaTypedExpr& expr);
 
 } // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -106,7 +106,9 @@ void registerArrayFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_sort_desc, prefix + "array_sort_desc");
 
-  exec::registerExpressionRewrite(rewriteArraySortCall);
+  exec::registerExpressionRewrite([prefix](const auto& expr) {
+    return rewriteArraySortCall(prefix, expr);
+  });
 
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_sum, prefix + "array_sum");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_repeat, prefix + "repeat");


### PR DESCRIPTION
In Prestissimo, functions are registered with a presto.default. prefix,
hence, "eq" is "presto.default.eq", "lt" is "presto.default. lt", etc. Make
sure that array_sort re-write can work with these names.

Also, allow INTEGER and BIGINT types for -1, 0, 1 constants in the 
comparison expression.