### PR TITLE
Fix comparisons for complex types using floats in RowContainer

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -341,7 +341,7 @@ std::optional<int32_t> compare(
   using T = typename TypeTraits<Kind>::NativeType;
   auto rightValue = right.asUnchecked<SimpleVector<T>>()->valueAt(index);
   auto leftValue = left.read<T>();
-  auto result = leftValue < rightValue ? -1 : leftValue == rightValue ? 0 : 1;
+  auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
   return flags.ascending ? result : result * -1;
 }
 
@@ -573,7 +573,7 @@ int32_t compare(
   using T = typename TypeTraits<Kind>::NativeType;
   T leftValue = left.read<T>();
   T rightValue = right.read<T>();
-  auto result = leftValue == rightValue ? 0 : leftValue < rightValue ? -1 : 1;
+  auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
   return flags.ascending ? result : result * -1;
 }
 

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -953,7 +953,7 @@ class RowContainer {
     }
     if (Kind == TypeKind::ROW || Kind == TypeKind::ARRAY ||
         Kind == TypeKind::MAP) {
-      return compareComplexType(row, column.offset(), decoded, index);
+      return compareComplexType(row, column.offset(), decoded, index, flags);
     }
     if (Kind == TypeKind::VARCHAR || Kind == TypeKind::VARBINARY) {
       auto result = compareStringAsc(
@@ -962,7 +962,7 @@ class RowContainer {
     }
     auto left = valueAt<T>(row, column.offset());
     auto right = decoded.valueAt<T>(index);
-    auto result = comparePrimitiveAsc(left, right);
+    auto result = SimpleVector<T>::comparePrimitiveAsc(left, right);
     return flags.ascending ? result : result * -1;
   }
 
@@ -1002,7 +1002,7 @@ class RowContainer {
 
     auto leftValue = valueAt<T>(left, leftOffset);
     auto rightValue = valueAt<T>(right, rightOffset);
-    auto result = comparePrimitiveAsc(leftValue, rightValue);
+    auto result = SimpleVector<T>::comparePrimitiveAsc(leftValue, rightValue);
     return flags.ascending ? result : result * -1;
   }
 
@@ -1014,21 +1014,6 @@ class RowContainer {
       RowColumn column,
       CompareFlags flags) {
     return compare<Kind>(left, right, type, column, column, flags);
-  }
-
-  template <typename T>
-  static inline int comparePrimitiveAsc(const T& left, const T& right) {
-    if constexpr (std::is_floating_point<T>::value) {
-      bool isLeftNan = std::isnan(left);
-      bool isRightNan = std::isnan(right);
-      if (isLeftNan) {
-        return isRightNan ? 0 : 1;
-      }
-      if (isRightNan) {
-        return -1;
-      }
-    }
-    return left < right ? -1 : left == right ? 0 : 1;
   }
 
   void storeComplexType(

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/VectorHasher.h"
 #include "velox/exec/tests/utils/RowContainerTestBase.h"
+#include "velox/expression/VectorReaders.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -284,121 +285,299 @@ class RowContainerTest : public exec::test::RowContainerTestBase {
     return rowContainer;
   }
 
+  // Count number of nulls at the start of the list.
   template <typename T>
-  void testCompareFloats(TypePtr type, bool ascending, bool nullsFirst) {
-    // NOTE: set 'isJoinBuild' to true to enable nullable sort key in test.
-    auto rowContainer = makeRowContainer({type}, {type}, false);
-    auto lowest = std::numeric_limits<T>::lowest();
-    auto min = std::numeric_limits<T>::min();
-    auto max = std::numeric_limits<T>::max();
-    auto nan = std::numeric_limits<T>::quiet_NaN();
-    auto inf = std::numeric_limits<T>::infinity();
-
-    facebook::velox::test::VectorMaker vectorMaker{pool_.get()};
-    VectorPtr values = vectorMaker.flatVectorNullable<T>(
-        {std::nullopt, max, inf, 0.0, nan, lowest, min});
-    int numRows = values->size();
-
-    SelectivityVector allRows(numRows);
-    DecodedVector decoded(*values, allRows);
-    std::vector<char*> rows(numRows);
-    std::vector<std::pair<int, char*>> indexedRows(numRows);
-    for (size_t i = 0; i < numRows; ++i) {
-      rows[i] = rowContainer->newRow();
-      rowContainer->store(decoded, i, rows[i], 0);
-      indexedRows[i] = std::make_pair(i, rows[i]);
+  static size_t countLeadingNulls(const std::vector<std::optional<T>>& values) {
+    for (auto i = 0; i < values.size(); ++i) {
+      if (values[i].has_value()) {
+        return i;
+      }
     }
+    return values.size();
+  }
 
-    std::vector<std::optional<T>> expectedOrder = {
-        std::nullopt, lowest, 0.0, min, max, inf, nan};
-    if (!ascending) {
-      if (nullsFirst) {
-        std::reverse(expectedOrder.begin() + 1, expectedOrder.end());
+  // Given a list of values sorted in ascending order with nulls first re-orders
+  // the elements to reverse the order and / or put nulls last.
+  template <typename T>
+  void changeSortingOrder(
+      std::vector<std::optional<T>>& values,
+      const CompareFlags& flags) {
+    if (flags.ascending) {
+      if (flags.nullsFirst) {
+        // Nothing to do. 'values' are expected to be already sorted in
+        // ascending order with nulls first.
       } else {
-        std::reverse(expectedOrder.begin(), expectedOrder.end());
+        // Move the nulls from the start of the list to the end of the list.
+        const auto numNulls = countLeadingNulls(values);
+        for (auto i = 0; i < values.size() - numNulls; ++i) {
+          values[i] = values[i + numNulls];
+        }
+
+        for (auto i = values.size() - numNulls; i < values.size(); ++i) {
+          values[i].reset();
+        }
       }
     } else {
-      if (!nullsFirst) {
-        for (int i = 0; i < expectedOrder.size() - 1; ++i) {
-          expectedOrder[i] = expectedOrder[i + 1];
-        }
-        expectedOrder[expectedOrder.size() - 1] = std::nullopt;
+      if (flags.nullsFirst) {
+        // Keeps nulls at the start of the list. Reverse the order of remaining
+        // non-null elements.
+        const auto numNulls = countLeadingNulls(values);
+        std::reverse(values.begin() + numNulls, values.end());
+      } else {
+        // Reverse the order of all elements.
+        std::reverse(values.begin(), values.end());
       }
     }
-    VectorPtr expected = vectorMaker.flatVectorNullable<T>(expectedOrder);
+  }
+
+  using IndexAndRow = std::pair<vector_size_t, char*>;
+  // A list of rows with unique zero-based indices.
+  using IndexAndRowVector = std::vector<IndexAndRow>;
+
+  static IndexAndRowVector indexRows(const std::vector<char*>& rows) {
+    IndexAndRowVector indexedRows;
+    indexedRows.reserve(rows.size());
+    for (auto i = 0; i < rows.size(); ++i) {
+      indexedRows.push_back({i, rows[i]});
+    }
+    return indexedRows;
+  }
+
+  VectorPtr copyValues(
+      const IndexAndRowVector& indexedRows,
+      const VectorPtr& values) {
+    const auto numRows = indexedRows.size();
+    auto copy = BaseVector::create(values->type(), numRows, pool_.get());
+    for (auto i = 0; i < numRows; ++i) {
+      copy->copy(values.get(), i, indexedRows[i].first, 1);
+    }
+    return copy;
+  }
+
+  static std::vector<char*> storeRows(
+      const DecodedVector& decoded,
+      vector_size_t numRows,
+      RowContainer& rowContainer) {
+    std::vector<char*> rows(numRows);
+    for (size_t i = 0; i < numRows; ++i) {
+      rows[i] = rowContainer.newRow();
+      rowContainer.store(decoded, i, rows[i], 0);
+    }
+
+    return rows;
+  }
+
+  template <typename T>
+  void testRowContainerCompareAPIs(
+      const TypePtr& type,
+      const VectorPtr& values,
+      const VectorPtr& expected,
+      std::optional<CompareFlags> flags) {
+    // If no flags provided then it must be the default of {true, true}.
+    SCOPED_TRACE(fmt::format(
+        "{}, ascending = {}, nullsFirst = {}",
+        type->toString(),
+        flags.has_value() ? flags.value().ascending : true,
+        flags.has_value() ? flags.value().nullsFirst : true));
+
+    // Set 'isJoinBuild' to true to enable nullable sort key in test.
+    auto rowContainer = makeRowContainer({type}, {type}, false);
+    int numRows = values->size();
+
+    DecodedVector decoded(*values);
+    auto rows = storeRows(decoded, numRows, *rowContainer);
+    auto indexedRows = indexRows(rows);
+
+    std::function<int(const char*, const char*)> compareRows =
+        [&](const auto& l, const auto& r) {
+          return rowContainer->compare(l, r, 0) < 0;
+        };
+
+    // If compare flags are specified pass them into the compare function.
+    if (flags.has_value()) {
+      compareRows = [&](const auto& l, const auto& r) {
+        return rowContainer->compare(l, r, 0, flags.value()) < 0;
+      };
+    }
+
+    // Verify compare method with two rows as input - using compareRows
     {
-      // Verify compare method with two rows as input
-      std::sort(rows.begin(), rows.end(), [&](const char* l, const char* r) {
-        return rowContainer->compare(l, r, 0, {nullsFirst, ascending}) < 0;
-      });
+      std::sort(rows.begin(), rows.end(), compareRows);
       VectorPtr result = BaseVector::create(type, numRows, pool_.get());
       rowContainer->extractColumn(rows.data(), numRows, 0, result);
       assertEqualVectors(expected, result);
     }
 
-    // Verify compare method with row and decoded vector as input
-    {
-      std::sort(
-          indexedRows.begin(),
-          indexedRows.end(),
-          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
-            return rowContainer->compare(
-                       l.second,
-                       rowContainer->columnAt(0),
-                       decoded,
-                       r.first,
-                       {nullsFirst, ascending}) < 0;
-          });
-      std::vector<std::optional<T>> sorted;
-      for (const auto& irow : indexedRows) {
-        if (decoded.isNullAt(irow.first)) {
-          sorted.push_back(std::nullopt);
-        } else {
-          sorted.push_back(decoded.valueAt<T>(irow.first));
-        }
-      }
-      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
-      assertEqualVectors(expected, result);
+    std::function<int(
+        const std::pair<int, char*>&, const std::pair<int, char*>&)>
+        compareDecodedAndRows = [&](const auto& l, const auto& r) {
+          return rowContainer->compare(
+                     l.second, rowContainer->columnAt(0), decoded, r.first) < 0;
+        };
+
+    if (flags.has_value()) {
+      compareDecodedAndRows = [&](const auto& l, const auto& r) {
+        return rowContainer->compare(
+                   l.second,
+                   rowContainer->columnAt(0),
+                   decoded,
+                   r.first,
+                   flags.value()) < 0;
+      };
     }
 
-    // Verify compareRows method with row as input.
+    // Verify compare method with row and decoded vector as input - using
+    // compareDecodedAndRows.
+    // This test assumes that the rows and decoded vector are in the same order
+    // so that indexRows can be sorted. The decoded vector is a different
+    // representation of the same row data. This allows for using sort which
+    // compares each element in decoded vector and each row value to each other
+    // testing the compare API as if the same row is sorted.
     {
-      std::sort(
-          indexedRows.begin(),
-          indexedRows.end(),
-          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
-            return rowContainer->compareRows(
-                       l.second, r.second, {{nullsFirst, ascending}}) < 0;
-          });
-      std::vector<std::optional<T>> sorted;
-      for (const auto& irow : indexedRows) {
-        if (decoded.isNullAt(irow.first)) {
-          sorted.push_back(std::nullopt);
-        } else {
-          sorted.push_back(decoded.valueAt<T>(irow.first));
-        }
-      }
-      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
+      std::sort(indexedRows.begin(), indexedRows.end(), compareDecodedAndRows);
+      auto result = copyValues(indexedRows, values);
       assertEqualVectors(expected, result);
     }
-    // Verify compareRows method with default compare flags.
-    if (ascending && nullsFirst) {
-      std::sort(
-          indexedRows.begin(),
-          indexedRows.end(),
-          [&](const std::pair<int, char*>& l, const std::pair<int, char*>& r) {
-            return rowContainer->compareRows(l.second, r.second) < 0;
-          });
-      std::vector<std::optional<T>> sorted;
-      for (const auto& irow : indexedRows) {
-        if (decoded.isNullAt(irow.first)) {
-          sorted.push_back(std::nullopt);
-        } else {
-          sorted.push_back(decoded.valueAt<T>(irow.first));
-        }
+  }
+
+  template <typename T, typename V>
+  void testOrderAndNullsFirstVariations(
+      const TypePtr& type,
+      const VectorPtr& values,
+      const std::vector<std::optional<V>>& ascNullsFirstOrder,
+      std::function<VectorPtr(const std::vector<std::optional<V>>&)>
+          generateExpectedVector) {
+    // The default flags are ascending == true, nullsFirst == true.
+    // std::nullopt means use the default for the compare function.
+    const std::vector<std::optional<CompareFlags>> compareFlags{
+        {{std::nullopt}}, {{true, false}}, {{false, true}}, {{false, false}}};
+
+    for (auto flags : compareFlags) {
+      std::vector<std::optional<V>> expectedOrder{ascNullsFirstOrder};
+      // The expectedOrder is ascNullsFirstOrder for the case
+      // where no compare flags are provided.
+      if (flags.has_value()) {
+        changeSortingOrder<V>(expectedOrder, flags.value());
       }
-      VectorPtr result = vectorMaker.template flatVectorNullable<T>(sorted);
-      assertEqualVectors(expected, result);
+      auto expected = generateExpectedVector(expectedOrder);
+
+      testRowContainerCompareAPIs<T>(type, values, expected, flags);
+    }
+  }
+
+#define TEST_FLOATING_TYPE_LIMIT_VARIABLES        \
+  auto lowest = std::numeric_limits<T>::lowest(); \
+  auto min = std::numeric_limits<T>::min();       \
+  auto max = std::numeric_limits<T>::max();       \
+  auto nan = std::numeric_limits<T>::quiet_NaN(); \
+  auto inf = std::numeric_limits<T>::infinity()
+
+  template <typename T>
+  void testComparePrimitiveFloats(const TypePtr& type) {
+    TEST_FLOATING_TYPE_LIMIT_VARIABLES;
+
+    auto values = makeNullableFlatVector<T>(
+        {std::nullopt, max, inf, 0.0, nan, lowest, min});
+
+    std::vector<std::optional<T>> ascNullsFirstOrder = {
+        std::nullopt, lowest, 0.0, min, max, inf, nan};
+
+    testOrderAndNullsFirstVariations<T, T>(
+        type, values, ascNullsFirstOrder, [&](const auto& expectedOrder) {
+          return makeNullableFlatVector<T>(expectedOrder);
+        });
+  }
+
+  template <typename T>
+  void testCompareArrayFloats(const TypePtr& type) {
+    TEST_FLOATING_TYPE_LIMIT_VARIABLES;
+
+    auto values = makeNullableArrayVector<T>(
+        {std::nullopt,
+         {{std::nullopt}},
+         {{max}},
+         {{inf}},
+         {{0.0}},
+         {{nan}},
+         {{lowest}},
+         {{min}}});
+
+    std::vector<std::optional<std::vector<std::optional<T>>>>
+        ascNullsFirstOrder = {
+            std::nullopt,
+            {{std::nullopt}},
+            {{lowest}},
+            {{0.0}},
+            {{min}},
+            {{max}},
+            {{inf}},
+            {{nan}}};
+
+    testOrderAndNullsFirstVariations<T, std::vector<std::optional<T>>>(
+        type, values, ascNullsFirstOrder, [&](const auto& expectedOrder) {
+          return makeNullableArrayVector<T>(expectedOrder);
+        });
+  }
+
+  template <typename T>
+  void testCompareMapFloats(const TypePtr& type) {
+    TEST_FLOATING_TYPE_LIMIT_VARIABLES;
+
+    auto values = makeNullableMapVector<T, int32_t>(
+        {{{std::nullopt}},
+         {{{max, 1}}},
+         {{{inf, 2}}},
+         {{{0.0, 3}}},
+         {{{nan, 4}}},
+         {{{lowest, 5}}},
+         {{{min, 6}}}});
+
+    std::vector<
+        std::optional<std::vector<std::pair<T, std::optional<int32_t>>>>>
+        ascNullsFirstOrder{
+            {{std::nullopt}},
+            {{{lowest, 5}}},
+            {{{0.0, 3}}},
+            {{{min, 6}}},
+            {{{max, 1}}},
+            {{{inf, 2}}},
+            {{{nan, 4}}}};
+
+    testOrderAndNullsFirstVariations<
+        T,
+        std::vector<std::pair<T, std::optional<int32_t>>>>(
+        type, values, ascNullsFirstOrder, [&](const auto& expectedOrder) {
+          return makeNullableMapVector<T, int32_t>(expectedOrder);
+        });
+  }
+
+  template <typename T>
+  void testCompareRowFloats(const TypePtr& type) {
+    TEST_FLOATING_TYPE_LIMIT_VARIABLES;
+
+    auto values = makeRowVector({makeNullableFlatVector<T>(
+        {std::nullopt, max, inf, 0.0, nan, lowest, min})});
+
+    std::vector<std::optional<T>> ascNullsFirstOrder = {
+        std::nullopt, lowest, 0.0, min, max, inf, nan};
+
+    testOrderAndNullsFirstVariations<T, T>(
+        type, values, ascNullsFirstOrder, [&](const auto& expectedOrder) {
+          return makeRowVector({makeNullableFlatVector<T>(expectedOrder)});
+        });
+  }
+#undef TEST_FLOATING_TYPE_LIMIT_VARIABLES
+
+  template <typename T>
+  void testCompareRowContainerTypeFloat(const TypePtr& type) {
+    if (type->isPrimitiveType()) {
+      testComparePrimitiveFloats<T>(type);
+    } else if (type->isArray()) {
+      testCompareArrayFloats<T>(type);
+    } else if (type->isMap()) {
+      testCompareMapFloats<T>(type);
+    } else if (type->isRow()) {
+      testCompareRowFloats<T>(type);
     }
   }
 };
@@ -944,24 +1123,40 @@ TEST_F(RowContainerTest, alignment) {
   }
 }
 
-// Verify comparison of fringe float valuesg
+// Verify comparison of fringe float values
 TEST_F(RowContainerTest, compareFloat) {
-  // Verify ascending order
-  testCompareFloats<float>(REAL(), true, true);
-  testCompareFloats<float>(REAL(), true, false);
-  //  Verify descending order
-  testCompareFloats<float>(REAL(), false, true);
-  testCompareFloats<float>(REAL(), false, false);
+  testCompareRowContainerTypeFloat<float>(REAL());
 }
 
 // Verify comparison of fringe double values
 TEST_F(RowContainerTest, compareDouble) {
-  // Verify ascending order
-  testCompareFloats<double>(DOUBLE(), true, true);
-  testCompareFloats<double>(DOUBLE(), true, false);
-  // Verify descending order
-  testCompareFloats<double>(DOUBLE(), false, true);
-  testCompareFloats<double>(DOUBLE(), false, false);
+  testCompareRowContainerTypeFloat<double>(DOUBLE());
+}
+
+TEST_F(RowContainerTest, compareArrayTypeFloat) {
+  testCompareRowContainerTypeFloat<float>(ARRAY(REAL()));
+}
+
+TEST_F(RowContainerTest, compareArrayTypeDouble) {
+  testCompareRowContainerTypeFloat<double>(ARRAY(DOUBLE()));
+}
+
+TEST_F(RowContainerTest, compareMapTypeFloat) {
+  testCompareRowContainerTypeFloat<float>(MAP(REAL(), INTEGER()));
+}
+
+TEST_F(RowContainerTest, compareMapTypeDouble) {
+  testCompareRowContainerTypeFloat<double>(MAP(DOUBLE(), INTEGER()));
+}
+
+TEST_F(RowContainerTest, compareRowTypeFloat) {
+  static const std::string colName{"floatCol"};
+  testCompareRowContainerTypeFloat<float>(ROW({colName}, {REAL()}));
+}
+
+TEST_F(RowContainerTest, compareRowTypeDouble) {
+  static const std::string colName{"doubleCol"};
+  testCompareRowContainerTypeFloat<double>(ROW({colName}, {DOUBLE()}));
 }
 
 TEST_F(RowContainerTest, partition) {

--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -329,6 +329,20 @@ class SimpleVector : public BaseVector {
     return asciiInfo;
   }
 
+  static int comparePrimitiveAsc(const T& left, const T& right) {
+    if constexpr (std::is_floating_point<T>::value) {
+      bool isLeftNan = std::isnan(left);
+      bool isRightNan = std::isnan(right);
+      if (isLeftNan) {
+        return isRightNan ? 0 : 1;
+      }
+      if (isRightNan) {
+        return -1;
+      }
+    }
+    return left < right ? -1 : left == right ? 0 : 1;
+  }
+
  protected:
   template <typename U = T>
   typename std::enable_if_t<std::is_same_v<U, StringView>, void>
@@ -374,21 +388,6 @@ class SimpleVector : public BaseVector {
         "Vector created with element size {} and used with size {}",
         elementSize_,
         sizeof(T));
-  }
-
- protected:
-  int comparePrimitiveAsc(const T& left, const T& right) const {
-    if constexpr (std::is_floating_point<T>::value) {
-      bool isLeftNan = std::isnan(left);
-      bool isRightNan = std::isnan(right);
-      if (isLeftNan) {
-        return isRightNan ? 0 : 1;
-      }
-      if (isRightNan) {
-        return -1;
-      }
-    }
-    return left < right ? -1 : left == right ? 0 : 1;
   }
 
   virtual void resetDataDependentFlags(const SelectivityVector* rows) override {


### PR DESCRIPTION
The issue is that `leftValue == rightValue` does not work if both sides are NaN. In fact, none of the comparisons with a NaN work. Equals is false and other comparisons cause an exception.
Therefore, for floating points additional logic is needed to handle the equals case.

The row container implementation contained two bugs when 
using complex types.

1.  Incorrect comparison implementation for floating point 
types when NaN values are used.
2. The comparison flags were not passed down to
lower level functions.
3. Refactor to use SimpleVector::comparePrimitiveAsc in RowContainer 
and ContainerRowSerde for a common comparison function.

In addition, the PR adds testing for floating point using the
RowContainer (and subsequent ContainerRowSerde).

When using floating point values in complex types (ROW, ARRAY, MAP (key))
the following operators are affected by the changes:

Operators:
FilterProject, TopN, TopNRowNumber, OrderBy, MergeExchange,
LocalMerge, HashProbe, NestedLoopJoinProbe

Functions:
array_distinct, array_duplicates, array_except, array_max,
array_min, array_has_duplicates, array_sort, array_sort_desc,
map_union, min, max, min_by, max_by, set_union

The lists may not be complete. Any operator/function that requires a
comparison of elements of complex types that use 
floating point type is affected.

Fixes https://github.com/prestodb/presto/issues/20283