### PR TITLE
Set error code to invalid argument by default or VeloxUserError

### DIFF
--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -111,6 +111,10 @@ class ExpressionBenchmarkBuilder
   // If disbleTesting=true for a group set, testing is skipped.
   void testBenchmarks();
 
+  test::VectorMaker& vectorMaker() {
+    return vectorMaker_;
+  }
+
   ExpressionBenchmarkSet& addBenchmarkSet(
       const std::string& name,
       const RowVectorPtr& inputRowVetor) {

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ set(velox_benchmark_deps
     velox_parse_utils
     velox_parse_expression
     velox_serialization
+    velox_benchmark_builder
     Folly::folly
     ${FOLLY_BENCHMARK}
     ${DOUBLE_CONVERSION}
@@ -65,3 +66,7 @@ target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
 add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
 target_link_libraries(velox_benchmark_basic_vector_fuzzer
                       ${velox_benchmark_deps} velox_vector_test_lib)
+
+add_executable(velox_cast_benchmark CastBenchmark.cpp)
+target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps}
+                      velox_vector_test_lib)

--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto invalidInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+
+  auto validInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+  invalidInput->resize(1000);
+  validInput->resize(1000);
+
+  for (int i = 0; i < 1000; i++) {
+    invalidInput->set(i, ""_sv);
+    validInput->set(i, StringView::makeInline(std::to_string(i)));
+  }
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_int",
+          vectorMaker.rowVector(
+              {"valid", "invalid"}, {validInput, invalidInput}))
+      .addExpression("try_invalid", "try_cast (invalid as int)")
+      .addExpression("try_valid", "try_cast (valid as int)")
+      .addExpression("valid", "cast(valid as int)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -94,6 +94,7 @@ VeloxException::VeloxException(
     const std::exception_ptr& e,
     std::string_view message,
     std::string_view errorSource,
+    std::string_view errorCode,
     bool isRetriable,
     Type exceptionType,
     std::string_view exceptionName)
@@ -106,7 +107,7 @@ VeloxException::VeloxException(
         state.failingExpression = "";
         state.message = message;
         state.errorSource = errorSource;
-        state.errorCode = "";
+        state.errorCode = errorCode;
         state.context = getExceptionContext().message(exceptionType);
         state.topLevelContext =
             getTopLevelExceptionContextString(exceptionType, state.context);

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -126,9 +126,26 @@ class VeloxException : public std::exception {
       const std::exception_ptr& e,
       std::string_view message,
       std::string_view errorSource,
+      std::string_view errorCode,
       bool isRetriable,
       Type exceptionType = Type::kSystem,
       std::string_view exceptionName = "VeloxException");
+
+  VeloxException(
+      const std::exception_ptr& e,
+      std::string_view message,
+      std::string_view errorSource,
+      bool isRetriable,
+      Type exceptionType = Type::kSystem,
+      std::string_view exceptionName = "VeloxException")
+      : VeloxException(
+            e,
+            message,
+            errorSource,
+            "",
+            isRetriable,
+            exceptionType,
+            exceptionName) {}
 
   // Inherited
   const char* what() const noexcept override {
@@ -269,6 +286,7 @@ class VeloxUserError : public VeloxException {
             e,
             message,
             error_source::kErrorSourceUser,
+            error_code::kInvalidArgument,
             isRetriable,
             Type::kUser,
             exceptionName) {}


### PR DESCRIPTION
Summary:
Default value for error code in VeloxUserError used to be ""
but any velox check macro or throw is used it is kInvalidArgument
This changes the default for VeloxUserError to kInvalidArgument

Differential Revision: D47338097

