### PR TITLE
Fail benchmark job on regression

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -194,7 +194,6 @@ jobs:
                 --baseline_path ${BASELINE_OUTPUT_PATH} \
                 --contender_path ${CONTENDER_OUTPUT_PATH} \
                 --recursive \
-                --do_not_fail
           echo "::endgroup::"
 
       - name: "Save PR number"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,7 +193,7 @@ jobs:
           ./scripts/benchmark-runner.py compare \
                 --baseline_path ${BASELINE_OUTPUT_PATH} \
                 --contender_path ${CONTENDER_OUTPUT_PATH} \
-                --recursive \
+                --recursive 
           echo "::endgroup::"
 
       - name: "Save PR number"


### PR DESCRIPTION
Previously we did not fail on regressions to avoid false positives in the introduction phase. Things are now stable enough to enable this job to fail.