### PR TITLE
Add Spark atan2 function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -18,6 +18,10 @@ Mathematical Functions
 
     Returns inverse hyperbolic sine of ``x``.
 
+.. spark:function:: atan2(x, y) -> double
+
+    Returns the angle in radians between the positive x-axis of a plane and the point given by the coordinates(x, y).
+
 .. spark:function:: atanh(x) -> double
 
     Returns inverse hyperbolic tangent of ``x``.

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -229,4 +229,12 @@ struct Log1pFunction {
     return true;
   }
 };
+
+template <typename T>
+struct Atan2Function {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput y, TInput x) {
+    result = std::atan2(y + 0.0, x + 0.0);
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -237,4 +237,5 @@ struct Atan2Function {
     result = std::atan2(y + 0.0, x + 0.0);
   }
 };
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -169,8 +169,6 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<RTrimSpaceFunction, Varchar, Varchar>({prefix + "rtrim"});
   registerFunction<RTrimFunction, Varchar, Varchar, Varchar>(
       {prefix + "rtrim"});
-  registerFunction<sparksql::Atan2Function, double, double, double>(
-      {prefix + "atan2"});
   registerFunction<TranslateFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "translate"});
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -169,6 +169,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<RTrimSpaceFunction, Varchar, Varchar>({prefix + "rtrim"});
   registerFunction<RTrimFunction, Varchar, Varchar, Varchar>(
       {prefix + "rtrim"});
+
   registerFunction<TranslateFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "translate"});
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -169,7 +169,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<RTrimSpaceFunction, Varchar, Varchar>({prefix + "rtrim"});
   registerFunction<RTrimFunction, Varchar, Varchar, Varchar>(
       {prefix + "rtrim"});
-
+  registerFunction<sparksql::Atan2Function, double, double, double>(
+      {prefix + "atan2"});
   registerFunction<TranslateFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "translate"});
 

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -61,6 +61,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<sparksql::FloorFunction, int64_t, double>(
       {prefix + "floor"});
   registerFunction<HypotFunction, double, double, double>({prefix + "hypot"});
+  registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -339,10 +339,9 @@ TEST_F(ArithmeticTest, hypot) {
 }
 
 TEST_F(ArithmeticTest, atan2) {
-  const auto atan2 =
-      [&](std::optional<double> y, std::optional<double> x) {
-        return evaluateOnce<double>("atan2(c0, c1)", y, x);
-      }
+  const auto atan2 = [&](std::optional<double> y, std::optional<double> x) {
+    return evaluateOnce<double>("atan2(c0, c1)", y, x);
+  };
 
   EXPECT_EQ(atan2(0, 0), 0.0);
 }

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -338,5 +338,12 @@ TEST_F(ArithmeticTest, hypot) {
   EXPECT_DOUBLE_EQ(5.70087712549569, hypot(3.5, -4.5).value());
 }
 
+TEST_F(ArithmeticTest, atan2) {
+  const auto atan2 = [&](std::optional<double> y, std::optional<double> x) {
+    return evaluateOnce<double>("atan2(c0, c1)", y, x);
+  };
+
+  EXPECT_EQ(atan2(0, 0), 0.0);
+}
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -339,9 +339,10 @@ TEST_F(ArithmeticTest, hypot) {
 }
 
 TEST_F(ArithmeticTest, atan2) {
-  const auto atan2 = [&](std::optional<double> y, std::optional<double> x) {
-    return evaluateOnce<double>("atan2(c0, c1)", y, x);
-  };
+  const auto atan2 =
+      [&](std::optional<double> y, std::optional<double> x) {
+        return evaluateOnce<double>("atan2(c0, c1)", y, x);
+      }
 
   EXPECT_EQ(atan2(0, 0), 0.0);
 }


### PR DESCRIPTION
Spark atan2 function will return 0.0 when use  atan2(0, 0). But presto will return 0.

```
scala> spark.sql(" select atan2(0,0)").show()
+-----------+
|ATAN2(0, 0)|
+-----------+
|        0.0|
+-----------+

```
Here is the link of spark atan2 [implementation](
https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L1225-L1239)