### PR TITLE
Fix string life cycle issue in map_agg

### DIFF
--- a/velox/functions/lib/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/tests/CMakeLists.txt
@@ -15,4 +15,4 @@
 add_library(velox_functions_aggregates_test_lib AggregationTestBase.cpp)
 
 target_link_libraries(velox_functions_aggregates_test_lib velox_exec_test_lib
-                      velox_vector_test_lib)
+                      velox_vector_test_lib velox_hive_connector)

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -91,14 +91,6 @@ struct StringViewAccumulator {
       vector_size_t index,
       HashStringAllocator* allocator) {
     auto value = decoded.valueAt<StringView>(index);
-    if (!value.isInline()) {
-      auto it = base.values.find(value);
-      if (it != base.values.end()) {
-        value = it->first;
-      } else {
-        value = strings.append(value, *allocator);
-      }
-    }
     base.values[store(value, allocator)]++;
   }
 

--- a/velox/functions/prestosql/aggregates/MapAccumulator.h
+++ b/velox/functions/prestosql/aggregates/MapAccumulator.h
@@ -66,17 +66,6 @@ struct MapAccumulator {
     }
   }
 
-  void insertRange(
-      const DecodedVector& decodedKeys,
-      const DecodedVector& decodedValues,
-      vector_size_t offset,
-      vector_size_t size,
-      HashStringAllocator& allocator) {
-    for (auto i = offset; i < offset + size; ++i) {
-      insert(decodedKeys, decodedValues, i, allocator);
-    }
-  }
-
   /// Returns number of key-value pairs.
   size_t size() const {
     return keys.size();
@@ -150,15 +139,6 @@ struct StringViewMapAccumulator {
     }
   }
 
-  void insertRange(
-      const DecodedVector& decodedKeys,
-      const DecodedVector& decodedValues,
-      vector_size_t offset,
-      vector_size_t size,
-      HashStringAllocator& allocator) {
-    base.insertRange(decodedKeys, decodedValues, offset, size, allocator);
-  }
-
   size_t size() const {
     return base.size();
   }
@@ -172,6 +152,7 @@ struct StringViewMapAccumulator {
 
   void free(HashStringAllocator& allocator) {
     strings.free(allocator);
+    base.free(allocator);
   }
 };
 
@@ -207,15 +188,6 @@ struct ComplexTypeMapAccumulator {
     }
 
     base.values.appendValue(decodedValues, index, &allocator);
-  }
-
-  void insertRange(
-      const DecodedVector& decodedKeys,
-      const DecodedVector& decodedValues,
-      vector_size_t offset,
-      vector_size_t size,
-      HashStringAllocator& allocator) {
-    base.insertRange(decodedKeys, decodedValues, offset, size, allocator);
   }
 
   size_t size() const {

--- a/velox/functions/prestosql/aggregates/MapAggregateBase.h
+++ b/velox/functions/prestosql/aggregates/MapAggregateBase.h
@@ -160,8 +160,9 @@ class MapAggregateBase : public exec::Aggregate {
         auto size = mapVector->sizeAt(decodedRow);
         auto tracker = trackRowSize(group);
         checkNullKeys(decodedKeys_, offset, size);
-        accumulator->insertRange(
-            decodedKeys_, decodedValues_, offset, size, *allocator_);
+        for (auto i = offset; i < offset + size; ++i) {
+          accumulator->insert(decodedKeys_, decodedValues_, i, *allocator_);
+        }
       }
     });
   }
@@ -187,8 +188,9 @@ class MapAggregateBase : public exec::Aggregate {
         auto offset = mapVector->offsetAt(decodedRow);
         auto size = mapVector->sizeAt(decodedRow);
         checkNullKeys(decodedKeys_, offset, size);
-        accumulator->insertRange(
-            decodedKeys_, decodedValues_, offset, size, *allocator_);
+        for (auto i = offset; i < offset + size; ++i) {
+          accumulator->insert(decodedKeys_, decodedValues_, i, *allocator_);
+        }
       }
     });
   }

--- a/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAggTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 
 using namespace facebook::velox::exec;
@@ -207,6 +208,24 @@ TEST_F(MapAggTest, selectiveMaskWithDuplicates) {
                   .singleAggregation({"c0"}, {"map_agg(c1, c2)"}, {"c3"})
                   .planNode();
   assertQuery(plan, {expectedResult});
+}
+
+TEST_F(MapAggTest, stringLifeCycle) {
+  vector_size_t num = 10;
+  std::vector<std::string> s(num);
+  for (int i = 0; i < num; ++i) {
+    s[i] = std::string(StringView::kInlineSize + 1, 'a' + i);
+  }
+  auto vectors = {makeRowVector(
+      {makeFlatVector<StringView>(
+           num, [&](vector_size_t i) { return StringView(s[i]); }),
+       makeFlatVector<double>(num, [](vector_size_t i) { return i + 0.05; })})};
+  auto expectedResult = makeRowVector({makeMapVector<StringView, double>(
+      1,
+      [&](vector_size_t /*row*/) { return num; },
+      [&](vector_size_t i) { return StringView(s[i]); },
+      [&](vector_size_t i) { return i + 0.05; })});
+  testReadFromFiles(vectors, {}, {"map_agg(c0, c1)"}, {expectedResult});
 }
 
 } // namespace


### PR DESCRIPTION
Summary: `MapAccumulator::insertRange` is calling the `insert` in base accumulator in all cases so it breaks for string and complex types.  Fix this by removing it from the accumulator because it's just a thin wrapper of a for loop over `insert`.

Differential Revision: D47375074

