### PR TITLE
Convert presto expression fuzzer tests to Gtests and reduce runtime.

### DIFF
--- a/velox/expression/tests/FuzzerRunner.h
+++ b/velox/expression/tests/FuzzerRunner.h
@@ -142,4 +142,15 @@ class FuzzerRunner {
     // Calling gtest here so that it can be recognized as tests in CI systems.
     return RUN_ALL_TESTS();
   }
+
+  static void runFromGtest(
+      const std::string& onlyFunctions,
+      size_t seed,
+      const std::unordered_set<std::string>& skipFunctions,
+      const std::string& specialForms) {
+    auto signatures = facebook::velox::getFunctionSignatures();
+    appendSpecialForms(specialForms, signatures);
+    facebook::velox::test::expressionFuzzer(
+        filterSignatures(signatures, onlyFunctions, skipFunctions), seed);
+  }
 };


### PR DESCRIPTION
Summary:
Without this, the tests do not run at diff time. (they run with a buck
test command that actually do not run them).
check for proof
https://www.internalfb.com/diff/D47675848?entry_point=27

when converted to GTEST they run with timeouts. so reduce to 8 mins. (10 mins is max)

Reviewed By: kgpai

Differential Revision: D47728207

