### PR TITLE
Add method to assert HashStringAllocator is empty

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -541,9 +541,10 @@ void HashStringAllocator::ensureAvailable(int32_t bytes, Position& position) {
   position = finishWrite(stream, 0).first;
 }
 
-void HashStringAllocator::checkConsistency() const {
+int64_t HashStringAllocator::checkConsistency() const {
   uint64_t numFree = 0;
   uint64_t freeBytes = 0;
+  int64_t allocatedBytes = 0;
   for (auto i = 0; i < pool_.numRanges(); ++i) {
     auto topRange = pool_.rangeAt(i);
     const auto kHugePageSize = memory::AllocationTraits::kHugePageSize;
@@ -586,6 +587,9 @@ void HashStringAllocator::checkConsistency() const {
           // continue header is readable and not free.
           auto continued = header->nextContinued();
           VELOX_CHECK(!continued->isFree());
+          allocatedBytes += header->size() - sizeof(void*);
+        } else {
+          allocatedBytes += header->size();
         }
         previousFree = header->isFree();
         header = reinterpret_cast<Header*>(header->end());
@@ -614,6 +618,12 @@ void HashStringAllocator::checkConsistency() const {
 
   VELOX_CHECK_EQ(numInFreeList, numFree_);
   VELOX_CHECK_EQ(bytesInFreeList, freeBytes_);
+  return allocatedBytes;
+}
+
+void HashStringAllocator::checkEmpty() const {
+  VELOX_CHECK_EQ(0, sizeFromPool_);
+  VELOX_CHECK_EQ(0, checkConsistency());
 }
 
 } // namespace facebook::velox

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -334,8 +334,15 @@ class HashStringAllocator : public StreamArena {
   }
 
   // Checks the free space accounting and consistency of
-  // Headers. Throws when detects corruption.
-  void checkConsistency() const;
+  // Headers. Throws when detects corruption. Returns the number of allocated
+  // payload bytes, excluding headers, continue links and other overhead.
+  int64_t checkConsistency() const;
+
+  /// Throws if 'this' is not empty. Checks consistency of
+  /// 'this'. This is a fast check for RowContainer users freeing the
+  /// variable length data they store. Can be used in non-debug
+  /// builds.
+  void checkEmpty() const;
 
  private:
   static constexpr int32_t kUnitSize = 16 * memory::AllocationTraits::kPageSize;

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -99,6 +99,7 @@ TEST_F(HashStringAllocatorTest, allocate) {
     for (auto i = 0; i < 10'000; ++i) {
       headers.push_back(allocate((i % 10) * 10));
     }
+    EXPECT_THROW(allocator_->checkEmpty(), VeloxException);
     allocator_->checkConsistency();
     for (int32_t step = 7; step >= 1; --step) {
       for (auto i = 0; i < headers.size(); i += step) {
@@ -110,6 +111,7 @@ TEST_F(HashStringAllocatorTest, allocate) {
       allocator_->checkConsistency();
     }
   }
+  allocator_->checkEmpty();
   // We allow for some free overhead for free lists after all is freed.
   EXPECT_LE(allocator_->retainedSize() - allocator_->freeSpace(), 250);
 }


### PR DESCRIPTION
Add method to assert HashStringAllocator is empty

HashStringAllocator::checkConsistency() returns the total allocated
without overheads. adds checkEmpty to check this and external
allocations are at 0. Serves as a fast check to see if aggregation
accumulators and simiilar clear their variable length content.
