### PR TITLE
Should not shrink memory pool when reclaiming memory without arbitrator

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -460,9 +460,9 @@ uint64_t Operator::MemoryReclaimer::reclaim(
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->pauseRequested());
 
-  int64_t before = pool->reservedBytes();
+  int64_t before = pool->root()->reservedBytes();
   op_->reclaim(targetBytes);
-  int64_t after = pool->reservedBytes();
+  int64_t after = pool->root()->reservedBytes();
   VELOX_CHECK_LE(after, before)
   return before - after;
 }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -464,7 +464,7 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   op_->reclaim(targetBytes);
   int64_t after = pool->reservedBytes();
   VELOX_CHECK_LE(after, before)
-  return after - before;
+  return before - after;
 }
 
 void Operator::MemoryReclaimer::abort(memory::MemoryPool* pool) {

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -460,8 +460,11 @@ uint64_t Operator::MemoryReclaimer::reclaim(
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->pauseRequested());
 
+  int64_t before = pool->reservedBytes();
   op_->reclaim(targetBytes);
-  return pool->shrink(targetBytes);
+  int64_t after = pool->reservedBytes();
+  VELOX_CHECK_LE(after, before)
+  return after - before;
 }
 
 void Operator::MemoryReclaimer::abort(memory::MemoryPool* pool) {


### PR DESCRIPTION
Based on current code base, `MemoryPool::grow()` can only be called by shared arbitrator. However `MemoryPool::shrink()` can be called from a call to `MemoryPool::reclaim` without an arbitrator involved. As a result a pool is contiguously shrunk but never grown.

Umbrella issue https://github.com/facebookincubator/velox/issues/5646