### PR TITLE
Allow partition keys to appear in tuple domains when filter pushdown is not supported

### DIFF
--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -122,6 +122,10 @@ class HiveTableHandle : public ConnectorTableHandle {
       const core::TypedExprPtr& remainingFilter,
       const RowTypePtr& dataColumns = nullptr);
 
+  const std::string& tableName() const {
+    return tableName_;
+  }
+
   bool isFilterPushdownEnabled() const {
     return filterPushdownEnabled_;
   }

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -2595,3 +2595,43 @@ TEST_F(TableScanTest, dictionaryMemo) {
   ASSERT_EQ(numPeelEncodings, 2);
 #endif
 }
+
+TEST_F(TableScanTest, filterPushdownDisabledChecks) {
+  auto data = makeRowVector({makeFlatVector<int32_t>(10, folly::identity)});
+  auto rowType = asRowType(data->type());
+  auto file = TempFilePath::create();
+  writeToFile(file->path, {data});
+  ColumnHandleMap assignments = {
+      {"ds", partitionKey("ds", VARCHAR())},
+      {"c0", regularColumn("c0", INTEGER())},
+  };
+  auto split = HiveConnectorSplitBuilder(file->path)
+                   .partitionKey("ds", "2023-07-12")
+                   .build();
+
+  auto tableHandle = makeTableHandle(
+      SubfieldFiltersBuilder().add("ds", equal("2023-07-12")).build(),
+      nullptr,
+      "hive_table",
+      nullptr,
+      false);
+  auto plan = exec::test::PlanBuilder(pool_.get())
+                  .tableScan(rowType, tableHandle, assignments)
+                  .planNode();
+  AssertQueryBuilder(plan).splits({split}).assertResults(data);
+
+  tableHandle = makeTableHandle(
+      SubfieldFiltersBuilder().add("c0", equal(5)).build(),
+      nullptr,
+      "hive_table",
+      nullptr,
+      false);
+  plan = exec::test::PlanBuilder(pool_.get())
+             .tableScan(rowType, tableHandle, assignments)
+             .planNode();
+  auto query = AssertQueryBuilder(plan);
+  query.splits({split});
+  VELOX_ASSERT_THROW(
+      query.copyResults(pool_.get()),
+      "Unexpected filter on table hive_table, field c0");
+}

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -80,11 +80,12 @@ class HiveConnectorTestBase : public OperatorTestBase {
       common::test::SubfieldFilters subfieldFilters = {},
       const core::TypedExprPtr& remainingFilter = nullptr,
       const std::string& tableName = "hive_table",
-      const RowTypePtr& dataColumns = nullptr) {
+      const RowTypePtr& dataColumns = nullptr,
+      bool filterPushdownEnabled = true) {
     return std::make_shared<connector::hive::HiveTableHandle>(
         kHiveConnectorId,
         tableName,
-        true,
+        filterPushdownEnabled,
         std::move(subfieldFilters),
         remainingFilter,
         dataColumns);

--- a/velox/type/Filter.h
+++ b/velox/type/Filter.h
@@ -1913,8 +1913,13 @@ static inline bool applyFilter(TFilter& filter, T value) {
   } else if constexpr (std::is_same_v<T, bool>) {
     return filter.testBool(value);
   } else {
-    VELOX_CHECK(false, "Bad argument type to filter");
+    VELOX_FAIL("Bad argument type to filter: {}", typeid(T).name());
   }
+}
+
+template <typename TFilter>
+static inline bool applyFilter(TFilter& filter, const std::string& value) {
+  return filter.testBytes(value.data(), value.size());
 }
 
 template <typename TFilter>


### PR DESCRIPTION
Summary: The validation before was too strict and we need to allow partition keys in this case.

Differential Revision: D47380624

