### PR TITLE
Add inverse_chi_squared Presto Function

### DIFF
--- a/velox/docs/functions/presto/math.rst
+++ b/velox/docs/functions/presto/math.rst
@@ -277,3 +277,9 @@ Probability Functions: inverse_cdf
     probability (p): P(N < n). The a, b parameters must be positive real values (all of type DOUBLE).
     The probability p must lie on the interval [0, 1].
 
+.. function:: inverse_chi_squared_cdf(df, p) -> double
+
+    Compute the inverse of the Chi-square cdf with given df (degrees of freedom) parameter for the cumulative
+    probability (p): P(N < n). The df parameter must be positive real values.
+    The probability p must lie on the interval [0, 1].
+

--- a/velox/functions/prestosql/Probability.h
+++ b/velox/functions/prestosql/Probability.h
@@ -18,6 +18,7 @@
 #include "boost/math/distributions/beta.hpp"
 #include "boost/math/distributions/binomial.hpp"
 #include "boost/math/distributions/cauchy.hpp"
+#include "boost/math/distributions/chi_squared.hpp"
 #include "velox/common/base/Exceptions.h"
 #include "velox/functions/Macros.h"
 
@@ -132,6 +133,22 @@ struct InverseBetaCDFFunction {
     VELOX_USER_CHECK((b > 0) && (b != kInf), "b must be > 0");
 
     boost::math::beta_distribution<> dist(a, b);
+    result = boost::math::quantile(dist, p);
+  }
+};
+
+template <typename T>
+struct InverseChiSquaredCDFFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+  static constexpr double kInf = std::numeric_limits<double>::infinity();
+
+  FOLLY_ALWAYS_INLINE void call(double& result, double df, double p) {
+    VELOX_USER_CHECK(
+        (p >= 0) && (p <= 1) && (p != kInf),
+        "p must be in the interval [0, 1]");
+    VELOX_USER_CHECK_GT(df, 0, "df must be greater than 0");
+
+    boost::math::chi_squared_distribution<> dist(df);
     result = boost::math::quantile(dist, p);
   }
 };

--- a/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArithmeticFunctionsRegistration.cpp
@@ -111,6 +111,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "cauchy_cdf"});
   registerFunction<InverseBetaCDFFunction, double, double, double, double>(
       {prefix + "inverse_beta_cdf"});
+  registerFunction<InverseChiSquaredCDFFunction, double, double, double>(
+      {prefix + "inverse_chi_squared_cdf"});
 }
 
 } // namespace

--- a/velox/functions/prestosql/tests/ProbabilityTest.cpp
+++ b/velox/functions/prestosql/tests/ProbabilityTest.cpp
@@ -221,5 +221,55 @@ TEST_F(ProbabilityTest, invBetaCDF) {
   VELOX_ASSERT_THROW(invBetaCDF(3, 5, 1.1), "p must be in the interval [0, 1]");
 }
 
+TEST_F(ProbabilityTest, inverseChiSquaredCDF) {
+  const auto invChiSquaredCDF = [&](std::optional<double> df,
+                                    std::optional<double> p) {
+    return evaluateOnce<double>("inverse_chi_squared_cdf(c0, c1)", df, p);
+  };
+
+  EXPECT_EQ(0.0, invChiSquaredCDF(3, 0.0));
+  EXPECT_EQ(1.4236522430352796, invChiSquaredCDF(3, 0.3));
+  EXPECT_EQ(11.344866730144370, invChiSquaredCDF(3, 0.99));
+  EXPECT_EQ(2.8093008564672404e-123, invChiSquaredCDF(5, kDoubleMin));
+  EXPECT_EQ(1.7976931348623157e+308, invChiSquaredCDF(kDoubleMax, 0.95));
+  EXPECT_EQ(std::nullopt, invChiSquaredCDF(std::nullopt, 0.94));
+  EXPECT_EQ(std::nullopt, invChiSquaredCDF(142.345, std::nullopt));
+  EXPECT_EQ(std::nullopt, invChiSquaredCDF(std::nullopt, std::nullopt));
+
+  // Test invalid inputs for df.
+  VELOX_ASSERT_THROW(invChiSquaredCDF(-3, 0.3), "df must be greater than 0");
+  VELOX_ASSERT_THROW(invChiSquaredCDF(kNan, 0.99), "df must be greater than 0");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(kInf, 0.99),
+      "Error in function boost::math::chi_squared_distribution<double>::chi_squared_distribution: Degrees of freedom argument is inf, but must be > 0 !");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(kBigIntMin, 0.15), "df must be greater than 0");
+
+  // Test invalid inputs for p.
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(3, 1.00001), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(40, kNan), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(40, kInf), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(11, kDoubleMax), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(500, kBigIntMin), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(234, kBigIntMax), "p must be in the interval [0, 1]");
+
+  // Test invalid inputs for both params.
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(-3, -0.001), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(kNan, kNan), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(kInf, kInf), "p must be in the interval [0, 1]");
+  VELOX_ASSERT_THROW(
+      invChiSquaredCDF(kBigIntMin, kBigIntMax),
+      "p must be in the interval [0, 1]");
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Add Presto function inverse_chi_squared_cdf following the Java implementation([source](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java#L883))

Resolves: https://github.com/facebookincubator/velox/issues/5333