### PR TITLE
Executor not found when resuming a single-thread-execution task during memory reclaiming procedure

### DIFF
--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -67,11 +67,13 @@ class QueryCtx {
     return cache_;
   }
 
+  bool isExecutorSupplied() const {
+    auto executor = executorOrNull();
+    return executor != nullptr;
+  }
+
   folly::Executor* executor() const {
-    if (executor_ != nullptr) {
-      return executor_;
-    }
-    auto executor = executorKeepalive_.get();
+    auto executor = executorOrNull();
     VELOX_CHECK(executor, "Executor was not supplied.");
     return executor;
   }
@@ -128,6 +130,14 @@ class QueryCtx {
       pool_ = memory::defaultMemoryManager().addRootPool(
           QueryCtx::generatePoolName(queryId));
     }
+  }
+
+  folly::Executor* executorOrNull() const {
+    if (executor_ != nullptr) {
+      return executor_;
+    }
+    auto executor = executorKeepalive_.get();
+    return executor;
   }
 
   const std::string queryId_;


### PR DESCRIPTION
The error message is `Executor was not supplied.`

See umbrella issue https://github.com/facebookincubator/velox/issues/5646