### PR TITLE
ensureLoadedRows should recursively load nested LazyVectors

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -666,7 +666,13 @@ VectorPtr BaseVector::transpose(BufferPtr indices, VectorPtr&& source) {
 bool isLazyNotLoaded(const BaseVector& vector) {
   switch (vector.encoding()) {
     case VectorEncoding::Simple::LAZY:
-      return !vector.as<LazyVector>()->isLoaded();
+      if (!vector.as<LazyVector>()->isLoaded()) {
+        return true;
+      }
+
+      // Lazy Vectors may wrap lazy vectors (e.g. nested Rows) so we need to go
+      // deeper.
+      return isLazyNotLoaded(*vector.as<LazyVector>()->loadedVector());
     case VectorEncoding::Simple::DICTIONARY:
     case VectorEncoding::Simple::SEQUENCE:
       return isLazyNotLoaded(*vector.valueVector());

--- a/velox/vector/DecodedVector.h
+++ b/velox/vector/DecodedVector.h
@@ -264,6 +264,12 @@ class DecodedVector {
     return wrap(std::move(data), wrapper, rows.end());
   }
 
+  // Given a SelectivityVector 'rows', updates 'unwrapped' resizing it to match
+  // the base Vector and selecting the rows in the base Vector that correspond
+  // to those selected by 'rows' in the original encoded Vector.
+  void unwrapRows(SelectivityVector& unwrapped, const SelectivityVector& rows)
+      const;
+
   struct DictionaryWrapping {
     BufferPtr indices;
     BufferPtr nulls;

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -270,6 +270,12 @@ class LazyVector : public BaseVector {
       SelectivityVector& baseRows);
 
  private:
+  static void ensureLoadedRowsImpl(
+      VectorPtr& vector,
+      DecodedVector& decoded,
+      const SelectivityVector& rows,
+      SelectivityVector& baseRows);
+
   std::unique_ptr<VectorLoader> loader_;
 
   // True if all values are loaded.


### PR DESCRIPTION
Summary:
ensureLoadedRows is supposed to ensure that the selected rows are fully loaded.  Unfortunately, today this
doesn't work with nested Lazy Row types, the top level Lazy Row will be loaded, but the nested ones will not.

The fix for this is for ensureLoadedRows to check isLazyNotLoaded on the LazyVector before it returns, and if it
returns false, that means that there is some nested Lazy Vector that needs to be loaded, so it should call itself
recursively.

One tricky point is that because we're decoding Vectors, the SelectivityVector needs to be updated to point to
the corresponding rows in the decoded Vector as we recurse.

Differential Revision: D47638265

