### PR TITLE
Implement Spark decimal add and subtract

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -27,6 +27,20 @@ Mathematical Functions
     Returns the result of adding x to y. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to sparks's operator ``+``.
 
+.. spark:function:: add(x, y) -> decimal
+
+    Returns the result of adding ``x`` to ``y``. The argument types should be DECIMAL, and can have different precisions and scales.
+    Fast path is implemented for cases that should not overflow. For the others, the whole parts and fractional parts of input decimals are added separately and combined finally.
+    The result type is calculated with the max precision of input precisions, the max scale of input scales, and one extra digit for possible carrier.
+    Overflow results in null output. Corresponds to Spark's operator ``+``.
+    
+    ::
+
+        SELECT CAST(1.1232100 as DECIMAL(38, 7)) + CAST(1 as DECIMAL(10, 0)); -- DECIMAL(38, 6) 2.123210
+        SELECT CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)) + CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)); -- DECIMAL(31, 3) -1999999999999999999999999999.998
+        SELECT CAST(99999999999999999999999999999999.99998 as DECIMAL(38, 6)) + CAST(-99999999999999999999999999999999.99999 as DECIMAL(38, 5)); -- DECIMAL(38, 6) -0.000010
+        SELECT CAST(-99999999999999999999999999999999990.0 as DECIMAL(38, 3)) + CAST(-0.00001 as DECIMAL(38, 7)); -- DECIMAL(38, 6) NULL
+
 .. spark:function:: bin(x) -> varchar
 
     Returns the string representation of the long value ``x`` represented in binary.
@@ -178,6 +192,18 @@ Mathematical Functions
 
     Returns the result of subtracting y from x. The types of x and y must be the same.
     For integral types, overflow results in an error. Corresponds to Spark's operator ``-``.
+
+.. spark:function:: subtract(x, y) -> decimal
+
+    Returns the result of subtracting ``y`` from ``x``. Reuses the logic of add function for decimal type.
+    Corresponds to Spark's operator ``-``.
+    
+    ::
+
+        SELECT CAST(1.1232100 as DECIMAL(38, 7)) - CAST(1 as DECIMAL(10, 0)); -- DECIMAL(38, 6) 0.123210
+        SELECT CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)) - CAST(-999999999999999999999999999.999 as DECIMAL(30, 3)); -- DECIMAL(31, 3) 0.000
+        SELECT CAST(99999999999999999999999999999999.99998 as DECIMAL(38, 6)) - CAST(-0.00001 as DECIMAL(38, 5)); -- DECIMAL(38, 6) 99999999999999999999999999999999.999990
+        SELECT CAST(-99999999999999999999999999999999990.0 as DECIMAL(38, 3)) - CAST(0.00001 as DECIMAL(38, 7)); -- DECIMAL(38, 6) NULL
 
 .. spark:function:: unaryminus(x) -> [same as x]
 

--- a/velox/functions/sparksql/DecimalArithmetic.cpp
+++ b/velox/functions/sparksql/DecimalArithmetic.cpp
@@ -33,6 +33,132 @@ std::string getResultScale(std::string precision, std::string scale) {
       scale);
 }
 
+template <typename A>
+inline static std::pair<A, A> getWholeAndFraction(
+    const A& value,
+    uint8_t scale) {
+  A whole = A(value / velox::DecimalUtil::kPowersOfTen[scale]);
+  return {whole, A(value - whole * velox::DecimalUtil::kPowersOfTen[scale])};
+}
+
+template <typename A>
+inline static int128_t checkAndIncreaseScale(const A& in, int16_t delta) {
+  return (delta <= 0) ? in : in * velox::DecimalUtil::kPowersOfTen[delta];
+}
+
+template <typename A>
+inline static A checkAndReduceScale(const A& in, int32_t delta) {
+  if (delta <= 0) {
+    return in;
+  } else {
+    A r;
+    bool overflow;
+    DecimalUtil::divideWithRoundUp<A, A, A>(
+        r, in, A(velox::DecimalUtil::kPowersOfTen[delta]), 0, overflow);
+    VELOX_DCHECK(!overflow);
+    return r;
+  }
+}
+
+// Both x_value and y_value must be >= 0.
+template <typename R, typename A, typename B>
+inline static R addLargePositive(
+    const A& a,
+    const B& b,
+    uint8_t aScale,
+    uint8_t bScale,
+    uint8_t rScale) {
+  VELOX_DCHECK_GE(a, 0);
+  VELOX_DCHECK_GE(b, 0);
+
+  // Separate out whole/fractions.
+  auto [aLeft, aRight] = getWholeAndFraction<A>(a, aScale);
+  auto [bLeft, bRight] = getWholeAndFraction<B>(b, bScale);
+
+  // Adjust fractional parts to higher scale.
+  auto higherScale = std::max(aScale, bScale);
+  int128_t aRightScaled =
+      checkAndIncreaseScale<A>(aRight, higherScale - aScale);
+  int128_t bRightScaled =
+      checkAndIncreaseScale<B>(bRight, higherScale - bScale);
+
+  R right;
+  int64_t carryToLeft;
+  auto multiplier = velox::DecimalUtil::kPowersOfTen[higherScale];
+  if (aRightScaled >= multiplier - bRightScaled) {
+    right = R(aRightScaled - (multiplier - bRightScaled));
+    carryToLeft = 1;
+  } else {
+    right = R(aRightScaled + bRightScaled);
+    carryToLeft = 0;
+  }
+  right = checkAndReduceScale<R>(R(right), higherScale - rScale);
+
+  auto left = R(aLeft) + R(bLeft) + R(carryToLeft);
+  return R(left * velox::DecimalUtil::kPowersOfTen[rScale]) + R(right);
+}
+
+/// A and b cannot be 0, and one must be positive and the other
+/// negative.
+template <typename R, typename A, typename B>
+inline static R addLargeNegative(
+    const A& a,
+    const B& b,
+    uint8_t aScale,
+    uint8_t bScale,
+    int32_t rScale) {
+  VELOX_DCHECK_NE(a, 0);
+  VELOX_DCHECK_NE(b, 0);
+  VELOX_DCHECK((a < 0 && b > 0) || (a > 0 && b < 0));
+
+  // Separate out whole/fractions.
+  auto [aLeft, aRight] = getWholeAndFraction<A>(a, aScale);
+  auto [bLeft, bRight] = getWholeAndFraction<B>(b, bScale);
+
+  // Adjust fractional parts to higher scale.
+  auto higherScale = std::max(aScale, bScale);
+  int128_t aRightScaled =
+      checkAndIncreaseScale<A>(aRight, higherScale - aScale);
+  int128_t bRightScaled =
+      checkAndIncreaseScale<B>(bRight, higherScale - bScale);
+
+  // Overflow not possible because one is +ve and the other is -ve.
+  int128_t left = static_cast<int128_t>(aLeft) + static_cast<int128_t>(bLeft);
+  auto right = aRightScaled + bRightScaled;
+
+  // If the whole and fractional parts have different signs, then we need to
+  // make the fractional part have the same sign as the whole part. If either
+  // left or right is zero, then nothing needs to be done.
+  if (left < 0 && right > 0) {
+    left += 1;
+    right -= velox::DecimalUtil::kPowersOfTen[higherScale];
+  } else if (left > 0 && right < 0) {
+    left -= 1;
+    right += velox::DecimalUtil::kPowersOfTen[higherScale];
+  }
+  right = checkAndReduceScale(R(right), higherScale - rScale);
+  return R((left * velox::DecimalUtil::kPowersOfTen[rScale]) + right);
+}
+
+template <typename R, typename A, typename B>
+inline static R addLarge(
+    const A& a,
+    const B& b,
+    uint8_t aScale,
+    uint8_t bScale,
+    int32_t rScale) {
+  if (a >= 0 && b >= 0) {
+    // Both positive or 0.
+    return addLargePositive<R, A, B>(a, b, aScale, bScale, rScale);
+  } else if (a <= 0 && b <= 0) {
+    // Both negative or 0.
+    return R(-addLargePositive<R, A, B>(A(-a), B(-b), aScale, bScale, rScale));
+  } else {
+    // One positive and the other negative.
+    return addLargeNegative<R, A, B>(a, b, aScale, bScale, rScale);
+  }
+}
+
 template <
     typename R /* Result Type */,
     typename A /* Argument1 */,
@@ -195,6 +321,117 @@ class DecimalBaseFunction : public exec::VectorFunction {
   const uint8_t rScale_;
 };
 
+class Addition {
+ public:
+  template <typename R, typename A, typename B>
+  inline static void apply(
+      R& r,
+      const A& a,
+      const B& b,
+      uint8_t aRescale,
+      uint8_t bRescale,
+      uint8_t /* aPrecision */,
+      uint8_t aScale,
+      uint8_t /* bPrecision */,
+      uint8_t bScale,
+      uint8_t rPrecision,
+      uint8_t rScale,
+      bool& /*overflow*/)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
+    if (rPrecision < LongDecimalType::kMaxPrecision) {
+      int128_t aRescaled = a * velox::DecimalUtil::kPowersOfTen[aRescale];
+      int128_t bRescaled = b * velox::DecimalUtil::kPowersOfTen[bRescale];
+      r = R(aRescaled + bRescaled);
+    } else {
+      int32_t minLz = DecimalUtil::minLeadingZeros<A, B>(a, b, aScale, bScale);
+      if (minLz >= 3) {
+        // If both numbers have at least MIN_LZ leading zeros, we can add them
+        // directly without the risk of overflow. We want the result to have at
+        // least 2 leading zeros, which ensures that it fits into the maximum
+        // decimal because 2^126 - 1 < 10^38 - 1. If both x and y have at least
+        // 3 leading zeros, then we are guaranteed that the result will have at
+        // lest 2 leading zeros.
+        int128_t aRescaled = a * velox::DecimalUtil::kPowersOfTen[aRescale];
+        int128_t bRescaled = b * velox::DecimalUtil::kPowersOfTen[bRescale];
+        auto higherScale = std::max(aScale, bScale);
+        int128_t sum = aRescaled + bRescaled;
+        r = checkAndReduceScale<R>(R(sum), higherScale - rScale);
+      } else {
+        // Slower-version: add whole/fraction parts separately, and then
+        // combine.
+        r = addLarge<R, A, B>(a, b, aScale, bScale, rScale);
+      }
+    }
+  }
+
+  inline static uint8_t
+  computeRescaleFactor(uint8_t fromScale, uint8_t toScale, uint8_t rScale = 0) {
+    return std::max(0, toScale - fromScale);
+  }
+
+  inline static std::pair<uint8_t, uint8_t> computeResultPrecisionScale(
+      const uint8_t aPrecision,
+      const uint8_t aScale,
+      const uint8_t bPrecision,
+      const uint8_t bScale) {
+    auto precision = std::max(aPrecision - aScale, bPrecision - bScale) +
+        std::max(aScale, bScale) + 1;
+    auto scale = std::max(aScale, bScale);
+    return DecimalUtil::adjustPrecisionScale(precision, scale);
+  }
+};
+
+class Subtraction {
+ public:
+  template <typename R, typename A, typename B>
+  inline static void apply(
+      R& r,
+      const A& a,
+      const B& b,
+      uint8_t aRescale,
+      uint8_t bRescale,
+      uint8_t aPrecision,
+      uint8_t aScale,
+      uint8_t bPrecision,
+      uint8_t bScale,
+      uint8_t rPrecision,
+      uint8_t rScale,
+      bool& overflow) {
+    Addition::apply<R, A, B>(
+        r,
+        a,
+        B(-b),
+        aRescale,
+        bRescale,
+        aPrecision,
+        aScale,
+        bPrecision,
+        bScale,
+        rPrecision,
+        rScale,
+        overflow);
+  }
+
+  inline static uint8_t
+  computeRescaleFactor(uint8_t fromScale, uint8_t toScale, uint8_t rScale = 0) {
+    return std::max(0, toScale - fromScale);
+  }
+
+  inline static std::pair<uint8_t, uint8_t> computeResultPrecisionScale(
+      const uint8_t aPrecision,
+      const uint8_t aScale,
+      const uint8_t bPrecision,
+      const uint8_t bScale) {
+    return Addition::computeResultPrecisionScale(
+        aPrecision, aScale, bPrecision, bScale);
+  }
+};
+
 class Multiply {
  public:
   // Derive from Arrow.
@@ -349,6 +586,28 @@ class Divide {
 };
 
 std::vector<std::shared_ptr<exec::FunctionSignature>>
+decimalAddSubtractSignature() {
+  return {
+      exec::FunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable("b_precision")
+          .integerVariable("b_scale")
+          .integerVariable(
+              "r_precision",
+              "min(38, max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1)")
+          .integerVariable(
+              "r_scale",
+              getResultScale(
+                  "max(a_precision - a_scale, b_precision - b_scale) + max(a_scale, b_scale) + 1",
+                  "max(a_scale, b_scale)"))
+          .returnType("DECIMAL(r_precision, r_scale)")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .argumentType("DECIMAL(b_precision, b_scale)")
+          .build()};
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
 decimalMultiplySignature() {
   return {exec::FunctionSignatureBuilder()
               .integerVariable("a_precision")
@@ -481,6 +740,16 @@ std::shared_ptr<exec::VectorFunction> createDecimalFunction(
   VELOX_UNSUPPORTED();
 }
 }; // namespace
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_add,
+    decimalAddSubtractSignature(),
+    createDecimalFunction<Addition>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_sub,
+    decimalAddSubtractSignature(),
+    createDecimalFunction<Subtraction>);
 
 VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
     udf_decimal_mul,

--- a/velox/functions/sparksql/DecimalUtil.h
+++ b/velox/functions/sparksql/DecimalUtil.h
@@ -35,8 +35,8 @@ class DecimalUtil {
   /// This method is used only when
   /// `spark.sql.decimalOperations.allowPrecisionLoss` is set to true.
   inline static std::pair<uint8_t, uint8_t> adjustPrecisionScale(
-      const uint8_t rPrecision,
-      const uint8_t rScale) {
+      uint8_t rPrecision,
+      uint8_t rScale) {
     if (rPrecision <= LongDecimalType::kMaxPrecision) {
       return {rPrecision, rScale};
     } else {
@@ -109,18 +109,27 @@ class DecimalUtil {
     return value;
   }
 
+  /// Returns the minumum number of leading zeros after scaling up two inputs
+  /// for certain scales. Inputs are decimal values of bigint or hugeint type.
   template <typename A, typename B>
-  inline static int32_t
-  minLeadingZeros(const A& a, const B& b, uint8_t aScale, uint8_t bScale) {
-    int32_t aLeadingZeros = bits::countLeadingZeros(absValue<A>(a));
-    int32_t bLeadingZeros = bits::countLeadingZeros(absValue<B>(b));
-    if (aScale < bScale) {
-      aLeadingZeros =
-          minLeadingZerosAfterScaling(aLeadingZeros, bScale - aScale);
-    } else if (aScale > bScale) {
-      bLeadingZeros =
-          minLeadingZerosAfterScaling(bLeadingZeros, aScale - bScale);
-    }
+  inline static uint32_t
+  minLeadingZeros(A a, B b, uint8_t aRescale, uint8_t bRescale) {
+    auto minLeadingZerosAfterRescale = [](int32_t numLeadingZeros,
+                                          uint8_t scale) {
+      if (scale == 0) {
+        return numLeadingZeros;
+      }
+      /// If a value containing 'numLeadingZeros' leading zeros is scaled up by
+      /// 'scale', the new leading zeros depend on the max bits need to be
+      /// increased.
+      return std::max(
+          numLeadingZeros - kMaxBitsRequiredIncreaseAfterScaling[scale], 0);
+    };
+
+    const int32_t aLeadingZeros = minLeadingZerosAfterRescale(
+        bits::countLeadingZeros(absValue<A>(a)), aRescale);
+    const int32_t bLeadingZeros = minLeadingZerosAfterRescale(
+        bits::countLeadingZeros(absValue<B>(b)), bRescale);
     return std::min(aLeadingZeros, bLeadingZeros);
   }
 
@@ -135,12 +144,8 @@ class DecimalUtil {
   /// int256_t as intermediate type, and then convert to real result type with
   /// overflow flag.
   template <typename R, typename A, typename B>
-  inline static R divideWithRoundUp(
-      R& r,
-      const A& a,
-      const B& b,
-      uint8_t aRescale,
-      bool& overflow) {
+  inline static R
+  divideWithRoundUp(R& r, A a, B b, uint8_t aRescale, bool& overflow) {
     if (b == 0) {
       overflow = true;
       return R(-1);
@@ -207,9 +212,11 @@ class DecimalUtil {
   }
 
  private:
-  /// We rely on the following formula:
-  /// bits_required(x * 10^y) <= bits_required(x) + floor(log2(10^y)) + 1
-  /// We precompute floor(log2(10^x)) + 1 for x = 0, 1, 2...75, 76
+  /// Maintains the max bits that need to be increased for rescaling a value by
+  /// certain scale. The calculation relies on the following formula:
+  /// bitsRequired(x * 10^y) <= bitsRequired(x) + floor(log2(10^y)) + 1.
+  /// This array stores the precomputed 'floor(log2(10^y)) + 1' for y = 0,
+  /// 1, 2, ..., 75, 76.
   static constexpr int32_t kMaxBitsRequiredIncreaseAfterScaling[] = {
       0,   4,   7,   10,  14,  17,  20,  24,  27,  30,  34,  37,  40,
       44,  47,  50,  54,  57,  60,  64,  67,  70,  74,  77,  80,  84,
@@ -219,23 +226,10 @@ class DecimalUtil {
       216, 220, 223, 226, 230, 233, 236, 240, 243, 246, 250, 253};
 
   template <typename A>
-  inline static int32_t maxBitsRequiredAfterScaling(
-      const A& num,
-      uint8_t aRescale) {
+  inline static int32_t maxBitsRequiredAfterScaling(A num, uint8_t aRescale) {
     auto valueAbs = absValue<A>(num);
     int32_t numOccupied = sizeof(A) * 8 - bits::countLeadingZeros(valueAbs);
     return numOccupied + kMaxBitsRequiredIncreaseAfterScaling[aRescale];
-  }
-
-  /// If we have a number with 'numLeadingZeros' leading zeros, and we scale it
-  /// up by 10^scale_by, this function returns the minimum number of leading
-  /// zeros the result can have.
-  inline static int32_t minLeadingZerosAfterScaling(
-      int32_t numLeadingZeros,
-      int32_t scaleBy) {
-    int32_t result =
-        numLeadingZeros - kMaxBitsRequiredIncreaseAfterScaling[scaleBy];
-    return result;
   }
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -91,6 +91,8 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<sparksql::Log10Function, double, double>({prefix + "log10"});
   registerRandFunctions(prefix);
 
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_add, prefix + "add");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_sub, prefix + "subtract");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_mul, prefix + "multiply");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_div, prefix + "divide");
 }

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -43,97 +43,255 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
     assertEqualVectors(expected, result);
   }
 
-  VectorPtr makeLongDecimalVector(
-      const std::vector<std::string>& value,
-      int8_t precision,
-      int8_t scale) {
-    if (value.size() == 1) {
-      return makeConstant<int128_t>(
-          HugeInt::parse(std::move(value[0])), 1, DECIMAL(precision, scale));
+  void testArithmeticFunction(
+      const std::string& functionName,
+      const std::vector<VectorPtr>& inputs,
+      const VectorPtr& expected) {
+    VELOX_USER_CHECK_EQ(
+        inputs.size(),
+        2,
+        "Two input vectors are needed for arithmetic function test.");
+    std::vector<core::TypedExprPtr> inputExprs = {
+        std::make_shared<core::FieldAccessTypedExpr>(inputs[0]->type(), "c0"),
+        std::make_shared<core::FieldAccessTypedExpr>(inputs[1]->type(), "c1")};
+    auto expr = std::make_shared<const core::CallTypedExpr>(
+        expected->type(), std::move(inputExprs), functionName);
+    testEncodings(expr, inputs, expected);
+  }
+
+  VectorPtr makeNullableLongDecimalVector(
+      const std::vector<std::string>& values,
+      const TypePtr& type) {
+    VELOX_USER_CHECK(
+        type->isDecimal(),
+        "Decimal type is needed to create long decimal vector.");
+    std::vector<std::optional<int128_t>> numbers;
+    numbers.reserve(values.size());
+    for (const auto& value : values) {
+      if (value == "null") {
+        numbers.emplace_back(std::nullopt);
+      } else {
+        numbers.emplace_back(HugeInt::parse(value));
+      }
     }
-    std::vector<int128_t> int128s;
-    for (auto& v : value) {
-      int128s.emplace_back(HugeInt::parse(std::move(v)));
-    }
-    return makeFlatVector<int128_t>(int128s, DECIMAL(precision, scale));
+    return makeNullableFlatVector<int128_t>(numbers, type);
   }
 }; // namespace
 
 TEST_F(DecimalArithmeticTest, add) {
-  // The result can be obtained by Spark unit test
-  //       test("add") {
-  //     val l1 = Literal.create(
-  //       Decimal(BigDecimal(1), 17, 3),
-  //       DecimalType(17, 3))
-  //     val l2 = Literal.create(
-  //       Decimal(BigDecimal(1), 17, 3),
-  //       DecimalType(17, 3))
-  //     checkEvaluation(Add(l1, l2), null)
-  //   }
-
   // Precision < 38.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeFlatVector(std::vector<int128_t>{502}, DECIMAL(31, 3)),
-      "add(c0, c1)",
-      {makeFlatVector(std::vector<int128_t>{201}, DECIMAL(30, 3)),
-       makeFlatVector(std::vector<int128_t>{301}, DECIMAL(30, 3))});
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"201", "601", "1366", "999999999999999999999999999999"},
+           DECIMAL(30, 3)),
+       makeNullableLongDecimalVector(
+           {"301", "901", "9866", "999999999999999999999999999999"},
+           DECIMAL(30, 3))},
+      makeNullableLongDecimalVector(
+          {"502", "1502", "11232", "1999999999999999999999999999998"},
+          DECIMAL(31, 3)));
 
   // Min leading zero >= 3.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeFlatVector(std::vector<int128_t>{2123210}, DECIMAL(38, 6)),
-      "add(c0, c1)",
-      {makeFlatVector(std::vector<int128_t>{11232100}, DECIMAL(38, 7)),
-       makeFlatVector(std::vector<int64_t>{1}, DECIMAL(10, 0))});
+  testArithmeticFunction(
+      "add",
+      {makeFlatVector(
+           std::vector<int128_t>{11232100, 9998888, 12345678, 2135632},
+           DECIMAL(38, 7)),
+       makeFlatVector(std::vector<int64_t>{1, 2, 3, 4}, DECIMAL(10, 0))},
+      makeFlatVector(
+          std::vector<int128_t>{2123210, 2999889, 4234568, 4213563},
+          DECIMAL(38, 6)));
 
-  // Carry to left 0.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"99999999999999999999999999999990000010"}, 38, 6),
-      "add(c0, c1)",
-      {makeLongDecimalVector({"9999999999999999999999999999999000000"}, 38, 5),
-       makeFlatVector(std::vector<int128_t>{100}, DECIMAL(38, 7))});
+  // No carry to left.
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"9999999999999999999999999999999000000",
+            "9999999999999999999999999999999900000",
+            "9999999999999999999999999999999990000",
+            "9999999999999999999999999999999999000"},
+           DECIMAL(38, 5)),
+       makeFlatVector(
+           std::vector<int128_t>{100, 99999, 1234, 999}, DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"99999999999999999999999999999990000010",
+           "99999999999999999999999999999999010000",
+           "99999999999999999999999999999999900123",
+           "99999999999999999999999999999999990100"},
+          DECIMAL(38, 6)));
 
-  // Carry to left 1.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"99999999999999999999999999999991500000"}, 38, 6),
-      "add(c0, c1)",
-      {makeLongDecimalVector({"9999999999999999999999999999999070000"}, 38, 5),
-       makeFlatVector(std::vector<int128_t>{8000000}, DECIMAL(38, 7))});
+  // Carry to left.
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"9999999999999999999999999999999070000",
+            "9999999999999999999999999999999050000",
+            "9999999999999999999999999999999870000",
+            "9999999999999999999999999999999890000"},
+           DECIMAL(38, 5)),
+       makeFlatVector(
+           std::vector<int128_t>{8000000, 5000000, 8000000, 1999999},
+           DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"99999999999999999999999999999991500000",
+           "99999999999999999999999999999991000000",
+           "99999999999999999999999999999999500000",
+           "99999999999999999999999999999999100000"},
+          DECIMAL(38, 6)));
 
   // Both -ve.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeFlatVector(std::vector<int128_t>{-3211}, DECIMAL(32, 3)),
-      "add(c0, c1)",
-      {makeFlatVector(std::vector<int128_t>{-201}, DECIMAL(30, 3)),
-       makeFlatVector(std::vector<int128_t>{-301}, DECIMAL(30, 2))});
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"-201", "-601", "-1366", "-999999999999999999999999999999"},
+           DECIMAL(30, 3)),
+       makeNullableLongDecimalVector(
+           {"-301", "-901", "-9866", "-999999999999999999999999999999"},
+           DECIMAL(30, 3))},
+      makeNullableLongDecimalVector(
+          {"-502", "-1502", "-11232", "-1999999999999999999999999999998"},
+          DECIMAL(31, 3)));
 
-  // -Ve and max precision.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"-99999999999999999999999999999990000010"}, 38, 6),
-      "add(c0, c1)",
-      {makeLongDecimalVector(
-           {"-09999999999999999999999999999999000000"}, 38, 5),
-       makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7))});
+  // Overflow when scaling up the whole part.
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"-99999999999999999999999999999999990000",
+            "99999999999999999999999999999999999000",
+            "-99999999999999999999999999999999999900",
+            "99999999999999999999999999999999999990"},
+           DECIMAL(38, 3)),
+       makeFlatVector(
+           std::vector<int128_t>{-100, 9999999, -999900, 99999},
+           DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"null", "null", "null", "null"}, DECIMAL(38, 6)));
+
   // Ve and -ve.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"99999999999999999999999999999989999990"}, 38, 6),
-      "add(c0, c1)",
-      {makeLongDecimalVector({"9999999999999999999999999999999000000"}, 38, 5),
-       makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7))});
-  // -Ve and ve.
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"99999999999999999999999999999989999990"}, 38, 6),
-      "add(c0, c1)",
-      {makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7)),
-       makeLongDecimalVector(
-           {"9999999999999999999999999999999000000"}, 38, 5)});
+  testArithmeticFunction(
+      "add",
+      {makeNullableLongDecimalVector(
+           {"99999999999999999999999999999989999990",
+            "-99999999999999999999999999999989999990",
+            "99999999999999999999999999999999999980",
+            "-99999999999999999999999999999999999980"},
+           DECIMAL(38, 6)),
+       makeNullableLongDecimalVector(
+           {"-9999999999999999999999999999998900000",
+            "9999999999999999999999999999998900000",
+            "-9999999999999999999999999999999999999",
+            "9999999999999999999999999999999999999"},
+           DECIMAL(38, 5))},
+      makeNullableLongDecimalVector(
+          {"999990", "-999990", "-10", "10"}, DECIMAL(38, 6)));
 }
 
 TEST_F(DecimalArithmeticTest, subtract) {
-  testDecimalExpr<TypeKind::HUGEINT>(
-      makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(31, 3)),
-      "subtract(c0, c1)",
-      {makeFlatVector(std::vector<int128_t>{201}, DECIMAL(30, 3)),
-       makeFlatVector(std::vector<int128_t>{301}, DECIMAL(30, 3))});
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"201", "601", "1366", "999999999999999999999999999999"},
+           DECIMAL(30, 3)),
+       makeNullableLongDecimalVector(
+           {"301", "901", "9866", "-999999999999999999999999999999"},
+           DECIMAL(30, 3))},
+      makeNullableLongDecimalVector(
+          {"-100", "-300", "-8500", "1999999999999999999999999999998"},
+          DECIMAL(31, 3)));
+
+  // Min leading zero >= 3.
+  testArithmeticFunction(
+      "subtract",
+      {makeFlatVector(
+           std::vector<int128_t>{11232100, 9998888, 12345678, 2135632},
+           DECIMAL(38, 7)),
+       makeFlatVector(std::vector<int64_t>{1, 2, 3, 4}, DECIMAL(10, 0))},
+      makeFlatVector(
+          std::vector<int128_t>{123210, -1000111, -1765432, -3786437},
+          DECIMAL(38, 6)));
+
+  // No carry to left.
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"9999999999999999999999999999999000000",
+            "9999999999999999999999999999999900000",
+            "9999999999999999999999999999999990000",
+            "9999999999999999999999999999999999000"},
+           DECIMAL(38, 5)),
+       makeFlatVector(
+           std::vector<int128_t>{-100, -99999, -1234, -999}, DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"99999999999999999999999999999990000010",
+           "99999999999999999999999999999999010000",
+           "99999999999999999999999999999999900123",
+           "99999999999999999999999999999999990100"},
+          DECIMAL(38, 6)));
+
+  // Carry to left.
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"9999999999999999999999999999999070000",
+            "9999999999999999999999999999999050000",
+            "9999999999999999999999999999999870000",
+            "9999999999999999999999999999999890000"},
+           DECIMAL(38, 5)),
+       makeFlatVector(
+           std::vector<int128_t>{-8000000, -5000000, -8000000, -1999999},
+           DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"99999999999999999999999999999991500000",
+           "99999999999999999999999999999991000000",
+           "99999999999999999999999999999999500000",
+           "99999999999999999999999999999999100000"},
+          DECIMAL(38, 6)));
+
+  // Both -ve.
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"-201", "-601", "-1366", "-999999999999999999999999999999"},
+           DECIMAL(30, 3)),
+       makeNullableLongDecimalVector(
+           {"-301", "-901", "-9866", "-999999999999999999999999999999"},
+           DECIMAL(30, 3))},
+      makeNullableLongDecimalVector(
+          {"100", "300", "8500", "0"}, DECIMAL(31, 3)));
+
+  // Overflow when scaling up the whole part.
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"-99999999999999999999999999999999990000",
+            "99999999999999999999999999999999999000",
+            "-99999999999999999999999999999999999900",
+            "99999999999999999999999999999999999990"},
+           DECIMAL(38, 3)),
+       makeFlatVector(
+           std::vector<int128_t>{100, -9999999, 999900, -99999},
+           DECIMAL(38, 7))},
+      makeNullableLongDecimalVector(
+          {"null", "null", "null", "null"}, DECIMAL(38, 6)));
+
+  // Ve and -ve.
+  testArithmeticFunction(
+      "subtract",
+      {makeNullableLongDecimalVector(
+           {"99999999999999999999999999999989999990",
+            "-99999999999999999999999999999989999990",
+            "99999999999999999999999999999999999980",
+            "-99999999999999999999999999999999999980"},
+           DECIMAL(38, 6)),
+       makeFlatVector(
+           std::vector<int128_t>{-1000000, 1000000, -1, 1}, DECIMAL(38, 5))},
+      makeNullableLongDecimalVector(
+          {"99999999999999999999999999999999999990",
+           "-99999999999999999999999999999999999990",
+           "99999999999999999999999999999999999990",
+           "-99999999999999999999999999999999999990"},
+          DECIMAL(38, 6)));
 }
 
 TEST_F(DecimalArithmeticTest, multiply) {
@@ -262,8 +420,8 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
   auto shortFlat = makeFlatVector<int64_t>({1000, 2000}, DECIMAL(17, 3));
   // Divide short and short, returning long.
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector(
-          {"500000000000000000000", "2000000000000000000000"}, 38, 21),
+      makeNullableLongDecimalVector(
+          {"500000000000000000000", "2000000000000000000000"}, DECIMAL(38, 21)),
       "divide(c0, c1)",
       {makeFlatVector<int64_t>({500, 4000}, DECIMAL(17, 3)), shortFlat});
 
@@ -277,15 +435,17 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
 
   // Divide long and short, returning long.
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector(
-          {"20" + std::string(20, '0'), "5" + std::string(20, '0')}, 38, 22),
+      makeNullableLongDecimalVector(
+          {"20" + std::string(20, '0'), "5" + std::string(20, '0')},
+          DECIMAL(38, 22)),
       "divide(c0, c1)",
       {shortFlat, longFlat});
 
   // Divide long and long, returning long.
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector(
-          {"5" + std::string(18, '0'), "3" + std::string(18, '0')}, 38, 18),
+      makeNullableLongDecimalVector(
+          {"5" + std::string(18, '0'), "3" + std::string(18, '0')},
+          DECIMAL(38, 18)),
       "divide(c0, c1)",
       {makeFlatVector<int128_t>({2500, 12000}, DECIMAL(20, 2)), longFlat});
 
@@ -313,23 +473,24 @@ TEST_F(DecimalArithmeticTest, decimalDivTest) {
   //     checkEvaluation(Divide(l1, l2), null)
   //   }
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector({"497512437810945273631840796019900493"}, 38, 6),
+      makeNullableLongDecimalVector(
+          {"497512437810945273631840796019900493"}, DECIMAL(38, 6)),
       "c0 / c1",
-      {makeLongDecimalVector({std::string(35, '9')}, 35, 6),
+      {makeNullableLongDecimalVector({std::string(35, '9')}, DECIMAL(35, 6)),
        makeConstant<int128_t>(201, 1, DECIMAL(20, 3))});
 
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector(
+      makeNullableLongDecimalVector(
           {"1000" + std::string(17, '0'), "500" + std::string(17, '0')},
-          24,
-          20),
+          DECIMAL(24, 20)),
       "1.00 / c0",
       {shortFlat});
 
   // Flat and Constant arguments.
   testDecimalExpr<TypeKind::HUGEINT>(
-      makeLongDecimalVector(
-          {"500" + std::string(4, '0'), "1000" + std::string(4, '0')}, 23, 7),
+      makeNullableLongDecimalVector(
+          {"500" + std::string(4, '0'), "1000" + std::string(4, '0')},
+          DECIMAL(23, 7)),
       "c0 / 2.00",
       {shortFlat});
 

--- a/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalArithmeticTest.cpp
@@ -59,6 +59,83 @@ class DecimalArithmeticTest : public SparkFunctionBaseTest {
   }
 }; // namespace
 
+TEST_F(DecimalArithmeticTest, add) {
+  // The result can be obtained by Spark unit test
+  //       test("add") {
+  //     val l1 = Literal.create(
+  //       Decimal(BigDecimal(1), 17, 3),
+  //       DecimalType(17, 3))
+  //     val l2 = Literal.create(
+  //       Decimal(BigDecimal(1), 17, 3),
+  //       DecimalType(17, 3))
+  //     checkEvaluation(Add(l1, l2), null)
+  //   }
+
+  // Precision < 38.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeFlatVector(std::vector<int128_t>{502}, DECIMAL(31, 3)),
+      "add(c0, c1)",
+      {makeFlatVector(std::vector<int128_t>{201}, DECIMAL(30, 3)),
+       makeFlatVector(std::vector<int128_t>{301}, DECIMAL(30, 3))});
+
+  // Min leading zero >= 3.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeFlatVector(std::vector<int128_t>{2123210}, DECIMAL(38, 6)),
+      "add(c0, c1)",
+      {makeFlatVector(std::vector<int128_t>{11232100}, DECIMAL(38, 7)),
+       makeFlatVector(std::vector<int64_t>{1}, DECIMAL(10, 0))});
+
+  // Carry to left 0.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeLongDecimalVector({"99999999999999999999999999999990000010"}, 38, 6),
+      "add(c0, c1)",
+      {makeLongDecimalVector({"9999999999999999999999999999999000000"}, 38, 5),
+       makeFlatVector(std::vector<int128_t>{100}, DECIMAL(38, 7))});
+
+  // Carry to left 1.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeLongDecimalVector({"99999999999999999999999999999991500000"}, 38, 6),
+      "add(c0, c1)",
+      {makeLongDecimalVector({"9999999999999999999999999999999070000"}, 38, 5),
+       makeFlatVector(std::vector<int128_t>{8000000}, DECIMAL(38, 7))});
+
+  // Both -ve.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeFlatVector(std::vector<int128_t>{-3211}, DECIMAL(32, 3)),
+      "add(c0, c1)",
+      {makeFlatVector(std::vector<int128_t>{-201}, DECIMAL(30, 3)),
+       makeFlatVector(std::vector<int128_t>{-301}, DECIMAL(30, 2))});
+
+  // -Ve and max precision.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeLongDecimalVector({"-99999999999999999999999999999990000010"}, 38, 6),
+      "add(c0, c1)",
+      {makeLongDecimalVector(
+           {"-09999999999999999999999999999999000000"}, 38, 5),
+       makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7))});
+  // Ve and -ve.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeLongDecimalVector({"99999999999999999999999999999989999990"}, 38, 6),
+      "add(c0, c1)",
+      {makeLongDecimalVector({"9999999999999999999999999999999000000"}, 38, 5),
+       makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7))});
+  // -Ve and ve.
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeLongDecimalVector({"99999999999999999999999999999989999990"}, 38, 6),
+      "add(c0, c1)",
+      {makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(38, 7)),
+       makeLongDecimalVector(
+           {"9999999999999999999999999999999000000"}, 38, 5)});
+}
+
+TEST_F(DecimalArithmeticTest, subtract) {
+  testDecimalExpr<TypeKind::HUGEINT>(
+      makeFlatVector(std::vector<int128_t>{-100}, DECIMAL(31, 3)),
+      "subtract(c0, c1)",
+      {makeFlatVector(std::vector<int128_t>{201}, DECIMAL(30, 3)),
+       makeFlatVector(std::vector<int128_t>{301}, DECIMAL(30, 3))});
+}
+
 TEST_F(DecimalArithmeticTest, multiply) {
   // The result can be obtained by Spark unit test
   //       test("multiply") {

--- a/velox/functions/sparksql/tests/DecimalUtilTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalUtilTest.cpp
@@ -43,4 +43,21 @@ TEST_F(DecimalUtilTest, divideWithRoundUp) {
   testDivideWithRoundUp<int64_t, int64_t, int64_t>(
       6, velox::DecimalUtil::kPowersOfTen[17], 20, 6000, false);
 }
+
+TEST_F(DecimalUtilTest, minLeadingZeros) {
+  auto result =
+      DecimalUtil::minLeadingZeros<int64_t, int64_t>(10000, 6000000, 10, 12);
+  ASSERT_EQ(result, 1);
+
+  result = DecimalUtil::minLeadingZeros<int64_t, int128_t>(
+      10000, 6'000'000'000'000'000'000, 10, 12);
+  ASSERT_EQ(result, 16);
+
+  result = DecimalUtil::minLeadingZeros<int128_t, int128_t>(
+      velox::DecimalUtil::kLongDecimalMax,
+      velox::DecimalUtil::kLongDecimalMin,
+      10,
+      12);
+  ASSERT_EQ(result, 0);
+}
 } // namespace facebook::velox::functions::sparksql::test

--- a/velox/type/DecimalUtil.cpp
+++ b/velox/type/DecimalUtil.cpp
@@ -54,7 +54,7 @@ std::string formatDecimal(uint8_t scale, int128_t unscaledValue) {
 }
 } // namespace
 
-std::string DecimalUtil::toString(const int128_t value, const TypePtr& type) {
+std::string DecimalUtil::toString(int128_t value, const TypePtr& type) {
   auto [precision, scale] = getDecimalPrecisionScale(*type);
   return formatDecimal(scale, value);
 }
@@ -91,7 +91,7 @@ int32_t DecimalUtil::toByteArray(int128_t value, char* out) {
 
 void DecimalUtil::computeAverage(
     int128_t& avg,
-    const int128_t& sum,
+    int128_t sum,
     int64_t count,
     int64_t overflow) {
   if (overflow == 0) {

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -98,7 +98,7 @@ class DecimalUtil {
   }
 
   /// Helper function to convert a decimal value to string.
-  static std::string toString(const int128_t value, const TypePtr& type);
+  static std::string toString(int128_t value, const TypePtr& type);
 
   template <typename T>
   inline static void fillDecimals(
@@ -147,11 +147,11 @@ class DecimalUtil {
 
   template <typename TInput, typename TOutput>
   inline static std::optional<TOutput> rescaleWithRoundUp(
-      const TInput inputValue,
-      const int fromPrecision,
-      const int fromScale,
-      const int toPrecision,
-      const int toScale) {
+      TInput inputValue,
+      int fromPrecision,
+      int fromScale,
+      int toPrecision,
+      int toScale) {
     int128_t rescaledValue = inputValue;
     auto scaleDifference = toScale - fromScale;
     bool isOverflow = false;
@@ -183,10 +183,8 @@ class DecimalUtil {
   }
 
   template <typename TInput, typename TOutput>
-  inline static std::optional<TOutput> rescaleInt(
-      const TInput inputValue,
-      const int toPrecision,
-      const int toScale) {
+  inline static std::optional<TOutput>
+  rescaleInt(TInput inputValue, int toPrecision, int toScale) {
     int128_t rescaledValue = static_cast<int128_t>(inputValue);
     bool isOverflow = __builtin_mul_overflow(
         rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
@@ -205,8 +203,8 @@ class DecimalUtil {
   template <typename R, typename A, typename B>
   inline static R divideWithRoundUp(
       R& r,
-      const A& a,
-      const B& b,
+      A a,
+      B b,
       bool noRoundUp,
       uint8_t aRescale,
       uint8_t /*bRescale*/) {
@@ -312,11 +310,8 @@ class DecimalUtil {
   }
 
   /// avg = (sum + overflow * kOverflowMultiplier) / count
-  static void computeAverage(
-      int128_t& avg,
-      const int128_t& sum,
-      int64_t count,
-      int64_t overflow);
+  static void
+  computeAverage(int128_t& avg, int128_t sum, int64_t count, int64_t overflow);
 
   /// Origins from java side BigInteger#bitLength.
   ///


### PR DESCRIPTION
Use Arrow Gandiva BasicDecimal128 algorithm to compute value.
Arrow implementation:
https://github.com/apache/arrow/blob/release-12.0.1-rc1/cpp/src/gandiva/precompiled/decimal_ops.cc#L211-L231

Spark result precision and scale maybe different with Presto, because it will use adjustPrecisionScale to change the precision and scale when precision is beyond 38.
And this implement can compute data without overflow in some situation.