### PR TITLE
Fix RowContainer::estimateRowSize()

### DIFF
--- a/velox/common/memory/AllocationPool.cpp
+++ b/velox/common/memory/AllocationPool.cpp
@@ -50,7 +50,7 @@ void AllocationPool::clear() {
 
 char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
   VELOX_CHECK_GT(bytes, 0, "Cannot allocate zero bytes");
-  if (availableInRun() >= bytes && alignment == 1) {
+  if (freeAddressableBytes() >= bytes && alignment == 1) {
     auto* result = startOfRun_ + currentOffset_;
     currentOffset_ += bytes;
     if (currentOffset_ > endOfReservedRun()) {
@@ -63,11 +63,11 @@ char* AllocationPool::allocateFixed(uint64_t bytes, int32_t alignment) {
 
   auto numPages = AllocationTraits::numPages(bytes + alignment - 1);
 
-  if (availableInRun() == 0) {
+  if (freeAddressableBytes() == 0) {
     newRunImpl(numPages);
   } else {
     auto alignedBytes = bytes + alignmentPadding(firstFreeInRun(), alignment);
-    if (availableInRun() < alignedBytes) {
+    if (freeAddressableBytes() < alignedBytes) {
       newRunImpl(numPages);
     }
   }

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -436,7 +436,7 @@ TEST_P(MemoryAllocatorTest, allocationPool) {
 
   {
     auto old = pool.numRanges();
-    auto bytes = pool.availableInRun();
+    auto bytes = pool.testingFreeAddressableBytes();
     pool.allocateFixed(bytes);
     pool.allocateFixed(1);
     ASSERT_EQ(pool.numRanges(), old + 1);
@@ -452,7 +452,7 @@ TEST_P(MemoryAllocatorTest, allocationPool) {
 
   {
     // Leaving 10 bytes room
-    pool.allocateFixed(pool.availableInRun() - 10);
+    pool.allocateFixed(pool.testingFreeAddressableBytes() - 10);
     auto old = pool.numRanges();
     auto buf = pool.allocateFixed(1, 64);
     ASSERT_EQ(reinterpret_cast<uintptr_t>(buf) % 64, 0);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -618,7 +618,7 @@ std::optional<int64_t> RowContainer::estimateRowSize() const {
   if (numRows_ == 0) {
     return std::nullopt;
   }
-  int64_t freeBytes = rows_.availableInRun() + fixedRowSize_ * numFreeRows_;
+  int64_t freeBytes = rows_.freeBytes() + fixedRowSize_ * numFreeRows_;
   int64_t usedSize = rows_.allocatedBytes() - freeBytes +
       stringAllocator_.retainedSize() - stringAllocator_.freeSpace();
   int64_t rowSize = usedSize / numRows_;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -585,7 +585,7 @@ class RowContainer {
   // reserved storage for variable length data.
   std::pair<uint64_t, uint64_t> freeSpace() const {
     return std::make_pair<uint64_t, uint64_t>(
-        rows_.availableInReservedRun() / fixedRowSize_ + numFreeRows_,
+        rows_.freeBytes() / fixedRowSize_ + numFreeRows_,
         stringAllocator_.freeSpace());
   }
 


### PR DESCRIPTION
Fix RowContainer::estimateRowSize()

Changes AllocationPool::availableInRun() to mean the space allocatable
without increasing the reservation. Adds availableInAddressRange() to
mean the space in the addresses mapped in the last run of the
AllocationPool. This is the number of allocatable bytes available
before needing a new Allocation/ContiguousAllocation.

Enhance the test for RowContainer::estimateSize(). This test produced
negative sizes before the fix, which went undetected because of
unsigned comparison. This would error out in Deltoid verifier.

Make the test make strings larger than max inline size. Check sizes.
