### PR TITLE
Do not generate logs for Velox user errors

### DIFF
--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -111,6 +111,10 @@ class ExpressionBenchmarkBuilder
   // If disbleTesting=true for a group set, testing is skipped.
   void testBenchmarks();
 
+  test::VectorMaker& vectorMaker() {
+    return vectorMaker_;
+  }
+
   ExpressionBenchmarkSet& addBenchmarkSet(
       const std::string& name,
       const RowVectorPtr& inputRowVetor) {

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ set(velox_benchmark_deps
     velox_parse_utils
     velox_parse_expression
     velox_serialization
+    velox_benchmark_builder
     Folly::folly
     ${FOLLY_BENCHMARK}
     ${DOUBLE_CONVERSION}
@@ -65,3 +66,7 @@ target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
 add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
 target_link_libraries(velox_benchmark_basic_vector_fuzzer
                       ${velox_benchmark_deps} velox_vector_test_lib)
+
+add_executable(velox_cast_benchmark CastBenchmark.cpp)
+target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps}
+                      velox_vector_test_lib)

--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto invalidInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+
+  auto validInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+  invalidInput->resize(1000);
+  validInput->resize(1000);
+
+  for (int i = 0; i < 1000; i++) {
+    invalidInput->set(i, ""_sv);
+    validInput->set(i, StringView::makeInline(std::to_string(i)));
+  }
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_int",
+          vectorMaker.rowVector(
+              {"valid", "invalid"}, {validInput, invalidInput}))
+      .addExpression("try_invalid", "try_cast (invalid as int)")
+      .addExpression("try_valid", "try_cast (valid as int)")
+      .addExpression("valid", "cast(valid as int)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -65,11 +65,13 @@ template <typename Exception, typename StringType>
   static_assert(
       !std::is_same_v<StringType, std::string>,
       "BUG: we should not pass std::string by value to veloxCheckFail");
-  LOG(ERROR) << "Line: " << args.file << ":" << args.line
-             << ", Function:" << args.function
-             << ", Expression: " << args.expression << " " << s
-             << ", Source: " << args.errorSource
-             << ", ErrorCode: " << args.errorCode;
+  if constexpr (!std::is_same_v<Exception, VeloxUserError>) {
+    LOG(ERROR) << "Line: " << args.file << ":" << args.line
+               << ", Function:" << args.function
+               << ", Expression: " << args.expression << " " << s
+               << ", Source: " << args.errorSource
+               << ", ErrorCode: " << args.errorCode;
+  }
 
   throw Exception(
       args.file,

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -94,6 +94,7 @@ VeloxException::VeloxException(
     const std::exception_ptr& e,
     std::string_view message,
     std::string_view errorSource,
+    std::string_view errorCode,
     bool isRetriable,
     Type exceptionType,
     std::string_view exceptionName)
@@ -106,7 +107,7 @@ VeloxException::VeloxException(
         state.failingExpression = "";
         state.message = message;
         state.errorSource = errorSource;
-        state.errorCode = "";
+        state.errorCode = errorCode;
         state.context = getExceptionContext().message(exceptionType);
         state.topLevelContext =
             getTopLevelExceptionContextString(exceptionType, state.context);

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -126,9 +126,26 @@ class VeloxException : public std::exception {
       const std::exception_ptr& e,
       std::string_view message,
       std::string_view errorSource,
+      std::string_view errorCode,
       bool isRetriable,
       Type exceptionType = Type::kSystem,
       std::string_view exceptionName = "VeloxException");
+
+  VeloxException(
+      const std::exception_ptr& e,
+      std::string_view message,
+      std::string_view errorSource,
+      bool isRetriable,
+      Type exceptionType = Type::kSystem,
+      std::string_view exceptionName = "VeloxException")
+      : VeloxException(
+            e,
+            message,
+            errorSource,
+            "",
+            isRetriable,
+            exceptionType,
+            exceptionName) {}
 
   // Inherited
   const char* what() const noexcept override {
@@ -269,6 +286,7 @@ class VeloxUserError : public VeloxException {
             e,
             message,
             error_source::kErrorSourceUser,
+            error_code::kInvalidArgument,
             isRetriable,
             Type::kUser,
             exceptionName) {}

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -39,14 +39,15 @@ namespace {
 std::string makeErrorMessage(
     const BaseVector& input,
     vector_size_t row,
-    const TypePtr& toType) {
+    const TypePtr& toType,
+    const std::string& details = "") {
   return fmt::format(
-      "Failed to cast from {} to {}: {}.",
+      "Failed to cast from {} to {}: {}. {}",
       input.type()->toString(),
       toType->toString(),
-      input.toString(row));
+      input.toString(row),
+      details);
 }
-
 /// The per-row level Kernel
 /// @tparam ToKind The cast target type
 /// @tparam FromKind The expression type
@@ -254,24 +255,26 @@ void applyCastPrimitives(
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
 
+  auto& resultType = resultFlatVector->type();
+  auto makeException =
+      [&](const auto& input, auto row, const std::string& errorDetails) {
+        return std::make_exception_ptr(VeloxUserError(
+            std::current_exception(),
+            makeErrorMessage(input, row, resultType, errorDetails),
+            false));
+      };
+
   if (!queryConfig.isCastToIntByTruncate()) {
     context.applyToSelectedNoThrow(rows, [&](int row) {
       try {
         // Passing a false truncate flag
         applyCastKernel<ToKind, FromKind, false>(
             row, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxRuntimeError& re) {
-        VELOX_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            re.message());
       } catch (const VeloxUserError& ue) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            ue.message());
+        context.setError(row, makeException(input, row, ue.message()));
+
       } catch (const std::exception& e) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            e.what());
+        context.setError(row, makeException(input, row, e.what()));
       }
     });
   } else {
@@ -280,24 +283,16 @@ void applyCastPrimitives(
         // Passing a true truncate flag
         applyCastKernel<ToKind, FromKind, true>(
             row, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxRuntimeError& re) {
-        VELOX_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            re.message());
       } catch (const VeloxUserError& ue) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            ue.message());
+        context.setError(row, makeException(input, row, ue.message()));
       } catch (const std::exception& e) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            e.what());
+        context.setError(row, makeException(input, row, e.what()));
       }
     });
   }
 
-  // If we're converting to a TIMESTAMP, check if we need to adjust the current
-  // GMT timezone to the user provided session timezone.
+  // If we're converting to a TIMESTAMP, check if we need to adjust the
+  // current GMT timezone to the user provided session timezone.
   if constexpr (ToKind == TypeKind::TIMESTAMP) {
     // If user explicitly asked us to adjust the timezone.
     if (queryConfig.adjustTimestampToTimezone()) {


### PR DESCRIPTION
Summary:
user errors are expected to surface to users or be
suppressed by try.
no need to log them per row, this can be expensive.

after:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_int##try_invalid                                        1.80s   554.97m
cast_int##try_valid                                         2.36ms    423.55
cast_int##valid                                             2.37ms    422.34
----------------------------------------------------------------------------
```
before:
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
cast_int##try_invalid                                        3.09s   324.03m
cast_int##try_valid                                         2.38ms    420.10
cast_int##valid                                             2.42ms    412.64
----------------------------------------------------------------------------
```

Differential Revision: D47340682

