### PR TITLE
Add array_cum_sum Presto function

### DIFF
--- a/velox/docs/functions/presto/array.rst
+++ b/velox/docs/functions/presto/array.rst
@@ -33,6 +33,12 @@ Array Functions
 
     Returns the average of all non-null elements of the array. If there are no non-null elements, returns null.
 
+.. function:: array_cum_sum(array(T)) -> array(T)
+    Returns the array whose elements are the cumulative sum of the input array, i.e. result[i] = input[1] + input[2] +
+    … + input[i]. If there there is null elements in the array, the cumulative sum at and after the element is null.
+
+        SELECT array_cum_sum(ARRAY [1, 2, null, 3]) -- array[1, 3, null, null]
+
 .. function:: array_distinct(array(E)) -> array(E)
 
     Remove duplicate values from the input array. ::

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -313,6 +313,51 @@ struct ArraySumFunction {
   }
 };
 
+template <typename TExecCtx, typename T>
+struct ArrayCumSumFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecCtx)
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<velox::Array<T>>& out,
+      const arg_type<velox::Array<T>>& in) {
+    T sum = 0;
+    auto len = in.size();
+
+    for (auto i = 0; i < len; i++) {
+      if (in[i].has_value()) {
+        if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+          sum += in[i].value();
+        } else {
+          sum = checkedPlus<T>(sum, in[i].value());
+        }
+        out.add_item() = sum;
+      } else {
+        for (auto j = i; j < len; j++) {
+          out.add_null();
+        }
+        break;
+      }
+    }
+    return;
+  }
+
+  FOLLY_ALWAYS_INLINE void callNullFree(
+      out_type<velox::Array<T>>& out,
+      const null_free_arg_type<velox::Array<T>>& in) {
+    T sum = 0;
+
+    for (const auto& item : in) {
+      if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+        sum += item;
+      } else {
+        sum = checkedPlus<T>(sum, item);
+      }
+      out.add_item() = sum;
+    }
+    return;
+  }
+};
+
 template <typename T>
 struct ArrayAverageFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -53,6 +53,12 @@ inline void registerArrayCombinationsFunctions(const std::string& prefix) {
 }
 
 template <typename T>
+inline void registerArrayCumSumFunction(const std::string& prefix) {
+  registerFunction<ParameterBinder<ArrayCumSumFunction, T>, Array<T>, Array<T>>(
+      {prefix + "array_cum_sum"});
+}
+
+template <typename T>
 inline void registerArrayHasDuplicatesFunctions(const std::string& prefix) {
   registerFunction<
       ParameterBinder<ArrayHasDuplicatesFunction, T>,
@@ -197,6 +203,14 @@ void registerArrayFunctions(const std::string& prefix) {
   registerArrayCombinationsFunctions<Varchar>(prefix);
   registerArrayCombinationsFunctions<Timestamp>(prefix);
   registerArrayCombinationsFunctions<Date>(prefix);
+
+  registerArrayCumSumFunction<int8_t>(prefix);
+  registerArrayCumSumFunction<int16_t>(prefix);
+  registerArrayCumSumFunction<int32_t>(prefix);
+  registerArrayCumSumFunction<int64_t>(prefix);
+  registerArrayCumSumFunction<int128_t>(prefix);
+  registerArrayCumSumFunction<float>(prefix);
+  registerArrayCumSumFunction<double>(prefix);
 
   registerArrayHasDuplicatesFunctions<int8_t>(prefix);
   registerArrayHasDuplicatesFunctions<int16_t>(prefix);

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ArrayConcatTest.cpp
   ArrayConstructorTest.cpp
   ArrayContainsTest.cpp
+  ArrayCumSumTest.cpp
   ArrayDistinctTest.cpp
   ArrayDuplicatesTest.cpp
   ArrayExceptTest.cpp


### PR DESCRIPTION
Adds Presto array function ```array_cum_sum```. Resolves https://github.com/prestodb/presto/issues/20293