### PR TITLE
Fix partially-streaming partial aggregation

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -637,9 +637,6 @@ bool GroupingSet::getOutput(
     if (table_) {
       table_->clear();
     }
-    if (remainingInput_) {
-      addRemainingInput();
-    }
     return false;
   }
   extractGroups(folly::Range<char**>(groups, numGroups), result);


### PR DESCRIPTION
Partially-streaming aggregation is used when input is clustered on a subset of
grouping keys.

There used to be a bug in partial aggregation of this kind where some input was
lost. 

GroupingSet::addInput would receive a batch with 2 groups. It would add the data
from the first group and put the data from the 2nd group aside
(as remainingInput_).

Then, HashAggregation would force flushing and call GroupingSet::getOutput
(), which would produce the output, clear the hash table and add
remainingInput_.

Then, HashAggregation would call GroupingSet::resetPartial() which would clear
the hash table again loosing 'remainingInput_' data added in previous step.

A fix is to not add remainingInput_ in GroupingSet::getOutput() and do that in
the next call to GroupingSet::addInput ()or GroupingSet::noMoreInput
().  GroupingSet::addInput() and noMoreInput() already have logic to process
remainingInput_, hence, the only change needed is to remove addRemainingInput_
call from getOutput().