### PR TITLE
Cancel Benchmark job on new commit

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,6 +28,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.repository }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Saves CI resources on repeated commits e.g. due to linting.

The group key influences which jobs will be canceled. By adding the workflow name we ensure that only other benchmark jobs will be canceled. `${{ github.head_ref || github.sha }}` Is necessary as this is run on `pull_request` and `push` as `head_ref` is the source branch for a PR but empty on `push` so we will not cancel consecutive runs on push to main as the commit sha is part of the key there instead of the branch name.

Closes #5623 