### PR TITLE
Pass memory pool to file data sink

### DIFF
--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -430,7 +430,9 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   options.schema = inputType_;
   options.memoryPool = connectorQueryCtx_->connectorMemoryPool();
   writers_.emplace_back(writerFactory->createWriter(
-      dwio::common::DataSink::create(writePath), options));
+      dwio::common::DataSink::create(
+          writePath, connectorQueryCtx_->memoryPool()),
+      options));
   // Extends the buffer used for partition rows calculations.
   partitionSizes_.emplace_back(0);
   partitionRows_.emplace_back(nullptr);

--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -31,8 +31,9 @@ void runTest() {
 
   ASSERT_FALSE(fs::exists(filePath.string()));
 
+  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
   auto localFileSink =
-      DataSink::create(fmt::format("file:{}", filePath.string()));
+      DataSink::create(fmt::format("file:{}", filePath.string()), pool.get());
   localFileSink->close();
 
   EXPECT_TRUE(fs::exists(filePath.string()));


### PR DESCRIPTION
Some file data sink needs allocate non-trivial amount memory from
the default memory pool which should allocate from the table writer
memory pool instead. This PR allows the table writer or connector
data sink passes its own memory pool when create file data sink. The
file data sink defined in dwio common lib is used for serialized file
data write to storage.