### PR TITLE
Add velox_dwio_parquet_table_scan_test into ctest

### DIFF
--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(
   velox_dwio_native_parquet_reader Folly::folly ${FOLLY_BENCHMARK})
 
 add_executable(velox_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
+add_test(velox_dwio_parquet_table_scan_test velox_dwio_parquet_table_scan_test)
 target_link_libraries(
   velox_dwio_parquet_table_scan_test
   velox_dwio_parquet_reader

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -71,7 +71,10 @@ target_link_libraries(
   velox_dwio_native_parquet_reader Folly::folly ${FOLLY_BENCHMARK})
 
 add_executable(velox_dwio_parquet_table_scan_test ParquetTableScanTest.cpp)
-add_test(velox_dwio_parquet_table_scan_test velox_dwio_parquet_table_scan_test)
+add_test(
+  NAME velox_dwio_parquet_table_scan_test
+  COMMAND velox_dwio_parquet_table_scan_test
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
   velox_dwio_parquet_table_scan_test
   velox_dwio_parquet_reader


### PR DESCRIPTION
`velox_dwio_parquet_table_scan_test` is not added into ctest. CI can not track it.