### PR TITLE
Optimize round-robin exchange

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -533,10 +533,10 @@ struct AlignedStlAllocator {
 
   static_assert(
       Alignment != 0,
-      "Alignment of AlignmentStlAllocator cannot be 0.");
+      "Alignment of AlignedStlAllocator cannot be 0.");
   static_assert(
       (Alignment & (Alignment - 1)) == 0,
-      "Alignment of AlignmentStlAllocator must be a power of 2.");
+      "Alignment of AlignedStlAllocator must be a power of 2.");
 
   template <class Other>
   struct rebind {

--- a/velox/connectors/hive/HivePartitionFunction.cpp
+++ b/velox/connectors/hive/HivePartitionFunction.cpp
@@ -219,7 +219,7 @@ HivePartitionFunction::HivePartitionFunction(
   }
 }
 
-void HivePartitionFunction::partition(
+std::optional<uint32_t> HivePartitionFunction::partition(
     const RowVector& input,
     std::vector<uint32_t>& partitions) {
   const auto numRows = input.size();
@@ -258,6 +258,8 @@ void HivePartitionFunction::partition(
           bucketToPartition_[((hashes_[i] & kInt32Max) % numBuckets_)];
     }
   }
+
+  return std::nullopt;
 }
 
 void HivePartitionFunction::precompute(

--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -40,8 +40,9 @@ class HivePartitionFunction : public core::PartitionFunction {
 
   ~HivePartitionFunction() override = default;
 
-  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
-      override;
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override;
 
  private:
   // Precompute single value hive hash for a constant partition key.

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -969,7 +969,10 @@ class PartitionFunction {
   /// @param input RowVector to split into partitions.
   /// @param [out] partitions Computed partition numbers for each row in
   /// 'input'.
-  virtual void partition(
+  /// @return Returns partition number in case all rows of 'input' are assigned
+  /// to the same partition. In this case 'partitions' vector is left unchanged.
+  /// Used to optimize round-robin partitioning in local exchange.
+  virtual std::optional<uint32_t> partition(
       const RowVector& input,
       std::vector<uint32_t>& partitions) = 0;
 };

--- a/velox/exec/HashPartitionFunction.cpp
+++ b/velox/exec/HashPartitionFunction.cpp
@@ -54,7 +54,7 @@ void HashPartitionFunction::init(
   }
 }
 
-void HashPartitionFunction::partition(
+std::optional<uint32_t> HashPartitionFunction::partition(
     const RowVector& input,
     std::vector<uint32_t>& partitions) {
   auto size = input.size();
@@ -83,6 +83,8 @@ void HashPartitionFunction::partition(
       partitions[i] = hashes_[i] % numPartitions_;
     }
   }
+
+  return std::nullopt;
 }
 
 std::unique_ptr<core::PartitionFunction> HashPartitionFunctionSpec::create(

--- a/velox/exec/HashPartitionFunction.h
+++ b/velox/exec/HashPartitionFunction.h
@@ -37,8 +37,9 @@ class HashPartitionFunction : public core::PartitionFunction {
 
   ~HashPartitionFunction() override = default;
 
-  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
-      override;
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override;
 
   int numPartitions() const {
     return numPartitions_;

--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -350,36 +350,48 @@ void LocalPartition::addInput(RowVectorPtr input) {
       blockingReasons_.push_back(blockingReason);
       futures_.push_back(std::move(future));
     }
-  } else {
-    partitionFunction_->partition(*input_, partitions_);
+    return;
+  }
 
-    auto numInput = input_->size();
-    auto indexBuffers = allocateIndexBuffers(numPartitions_, numInput, pool());
-    auto rawIndices = getRawIndices(indexBuffers);
-
-    std::vector<vector_size_t> maxIndex(numPartitions_, 0);
-    for (auto i = 0; i < numInput; ++i) {
-      auto partition = partitions_[i];
-      rawIndices[partition][maxIndex[partition]] = i;
-      ++maxIndex[partition];
+  const auto singlePartition =
+      partitionFunction_->partition(*input_, partitions_);
+  if (singlePartition.has_value()) {
+    ContinueFuture future;
+    auto blockingReason =
+        queues_[singlePartition.value()]->enqueue(input_, &future);
+    if (blockingReason != BlockingReason::kNotBlocked) {
+      blockingReasons_.push_back(blockingReason);
+      futures_.push_back(std::move(future));
     }
+    return;
+  }
 
-    for (auto i = 0; i < numPartitions_; i++) {
-      auto partitionSize = maxIndex[i];
-      if (partitionSize == 0) {
-        // Do not enqueue empty partitions.
-        continue;
-      }
-      indexBuffers[i]->setSize(partitionSize * sizeof(vector_size_t));
-      auto partitionData =
-          wrapChildren(input_, partitionSize, std::move(indexBuffers[i]));
+  auto numInput = input_->size();
+  auto indexBuffers = allocateIndexBuffers(numPartitions_, numInput, pool());
+  auto rawIndices = getRawIndices(indexBuffers);
 
-      ContinueFuture future;
-      auto reason = queues_[i]->enqueue(partitionData, &future);
-      if (reason != BlockingReason::kNotBlocked) {
-        blockingReasons_.push_back(reason);
-        futures_.push_back(std::move(future));
-      }
+  std::vector<vector_size_t> maxIndex(numPartitions_, 0);
+  for (auto i = 0; i < numInput; ++i) {
+    auto partition = partitions_[i];
+    rawIndices[partition][maxIndex[partition]] = i;
+    ++maxIndex[partition];
+  }
+
+  for (auto i = 0; i < numPartitions_; i++) {
+    auto partitionSize = maxIndex[i];
+    if (partitionSize == 0) {
+      // Do not enqueue empty partitions.
+      continue;
+    }
+    indexBuffers[i]->setSize(partitionSize * sizeof(vector_size_t));
+    auto partitionData =
+        wrapChildren(input_, partitionSize, std::move(indexBuffers[i]));
+
+    ContinueFuture future;
+    auto reason = queues_[i]->enqueue(partitionData, &future);
+    if (reason != BlockingReason::kNotBlocked) {
+      blockingReasons_.push_back(reason);
+      futures_.push_back(std::move(future));
     }
   }
 }

--- a/velox/exec/RoundRobinPartitionFunction.h
+++ b/velox/exec/RoundRobinPartitionFunction.h
@@ -20,21 +20,18 @@
 
 namespace facebook::velox::exec {
 
+/// Assigns batches of rows to different partitions in a round-robin fashion.
 class RoundRobinPartitionFunction : public core::PartitionFunction {
  public:
   explicit RoundRobinPartitionFunction(int numPartitions)
       : numPartitions_{numPartitions} {}
 
-  ~RoundRobinPartitionFunction() override = default;
-
-  void partition(const RowVector& input, std::vector<uint32_t>& partitions)
-      override {
-    auto size = input.size();
-    partitions.resize(size);
-    for (auto i = 0; i < size; ++i) {
-      partitions[i] = counter_ % numPartitions_;
-      ++counter_;
-    }
+  std::optional<uint32_t> partition(
+      const RowVector& /*input*/,
+      std::vector<uint32_t>& /*partitions*/) override {
+    const auto partition = counter_ % numPartitions_;
+    ++counter_;
+    return partition;
   }
 
  private:

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -30,16 +30,14 @@ TEST_F(RoundRobinPartitionFunctionTest, basic) {
   auto pool = memory::addDefaultLeafMemoryPool();
   test::VectorMaker vm(pool.get());
 
-  auto data = vm.rowVector(ROW({}, {}), 31);
+  auto data = vm.rowVector(ROW({}, {}), 1024);
   std::vector<uint32_t> partitions;
-  partitionFunction.partition(*data, partitions);
   for (auto i = 0; i < 31; ++i) {
-    ASSERT_EQ(i % 10, partitions[i]) << "at " << i;
-  }
-
-  partitionFunction.partition(*data, partitions);
-  for (auto i = 0; i < 31; ++i) {
-    ASSERT_EQ((i + 31) % 10, partitions[i]) << "at " << i;
+    SCOPED_TRACE(i);
+    auto partition = partitionFunction.partition(*data, partitions);
+    ASSERT_TRUE(partition.has_value());
+    ASSERT_EQ(i % 10, partition.value());
+    ASSERT_TRUE(partitions.empty());
   }
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -915,6 +915,63 @@ PlanBuilder& PlanBuilder::localPartitionRoundRobin() {
   return *this;
 }
 
+namespace {
+class RoundRobinRowPartitionFunction : public core::PartitionFunction {
+ public:
+  explicit RoundRobinRowPartitionFunction(int numPartitions)
+      : numPartitions_{numPartitions} {}
+
+  std::optional<uint32_t> partition(
+      const RowVector& input,
+      std::vector<uint32_t>& partitions) override {
+    auto size = input.size();
+    partitions.resize(size);
+    for (auto i = 0; i < size; ++i) {
+      partitions[i] = counter_ % numPartitions_;
+      ++counter_;
+    }
+    return std::nullopt;
+  }
+
+ private:
+  const int numPartitions_;
+  uint32_t counter_{0};
+};
+
+class RoundRobinRowPartitionFunctionSpec : public core::PartitionFunctionSpec {
+ public:
+  std::unique_ptr<core::PartitionFunction> create(
+      int numPartitions) const override {
+    return std::make_unique<RoundRobinRowPartitionFunction>(numPartitions);
+  }
+
+  std::string toString() const override {
+    return "ROUND ROBIN ROW";
+  }
+
+  folly::dynamic serialize() const override {
+    folly::dynamic obj = folly::dynamic::object;
+    obj["name"] = fmt::format("RoundRobinRowPartitionFunctionSpec");
+    return obj;
+  }
+
+  static core::PartitionFunctionSpecPtr deserialize(
+      const folly::dynamic& /*obj*/,
+      void* /*context*/) {
+    return std::make_shared<RoundRobinRowPartitionFunctionSpec>();
+  }
+};
+} // namespace
+
+PlanBuilder& PlanBuilder::localPartitionRoundRobinRow() {
+  planNode_ = std::make_shared<core::LocalPartitionNode>(
+      nextPlanNodeId(),
+      core::LocalPartitionNode::Type::kRepartition,
+      std::make_shared<RoundRobinRowPartitionFunctionSpec>(),
+      std::vector<core::PlanNodePtr>{planNode_});
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::hashJoin(
     const std::vector<std::string>& leftKeys,
     const std::vector<std::string>& rightKeys,

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -589,7 +589,7 @@ class PlanBuilder {
           bucketProperty);
 #endif
 
-  /// Add a LocalPartitionNode to partition the input using row-wise
+  /// Add a LocalPartitionNode to partition the input using batch-level
   /// round-robin. Number of partitions is determined at runtime based on
   /// parallelism of the downstream pipeline.
   ///
@@ -600,6 +600,11 @@ class PlanBuilder {
   /// A convenience method to add a LocalPartitionNode with a single source (the
   /// current plan node).
   PlanBuilder& localPartitionRoundRobin();
+
+  /// Add a LocalPartitionNode to partition the input using row-wise
+  /// round-robin. Number of partitions is determined at runtime based on
+  /// parallelism of the downstream pipeline.
+  PlanBuilder& localPartitionRoundRobinRow();
 
   /// Add a HashJoinNode to join two inputs using one or more join keys and an
   /// optional filter.

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -324,7 +324,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
     // Spilling needs at least 2 batches of input. Use round-robin
     // repartitioning to split input into multiple batches.
     core::PlanNodeId partialNodeId;
-    builder.localPartitionRoundRobin()
+    builder.localPartitionRoundRobinRow()
         .partialAggregation(groupingKeysWithPartialKey, paritialAggregates)
         .capturePlanNodeId(partialNodeId)
         .localPartition(groupingKeysWithPartialKey)
@@ -433,7 +433,7 @@ void AggregationTestBase::testAggregationsWithCompanion(
         .partialAggregation(groupingKeys, mergeAggregates);
 
     if (groupingKeys.empty()) {
-      builder.localPartitionRoundRobin();
+      builder.localPartitionRoundRobinRow();
     } else {
       builder.localPartition(groupingKeys);
     }
@@ -644,7 +644,7 @@ void AggregationTestBase::testAggregations(
     // Spilling needs at least 2 batches of input. Use round-robin
     // repartitioning to split input into multiple batches.
     core::PlanNodeId partialNodeId;
-    builder.localPartitionRoundRobin()
+    builder.localPartitionRoundRobinRow()
         .partialAggregation(groupingKeys, aggregates)
         .capturePlanNodeId(partialNodeId)
         .localPartition(groupingKeys)
@@ -803,7 +803,7 @@ void AggregationTestBase::testAggregations(
     builder.partialAggregation(groupingKeys, aggregates);
 
     if (groupingKeys.empty()) {
-      builder.localPartitionRoundRobin();
+      builder.localPartitionRoundRobinRow();
     } else {
       builder.localPartition(groupingKeys);
     }


### PR DESCRIPTION
Optimize round-robin exchange to partition data at the batch level vs.
row-level. Partitioning at the row-level introduces significant overheads and
shows up high on the profile. Batch-level partitioning is sufficient.

Fixes #5324