### PR TITLE
Fix missing call to base seekToRowGroup in SelectiveFloatingPointColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -56,7 +56,7 @@ class SelectiveByteRleColumnReader
   }
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    dwio::common::SelectiveByteRleColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     if (boolRle_) {
       boolRle_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -34,7 +34,7 @@ class SelectiveIntegerDictionaryColumnReader
       uint32_t numBytes);
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    SelectiveIntegerColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     if (inDictionaryReader_) {
       inDictionaryReader_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -57,7 +57,7 @@ class SelectiveIntegerDirectColumnReader
   }
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    dwio::common::SelectiveIntegerColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     ints->seekToRowGroup(positionsProvider);
 

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.h
@@ -38,7 +38,7 @@ class SelectiveListColumnReader
   }
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    dwio::common::SelectiveListColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
     length_->seekToRowGroup(positionsProvider);
 
@@ -74,7 +74,7 @@ class SelectiveMapColumnReader : public dwio::common::SelectiveMapColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    dwio::common::SelectiveMapColumnReader::seekToRowGroup(index);
     auto positionsProvider = formatData_->seekToRowGroup(index);
 
     length_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -41,7 +41,7 @@ class SelectiveStructColumnReaderBase
   void seekTo(vector_size_t offset, bool readsNullsOnly) override;
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    dwio::common::SelectiveStructColumnReaderBase::seekToRowGroup(index);
     if (isTopLevel_ && !formatData_->hasNulls()) {
       readOffset_ = index * rowsPerRowGroup_;
       return;

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -56,6 +56,7 @@ uint64_t SelectiveTimestampColumnReader::skip(uint64_t numValues) {
 }
 
 void SelectiveTimestampColumnReader::seekToRowGroup(uint32_t index) {
+  SelectiveColumnReader::seekToRowGroup(index);
   auto positionsProvider = formatData_->seekToRowGroup(index);
   seconds_->seekToRowGroup(positionsProvider);
   nano_->seekToRowGroup(positionsProvider);

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -280,7 +280,7 @@ TEST_F(E2EFilterTest, timestamp) {
 }
 
 TEST_F(E2EFilterTest, listAndMap) {
-  int numCombinations = 10;
+  int numCombinations = 20;
 #if !defined(NDEBUG) || defined(TSAN_BUILD)
   // The test is running slow under dev/debug and TSAN build; reduce the number
   // of combinations to avoid timeout.
@@ -290,7 +290,7 @@ TEST_F(E2EFilterTest, listAndMap) {
       "long_val:bigint,"
       "long_val_2:bigint,"
       "int_val:int,"
-      "array_val:array<struct<array_member: array<int>>>,"
+      "array_val:array<struct<array_member: array<int>, float_val:float, long_val:bigint, string_val:string>>,"
       "map_val:map<bigint,struct<nested_map: map<int, int>>>",
       [&]() {},
       true,

--- a/velox/dwio/parquet/reader/BooleanColumnReader.h
+++ b/velox/dwio/parquet/reader/BooleanColumnReader.h
@@ -35,7 +35,7 @@ class BooleanColumnReader : public dwio::common::SelectiveByteRleColumnReader {
             nodeType->type) {}
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    SelectiveByteRleColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
     formatData_->as<ParquetData>().seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -27,7 +27,6 @@ class FloatingPointColumnReader
  public:
   using ValueType = TRequested;
 
-  using root = dwio::common::SelectiveColumnReader;
   using base =
       dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>;
 
@@ -38,10 +37,10 @@ class FloatingPointColumnReader
       common::ScanSpec& scanSpec);
 
   void seekToRowGroup(uint32_t index) override {
-    root::seekToRowGroup(index);
-    root::scanState().clear();
-    root::readOffset_ = 0;
-    root::formatData_->as<ParquetData>().seekToRowGroup(index);
+    base::seekToRowGroup(index);
+    this->scanState().clear();
+    this->readOffset_ = 0;
+    this->formatData_->template as<ParquetData>().seekToRowGroup(index);
   }
 
   uint64_t skip(uint64_t numValues) override;
@@ -49,7 +48,7 @@ class FloatingPointColumnReader
   void read(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls)
       override {
     using T = FloatingPointColumnReader<TData, TRequested>;
-    base::template readCommon<T>(offset, rows, incomingNulls);
+    this->template readCommon<T>(offset, rows, incomingNulls);
   }
 
   template <typename TVisitor>
@@ -71,7 +70,7 @@ FloatingPointColumnReader<TData, TRequested>::FloatingPointColumnReader(
 template <typename TData, typename TRequested>
 uint64_t FloatingPointColumnReader<TData, TRequested>::skip(
     uint64_t numValues) {
-  return root::formatData_->skip(numValues);
+  return this->formatData_->skip(numValues);
 }
 
 template <typename TData, typename TRequested>
@@ -79,8 +78,8 @@ template <typename TVisitor>
 void FloatingPointColumnReader<TData, TRequested>::readWithVisitor(
     RowSet rows,
     TVisitor visitor) {
-  root::formatData_->as<ParquetData>().readWithVisitor(visitor);
-  root::readOffset_ += rows.back() + 1;
+  this->formatData_->template as<ParquetData>().readWithVisitor(visitor);
+  this->readOffset_ += rows.back() + 1;
 }
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -42,7 +42,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
   }
 
   void seekToRowGroup(uint32_t index) override {
-    SelectiveColumnReader::seekToRowGroup(index);
+    SelectiveIntegerColumnReader::seekToRowGroup(index);
     scanState().clear();
     readOffset_ = 0;
     formatData_->as<ParquetData>().seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -135,7 +135,7 @@ void MapColumnReader::enqueueRowGroup(
 }
 
 void MapColumnReader::seekToRowGroup(uint32_t index) {
-  SelectiveColumnReader::seekToRowGroup(index);
+  SelectiveMapColumnReader::seekToRowGroup(index);
   readOffset_ = 0;
   childTargetReadOffset_ = 0;
   BufferPtr noBuffer;
@@ -240,7 +240,7 @@ void ListColumnReader::enqueueRowGroup(
 }
 
 void ListColumnReader::seekToRowGroup(uint32_t index) {
-  SelectiveColumnReader::seekToRowGroup(index);
+  SelectiveListColumnReader::seekToRowGroup(index);
   readOffset_ = 0;
   childTargetReadOffset_ = 0;
   BufferPtr noBuffer;

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -109,7 +109,7 @@ void StructColumnReader::enqueueRowGroup(
 }
 
 void StructColumnReader::seekToRowGroup(uint32_t index) {
-  SelectiveColumnReader::seekToRowGroup(index);
+  SelectiveStructColumnReader::seekToRowGroup(index);
   BufferPtr noBuffer;
   formatData_->as<ParquetData>().setNulls(noBuffer, 0);
   readOffset_ = 0;


### PR DESCRIPTION
Summary:
This is causing `parentNullsRecordedTo_` not being reset when we switch
between row groups.

Also clean up the calls to base methods in selective readers in this diff.

Differential Revision: D47478190

