### PR TITLE
Make memory abort the default handling when arbitration fail

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -162,14 +162,12 @@ class MemoryArbitrator {
         capacity_(config.capacity),
         initMemoryPoolCapacity_(config.initMemoryPoolCapacity),
         minMemoryPoolCapacityTransferSize_(
-            config.minMemoryPoolCapacityTransferSize),
-        retryArbitrationFailure_(config.retryArbitrationFailure) {}
+            config.minMemoryPoolCapacityTransferSize) {}
 
   const Kind kind_;
   const uint64_t capacity_;
   const uint64_t initMemoryPoolCapacity_;
   const uint64_t minMemoryPoolCapacityTransferSize_;
-  const bool retryArbitrationFailure_;
 };
 
 std::ostream& operator<<(std::ostream& out, const MemoryArbitrator::Kind& kind);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -182,7 +182,7 @@ bool SharedArbitrator::growMemory(
     if (arbitrateMemory(requestor, candidates, targetBytes)) {
       return true;
     }
-    if (!retryArbitrationFailure_ || numRetries > 0) {
+    if (numRetries > 0) {
       break;
     }
     VELOX_CHECK(!requestor->aborted());


### PR DESCRIPTION
Make memory abort handling after the memory arbitration failure
a default option so we always abort the query with the largest memory
consumption on arbitration failure. We will add arbitration retry later on
if needs to handle query dynamics.