### PR TITLE
Disable zero-copy string compute for array_union

### DIFF
--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -697,35 +697,4 @@ struct ArrayUnionFunction {
   }
 };
 
-template <typename T>
-struct ArrayUnionFunctionString {
-  VELOX_DEFINE_FUNCTION_TYPES(T);
-
-  static constexpr int32_t reuse_strings_from_arg = 0;
-
-  // String version that avoids copy of strings.
-  FOLLY_ALWAYS_INLINE void call(
-      out_type<Array<Varchar>>& out,
-      const arg_type<Array<Varchar>>& inputArray1,
-      const arg_type<Array<Varchar>>& inputArray2) {
-    folly::F14FastSet<StringView> elementSet;
-    bool nullAdded = false;
-    auto addItems = [&](auto& inputArray) {
-      for (const auto& item : inputArray) {
-        if (item.has_value()) {
-          if (elementSet.insert(item.value()).second) {
-            auto& newItem = out.add_item();
-            newItem.setNoCopy(item.value());
-          }
-        } else if (!nullAdded) {
-          nullAdded = true;
-          out.add_null();
-        }
-      }
-    };
-    addItems(inputArray1);
-    addItems(inputArray2);
-  }
-};
-
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -194,11 +194,6 @@ void registerArrayFunctions(const std::string& prefix) {
       Array<Generic<T1>>,
       int64_t>({prefix + "trim_array"});
 
-  registerFunction<
-      ArrayUnionFunctionString,
-      Array<Varchar>,
-      Array<Varchar>,
-      Array<Varchar>>({prefix + "array_union"});
   registerArrayUnionFunctions<int8_t>(prefix);
   registerArrayUnionFunctions<int16_t>(prefix);
   registerArrayUnionFunctions<int32_t>(prefix);


### PR DESCRIPTION
Although `ArrayUnionFunctionString` sets `reuse_strings_from_arg = 0`, it only allows reusing the string buffer from the first argument but not the second. Since zero-copy will not be used, no point to create a separate function for it.