### PR TITLE
Add simple array_agg function

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -259,6 +259,7 @@ void deserializeOne<TypeKind::ROW>(
       deserializeSwitch(in, index, *child);
     }
   }
+  result.setNull(index, false);
 }
 
 // Reads the size, null flags and deserializes from 'in', appending to
@@ -293,6 +294,7 @@ void deserializeOne<TypeKind::ARRAY>(
   vector_size_t offset;
   auto size = deserializeArray(in, *array->elements(), offset);
   array->setOffsetAndSize(index, offset, size);
+  result.setNull(index, false);
 }
 
 template <>
@@ -312,6 +314,7 @@ void deserializeOne<TypeKind::MAP>(
   VELOX_CHECK_EQ(keySize, valueSize);
   VELOX_CHECK_EQ(keyOffset, valueOffset);
   map->setOffsetAndSize(index, keyOffset, keySize);
+  result.setNull(index, false);
 }
 
 void deserializeSwitch(

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1058,7 +1058,6 @@ void GroupingSet::toIntermediate(
       std::fill(firstGroup_.begin(), firstGroup_.end(), intermediateGroups_[0]);
       function->extractAccumulators(
           firstGroup_.data(), intermediateGroups_.size(), &aggregateVector);
-      function->clear();
       continue;
     }
 
@@ -1074,12 +1073,16 @@ void GroupingSet::toIntermediate(
         intermediateGroups_.data(),
         intermediateGroups_.size(),
         &aggregateVector);
-    function->clear();
   }
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
   }
+
+  // It's unnecessary to call function->clear() to reset the internal states of
+  // aggregation functions because toIntermediate() is already called at the end
+  // of HashAggregation::getOutput(). When toIntermediate() is called, the
+  // aggregaiton function instances won't be reused after it returns.
   tempVectors_.clear();
 }
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -233,10 +233,11 @@ add_executable(velox_aggregation_runner_test AggregationRunnerTest.cpp)
 target_link_libraries(velox_aggregation_runner_test velox_aggregation_fuzzer
                       velox_aggregates velox_vector_test_lib gtest gtest_main)
 
-add_library(velox_simple_aggregate SimpleAverageAggregate.cpp)
+add_library(velox_simple_aggregate SimpleAverageAggregate.cpp
+                                   SimpleArrayAggAggregate.cpp)
 
 target_link_libraries(velox_simple_aggregate velox_exec velox_expression
-                      velox_expression_functions)
+                      velox_expression_functions velox_aggregates)
 
 add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp)
 

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/exec/SimpleAggregateAdapter.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/tests/SimpleAggregateFunctionsRegistration.h"
 #include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
@@ -26,6 +27,8 @@ namespace facebook::velox::aggregate::test {
 namespace {
 
 const char* const kSimpleAvg = "simple_avg";
+const char* const kSimpleArrayAgg = "simple_array_agg";
+const char* const kSimpleCountNulls = "simple_count_nulls";
 
 class SimpleAverageAggregationTest : public AggregationTestBase {
  protected:
@@ -105,6 +108,288 @@ TEST_F(SimpleAverageAggregationTest, averageAggregate) {
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt})});
   expected = makeRowVector({makeNullableFlatVector<double>({std::nullopt})});
   testAggregations({inputVectors}, {}, {"simple_avg(c0)"}, {expected});
+}
+
+class SimpleArrayAggAggregationTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    disallowInputShuffle();
+
+    registerSimpleArrayAggAggregate(kSimpleArrayAgg);
+  }
+};
+
+TEST_F(SimpleArrayAggAggregationTest, numbers) {
+  auto inputVectors = makeRowVector(
+      {makeFlatVector<bool>(
+           {true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false,
+            true,
+            false}),
+       makeFlatVector<bool>(
+           {true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            true,
+            false,
+            false}),
+       makeNullableFlatVector<int64_t>(
+           {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::nullopt, std::nullopt}),
+       makeNullableFlatVector<double>(
+           {1.1,
+            2.2,
+            3.3,
+            4.4,
+            5.5,
+            6.6,
+            7.7,
+            8.8,
+            9.9,
+            11,
+            std::nullopt,
+            std::nullopt})});
+  auto expected = makeRowVector(
+      {makeNullableArrayVector<int64_t>(
+           {{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, std::nullopt, std::nullopt}}),
+       makeNullableArrayVector<double>(
+           {{1.1,
+             2.2,
+             3.3,
+             4.4,
+             5.5,
+             6.6,
+             7.7,
+             8.8,
+             9.9,
+             11,
+             std::nullopt,
+             std::nullopt}})});
+  testAggregations(
+      {inputVectors},
+      {},
+      {"simple_array_agg(c2)", "simple_array_agg(c3)"},
+      {expected});
+
+  expected = makeRowVector(
+      {makeFlatVector<bool>({true, false}),
+       makeNullableArrayVector<int64_t>(
+           {{1, 3, 5, 7, 9, std::nullopt}, {2, 4, 6, 8, 10, std::nullopt}}),
+       makeNullableArrayVector<double>(
+           {{1.1, 3.3, 5.5, 7.7, 9.9, std::nullopt},
+            {2.2, 4.4, 6.6, 8.8, 11, std::nullopt}})});
+  testAggregations(
+      {inputVectors},
+      {"c0"},
+      {"simple_array_agg(c2)", "simple_array_agg(c3)"},
+      {expected});
+
+  expected = makeRowVector(
+      {makeFlatVector<bool>({true, false}),
+       vectorMaker_.arrayVectorNullable<int64_t>(
+           {{{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}}, {{std::nullopt, std::nullopt}}}),
+       vectorMaker_.arrayVectorNullable<double>(
+           {{{1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9, 11}},
+            {{std::nullopt, std::nullopt}}})});
+  testAggregations(
+      {inputVectors},
+      {"c1"},
+      {"simple_array_agg(c2)", "simple_array_agg(c3)"},
+      {expected});
+
+  inputVectors = makeRowVector({makeNullableFlatVector<int64_t>(
+      {std::nullopt, std::nullopt, std::nullopt})});
+  expected = makeRowVector({vectorMaker_.arrayVectorNullable<int64_t>(
+      {{{std::nullopt, std::nullopt, std::nullopt}}})});
+  testAggregations({inputVectors}, {}, {"simple_array_agg(c0)"}, {expected});
+}
+
+TEST_F(SimpleArrayAggAggregationTest, nestedArray) {
+  auto inputVectors = makeRowVector(
+      {makeFlatVector<bool>({true, false, true, false, true, false}),
+       vectorMaker_.arrayVectorNullable<int32_t>(
+           {{{1, 2}},
+            {{3, 4}},
+            {{5, 6}},
+            {{7, 8}},
+            std::nullopt,
+            std::nullopt}),
+       vectorMaker_.arrayVectorNullable<StringView>(
+           {{{"1a", "2a"}},
+            {{"3a", "4a"}},
+            {{"5a", "6a"}},
+            {{"7a", "8a"}},
+            std::nullopt,
+            std::nullopt})});
+
+  auto expected = makeRowVector(
+      {makeFlatVector<bool>({true, false}),
+       makeNullableNestedArrayVector<int32_t>(
+           {{{{{1, 2}}, {{5, 6}}, std::nullopt}},
+            {{{{3, 4}}, {{7, 8}}, std::nullopt}}}),
+       makeNullableNestedArrayVector<StringView>(
+           {{{{{"1a", "2a"}}, {{"5a", "6a"}}, std::nullopt}},
+            {{{{"3a", "4a"}}, {{"7a", "8a"}}, std::nullopt}}})});
+  testAggregations(
+      {inputVectors},
+      {"c0"},
+      {"simple_array_agg(c1)", "simple_array_agg(c2)"},
+      {expected});
+
+  expected = makeRowVector(
+      {makeNullableNestedArrayVector<int32_t>(
+           {{{{{1, 2}},
+              {{3, 4}},
+              {{5, 6}},
+              {{7, 8}},
+              std::nullopt,
+              std::nullopt}}}),
+       makeNullableNestedArrayVector<StringView>(
+           {{{{{"1a", "2a"}},
+              {{"3a", "4a"}},
+              {{"5a", "6a"}},
+              {{"7a", "8a"}},
+              std::nullopt,
+              std::nullopt}}})});
+  testAggregations(
+      {inputVectors},
+      {},
+      {"simple_array_agg(c1)", "simple_array_agg(c2)"},
+      {expected});
+}
+
+// A testing aggregation function that counts the number of nulls in inputs.
+// Return NULL for a group if there is no input null in the group.
+class CountNullsAggregate {
+ public:
+  using InputType = Row<double>; // Input vector type wrapped in Row.
+  using IntermediateType = int64_t; // Intermediate result type.
+  using OutputType = int64_t; // Output vector type.
+
+  static constexpr bool default_null_behavior_ = false;
+
+  struct Accumulator {
+    int64_t nullsCount_;
+
+    Accumulator() = delete;
+
+    explicit Accumulator(HashStringAllocator* /*allocator*/) {
+      nullsCount_ = 0;
+    }
+
+    bool addInput(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<double> data) {
+      if (!data.has_value()) {
+        nullsCount_++;
+        return true;
+      }
+      return false;
+    }
+
+    bool combine(
+        HashStringAllocator* /*allocator*/,
+        exec::optional_arg_type<int64_t> nullsCount) {
+      if (nullsCount.has_value()) {
+        nullsCount_ += nullsCount.value();
+        return true;
+      }
+      return false;
+    }
+
+    bool writeFinalResult(bool nonNull, exec::out_type<OutputType>& out) {
+      return writeResult<OutputType>(nonNull, out);
+    }
+
+    bool writeIntermediateResult(
+        bool nonNull,
+        exec::out_type<IntermediateType>& out) {
+      return writeResult<IntermediateType>(nonNull, out);
+    }
+
+   private:
+    template <typename T>
+    bool writeResult(bool nonNull, exec::out_type<T>& out) {
+      if (nonNull) {
+        out = nullsCount_;
+        return true;
+      }
+      return false;
+    }
+  };
+
+  using AccumulatorType = Accumulator;
+};
+
+bool registerSimpleCountNullsAggregate(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("bigint")
+          .intermediateType("bigint")
+          .argumentType("double")
+          .build()};
+
+  exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_LE(
+            argTypes.size(), 1, "{} takes at most one argument", name);
+        return std::make_unique<SimpleAggregateAdapter<CountNullsAggregate>>(
+            resultType);
+      });
+  return true;
+}
+
+void registerSimpleCountNullsAggregate() {
+  registerSimpleCountNullsAggregate(kSimpleCountNulls);
+}
+
+class SimpleCountNullsAggregationTest : public AggregationTestBase {
+ protected:
+  SimpleCountNullsAggregationTest() {
+    registerSimpleCountNullsAggregate();
+  }
+};
+
+TEST_F(SimpleCountNullsAggregationTest, basic) {
+  auto vectors = makeRowVector(
+      {makeNullableFlatVector<bool>({true, false, true, false, true, false}),
+       makeNullableFlatVector<bool>({true, false, false, true, false, true}),
+       makeNullableFlatVector<double>(
+           {1.1, std::nullopt, std::nullopt, 4.4, std::nullopt, 5.5})});
+
+  auto expected = makeRowVector(
+      {makeNullableFlatVector<bool>({true, false}),
+       makeNullableFlatVector<int64_t>({2, 1})});
+  testAggregations({vectors}, {"c0"}, {"simple_count_nulls(c2)"}, {expected});
+
+  expected = makeRowVector(
+      {makeNullableFlatVector<bool>({true, false}),
+       makeNullableFlatVector<int64_t>({std::nullopt, 3})});
+  testAggregations({vectors}, {"c1"}, {"simple_count_nulls(c2)"}, {expected});
+
+  expected = makeRowVector({makeNullableFlatVector<int64_t>({3})});
+  testAggregations({vectors}, {}, {"simple_count_nulls(c2)"}, {expected});
 }
 
 } // namespace

--- a/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
+++ b/velox/exec/tests/SimpleAggregateFunctionsRegistration.h
@@ -25,4 +25,7 @@ namespace facebook::velox::aggregate {
 exec::AggregateRegistrationResult registerSimpleAverageAggregate(
     const std::string& name);
 
+exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
+    const std::string& name);
+
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/expression/FunctionSignature.h"
+#include "velox/expression/VectorWriters.h"
+#include "velox/functions/prestosql/aggregates/ValueList.h"
+
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::aggregate {
+
+namespace {
+
+// Write ValueList accumulators to Array-typed intermediate or final result
+// vectors.
+// TODO: This API only works if it is the only logic writing to `writer`.
+template <typename T>
+void copyValueListToArrayWriter(ArrayWriter<T>& writer, ValueList& elements) {
+  writer.resetLength();
+  auto size = elements.size();
+  if (size == 0) {
+    return;
+  }
+  writer.reserve(size);
+
+  ValueListReader reader(elements);
+  for (vector_size_t i = 0; i < size; ++i) {
+    reader.next(*writer.elementsVector(), writer.valuesOffset() + i);
+    writer.elementsVector()->setNull(
+        writer.valuesOffset() + i,
+        writer.elementsVector()->isNullAt(writer.valuesOffset() + i));
+  }
+  writer.resize(size);
+}
+
+class ArrayAggAggregate {
+ public:
+  // Type(s) of input vector(s) wrapped in Row.
+  using InputType = Row<Generic<T1>>;
+
+  // Type of intermediate result vector.
+  using IntermediateType = Array<Generic<T1>>;
+
+  // Type of output vector.
+  using OutputType = Array<Generic<T1>>;
+
+  static constexpr bool default_null_behavior_ = false;
+
+  struct AccumulatorType {
+    ValueList elements_;
+
+    AccumulatorType() = delete;
+
+    // Constructor used in initializeNewGroups().
+    explicit AccumulatorType(HashStringAllocator* /*allocator*/)
+        : elements_{} {}
+
+    static constexpr bool is_fixed_size_ = false;
+
+    // addInput expects one parameter of exec::optional_arg_type<T> for each
+    // child-type T wrapped in InputType.
+    bool addInput(
+        HashStringAllocator* allocator,
+        exec::optional_arg_type<Generic<T1>> data) {
+      elements_.appendValue(data, allocator);
+      return true;
+    }
+
+    // combine expects one parameter of
+    // exec::optional_arg_type<IntermediateType>.
+    bool combine(
+        HashStringAllocator* allocator,
+        exec::optional_arg_type<Array<Generic<T1>>> other) {
+      if (!other.has_value()) {
+        return true;
+      }
+      for (auto element : other.value()) {
+        elements_.appendValue(element, allocator);
+      }
+      return true;
+    }
+
+    bool writeFinalResult(
+        bool nonNullGroup,
+        exec::out_type<Array<Generic<T1>>>& out) {
+      if (!nonNullGroup || elements_.size() == 0) {
+        return false;
+      }
+      copyValueListToArrayWriter(out, elements_);
+      return true;
+    }
+
+    bool writeIntermediateResult(
+        bool nonNullGroup,
+        exec::out_type<Array<Generic<T1>>>& out) {
+      // If the group's accumulator is null, the corresponding intermediate
+      // result is null too.
+      if (!nonNullGroup || elements_.size() == 0) {
+        return false;
+      }
+      copyValueListToArrayWriter(out, elements_);
+      return true;
+    }
+
+    void destroy(HashStringAllocator* allocator) {
+      elements_.free(allocator);
+    }
+  };
+};
+
+} // namespace
+
+exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
+    const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
+      exec::AggregateFunctionSignatureBuilder()
+          .typeVariable("E")
+          .returnType("array(E)")
+          .intermediateType("array(E)")
+          .argumentType("E")
+          .build()};
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step /*step*/,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_EQ(
+            argTypes.size(), 1, "{} takes at most one argument", name);
+        return std::make_unique<SimpleAggregateAdapter<ArrayAggAggregate>>(
+            resultType);
+      });
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1077,6 +1077,14 @@ class GenericView {
     return decoded_.base()->hashValueAt(decodedIndex());
   }
 
+  bool isNull() const {
+    return decoded_.isNullAt(index_);
+  }
+
+  const BaseVector* base() const {
+    return decoded_.base();
+  }
+
   bool operator==(const GenericView& other) const {
     return decoded_.base()->equalValueAt(
         other.decoded_.base(), decodedIndex(), other.decodedIndex());

--- a/velox/expression/ComplexWriterTypes.h
+++ b/velox/expression/ComplexWriterTypes.h
@@ -212,6 +212,16 @@ class ArrayWriter {
     add_items(data);
   }
 
+  // Don't mutate elementVecotr_ through this API unless you know what you're
+  // doing.
+  typename child_writer_t::vector_t* elementsVector() {
+    return elementsVector_;
+  }
+
+  vector_size_t valuesOffset() const {
+    return valuesOffset_;
+  }
+
   // Any vector type with std-like optional-free interface.
   template <typename VectorType>
   void add_items(const VectorType& data) {

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -48,6 +48,7 @@ target_link_libraries(
   velox_aggregates
   velox_common_hyperloglog
   velox_exec
+  velox_expression
   velox_presto_serializer
   velox_functions_aggregates
   velox_functions_lib

--- a/velox/functions/prestosql/aggregates/ValueList.h
+++ b/velox/functions/prestosql/aggregates/ValueList.h
@@ -18,6 +18,7 @@
 
 #include "velox/common/memory/HashStringAllocator.h"
 #include "velox/exec/Aggregate.h"
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/DecodedVector.h"
 
@@ -32,6 +33,18 @@ class ValueList {
       const DecodedVector& decoded,
       vector_size_t index,
       HashStringAllocator* allocator);
+
+  template <typename T>
+  void appendValue(
+      const exec::OptionalAccessor<Generic<T>>& value,
+      HashStringAllocator* allocator) {
+    if (!value.has_value()) {
+      appendNull(allocator);
+    } else {
+      VELOX_DCHECK(!value->isNull());
+      appendNonNull(*value->base(), value->decodedIndex(), allocator);
+    }
+  }
 
   void appendRange(
       const VectorPtr& vector,

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/tests/SimpleAggregateFunctionsRegistration.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -27,271 +28,314 @@ namespace facebook::velox::aggregate::test {
 
 namespace {
 
-class ArrayAggTest : public AggregationTestBase {};
+class ArrayAggTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+
+    registerSimpleArrayAggAggregate("simple_array_agg");
+  }
+};
 
 TEST_F(ArrayAggTest, groupBy) {
-  constexpr int32_t kNumGroups = 10;
-  std::vector<RowVectorPtr> batches;
-  // We make 10 groups. each with 10 arrays. Each array consists of n
-  // arrays of varchar. These 10 groups are repeated 10 times. The
-  // expected result is that there is, for each key, an array of 100
-  // elements with, for key k, batch[k[, batch[k + 10], ... batch[k +
-  // 90], repeated 10 times.
-  batches.push_back(
-      std::static_pointer_cast<RowVector>(velox::test::BatchMaker::createBatch(
-          ROW({"c0", "a"}, {INTEGER(), ARRAY(VARCHAR())}), 100, *pool_)));
-  // We divide the rows into 10 groups.
-  auto keys = batches[0]->childAt(0)->as<FlatVector<int32_t>>();
-  for (auto i = 0; i < keys->size(); ++i) {
-    if (i % 10 == 0) {
-      keys->setNull(i, true);
-    } else {
-      keys->set(i, i % kNumGroups);
+  auto testFunction = [this](const std::string& functionName) {
+    constexpr int32_t kNumGroups = 10;
+    std::vector<RowVectorPtr> batches;
+    // We make 10 groups. each with 10 arrays. Each array consists of n
+    // arrays of varchar. These 10 groups are repeated 10 times. The
+    // expected result is that there is, for each key, an array of 100
+    // elements with, for key k, batch[k[, batch[k + 10], ... batch[k +
+    // 90], repeated 10 times.
+    batches.push_back(std::static_pointer_cast<RowVector>(
+        velox::test::BatchMaker::createBatch(
+            ROW({"c0", "a"}, {INTEGER(), ARRAY(VARCHAR())}), 100, *pool_)));
+    // We divide the rows into 10 groups.
+    auto keys = batches[0]->childAt(0)->as<FlatVector<int32_t>>();
+    for (auto i = 0; i < keys->size(); ++i) {
+      if (i % 10 == 0) {
+        keys->setNull(i, true);
+      } else {
+        keys->set(i, i % kNumGroups);
+      }
     }
-  }
-  // We make 10 repeats of the first batch.
-  for (auto i = 0; i < 9; ++i) {
-    batches.push_back(batches[0]);
-  }
+    // We make 10 repeats of the first batch.
+    for (auto i = 0; i < 9; ++i) {
+      batches.push_back(batches[0]);
+    }
 
-  createDuckDbTable(batches);
-  testAggregations(
-      batches,
-      {"c0"},
-      {"array_agg(a)"},
-      "SELECT c0, array_agg(a) FROM tmp GROUP BY c0");
+    createDuckDbTable(batches);
+    testAggregations(
+        batches,
+        {"c0"},
+        {"array_agg(a)"},
+        "SELECT c0, array_agg(a) FROM tmp GROUP BY c0");
 
-  // Having one function supporting toIntermediate and one does not, make sure
-  // the row container is recreated with only the function wihtout
-  // toIntermediate support.
-  testAggregations(
-      batches,
-      {"c0"},
-      {"array_agg(a)", "max(c0)"},
-      "SELECT c0, array_agg(a), max(c0) FROM tmp GROUP BY c0");
+    // Having one function supporting toIntermediate and one does not, make sure
+    // the row container is recreated with only the function wihtout
+    // toIntermediate support.
+    testAggregations(
+        batches,
+        {"c0"},
+        {fmt::format("{}(a)", functionName), "max(c0)"},
+        "SELECT c0, array_agg(a), max(c0) FROM tmp GROUP BY c0");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 TEST_F(ArrayAggTest, sortedGroupBy) {
-  auto data = makeRowVector({
-      makeFlatVector<int16_t>({1, 1, 2, 2, 1, 2, 1}),
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
-      makeFlatVector<int32_t>({11, 44, 22, 55, 33, 66, 77}),
-  });
+  auto testFunction = [this](const std::string& functionName) {
+    auto data = makeRowVector({
+        makeFlatVector<int16_t>({1, 1, 2, 2, 1, 2, 1}),
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
+        makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
+        makeFlatVector<int32_t>({11, 44, 22, 55, 33, 66, 77}),
+    });
 
-  createDuckDbTable({data});
+    createDuckDbTable({data});
 
-  // Sorted aggregations over same inputs.
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .singleAggregation(
-                      {"c0"},
-                      {
-                          "sum(c1)",
-                          "array_agg(c1 ORDER BY c2 DESC)",
-                          "avg(c1)",
-                          "array_agg(c1 ORDER BY c3)",
-                      })
-                  .planNode();
+    // Sorted aggregations over same inputs.
+    auto plan =
+        PlanBuilder()
+            .values({data})
+            .singleAggregation(
+                {"c0"},
+                {
+                    "sum(c1)",
+                    fmt::format("{}(c1 ORDER BY c2 DESC)", functionName),
+                    "avg(c1)",
+                    fmt::format("{}(c1 ORDER BY c3)", functionName),
+                })
+            .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT c0, sum(c1), array_agg(c1 ORDER BY c2 DESC), avg(c1), array_agg(c1 ORDER BY c3) "
-          " FROM tmp GROUP BY 1");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT c0, sum(c1), array_agg(c1 ORDER BY c2 DESC), avg(c1), array_agg(c1 ORDER BY c3) "
+            " FROM tmp GROUP BY 1");
 
-  // Sorted aggregations over different inputs.
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation(
-                 {"c0"},
-                 {
-                     "array_agg(c1 ORDER BY c2 DESC)",
-                     "avg(c1)",
-                     "array_agg(c2 ORDER BY c3)",
-                     "sum(c1)",
-                 })
-             .planNode();
+    // Sorted aggregations over different inputs.
+    plan = PlanBuilder()
+               .values({data})
+               .singleAggregation(
+                   {"c0"},
+                   {
+                       fmt::format("{}(c1 ORDER BY c2 DESC)", functionName),
+                       "avg(c1)",
+                       fmt::format("{}(c2 ORDER BY c3)", functionName),
+                       "sum(c1)",
+                   })
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT c0, array_agg(c1 ORDER BY c2 DESC), avg(c1), array_agg(c2 ORDER BY c3), sum(c1) "
-          " FROM tmp GROUP BY 1");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT c0, array_agg(c1 ORDER BY c2 DESC), avg(c1), array_agg(c2 ORDER BY c3), sum(c1) "
+            " FROM tmp GROUP BY 1");
 
-  // Sorted aggregation with multiple sorting keys.
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation(
-                 {"c0"},
-                 {
-                     "array_agg(c1 ORDER BY c2 DESC, c3)",
-                     "sum(c1)",
-                 })
-             .planNode();
+    // Sorted aggregation with multiple sorting keys.
+    plan = PlanBuilder()
+               .values({data})
+               .singleAggregation(
+                   {"c0"},
+                   {
+                       fmt::format("{}(c1 ORDER BY c2 DESC, c3)", functionName),
+                       "sum(c1)",
+                   })
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT c0, array_agg(c1 ORDER BY c2 DESC, c3), sum(c1) "
-          " FROM tmp GROUP BY 1");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT c0, array_agg(c1 ORDER BY c2 DESC, c3), sum(c1) "
+            " FROM tmp GROUP BY 1");
 
-  // Sorted aggregation with mask.
-  plan = PlanBuilder()
-             .values({data})
-             .project({"c0", "c1", "c2", "c1 % 2 = 1 as m"})
-             .singleAggregation(
-                 {"c0"},
-                 {
-                     "array_agg(c1 ORDER BY c2 DESC)",
-                     "sum(c1)",
-                 },
-                 {"m", "m"})
-             .planNode();
+    // Sorted aggregation with mask.
+    plan = PlanBuilder()
+               .values({data})
+               .project({"c0", "c1", "c2", "c1 % 2 = 1 as m"})
+               .singleAggregation(
+                   {"c0"},
+                   {
+                       fmt::format("{}(c1 ORDER BY c2 DESC)", functionName),
+                       "sum(c1)",
+                   },
+                   {"m", "m"})
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT c0, array_agg(c1 ORDER BY c2 DESC) FILTER (WHERE c1 % 2 = 1), sum(c1)  FILTER (WHERE c1 % 2 = 1)"
-          " FROM tmp GROUP BY 1");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT c0, array_agg(c1 ORDER BY c2 DESC) FILTER (WHERE c1 % 2 = 1), sum(c1)  FILTER (WHERE c1 % 2 = 1)"
+            " FROM tmp GROUP BY 1");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 TEST_F(ArrayAggTest, global) {
-  vector_size_t size = 10;
+  auto testFunction = [this](const std::string& functionName) {
+    vector_size_t size = 10;
 
-  std::vector<RowVectorPtr> vectors = {makeRowVector({makeFlatVector<int32_t>(
-      size, [](vector_size_t row) { return row * 2; }, nullEvery(3))})};
+    std::vector<RowVectorPtr> vectors = {makeRowVector({makeFlatVector<int32_t>(
+        size, [](vector_size_t row) { return row * 2; }, nullEvery(3))})};
 
-  createDuckDbTable(vectors);
-  testAggregations(
-      vectors, {}, {"array_agg(c0)"}, "SELECT array_agg(c0) FROM tmp");
+    createDuckDbTable(vectors);
+    testAggregations(
+        vectors,
+        {},
+        {fmt::format("{}(c0)", functionName)},
+        "SELECT array_agg(c0) FROM tmp");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 TEST_F(ArrayAggTest, globalNoData) {
-  auto data = makeRowVector(ROW({"c0"}, {INTEGER()}), 0);
+  auto testFunction = [this](const std::string& functionName) {
+    auto data = makeRowVector(ROW({"c0"}, {INTEGER()}), 0);
 
-  testAggregations({data}, {}, {"array_agg(c0)"}, "SELECT null");
+    testAggregations(
+        {data}, {}, {fmt::format("{}(c0)", functionName)}, "SELECT null");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 TEST_F(ArrayAggTest, sortedGlobal) {
-  auto data = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
-      makeFlatVector<int32_t>({11, 33, 22, 44, 66, 55, 77}),
-  });
+  auto testFunction = [this](const std::string& functionName) {
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
+        makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
+        makeFlatVector<int32_t>({11, 33, 22, 44, 66, 55, 77}),
+    });
 
-  createDuckDbTable({data});
+    createDuckDbTable({data});
 
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .singleAggregation(
-                      {},
-                      {
-                          "sum(c0)",
-                          "array_agg(c0 ORDER BY c1 DESC)",
-                          "avg(c0)",
-                          "array_agg(c0 ORDER BY c2)",
-                      })
-                  .planNode();
+    auto plan =
+        PlanBuilder()
+            .values({data})
+            .singleAggregation(
+                {},
+                {
+                    "sum(c0)",
+                    fmt::format("{}(c0 ORDER BY c1 DESC)", functionName),
+                    "avg(c0)",
+                    fmt::format("{}(c0 ORDER BY c2)", functionName),
+                })
+            .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), avg(c0), array_agg(c0 ORDER BY c2) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), avg(c0), array_agg(c0 ORDER BY c2) FROM tmp");
 
-  // Sorted aggregations over different inputs.
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation(
-                 {},
-                 {
-                     "sum(c0)",
-                     "array_agg(c0 ORDER BY c1 DESC)",
-                     "avg(c0)",
-                     "array_agg(c1 ORDER BY c2)",
-                 })
-             .planNode();
+    // Sorted aggregations over different inputs.
+    plan = PlanBuilder()
+               .values({data})
+               .singleAggregation(
+                   {},
+                   {
+                       "sum(c0)",
+                       fmt::format("{}(c0 ORDER BY c1 DESC)", functionName),
+                       "avg(c0)",
+                       fmt::format("{}(c1 ORDER BY c2)", functionName),
+                   })
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), avg(c0), array_agg(c1 ORDER BY c2) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), avg(c0), array_agg(c1 ORDER BY c2) FROM tmp");
 
-  // Sorted aggregation with multiple sorting keys.
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation(
-                 {},
-                 {
-                     "sum(c0)",
-                     "array_agg(c0 ORDER BY c1 DESC, c2)",
-                 })
-             .planNode();
+    // Sorted aggregation with multiple sorting keys.
+    plan = PlanBuilder()
+               .values({data})
+               .singleAggregation(
+                   {},
+                   {
+                       "sum(c0)",
+                       fmt::format("{}(c0 ORDER BY c1 DESC, c2)", functionName),
+                   })
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC, c2) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC, c2) FROM tmp");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 TEST_F(ArrayAggTest, sortedGlobalWithMask) {
-  auto data = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
-      makeFlatVector<int32_t>({11, 33, 22, 44, 66, 55, 77}),
-  });
+  auto testFunction = [this](const std::string& functionName) {
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6, 7}),
+        makeFlatVector<int64_t>({10, 20, 30, 40, 50, 60, 70}),
+        makeFlatVector<int32_t>({11, 33, 22, 44, 66, 55, 77}),
+    });
 
-  createDuckDbTable({data});
+    createDuckDbTable({data});
 
-  auto plan =
-      PlanBuilder()
-          .values({data})
-          .project({"c0", "c1", "c2", "c0 % 2 = 1 as m1", "c0 % 3 = 0 as m2"})
-          .singleAggregation(
-              {},
-              {
-                  "sum(c0)",
-                  "array_agg(c0 ORDER BY c1 DESC)",
-                  "array_agg(c0 ORDER BY c2)",
-              },
-              {"", "m1", "m2"})
-          .planNode();
+    auto plan =
+        PlanBuilder()
+            .values({data})
+            .project({"c0", "c1", "c2", "c0 % 2 = 1 as m1", "c0 % 3 = 0 as m2"})
+            .singleAggregation(
+                {},
+                {
+                    "sum(c0)",
+                    fmt::format("{}(c0 ORDER BY c1 DESC)", functionName),
+                    fmt::format("{}(c0 ORDER BY c2)", functionName),
+                },
+                {"", "m1", "m2"})
+            .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC) FILTER (WHERE c0 % 2 = 1), array_agg(c0 ORDER BY c2) FILTER (WHERE c0 % 3 = 0) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC) FILTER (WHERE c0 % 2 = 1), array_agg(c0 ORDER BY c2) FILTER (WHERE c0 % 3 = 0) FROM tmp");
 
-  // No rows excluded by the mask.
-  plan = PlanBuilder()
-             .values({data})
-             .project({"c0", "c1", "c2", "c0 > 0 as m1"})
-             .singleAggregation(
-                 {},
-                 {
-                     "sum(c0)",
-                     "array_agg(c0 ORDER BY c1 DESC)",
-                     "array_agg(c0 ORDER BY c2)",
-                 },
-                 {
-                     "",
-                     "m1",
-                 })
-             .planNode();
+    // No rows excluded by the mask.
+    plan = PlanBuilder()
+               .values({data})
+               .project({"c0", "c1", "c2", "c0 > 0 as m1"})
+               .singleAggregation(
+                   {},
+                   {
+                       "sum(c0)",
+                       fmt::format("{}(c0 ORDER BY c1 DESC)", functionName),
+                       fmt::format("{}(c0 ORDER BY c2)", functionName),
+                   },
+                   {
+                       "",
+                       "m1",
+                   })
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), array_agg(c0 ORDER BY c2) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC), array_agg(c0 ORDER BY c2) FROM tmp");
 
-  // All rows are excluded by the mask.
-  plan = PlanBuilder()
-             .values({data})
-             .project({"c0", "c1", "c2", "c0 < 0 as m1", "c0 % 3 = 0 as m2"})
-             .singleAggregation(
-                 {},
-                 {
-                     "sum(c0)",
-                     "array_agg(c0 ORDER BY c1 DESC)",
-                     "array_agg(c0 ORDER BY c2)",
-                 },
-                 {"", "m1", "m2"})
-             .planNode();
+    // All rows are excluded by the mask.
+    plan = PlanBuilder()
+               .values({data})
+               .project({"c0", "c1", "c2", "c0 < 0 as m1", "c0 % 3 = 0 as m2"})
+               .singleAggregation(
+                   {},
+                   {
+                       "sum(c0)",
+                       fmt::format("{}(c0 ORDER BY c1 DESC)", functionName),
+                       fmt::format("{}(c0 ORDER BY c2)", functionName),
+                   },
+                   {"", "m1", "m2"})
+               .planNode();
 
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .assertResults(
-          "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC) FILTER (WHERE c1 < 0), array_agg(c0 ORDER BY c2) FILTER (WHERE c1 % 3 = 0) FROM tmp");
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .assertResults(
+            "SELECT sum(c0), array_agg(c0 ORDER BY c1 DESC) FILTER (WHERE c1 < 0), array_agg(c0 ORDER BY c2) FILTER (WHERE c1 % 3 = 0) FROM tmp");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 namespace {
@@ -308,49 +352,60 @@ std::vector<RowVectorPtr> split(const RowVectorPtr& data) {
 } // namespace
 
 TEST_F(ArrayAggTest, mask) {
-  // Global aggregation with all-false mask.
-  auto data = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-      makeConstant(false, 5),
-  });
+  auto testFunction = [this](const std::string& functionName) {
+    // Global aggregation with all-false mask.
+    auto data = makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+        makeConstant(false, 5),
+    });
 
-  testAggregations(
-      split(data), {}, {"array_agg(c0) FILTER (WHERE c1)"}, "SELECT null");
+    testAggregations(
+        split(data),
+        {},
+        {fmt::format("{}(c0) FILTER (WHERE c1)", functionName)},
+        "SELECT null");
 
-  // Global aggregation with a non-constant mask.
-  data = makeRowVector({
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-      makeFlatVector<bool>({true, false, true, false, true}),
-  });
+    // Global aggregation with a non-constant mask.
+    data = makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+        makeFlatVector<bool>({true, false, true, false, true}),
+    });
 
-  testAggregations(
-      split(data), {}, {"array_agg(c0) FILTER (WHERE c1)"}, "SELECT [1, 3, 5]");
+    testAggregations(
+        split(data),
+        {},
+        {fmt::format("{}(c0) FILTER (WHERE c1)", functionName)},
+        "SELECT [1, 3, 5]");
 
-  // Group-by with all-false mask.
-  data = makeRowVector({
-      makeFlatVector<int64_t>({10, 20, 10, 20, 20}),
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-      makeConstant(false, 5),
-  });
+    // Group-by with all-false mask.
+    data = makeRowVector({
+        makeFlatVector<int64_t>({10, 20, 10, 20, 20}),
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+        makeConstant(false, 5),
+    });
 
-  testAggregations(
-      split(data),
-      {"c0"},
-      {"array_agg(c1) FILTER (WHERE c2)"},
-      "VALUES (10, null), (20, null)");
+    testAggregations(
+        split(data),
+        {"c0"},
+        {fmt::format("{}(c1) FILTER (WHERE c2)", functionName)},
+        "VALUES (10, null), (20, null)");
 
-  // Group-by with a non-constant mask.
-  data = makeRowVector({
-      makeFlatVector<int64_t>({10, 20, 10, 20, 20}),
-      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
-      makeFlatVector<bool>({true, false, true, false, true}),
-  });
+    // Group-by with a non-constant mask.
+    data = makeRowVector({
+        makeFlatVector<int64_t>({10, 20, 10, 20, 20}),
+        makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+        makeFlatVector<bool>({true, false, true, false, true}),
+    });
 
-  testAggregations(
-      split(data),
-      {"c0"},
-      {"array_agg(c1) FILTER (WHERE c2)"},
-      "VALUES (10, [1, 3]), (20, [5])");
+    testAggregations(
+        split(data),
+        {"c0"},
+        {fmt::format("{}(c1) FILTER (WHERE c2)", functionName)},
+        "VALUES (10, [1, 3]), (20, [5])");
+  };
+
+  testFunction("array_agg");
+  testFunction("simple_array_agg");
 }
 
 } // namespace

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -33,6 +33,13 @@ class ValueListTest : public functions::test::FunctionBaseTest {
   read(aggregate::ValueList& values, const TypePtr& type, vector_size_t size) {
     aggregate::ValueListReader reader(values);
     auto result = BaseVector::create(type, size, pool());
+
+    // Initialize result to all-nulls to ensure ValueListReader::next() reset
+    // null bits correctly.
+    for (auto i = 0; i < size; ++i) {
+      result->setNull(i, true);
+    }
+
     for (auto i = 0; i < size; i++) {
       reader.next(*result, i);
     }


### PR DESCRIPTION
Summary: Test the SimpleAggregateAdapter with array_agg function that has non-default-null behavior. Also test the non-default-null behavior with a synthetic UDAF simple_count_nulls.

Differential Revision: D47166258

