### PR TITLE
Start to reconcile nodeType and type in SelectiveColumnReader

### DIFF
--- a/velox/dwio/common/ColumnLoader.cpp
+++ b/velox/dwio/common/ColumnLoader.cpp
@@ -76,7 +76,7 @@ void ColumnLoader::loadInternal(
   structReader_->advanceFieldReader(fieldReader_, offset);
   fieldReader_->scanSpec()->setValueHook(hook);
   fieldReader_->read(offset, effectiveRows, incomingNulls);
-  if (fieldReader_->type()->kind() == TypeKind::ROW) {
+  if (fieldReader_->fileType().type->kind() == TypeKind::ROW) {
     // 'fieldReader_' may itself produce LazyVectors. For this it must have its
     // result row numbers set.
     static_cast<SelectiveStructColumnReaderBase*>(fieldReader_)

--- a/velox/dwio/common/ColumnVisitors.h
+++ b/velox/dwio/common/ColumnVisitors.h
@@ -708,9 +708,9 @@ class DictionaryColumnVisitor
             values),
         state_(reader->scanState().rawState),
         width_(
-            reader->type()->kind() == TypeKind::BIGINT        ? 8
-                : reader->type()->kind() == TypeKind::INTEGER ? 4
-                                                              : 2) {}
+            reader->fileType().type->kind() == TypeKind::BIGINT        ? 8
+                : reader->fileType().type->kind() == TypeKind::INTEGER ? 4
+                                                                       : 2) {}
 
   FOLLY_ALWAYS_INLINE bool isInDict() {
     if (inDict()) {

--- a/velox/dwio/common/SelectiveByteRleColumnReader.cpp
+++ b/velox/dwio/common/SelectiveByteRleColumnReader.cpp
@@ -19,26 +19,26 @@
 namespace facebook::velox::dwio::common {
 
 void SelectiveByteRleColumnReader::getValues(RowSet rows, VectorPtr* result) {
-  switch (nodeType_->type->kind()) {
+  switch (requestedType_->kind()) {
     case TypeKind::BOOLEAN:
-      getFlatValues<int8_t, bool>(rows, result, nodeType_->type);
+      getFlatValues<int8_t, bool>(rows, result, requestedType_);
       break;
     case TypeKind::TINYINT:
-      getFlatValues<int8_t, int8_t>(rows, result, nodeType_->type);
+      getFlatValues<int8_t, int8_t>(rows, result, requestedType_);
       break;
     case TypeKind::SMALLINT:
-      getFlatValues<int8_t, int16_t>(rows, result, nodeType_->type);
+      getFlatValues<int8_t, int16_t>(rows, result, requestedType_);
       break;
     case TypeKind::INTEGER:
-      getFlatValues<int8_t, int32_t>(rows, result, nodeType_->type);
+      getFlatValues<int8_t, int32_t>(rows, result, requestedType_);
       break;
     case TypeKind::BIGINT:
-      getFlatValues<int8_t, int64_t>(rows, result, nodeType_->type);
+      getFlatValues<int8_t, int64_t>(rows, result, requestedType_);
       break;
     default:
       VELOX_FAIL(
           "Result type not supported in ByteRLE encoding: {}",
-          nodeType_->type->toString());
+          requestedType_->toString());
   }
 }
 

--- a/velox/dwio/common/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/common/SelectiveByteRleColumnReader.h
@@ -23,15 +23,15 @@ namespace facebook::velox::dwio::common {
 class SelectiveByteRleColumnReader : public SelectiveColumnReader {
  public:
   SelectiveByteRleColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      const TypePtr& requestedType,
       dwio::common::FormatParams& params,
       velox::common::ScanSpec& scanSpec,
-      const TypePtr& type)
+      std::shared_ptr<const dwio::common::TypeWithId> type)
       : SelectiveColumnReader(
-            std::move(requestedType),
+            requestedType,
             params,
             scanSpec,
-            type) {}
+            std::move(type)) {}
 
   bool hasBulkPath() const override {
     return false;

--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -42,15 +42,15 @@ void ScanState::updateRawState() {
 }
 
 SelectiveColumnReader::SelectiveColumnReader(
-    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+    const TypePtr& requestedType,
     dwio::common::FormatParams& params,
     velox::common::ScanSpec& scanSpec,
-    const TypePtr& type)
+    std::shared_ptr<const dwio::common::TypeWithId> type)
     : memoryPool_(params.pool()),
-      nodeType_(requestedType),
-      formatData_(params.toFormatData(requestedType, scanSpec)),
+      fileType_(type),
+      formatData_(params.toFormatData(type, scanSpec)),
       scanSpec_(&scanSpec),
-      type_{type} {}
+      requestedType_(requestedType) {}
 
 void SelectiveColumnReader::filterRowGroups(
     uint64_t rowGroupSize,

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -123,10 +123,10 @@ class SelectiveColumnReader {
   static constexpr uint64_t kStringBufferSize = 16 * 1024;
 
   SelectiveColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      const TypePtr& requestedType,
       dwio::common::FormatParams& params,
       velox::common::ScanSpec& scanSpec,
-      const TypePtr& type);
+      std::shared_ptr<const dwio::common::TypeWithId> type);
 
   virtual ~SelectiveColumnReader() = default;
 
@@ -194,12 +194,12 @@ class SelectiveColumnReader {
     parentNullsRecordedTo_ = 0;
   }
 
-  const TypePtr& type() const {
-    return type_;
+  const TypePtr& requestedType() const {
+    return requestedType_;
   }
 
-  const TypeWithId& nodeType() const {
-    return *nodeType_;
+  const TypeWithId& fileType() const {
+    return *fileType_;
   }
 
   // The below functions are called from ColumnVisitor to fill the result set.
@@ -531,7 +531,7 @@ class SelectiveColumnReader {
   memory::MemoryPool& memoryPool_;
 
   // The file data type
-  std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
+  std::shared_ptr<const dwio::common::TypeWithId> fileType_;
 
   // Format specific state and functions.
   std::unique_ptr<dwio::common::FormatData> formatData_;
@@ -541,8 +541,8 @@ class SelectiveColumnReader {
   // run time based on adaptation. Owned by caller.
   velox::common::ScanSpec* FOLLY_NONNULL scanSpec_;
 
-  // The file data type?
-  TypePtr type_;
+  // The requested data type
+  TypePtr requestedType_;
 
   // Row number after last read row, relative to stripe start.
   vector_size_t readOffset_ = 0;

--- a/velox/dwio/common/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/common/SelectiveFloatingPointColumnReader.h
@@ -25,15 +25,15 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
  public:
   using ValueType = TRequested;
   SelectiveFloatingPointColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-      const TypePtr& dataType,
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec)
       : SelectiveColumnReader(
-            std::move(requestedType),
+            requestedType,
             params,
             scanSpec,
-            dataType) {}
+            std::move(dataType)) {}
 
   // Offers fast path only if data and result widths match.
   bool hasBulkPath() const override {
@@ -45,7 +45,7 @@ class SelectiveFloatingPointColumnReader : public SelectiveColumnReader {
   readCommon(vector_size_t offset, RowSet rows, const uint64_t* incomingNulls);
 
   void getValues(RowSet rows, VectorPtr* result) override {
-    getFlatValues<TRequested, TRequested>(rows, result, nodeType_->type);
+    getFlatValues<TRequested, TRequested>(rows, result, requestedType_);
   }
 
  protected:

--- a/velox/dwio/common/SelectiveIntegerColumnReader.h
+++ b/velox/dwio/common/SelectiveIntegerColumnReader.h
@@ -25,18 +25,18 @@ namespace facebook::velox::dwio::common {
 class SelectiveIntegerColumnReader : public SelectiveColumnReader {
  public:
   SelectiveIntegerColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      const TypePtr& requestedType,
       dwio::common::FormatParams& params,
       velox::common::ScanSpec& scanSpec,
-      const TypePtr& type)
+      std::shared_ptr<const dwio::common::TypeWithId> type)
       : SelectiveColumnReader(
-            std::move(requestedType),
+            requestedType,
             params,
             scanSpec,
-            type) {}
+            std::move(type)) {}
 
   void getValues(RowSet rows, VectorPtr* result) override {
-    getIntValues(rows, nodeType_->type, result);
+    getIntValues(rows, requestedType_, result);
   }
 
  protected:

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -141,7 +141,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     FormatParams& params,
     velox::common::ScanSpec& scanSpec)
-    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
+    : SelectiveRepeatedColumnReader(dataType->type, params, scanSpec, dataType),
       requestedType_{requestedType} {}
 
 uint64_t SelectiveListColumnReader::skip(uint64_t numValues) {
@@ -205,7 +205,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     FormatParams& params,
     velox::common::ScanSpec& scanSpec)
-    : SelectiveRepeatedColumnReader(dataType, params, scanSpec, dataType->type),
+    : SelectiveRepeatedColumnReader(dataType->type, params, scanSpec, dataType),
       requestedType_{requestedType} {}
 
 uint64_t SelectiveMapColumnReader::skip(uint64_t numValues) {

--- a/velox/dwio/common/SelectiveRepeatedColumnReader.h
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.h
@@ -37,11 +37,15 @@ class SelectiveRepeatedColumnReader : public SelectiveColumnReader {
   static constexpr int32_t kBufferSize = 1024;
 
   SelectiveRepeatedColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
+      const TypePtr& requestedType,
       FormatParams& params,
       velox::common::ScanSpec& scanSpec,
-      const TypePtr& type)
-      : SelectiveColumnReader(std::move(nodeType), params, scanSpec, type) {}
+      std::shared_ptr<const dwio::common::TypeWithId> type)
+      : SelectiveColumnReader(
+            requestedType,
+            params,
+            scanSpec,
+            std::move(type)) {}
 
   /// Reads 'numLengths' next lengths into 'result'. If 'nulls' is
   /// non-null, each kNull bit signifies a null with a length of 0 to

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -210,10 +210,10 @@ bool SelectiveStructColumnReaderBase::isChildConstant(
                                                   // a filter on a subfield of a
                                                   // row type that doesn't exist
                                                   // in the output.
-       nodeType_->type->kind() !=
+       fileType_->type->kind() !=
            TypeKind::MAP && // If this is the case it means this is a flat map,
                             // so it can't have "missing" fields.
-       childSpec.channel() >= nodeType_->size());
+       childSpec.channel() >= fileType_->size());
 }
 
 namespace {

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -106,7 +106,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       FormatParams& params,
       velox::common::ScanSpec& scanSpec,
       bool isRoot = false)
-      : SelectiveColumnReader(dataType, params, scanSpec, dataType->type),
+      : SelectiveColumnReader(dataType->type, params, scanSpec, dataType),
         requestedType_(requestedType),
         debugString_(
             getExceptionContext().message(VeloxException::Type::kSystem)),

--- a/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveByteRleColumnReader.h
@@ -26,17 +26,17 @@ class SelectiveByteRleColumnReader
   using ValueType = int8_t;
 
   SelectiveByteRleColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
       bool isBool)
       : dwio::common::SelectiveByteRleColumnReader(
-            std::move(requestedType),
+            requestedType->type,
             params,
             scanSpec,
-            dataType->type) {
-    EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+            std::move(dataType)) {
+    EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
     auto& stripe = params.stripeStreams();
     if (isBool) {
       boolRle_ = createBooleanRleDecoder(

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<SelectiveColumnReader> buildIntegerReader(
     DwrfParams& params,
     uint32_t numBytes,
     common::ScanSpec& scanSpec) {
-  EncodingKey ek{requestedType->id, params.flatMapContext().sequence};
+  EncodingKey ek{dataType->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   switch (static_cast<int64_t>(stripe.getEncoding(ek).kind())) {
     case proto::ColumnEncoding_Kind_DICTIONARY:
@@ -93,16 +93,16 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
       if (requestedType->type->kind() == TypeKind::REAL) {
         return std::make_unique<
             SelectiveFloatingPointColumnReader<float, float>>(
-            requestedType, dataType->type, params, scanSpec);
+            requestedType->type, dataType, params, scanSpec);
       } else {
         return std::make_unique<
             SelectiveFloatingPointColumnReader<float, double>>(
-            requestedType, dataType->type, params, scanSpec);
+            requestedType->type, dataType, params, scanSpec);
       }
     case TypeKind::DOUBLE:
       return std::make_unique<
           SelectiveFloatingPointColumnReader<double, double>>(
-          requestedType, dataType->type, params, scanSpec);
+          requestedType->type, dataType, params, scanSpec);
     case TypeKind::ROW:
       return std::make_unique<SelectiveStructColumnReader>(
           requestedType, dataType, params, scanSpec, isRoot);
@@ -118,17 +118,17 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
         case proto::ColumnEncoding_Kind_DIRECT:
         case proto::ColumnEncoding_Kind_DIRECT_V2:
           return std::make_unique<SelectiveStringDirectColumnReader>(
-              requestedType, params, scanSpec);
+              dataType, params, scanSpec);
         case proto::ColumnEncoding_Kind_DICTIONARY:
         case proto::ColumnEncoding_Kind_DICTIONARY_V2:
           return std::make_unique<SelectiveStringDictionaryColumnReader>(
-              requestedType, params, scanSpec);
+              dataType, params, scanSpec);
         default:
           DWIO_RAISE("buildReader string unknown encoding");
       }
     case TypeKind::TIMESTAMP:
       return std::make_unique<SelectiveTimestampColumnReader>(
-          requestedType, params, scanSpec);
+          dataType, params, scanSpec);
     default:
       DWIO_RAISE(
           "buildReader unhandled type: " +

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -32,8 +32,8 @@ class SelectiveFloatingPointColumnReader
       dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>;
 
   SelectiveFloatingPointColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-      const TypePtr& dataType,
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       DwrfParams& params,
       common::ScanSpec& scanSpec);
 
@@ -61,17 +61,17 @@ class SelectiveFloatingPointColumnReader
 template <typename TData, typename TRequested>
 SelectiveFloatingPointColumnReader<TData, TRequested>::
     SelectiveFloatingPointColumnReader(
-        std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-        const TypePtr& dataType,
+        const TypePtr& requestedType,
+        std::shared_ptr<const dwio::common::TypeWithId> dataType,
         DwrfParams& params,
         common::ScanSpec& scanSpec)
     : dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>(
-          std::move(requestedType),
-          dataType,
+          requestedType,
+          std::move(dataType),
           params,
           scanSpec),
       decoder_(params.stripeStreams().getStream(
-          EncodingKey{this->nodeType_->id, params.flatMapContext().sequence}
+          EncodingKey{this->fileType_->id, params.flatMapContext().sequence}
               .forKind(proto::Stream_Kind_DATA),
           params.streamLabels().label(),
           true)) {}

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.h
@@ -29,7 +29,7 @@ class SelectiveIntegerDictionaryColumnReader
 
   SelectiveIntegerDictionaryColumnReader(
       const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
-      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
       uint32_t numBytes);

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.cpp
@@ -29,7 +29,7 @@ void SelectiveIntegerDirectColumnReader::read(
     RowSet rows,
     const uint64_t* incomingNulls) {
   VELOX_WIDTH_DISPATCH(
-      dwio::common::sizeOfIntKind(type_->kind()),
+      dwio::common::sizeOfIntKind(fileType_->type->kind()),
       prepareRead,
       offset,
       rows,

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDirectColumnReader.h
@@ -28,17 +28,17 @@ class SelectiveIntegerDirectColumnReader
   using ValueType = int64_t;
 
   SelectiveIntegerDirectColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       DwrfParams& params,
       uint32_t numBytes,
       common::ScanSpec& scanSpec)
       : SelectiveIntegerColumnReader(
-            std::move(requestedType),
+            requestedType->type,
             params,
             scanSpec,
-            dataType->type) {
-    EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+            std::move(dataType)) {
+    EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
     auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
     auto& stripe = params.stripeStreams();
     bool dataVInts = stripe.getUseVInts(data);

--- a/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveRepeatedColumnReader.cpp
@@ -54,9 +54,9 @@ SelectiveListColumnReader::SelectiveListColumnReader(
           dataType,
           params,
           scanSpec),
-      length_(makeLengthDecoder(*nodeType_, params, memoryPool_)) {
-  DWIO_ENSURE_EQ(nodeType_->id, dataType->id, "working on the same node");
-  EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+      length_(makeLengthDecoder(*fileType_, params, memoryPool_)) {
+  DWIO_ENSURE_EQ(fileType_->id, dataType->id, "working on the same node");
+  EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   // count the number of selected sub-columns
   const auto& cs = stripe.getColumnSelector();
@@ -76,7 +76,7 @@ SelectiveListColumnReader::SelectiveListColumnReader(
       params.streamLabels(),
       flatMapContextFromEncodingKey(encodingKey));
   child_ = SelectiveDwrfReader::build(
-      childType, nodeType_->childAt(0), childParams, *scanSpec_->children()[0]);
+      childType, fileType_->childAt(0), childParams, *scanSpec_->children()[0]);
   children_ = {child_.get()};
 }
 
@@ -90,9 +90,9 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
           dataType,
           params,
           scanSpec),
-      length_(makeLengthDecoder(*nodeType_, params, memoryPool_)) {
-  DWIO_ENSURE_EQ(nodeType_->id, dataType->id, "working on the same node");
-  EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+      length_(makeLengthDecoder(*fileType_, params, memoryPool_)) {
+  DWIO_ENSURE_EQ(fileType_->id, dataType->id, "working on the same node");
+  EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   if (scanSpec_->children().empty()) {
     scanSpec_->getOrCreateChild(
@@ -116,7 +116,7 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       flatMapContextFromEncodingKey(encodingKey));
   keyReader_ = SelectiveDwrfReader::build(
       keyType,
-      nodeType_->childAt(0),
+      fileType_->childAt(0),
       keyParams,
       *scanSpec_->children()[0].get());
 
@@ -130,12 +130,12 @@ SelectiveMapColumnReader::SelectiveMapColumnReader(
       flatMapContextFromEncodingKey(encodingKey));
   elementReader_ = SelectiveDwrfReader::build(
       valueType,
-      nodeType_->childAt(1),
+      fileType_->childAt(1),
       elementParams,
       *scanSpec_->children()[1]);
   children_ = {keyReader_.get(), elementReader_.get()};
 
-  VLOG(1) << "[Map] Initialized map column reader for node " << nodeType_->id;
+  VLOG(1) << "[Map] Initialized map column reader for node " << fileType_->id;
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.cpp
@@ -26,11 +26,11 @@ SelectiveStringDictionaryColumnReader::SelectiveStringDictionaryColumnReader(
     const std::shared_ptr<const TypeWithId>& nodeType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type),
+    : SelectiveColumnReader(nodeType->type, params, scanSpec, nodeType),
       lastStrideIndex_(-1),
       provider_(params.stripeStreams().getStrideIndexProvider()) {
   auto& stripe = params.stripeStreams();
-  EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+  EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
   version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   scanState_.dictionary.numValues =
       stripe.getEncoding(encodingKey).dictionarysize();
@@ -181,7 +181,7 @@ void SelectiveStringDictionaryColumnReader::makeDictionaryBaseVector() {
 
     dictionaryValues_ = std::make_shared<FlatVector<StringView>>(
         &memoryPool_,
-        type_,
+        fileType_->type,
         BufferPtr(nullptr), // TODO nulls
         scanState_.dictionary.numValues +
             scanState_.dictionary2.numValues, // length
@@ -191,7 +191,7 @@ void SelectiveStringDictionaryColumnReader::makeDictionaryBaseVector() {
   } else {
     dictionaryValues_ = std::make_shared<FlatVector<StringView>>(
         &memoryPool_,
-        type_,
+        fileType_->type,
         BufferPtr(nullptr), // TODO nulls
         scanState_.dictionary.numValues /*length*/,
         scanState_.dictionary.values,

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -24,7 +24,7 @@ SelectiveStringDirectColumnReader::SelectiveStringDirectColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& nodeType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {
+    : SelectiveColumnReader(nodeType->type, params, scanSpec, nodeType) {
   EncodingKey encodingKey{nodeType->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   RleVersion rleVersion =

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -51,7 +51,7 @@ class SelectiveStringDirectColumnReader
     rawStringBuffer_ = nullptr;
     rawStringSize_ = 0;
     rawStringUsed_ = 0;
-    getFlatValues<StringView, StringView>(rows, result, type_);
+    getFlatValues<StringView, StringView>(rows, result, requestedType());
   }
 
  private:

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -35,7 +35,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
           params,
           scanSpec,
           isRoot) {
-  EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+  EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   auto encoding = static_cast<int64_t>(stripe.getEncoding(encodingKey).kind());
   DWIO_ENSURE_EQ(
@@ -54,7 +54,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
       childSpec->setSubscript(kConstantChildSpecSubscript);
       continue;
     }
-    auto childDataType = nodeType_->childByName(childSpec->fieldName());
+    auto childDataType = fileType_->childByName(childSpec->fieldName());
     auto childRequestedType =
         requestedType_->childByName(childSpec->fieldName());
     auto labels = params.streamLabels().append(folly::to<std::string>(i));

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -37,7 +37,7 @@ class SelectiveStructColumnReaderBase
             scanSpec,
             isRoot),
         rowsPerRowGroup_(formatData_->rowsPerRowGroup().value()) {
-    VELOX_CHECK_EQ(nodeType_->id, dataType->id, "working on the same node");
+    VELOX_CHECK_EQ(fileType_->id, dataType->id, "working on the same node");
   }
 
   void seekTo(vector_size_t offset, bool readsNullsOnly) override;

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -26,8 +26,8 @@ SelectiveTimestampColumnReader::SelectiveTimestampColumnReader(
     const std::shared_ptr<const TypeWithId>& nodeType,
     DwrfParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {
-  EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+    : SelectiveColumnReader(nodeType->type, params, scanSpec, nodeType) {
+  EncodingKey encodingKey{fileType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
   version_ = convertRleVersion(stripe.getEncoding(encodingKey).kind());
   auto data = encodingKey.forKind(proto::Stream_Kind_DATA);
@@ -157,7 +157,7 @@ void SelectiveTimestampColumnReader::getValues(RowSet rows, VectorPtr* result) {
   fillTimestamps(rawTs, rawNulls, secondsData, nanosData, numValues_);
   values_ = tsValues;
   rawValues_ = values_->asMutable<char>();
-  getFlatValues<Timestamp, Timestamp>(rows, result, type_, true);
+  getFlatValues<Timestamp, Timestamp>(rows, result, fileType_->type, true);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/parquet/reader/BooleanColumnReader.h
+++ b/velox/dwio/parquet/reader/BooleanColumnReader.h
@@ -29,10 +29,10 @@ class BooleanColumnReader : public dwio::common::SelectiveByteRleColumnReader {
       ParquetParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveByteRleColumnReader(
-            nodeType,
+            nodeType->type,
             params,
             scanSpec,
-            nodeType->type) {}
+            nodeType) {}
 
   void seekToRowGroup(uint32_t index) override {
     SelectiveByteRleColumnReader::seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/FloatingPointColumnReader.h
+++ b/velox/dwio/parquet/reader/FloatingPointColumnReader.h
@@ -31,8 +31,8 @@ class FloatingPointColumnReader
       dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>;
 
   FloatingPointColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> nodeType,
-      const TypePtr& dataType,
+      const TypePtr& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 
@@ -57,13 +57,13 @@ class FloatingPointColumnReader
 
 template <typename TData, typename TRequested>
 FloatingPointColumnReader<TData, TRequested>::FloatingPointColumnReader(
-    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-    const TypePtr& dataType,
+    const TypePtr& requestedType,
+    std::shared_ptr<const dwio::common::TypeWithId> dataType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
     : dwio::common::SelectiveFloatingPointColumnReader<TData, TRequested>(
-          std::move(requestedType),
-          dataType,
+          requestedType,
+          std::move(dataType),
           params,
           scanSpec) {}
 

--- a/velox/dwio/parquet/reader/IntegerColumnReader.h
+++ b/velox/dwio/parquet/reader/IntegerColumnReader.h
@@ -24,19 +24,19 @@ namespace facebook::velox::parquet {
 class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
  public:
   IntegerColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
-      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveIntegerColumnReader(
-            std::move(requestedType),
+            requestedType->type,
             params,
             scanSpec,
-            dataType->type) {}
+            std::move(dataType)) {}
 
   bool hasBulkPath() const override {
-    return !this->type()->isLongDecimal() &&
-        ((this->type()->isShortDecimal())
+    return !this->fileType().type->isLongDecimal() &&
+        ((this->fileType().type->isShortDecimal())
              ? formatData_->as<ParquetData>().hasDictionary()
              : true);
   }
@@ -59,7 +59,7 @@ class IntegerColumnReader : public dwio::common::SelectiveIntegerColumnReader {
       const uint64_t* /*incomingNulls*/) override {
     auto& data = formatData_->as<ParquetData>();
     VELOX_WIDTH_DISPATCH(
-        parquetSizeOfIntKind(type_->kind()),
+        parquetSizeOfIntKind(fileType_->type->kind()),
         prepareRead,
         offset,
         rows,

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -50,10 +50,10 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::REAL:
       return std::make_unique<FloatingPointColumnReader<float, float>>(
-          dataType, dataType->type, params, scanSpec);
+          dataType->type, dataType, params, scanSpec);
     case TypeKind::DOUBLE:
       return std::make_unique<FloatingPointColumnReader<double, double>>(
-          dataType, dataType->type, params, scanSpec);
+          dataType->type, dataType, params, scanSpec);
 
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(dataType, params, scanSpec);

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -23,7 +23,7 @@ StringColumnReader::StringColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& nodeType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {}
+    : SelectiveColumnReader(nodeType->type, params, scanSpec, nodeType) {}
 
 uint64_t StringColumnReader::skip(uint64_t numValues) {
   formatData_->skip(numValues);
@@ -128,7 +128,7 @@ void StringColumnReader::read(
 void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
   if (scanState_.dictionary.values) {
     auto dictionaryValues =
-        formatData_->as<ParquetData>().dictionaryValues(type_);
+        formatData_->as<ParquetData>().dictionaryValues(fileType_->type);
     compactScalarValues<int32_t, int32_t>(rows, false);
 
     *result = std::make_shared<DictionaryVector<StringView>>(
@@ -144,13 +144,13 @@ void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
   rawStringBuffer_ = nullptr;
   rawStringSize_ = 0;
   rawStringUsed_ = 0;
-  getFlatValues<StringView, StringView>(rows, result, type_);
+  getFlatValues<StringView, StringView>(rows, result, fileType_->type);
 }
 
 void StringColumnReader::dedictionarize() {
   if (scanSpec_->keepValues()) {
     auto dict = formatData_->as<ParquetData>()
-                    .dictionaryValues(type_)
+                    .dictionaryValues(fileType_->type)
                     ->as<FlatVector<StringView>>();
     auto valuesCapacity = values_->capacity();
     auto indices = values_->as<vector_size_t>();


### PR DESCRIPTION
Summary:
SelectiveColumnReader currently has two types, type and nodeType.  Historically these have been the same,
since we pass in the file type as the requested output type as well as the type in the file.  With the recent changes
to support missing struct fields, these two have diverged. In some readers the nodeType is the requestedType
(mostly primitive types: ints, float points, etc.), while in others it's the file type (complex types like structs, arrays,
and maps).  This leads to bugs when there are missing fields in a struct, because we use the ID from the
nodeType to look up streams/encodings in the file, if nodeType is the requested type, the IDs in the type won't
match the IDs in the file.

To fix this, and hopefully clarify this, I've renamed nodeType and type to requestedType and fileType.  I've also
updated the logic to always use the IDs from fileType.  In general, since we passed fileType for both types in the
past, I generally used fileType for everything.  The exception is in get*Values (getIntValues, getFloatValues, etc.)
where we construct the output Vector, here we want to use requestedType to enable upcasting (the logic is there
to support it, we just didn't have it because we weren't passing in the right type).

I don't think I've cleaned up everything that could be clarified, but this is already a large change.  This is enough
Ato establish requestedType and fileType and fix the bugs referenced above.

Note that Parquet still uses the file type for nodeType/type (now requestedType/fileType) so it's behavior is
unaffected by this change).

Differential Revision: D47637842

