### PR TITLE
Fix final selection handling while executing lamda expressions

### DIFF
--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -921,6 +921,10 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
   }
 
   // Prepare the rows and vectors to peel.
+
+  // Use finalSelection to generate peel to ensure those rows can be translated
+  // and ensure consistent peeling across multiple calls to this expression if
+  // its a shared subexpression.
   const auto& rowsToPeel =
       context.isFinalSelection() ? rows : *context.finalSelection();
   auto numFields = context.row()->childrenSize();
@@ -932,7 +936,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
     auto fieldVector = context.getField(fieldIndex);
     if (fieldVector->isConstantEncoding()) {
       // Make sure constant encoded fields are loaded
-      fieldVector = context.ensureFieldLoaded(fieldIndex, rows);
+      fieldVector = context.ensureFieldLoaded(fieldIndex, rowsToPeel);
     }
     vectorsToPeel.push_back(fieldVector);
   }

--- a/velox/functions/prestosql/ArrayMatch.cpp
+++ b/velox/functions/prestosql/ArrayMatch.cpp
@@ -43,11 +43,9 @@ class MatchFunction : public exec::VectorFunction {
     std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
     auto numElements = flatArray->elements()->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection = toElementRows<ArrayVector>(
-          numElements, *context.finalSelection(), flatArray.get());
-    }
+    SelectivityVector validRowsInReusedResult;
+    validRowsInReusedResult =
+        toElementRows<ArrayVector>(numElements, rows, flatArray.get());
 
     VectorPtr matchBits;
     auto elementToTopLevelRows = getElementToTopLevelRows(
@@ -68,7 +66,7 @@ class MatchFunction : public exec::VectorFunction {
           numElements, entry.callable, *entry.rows, flatArray);
       entry.callable->applyNoThrow(
           elementRows,
-          finalSelection,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -280,11 +280,8 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
     std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
     auto newNumElements = flatArray->elements()->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection = toElementRows<ArrayVector>(
-          newNumElements, *context.finalSelection(), flatArray.get());
-    }
+    SelectivityVector validRowsInReusedResult =
+        toElementRows<ArrayVector>(newNumElements, rows, flatArray.get());
 
     // Compute sorting keys.
     VectorPtr newElements;
@@ -303,7 +300,7 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
 
       entry.callable->apply(
           elementRows,
-          finalSelection,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -70,12 +70,6 @@ class FilterFunctionBase : public exec::VectorFunction {
     auto rawResultOffsets = resultOffsets->asMutable<vector_size_t>();
     auto numElements = lambdaArgs[0]->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection =
-          toElementRows<T>(numElements, *context.finalSelection(), input.get());
-    }
-
     auto elementToTopLevelRows = getElementToTopLevelRows(
         numElements, rows, input.get(), context.pool());
 
@@ -90,7 +84,7 @@ class FilterFunctionBase : public exec::VectorFunction {
       VectorPtr bits;
       entry.callable->apply(
           elementRows,
-          finalSelection,
+          nullptr,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -147,7 +147,9 @@ class MapZipWithFunction : public exec::VectorFunction {
     std::vector<VectorPtr> lambdaArgs = {
         mergedKeys, mergedLeftValues, mergedRightValues};
 
-    const SelectivityVector allElementRows(index);
+    // Make sure already populated entries in newElements do not get
+    // overwritten.
+    const SelectivityVector validRowsInReusedResult(index);
 
     VectorPtr mergedValues;
 
@@ -179,13 +181,9 @@ class MapZipWithFunction : public exec::VectorFunction {
             *entry.rows, index, mergeResults.rawNewSizes, context.pool());
       }
 
-      // Make sure already populated entries in newElements do not get
-      // overwritten.
-      exec::ScopedFinalSelectionSetter(context, &allElementRows, true, true);
-
       entry.callable->apply(
           elementRows,
-          allElementRows,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -50,11 +50,8 @@ class TransformFunction : public exec::VectorFunction {
     std::vector<VectorPtr> lambdaArgs = {flatArray->elements()};
     auto newNumElements = flatArray->elements()->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection = toElementRows<ArrayVector>(
-          newNumElements, *context.finalSelection(), flatArray.get());
-    }
+    SelectivityVector validRowsInReusedResult =
+        toElementRows<ArrayVector>(newNumElements, rows, flatArray.get());
 
     // transformed elements
     VectorPtr newElements;
@@ -73,7 +70,7 @@ class TransformFunction : public exec::VectorFunction {
 
       entry.callable->apply(
           elementRows,
-          finalSelection,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -52,11 +52,8 @@ class TransformKeysFunction : public exec::VectorFunction {
         flatMap->mapKeys(), flatMap->mapValues()};
     auto numKeys = flatMap->mapKeys()->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection = toElementRows<MapVector>(
-          numKeys, *context.finalSelection(), flatMap.get());
-    }
+    SelectivityVector validRowsInReusedResult =
+        toElementRows<MapVector>(numKeys, rows, flatMap.get());
 
     VectorPtr transformedKeys;
 
@@ -74,7 +71,7 @@ class TransformKeysFunction : public exec::VectorFunction {
 
       entry.callable->apply(
           keyRows,
-          finalSelection,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -51,11 +51,8 @@ class TransformValuesFunction : public exec::VectorFunction {
         flatMap->mapKeys(), flatMap->mapValues()};
     auto numValues = flatMap->mapValues()->size();
 
-    SelectivityVector finalSelection;
-    if (!context.isFinalSelection()) {
-      finalSelection = toElementRows<MapVector>(
-          numValues, *context.finalSelection(), flatMap.get());
-    }
+    SelectivityVector validRowsInReusedResult =
+        toElementRows<MapVector>(numValues, rows, flatMap.get());
 
     VectorPtr transformedValues;
 
@@ -73,7 +70,7 @@ class TransformValuesFunction : public exec::VectorFunction {
 
       entry.callable->apply(
           valueRows,
-          finalSelection,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -92,7 +92,7 @@ class ZipWithFunction : public exec::VectorFunction {
     auto* rawOffsets = resultBuffers.offsets->as<vector_size_t>();
     auto* rawSizes = resultBuffers.sizes->as<vector_size_t>();
 
-    const SelectivityVector allElementRows(numResultElements);
+    const SelectivityVector validRowsInReusedResult(numResultElements);
 
     VectorPtr newElements;
 
@@ -129,13 +129,9 @@ class ZipWithFunction : public exec::VectorFunction {
         });
       }
 
-      // Make sure already populated entries in newElements do not get
-      // overwritten.
-      exec::ScopedFinalSelectionSetter(context, &allElementRows, true, true);
-
       entry.callable->apply(
           elementRows,
-          allElementRows,
+          &validRowsInReusedResult,
           wrapCapture,
           &context,
           lambdaArgs,

--- a/velox/vector/FunctionVector.h
+++ b/velox/vector/FunctionVector.h
@@ -42,15 +42,17 @@ class Callable {
   /// function to elements of repeated types, so that the values of the
   /// arguments and captures are not aligned. This serves to align these. If
   /// nullptr, the captures are passed as is.
-  /// @param finalSelection It can be empty when context->isFinalSelection() is
-  /// true and must be a valid selectivity vector otherwise.
+  /// @param validRowsInReusedResult This selectivity vector is used to store
+  /// all valid rows in 'result' that can be reused between multiple Callables
+  /// in a function vector. It helps preserve rows that are valid in 'result'
+  /// but on which this callable does not apply.
   /// @param elementToTopLevelRows A mapping from element rows (i.e., the rows
   /// argument) to top-level rows of the complex-typed input of the lambda
   /// function. elementToTopLevelRows could be a nullptr, meaning the element
   /// rows are identical to top-level rows.
   virtual void apply(
       const SelectivityVector& rows,
-      const SelectivityVector& finalSelection,
+      const SelectivityVector* validRowsInReusedResult,
       const BufferPtr& wrapCapture,
       exec::EvalCtx* context,
       const std::vector<VectorPtr>& args,
@@ -61,7 +63,7 @@ class Callable {
   /// 'elementErrors', and errors in 'context' are not updated.
   virtual void applyNoThrow(
       const SelectivityVector& rows,
-      const SelectivityVector& finalSelection,
+      const SelectivityVector* validRowsInReusedResult,
       const BufferPtr& wrapCapture,
       exec::EvalCtx* context,
       const std::vector<VectorPtr>& args,


### PR DESCRIPTION
Summary:
Currently, final selection is passed down to lambdas via the lambda's context. However, since lambdas can take in both results from evaluated expressions and top level fields as input, the final selection rows don’t apply to the former as they can have different sizes or valid rows. The evaluation loop inside the lambda can therefore run into errors when it executed code that uses final selection and assumes the input row is a top level row that only contains fields/columns. This change fixes it by ensuring that all captured fields are loaded before executing the lambda and final selection is not passed down to it.

TODO cleanup:
Remove finalSelection being passed to ExprCallable::apply*

Differential Revision: D47417956

