### PR TITLE
Fix arbitrary output buffer finish condition to support scaled writer

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1755,9 +1755,9 @@ PlanNodePtr PartitionedOutputNode::create(
     void* context) {
   return std::make_shared<PartitionedOutputNode>(
       deserializePlanNodeId(obj),
+      stringToKind(obj["kind"].asString()),
       ISerializable::deserialize<std::vector<ITypedExpr>>(obj["keys"], context),
       obj["numPartitions"].asInt(),
-      stringToKind(obj["kind"].asString()),
       obj["replicateNullsAndAny"].asBool(),
       ISerializable::deserialize<PartitionFunctionSpec>(
           obj["partitionFunctionSpec"], context),

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1097,14 +1097,13 @@ class PartitionedOutputNode : public PlanNode {
       PlanNodePtr source)
       : PartitionedOutputNode(
             id,
+            broadcast ? Kind::kBroadcast : Kind::kPartitioned,
             keys,
             numPartitions,
-            broadcast ? Kind::kBroadcast : Kind::kPartitioned,
             replicateNullsAndAny,
             partitionFunctionSpec,
             outputType,
             source) {}
-#endif
 
   PartitionedOutputNode(
       const PlanNodeId& id,
@@ -1115,11 +1114,31 @@ class PartitionedOutputNode : public PlanNode {
       PartitionFunctionSpecPtr partitionFunctionSpec,
       RowTypePtr outputType,
       PlanNodePtr source)
+      : PartitionedOutputNode(
+            id,
+            kind,
+            keys,
+            numPartitions,
+            replicateNullsAndAny,
+            std::move(partitionFunctionSpec),
+            std::move(outputType),
+            std::move(source)) {}
+#endif
+
+  PartitionedOutputNode(
+      const PlanNodeId& id,
+      Kind kind,
+      const std::vector<TypedExprPtr>& keys,
+      int numPartitions,
+      bool replicateNullsAndAny,
+      PartitionFunctionSpecPtr partitionFunctionSpec,
+      RowTypePtr outputType,
+      PlanNodePtr source)
       : PlanNode(id),
+        kind_(kind),
         sources_{{std::move(source)}},
         keys_(keys),
         numPartitions_(numPartitions),
-        kind_(kind),
         replicateNullsAndAny_(replicateNullsAndAny),
         partitionFunctionSpec_(std::move(partitionFunctionSpec)),
         outputType_(std::move(outputType)) {
@@ -1129,10 +1148,11 @@ class PartitionedOutputNode : public PlanNode {
           keys_.empty(),
           "Non-empty partitioning keys require more than one partition");
     }
-    if (isBroadcast()) {
+    if (!isPartitioned()) {
       VELOX_CHECK(
           keys_.empty(),
-          "Broadcast partitioning doesn't allow for partitioning keys");
+          "{} partitioning doesn't allow for partitioning keys",
+          kindString(kind_));
     }
   }
 
@@ -1144,9 +1164,23 @@ class PartitionedOutputNode : public PlanNode {
     std::vector<TypedExprPtr> noKeys;
     return std::make_shared<PartitionedOutputNode>(
         id,
+        Kind::kBroadcast,
         noKeys,
         numPartitions,
-        Kind::kBroadcast,
+        false,
+        std::make_shared<GatherPartitionFunctionSpec>(),
+        std::move(outputType),
+        std::move(source));
+  }
+
+  static std::shared_ptr<PartitionedOutputNode>
+  arbitrary(const PlanNodeId& id, RowTypePtr outputType, PlanNodePtr source) {
+    std::vector<TypedExprPtr> noKeys;
+    return std::make_shared<PartitionedOutputNode>(
+        id,
+        Kind::kArbitrary,
+        noKeys,
+        1,
         false,
         std::make_shared<GatherPartitionFunctionSpec>(),
         std::move(outputType),
@@ -1158,9 +1192,9 @@ class PartitionedOutputNode : public PlanNode {
     std::vector<TypedExprPtr> noKeys;
     return std::make_shared<PartitionedOutputNode>(
         id,
+        Kind::kPartitioned,
         noKeys,
         1,
-        Kind::kPartitioned,
         false,
         std::make_shared<GatherPartitionFunctionSpec>(),
         std::move(outputType),
@@ -1187,8 +1221,16 @@ class PartitionedOutputNode : public PlanNode {
     return numPartitions_;
   }
 
+  bool isPartitioned() const {
+    return kind_ == Kind::kPartitioned;
+  }
+
   bool isBroadcast() const {
     return kind_ == Kind::kBroadcast;
+  }
+
+  bool isArbitrary() const {
+    return kind_ == Kind::kArbitrary;
   }
 
   Kind kind() const {
@@ -1222,10 +1264,10 @@ class PartitionedOutputNode : public PlanNode {
  private:
   void addDetails(std::stringstream& stream) const override;
 
+  const Kind kind_;
   const std::vector<PlanNodePtr> sources_;
   const std::vector<TypedExprPtr> keys_;
   const int numPartitions_;
-  const Kind kind_;
   const bool replicateNullsAndAny_;
   const PartitionFunctionSpecPtr partitionFunctionSpec_;
   const RowTypePtr outputType_;

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -103,7 +103,7 @@ BlockingReason Destination::flush(
 
 PartitionedOutput::PartitionedOutput(
     int32_t operatorId,
-    DriverCtx* FOLLY_NONNULL ctx,
+    DriverCtx* ctx,
     const std::shared_ptr<const core::PartitionedOutputNode>& planNode)
     : Operator(
           ctx,
@@ -131,9 +131,12 @@ PartitionedOutput::PartitionedOutput(
       maxBufferedBytes_(ctx->task->queryCtx()
                             ->queryConfig()
                             .maxPartitionedOutputBufferSize()) {
-  if (numDestinations_ == 1 || planNode->isBroadcast()) {
-    VELOX_CHECK(keyChannels_.empty());
-    VELOX_CHECK_NULL(partitionFunction_);
+  if (!planNode->isPartitioned()) {
+    VELOX_USER_CHECK_EQ(numDestinations_, 1);
+  }
+  if (numDestinations_ == 1) {
+    VELOX_USER_CHECK(keyChannels_.empty());
+    VELOX_USER_CHECK_NULL(partitionFunction_);
   }
 }
 

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -27,7 +27,7 @@ class Destination {
   Destination(
       const std::string& taskId,
       int destination,
-      memory::MemoryPool* FOLLY_NONNULL pool)
+      memory::MemoryPool* pool)
       : taskId_(taskId), destination_(destination), pool_(pool) {
     setTargetSizePct();
   }
@@ -52,13 +52,13 @@ class Destination {
       const RowVectorPtr& output,
       PartitionedOutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
-      bool* FOLLY_NONNULL atEnd,
-      ContinueFuture* FOLLY_NONNULL future);
+      bool* atEnd,
+      ContinueFuture* future);
 
   BlockingReason flush(
       PartitionedOutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
-      ContinueFuture* FOLLY_NULLABLE future);
+      ContinueFuture* future);
 
   bool isFinished() const {
     return finished_;
@@ -91,7 +91,7 @@ class Destination {
 
   const std::string taskId_;
   const int destination_;
-  memory::MemoryPool* FOLLY_NONNULL const pool_;
+  memory::MemoryPool* const pool_;
   uint64_t bytesInCurrent_{0};
   std::vector<IndexRange> rows_;
 
@@ -130,7 +130,7 @@ class PartitionedOutput : public Operator {
 
   PartitionedOutput(
       int32_t operatorId,
-      DriverCtx* FOLLY_NONNULL ctx,
+      DriverCtx* ctx,
       const std::shared_ptr<const core::PartitionedOutputNode>& planNode);
 
   void addInput(RowVectorPtr input) override;
@@ -146,7 +146,7 @@ class PartitionedOutput : public Operator {
     return true;
   }
 
-  BlockingReason isBlocked(ContinueFuture* FOLLY_NONNULL future) override {
+  BlockingReason isBlocked(ContinueFuture* future) override {
     if (blockingReason_ != BlockingReason::kNotBlocked) {
       *future = std::move(future_);
       blockingReason_ = BlockingReason::kNotBlocked;

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -848,9 +848,9 @@ PlanBuilder& PlanBuilder::partitionedOutput(
       : extract(planNode_->outputType(), outputLayout);
   planNode_ = std::make_shared<core::PartitionedOutputNode>(
       nextPlanNodeId(),
+      core::PartitionedOutputNode::Kind::kPartitioned,
       exprs(keys),
       numPartitions,
-      core::PartitionedOutputNode::Kind::kPartitioned,
       replicateNullsAndAny,
       std::move(partitionFunctionSpec),
       outputType,


### PR DESCRIPTION
Fix the finish condition in Arbitrator output buffer that changes
the previous condition of (1) no more input buffers (noMoreData());
(2) empty arbitrary buffer & empty destination buffers; (3) no more
destination buffers (no more buffer flag set up updateOutputBuffers()
from Presto coordinator when used for scale writer in Prestissimo) to
the new condition of (1) + (2) which removes (3).

The reason is that the scale writer scheduler in Presto coordinator will
keep the table writer execution stage in Scheduling state until all its
child execution stages finished (the source stage). And the coordinator
will only update the output buffer in source stage with no more buffer
flag after the table writer stage starts into running stage as that's point
that the table writer stage knows it won't schedule or add any new table 
writer task in the cluster. Then this forces a circular dependency and it is
due to the finish condition check in Velox. For an arbitrary output buffer,
it can mark as finished once it doesn't have any new input buffers and all
the pending buffers have been consumed by the table writer stage. This is
unlike to broadcast output buffers which wait for the no more destination
output buffer signal to stop replication. This is no problem for broadcast
output buffer use case as the latter use regular task scheduler.

The scaled writer feature: #5665 
