### PR TITLE
Fix serialization of null timestamps in CompactRow

### DIFF
--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -271,13 +271,20 @@ TEST_F(CompactRowTest, timestamp) {
 
   testRoundTrip(data);
 
+  // Serialize null Timestamp values with null flags set over a large
+  // non-serializable value (e.g. a value that triggers an exception in
+  // Timestamp::toMicros()).
   data = makeRowVector({
-      makeNullableFlatVector<Timestamp>({
+      makeFlatVector<Timestamp>({
           ts(0),
-          std::nullopt,
+          Timestamp::max(),
           ts(123'456),
+          Timestamp::min(),
       }),
   });
+
+  data->childAt(0)->setNull(1, true);
+  data->childAt(0)->setNull(3, true);
 
   testRoundTrip(data);
 }
@@ -413,7 +420,7 @@ TEST_F(CompactRowTest, map) {
       }),
   });
 
-  //  testRoundTrip(data);
+  testRoundTrip(data);
 }
 
 TEST_F(CompactRowTest, row) {


### PR DESCRIPTION
Do not serialize timestamp values that have null flag set to avoid "Could not
convert Timestamp to microseconds" errors.