### PR TITLE
Fix ContainerRowSerde::deserialize() to clear null bit

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -259,6 +259,7 @@ void deserializeOne<TypeKind::ROW>(
       deserializeSwitch(in, index, *child);
     }
   }
+  result.setNull(index, false);
 }
 
 // Reads the size, null flags and deserializes from 'in', appending to
@@ -293,6 +294,7 @@ void deserializeOne<TypeKind::ARRAY>(
   vector_size_t offset;
   auto size = deserializeArray(in, *array->elements(), offset);
   array->setOffsetAndSize(index, offset, size);
+  result.setNull(index, false);
 }
 
 template <>
@@ -312,6 +314,7 @@ void deserializeOne<TypeKind::MAP>(
   VELOX_CHECK_EQ(keySize, valueSize);
   VELOX_CHECK_EQ(keyOffset, valueOffset);
   map->setOffsetAndSize(index, keyOffset, keySize);
+  result.setNull(index, false);
 }
 
 void deserializeSwitch(

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -33,6 +33,13 @@ class ValueListTest : public functions::test::FunctionBaseTest {
   read(aggregate::ValueList& values, const TypePtr& type, vector_size_t size) {
     aggregate::ValueListReader reader(values);
     auto result = BaseVector::create(type, size, pool());
+
+    // Initialize result to all-nulls to ensure ValueListReader::next() reset
+    // null bits correctly.
+    for (auto i = 0; i < size; ++i) {
+      result->setNull(i, true);
+    }
+
     for (auto i = 0; i < size; i++) {
       reader.next(*result, i);
     }


### PR DESCRIPTION
Summary:
Before this fix, ContainerRowSerde::deserialize() doesn't clear the null
bit of the result vector for array, map, and row types. When the result
vector has pre-existing nulls, this would cause incorrect result. This diff
fixes this bug by clearing the null bit.

Reviewed By: bikramSingh91

Differential Revision: D47657007

