### PR TITLE
Disable experimental consistency check

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1079,7 +1079,6 @@ void GroupingSet::toIntermediate(
   if (intermediateRows_) {
     intermediateRows_->eraseRows(folly::Range<char**>(
         intermediateGroups_.data(), intermediateGroups_.size()));
-    intermediateRows_->stringAllocator().checkEmpty();
   }
   tempVectors_.clear();
 }

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -23,8 +23,6 @@
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/VectorTypeUtils.h"
 
-DECLARE_bool(velox_row_container_check_free);
-
 namespace facebook::velox::exec {
 
 class Aggregate;
@@ -1106,7 +1104,7 @@ class RowContainer {
   // Free any aggregates associated with the 'rows'.
   void freeAggregates(folly::Range<char**> rows);
 
-  const bool checkFree_{FLAGS_velox_row_container_check_free};
+  const bool checkFree_ = false;
 
   const std::vector<TypePtr> keyTypes_;
   const bool nullableKeys_;

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -120,9 +120,3 @@ DEFINE_bool(
     "exception. This is only used by test to control the test error output size");
 
 DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");
-
-DEFINE_bool(
-    velox_row_container_check_free,
-    false,
-    "Check that variable length data in RowContainers is freed when "
-    "freeing the row");


### PR DESCRIPTION
Summary: A recently added consistency check needs additional changes to memory management in aggregations to ensure that it always hold otherwise it would fail in some cases where it should not. Removing it for now till those additional changes are merged.

Differential Revision: D47803340

