### PR TITLE
Speed up writing parquet files

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -33,6 +33,7 @@ struct ArrowContext;
 struct WriterOptions {
   bool enableDictionary = true;
   int64_t dataPageSize = 1'024 * 1'024;
+  int64_t maxFlushSize = 1'024 * 1'024; // 1M
   int32_t rowsInRowGroup = 10'000;
   int64_t maxRowGroupLength = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;


### PR DESCRIPTION
Currently we support writing parquet files, but as the amount of written data increases, the writing speed becomes slower and slower.

This is because the data is first written to `ArrowDataBufferSink buffer_` object, which maintains the data in memory. When the size of the written data + the size of the written data is greater than the capacity of buffer_(`buffer_.size() + data->size() > buffer_.capacity()`), the expansion of `buffer_` will be triggered at this time, it will call `memcpy` for data copy. Unfortunately, this expansion is performed almost every time `ArrowDataBufferSink.Write` is called, resulting in slower and slower data writing. See relevant code here.

With this PR, when the size of the data written in `buffer_` is greater than 1M, the flush operation will be performed, and the flush operation will write the data to the file system and clear the data in `buffer_`.

In this way, the number of expansion operations will be reduced, thereby improving the performance of writing data.