### PR TITLE
Add float/double pmod spark function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -87,6 +87,7 @@ Mathematical Functions
 .. spark:function:: pmod(n, m) -> [same as n]
 
     Returns the positive remainder of n divided by m.
+    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, FLOAT and DOUBLE.
 
 .. spark:function:: power(x, p) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -46,7 +46,7 @@ struct RemainderFunction {
 };
 
 template <typename T>
-struct PModFunction {
+struct PModIntFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a, const TInput n)
 #if defined(__has_feature)
@@ -62,6 +62,20 @@ struct PModFunction {
     }
 
     result = (r > 0) ? r : (r + n) % n;
+    return true;
+  }
+};
+
+template <typename T>
+struct PModFloatFunction {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE bool
+  call(TInput& result, const TInput a, const TInput n) {
+    if (UNLIKELY(n == (TInput)0)) {
+      return false;
+    }
+    TInput r = fmod(a, n);
+    result = (r > 0) ? r : fmod(r + n, n);
     return true;
   }
 };

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -42,7 +42,8 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<Log1pFunction, double, double>({prefix + "log1p"});
   registerFunction<ToBinaryStringFunction, Varchar, int64_t>({prefix + "bin"});
   registerFunction<ExpFunction, double, double>({prefix + "exp"});
-  registerBinaryIntegral<PModFunction>({prefix + "pmod"});
+  registerBinaryIntegral<PModIntFunction>({prefix + "pmod"});
+  registerBinaryFloatingPoint<PModFloatFunction>({prefix + "pmod"});
   registerFunction<PowerFunction, double, double, double>({prefix + "power"});
   registerUnaryNumeric<RoundFunction>({prefix + "round"});
   registerFunction<RoundFunction, int8_t, int8_t, int32_t>({prefix + "round"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -75,12 +75,15 @@ TEST_F(PmodTest, float) {
   EXPECT_FLOAT_EQ(0.2, pmod<float>(0.5, 0.3).value());
   EXPECT_FLOAT_EQ(0.9, pmod<float>(-1.1, 2).value());
   EXPECT_EQ(std::nullopt, pmod<float>(2.14159, 0.0));
+  EXPECT_DOUBLE_EQ(0.1, pmod<double>(0.7, -0.3).value());
+
 }
 
 TEST_F(PmodTest, double) {
   EXPECT_DOUBLE_EQ(0.2, pmod<double>(0.5, 0.3).value());
   EXPECT_DOUBLE_EQ(0.9, pmod<double>(-1.1, 2).value());
   EXPECT_EQ(std::nullopt, pmod<double>(2.14159, 0.0));
+  EXPECT_DOUBLE_EQ(0.1, pmod<double>(0.7, -0.3).value());
 }
 
 class RemainderTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -76,7 +76,6 @@ TEST_F(PmodTest, float) {
   EXPECT_FLOAT_EQ(0.9, pmod<float>(-1.1, 2).value());
   EXPECT_EQ(std::nullopt, pmod<float>(2.14159, 0.0));
   EXPECT_DOUBLE_EQ(0.1, pmod<double>(0.7, -0.3).value());
-
 }
 
 TEST_F(PmodTest, double) {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -71,6 +71,18 @@ TEST_F(PmodTest, int64) {
   EXPECT_EQ(0, pmod<int64_t>(INT64_MIN, -1));
 }
 
+TEST_F(PmodTest, float) {
+  EXPECT_FLOAT_EQ(0.2, pmod<float>(0.5, 0.3).value());
+  EXPECT_FLOAT_EQ(0.9, pmod<float>(-1.1, 2).value());
+  EXPECT_EQ(std::nullopt, pmod<float>(2.14159, 0.0));
+}
+
+TEST_F(PmodTest, double) {
+  EXPECT_DOUBLE_EQ(0.2, pmod<double>(0.5, 0.3).value());
+  EXPECT_DOUBLE_EQ(0.9, pmod<double>(-1.1, 2).value());
+  EXPECT_EQ(std::nullopt, pmod<double>(2.14159, 0.0));
+}
+
 class RemainderTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>


### PR DESCRIPTION
pmod sematics:
pmod(expr1, expr2) - Returns the positive value of expr1 mod expr2.

Pmod function is only existed in spark. Presto do not have this function.
The difference between mod and pmod is that **pmod will return positive value**.
Spark inplementation link : https://github.com/apache/spark/blob/v3.3.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/arithmetic.scala#L754-L779
```
scala> spark.sql("SELECT pmod(-10, 3);").show()
+------------+
|pmod(-10, 3)|
+------------+
|           2|
+------------+


scala> spark.sql("SELECT mod(-10, 3);").show()
+-----------+
|mod(-10, 3)|
+-----------+
|         -1|
+-----------+

```
