### PR TITLE
Store debug context in thread local variable

### DIFF
--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_process ProcessBase.cpp StackTrace.cpp TraceContext.cpp)
+add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
+                          TraceContext.cpp)
 
 target_link_libraries(velox_process velox_flag_definitions Folly::folly
                       glog::glog)

--- a/velox/common/process/ThreadDebugInfo.cpp
+++ b/velox/common/process/ThreadDebugInfo.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/ThreadDebugInfo.h"
+
+#include <folly/experimental/symbolizer/SignalHandler.h>
+#include <glog/logging.h>
+
+namespace facebook::velox::process {
+thread_local const ThreadDebugInfo* threadDebugInfo = nullptr;
+
+static void printCurrentQueryId() {
+  const ThreadDebugInfo* info = GetThreadDebugInfo();
+  if (info == nullptr) {
+    const char* msg =
+        "Fatal signal handler. "
+        "ThreadDebugInfo object not found.";
+    write(STDERR_FILENO, msg, strlen(msg));
+  } else {
+    const char* msg = "Fatal signal handler. Query Id= ";
+    write(STDERR_FILENO, msg, strlen(msg));
+    write(STDERR_FILENO, info->queryId_.c_str(), info->queryId_.length());
+  }
+  write(STDERR_FILENO, "\n", 1);
+}
+
+const ThreadDebugInfo* GetThreadDebugInfo() {
+  return threadDebugInfo;
+}
+ScopedThreadDebugInfo::ScopedThreadDebugInfo(
+    const ThreadDebugInfo& localDebugInfo) {
+  prevThreadDebugInfo_ = threadDebugInfo;
+  threadDebugInfo = &localDebugInfo;
+}
+
+ScopedThreadDebugInfo::~ScopedThreadDebugInfo() {
+  threadDebugInfo = prevThreadDebugInfo_;
+}
+
+void addDefaultFatalSignalHandler() {
+  static bool initialized = false;
+  if (!initialized) {
+    folly::symbolizer::addFatalSignalCallback(&printCurrentQueryId);
+    initialized = true;
+  }
+}
+
+} // namespace facebook::velox::process

--- a/velox/common/process/ThreadDebugInfo.h
+++ b/velox/common/process/ThreadDebugInfo.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace facebook::velox::process {
+
+// Used to store thread local information which can be retrieved by a signal
+// handler and logged.
+struct ThreadDebugInfo {
+  std::string queryId_;
+};
+
+// A RAII class to store thread local debug information.
+class ScopedThreadDebugInfo {
+ public:
+  explicit ScopedThreadDebugInfo(const ThreadDebugInfo& localDebugInfo);
+  ~ScopedThreadDebugInfo();
+
+ private:
+  const ThreadDebugInfo* prevThreadDebugInfo_ = nullptr;
+};
+
+// Get the current thread local debug information. Used by signal handlers or
+// can be accessed during a debug session. Returns nullptr if no debug info is
+// set.
+const ThreadDebugInfo* GetThreadDebugInfo();
+
+// Install a signal handler to dump thread local debug information. This should
+// be called before calling folly::symbolizer::installFatalSignalCallbacks()
+// which is usually called at startup via folly::Init(). This is just a default
+// implementation but you can install your own signal handler. Make sure to
+// install one at the start of your program.
+void addDefaultFatalSignalHandler();
+
+} // namespace facebook::velox::process

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "velox/common/future/VeloxPromise.h"
+#include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/connectors/Connector.h"
 #include "velox/core/PlanNode.h"
@@ -223,6 +224,7 @@ struct DriverCtx {
 
   std::shared_ptr<Task> task;
   Driver* driver;
+  facebook::velox::process::ThreadDebugInfo threadDebugInfo;
 
   explicit DriverCtx(
       std::shared_ptr<Task> _task,

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -539,6 +539,9 @@ void Task::start(
     std::shared_ptr<Task> self,
     uint32_t maxDrivers,
     uint32_t concurrentSplitGroups) {
+  facebook::velox::process::ThreadDebugInfo threadDebugInfo{
+      .queryId_ = self->queryCtx()->queryId()};
+  facebook::velox::process::ScopedThreadDebugInfo scopedInfo(threadDebugInfo);
   try {
     VELOX_CHECK_GE(
         maxDrivers,

--- a/velox/exec/tests/Main.cpp
+++ b/velox/exec/tests/Main.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/common/process/ThreadDebugInfo.h"
+
 #include <folly/Unit.h>
 #include <folly/init/Init.h>
 #include <gtest/gtest.h>
@@ -20,6 +22,8 @@
 // This main is needed for some tests on linux.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
+  // Signal handler required for ThreadDebugInfoTest
+  facebook::velox::process::addDefaultFatalSignalHandler();
   folly::init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/exec/tests/ThreadDebugInfoTest.cpp
+++ b/velox/exec/tests/ThreadDebugInfoTest.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/process/ThreadDebugInfo.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/Udf.h"
+
+#include <folly/Unit.h>
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+// Only build if address sanitizer is not enabled since this test initiated a
+// segfault which should be captured by the signal handler but gets caught by
+// the address sanitizer handler instead which print a different error log.
+
+// For clang
+#ifdef __has_feature
+#define IS_BUILDING_WITH_ASAN() __has_feature(address_sanitizer)
+#else
+// For GCC
+#if defined(__SANITIZE_ADDRESS__) && __SANITIZE_ADDRESS__
+#define IS_BUILDING_WITH_ASAN() 1
+#else
+#define IS_BUILDING_WITH_ASAN() 0
+#endif
+#endif
+
+#if IS_BUILDING_WITH_ASAN() == 0
+// Ensure the test class name has "DeathTest" as a prefix to ensure this runs in
+// a single thread since the ASSERT_DEATH forks the process.
+class ThreadDebugInfoDeathTest : public OperatorTestBase {};
+
+namespace {
+
+template <typename T>
+struct InduceSegFaultFunction {
+  template <typename TResult, typename TInput>
+  void call(TResult& out, const TInput& in) {
+    int* nullpointer = nullptr;
+    *nullpointer = 6;
+  }
+};
+} // namespace
+
+TEST_F(ThreadDebugInfoDeathTest, withinSeperateDriverThread) {
+  auto vector = makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
+  registerFunction<InduceSegFaultFunction, int64_t, int64_t>({"segFault"});
+  auto op = PlanBuilder().values({vector}).project({"segFault(c0)"}).planNode();
+
+  ASSERT_DEATH(
+      (assertQuery(op, vector)),
+      ".*Fatal signal handler. Query Id= TaskCursorQuery_0.*");
+}
+
+TEST_F(ThreadDebugInfoDeathTest, withinQueryCompilation) {
+  auto vector = makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
+  registerFunction<InduceSegFaultFunction, int64_t, int64_t>({"segFault"});
+  // Call expression with a constant to trigger the constant folding during
+  // compilation.
+  auto op = PlanBuilder().values({vector}).project({"segFault(1)"}).planNode();
+
+  ASSERT_DEATH(
+      (assertQuery(op, vector)),
+      ".*Fatal signal handler. Query Id= TaskCursorQuery_0.*");
+}
+
+TEST_F(ThreadDebugInfoDeathTest, withinTheCallingThread) {
+  auto vector = makeRowVector({makeFlatVector<int64_t>({1, 2, 3, 4, 5, 6})});
+  registerFunction<InduceSegFaultFunction, int64_t, int64_t>({"segFault"});
+  auto plan =
+      PlanBuilder().values({vector}).project({"segFault(c0)"}).planFragment();
+
+  auto queryCtx = std::make_shared<core::QueryCtx>(
+      executor_.get(),
+      std::unordered_map<std::string, std::string>{},
+      std::unordered_map<std::string, std::shared_ptr<Config>>{},
+      memory::MemoryAllocator::getInstance(),
+      nullptr,
+      nullptr,
+      "TaskCursorQuery_0");
+  auto task = exec::Task::create(
+      "single.execution.task.0", std::move(plan), 0, queryCtx);
+
+  ASSERT_DEATH(
+      (task->next()), ".*Fatal signal handler. Query Id= TaskCursorQuery_0.*");
+}
+
+#endif


### PR DESCRIPTION
Summary: This change introduces a way to store thread local context which can be logged by installing signal handlers as it is accesible via a global function GetThreadDebugInfo(). Currently, only the query id is stored but it can be extended to add more information.

Differential Revision: D47570239

