### PR TITLE
Reduce window tests timing

### DIFF
--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -37,16 +37,12 @@ inline const std::vector<std::string> kOverClauses = {
     "partition by c0 order by c1 nulls first, c2, c3",
     "partition by c0, c2 order by c1 nulls first, c3",
     "partition by c0 order by c1 desc nulls first, c2, c3",
-    "partition by c0, c2 order by c1 desc nulls first, c3",
 
     // No partition by clause.
     "order by c0 asc nulls first, c1 desc, c2, c3",
     "order by c1 asc, c0 desc nulls last, c2 desc, c3",
     "order by c0 asc, c2 desc, c1 asc nulls last, c3",
-    "order by c2 asc, c1 desc nulls first, c0, c3",
-
-    "order by c0 asc nulls first, c1 desc nulls first, c2, c3",
-    "order by c1 desc nulls first, c0 asc nulls first, c2, c3",
+    "order by c2 asc nulls first, c1 desc nulls first, c0, c3",
 
     // No order by clause.
     "partition by c0, c1, c2, c3",
@@ -65,7 +61,6 @@ inline const std::vector<std::string> kFrameClauses = {
     // unbounded following frame combinations.
     "rows unbounded preceding",
     "rows current row",
-    "rows between current row and unbounded following",
     "rows between unbounded preceding and unbounded following",
 
     // Frame clauses in ROWS mode with k preceding and k following frame bounds,
@@ -74,27 +69,25 @@ inline const std::vector<std::string> kFrameClauses = {
     "rows between 5 preceding and unbounded following",
     "rows between current row and 5 following",
     "rows between unbounded preceding and 5 following",
-
-    "rows between 1 preceding and 5 following",
     "rows between 5 preceding and 5 following",
 
     // Frame clauses in ROWS mode with k preceding and k following frame bounds,
     // where k is a column.
     "rows between c2 preceding and current row",
-    "rows between c2 preceding and unbounded following",
     "rows between current row and c2 following",
-    "rows between unbounded preceding and c2 following",
     "rows between c2 preceding and c2 following",
     "rows between c3 preceding and c2 following",
-    "rows between c2 preceding and c3 following",
+};
 
-    // Frame clauses with invalid frames.
+// These frame clauses could have empty or partial frames.
+inline const std::vector<std::string> kEmptyFrameClauses = {
     "rows between unbounded preceding and 1 preceding",
     "rows between 1 preceding and 4 preceding",
     "rows between 1 following and unbounded following",
     "rows between 4 following and 1 following",
     "rows between c2 preceding and c3 preceding",
     "rows between c2 following and c3 following",
+
 };
 
 class WindowTestBase : public exec::test::OperatorTestBase {

--- a/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
+++ b/velox/functions/prestosql/window/tests/SimpleAggregatesTest.cpp
@@ -52,8 +52,14 @@ class AggregateWindowTestBase : public WindowTestBase {
   }
 
   void testWindowFunction(const std::vector<RowVectorPtr>& vectors) {
+    testWindowFunction(vectors, kFrameClauses);
+  }
+
+  void testWindowFunction(
+      const std::vector<RowVectorPtr>& vectors,
+      const std::vector<std::string>& frameClauses) {
     WindowTestBase::testWindowFunction(
-        vectors, function_, {overClause_}, kFrameClauses);
+        vectors, function_, {overClause_}, frameClauses);
   }
 
   const std::string function_;
@@ -85,8 +91,9 @@ TEST_P(SimpleAggregatesTest, basic) {
 // Tests function with a dataset with a single partition but 2 input row
 // vectors.
 TEST_P(SimpleAggregatesTest, singlePartition) {
-  testWindowFunction(
-      {makeSinglePartitionVector(50), makeSinglePartitionVector(40)});
+  auto input = {makeSinglePartitionVector(50), makeSinglePartitionVector(40)};
+  testWindowFunction(input);
+  testWindowFunction(input, kEmptyFrameClauses);
 }
 
 // Tests function with a dataset where all partitions have a single row.


### PR DESCRIPTION
This PR reduces test timings by:
i) Running empty frames tests only once per function instead on a per function, per overclause basis each time.
ii) Remove some redundant over by clauses
iii) Combine all types value testing into one function with all types instead of separately.

These simplifications bring down test timing. On my laptop:
velox_windows_rank_test : 8s (new), 34s (old) 
velox_windows_value_test : 20s (new), 1m 8s (old) 
velox_windows_agg_test : 10s (new), 46s (old) 