### PR TITLE
Introduce compressionKind in HiveInsertTableHandle

### DIFF
--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -70,6 +70,8 @@ std::string compressionKindToString(CompressionKind kind) {
       return "zstd";
     case CompressionKind_LZ4:
       return "lz4";
+    case CompressionKind_GZIP:
+      return "gzip";
   }
   return folly::to<std::string>("unknown - ", kind);
 }

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -438,6 +438,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   dwio::common::WriterOptions options;
   options.schema = inputType_;
   options.memoryPool = connectorQueryCtx_->connectorMemoryPool();
+  options.compressionKind = insertTableHandle_->compressionKind();
   ioStats_.emplace_back(std::make_shared<dwio::common::IoStatistics>());
   writers_.emplace_back(writerFactory->createWriter(
       dwio::common::DataSink::create(

--- a/velox/dwio/common/Closeable.h
+++ b/velox/dwio/common/Closeable.h
@@ -52,7 +52,6 @@ class Closeable {
   virtual void doClose() {}
 
   void destroy() {
-    DCHECK(closed_);
     if (!closed_) {
       DWIO_WARN_EVERY_N(1000, "close() not called");
       try {
@@ -61,6 +60,7 @@ class Closeable {
         DWIO_WARN("failed to call close()");
       }
     }
+    DCHECK(closed_);
   }
 
  private:

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 
 #include <folly/Executor.h>
+#include "velox/common/compression/Compression.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
@@ -599,6 +600,7 @@ class ReaderOptions {
 struct WriterOptions {
   TypePtr schema;
   velox::memory::MemoryPool* memoryPool;
+  std::optional<velox::common::CompressionKind> compressionKind = {};
 };
 
 } // namespace common

--- a/velox/dwio/dwrf/common/Common.cpp
+++ b/velox/dwio/dwrf/common/Common.cpp
@@ -98,9 +98,9 @@ CompressionKind orcCompressionToCompressionKind(
     case proto::orc::CompressionKind::LZO:
       return CompressionKind::CompressionKind_LZO;
     case proto::orc::CompressionKind::LZ4:
-      return CompressionKind::CompressionKind_ZSTD;
-    case proto::orc::CompressionKind::ZSTD:
       return CompressionKind::CompressionKind_LZ4;
+    case proto::orc::CompressionKind::ZSTD:
+      return CompressionKind::CompressionKind_ZSTD;
   }
   return CompressionKind::CompressionKind_NONE;
 }

--- a/velox/dwio/dwrf/common/Compression.cpp
+++ b/velox/dwio/dwrf/common/Compression.cpp
@@ -466,7 +466,9 @@ std::unique_ptr<BufferedOutputStream> createCompressor(
     case common::CompressionKind_LZO:
     case common::CompressionKind_LZ4:
     default:
-      DWIO_RAISE("compression codec");
+      VELOX_UNSUPPORTED(
+          "Unsupported dwrf compression type: {}",
+          compressionKindToString(kind));
   }
   return std::make_unique<PagedOutputStream>(
       bufferPool, bufferHolder, config, std::move(compressor), encrypter);

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -495,8 +495,14 @@ void Writer::close() {
 }
 
 dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
+  std::map<std::string, std::string> configs;
+  if (options.compressionKind.has_value()) {
+    configs.emplace(
+        Config::COMPRESSION.configKey(),
+        std::to_string(options.compressionKind.value()));
+  }
   dwrf::WriterOptions dwrfOptions;
-  dwrfOptions.config = std::make_shared<Config>();
+  dwrfOptions.config = Config::fromMap(configs);
   dwrfOptions.schema = std::move(options.schema);
   dwrfOptions.memoryPool = options.memoryPool;
   return dwrfOptions;

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -187,6 +187,9 @@ parquet::WriterOptions getParquetOptions(
     const dwio::common::WriterOptions& options) {
   parquet::WriterOptions parquetOptions;
   parquetOptions.memoryPool = options.memoryPool;
+  if (options.compressionKind.has_value()) {
+    parquetOptions.compression = options.compressionKind.value();
+  }
   return parquetOptions;
 }
 

--- a/velox/exec/tests/utils/HiveConnectorTestBase.cpp
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.cpp
@@ -181,14 +181,16 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const std::vector<TypePtr>& tableColumnTypes,
     const std::vector<std::string>& partitionedBy,
     std::shared_ptr<connector::hive::LocationHandle> locationHandle,
-    const dwio::common::FileFormat tableStorageFormat) {
+    const dwio::common::FileFormat tableStorageFormat,
+    const std::optional<common::CompressionKind> compressionKind) {
   return makeHiveInsertTableHandle(
       tableColumnNames,
       tableColumnTypes,
       partitionedBy,
       nullptr,
       std::move(locationHandle),
-      tableStorageFormat);
+      tableStorageFormat,
+      compressionKind);
 }
 
 // static
@@ -199,7 +201,8 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
     const std::vector<std::string>& partitionedBy,
     std::shared_ptr<connector::hive::HiveBucketProperty> bucketProperty,
     std::shared_ptr<connector::hive::LocationHandle> locationHandle,
-    const dwio::common::FileFormat tableStorageFormat) {
+    const dwio::common::FileFormat tableStorageFormat,
+    const std::optional<common::CompressionKind> compressionKind) {
   std::vector<std::shared_ptr<const connector::hive::HiveColumnHandle>>
       columnHandles;
   std::vector<std::string> bucketedBy;
@@ -249,7 +252,11 @@ HiveConnectorTestBase::makeHiveInsertTableHandle(
   VELOX_CHECK_EQ(numBucketColumns, bucketedBy.size());
   VELOX_CHECK_EQ(numSortingColumns, sortedBy.size());
   return std::make_shared<connector::hive::HiveInsertTableHandle>(
-      columnHandles, locationHandle, tableStorageFormat, bucketProperty);
+      columnHandles,
+      locationHandle,
+      tableStorageFormat,
+      bucketProperty,
+      compressionKind);
 }
 
 std::shared_ptr<connector::hive::HiveColumnHandle>

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -132,6 +132,7 @@ class HiveConnectorTestBase : public OperatorTestBase {
   /// @param bucketProperty if not nulll, specifies the property for a bucket
   /// table.
   /// @param locationHandle Location handle for the table write.
+  /// @param compressionKind compression algorithm to use for table write.
   static std::shared_ptr<connector::hive::HiveInsertTableHandle>
   makeHiveInsertTableHandle(
       const std::vector<std::string>& tableColumnNames,
@@ -140,7 +141,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       std::shared_ptr<connector::hive::HiveBucketProperty> bucketProperty,
       std::shared_ptr<connector::hive::LocationHandle> locationHandle,
       const dwio::common::FileFormat tableStorageFormat =
-          dwio::common::FileFormat::DWRF);
+          dwio::common::FileFormat::DWRF,
+      const std::optional<common::CompressionKind> compressionKind = {});
 
   static std::shared_ptr<connector::hive::HiveInsertTableHandle>
   makeHiveInsertTableHandle(
@@ -149,7 +151,8 @@ class HiveConnectorTestBase : public OperatorTestBase {
       const std::vector<std::string>& partitionedBy,
       std::shared_ptr<connector::hive::LocationHandle> locationHandle,
       const dwio::common::FileFormat tableStorageFormat =
-          dwio::common::FileFormat::DWRF);
+          dwio::common::FileFormat::DWRF,
+      const std::optional<common::CompressionKind> compressionKind = {});
 
   static std::shared_ptr<connector::hive::HiveColumnHandle> regularColumn(
       const std::string& name,


### PR DESCRIPTION
As of now, velox use config to decide compression type for write.
We want the ability to use the dynamically passed-in compression
type by application.

In this PR, we introduce compressionKind in HiveInsertTableHandle
to give applications the ability to do so, if it's not passed in,
we use the config compressionKind by default.

Tests on parquet writer using compression would be added once 
https://github.com/facebookincubator/velox/issues/5796  and https://github.com/facebookincubator/velox/issues/5865 are resolved