### PR TITLE
Add error message for IGNORE NULLS with Aggregate windows

### DIFF
--- a/velox/exec/AggregateWindow.cpp
+++ b/velox/exec/AggregateWindow.cpp
@@ -35,10 +35,13 @@ class AggregateWindowFunction : public exec::WindowFunction {
       const std::string& name,
       const std::vector<exec::WindowFunctionArg>& args,
       const TypePtr& resultType,
+      bool ignoreNulls,
       velox::memory::MemoryPool* pool,
       HashStringAllocator* stringAllocator,
       const core::QueryConfig& config)
       : WindowFunction(resultType, pool, stringAllocator) {
+    VELOX_USER_CHECK(
+        !ignoreNulls, "Aggregate window functions do not support IGNORE NULLS");
     argTypes_.reserve(args.size());
     argIndices_.reserve(args.size());
     argVectors_.reserve(args.size());
@@ -391,13 +394,19 @@ void registerAggregateWindowFunction(const std::string& name) {
         [name](
             const std::vector<exec::WindowFunctionArg>& args,
             const TypePtr& resultType,
-            bool /*ignoreNulls*/,
+            bool ignoreNulls,
             velox::memory::MemoryPool* pool,
             HashStringAllocator* stringAllocator,
             const core::QueryConfig& config)
             -> std::unique_ptr<exec::WindowFunction> {
           return std::make_unique<AggregateWindowFunction>(
-              name, args, resultType, pool, stringAllocator, config);
+              name,
+              args,
+              resultType,
+              ignoreNulls,
+              pool,
+              stringAllocator,
+              config);
         });
   }
 }


### PR DESCRIPTION
DuckDB does not support IGNORE NULLs for Aggregate windows so the PlanBuilder cannot be used for a test-case.

There will be a follow up for IGNORE NULLs with Aggregate following Presto semantics shortly and will use some new testing framework for it.