### PR TITLE
Fix deserialization of nullable structs in CompactRow

### DIFF
--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -149,7 +149,7 @@ int32_t CompactRow::serializeRow(vector_size_t index, char* buffer) {
     auto& child = children_[i];
 
     // Write fixed-width value.
-    if (childIsFixedWidth_[i]) {
+    if (childIsFixedWidth_[i] && child.valueBytes_ > 0) {
       child.serializeFixedWidth(childIndex, buffer + valuesOffset);
       valuesOffset += child.valueBytes_;
     }

--- a/velox/row/CompactRow.cpp
+++ b/velox/row/CompactRow.cpp
@@ -920,11 +920,10 @@ RowVectorPtr deserializeRows(
     auto* rawFieldNulls = fieldNulls.back()->asMutable<uint8_t>();
     for (auto row = 0; row < numRows; ++row) {
       auto* serializedNulls = readNulls(data[row].data() + offsets[row]);
-      bits::setBit(
-          rawFieldNulls,
-          row,
+      const auto isNull =
           (rawNulls != nullptr && bits::isBitNull(rawNulls, row)) ||
-              !bits::isBitSet(serializedNulls, i));
+          bits::isBitSet(serializedNulls, i);
+      bits::setBit(rawFieldNulls, row, !isNull);
     }
   }
 

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -443,6 +443,8 @@ TEST_F(CompactRowTest, row) {
               makeFlatVector<int32_t>({1, 2, 3, 4, 5}),
               makeNullableFlatVector<int64_t>({-1, 2, -3, std::nullopt, -5}),
               makeFlatVector<double>({1.05, 2.05, 3.05, 4.05, 5.05}),
+              makeFlatVector<std::string>(
+                  {"a", "Abc", "Long test string", "", "d"}),
           },
           nullEvery(2)),
   });

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -60,11 +60,6 @@ class CompactRowTest : public ::testing::Test, public VectorTestBase {
     VELOX_CHECK_EQ(offset, totalSize);
 
     auto copy = CompactRow::deserialize(serialized, rowType, pool());
-
-    //    LOG(ERROR) << data->toString(0, 10);
-
-    //    LOG(ERROR) << copy->toString(0, 10);
-
     assertEqualVectors(data, copy);
   }
 };
@@ -501,8 +496,6 @@ TEST_F(CompactRowTest, fuzz) {
 
     fuzzer.reSeed(seed);
     auto data = fuzzer.fuzzInputRow(rowType);
-
-    //    LOG(ERROR) << data->toString(0, 10);
 
     testRoundTrip(data);
 


### PR DESCRIPTION
Summary:
Null flags were not deserialized correctly causing crashes for nullable structs
containing strings of complex type fields.

Differential Revision: D47746192

