### PR TITLE
Fix GroupingSet::toIntermediate fast path

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -307,10 +307,15 @@ namespace {
 
 void initializeAggregates(
     const std::vector<AggregateInfo>& aggregates,
-    RowContainer& rows) {
+    RowContainer& rows,
+    bool excludeToIntermediate) {
   const auto numKeys = rows.keyTypes().size();
-  for (auto i = 0; i < aggregates.size(); ++i) {
-    auto& function = aggregates[i].function;
+  int i = 0;
+  for (auto& aggregate : aggregates) {
+    auto& function = aggregate.function;
+    if (excludeToIntermediate && function->supportsToIntermediate()) {
+      continue;
+    }
     function->setAllocator(&rows.stringAllocator());
 
     const auto rowColumn = rows.columnAt(numKeys + i);
@@ -319,15 +324,19 @@ void initializeAggregates(
         rowColumn.nullByte(),
         rowColumn.nullMask(),
         rows.rowSizeOffset());
+    ++i;
   }
 }
 } // namespace
 
-std::vector<Accumulator> GroupingSet::accumulators() {
+std::vector<Accumulator> GroupingSet::accumulators(bool excludeToIntermediate) {
   std::vector<Accumulator> accumulators;
   accumulators.reserve(aggregates_.size());
   for (auto& aggregate : aggregates_) {
-    accumulators.push_back(Accumulator{aggregate.function.get()});
+    if (!excludeToIntermediate ||
+        !aggregate.function->supportsToIntermediate()) {
+      accumulators.push_back(Accumulator{aggregate.function.get()});
+    }
   }
 
   if (sortedAggregations_ != nullptr) {
@@ -345,14 +354,14 @@ std::vector<Accumulator> GroupingSet::accumulators() {
 void GroupingSet::createHashTable() {
   if (ignoreNullKeys_) {
     table_ = HashTable<true>::createForAggregation(
-        std::move(hashers_), accumulators(), &pool_);
+        std::move(hashers_), accumulators(false), &pool_);
   } else {
     table_ = HashTable<false>::createForAggregation(
-        std::move(hashers_), accumulators(), &pool_);
+        std::move(hashers_), accumulators(false), &pool_);
   }
 
   RowContainer& rows = *table_->rows();
-  initializeAggregates(aggregates_, rows);
+  initializeAggregates(aggregates_, rows, false);
 
   auto numColumns = rows.keyTypes().size() + aggregates_.size();
 
@@ -866,7 +875,7 @@ bool GroupingSet::getOutputWithSpill(
     mergeRows_ = std::make_unique<RowContainer>(
         keyTypes,
         !ignoreNullKeys_,
-        accumulators(),
+        accumulators(false),
         std::vector<TypePtr>(),
         false,
         false,
@@ -875,7 +884,7 @@ bool GroupingSet::getOutputWithSpill(
         &pool_,
         table_->rows()->stringAllocatorShared());
 
-    initializeAggregates(aggregates_, *mergeRows_);
+    initializeAggregates(aggregates_, *mergeRows_, false);
 
     // Take ownership of the rows and free the hash table. The table will not be
     // needed for producing spill output.
@@ -979,11 +988,20 @@ void GroupingSet::abandonPartialAggregation() {
     }
   }
 
-  VELOX_CHECK_EQ(table_->rows()->numRows(), 0)
-  intermediateRows_ = table_->moveRows();
-  intermediateRows_->clear();
-
-  table_ = nullptr;
+  VELOX_CHECK_EQ(table_->rows()->numRows(), 0);
+  intermediateRows_ = std::make_unique<RowContainer>(
+      table_->rows()->keyTypes(),
+      !ignoreNullKeys_,
+      accumulators(true),
+      std::vector<TypePtr>(),
+      false,
+      false,
+      false,
+      false,
+      &pool_,
+      table_->rows()->stringAllocatorShared());
+  initializeAggregates(aggregates_, *intermediateRows_, true);
+  table_.reset();
 }
 
 void GroupingSet::toIntermediate(

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -191,9 +191,11 @@ class GroupingSet {
   // groups.
   void extractSpillResult(const RowVectorPtr& result);
 
-  // Return a list of accumulators for 'aggregates_' plus one more accumulator
-  // for 'sortedAggregations_'.
-  std::vector<Accumulator> accumulators();
+  // Return a list of accumulators for 'aggregates_', plus one more accumulator
+  // for 'sortedAggregations_', and one for each 'distinctAggregations_'.  When
+  // 'excludeToIntermediate' is true, skip the functions that support
+  // 'toIntermediate'.
+  std::vector<Accumulator> accumulators(bool excludeToIntermediate);
 
   std::vector<column_index_t> keyChannels_;
 

--- a/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArrayAggTest.cpp
@@ -60,6 +60,15 @@ TEST_F(ArrayAggTest, groupBy) {
       {"c0"},
       {"array_agg(a)"},
       "SELECT c0, array_agg(a) FROM tmp GROUP BY c0");
+
+  // Having one function supporting toIntermediate and one does not, make sure
+  // the row container is recreated with only the function wihtout
+  // toIntermediate support.
+  testAggregations(
+      batches,
+      {"c0"},
+      {"array_agg(a)", "max(c0)"},
+      "SELECT c0, array_agg(a), max(c0) FROM tmp GROUP BY c0");
 }
 
 TEST_F(ArrayAggTest, sortedGroupBy) {


### PR DESCRIPTION
Summary:
When multiple aggregates exist and only some of them support
`toIntermediate`, we still need to construct the `RowContainer` for those who do
not support `toIntermediate`.  In this case when we clean up the `RowContainer`,
we try to destroy the rows using the aggregates with fast path by mistake and
result in bad memory access.  Fix this by creating a new `RowContainer` that
contains only aggregates that do not support `toIntermediate`.

Differential Revision: D47760457

