### PR TITLE
Remove row count check from PrestoSerializer

### DIFF
--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -1843,7 +1843,6 @@ void PrestoVectorSerde::deserialize(
   auto childTypes = type->as<TypeKind::ROW>().children();
   if (!needCompression(*codec)) {
     auto numColumns = source->read<int32_t>();
-    VELOX_CHECK_EQ(numColumns, type->as<TypeKind::ROW>().size());
     readColumns(source, pool, childTypes, children, useLosslessTimestamp);
   } else {
     auto compressBuf = folly::IOBuf::create(compressedSize);


### PR DESCRIPTION
Summary:
Recently introduced check breaks one of the existing flows where number of
columns in the serialized bufer is larger than number of columns defined in the
type.

Reviewed By: mbasmanova

Differential Revision: D47755148

