### PR TITLE
Handle memory arbitration trigger from non-driver execution context

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -205,6 +205,11 @@ class QueryConfig {
   static constexpr const char* kHashProbeFinishEarlyOnEmptyBuild =
       "hash_probe_finish_early_on_empty_build";
 
+  /// The minimum number of table rows that can trigger the parallel hash join
+  /// table build.
+  static constexpr const char* kMinTableRowsForParallelJoinBuild =
+      "min_table_rows_for_parallel_join_build";
+
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
@@ -321,7 +326,7 @@ class QueryConfig {
   }
 
   /// Returns 'is aggregation spilling enabled' flag. Must also check the
-  /// spillEnabled()!
+  /// spillEnabled()!g
   bool aggregationSpillEnabled() const {
     return get<bool>(kAggregationSpillEnabled, true);
   }
@@ -408,6 +413,10 @@ class QueryConfig {
 
   bool hashProbeFinishEarlyOnEmptyBuild() const {
     return get<bool>(kHashProbeFinishEarlyOnEmptyBuild, true);
+  }
+
+  uint32_t minTableRowsForParallelJoinBuild() const {
+    return get<uint32_t>(kMinTableRowsForParallelJoinBuild, 1'000);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -71,6 +71,10 @@ Generic Configuration
      - 32MB
      - The target size for a Task's buffered output. The producer Drivers are blocked when the buffered size exceeds this.
        The Drivers are resumed when the buffered size goes below PartitionedOutputBufferManager::kContinuePct (90)% of this.
+   * - min_table_rows_for_parallel_join_build
+     - integer
+     - 1000
+     - The minimum number of table rows that can trigger the parallel hash join table build.
 
 Expression Evaluation Configuration
 -----------------------------------

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -91,7 +91,7 @@ std::ostream& operator<<(std::ostream& out, const StopReason& reason);
 // suspended, off thread or blocked.
 struct ThreadState {
   // The thread currently running this.
-  std::atomic<std::thread::id> thread{};
+  std::atomic<std::thread::id> thread{std::thread::id()};
   // The tid of 'thread'. Allows finding the thread in a debugger.
   std::atomic<int32_t> tid{0};
   // True if queued on an executor but not on thread.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -415,6 +415,13 @@ void Operator::MemoryReclaimer::enterArbitration() {
   // The driver must be alive as the operator is still under memory arbitration
   // processing.
   VELOX_CHECK_NOT_NULL(driver);
+  if (FOLLY_UNLIKELY(!driver->state().isOnThread())) {
+    // NOTE: some memory arbitration are triggered from non-driver execution
+    // context such as async streaming shuffle, table scan prefetch etc. We
+    // should guarantee that such async operations won't mutate the operator
+    // state.
+    return;
+  }
   VELOX_CHECK_EQ(std::this_thread::get_id(), driver->state().thread);
   if (driver->task()->enterSuspended(driver->state()) != StopReason::kNone) {
     // There is no need for arbitration if the associated task has already
@@ -428,6 +435,10 @@ void Operator::MemoryReclaimer::leaveArbitration() noexcept {
   // The driver must be alive as the operator is still under memory arbitration
   // processing.
   VELOX_CHECK_NOT_NULL(driver);
+  if (FOLLY_UNLIKELY(!driver->state().isOnThread())) {
+    // NOTE: see the comment in enterArbitration.
+    return;
+  }
   VELOX_CHECK_EQ(std::this_thread::get_id(), driver->state().thread);
   driver->task()->leaveSuspended(driver->state());
 }

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -40,6 +40,7 @@ RowNumber::RowNumber(
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
+        0, // minTableSizeForParallelJoinBuild
         pool());
     lookup_ = std::make_unique<HashLookup>(table_->hashers());
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -50,6 +50,7 @@ TopNRowNumber::TopNRowNumber(
         false, // allowDuplicates
         false, // isJoinBuild
         false, // hasProbedFlag
+        0, // minTableSizeForParallelJoinBuild
         pool());
     partitionOffset_ = table_->rows()->columnAt(numKeys).offset();
     lookup_ = std::make_unique<HashLookup>(table_->hashers());

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -171,7 +171,12 @@ class HashTableBenchmark : public VectorTestBase {
             params_.buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, pool_.get());
+          std::move(keyHashers),
+          dependentTypes,
+          true,
+          false,
+          1'000,
+          pool_.get());
 
       makeRows(params_.size, 1, sequence, params_.buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -75,7 +75,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::make_unique<VectorHasher>(rowType_->childAt(channel), channel));
     }
     return HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, pool_.get());
+        std::move(keyHashers), {}, true, false, 1'000, pool_.get());
   }
 
   std::vector<ContinueFuture> createEmptyFutures(int32_t count) {

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -79,7 +79,12 @@ class HashTableTest : public testing::TestWithParam<bool> {
             buildType->childAt(channel), channel));
       }
       auto table = HashTable<true>::createForJoin(
-          std::move(keyHashers), dependentTypes, true, false, pool_.get());
+          std::move(keyHashers),
+          dependentTypes,
+          true,
+          false,
+          1'000,
+          pool_.get());
 
       makeRows(size, 1, sequence, buildType, batches);
       copyVectorsToTable(batches, startOffset, table.get());
@@ -452,7 +457,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     std::vector<std::unique_ptr<VectorHasher>> hashers;
     hashers.push_back(std::make_unique<VectorHasher>(keys->type(), 0));
     auto table = HashTable<false>::createForJoin(
-        std::move(hashers), {BIGINT()}, true, false, pool_.get());
+        std::move(hashers), {BIGINT()}, true, false, 1'000, pool_.get());
     copyVectorsToTable({batch}, 0, table.get());
     table->prepareJoinTable({}, executor_.get());
     ASSERT_EQ(table->hashMode(), mode);
@@ -703,7 +708,7 @@ TEST_P(HashTableTest, regularHashingTableSize) {
           std::make_unique<VectorHasher>(type->childAt(channel), channel));
     }
     auto table = HashTable<true>::createForJoin(
-        std::move(keyHashers), {}, true, false, pool_.get());
+        std::move(keyHashers), {}, true, false, 1'000, pool_.get());
     std::vector<RowVectorPtr> batches;
     makeRows(1 << 12, 1, 0, type, batches);
     copyVectorsToTable(batches, 0, table.get());


### PR DESCRIPTION
Not all the memory arbitration are triggered from driver execution context
such as async table scan prefetch or async streaming shuffle return path.
Given that, we need to allow the memory arbitration to handle such case.
To enter/leave memory arbitration, we need to skip the driver suspension
enter/leave step if it is not under driver execution context.
This PR add unit tests to trigger memory arbitration under driver init and 
parallel table build. We will fix these two cases in followup at least for parallel
table join to avoid the memory allocations during the parallel join. Otherwise
the memory arbitration will hang the arbitration process.