### PR TITLE
Back out "Fix unmap sizes"

### DIFF
--- a/velox/benchmarks/ExpressionBenchmarkBuilder.cpp
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.cpp
@@ -23,9 +23,8 @@ namespace facebook::velox {
 ExpressionBenchmarkSet& ExpressionBenchmarkSet::addExpression(
     const std::string& name,
     const std::string& expression) {
-  VELOX_CHECK(!expressions_.count(name), "expression name already used");
-  expressions_.emplace(
-      name, builder_.compileExpression(expression, inputType_));
+  expressions_.push_back(
+      std::make_pair(name, builder_.compileExpression(expression, inputType_)));
   return *this;
 }
 

--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -111,6 +111,10 @@ class ExpressionBenchmarkBuilder
   // If disbleTesting=true for a group set, testing is skipped.
   void testBenchmarks();
 
+  test::VectorMaker& vectorMaker() {
+    return vectorMaker_;
+  }
+
   ExpressionBenchmarkSet& addBenchmarkSet(
       const std::string& name,
       const RowVectorPtr& inputRowVetor) {

--- a/velox/benchmarks/ExpressionBenchmarkBuilder.h
+++ b/velox/benchmarks/ExpressionBenchmarkBuilder.h
@@ -72,7 +72,7 @@ class ExpressionBenchmarkSet {
       : inputType_(inputType), builder_(builder) {}
 
   // All the expressions that belongs to this set.
-  std::map<std::string, exec::ExprSet> expressions_;
+  std::vector<std::pair<std::string, exec::ExprSet>> expressions_;
 
   // The input that will be used for for benchmarking expressions. If not set,
   // a flat input vector is fuzzed using fuzzerOptions_.

--- a/velox/benchmarks/basic/CMakeLists.txt
+++ b/velox/benchmarks/basic/CMakeLists.txt
@@ -20,6 +20,7 @@ set(velox_benchmark_deps
     velox_parse_utils
     velox_parse_expression
     velox_serialization
+    velox_benchmark_builder
     Folly::folly
     ${FOLLY_BENCHMARK}
     ${DOUBLE_CONVERSION}
@@ -65,3 +66,7 @@ target_link_libraries(velox_like_functions_benchmark ${velox_benchmark_deps}
 add_executable(velox_benchmark_basic_vector_fuzzer VectorFuzzer.cpp)
 target_link_libraries(velox_benchmark_basic_vector_fuzzer
                       ${velox_benchmark_deps} velox_vector_test_lib)
+
+add_executable(velox_cast_benchmark CastBenchmark.cpp)
+target_link_libraries(velox_cast_benchmark ${velox_benchmark_deps}
+                      velox_vector_test_lib)

--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -48,10 +48,14 @@ int main(int argc, char** argv) {
           "cast_int",
           vectorMaker.rowVector(
               {"valid", "empty", "nan"}, {validInput, invalidInput, nanInput}))
-      .addExpression("try_invalid_empty_input", "try_cast (empty as int)")
-      .addExpression("try_invalid_nan", "try_cast (nan as int)")
-      .addExpression("try_valid", "try_cast (valid as int)")
-      .addExpression("valid", "cast(valid as int)")
+      .addExpression("try_cast_invalid_empty_input", "try_cast (empty as int) ")
+      .addExpression(
+          "tryexpr_cast_invalid_empty_input", "try (cast (empty as int))")
+      .addExpression("try_cast_invalid_nan", "try_cast (nan as int)")
+      .addExpression("tryexpr_cast_invalid_nan", "try (cast (nan as int))")
+      .addExpression("try_cast_valid", "try_cast (valid as int)")
+      .addExpression("tryexpr_cast_valid", "try (cast (valid as int))")
+      .addExpression("cast_valid", "cast(valid as int)")
       .withIterations(100)
       .disableTesting();
 

--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+
+using namespace facebook;
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+
+  auto vectorMaker = benchmarkBuilder.vectorMaker();
+  auto invalidInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+
+  auto validInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+  invalidInput->resize(1000);
+  validInput->resize(1000);
+
+  for (int i = 0; i < 1000; i++) {
+    invalidInput->set(i, ""_sv);
+    validInput->set(i, StringView::makeInline(std::to_string(i)));
+  }
+
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "cast_int",
+          vectorMaker.rowVector(
+              {"valid", "invalid"}, {validInput, invalidInput}))
+      .addExpression("try_invalid", "try_cast (invalid as int)")
+      .addExpression("try_valid", "try_cast (valid as int)")
+      .addExpression("valid", "cast(valid as int)")
+      .withIterations(100)
+      .disableTesting();
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -65,11 +65,13 @@ template <typename Exception, typename StringType>
   static_assert(
       !std::is_same_v<StringType, std::string>,
       "BUG: we should not pass std::string by value to veloxCheckFail");
-  LOG(ERROR) << "Line: " << args.file << ":" << args.line
-             << ", Function:" << args.function
-             << ", Expression: " << args.expression << " " << s
-             << ", Source: " << args.errorSource
-             << ", ErrorCode: " << args.errorCode;
+  if constexpr (!std::is_same_v<Exception, VeloxUserError>) {
+    LOG(ERROR) << "Line: " << args.file << ":" << args.line
+               << ", Function:" << args.function
+               << ", Expression: " << args.expression << " " << s
+               << ", Source: " << args.errorSource
+               << ", ErrorCode: " << args.errorCode;
+  }
 
   throw Exception(
       args.file,

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -94,6 +94,7 @@ VeloxException::VeloxException(
     const std::exception_ptr& e,
     std::string_view message,
     std::string_view errorSource,
+    std::string_view errorCode,
     bool isRetriable,
     Type exceptionType,
     std::string_view exceptionName)
@@ -106,7 +107,7 @@ VeloxException::VeloxException(
         state.failingExpression = "";
         state.message = message;
         state.errorSource = errorSource;
-        state.errorCode = "";
+        state.errorCode = errorCode;
         state.context = getExceptionContext().message(exceptionType);
         state.topLevelContext =
             getTopLevelExceptionContextString(exceptionType, state.context);

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -126,9 +126,26 @@ class VeloxException : public std::exception {
       const std::exception_ptr& e,
       std::string_view message,
       std::string_view errorSource,
+      std::string_view errorCode,
       bool isRetriable,
       Type exceptionType = Type::kSystem,
       std::string_view exceptionName = "VeloxException");
+
+  VeloxException(
+      const std::exception_ptr& e,
+      std::string_view message,
+      std::string_view errorSource,
+      bool isRetriable,
+      Type exceptionType = Type::kSystem,
+      std::string_view exceptionName = "VeloxException")
+      : VeloxException(
+            e,
+            message,
+            errorSource,
+            "",
+            isRetriable,
+            exceptionType,
+            exceptionName) {}
 
   // Inherited
   const char* what() const noexcept override {
@@ -269,6 +286,7 @@ class VeloxUserError : public VeloxException {
             e,
             message,
             error_source::kErrorSourceUser,
+            error_code::kInvalidArgument,
             isRetriable,
             Type::kUser,
             exceptionName) {}

--- a/velox/common/memory/MallocAllocator.cpp
+++ b/velox/common/memory/MallocAllocator.cpp
@@ -128,7 +128,7 @@ bool MallocAllocator::allocateContiguousImpl(
   auto numContiguousCollateralPages = allocation.numPages();
   if (numContiguousCollateralPages > 0) {
     useHugePages(allocation, false);
-    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
+    if (::munmap(allocation.data(), allocation.size()) < 0) {
       VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno) << "for "
                            << allocation.data() << ", " << allocation.size();
     }
@@ -223,7 +223,7 @@ void MallocAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   useHugePages(allocation, false);
   const auto bytes = allocation.size();
   const auto numPages = allocation.numPages();
-  if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
+  if (::munmap(allocation.data(), bytes) < 0) {
     VELOX_MEM_LOG(ERROR) << "Error for munmap(" << allocation.data() << ", "
                          << bytes << "): '" << folly::errnoStr(errno) << "'";
   }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -246,9 +246,9 @@ bool MmapAllocator::allocateContiguousImpl(
     useHugePages(allocation, false);
     if (useMmapArena_) {
       std::lock_guard<std::mutex> l(arenaMutex_);
-      managedArenas_->free(allocation.data(), allocation.maxSize());
+      managedArenas_->free(allocation.data(), allocation.size());
     } else {
-      if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
+      if (::munmap(allocation.data(), allocation.size()) < 0) {
         VELOX_MEM_LOG(ERROR) << "munmap got " << folly::errnoStr(errno)
                              << " for " << allocation.toString();
       }
@@ -371,9 +371,9 @@ void MmapAllocator::freeContiguousImpl(ContiguousAllocation& allocation) {
   useHugePages(allocation, false);
   if (useMmapArena_) {
     std::lock_guard<std::mutex> l(arenaMutex_);
-    managedArenas_->free(allocation.data(), allocation.maxSize());
+    managedArenas_->free(allocation.data(), allocation.size());
   } else {
-    if (::munmap(allocation.data(), allocation.maxSize()) < 0) {
+    if (::munmap(allocation.data(), allocation.size()) < 0) {
       VELOX_MEM_LOG(ERROR) << "munmap returned " << folly::errnoStr(errno)
                            << " for " << allocation.toString();
     }

--- a/velox/common/memory/tests/MemoryAllocatorTest.cpp
+++ b/velox/common/memory/tests/MemoryAllocatorTest.cpp
@@ -21,7 +21,6 @@
 #include "velox/common/memory/MmapArena.h"
 #include "velox/common/testutil/TestValue.h"
 
-#include <fstream>
 #include <thread>
 
 #include <folly/Random.h>
@@ -35,13 +34,6 @@ DECLARE_int32(velox_memory_pool_mb);
 using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::memory {
-namespace {
-// Virtual and resident set size for a process in kPageSize pages.
-struct ProcessSize {
-  int64_t vsize;
-  int64_t rss;
-};
-} // namespace
 
 static constexpr uint64_t kCapacityBytes = 256UL * 1024 * 1024;
 static constexpr MachinePageCount kCapacityPages =
@@ -111,51 +103,6 @@ class MemoryAllocatorTest : public testing::TestWithParam<bool> {
     EXPECT_GE(result.numPages(), numPages);
     initializeContents(result);
     return true;
-  }
-
-  /// Returns the virtual and resident sizes of the process in 4K pages. Only
-  /// defined for Linux.
-  std::optional<ProcessSize> processSize() {
-#ifdef linux
-    auto pid = getpid();
-    system(
-        fmt::format("ps -eo 'pid,vsize,rss' |grep \"${}\" >/tmp/{}", pid, pid)
-            .c_str());
-    std::ifstream in(fmt::format("/tmp/{}", pid));
-    std::string line;
-    std::getline(in, line);
-    int32_t resultPid;
-    int32_t vsize;
-    int32_t rss;
-    if (sscanf(line.c_str(), "%d %d %d", &resultPid, &vsize, &rss) != 3) {
-      return std::nullopt;
-    }
-    constexpr int64_t kKBInPage = AllocationTraits::kPageSize / 1024;
-    return ProcessSize{vsize / kKBInPage, rss / kKBInPage};
-#else
-    return std::nullopt;
-#endif
-  }
-
-  void checkProcessSize(std::optional<ProcessSize> base, ProcessSize delta) {
-    // RSS and Vsize changes can be rounded up by huge page
-    // size. Whether a range if is backed by huge pages, the RSS
-    // increment for write can be 2MB instead of 4K. Vsize has also
-    // been seen to be rounded up. Generally process size reported by
-    // ps is a close match to mmap/madvise/munmap/writing to memory.
-    const int64_t kMargin = AllocationTraits::numPagesInHugePage();
-    if (!base.has_value()) {
-      return;
-    }
-    // If the initial size could be had, we error out if the current sizes
-    // cannot be had.
-    auto current = processSize().value();
-    auto expected = base.value().vsize + delta.vsize;
-    EXPECT_LE(expected, current.vsize);
-    EXPECT_GE(expected + kMargin, current.vsize);
-    expected = base.value().rss + delta.rss;
-    EXPECT_LE(expected, current.rss);
-    EXPECT_GE(expected + kMargin, current.rss);
   }
 
   void initializeContents(Allocation& alloc) {
@@ -1052,25 +999,6 @@ TEST_P(MemoryAllocatorTest, allocContiguousGrow) {
   EXPECT_EQ(
       kCapacityPages - kInitialLarge - 5 * kMinGrow, instance_->numAllocated());
   freeSmall(kCapacityPages);
-}
-
-TEST_P(MemoryAllocatorTest, allocContiguousVsize) {
-  // Works with malloc and mmap allocators where MmapArena is not on.
-  auto initialSize = processSize();
-
-  ContiguousAllocation large;
-  instance_->allocateContiguous(1024, nullptr, large, nullptr, 2048);
-  initializeContents(large);
-  // vsize grows by 2048, rss by 1024
-  checkProcessSize(initialSize, {2048, 1024});
-  instance_->allocateContiguous(4096, nullptr, large, nullptr, 10240);
-  initializeContents(large);
-  checkProcessSize(initialSize, {10240, 4096});
-  instance_->growContiguous(1024, large);
-  initializeContents(large);
-  checkProcessSize(initialSize, {10240, 4096 + 1024});
-  instance_->freeContiguous(large);
-  checkProcessSize(initialSize, {0, 0});
 }
 
 TEST_P(MemoryAllocatorTest, allocateBytes) {

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include <velox/common/base/VeloxException.h>
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/CoreTypeSystem.h"
+#include "velox/expression/PeeledEncoding.h"
+#include "velox/expression/StringWriter.h"
+#include "velox/external/date/tz.h"
+#include "velox/functions/lib/RowsTranslationUtil.h"
+#include "velox/type/Type.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/FunctionVector.h"
+#include "velox/vector/SelectivityVector.h"
+
+namespace facebook::velox::exec {
+namespace {
+
+inline std::string makeErrorMessage(
+    const BaseVector& input,
+    vector_size_t row,
+    const TypePtr& toType,
+    const std::string& details = "") {
+  return fmt::format(
+      "Failed to cast from {} to {}: {}. {}",
+      input.type()->toString(),
+      toType->toString(),
+      input.toString(row),
+      details);
+}
+
+inline std::exception_ptr makeBadCastException(
+    const TypePtr& resultType,
+    const BaseVector& input,
+    vector_size_t row,
+    const std::string& errorDetails) {
+  return std::make_exception_ptr(VeloxUserError(
+      std::current_exception(),
+      makeErrorMessage(input, row, resultType, errorDetails),
+      false));
+};
+
+} // namespace
+
+template <typename Func>
+void CastExpr::applyToSelectedNoThrowLocal(
+    EvalCtx& context,
+    const SelectivityVector& rows,
+    VectorPtr& result,
+    Func&& func) {
+  if (setNullInResultAtError()) {
+    rows.template applyToSelected([&](auto row) INLINE_LAMBDA {
+      try {
+        func(row);
+      } catch (...) {
+        result->setNull(row, true);
+      }
+    });
+  } else {
+    rows.template applyToSelected([&](auto row) INLINE_LAMBDA {
+      try {
+        func(row);
+      } catch (const VeloxException& e) {
+        // Avoid double throwing.
+        context.setVeloxExceptionError(row, std::current_exception());
+      } catch (const std::exception& e) {
+        context.setError(row, std::current_exception());
+      }
+    });
+  }
+}
+
+/// The per-row level Kernel
+/// @tparam ToKind The cast target type
+/// @tparam FromKind The expression type
+/// @param row The index of the current row
+/// @param input The input vector (of type FromKind)
+/// @param result The output vector (of type ToKind)
+template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
+void CastExpr::applyCastKernel(
+    vector_size_t row,
+    EvalCtx& context,
+    const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
+    FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
+  auto inputRowValue = input->valueAt(row);
+
+  // Optimize empty input strings casting by avoiding throwing exceptions.
+  if constexpr (
+      FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
+    if constexpr (
+        TypeTraits<ToKind>::isPrimitiveType &&
+        TypeTraits<ToKind>::isFixedWidth) {
+      if (inputRowValue.size() == 0) {
+        if (setNullInResultAtError()) {
+          result->setNull(row, true);
+        } else {
+          context.setVeloxExceptionError(
+              row,
+              makeBadCastException(
+                  result->type(), *input, row, "Empty string"));
+        }
+        return;
+      }
+    }
+  }
+
+  auto output = util::Converter<ToKind, void, Truncate>::cast(inputRowValue);
+
+  if constexpr (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
+    // Write the result output to the output vector
+    auto writer = exec::StringWriter<>(result, row);
+    writer.copy_from(output);
+    writer.finalize();
+  } else {
+    result->set(row, output);
+  }
+}
+
+template <typename TInput, typename TOutput>
+void CastExpr::applyDecimalCastKernel(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& fromType,
+    const TypePtr& toType,
+    VectorPtr& castResult) {
+  auto sourceVector = input.as<SimpleVector<TInput>>();
+  auto castResultRawBuffer =
+      castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
+  const auto& fromPrecisionScale = getDecimalPrecisionScale(*fromType);
+  const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
+
+  applyToSelectedNoThrowLocal(
+      context, rows, castResult, [&](vector_size_t row) {
+        auto rescaledValue = DecimalUtil::rescaleWithRoundUp<TInput, TOutput>(
+            sourceVector->valueAt(row),
+            fromPrecisionScale.first,
+            fromPrecisionScale.second,
+            toPrecisionScale.first,
+            toPrecisionScale.second);
+        if (rescaledValue.has_value()) {
+          castResultRawBuffer[row] = rescaledValue.value();
+        } else {
+          castResult->setNull(row, true);
+        }
+      });
+}
+
+template <typename TInput, typename TOutput>
+void CastExpr::applyIntToDecimalCastKernel(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& toType,
+    VectorPtr& castResult) {
+  auto sourceVector = input.as<SimpleVector<TInput>>();
+  auto castResultRawBuffer =
+      castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
+  const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
+  applyToSelectedNoThrowLocal(
+      context, rows, castResult, [&](vector_size_t row) {
+        auto rescaledValue = DecimalUtil::rescaleInt<TInput, TOutput>(
+            sourceVector->valueAt(row),
+            toPrecisionScale.first,
+            toPrecisionScale.second);
+        if (rescaledValue.has_value()) {
+          castResultRawBuffer[row] = rescaledValue.value();
+        } else {
+          castResult->setNull(row, true);
+        }
+      });
+}
+
+template <typename TInput>
+VectorPtr CastExpr::applyDecimalToDoubleCast(
+    const SelectivityVector& rows,
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const TypePtr& fromType) {
+  VectorPtr result;
+  context.ensureWritable(rows, DOUBLE(), result);
+  (*result).clearNulls(rows);
+  auto resultBuffer =
+      result->asUnchecked<FlatVector<double>>()->mutableRawValues();
+  const auto precisionScale = getDecimalPrecisionScale(*fromType);
+  const auto simpleInput = input.as<SimpleVector<TInput>>();
+  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+    auto output = util::Converter<TypeKind::DOUBLE, void, false>::cast(
+        simpleInput->valueAt(row));
+    resultBuffer[row] =
+        output / DecimalUtil::kPowersOfTen[precisionScale.second];
+  });
+
+  return result;
+}
+
+template <TypeKind ToKind, TypeKind FromKind>
+void CastExpr::applyCastPrimitives(
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const BaseVector& input,
+    VectorPtr& result) {
+  using To = typename TypeTraits<ToKind>::NativeType;
+  using From = typename TypeTraits<FromKind>::NativeType;
+  auto* resultFlatVector = result->as<FlatVector<To>>();
+  auto* inputSimpleVector = input.as<SimpleVector<From>>();
+
+  const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
+  auto& resultType = resultFlatVector->type();
+
+  auto setError = [&](vector_size_t row, const std::string& details) {
+    if (setNullInResultAtError()) {
+      result->setNull(row, true);
+    } else {
+      context.setVeloxExceptionError(
+          row, makeBadCastException(resultType, input, row, details));
+    }
+  };
+
+  if (!queryConfig.isCastToIntByTruncate()) {
+    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+      try {
+        applyCastKernel<ToKind, FromKind, false /*truncate*/>(
+            row, context, inputSimpleVector, resultFlatVector);
+
+      } catch (const VeloxUserError& ue) {
+        setError(row, ue.message());
+      } catch (const std::exception& e) {
+        setError(row, e.what());
+      }
+    });
+
+  } else {
+    applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+      try {
+        applyCastKernel<ToKind, FromKind, true /*truncate*/>(
+            row, context, inputSimpleVector, resultFlatVector);
+      } catch (const VeloxUserError& ue) {
+        setError(row, ue.message());
+      } catch (const std::exception& e) {
+        setError(row, e.what());
+      }
+    });
+  }
+
+  // If we're converting to a TIMESTAMP, check if we need to adjust the
+  // current GMT timezone to the user provided session timezone.
+  if constexpr (ToKind == TypeKind::TIMESTAMP) {
+    // If user explicitly asked us to adjust the timezone.
+    if (queryConfig.adjustTimestampToTimezone()) {
+      auto sessionTzName = queryConfig.sessionTimezone();
+      if (!sessionTzName.empty()) {
+        // locate_zone throws runtime_error if the timezone couldn't be found
+        // (so we're safe to dereference the pointer).
+        auto* timeZone = date::locate_zone(sessionTzName);
+        auto rawTimestamps = resultFlatVector->mutableRawValues();
+
+        applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+          rawTimestamps[row].toGMT(*timeZone);
+        });
+      }
+    }
+  }
+}
+
+template <TypeKind ToKind>
+void CastExpr::applyCastPrimitivesDispatch(
+    const TypePtr& fromType,
+    const TypePtr& toType,
+    const SelectivityVector& rows,
+    exec::EvalCtx& context,
+    const BaseVector& input,
+    VectorPtr& result) {
+  context.ensureWritable(rows, toType, result);
+
+  // This already excludes complex types, hugeint and unknown from type kinds.
+  VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
+      applyCastPrimitives,
+      ToKind,
+      fromType->kind() /*dispatched*/,
+      rows,
+      context,
+      input,
+      result);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -24,6 +24,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/PeeledEncoding.h"
+#include "velox/expression/ScopedVarSetter.h"
 #include "velox/expression/StringWriter.h"
 #include "velox/external/date/tz.h"
 #include "velox/functions/lib/RowsTranslationUtil.h"
@@ -34,74 +35,7 @@
 
 namespace facebook::velox::exec {
 
-namespace {
-
-std::string makeErrorMessage(
-    const BaseVector& input,
-    vector_size_t row,
-    const TypePtr& toType,
-    const std::string& details = "") {
-  return fmt::format(
-      "Failed to cast from {} to {}: {}. {}",
-      input.type()->toString(),
-      toType->toString(),
-      input.toString(row),
-      details);
-}
-
-std::exception_ptr makeBadCastException(
-    const TypePtr& resultType,
-    const BaseVector& input,
-    vector_size_t row,
-    const std::string& errorDetails) {
-  return std::make_exception_ptr(VeloxUserError(
-      std::current_exception(),
-      makeErrorMessage(input, row, resultType, errorDetails),
-      false));
-};
-
-/// The per-row level Kernel
-/// @tparam ToKind The cast target type
-/// @tparam FromKind The expression type
-/// @param row The index of the current row
-/// @param input The input vector (of type FromKind)
-/// @param result The output vector (of type ToKind)
-template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
-void applyCastKernel(
-    vector_size_t row,
-    EvalCtx& context,
-    const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
-    FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
-  auto inputRowValue = input->valueAt(row);
-
-  // Optimize empty input strings casting by avoiding throwing exceptions.
-  if constexpr (
-      FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
-    if constexpr (
-        TypeTraits<ToKind>::isPrimitiveType &&
-        TypeTraits<ToKind>::isFixedWidth) {
-      if (inputRowValue.size() == 0) {
-        context.setVeloxExceptionError(
-            row,
-            makeBadCastException(result->type(), *input, row, "Empty string"));
-        return;
-      }
-    }
-  }
-
-  auto output = util::Converter<ToKind, void, Truncate>::cast(inputRowValue);
-
-  if constexpr (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
-    // Write the result output to the output vector
-    auto writer = exec::StringWriter<>(result, row);
-    writer.copy_from(output);
-    writer.finalize();
-  } else {
-    result->set(row, output);
-  }
-}
-
-VectorPtr castFromDate(
+VectorPtr CastExpr::castFromDate(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
@@ -114,7 +48,7 @@ VectorPtr castFromDate(
   switch (toType->kind()) {
     case TypeKind::VARCHAR: {
       auto* resultFlatVector = castResult->as<FlatVector<StringView>>();
-      context.applyToSelectedNoThrow(rows, [&](int row) {
+      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         try {
           auto output = DATE()->toString(inputFlatVector->valueAt(row));
           auto writer = exec::StringWriter<>(resultFlatVector, row);
@@ -134,12 +68,13 @@ VectorPtr castFromDate(
     case TypeKind::TIMESTAMP: {
       static const int64_t kMillisPerDay{86'400'000};
       auto* resultFlatVector = castResult->as<FlatVector<Timestamp>>();
-      context.applyToSelectedNoThrow(rows, [&](int row) {
+      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         resultFlatVector->set(
             row,
             Timestamp::fromMillis(
                 inputFlatVector->valueAt(row) * kMillisPerDay));
       });
+
       return castResult;
     }
     default:
@@ -148,7 +83,7 @@ VectorPtr castFromDate(
   }
 }
 
-VectorPtr castToDate(
+VectorPtr CastExpr::castToDate(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
@@ -160,7 +95,7 @@ VectorPtr castToDate(
   switch (fromType->kind()) {
     case TypeKind::VARCHAR: {
       auto* inputVector = input.as<SimpleVector<StringView>>();
-      context.applyToSelectedNoThrow(rows, [&](int row) {
+      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         try {
           auto inputString = inputVector->valueAt(row);
           resultFlatVector->set(row, DATE()->toDays(inputString));
@@ -172,12 +107,13 @@ VectorPtr castToDate(
               makeErrorMessage(input, row, DATE()) + " " + e.what());
         }
       });
+
       return castResult;
     }
     case TypeKind::TIMESTAMP: {
       auto* inputVector = input.as<SimpleVector<Timestamp>>();
       static const int32_t kSecsPerDay{86'400};
-      context.applyToSelectedNoThrow(rows, [&](int row) {
+      applyToSelectedNoThrowLocal(context, rows, castResult, [&](int row) {
         auto input = inputVector->valueAt(row);
         auto seconds = input.getSeconds();
         if (seconds >= 0 || seconds % kSecsPerDay == 0) {
@@ -189,6 +125,7 @@ VectorPtr castToDate(
           resultFlatVector->set(row, seconds / kSecsPerDay - 1);
         }
       });
+
       return castResult;
     }
     default:
@@ -196,171 +133,6 @@ VectorPtr castToDate(
           "Cast from {} to DATE is not supported", fromType->toString());
   }
 }
-
-template <typename TInput, typename TOutput>
-void applyDecimalCastKernel(
-    const SelectivityVector& rows,
-    const BaseVector& input,
-    exec::EvalCtx& context,
-    const TypePtr& fromType,
-    const TypePtr& toType,
-    VectorPtr& castResult) {
-  auto sourceVector = input.as<SimpleVector<TInput>>();
-  auto castResultRawBuffer =
-      castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
-  const auto& fromPrecisionScale = getDecimalPrecisionScale(*fromType);
-  const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
-  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
-    auto rescaledValue = DecimalUtil::rescaleWithRoundUp<TInput, TOutput>(
-        sourceVector->valueAt(row),
-        fromPrecisionScale.first,
-        fromPrecisionScale.second,
-        toPrecisionScale.first,
-        toPrecisionScale.second);
-    if (rescaledValue.has_value()) {
-      castResultRawBuffer[row] = rescaledValue.value();
-    } else {
-      castResult->setNull(row, true);
-    }
-  });
-}
-
-template <typename TInput, typename TOutput>
-void applyIntToDecimalCastKernel(
-    const SelectivityVector& rows,
-    const BaseVector& input,
-    exec::EvalCtx& context,
-    const TypePtr& toType,
-    VectorPtr& castResult) {
-  auto sourceVector = input.as<SimpleVector<TInput>>();
-  auto castResultRawBuffer =
-      castResult->asUnchecked<FlatVector<TOutput>>()->mutableRawValues();
-  const auto& toPrecisionScale = getDecimalPrecisionScale(*toType);
-  context.applyToSelectedNoThrow(rows, [&](vector_size_t row) {
-    auto rescaledValue = DecimalUtil::rescaleInt<TInput, TOutput>(
-        sourceVector->valueAt(row),
-        toPrecisionScale.first,
-        toPrecisionScale.second);
-    if (rescaledValue.has_value()) {
-      castResultRawBuffer[row] = rescaledValue.value();
-    } else {
-      castResult->setNull(row, true);
-    }
-  });
-}
-
-template <typename TInput>
-VectorPtr applyDecimalToDoubleCast(
-    const SelectivityVector& rows,
-    const BaseVector& input,
-    exec::EvalCtx& context,
-    const TypePtr& fromType) {
-  VectorPtr result;
-  context.ensureWritable(rows, DOUBLE(), result);
-  (*result).clearNulls(rows);
-  auto resultBuffer =
-      result->asUnchecked<FlatVector<double>>()->mutableRawValues();
-  const auto precisionScale = getDecimalPrecisionScale(*fromType);
-  const auto simpleInput = input.as<SimpleVector<TInput>>();
-  context.applyToSelectedNoThrow(rows, [&](int row) {
-    auto output = util::Converter<TypeKind::DOUBLE, void, false>::cast(
-        simpleInput->valueAt(row));
-    resultBuffer[row] =
-        output / DecimalUtil::kPowersOfTen[precisionScale.second];
-  });
-  return result;
-}
-
-template <TypeKind ToKind, TypeKind FromKind>
-void applyCastPrimitives(
-    const SelectivityVector& rows,
-    exec::EvalCtx& context,
-    const BaseVector& input,
-    VectorPtr& result) {
-  using To = typename TypeTraits<ToKind>::NativeType;
-  using From = typename TypeTraits<FromKind>::NativeType;
-  auto* resultFlatVector = result->as<FlatVector<To>>();
-  auto* inputSimpleVector = input.as<SimpleVector<From>>();
-
-  const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-  auto& resultType = resultFlatVector->type();
-
-  auto setVeloxError = [&](vector_size_t row, const std::string& details) {
-    context.setVeloxExceptionError(
-        row, makeBadCastException(resultType, input, row, details));
-  };
-
-  auto setError = [&](vector_size_t row, const std::string& details) {
-    context.setError(
-        row, makeBadCastException(resultType, input, row, details));
-  };
-
-  if (!queryConfig.isCastToIntByTruncate()) {
-    context.applyToSelectedNoThrow(rows, [&](int row) {
-      try {
-        applyCastKernel<ToKind, FromKind, false /*truncate*/>(
-            row, context, inputSimpleVector, resultFlatVector);
-
-      } catch (const VeloxUserError& ue) {
-        setVeloxError(row, ue.message());
-      } catch (const std::exception& e) {
-        setError(row, e.what());
-      }
-    });
-  } else {
-    context.applyToSelectedNoThrow(rows, [&](int row) {
-      try {
-        applyCastKernel<ToKind, FromKind, true /*truncate*/>(
-            row, context, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxUserError& ue) {
-        setVeloxError(row, ue.message());
-      } catch (const std::exception& e) {
-        setError(row, e.what());
-      }
-    });
-  }
-
-  // If we're converting to a TIMESTAMP, check if we need to adjust the
-  // current GMT timezone to the user provided session timezone.
-  if constexpr (ToKind == TypeKind::TIMESTAMP) {
-    // If user explicitly asked us to adjust the timezone.
-    if (queryConfig.adjustTimestampToTimezone()) {
-      auto sessionTzName = queryConfig.sessionTimezone();
-      if (!sessionTzName.empty()) {
-        // locate_zone throws runtime_error if the timezone couldn't be found
-        // (so we're safe to dereference the pointer).
-        auto* timeZone = date::locate_zone(sessionTzName);
-        auto rawTimestamps = resultFlatVector->mutableRawValues();
-
-        rows.applyToSelected(
-            [&](int row) { rawTimestamps[row].toGMT(*timeZone); });
-      }
-    }
-  }
-}
-
-template <TypeKind ToKind>
-void applyCastPrimitivesDispatch(
-    const TypePtr& fromType,
-    const TypePtr& toType,
-    const SelectivityVector& rows,
-    exec::EvalCtx& context,
-    const BaseVector& input,
-    VectorPtr& result) {
-  context.ensureWritable(rows, toType, result);
-
-  // This already excludes complex types, hugeint and unknown from type kinds.
-  VELOX_DYNAMIC_SCALAR_TEMPLATE_TYPE_DISPATCH(
-      applyCastPrimitives,
-      ToKind,
-      fromType->kind() /*dispatched*/,
-      rows,
-      context,
-      input,
-      result);
-}
-
-} // namespace
 
 VectorPtr CastExpr::applyMap(
     const SelectivityVector& rows,
@@ -392,13 +164,16 @@ VectorPtr CastExpr::applyMap(
   if (fromType.keyType() == toType.keyType()) {
     newMapKeys = input->mapKeys();
   } else {
-    apply(
-        nestedRows,
-        mapKeys,
-        context,
-        fromType.keyType(),
-        toType.keyType(),
-        newMapKeys);
+    {
+      ScopedVarSetter holder(&inTopLevel, false);
+      apply(
+          nestedRows,
+          mapKeys,
+          context,
+          fromType.keyType(),
+          toType.keyType(),
+          newMapKeys);
+    }
   }
 
   // Cast values
@@ -406,18 +181,17 @@ VectorPtr CastExpr::applyMap(
   if (fromType.valueType() == toType.valueType()) {
     newMapValues = mapValues;
   } else {
-    apply(
-        nestedRows,
-        mapValues,
-        context,
-        fromType.valueType(),
-        toType.valueType(),
-        newMapValues);
+    {
+      ScopedVarSetter holder(&inTopLevel, false);
+      apply(
+          nestedRows,
+          mapValues,
+          context,
+          fromType.valueType(),
+          toType.valueType(),
+          newMapValues);
+    }
   }
-
-  context.addElementErrorsToTopLevel(
-      nestedRows, elementToTopLevelRows, oldErrors);
-  context.swapErrors(oldErrors);
 
   // Returned map vector should be addressable for every element, even those
   // that are not selected.
@@ -426,7 +200,6 @@ VectorPtr CastExpr::applyMap(
     // We extends size since that is cheap.
     newMapKeys->resize(input->mapKeys()->size());
     newMapValues->resize(input->mapValues()->size());
-
   } else if (
       newMapKeys->size() < input->mapKeys()->size() ||
       newMapValues->size() < input->mapValues()->size()) {
@@ -434,12 +207,13 @@ VectorPtr CastExpr::applyMap(
         AlignedBuffer::allocate<vector_size_t>(rows.end(), context.pool(), 0);
     auto* inputSizes = input->rawSizes();
     auto* rawSizes = sizes->asMutable<vector_size_t>();
+
     rows.applyToSelected(
         [&](vector_size_t row) { rawSizes[row] = inputSizes[row]; });
   }
 
   // Assemble the output map
-  return std::make_shared<MapVector>(
+  VectorPtr result = std::make_shared<MapVector>(
       context.pool(),
       MAP(toType.keyType(), toType.valueType()),
       input->nulls(),
@@ -448,6 +222,21 @@ VectorPtr CastExpr::applyMap(
       sizes,
       newMapKeys,
       newMapValues);
+
+  if (context.errors()) {
+    if (setNullInResultAtError()) {
+      // Errors in context.errors() should be translated to nulls in the top
+      // level rows.
+      context.convertElementErrorsToTopLevelNulls(
+          nestedRows, elementToTopLevelRows, result);
+    } else {
+      context.addElementErrorsToTopLevel(
+          nestedRows, elementToTopLevelRows, oldErrors);
+    }
+  }
+  // Restore original state.
+  context.swapErrors(oldErrors);
+  return result;
 }
 
 VectorPtr CastExpr::applyArray(
@@ -469,19 +258,16 @@ VectorPtr CastExpr::applyArray(
   context.swapErrors(oldErrors);
 
   VectorPtr newElements;
-  apply(
-      nestedRows,
-      arrayElements,
-      context,
-      fromType.elementType(),
-      toType.elementType(),
-      newElements);
-
-  if (context.errors()) {
-    context.addElementErrorsToTopLevel(
-        nestedRows, elementToTopLevelRows, oldErrors);
+  {
+    ScopedVarSetter holder(&inTopLevel, false);
+    apply(
+        nestedRows,
+        arrayElements,
+        context,
+        fromType.elementType(),
+        toType.elementType(),
+        newElements);
   }
-  context.swapErrors(oldErrors);
 
   // Returned array vector should be addressable for every element, even those
   // that are not selected.
@@ -498,7 +284,7 @@ VectorPtr CastExpr::applyArray(
         [&](vector_size_t row) { rawSizes[row] = inputSizes[row]; });
   }
 
-  return std::make_shared<ArrayVector>(
+  VectorPtr result = std::make_shared<ArrayVector>(
       context.pool(),
       ARRAY(toType.elementType()),
       input->nulls(),
@@ -506,6 +292,21 @@ VectorPtr CastExpr::applyArray(
       input->offsets(),
       sizes,
       newElements);
+
+  if (context.errors()) {
+    if (setNullInResultAtError()) {
+      // Errors in context.errors() should be translated to nulls in the top
+      // level rows.
+      context.convertElementErrorsToTopLevelNulls(
+          nestedRows, elementToTopLevelRows, result);
+    } else {
+      context.addElementErrorsToTopLevel(
+          nestedRows, elementToTopLevelRows, oldErrors);
+    }
+  }
+  // Restore original state.
+  context.swapErrors(oldErrors);
+  return result;
 }
 
 VectorPtr CastExpr::applyRow(
@@ -526,6 +327,13 @@ VectorPtr CastExpr::applyRow(
   // Cast each row child to its corresponding output child
   std::vector<VectorPtr> newChildren;
   newChildren.reserve(numOutputChildren);
+
+  ErrorVectorPtr oldErrors;
+  if (setNullInResultAtError()) {
+    // We need to isolate errors that happen during the cast from previous
+    // errors since those translate to nulls, unlike exisiting errors.
+    context.swapErrors(oldErrors);
+  }
 
   for (auto toChildrenIndex = 0; toChildrenIndex < numOutputChildren;
        toChildrenIndex++) {
@@ -563,7 +371,8 @@ VectorPtr CastExpr::applyRow(
       if (toChildType == inputChild->type()) {
         outputChild = inputChild;
       } else {
-        // Apply cast for the child
+        // Apply cast for the child.
+        ScopedVarSetter holder(&inTopLevel, false);
         apply(
             rows,
             inputChild,
@@ -577,12 +386,27 @@ VectorPtr CastExpr::applyRow(
   }
 
   // Assemble the output row
-  return std::make_shared<RowVector>(
+  VectorPtr result = std::make_shared<RowVector>(
       context.pool(),
       toType,
       input->nulls(),
       rows.end(),
       std::move(newChildren));
+
+  if (setNullInResultAtError()) {
+    // Set errors as nulls.
+    if (auto errors = context.errors()) {
+      rows.applyToSelected([&](auto row) {
+        if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
+          result->setNull(row, true);
+        }
+      });
+    }
+    // Restore original state.
+    context.swapErrors(oldErrors);
+  }
+
+  return result;
 }
 
 template <typename toDecimalType>
@@ -776,7 +600,15 @@ void CastExpr::evalSpecialForm(
   auto fromType = inputs_[0]->type();
   auto toType = std::const_pointer_cast<const Type>(type_);
 
+  inTopLevel = true;
+  auto originalThrowOnError = context.throwOnError();
+  if (nullOnFailure()) {
+    *context.mutableThrowOnError() = false;
+  }
+
   apply(rows, input, context, fromType, toType, result);
+  *context.mutableThrowOnError() = originalThrowOnError;
+
   // Return 'input' back to the vector pool in 'context' so it can be reused.
   context.releaseVector(input);
 }
@@ -795,7 +627,7 @@ std::string CastExpr::toString(bool recursive) const {
 
 std::string CastExpr::toSql(std::vector<VectorPtr>* complexConstants) const {
   std::stringstream out;
-  out << "cast(";
+  out << (nullOnFailure_ ? "try_cast" : "cast(");
   appendInputsSql(out, complexConstants);
   out << " as ";
   toTypeSql(type_, out);
@@ -818,6 +650,24 @@ ExprPtr CastCallToSpecialForm::constructSpecialForm(
       "CAST statements expect exactly 1 argument, received {}",
       compiledChildren.size());
   return std::make_shared<CastExpr>(
-      type, std::move(compiledChildren[0]), trackCpuUsage);
+      type, std::move(compiledChildren[0]), trackCpuUsage, false);
+}
+
+TypePtr TryCastCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& /* argTypes */) {
+  VELOX_FAIL("CAST expressions do not support type resolution.");
+}
+
+ExprPtr TryCastCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage) {
+  VELOX_CHECK_EQ(
+      compiledChildren.size(),
+      1,
+      "CAST statements expect exactly 1 argument, received {}",
+      compiledChildren.size());
+  return std::make_shared<CastExpr>(
+      type, std::move(compiledChildren[0]), trackCpuUsage, true);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -48,6 +48,18 @@ std::string makeErrorMessage(
       input.toString(row),
       details);
 }
+
+std::exception_ptr makeException(
+    const TypePtr& resultType,
+    const BaseVector& input,
+    vector_size_t row,
+    const std::string& errorDetails) {
+  return std::make_exception_ptr(VeloxUserError(
+      std::current_exception(),
+      makeErrorMessage(input, row, resultType, errorDetails),
+      false));
+};
+
 /// The per-row level Kernel
 /// @tparam ToKind The cast target type
 /// @tparam FromKind The expression type
@@ -57,10 +69,26 @@ std::string makeErrorMessage(
 template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
 void applyCastKernel(
     vector_size_t row,
+    EvalCtx& context,
     const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
     FlatVector<typename TypeTraits<ToKind>::NativeType>* result) {
-  auto output =
-      util::Converter<ToKind, void, Truncate>::cast(input->valueAt(row));
+  auto inputRowValue = input->valueAt(row);
+
+  // Optimize empty input strings casting by avoiding throwing exceptions.
+  if constexpr (
+      FromKind == TypeKind::VARCHAR || FromKind == TypeKind::VARBINARY) {
+    if constexpr (
+        TypeTraits<ToKind>::isPrimitiveType &&
+        TypeTraits<ToKind>::isFixedWidth) {
+      if (inputRowValue.size() == 0) {
+        context.setError(
+            row, makeException(result->type(), *input, row, "Empty string"));
+        return;
+      }
+    }
+  }
+
+  auto output = util::Converter<ToKind, void, Truncate>::cast(inputRowValue);
 
   if constexpr (ToKind == TypeKind::VARCHAR || ToKind == TypeKind::VARBINARY) {
     // Write the result output to the output vector
@@ -254,39 +282,33 @@ void applyCastPrimitives(
   auto* inputSimpleVector = input.as<SimpleVector<From>>();
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
-
   auto& resultType = resultFlatVector->type();
-  auto makeException =
-      [&](const auto& input, auto row, const std::string& errorDetails) {
-        return std::make_exception_ptr(VeloxUserError(
-            std::current_exception(),
-            makeErrorMessage(input, row, resultType, errorDetails),
-            false));
-      };
+
+  auto setError = [&](vector_size_t row, const std::string& details) {
+    context.setError(row, makeException(resultType, input, row, details));
+  };
 
   if (!queryConfig.isCastToIntByTruncate()) {
     context.applyToSelectedNoThrow(rows, [&](int row) {
       try {
-        // Passing a false truncate flag
-        applyCastKernel<ToKind, FromKind, false>(
-            row, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxUserError& ue) {
-        context.setError(row, makeException(input, row, ue.message()));
+        applyCastKernel<ToKind, FromKind, false /*truncate*/>(
+            row, context, inputSimpleVector, resultFlatVector);
 
+      } catch (const VeloxUserError& ue) {
+        setError(row, ue.message());
       } catch (const std::exception& e) {
-        context.setError(row, makeException(input, row, e.what()));
+        setError(row, e.what());
       }
     });
   } else {
     context.applyToSelectedNoThrow(rows, [&](int row) {
       try {
-        // Passing a true truncate flag
-        applyCastKernel<ToKind, FromKind, true>(
-            row, inputSimpleVector, resultFlatVector);
+        applyCastKernel<ToKind, FromKind, true /*truncate*/>(
+            row, context, inputSimpleVector, resultFlatVector);
       } catch (const VeloxUserError& ue) {
-        context.setError(row, makeException(input, row, ue.message()));
+        setError(row, ue.message());
       } catch (const std::exception& e) {
-        context.setError(row, makeException(input, row, e.what()));
+        setError(row, e.what());
       }
     });
   }

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -39,14 +39,15 @@ namespace {
 std::string makeErrorMessage(
     const BaseVector& input,
     vector_size_t row,
-    const TypePtr& toType) {
+    const TypePtr& toType,
+    const std::string& details = "") {
   return fmt::format(
-      "Failed to cast from {} to {}: {}.",
+      "Failed to cast from {} to {}: {}. {}",
       input.type()->toString(),
       toType->toString(),
-      input.toString(row));
+      input.toString(row),
+      details);
 }
-
 /// The per-row level Kernel
 /// @tparam ToKind The cast target type
 /// @tparam FromKind The expression type
@@ -254,24 +255,26 @@ void applyCastPrimitives(
 
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
 
+  auto& resultType = resultFlatVector->type();
+  auto makeException =
+      [&](const auto& input, auto row, const std::string& errorDetails) {
+        return std::make_exception_ptr(VeloxUserError(
+            std::current_exception(),
+            makeErrorMessage(input, row, resultType, errorDetails),
+            false));
+      };
+
   if (!queryConfig.isCastToIntByTruncate()) {
     context.applyToSelectedNoThrow(rows, [&](int row) {
       try {
         // Passing a false truncate flag
         applyCastKernel<ToKind, FromKind, false>(
             row, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxRuntimeError& re) {
-        VELOX_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            re.message());
       } catch (const VeloxUserError& ue) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            ue.message());
+        context.setError(row, makeException(input, row, ue.message()));
+
       } catch (const std::exception& e) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            e.what());
+        context.setError(row, makeException(input, row, e.what()));
       }
     });
   } else {
@@ -280,24 +283,16 @@ void applyCastPrimitives(
         // Passing a true truncate flag
         applyCastKernel<ToKind, FromKind, true>(
             row, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxRuntimeError& re) {
-        VELOX_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            re.message());
       } catch (const VeloxUserError& ue) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            ue.message());
+        context.setError(row, makeException(input, row, ue.message()));
       } catch (const std::exception& e) {
-        VELOX_USER_FAIL(
-            makeErrorMessage(input, row, resultFlatVector->type()) + " " +
-            e.what());
+        context.setError(row, makeException(input, row, e.what()));
       }
     });
   }
 
-  // If we're converting to a TIMESTAMP, check if we need to adjust the current
-  // GMT timezone to the user provided session timezone.
+  // If we're converting to a TIMESTAMP, check if we need to adjust the
+  // current GMT timezone to the user provided session timezone.
   if constexpr (ToKind == TypeKind::TIMESTAMP) {
     // If user explicitly asked us to adjust the timezone.
     if (queryConfig.adjustTimestampToTimezone()) {

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -49,7 +49,7 @@ std::string makeErrorMessage(
       details);
 }
 
-std::exception_ptr makeException(
+std::exception_ptr makeBadCastException(
     const TypePtr& resultType,
     const BaseVector& input,
     vector_size_t row,
@@ -81,8 +81,9 @@ void applyCastKernel(
         TypeTraits<ToKind>::isPrimitiveType &&
         TypeTraits<ToKind>::isFixedWidth) {
       if (inputRowValue.size() == 0) {
-        context.setError(
-            row, makeException(result->type(), *input, row, "Empty string"));
+        context.setVeloxExceptionError(
+            row,
+            makeBadCastException(result->type(), *input, row, "Empty string"));
         return;
       }
     }
@@ -284,8 +285,14 @@ void applyCastPrimitives(
   const auto& queryConfig = context.execCtx()->queryCtx()->queryConfig();
   auto& resultType = resultFlatVector->type();
 
+  auto setVeloxError = [&](vector_size_t row, const std::string& details) {
+    context.setVeloxExceptionError(
+        row, makeBadCastException(resultType, input, row, details));
+  };
+
   auto setError = [&](vector_size_t row, const std::string& details) {
-    context.setError(row, makeException(resultType, input, row, details));
+    context.setError(
+        row, makeBadCastException(resultType, input, row, details));
   };
 
   if (!queryConfig.isCastToIntByTruncate()) {
@@ -295,7 +302,7 @@ void applyCastPrimitives(
             row, context, inputSimpleVector, resultFlatVector);
 
       } catch (const VeloxUserError& ue) {
-        setError(row, ue.message());
+        setVeloxError(row, ue.message());
       } catch (const std::exception& e) {
         setError(row, e.what());
       }
@@ -306,7 +313,7 @@ void applyCastPrimitives(
         applyCastKernel<ToKind, FromKind, true /*truncate*/>(
             row, context, inputSimpleVector, resultFlatVector);
       } catch (const VeloxUserError& ue) {
-        setError(row, ue.message());
+        setVeloxError(row, ue.message());
       } catch (const std::exception& e) {
         setError(row, e.what());
       }

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -71,13 +71,14 @@ class CastExpr : public SpecialForm {
   /// @param type The target type of the cast expression
   /// @param expr The expression to cast
   /// @param trackCpuUsage Whether to track CPU usage
-  CastExpr(TypePtr type, ExprPtr&& expr, bool trackCpuUsage)
+  CastExpr(TypePtr type, ExprPtr&& expr, bool trackCpuUsage, bool nullOnFailure)
       : SpecialForm(
             type,
             std::vector<ExprPtr>({expr}),
             kCast.data(),
             false /* supportsFlatNoNullsFastPath */,
-            trackCpuUsage) {
+            trackCpuUsage),
+        nullOnFailure_(nullOnFailure) {
     auto fromType = inputs_[0]->type();
     castFromOperator_ = getCustomTypeCastOperator(fromType->toString());
     if (castFromOperator_ && !castFromOperator_->isSupportedToType(type)) {
@@ -160,6 +161,86 @@ class CastExpr : public SpecialForm {
       const TypePtr& toType,
       VectorPtr& result);
 
+  template <typename Func>
+  void applyToSelectedNoThrowLocal(
+      EvalCtx& context,
+      const SelectivityVector& rows,
+      VectorPtr& result,
+      Func&& func);
+
+  /// The per-row level Kernel
+  /// @tparam ToKind The cast target type
+  /// @tparam FromKind The expression type
+  /// @param row The index of the current row
+  /// @param input The input vector (of type FromKind)
+  /// @param result The output vector (of type ToKind)
+  template <TypeKind ToKind, TypeKind FromKind, bool Truncate>
+  void applyCastKernel(
+      vector_size_t row,
+      EvalCtx& context,
+      const SimpleVector<typename TypeTraits<FromKind>::NativeType>* input,
+      FlatVector<typename TypeTraits<ToKind>::NativeType>* result);
+
+  VectorPtr castFromDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType);
+
+  VectorPtr castToDate(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType);
+
+  template <typename TInput, typename TOutput>
+  void applyDecimalCastKernel(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      VectorPtr& castResult);
+
+  template <typename TInput, typename TOutput>
+  void applyIntToDecimalCastKernel(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType,
+      VectorPtr& castResult);
+
+  template <typename TInput>
+  VectorPtr applyDecimalToDoubleCast(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType);
+
+  template <TypeKind ToKind, TypeKind FromKind>
+  void applyCastPrimitives(
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input,
+      VectorPtr& result);
+
+  template <TypeKind ToKind>
+  void applyCastPrimitivesDispatch(
+      const TypePtr& fromType,
+      const TypePtr& toType,
+      const SelectivityVector& rows,
+      exec::EvalCtx& context,
+      const BaseVector& input,
+      VectorPtr& result);
+
+  bool nullOnFailure() const {
+    return nullOnFailure_;
+  }
+
+  bool setNullInResultAtError() const {
+    return nullOnFailure() && inTopLevel;
+  }
+
   // Custom cast operator for the from-type. Nullptr if the type is native or
   // doesn't support cast-from.
   CastOperatorPtr castFromOperator_;
@@ -167,6 +248,10 @@ class CastExpr : public SpecialForm {
   // Custom cast operator for the to-type. Nullptr if the type is native or
   // doesn't support cast-to.
   CastOperatorPtr castToOperator_;
+
+  bool nullOnFailure_;
+
+  bool inTopLevel = false;
 };
 
 class CastCallToSpecialForm : public FunctionCallToSpecialForm {
@@ -179,4 +264,15 @@ class CastCallToSpecialForm : public FunctionCallToSpecialForm {
       bool trackCpuUsage) override;
 };
 
+class TryCastCallToSpecialForm : public FunctionCallToSpecialForm {
+ public:
+  TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
+
+  ExprPtr constructSpecialForm(
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage) override;
+};
 } // namespace facebook::velox::exec
+
+#include "velox/expression/CastExpr-inl.h"

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -167,6 +167,18 @@ void EvalCtx::setError(
   addError(index, toVeloxException(exceptionPtr), errors_);
 }
 
+// This should be used onlly when exceptionPtr is guranteed to be a
+// VeloxException.
+void EvalCtx::setVeloxExceptionError(
+    vector_size_t index,
+    const std::exception_ptr& exceptionPtr) {
+  if (throwOnError_) {
+    std::rethrow_exception(exceptionPtr);
+  }
+
+  addError(index, exceptionPtr, errors_);
+}
+
 void EvalCtx::setErrors(
     const SelectivityVector& rows,
     const std::exception_ptr& exceptionPtr) {

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -211,6 +211,23 @@ void EvalCtx::addElementErrorsToTopLevel(
   });
 }
 
+void EvalCtx::convertElementErrorsToTopLevelNulls(
+    const SelectivityVector& elementRows,
+    const BufferPtr& elementToTopLevelRows,
+    VectorPtr& result) {
+  if (!errors_) {
+    return;
+  }
+
+  const auto* rawElementToTopLevelRows =
+      elementToTopLevelRows->as<vector_size_t>();
+  elementRows.applyToSelected([&](auto row) {
+    if (errors_->isIndexInRange(row) && !errors_->isNullAt(row)) {
+      result->setNull(rawElementToTopLevelRows[row], true);
+    }
+  });
+}
+
 const VectorPtr& EvalCtx::getField(int32_t index) const {
   const VectorPtr* field;
   if (!peeledFields_.empty()) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -134,6 +134,13 @@ class EvalCtx {
       const BufferPtr& elementToTopLevelRows,
       ErrorVectorPtr& topLevelErrors);
 
+  // Given a mapping from element rows to top-level rows, set errors in
+  // in the elements as nulls int the top level row.
+  void convertElementErrorsToTopLevelNulls(
+      const SelectivityVector& elementRows,
+      const BufferPtr& elementToTopLevelRows,
+      VectorPtr& result);
+
   void deselectErrors(SelectivityVector& rows) const {
     if (!errors_) {
       return;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -412,13 +412,11 @@ ExprPtr compileRewrittenExpression(
   } else if (auto cast = dynamic_cast<const core::CastTypedExpr*>(expr.get())) {
     VELOX_CHECK(!compiledInputs.empty());
     auto castExpr = std::make_shared<CastExpr>(
-        resultType, std::move(compiledInputs[0]), trackCpuUsage);
-    if (cast->nullOnFailure()) {
-      result =
-          getSpecialForm(config, "try", resultType, {castExpr}, trackCpuUsage);
-    } else {
-      result = castExpr;
-    }
+        resultType,
+        std::move(compiledInputs[0]),
+        trackCpuUsage,
+        cast->nullOnFailure());
+    result = castExpr;
   } else if (auto call = dynamic_cast<const core::CallTypedExpr*>(expr.get())) {
     if (auto specialForm = getSpecialForm(
             config,

--- a/velox/expression/FunctionCallToSpecialForm.cpp
+++ b/velox/expression/FunctionCallToSpecialForm.cpp
@@ -32,6 +32,7 @@ RegistryType makeRegistry() {
   registry.emplace(
       "and", std::make_unique<ConjunctCallToSpecialForm>(true /* isAnd */));
   registry.emplace("cast", std::make_unique<CastCallToSpecialForm>());
+  registry.emplace("try_cast", std::make_unique<TryCastCallToSpecialForm>());
   registry.emplace("coalesce", std::make_unique<CoalesceCallToSpecialForm>());
   registry.emplace("if", std::make_unique<IfCallToSpecialForm>());
   registry.emplace(

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -674,6 +674,28 @@ TEST_F(CastExprTest, mapCast) {
       VELOX_CHECK(start + size - 1 < valuesSize);
     }
   }
+
+  // Error handling.
+  {
+    auto data = makeRowVector(
+        {makeMapVector<StringView, StringView>({{{"1", "2"}}, {{"", "1"}}})});
+    auto result1 = evaluate("try_cast(c0 as map(int, int))", data);
+    auto result2 = evaluate("try(cast(c0 as map(int, int)))", data);
+    ASSERT_FALSE(result1->isNullAt(0));
+    ASSERT_TRUE(result1->isNullAt(1));
+
+    ASSERT_FALSE(result2->isNullAt(0));
+    ASSERT_TRUE(result2->isNullAt(1));
+    ASSERT_THROW(evaluate("cast(c0 as map(int, int)", data), VeloxException);
+  }
+
+  {
+    auto result = evaluate(
+        "try_cast(map(array_constructor('1'), array_constructor(''))  as map(int, int))",
+        makeRowVector({makeFlatVector<int32_t>({1, 2})}));
+    ASSERT_TRUE(result->isNullAt(0));
+    ASSERT_TRUE(result->isNullAt(1));
+  }
 }
 
 TEST_F(CastExprTest, arrayCast) {
@@ -732,6 +754,34 @@ TEST_F(CastExprTest, arrayCast) {
       VELOX_CHECK(start + size - 1 < elementsSize);
     }
   }
+
+  // Error handling.
+  {
+    auto data =
+        makeRowVector({makeArrayVector<StringView>({{"1", "2"}, {"", "1"}})});
+    auto result1 = evaluate("try_cast(c0 as bigint[])", data);
+    auto result2 = evaluate("try(cast(c0 as bigint[]))", data);
+
+    auto expected = makeNullableArrayVector<int64_t>({{{1, 2}}, std::nullopt});
+
+    assertEqualVectors(result1, expected);
+    assertEqualVectors(result2, expected);
+
+    ASSERT_THROW(evaluate("cast(c0 as bigint[])", data), VeloxException);
+  }
+
+  {
+    auto data = makeNullableNestedArrayVector<StringView>({
+        {{{{"1"_sv, "2"_sv}}, {{""_sv}}}}, // row0
+        {{{{std::nullopt, "4"_sv}}}}, // row1
+    });
+    auto expected = makeNullableNestedArrayVector<int64_t>({
+        std::nullopt, // row0
+        {{{{std::nullopt, 4}}}}, // row1
+
+    });
+    testComplexCast("c0", data, expected, true);
+  }
 }
 
 TEST_F(CastExprTest, rowCast) {
@@ -781,6 +831,55 @@ TEST_F(CastExprTest, rowCast) {
     auto expectedRowVector = makeRowVector(
         {"c0", "b"}, {doubleVectorNullEvery11, intVectorNullAll}, nullEvery(5));
     testComplexCast("c0", rowVector, expectedRowVector);
+  }
+
+  // Error handling.
+  {
+    auto data = makeRowVector(
+        {makeFlatVector<StringView>({"1", ""}),
+         makeFlatVector<StringView>({"2", "3"})});
+
+    auto expected = makeRowVector(
+        {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({2, 3})});
+    expected->setNull(1, true);
+
+    testComplexCast("c0", data, expected, true);
+  }
+
+  {
+    auto data = makeRowVector(
+        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+         makeFlatVector<StringView>({"2", ""})});
+
+    auto expected1 = makeRowVector(
+        {makeArrayVector<int32_t>({{1 /*will be null*/}, {3, 4}}),
+         makeFlatVector<StringView>({"2" /*will be null*/, ""})});
+    expected1->setNull(0, true);
+
+    auto expected2 = makeRowVector(
+        {makeArrayVector<StringView>({{"1", ""}, {"3", "4"}}),
+         makeFlatVector<int32_t>({2, 0 /*null*/})});
+    expected2->setNull(1, true);
+
+    auto expected3 = makeRowVector(
+        {makeArrayVector<int32_t>({{1}}), makeFlatVector<int32_t>(1)});
+    expected3->resize(2);
+    expected3->setNull(0, true);
+    expected3->setNull(1, true);
+
+    testComplexCast("c0", data, expected1, true);
+    testComplexCast("c0", data, expected2, true);
+    testComplexCast("c0", data, expected3, true);
+  }
+
+  // Null handling for nested structs.
+  {
+    auto data =
+        makeRowVector({makeRowVector({makeFlatVector<StringView>({"1", ""})})});
+    auto expected =
+        makeRowVector({makeRowVector({makeFlatVector<int32_t>({1, 0})})});
+    expected->setNull(1, true);
+    testComplexCast("c0", data, expected, true);
   }
 }
 
@@ -1149,7 +1248,8 @@ TEST_F(CastExprTest, dictionaryOverConst) {
 }
 
 namespace {
-// Wrap input in a dictionary that point to subset of rows of the inner vector.
+// Wrap input in a dictionary that point to subset of rows of the inner
+// vector.
 class TestingDictionaryToFewerRowsFunction : public exec::VectorFunction {
  public:
   TestingDictionaryToFewerRowsFunction() {}
@@ -1187,16 +1287,16 @@ TEST_F(CastExprTest, dictionaryEncodedNestedInput) {
   // Cast ARRAY<ROW<BIGINT>> to ARRAY<ROW<VARCHAR>> where the outermost ARRAY
   // layer and innermost BIGINT layer are dictionary-encoded. This test case
   // ensures that when casting the ROW<BIGINT> vector, the result ROW vector
-  // would not be longer than the result VARCHAR vector. In the test below, the
-  // ARRAY vector has 2 rows, each containing 3 elements. The ARRAY vector is
-  // wrapped in a dictionary layer that only references its first row, hence
-  // only the first 3 out of 6 rows are evaluated for the ROW and BIGINT vector.
-  // The BIGINT vector is also dictionary-encoded, so CastExpr produces a result
-  // VARCHAR vector of length 3. If the casting of the ROW vector produces a
-  // result ROW<VARCHAR> vector of the length of all rows, i.e., 6, the
-  // subsequent call to Expr::addNull() would throw due to the attempt of
-  // accessing the element VARCHAR vector at indices corresonding to the
-  // non-existent ROW at indices 3--5.
+  // would not be longer than the result VARCHAR vector. In the test below,
+  // the ARRAY vector has 2 rows, each containing 3 elements. The ARRAY vector
+  // is wrapped in a dictionary layer that only references its first row,
+  // hence only the first 3 out of 6 rows are evaluated for the ROW and BIGINT
+  // vector. The BIGINT vector is also dictionary-encoded, so CastExpr
+  // produces a result VARCHAR vector of length 3. If the casting of the ROW
+  // vector produces a result ROW<VARCHAR> vector of the length of all rows,
+  // i.e., 6, the subsequent call to Expr::addNull() would throw due to the
+  // attempt of accessing the element VARCHAR vector at indices corresonding
+  // to the non-existent ROW at indices 3--5.
   exec::registerVectorFunction(
       "add_dict",
       TestingDictionaryToFewerRowsFunction::signatures(),
@@ -1236,4 +1336,36 @@ TEST_F(CastExprTest, smallerNonNullRowsSizeThanRows) {
       "coalesce(c1, cast(add_dict_with_2_trailing_nulls(c0) as double))", data);
   auto expected = makeNullableFlatVector<double>({4, 6, 7, std::nullopt});
   assertEqualVectors(expected, result);
+}
+
+TEST_F(CastExprTest, tryCastDoesNotHideInputsErrors) {
+  auto test = [&](const std::string& castExprThatThrow,
+                  const std::string& type,
+                  const auto& data) {
+    ASSERT_THROW(
+        auto result = evaluate(
+            fmt::format("try_cast({} as {})", castExprThatThrow, type), data),
+        VeloxException);
+
+    ASSERT_NO_THROW(evaluate(
+        fmt::format("try (cast ({} as {}))", castExprThatThrow, type), data));
+    ASSERT_NO_THROW(evaluate(fmt::format("try_{}", castExprThatThrow), data));
+    ASSERT_NO_THROW(evaluate(fmt::format("try ({})", castExprThatThrow), data));
+  };
+
+  {
+    auto data = makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4})});
+    test("cast('' as int)", "int", data);
+  }
+
+  {
+    auto data =
+        makeRowVector({makeArrayVector<StringView>({{"1", "", "3", "4"}})});
+    test("cast(c0 as integer[])", "integer[]", data);
+    test("cast(map(c0, c0) as map(int, int))", "map(int, int)", data);
+    test(
+        "cast(row_constructor(c0, c0, c0) as struct(a int[], b bigint[], c float[]))",
+        "struct(a int[], b bigint[], c float[])",
+        data);
+  }
 }

--- a/velox/functions/lib/RowsTranslationUtil.h
+++ b/velox/functions/lib/RowsTranslationUtil.h
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#pragma once
+
 #include "velox/common/base/Nulls.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/SelectivityVector.h"


### PR DESCRIPTION
Summary:
Original commit changeset: b1e7c053fffc

Original Phabricator Diff: D47502982

The test MemoryAllocatorTest.allocContiguousVsize introduced by this diff
is facing on circleCI.
```
38: ../../velox/common/memory/tests/MemoryAllocatorTest.cpp:154: Failure
38: Expected: (expected) <= (current.vsize), actual: 698285 vs 481515
38: ../../velox/common/memory/tests/MemoryAllocatorTest.cpp:158: Failure
38: Expected: (expected + kMargin) >= (current.rss), actual: 15273 vs 82309
```

Differential Revision: D47539934

