### PR TITLE
Fix Protobuf include directory in velox_dwio_common

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -20,8 +20,6 @@ elseif(${VELOX_BUILD_TEST_UTILS})
   add_subdirectory(tests/utils)
 endif()
 
-include_directories(/opt/homebrew/opt/protobuf/include)
-
 add_library(
   velox_dwio_common
   BitConcatenation.cpp
@@ -53,6 +51,8 @@ add_library(
   TypeUtils.cpp
   TypeWithId.cpp
   WriterFactory.cpp)
+
+target_include_directories(velox_dwio_common PRIVATE ${Protobuf_INCLUDE_DIRS})
 
 target_link_libraries(
   velox_dwio_common


### PR DESCRIPTION
Replace hard-coded Protobuf include path with ${Protobuf_INCLUDE_DIRS}
Fixes the following build error in the presence of other protobuf versions

```
"google::protobuf::io::ZeroCopyInputStream::ReadCord(absl::lts_20230125::Cord*, int)", referenced from:
      vtable for facebook::velox::dwio::common::CacheInputStream in libvelox_dwio_common.a(CacheInputStream.cpp.o)
      vtable for facebook::velox::dwio::common::SeekableInputStream in libvelox_dwio_common.a(CacheInputStream.cpp.o)
      vtable for facebook::velox::dwio::common::SeekableArrayInputStream in libvelox_dwio_common.a(SeekableInputStream.cpp.o)
      vtable for facebook::velox::dwio::common::SeekableFileInputStream in libvelox_dwio_common.a(SeekableInputStream.cpp.o)
      vtable for facebook::velox::dwio::common::SeekableInputStream in libvelox_dwio_common.a(SeekableInputStream.cpp.o)
```