### PR TITLE
Fix a memory reservation rollback bug in growContinuous

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -93,8 +93,7 @@ void ContiguousAllocation::clear() {
 }
 
 MachinePageCount ContiguousAllocation::numPages() const {
-  return bits::roundUp(size_, AllocationTraits::kPageSize) /
-      AllocationTraits::kPageSize;
+  return AllocationTraits::numPages(size_);
 }
 
 std::optional<folly::Range<char*>> ContiguousAllocation::hugePageRange() const {

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -42,8 +42,15 @@ struct AllocationTraits {
     return numPages * kPageSize;
   }
 
-  static MachinePageCount numPages(uint64_t bytes) {
+  FOLLY_ALWAYS_INLINE static MachinePageCount numPages(uint64_t bytes) {
     return bits::roundUp(bytes, kPageSize) / kPageSize;
+  }
+
+  /// The number of pages in a huge page.
+  FOLLY_ALWAYS_INLINE static MachinePageCount numPagesInHugePage() {
+    VELOX_DCHECK_GE(kHugePageSize, kPageSize);
+    VELOX_DCHECK_EQ(kHugePageSize % kPageSize, 0);
+    return kHugePageSize / kPageSize;
   }
 };
 

--- a/velox/common/memory/AllocationPool.h
+++ b/velox/common/memory/AllocationPool.h
@@ -17,7 +17,7 @@
 
 #include "velox/common/memory/Memory.h"
 
-namespace facebook::velox {
+namespace facebook::velox::memory {
 // A set of Allocations holding the fixed width payload
 // rows. The Runs are filled to the end except for the last one. This
 // is used for iterating over the payload for rehashing, returning
@@ -28,9 +28,6 @@ namespace facebook::velox {
 class AllocationPool {
  public:
   static constexpr int32_t kMinPages = 16;
-  static constexpr int64_t kPageSize = memory::AllocationTraits::kPageSize;
-  static constexpr int64_t kHugePageSize =
-      memory::AllocationTraits::kHugePageSize;
 
   explicit AllocationPool(memory::MemoryPool* pool) : pool_(pool) {}
 
@@ -156,4 +153,4 @@ class AllocationPool {
   int64_t hugePageThreshold_{kDefaultHugePageThreshold};
 };
 
-} // namespace facebook::velox
+} // namespace facebook::velox::memory

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -433,7 +433,7 @@ class HashStringAllocator : public StreamArena {
   Header* FOLLY_NULLABLE currentHeader_ = nullptr;
 
   // Pool for getting new slabs.
-  AllocationPool pool_;
+  memory::AllocationPool pool_;
 
   // Map from pointer to size for large blocks allocated from pool().
   folly::F14FastMap<void*, size_t> allocationsFromPool_;

--- a/velox/common/memory/tests/AllocationPoolTest.cpp
+++ b/velox/common/memory/tests/AllocationPoolTest.cpp
@@ -40,7 +40,7 @@ class AllocationPoolTest : public testing::Test {
 
 TEST_F(AllocationPoolTest, hugePages) {
   constexpr int64_t kHugePageSize = memory::AllocationTraits::kHugePageSize;
-  auto allocationPool = std::make_unique<AllocationPool>(pool_.get());
+  auto allocationPool = std::make_unique<memory::AllocationPool>(pool_.get());
   allocationPool->setHugePageThreshold(128 << 10);
   int32_t counter = 0;
   for (;;) {

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -26,6 +26,10 @@ namespace facebook::velox::memory {
 
 class AllocationTest : public testing::Test {};
 
+TEST_F(AllocationTest, basic) {
+  ASSERT_EQ(AllocationTraits::numPagesInHugePage(), 512);
+}
+
 // This test is to verify that Allocation doesn't merge different append buffers
 // into the same PageRun even if two buffers are contiguous in memory space.
 TEST_F(AllocationTest, append) {

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -43,7 +43,7 @@ class BufferedInput {
         pool_{pool},
         maxMergeDistance_{maxMergeDistance},
         wsVRLoad_{wsVRLoad},
-        allocPool_{std::make_unique<AllocationPool>(&pool)} {}
+        allocPool_{std::make_unique<memory::AllocationPool>(&pool)} {}
 
   BufferedInput(
       std::shared_ptr<ReadFileInputStream> input,
@@ -54,7 +54,7 @@ class BufferedInput {
         pool_(pool),
         maxMergeDistance_{maxMergeDistance},
         wsVRLoad_{wsVRLoad},
-        allocPool_{std::make_unique<AllocationPool>(&pool)} {}
+        allocPool_{std::make_unique<memory::AllocationPool>(&pool)} {}
 
   BufferedInput(BufferedInput&&) = default;
   virtual ~BufferedInput() = default;
@@ -146,7 +146,7 @@ class BufferedInput {
  private:
   uint64_t maxMergeDistance_;
   std::optional<bool> wsVRLoad_;
-  std::unique_ptr<AllocationPool> allocPool_;
+  std::unique_ptr<memory::AllocationPool> allocPool_;
 
   // Regions enqueued for reading
   std::vector<velox::common::Region> regions_;

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -21,6 +21,8 @@ elseif(${VELOX_BUILD_TEST_UTILS})
   add_subdirectory(tests/utils)
 endif()
 
+include_directories(/opt/homebrew/opt/protobuf/include)
+
 add_library(
   velox_dwio_common
   BitConcatenation.cpp

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -407,7 +407,7 @@ void DwrfRowReader::startNextStripe() {
   auto dataType = getReader().getSchemaWithId();
   FlatMapContext flatMapContext;
   flatMapContext.keySelectionCallback = options_.getKeySelectionCallback();
-  AllocationPool pool(&getReader().getMemoryPool());
+  memory::AllocationPool pool(&getReader().getMemoryPool());
   StreamLabels streamLabels(pool);
 
   if (scanSpec) {

--- a/velox/dwio/dwrf/reader/StreamLabels.h
+++ b/velox/dwio/dwrf/reader/StreamLabels.h
@@ -22,17 +22,17 @@ namespace facebook::velox::dwrf {
 
 class StreamLabels {
  public:
-  explicit StreamLabels(AllocationPool& pool) : pool_(pool) {}
+  explicit StreamLabels(memory::AllocationPool& pool) : pool_(pool) {}
 
   StreamLabels append(std::string_view suffix) const;
 
   std::string_view label() const;
 
  private:
-  StreamLabels(AllocationPool& pool, std::string_view label)
+  StreamLabels(memory::AllocationPool& pool, std::string_view label)
       : pool_{pool}, label_{label} {}
 
-  AllocationPool& pool_;
+  memory::AllocationPool& pool_;
   std::string_view label_;
 };
 

--- a/velox/dwio/dwrf/test/ColumnWriterTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTests.cpp
@@ -338,7 +338,7 @@ void testDataTypeWriter(
     auto typeWithId = TypeWithId::create(rowType);
     auto reqType = typeWithId->childAt(0);
 
-    AllocationPool allocPool(pool.get());
+    memory::AllocationPool allocPool(pool.get());
     StreamLabels labels(allocPool);
     auto reader = ColumnReader::build(
         reqType,
@@ -925,7 +925,7 @@ void testMapWriter(
       TestStripeStreams streams(
           context, sf, rowType, &pool, returnFlatVector, structReaderContext);
       auto pool = addDefaultLeafMemoryPool();
-      AllocationPool allocPool(pool.get());
+      memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       const auto reader =
           ColumnReader::build(dataTypeWithId, dataTypeWithId, streams, labels);
@@ -1060,7 +1060,7 @@ void testMapWriterRow(
       TestStripeStreams streams(
           context, sf, rowType, &pool, returnFlatVector, structReaderContext);
       auto pool = addDefaultLeafMemoryPool();
-      AllocationPool allocPool(pool.get());
+      memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       const auto reader =
           ColumnReader::build(dataTypeWithId, dataTypeWithId, streams, labels);
@@ -2067,7 +2067,7 @@ struct IntegerColumnWriterTypedTestCase {
       }
 
       auto reqType = TypeWithId::create(rowType)->childAt(0);
-      AllocationPool allocPool(pool.get());
+      memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
           ColumnReader::build(reqType, reqType, streams, labels);
@@ -3301,7 +3301,7 @@ struct StringColumnWriterTestCase {
       }
 
       auto reqType = TypeWithId::create(rowType)->childAt(0);
-      AllocationPool allocPool(pool.get());
+      memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
           ColumnReader::build(reqType, reqType, streams, labels);
@@ -4373,7 +4373,7 @@ struct DictColumnWriterTestCase {
         .WillRepeatedly(Return(0));
     auto rowTypeWithId = TypeWithId::create(rowType);
     auto reqType = rowTypeWithId->childAt(0);
-    AllocationPool allocPool(pool.get());
+    memory::AllocationPool allocPool(pool.get());
     StreamLabels labels(allocPool);
     auto reader = ColumnReader::build(reqType, reqType, streams, labels);
     VectorPtr out;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1134,7 +1134,7 @@ TEST(TestReader, testUpcastBoolean) {
           HiveTypeParser().parse("struct<col0:int>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  AllocationPool allocPool(defaultPool.get());
+  memory::AllocationPool allocPool(defaultPool.get());
   StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
       TypeWithId::create(reqType),
@@ -1183,7 +1183,7 @@ TEST(TestReader, testUpcastIntDirect) {
 
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  AllocationPool allocPool(defaultPool.get());
+  memory::AllocationPool allocPool(defaultPool.get());
   StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
       TypeWithId::create(reqType),
@@ -1249,7 +1249,7 @@ TEST(TestReader, testUpcastIntDict) {
           HiveTypeParser().parse("struct<col0:bigint>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  AllocationPool allocPool(defaultPool.get());
+  memory::AllocationPool allocPool(defaultPool.get());
   StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
       TypeWithId::create(reqType),
@@ -1303,7 +1303,7 @@ TEST(TestReader, testUpcastFloat) {
           HiveTypeParser().parse("struct<col0:double>"));
   ColumnSelector cs(reqType, rowType);
   EXPECT_CALL(streams, getColumnSelectorProxy()).WillRepeatedly(Return(&cs));
-  AllocationPool allocPool(defaultPool.get());
+  memory::AllocationPool allocPool(defaultPool.get());
   StreamLabels labels(allocPool);
   std::unique_ptr<ColumnReader> reader = ColumnReader::build(
       TypeWithId::create(reqType),

--- a/velox/dwio/dwrf/test/StreamLabelsTests.cpp
+++ b/velox/dwio/dwrf/test/StreamLabelsTests.cpp
@@ -19,7 +19,7 @@
 #include "velox/dwio/dwrf/reader/StreamLabels.h"
 
 using namespace ::testing;
-using facebook::velox::AllocationPool;
+using facebook::velox::memory::AllocationPool;
 using namespace facebook::velox::dwrf;
 
 TEST(StreamLabelsTest, E2E) {

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -207,7 +207,7 @@ class ColumnReaderTestBase {
   virtual bool returnFlatVector() const = 0;
 
   MockStripeStreams streams_;
-  AllocationPool pool_;
+  memory::AllocationPool pool_;
   StreamLabels labels_;
   std::unique_ptr<ColumnReader> columnReader_;
   std::unique_ptr<SelectiveColumnReader> selectiveColumnReader_;

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -641,7 +641,7 @@ TEST(StripeStream, shareDictionary) {
       ss, getStreamProxy(2, Not(0), proto::Stream_Kind_DICTIONARY_DATA, _))
       .WillRepeatedly(Return(nullptr));
 
-  facebook::velox::AllocationPool allocPool(pool.get());
+  facebook::velox::memory::AllocationPool allocPool(pool.get());
   StreamLabels labels(allocPool);
   std::vector<std::function<facebook::velox::BufferPtr()>> dictInits{};
   dictInits.push_back(

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -71,7 +71,7 @@ class WriterContext : public CompressionBufferPool {
       handler_ = std::make_unique<encryption::EncryptionHandler>();
     }
     validateConfigs();
-    VLOG(1) << fmt::format("Compression config: {}", compression);
+    VLOG(2) << fmt::format("Compression config: {}", compression);
     compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
         *generalPool_, compressionBlockSize + PAGE_HEADER_SIZE);
   }

--- a/velox/exec/AggregateCompanionAdapter.cpp
+++ b/velox/exec/AggregateCompanionAdapter.cpp
@@ -157,7 +157,7 @@ int32_t AggregateCompanionAdapter::ExtractFunction::setOffset() const {
 }
 
 char** AggregateCompanionAdapter::ExtractFunction::allocateGroups(
-    AllocationPool& allocationPool,
+    memory::AllocationPool& allocationPool,
     const SelectivityVector& rows,
     uint64_t offsetInGroup) const {
   auto* groups =
@@ -197,7 +197,7 @@ void AggregateCompanionAdapter::ExtractFunction::apply(
     VectorPtr& result) const {
   // Set up data members of fn_.
   HashStringAllocator stringAllocator{context.pool()};
-  AllocationPool allocationPool{context.pool()};
+  memory::AllocationPool allocationPool{context.pool()};
   fn_->setAllocator(&stringAllocator);
 
   auto offset = setOffset();

--- a/velox/exec/AggregateCompanionAdapter.h
+++ b/velox/exec/AggregateCompanionAdapter.h
@@ -149,7 +149,7 @@ struct AggregateCompanionAdapter {
     int32_t setOffset() const;
 
     char** allocateGroups(
-        AllocationPool& allocationPool,
+        memory::AllocationPool& allocationPool,
         const SelectivityVector& rows,
         uint64_t offsetInGroup) const;
 

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -237,7 +237,7 @@ class GroupingSet {
   // Used to allocate memory for a single row accumulating results of global
   // aggregation
   HashStringAllocator stringAllocator_;
-  AllocationPool rows_;
+  memory::AllocationPool rows_;
   const bool isAdaptive_;
 
   bool noMoreInput_{false};

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -1136,7 +1136,7 @@ class RowContainer {
   char* FOLLY_NULLABLE firstFreeRow_ = nullptr;
   uint64_t numFreeRows_ = 0;
 
-  AllocationPool rows_;
+  memory::AllocationPool rows_;
   HashStringAllocator stringAllocator_;
 
   // Partition number for each row. Used only in parallel hash join build.


### PR DESCRIPTION
The recently added growContiguous doesn't rollback reservation
correctly if mapped memory capacity enforcement fails. It rollback
the number of pages instead of bytes.
This PR also covers all the failure cases in MmapAllocator plus some
minor code refactor in allocation objects and testing.