### PR TITLE
Add 'distinct' flag to AggregationNode::Aggregate

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -195,6 +195,10 @@ void AggregationNode::addDetails(std::stringstream& stream) const {
     }
     const auto& aggregate = aggregates_[i];
     stream << aggregateNames_[i] << " := " << aggregate.call->toString();
+    if (aggregate.distinct) {
+      stream << " distinct";
+    }
+
     if (aggregate.mask) {
       stream << " mask: " << aggregate.mask->name();
     }
@@ -297,6 +301,7 @@ folly::dynamic AggregationNode::Aggregate::serialize() const {
   }
   obj["sortingKeys"] = ISerializable::serialize(sortingKeys);
   obj["sortingOrders"] = serializeSortingOrders(sortingOrders);
+  obj["distinct"] = distinct;
   return obj;
 }
 
@@ -311,7 +316,9 @@ AggregationNode::Aggregate AggregationNode::Aggregate::deserialize(
   }
   auto sortingKeys = deserializeFields(obj["sortingKeys"], context);
   auto sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
-  return {call, mask, std::move(sortingKeys), std::move(sortingOrders)};
+  bool distinct = obj["distinct"].asBool();
+  return {
+      call, mask, std::move(sortingKeys), std::move(sortingOrders), distinct};
 }
 
 // static

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -508,6 +508,10 @@ class AggregationNode : public PlanNode {
     /// A list of sorting orders that goes together with 'sortingKeys'.
     std::vector<SortOrder> sortingOrders;
 
+    /// Boolean indicating whether inputs must be de-duplicated before
+    /// aggregating.
+    bool distinct{false};
+
     folly::dynamic serialize() const;
 
     static Aggregate deserialize(const folly::dynamic& obj, void* context);

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -79,6 +79,14 @@ TEST_F(PlanNodeSerdeTest, aggregation) {
              .planNode();
 
   testSerde(plan);
+
+  // Aggregation over distinct inputs.
+  plan = PlanBuilder()
+             .values({data_})
+             .singleAggregation({"c0"}, {"sum(distinct c1)", "avg(c1)"})
+             .planNode();
+
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, assignUniqueId) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -183,12 +183,17 @@ TEST_F(PlanNodeToStringTest, aggregation) {
   auto plan = PlanBuilder()
                   .values({data_})
                   .partialAggregation(
-                      {}, {"sum(c0) AS a", "avg(c1) AS b", "min(c2) AS c"})
+                      {},
+                      {"sum(c0) AS a",
+                       "avg(c1) AS b",
+                       "min(c2) AS c",
+                       "count(distinct c1)"})
                   .planNode();
 
   ASSERT_EQ("-- Aggregation\n", plan->toString());
   ASSERT_EQ(
-      "-- Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"])] -> a:BIGINT, b:ROW<\"\":DOUBLE,\"\":BIGINT>, c:BIGINT\n",
+      "-- Aggregation[PARTIAL a := sum(ROW[\"c0\"]), b := avg(ROW[\"c1\"]), c := min(ROW[\"c2\"]), a3 := count(ROW[\"c1\"]) distinct] "
+      "-> a:BIGINT, b:ROW<\"\":DOUBLE,\"\":BIGINT>, c:BIGINT, a3:BIGINT\n",
       plan->toString(true, false));
 
   // Global aggregation with masks.
@@ -212,12 +217,14 @@ TEST_F(PlanNodeToStringTest, aggregation) {
   // Group-by aggregation.
   plan = PlanBuilder()
              .values({data_})
-             .singleAggregation({"c0"}, {"sum(c1) AS a", "avg(c2) AS b"})
+             .singleAggregation(
+                 {"c0"}, {"sum(c1) AS a", "avg(c2) AS b", "count(distinct c2)"})
              .planNode();
 
   ASSERT_EQ("-- Aggregation\n", plan->toString());
   ASSERT_EQ(
-      "-- Aggregation[SINGLE [c0] a := sum(ROW[\"c1\"]), b := avg(ROW[\"c2\"])] -> c0:SMALLINT, a:BIGINT, b:DOUBLE\n",
+      "-- Aggregation[SINGLE [c0] a := sum(ROW[\"c1\"]), b := avg(ROW[\"c2\"]), a2 := count(ROW[\"c2\"]) distinct] "
+      "-> c0:SMALLINT, a:BIGINT, b:DOUBLE, a2:BIGINT\n",
       plan->toString(true, false));
 
   // Group-by aggregation with masks.

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -580,6 +580,8 @@ PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
       agg.mask = field(masks[i]);
     }
 
+    agg.distinct = untypedExpr.distinct;
+
     if (!untypedExpr.orderBy.empty()) {
       VELOX_CHECK(
           step == core::AggregationNode::Step::kSingle,


### PR DESCRIPTION
Allow to specify that aggregation should be applies to de-duplicated inputs.

PR #5632 adds the implementation.