### PR TITLE
Make Parquet Native Reader as the default

### DIFF
--- a/velox/dwio/parquet/RegisterParquetReader.h
+++ b/velox/dwio/parquet/RegisterParquetReader.h
@@ -21,7 +21,7 @@ namespace facebook::velox::parquet {
 enum class ParquetReaderType { DUCKDB, NATIVE };
 
 void registerParquetReaderFactory(
-    ParquetReaderType parquetReaderType = ParquetReaderType::DUCKDB);
+    ParquetReaderType parquetReaderType = ParquetReaderType::NATIVE);
 
 void unregisterParquetReaderFactory();
 

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetReaderTest.cpp
@@ -17,9 +17,6 @@
 #include "velox/dwio/parquet/duckdb_reader/ParquetReader.h"
 #include "velox/dwio/parquet/tests/ParquetReaderTestBase.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
-#include "velox/type/Filter.h"
-#include "velox/type/Type.h"
-#include "velox/vector/ComplexVector.h"
 
 #include <gtest/gtest.h>
 #include <array>

--- a/velox/dwio/parquet/tests/duckdb_reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/duckdb_reader/ParquetTableScanTest.cpp
@@ -22,7 +22,6 @@
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
-#include "velox/type/tests/SubfieldFiltersBuilder.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -36,7 +35,7 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
     unregisterParquetReaderFactory();
-    registerParquetReaderFactory();
+    registerParquetReaderFactory(ParquetReaderType::DUCKDB);
   }
 
   void TearDown() override {


### PR DESCRIPTION
Parquet Native Reader has been in use for a while now and it is safe to make it the default.
The DuckDB Parquet Reader will be removed soon.