### PR TITLE
Store output Type information for each ScanSpec node

### DIFF
--- a/velox/dwio/common/ScanSpec.h
+++ b/velox/dwio/common/ScanSpec.h
@@ -320,33 +320,37 @@ class ScanSpec {
   // out.
   ScanSpec* addFieldRecursively(
       const std::string& name,
-      const Type&,
+      const TypePtr& type,
       column_index_t channel);
 
   // Add a field for map key.
   ScanSpec* addMapKeyField();
 
   // Add a field for map key, along with its child recursively.
-  ScanSpec* addMapKeyFieldRecursively(const Type&);
+  ScanSpec* addMapKeyFieldRecursively(const TypePtr&);
 
   // Add a field for map value.
   ScanSpec* addMapValueField();
 
   // Add a field for map value, along with its child recursively.
-  ScanSpec* addMapValueFieldRecursively(const Type&);
+  ScanSpec* addMapValueFieldRecursively(const TypePtr&);
 
   // Add a field for array element.
   ScanSpec* addArrayElementField();
 
   // Add a field for array element, along with its child recursively.
-  ScanSpec* addArrayElementFieldRecursively(const Type&);
+  ScanSpec* addArrayElementFieldRecursively(const TypePtr&);
 
   // Add all child fields on the type recursively to this ScanSpec, all
   // projected out.
-  void addAllChildFields(const Type&);
+  void addAllChildFields(const TypePtr&);
+
+  const TypePtr& getOutputType() const;
 
  private:
   void reorder();
+
+  TypePtr outputType_;
 
   // Serializes stableChildren().
   std::mutex mutex_;

--- a/velox/dwio/common/tests/E2EFilterTestBase.cpp
+++ b/velox/dwio/common/tests/E2EFilterTestBase.cpp
@@ -584,7 +584,7 @@ void E2EFilterTestBase::testMetadataFilter() {
         vectorMaker.rowVector({"a", "b", "c"}, {column, column, column})};
     writeToMemory(batches[0]->type(), batches, false);
     auto spec = std::make_shared<common::ScanSpec>("<root>");
-    spec->addAllChildFields(*batches[0]->type());
+    spec->addAllChildFields(batches[0]->type());
     auto untypedExpr = parse::parseExpr("a = 1 or b + c = 2", {});
     auto typedExpr = core::Expressions::inferTypes(
         untypedExpr, batches[0]->type(), leafPool_.get());
@@ -632,19 +632,19 @@ void E2EFilterTestBase::testSubfieldsPruning() {
       requiredA.push_back(i);
     }
   }
-  spec->addFieldRecursively("a", *BIGINT(), 0)
+  spec->addFieldRecursively("a", BIGINT(), 0)
       ->setFilter(common::createBigintValues(requiredA, false));
   std::vector<int64_t> requiredB;
   for (int i = 0; i < kMapSize; i += 2) {
     requiredB.push_back(i);
   }
-  auto specB = spec->addFieldRecursively("b", *MAP(BIGINT(), BIGINT()), 1);
+  auto specB = spec->addFieldRecursively("b", MAP(BIGINT(), BIGINT()), 1);
   specB->setFilter(exec::isNotNull());
   specB->childByName(common::ScanSpec::kMapKeysFieldName)
       ->setFilter(common::createBigintValues(requiredB, false));
-  spec->addFieldRecursively("c", *ARRAY(BIGINT()), 2)
+  spec->addFieldRecursively("c", ARRAY(BIGINT()), 2)
       ->setMaxArrayElementsCount(6);
-  auto specD = spec->addFieldRecursively("d", *MAP(BIGINT(), VARCHAR()), 3);
+  auto specD = spec->addFieldRecursively("d", MAP(BIGINT(), VARCHAR()), 3);
   specD->childByName(common::ScanSpec::kMapKeysFieldName)
       ->setFilter(common::createBigintValues({1}, false));
   ReaderOptions readerOpts{leafPool_.get()};
@@ -723,7 +723,7 @@ void E2EFilterTestBase::testMutationCornerCases() {
   // 2. Whole batch deletion.
   // 3. Delete last a few rows in a batch.
   auto spec = std::make_shared<common::ScanSpec>("<root>");
-  spec->addAllChildFields(*rowType);
+  spec->addAllChildFields(rowType);
   RowReaderOptions rowReaderOpts;
   setUpRowReaderOptions(rowReaderOpts, spec);
   auto rowReader = reader->createRowReader(rowReaderOpts);

--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -350,7 +350,7 @@ std::vector<FilterSpec> FilterGenerator::makeRandomSpecs(
 std::shared_ptr<ScanSpec> FilterGenerator::makeScanSpec(
     const SubfieldFilters& filters) {
   auto spec = std::make_shared<ScanSpec>("root");
-  spec->addAllChildFields(*rowType_);
+  spec->addAllChildFields(rowType_);
   addToScanSpec(filters, *spec);
   return spec;
 }
@@ -676,7 +676,7 @@ std::shared_ptr<ScanSpec> FilterGenerator::makeScanSpec(
     std::vector<RowVectorPtr>& batches,
     memory::MemoryPool* pool) {
   auto root = std::make_shared<ScanSpec>("<root>");
-  root->addAllChildFields(*rowType_);
+  root->addAllChildFields(rowType_);
   auto* first = batches[0].get();
   for (auto& path : prunable) {
     Subfield subfield(path);

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1816,7 +1816,7 @@ TEST(TestReader, appendRowNumberColumn) {
   auto [writer, reader] = createWriterReader(batches, *pool);
 
   auto spec = std::make_shared<common::ScanSpec>("<root>");
-  spec->addAllChildFields(*schema);
+  spec->addAllChildFields(schema);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(spec);
   rowReaderOpts.setAppendRowNumberColumn(true);
@@ -1843,7 +1843,7 @@ TEST(TestReader, reuseRowNumberColumn) {
   auto [writer, reader] = createWriterReader(batches, *pool);
 
   auto spec = std::make_shared<common::ScanSpec>("<root>");
-  spec->addAllChildFields(*schema);
+  spec->addAllChildFields(schema);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(spec);
   rowReaderOpts.setAppendRowNumberColumn(true);

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -136,7 +136,7 @@ class ColumnReaderTestBase {
     if (useSelectiveReader()) {
       if (!scanSpec) {
         scanSpec_ = std::make_unique<common::ScanSpec>("root");
-        scanSpec_->addAllChildFields(*dataTypeWithId->type);
+        scanSpec_->addAllChildFields(dataTypeWithId->type);
         scanSpec = scanSpec_.get();
       }
       makeFieldSpecs("", 0, rowType, scanSpec);
@@ -811,7 +811,7 @@ TEST_P(TestColumnReader, testIntegerRLEv2) {
   VectorPtr batch = newBatch(rowType);
   if (useSelectiveReader()) {
     auto scanSpec = std::make_unique<common::ScanSpec>("root");
-    scanSpec->addAllChildFields(*dataType);
+    scanSpec->addAllChildFields(dataType);
     scanSpec->childByName("col_0")->setFilter(
         std::make_unique<common::BigintRange>(2100, 2140, false));
     scanSpec->childByName("col_1")->setFilter(

--- a/velox/dwio/parquet/tests/ParquetReaderTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetReaderTestBase.h
@@ -104,7 +104,7 @@ class ParquetReaderTestBase : public testing::Test {
   std::shared_ptr<velox::common::ScanSpec> makeScanSpec(
       const RowTypePtr& rowType) {
     auto scanSpec = std::make_shared<velox::common::ScanSpec>("");
-    scanSpec->addAllChildFields(*rowType);
+    scanSpec->addAllChildFields(rowType);
     return scanSpec;
   }
 


### PR DESCRIPTION
This PR incorporates outputType_ as output type information into ScanSpec nodes recursively to all its children. This type information is essential for determining the appropriate Parquet Column Reader. This particular reader is then utilized to generate a Flat Vector that matches the outputType_. This update is one of the modifications necessary for issue #5770.