### PR TITLE
Unify 'Aggregation function not registered' errors

### DIFF
--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -246,7 +246,7 @@ TypePtr Aggregate::intermediateType(
     const std::vector<TypePtr>& argTypes) {
   auto signatures = getAggregateFunctionSignatures(name);
   if (!signatures.has_value()) {
-    VELOX_USER_FAIL("Aggregate function '{}' not registered", name);
+    VELOX_USER_FAIL("Aggregate function not registered: {}", name);
   }
   for (auto& signature : signatures.value()) {
     SignatureBinder binder(*signature, argTypes);

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -430,7 +430,7 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
   params.planNode = makePlan(missingFunc);
   VELOX_ASSERT_THROW(
       readCursor(params, [](Task*) {}),
-      "Aggregate function 'missing-function' not registered");
+      "Aggregate function not registered: missing-function");
 
   params.planNode = makePlan(wrongInputTypes);
   VELOX_ASSERT_THROW(
@@ -491,7 +491,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
   params.planNode = plan;
   VELOX_ASSERT_THROW(
       readCursor(params, [](Task*) {}),
-      "Aggregate function 'missing-lambda' not registered");
+      "Aggregate function not registered: missing-lambda");
 }
 
 TEST_F(AggregationTest, global) {


### PR DESCRIPTION
We used to throw 2 slightly different error messages for the same condition:

```
Aggregation function not registered: xxx

Aggregation function 'xxx' not registered
```