### PR TITLE
Add to configure table write threads in dataframe

### DIFF
--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -101,6 +101,7 @@ RowVectorPtr TableWriter::getOutput() {
   finished_ = true;
 
   if (outputType_->size() == 1) {
+    // NOTE: this is for non-prestissimo use cases.
     return std::make_shared<RowVector>(
         pool(),
         outputType_,


### PR DESCRIPTION
Summary:
Velox uses two query configs to configure the number of write threads
in dataframe execution instead of the max number of drivers. The
reason is to avoid writing too many small files so that make the number of
writer threads separate configs

Reviewed By: HuamengJiang

Differential Revision: D47492460

