### PR TITLE
Improve variant::toJson API

### DIFF
--- a/velox/parse/Expressions.h
+++ b/velox/parse/Expressions.h
@@ -194,7 +194,7 @@ class ConstantExpr : public IExpr,
         value_{std::move(value)} {}
 
   std::string toString() const override {
-    return appendAliasIfExists(variant{value_}.toJson());
+    return appendAliasIfExists(variant{value_}.toJson(type_));
   }
 
   const variant& value() const {

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -174,11 +174,6 @@ void variant::throwCheckPtrError() const {
   throw std::invalid_argument{"missing variant value"};
 }
 
-std::string variant::toJson() const {
-  const auto type = fromKindToScalerType(kind_);
-  return toJson(type);
-}
-
 std::string variant::toJson(const TypePtr& type) const {
   // todo(youknowjack): consistent story around std::stringifying, converting,
   // and other basic operations. Stringification logic should not be specific
@@ -203,9 +198,9 @@ std::string variant::toJson(const TypePtr& type) const {
           b += ",";
         }
         b += "{\"key\":";
-        b += pair.first.toJson();
+        b += pair.first.toJson(type);
         b += ",\"value\":";
-        b += pair.second.toJson();
+        b += pair.second.toJson(type);
         b += "}";
         first = false;
       }
@@ -221,7 +216,7 @@ std::string variant::toJson(const TypePtr& type) const {
         if (!first) {
           b += ",";
         }
-        b += v.toJson();
+        b += v.toJson(type);
         first = false;
       }
       b += "]";
@@ -236,7 +231,7 @@ std::string variant::toJson(const TypePtr& type) const {
         if (!first) {
           b += ",";
         }
-        b += v.toJson();
+        b += v.toJson(type);
         first = false;
       }
       b += "]";

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -174,6 +174,11 @@ void variant::throwCheckPtrError() const {
   throw std::invalid_argument{"missing variant value"};
 }
 
+std::string variant::toJson() const {
+  const auto type = fromKindToScalerType(kind_);
+  return toJson(type);
+}
+
 std::string variant::toJson(const TypePtr& type) const {
   // todo(youknowjack): consistent story around std::stringifying, converting,
   // and other basic operations. Stringification logic should not be specific

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -396,10 +396,10 @@ class variant {
     }
   }
 
-  // Use type to interpret the Variant.
+  // Use type to interpret the output.
   std::string toJson(const TypePtr& type) const;
 
-  // Use physical types to interpret the Variant.
+  // Use the variant's physical type to interpret the output.
   std::string toJson() const;
 
   // Used by python binding, do not change signature.

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -396,9 +396,13 @@ class variant {
     }
   }
 
-  std::string toJson(const TypePtr& type = nullptr) const;
+  // Use type to interpret the Variant.
+  std::string toJson(const TypePtr& type) const;
 
-  /// Used by python binding, do not change signature.
+  // Use physical types to interpret the Variant.
+  std::string toJson() const;
+
+  // Used by python binding, do not change signature.
   std::string pyToJson() const {
     return toJson();
   }

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -399,12 +399,10 @@ class variant {
   // Use type to interpret the output.
   std::string toJson(const TypePtr& type) const;
 
-  // Use the variant's physical type to interpret the output.
-  std::string toJson() const;
-
   // Used by python binding, do not change signature.
   std::string pyToJson() const {
-    return toJson();
+    const auto type = fromKindToScalerType(kind_);
+    return toJson(type);
   }
 
   folly::dynamic serialize() const;
@@ -540,11 +538,6 @@ class variant {
       default:
         return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(kind2type, kind_);
     }
-  }
-
-  friend std::ostream& operator<<(std::ostream& stream, const variant& k) {
-    stream << k.toJson();
-    return stream;
   }
 
   // Uses kEpsilon to compare floating point types (REAL and DOUBLE).

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -15,7 +15,6 @@
  */
 #include "velox/type/Variant.h"
 #include <gtest/gtest.h>
-#include <velox/type/Type.h>
 #include <numeric>
 
 using namespace facebook::velox;

--- a/velox/type/tests/VariantTest.cpp
+++ b/velox/type/tests/VariantTest.cpp
@@ -264,7 +264,8 @@ TEST_F(VariantSerializationTest, serializeOpaque) {
 }
 
 TEST_F(VariantSerializationTest, opaqueToString) {
-  auto s = var_.toJson();
+  const auto type = fromKindToScalerType(var_.kind());
+  auto s = var_.toJson(type);
   EXPECT_EQ(
       s,
       "Opaque<type:OPAQUE<SerializableClass>,value:\"{\"name\":\"test_class\",\"value\":false}\">");


### PR DESCRIPTION
Variant stores only the physical value and typeKind. It can be interpreted using the physical type.
But a Variant can also be interpreted by using a LogicalType on top if a type is specified.
This PR clarifies the toJson() API based on the above semantics.

See discussion: https://github.com/facebookincubator/velox/discussions/4069#discussioncomment-6488542