### PR TITLE
Add benchmark for CompactRow::serialize

### DIFF
--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -149,7 +149,7 @@ int32_t CompactRow::serializeRow(vector_size_t index, char* buffer) {
     auto& child = children_[i];
 
     // Write fixed-width value.
-    if (childIsFixedWidth_[i]) {
+    if (childIsFixedWidth_[i] && child.valueBytes_ > 0) {
       child.serializeFixedWidth(childIndex, buffer + valuesOffset);
       valuesOffset += child.valueBytes_;
     }

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -60,11 +60,6 @@ class CompactRowTest : public ::testing::Test, public VectorTestBase {
     VELOX_CHECK_EQ(offset, totalSize);
 
     auto copy = CompactRow::deserialize(serialized, rowType, pool());
-
-    //    LOG(ERROR) << data->toString(0, 10);
-
-    //    LOG(ERROR) << copy->toString(0, 10);
-
     assertEqualVectors(data, copy);
   }
 };
@@ -501,8 +496,6 @@ TEST_F(CompactRowTest, fuzz) {
 
     fuzzer.reSeed(seed);
     auto data = fuzzer.fuzzInputRow(rowType);
-
-    //    LOG(ERROR) << data->toString(0, 10);
 
     testRoundTrip(data);
 


### PR DESCRIPTION
Summary: Performance of CompactRow::serialize is on par with UnsafeRow::serialize. However, CompactRow produces smaller serialized buffers leading to faster compression and decompression.

Differential Revision: D47733671

