### PR TITLE
Fix row type equivalent comparison method

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -375,7 +375,7 @@ bool RowType::equivalent(const Type& other) const {
     return false;
   }
   for (size_t i = 0; i < size(); ++i) {
-    if (*childAt(i) != *otherTyped.childAt(i)) {
+    if (!childAt(i)->equivalent(*otherTyped.childAt(i))) {
       return false;
     }
   }

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -794,3 +794,28 @@ TEST(TypeTest, fromKindToScalerType) {
     EXPECT_ANY_THROW(fromKindToScalerType(kind));
   }
 }
+
+TEST(TypeTest, rowEquvialentCheckWithChildRowsWithDifferentNames) {
+  std::vector<TypePtr> types;
+  std::vector<TypePtr> typesWithDifferentNames;
+  RowTypePtr childRowType1 =
+      ROW({"a", "b", "c"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr childRowType2 =
+      ROW({"d", "e", "f"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr childRowType3 =
+      ROW({"x", "y", "z"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr childRowType1WithDifferentNames =
+      ROW({"A", "B", "C"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr childRowType2WithDifferentNames =
+      ROW({"D", "E", "F"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr childRowType3WithDifferentNames =
+      ROW({"X", "Y", "Z"}, {TINYINT(), VARBINARY(), BIGINT()});
+  RowTypePtr rowType =
+      ROW({"A", "B", "C"}, {childRowType1, childRowType2, childRowType3});
+  RowTypePtr rowTypeWithDifferentName =
+      ROW({"a", "b", "c"},
+          {childRowType1WithDifferentNames,
+           childRowType2WithDifferentNames,
+           childRowType3WithDifferentNames});
+  ASSERT_TRUE(rowTypeWithDifferentName->equivalent(*rowType));
+}


### PR DESCRIPTION
Row type equivalent method shall recursively equivalent method
of each child type for comparison instead ==operator.