### PR TITLE
Support all Spark patterns in cast(varchar as date)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -80,6 +80,21 @@ class QueryConfig {
   // decimal part, otherwise rounds.
   static constexpr const char* kCastToIntByTruncate = "cast_to_int_by_truncate";
 
+  /// If set, cast from string to date allows only ISO 8601 formatted strings:
+  /// [+-](YYYY-MM-DD). Otherwise, allows all patterns supported by Spark:
+  /// `[+-]yyyy*`
+  /// `[+-]yyyy*-[m]m`
+  /// `[+-]yyyy*-[m]m-[d]d`
+  /// `[+-]yyyy*-[m]m-[d]d *`
+  /// `[+-]yyyy*-[m]m-[d]dT*`
+  /// The asterisk `*` in `yyyy*` stands for any numbers.
+  /// For the last two patterns, the trailing `*` can represent none or any
+  /// sequence of characters, e.g:
+  ///   "1970-01-01 123"
+  ///   "1970-01-01 (BC)"
+  static constexpr const char* kCastStringToDateIsIso8601 =
+      "cast_string_to_date_is_iso_8601";
+
   /// Used for backpressure to block local exchange producers when the local
   /// exchange buffer reaches or exceeds this size.
   static constexpr const char* kMaxLocalExchangeBufferSize =
@@ -327,6 +342,10 @@ class QueryConfig {
 
   bool isCastToIntByTruncate() const {
     return get<bool>(kCastToIntByTruncate, false);
+  }
+
+  bool isIso8601() const {
+    return get<bool>(kCastStringToDateIsIso8601, true);
   }
 
   bool codegenEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -82,6 +82,8 @@ Generic Configuration
      - 1000
      - The minimum number of table rows that can trigger the parallel hash join table build.
 
+.. _expression-evaluation-conf:
+
 Expression Evaluation Configuration
 -----------------------------------
 .. list-table::
@@ -109,6 +111,21 @@ Expression Evaluation Configuration
      - bool
      - false
      - This flags forces the cast from float/double/decimal/string to integer to be performed by truncating the decimal part instead of rounding.
+   * - cast_string_to_date_is_iso_8601
+     - bool
+     - true
+     - If set, cast from string to date allows only ISO 8601 formatted strings: ``[+-](YYYY-MM-DD)``.
+       Otherwise, allows all patterns supported by Spark:
+         * ``[+-]yyyy*``
+         * ``[+-]yyyy*-[m]m``
+         * ``[+-]yyyy*-[m]m-[d]d``
+         * ``[+-]yyyy*-[m]m-[d]d *``
+         * ``[+-]yyyy*-[m]m-[d]dT*``
+       The asterisk ``*`` in ``yyyy*`` stands for any numbers.
+       For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
+         * "1970-01-01 123"
+         * "1970-01-01 (BC)"
+>>>>>>> add cast option to distinguish sparksql/presto cast
 
 Memory Management
 -----------------

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -125,7 +125,7 @@ Expression Evaluation Configuration
        For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
          * "1970-01-01 123"
          * "1970-01-01 (BC)"
->>>>>>> add cast option to distinguish sparksql/presto cast
+       Regardless of this setting's value, leading and trailing spaces will be trimmed.
 
 Memory Management
 -----------------

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -125,7 +125,7 @@ Expression Evaluation Configuration
        For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
          * "1970-01-01 123"
          * "1970-01-01 (BC)"
-       Regardless of this setting's value, leading and trailing spaces will be trimmed.
+       Regardless of this setting's value, leading spaces will be trimmed.
 
 Memory Management
 -----------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -501,20 +501,55 @@ Cast to Date
 From strings
 ^^^^^^^^^^^^
 
-Casting from a string to date is allowed if the string represents a date in the
-format `YYYY-MM-DD`. Casting from invalid input values throws.
+By default, only ISO 8601 strings are supported: `[+-]YYYY-MM-DD`.
 
-Valid example
+If cast_string_to_date_is_iso_8601 is set to false, all Spark supported patterns are allowed.
+See the documentation for cast_string_to_date_is_iso_8601 in :ref:`Expression Evaluation Configuration<expression-evaluation-conf>`
+for the full list of supported patterns.
+
+Casting from invalid input values throws.
+
+Valid examples
+
+**cast_string_to_date_is_iso_8601=true**
 
 ::
 
   SELECT cast('1970-01-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
 
-Invalid example
+**cast_string_to_date_is_iso_8601=false**
+
+::
+
+  SELECT cast('1970' as date); -- 1970-01-01
+  SELECT cast('1970-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01T123' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 (BC)' as date); -- 1970-01-01
+
+Invalid examples
+
+**cast_string_to_date_is_iso_8601=true**
+
+::
+
+  SELECT cast('2012' as date); -- Invalid argument
+  SELECT cast('2012-10' as date); -- Invalid argument
+  SELECT cast('2012-10-23T123' as date); -- Invalid argument
+  SELECT cast('2012-10-23 (BC)' as date); -- Invalid argument
+  SELECT cast('2012-Oct-23' as date); -- Invalid argument
+  SELECT cast('2012/10/23' as date); -- Invalid argument
+  SELECT cast('2012.10.23' as date); -- Invalid argument
+
+**cast_string_to_date_is_iso_8601=false**
 
 ::
 
   SELECT cast('2012-Oct-23' as date); -- Invalid argument
+  SELECT cast('2012/10/23' as date); -- Invalid argument
+  SELECT cast('2012.10.23' as date); -- Invalid argument
 
 From timestamp
 ^^^^^^^^^^^^^^

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -516,7 +516,6 @@ Valid examples
 ::
 
   SELECT cast('1970-01-01' as date); -- 1970-01-01
-  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
 
 **cast_string_to_date_is_iso_8601=false**
 
@@ -542,6 +541,7 @@ Invalid examples
   SELECT cast('2012-Oct-23' as date); -- Invalid argument
   SELECT cast('2012/10/23' as date); -- Invalid argument
   SELECT cast('2012.10.23' as date); -- Invalid argument
+  SELECT cast('2012-10-23 ' as date); -- Invalid argument
 
 **cast_string_to_date_is_iso_8601=false**
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -32,27 +32,6 @@
 
 namespace facebook::velox::exec {
 
-namespace {
-std::string castFromDateErrorMessage(
-    const StringView& inputString,
-    bool isStandardCast) {
-  if (isStandardCast) {
-    return fmt::format(
-        "Unable to parse date value: \"{}\"."
-        "Valid date string pattern is (YYYY-MM-DD), "
-        "and can be prefixed with [+-]",
-        inputString);
-  } else {
-    return fmt::format(
-        "Unable to parse date value: \"{}\"."
-        "Valid date string patterns include "
-        "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with \"[+-]\" "
-        "or suffixed with trailing spaces or trailing 'T' with any characters.",
-        inputString);
-  }
-}
-} // namespace
-
 VectorPtr CastExpr::castFromDate(
     const SelectivityVector& rows,
     const BaseVector& input,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -673,9 +673,7 @@ TEST_F(CastExprTest, date) {
          "1970-1-02",
          "+1970-01-02",
          "-1-1-1",
-         "1970-01-01 ",
          " 1970-01-01",
-         " 1970-01-01 ",
          std::nullopt},
         {0,
          18262,
@@ -689,8 +687,6 @@ TEST_F(CastExprTest, date) {
          1,
          1,
          -719893,
-         0,
-         0,
          0,
          std::nullopt},
         false,
@@ -761,6 +757,10 @@ TEST_F(CastExprTest, invalidDate) {
       "date", {"2015-03-18T123412"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
       "date", {"2015-03-18 (BC)"}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"1970-01-01 "}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {" 1970-01-01 "}, {0}, true, false, VARCHAR(), DATE());
 }
 
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -668,11 +668,14 @@ TEST_F(CastExprTest, date) {
          "1812-04-15",
          "1920-01-02",
          "12345-12-18",
-         "2015-3-1",
-         "2015-3-18",
+         "1970-1-2",
+         "1970-01-2",
+         "1970-1-02",
          "+1970-01-02",
          "-1-1-1",
          "1970-01-01 ",
+         " 1970-01-01",
+         " 1970-01-01 ",
          std::nullopt},
         {0,
          18262,
@@ -681,10 +684,13 @@ TEST_F(CastExprTest, date) {
          -57604,
          -18262,
          3789742,
-         16495,
-         16512,
+         1,
+         1,
+         1,
          1,
          -719893,
+         0,
+         0,
          0,
          std::nullopt},
         false,
@@ -693,17 +699,16 @@ TEST_F(CastExprTest, date) {
         DATE());
   }
 
-  // Valid cases for cast_string_to_date_iso_8601=false.
   setCastStringToDateIsIso8601(false);
   testCast<std::string, int32_t>(
       "date",
       {"12345",
        "2015",
        "2015-03",
-       "2015-03-18 ",
-       "2015-03-18 123142",
        "2015-03-18T",
-       "2015-03-18T123123"},
+       "2015-03-18T123123",
+       "2015-03-18 123142",
+       "2015-03-18 (BC)"},
       {3789391, 16436, 16495, 16512, 16512, 16512, 16512},
       false,
       false,
@@ -745,13 +750,15 @@ TEST_F(CastExprTest, invalidDate) {
 
   setCastStringToDateIsIso8601(true);
   testCast<std::string, int32_t>(
-      "date", {"2015"}, {0}, true, false, VARCHAR(), DATE());
+      "date", {"12345"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
       "date", {"2015-03"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
+      "date", {"2015-03-18 123412"}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
       "date", {"2015-03-18T"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
-      "date", {"2015-03-18 "}, {0}, true, false, VARCHAR(), DATE());
+      "date", {"2015-03-18T123412"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
       "date", {"2015-03-18 (BC)"}, {0}, true, false, VARCHAR(), DATE());
 }

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -61,6 +61,12 @@ class CastExprTest : public functions::test::CastBaseTest {
     });
   }
 
+  void setCastStringToDateIsIso8601(bool value) {
+    queryCtx_->testingOverrideConfigUnsafe({
+        {core::QueryConfig::kCastStringToDateIsIso8601, std::to_string(value)},
+    });
+  }
+
   std::shared_ptr<core::ConstantTypedExpr> makeConstantNullExpr(TypeKind kind) {
     return std::make_shared<core::ConstantTypedExpr>(
         createType(kind, {}), variant(kind));
@@ -651,49 +657,103 @@ TEST_F(CastExprTest, timestampAdjustToTimezoneInvalid) {
 }
 
 TEST_F(CastExprTest, date) {
-  std::vector<std::optional<std::string>> input{
-      "1970-01-01",
-      "2020-01-01",
-      "2135-11-09",
-      "1969-12-27",
-      "1812-04-15",
-      "1920-01-02",
-      std::nullopt,
-  };
-  std::vector<std::optional<int32_t>> result{
-      0,
-      18262,
-      60577,
-      -5,
-      -57604,
-      -18262,
-      std::nullopt,
-  };
+  for (bool isIso8601 : {true, false}) {
+    setCastStringToDateIsIso8601(isIso8601);
+    testCast<std::string, int32_t>(
+        "date",
+        {"1970-01-01",
+         "2020-01-01",
+         "2135-11-09",
+         "1969-12-27",
+         "1812-04-15",
+         "1920-01-02",
+         "12345-12-18",
+         "2015-3-1",
+         "2015-3-18",
+         "+1970-01-02",
+         "-1-1-1",
+         "1970-01-01 ",
+         std::nullopt},
+        {0,
+         18262,
+         60577,
+         -5,
+         -57604,
+         -18262,
+         3789742,
+         16495,
+         16512,
+         1,
+         -719893,
+         0,
+         std::nullopt},
+        false,
+        false,
+        VARCHAR(),
+        DATE());
+  }
 
+  // Valid cases for cast_string_to_date_iso_8601=false.
+  setCastStringToDateIsIso8601(false);
   testCast<std::string, int32_t>(
-      "date", input, result, false, false, VARCHAR(), DATE());
-
-  setCastIntByTruncate(true);
-  testCast<std::string, int32_t>(
-      "date", input, result, false, false, VARCHAR(), DATE());
+      "date",
+      {"12345",
+       "2015",
+       "2015-03",
+       "2015-03-18 ",
+       "2015-03-18 123142",
+       "2015-03-18T",
+       "2015-03-18T123123"},
+      {3789391, 16436, 16495, 16512, 16512, 16512, 16512},
+      false,
+      false,
+      VARCHAR(),
+      DATE());
 }
 
 TEST_F(CastExprTest, invalidDate) {
-  testCast<int8_t, int32_t>("date", {12}, {0}, true, false, TINYINT(), DATE());
-  testCast<int16_t, int32_t>(
-      "date", {1234}, {0}, true, false, SMALLINT(), DATE());
-  testCast<int32_t, int32_t>(
-      "date", {1234}, {0}, true, false, INTEGER(), DATE());
-  testCast<int64_t, int32_t>(
-      "date", {1234}, {0}, true, false, BIGINT(), DATE());
+  for (bool isIso8601 : {true, false}) {
+    setCastStringToDateIsIso8601(isIso8601);
 
-  testCast<float, int32_t>("date", {12.99}, {0}, true, false, REAL(), DATE());
-  testCast<double, int32_t>(
-      "date", {12.99}, {0}, true, false, DOUBLE(), DATE());
+    testCast<int8_t, int32_t>(
+        "date", {12}, {0}, true, false, TINYINT(), DATE());
+    testCast<int16_t, int32_t>(
+        "date", {1234}, {0}, true, false, SMALLINT(), DATE());
+    testCast<int32_t, int32_t>(
+        "date", {1234}, {0}, true, false, INTEGER(), DATE());
+    testCast<int64_t, int32_t>(
+        "date", {1234}, {0}, true, false, BIGINT(), DATE());
 
-  // Parsing an ill-formated date.
+    testCast<float, int32_t>("date", {12.99}, {0}, true, false, REAL(), DATE());
+    testCast<double, int32_t>(
+        "date", {12.99}, {0}, true, false, DOUBLE(), DATE());
+
+    // Parsing ill-formated dates.
+    testCast<std::string, int32_t>(
+        "date", {"2012-Oct-23"}, {0}, true, false, VARCHAR(), DATE());
+    testCast<std::string, int32_t>(
+        "date", {"2015-03-18X"}, {0}, true, false, VARCHAR(), DATE());
+    testCast<std::string, int32_t>(
+        "date", {"2015/03/18"}, {0}, true, false, VARCHAR(), DATE());
+    testCast<std::string, int32_t>(
+        "date", {"2015.03.18"}, {0}, true, false, VARCHAR(), DATE());
+    testCast<std::string, int32_t>(
+        "date", {"20150318"}, {0}, true, false, VARCHAR(), DATE());
+    testCast<std::string, int32_t>(
+        "date", {"2015-031-8"}, {0}, true, false, VARCHAR(), DATE());
+  }
+
+  setCastStringToDateIsIso8601(true);
   testCast<std::string, int32_t>(
-      "date", {"2012-Oct-23"}, {0}, true, false, VARCHAR(), DATE());
+      "date", {"2015"}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-03"}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-03-18T"}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-03-18 "}, {0}, true, false, VARCHAR(), DATE());
+  testCast<std::string, int32_t>(
+      "date", {"2015-03-18 (BC)"}, {0}, true, false, VARCHAR(), DATE());
 }
 
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -612,7 +612,9 @@ int32_t castFromDateString(const char* str, size_t len, bool isIso8601) {
       VELOX_USER_FAIL(
           "Unable to parse date value: \"{}\"."
           "Valid date string patterns include "
-          "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]",
+          "(yyyy*, yyyy*-[m]m, yyyy*-[m]m-[d]d, "
+          "yyyy*-[m]m-[d]d *, yyyy*-[m]m-[d]dT*), "
+          "and any pattern prefixed with [+-]",
           std::string(str, len));
     }
   }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -269,15 +269,6 @@ bool tryParseDateString(
   }
 
   if (mode == ParseMode::kStandardCast) {
-    // Skip trailing spaces.
-    while (pos < len && characterIsSpace(buf[pos])) {
-      pos++;
-    }
-    // Check position. if end was not reached, non-space chars remaining.
-    if (pos < len) {
-      return false;
-    }
-
     daysSinceEpoch = daysSinceEpochFromDate(year, month, day);
 
     if (pos == len) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -268,7 +268,6 @@ bool tryParseDateString(
     return false;
   }
 
-  // In standard-cast mode, no more trailing characters.
   if (mode == ParseMode::kStandardCast) {
     // Skip trailing spaces.
     while (pos < len && characterIsSpace(buf[pos])) {
@@ -287,7 +286,7 @@ bool tryParseDateString(
     return false;
   }
 
-  // In non-standard cast mode, any optional trailing 'T' or spaces followed
+  // In non-standard cast mode, an optional trailing 'T' or space followed
   // by any optional characters are valid patterns.
   if (mode == ParseMode::kNonStandardCast) {
     daysSinceEpoch = daysSinceEpochFromDate(year, month, day);

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -595,15 +595,26 @@ int64_t fromDateString(const char* str, size_t len) {
   return daysSinceEpoch;
 }
 
-std::optional<int32_t>
-castFromDateString(const char* str, size_t len, bool isStandardCast) {
+int32_t castFromDateString(const char* str, size_t len, bool isIso8601) {
   int64_t daysSinceEpoch;
   size_t pos = 0;
 
   auto mode =
-      isStandardCast ? ParseMode::kStandardCast : ParseMode::kNonStandardCast;
+      isIso8601 ? ParseMode::kStandardCast : ParseMode::kNonStandardCast;
   if (!tryParseDateString(str, len, pos, daysSinceEpoch, mode)) {
-    return std::nullopt;
+    if (isIso8601) {
+      VELOX_USER_FAIL(
+          "Unable to parse date value: \"{}\"."
+          "Valid date string pattern is (YYYY-MM-DD), "
+          "and can be prefixed with [+-]",
+          std::string(str, len));
+    } else {
+      VELOX_USER_FAIL(
+          "Unable to parse date value: \"{}\"."
+          "Valid date string patterns include "
+          "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]",
+          std::string(str, len));
+    }
   }
   return daysSinceEpoch;
 }

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -85,8 +85,8 @@ inline int64_t fromDateString(const StringView& str) {
 }
 
 /// Cast string to date.
-/// When isStandardCast = true, only support "[+-]YYYY-MM-DD" format (ISO 8601).
-/// When isStandardCast = false, supported date formats include:
+/// When isIso8601 = true, only support "[+-]YYYY-MM-DD" format (ISO 8601).
+/// When isIso8601 = false, supported date formats include:
 ///
 /// `[+-]YYYY*`
 /// `[+-]YYYY*-[M]M`
@@ -96,13 +96,10 @@ inline int64_t fromDateString(const StringView& str) {
 /// `[+-]YYYY*-[M]M-[D]DT*`
 ///
 /// Throws VeloxUserError if the format or date is invalid.
-std::optional<int32_t>
-castFromDateString(const char* buf, size_t len, bool isStandardCast);
+int32_t castFromDateString(const char* buf, size_t len, bool isIso8601);
 
-inline std::optional<int32_t> castFromDateString(
-    const StringView& str,
-    bool isStandardCast) {
-  return castFromDateString(str.data(), str.size(), isStandardCast);
+inline int32_t castFromDateString(const StringView& str, bool isIso8601) {
+  return castFromDateString(str.data(), str.size(), isIso8601);
 }
 
 // Extracts the day of the week from the number of days since epoch

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -85,8 +85,8 @@ inline int64_t fromDateString(const StringView& str) {
 }
 
 /// Cast string to date.
-/// When isNonStandardCast = false, only support "[+-]YYYY-MM-DD" format.
-/// When isNonStandardCast = true, supported date formats include:
+/// When isStandardCast = true, only support "[+-]YYYY-MM-DD" format (ISO 8601).
+/// When isStandardCast = false, supported date formats include:
 ///
 /// `[+-]YYYY*`
 /// `[+-]YYYY*-[M]M`
@@ -96,12 +96,13 @@ inline int64_t fromDateString(const StringView& str) {
 /// `[+-]YYYY*-[M]M-[D]DT*`
 ///
 /// Throws VeloxUserError if the format or date is invalid.
-int32_t castFromDateString(const char* buf, size_t len, bool isNonStandardCast);
+std::optional<int32_t>
+castFromDateString(const char* buf, size_t len, bool isStandardCast);
 
-inline int32_t castFromDateString(
+inline std::optional<int32_t> castFromDateString(
     const StringView& str,
-    bool isNonStandardCast) {
-  return castFromDateString(str.data(), str.size(), isNonStandardCast);
+    bool isStandardCast) {
+  return castFromDateString(str.data(), str.size(), isStandardCast);
 }
 
 // Extracts the day of the week from the number of days since epoch

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/type/TimestampConversion.h"
+#include <common/base/tests/GTestUtils.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include "velox/common/base/VeloxException.h"
@@ -110,44 +111,70 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
 }
 
 TEST(DateTimeUtilTest, castFromDateString) {
-  for (bool standard : {true, false}) {
-    EXPECT_EQ(0, castFromDateString("1970-01-01", standard));
-    EXPECT_EQ(0, castFromDateString("1970-01-01 ", standard));
-    EXPECT_EQ(3789742, castFromDateString("12345-12-18", standard));
+  for (bool isIso8601 : {true, false}) {
+    EXPECT_EQ(0, castFromDateString("1970-01-01", isIso8601));
+    EXPECT_EQ(3789742, castFromDateString("12345-12-18", isIso8601));
 
-    EXPECT_EQ(1, castFromDateString("+1970-1-2", standard));
-    EXPECT_EQ(1, castFromDateString("+1970-01-2", standard));
-    EXPECT_EQ(1, castFromDateString("+1970-1-02", standard));
+    EXPECT_EQ(1, castFromDateString("1970-1-2", isIso8601));
+    EXPECT_EQ(1, castFromDateString("1970-01-2", isIso8601));
+    EXPECT_EQ(1, castFromDateString("1970-1-02", isIso8601));
 
-    EXPECT_EQ(1, castFromDateString("+1970-01-02", standard));
-    EXPECT_EQ(-719893, castFromDateString("-1-1-1", standard));
+    EXPECT_EQ(1, castFromDateString("+1970-01-02", isIso8601));
+    EXPECT_EQ(-719893, castFromDateString("-1-1-1", isIso8601));
+
+    EXPECT_EQ(0, castFromDateString("1970-01-01 ", isIso8601));
+    EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", isIso8601));
+    EXPECT_EQ(0, castFromDateString(" 1970-01-01", isIso8601));
   }
 
   EXPECT_EQ(3789391, castFromDateString("12345", false));
+  EXPECT_EQ(16436, castFromDateString("2015", false));
   EXPECT_EQ(16495, castFromDateString("2015-03", false));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18 ", false));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18 123412", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18T", false));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18T123412", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18T123123", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 123142", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18 (BC)", false));
 }
 
 TEST(DateTimeUtilTest, castFromDateStringInvalid) {
-  for (bool standard : {true, false}) {
-    EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18X", standard));
-    EXPECT_EQ(std::nullopt, castFromDateString("2015/03/18", standard));
-    EXPECT_EQ(std::nullopt, castFromDateString("2015.03.18", standard));
-    EXPECT_EQ(std::nullopt, castFromDateString("20150318", standard));
-    EXPECT_EQ(std::nullopt, castFromDateString("2015-031-8", standard));
+  auto testCastFromDateStringInvalid = [&](const StringView& str,
+                                           bool isIso8601) {
+    if (isIso8601) {
+      VELOX_ASSERT_THROW(
+          castFromDateString(str, isIso8601),
+          fmt::format(
+              "Unable to parse date value: \"{}\"."
+              "Valid date string pattern is (YYYY-MM-DD), "
+              "and can be prefixed with [+-]",
+              std::string(str.data(), str.size())));
+    } else {
+      VELOX_ASSERT_THROW(
+          castFromDateString(str, isIso8601),
+          fmt::format(
+              "Unable to parse date value: \"{}\"."
+              "Valid date string patterns include "
+              "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]",
+              std::string(str.data(), str.size())));
+    }
+  };
+
+  for (bool isIso8601 : {true, false}) {
+    testCastFromDateStringInvalid("2012-Oct-23", isIso8601);
+    testCastFromDateStringInvalid("2012-Oct-23", isIso8601);
+    testCastFromDateStringInvalid("2015-03-18X", isIso8601);
+    testCastFromDateStringInvalid("2015/03/18", isIso8601);
+    testCastFromDateStringInvalid("2015.03.18", isIso8601);
+    testCastFromDateStringInvalid("20150318", isIso8601);
+    testCastFromDateStringInvalid("2015-031-8", isIso8601);
   }
 
-  EXPECT_EQ(std::nullopt, castFromDateString("12345", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 ", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 123412", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18T", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18T123412", true));
-  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 (BC)", true));
+  testCastFromDateStringInvalid("12345", true);
+  testCastFromDateStringInvalid("2015", true);
+  testCastFromDateStringInvalid("2015-03", true);
+  testCastFromDateStringInvalid("2015-03-18 123412", true);
+  testCastFromDateStringInvalid("2015-03-18T", true);
+  testCastFromDateStringInvalid("2015-03-18T123412", true);
+  testCastFromDateStringInvalid("2015-03-18 (BC)", true);
 }
 
 TEST(DateTimeUtilTest, fromTimeString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -121,8 +121,6 @@ TEST(DateTimeUtilTest, castFromDateString) {
     EXPECT_EQ(1, castFromDateString("+1970-01-02", isIso8601));
     EXPECT_EQ(-719893, castFromDateString("-1-1-1", isIso8601));
 
-    EXPECT_EQ(0, castFromDateString("1970-01-01 ", isIso8601));
-    EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", isIso8601));
     EXPECT_EQ(0, castFromDateString(" 1970-01-01", isIso8601));
   }
 
@@ -133,6 +131,9 @@ TEST(DateTimeUtilTest, castFromDateString) {
   EXPECT_EQ(16512, castFromDateString("2015-03-18T123123", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18 123142", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18 (BC)", false));
+
+  EXPECT_EQ(0, castFromDateString("1970-01-01 ", false));
+  EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", false));
 }
 
 TEST(DateTimeUtilTest, castFromDateStringInvalid) {
@@ -176,6 +177,9 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
   testCastFromDateStringInvalid("2015-03-18T", true);
   testCastFromDateStringInvalid("2015-03-18T123412", true);
   testCastFromDateStringInvalid("2015-03-18 (BC)", true);
+
+  testCastFromDateStringInvalid("1970-01-01 ", true);
+  testCastFromDateStringInvalid(" 1970-01-01 ", true);
 }
 
 TEST(DateTimeUtilTest, fromTimeString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -153,7 +153,9 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
           fmt::format(
               "Unable to parse date value: \"{}\"."
               "Valid date string patterns include "
-              "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]",
+              "(yyyy*, yyyy*-[m]m, yyyy*-[m]m-[d]d, "
+              "yyyy*-[m]m-[d]d *, yyyy*-[m]m-[d]dT*), "
+              "and any pattern prefixed with [+-]",
               std::string(str.data(), str.size())));
     }
   };

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -110,42 +110,44 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
 }
 
 TEST(DateTimeUtilTest, castFromDateString) {
-  for (bool nonStandard : {true, false}) {
-    EXPECT_EQ(0, castFromDateString("1970-01-01", nonStandard));
-    EXPECT_EQ(3789742, castFromDateString("12345-12-18", nonStandard));
+  for (bool standard : {true, false}) {
+    EXPECT_EQ(0, castFromDateString("1970-01-01", standard));
+    EXPECT_EQ(0, castFromDateString("1970-01-01 ", standard));
+    EXPECT_EQ(3789742, castFromDateString("12345-12-18", standard));
 
-    EXPECT_EQ(1, castFromDateString("+1970-1-2", nonStandard));
-    EXPECT_EQ(1, castFromDateString("+1970-01-2", nonStandard));
-    EXPECT_EQ(1, castFromDateString("+1970-1-02", nonStandard));
+    EXPECT_EQ(1, castFromDateString("+1970-1-2", standard));
+    EXPECT_EQ(1, castFromDateString("+1970-01-2", standard));
+    EXPECT_EQ(1, castFromDateString("+1970-1-02", standard));
 
-    EXPECT_EQ(1, castFromDateString("+1970-01-02", nonStandard));
-    EXPECT_EQ(-719893, castFromDateString("-1-1-1", nonStandard));
+    EXPECT_EQ(1, castFromDateString("+1970-01-02", standard));
+    EXPECT_EQ(-719893, castFromDateString("-1-1-1", standard));
   }
 
-  EXPECT_EQ(3789391, castFromDateString("12345", true));
-  EXPECT_EQ(16495, castFromDateString("2015-03", true));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18 ", true));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18 123412", true));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18T", true));
-  EXPECT_EQ(16512, castFromDateString("2015-03-18T123412", true));
+  EXPECT_EQ(3789391, castFromDateString("12345", false));
+  EXPECT_EQ(16495, castFromDateString("2015-03", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 ", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 123412", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18T", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18T123412", false));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 (BC)", false));
 }
 
 TEST(DateTimeUtilTest, castFromDateStringInvalid) {
-  for (bool nonStandard : {true, false}) {
-    EXPECT_THROW(
-        castFromDateString("2015-03-18X", nonStandard), VeloxUserError);
-    EXPECT_THROW(castFromDateString("2015/03/18", nonStandard), VeloxUserError);
-    EXPECT_THROW(castFromDateString("2015.03.18", nonStandard), VeloxUserError);
-    EXPECT_THROW(castFromDateString("20150318", nonStandard), VeloxUserError);
-    EXPECT_THROW(castFromDateString("2015-031-8", nonStandard), VeloxUserError);
+  for (bool standard : {true, false}) {
+    EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18X", standard));
+    EXPECT_EQ(std::nullopt, castFromDateString("2015/03/18", standard));
+    EXPECT_EQ(std::nullopt, castFromDateString("2015.03.18", standard));
+    EXPECT_EQ(std::nullopt, castFromDateString("20150318", standard));
+    EXPECT_EQ(std::nullopt, castFromDateString("2015-031-8", standard));
   }
 
-  EXPECT_THROW(castFromDateString("12345", false), VeloxUserError);
-  EXPECT_THROW(castFromDateString("2015-03", false), VeloxUserError);
-  EXPECT_THROW(castFromDateString("2015-03-18 ", false), VeloxUserError);
-  EXPECT_THROW(castFromDateString("2015-03-18 123412", false), VeloxUserError);
-  EXPECT_THROW(castFromDateString("2015-03-18T", false), VeloxUserError);
-  EXPECT_THROW(castFromDateString("2015-03-18T123412", false), VeloxUserError);
+  EXPECT_EQ(std::nullopt, castFromDateString("12345", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 ", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 123412", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18T", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18T123412", true));
+  EXPECT_EQ(std::nullopt, castFromDateString("2015-03-18 (BC)", true));
 }
 
 TEST(DateTimeUtilTest, fromTimeString) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -15,10 +15,9 @@
  */
 
 #include "velox/type/TimestampConversion.h"
-#include <common/base/tests/GTestUtils.h>
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>
 #include "velox/common/base/VeloxException.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/external/date/tz.h"
 #include "velox/type/Timestamp.h"
 #include "velox/type/tz/TimeZoneMap.h"


### PR DESCRIPTION
Below patterns are considered valid to cast from string to date in spark sql functions:

1. Year only: "YYYY"
2. Year and month only: "YYYY-MM"
3. Any characters after trailing spaces: "YYYY-MM-DD ", "YYYY-MM-DD 123", "YYYY-MM-DD (BC)"
4. Any characters after trailing character 'T': "YYYY-MM-DDT"

Below patterns are invalid:

1. Year is too large (exceed INT32_MAX): 20150318
2. Other separators "YYYY/MM/DD"

Reference: 
Spark cast from string to date:
https://github.com/apache/spark/blob/3e5203c64c06cc8a8560dfa0fb6f52e74589b583/sql/api/src/main/scala/org/apache/spark/sql/catalyst/util/SparkDateTimeUtils.scala#L286-L298

Unit test:
CastExprTest::fromStringToDate is derived from https://github.com/apache/spark/blob/3a9185964a0de3c720a6b77d38a446258b73468e/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastSuiteBase.scala#L103-L126
CastExprTest::fromStringToDateInvalid is derived from 
https://github.com/apache/spark/blob/3a9185964a0de3c720a6b77d38a446258b73468e/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/CastWithAnsiOffSuite.scala#L67-L73