### PR TITLE
Add flow control to ExchangeClient

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -85,6 +85,11 @@ class QueryConfig {
   static constexpr const char* kMaxLocalExchangeBufferSize =
       "max_local_exchange_buffer_size";
 
+  static constexpr const char* kExchangeFlowControl =
+      "exchange.enable_flow_control";
+
+  static constexpr const char* kExchangeBufferSize = "exchange.max_buffer_size";
+
   static constexpr const char* kMaxPartialAggregationMemory =
       "max_partial_aggregation_memory";
 
@@ -255,6 +260,15 @@ class QueryConfig {
   uint64_t maxLocalExchangeBufferSize() const {
     static constexpr uint64_t kDefault = 32UL << 20;
     return get<uint64_t>(kMaxLocalExchangeBufferSize, kDefault);
+  }
+
+  bool exchangeFlowControlEnabled() const {
+    return get<bool>(kExchangeFlowControl, false);
+  }
+
+  uint64_t exchangeBufferSize() const {
+    static constexpr uint64_t kDefault = 32UL << 20;
+    return get<uint64_t>(kExchangeBufferSize, kDefault);
   }
 
   uint64_t preferredOutputBatchBytes() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -66,6 +66,18 @@ Generic Configuration
      - integer
      - 32MB
      - Used for backpressure to block local exchange producers when the local exchange buffer reaches or exceeds this size.
+   * - exchange.enable_flow_control
+     - boolean
+     - false
+     - If true, enable flow control in exchange. Flow control limits network bandwidth used by exchange client.
+       This helps in reducing memory usage at cost of efficiency. Flow control parameters are further controlled by
+       ``exchange.max_buffer_size``.
+   * - exchange.max_buffer_size
+     - integer
+     - 32MB
+     - Size of buffer in the exchange client that holds data fetched from other nodes before it is processed.
+       A larger buffer can increase network throughput for larger clusters and thus decrease query processing time,
+       but will reduce the amount of memory available for other usages.
    * - max_page_partitioning_buffer_size
      - integer
      - 32MB

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -74,12 +74,21 @@ class SerializedPage {
   std::function<void(folly::IOBuf&)> onDestructionCb_;
 };
 
+class ExchangeSource;
+class ExchangeClient;
+
 // Queue of results retrieved from source. Owned by shared_ptr by
 // Exchange and client threads and registered callbacks waiting
 // for input.
 class ExchangeQueue {
  public:
-  explicit ExchangeQueue(int64_t minBytes) : minBytes_(minBytes) {}
+  explicit ExchangeQueue(
+      int64_t minBytes,
+      int64_t maxBytes = -1,
+      std::weak_ptr<ExchangeClient> client = std::weak_ptr<ExchangeClient>())
+      : minBytes_(minBytes), client_(std::move(client)) {
+    maxBytes_ = maxBytes == -1 ? minBytes : maxBytes;
+  }
 
   ~ExchangeQueue() {
     clearAllPromises();
@@ -93,11 +102,20 @@ class ExchangeQueue {
     return queue_.empty();
   }
 
+  int32_t numCompleted() const {
+    return numCompleted_;
+  }
+
+  int32_t& numPending() {
+    return numPending_;
+  }
+
   void enqueueLocked(
       std::unique_ptr<SerializedPage>&& page,
       std::vector<ContinuePromise>& promises) {
     if (page == nullptr) {
       ++numCompleted_;
+      --numPending_;
       auto completedPromises = checkCompleteLocked();
       promises.reserve(promises.size() + completedPromises.size());
       for (auto& promise : completedPromises) {
@@ -105,7 +123,14 @@ class ExchangeQueue {
       }
       return;
     }
+
+    auto pageSize = page->size();
     totalBytes_ += page->size();
+    receivedBytes_ += page->size();
+    if (totalBytes_ > peakBytes_) {
+      peakBytes_ = totalBytes_;
+    }
+    ++receivedPages_;
     queue_.push_back(std::move(page));
     if (!promises_.empty()) {
       // Resume one of the waiting drivers.
@@ -159,9 +184,38 @@ class ExchangeQueue {
     return page;
   }
 
+  // Returns a guess for a typical reply unit size. An expected reply size is
+  // the requested bytes rounded up to the next multiple of the estimate. Actual
+  // reply sizes have no hard limit.
+  uint64_t expectedSerializedPageSize() const;
+
+  // Marks that 'numRequests', each for 'bytes' have been started.
+  void recordRequestLocked(int32_t numRequests, uint64_t bytes) {
+    numPending_ += numRequests;
+    expectedBytes_ += bytes;
+  }
+
+  /// Records that a pending request arrived with 'bytes' of payload. Decreases
+  /// expected reply bytes.
+  void recordReplyLocked(int64_t bytes) {
+    if (numPending_ <= 1) {
+      expectedBytes_ = 0;
+      return;
+    }
+    expectedBytes_ = std::max<int64_t>(
+        0,
+        expectedBytes_ -
+            std::max<int64_t>(bytes, expectedBytes_ / numPending_));
+  }
+
   // Returns the total bytes held by SerializedPages in 'this'.
   uint64_t totalBytes() const {
     return totalBytes_;
+  }
+
+  // Returns the maximum value of totalBytes() so far.
+  uint64_t peakBytes() const {
+    return peakBytes_;
   }
 
   // Returns the target size for totalBytes(). An exchange client
@@ -169,6 +223,18 @@ class ExchangeQueue {
   // minBytes().
   uint64_t minBytes() const {
     return minBytes_;
+  }
+
+  uint64_t maxBytes() const {
+    return maxBytes_;
+  }
+
+  int64_t expectedBytes() const {
+    return expectedBytes_;
+  }
+
+  void clearExpectedBytes() {
+    expectedBytes_ = 0;
   }
 
   void addSourceLocked() {
@@ -194,6 +260,10 @@ class ExchangeQueue {
     }
     clearPromises(promises);
   }
+
+  /// After a reply has arrived, finds other sources to request. See the same
+  /// method in ExchangeClient for the meaning of the arguments.
+  int64_t requestIfDue(const std::shared_ptr<ExchangeSource>& replySource);
 
  private:
   std::vector<ContinuePromise> closeLocked() {
@@ -244,6 +314,27 @@ class ExchangeQueue {
   // If 'totalBytes_' < 'minBytes_', an exchange should request more data from
   // producers.
   uint64_t minBytes_;
+
+  // Maximum size of queue. Set request sizes and cap outstanding
+  // requests so as not to overrun this when data arrives.
+  uint64_t maxBytes_;
+
+  std::weak_ptr<ExchangeClient> client_;
+
+  // Number of sources with a pending request.
+  int32_t numPending_{0};
+
+  // Volume expected from pending requests.
+  int64_t expectedBytes_{0};
+
+  // Number of SerializedPages received.
+  int64_t receivedPages_{0};
+
+  // Total size of SerializedPages received. Used to calculate an average
+  // expected size.
+  int64_t receivedBytes_{0};
+  // Maximum value of totalBytes_.
+  int64_t peakBytes_{0};
 };
 
 class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
@@ -253,6 +344,10 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
       int destination,
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool)>;
+
+  // Sequence number given to requestIfDue to mark request expired without
+  // producing data.
+  static constexpr int64_t kNoReply = ~0L;
 
   ExchangeSource(
       const std::string& taskId,
@@ -281,10 +376,36 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // threads from issuing the same request.
   virtual bool shouldRequestLocked() = 0;
 
+  void clearPendingLocked() {
+    requestPending_ = false;
+  }
+
+  bool isPending() const {
+    return requestPending_;
+  }
+
+  bool isRequestable() const {
+    return !requestPending_ && !atEnd_;
+  }
+
+  bool isAtEnd() const {
+    return atEnd_;
+  }
+
   // Requests the producer to generate more data. Call only if shouldRequest()
   // was true. The object handles its own lifetime by acquiring a
   // shared_from_this() pointer if needed.
   virtual void request() = 0;
+
+  // Requests the producer to generate more data. Call only if
+  // shouldRequest() was true. The object handles its own lifetime by
+  // acquiring a shared_from_this() pointer if needed.  'mexBytes'
+  // specifies a cap on the data to receive. The cap can be exceeded
+  // if the producer has a single indivisible item that is larger than
+  // the cap.
+  virtual void request(uint64_t maxBytes) {
+    return request();
+  }
 
   // Close the exchange source. May be called before all data
   // has been received and proessed. This can happen in case
@@ -356,20 +477,34 @@ struct RemoteConnectorSplit : public connector::ConnectorSplit {
 // per consumer thread.
 class ExchangeClient {
  public:
-  static constexpr int32_t kDefaultMinSize = 32 << 20; // 32 MB.
+  static constexpr int32_t kDefaultBufferSize = 32 << 20; // 32 MB.
 
   ExchangeClient(
       int destination,
       memory::MemoryPool* pool,
-      int64_t minSize = kDefaultMinSize)
+      int64_t minSize = kDefaultBufferSize,
+      bool enableFlowControl = false)
       : destination_(destination),
         pool_(pool),
+        enableFlowControl_(enableFlowControl),
         queue_(std::make_shared<ExchangeQueue>(minSize)) {
     VELOX_CHECK_NOT_NULL(pool_);
     VELOX_CHECK(
         destination >= 0,
         "Exchange client destination must be greater than zero, got {}",
         destination);
+  }
+
+  static std::shared_ptr<ExchangeClient> create(
+      int destination,
+      memory::MemoryPool* pool,
+      int64_t bufferSize = kDefaultBufferSize,
+      bool enableFlowControl = false) {
+    auto client = std::make_shared<ExchangeClient>(
+        destination, pool, bufferSize, enableFlowControl);
+    client->queue_ =
+        std::make_shared<ExchangeQueue>(bufferSize * 0.8, bufferSize, client);
+    return client;
   }
 
   ~ExchangeClient();
@@ -398,6 +533,18 @@ class ExchangeClient {
 
   std::unique_ptr<SerializedPage> next(bool* atEnd, ContinueFuture* future);
 
+  // Sends as many requests as are expected to fit in 'queue_->maxBytes()' to
+  // sources with no pending request. If called after receiving a
+  // reply on the callback thread of the receive-notify, 'replySource'
+  // should either be sent a request for more data, or an ack starting at
+  // 'replySequence'. This is supposed to be done by the caller, and is
+  // indicated by the return value.
+  //
+  // This function is no-op when flow control is disabled.
+  // Returns an integer whether additional requesting needs to be done
+  // for the 'replySource'. If not, returns 0.
+  int64_t requestIfDue(const std::shared_ptr<ExchangeSource>& replySource);
+
   std::string toString() const;
 
   std::string toJsonString() const;
@@ -405,10 +552,16 @@ class ExchangeClient {
  private:
   const int destination_;
   memory::MemoryPool* const pool_;
+  bool enableFlowControl_;
   std::shared_ptr<ExchangeQueue> queue_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
+
+  // Next source to request. Clock hand over 'sources_'.
+  int32_t nextSourceIndex_{0};
+
   bool closed_{false};
+  int64_t numNothingRequestable_{0};
 };
 
 class Exchange : public SourceOperator {

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -122,7 +122,7 @@ class MergeExchangeSource : public MergeSource {
       int destination,
       memory::MemoryPool* FOLLY_NONNULL pool)
       : mergeExchange_(mergeExchange),
-        client_(std::make_unique<ExchangeClient>(destination, pool)) {
+        client_(ExchangeClient::create(destination, pool)) {
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
   }
@@ -181,7 +181,7 @@ class MergeExchangeSource : public MergeSource {
 
  private:
   MergeExchange* const mergeExchange_;
-  std::unique_ptr<ExchangeClient> client_;
+  std::shared_ptr<ExchangeClient> client_;
   std::unique_ptr<ByteStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -32,7 +32,7 @@ BlockingReason Destination::advance(
     return BlockingReason::kNotBlocked;
   }
   uint32_t adjustedMaxBytes = std::max(
-      PartitionedOutput::kMinDestinationSize,
+      PartitionedOutputBuffer::kMinDestinationSize,
       (maxBytes * targetSizePct_) / 100);
   if (bytesInCurrent_ >= adjustedMaxBytes) {
     return flush(bufferManager, bufferReleaseFn, future);
@@ -324,7 +324,8 @@ RowVectorPtr PartitionedOutput::getOutput() {
     // small to be worth transfer.
     for (auto& destination : destinations_) {
       if (destination.get() == blockedDestination ||
-          destination->serializedBytes() < kMinDestinationSize) {
+          destination->serializedBytes() <
+              PartitionedOutputBuffer::kMinDestinationSize) {
         continue;
       }
       destination->flush(*bufferManager, bufferReleaseFn_, nullptr);

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -124,10 +124,6 @@ class Destination {
 // dropping columns from its input.
 class PartitionedOutput : public Operator {
  public:
-  // Minimum flush size for non-final flush. 60KB + overhead fits a
-  // network MTU of 64K.
-  static constexpr uint64_t kMinDestinationSize = 60 * 1024;
-
   PartitionedOutput(
       int32_t operatorId,
       DriverCtx* FOLLY_NONNULL ctx,

--- a/velox/exec/PartitionedOutputBufferManager.cpp
+++ b/velox/exec/PartitionedOutputBufferManager.cpp
@@ -611,6 +611,25 @@ void PartitionedOutputBuffer::terminate() {
   }
 }
 
+void PartitionedOutputBuffer::testingClearNotifys() {
+  std::vector<DataAvailable> notifys;
+  {
+    std::lock_guard<std::mutex> l(mutex_);
+    for (auto i = 0; i < buffers_.size(); ++i) {
+      auto destination = buffers_[i].get();
+      if (destination) {
+        auto notify = destination->getAndClearNotify();
+        if (notify.callback) {
+          notifys.push_back(std::move(notify));
+        }
+      }
+    }
+  }
+  for (auto& notify : notifys) {
+    notify.notify();
+  }
+}
+
 std::string PartitionedOutputBuffer::toString() {
   std::lock_guard<std::mutex> l(mutex_);
   return toStringLocked();
@@ -776,6 +795,17 @@ void PartitionedOutputBufferManager::removeTask(const std::string& taskId) {
       });
   if (buffer != nullptr) {
     buffer->terminate();
+  }
+}
+
+void PartitionedOutputBufferManager::testingClearNotifys(
+    std::function<bool(const std::string&)> tasksToClear) {
+  auto buffers =
+      buffers_.withLock([&](const auto& buffers) { return buffers; });
+  for (auto pair : buffers) {
+    if (tasksToClear(pair.first)) {
+      pair.second->testingClearNotifys();
+    }
   }
 }
 

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -129,6 +129,10 @@ class DestinationBuffer {
 
 class PartitionedOutputBuffer {
  public:
+  // Minimum flush size for non-final flush. 60KB + overhead fits a
+  // network MTU of 64K.
+  static constexpr uint64_t kMinDestinationSize = 60 * 1024;
+
   PartitionedOutputBuffer(
       std::shared_ptr<Task> task,
       core::PartitionedOutputNode::Kind kind,

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -185,6 +185,11 @@ class PartitionedOutputBuffer {
   // producer task has an error or cancellation.
   void terminate();
 
+  /// Removes any DataAvailable callbacks that may have been added to
+  /// destination buffers. Calls the callback of each with no data. Used for
+  /// simulating a 'no data' response from a remote source.
+  void testingClearNotifys();
+
   std::string toString();
 
   // Gets the memory utilization ratio in this output buffer.
@@ -358,6 +363,12 @@ class PartitionedOutputBufferManager {
       std::function<std::unique_ptr<OutputStreamListener>()> factory) {
     listenerFactory_ = factory;
   }
+
+  /// Removes any DataAvailable callbacks that may have been added to
+  /// destination buffers. Calls the callback of each with no data. Used for
+  /// simulating a 'no data' response from a remote source.
+  void testingClearNotifys(
+      std::function<bool(const std::string&)> tasksToClear);
 
   std::string toString();
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2300,12 +2300,11 @@ void Task::createExchangeClient(
       getExchangeClientLocked(planNodeId),
       "Exchange client has been created for planNode: {}",
       planNodeId);
-  // Low-water mark for filling the exchange queue is 1/2 of the per worker
-  // buffer size of the producers.
-  exchangeClients_[pipelineId] = std::make_shared<ExchangeClient>(
+  exchangeClients_[pipelineId] = ExchangeClient::create(
       destination_,
       addExchangeClientPool(planNodeId, pipelineId),
-      queryCtx()->queryConfig().maxPartitionedOutputBufferSize() / 2);
+      queryCtx()->queryConfig().exchangeBufferSize(),
+      queryCtx()->queryConfig().exchangeFlowControlEnabled());
   exchangeClientByPlanNode_.emplace(planNodeId, exchangeClients_[pipelineId]);
 }
 

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <folly/executors/IOThreadPoolExecutor.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/Exchange.h"
@@ -20,6 +21,57 @@
 namespace facebook::velox::exec {
 
 namespace {
+
+class TestingExchangeSource : public ExchangeSource {
+ public:
+  TestingExchangeSource(
+      const std::string& taskId,
+      int destination,
+      std::shared_ptr<ExchangeQueue> queue,
+      memory::MemoryPool* pool)
+      : ExchangeSource(taskId, destination, queue, pool) {}
+
+  bool shouldRequestLocked() override {
+    if (atEnd_) {
+      return false;
+    }
+    return !requestPending_.exchange(true);
+  }
+
+  void request() override {
+    request(2);
+  }
+
+  void request(uint64_t bytes) override {
+    VELOX_CHECK(requestPending_);
+    std::vector<ContinuePromise> promises;
+    {
+      std::lock_guard<std::mutex> l(queue_->mutex());
+      requestPending_ = false;
+      if (sentBytes_ == 10) {
+        queue_->enqueueLocked(nullptr, promises);
+        atEnd_ = true;
+      } else {
+        auto page =
+            std::make_unique<SerializedPage>(folly::IOBuf::copyBuffer("a", 1));
+        sentBytes_ += page->size();
+        queue_->recordReplyLocked(page->size());
+        queue_->enqueueLocked(std::move(page), promises);
+      }
+    }
+    for (auto& promise : promises) {
+      promise.setValue();
+    }
+  }
+
+  void close() override {}
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {{"sentBytes", sentBytes_}};
+  }
+
+  int sentBytes_{0};
+};
 
 TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
   std::shared_ptr<memory::MemoryPool> rootPool{
@@ -29,19 +81,61 @@ TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
   ExchangeSource::registerFactory(
       [](const auto& taskId, auto destination, auto queue, auto pool)
           -> std::shared_ptr<ExchangeSource> {
-        throw std::runtime_error("Testing error");
+        if (taskId.find("$$") != std::string::npos) {
+          throw std::runtime_error("Testing error");
+        }
+        return nullptr;
       });
 
   ExchangeClient client(1, pool.get());
   VELOX_ASSERT_THROW(
-      client.addRemoteTaskId("task.1.2.3"),
-      "Failed to create ExchangeSource: Testing error. Task ID: task.1.2.3.");
+      client.addRemoteTaskId("$$task.1.2.3"),
+      "Failed to create ExchangeSource: Testing error. Task ID: $$task.1.2.3.");
 
   // Test with a very long task ID. Make sure it is truncated.
   VELOX_ASSERT_THROW(
-      client.addRemoteTaskId(std::string(1024, 'x')),
+      client.addRemoteTaskId(std::string(1024, 'x') + "$$"),
       "Failed to create ExchangeSource: Testing error. "
       "Task ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.");
+}
+
+TEST(ExchangeClientTest, basic) {
+  auto executor = std::make_unique<folly::IOThreadPoolExecutor>(10);
+  std::shared_ptr<memory::MemoryPool> rootPool{
+      memory::defaultMemoryManager().addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
+
+  ExchangeSource::registerFactory(
+      [](const std::string& taskId,
+         int destination,
+         std::shared_ptr<velox::exec::ExchangeQueue> queue,
+         velox::memory::MemoryPool* pool) {
+        return std::make_unique<TestingExchangeSource>(
+            taskId, destination, queue, pool);
+      });
+  int bufferSize = 32 * 1024 * 1024;
+  auto client = ExchangeClient::create(1, pool.get(), bufferSize);
+  client->addRemoteTaskId("0");
+  client->addRemoteTaskId("1");
+  client->noMoreRemoteTasks();
+  VELOX_CHECK_EQ(client->queue()->totalBytes(), 2);
+
+  bool atEnd = false;
+  ContinueFuture dataFuture;
+  auto page = client->next(&atEnd, &dataFuture);
+  // next() will add 2 pages, and dequeue 1 page.
+  VELOX_CHECK_EQ(client->queue()->totalBytes(), 3);
+
+  for (int i = 0; i < 19; ++i) {
+    auto page = client->next(&atEnd, &dataFuture);
+    VELOX_CHECK_EQ(page->size(), 1);
+  }
+  VELOX_CHECK_NULL(client->next(&atEnd, &dataFuture));
+  VELOX_CHECK_EQ(client->queue()->numCompleted(), 2);
+  int expectedSize = (bufferSize + 20) / 22;
+  VELOX_CHECK_EQ(client->queue()->expectedSerializedPageSize(), expectedSize);
+  VELOX_CHECK_EQ(client->stats()["peakBytes"].max, 11);
+  VELOX_CHECK(atEnd);
 }
 
 } // namespace


### PR DESCRIPTION
This PR adds 2 commits to enable flow control in Exchange. I can squash them later, or put as separate PRs. Both are needed to be looked at together to understand the API changes.

Flow control is controlled by 2 configs: exchange.enable_flow_control and exchange.max_buffer_size. Latter config tries to bound memory used by exchange client within max buffer size. This is done by setting a cap on number of sources we request, and how much data we request from each source. The changes are done in a backwards complatible fashion - so existing ExchangeSource implementations continue to work.

Commit 1:

* Adds `exchange(int bytes)` API to ExchangeSource. This will request the producer to limit its reply to within requested size.

* Adds requestIfDue() API that is expected to be used by all ExchangeSource. This method does the flow control, and is implemented in 2nd commit. Adds other APIs in ExchangeQueue that are needed in future.
  
  * Adds unit test for ExchangeClient, with a custom testing source implementation.
  
 Commit 2:
 
 * implements major logic of flow control in `ExchangeClient::requestIfDue`. Add a unit test to check if memory used by exchange client is within limits. Also add an integration test using MultiFragmentTest.

* *  API explanation for requestIfDue is explained in the comments:

```
  // Sends as many requests as are expected to fit in 'queue_->maxBytes()' to
  // sources with no pending request. If called after receiving a
  // reply on the callback thread of the receive-notify, 'replySource'
  // should either be sent a request for more data, or an ack starting at
  // 'replySequence'. This is supposed to be done by the caller, and is
  // indicated by the return value.
  //
  // This function is no-op when flow control is disabled.
  // Returns an integer whether additional requesting needs to be done
  // for the 'replySource'. If not, returns 0.
  ```

 
In case of flow control disabled, `requestIfDue` returns immediately. ExchangeSource behave exactly same as they did before.

When flow control is enabled, responsibility of requesting and calling `shouldRequestLocked()` falls on `requestIfDue`. It may additionally want to send requests/acks to the `replySource`. Responsibility of this stays in the caller.

If we try to change these responsibilites, API might change - and many details will need to be taken care of. 