### PR TITLE
Add support for Tinyint Type in Native Parquet Reader

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -164,6 +164,18 @@ void SelectiveColumnReader::getIntValues(
           VELOX_FAIL("Unsupported value size: {}", valueSize_);
       }
       break;
+      case TypeKind::TINYINT:
+        switch (valueSize_) {
+          case 4:
+            getFlatValues<int32_t, int8_t>(rows, result, requestedType);
+            break;
+          case 2:
+            getFlatValues<int16_t, int8_t>(rows, result, requestedType);
+            break;
+          default:
+            VELOX_FAIL("Unsupported value size: {}", valueSize_);
+        }
+        break;
       case TypeKind::INTEGER:
         switch (valueSize_) {
           case 8:

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -130,6 +130,7 @@ TEST_F(E2EFilterTest, compression) {
     options_.compression = compression;
 
     testWithTypes(
+        "tinyint_val:tinyint,"
         "short_val:smallint,"
         "int_val:int,"
         "long_val:bigint",
@@ -163,9 +164,19 @@ TEST_F(E2EFilterTest, compression) {
               -999, // rareMin
               30000, // rareMax
               true); // keepNulls
+
+          makeIntDistribution<int8_t>(
+              "tinyint_val",
+              10, // min
+              100, // max
+              22, // repeats
+              19, // rareFrequency
+              -99, // rareMin
+              3000, // rareMax
+              true); // keepNulls
         },
         true,
-        {"short_val", "int_val", "long_val"},
+        {"tinyint_val", "short_val", "int_val", "long_val"},
         3);
   }
 }


### PR DESCRIPTION
Currently, Native Parquet reader does not support reading tinyint type data, The following steps can be reproduced
```
presto:tpch_velox> create table test (id tinyint) with (format = 'PARQUET');
CREATE TABLE
presto:tpch_velox> insert into test values (cast(1 as tinyint)), (cast(-128 as tinyint)), (cast(127 as tinyint));
INSERT: 3 rows

Query 20230726_074816_00009_a5y5r, FINISHED, 2 nodes
Splits: 2 total, 2 done (100.00%)
0:22 [0 rows, 0B] [0 rows/s, 0B/s]

presto:tpch_velox> select * from test;

Query 20230726_074850_00010_a5y5r, FAILED, 1 node
Splits: 2 total, 0 done (0.00%)
0:03 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20230726_074850_00010_a5y5r failed:  Not a valid type for integer reader: TINYINT Split [Hive: file:/Users/wypb/data/hive/warehouse/tpch_velox.db/test/20230726_074816_00009_a5y5r.1.0.0.0_0_5_dc4c7936-20f8-4cdd-8182-55e06b4d4fcd 0 - 356] Task 20230726_074850_00010_a5y5r.1.0.0.0

presto:tpch_velox>
```
