### PR TITLE
Fix aggregate merge containers and chekc RowContainer variable length…

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -872,7 +872,8 @@ bool GroupingSet::getOutputWithSpill(
         false,
         false,
         false,
-        &pool_);
+        &pool_,
+        table_->rows()->stringAllocatorShared());
 
     initializeAggregates(aggregates_, *mergeRows_);
 
@@ -1063,6 +1064,7 @@ void GroupingSet::toIntermediate(
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
+    intermediateRows_->stringAllocator().checkEmpty();
   }
   tempVectors_.clear();
 }

--- a/velox/exec/SetAccumulator.h
+++ b/velox/exec/SetAccumulator.h
@@ -89,7 +89,10 @@ struct SetAccumulator {
     return index - offset;
   }
 
-  void free(HashStringAllocator& allocator) {}
+  void free(HashStringAllocator& allocator) {
+    using UT = decltype(uniqueValues);
+    uniqueValues.~UT();
+  }
 };
 
 /// Maintains a set of unique strings.
@@ -146,6 +149,8 @@ struct StringViewSetAccumulator {
 
   void free(HashStringAllocator& allocator) {
     strings.free(allocator);
+    using Base = decltype(base);
+    base.~Base();
   }
 };
 
@@ -214,6 +219,8 @@ struct ComplexTypeSetAccumulator {
 
   void free(HashStringAllocator& allocator) {
     values.free(allocator);
+    using Base = decltype(base);
+    base.~Base();
   }
 };
 

--- a/velox/exec/StreamingAggregation.cpp
+++ b/velox/exec/StreamingAggregation.cpp
@@ -123,11 +123,7 @@ StreamingAggregation::StreamingAggregation(
 }
 
 void StreamingAggregation::close() {
-  for (int32_t i = 0; i < aggregates_.size(); ++i) {
-    if (aggregates_[i]->accumulatorUsesExternalMemory()) {
-      aggregates_[i]->destroy(folly::Range(groups_.data(), groups_.size()));
-    }
-  }
+  rows_->clear();
   Operator::close();
 }
 

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -18,6 +18,8 @@
 #include "velox/exec/VectorHasher.h"
 #include "velox/exec/tests/utils/RowContainerTestBase.h"
 
+DECLARE_bool(velox_row_container_check_free);
+
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 using namespace facebook::velox::test;
@@ -1168,4 +1170,58 @@ TEST_F(RowContainerTest, probedFlag) {
       makeNullableFlatVector<bool>(
           {true, true, true, true, std::nullopt, true}),
       result);
+}
+
+template <typename T>
+inline T* valueAt(char* row, int32_t offset) {
+  return reinterpret_cast<T*>(row + offset);
+}
+
+TEST_F(RowContainerTest, shareAndClear) {
+  gflags::FlagSaver save;
+  FLAGS_velox_row_container_check_free = true;
+
+  std::vector<TypePtr> types = {VARCHAR()};
+  static constexpr int32_t kLength = 1000;
+  auto firstRowContainer = std::make_unique<RowContainer>(types, pool_.get());
+  auto firstRow = firstRowContainer->newRow();
+  auto offset = firstRowContainer->columnAt(0).offset();
+  *valueAt<StringView>(firstRow, offset) = StringView(
+      firstRowContainer->stringAllocator().allocate(kLength)->begin(), kLength);
+
+  auto secondRowContainer = std::make_unique<RowContainer>(
+      types,
+      true,
+      std::vector<Accumulator>(),
+      std::vector<TypePtr>(),
+      false,
+      false,
+      false,
+      false,
+      pool_.get(),
+      firstRowContainer->stringAllocatorShared());
+
+  auto secondRow = secondRowContainer->newRow();
+  *valueAt<StringView>(secondRow, offset) = StringView(
+      secondRowContainer->stringAllocator().allocate(kLength)->begin(),
+      kLength);
+
+  // Both containers have each one string in the shared stringAllocator().
+  EXPECT_EQ(
+      2 * kLength, secondRowContainer->stringAllocator().checkConsistency());
+
+  auto extra = secondRowContainer->stringAllocator().allocate(kLength);
+
+  firstRowContainer.reset();
+
+  // Now there is the string from second and the extra string in the allocator.
+  EXPECT_EQ(
+      2 * kLength, secondRowContainer->stringAllocator().checkConsistency());
+
+  // The second deletes its rows but the allocator is now singly
+  // referenced but not empty because of 'extra'.
+  VELOX_ASSERT_THROW(secondRowContainer->clear(), "");
+  secondRowContainer->stringAllocator().free(extra);
+
+  secondRowContainer->clear();
 }

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -120,3 +120,9 @@ DEFINE_bool(
     "exception. This is only used by test to control the test error output size");
 
 DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");
+
+DEFINE_bool(
+    velox_row_container_check_free,
+    false,
+    "Check that variable length data in RowContainers is freed when "
+    "freeing the row");


### PR DESCRIPTION
… free

In the case of merging after spilling, we have a source RowContainer and a merge RowContainer that share the same Aggregates. Therefore they must also share the same HashStringAllocator since this is referenced from the Aggregates. Adds a constructor parameter for sharing the stringAllocator of another RowContainer.

We add a flag to check that deleting the rows from a RowContainer causes its stringAllocator to go empty. This is needed in order to enforce that aggregates, when spilling, free the space they should in the container.