### PR TITLE
Fix leak of HashStringAllocator external alloc

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -57,9 +57,21 @@ void markAsFree(HashStringAllocator::Header* FOLLY_NONNULL header) {
 } // namespace
 
 HashStringAllocator::~HashStringAllocator() {
+  clear();
+}
+
+void HashStringAllocator::clear() {
+  numFree_ = 0;
+  freeBytes_ = 0;
+  freeNonEmpty_ = 0;
   for (auto& pair : allocationsFromPool_) {
     pool()->free(pair.first, pair.second);
   }
+  allocationsFromPool_.clear();
+  for (auto i = 0; i < kNumFreeLists; ++i) {
+    new (&free_[i]) CompactDoubleList();
+  }
+  pool_.clear();
 }
 
 void* HashStringAllocator::allocateFromPool(size_t size) {

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -323,15 +323,7 @@ class HashStringAllocator : public StreamArena {
   }
 
   // Frees all memory associated with 'this' and leaves 'this' ready for reuse.
-  void clear() {
-    numFree_ = 0;
-    freeBytes_ = 0;
-    freeNonEmpty_ = 0;
-    for (auto i = 0; i < kNumFreeLists; ++i) {
-      new (&free_[i]) CompactDoubleList();
-    }
-    pool_.clear();
-  }
+  void clear();
 
   memory::MemoryPool* FOLLY_NONNULL pool() const {
     return pool_.pool();


### PR DESCRIPTION
Destruction/clear() of HashStringAllocator must free allocations it made directly from its pool(). Normally we do not see this because uses with aggregates destruct the accumulators before freeing the HSA. In this way the external allocations are freed when freeing the accumulator and are not left hanging until the HSA itself is cleared. But HSA semantics still require free of unfreed external allocations on destruction since whether an allocation is external or not is transparent to the user.

Test verifies that clear() frees external allocations. Prior to the change, only destruction did free these.