### PR TITLE
fix TimeStamp toString precision

### DIFF
--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -59,8 +59,8 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
   }
 
   auto seconds = std::floor(unixtime);
-  auto nanos = unixtime - seconds;
-  return Timestamp(seconds, nanos * kNanosecondsInSecond);
+  auto nanos = std::llround((unixtime - seconds) * kMillisecondsInSecond);
+  return Timestamp(seconds, nanos * kNanosecondsInMillisecond);
 }
 
 namespace {

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3229,3 +3229,26 @@ TEST_F(DateTimeFunctionsTest, timestampWithTimezoneComparisons) {
   auto expectedGte = makeNullableFlatVector<bool>({true, false, true});
   runAndCompare("c0 >= c1", inputs, expectedGte);
 }
+
+TEST_F(DateTimeFunctionsTest, debug) {
+  auto c0 = makeFlatVector<double>(
+      {1623748302.,
+       1623748302.0,
+       1623748302.02,
+       1623748302.023,
+       1623748303.123,
+       1623748304.009,
+       1623748304.001});
+  auto input = makeRowVector({c0});
+  auto actual = evaluate("cast(from_unixtime(c0) as varchar)", input);
+  std::vector<StringView> expectedResult{
+      "2021-06-15T09:11:42.000",
+      "2021-06-15T09:11:42.000",
+      "2021-06-15T09:11:42.020",
+      "2021-06-15T09:11:42.023",
+      "2021-06-15T09:11:43.123",
+      "2021-06-15T09:11:44.009",
+      "2021-06-15T09:11:44.001",
+  };
+  assertEqualVectors(makeFlatVector<StringView>(expectedResult), actual);
+}


### PR DESCRIPTION
Details in https://github.com/facebookincubator/velox/issues/5595