### PR TITLE
Compact row-wise serde

### DIFF
--- a/velox/docs/develop.rst
+++ b/velox/docs/develop.rst
@@ -23,6 +23,7 @@ This guide is intended for Velox contributors and developers of Velox-based appl
     develop/simd
     develop/spilling
     develop/unsaferow
+    develop/compactrow
     develop/testing
     develop/debugging
     develop/TpchBenchmark

--- a/velox/docs/develop/compactrow.rst
+++ b/velox/docs/develop/compactrow.rst
@@ -1,0 +1,118 @@
+===============================
+CompactRow Serialization Format
+===============================
+
+CompactRow is a row-wise serialization format provided by Velox as an
+alternative to UnsafeRow format. CompactRow is more space efficient then
+UnsafeRow and results in fewer bytes shuffled which has a cascading effect on
+CPU usage (for compression and checksumming) and memory (for buffering).
+
+A row is a contiguous buffer that starts with null flags, followed by individual
+fields.
+
+nulls | field1 | field 2 | …
+
+Nulls section uses one bit per field to indicate which fields are null. If there
+are 10 fields, there will be 2 bytes of null flags (16 bits total, 10 bits
+used, 6 bits unused).
+
+Fixed-width fields (integers, boolean, floating point numbers) take up a fixed
+number of bytes regardless of whether they are null or not. A row with 10
+bigint fields takes up 2 + 10 * 8 = 82 bytes. 2 bytes for null flags + 8 bytes
+per field.
+
+The sizes of fixed-width fields are:
+
+================   ==============================================
+Type               Number of bytes used for serialization
+================   ==============================================
+BOOLEAN            1
+TINYINT            1
+SMALLINT           2
+INTEGER            4
+BIGINT             8
+HUGEINT            16
+REAL               4
+DOUBLE             8
+TIMESTAMP          8
+UNKNOWN            0
+================   ==============================================
+
+Strings (VARCHAR and VARBINARY) use 4 bytes for size plus the length of the
+string. Empty string uses 4 bytes. 1-character string uses 5 bytes.
+20-character ASCII string uses 24 bytes. Null strings do not take up space
+(other than one bit in the nulls section).
+
+Arrays of fixed-width values or strings, e.g. arrays of integers, use 4 bytes
+for the size of the array, a few bytes for nulls flags indicating null-ness of
+the elements (1 bit per element) plus the space taken by the elements
+themselves.
+
+For example, an array of 5 integers [1, 2, 3, 4, 5] uses 4 bytes for size, 1
+byte for 5 null flags and 5 * 4 bytes for 5 values. A total of 25 bytes.
+
+
+============    ====    ========    ======  ======  ======  ======  ======
+Description     Size    Nulls       Elem 1  Elem 2  Elem 3  Elem 4  Elem 5
+============    ====    ========    ======  ======  ======  ======  ======
+# of bytes      4       1           4       4       4       4       4
+Value           5       00000000    1       2       3       4       5
+============    ====    ========    ======  ======  ======  ======  ======
+
+An array of 4 strings [null, “Abc”, null, “Mountains and rivers”] uses 36 bytes:
+
+============    ====    ========    =======     ======  =======     =====================
+Description     Size    Nulls       Size s2     s2      Size s4     s4
+============    ====    ========    =======     ======  =======     =====================
+# of bytes      4       1           4           3       4           20
+Value           4       10100000    1           Abc     20          Mountains and rivers
+============    ====    ========    =======     ======  =======     =====================
+
+Serialization of an array of complex type elements, e.g. an array of arrays, maps or structs, includes a few additional fields: the total serialized size plus offset of each element in the serialized buffer.
+
+- 4 bytes - array size.
+- N bytes - null flags, 1 bit per element.
+- 4 bytes - Total serialized size of the array excluding first 2 fields (size and nulls).
+- 4 bytes per element - Offsets of the elements in the serialized buffer relative to the position right after the total serialized size.
+- Elements.
+
+For example, an array of integers [[1, 2, 3], [4, 5], [6]] uses N bytes:
+
+- 4 bytes - size - 3
+- 1 byte - nulls - 00000000
+- 4 bytes - total serialized size - 55
+- 4 bytes - offset of the 1st element - 12
+- 4 bytes - offset of the 2nd element - 29
+- 4 bytes - offset of the 3rd element - 42
+- —-- Start of the 1st element: [1, 2, 3]
+- 4 bytes - size - 3
+- 1 byte - nulls - 00000000
+- 4 bytes - element 1 - 1
+- 4 bytes - element 2 - 2
+- 4 bytes - element 3 - 3
+- —-- Start of the 2nd element: [4, 5]
+- 4 bytes - size - 2
+- 1 byte - nulls - 00000000
+- 4 bytes - element 1 - 4
+- 4 bytes - element 2 - 5
+- —-- Start of the 2nd element: [6]
+- 4 bytes - size - 1
+- 1 byte - nulls - 00000000
+- 4 bytes - element 1 - 6
+
+A map is serialized as the keys array followed by the values array.
+
+A struct is serialized the same as the top-level row.
+
+Compared to UnsafeRow, on average CompactRow serialization is about twice shorter. Some examples are:
+
+======================  =========   ==========
+Type                    UnsafeRow   CompactRow
+======================  =========   ==========
+INTEGER                 8           4
+BIGINT                  8           8
+REAL                    8           4
+DOUBLE                  8           8
+VARCHAR: “” (empty)     8           4
+VARCHAR: “Abc”          16          7
+======================  =========   ==========

--- a/velox/row/CMakeLists.txt
+++ b/velox/row/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_row_fast UnsafeRowFast.cpp)
+add_library(velox_row_fast UnsafeRowFast.cpp CompactRow.cpp)
 
 target_link_libraries(velox_row_fast velox_vector)
 

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -1,0 +1,714 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/row/CompactRow.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::row {
+
+CompactRow::CompactRow(const RowVectorPtr& vector)
+    : typeKind_{vector->typeKind()}, decoded_{*vector} {
+  initialize(vector->type());
+}
+
+CompactRow::CompactRow(const VectorPtr& vector)
+    : typeKind_{vector->typeKind()}, decoded_{*vector} {
+  initialize(vector->type());
+}
+
+void CompactRow::initialize(const TypePtr& type) {
+  auto base = decoded_.base();
+  switch (typeKind_) {
+    case TypeKind::ARRAY: {
+      auto arrayBase = base->as<ArrayVector>();
+      children_.push_back(CompactRow(arrayBase->elements()));
+      childIsFixedWidth_.push_back(
+          arrayBase->elements()->type()->isFixedWidth());
+      break;
+    }
+    case TypeKind::MAP: {
+      auto mapBase = base->as<MapVector>();
+      children_.push_back(CompactRow(mapBase->mapKeys()));
+      children_.push_back(CompactRow(mapBase->mapValues()));
+      childIsFixedWidth_.push_back(mapBase->mapKeys()->type()->isFixedWidth());
+      childIsFixedWidth_.push_back(
+          mapBase->mapValues()->type()->isFixedWidth());
+      break;
+    }
+    case TypeKind::ROW: {
+      auto rowBase = base->as<RowVector>();
+      for (const auto& child : rowBase->children()) {
+        children_.push_back(CompactRow(child));
+        childIsFixedWidth_.push_back(child->type()->isFixedWidth());
+      }
+
+      rowNullBytes_ = bits::nbytes(type->size());
+      break;
+    }
+    case TypeKind::BOOLEAN:
+      valueBytes_ = 1;
+      fixedWidthTypeKind_ = true;
+      break;
+    case TypeKind::TINYINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::SMALLINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::INTEGER:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::BIGINT:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::REAL:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::DOUBLE:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::UNKNOWN:
+      valueBytes_ = type->cppSizeInBytes();
+      fixedWidthTypeKind_ = true;
+      supportsBulkCopy_ = decoded_.isIdentityMapping();
+      break;
+    case TypeKind::TIMESTAMP:
+      valueBytes_ = sizeof(int64_t);
+      fixedWidthTypeKind_ = true;
+      break;
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY:
+      // Nothing to do.
+      break;
+    default:
+      VELOX_UNSUPPORTED("Unsupported type: {}", type->toString());
+  }
+}
+
+// static
+std::optional<int32_t> CompactRow::fixedRowSize(const RowTypePtr& rowType) {
+  const size_t numFields = rowType->size();
+  const size_t nullLength = bits::nbytes(numFields);
+
+  size_t size = nullLength;
+  for (const auto& child : rowType->children()) {
+    if (child->isTimestamp()) {
+      size += sizeof(int64_t);
+    } else if (child->isFixedWidth()) {
+      size += child->cppSizeInBytes();
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  return size;
+}
+
+int32_t CompactRow::rowSize(vector_size_t index) {
+  return rowRowSize(index);
+}
+
+int32_t CompactRow::rowRowSize(vector_size_t index) {
+  auto childIndex = decoded_.index(index);
+
+  const auto numFields = children_.size();
+  int32_t size = rowNullBytes_;
+
+  for (auto i = 0; i < numFields; ++i) {
+    if (childIsFixedWidth_[i]) {
+      size += children_[i].valueBytes_;
+    } else if (!children_[i].isNullAt(childIndex)) {
+      size += children_[i].variableWidthRowSize(childIndex);
+    }
+  }
+
+  return size;
+}
+
+int32_t CompactRow::serializeRow(vector_size_t index, char* buffer) {
+  auto childIndex = decoded_.index(index);
+
+  int64_t valuesOffset = rowNullBytes_;
+
+  auto* nulls = reinterpret_cast<uint8_t*>(buffer);
+
+  for (auto i = 0; i < children_.size(); ++i) {
+    auto& child = children_[i];
+
+    // Write fixed-width value.
+    if (childIsFixedWidth_[i]) {
+      child.serializeFixedWidth(childIndex, buffer + valuesOffset);
+      valuesOffset += child.valueBytes_;
+    }
+
+    // Write null bit.
+    if (child.isNullAt(childIndex)) {
+      bits::setBit(nulls, i, true);
+      continue;
+    }
+
+    // Write non-null variable-width value.
+    if (!childIsFixedWidth_[i]) {
+      auto size =
+          child.serializeVariableWidth(childIndex, buffer + valuesOffset);
+      valuesOffset += size;
+    }
+  }
+
+  return valuesOffset;
+}
+
+bool CompactRow::isNullAt(vector_size_t index) {
+  return decoded_.isNullAt(index);
+}
+
+int32_t CompactRow::variableWidthRowSize(vector_size_t index) {
+  switch (typeKind_) {
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY: {
+      auto value = decoded_.valueAt<StringView>(index);
+      return sizeof(int32_t) + value.size();
+    }
+    case TypeKind::ARRAY:
+      return arrayRowSize(index);
+    case TypeKind::MAP:
+      return mapRowSize(index);
+    case TypeKind::ROW:
+      return rowRowSize(index);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+  };
+}
+
+int32_t CompactRow::arrayRowSize(vector_size_t index) {
+  auto baseIndex = decoded_.index(index);
+
+  // array size | null bits | elements
+  auto arrayBase = decoded_.base()->asUnchecked<ArrayVector>();
+  auto offset = arrayBase->offsetAt(baseIndex);
+  auto size = arrayBase->sizeAt(baseIndex);
+
+  return arrayRowSize(children_[0], offset, size, childIsFixedWidth_[0]);
+}
+
+int32_t CompactRow::arrayRowSize(
+    CompactRow& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    bool fixedWidth) {
+  const int32_t nullBytes = bits::nbytes(size);
+
+  int32_t rowSize = sizeof(int32_t) + nullBytes;
+  if (fixedWidth) {
+    return rowSize + size * elements.valueBytes();
+  }
+
+  for (auto i = 0; i < size; ++i) {
+    if (!elements.isNullAt(offset + i)) {
+      rowSize += elements.variableWidthRowSize(offset + i);
+    }
+  }
+
+  return rowSize;
+}
+
+int32_t CompactRow::serializeArray(vector_size_t index, char* buffer) {
+  auto baseIndex = decoded_.index(index);
+
+  // array size | null bits | elements
+  auto arrayBase = decoded_.base()->asUnchecked<ArrayVector>();
+  auto offset = arrayBase->offsetAt(baseIndex);
+  auto size = arrayBase->sizeAt(baseIndex);
+
+  return serializeAsArray(
+      children_[0], offset, size, childIsFixedWidth_[0], buffer);
+}
+
+int32_t CompactRow::serializeAsArray(
+    CompactRow& elements,
+    vector_size_t offset,
+    vector_size_t size,
+    bool fixedWidth,
+    char* buffer) {
+  // array size | null bits | elements
+
+  // Write array size.
+  *reinterpret_cast<int32_t*>(buffer) = size;
+
+  const int32_t nullBytes = bits::nbytes(size);
+  const int32_t nullsOffset = sizeof(int32_t);
+
+  int32_t elementsOffset = nullsOffset + nullBytes;
+
+  auto* rawNulls = reinterpret_cast<uint8_t*>(buffer + nullsOffset);
+
+  if (elements.supportsBulkCopy_) {
+    if (elements.decoded_.mayHaveNulls()) {
+      for (auto i = 0; i < size; ++i) {
+        if (elements.isNullAt(offset + i)) {
+          bits::setBit(rawNulls, i, true);
+        }
+      }
+    }
+    elements.serializeFixedWidth(offset, size, buffer + elementsOffset);
+    return elementsOffset + size * elements.valueBytes_;
+  }
+
+  for (auto i = 0; i < size; ++i) {
+    if (elements.isNullAt(offset + i)) {
+      bits::setBit(rawNulls, i, true);
+      if (fixedWidth) {
+        elementsOffset += elements.valueBytes_;
+      }
+    } else {
+      if (fixedWidth) {
+        elements.serializeFixedWidth(offset + i, buffer + elementsOffset);
+        elementsOffset += elements.valueBytes_;
+      } else {
+        auto serializedBytes = elements.serializeVariableWidth(
+            offset + i, buffer + elementsOffset);
+
+        elementsOffset += serializedBytes;
+      }
+    }
+  }
+  return elementsOffset;
+}
+
+int32_t CompactRow::mapRowSize(vector_size_t index) {
+  auto baseIndex = decoded_.index(index);
+
+  //  <keys array> | <values array>
+
+  auto mapBase = decoded_.base()->asUnchecked<MapVector>();
+  auto offset = mapBase->offsetAt(baseIndex);
+  auto size = mapBase->sizeAt(baseIndex);
+
+  return arrayRowSize(children_[0], offset, size, childIsFixedWidth_[0]) +
+      arrayRowSize(children_[1], offset, size, childIsFixedWidth_[1]);
+}
+
+int32_t CompactRow::serializeMap(vector_size_t index, char* buffer) {
+  auto baseIndex = decoded_.index(index);
+
+  //  <keys array> | <values array>
+
+  auto mapBase = decoded_.base()->asUnchecked<MapVector>();
+  auto offset = mapBase->offsetAt(baseIndex);
+  auto size = mapBase->sizeAt(baseIndex);
+
+  auto keysSerializedBytes = serializeAsArray(
+      children_[0], offset, size, childIsFixedWidth_[0], buffer);
+
+  auto valuesSerializedBytes = serializeAsArray(
+      children_[1],
+      offset,
+      size,
+      childIsFixedWidth_[1],
+      buffer + keysSerializedBytes);
+
+  return keysSerializedBytes + valuesSerializedBytes;
+}
+
+int32_t CompactRow::serialize(vector_size_t index, char* buffer) {
+  return serializeRow(index, buffer);
+}
+
+void CompactRow::serializeFixedWidth(vector_size_t index, char* buffer) {
+  VELOX_DCHECK(fixedWidthTypeKind_);
+  switch (typeKind_) {
+    case TypeKind::BOOLEAN:
+      *reinterpret_cast<bool*>(buffer) = decoded_.valueAt<bool>(index);
+      break;
+    case TypeKind::TIMESTAMP:
+      *reinterpret_cast<int64_t*>(buffer) =
+          decoded_.valueAt<Timestamp>(index).toMicros();
+      break;
+    default:
+      memcpy(
+          buffer,
+          decoded_.data<char>() + decoded_.index(index) * valueBytes_,
+          valueBytes_);
+  }
+}
+
+void CompactRow::serializeFixedWidth(
+    vector_size_t offset,
+    vector_size_t size,
+    char* buffer) {
+  VELOX_DCHECK(supportsBulkCopy_);
+  // decoded_.data<char>() can be null if all values are null.
+  if (decoded_.data<char>()) {
+    memcpy(
+        buffer,
+        decoded_.data<char>() + decoded_.index(offset) * valueBytes_,
+        valueBytes_ * size);
+  }
+}
+
+int32_t CompactRow::serializeVariableWidth(vector_size_t index, char* buffer) {
+  switch (typeKind_) {
+    case TypeKind::VARCHAR:
+      FOLLY_FALLTHROUGH;
+    case TypeKind::VARBINARY: {
+      auto value = decoded_.valueAt<StringView>(index);
+      *reinterpret_cast<int32_t*>(buffer) = value.size();
+      if (!value.empty()) {
+        memcpy(buffer + sizeof(int32_t), value.data(), value.size());
+      }
+      return sizeof(int32_t) + value.size();
+    }
+    case TypeKind::ARRAY:
+      return serializeArray(index, buffer);
+    case TypeKind::MAP:
+      return serializeMap(index, buffer);
+    case TypeKind::ROW:
+      return serializeRow(index, buffer);
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected type kind: {}", mapTypeKindToName(typeKind_));
+  };
+}
+
+namespace {
+
+/// @param nulls Null flags for the values.
+/// @param offsets In/out parameter that specifies offsets in 'data' for the
+/// serialized values. Advanced past the serialized value.
+template <TypeKind Kind>
+VectorPtr deserializeFixedWidth(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  using T = typename TypeTraits<Kind>::NativeType;
+
+  const auto numRows = data.size();
+  auto flatVector = BaseVector::create<FlatVector<T>>(type, numRows, pool);
+
+  auto* rawNulls = nulls->as<uint64_t>();
+
+  for (auto i = 0; i < numRows; ++i) {
+    if (bits::isBitNull(rawNulls, i)) {
+      flatVector->setNull(i, true);
+    } else if constexpr (std::is_same_v<T, Timestamp>) {
+      int64_t micros =
+          *reinterpret_cast<const int64_t*>(data[i].data() + offsets[i]);
+      flatVector->set(i, Timestamp::fromMicros(micros));
+    } else {
+      T value = *reinterpret_cast<const T*>(data[i].data() + offsets[i]);
+      flatVector->set(i, value);
+    }
+
+    if constexpr (std::is_same_v<T, Timestamp>) {
+      offsets[i] += sizeof(int64_t);
+    } else {
+      offsets[i] += sizeof(T);
+    }
+  }
+
+  return flatVector;
+}
+
+template <TypeKind Kind>
+VectorPtr deserializeFixedWidthArrays(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& sizes,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  using T = typename TypeTraits<Kind>::NativeType;
+
+  const auto numRows = data.size();
+  auto* rawSizes = sizes->as<vector_size_t>();
+
+  vector_size_t total = 0;
+  for (auto i = 0; i < numRows; ++i) {
+    total += rawSizes[i];
+  }
+
+  auto flatVector = BaseVector::create<FlatVector<T>>(type, total, pool);
+
+  vector_size_t index = 0;
+  for (auto i = 0; i < numRows; ++i) {
+    const auto size = rawSizes[i];
+    if (size > 0) {
+      auto nullBytes = bits::nbytes(size);
+
+      auto* rawElementNulls =
+          reinterpret_cast<const uint8_t*>(data[i].data() + offsets[i]);
+
+      offsets[i] += nullBytes;
+
+      for (auto j = 0; j < size; ++j) {
+        if (bits::isBitSet(rawElementNulls, j)) {
+          flatVector->setNull(index++, true);
+        } else {
+          T value = *reinterpret_cast<const T*>(data[i].data() + offsets[i]);
+          flatVector->set(index++, value);
+        }
+        offsets[i] += sizeof(T);
+      }
+    }
+  }
+
+  return flatVector;
+}
+
+VectorPtr deserializeStrings(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+  auto flatVector =
+      BaseVector::create<FlatVector<StringView>>(type, numRows, pool);
+
+  auto* rawNulls = nulls->as<uint64_t>();
+
+  for (auto i = 0; i < numRows; ++i) {
+    if (bits::isBitNull(rawNulls, i)) {
+      flatVector->setNull(i, true);
+    } else {
+      auto* buffer = data[i].data() + offsets[i];
+      int32_t size = *reinterpret_cast<const int32_t*>(buffer);
+      StringView value(buffer + sizeof(int32_t), size);
+      flatVector->set(i, value);
+      offsets[i] += sizeof(int32_t) + size;
+    }
+  }
+
+  return flatVector;
+}
+
+VectorPtr deserializeStringArrays(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& sizes,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+  auto* rawSizes = sizes->as<vector_size_t>();
+
+  vector_size_t total = 0;
+  for (auto i = 0; i < numRows; ++i) {
+    total += rawSizes[i];
+  }
+
+  auto flatVector =
+      BaseVector::create<FlatVector<StringView>>(type, total, pool);
+
+  vector_size_t index = 0;
+  for (auto i = 0; i < numRows; ++i) {
+    const auto size = rawSizes[i];
+    if (size > 0) {
+      auto nullBytes = bits::nbytes(size);
+
+      auto* rawElementNulls =
+          reinterpret_cast<const uint8_t*>(data[i].data() + offsets[i]);
+
+      offsets[i] += nullBytes;
+
+      for (auto j = 0; j < size; ++j) {
+        if (bits::isBitSet(rawElementNulls, j)) {
+          flatVector->setNull(index++, true);
+        } else {
+          auto* buffer = data[i].data() + offsets[i];
+          int32_t stringSize = *reinterpret_cast<const int32_t*>(buffer);
+          StringView value(buffer + sizeof(int32_t), stringSize);
+          flatVector->set(index++, value);
+          offsets[i] += sizeof(int32_t) + stringSize;
+        }
+      }
+    }
+  }
+
+  return flatVector;
+}
+
+ArrayVectorPtr deserializeArrays(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+
+  auto* rawNulls = nulls->as<uint64_t>();
+
+  BufferPtr arrayOffsets = allocateOffsets(numRows, pool);
+  auto* rawArrayOffsets = arrayOffsets->asMutable<vector_size_t>();
+
+  BufferPtr arraySizes = allocateSizes(numRows, pool);
+  auto* rawArraySizes = arraySizes->asMutable<vector_size_t>();
+
+  vector_size_t arrayOffset = 0;
+
+  for (auto i = 0; i < numRows; ++i) {
+    if (!bits::isBitNull(rawNulls, i)) {
+      auto* buffer = data[i].data() + offsets[i];
+      int32_t size = *reinterpret_cast<const int32_t*>(buffer);
+
+      offsets[i] += sizeof(int32_t);
+
+      rawArrayOffsets[i] = arrayOffset;
+      rawArraySizes[i] = size;
+      arrayOffset += size;
+    }
+  }
+
+  VectorPtr elements;
+  const auto& elementType = type->childAt(0);
+  if (elementType->isFixedWidth()) {
+    elements = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        deserializeFixedWidthArrays,
+        elementType->kind(),
+        elementType,
+        data,
+        arraySizes,
+        offsets,
+        pool);
+  } else {
+    switch (elementType->kind()) {
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+        elements = deserializeStringArrays(
+            elementType, data, arraySizes, offsets, pool);
+        break;
+      case TypeKind::ARRAY:
+      case TypeKind::MAP:
+      case TypeKind::ROW:
+      default:
+        VELOX_NYI();
+    }
+  }
+
+  return std::make_shared<ArrayVector>(
+      pool, type, nulls, numRows, arrayOffsets, arraySizes, elements);
+}
+
+VectorPtr deserializeMaps(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  auto arrayOfKeys =
+      deserializeArrays(ARRAY(type->childAt(0)), data, nulls, offsets, pool);
+  auto arrayOfValues =
+      deserializeArrays(ARRAY(type->childAt(1)), data, nulls, offsets, pool);
+
+  return std::make_shared<MapVector>(
+      pool,
+      type,
+      nulls,
+      data.size(),
+      arrayOfKeys->offsets(),
+      arrayOfKeys->sizes(),
+      arrayOfKeys->elements(),
+      arrayOfValues->elements());
+}
+
+RowVectorPtr deserializeRows(
+    const TypePtr& type,
+    const std::vector<std::string_view>& data,
+    const BufferPtr& nulls,
+    std::vector<size_t>& offsets,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+  const size_t numFields = type->size();
+  const size_t nullLength = bits::nbytes(numFields);
+
+  std::vector<VectorPtr> fields;
+
+  auto* rawRowNulls = nulls != nullptr ? nulls->as<uint64_t>() : nullptr;
+
+  std::vector<BufferPtr> fieldNulls;
+  fieldNulls.reserve(numFields);
+  for (auto i = 0; i < numFields; ++i) {
+    fieldNulls.emplace_back(allocateNulls(numRows, pool));
+    auto* rawFieldNulls = fieldNulls.back()->asMutable<uint8_t>();
+    for (auto row = 0; row < numRows; ++row) {
+      auto* serializedNulls = data[row].data() + offsets[row];
+      bits::setBit(
+          rawFieldNulls,
+          row,
+          (rawRowNulls != nullptr && bits::isBitNull(rawRowNulls, row)) ||
+              !bits::isBitSet(serializedNulls, i));
+    }
+  }
+
+  for (auto row = 0; row < numRows; ++row) {
+    offsets[row] += nullLength;
+  }
+
+  for (auto i = 0; i < numFields; ++i) {
+    VectorPtr field;
+
+    const auto typeKind = type->childAt(i)->kind();
+
+    if (type->childAt(i)->isFixedWidth()) {
+      field = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+          deserializeFixedWidth,
+          type->childAt(i)->kind(),
+          type->childAt(i),
+          data,
+          fieldNulls[i],
+          offsets,
+          pool);
+    } else {
+      switch (typeKind) {
+        case TypeKind::VARCHAR:
+        case TypeKind::VARBINARY:
+          field = deserializeStrings(
+              type->childAt(i), data, fieldNulls[i], offsets, pool);
+          break;
+        case TypeKind::ARRAY:
+          field = deserializeArrays(
+              type->childAt(i), data, fieldNulls[i], offsets, pool);
+          break;
+        case TypeKind::MAP:
+          field = deserializeMaps(
+              type->childAt(i), data, fieldNulls[i], offsets, pool);
+          break;
+        case TypeKind::ROW:
+          field = deserializeRows(
+              type->childAt(i), data, fieldNulls[i], offsets, pool);
+          break;
+        default:
+          VELOX_NYI();
+      }
+    }
+
+    fields.emplace_back(std::move(field));
+  }
+
+  return std::make_shared<RowVector>(
+      pool, type, nulls, numRows, std::move(fields));
+}
+
+} // namespace
+
+// static
+RowVectorPtr CompactRow::deserialize(
+    const std::vector<std::string_view>& data,
+    const RowTypePtr& rowType,
+    memory::MemoryPool* pool) {
+  const auto numRows = data.size();
+  std::vector<size_t> offsets(numRows, 0);
+
+  return deserializeRows(rowType, data, nullptr, offsets, pool);
+}
+
+} // namespace facebook::velox::row

--- a/velox/row/CompactRow.h
+++ b/velox/row/CompactRow.h
@@ -43,7 +43,7 @@ class CompactRow {
       const RowTypePtr& rowType,
       memory::MemoryPool* pool);
 
- protected:
+ private:
   explicit CompactRow(const VectorPtr& vector);
 
   void initialize(const TypePtr& type);

--- a/velox/row/CompactRow.h
+++ b/velox/row/CompactRow.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::row {
+
+class CompactRow {
+ public:
+  explicit CompactRow(const RowVectorPtr& vector);
+
+  /// Returns row size if all fields are fixed width. Return std::nullopt if
+  /// there are variable-width fields.
+  static std::optional<int32_t> fixedRowSize(const RowTypePtr& rowType);
+
+  /// Returns serialized size of the row at specified index. Use only if
+  /// 'fixedRowSize' returned std::nullopt.
+  int32_t rowSize(vector_size_t index);
+
+  /// Serializes row at specified index into 'buffer'.
+  /// 'buffer' must have sufficient capacity and set to all zeros.
+  int32_t serialize(vector_size_t index, char* buffer);
+
+  /// Deserializes multiple rows into a RowVector of specified type. The type
+  /// must match the contents of the serialized rows.
+  static RowVectorPtr deserialize(
+      const std::vector<std::string_view>& data,
+      const RowTypePtr& rowType,
+      memory::MemoryPool* pool);
+
+ protected:
+  explicit CompactRow(const VectorPtr& vector);
+
+  void initialize(const TypePtr& type);
+
+  bool isNullAt(vector_size_t);
+
+  /// Fixed-width types only. Returns number of bytes used by single value.
+  int32_t valueBytes() const {
+    return valueBytes_;
+  }
+
+  /// Writes fixed-width value at specified index into 'buffer'. Value must not
+  /// be null.
+  void serializeFixedWidth(vector_size_t index, char* buffer);
+
+  /// Writes range of fixed-width values between 'offset' and 'offset + size'
+  /// into 'buffer'. Values can be null.
+  void
+  serializeFixedWidth(vector_size_t offset, vector_size_t size, char* buffer);
+
+  /// Returns serialized size of variable-width row.
+  int32_t variableWidthRowSize(vector_size_t index);
+
+  /// Writes variable-width value at specified index into 'buffer'. Value must
+  /// not be null. Returns number of bytes written to 'buffer'.
+  int32_t serializeVariableWidth(vector_size_t index, char* buffer);
+
+ private:
+  /// Returns serialized size of array row.
+  int32_t arrayRowSize(vector_size_t index);
+
+  /// Serializes array value to buffer. Value must not be null. Returns number
+  /// of bytes written to 'buffer'.
+  int32_t serializeArray(vector_size_t index, char* buffer);
+
+  /// Returns serialized size of map row.
+  int32_t mapRowSize(vector_size_t index);
+
+  /// Serializes map value to buffer. Value must not be null. Returns number of
+  /// bytes written to 'buffer'.
+  int32_t serializeMap(vector_size_t index, char* buffer);
+
+  /// Returns serialized size of a range of values.
+  int32_t arrayRowSize(
+      CompactRow& elements,
+      vector_size_t offset,
+      vector_size_t size,
+      bool fixedWidth);
+
+  /// Serializes a range of values into buffer. Returns number of bytes written
+  /// to 'buffer'.
+  int32_t serializeAsArray(
+      CompactRow& elements,
+      vector_size_t offset,
+      vector_size_t size,
+      bool fixedWidth,
+      char* buffer);
+
+  /// Returns serialized size of struct value.
+  int32_t rowRowSize(vector_size_t index);
+
+  /// Serializes struct value to buffer. Value must not be null.
+  int32_t serializeRow(vector_size_t index, char* buffer);
+
+  const TypeKind typeKind_;
+  DecodedVector decoded_;
+
+  /// True if values of 'typeKind_' have fixed width.
+  bool fixedWidthTypeKind_{false};
+
+  /// ARRAY, MAP and ROW types only.
+  std::vector<CompactRow> children_;
+  std::vector<bool> childIsFixedWidth_;
+
+  /// True if this is a flat fixed-width vector whose consecutive values can be
+  /// copied into serialized buffer in bulk.
+  bool supportsBulkCopy_{false};
+
+  // ROW type only. Number of bytes used by null flags.
+  size_t rowNullBytes_;
+
+  // Fixed-width types only. Number of bytes used for a single value.
+  size_t valueBytes_;
+};
+} // namespace facebook::velox::row

--- a/velox/row/tests/CMakeLists.txt
+++ b/velox/row/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_row_test UnsafeRowFuzzTest.cpp)
+add_executable(velox_row_test UnsafeRowFuzzTest.cpp CompactRowTest.cpp)
 
 add_test(velox_row_test velox_row_test)
 

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/row/CompactRow.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+using namespace facebook::velox::test;
+
+namespace facebook::velox::row {
+namespace {
+
+class CompactRowTest : public ::testing::Test, public VectorTestBase {
+ protected:
+  void testRoundTrip(const RowVectorPtr& data) {
+    SCOPED_TRACE(data->toString());
+
+    auto rowType = asRowType(data->type());
+    auto numRows = data->size();
+
+    CompactRow row(data);
+
+    size_t totalSize = 0;
+    if (auto fixedRowSize = CompactRow::fixedRowSize(rowType)) {
+      totalSize = fixedRowSize.value() * numRows;
+    } else {
+      for (auto i = 0; i < numRows; ++i) {
+        totalSize += row.rowSize(i);
+      }
+    }
+
+    std::vector<std::string_view> serialized;
+
+    BufferPtr buffer = AlignedBuffer::allocate<char>(totalSize, pool(), 0);
+    auto* rawBuffer = buffer->asMutable<char>();
+    size_t offset = 0;
+    for (auto i = 0; i < numRows; ++i) {
+      auto size = row.serialize(i, rawBuffer + offset);
+      serialized.push_back(std::string_view(rawBuffer + offset, size));
+      offset += size;
+
+      VELOX_CHECK_EQ(size, row.rowSize(i), "Row {}", i);
+    }
+
+    VELOX_CHECK_EQ(offset, totalSize);
+
+    auto copy = CompactRow::deserialize(serialized, rowType, pool());
+
+    //    LOG(ERROR) << copy->toString(0, 10);
+
+    assertEqualVectors(data, copy);
+  }
+};
+
+TEST_F(CompactRowTest, fixedRowSize) {
+  ASSERT_EQ(1 + 1, CompactRow::fixedRowSize(ROW({BOOLEAN()})));
+  ASSERT_EQ(1 + 8, CompactRow::fixedRowSize(ROW({BIGINT()})));
+  ASSERT_EQ(1 + 4, CompactRow::fixedRowSize(ROW({INTEGER()})));
+  ASSERT_EQ(1 + 2, CompactRow::fixedRowSize(ROW({SMALLINT()})));
+  ASSERT_EQ(1 + 8, CompactRow::fixedRowSize(ROW({DOUBLE()})));
+  ASSERT_EQ(std::nullopt, CompactRow::fixedRowSize(ROW({VARCHAR()})));
+  ASSERT_EQ(std::nullopt, CompactRow::fixedRowSize(ROW({ARRAY(BIGINT())})));
+  ASSERT_EQ(
+      1 + 1 + 8 + 4 + 2 + 8,
+      CompactRow::fixedRowSize(
+          ROW({BOOLEAN(), BIGINT(), INTEGER(), SMALLINT(), DOUBLE()})));
+
+  ASSERT_EQ(std::nullopt, CompactRow::fixedRowSize(ROW({BIGINT(), VARCHAR()})));
+  ASSERT_EQ(
+      std::nullopt,
+      CompactRow::fixedRowSize(ROW({BIGINT(), ROW({VARCHAR()})})));
+}
+
+TEST_F(CompactRowTest, rowSizeString) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"a", "abc", "Longer string", "d", ""}),
+  });
+
+  CompactRow row(data);
+
+  // 1 byte for null flags. 4 bytes for string size. N bytes for the string
+  // itself.
+  ASSERT_EQ(1 + 4 + 1, row.rowSize(0));
+  ASSERT_EQ(1 + 4 + 3, row.rowSize(1));
+  ASSERT_EQ(1 + 4 + 13, row.rowSize(2));
+  ASSERT_EQ(1 + 4 + 1, row.rowSize(3));
+  ASSERT_EQ(1 + 4 + 0, row.rowSize(4));
+}
+
+TEST_F(CompactRowTest, rowSizeArrayOfBigint) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {},
+          {6},
+      }),
+  });
+
+  {
+    CompactRow row(data);
+
+    // 1 byte for null flags. 4 bytes for array size. 1 byte for null flags
+    // for elements. N bytes for array elements.
+    ASSERT_EQ(1 + 4 + 1 + 8 * 3, row.rowSize(0));
+    ASSERT_EQ(1 + 4 + 1 + 8 * 2, row.rowSize(1));
+    ASSERT_EQ(1 + 4, row.rowSize(2));
+    ASSERT_EQ(1 + 4 + 1 + 8, row.rowSize(3));
+  }
+
+  data = makeRowVector({
+      makeNullableArrayVector<int64_t>({
+          {{1, 2, std::nullopt, 3}},
+          {{4, 5}},
+          {{}},
+          std::nullopt,
+          {{6}},
+      }),
+  });
+
+  {
+    CompactRow row(data);
+
+    // 1 byte for null flags. 4 bytes for array size. 1 byte for null flags
+    // for elements. N bytes for array elements.
+    ASSERT_EQ(1 + 4 + 1 + 8 * 4, row.rowSize(0));
+    ASSERT_EQ(1 + 4 + 1 + 8 * 2, row.rowSize(1));
+    ASSERT_EQ(1 + 4, row.rowSize(2));
+    ASSERT_EQ(1, row.rowSize(3));
+    ASSERT_EQ(1 + 4 + 1 + 8, row.rowSize(4));
+  }
+}
+
+TEST_F(CompactRowTest, rowSizeMixed) {
+  auto data = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, 2, 3, std::nullopt}),
+      makeNullableFlatVector<std::string>({"a", "abc", "", std::nullopt}),
+  });
+
+  CompactRow row(data);
+
+  // 1 byte for null flags. 8 bytes for bigint field. 4 bytes for string size.
+  // N bytes for the string itself.
+  ASSERT_EQ(1 + 8 + (4 + 1), row.rowSize(0));
+  ASSERT_EQ(1 + 8 + (4 + 3), row.rowSize(1));
+  ASSERT_EQ(1 + 8 + (4 + 0), row.rowSize(2));
+  ASSERT_EQ(1 + 8, row.rowSize(3));
+}
+
+TEST_F(CompactRowTest, rowSizeArrayOfStrings) {
+  auto data = makeRowVector({
+      makeArrayVector<std::string>({
+          {"a", "Abc"},
+          {},
+          {"a", "Longer string", "abc"},
+      }),
+  });
+
+  {
+    CompactRow row(data);
+
+    // 1 byte for null flags. 4 bytes for array size. 1 byte for nulls flags
+    // for elements. N bytes for elements. Each string element is 4 bytes for
+    // size + string length.
+    ASSERT_EQ(1 + 4 + 1 + (4 + 1) + (4 + 3), row.rowSize(0));
+    ASSERT_EQ(1 + 4, row.rowSize(1));
+    ASSERT_EQ(1 + 4 + 1 + (4 + 1) + (4 + 13) + (4 + 3), row.rowSize(2));
+  }
+
+  data = makeRowVector({
+      makeNullableArrayVector<std::string>({
+          {{"a", "Abc", std::nullopt}},
+          {{}},
+          std::nullopt,
+          {{"a", std::nullopt, "Longer string", "abc"}},
+      }),
+  });
+
+  {
+    CompactRow row(data);
+
+    // Null strings do use take space.
+    ASSERT_EQ(1 + 4 + 1 + (4 + 1) + (4 + 3) + 0, row.rowSize(0));
+    ASSERT_EQ(1 + 4, row.rowSize(1));
+    ASSERT_EQ(1, row.rowSize(2));
+    ASSERT_EQ(1 + 4 + 1 + (4 + 1) + 0 + (4 + 13) + (4 + 3), row.rowSize(3));
+  }
+}
+
+TEST_F(CompactRowTest, boolean) {
+  auto data = makeRowVector({
+      makeFlatVector<bool>(
+          {true, false, true, true, false, false, true, false}),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeNullableFlatVector<bool>({
+          true,
+          false,
+          std::nullopt,
+          true,
+          std::nullopt,
+          false,
+          true,
+          false,
+      }),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, bigint) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 3, 4, 5}),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeNullableFlatVector<int64_t>(
+          {1, std::nullopt, 3, std::nullopt, 5, std::nullopt}),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, timestamp) {
+  auto data = makeRowVector({
+      makeFlatVector<Timestamp>({
+          Timestamp::fromMicros(0),
+          Timestamp::fromMicros(1),
+          Timestamp::fromMicros(2),
+      }),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeNullableFlatVector<Timestamp>({
+          Timestamp::fromMicros(0),
+          std::nullopt,
+          Timestamp::fromMicros(123'456),
+      }),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, string) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"a", "Abc", "", "Longer test string"}),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, mix) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({"a", "Abc", "", "Longer test string"}),
+      makeFlatVector<int64_t>({1, 2, 3, 4}),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, arrayOfBigint) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6},
+          {},
+      }),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeNullableArrayVector<int64_t>({
+          {{1, 2, std::nullopt, 3}},
+          {{4, 5, std::nullopt}},
+          {{std::nullopt, 6}},
+          {{std::nullopt}},
+          std::nullopt,
+          {{}},
+      }),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, arrayOfString) {
+  auto data = makeRowVector({
+      makeArrayVector<std::string>({
+          {"a", "abc", "Longer test string"},
+          {"b", "Abc 12345 ...test", "foo"},
+          {},
+      }),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeNullableArrayVector<std::string>({
+          {{"a", std::nullopt, "abc", "Longer test string"}},
+          {{std::nullopt,
+            "b",
+            std::nullopt,
+            "Abc 12345 ...test",
+            std::nullopt,
+            "foo"}},
+          {{}},
+          {{std::nullopt}},
+          std::nullopt,
+      }),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, map) {
+  auto data = makeRowVector({
+      makeMapVector<int16_t, int64_t>(
+          {{{1, 10}, {2, 20}, {3, 30}}, {{1, 11}, {2, 22}}, {{4, 444}}, {}}),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeMapVector<std::string, std::string>({
+          {{"a", "100"},
+           {"b", "200"},
+           {"Long string for testing", "Another long string"}},
+          {{"abc", "300"}, {"d", "400"}},
+          {},
+      }),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, row) {
+  auto data = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<double>({1.05, 2.05, 3.05, 4.05, 5.05}),
+      }),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeRowVector({
+          makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+          makeFlatVector<std::string>(
+              {"a", "Abc", "Long test string", "", "d"}),
+          makeFlatVector<double>({1.05, 2.05, 3.05, 4.05, 5.05}),
+      }),
+  });
+
+  testRoundTrip(data);
+
+  data = makeRowVector({
+      makeRowVector(
+          {
+              makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
+              makeNullableFlatVector<int64_t>({-1, 2, -3, std::nullopt, -5}),
+              makeFlatVector<double>({1.05, 2.05, 3.05, 4.05, 5.05}),
+          },
+          nullEvery(2)),
+  });
+
+  testRoundTrip(data);
+}
+
+TEST_F(CompactRowTest, fuzz) {
+  auto rowType = ROW(
+      {BIGINT(),
+       ARRAY(BIGINT()),
+       DOUBLE(),
+       MAP(VARCHAR(), VARCHAR()),
+       VARCHAR()});
+
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 1'000;
+  opts.nullRatio = 0.1;
+  opts.containerHasNulls = false;
+  opts.dictionaryHasNulls = false;
+  opts.stringVariableLength = true;
+  opts.stringLength = 20;
+  opts.containerVariableLength = true;
+  opts.complexElementsMaxSize = 1'000;
+
+  // Spark uses microseconds to store timestamp
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds,
+  opts.containerLength = 10;
+
+  VectorFuzzer fuzzer(opts, pool_.get());
+
+  const auto iterations = 200;
+  for (size_t i = 0; i < iterations; ++i) {
+    auto seed = folly::Random::rand32();
+
+    LOG(INFO) << i << ": seed: " << seed;
+    SCOPED_TRACE(fmt::format("seed: {}", seed));
+
+    fuzzer.reSeed(seed);
+    auto data = fuzzer.fuzzInputRow(rowType);
+
+    testRoundTrip(data);
+  }
+}
+
+} // namespace
+} // namespace facebook::velox::row

--- a/velox/serializers/CMakeLists.txt
+++ b/velox/serializers/CMakeLists.txt
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(velox_presto_serializer PrestoSerializer.cpp
-                                    UnsafeRowSerializer.cpp)
+add_library(
+  velox_presto_serializer PrestoSerializer.cpp UnsafeRowSerializer.cpp
+                          CompactRowSerializer.cpp)
 
 target_link_libraries(velox_presto_serializer velox_vector)
 

--- a/velox/serializers/CompactRowSerializer.cpp
+++ b/velox/serializers/CompactRowSerializer.cpp
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/CompactRowSerializer.h"
+#include <folly/lang/Bits.h>
+#include "velox/row/CompactRow.h"
+
+namespace facebook::velox::serializer {
+
+void CompactRowVectorSerde::estimateSerializedSize(
+    VectorPtr /* vector */,
+    const folly::Range<const IndexRange*>& /* ranges */,
+    vector_size_t** /* sizes */) {
+  VELOX_UNSUPPORTED();
+}
+
+namespace {
+class CompactRowVectorSerializer : public VectorSerializer {
+ public:
+  using TRowSize = uint32_t;
+
+  explicit CompactRowVectorSerializer(StreamArena* streamArena)
+      : pool_{streamArena->pool()} {}
+
+  void append(
+      const RowVectorPtr& vector,
+      const folly::Range<const IndexRange*>& ranges) override {
+    size_t totalSize = 0;
+    row::CompactRow row(vector);
+    if (auto fixedRowSize =
+            row::CompactRow::fixedRowSize(asRowType(vector->type()))) {
+      for (const auto& range : ranges) {
+        totalSize += (fixedRowSize.value() + sizeof(TRowSize)) * range.size;
+      }
+
+    } else {
+      for (const auto& range : ranges) {
+        for (auto i = range.begin; i < range.begin + range.size; ++i) {
+          totalSize += row.rowSize(i) + sizeof(TRowSize);
+        }
+      }
+    }
+
+    if (totalSize == 0) {
+      return;
+    }
+
+    BufferPtr buffer = AlignedBuffer::allocate<char>(totalSize, pool_, 0);
+    auto rawBuffer = buffer->asMutable<char>();
+    buffers_.push_back(std::move(buffer));
+
+    size_t offset = 0;
+    for (auto& range : ranges) {
+      for (auto i = range.begin; i < range.begin + range.size; ++i) {
+        // Write row data.
+        TRowSize size = row.serialize(i, rawBuffer + offset + sizeof(TRowSize));
+
+        // Write raw size. Needs to be in big endian order.
+        *(TRowSize*)(rawBuffer + offset) = folly::Endian::big(size);
+        offset += sizeof(TRowSize) + size;
+      }
+    }
+  }
+
+  void flush(OutputStream* stream) override {
+    for (const auto& buffer : buffers_) {
+      stream->write(buffer->as<char>(), buffer->size());
+    }
+    buffers_.clear();
+  }
+
+ private:
+  memory::MemoryPool* const FOLLY_NONNULL pool_;
+  std::vector<BufferPtr> buffers_;
+};
+} // namespace
+
+std::unique_ptr<VectorSerializer> CompactRowVectorSerde::createSerializer(
+    RowTypePtr /* type */,
+    int32_t /* numRows */,
+    StreamArena* streamArena,
+    const Options* /* options */) {
+  return std::make_unique<CompactRowVectorSerializer>(streamArena);
+}
+
+void CompactRowVectorSerde::deserialize(
+    ByteStream* source,
+    velox::memory::MemoryPool* pool,
+    RowTypePtr type,
+    RowVectorPtr* result,
+    const Options* /* options */) {
+  std::vector<std::string_view> serializedRows;
+  while (!source->atEnd()) {
+    // First read row size in big endian order.
+    auto rowSize = folly::Endian::big(
+        source->read<CompactRowVectorSerializer::TRowSize>());
+    auto row = source->nextView(rowSize);
+    VELOX_CHECK_EQ(row.size(), rowSize);
+    serializedRows.push_back(row);
+  }
+
+  if (serializedRows.empty()) {
+    *result = BaseVector::create<RowVector>(type, 0, pool);
+    return;
+  }
+
+  *result = velox::row::CompactRow::deserialize(serializedRows, type, pool);
+}
+
+// static
+void CompactRowVectorSerde::registerVectorSerde() {
+  velox::registerVectorSerde(std::make_unique<CompactRowVectorSerde>());
+}
+
+} // namespace facebook::velox::serializer

--- a/velox/serializers/CompactRowSerializer.h
+++ b/velox/serializers/CompactRowSerializer.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/VectorStream.h"
+
+namespace facebook::velox::serializer {
+
+class CompactRowVectorSerde : public VectorSerde {
+ public:
+  CompactRowVectorSerde() = default;
+  // We do not implement this method since it is not used in production code.
+  void estimateSerializedSize(
+      VectorPtr vector,
+      const folly::Range<const IndexRange*>& ranges,
+      vector_size_t** sizes) override;
+
+  // This method is not used in production code. It is only used to
+  // support round-trip tests for deserialization.
+  std::unique_ptr<VectorSerializer> createSerializer(
+      RowTypePtr type,
+      int32_t numRows,
+      StreamArena* streamArena,
+      const Options* options) override;
+
+  // This method is used when reading data from the exchange.
+  void deserialize(
+      ByteStream* source,
+      velox::memory::MemoryPool* pool,
+      RowTypePtr type,
+      RowVectorPtr* result,
+      const Options* options) override;
+
+  static void registerVectorSerde();
+};
+
+} // namespace facebook::velox::serializer

--- a/velox/serializers/tests/CMakeLists.txt
+++ b/velox/serializers/tests/CMakeLists.txt
@@ -14,7 +14,7 @@
 add_executable(
   velox_presto_serializer_test
   PrestoOutputStreamListenerTest.cpp PrestoSerializerTest.cpp
-  UnsafeRowSerializerTest.cpp)
+  UnsafeRowSerializerTest.cpp CompactRowSerializerTest.cpp)
 
 add_test(velox_presto_serializer_test velox_presto_serializer_test)
 

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -94,7 +94,7 @@ TEST_F(CompactRowSerializerTest, fuzz) {
       ARRAY(INTEGER()),
       ARRAY(INTEGER()),
       MAP(VARCHAR(), INTEGER()),
-      //      MAP(VARCHAR(), ARRAY(INTEGER())),
+      MAP(VARCHAR(), ARRAY(INTEGER())),
   });
 
   VectorFuzzer::Options opts;

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/serializers/CompactRowSerializer.h"
+#include <gtest/gtest.h>
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::serializer {
+namespace {
+
+class CompactRowSerializerTest : public ::testing::Test,
+                                 public test::VectorTestBase {
+ protected:
+  void SetUp() override {
+    pool_ = memory::addDefaultLeafMemoryPool();
+    serde_ = std::make_unique<serializer::CompactRowVectorSerde>();
+  }
+
+  void serialize(RowVectorPtr rowVector, std::ostream* output) {
+    auto numRows = rowVector->size();
+
+    std::vector<IndexRange> rows(numRows);
+    for (int i = 0; i < numRows; i++) {
+      rows[i] = IndexRange{i, 1};
+    }
+
+    auto arena = std::make_unique<StreamArena>(pool_.get());
+    auto rowType = asRowType(rowVector->type());
+    auto serializer = serde_->createSerializer(rowType, numRows, arena.get());
+
+    serializer->append(rowVector, folly::Range(rows.data(), numRows));
+    OStreamOutputStream out(output);
+    serializer->flush(&out);
+  }
+
+  std::unique_ptr<ByteStream> toByteStream(const std::string_view& input) {
+    auto byteStream = std::make_unique<ByteStream>();
+    ByteRange byteRange{
+        reinterpret_cast<uint8_t*>(const_cast<char*>(input.data())),
+        (int32_t)input.length(),
+        0};
+    byteStream->resetInput({byteRange});
+    return byteStream;
+  }
+
+  RowVectorPtr deserialize(
+      const RowTypePtr& rowType,
+      const std::string_view& input) {
+    auto byteStream = toByteStream(input);
+
+    RowVectorPtr result;
+    serde_->deserialize(byteStream.get(), pool_.get(), rowType, &result);
+    return result;
+  }
+
+  void testRoundTrip(RowVectorPtr rowVector) {
+    std::ostringstream out;
+    serialize(rowVector, &out);
+
+    auto rowType = asRowType(rowVector->type());
+    auto deserialized = deserialize(rowType, out.str());
+    test::assertEqualVectors(deserialized, rowVector);
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<VectorSerde> serde_;
+};
+
+TEST_F(CompactRowSerializerTest, fuzz) {
+  auto rowType = ROW({
+      BOOLEAN(),
+      TINYINT(),
+      SMALLINT(),
+      INTEGER(),
+      BIGINT(),
+      REAL(),
+      DOUBLE(),
+      VARCHAR(),
+      TIMESTAMP(),
+      ROW({VARCHAR(), INTEGER()}),
+      ARRAY(INTEGER()),
+      ARRAY(INTEGER()),
+      MAP(VARCHAR(), INTEGER()),
+      //      MAP(VARCHAR(), ARRAY(INTEGER())),
+  });
+
+  VectorFuzzer::Options opts;
+  opts.vectorSize = 5;
+  opts.nullRatio = 0.1;
+  opts.containerHasNulls = false;
+  opts.dictionaryHasNulls = false;
+  opts.stringVariableLength = true;
+  opts.stringLength = 20;
+  opts.containerVariableLength = false;
+
+  // Spark uses microseconds to store timestamp
+  opts.timestampPrecision =
+      VectorFuzzer::Options::TimestampPrecision::kMicroSeconds;
+  opts.containerLength = 10;
+
+  auto seed = folly::Random::rand32();
+
+  LOG(ERROR) << "Seed: " << seed;
+  SCOPED_TRACE(fmt::format("seed: {}", seed));
+  VectorFuzzer fuzzer(opts, pool_.get(), seed);
+
+  auto data = fuzzer.fuzzRow(rowType);
+  testRoundTrip(data);
+}
+
+} // namespace
+} // namespace facebook::velox::serializer


### PR DESCRIPTION
We noticed that UnsafeRow serialization format is not very space-efficient. In
one of the production queries we saw UnsafeRow producing 1.6x more bytes than
native Presto-on-Spark row-wise serde.

UnsafeRow uses at least 16 bytes to serialize non-empty string. 1-character string uses 16 bytes. All strings up to 8 characters use 16 bytes. Empty string uses 8 bytes. 9-character string uses 24 bytes. Presto-on-Spark serialization uses 4 + sizeof(string) bytes per strings. 

- "": 4 vs. 8 bytes
- "a": 5  vs. 16 bytes
- "abc": 7 vs. 16 bytes
- 9 character string: 13 vs. 24 bytes

Null values use 8 bytes in UnsafeRow and 1 byte in Presto-on-Spark.

32-bit floating point values use 8 bytes in UnsafeRow and 4 bytes in Presto-on-Spark.

We introduce CompactRow serde to replace UnsafeRow for Presto-on-Spark native
shuffle. Here are some examples of the difference in serialized sizes:

```
[ROW ROW<c0:BIGINT>: 5 elements, no nulls]
Compact vs. Unsafe: 45 vs. 80, 1.77778

[ROW ROW<c0:VARCHAR>: 4 elements, no nulls]
Compact vs. Unsafe: 42 vs. 104, 2.47619

[ROW ROW<c0:ARRAY<BIGINT>>: 4 elements, no nulls]
Compact vs. Unsafe: 71 vs. 168, 2.3662

[ROW ROW<c0:ARRAY<VARCHAR>>: 3 elements, no nulls]
Compact vs. Unsafe: 84 vs. 216, 2.57143

[ROW ROW<f0:BOOLEAN,f1:VARBINARY,f2:TIMESTAMP,f3:VARCHAR>: 100 elements, no nulls]
Compact vs. Unsafe: 3365 vs. 6320, 1.87816

[ROW ROW<f0:ROW<f0:VARCHAR,f1:TINYINT,f2:ARRAY<ARRAY<MAP<VARBINARY,INTEGER>>>,f3:VARCHAR,f4:ROW<f0:TINYINT,f1:ROW<f0:DOUBLE,f1:MAP<VARBINARY,TINYINT>,f2:MAP<REAL,BOOLEAN>,f3:DOUBLE,f4:ROW<f0:VARCHAR,f1:BOOLEAN,f2:TINYINT,f3:BOOLEAN,f4:REAL,f5:TINYINT,f6:VARBINARY>>,f2:ARRAY<ROW<f0:VARBINARY,f1:VARCHAR,f2:REAL,f3:REAL,f4:TIMESTAMP,f5:VARCHAR,f6:TINYINT>>,f3:MAP<BIGINT,ARRAY<BOOLEAN>>,f4:REAL,f5:SMALLINT>,f5:ROW<f0:ROW<f0:BOOLEAN,f1:DOUBLE,f2:REAL>,f1:REAL,f2:ARRAY<ROW<f0:TIMESTAMP,f1:SMALLINT,f2:VARCHAR,f3:VARCHAR>>>,f6:DOUBLE>>: 100 elements, no nulls]
Compact vs. Unsafe: 195561 vs. 417896, 2.13691

[ROW ROW<f0:ROW<f0:ARRAY<ROW<f0:MAP<SMALLINT,TINYINT>,f1:REAL,f2:MAP<SMALLINT,SMALLINT>,f3:MAP<TIMESTAMP,TINYINT>,f4:ROW<f0:REAL>>>,f1:ARRAY<VARCHAR>,f2:MAP<SMALLINT,ARRAY<BIGINT>>,f3:VARCHAR,f4:BOOLEAN>,f1:ARRAY<ARRAY<TINYINT>>>: 100 elements, no nulls]
Compact vs. Unsafe: 61981 vs. 174880, 2.82151

[ROW ROW<f0:ARRAY<MAP<DOUBLE,REAL>>,f1:ARRAY<INTEGER>,f2:MAP<VARBINARY,VARCHAR>,f3:ROW<f0:MAP<SMALLINT,SMALLINT>>,f4:ARRAY<ARRAY<ARRAY<ARRAY<VARBINARY>>>>,f5:REAL>: 100 elements, no nulls]
Compact vs. Unsafe: 66801 vs. 120496, 1.80381

[ROW ROW<f0:DOUBLE,f1:TIMESTAMP,f2:TINYINT,f3:ARRAY<BOOLEAN>>: 100 elements, no nulls]
Compact vs. Unsafe: 2809 vs. 6344, 2.25845

[ROW ROW<f0:MAP<REAL,ARRAY<ARRAY<ROW<f0:TINYINT,f1:BOOLEAN,f2:TIMESTAMP>>>>,f1:ARRAY<SMALLINT>,f2:INTEGER,f3:DOUBLE,f4:REAL,f5:ARRAY<INTEGER>>: 100 elements, no nulls]
Compact vs. Unsafe: 11512 vs. 25848, 2.24531

[ROW ROW<f0:BOOLEAN>: 100 elements, no nulls]
Compact vs. Unsafe: 200 vs. 1600, 8

[ROW ROW<"":REAL,"":ARRAY<REAL>>: 100 elements, no nulls]
Compact vs. Unsafe: 2826 vs. 5960, 2.10899
```

I re-run the original production query with CompactRow and I'm seeing 1.6x less
bytes shuffled and 30% less CPU time used for the whole query.

Documented the new format.