### PR TITLE
Fix destroy() in Velox aggregates

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -591,6 +591,7 @@ void GroupingSet::destroyGlobalAggregations() {
   }
   for (int32_t i = 0; i < aggregates_.size(); ++i) {
     auto& function = aggregates_[i].function;
+    auto groups = lookup_->hits.data();
     if (function->accumulatorUsesExternalMemory()) {
       auto groups = lookup_->hits.data();
       function->destroy(folly::Range(groups, 1));
@@ -1079,6 +1080,9 @@ void GroupingSet::toIntermediate(
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
+    if (intermediateRows_->checkFree()) {
+      intermediateRows_->stringAllocator().checkEmpty();
+    }
   }
 
   // It's unnecessary to call function->clear() to reset the internal states of

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -687,6 +687,10 @@ class RowContainer {
     return mutable_;
   }
 
+  bool checkFree() const {
+    return checkFree_;
+  }
+
  private:
   // Offset of the pointer to the next free row on a free row.
   static constexpr int32_t kNextFreeOffset = 0;

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -278,4 +278,21 @@ bool TopNRowNumber::isFinished() {
   return finished_;
 }
 
+void TopNRowNumber::close() {
+  if (table_) {
+    partitionIt_.reset();
+    partitions_.resize(1000);
+    while (auto numPartitions = table_->listAllRows(
+               &partitionIt_,
+               partitions_.size(),
+               RowContainer::kUnlimited,
+               partitions_.data())) {
+      for (auto i = 0; i < numPartitions; ++i) {
+        std::destroy_at(
+            reinterpret_cast<TopRows*>(partitions_[i] + partitionOffset_));
+      }
+    }
+  }
+}
+
 } // namespace facebook::velox::exec

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -57,6 +57,8 @@ class TopNRowNumber : public Operator {
 
   bool isFinished() override;
 
+  void close() override;
+
  private:
   /// A priority queue to keep track of top 'limit' rows for a given partition.
   struct TopRows {

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -199,7 +199,12 @@ class ApproxDistinctAggregate : public exec::Aggregate {
         });
   }
 
-  void destroy(folly::Range<char**> /*groups*/) override {}
+  void destroy(folly::Range<char**> groups) override {
+    for (auto group : groups) {
+      // All accumulators are default constructed also for nulls.
+      std::destroy_at(value<HllAccumulator>(group));
+    }
+  }
 
   void addRawInput(
       char** groups,

--- a/velox/functions/prestosql/aggregates/MapAccumulator.h
+++ b/velox/functions/prestosql/aggregates/MapAccumulator.h
@@ -105,6 +105,7 @@ struct MapAccumulator {
   }
 
   void free(HashStringAllocator& allocator) {
+    std::destroy_at(&keys);
     values.free(&allocator);
   }
 };

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -269,12 +269,13 @@ class MapUnionSumAggregate : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    if constexpr (std::is_same_v<K, StringView>) {
-      for (auto* group : groups) {
+    for (auto* group : groups) {
+      if constexpr (std::is_same_v<K, StringView>) {
         if (!isNull(group)) {
           value<AccumulatorType>(group)->strings.free(*allocator_);
         }
       }
+      std::destroy_at(value<AccumulatorType>(group));
     }
   }
 

--- a/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -352,6 +352,9 @@ class LastAggregate : public FirstLastAggregateBase<numeric, TData> {
 
     if (!decodedVector.isNullAt(index)) {
       Aggregate::clearNull(group);
+      if (accumulator->has_value()) {
+        accumulator->value().destroy(Aggregate::allocator_);
+      }
       *accumulator = SingleValueAccumulator();
       accumulator->value().write(
           decodedVector.base(), index, Aggregate::allocator_);
@@ -359,6 +362,9 @@ class LastAggregate : public FirstLastAggregateBase<numeric, TData> {
     }
 
     if constexpr (!ignoreNull) {
+      if (accumulator->has_value()) {
+        accumulator->value().destroy(Aggregate::allocator_);
+      }
       Aggregate::setNull(group);
       *accumulator = SingleValueAccumulator();
     }


### PR DESCRIPTION
Fix destroy() in Velox aggregates

Aggregates are expected to free their variable length storage in stringAllocator_ of their RowContainer. This adds the required frees. In an accumulator contains a container, like F14* or std::vector or std::priority_qeue, the container's destructor must be called even if the container is empty.

We check that the HashStringAllocator for variable length content is
empty at destruction. We call destroy() of the accumulators innstead
of relying on a clear of the HashStringAllocator.

In the event of spilling, a fraction of the accumulators is
freed. The above check make sure that the right data gets freed in
spilling. Under other conditions the clear of the HashStringAllocator
would in principle work for cases where any containers exclusively
allocate from the HashStringAllocator and are otherwise trivially
destructible.

Fixes destruction of xpriority queues in TopNRowNumber.cpp. This is analogous to the case with aggregates.

The global check in RowContainer for enforcing destruct of aggregates
is not enabled.
