### PR TITLE
Add support for aggregations over distinct inputs

### DIFF
--- a/velox/exec/AggregateInfo.h
+++ b/velox/exec/AggregateInfo.h
@@ -44,6 +44,10 @@ struct AggregateInfo {
   /// Optional list of sorting orders that goes with 'sortingKeys'.
   std::vector<core::SortOrder> sortingOrders;
 
+  /// Boolean indicating whether inputs must be de-duplicated before
+  /// aggregating.
+  bool distinct{false};
+
   /// Index of the result column in the output RowVector.
   column_index_t output;
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   AggregateWindow.cpp
   ArrowStream.cpp
   ContainerRowSerde.cpp
+  DistinctAggregations.cpp
   Driver.cpp
   EnforceSingleRow.cpp
   Exchange.cpp

--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/DistinctAggregations.h"
+#include "velox/exec/SetAccumulator.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+
+template <typename T>
+class TypedDistinctAggregations : public DistinctAggregations {
+ public:
+  TypedDistinctAggregations(
+      std::vector<AggregateInfo*> aggregates,
+      const RowTypePtr& inputType,
+      memory::MemoryPool* pool)
+      : aggregates_{std::move(aggregates)},
+        input_{aggregates_[0]->inputs[0]},
+        inputType_{inputType->childAt(input_)},
+        pool_{pool} {}
+
+  using AccumulatorType = aggregate::prestosql::SetAccumulator<T>;
+
+  /// Returns metadata about the accumulator used to store unique inputs.
+  Accumulator accumulator() const override {
+    return {
+        false, // isFixedSize
+        sizeof(AccumulatorType),
+        false, // usesExternalMemory
+        1, // alignment
+        [this](folly::Range<char**> groups) {
+          for (auto* group : groups) {
+            auto* accumulator =
+                reinterpret_cast<AccumulatorType*>(group + offset_);
+            accumulator->free(*allocator_);
+          }
+        }};
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    for (auto i : indices) {
+      groups[i][nullByte_] |= nullMask_;
+      new (groups[i] + offset_) AccumulatorType(inputType_, allocator_);
+    }
+
+    for (auto i = 0; i < aggregates_.size(); ++i) {
+      const auto& aggregate = *aggregates_[i];
+      aggregate.function->initializeNewGroups(groups, indices);
+    }
+  }
+
+  void addInput(
+      char** groups,
+      const RowVectorPtr& input,
+      const SelectivityVector& rows) override {
+    decodedInput_.decode(*input->childAt(input_), rows);
+
+    rows.applyToSelected([&](vector_size_t i) {
+      auto* group = groups[i];
+      auto* accumulator = reinterpret_cast<AccumulatorType*>(group + offset_);
+
+      RowSizeTracker<char, uint32_t> tracker(
+          group[rowSizeOffset_], *allocator_);
+      accumulator->addValue(decodedInput_, i, allocator_);
+    });
+  }
+
+  void addSingleGroupInput(
+      char* group,
+      const RowVectorPtr& input,
+      const SelectivityVector& rows) override {
+    decodedInput_.decode(*input->childAt(input_), rows);
+
+    auto* accumulator = reinterpret_cast<AccumulatorType*>(group + offset_);
+    RowSizeTracker<char, uint32_t> tracker(group[rowSizeOffset_], *allocator_);
+    rows.applyToSelected([&](vector_size_t i) {
+      accumulator->addValue(decodedInput_, i, allocator_);
+    });
+  }
+
+  void extractValues(folly::Range<char**> groups, const RowVectorPtr& result)
+      override {
+    SelectivityVector rows;
+    for (auto i = 0; i < aggregates_.size(); ++i) {
+      const auto& aggregate = *aggregates_[i];
+
+      // For each group, add distinct inputs to aggregate.
+      for (auto* group : groups) {
+        auto* accumulator = reinterpret_cast<AccumulatorType*>(group + offset_);
+
+        // TODO Process group rows in batches to avoid creating very large input
+        // vectors.
+        auto data = BaseVector::create(inputType_, accumulator->size(), pool_);
+        if constexpr (std::is_same_v<T, ComplexType>) {
+          accumulator->extractValues(*data, 0);
+        } else {
+          accumulator->extractValues(*(data->template as<FlatVector<T>>()), 0);
+        }
+
+        rows.resize(data->size());
+        aggregate.function->addSingleGroupRawInput(group, rows, {data}, false);
+      }
+
+      aggregate.function->extractValues(
+          groups.data(), groups.size(), &result->childAt(aggregate.output));
+
+      // Release memory back to HashStringAllocator to allow next
+      // aggregate to re-use it.
+      aggregate.function->destroy(groups);
+    }
+  }
+
+ private:
+  const std::vector<AggregateInfo*> aggregates_;
+  const column_index_t input_;
+  const TypePtr inputType_;
+  memory::MemoryPool* const pool_;
+
+  DecodedVector decodedInput_;
+};
+
+} // namespace
+
+// static
+std::unique_ptr<DistinctAggregations> DistinctAggregations::create(
+    std::vector<AggregateInfo*> aggregates,
+    const RowTypePtr& inputType,
+    memory::MemoryPool* pool) {
+  column_index_t input;
+
+  VELOX_CHECK(!aggregates.empty());
+  for (auto i = 0; i < aggregates.size(); ++i) {
+    auto* aggregate = aggregates[i];
+    VELOX_USER_CHECK_EQ(aggregate->inputs.size(), 1);
+    if (i == 0) {
+      input = aggregate->inputs[0];
+    } else {
+      VELOX_CHECK_EQ(input, aggregate->inputs[0]);
+    }
+  }
+
+  const auto type = inputType->childAt(input);
+
+  switch (type->kind()) {
+    case TypeKind::BOOLEAN:
+      return std::make_unique<TypedDistinctAggregations<bool>>(
+          aggregates, inputType, pool);
+    case TypeKind::TINYINT:
+      return std::make_unique<TypedDistinctAggregations<int8_t>>(
+          aggregates, inputType, pool);
+    case TypeKind::SMALLINT:
+      return std::make_unique<TypedDistinctAggregations<int16_t>>(
+          aggregates, inputType, pool);
+    case TypeKind::INTEGER:
+      return std::make_unique<TypedDistinctAggregations<int32_t>>(
+          aggregates, inputType, pool);
+    case TypeKind::BIGINT:
+      return std::make_unique<TypedDistinctAggregations<int64_t>>(
+          aggregates, inputType, pool);
+    case TypeKind::REAL:
+      return std::make_unique<TypedDistinctAggregations<float>>(
+          aggregates, inputType, pool);
+    case TypeKind::DOUBLE:
+      return std::make_unique<TypedDistinctAggregations<double>>(
+          aggregates, inputType, pool);
+    case TypeKind::TIMESTAMP:
+      return std::make_unique<TypedDistinctAggregations<Timestamp>>(
+          aggregates, inputType, pool);
+    case TypeKind::VARCHAR:
+      return std::make_unique<TypedDistinctAggregations<StringView>>(
+          aggregates, inputType, pool);
+    case TypeKind::ARRAY:
+    case TypeKind::MAP:
+    case TypeKind::ROW:
+      return std::make_unique<TypedDistinctAggregations<ComplexType>>(
+          aggregates, inputType, pool);
+    default:
+      VELOX_UNREACHABLE("Unexpected type {}", type->toString());
+  }
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/DistinctAggregations.h
+++ b/velox/exec/DistinctAggregations.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateInfo.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::velox::exec {
+
+/// Computes aggregations over de-duplicated inputs. Supports aggregations with
+/// single input column only.
+class DistinctAggregations {
+ public:
+  /// @param aggregates Non-empty list of
+  /// aggregates that require inputs to be de-duplicated. All
+  /// aggregates should have the same inputs.
+  /// Aggregates with multiple inputs are not supported.
+  /// @param inputType Input row type for the aggregation operator.
+  /// @param pool Memory pool.
+  static std::unique_ptr<DistinctAggregations> create(
+      std::vector<AggregateInfo*> aggregates,
+      const RowTypePtr& inputType,
+      memory::MemoryPool* pool);
+
+  virtual ~DistinctAggregations() = default;
+
+  virtual Accumulator accumulator() const = 0;
+
+  /// Aggregate-like APIs to aggregate input rows per group.
+  void setAllocator(HashStringAllocator* allocator) {
+    allocator_ = allocator;
+  }
+
+  void setOffsets(
+      int32_t offset,
+      int32_t nullByte,
+      uint8_t nullMask,
+      int32_t rowSizeOffset) {
+    offset_ = offset;
+    nullByte_ = nullByte;
+    nullMask_ = nullMask;
+    rowSizeOffset_ = rowSizeOffset;
+  }
+
+  virtual void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) = 0;
+
+  virtual void addInput(
+      char** groups,
+      const RowVectorPtr& input,
+      const SelectivityVector& rows) = 0;
+
+  virtual void addSingleGroupInput(
+      char* group,
+      const RowVectorPtr& input,
+      const SelectivityVector& rows) = 0;
+
+  /// Computes aggregations and stores results in the specified 'result' vector.
+  virtual void extractValues(
+      folly::Range<char**> groups,
+      const RowVectorPtr& result) = 0;
+
+ protected:
+  HashStringAllocator* allocator_;
+  int32_t offset_;
+  int32_t nullByte_;
+  uint8_t nullMask_;
+  int32_t rowSizeOffset_;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/AggregateInfo.h"
 #include "velox/exec/AggregationMasks.h"
+#include "velox/exec/DistinctAggregations.h"
 #include "velox/exec/HashTable.h"
 #include "velox/exec/SortedAggregations.h"
 #include "velox/exec/Spiller.h"
@@ -207,6 +208,7 @@ class GroupingSet {
   std::vector<AggregateInfo> aggregates_;
   AggregationMasks masks_;
   std::unique_ptr<SortedAggregations> sortedAggregations_;
+  std::vector<std::unique_ptr<DistinctAggregations>> distinctAggregations_;
 
   const bool ignoreNullKeys_;
 

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -110,6 +110,7 @@ HashAggregation::HashAggregation(
     const auto& aggregate = aggregationNode->aggregates()[i];
 
     AggregateInfo info;
+    info.distinct = aggregate.distinct;
     auto argTypes =
         populateAggregateInputs(aggregate, inputType->asRow(), info, pool());
 

--- a/velox/functions/prestosql/aggregates/tests/SumTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SumTest.cpp
@@ -600,5 +600,28 @@ TEST_F(SumTest, floatAggregateOverflow) {
   testAggregateOverflow<double, double>();
 }
 
+TEST_F(SumTest, distinct) {
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2, 1, 1, 2, 2}),
+      makeFlatVector<int32_t>({1, 1, 2, 2, 3, 1, 1, 1}),
+  });
+
+  createDuckDbTable({data});
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .singleAggregation({}, {"sum(distinct c1)"})
+                  .planNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults("SELECT sum(distinct c1) FROM tmp");
+
+  plan = PlanBuilder()
+             .values({data})
+             .singleAggregation({"c0"}, {"sum(distinct c1)"})
+             .planNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .assertResults("SELECT c0, sum(distinct c1) FROM tmp GROUP BY 1");
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Add support for queries like SELECT count(distinct x) FROM t.

Inputs are first accumulated into SetAccumulators. When all input has been
received, unique values are aggregated.