### PR TITLE
Make sure parallel build won't allocation memory

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -596,12 +596,17 @@ class HashTable : public BaseHashTable {
   // Inserts the rows in 'partition' from this and 'otherTables' into 'this'.
   // The rows that would have gone past the end of the partition are returned in
   // 'overflow'.
-  void buildJoinPartition(uint8_t partition, std::vector<char*>& overflow);
+  void buildJoinPartition(
+      uint8_t partition,
+      const std::vector<std::unique_ptr<RowPartitions>>& rowPartitions,
+      std::vector<char*>& overflow);
 
   // Assigns a partition to each row of 'subtable' in RowPartitions of
   // subtable's RowContainer. If 'hashMode_' is kNormalizedKeys, records the
   // normalized key of each row below the row in its container.
-  void partitionRows(HashTable<ignoreNullKeys>& subtable);
+  void partitionRows(
+      HashTable<ignoreNullKeys>& subtable,
+      RowPartitions& rowPartitions);
 
   // Calculates hashes for 'rows' and returns them in 'hashes'. If
   // 'initNormalizedKeys' is true, the normalized keys are stored

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -643,25 +643,31 @@ class RowContainer {
     return (row[nullByte] & nullMask) != 0;
   }
 
-  /// Retrieves rows from 'iterator' whose partition equals
-  /// 'partition'. Writes up to 'maxRows' pointers to the rows in
-  /// 'result'. Returns the number of rows retrieved, 0 when no more
-  /// rows are found. 'iterator' is expected to be in initial state
-  /// on first call.
+  /// Creates a container to store a partition number for each row in this row
+  /// container. This is used by parallel join build which is responsible for
+  /// filling this. This function also marks this row container as immutable
+  /// after this call, we expect the user only call this once.
+  std::unique_ptr<RowPartitions> createRowPartitions(memory::MemoryPool& pool);
+
+  /// Retrieves rows from 'iterator' whose partition equals 'partition'. Writes
+  /// up to 'maxRows' pointers to the rows in 'result'. 'rowPartitions' contains
+  /// the partition number of each row in this container. The function returns
+  /// the number of rows retrieved, 0 when no more rows are found. 'iterator' is
+  /// expected to be in initial state on first call.
   int32_t listPartitionRows(
       RowContainerIterator& iterator,
       uint8_t partition,
       int32_t maxRows,
+      const RowPartitions& rowPartitions,
       char* FOLLY_NONNULL* FOLLY_NONNULL result);
-
-  /// Returns a container with a partition number for each row. This
-  /// is created on first use. The caller is responsible for filling
-  /// this.
-  RowPartitions& partitions();
 
   /// Advances 'iterator' by 'numRows'. The current row after skip is
   /// in iter.currentRow(). This is null if past end. Public for testing.
   void skip(RowContainerIterator& iterator, int32_t numRows);
+
+  bool testingMutable() const {
+    return mutable_;
+  }
 
  private:
   // Offset of the pointer to the next free row on a free row.
@@ -1087,6 +1093,12 @@ class RowContainer {
 
   const std::vector<TypePtr> keyTypes_;
   const bool nullableKeys_;
+  const bool isJoinBuild_;
+
+  // Indicates if we can add new row to this row container. It is set to false
+  // after user calls 'getRowPartitions()' to create 'rowPartitions' object for
+  // parallel join build.
+  bool mutable_{true};
 
   std::vector<Accumulator> accumulators_;
 
@@ -1095,7 +1107,6 @@ class RowContainer {
   // to 'typeKinds_' and 'rowColumns_'.
   std::vector<TypePtr> types_;
   std::vector<TypeKind> typeKinds_;
-  const bool isJoinBuild_;
   int32_t nextOffset_ = 0;
   // Bit position of null bit  in the row. 0 if no null flag. Order is keys,
   // accumulators, dependent.
@@ -1135,9 +1146,6 @@ class RowContainer {
 
   memory::AllocationPool rows_;
   HashStringAllocator stringAllocator_;
-
-  // Partition number for each row. Used only in parallel hash join build.
-  std::unique_ptr<RowPartitions> partitions_;
 
   int alignment_ = 1;
 };

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -88,9 +88,9 @@ struct TaskStats {
 
   /// Output buffer's memory utilization ratio measured as
   /// current buffer usage / max buffer size
-  double outputBufferUtilization;
+  double outputBufferUtilization{0};
   /// Indicates if output buffer is over-utilized and thus blocks the producers.
-  bool outputBufferOverutilized;
+  bool outputBufferOverutilized{false};
 };
 
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/utils/RowContainerTestBase.h
+++ b/velox/exec/tests/utils/RowContainerTestBase.h
@@ -54,7 +54,7 @@ class RowContainerTestBase : public testing::Test,
       const std::vector<TypePtr>& keyTypes,
       const std::vector<TypePtr>& dependentTypes,
       bool isJoinBuild = true) {
-    return std::make_unique<RowContainer>(
+    auto container = std::make_unique<RowContainer>(
         keyTypes,
         !isJoinBuild,
         std::vector<Accumulator>{},
@@ -64,6 +64,8 @@ class RowContainerTestBase : public testing::Test,
         true,
         true,
         pool_.get());
+    VELOX_CHECK(container->testingMutable());
+    return container;
   }
 };
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Move rowPartitions creation out of parallel join build thread to make
sure the memory allocation is always triggered in driver thread otherwise
it might cause tricky thread hanging issue when integrated with memory
arbitration. This PR also moves the ownership of row partitions out of
hash table.