### PR TITLE
Cast from timestamp to date must honor session timezone

### DIFF
--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -34,6 +34,9 @@ add_executable(velox_benchmark_basic_comparison_conjunct ComparisonConjunct.cpp)
 target_link_libraries(velox_benchmark_basic_comparison_conjunct
                       ${velox_benchmark_deps})
 
+add_executable(velox_benchmark_basic_simple_cast SimpleCastExpr.cpp)
+target_link_libraries(velox_benchmark_basic_simple_cast ${velox_benchmark_deps})
+
 add_executable(velox_benchmark_basic_decoded_vector DecodedVector.cpp)
 target_link_libraries(velox_benchmark_basic_decoded_vector
                       ${velox_benchmark_deps})

--- a/velox/benchmarks/basic/SimpleCastExpr.cpp
+++ b/velox/benchmarks/basic/SimpleCastExpr.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include <gflags/gflags.h>
+
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/ArithmeticImpl.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::test;
+
+namespace {
+class SimpleCastBenchmark : public functions::test::FunctionBenchmarkBase {
+ public:
+  explicit SimpleCastBenchmark() : FunctionBenchmarkBase() {}
+
+  RowVectorPtr makeRowVector(vector_size_t size) {
+    VectorFuzzer::Options opts;
+    opts.vectorSize = size;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+    std::vector<VectorPtr> children;
+    children.emplace_back(fuzzer.fuzzFlat(TIMESTAMP())); // Col a
+    return std::make_shared<RowVector>(
+        pool(), inputType_, nullptr, size, std::move(children));
+  }
+
+  static constexpr auto kNumSmallRuns = 10'000;
+  static constexpr auto kNumMediumRuns = 1000;
+  static constexpr auto kNumLargeRuns = 100;
+
+  void runSmall(const std::string& expression) {
+    run(expression, kNumSmallRuns, smallRowVector_);
+  }
+
+  void runMedium(const std::string& expression) {
+    run(expression, kNumMediumRuns, mediumRowVector_);
+  }
+
+  void runLarge(const std::string& expression) {
+    run(expression, kNumLargeRuns, largeRowVector_);
+  }
+
+  // Compiles and runs the `expression` `iterations` number of times.
+  size_t run(
+      const std::string& expression,
+      size_t iterations,
+      const RowVectorPtr& input) {
+    folly::BenchmarkSuspender suspender;
+    auto exprSet = compileExpression(expression, inputType_);
+    suspender.dismiss();
+
+    size_t count = 0;
+    for (auto i = 0; i < iterations; i++) {
+      count += evaluate(exprSet, input)->size();
+    }
+    return count;
+  }
+
+ private:
+  const TypePtr inputType_ = ROW({
+      {"a", TIMESTAMP()},
+  });
+  const RowVectorPtr smallRowVector_ = makeRowVector(100);
+  const RowVectorPtr mediumRowVector_ = makeRowVector(1'000);
+  const RowVectorPtr largeRowVector_ = makeRowVector(10'000);
+};
+
+std::unique_ptr<SimpleCastBenchmark> benchmark;
+
+BENCHMARK(castTimestampDate) {
+  benchmark->setAdjustTimestampToTimezone("false");
+  benchmark->runSmall("cast (a as date)");
+  benchmark->runMedium("cast (a as date)");
+  benchmark->runLarge("cast (a as date)");
+}
+
+BENCHMARK(castTimestampDateAdjustTimeZone) {
+  benchmark->setTimezone("America/Los_Angeles");
+  benchmark->setAdjustTimestampToTimezone("true");
+  benchmark->runSmall("cast (a as date)");
+  benchmark->runMedium("cast (a as date)");
+  benchmark->runLarge("cast (a as date)");
+}
+} // namespace
+
+int main(int argc, char* argv[]) {
+  folly::init(&argc, &argv);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  benchmark = std::make_unique<SimpleCastBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -46,7 +46,9 @@ Generic Configuration
      - false
      - If true, timezone-less timestamp conversions (e.g. string to timestamp, when the string does not specify a timezone)
        will be adjusted to the user provided `session_timezone` (if any). For instance: if this option is true and user
-       supplied "America/Los_Angeles", then "1970-01-01" will be converted to -28800 instead of 0.
+       supplied "America/Los_Angeles", then "1970-01-01" will be converted to -28800 instead of 0. Similarly, timestamp
+       to date conversions will adhere to user 'session_timezone', e.g: Timestamp(0) to Date will be -1 (number of days
+       since epoch) for "America/Los_Angeles".
    * - track_operator_cpu_usage
      - bool
      - true

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -330,18 +330,36 @@ TEST_F(CastExprTest, dateToTimestamp) {
 }
 
 TEST_F(CastExprTest, timestampToDate) {
+  setTimezone("");
+  std::vector<std::optional<Timestamp>> inputTimestamps = {
+      Timestamp(0, 0),
+      Timestamp(946684800, 0),
+      Timestamp(1257724800, 0),
+      std::nullopt,
+  };
+
   testCast<Timestamp, int32_t>(
       "date",
-      {
-          Timestamp(0, 0),
-          Timestamp(946684800, 0),
-          Timestamp(1257724800, 0),
-          std::nullopt,
-      },
+      inputTimestamps,
       {
           0,
           10957,
           14557,
+          std::nullopt,
+      },
+      false,
+      false,
+      TIMESTAMP(),
+      DATE());
+
+  setTimezone("America/Los_Angeles");
+  testCast<Timestamp, int32_t>(
+      "date",
+      inputTimestamps,
+      {
+          -1,
+          10956,
+          14556,
           std::nullopt,
       },
       false,

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -29,6 +29,17 @@ class FunctionBenchmarkBase {
     parse::registerTypeResolver();
   }
 
+  void setTimezone(const std::string& value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kSessionTimezone, value},
+    });
+  }
+
+  void setAdjustTimestampToTimezone(const std::string& value) {
+    queryCtx_->testingOverrideConfigUnsafe(
+        {{core::QueryConfig::kAdjustTimestampToTimezone, value}});
+  }
+
   exec::ExprSet compileExpression(
       const std::string& text,
       const TypePtr& rowType) {


### PR DESCRIPTION
Timestamp to date conversion doesn't honor session timezone when queryConfig `adjust_timestamp_to_session_timezone` to true. This change addresses that.

Testing:
Added unit tests for casting timestamp with timezone to date.

Tested e2e on local machine.
```
presto> select date(from_unixtime(c0)) from (values(0)) t(c0);
   _col0    
------------
 1969-12-31 
```

Resolves: https://github.com/facebookincubator/velox/issues/5596