### PR TITLE
Fix the parquet writer API incompatible issue in different ARROW version

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -149,13 +149,14 @@ void Writer::write(const VectorPtr& data) {
       recordBatch->schema(), recordBatch->columns(), data->size());
   if (!arrowContext_->writer) {
     auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
-    PARQUET_THROW_NOT_OK(::parquet::arrow::FileWriter::Open(
-        *recordBatch->schema(),
-        arrow::default_memory_pool(),
-        stream_,
-        arrowContext_->properties,
-        arrowProperties,
-        &arrowContext_->writer));
+    PARQUET_ASSIGN_OR_THROW(
+        arrowContext_->writer,
+        ::parquet::arrow::FileWriter::Open(
+            *recordBatch->schema(),
+            arrow::default_memory_pool(),
+            stream_,
+            arrowContext_->properties,
+            arrowProperties));
   }
 
   PARQUET_THROW_NOT_OK(


### PR DESCRIPTION
We encounter the following compile issue when compile gluten directly using the main branch. Because the existing FileWriter::Open API is deprecated in Arrow 11.0.0. This PR change the FileWriter::Open API to adapt to higher arrow version.


```
../../velox/dwio/parquet/writer/Writer.cpp:158:33: error: ‘static arrow::Status parquet::arrow::FileWriter::Open(const arrow::Schema&, parquet::MemoryPool*, std::shared_ptr<arrow::io::OutputStream>, std::shared_ptr<parquet::WriterProperties>, std::shared_ptr<parquet::ArrowWriterProperties>, std::unique_ptr<parquet::arrow::FileWriter>*)’ is deprecated: Deprecated in 11.0.0. Use Result-returning variants instead. [-Werror=deprecated-declarations]
  158 |           &arrowContext_->writer));
```