### PR TITLE
Fix GroupingSet::toIntermediate fast path

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -41,6 +41,7 @@ class TypedDistinctAggregations : public DistinctAggregations {
         sizeof(AccumulatorType),
         false, // usesExternalMemory
         1, // alignment
+        false, // supportsToIntermediate
         [this](folly::Range<char**> groups) {
           for (auto* group : groups) {
             auto* accumulator =

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1062,8 +1062,10 @@ void GroupingSet::toIntermediate(
     function->clear();
   }
   if (intermediateRows_) {
-    intermediateRows_->eraseRows(folly::Range<char**>(
-        intermediateGroups_.data(), intermediateGroups_.size()));
+    intermediateRows_->eraseRows(
+        folly::Range<char**>(
+            intermediateGroups_.data(), intermediateGroups_.size()),
+        true);
     intermediateRows_->stringAllocator().checkEmpty();
   }
   tempVectors_.clear();

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -36,6 +36,7 @@ class Accumulator {
       int32_t fixedSize,
       bool usesExternalMemory,
       int32_t alignment,
+      bool supportsToIntermediate,
       std::function<void(folly::Range<char**> groups)> destroyFunction);
 
   explicit Accumulator(Aggregate* aggregate);
@@ -47,6 +48,10 @@ class Accumulator {
   bool usesExternalMemory() const;
 
   int32_t alignment() const;
+
+  bool supportsToIntermediate() const {
+    return supportsToIntermediate_;
+  }
 
   void destroy(folly::Range<char**> groups);
 
@@ -61,6 +66,7 @@ class Accumulator {
   const int32_t fixedSize_;
   const bool usesExternalMemory_;
   const int32_t alignment_;
+  const bool supportsToIntermediate_;
   std::function<void(folly::Range<char**> groups)> destroyFunction_;
   Aggregate* aggregate_{nullptr};
 };
@@ -251,7 +257,9 @@ class RowContainer {
 
   // Adds 'rows' to the free rows list and frees any associated
   // variable length data.
-  void eraseRows(folly::Range<char**> rows);
+  void eraseRows(
+      folly::Range<char**> rows,
+      bool skipToIntermediateAggregates = false);
 
   void incrementRowSize(char* FOLLY_NONNULL row, uint64_t bytes) {
     uint32_t* ptr = reinterpret_cast<uint32_t*>(row + rowSizeOffset_);

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -110,6 +110,7 @@ Accumulator SortedAggregations::accumulator() const {
       sizeof(RowPointers),
       false,
       1,
+      false,
       [this](folly::Range<char**> groups) {
         for (auto* group : groups) {
           auto* accumulator = reinterpret_cast<RowPointers*>(group + offset_);

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -41,7 +41,8 @@ TopNRowNumber::TopNRowNumber(
   const auto numKeys = keys.size();
 
   if (numKeys > 0) {
-    Accumulator accumulator{true, sizeof(TopRows), false, 1, [](auto) {}};
+    Accumulator accumulator{
+        true, sizeof(TopRows), false, 1, false, [](auto) {}};
 
     table_ = std::make_unique<HashTable<false>>(
         createVectorHashers(inputType_, keys),

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -58,8 +58,8 @@ TEST_F(ArrayAggTest, groupBy) {
   testAggregations(
       batches,
       {"c0"},
-      {"array_agg(a)"},
-      "SELECT c0, array_agg(a) FROM tmp GROUP BY c0");
+      {"array_agg(a)", "max(c0)"},
+      "SELECT c0, array_agg(a), max(c0) FROM tmp GROUP BY c0");
 }
 
 TEST_F(ArrayAggTest, sortedGroupBy) {


### PR DESCRIPTION
Summary:
When multiple aggregates exist and only some of them support
`toIntermediate`, we still need to construct the `RowContainer` for those who do
not support `toIntermediate`.  In this case when we clean up the `RowContainer`,
we try to destroy the rows using the aggregates with fast path by mistake and
result in bad memory access.  Fix this by skipping calling destroy for aggregate
with fast path in `RowContainer::eraseRows`.

Differential Revision: D47709835

