### PR TITLE
Update coverage maps for Spark/Presto.

### DIFF
--- a/velox/docs/functions.rst
+++ b/velox/docs/functions.rst
@@ -61,75 +61,76 @@ for :doc:`all <functions/presto/coverage>` and :doc:`most used
     ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================
     Scalar Functions                                                                                                            Aggregate Functions                         Window Functions
     ======================================================================================================================  ==  ======================================  ==  ======================================
-    :func:`abs`                             :func:`filter`                          :func:`quarter`                             :func:`approx_distinct`                     :func:`cume_dist`
-    :func:`acos`                            :func:`flatten`                         :func:`radians`                             :func:`approx_most_frequent`                :func:`dense_rank`
-    :func:`all_match`                       :func:`floor`                           :func:`rand`                                :func:`approx_percentile`                   :func:`first_value`
-    :func:`any_match`                       :func:`format_datetime`                 :func:`random`                              :func:`approx_set`                          :func:`lag`
-    :func:`array_average`                   :func:`from_base`                       :func:`reduce`                              :func:`arbitrary`                           :func:`last_value`
-    :func:`array_constructor`               :func:`from_base64`                     :func:`regexp_extract`                      :func:`array_agg`                           :func:`lead`
-    :func:`array_distinct`                  :func:`from_base64url`                  :func:`regexp_extract_all`                  :func:`avg`                                 :func:`nth_value`
-    :func:`array_duplicates`                :func:`from_big_endian_32`              :func:`regexp_like`                         :func:`bitwise_and_agg`                     :func:`ntile`
-    :func:`array_except`                    :func:`from_big_endian_64`              :func:`regexp_replace`                      :func:`bitwise_or_agg`                      :func:`percent_rank`
-    :func:`array_frequency`                 :func:`from_hex`                        :func:`repeat`                              :func:`bool_and`                            :func:`rank`
-    :func:`array_has_duplicates`            :func:`from_unixtime`                   :func:`replace`                             :func:`bool_or`                             :func:`row_number`
-    :func:`array_intersect`                 :func:`from_utf8`                       :func:`reverse`                             :func:`checksum`
-    :func:`array_join`                      :func:`greatest`                        :func:`round`                               :func:`corr`
-    :func:`array_max`                       :func:`gt`                              :func:`rpad`                                :func:`count`
-    :func:`array_min`                       :func:`gte`                             :func:`rtrim`                               :func:`count_if`
-    :func:`array_normalize`                 :func:`hmac_md5`                        :func:`second`                              :func:`covar_pop`
-    :func:`array_position`                  :func:`hmac_sha1`                       :func:`sequence`                            :func:`covar_samp`
-    :func:`array_sort`                      :func:`hmac_sha256`                     :func:`sha1`                                :func:`every`
-    :func:`array_sum`                       :func:`hmac_sha512`                     :func:`sha256`                              :func:`histogram`
-    :func:`arrays_overlap`                  :func:`hour`                            :func:`sha512`                              :func:`kurtosis`
-    :func:`asin`                            in                                      :func:`shuffle`                             :func:`map_agg`
-    :func:`atan`                            :func:`infinity`                        :func:`sign`                                :func:`map_union`
-    :func:`atan2`                           :func:`is_finite`                       :func:`sin`                                 :func:`map_union_sum`
-    :func:`beta_cdf`                        :func:`is_infinite`                     :func:`slice`                               :func:`max`
-    :func:`between`                         :func:`is_json_scalar`                  :func:`split`                               :func:`max_by`
-    :func:`binomial_cdf`                    :func:`is_nan`                          :func:`split_part`                          :func:`max_data_size_for_stats`
-    :func:`bit_count`                       :func:`is_null`                         :func:`spooky_hash_v2_32`                   :func:`merge`
-    :func:`bitwise_and`                     :func:`json_array_contains`             :func:`spooky_hash_v2_64`                   :func:`min`
-    :func:`bitwise_arithmetic_shift_right`  :func:`json_array_length`               :func:`sqrt`                                :func:`min_by`
-    :func:`bitwise_left_shift`              :func:`json_extract`                    :func:`strpos`                              :func:`regr_intercept`
-    :func:`bitwise_logical_shift_right`     :func:`json_extract_scalar`             :func:`strrpos`                             :func:`regr_slope`
-    :func:`bitwise_not`                     :func:`json_format`                     :func:`subscript`                           :func:`set_agg`
-    :func:`bitwise_or`                      :func:`json_parse`                      :func:`substr`                              :func:`set_union`
-    :func:`bitwise_right_shift`             :func:`json_size`                       :func:`tan`                                 :func:`skewness`
-    :func:`bitwise_right_shift_arithmetic`  :func:`least`                           :func:`tanh`                                :func:`stddev`
-    :func:`bitwise_shift_left`              :func:`length`                          :func:`timezone_hour`                       :func:`stddev_pop`
-    :func:`bitwise_xor`                     :func:`like`                            :func:`timezone_minute`                     :func:`stddev_samp`
-    :func:`cardinality`                     :func:`ln`                              :func:`to_base`                             :func:`sum`
-    :func:`cbrt`                            :func:`log10`                           :func:`to_base64`                           :func:`sum_data_size_for_stats`
-    :func:`ceil`                            :func:`log2`                            :func:`to_base64url`                        :func:`var_pop`
-    :func:`ceiling`                         :func:`lower`                           :func:`to_big_endian_32`                    :func:`var_samp`
-    :func:`chr`                             :func:`lpad`                            :func:`to_big_endian_64`                    :func:`variance`
-    :func:`clamp`                           :func:`lt`                              :func:`to_hex`
-    :func:`codepoint`                       :func:`lte`                             :func:`to_ieee754_64`
-    :func:`combinations`                    :func:`ltrim`                           :func:`to_unixtime`
-    :func:`concat`                          :func:`map`                             :func:`to_utf8`
-    :func:`contains`                        :func:`map_concat`                      :func:`transform`
-    :func:`cos`                             :func:`map_entries`                     :func:`transform_keys`
-    :func:`cosh`                            :func:`map_filter`                      :func:`transform_values`
-    :func:`crc32`                           :func:`map_from_entries`                :func:`trim`
-    :func:`current_date`                    :func:`map_keys`                        :func:`trim_array`
-    :func:`date`                            :func:`map_values`                      :func:`truncate`
-    :func:`date_add`                        :func:`map_zip_with`                    :func:`upper`
-    :func:`date_diff`                       :func:`md5`                             :func:`url_decode`
-    :func:`date_format`                     :func:`millisecond`                     :func:`url_encode`
-    :func:`date_parse`                      :func:`minus`                           :func:`url_extract_fragment`
-    :func:`date_trunc`                      :func:`minute`                          :func:`url_extract_host`
-    :func:`day`                             :func:`mod`                             :func:`url_extract_parameter`
-    :func:`day_of_month`                    :func:`month`                           :func:`url_extract_path`
-    :func:`day_of_week`                     :func:`multiply`                        :func:`url_extract_port`
-    :func:`day_of_year`                     :func:`nan`                             :func:`url_extract_protocol`
-    :func:`degrees`                         :func:`negate`                          :func:`url_extract_query`
-    :func:`distinct_from`                   :func:`neq`                             :func:`week`
-    :func:`divide`                          :func:`none_match`                      :func:`week_of_year`
-    :func:`dow`                             :func:`normal_cdf`                      :func:`width_bucket`
-    :func:`doy`                             not                                     :func:`xxhash64`
-    :func:`e`                               :func:`parse_datetime`                  :func:`year`
-    :func:`element_at`                      :func:`pi`                              :func:`year_of_week`
-    :func:`empty_approx_set`                :func:`plus`                            :func:`yow`
-    :func:`eq`                              :func:`pow`                             :func:`zip`
-    :func:`exp`                             :func:`power`                           :func:`zip_with`
+    :func:`abs`                             :func:`filter`                          :func:`radians`                             :func:`approx_distinct`                     :func:`cume_dist`
+    :func:`acos`                            :func:`flatten`                         :func:`rand`                                :func:`approx_most_frequent`                :func:`dense_rank`
+    :func:`all_match`                       :func:`floor`                           :func:`random`                              :func:`approx_percentile`                   :func:`first_value`
+    :func:`any_match`                       :func:`format_datetime`                 :func:`reduce`                              :func:`approx_set`                          :func:`lag`
+    :func:`array_average`                   :func:`from_base`                       :func:`regexp_extract`                      :func:`arbitrary`                           :func:`last_value`
+    :func:`array_constructor`               :func:`from_base64`                     :func:`regexp_extract_all`                  :func:`array_agg`                           :func:`lead`
+    :func:`array_distinct`                  :func:`from_base64url`                  :func:`regexp_like`                         :func:`avg`                                 :func:`nth_value`
+    :func:`array_duplicates`                :func:`from_big_endian_32`              :func:`regexp_replace`                      :func:`bitwise_and_agg`                     :func:`ntile`
+    :func:`array_except`                    :func:`from_big_endian_64`              :func:`repeat`                              :func:`bitwise_or_agg`                      :func:`percent_rank`
+    :func:`array_frequency`                 :func:`from_hex`                        :func:`replace`                             :func:`bool_and`                            :func:`rank`
+    :func:`array_has_duplicates`            :func:`from_unixtime`                   :func:`reverse`                             :func:`bool_or`                             :func:`row_number`
+    :func:`array_intersect`                 :func:`from_utf8`                       :func:`round`                               :func:`checksum`
+    :func:`array_join`                      :func:`greatest`                        :func:`rpad`                                :func:`corr`
+    :func:`array_max`                       :func:`gt`                              :func:`rtrim`                               :func:`count`
+    :func:`array_min`                       :func:`gte`                             :func:`second`                              :func:`count_if`
+    :func:`array_normalize`                 :func:`hmac_md5`                        :func:`sequence`                            :func:`covar_pop`
+    :func:`array_position`                  :func:`hmac_sha1`                       :func:`sha1`                                :func:`covar_samp`
+    :func:`array_sort`                      :func:`hmac_sha256`                     :func:`sha256`                              :func:`every`
+    :func:`array_sort_desc`                 :func:`hmac_sha512`                     :func:`sha512`                              :func:`histogram`
+    :func:`array_sum`                       :func:`hour`                            :func:`shuffle`                             :func:`kurtosis`
+    :func:`arrays_overlap`                  in                                      :func:`sign`                                :func:`map_agg`
+    :func:`asin`                            :func:`infinity`                        :func:`sin`                                 :func:`map_union`
+    :func:`atan`                            :func:`is_finite`                       :func:`slice`                               :func:`map_union_sum`
+    :func:`atan2`                           :func:`is_infinite`                     :func:`split`                               :func:`max`
+    :func:`beta_cdf`                        :func:`is_json_scalar`                  :func:`split_part`                          :func:`max_by`
+    :func:`between`                         :func:`is_nan`                          :func:`spooky_hash_v2_32`                   :func:`max_data_size_for_stats`
+    :func:`binomial_cdf`                    :func:`is_null`                         :func:`spooky_hash_v2_64`                   :func:`merge`
+    :func:`bit_count`                       :func:`json_array_contains`             :func:`sqrt`                                :func:`min`
+    :func:`bitwise_and`                     :func:`json_array_length`               :func:`strpos`                              :func:`min_by`
+    :func:`bitwise_arithmetic_shift_right`  :func:`json_extract`                    :func:`strrpos`                             :func:`regr_intercept`
+    :func:`bitwise_left_shift`              :func:`json_extract_scalar`             :func:`subscript`                           :func:`regr_slope`
+    :func:`bitwise_logical_shift_right`     :func:`json_format`                     :func:`substr`                              :func:`set_agg`
+    :func:`bitwise_not`                     :func:`json_parse`                      :func:`tan`                                 :func:`set_union`
+    :func:`bitwise_or`                      :func:`json_size`                       :func:`tanh`                                :func:`skewness`
+    :func:`bitwise_right_shift`             :func:`least`                           :func:`timezone_hour`                       :func:`stddev`
+    :func:`bitwise_right_shift_arithmetic`  :func:`length`                          :func:`timezone_minute`                     :func:`stddev_pop`
+    :func:`bitwise_shift_left`              :func:`like`                            :func:`to_base`                             :func:`stddev_samp`
+    :func:`bitwise_xor`                     :func:`ln`                              :func:`to_base64`                           :func:`sum`
+    :func:`cardinality`                     :func:`log10`                           :func:`to_base64url`                        :func:`sum_data_size_for_stats`
+    :func:`cbrt`                            :func:`log2`                            :func:`to_big_endian_32`                    :func:`var_pop`
+    :func:`ceil`                            :func:`lower`                           :func:`to_big_endian_64`                    :func:`var_samp`
+    :func:`ceiling`                         :func:`lpad`                            :func:`to_hex`                              :func:`variance`
+    :func:`chr`                             :func:`lt`                              :func:`to_ieee754_64`
+    :func:`clamp`                           :func:`lte`                             :func:`to_unixtime`
+    :func:`codepoint`                       :func:`ltrim`                           :func:`to_utf8`
+    :func:`combinations`                    :func:`map`                             :func:`transform`
+    :func:`concat`                          :func:`map_concat`                      :func:`transform_keys`
+    :func:`contains`                        :func:`map_entries`                     :func:`transform_values`
+    :func:`cos`                             :func:`map_filter`                      :func:`trim`
+    :func:`cosh`                            :func:`map_from_entries`                :func:`trim_array`
+    :func:`crc32`                           :func:`map_keys`                        :func:`truncate`
+    :func:`current_date`                    :func:`map_values`                      :func:`upper`
+    :func:`date`                            :func:`map_zip_with`                    :func:`url_decode`
+    :func:`date_add`                        :func:`md5`                             :func:`url_encode`
+    :func:`date_diff`                       :func:`millisecond`                     :func:`url_extract_fragment`
+    :func:`date_format`                     :func:`minus`                           :func:`url_extract_host`
+    :func:`date_parse`                      :func:`minute`                          :func:`url_extract_parameter`
+    :func:`date_trunc`                      :func:`mod`                             :func:`url_extract_path`
+    :func:`day`                             :func:`month`                           :func:`url_extract_port`
+    :func:`day_of_month`                    :func:`multiply`                        :func:`url_extract_protocol`
+    :func:`day_of_week`                     :func:`nan`                             :func:`url_extract_query`
+    :func:`day_of_year`                     :func:`negate`                          :func:`week`
+    :func:`degrees`                         :func:`neq`                             :func:`week_of_year`
+    :func:`distinct_from`                   :func:`none_match`                      :func:`width_bucket`
+    :func:`divide`                          :func:`normal_cdf`                      :func:`xxhash64`
+    :func:`dow`                             not                                     :func:`year`
+    :func:`doy`                             :func:`parse_datetime`                  :func:`year_of_week`
+    :func:`e`                               :func:`pi`                              :func:`yow`
+    :func:`element_at`                      :func:`plus`                            :func:`zip`
+    :func:`empty_approx_set`                :func:`pow`                             :func:`zip_with`
+    :func:`eq`                              :func:`power`
+    :func:`exp`                             :func:`quarter`
     ======================================  ======================================  ======================================  ==  ======================================  ==  ======================================

--- a/velox/docs/functions/presto/coverage.rst
+++ b/velox/docs/functions/presto/coverage.rst
@@ -18,44 +18,44 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(1) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(2) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(2) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(3) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(4) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(4) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(5) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(5) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(6) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(7) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(7) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(7) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(8) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(8) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(9) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(9) td:nth-child(9) {background-color: #6BA81E;}
     table.coverage tr:nth-child(10) td:nth-child(1) {background-color: #6BA81E;}
@@ -74,113 +74,114 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(12) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(12) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(12) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(13) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(13) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(14) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(14) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(14) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(15) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(15) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(16) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(17) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(17) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(18) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(18) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(19) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(20) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(20) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(21) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(21) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(22) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(23) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(24) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(24) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(26) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(4) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(26) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(27) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(27) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(28) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(28) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(29) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(30) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(30) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(30) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(32) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(33) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(36) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(36) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(37) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(38) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(39) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(40) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(41) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(41) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(41) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(42) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(42) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(43) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(44) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(44) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(45) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(45) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(46) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(46) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(47) td:nth-child(1) {background-color: #6BA81E;}
@@ -188,65 +189,64 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     table.coverage tr:nth-child(47) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(48) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(48) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(49) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(49) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(50) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(50) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(50) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(51) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(51) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(51) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(52) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(53) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(54) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(53) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(54) td:nth-child(2) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(54) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(55) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(55) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(56) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(56) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(56) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(57) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(57) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(57) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(58) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(58) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(60) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(61) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(61) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(7) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(63) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(63) td:nth-child(7) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(64) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(7) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(66) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(66) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(66) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(67) td:nth-child(3) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(67) td:nth-child(5) {background-color: #6BA81E;}
-    table.coverage tr:nth-child(69) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(69) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(70) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(71) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(71) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(71) td:nth-child(3) {background-color: #6BA81E;}
     </style>
 
 .. table::
@@ -256,74 +256,75 @@ Here is a list of all scalar and aggregate Presto functions with functions that 
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================
     Scalar Functions                                                                                                                                                                                                      Aggregate Functions                           Window Functions
     ================================================================================================================================================================================================================  ==  ========================================  ==  ========================================
-    :func:`abs`                               :func:`date_diff`                         :func:`is_json_scalar`                    render                                    st_points                                     :func:`approx_distinct`                       :func:`cume_dist`
-    :func:`acos`                              :func:`date_format`                       :func:`is_nan`                            :func:`repeat`                            st_polygon                                    :func:`approx_most_frequent`                  :func:`dense_rank`
-    :func:`all_match`                         :func:`date_parse`                        is_subnet_of                              :func:`replace`                           st_relate                                     :func:`approx_percentile`                     :func:`first_value`
-    :func:`any_match`                         :func:`date_trunc`                        jaccard_index                             :func:`reverse`                           st_startpoint                                 :func:`approx_set`                            :func:`lag`
-    :func:`array_average`                     :func:`day`                               :func:`json_array_contains`               rgb                                       st_symdifference                              :func:`arbitrary`                             :func:`last_value`
-    :func:`array_distinct`                    :func:`day_of_month`                      json_array_get                            :func:`round`                             st_touches                                    :func:`array_agg`                             :func:`lead`
-    :func:`array_duplicates`                  :func:`day_of_week`                       :func:`json_array_length`                 :func:`rpad`                              st_union                                      :func:`avg`                                   :func:`nth_value`
-    :func:`array_except`                      :func:`day_of_year`                       json_extract                              :func:`rtrim`                             st_within                                     :func:`bitwise_and_agg`                       :func:`ntile`
-    :func:`array_frequency`                   :func:`degrees`                           :func:`json_extract_scalar`               scale_qdigest                             st_x                                          :func:`bitwise_or_agg`                        :func:`percent_rank`
-    :func:`array_has_duplicates`              :func:`dow`                               :func:`json_format`                       :func:`second`                            st_xmax                                       :func:`bool_and`                              :func:`rank`
-    :func:`array_intersect`                   :func:`doy`                               :func:`json_parse`                        :func:`sequence`                          st_xmin                                       :func:`bool_or`                               :func:`row_number`
-    :func:`array_join`                        :func:`e`                                 :func:`json_size`                         :func:`sha1`                              st_y                                          :func:`checksum`
-    :func:`array_max`                         :func:`element_at`                        :func:`least`                             :func:`sha256`                            st_ymax                                       classification_fall_out
-    :func:`array_min`                         :func:`empty_approx_set`                  :func:`length`                            :func:`sha512`                            st_ymin                                       classification_miss_rate
-    :func:`array_normalize`                   enum_key                                  levenshtein_distance                      :func:`shuffle`                           :func:`strpos`                                classification_precision
-    :func:`array_position`                    :func:`exp`                               line_interpolate_point                    :func:`sign`                              :func:`strrpos`                               classification_recall
-    array_remove                              expand_envelope                           line_locate_point                         simplify_geometry                         :func:`substr`                                classification_thresholds
-    :func:`array_sort`                        features                                  :func:`ln`                                :func:`sin`                               :func:`tan`                                   convex_hull_agg
-    :func:`array_sum`                         :func:`filter`                            localtime                                 :func:`slice`                             :func:`tanh`                                  :func:`corr`
-    array_union                               flatten                                   localtimestamp                            spatial_partitions                        :func:`timezone_hour`                         :func:`count`
-    :func:`arrays_overlap`                    flatten_geometry_collections              :func:`log10`                             :func:`split`                             :func:`timezone_minute`                       :func:`count_if`
-    :func:`asin`                              :func:`floor`                             :func:`log2`                              :func:`split_part`                        :func:`to_base`                               :func:`covar_pop`
-    :func:`atan`                              fnv1_32                                   :func:`lower`                             split_to_map                              :func:`to_base64`                             :func:`covar_samp`
-    :func:`atan2`                             fnv1_64                                   :func:`lpad`                              split_to_multimap                         :func:`to_base64url`                          differential_entropy
-    bar                                       fnv1a_32                                  :func:`ltrim`                             :func:`spooky_hash_v2_32`                 :func:`to_big_endian_32`                      entropy
-    :func:`beta_cdf`                          fnv1a_64                                  :func:`map`                               :func:`spooky_hash_v2_64`                 :func:`to_big_endian_64`                      evaluate_classifier_predictions
-    bing_tile                                 :func:`format_datetime`                   :func:`map_concat`                        :func:`sqrt`                              to_geometry                                   :func:`every`
-    bing_tile_at                              :func:`from_base`                         :func:`map_entries`                       st_area                                   :func:`to_hex`                                geometric_mean
-    bing_tile_children                        :func:`from_base64`                       :func:`map_filter`                        st_asbinary                               to_ieee754_32                                 geometry_union_agg
-    bing_tile_coordinates                     :func:`from_base64url`                    map_from_entries                          st_astext                                 :func:`to_ieee754_64`                         :func:`histogram`
-    bing_tile_parent                          :func:`from_big_endian_32`                :func:`map_keys`                          st_boundary                               to_iso8601                                    khyperloglog_agg
-    bing_tile_polygon                         :func:`from_big_endian_64`                map_normalize                             st_buffer                                 to_milliseconds                               kurtosis
-    bing_tile_quadkey                         :func:`from_hex`                          :func:`map_values`                        st_centroid                               to_spherical_geography                        learn_classifier
-    bing_tile_zoom_level                      from_ieee754_32                           :func:`map_zip_with`                      st_contains                               :func:`to_unixtime`                           learn_libsvm_classifier
-    bing_tiles_around                         from_ieee754_64                           :func:`md5`                               st_convexhull                             :func:`to_utf8`                               learn_libsvm_regressor
-    :func:`binomial_cdf`                      from_iso8601_date                         merge_hll                                 st_coorddim                               :func:`transform`                             learn_regressor
-    :func:`bit_count`                         from_iso8601_timestamp                    merge_khll                                st_crosses                                :func:`transform_keys`                        make_set_digest
-    :func:`bitwise_and`                       :func:`from_unixtime`                     :func:`millisecond`                       st_difference                             :func:`transform_values`                      :func:`map_agg`
-    :func:`bitwise_arithmetic_shift_right`    :func:`from_utf8`                         :func:`minute`                            st_dimension                              :func:`trim`                                  :func:`map_union`
-    :func:`bitwise_left_shift`                geometry_as_geojson                       :func:`mod`                               st_disjoint                               :func:`truncate`                              :func:`map_union_sum`
-    :func:`bitwise_logical_shift_right`       geometry_from_geojson                     :func:`month`                             st_distance                               typeof                                        :func:`max`
-    :func:`bitwise_not`                       geometry_invalid_reason                   multimap_from_entries                     st_endpoint                               uniqueness_distribution                       :func:`max_by`
-    :func:`bitwise_or`                        geometry_nearest_points                   myanmar_font_encoding                     st_envelope                               :func:`upper`                                 :func:`merge`
-    :func:`bitwise_right_shift`               geometry_to_bing_tiles                    myanmar_normalize_unicode                 st_envelopeaspts                          :func:`url_decode`                            merge_set_digest
-    :func:`bitwise_right_shift_arithmetic`    geometry_to_dissolved_bing_tiles          :func:`nan`                               st_equals                                 :func:`url_encode`                            :func:`min`
-    :func:`bitwise_shift_left`                geometry_union                            ngrams                                    st_exteriorring                           :func:`url_extract_fragment`                  :func:`min_by`
-    :func:`bitwise_xor`                       great_circle_distance                     :func:`none_match`                        st_geometries                             :func:`url_extract_host`                      multimap_agg
-    :func:`cardinality`                       :func:`greatest`                          :func:`normal_cdf`                        st_geometryfromtext                       :func:`url_extract_parameter`                 numeric_histogram
-    cauchy_cdf                                hamming_distance                          normalize                                 st_geometryn                              :func:`url_extract_path`                      qdigest_agg
-    :func:`cbrt`                              hash_counts                               now                                       st_geometrytype                           :func:`url_extract_port`                      reduce_agg
-    :func:`ceil`                              :func:`hmac_md5`                          :func:`parse_datetime`                    st_geomfrombinary                         :func:`url_extract_protocol`                  :func:`regr_intercept`
-    :func:`ceiling`                           :func:`hmac_sha1`                         parse_duration                            st_interiorringn                          :func:`url_extract_query`                     :func:`regr_slope`
-    chi_squared_cdf                           :func:`hmac_sha256`                       parse_presto_data_size                    st_interiorrings                          value_at_quantile                             set_agg
-    :func:`chr`                               :func:`hmac_sha512`                       :func:`pi`                                st_intersection                           values_at_quantiles                           set_union
-    classify                                  :func:`hour`                              poisson_cdf                               st_intersects                             :func:`week`                                  skewness
-    :func:`codepoint`                         :func:`infinity`                          :func:`pow`                               st_isclosed                               :func:`week_of_year`                          spatial_partitioning
-    color                                     intersection_cardinality                  :func:`power`                             st_isempty                                weibull_cdf                                   :func:`stddev`
-    :func:`combinations`                      inverse_beta_cdf                          quantile_at_value                         st_isring                                 :func:`width_bucket`                          :func:`stddev_pop`
-    :func:`concat`                            inverse_binomial_cdf                      :func:`quarter`                           st_issimple                               wilson_interval_lower                         :func:`stddev_samp`
-    :func:`contains`                          inverse_cauchy_cdf                        :func:`radians`                           st_isvalid                                wilson_interval_upper                         :func:`sum`
-    :func:`cos`                               inverse_chi_squared_cdf                   :func:`rand`                              st_length                                 word_stem                                     tdigest_agg
-    :func:`cosh`                              inverse_normal_cdf                        :func:`random`                            st_linefromtext                           :func:`xxhash64`                              :func:`var_pop`
-    cosine_similarity                         inverse_poisson_cdf                       :func:`reduce`                            st_linestring                             :func:`year`                                  :func:`var_samp`
-    :func:`crc32`                             inverse_weibull_cdf                       :func:`regexp_extract`                    st_multipoint                             :func:`year_of_week`                          :func:`variance`
-    :func:`current_date`                      ip_prefix                                 :func:`regexp_extract_all`                st_numgeometries                          :func:`yow`
-    current_time                              ip_subnet_max                             :func:`regexp_like`                       st_numinteriorring                        :func:`zip`
-    current_timestamp                         ip_subnet_min                             :func:`regexp_replace`                    st_numpoints                              :func:`zip_with`
-    current_timezone                          ip_subnet_range                           regexp_split                              st_overlaps
-    :func:`date`                              :func:`is_finite`                         regress                                   st_point
-    :func:`date_add`                          :func:`is_infinite`                       reidentification_potential                st_pointn
+    :func:`abs`                               :func:`date_diff`                         :func:`is_nan`                            :func:`replace`                           st_startpoint                                 :func:`approx_distinct`                       :func:`cume_dist`
+    :func:`acos`                              :func:`date_format`                       is_subnet_of                              :func:`reverse`                           st_symdifference                              :func:`approx_most_frequent`                  :func:`dense_rank`
+    :func:`all_match`                         :func:`date_parse`                        jaccard_index                             rgb                                       st_touches                                    :func:`approx_percentile`                     :func:`first_value`
+    :func:`any_match`                         :func:`date_trunc`                        :func:`json_array_contains`               :func:`round`                             st_union                                      :func:`approx_set`                            :func:`lag`
+    :func:`array_average`                     :func:`day`                               json_array_get                            :func:`rpad`                              st_within                                     :func:`arbitrary`                             :func:`last_value`
+    :func:`array_distinct`                    :func:`day_of_month`                      :func:`json_array_length`                 :func:`rtrim`                             st_x                                          :func:`array_agg`                             :func:`lead`
+    :func:`array_duplicates`                  :func:`day_of_week`                       json_extract                              scale_qdigest                             st_xmax                                       :func:`avg`                                   :func:`nth_value`
+    :func:`array_except`                      :func:`day_of_year`                       :func:`json_extract_scalar`               :func:`second`                            st_xmin                                       :func:`bitwise_and_agg`                       :func:`ntile`
+    :func:`array_frequency`                   :func:`degrees`                           :func:`json_format`                       :func:`sequence`                          st_y                                          :func:`bitwise_or_agg`                        :func:`percent_rank`
+    :func:`array_has_duplicates`              :func:`dow`                               :func:`json_parse`                        :func:`sha1`                              st_ymax                                       :func:`bool_and`                              :func:`rank`
+    :func:`array_intersect`                   :func:`doy`                               :func:`json_size`                         :func:`sha256`                            st_ymin                                       :func:`bool_or`                               :func:`row_number`
+    :func:`array_join`                        :func:`e`                                 :func:`least`                             :func:`sha512`                            :func:`strpos`                                :func:`checksum`
+    :func:`array_max`                         :func:`element_at`                        :func:`length`                            :func:`shuffle`                           :func:`strrpos`                               classification_fall_out
+    :func:`array_min`                         :func:`empty_approx_set`                  levenshtein_distance                      :func:`sign`                              :func:`substr`                                classification_miss_rate
+    :func:`array_normalize`                   enum_key                                  line_interpolate_point                    simplify_geometry                         :func:`tan`                                   classification_precision
+    :func:`array_position`                    :func:`exp`                               line_locate_point                         :func:`sin`                               :func:`tanh`                                  classification_recall
+    array_remove                              expand_envelope                           :func:`ln`                                :func:`slice`                             :func:`timezone_hour`                         classification_thresholds
+    :func:`array_sort`                        features                                  localtime                                 spatial_partitions                        :func:`timezone_minute`                       convex_hull_agg
+    :func:`array_sort_desc`                   :func:`filter`                            localtimestamp                            :func:`split`                             :func:`to_base`                               :func:`corr`
+    :func:`array_sum`                         flatten                                   :func:`log10`                             :func:`split_part`                        :func:`to_base64`                             :func:`count`
+    array_union                               flatten_geometry_collections              :func:`log2`                              split_to_map                              :func:`to_base64url`                          :func:`count_if`
+    :func:`arrays_overlap`                    :func:`floor`                             :func:`lower`                             split_to_multimap                         :func:`to_big_endian_32`                      :func:`covar_pop`
+    :func:`asin`                              fnv1_32                                   :func:`lpad`                              :func:`spooky_hash_v2_32`                 :func:`to_big_endian_64`                      :func:`covar_samp`
+    :func:`atan`                              fnv1_64                                   :func:`ltrim`                             :func:`spooky_hash_v2_64`                 to_geometry                                   differential_entropy
+    :func:`atan2`                             fnv1a_32                                  :func:`map`                               :func:`sqrt`                              :func:`to_hex`                                entropy
+    bar                                       fnv1a_64                                  :func:`map_concat`                        st_area                                   to_ieee754_32                                 evaluate_classifier_predictions
+    :func:`beta_cdf`                          :func:`format_datetime`                   :func:`map_entries`                       st_asbinary                               :func:`to_ieee754_64`                         :func:`every`
+    bing_tile                                 :func:`from_base`                         :func:`map_filter`                        st_astext                                 to_iso8601                                    geometric_mean
+    bing_tile_at                              :func:`from_base64`                       map_from_entries                          st_boundary                               to_milliseconds                               geometry_union_agg
+    bing_tile_children                        :func:`from_base64url`                    :func:`map_keys`                          st_buffer                                 to_spherical_geography                        :func:`histogram`
+    bing_tile_coordinates                     :func:`from_big_endian_32`                map_normalize                             st_centroid                               :func:`to_unixtime`                           khyperloglog_agg
+    bing_tile_parent                          :func:`from_big_endian_64`                :func:`map_values`                        st_contains                               :func:`to_utf8`                               kurtosis
+    bing_tile_polygon                         :func:`from_hex`                          :func:`map_zip_with`                      st_convexhull                             :func:`transform`                             learn_classifier
+    bing_tile_quadkey                         from_ieee754_32                           :func:`md5`                               st_coorddim                               :func:`transform_keys`                        learn_libsvm_classifier
+    bing_tile_zoom_level                      from_ieee754_64                           merge_hll                                 st_crosses                                :func:`transform_values`                      learn_libsvm_regressor
+    bing_tiles_around                         from_iso8601_date                         merge_khll                                st_difference                             :func:`trim`                                  learn_regressor
+    :func:`binomial_cdf`                      from_iso8601_timestamp                    :func:`millisecond`                       st_dimension                              :func:`truncate`                              make_set_digest
+    :func:`bit_count`                         :func:`from_unixtime`                     :func:`minute`                            st_disjoint                               typeof                                        :func:`map_agg`
+    :func:`bitwise_and`                       :func:`from_utf8`                         :func:`mod`                               st_distance                               uniqueness_distribution                       :func:`map_union`
+    :func:`bitwise_arithmetic_shift_right`    geometry_as_geojson                       :func:`month`                             st_endpoint                               :func:`upper`                                 :func:`map_union_sum`
+    :func:`bitwise_left_shift`                geometry_from_geojson                     multimap_from_entries                     st_envelope                               :func:`url_decode`                            :func:`max`
+    :func:`bitwise_logical_shift_right`       geometry_invalid_reason                   myanmar_font_encoding                     st_envelopeaspts                          :func:`url_encode`                            :func:`max_by`
+    :func:`bitwise_not`                       geometry_nearest_points                   myanmar_normalize_unicode                 st_equals                                 :func:`url_extract_fragment`                  :func:`merge`
+    :func:`bitwise_or`                        geometry_to_bing_tiles                    :func:`nan`                               st_exteriorring                           :func:`url_extract_host`                      merge_set_digest
+    :func:`bitwise_right_shift`               geometry_to_dissolved_bing_tiles          ngrams                                    st_geometries                             :func:`url_extract_parameter`                 :func:`min`
+    :func:`bitwise_right_shift_arithmetic`    geometry_union                            :func:`none_match`                        st_geometryfromtext                       :func:`url_extract_path`                      :func:`min_by`
+    :func:`bitwise_shift_left`                great_circle_distance                     :func:`normal_cdf`                        st_geometryn                              :func:`url_extract_port`                      multimap_agg
+    :func:`bitwise_xor`                       :func:`greatest`                          normalize                                 st_geometrytype                           :func:`url_extract_protocol`                  numeric_histogram
+    :func:`cardinality`                       hamming_distance                          now                                       st_geomfrombinary                         :func:`url_extract_query`                     qdigest_agg
+    cauchy_cdf                                hash_counts                               :func:`parse_datetime`                    st_interiorringn                          value_at_quantile                             reduce_agg
+    :func:`cbrt`                              :func:`hmac_md5`                          parse_duration                            st_interiorrings                          values_at_quantiles                           :func:`regr_intercept`
+    :func:`ceil`                              :func:`hmac_sha1`                         parse_presto_data_size                    st_intersection                           :func:`week`                                  :func:`regr_slope`
+    :func:`ceiling`                           :func:`hmac_sha256`                       :func:`pi`                                st_intersects                             :func:`week_of_year`                          set_agg
+    chi_squared_cdf                           :func:`hmac_sha512`                       poisson_cdf                               st_isclosed                               weibull_cdf                                   set_union
+    :func:`chr`                               :func:`hour`                              :func:`pow`                               st_isempty                                :func:`width_bucket`                          skewness
+    classify                                  :func:`infinity`                          :func:`power`                             st_isring                                 wilson_interval_lower                         spatial_partitioning
+    :func:`codepoint`                         intersection_cardinality                  quantile_at_value                         st_issimple                               wilson_interval_upper                         :func:`stddev`
+    color                                     inverse_beta_cdf                          :func:`quarter`                           st_isvalid                                word_stem                                     :func:`stddev_pop`
+    :func:`combinations`                      inverse_binomial_cdf                      :func:`radians`                           st_length                                 :func:`xxhash64`                              :func:`stddev_samp`
+    :func:`concat`                            inverse_cauchy_cdf                        :func:`rand`                              st_linefromtext                           :func:`year`                                  :func:`sum`
+    :func:`contains`                          inverse_chi_squared_cdf                   :func:`random`                            st_linestring                             :func:`year_of_week`                          tdigest_agg
+    :func:`cos`                               inverse_normal_cdf                        :func:`reduce`                            st_multipoint                             :func:`yow`                                   :func:`var_pop`
+    :func:`cosh`                              inverse_poisson_cdf                       :func:`regexp_extract`                    st_numgeometries                          :func:`zip`                                   :func:`var_samp`
+    cosine_similarity                         inverse_weibull_cdf                       :func:`regexp_extract_all`                st_numinteriorring                        :func:`zip_with`                              :func:`variance`
+    :func:`crc32`                             ip_prefix                                 :func:`regexp_like`                       st_numpoints
+    :func:`current_date`                      ip_subnet_max                             :func:`regexp_replace`                    st_overlaps
+    current_time                              ip_subnet_min                             regexp_split                              st_point
+    current_timestamp                         ip_subnet_range                           regress                                   st_pointn
+    current_timezone                          :func:`is_finite`                         reidentification_potential                st_points
+    :func:`date`                              :func:`is_infinite`                       render                                    st_polygon
+    :func:`date_add`                          :func:`is_json_scalar`                    :func:`repeat`                            st_relate
     ========================================  ========================================  ========================================  ========================================  ========================================  ==  ========================================  ==  ========================================

--- a/velox/docs/functions/spark/coverage.rst
+++ b/velox/docs/functions/spark/coverage.rst
@@ -6,6 +6,7 @@
     table.coverage td:nth-child(6) {background-color: lightblue;}
     table.coverage td:nth-child(8) {background-color: lightblue;}
     table.coverage tr:nth-child(1) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(2) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(3) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(5) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(6) td:nth-child(3) {background-color: #6BA81E;}
@@ -23,6 +24,7 @@
     table.coverage tr:nth-child(21) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(22) td:nth-child(4) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(23) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(24) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(25) td:nth-child(5) {background-color: #6BA81E;}
@@ -31,12 +33,14 @@
     table.coverage tr:nth-child(27) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(29) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(1) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(31) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(31) td:nth-child(5) {background-color: #6BA81E;}
     table.coverage tr:nth-child(32) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(33) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(34) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(35) td:nth-child(3) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(36) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(37) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(38) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(39) td:nth-child(4) {background-color: #6BA81E;}
@@ -57,10 +61,12 @@
     table.coverage tr:nth-child(57) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(58) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(59) td:nth-child(2) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(59) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(60) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(1) {background-color: #6BA81E;}
     table.coverage tr:nth-child(62) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(64) td:nth-child(5) {background-color: #6BA81E;}
+    table.coverage tr:nth-child(65) td:nth-child(2) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(3) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(4) {background-color: #6BA81E;}
     table.coverage tr:nth-child(65) td:nth-child(5) {background-color: #6BA81E;}
@@ -76,7 +82,7 @@
     Scalar Functions                                                                                                                                                                                                           Aggregate Functions                            Window Functions
     =====================================================================================================================================================================================================================  ==  =========================================  ==  =========================================
     :spark:func:`abs`                          count_if                                   inline                                     nvl                                        sqrt                                           any                                            cume_dist                                
-    acos                                       count_min_sketch                           inline_outer                               nvl2                                       stack                                          approx_count_distinct                          dense_rank                               
+    :spark:func:`acos                          count_min_sketch                           inline_outer                               nvl2                                       stack                                          approx_count_distinct                          dense_rank                               
     :spark:func:`acosh`                        covar_pop                                  input_file_block_length                    octet_length                               std                                            approx_percentile                              first_value                              
     add_months                                 covar_samp                                 input_file_block_start                     or                                         stddev                                         array_agg                                      lag                                      
     :spark:func:`aggregate`                    crc32                                      input_file_name                            overlay                                    stddev_pop                                     avg                                            last_value                               
@@ -97,7 +103,7 @@
     array_repeat                               datediff                                   lcase                                      radians                                    tinyint                                        :spark:func:`first`                                                                     
     :spark:func:`array_sort`                   day                                        lead                                       raise_error                                to_csv                                         first_value                                                                             
     array_union                                dayofmonth                                 :spark:func:`least`                        :spark:func:`rand`                         to_date                                        grouping                                                                                
-    arrays_overlap                             dayofweek                                  left                                       randn                                      to_json                                        grouping_id                                                                             
+    arrays_overlap                             dayofweek                                  :spark:funce:`left`                        randn                                      to_json                                        grouping_id                                                                             
     arrays_zip                                 dayofyear                                  :spark:func:`length`                       random                                     to_timestamp                                   histogram_numeric                                                                       
     :spark:func:`ascii`                        decimal                                    levenshtein                                range                                      :spark:func:`to_unix_timestamp`                kurtosis                                                                                
     asin                                       decode                                     like                                       rank                                       to_utc_timestamp                               :spark:func:`last`                                                                      
@@ -105,12 +111,12 @@
     assert_true                                dense_rank                                 locate                                     regexp                                     transform_keys                                 max                                                                                     
     atan                                       div                                        log                                        :spark:func:`regexp_extract`               transform_values                               max_by                                                                                  
     atan2                                      double                                     log10                                      regexp_extract_all                         translate                                      mean                                                                                    
-    :spark:func:`atanh`                        e                                          log1p                                      regexp_like                                :spark:func:`trim`                             min                                                                                     
+    :spark:func:`atanh`                        e                                          :spark:func:`log1p`                        regexp_like                                :spark:func:`trim`                             min                                                                                     
     avg                                        :spark:func:`element_at`                   log2                                       regexp_replace                             trunc                                          min_by                                                                                  
     base64                                     elt                                        :spark:func:`lower`                        repeat                                     try_add                                        percentile                                                                              
     :spark:func:`between`                      encode                                     lpad                                       :spark:func:`replace`                      try_divide                                     percentile_approx                                                                       
     bigint                                     every                                      :spark:func:`ltrim`                        reverse                                    typeof                                         regr_avgx                                                                               
-    bin                                        exists                                     make_date                                  right                                      ucase                                          regr_avgy                                                                               
+    :spark:func:`bin`                          exists                                     make_date                                  right                                      ucase                                          regr_avgy                                                                               
     binary                                     :spark:func:`exp`                          make_dt_interval                           rint                                       unbase64                                       regr_count                                                                              
     bit_and                                    explode                                    make_interval                              :spark:func:`rlike`                        unhex                                          regr_r2                                                                                 
     bit_count                                  explode_outer                              make_timestamp                             :spark:func:`round`                        unix_date                                      skewness                                                                                
@@ -133,13 +139,13 @@
     char_length                                from_utc_timestamp                         minute                                     sign                                       xpath_boolean                                                                                                                          
     character_length                           :spark:func:`get_json_object`              mod                                        signum                                     xpath_double                                                                                                                           
     :spark:func:`chr`                          getbit                                     monotonically_increasing_id                sin                                        xpath_float                                                                                                                            
-    coalesce                                   :spark:func:`greatest`                     month                                      sinh                                       xpath_int                                                                                                                              
+    coalesce                                   :spark:func:`greatest`                     month                                      :spark:func:`sinh`                         xpath_int                                                                                                                              
     collect_list                               grouping                                   months_between                             :spark:func:`size`                         xpath_long                                                                                                                             
     collect_set                                grouping_id                                named_struct                               skewness                                   xpath_number                                                                                                                           
     :spark:func:`concat`                       :spark:func:`hash`                         nanvl                                      slice                                      xpath_short                                                                                                                            
     concat_ws                                  hex                                        negative                                   smallint                                   xpath_string                                                                                                                           
     conv                                       hour                                       next_day                                   some                                       :spark:func:`xxhash64`                                                                                                                 
-    corr                                       hypot                                      :spark:func:`not`                          :spark:func:`sort_array`                   :spark:func:`year`                                                                                                                     
+    corr                                       :spark:func:`hypot`                        :spark:func:`not`                          :spark:func:`sort_array`                   :spark:func:`year`                                                                                                                     
     cos                                        if                                         now                                        soundex                                    zip_with                                                                                                                               
     cosh                                       ifnull                                     nth_value                                  space                                                                                                                                                                             
     cot                                        :spark:func:`in`                           ntile                                      spark_partition_id                                                                                                                                                                

--- a/velox/docs/spark_functions.rst
+++ b/velox/docs/spark_functions.rst
@@ -58,30 +58,32 @@ for :doc:`all <functions/spark/coverage>` functions.
     ================================  ================================  ================================  ==  ================================  ==  ================================
     Scalar Functions                                                                                          Aggregate Functions                   Window Functions
     ====================================================================================================  ==  ================================  ==  ================================
-    :spark:func:`abs`                 :spark:func:`floor`               :spark:func:`rand`                    :spark:func:`bit_xor`                 :spark:func:`nth_value`         
-    :spark:func:`acosh`               :spark:func:`get_json_object`     :spark:func:`regexp_extract`          :spark:func:`first`                                                   
-    :spark:func:`add`                 :spark:func:`greaterthan`         :spark:func:`remainder`               :spark:func:`first_ignore_null`                                       
-    :spark:func:`aggregate`           :spark:func:`greaterthanorequal`  :spark:func:`replace`                 :spark:func:`last`                                                    
-    :spark:func:`array`               :spark:func:`greatest`            :spark:func:`rlike`                   :spark:func:`last_ignore_null`                                        
-    :spark:func:`array_contains`      :spark:func:`hash`                :spark:func:`round`                                                                                         
+    :spark:func:`abs`                 :spark:func:`floor`               :spark:func:`power`                   :spark:func:`bit_xor`                 :spark:func:`nth_value`         
+    :spark:func:`acos`                :spark:func:`get_json_object`     :spark:func:`rand`                    :spark:func:`first`                                                   
+    :spark:func:`acosh`               :spark:func:`greaterthan`         :spark:func:`regexp_extract`          :spark:func:`first_ignore_null`                                       
+    :spark:func:`add`                 :spark:func:`greaterthanorequal`  :spark:func:`remainder`               :spark:func:`last`                                                    
+    :spark:func:`aggregate`           :spark:func:`greatest`            :spark:func:`replace`                 :spark:func:`last_ignore_null`                                        
+    :spark:func:`array`               :spark:func:`hash`                :spark:func:`rlike`                                                                                         
+    :spark:func:`array_contains`      :spark:func:`hypot`               :spark:func:`round`                                                                                         
     :spark:func:`array_intersect`     :spark:func:`in`                  :spark:func:`rtrim`                                                                                         
     :spark:func:`array_sort`          :spark:func:`instr`               :spark:func:`sec`                                                                                           
     :spark:func:`ascii`               :spark:func:`isnotnull`           :spark:func:`sha1`                                                                                          
     :spark:func:`asinh`               :spark:func:`isnull`              :spark:func:`sha2`                                                                                          
     :spark:func:`atanh`               :spark:func:`least`               :spark:func:`shiftleft`                                                                                     
-    :spark:func:`between`             :spark:func:`length`              :spark:func:`shiftright`                                                                                    
+    :spark:func:`between`             :spark:func:`left`                :spark:func:`shiftright`                                                                                    
+    :spark:func:`bin`                 :spark:func:`length`              :spark:func:`sinh`                                                                                          
     :spark:func:`bitwise_and`         :spark:func:`lessthan`            :spark:func:`size`                                                                                          
     :spark:func:`bitwise_or`          :spark:func:`lessthanorequal`     :spark:func:`sort_array`                                                                                    
-    :spark:func:`ceil`                :spark:func:`lower`               :spark:func:`split`                                                                                         
-    :spark:func:`chr`                 :spark:func:`ltrim`               :spark:func:`startswith`                                                                                    
-    :spark:func:`concat`              :spark:func:`map`                 :spark:func:`substring`                                                                                     
-    :spark:func:`contains`            :spark:func:`map_filter`          :spark:func:`subtract`                                                                                      
-    :spark:func:`csc`                 :spark:func:`map_from_arrays`     :spark:func:`to_unix_timestamp`                                                                             
-    :spark:func:`divide`              :spark:func:`md5`                 :spark:func:`transform`                                                                                     
-    :spark:func:`element_at`          :spark:func:`might_contain`       :spark:func:`trim`                                                                                          
-    :spark:func:`endswith`            :spark:func:`multiply`            :spark:func:`unaryminus`                                                                                    
-    :spark:func:`equalnullsafe`       :spark:func:`not`                 :spark:func:`unix_timestamp`                                                                                
-    :spark:func:`equalto`             :spark:func:`notequalto`          :spark:func:`upper`                                                                                         
-    :spark:func:`exp`                 :spark:func:`pmod`                :spark:func:`xxhash64`                                                                                      
-    :spark:func:`filter`              :spark:func:`power`               :spark:func:`year`                                                                                          
+    :spark:func:`ceil`                :spark:func:`log1p`               :spark:func:`split`                                                                                         
+    :spark:func:`chr`                 :spark:func:`lower`               :spark:func:`startswith`                                                                                    
+    :spark:func:`concat`              :spark:func:`ltrim`               :spark:func:`substring`                                                                                     
+    :spark:func:`contains`            :spark:func:`map`                 :spark:func:`subtract`                                                                                      
+    :spark:func:`csc`                 :spark:func:`map_filter`          :spark:func:`to_unix_timestamp`                                                                             
+    :spark:func:`divide`              :spark:func:`map_from_arrays`     :spark:func:`transform`                                                                                     
+    :spark:func:`element_at`          :spark:func:`md5`                 :spark:func:`trim`                                                                                          
+    :spark:func:`endswith`            :spark:func:`might_contain`       :spark:func:`unaryminus`                                                                                    
+    :spark:func:`equalnullsafe`       :spark:func:`multiply`            :spark:func:`unix_timestamp`                                                                                
+    :spark:func:`equalto`             :spark:func:`not`                 :spark:func:`upper`                                                                                         
+    :spark:func:`exp`                 :spark:func:`notequalto`          :spark:func:`xxhash64`                                                                                      
+    :spark:func:`filter`              :spark:func:`pmod`                :spark:func:`year`                                                                                          
     ================================  ================================  ================================  ==  ================================  ==  ================================

--- a/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
+++ b/velox/functions/prestosql/coverage/data/all_scalar_functions.txt
@@ -16,6 +16,7 @@ array_normalize
 array_position
 array_remove
 array_sort
+array_sort_desc
 array_sum
 array_union
 arrays_overlap


### PR DESCRIPTION
### Summary
Update functions coverage maps in SparkSQL/Presto to reflect current additions

Until commit: b414dd4fa6734b1cc3c9c73fde5c08c7a799f162
1. Spark:
https://facebookincubator.github.io/velox/spark_functions.html
https://facebookincubator.github.io/velox/functions/spark/coverage.html

2. Presto:
https://facebookincubator.github.io/velox/functions.html
https://facebookincubator.github.io/velox/functions/presto/coverage.html

### Function commits lists:
1. Spark:
acos 57e1600eeab3a7849e9a368a2c464ceb074e6259
bin 148676b1d6cf1186e0cd0ab596442f0c9cc57a8a
hypot 6819495907ec5d917809eee9c26f009c1699c15a
left 9cbeb8b190b9cbcb3f5a7413e78ccaa2620aabf3
log1p f50e27cce57b41bb4c61aed32c75e4a2910ddcac
sinh 8b1d6ba4c4900813593707e55095d5cdeafdb507

2. Presto:
array_sort_desc 7e27cac1b6eca0449601c405c8dfc02f1db3b888