### PR TITLE
Fix GroupingSet::toIntermediate for accumulator destroy

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -259,6 +259,7 @@ void deserializeOne<TypeKind::ROW>(
       deserializeSwitch(in, index, *child);
     }
   }
+  result.setNull(index, false);
 }
 
 // Reads the size, null flags and deserializes from 'in', appending to
@@ -293,6 +294,7 @@ void deserializeOne<TypeKind::ARRAY>(
   vector_size_t offset;
   auto size = deserializeArray(in, *array->elements(), offset);
   array->setOffsetAndSize(index, offset, size);
+  result.setNull(index, false);
 }
 
 template <>
@@ -312,6 +314,7 @@ void deserializeOne<TypeKind::MAP>(
   VELOX_CHECK_EQ(keySize, valueSize);
   VELOX_CHECK_EQ(keyOffset, valueOffset);
   map->setOffsetAndSize(index, keyOffset, keySize);
+  result.setNull(index, false);
 }
 
 void deserializeSwitch(

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1058,7 +1058,6 @@ void GroupingSet::toIntermediate(
       std::fill(firstGroup_.begin(), firstGroup_.end(), intermediateGroups_[0]);
       function->extractAccumulators(
           firstGroup_.data(), intermediateGroups_.size(), &aggregateVector);
-      function->clear();
       continue;
     }
 
@@ -1074,12 +1073,16 @@ void GroupingSet::toIntermediate(
         intermediateGroups_.data(),
         intermediateGroups_.size(),
         &aggregateVector);
-    function->clear();
   }
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
   }
+
+  // It's unnecessary to call function->clear() to reset the internal states of
+  // aggregation functions because toIntermediate() is already called at the end
+  // of HashAggregation::getOutput(). When toIntermediate() is called, the
+  // aggregaiton function instances won't be reused after it returns.
   tempVectors_.clear();
 }
 

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -33,6 +33,13 @@ class ValueListTest : public functions::test::FunctionBaseTest {
   read(aggregate::ValueList& values, const TypePtr& type, vector_size_t size) {
     aggregate::ValueListReader reader(values);
     auto result = BaseVector::create(type, size, pool());
+
+    // Initialize result to all-nulls to ensure ValueListReader::next() reset
+    // null bits correctly.
+    for (auto i = 0; i < size; ++i) {
+      result->setNull(i, true);
+    }
+
     for (auto i = 0; i < size; i++) {
       reader.next(*result, i);
     }


### PR DESCRIPTION
Summary:
When a UDAF doesn't have its own toIntermediate() implementation,
GroupingSet::toIntermediate() calls function->addRawInput() and
function->extractAccumulators() to compute the intermediate result,
and then calls RowContainer::eraseRows() to free the RowContainer.
eraseRows() calls Aggregate::destroy() which, for some UDAFs that
use ValueList, frees up the accumulator only at non-null groups.
However, GroupingSet::toIntermediate() currently calls Aggregate::clear()
that resets the null-flag before calling eraseRows(). This causes
Aggregate::destroy() to consider all groups to be non-null and attempt
to free non-existing accumulators at null-groups. This diff fixes the bug
by moving calls to clear() after the call to eraseRows().

This diff fixes https://github.com/facebookincubator/velox/issues/5823.

Reviewed By: Yuhta

Differential Revision: D47746429

