### PR TITLE
Fix empty sub table case for parallel join build

### DIFF
--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -763,10 +763,10 @@ int32_t RowContainer::listPartitionRows(
 
 RowPartitions::RowPartitions(int32_t numRows, memory::MemoryPool& pool)
     : capacity_(numRows) {
-  auto numPages =
-      bits::roundUp(capacity_, memory::AllocationTraits::kPageSize) /
-      memory::AllocationTraits::kPageSize;
-  pool.allocateNonContiguous(numPages, allocation_);
+  const auto numPages = memory::AllocationTraits::numPages(capacity_);
+  if (numPages > 0) {
+    pool.allocateNonContiguous(numPages, allocation_);
+  }
 }
 
 void RowPartitions::appendPartitions(folly::Range<const uint8_t*> partitions) {

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -1046,6 +1046,17 @@ TEST_F(RowContainerTest, partition) {
   }
 }
 
+TEST_F(RowContainerTest, partitionWithEmptyRowContainer) {
+  auto rowType = ROW(
+      {{"int_val", INTEGER()},
+       {"long_val", BIGINT()},
+       {"string_val", VARCHAR()}});
+  auto rowContainer =
+      std::make_unique<RowContainer>(rowType->children(), pool_.get());
+  auto partitions = rowContainer->createRowPartitions(*pool_);
+  ASSERT_EQ(partitions->size(), 0);
+}
+
 TEST_F(RowContainerTest, probedFlag) {
   auto rowContainer = std::make_unique<RowContainer>(
       std::vector<TypePtr>{BIGINT()}, // keyTypes


### PR DESCRIPTION
If the sub table is empty, then we shall avoid allocation memory as
the memory allocator doesn't allow zero page allocation. Verify with
fuzzer test.