### PR TITLE
Fix scan spec building when multiple subfields sharing same map subscript

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -68,6 +68,12 @@ struct SubfieldSpec {
   bool filterOnly;
 };
 
+template <typename T>
+void deduplicate(std::vector<T>& values) {
+  std::sort(values.begin(), values.end());
+  values.erase(std::unique(values.begin(), values.end()), values.end());
+}
+
 // Recursively add subfields to scan spec.
 void addSubfields(
     const Type& type,
@@ -153,8 +159,10 @@ void addSubfields(
       }
       std::unique_ptr<common::Filter> filter;
       if (stringKey) {
+        deduplicate(stringSubscripts);
         filter = std::make_unique<common::BytesValues>(stringSubscripts, false);
       } else {
+        deduplicate(longSubscripts);
         filter = common::createBigintValues(longSubscripts, false);
       }
       keys->setFilter(std::move(filter));

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -184,11 +184,18 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
 }
 
 TEST_F(HiveConnectorTest, makeScanSpec_filtersNotInRequiredSubfields) {
-  auto columnType = ROW({{"c0c0", BIGINT()}, {"c0c1", VARCHAR()}});
+  auto columnType = ROW(
+      {{"c0c0", BIGINT()},
+       {"c0c1", VARCHAR()},
+       {"c0c2", ROW({{"c0c2c0", BIGINT()}})},
+       {"c0c3", ROW({{"c0c3c0", BIGINT()}})}});
   auto rowType = ROW({{"c0", columnType}});
-  auto columnHandle = makeColumnHandle("c0", columnType, {"c0.c0c1"});
+  auto columnHandle =
+      makeColumnHandle("c0", columnType, {"c0.c0c1", "c0.c0c3"});
   SubfieldFilters filters;
   filters.emplace(Subfield("c0.c0c0"), exec::equal(42));
+  filters.emplace(Subfield("c0.c0c2"), exec::isNotNull());
+  filters.emplace(Subfield("c0.c0c3"), exec::isNotNull());
   auto scanSpec = HiveDataSource::makeScanSpec(
       filters, rowType, {columnHandle.get()}, {}, pool_.get());
   auto* c0c0 = scanSpec->childByName("c0")->childByName("c0c0");
@@ -197,6 +204,14 @@ TEST_F(HiveConnectorTest, makeScanSpec_filtersNotInRequiredSubfields) {
   auto* c0c1 = scanSpec->childByName("c0")->childByName("c0c1");
   ASSERT_FALSE(c0c1->isConstant());
   ASSERT_FALSE(c0c1->filter());
+  auto* c0c2 = scanSpec->childByName("c0")->childByName("c0c2");
+  ASSERT_FALSE(c0c2->isConstant());
+  ASSERT_TRUE(c0c2->filter());
+  ASSERT_TRUE(c0c2->childByName("c0c2c0")->isConstant());
+  auto* c0c3 = scanSpec->childByName("c0")->childByName("c0c3");
+  ASSERT_FALSE(c0c3->isConstant());
+  ASSERT_TRUE(c0c3->filter());
+  ASSERT_FALSE(c0c3->childByName("c0c3c0")->isConstant());
 }
 
 TEST_F(HiveConnectorTest, extractFiltersFromRemainingFilter) {

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -496,9 +496,10 @@ class SelectiveColumnReader {
   template <typename T, typename TVector>
   void upcastScalarValues(RowSet rows);
 
-  // Returns true if compactScalarValues and upcastScalarValues should
-  // move null flags. Checks consistency of nulls-related state.
-  bool shouldMoveNulls(RowSet rows);
+  // Return the source null bits if compactScalarValues and upcastScalarValues
+  // should move null flags.  Return nullptr if nulls does not need to be moved.
+  // Checks consistency of nulls-related state.
+  const uint64_t* shouldMoveNulls(RowSet rows);
 
   void addStringValue(folly::StringPiece value);
 

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -128,8 +128,8 @@ void SelectiveStructColumnReaderBase::read(
     activeRows = outputRows_;
   }
 
-  VELOX_CHECK(!children_.empty());
   auto& childSpecs = scanSpec_->children();
+  VELOX_CHECK(!childSpecs.empty());
   for (size_t i = 0; i < childSpecs.size(); ++i) {
     auto& childSpec = childSpecs[i];
     if (isChildConstant(*childSpec)) {
@@ -293,7 +293,7 @@ void setNullField(vector_size_t size, VectorPtr& field) {
 void SelectiveStructColumnReaderBase::getValues(
     RowSet rows,
     VectorPtr* result) {
-  VELOX_CHECK(!children_.empty());
+  VELOX_CHECK(!scanSpec_->children().empty());
   VELOX_CHECK(
       *result != nullptr,
       "SelectiveStructColumnReaderBase expects a non-null result");

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -1893,3 +1893,39 @@ TEST(TestReader, reuseRowNumberColumn) {
     ASSERT_NE(rowNum.get(), result->asUnchecked<RowVector>()->childAt(1).get());
   }
 }
+
+TEST(TestReader, failToReuseReaderNulls) {
+  auto* pool = defaultPool.get();
+  VectorMaker maker(pool);
+  auto c0 = maker.rowVector(
+      {"a", "b"},
+      {
+          maker.flatVector<int64_t>(11, folly::identity),
+          maker.flatVector<int64_t>(
+              11, folly::identity, [](auto i) { return i % 3 == 0; }),
+      });
+  // Set a null so that the children will not be loaded lazily.
+  bits::setNull(c0->mutableRawNulls(), 10);
+  auto data = maker.rowVector({
+      c0,
+      maker.rowVector({"c"}, {maker.flatVector<int64_t>(11, folly::identity)}),
+  });
+  auto schema = asRowType(data->type());
+  auto [writer, reader] = createWriterReader({data}, *pool);
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addAllChildFields(*schema);
+  spec->childByName("c0")->childByName("a")->setFilter(
+      std::make_unique<common::BigintRange>(
+          0, std::numeric_limits<int64_t>::max(), false));
+  spec->childByName("c1")->childByName("c")->setFilter(
+      std::make_unique<common::BigintRange>(0, 4, false));
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(spec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto result = BaseVector::create(schema, 0, pool);
+  ASSERT_EQ(rowReader->next(10, result), 10);
+  ASSERT_EQ(result->size(), 5);
+  for (int i = 0; i < result->size(); ++i) {
+    ASSERT_TRUE(result->equalValueAt(data.get(), i, i)) << result->toString(i);
+  }
+}


### PR DESCRIPTION
Summary: When 2 subfields sharing some common ancestor, we generate duplicate map subscripts and use them to generate filter on keys.  This is not allowed and need to be deduplicated before constructing the filter.

Differential Revision: D47804920

