### PR TITLE
Make row number generation optional in RowNumber operator

### DIFF
--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -53,6 +53,7 @@ class RowNumber : public Operator {
   FlatVector<int64_t>& getOrCreateRowNumberVector(vector_size_t size);
 
   const std::optional<int32_t> limit_;
+  const bool generateRowNumber_;
 
   /// Hash table to store number of rows seen so far per partition. Not used if
   /// there are no partitioning keys.

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -413,6 +413,7 @@ TEST_F(PlanNodeSerdeTest, window) {
 }
 
 TEST_F(PlanNodeSerdeTest, rowNumber) {
+  // Test with emitting the row number.
   auto plan = PlanBuilder().values({data_}).rowNumber({}).planNode();
   testSerde(plan);
 
@@ -420,6 +421,26 @@ TEST_F(PlanNodeSerdeTest, rowNumber) {
   testSerde(plan);
 
   plan = PlanBuilder().values({data_}).rowNumber({"c1", "c2"}, 10).planNode();
+  testSerde(plan);
+
+  // Test without emitting the row number.
+  plan = PlanBuilder()
+             .values({data_})
+             .rowNumber({}, std::nullopt, false)
+             .planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .rowNumber({"c2", "c0"}, std::nullopt, false)
+             .planNode();
+  testSerde(plan);
+
+  plan = PlanBuilder()
+             .values({data_})
+             .rowNumber({"c1", "c2"}, 10, false)
+             .planNode();
+  testSerde(plan);
 }
 
 TEST_F(PlanNodeSerdeTest, scan) {

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -701,6 +701,7 @@ TEST_F(PlanNodeToStringTest, window) {
 }
 
 TEST_F(PlanNodeToStringTest, rowNumber) {
+  // Emit row number.
   auto plan =
       PlanBuilder().tableScan(ROW({"a"}, {VARCHAR()})).rowNumber({}).planNode();
 
@@ -709,6 +710,16 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
       "-- RowNumber[] -> a:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false));
 
+  // Dont' emit row number.
+  plan = PlanBuilder()
+             .tableScan(ROW({"a"}, {VARCHAR()}))
+             .rowNumber({}, std::nullopt, false)
+             .planNode();
+
+  ASSERT_EQ("-- RowNumber\n", plan->toString());
+  ASSERT_EQ("-- RowNumber[] -> a:VARCHAR\n", plan->toString(true, false));
+
+  // Emit row number.
   plan = PlanBuilder()
              .tableScan(ROW({"a", "b"}, {BIGINT(), VARCHAR()}))
              .rowNumber({"a", "b"})
@@ -719,6 +730,18 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
       "-- RowNumber[partition by (a, b)] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
       plan->toString(true, false));
 
+  // Don't emit row number.
+  plan = PlanBuilder()
+             .tableScan(ROW({"a", "b"}, {BIGINT(), VARCHAR()}))
+             .rowNumber({"a", "b"}, std::nullopt, false)
+             .planNode();
+
+  ASSERT_EQ("-- RowNumber\n", plan->toString());
+  ASSERT_EQ(
+      "-- RowNumber[partition by (a, b)] -> a:BIGINT, b:VARCHAR\n",
+      plan->toString(true, false));
+
+  // Emit row number.
   plan = PlanBuilder()
              .tableScan(ROW({"a", "b"}, {BIGINT(), VARCHAR()}))
              .rowNumber({"b"}, 10)
@@ -727,6 +750,17 @@ TEST_F(PlanNodeToStringTest, rowNumber) {
   ASSERT_EQ("-- RowNumber\n", plan->toString());
   ASSERT_EQ(
       "-- RowNumber[partition by (b) limit 10] -> a:BIGINT, b:VARCHAR, row_number:BIGINT\n",
+      plan->toString(true, false));
+
+  // Don't emit row number.
+  plan = PlanBuilder()
+             .tableScan(ROW({"a", "b"}, {BIGINT(), VARCHAR()}))
+             .rowNumber({"b"}, 10, false)
+             .planNode();
+
+  ASSERT_EQ("-- RowNumber\n", plan->toString());
+  ASSERT_EQ(
+      "-- RowNumber[partition by (b) limit 10] -> a:BIGINT, b:VARCHAR\n",
       plan->toString(true, false));
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -1424,9 +1424,18 @@ PlanBuilder& PlanBuilder::window(
 
 PlanBuilder& PlanBuilder::rowNumber(
     const std::vector<std::string>& partitionKeys,
-    std::optional<int32_t> limit) {
+    std::optional<int32_t> limit,
+    const bool generateRowNumber) {
+  std::optional<std::string> rowNumberColumnName;
+  if (generateRowNumber) {
+    rowNumberColumnName = "row_number";
+  }
   planNode_ = std::make_shared<core::RowNumberNode>(
-      nextPlanNodeId(), fields(partitionKeys), "row_number", limit, planNode_);
+      nextPlanNodeId(),
+      fields(partitionKeys),
+      rowNumberColumnName,
+      limit,
+      planNode_);
   return *this;
 }
 

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -722,7 +722,8 @@ class PlanBuilder {
   /// optional limit and no sorting.
   PlanBuilder& rowNumber(
       const std::vector<std::string>& partitionKeys,
-      std::optional<int32_t> limit = std::nullopt);
+      std::optional<int32_t> limit = std::nullopt,
+      bool generateRowNumber = true);
 
   /// Add a TopNRowNumberNode to compute single row_number window function with
   /// a limit applied to sorted partitions.


### PR DESCRIPTION
Changes in the Presto coordinator, made with PR
https://github.com/prestodb/presto/pull/19835 allows the row number generation to be skipped for a partial RowNumber node that feeds the Exchange operator. It reduces the amount of data sent.

The implementation is similar to the TopNRowNumber node and operator capability to skip row generation.

A subsequent PR is needed for Prestissimo to make use of the new capability when converting the Presto plan into the Velox plan.

This resolves the end-to-end test issue discussed in issue https://github.com/prestodb/presto/issues/20227.