### PR TITLE
Add OOM protection for table creation in hash build

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -702,6 +702,9 @@ void HashBuild::noMoreInputInternal() {
 
 bool HashBuild::finishHashBuild() {
   checkRunning();
+  // Release the unused memory reservation before building the merged join
+  // table.
+  pool()->release();
 
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<Driver>> peers;
@@ -727,82 +730,116 @@ bool HashBuild::finishHashBuild() {
     }
   });
 
+  if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
+      !joinNode_->filter()) {
+    joinBridge_->setAntiJoinHasNullKeys();
+    return true;
+  }
+
+  std::vector<HashBuild*> otherBuilds;
+  otherBuilds.reserve(peers.size());
+  uint64_t numRows = table_->rows()->numRows();
+  for (auto& peer : peers) {
+    auto op = peer->findOperator(planNodeId());
+    HashBuild* build = dynamic_cast<HashBuild*>(op);
+    VELOX_CHECK_NOT_NULL(build);
+    if (build->joinHasNullKeys_) {
+      joinHasNullKeys_ = true;
+      if (isAntiJoin(joinType_) && nullAware_ && !joinNode_->filter()) {
+        joinBridge_->setAntiJoinHasNullKeys();
+        return true;
+      }
+    }
+    numRows += build->table_->rows()->numRows();
+    otherBuilds.push_back(build);
+  }
+
+  ensureTableFits(numRows);
+
+  NonReclaimableSection guard(this);
   std::vector<std::unique_ptr<BaseHashTable>> otherTables;
   otherTables.reserve(peers.size());
   SpillPartitionSet spillPartitions;
   Spiller::Stats spillStats;
-  if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
-      !joinNode_->filter()) {
-    joinBridge_->setAntiJoinHasNullKeys();
-  } else {
-    for (auto& peer : peers) {
-      auto op = peer->findOperator(planNodeId());
-      HashBuild* build = dynamic_cast<HashBuild*>(op);
-      VELOX_CHECK_NOT_NULL(build);
-      if (build->joinHasNullKeys_) {
-        joinHasNullKeys_ = true;
-        if (isAntiJoin(joinType_) && nullAware_ && !joinNode_->filter()) {
-          break;
-        }
-      }
-      otherTables.push_back(std::move(build->table_));
-      if (build->spiller_ != nullptr) {
-        spillStats += build->spiller_->stats();
-        build->spiller_->finishSpill(spillPartitions);
-      }
-    }
-
-    if (joinHasNullKeys_ && isAntiJoin(joinType_) && nullAware_ &&
-        !joinNode_->filter()) {
-      joinBridge_->setAntiJoinHasNullKeys();
-    } else {
-      if (spiller_ != nullptr) {
-        spillStats += spiller_->stats();
-
-        {
-          auto lockedStats = stats_.wlock();
-          lockedStats->spilledBytes += spillStats.spilledBytes;
-          lockedStats->spilledRows += spillStats.spilledRows;
-          lockedStats->spilledPartitions += spillStats.spilledPartitions;
-          lockedStats->spilledFiles += spillStats.spilledFiles;
-        }
-
-        spiller_->finishSpill(spillPartitions);
-
-        // Verify all the spilled partitions are not empty as we won't spill on
-        // an empty one.
-        for (const auto& spillPartitionEntry : spillPartitions) {
-          VELOX_CHECK_GT(spillPartitionEntry.second->numFiles(), 0);
-        }
-      }
-
-      // TODO: re-enable parallel join build with spilling triggered after
-      // https://github.com/facebookincubator/velox/issues/3567 is fixed.
-      const bool allowParallelJoinBuild =
-          !otherTables.empty() && spillPartitions.empty();
-      table_->prepareJoinTable(
-          std::move(otherTables),
-          allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
-                                 : nullptr);
-      addRuntimeStats();
-      if (joinBridge_->setHashTable(
-              std::move(table_),
-              std::move(spillPartitions),
-              joinHasNullKeys_)) {
-        spillGroup_->restart();
-      }
+  for (auto* build : otherBuilds) {
+    VELOX_CHECK_NOT_NULL(build->table_);
+    otherTables.push_back(std::move(build->table_));
+    if (build->spiller_ != nullptr) {
+      spillStats += build->spiller_->stats();
+      build->spiller_->finishSpill(spillPartitions);
     }
   }
 
+  if (spiller_ != nullptr) {
+    spillStats += spiller_->stats();
+
+    {
+      auto lockedStats = stats_.wlock();
+      lockedStats->spilledBytes += spillStats.spilledBytes;
+      lockedStats->spilledRows += spillStats.spilledRows;
+      lockedStats->spilledPartitions += spillStats.spilledPartitions;
+      lockedStats->spilledFiles += spillStats.spilledFiles;
+    }
+
+    spiller_->finishSpill(spillPartitions);
+
+    // Verify all the spilled partitions are not empty as we won't spill on
+    // an empty one.
+    for (const auto& spillPartitionEntry : spillPartitions) {
+      VELOX_CHECK_GT(spillPartitionEntry.second->numFiles(), 0);
+    }
+  }
+
+  // TODO: re-enable parallel join build with spilling triggered after
+  // https://github.com/facebookincubator/velox/issues/3567 is fixed.
+  const bool allowParallelJoinBuild =
+      !otherTables.empty() && spillPartitions.empty();
+  table_->prepareJoinTable(
+      std::move(otherTables),
+      allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
+                             : nullptr);
+  addRuntimeStats();
+  if (joinBridge_->setHashTable(
+          std::move(table_), std::move(spillPartitions), joinHasNullKeys_)) {
+    spillGroup_->restart();
+  }
+
+  // Release the unused memory reservation since we have finished the merged
+  // table build.
+  pool()->release();
   return true;
+}
+
+void HashBuild::ensureTableFits(uint64_t numRows) {
+  // NOTE: we don't need memory reservation if all the partitions have been
+  // spilled as nothing need to be built.
+  if (!spillEnabled() || spiller_ == nullptr || spiller_->isAllSpilled()) {
+    return;
+  }
+
+  TestValue::adjust("facebook::velox::exec::HashBuild::ensureTableFits", this);
+
+  // NOTE: reserve a bit more memory to consider the extra memory used for
+  // parallel table build operation.
+  const uint64_t bytesToReserve = table_->estimateHashTableSize(numRows) * 1.1;
+  if (pool()->maybeReserve(bytesToReserve)) {
+    return;
+  }
+
+  // NOTE: the memory arbitrator must have spilled everything from this hash
+  // build operator and all its peers.
+  VELOX_CHECK(spiller_->isAllSpilled());
+
+  // Throw a memory cap exceeded error to fail this query.
+  VELOX_MEM_POOL_CAP_EXCEEDED(fmt::format(
+      "Failed to reserve {} to build table with {} rows from {}",
+      succinctBytes(bytesToReserve),
+      numRows,
+      pool()->name()));
 }
 
 void HashBuild::postHashBuildProcess() {
   checkRunning();
-
-  // Release the unused memory reservation since we have finished the table
-  // build.
-  pool()->release();
 
   if (!spillEnabled()) {
     setState(State::kFinish);
@@ -1012,7 +1049,8 @@ void HashBuild::reclaim(uint64_t /*unused*/) {
 
   // NOTE: a hash build operator is reclaimable if it is in the middle of table
   // build processing and is not under non-reclaimable execution section.
-  if ((state_ != State::kRunning) || nonReclaimableSection_) {
+  if ((state_ != State::kRunning && state_ != State::kWaitForBuild) ||
+      nonReclaimableSection_) {
     // TODO: add stats to record the non-reclaimable case and reduce the log
     // frequency if it is too verbose.
     LOG(WARNING) << "Can't reclaim from hash build operator, state_["
@@ -1029,7 +1067,8 @@ void HashBuild::reclaim(uint64_t /*unused*/) {
     HashBuild* buildOp = dynamic_cast<HashBuild*>(op);
     VELOX_CHECK_NOT_NULL(buildOp);
     VELOX_CHECK(buildOp->canReclaim());
-    if ((buildOp->state_ != State::kRunning) ||
+    if ((buildOp->state_ != State::kRunning &&
+         buildOp->state_ != State::kWaitForBuild) ||
         buildOp->nonReclaimableSection_) {
       // TODO: add stats to record the non-reclaimable case and reduce the log
       // frequency if it is too verbose.

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -149,6 +149,11 @@ class HashBuild final : public Operator {
   // accordingly.
   bool ensureInputFits(RowVectorPtr& input);
 
+  // Invoked to ensure there is sufficient memory to build the join table with
+  // the specified 'numRows' if spilling is enabled. The function throws to fail
+  // the query if the memory reservation fails.
+  void ensureTableFits(uint64_t numRows);
+
   // Invoked to reserve memory for 'input' if disk spilling is enabled. The
   // function returns true on success, otherwise false.
   bool reserveMemory(const RowVectorPtr& input);

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -311,12 +311,12 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
   raw_vector<uint64_t> sizes;
   starts.reserve(ranges.size());
   sizes.reserve(ranges.size());
-  for (auto& range : ranges) {
+  for (const auto& range : ranges) {
     starts.push_back(reinterpret_cast<uintptr_t>(range.data()));
     sizes.push_back(range.size());
   }
   int32_t numRows = 0;
-  for (auto row : rows) {
+  for (const auto& row : rows) {
     auto address = reinterpret_cast<uintptr_t>(row);
     auto it = std::lower_bound(starts.begin(), starts.end(), address);
     if (it == starts.end()) {
@@ -325,7 +325,7 @@ int32_t RowContainer::findRows(folly::Range<char**> rows, char** result) {
       }
       continue;
     }
-    auto index = it - starts.begin();
+    const auto index = it - starts.begin();
     if (address == starts[index]) {
       result[numRows++] = row;
       continue;

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -251,7 +251,7 @@ class RowContainer {
   // variable length data.
   void eraseRows(folly::Range<char**> rows);
 
-  // Copies elements of 'rows'where the char* points to a row inside 'this'  to
+  // Copies elements of 'rows' where the char* points to a row inside 'this' to
   // 'result' and returns the number copied. 'result' should have space for
   // 'rows.size()'.
   int32_t findRows(folly::Range<char**> rows, char** result);

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -71,6 +71,7 @@ class HashTableTest : public testing::TestWithParam<bool> {
     }
     int32_t startOffset = 0;
     std::vector<std::unique_ptr<BaseHashTable>> otherTables;
+    uint64_t numRows{0};
     for (auto way = 0; way < numWays; ++way) {
       std::vector<RowVectorPtr> batches;
       std::vector<std::unique_ptr<VectorHasher>> keyHashers;
@@ -92,13 +93,21 @@ class HashTableTest : public testing::TestWithParam<bool> {
       if (!topTable_) {
         topTable_ = std::move(table);
       } else {
+        numRows += table->rows()->numRows();
         otherTables.push_back(std::move(table));
       }
       batches_.insert(batches_.end(), batches.begin(), batches.end());
       startOffset += size;
     }
+    numRows += topTable_->rows()->numRows();
+    const uint64_t estimatedTableSize =
+        topTable_->estimateHashTableSize(numRows);
+    const uint64_t usedMemoryBytes = topTable_->rows()->pool()->currentBytes();
     topTable_->prepareJoinTable(std::move(otherTables), executor_.get());
-    EXPECT_EQ(topTable_->hashMode(), mode);
+    ASSERT_GE(
+        estimatedTableSize,
+        topTable_->rows()->pool()->currentBytes() - usedMemoryBytes);
+    ASSERT_EQ(topTable_->hashMode(), mode);
     LOG(INFO) << "Made table " << describeTable();
     testProbe();
     testEraseEveryN(3);
@@ -477,7 +486,10 @@ class HashTableTest : public testing::TestWithParam<bool> {
     ASSERT_EQ(0, table->listNullKeyRows(&iter, rows.size(), rows.data()));
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> rootPool_{
+      memory::defaultMemoryManager().addRootPool("HashTableTest")};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      rootPool_->addLeafChild("HashTableTest")};
   std::unique_ptr<test::VectorMaker> vectorMaker_{
       std::make_unique<test::VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.


### PR DESCRIPTION
The hash table itself can take a large amount of space when
prepare join table after all the hash build operators finish. This
step is non-reclaimable as we don't support spilling at that stage
if the memory allocation fails, the query might fail. Add a step to
reserve memory in that step to trigger spilling if the memory 
reservation fails.

Also add utility to hast table to estimate the new hash table size
given the number distinct which is used by hash build to ensure
memory for table build.