### PR TITLE
Add fast map for assigning ids to int64 values

### DIFF
--- a/velox/common/base/BigintIdMap.cpp
+++ b/velox/common/base/BigintIdMap.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/BigintIdMap.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox {
+
+void BigintIdMap::makeTable(int64_t capacity) {
+  VELOX_CHECK_LE(capacity, kMaxCapacity);
+  byteSize_ = capacity * kEntrySize + kReadPadding;
+  table_ = reinterpret_cast<char*>(pool_.allocate(byteSize_));
+  memset(table_, 0, byteSize_);
+  capacity_ = capacity;
+  sizeMask_ = capacity_ - 1;
+  limit_ = capacity_ * kEntrySize;
+  maxEntries_ = capacity_ - capacity_ / 4;
+}
+
+void BigintIdMap::resize(int64_t newCapacity) {
+  VELOX_CHECK_LE(newCapacity, kMaxCapacity);
+
+  auto oldCapacity = capacity_;
+  auto oldTable = table_;
+  auto oldByteSize = byteSize_;
+  makeTable(newCapacity);
+  for (auto i = 0; i < oldCapacity; ++i) {
+    auto ptr = valuePtr(oldTable, i);
+    if (*ptr == kEmptyMarker) {
+      continue;
+    }
+    auto newIndex = indexOfEntry(*ptr);
+    auto newPtr = valuePtr(table_, newIndex);
+    while (*newPtr != kEmptyMarker) {
+      newIndex = (newIndex + 1) & sizeMask_;
+      newPtr = valuePtr(table_, newIndex);
+    }
+    *newPtr = *ptr;
+    *idPtr(newPtr) = *idPtr(ptr);
+  }
+  pool_.free(oldTable, oldByteSize);
+}
+
+} // namespace facebook::velox

--- a/velox/common/base/BigintIdMap.h
+++ b/velox/common/base/BigintIdMap.h
@@ -1,0 +1,310 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/Range.h>
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/SimdUtil.h"
+#include "velox/common/memory/HashStringAllocator.h"
+
+namespace facebook::velox {
+
+/// A map that assigns consecutive int32_t ids to arbitrary int64_t values.
+class BigintIdMap {
+ public:
+  static constexpr int64_t kNotFound = ~0L;
+  static constexpr int64_t kEmptyMarker = 0;
+  static constexpr int64_t kMaxCapacity = 1 << 30; // 1G entries, 12GB
+
+  BigintIdMap(int32_t capacity, memory::MemoryPool& pool) : pool_(pool) {
+    makeTable(std::max<int32_t>(
+        2 * sizeof(xsimd::batch<int64_t, A>), bits::nextPowerOfTwo(capacity)));
+  }
+
+  BigintIdMap(const BigintIdMap& other) = delete;
+  BigintIdMap(BigintIdMap&& other) = delete;
+  void operator=(const BigintIdMap& other) = delete;
+  void operator=(BigintIdMap&& other) = delete;
+
+  ~BigintIdMap() {
+    if (table_) {
+      pool_.free(table_, byteSize_);
+    }
+  }
+
+  /// Returns a batch of unique ids for a batch of arbitrary int64_t
+  /// values. Each value is given an int32_t id when first seen and
+  /// this same id will be given on subsequent occurrences. 'mask'
+  /// specifies the active lanes of 'x'. The id for a non-active lane
+  /// of x is always zero. Ids for values start at 1.
+  xsimd::batch<int64_t> makeIds(
+      xsimd::batch<int64_t> x,
+      uint8_t mask = kAllSet) {
+    xsimd::batch_bool<int64_t> activeLanes;
+    if (FOLLY_UNLIKELY(mask != kAllSet)) {
+      if (FOLLY_UNLIKELY(!mask)) {
+        return xsimd::broadcast<int64_t>(0);
+      }
+      activeLanes = simd::fromBitMask<int64_t, int64_t>(mask);
+    } else {
+      activeLanes = x == x; // All true.
+    }
+    // 0 is the id for a non-active lane.
+    auto ready = xsimd::batch<int64_t>::broadcast(0);
+
+    auto emptyMarkerVector = x == xsimd::broadcast<int64_t>(kEmptyMarker);
+    auto emptyMarkerMask = simd::toBitMask(emptyMarkerVector);
+    if (FOLLY_UNLIKELY(emptyMarkerMask)) {
+      if (!emptyId_ && (emptyMarkerMask & mask)) {
+        // Assign an id to kEmptyMarker when it first occurs on an active lane.
+        emptyId_ = ++lastId_;
+        emptyBatch_ = xsimd::broadcast(static_cast<int64_t>(emptyId_));
+      }
+      ready =
+          xsimd::select(emptyMarkerVector & activeLanes, emptyBatch_, ready);
+      activeLanes = activeLanes & ~emptyMarkerVector;
+      if (FOLLY_UNLIKELY(!simd::toBitMask(activeLanes))) {
+        return ready;
+      }
+    }
+
+    auto indices = makeIndices(x);
+    auto data = simd::maskGather<int64_t, int64_t, 4>(
+        ready, activeLanes, reinterpret_cast<const int64_t*>(table_), indices);
+
+    auto matchVector = (x == data) & activeLanes;
+    ready = simd::maskGather<int64_t, int64_t, 4>(
+        ready,
+        matchVector,
+        reinterpret_cast<const int64_t*>(table_) + 1,
+        indices);
+    uint16_t matches = simd::toBitMask(matchVector | ~activeLanes);
+    if (matches == kAllSet) {
+      return ready & kLow32;
+    }
+    // Store the indices and the values to look up in memory.
+    auto indexVector = indices;
+    auto dataVector = x;
+    auto resultVector = ready;
+    auto indexArray = reinterpret_cast<int64_t*>(&indexVector);
+    auto dataArray = reinterpret_cast<int64_t*>(&dataVector);
+    auto resultArray = reinterpret_cast<int64_t*>(&resultVector);
+    uint16_t misses = matches ^ kAllSet;
+    while (misses) {
+      auto index = bits::getAndClearLastSetBit(misses);
+      int64_t byteOffset = 4 * indexArray[index];
+      for (;;) {
+        auto value = *reinterpret_cast<int64_t*>(table_ + byteOffset);
+        if (value == kEmptyMarker) {
+          *reinterpret_cast<int64_t*>(table_ + byteOffset) = dataArray[index];
+          resultArray[index] =
+              *reinterpret_cast<uint32_t*>(table_ + byteOffset + 8) = ++lastId_;
+          ++numEntries_;
+          break;
+        }
+        if (value == dataArray[index]) {
+          resultArray[index] = *reinterpret_cast<uint32_t*>(
+              table_ + byteOffset + sizeof(int64_t));
+          break;
+        }
+        byteOffset += kEntrySize;
+        if (byteOffset >= limit_) {
+          byteOffset = 0;
+        }
+      }
+    }
+    if (numEntries_ > maxEntries_) {
+      resize(capacity_ * 2);
+    }
+    return xsimd::load_unaligned(resultArray) & kLow32;
+  }
+
+  /// Returns a batch of ids for lanes of 'x'. If a lane of 'x' does
+  /// not have an id, kNotFound is returned in the corresponding
+  /// lane. 'mask' allows specifying the active lanes. Inactive lanes
+  /// are 0 in the result.
+  xsimd::batch<int64_t> findIds(
+      xsimd::batch<int64_t> x,
+      uint8_t mask = kAllSet) {
+    xsimd::batch_bool<int64_t> activeLanes;
+    if (FOLLY_UNLIKELY(mask != kAllSet)) {
+      if (FOLLY_UNLIKELY(!mask)) {
+        return xsimd::broadcast<int64_t>(0);
+      }
+      activeLanes = simd::fromBitMask<int64_t, int64_t>(mask);
+    } else {
+      activeLanes = x == x; // All true.
+    }
+    auto ready = xsimd::batch<int64_t>::broadcast(0);
+
+    xsimd::batch_bool<int64_t> emptyMarkerVector =
+        x == xsimd::broadcast<int64_t>(kEmptyMarker);
+    auto emptyMarkerMask = simd::toBitMask(emptyMarkerVector);
+    if (FOLLY_UNLIKELY(emptyMarkerMask)) {
+      ready =
+          xsimd::select(emptyMarkerVector & activeLanes, emptyBatch_, ready);
+      activeLanes = activeLanes & ~emptyMarkerVector;
+      if (FOLLY_UNLIKELY(!simd::toBitMask(activeLanes))) {
+        return ready;
+      }
+    }
+
+    auto indices = makeIndices(x);
+    auto data = simd::maskGather<int64_t, int64_t, 4>(
+        ready, activeLanes, reinterpret_cast<const int64_t*>(table_), indices);
+
+    auto missVector = (data == kEmptyMarker) & activeLanes;
+    auto matchVector = (x == data) & activeLanes;
+    ready = simd::maskGather<int64_t, int64_t, 4>(
+        ready,
+        matchVector,
+        reinterpret_cast<const int64_t*>(table_) + 1,
+        indices);
+    // Clear the high bits of the loaded words.
+    ready = xsimd::select(matchVector, ready & kLow32, ready);
+    ready = xsimd::select(missVector, xsimd::broadcast(kNotFound), ready);
+    uint16_t matches = simd::toBitMask(matchVector | ~activeLanes | missVector);
+    if (matches == kAllSet) {
+      return ready;
+    }
+
+    // Store the indices and the values to look up in memory.
+    // Look at the next 12 byte entry.
+    volatile auto indexVector = indices + 3;
+    volatile auto dataVector = x;
+    auto resultVector = ready;
+    auto indexArray = reinterpret_cast<volatile int64_t*>(&indexVector);
+    auto dataArray = reinterpret_cast<volatile int64_t*>(&dataVector);
+    auto resultArray = reinterpret_cast<int64_t*>(&resultVector);
+    uint16_t misses = matches ^ kAllSet;
+    while (misses) {
+      auto index = bits::getAndClearLastSetBit(misses);
+      int64_t byteOffset = 4 * (indexArray[index]);
+      if (UNLIKELY(byteOffset >= limit_)) {
+        byteOffset = 0;
+      }
+      for (;;) {
+        auto value = *reinterpret_cast<int64_t*>(table_ + byteOffset);
+        if (value == kEmptyMarker) {
+          resultArray[index] = kNotFound;
+          break;
+        }
+        if (value == dataArray[index]) {
+          resultArray[index] = *reinterpret_cast<uint32_t*>(
+              table_ + byteOffset + sizeof(int64_t));
+          break;
+        }
+        byteOffset += kEntrySize;
+        if (byteOffset >= limit_) {
+          byteOffset = 0;
+        }
+      }
+    }
+    return xsimd::load_unaligned(reinterpret_cast<int64_t*>(&resultVector));
+  }
+
+ private:
+  using A = xsimd::default_arch;
+
+  static constexpr int32_t kAllSet =
+      bits::lowMask(xsimd::batch<int64_t, xsimd::default_arch>::size);
+  static constexpr int32_t kEntrySize = sizeof(int64_t) + sizeof(int32_t);
+  static constexpr int64_t kLow32 = (1L << 32) - 1;
+
+  // Number of bytes past end of last entry that may get read. The last id is
+  // accessed with a width of 8.
+  static constexpr int32_t kReadPadding = 4;
+
+  // Constants for hash calculation.
+  static constexpr uint64_t kMultLow = 1971049UL;
+  static constexpr uint64_t kMultHigh = 1470709UL;
+
+  // Allocates a new table.
+  void makeTable(int64_t capacity);
+
+  // Returns the pointer to the value of the 'i'th entry in 'table'.
+  int64_t* valuePtr(void* table, int32_t i) {
+    return reinterpret_cast<int64_t*>(
+        reinterpret_cast<char*>(table) + kEntrySize * i);
+  }
+
+  // Returns the pointer of the int32_t id for an entry.
+  int32_t* idPtr(int64_t* valuePtr) {
+    return reinterpret_cast<int32_t*>(valuePtr + 1);
+  }
+
+  // Rehashes 'this' to a size of 'newCapacity'.
+  void resize(int64_t newCapacity);
+
+  // Returns the hashed position of 'value' as a
+  // an index into an array of 12 byte entries. The function  is the same as
+  // indices()  for a single value. The difference is that indices returns
+  // distances in 4 byte words and this returns them i
+  int64_t indexOfEntry(int64_t value) {
+    uint32_t high = kMultHigh * (static_cast<uint64_t>(value) >> 32);
+    uint32_t low = kMultLow * static_cast<uint32_t>(value);
+    auto entry = ((high ^ low) & sizeMask_);
+    return entry;
+  }
+
+  xsimd::batch<int64_t> makeIndices(xsimd::batch<int64_t> values) {
+    auto multiplier =
+        xsimd::batch<uint64_t>::broadcast(kMultHigh << 32 | kMultLow);
+    auto hash = simd::reinterpretBatch<uint64_t>(
+        simd::reinterpretBatch<uint32_t>(values) *
+        simd::reinterpretBatch<uint32_t>(multiplier));
+    auto indices =
+        simd::reinterpretBatch<int64_t>(((hash >> 32) ^ hash) & sizeMask_);
+    return indices + indices + indices;
+  }
+
+  memory::MemoryPool& pool_;
+
+  // Counter for assigning ids to values.
+  int32_t lastId_{0};
+
+  // Id for value == kEmptyMarker
+  int32_t emptyId_{0};
+
+  //  emptyId_ in all lanes. kNotFound in all lanes if empty marker does not
+  //  occur as an entry.
+  xsimd::batch<int64_t> emptyBatch_{xsimd::broadcast(kNotFound)};
+
+  // Entries, 12 bytes per entry, 8 first are the value, the next 4 are its
+  // assigned id.
+  char* table_{nullptr};
+
+  // Number of 12 byte entries in 'table_'.
+  int64_t capacity_;
+
+  // Mask, one less than 'capacity_'.
+  int64_t sizeMask_;
+
+  // Allocation byte size of 'table_', including padding.
+  int64_t byteSize_;
+
+  // Byte offset of first byte after last byte of 'table_'.
+  int64_t limit_;
+
+  // Count of non-empty entries in 'table_'.
+  int32_t numEntries_{0};
+
+  // Count of entries after which a resize() should be done.
+  int32_t maxEntries_;
+};
+
+} // namespace facebook::velox

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -43,3 +43,14 @@ endif()
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(benchmarks)
 endif()
+
+add_library(velox_id_map BigintIdMap.cpp)
+target_link_libraries(
+  velox_id_map
+  velox_memory
+  velox_flag_definitions
+  velox_process
+  glog::glog
+  Folly::folly
+  fmt::fmt
+  gflags::gflags)

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1253,4 +1253,26 @@ xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A> data, const A& arch) {
   return detail::ReinterpretBatch<T, U, A>::apply(data, arch);
 }
 
+template <typename A>
+inline bool memEqualUnsafe(const void* x, const void* y, int32_t size) {
+  constexpr int32_t kBatch = xsimd::batch<uint8_t, A>::size;
+
+  auto left = reinterpret_cast<const uint8_t*>(x);
+  auto right = reinterpret_cast<const uint8_t*>(y);
+  while (size > 0) {
+    auto bits = toBitMask(
+        xsimd::batch<uint8_t, A>::load_unaligned(left) ==
+        xsimd::batch<uint8_t, A>::load_unaligned(right));
+    if (bits == allSetBitMask<uint8_t, A>()) {
+      left += kBatch;
+      right += kBatch;
+      size -= kBatch;
+      continue;
+    }
+    auto leading = __builtin_ctz(~bits);
+    return leading >= size;
+  }
+  return true;
+}
+
 } // namespace facebook::velox::simd

--- a/velox/common/base/SimdUtil.h
+++ b/velox/common/base/SimdUtil.h
@@ -414,6 +414,11 @@ inline bool isDense(const T* values, int32_t size) {
 template <typename T, typename U, typename A = xsimd::default_arch>
 xsimd::batch<T, A> reinterpretBatch(xsimd::batch<U, A>, const A& = {});
 
+// Compares memory at 'x' and 'y' and returns true if 'size' leading bytes are
+// equal. May address up to SIMD width -1 past end of either 'x' or 'y'.
+template <typename A = xsimd::default_arch>
+inline bool memEqualUnsafe(const void* x, const void* y, int32_t size);
+
 } // namespace facebook::velox::simd
 
 #include "velox/common/base/SimdUtil-inl.h"

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -42,5 +42,21 @@ target_link_libraries(
   gtest_main
   pthread)
 
+add_executable(velox_id_map_test IdMapTest.cpp)
+
+add_test(velox_id_map_test velox_id_map_test)
+
+target_link_libraries(
+  velox_id_map_test
+  velox_id_map
+  velox_common_base
+  velox_memory
+  Boost::headers
+  gflags::gflags
+  glog::glog
+  gtest
+  gtest_main
+  pthread)
+
 add_executable(velox_memcpy_meter Memcpy.cpp)
 target_link_libraries(velox_memcpy_meter velox_common_base pthread)

--- a/velox/common/base/tests/IdMapTest.cpp
+++ b/velox/common/base/tests/IdMapTest.cpp
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/container/F14Set.h>
+#include <folly/hash/Hash.h>
+#include "velox/common/base/BigintIdMap.h"
+#include "velox/common/base/SelectivityInfo.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+
+struct IdMapHasher {
+  size_t operator()(const std::pair<int64_t, int32_t>& item) const {
+    return folly::hasher<int64_t>()(item.first);
+  }
+};
+
+struct IdMapComparer {
+  bool operator()(
+      const std::pair<int64_t, int32_t>& left,
+      const std::pair<int64_t, int32_t>& right) const {
+    return left.first == right.first;
+  }
+};
+
+class F14IdMap {
+ public:
+  F14IdMap(int32_t initial) : set_(initial) {}
+
+  int32_t id(int64_t value) {
+    std::pair<int64_t, int32_t> item(
+        value, static_cast<int32_t>(set_.size() + 1));
+    return set_.insert(item).first->second;
+  }
+
+  int64_t findId(int64_t value) {
+    std::pair<int64_t, int32_t> item(
+        value, static_cast<int32_t>(set_.size() + 1));
+    auto it = set_.find(item);
+    if (it == set_.end()) {
+      return BigintIdMap::kNotFound;
+    }
+    return it->second;
+  }
+
+ private:
+  folly::F14FastSet<std::pair<int64_t, int32_t>, IdMapHasher, IdMapComparer>
+      set_;
+};
+
+class IdMapTest : public testing::Test {
+ protected:
+  static constexpr int32_t kBatchSize =
+      xsimd::batch<int64_t, xsimd::default_arch>::size;
+
+  using int64x4 = int64_t[4];
+
+  struct int64x4s {
+    int64_t n1;
+    int64_t n2;
+    int64_t n3;
+    int64_t n4;
+  };
+
+  void SetUp() override {
+    root_ = memory::MemoryManager::getInstance().addRootPool("IdMapRoot");
+    pool_ = root_->addLeafChild("IdMapLeakLeaf");
+  }
+
+  void testCase(int64_t size, int64_t range) {
+    std::vector<int64_t> data;
+    testData(size, range, data);
+    auto result = test(data);
+    std::cout << fmt::format(
+                     "Size={} range={} clocks IdMap={} F14={} ({}%)",
+                     size,
+                     range,
+                     result.first,
+                     result.second,
+                     100 * result.second / result.first)
+              << std::endl;
+  }
+
+  void testData(int64_t size, int64_t range, std::vector<int64_t>& data) {
+    size = bits::roundUp(size, kBatchSize);
+    data.reserve(size);
+    for (auto i = 0; i < size; ++i) {
+      data.push_back(1 + (i % range));
+    }
+  }
+
+  // Feeds 'data' into a BigintIdMap and the F14IdMap reference implementation
+  // and checks that the outcome is the same. returns the total clocks for
+  // BigIntIdMap and F14IdMap.
+  std::pair<float, float> test(const std::vector<int64_t>& data) {
+    BigintIdMap map(1024, *pool_);
+    F14IdMap f14(1024);
+    SelectivityInfo mapInfo;
+    SelectivityInfo f14Info;
+    {
+      SelectivityTimer t(mapInfo, data.size());
+      for (auto i = 0; i + kBatchSize <= data.size(); i += kBatchSize) {
+        map.makeIds(xsimd::batch<int64_t>::load_unaligned(data.data() + i));
+      }
+    }
+    {
+      SelectivityTimer t(f14Info, data.size());
+      for (auto i = 0; i < data.size(); ++i) {
+        f14.id(data[i]);
+      }
+    }
+    for (auto i = 0; i + kBatchSize <= data.size(); i += kBatchSize) {
+      auto ids =
+          map.findIds(xsimd::batch<int64_t>::load_unaligned(data.data() + i));
+      auto idsArray = reinterpret_cast<int64_t*>(&ids);
+      for (auto j = 0; j < kBatchSize; ++j) {
+        auto reference = f14.findId(data[i + j]);
+        EXPECT_EQ(reference, idsArray[j]);
+        if (reference != idsArray[j]) {
+          break;
+        }
+      }
+    }
+    return std::make_pair<float, float>(
+        mapInfo.timeToDropValue(), f14Info.timeToDropValue());
+  }
+
+  void expect4(int64_t n1, int64_t n2, int64_t n3, int64_t n4, int64x4s data) {
+    EXPECT_EQ(n1, data.n1);
+    EXPECT_EQ(n2, data.n2);
+    EXPECT_EQ(n3, data.n3);
+    EXPECT_EQ(n4, data.n4);
+  }
+
+  // A test function with exactly 4 lanes. Does 2x2 lanes, for lanes or 4 lanes
+  // twice depending on the actual width.
+  int64x4s makeIds4(BigintIdMap& map, int64x4 values, int16_t mask = 15) {
+    int64x4s result;
+    if constexpr (kBatchSize == 2) {
+      auto r1 = map.makeIds(xsimd::load_unaligned(values), mask & 3);
+      auto r2 = map.makeIds(xsimd::load_unaligned(&values[0] + 2), mask >> 2);
+      r1.store_unaligned(&result.n1);
+      r2.store_unaligned(&result.n3);
+    } else if constexpr (kBatchSize == 4) {
+      auto r1 = map.makeIds(xsimd::load_unaligned(values), mask);
+      memcpy(&result.n1, &r1, sizeof(result));
+    } else if constexpr (kBatchSize == 8) {
+      int64_t values8[8];
+      memcpy(values8, values, sizeof(result));
+      memcpy(&values8[4], values, sizeof(result));
+      auto r8 = map.makeIds(xsimd::load_unaligned(values8), mask | (mask << 4));
+      EXPECT_EQ(
+          0,
+          memcmp(&r8, reinterpret_cast<int64_t*>(&r8) + 4, 4 * sizeof(int64_t)))
+          << "The 4 first and last lanes of an 8 wide operation must match";
+      memcpy(&result.n1, values8, sizeof(result));
+    }
+    return result;
+  }
+
+  int64x4s findIds4(BigintIdMap& map, int64x4 values, int16_t mask = 15) {
+    int64x4s result;
+    if constexpr (kBatchSize == 2) {
+      auto r1 = map.findIds(xsimd::load_unaligned(values), mask & 3);
+      auto r2 = map.findIds(xsimd::load_unaligned(&values[0] + 2), mask >> 2);
+      r1.store_unaligned(&result.n1);
+      r2.store_unaligned(&result.n3);
+    } else if constexpr (kBatchSize == 4) {
+      auto r1 = map.findIds(xsimd::load_unaligned(values), mask);
+      memcpy(&result.n1, &r1, sizeof(result));
+    } else if constexpr (kBatchSize == 8) {
+      int64_t values8[8];
+      memcpy(values8, values, sizeof(result));
+      memcpy(&values8[4], values, sizeof(result));
+      auto r8 = map.findIds(xsimd::load_unaligned(values8), mask | (mask << 4));
+      EXPECT_EQ(
+          0,
+          memcmp(&r8, reinterpret_cast<int64_t*>(&r8) + 4, 4 * sizeof(int64_t)))
+          << "The 4 first and last lanes of an 8 wide operation must match";
+      memcpy(&result.n1, values8, sizeof(result));
+    }
+
+    return result;
+  }
+
+  std::shared_ptr<memory::MemoryPool> root_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(IdMapTest, basic) {
+  testCase(1000, 3);
+  testCase(1000, 1000);
+  testCase(10000, 2500);
+  testCase(1000000, 1000000);
+  testCase(5000000, 1000000);
+}
+
+TEST_F(IdMapTest, zerosAndMasks) {
+  constexpr int64_t kNotFound = BigintIdMap::kNotFound;
+
+  BigintIdMap map(1024, *pool_);
+  int64_t zeros[4] = {0, 0, 0, 0};
+  int64_t oneZero[4] = {1, 0, 2, 3};
+
+  // All lanes disabled makes all 0.
+  expect4(0, 0, 0, 0, makeIds4(map, oneZero, 0));
+
+  // Last lane is on, gets first id 1.
+  expect4(0, 0, 0, 1, makeIds4(map, oneZero, 8));
+
+  // All lanes are on, the zero gets the next id (2) and the non-zeros get 3
+  // and 4.
+  expect4(3, 2, 4, 1, makeIds4(map, oneZero));
+  expect4(3, 2, 4, 1, findIds4(map, oneZero));
+
+  // All zeros gets 2 (id of 0)  for the active lanes and 0 for inactive.
+  expect4(2, 0, 2, 0, makeIds4(map, zeros, 5));
+
+  expect4(2, 2, 2, 2, findIds4(map, zeros));
+
+  BigintIdMap mapWithNoZero(1024, *pool_);
+  // We insert the same values and mask out the 0.
+  expect4(1, 0, 2, 3, makeIds4(mapWithNoZero, oneZero, 13));
+  expect4(
+      kNotFound,
+      kNotFound,
+      kNotFound,
+      kNotFound,
+      findIds4(mapWithNoZero, zeros));
+
+  // Zero for inactive, not found for active.
+  expect4(kNotFound, 0, kNotFound, 0, findIds4(mapWithNoZero, zeros, 5));
+
+  int64_t mix[4] = {10, 1, 0, 2};
+  expect4(kNotFound, 1, kNotFound, 2, findIds4(mapWithNoZero, mix));
+
+  expect4(kNotFound, 0, kNotFound, 0, findIds4(mapWithNoZero, mix, 5));
+}
+
+TEST_F(IdMapTest, collisions) {
+  constexpr int64_t kNotFound = BigintIdMap::kNotFound;
+  // We check the found and not found stay the same as the table gets filled
+  F14IdMap reference(32);
+  BigintIdMap map(8, *pool_);
+  std::vector<int64_t> data;
+  for (auto i = 0; i < 2048; ++i) {
+    data.push_back((i + 1) * 0xfeedda7a58ff1e00);
+  }
+  // Add an empty marker.
+  data[1333] = 0;
+  for (auto fill = 0; fill < data.size(); fill += kBatchSize) {
+    // Check that data not inserted is not found.
+    for (auto i = fill; i < data.size(); i += kBatchSize) {
+      auto expectedEmpty = map.findIds(xsimd::load_unaligned(data.data() + i));
+      for (auto j = 0; j < kBatchSize; ++j) {
+        EXPECT_EQ(kNotFound, reinterpret_cast<int64_t*>(&expectedEmpty)[j]);
+        EXPECT_EQ(kNotFound, reference.findId(data[i + j]));
+      }
+    }
+
+    // Add a group of 4 new entries.
+    auto ids = map.makeIds(xsimd::load_unaligned(data.data() + fill));
+    for (auto j = 0; j < kBatchSize; ++j) {
+      // If there is a zero added, add it to 'reference' before the other values
+      // to match the special treatment of empty marker.
+      if (data[fill + j] == 0) {
+        reference.id(0);
+      }
+    }
+    for (auto j = 0; j < kBatchSize; ++j) {
+      EXPECT_EQ(
+          reference.id(data[fill + j]), reinterpret_cast<int64_t*>(&ids)[j]);
+    }
+
+    // Check that all inserted is still found.
+    for (auto i = 0; i <= fill; i += kBatchSize) {
+      auto ids = map.findIds(xsimd::load_unaligned(data.data() + i));
+      for (auto j = 0; j < kBatchSize; ++j) {
+        EXPECT_EQ(
+            reference.findId(data[i + j]), reinterpret_cast<int64_t*>(&ids)[j]);
+      }
+    }
+  }
+}

--- a/velox/common/base/tests/SimdUtilTest.cpp
+++ b/velox/common/base/tests/SimdUtilTest.cpp
@@ -376,4 +376,27 @@ TEST_F(SimdUtilTest, reinterpretBatch) {
   validateReinterpretBatch<int64_t>();
 }
 
+TEST_F(SimdUtilTest, memEqual) {
+  constexpr int32_t kSize = 132;
+  struct {
+    char x[kSize];
+    char y[kSize];
+    char padding[sizeof(xsimd::batch<uint8_t>)];
+  } data;
+  memset(&data, 11, sizeof(data));
+  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, kSize));
+  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 17));
+  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 32));
+  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 33));
+
+  // Make data at 67 not equal.
+  data.y[67] = 0;
+  EXPECT_TRUE(simd::memEqualUnsafe(data.x, data.y, 67));
+  EXPECT_FALSE(simd::memEqualUnsafe(data.x, data.y, 68));
+
+  // Redo the test offset by 1 to test unaligned.
+  EXPECT_TRUE(simd::memEqualUnsafe(&data.x[1], &data.y[1], 66));
+  EXPECT_FALSE(simd::memEqualUnsafe(&data.x[1], &data.y[1], 67));
+}
+
 } // namespace


### PR DESCRIPTION
Adds a BigintIdMap utility for use in mapping 64 bit values to unique ids. Can be used in writing dictionary encoding or in VectorHasher. This is 2-4x faster than the corresponding use of F14FastSet.

The table consists of 12 byte entries with 64 bits of value and 32 bits of id. We process 4 values at a time with avx2.

There is a bit mask to disable some values, e.g. for nulls in VectorHasher. These come out as 0. The ids assigned to values start at 1 to distinguish from 0 for non-active lane. The value 0 is used to mark an empty slot in the table. Hence an input of 0 must be treated separately.

The test prints out clock counts for different sizes and frequencies of repeats. The test also checks special cases with inactive lanes and zeros.