### PR TITLE
Add support for biasing expression fuzzer runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -644,11 +644,12 @@ jobs:
     steps:
       - pre-steps
       - run:
-          name: "Get Merge Base function signatures"
+          name: "Get merge base function signatures"
           command: |
             source ~/.bashrc
             conda create -y --name pyveloxenv python=3.7
             conda activate pyveloxenv
+            cp ./scripts/signature.py /tmp/signature.py
             pip install deepdiff
             git remote add upstream https://github.com/facebookincubator/velox
             git fetch upstream
@@ -659,7 +660,8 @@ jobs:
             git submodule update --init --recursive
             LD_LIBRARY_PATH=/usr/local/lib make python-clean
             LD_LIBRARY_PATH=/usr/local/lib make python-build
-            python ./scripts/signature.py export --spark --presto /tmp/merge_base_signatures.json
+            python /tmp/signature.py export --spark spark_merge_base_signatures.json
+            python /tmp/signature.py export --presto presto_merge_base_signatures.json
       - checkout
       - run:
           name: "Build"
@@ -668,17 +670,46 @@ jobs:
               ccache -s
           no_output_timeout: 1h
       - run:
-          name: "Build and Test PyVelox"
+          name: "Build and test PyVelox"
           command: |
             conda init bash
             source ~/.bashrc
             conda activate pyveloxenv
             LD_LIBRARY_PATH=/usr/local/lib make python-test
       - run:
-          name: "Check function signatures"
+          name: "Check and create bias function signatures"
           command: |
             source ~/.bashrc
             conda activate pyveloxenv
             pip install deepdiff
-            python ./scripts/signature.py export --spark --presto /tmp/pr_signatures.json
-            python ./scripts/signature.py bias /tmp/merge_base_signatures.json /tmp/pr_signatures.json ./_build/debug/velox/expression/tests/velox_expression_fuzzer_test
+            python ./scripts/signature.py export --presto presto_pr_signatures.json
+            python ./scripts/signature.py export --spark spark_pr_signatures.json
+            python ./scripts/signature.py bias presto_merge_base_signatures.json presto_pr_signatures.json /tmp/presto_bias_functions 
+            python ./scripts/signature.py bias spark_merge_base_signatures.json spark_pr_signatures.json /tmp/spark_bias_functions 
+
+      - fuzzer-run:
+          fuzzer_output: "/tmp/fuzzer.log"
+          fuzzer_repro: "/tmp/fuzzer_repro"
+          fuzzer_name: "Expression Bias Run"
+          fuzzer_exe: "[ -f /tmp/presto_bias_functions ] && _build/debug/velox/expression/tests/velox_expression_fuzzer_test"
+          fuzzer_args: " --seed ${RANDOM} --lazy_vector_generation_ratio 0.2 \
+          --assign_function_tickets  $(cat /tmp/presto_bias_functions) \
+          --duration_sec 3600 --enable_variadic_signatures \
+          --velox_fuzzer_enable_complex_types \
+          --velox_fuzzer_enable_column_reuse \
+          --velox_fuzzer_enable_expression_reuse \
+          --max_expression_trees_per_step 2 \
+          --retry_with_try \
+          --enable_dereference \
+          --logtostderr=1 --minloglevel=0 \
+          --repro_persist_path=/tmp/fuzzer_repro"
+
+      - fuzzer-run:
+          fuzzer_output: "/tmp/spark_fuzzer.log"
+          fuzzer_repro: "/tmp/spark_fuzzer_repro"
+          fuzzer_name: "Spark Bias Run"
+          fuzzer_exe: "[ -f /tmp/spark_bias_functions ] &&_build/debug/velox/expression/tests/spark_expression_fuzzer_test"
+          fuzzer_args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \
+          --assign_function_tickets  $(cat /tmp/spark_bias_functions) \
+          --repro_persist_path=/tmp/spark_fuzzer_repro"
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ commands:
       - run:
           name: "Run << parameters.fuzzer_name >> Fuzzer"
           command: |
-            eval " << parameters.fuzzer_exe >> << parameters.fuzzer_args >> " \
+            eval ' << parameters.fuzzer_exe >> << parameters.fuzzer_args >> ' \
                   2>&1 | tee "<< parameters.fuzzer_output >>" || ( \
                     tail -n 1000 "<< parameters.fuzzer_output >>" ; \
                     echo "FAIL: << parameters.fuzzer_name >> run failed"; \
@@ -691,7 +691,7 @@ jobs:
           fuzzer_output: "/tmp/fuzzer.log"
           fuzzer_repro: "/tmp/fuzzer_repro"
           fuzzer_name: "Expression Bias Run"
-          fuzzer_exe: "[ -f /tmp/presto_bias_functions ] && _build/debug/velox/expression/tests/velox_expression_fuzzer_test"
+          fuzzer_exe: "if [ -f /tmp/presto_bias_functions ]; then _build/debug/velox/expression/tests/velox_expression_fuzzer_test"
           fuzzer_args: " --seed ${RANDOM} --lazy_vector_generation_ratio 0.2 \
           --assign_function_tickets  $(cat /tmp/presto_bias_functions) \
           --duration_sec 3600 --enable_variadic_signatures \
@@ -702,14 +702,14 @@ jobs:
           --retry_with_try \
           --enable_dereference \
           --logtostderr=1 --minloglevel=0 \
-          --repro_persist_path=/tmp/fuzzer_repro"
+          --repro_persist_path=/tmp/fuzzer_repro ; fi"
 
       - fuzzer-run:
           fuzzer_output: "/tmp/spark_fuzzer.log"
           fuzzer_repro: "/tmp/spark_fuzzer_repro"
           fuzzer_name: "Spark Bias Run"
-          fuzzer_exe: "[ -f /tmp/spark_bias_functions ] &&_build/debug/velox/expression/tests/spark_expression_fuzzer_test"
+          fuzzer_exe: "if [ -f /tmp/spark_bias_functions ];  then _build/debug/velox/expression/tests/spark_expression_fuzzer_test"
           fuzzer_args: " --seed ${RANDOM} --duration_sec 3600 --logtostderr=1 --minloglevel=0 \
           --assign_function_tickets  $(cat /tmp/spark_bias_functions) \
-          --repro_persist_path=/tmp/spark_fuzzer_repro"
+          --repro_persist_path=/tmp/spark_fuzzer_repro ; fi"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ workflows:
   dist-compile:
     jobs:
       - linux-build
+      - linux-pr-fuzzer-run
       - linux-build-options
       - linux-adapters
       - macos-build:
@@ -357,34 +358,6 @@ jobs:
          name: "Run Example Binaries"
          command: |
            find _build/debug/velox/examples/ -maxdepth 1 -type f -executable -exec "{}" \;
-      - run:
-          name: "Build and Test PyVelox"
-          command: |
-            conda init bash
-            source ~/.bashrc
-            conda create -y --name pyveloxenv python=3.7
-            conda activate pyveloxenv
-            LD_LIBRARY_PATH=/usr/local/lib make python-test
-      - run:
-          name: "Check function signatures"
-          command: |
-            source ~/.bashrc
-            conda activate pyveloxenv
-            pip install deepdiff
-            python ./scripts/signature.py export --spark --presto /tmp/pr_signatures.json
-            cp ./scripts/signature.py /tmp/signature.py
-            git remote add upstream https://github.com/facebookincubator/velox
-            git fetch upstream
-            merge_base=$(git merge-base  'upstream/main' `git rev-parse HEAD`) || \
-            { echo "::error::Failed to find merge_base"; exit 1; }
-            echo "Merge Base: $merge_base"
-            git checkout $merge_base
-            git submodule update --init --recursive
-            LD_LIBRARY_PATH=/usr/local/lib make python-clean
-            LD_LIBRARY_PATH=/usr/local/lib make python-build
-            cp /tmp/signature.py ./scripts/signature.py
-            python ./scripts/signature.py export --spark --presto /tmp/main_signatures.json
-            python ./scripts/signature.py diff /tmp/main_signatures.json /tmp/pr_signatures.json
       - post-steps
 
   linux-build-release:
@@ -665,3 +638,47 @@ jobs:
             git config --global user.name "velox"
             cd presto/presto-native-execution
             make runtime-container
+
+  linux-pr-fuzzer-run:
+    executor: build
+    steps:
+      - pre-steps
+      - run:
+          name: "Get Merge Base function signatures"
+          command: |
+            source ~/.bashrc
+            conda create -y --name pyveloxenv python=3.7
+            conda activate pyveloxenv
+            pip install deepdiff
+            git remote add upstream https://github.com/facebookincubator/velox
+            git fetch upstream
+            merge_base=$(git merge-base  'upstream/main' `git rev-parse HEAD`) || \
+            { echo "::error::Failed to find merge_base"; exit 1; }
+            echo "Merge Base: $merge_base"
+            git checkout $merge_base
+            git submodule update --init --recursive
+            LD_LIBRARY_PATH=/usr/local/lib make python-clean
+            LD_LIBRARY_PATH=/usr/local/lib make python-build
+            python ./scripts/signature.py export --spark --presto /tmp/merge_base_signatures.json
+      - checkout
+      - run:
+          name: "Build"
+          command: |
+              make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+              ccache -s
+          no_output_timeout: 1h
+      - run:
+          name: "Build and Test PyVelox"
+          command: |
+            conda init bash
+            source ~/.bashrc
+            conda activate pyveloxenv
+            LD_LIBRARY_PATH=/usr/local/lib make python-test
+      - run:
+          name: "Check function signatures"
+          command: |
+            source ~/.bashrc
+            conda activate pyveloxenv
+            pip install deepdiff
+            python ./scripts/signature.py export --spark --presto /tmp/pr_signatures.json
+            python ./scripts/signature.py bias /tmp/merge_base_signatures.json /tmp/pr_signatures.json ./_build/debug/velox/expression/tests/velox_expression_fuzzer_test

--- a/scripts/tests/test_signature.py
+++ b/scripts/tests/test_signature.py
@@ -1,0 +1,70 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from scripts.signature import bias_signatures
+from pathlib import Path
+import json
+
+
+def read_from_file(file_path):
+    return Path(file_path).read_text()
+
+
+def test_bias(base_signatures, contender_signatures):
+    return bias_signatures(
+        json.loads(base_signatures), json.loads(contender_signatures), 10
+    )
+
+
+class SignatureTest(unittest.TestCase):
+    def test_bias(self):
+        # Remove a signature
+        _, return_value = test_bias(
+            """{"reverse": ["(array(T)) -> array(T)"]}""",
+            """{"reverse": []}""",
+        )
+
+        self.assertEqual(return_value, 1)
+
+        # Add a new signature
+        bias_functions, _ = test_bias(
+            """{"reverse": ["(array(T)) -> array(T)"]}""",
+            """{"reverse": ["(array(T)) -> array(T)"],
+                   "foo": ["(varchar) -> varchar"]}""",
+        )
+
+        self.assertEqual(bias_functions, "foo=10")
+
+        # Modify a signature.
+        bias_functions, _ = test_bias(
+            """{"reverse": ["(array(T)) -> array(T)"]}""",
+            """{"reverse": ["(array(T)) -> array(T)", "(varchar) -> varchar"]}""",
+        )
+
+        self.assertEqual(bias_functions, "reverse=10")
+
+        # Add more than one signature change
+        bias_functions, _ = test_bias(
+            """{"reverse": ["(array(T)) -> array(T)"]}""",
+            """{"reverse": ["(array(T)) -> array(T)"],
+                   "foo": ["(varchar) -> varchar"],
+                   "bar": ["(varchar) -> varchar"]}""",
+        )
+
+        self.assertEqual(bias_functions, "bar=10,foo=10")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This adds a new function called 'bias' to signature.py that is used to compare merge base signatures with pr signatures. 
Any changes to a function signature will result in the following: 
 * Incompatible changes : i.e removal of a signature etc , will cause job to fail (i.e behavior same as current function signature check). 
 * Addition of new functions or a new signatures to a pre-existing functions, will result in creation of a bias function file at specified output path with the string of the functions to be biased. For e.g adding reverse and foo to presto function signatures will result in a file `/tmp/bias_functions` with contents : `foo=10,reverse=10` . 

Currently we default to 10 tickets for every biased function. 
