### PR TITLE
Remove target filename conflict for TableWriters of the same task

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -231,7 +231,8 @@ class ConnectorQueryCtx {
         scanId_(fmt::format("{}.{}", taskId, planNodeId)),
         queryId_(queryId),
         taskId_(taskId),
-        driverId_(driverId) {}
+        driverId_(driverId),
+        planNodeId_(planNodeId) {}
 
   /// Returns the associated operator's memory pool which is a leaf kind of
   /// memory pool, used for direct memory allocation use.
@@ -280,6 +281,10 @@ class ConnectorQueryCtx {
     return driverId_;
   }
 
+  const std::string& planNodeId() const {
+    return planNodeId_;
+  }
+
  private:
   memory::MemoryPool* operatorPool_;
   memory::MemoryPool* connectorPool_;
@@ -290,6 +295,7 @@ class ConnectorQueryCtx {
   const std::string queryId_;
   const std::string taskId_;
   const int driverId_;
+  const std::string planNodeId_;
 };
 
 class Connector {

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -502,11 +502,15 @@ std::pair<std::string, std::string> HiveDataSink::getWriterFileNames(
     targetFileName = computeBucketedFileName(
         connectorQueryCtx_->queryId(), bucketId.value());
   } else {
+    // targetFileName includes planNodeId and Uuid. As a result, different table
+    // writers run by the same task driver or the same table writer run in
+    // different task tries would have different targetFileNames.
     targetFileName = fmt::format(
-        "{}_{}_{}",
+        "{}_{}_{}_{}",
         connectorQueryCtx_->taskId(),
         connectorQueryCtx_->driverId(),
-        isCommitRequired() ? "0" : makeUuid());
+        connectorQueryCtx_->planNodeId(),
+        makeUuid());
   }
   const std::string writeFileName = isCommitRequired()
       ? fmt::format(".tmp.velox.{}_{}", targetFileName, makeUuid())


### PR DESCRIPTION
Current implementation of TableWriter has target filename composed
of taskId + driverId. This causes conflict when write filenames
are renamed to target filenames, if a single fragment has multiple
TableWrite nodes and thus the TableWriter operators are run by
the same task sharing the same taskId + driverId.

This fix adds UUID randomness to the target filename to resolve
the conflict, as well as planNodeId for debuggability. To get
operator planNodeId in HiveDataSink, make ConnectorQueryCtx keep
track of planNodeId and retrieve it from there.

For multiple tries/attempts of the same task, it will
leave the deduplication of target files to the caller system.