### PR TITLE
Updated lz4 manifest to exlude ls4-static on CentOS Stream 9

### DIFF
--- a/build/fbcode_builder/manifests/lz4
+++ b/build/fbcode_builder/manifests/lz4
@@ -6,8 +6,8 @@ lz4
 
 [rpms]
 lz4-devel
-# centos (not centos_stream that is Meta internal) 8 is missing this
-[rpms.not(all(distro=centos,distro_vers=8))]
+# centos 8 and centos_stream 9 are missing this rpm
+[rpms.not(any(all(distro=centos,distro_vers=8),all(distro=centos_stream,distro_vers=9)))]
 lz4-static
 
 [debs]


### PR DESCRIPTION
Summary:
Ran into issue install dependenices via: `sudo opensource/fbcode_builder/getdeps.py install-system-deps --recursive eden`
```
...
Error: Unable to find a match: lz4-static
...
```

Reviewed By: chadaustin

Differential Revision: D47688409

