### PR TITLE
Store Parquet Logical Type information within ParquetTypeWithId

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -177,6 +177,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               ParquetTypeWithId::kNonLeaf, // columnIdx,
               std::move(name),
               std::nullopt,
+              std::nullopt,
               maxRepeat + 1,
               maxDefine);
         }
@@ -195,6 +196,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               maxSchemaElementIdx,
               ParquetTypeWithId::kNonLeaf, // columnIdx,
               std::move(name),
+              std::nullopt,
               std::nullopt,
               maxRepeat,
               maxDefine);
@@ -220,6 +222,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               ParquetTypeWithId::kNonLeaf, // columnIdx,
               std::move(name),
               std::nullopt,
+              std::nullopt,
               maxRepeat,
               maxDefine);
         } else if (children.size() == 2) {
@@ -233,6 +236,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
               maxSchemaElementIdx,
               ParquetTypeWithId::kNonLeaf, // columnIdx,
               std::move(name),
+              std::nullopt,
               std::nullopt,
               maxRepeat,
               maxDefine);
@@ -248,6 +252,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             ParquetTypeWithId::kNonLeaf, // columnIdx,
             std::move(name),
             std::nullopt,
+            std::nullopt,
             maxRepeat,
             maxDefine);
       }
@@ -260,6 +265,10 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
     int32_t type_length =
         schemaElement.__isset.type_length ? schemaElement.type_length : 0;
     std::vector<std::shared_ptr<const dwio::common::TypeWithId>> children;
+    const std::optional<thrift::LogicalType> logicalType_ =
+        schemaElement.__isset.logicalType
+        ? std::optional<thrift::LogicalType>(schemaElement.logicalType)
+        : std::nullopt;
     std::shared_ptr<const ParquetTypeWithId> leafTypePtr =
         std::make_shared<const ParquetTypeWithId>(
             veloxType,
@@ -269,6 +278,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
             columnIdx++,
             name,
             schemaElement.type,
+            logicalType_,
             maxRepeat,
             maxDefine,
             precision,
@@ -288,6 +298,7 @@ std::shared_ptr<const ParquetTypeWithId> ReaderBase::getParquetColumnInfo(
           maxSchemaElementIdx,
           columnIdx++,
           std::move(name),
+          std::nullopt,
           std::nullopt,
           maxRepeat,
           maxDefine - 1);

--- a/velox/dwio/parquet/reader/ParquetTypeWithId.h
+++ b/velox/dwio/parquet/reader/ParquetTypeWithId.h
@@ -42,6 +42,7 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
       uint32_t column,
       std::string name,
       std::optional<thrift::Type::type> parquetType,
+      std::optional<thrift::LogicalType> logicalType,
       uint32_t maxRepeat,
       uint32_t maxDefine,
       int32_t precision = 0,
@@ -50,6 +51,7 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
       : TypeWithId(type, std::move(children), id, maxId, column),
         name_(name),
         parquetType_(parquetType),
+        logicalType_(logicalType),
         maxRepeat_(maxRepeat),
         maxDefine_(maxDefine),
         precision_(precision),
@@ -74,6 +76,7 @@ class ParquetTypeWithId : public dwio::common::TypeWithId {
 
   const std::string name_;
   const std::optional<thrift::Type::type> parquetType_;
+  const std::optional<thrift::LogicalType> logicalType_;
   const uint32_t maxRepeat_;
   const uint32_t maxDefine_;
   const int32_t precision_;


### PR DESCRIPTION
This PR integrates Parquet's LogicalType into ParquetTypeWithId. This LogicalType information will be used in choosing the correct Parquet Column Reader, determined by various factors contained in the LogicalType, such as the sign of the parquet column, the bit width, and the specific Logical Type of the column. This enhancement is among the necessary changes for issue #5770.