### PR TITLE
Fix setting kFileColumnNamesReadAsLowerCase through connector config

### DIFF
--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -46,6 +46,9 @@ class HiveConnector : public Connector {
         HiveConfig::maxCoalescedBytes(connectorQueryCtx->config()));
     options.setMaxCoalesceDistance(
         HiveConfig::maxCoalescedDistanceBytes(connectorQueryCtx->config()));
+    options.setFileColumnNamesReadAsLowerCase(
+        HiveConfig::isFileColumnNamesReadAsLowerCase(
+            connectorQueryCtx->config()));
     return std::make_unique<HiveDataSource>(
         outputType,
         tableHandle,
@@ -54,8 +57,6 @@ class HiveConnector : public Connector {
         connectorQueryCtx->expressionEvaluator(),
         connectorQueryCtx->allocator(),
         connectorQueryCtx->scanId(),
-        HiveConfig::isFileColumnNamesReadAsLowerCase(
-            connectorQueryCtx->config()),
         executor_,
         options);
   }

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -292,6 +292,9 @@ void checkColumnNameLowerCase(const SubfieldFilters& filters) {
 }
 
 void checkColumnNameLowerCase(const core::TypedExprPtr& typeExpr) {
+  if (typeExpr == nullptr) {
+    return;
+  }
   checkColumnNameLowerCase(typeExpr->type());
   for (auto& type : typeExpr->inputs()) {
     checkColumnNameLowerCase(type);
@@ -360,7 +363,6 @@ HiveDataSource::HiveDataSource(
     core::ExpressionEvaluator* expressionEvaluator,
     memory::MemoryAllocator* allocator,
     const std::string& scanId,
-    bool fileColumnNamesReadAsLowerCase,
     folly::Executor* executor,
     const dwio::common::ReaderOptions& options)
     : fileHandleFactory_(fileHandleFactory),
@@ -405,7 +407,7 @@ HiveDataSource::HiveDataSource(
   VELOX_CHECK(
       hiveTableHandle != nullptr,
       "TableHandle must be an instance of HiveTableHandle");
-  if (fileColumnNamesReadAsLowerCase) {
+  if (readerOpts_.isFileColumnNamesReadAsLowerCase()) {
     checkColumnNameLowerCase(outputType);
     checkColumnNameLowerCase(hiveTableHandle->subfieldFilters());
     checkColumnNameLowerCase(hiveTableHandle->remainingFilter());

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -39,7 +39,6 @@ class HiveDataSource : public DataSource {
       core::ExpressionEvaluator* expressionEvaluator,
       memory::MemoryAllocator* allocator,
       const std::string& scanId,
-      bool fileColumnNamesReadAsLowerCase,
       folly::Executor* executor,
       const dwio::common::ReaderOptions& options);
 


### PR DESCRIPTION
Previously, setting `HiveConfig::kFileColumnNamesReadAsLowerCase` as true through connector config did not take effect at [ParquetReader.h#L69-L71](https://github.com/facebookincubator/velox/blob/main/velox/dwio/parquet/reader/ParquetReader.h#L69-L71) because it is not set to reader options, and thus the result became all nulls due to mismatched name case.