### PR TITLE
fix getdeps build

### DIFF
--- a/build/fbcode_builder/manifests/edencommon
+++ b/build/fbcode_builder/manifests/edencommon
@@ -11,6 +11,7 @@ repo_url = https://github.com/facebookexperimental/edencommon.git
 builder = cmake
 
 [dependencies]
+fmt
 folly
 gflags
 glog


### PR DESCRIPTION
Summary:
When I introduced ProcessId, I forgot to fix the open source
build. This diff also works around a bug in fmt 8.

Reviewed By: kmancini

Differential Revision: D47485282

