### PR TITLE
Clear containsLazyAndIsWrapped_ while reusing RowVector

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -230,6 +230,7 @@ VectorPtr tryReuseResult(const VectorPtr& result) {
       // recreating the result vector on each batch currently, so no issue with
       // reusability now).
       result->reuseNulls();
+      result->clearContainingLazyAndWrapped();
       return result;
     case VectorEncoding::Simple::LAZY: {
       auto& lazy = static_cast<const LazyVector&>(*result);

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -744,6 +744,10 @@ class BaseVector {
     return true;
   }
 
+  void clearContainingLazyAndWrapped() {
+    containsLazyAndIsWrapped_ = false;
+  }
+
   bool memoDisabled() const {
     return memoDisabled_;
   }


### PR DESCRIPTION
Summary: When the result `RowVector` is reused in reader, if it contains lazy child and was wrapped as remaining filter results before, the `containsLazyAndIsWrapped_` flag is set and not cleared when it is reused again.  We need to clear the flag.

Differential Revision: D47504997

