### PR TITLE
Add inverse_normal_cdf Presto Function

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -282,3 +282,9 @@ Probability Functions: inverse_cdf
     probability (p): P(N < n). The a, b parameters must be positive real values (all of type DOUBLE).
     The probability p must lie on the interval [0, 1].
 
+.. function:: inverse_normal_cdf(mean, sd, p) -> double
+
+    Compute the inverse of the Normal cdf with given mean and standard
+    deviation (sd) for the cumulative probability (p): P(N < n). The mean must be
+    a real value and the standard deviation must be a real and positive value (both of type DOUBLE).
+    The probability p must lie on the interval (0, 1).

--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -19,6 +19,7 @@
 #include "boost/math/distributions/binomial.hpp"
 #include "boost/math/distributions/cauchy.hpp"
 #include "boost/math/distributions/chi_squared.hpp"
+#include "boost/math/special_functions/erf.hpp"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
 
@@ -147,6 +148,19 @@ struct ChiSquaredCDFFunction {
 
     boost::math::chi_squared_distribution<> dist(df);
     result = boost::math::cdf(dist, value);
+  }
+};
+
+template <typename T>
+struct InverseNormalCDFFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(double& result, double m, double sd, double p) {
+    VELOX_USER_CHECK((p >= 0) && (p <= 1), "p must be 0 > p > 1");
+    VELOX_USER_CHECK_GT(sd, 0, "standardDeviation must be > 0");
+
+    static const double kSqrtOfTwo = sqrt(2);
+    result = m + sd * kSqrtOfTwo * boost::math::erf_inv(2 * p - 1);
   }
 };
 

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -113,6 +113,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "chi_squared_cdf"});
   registerFunction<InverseBetaCDFFunction, double, double, double, double>(
       {prefix + "inverse_beta_cdf"});
+  registerFunction<InverseNormalCDFFunction, double, double, double, double>(
+      {prefix + "inverse_normal_cdf"});
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -236,5 +236,54 @@ TEST_F(ProbabilityTest, chiSquaredCDF) {
   VELOX_ASSERT_THROW(chiSquaredCDF(3, -10), "value must non-negative");
 }
 
+TEST_F(ProbabilityTest, inverseNormalCDF) {
+  const auto inverseNormalCDF = [&](std::optional<double> mean,
+                                    std::optional<double> sd,
+                                    std::optional<double> p) {
+    return evaluateOnce<double>("inverse_normal_cdf(c0, c1, c2)", mean, sd, p);
+  };
+
+  EXPECT_EQ(inverseNormalCDF(0, 1, 0.3), -0.52440051270804089);
+  EXPECT_EQ(inverseNormalCDF(10, 9, 0.9), 21.533964089901406);
+  EXPECT_EQ(inverseNormalCDF(0.5, 0.25, 0.65), 0.59633011660189195);
+  EXPECT_EQ(inverseNormalCDF(0, 1, 0.00001), -4.2648907939226017);
+
+  EXPECT_EQ(inverseNormalCDF(kDoubleMin, 0.25, 0.65), 0.096330116601891919);
+  EXPECT_EQ(inverseNormalCDF(kDoubleMax, 0.25, 0.65), 1.7976931348623157e+308);
+  EXPECT_EQ(inverseNormalCDF(0.5, kDoubleMin, 0.65), 0.5);
+  EXPECT_THAT(inverseNormalCDF(0.5, kDoubleMax, 0.65), IsInf());
+  EXPECT_THAT(inverseNormalCDF(kNan, 2, 0.1985), IsNan());
+
+  EXPECT_EQ(inverseNormalCDF(std::nullopt, 1, 1), std::nullopt);
+  EXPECT_EQ(inverseNormalCDF(1, 1, std::nullopt), std::nullopt);
+  EXPECT_EQ(inverseNormalCDF(std::nullopt, 1, std::nullopt), std::nullopt);
+  EXPECT_EQ(
+      inverseNormalCDF(std::nullopt, std::nullopt, std::nullopt), std::nullopt);
+
+  EXPECT_THAT(inverseNormalCDF(kInf, 1, 0.1985), IsInf());
+  EXPECT_THAT(inverseNormalCDF(0, kInf, 0.1985), IsInf());
+  EXPECT_THAT(inverseNormalCDF(-kInf, 1, 0.1985), IsInf());
+
+  // Test invalid inputs.
+  VELOX_ASSERT_THROW(
+      inverseNormalCDF(0, -kInf, 0.1985), "standardDeviation must be > 0");
+  VELOX_ASSERT_THROW(inverseNormalCDF(0, 1, kInf), "p must be 0 > p > 1");
+  VELOX_ASSERT_THROW(inverseNormalCDF(0, 1, -kInf), "p must be 0 > p > 1");
+
+  VELOX_ASSERT_THROW(
+      inverseNormalCDF(0, kNan, 0.1985), "standardDeviation must be > 0");
+  VELOX_ASSERT_THROW(inverseNormalCDF(0, 1, kNan), "p must be 0 > p > 1");
+  VELOX_ASSERT_THROW(inverseNormalCDF(kNan, kNan, kNan), "p must be 0 > p > 1");
+
+  VELOX_ASSERT_THROW(inverseNormalCDF(0, 1, kDoubleMax), "p must be 0 > p > 1");
+  VELOX_ASSERT_THROW(
+      inverseNormalCDF(0, 1, kDoubleMin),
+      "Error in function boost::math::erf_inv<double>(double, double): Overflow Error");
+
+  VELOX_ASSERT_THROW(
+      inverseNormalCDF(0, 0, 0.1985), "standardDeviation must be > 0");
+  VELOX_ASSERT_THROW(inverseNormalCDF(0, 1, 1.00001), "p must be 0 > p > 1");
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Add Presto function inverse_normal_cdf following the Java implementation([source](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java#L803))

Resolves: https://github.com/facebookincubator/velox/issues/5476