### PR TITLE
Avoid rethrow in setError

### DIFF
--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -167,6 +167,18 @@ void EvalCtx::setError(
   addError(index, toVeloxException(exceptionPtr), errors_);
 }
 
+// This should be used onlly when exceptionPtr is guranteed to be a
+// VeloxException.
+void EvalCtx::setVeloxExceptionError(
+    vector_size_t index,
+    const std::exception_ptr& exceptionPtr) {
+  if (throwOnError_) {
+    std::rethrow_exception(exceptionPtr);
+  }
+
+  addError(index, exceptionPtr, errors_);
+}
+
 void EvalCtx::setErrors(
     const SelectivityVector& rows,
     const std::exception_ptr& exceptionPtr) {


### PR DESCRIPTION
Summary:
applyToSelectedpNoThrow already catch the thrown exception if any is thrown.
When the thrown exception is a Velox exception, it will be thrown again inside setError->toVeloxException.

This diff introduces context.setVeloxExceptionError to avoid that,
the function can also be called directly when the user constructs a Velox exception
and calls set error.

runtime for cast benchmark cast_int##try_invalid_empty_input
  655.78ms  -> 465.23ms

Differential Revision: D47351850

