### PR TITLE
Expose output buffer's utilization to TaskStats

### DIFF
--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -633,6 +633,14 @@ std::string PartitionedOutputBuffer::toStringLocked() const {
   return out.str();
 }
 
+double PartitionedOutputBuffer::getUtilization() {
+  return totalSize_ / (double)maxSize_;
+}
+
+bool PartitionedOutputBuffer::isOverutilized() {
+  return (totalSize_ > maxSize_) && !atEnd_;
+}
+
 // static
 std::weak_ptr<PartitionedOutputBufferManager>
 PartitionedOutputBufferManager::getInstance() {
@@ -781,6 +789,23 @@ std::string PartitionedOutputBufferManager::toString() {
     out << "]";
     return out.str();
   });
+}
+
+double PartitionedOutputBufferManager::getUtilization(
+    const std::string& taskId) {
+  auto buffer = getBufferIfExists(taskId);
+  if (buffer != nullptr) {
+    return buffer->getUtilization();
+  }
+  return 0;
+}
+
+bool PartitionedOutputBufferManager::isOverutilized(const std::string& taskId) {
+  auto buffer = getBufferIfExists(taskId);
+  if (buffer != nullptr) {
+    return buffer->isOverutilized();
+  }
+  return false;
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -183,6 +183,13 @@ class PartitionedOutputBuffer {
 
   std::string toString();
 
+  // Gets the memory utilization ratio in this output buffer.
+  double getUtilization();
+
+  // Indicates if this output buffer is over-utilized and thus blocks its
+  // producers.
+  bool isOverutilized();
+
  private:
   // Percentage of maxSize below which a blocked producer should
   // be unblocked.
@@ -349,6 +356,14 @@ class PartitionedOutputBufferManager {
   }
 
   std::string toString();
+
+  // Gets the memory utilization ratio for the output buffer from a task of
+  // taskId, if the task of this taskId is not found, return 0.
+  double getUtilization(const std::string& taskId);
+
+  // If the output buffer from a task of taskId is over-utilized and blocks its
+  // producers. When the task of this taskId is not found, return false.
+  bool isOverutilized(const std::string& taskId);
 
   // Retrieves the set of buffers for a query if exists.
   // Returns NULL if task not found.

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1795,6 +1795,10 @@ TaskStats Task::taskStats() const {
     }
   }
 
+  auto bufferManager = bufferManager_.lock();
+  taskStats.outputBufferUtilization = bufferManager->getUtilization(taskId_);
+  taskStats.outputBufferOverutilized = bufferManager->isOverutilized(taskId_);
+
   return taskStats;
 }
 

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -85,6 +85,12 @@ struct TaskStats {
   uint64_t numRunningDrivers{0};
   /// Drivers blocked for various reasons. Based on enum BlockingReason.
   std::unordered_map<BlockingReason, uint64_t> numBlockedDrivers;
+
+  /// Output buffer's memory utilization ratio measured as
+  /// current buffer usage / max buffer size
+  double outputBufferUtilization;
+  /// Indicates if output buffer is over-utilized and thus blocks the producers.
+  bool outputBufferOverutilized;
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
For support of scaled table writer: https://github.com/facebookincubator/velox/issues/5665

Add API in PartitionedOutputBuffer to expose its output buffer's utilization.
Add API in PartitionedOutputBufferManager to look for a output buffer's 
utilization for a certain task of taskId.
Expose output buffer's utilization to TaskStats in Task.