### PR TITLE
Make TableWriter report physicalWrittenBytes to OperatorStats

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -136,6 +136,11 @@ class DataSink {
   /// TODO maybe at some point we want to make it async.
   virtual void appendData(RowVectorPtr input) = 0;
 
+  /// Returns the number of bytes written on disk by this data sink so far.
+  virtual int64_t getCompletedBytes() const {
+    return 0;
+  }
+
   /// Called once after all data has been added via possibly multiple calls to
   /// appendData(). Could return data in the string form that would be included
   /// in the output. After calling this function, only close() could be called.

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -384,6 +384,8 @@ class HiveDataSink : public DataSink {
 
   void appendData(RowVectorPtr input) override;
 
+  int64_t getCompletedBytes() const override;
+
   std::vector<std::string> finish() const override;
 
   void close() override;
@@ -454,6 +456,8 @@ class HiveDataSink : public DataSink {
   // writers_ are both indexed by partitionId.
   std::vector<std::shared_ptr<HiveWriterInfo>> writerInfo_;
   std::vector<std::unique_ptr<dwio::common::Writer>> writers_;
+  // IO statistics collected for each writer.
+  std::vector<std::shared_ptr<dwio::common::IoStatistics>> ioStats_;
 
   // Below are structures updated when processing current input. partitionIds_
   // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -91,6 +91,7 @@ void TableWriter::addInput(RowVectorPtr input) {
   }
   dataSink_->appendData(mappedInput);
   numWrittenRows_ += input->size();
+  updateWrittenBytes();
 }
 
 RowVectorPtr TableWriter::getOutput() {
@@ -99,6 +100,7 @@ RowVectorPtr TableWriter::getOutput() {
     return nullptr;
   }
   finished_ = true;
+  updateWrittenBytes();
 
   if (outputType_->size() == 1) {
     // NOTE: this is for non-prestissimo use cases.
@@ -154,6 +156,12 @@ RowVectorPtr TableWriter::getOutput() {
 
   return std::make_shared<RowVector>(
       pool(), outputType_, nullptr, numOutputRows, columns);
+}
+
+void TableWriter::updateWrittenBytes() {
+  const auto writtenBytes = dataSink_->getCompletedBytes();
+  auto lockedStats = stats_.wlock();
+  lockedStats->physicalWrittenBytes = writtenBytes;
 }
 
 std::string TableWriteTraits::rowCountColumnName() {

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -104,6 +104,9 @@ class TableWriter : public Operator {
  private:
   void createDataSink();
 
+  // Updates physicalWrittenBytes in OperatorStats with current written bytes.
+  void updateWrittenBytes();
+
   const DriverCtx* const driverCtx_;
   memory::MemoryPool* const connectorPool_;
   const std::shared_ptr<connector::ConnectorInsertTableHandle>


### PR DESCRIPTION
For support of scaled table writer: https://github.com/facebookincubator/velox/issues/5665

In table writer operator, add function `updateWrittenBytes` to acquire the written 
data size from underlying dataSink.
This function is invoked whenever we add input or get output from table writer operator.