### PR TITLE
don't build boost wave

### DIFF
--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -92,7 +92,6 @@ job_weight_mib = 512
 --with-thread
 --with-timer
 --with-type_erasure
---with-wave
 
 [bootstrap.args.os=darwin]
 # Not really gcc, but CI puts a broken clang in the PATH, and saying gcc


### PR DESCRIPTION
Summary:
We're seeing what looks like incompatibilities between Xcode 14.3.1
and Boost Wave:

```
   /Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__algorithm/copy.h:62:75: error: 'iterator_type' is a private member of 'boost::spirit::multi_pass<std::pair<boost::wave::cpplexer::impl::lex_iterator_functor_shim<boost::wave::cpplexer::lex_token<> >, boost::wave::cpplexer::lex_input_interface<boost::wave::cpplexer::lex_token<> > *>, boost::spirit::iterator_policies::default_policy<boost::spirit::iterator_policies::ref_counted, boost::spirit::iterator_policies::no_check, boost::spirit::iterator_policies::split_functor_input> >'
                      && __is_cpp17_contiguous_iterator<typename _InIter::iterator_type>::value
                                                                          ^
```

We don't use Boost Wave anywhere, so don't build it.

Reviewed By: xavierd

Differential Revision: D47489625

