### PR TITLE
Pin protobuf to bundled version 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -432,7 +432,7 @@ endif()
 if(NOT ${VELOX_BUILD_MINIMAL})
   # Locate or build protobuf.
   set_source(Protobuf)
-  resolve_dependency(Protobuf 3.21.4)
+  resolve_dependency(Protobuf 3.21 EXACT)
   include_directories(${Protobuf_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
This PR is pinning the Protobuf version to 3.21.4 (the bundled version).

Problem:
Prestissimo includes headers from folly which in turn includes headers from protobuf. Thus, the correct headers need to be included which is not the case in all situations. This PR attempts to enable a fix to the prestissimo build.

Prestissimo builds have to deal with a variety of issues when the system does not include the expected version of Protobuf. Observed issues are:

- on Ubuntu 22.04 (or older) if protobuf was installed prestissimo includes the system include files which are older than the required version 3.21.4 causing compilation issues
- on Mac homebrew might have installed a newer version (to the system) of protobuf (version 23.4) which has new dependencies (ABSEIL library) and causes link issues on build - the workaround is to unlink and relink protobuf@21 (see issue https://github.com/prestodb/presto/issues/20022) or have no protobuf installed to use the bundled version.

Solution:
Pin the version of protobuf to the bundled version. This allows ystems with too old or too new protobuf installed to avoid build issues.
If the system protobuf does not exactly match the expected version, use the bundled version to avoid issues with newer system versions that require additional dependency work (or cmake update).
