### PR TITLE
Remove PARENT_SCOPE when setting VELOX_GTEST_INCUDE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -482,9 +482,7 @@ include_directories(SYSTEM velox/external/duckdb/tpch/dbgen/include)
 if(NOT VELOX_DISABLE_GOOGLETEST)
   set(gtest_SOURCE BUNDLED)
   resolve_dependency(gtest)
-  set(VELOX_GTEST_INCUDE_DIR
-      "${gtest_SOURCE_DIR}/googletest/include"
-      PARENT_SCOPE)
+  set(VELOX_GTEST_INCUDE_DIR "${gtest_SOURCE_DIR}/googletest/include")
 endif()
 
 set(xsimd_SOURCE BUNDLED)


### PR DESCRIPTION
Cmake was unable to set VELOX_GTEST_INCUDE_DIR on MacOSxSDK13.1 and the
subsequent build would fail to find the gtest header files. This commit
fixes the issue by removing the PARENT_SCOPE keyword.

Resolves https://github.com/facebookincubator/velox/issues/5630