### PR TITLE
Add support to write to GCS filesystems.

### DIFF
--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -171,7 +171,9 @@ class GCSReadFile final : public ReadFile {
 
 class GCSWriteFile final : public WriteFile {
  public:
-  explicit GCSWriteFile(std::string path, std::shared_ptr<gcs::Client> client)
+  explicit GCSWriteFile(
+      const std::string& path,
+      std::shared_ptr<gcs::Client> client)
       : client_(client) {
     setBucketAndKeyFromGCSPath(path, bucket_, key_);
   }

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -206,7 +206,7 @@ class GCSWriteFile final : public WriteFile {
   }
 
   void append(const std::string_view data) {
-    VELOX_CHECK(isFileOpen(), "File is closed");
+    VELOX_CHECK(isFileOpen(), "File is not open");
     stream_ << data;
     size_ += data.size();
   }

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -186,7 +186,7 @@ class GCSWriteFile final : public WriteFile {
       return;
     }
 
-    // check that it doesn't exist , if it does throw an error
+    // Check that it doesn't exist, if it does throw an error
     auto object_metadata = client_->GetObjectMetadata(bucket_, key_);
 
     if (object_metadata.ok()) {
@@ -204,19 +204,19 @@ class GCSWriteFile final : public WriteFile {
   }
 
   void append(const std::string_view data) {
-    VELOX_CHECK((!closed_ && stream_.IsOpen()), "File is closed");
+    VELOX_CHECK(isFileOpen(), "File is closed");
     stream_ << data;
     size_ += data.size();
   }
 
   void flush() {
-    if (!closed_ && stream_.IsOpen()) {
+    if (isFileOpen()) {
       stream_.flush();
     }
   }
 
   void close() {
-    if (!closed_ && stream_.IsOpen()) {
+    if (isFileOpen()) {
       stream_.flush();
       stream_.Close();
       closed_ = true;
@@ -228,6 +228,10 @@ class GCSWriteFile final : public WriteFile {
   }
 
  private:
+  inline bool isFileOpen() {
+    return (!closed_ && stream_.IsOpen());
+  }
+
   gcs::ObjectWriteStream stream_;
   std::shared_ptr<gcs::Client> client_;
   std::string bucket_;

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
@@ -20,70 +20,70 @@
 
 namespace facebook::velox::filesystems {
 
-// Implementation of GCS filesystem and file interface.
-// We provide a registration method for read and write files so the appropriate
-// type of file can be constructed based on a filename. See the
-// (register|generate)ReadFile and (register|generate)WriteFile functions.
+/// Implementation of GCS filesystem and file interface.
+/// We provide a registration method for read and write files so the appropriate
+/// type of file can be constructed based on a filename. See the
+/// (register|generate)ReadFile and (register|generate)WriteFile functions.
 class GCSFileSystem : public FileSystem {
  public:
   explicit GCSFileSystem(std::shared_ptr<const Config> config);
 
-  // Initialize the google::cloud::storage::Client from the input Config
-  // parameters.
+  /// Initialize the google::cloud::storage::Client from the input Config
+  /// parameters.
   void initializeClient();
 
-  // Initialize a ReadFile
-  // First the method google::cloud::storage::Client::GetObjectMetadata
-  // is used to validate
-  // [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]] then
-  // the method google::cloud::storage::Client::ReadObject
-  // is used to read sequentially
-  // [[https://cloud.google.com/storage/docs/samples/storage-stream-file-download]].
+  /// Initialize a ReadFile
+  /// First the method google::cloud::storage::Client::GetObjectMetadata
+  /// is used to validate
+  /// [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]]
+  /// then the method google::cloud::storage::Client::ReadObject
+  /// is used to read sequentially
+  /// [[https://cloud.google.com/storage/docs/samples/storage-stream-file-download]].
   std::unique_ptr<ReadFile> openFileForRead(
       std::string_view path,
       const FileOptions& options = {}) override;
 
-  // Initialize a WriteFile
-  // First the method google::cloud::storage::Client::GetObjectMetadata
-  // is used to validate
-  // [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]]
-  // then the method google::cloud::storage::Client::WriteObject
-  // is used to append sequentially
-  // [[https://cloud.google.com/storage/docs/samples/storage-stream-file-upload]].
-  // The default buffer size is currently 8 MiB
-  // but this default value can change.
-  // [[https://cloud.google.com/storage/docs/resumable-uploads]].
-  // The in-memory buffer is kept until the instance is closed or there is an
-  // excess of data. If any previously buffered data and the data to append are
-  // larger than the maximum size of the internal buffer then the largest amount
-  // of data that is a multiple of the upload quantum (256KiB) is flushed. Any
-  // data in excess of a multiple of the upload quantum are buffered
-  // for the next upload.
+  /// Initialize a WriteFile
+  /// First the method google::cloud::storage::Client::GetObjectMetadata
+  /// is used to validate
+  /// [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]]
+  /// then the method google::cloud::storage::Client::WriteObject
+  /// is used to append sequentially
+  /// [[https://cloud.google.com/storage/docs/samples/storage-stream-file-upload]].
+  /// The default buffer size is currently 8 MiB
+  /// but this default value can change.
+  /// [[https://cloud.google.com/storage/docs/resumable-uploads]].
+  /// The in-memory buffer is kept until the instance is closed or there is an
+  /// excess of data. If any previously buffered data and the data to append are
+  /// larger than the maximum size of the internal buffer then the largest
+  /// amount of data that is a multiple of the upload quantum (256KiB) is
+  /// flushed. Any data in excess of a multiple of the upload quantum are
+  /// buffered for the next upload.
   std::unique_ptr<WriteFile> openFileForWrite(
       std::string_view path,
       const FileOptions& options = {}) override;
 
-  // Returns the name of the adapter (GCS)
+  /// Returns the name of the adapter (GCS)
   std::string name() const override;
 
-  // Unsupported
+  /// Unsupported
   void remove(std::string_view path) override;
 
-  // Check that the path exists by using
-  // google::cloud::storage::Client::GetObjectMetadata
+  /// Check that the path exists by using
+  /// google::cloud::storage::Client::GetObjectMetadata
   bool exists(std::string_view path) override;
 
-  // List the objects associated to a path using
-  // google::cloud::storage::Client::ListObjects
+  /// List the objects associated to a path using
+  /// google::cloud::storage::Client::ListObjects
   std::vector<std::string> list(std::string_view path) override;
 
-  // Unsupported
+  /// Unsupported
   void rename(std::string_view, std::string_view, bool) override;
 
-  // Unsupported
+  /// Unsupported
   void mkdir(std::string_view path) override;
 
-  // Unsupported
+  /// Unsupported
   void rmdir(std::string_view path) override;
 
  protected:

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
@@ -32,13 +32,33 @@ class GCSFileSystem : public FileSystem {
   // parameters.
   void initializeClient();
 
-  // Initialize a ReadFile using
-  // google::cloud::storage::Client::GetObjectMetadata
+  // Initialize a ReadFile
+  // First the method google::cloud::storage::Client::GetObjectMetadata
+  // is used to validate
+  // [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]] then
+  // the method google::cloud::storage::Client::ReadObject
+  // is used to read sequentially
+  // [[https://cloud.google.com/storage/docs/samples/storage-stream-file-download]].
   std::unique_ptr<ReadFile> openFileForRead(
       std::string_view path,
       const FileOptions& options = {}) override;
 
-  // Not yet implemented
+  // Initialize a WriteFile
+  // First the method google::cloud::storage::Client::GetObjectMetadata
+  // is used to validate
+  // [[https://cloud.google.com/storage/docs/samples/storage-get-metadata]]
+  // then the method google::cloud::storage::Client::WriteObject
+  // is used to append sequentially
+  // [[https://cloud.google.com/storage/docs/samples/storage-stream-file-upload]].
+  // The default buffer size is currently 8 MiB
+  // but this default value can change.
+  // [[https://cloud.google.com/storage/docs/resumable-uploads]].
+  // The in-memory buffer is kept until the instance is closed or there is an
+  // excess of data. If any previously buffered data and the data to append are
+  // larger than the maximum size of the internal buffer then the largest amount
+  // of data that is a multiple of the upload quantum (256KiB) is flushed. Any
+  // data in excess of a multiple of the upload quantum are buffered
+  // for the next upload.
   std::unique_ptr<WriteFile> openFileForWrite(
       std::string_view path,
       const FileOptions& options = {}) override;

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
@@ -233,7 +233,7 @@ TEST_F(GCSFileSystemTest, writeAndReadFile) {
   writeFile->flush();
   writeFile->close();
   VELOX_ASSERT_THROW(
-      writeFile->append(dataContent.substr(0, 10)), "File is closed");
+      writeFile->append(dataContent.substr(0, 10)), "File is not open");
 
   auto readFile = gcfs.openFileForRead(gcsFile);
   std::int64_t size = readFile->size();

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
@@ -16,6 +16,7 @@
 
 #include "connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "connectors/hive/storage_adapters/gcs/GCSUtil.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/core/Config.h"
@@ -231,13 +232,8 @@ TEST_F(GCSFileSystemTest, writeAndReadFile) {
   EXPECT_EQ(writeFile->size(), contentSize);
   writeFile->flush();
   writeFile->close();
-
-  try {
-    writeFile->append(dataContent.substr(0, 10));
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(err.message(), std::string("File is closed"));
-  }
+  VELOX_ASSERT_THROW(
+      writeFile->append(dataContent.substr(0, 10)), "File is closed");
 
   auto readFile = gcfs.openFileForRead(gcsFile);
   std::int64_t size = readFile->size();
@@ -251,13 +247,7 @@ TEST_F(GCSFileSystemTest, openExistingFileForWrite) {
 
   filesystems::GCSFileSystem gcfs(testGcsOptions());
   gcfs.initializeClient();
-
-  try {
-    auto writeFile = gcfs.openFileForWrite(gcsFile);
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(err.message(), std::string("File already exists"));
-  }
+  VELOX_ASSERT_THROW(gcfs.openFileForWrite(gcsFile), "File already exists");
 }
 
 TEST_F(GCSFileSystemTest, renameNotImplemented) {
@@ -267,13 +257,10 @@ TEST_F(GCSFileSystemTest, renameNotImplemented) {
   const std::string gcsNewFile = gcsURI(preexistingBucketName(), file);
   filesystems::GCSFileSystem gcfs(testGcsOptions());
   gcfs.initializeClient();
-  try {
-    gcfs.openFileForRead(gcsExistingFile);
-    gcfs.rename(gcsExistingFile, gcsNewFile, true);
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(err.message(), std::string("rename for GCS not implemented"));
-  }
+  gcfs.openFileForRead(gcsExistingFile);
+  VELOX_ASSERT_THROW(
+      gcfs.rename(gcsExistingFile, gcsNewFile, true),
+      "rename for GCS not implemented");
 }
 
 TEST_F(GCSFileSystemTest, mkdirNotImplemented) {
@@ -281,12 +268,8 @@ TEST_F(GCSFileSystemTest, mkdirNotImplemented) {
   const std::string gcsNewDirectory = gcsURI(preexistingBucketName(), dir);
   filesystems::GCSFileSystem gcfs(testGcsOptions());
   gcfs.initializeClient();
-  try {
-    gcfs.mkdir(gcsNewDirectory);
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(err.message(), std::string("mkdir for GCS not implemented"));
-  }
+  VELOX_ASSERT_THROW(
+      gcfs.mkdir(gcsNewDirectory), "mkdir for GCS not implemented");
 }
 
 TEST_F(GCSFileSystemTest, rmdirNotImplemented) {
@@ -294,12 +277,7 @@ TEST_F(GCSFileSystemTest, rmdirNotImplemented) {
   const std::string gcsDirectory = gcsURI(preexistingBucketName(), dir);
   filesystems::GCSFileSystem gcfs(testGcsOptions());
   gcfs.initializeClient();
-  try {
-    gcfs.rmdir(gcsDirectory);
-    FAIL() << "Expected VeloxException";
-  } catch (VeloxException const& err) {
-    EXPECT_EQ(err.message(), std::string("rmdir for GCS not implemented"));
-  }
+  VELOX_ASSERT_THROW(gcfs.rmdir(gcsDirectory), "rmdir for GCS not implemented");
 }
 
 TEST_F(GCSFileSystemTest, missingFile) {


### PR DESCRIPTION
This change adds support to write to GCS (Google Cloud Storage).

The provided filesystem expects uris with the protocol gs:// following the convention gs://bucket/object.

The bucket must exist in advance. The file must not exist.