### PR TITLE
Enhance testing for array_agg with mask

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -555,7 +555,21 @@ PlanBuilder::AggregatesAndNames PlanBuilder::createAggregateExpressionsAndNames(
     core::AggregationNode::Aggregate agg;
     agg.call = std::dynamic_pointer_cast<const core::CallTypedExpr>(
         inferTypes(untypedExpr.expr));
+    if (untypedExpr.maskExpr != nullptr) {
+      auto maskExpr =
+          std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+              inferTypes(untypedExpr.maskExpr));
+      VELOX_CHECK_NOT_NULL(
+          maskExpr,
+          "FILTER clause must use a column name, not an expression: {}",
+          aggregate);
+      agg.mask = maskExpr;
+    }
+
     if (i < masks.size() && !masks[i].empty()) {
+      VELOX_CHECK_NULL(
+          agg.mask,
+          "Aggregation mask should be specified only once (either explicitly or using FILTER clause)");
       agg.mask = field(masks[i]);
     }
 

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -292,11 +292,8 @@ TEST_F(ArrayAggTest, mask) {
       makeConstant(false, 5),
   });
 
-  auto plan = PlanBuilder()
-                  .values({data})
-                  .singleAggregation({}, {"array_agg(c0)"}, {"c1"})
-                  .planNode();
-  assertQuery(plan, "SELECT null");
+  testAggregations(
+      {data}, {}, {"array_agg(c0) FILTER (WHERE c1)"}, "SELECT null");
 
   // Global aggregation with a non-constant mask.
   data = makeRowVector({
@@ -304,11 +301,8 @@ TEST_F(ArrayAggTest, mask) {
       makeFlatVector<bool>({true, false, true, false, true}),
   });
 
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation({}, {"array_agg(c0)"}, {"c1"})
-             .planNode();
-  assertQuery(plan, "SELECT [1, 3, 5]");
+  testAggregations(
+      {data}, {}, {"array_agg(c0) FILTER (WHERE c1)"}, "SELECT [1, 3, 5]");
 
   // Group-by with all-false mask.
   data = makeRowVector({
@@ -317,11 +311,11 @@ TEST_F(ArrayAggTest, mask) {
       makeConstant(false, 5),
   });
 
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation({"c0"}, {"array_agg(c1)"}, {"c2"})
-             .planNode();
-  assertQuery(plan, "VALUES (10, null), (20, null)");
+  testAggregations(
+      {data},
+      {"c0"},
+      {"array_agg(c1) FILTER (WHERE c2)"},
+      "VALUES (10, null), (20, null)");
 
   // Group-by with a non-constant mask.
   data = makeRowVector({
@@ -330,11 +324,11 @@ TEST_F(ArrayAggTest, mask) {
       makeFlatVector<bool>({true, false, true, false, true}),
   });
 
-  plan = PlanBuilder()
-             .values({data})
-             .singleAggregation({"c0"}, {"array_agg(c1)"}, {"c2"})
-             .planNode();
-  assertQuery(plan, "VALUES (10, [1, 3]), (20, [5])");
+  testAggregations(
+      {data},
+      {"c0"},
+      {"array_agg(c1) FILTER (WHERE c2)"},
+      "VALUES (10, [1, 3]), (20, [5])");
 }
 
 } // namespace


### PR DESCRIPTION
Add support for masked aggregations to AggregateTestBase::testAggregations and
use it to enhance testing of array_agg.