### PR TITLE
Fix unmap sizes

### DIFF
--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -128,7 +128,7 @@ bool MallocAllocator::allocateContiguousImpl(
   auto numContiguousCollateralPages = allocation.numPages();
   if (numContiguousCollateralPages > 0) {
     useHugePages(allocation, false);
-    if (::munmap(allocation.data(), allocation.size()) < 0) {
+    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
       VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << "for "
                            << allocation.data() << ", " << allocation.size();
     }
@@ -223,7 +223,7 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   useHugePages(allocation, false);
   const auto bytes = allocation.size();
   const auto numPages = allocation.numPages();
-  if (::munmap(allocation.data(), bytes) < 0) {
+  if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
     VELOX_MEM_LOG(ERROR) << "Error for munmap(" << allocation.data() << ", "
                          << bytes << "): '" << folly::errnoStr(errno) << "'";
   }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -246,9 +246,9 @@ bool MmapAllocator::allocateContiguousImpl(
     useHugePages(allocation, false);
     if (useMmapArena_) {
       std::lock_guard<std::mutex> l(arenaMutex_);
-      managedArenas_->free(allocation.data(), allocation.size());
+      managedArenas_->free(allocation.data(), allocation.maxSize());
     } else {
-      if (::munmap(allocation.data(), allocation.size()) < 0) {
+      if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
         VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno)
                              << " for " << allocation.toString();
       }
@@ -371,9 +371,9 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   useHugePages(allocation, false);
   if (useMmapArena_) {
     std::lock_guard<std::mutex> l(arenaMutex_);
-    managedArenas_->free(allocation.data(), allocation.size());
+    managedArenas_->free(allocation.data(), allocation.maxSize());
   } else {
-    if (::munmap(allocation.data(), allocation.size()) < 0) {
+    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
       VELOX_MEM_LOG(ERROR) << "munmap returned " << folly::errnoStr(errno)
                            << " for " << allocation.toString();
     }

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -21,6 +21,7 @@
 #include "velox/common/memory/MmapArena.h"
 #include "velox/common/testutil/TestValue.h"
 
+#include <fstream>
 #include <thread>
 
 #include <folly/Random.h>
@@ -34,6 +35,13 @@ DECLARE_int32(velox_memory_pool_mb);
 using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::memory {
+namespace {
+// Virtual and resident set size for a process in kPageSize pages.
+struct ProcessSize {
+  int64_t vsize;
+  int64_t rss;
+};
+} // namespace
 
 static constexpr uint64_t kCapacityBytes = 256UL * 1024 * 1024;
 static constexpr MachinePageCount kCapacityPages =
@@ -103,6 +111,51 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     EXPECT_GE(result.numPages(), numPages);
     initializeContents(result);
     return true;
+  }
+
+  /// Returns the virtual and resident sizes of the process in 4K pages. Only
+  /// defined for Linux.
+  std::optional<ProcessSize> processSize() {
+#ifdef linux
+    auto pid = getpid();
+    system(
+        fmt::format("ps -eo 'pid,vsize,rss' |grep \"${}\" >/tmp/{}", pid, pid)
+            .c_str());
+    std::ifstream in(fmt::format("/tmp/{}", pid));
+    std::string line;
+    std::getline(in, line);
+    int32_t resultPid;
+    int32_t vsize;
+    int32_t rss;
+    if (sscanf(line.c_str(), "%d %d %d", &resultPid, &vsize, &rss) != 3) {
+      return std::nullopt;
+    }
+    constexpr int64_t kKBInPage = AllocationTraits::kPageSize / 1024;
+    return ProcessSize{vsize / kKBInPage, rss / kKBInPage};
+#else
+    return std::nullopt;
+#endif
+  }
+
+  void checkProcessSize(std::optional<ProcessSize> base, ProcessSize delta) {
+    // RSS and Vsize changes can be rounded up by huge page
+    // size. Whether a range if is backed by huge pages, the RSS
+    // increment for write can be 2MB instead of 4K. Vsize has also
+    // been seen to be rounded up. Generally process size reported by
+    // ps is a close match to mmap/madvise/munmap/writing to memory.
+    const int64_t kMargin = AllocationTraits::numPagesInHugePage();
+    if (!base.has_value()) {
+      return;
+    }
+    // If the initial size could be had, we error out if the current sizes
+    // cannot be had.
+    auto current = processSize().value();
+    auto expected = base.value().vsize + delta.vsize;
+    EXPECT_LE(expected, current.vsize);
+    EXPECT_GE(expected + kMargin, current.vsize);
+    expected = base.value().rss + delta.rss;
+    EXPECT_LE(expected, current.rss);
+    EXPECT_GE(expected + kMargin, current.rss);
   }
 
   void initializeContents(Allocation& alloc) {
@@ -999,6 +1052,25 @@ TEST_P(MemoryAllocatorTest, allocContiguousGrow) {
   EXPECT_EQ(
       kCapacityPages - kInitialLarge - 5 * kMinGrow, instance_->numAllocated());
   freeSmall(kCapacityPages);
+}
+
+TEST_P(MemoryAllocatorTest, allocContiguousVsize) {
+  // Works with malloc and mmap allocators where MmapArena is not on.
+  auto initialSize = processSize();
+
+  ContiguousAllocation large;
+  instance_->allocateContiguous(1024, nullptr, large, nullptr, 2048);
+  initializeContents(large);
+  // vsize grows by 2048, rss by 1024
+  checkProcessSize(initialSize, {2048, 1024});
+  instance_->allocateContiguous(4096, nullptr, large, nullptr, 10240);
+  initializeContents(large);
+  checkProcessSize(initialSize, {10240, 4096});
+  instance_->growContiguous(1024, large);
+  initializeContents(large);
+  checkProcessSize(initialSize, {10240, 4096 + 1024});
+  instance_->freeContiguous(large);
+  checkProcessSize(initialSize, {0, 0});
 }
 
 TEST_P(MemoryAllocatorTest, allocateBytes) {


### PR DESCRIPTION
When a mmap is made with a different size and maxsize, the unmap must unmap maxsize. But the utilization must be decremented by size. Failure to do this explodes the number of mmaps and fragments the address space by leaving unused tails of large mmaps hanging after unmapping the head.

To validate the effect, the test must access the process rss. Does this with Linux specific ps.