### PR TITLE
Fix TryExpr::nullOutErrors

### DIFF
--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -126,11 +126,28 @@ void TryExpr::nullOutErrors(
         result = BaseVector::wrapInDictionary(nulls, indices, size, result);
       }
     } else {
-      rows.applyToSelected([&](auto row) {
-        if (row < errors->size() && !errors->isNullAt(row)) {
-          result->setNull(row, true);
-        }
-      });
+      if (result.unique() && result->isNullsWritable()) {
+        rows.applyToSelected([&](auto row) {
+          if (row < errors->size() && !errors->isNullAt(row)) {
+            result->setNull(row, true);
+          }
+        });
+      } else {
+        auto nulls = allocateNulls(rows.end(), context.pool());
+        auto* rawNulls = nulls->asMutable<uint64_t>();
+        auto indices = allocateIndices(rows.end(), context.pool());
+        auto* rawIndices = indices->asMutable<vector_size_t>();
+
+        rows.applyToSelected([&](auto row) {
+          rawIndices[row] = row;
+          if (row < errors->size() && !errors->isNullAt(row)) {
+            bits::setNull(rawNulls, row, true);
+          }
+        });
+
+        result =
+            BaseVector::wrapInDictionary(nulls, indices, rows.end(), result);
+      }
     }
   }
 }

--- a/velox/functions/prestosql/tests/TransformKeysTest.cpp
+++ b/velox/functions/prestosql/tests/TransformKeysTest.cpp
@@ -66,11 +66,11 @@ TEST_F(TransformKeysTest, duplicateKeys) {
   });
 
   VELOX_ASSERT_THROW(
-      evaluate<MapVector>("transform_keys(c0, (k, v) -> 10 + k % 2)", input),
+      evaluate("transform_keys(c0, (k, v) -> 10 + k % 2)", input),
       "Duplicate map keys (11) are not allowed");
 
-  ASSERT_NO_THROW(evaluate<MapVector>(
-      "try(transform_keys(c0, (k, v) -> 10 + k % 2))", input));
+  ASSERT_NO_THROW(
+      evaluate("try(transform_keys(c0, (k, v) -> 10 + k % 2))", input));
 }
 
 TEST_F(TransformKeysTest, differentResultType) {


### PR DESCRIPTION
Summary:
TryExpr::nullOutErrors used to call result->setNull() with out
checking that result is writable. This fix that.

fix https://github.com/facebookincubator/velox/issues/5699

Reviewed By: mbasmanova

Differential Revision: D47569367

