### PR TITLE
Implement Aggregate::toIntermediate for map_agg

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -209,6 +209,11 @@ class Aggregate {
   /// which have the same meaning as in addRawInput. The result is
   /// placed in 'result'. 'result is allocated if nullptr, otherwise
   /// it is expected to be a writable flat vector of the right type.
+  ///
+  /// @param rows A set of rows to produce intermediate results for. The
+  /// 'result' is expected to have rows.size() rows. Invalid rows represent rows
+  /// that were masked out, these need to have correct intermediate results as
+  /// well. It is possible that all entries in 'rows' are invalid (masked out).
   virtual void toIntermediate(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,


### PR DESCRIPTION
Implement Aggregate::toIntermediate for map_agg to optimize
abandon-partial-aggregation use case.

This is the first implementation of the API. Not surprising, it exposed some
bugs in the aggregation framework. 

GroupingSet::abandonPartialAggregation clears the hash table causing destruction
of the HashStringAllocator that was provided to the aggregate function. This
causes crashes when Aggregate::toIntermediate tries to access the allocator.
Fixed that.

Also, the API documentation wasn't clear about how to interpret the 'rows'
parameter. Updated the documentation.