### PR TITLE
Support reading files with additional row subfields in HiveConnector

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -134,7 +134,9 @@ class HiveDataSource : public DataSource {
   // hold adaptation.
   void resetSplit();
 
-  void configureRowReaderOptions(dwio::common::RowReaderOptions&) const;
+  void configureRowReaderOptions(
+      dwio::common::RowReaderOptions&,
+      const RowTypePtr& rowType) const;
 
   const RowTypePtr outputType_;
   // Column handles for the partition key columns keyed on partition key column

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -511,7 +511,7 @@ class SelectiveColumnReader {
 
   memory::MemoryPool& memoryPool_;
 
-  // Requested Velox type
+  // The file data type
   std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
 
   // Format specific state and functions.

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -187,7 +187,7 @@ void SelectiveListColumnReader::getValues(RowSet rows, VectorPtr* result) {
   makeOffsetsAndSizes(rows);
   VectorPtr elements;
   if (child_ && !nestedRows_.empty()) {
-    prepareStructResult(type_->childAt(0), &elements);
+    prepareStructResult(requestedType_->type->childAt(0), &elements);
     child_->getValues(nestedRows_, &elements);
   }
   *result = std::make_shared<ArrayVector>(
@@ -274,7 +274,7 @@ void SelectiveMapColumnReader::getValues(RowSet rows, VectorPtr* result) {
       "SelectiveMapColumnReader::getValues");
   if (!nestedRows_.empty()) {
     keyReader_->getValues(nestedRows_, &keys);
-    prepareStructResult(type_->childAt(1), &values);
+    prepareStructResult(requestedType_->type->childAt(1), &values);
     elementReader_->getValues(nestedRows_, &values);
   }
   *result = std::make_shared<MapVector>(

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -417,7 +417,8 @@ void DwrfRowReader::startNextStripe() {
         stripeStreams,
         streamLabels,
         scanSpec,
-        flatMapContext);
+        flatMapContext,
+        true); // isRoot
     selectiveColumnReader_->setIsTopLevel();
   } else {
     columnReader_ = ColumnReader::build(

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -57,7 +57,11 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
     const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     DwrfParams& params,
-    common::ScanSpec& scanSpec) {
+    common::ScanSpec& scanSpec,
+    bool isRoot) {
+  DWIO_ENSURE(
+      !isRoot || dataType->type->kind() == TypeKind::ROW,
+      "The root object can only be a row.");
   dwio::common::typeutils::checkTypeCompatibility(
       *dataType->type, *requestedType->type);
   EncodingKey ek{dataType->id, params.flatMapContext().sequence};
@@ -99,7 +103,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
           requestedType, dataType->type, params, scanSpec);
     case TypeKind::ROW:
       return std::make_unique<SelectiveStructColumnReader>(
-          requestedType, dataType, params, scanSpec);
+          requestedType, dataType, params, scanSpec, isRoot);
     case TypeKind::BOOLEAN:
       return std::make_unique<SelectiveByteRleColumnReader>(
           requestedType, dataType, params, scanSpec, true);

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.h
@@ -29,7 +29,8 @@ class SelectiveDwrfReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       DwrfParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      bool isRoot = false);
 
   // Compatibility wrapper for tests. Takes the components of DwrfParams as
   // separate.
@@ -39,9 +40,10 @@ class SelectiveDwrfReader {
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
       common::ScanSpec* FOLLY_NONNULL scanSpec,
-      FlatMapContext flatMapContext = {}) {
+      FlatMapContext flatMapContext = {},
+      bool isRoot = false) {
     auto params = DwrfParams(stripe, streamLabels, flatMapContext);
-    return build(requestedType, dataType, params, *scanSpec);
+    return build(requestedType, dataType, params, *scanSpec, isRoot);
   }
 };
 

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -27,12 +27,14 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     const std::shared_ptr<const TypeWithId>& requestedType,
     const std::shared_ptr<const TypeWithId>& dataType,
     DwrfParams& params,
-    common::ScanSpec& scanSpec)
+    common::ScanSpec& scanSpec,
+    bool isRoot)
     : SelectiveStructColumnReaderBase(
           requestedType,
           dataType,
           params,
-          scanSpec) {
+          scanSpec,
+          isRoot) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   auto encoding = static_cast<int64_t>(stripe.getEncoding(encodingKey).kind());
@@ -48,7 +50,8 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
   auto& childSpecs = scanSpec.stableChildren();
   for (auto i = 0; i < childSpecs.size(); ++i) {
     auto childSpec = childSpecs[i];
-    if (childSpec->isConstant()) {
+    if (isChildConstant(*childSpec)) {
+      childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;
     }
     auto childDataType = nodeType_->childByName(childSpec->fieldName());

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -28,12 +28,14 @@ class SelectiveStructColumnReaderBase
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       DwrfParams& params,
-      common::ScanSpec& scanSpec)
+      common::ScanSpec& scanSpec,
+      bool isRoot = false)
       : dwio::common::SelectiveStructColumnReaderBase(
             requestedType,
             dataType,
             params,
-            scanSpec),
+            scanSpec,
+            isRoot),
         rowsPerRowGroup_(formatData_->rowsPerRowGroup().value()) {
     VELOX_CHECK_EQ(nodeType_->id, dataType->id, "working on the same node");
   }
@@ -81,7 +83,8 @@ struct SelectiveStructColumnReader : SelectiveStructColumnReaderBase {
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       DwrfParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      bool isRoot = false);
 
  private:
   void addChild(std::unique_ptr<SelectiveColumnReader> child) {


### PR DESCRIPTION
Summary:
Today, if a Row type in a column in a Hive table has had additional fields added to it, the reader crashes attempting to read it.

The fix here is 2-fold:
1) update the ScanSpec to add null constants for these new fields
2) update the RowType we pass to ColumnSelector to include these new fields

1 is necessary in order to read null constants for these missing fields

2 is necessary so that requestedType_ is set to the correct Type in dwio, this is important for Rows nested in Arrays or Maps

I think this also adds support for other schema evolutions like upcasting of numeric types.

Differential Revision: D47478124

