### PR TITLE
Fix PrestoSerializer for RowNumber optimization

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1733,6 +1733,13 @@ void PrestoVectorSerde::deserialize(
   VELOX_CHECK_EQ(
       checksum, actualCheckSum, "Received corrupted serialized page.");
 
+  if (type->children().empty()) {
+    // Skip the reading of if we only need a trivially empty vector of its size
+    // set for certain optimizations like RowNumber.
+    source->skip(uncompressedSize);
+    return;
+  }
+
   // skip number of columns
   source->skip(4);
 


### PR DESCRIPTION
This fix is to address following scenario when row_number optimization is involved.
Consider query 
```SELECT rn FROM (SELECT row_number() over() rn, * from orders) WHERE rn = 113;```

Part of Fragment 1 (non-leaf): Exchange->RowNumber
This exchange node is constructed without outputVariableTypes. This is because the fragment only needs column rn which is an implicit column of RowNumber operator. To construct this column, all this RowNumber node needs for its input is the length without any content. Now because of this, the following happens:

Exchange operator is given a valid serialized page (with payload) to deserialize. Exchange operator does not know the outputType due to above explained. Exchange::getOutput() is called first time. It reads all headers without reading any actual data (due to absent of outputType), leaving inputStream_ half consumed, which makes it read the second time. Then second time reading the same inputStream_ continuing from the previous offset but still trying to read headers, causing failure.

We should allow the 'optimized' vector to be deserialized correctly and mark the finish of inputStream_ reading to avoid the above bug.

This fixes the disabled test in Presto's e2e window query test.
