### PR TITLE
Extend testing for abandon-partial-aggregation logic

### DIFF
--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -674,7 +674,7 @@ void AggregationTestBase::testAggregations(
     }
   }
 
-  if (!groupingKeys.empty() && allowInputShuffle_) {
+  if (!groupingKeys.empty()) {
     SCOPED_TRACE("Run partial + final with abandon partial agg");
     PlanBuilder builder(pool());
     makeSource(builder);


### PR DESCRIPTION
Testing used to be limited to aggregate functions that are no sensitive to the
order of inputs. However, this restriction is unnecessary. Removed it.