### PR TITLE
Make Accumulator(Aggregate*) constructor explicit

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -327,7 +327,7 @@ std::vector<Accumulator> GroupingSet::accumulators() {
   std::vector<Accumulator> accumulators;
   accumulators.reserve(aggregates_.size());
   for (auto& aggregate : aggregates_) {
-    accumulators.push_back(aggregate.function.get());
+    accumulators.push_back(Accumulator{aggregate.function.get()});
   }
 
   if (sortedAggregations_ != nullptr) {

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -36,7 +36,7 @@ class Accumulator {
       int32_t alignment,
       std::function<void(folly::Range<char**> groups)> destroyFunction);
 
-  Accumulator(Aggregate* aggregate);
+  explicit Accumulator(Aggregate* aggregate);
 
   bool isFixedSize() const;
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -96,7 +96,7 @@ StreamingAggregation::StreamingAggregation(
   std::vector<Accumulator> accumulators;
   accumulators.reserve(aggregates_.size());
   for (auto& aggregate : aggregates_) {
-    accumulators.push_back(aggregate.get());
+    accumulators.push_back(Accumulator{aggregate.get()});
   }
 
   rows_ = std::make_unique<RowContainer>(

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -556,7 +556,7 @@ TEST_P(HashTableTest, clear) {
       config);
 
   auto table = HashTable<true>::createForAggregation(
-      std::move(keyHashers), {{aggregate.get()}}, pool_.get());
+      std::move(keyHashers), {Accumulator{aggregate.get()}}, pool_.get());
   ASSERT_NO_THROW(table->clear());
 }
 


### PR DESCRIPTION
Implicit conversion of Aggregate* to Accumulator is surprising to the reader and
creates an impression that the code is wrong. Make this conversion explicit.