### PR TITLE
Add dedupe logic for InPredicate constant list

### DIFF
--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -406,8 +406,30 @@ TEST_F(InPredicateTest, doubleWithZero) {
   expected = makeNullableFlatVector<bool>({true, true});
   assertEqualVectors(expected, result);
 
-  // TODO : zero and negative zero, BigintValuesUsingBitmask, depending on
-  // another fix
+  // duplicate 0
+  input = makeRowVector({
+      makeNullableFlatVector<double>({0.0, -0.0}, DOUBLE()),
+  });
+  predicate = "c0 IN ( 0.0, 0.0, -0.0 )";
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  expected = makeNullableFlatVector<bool>({true, true});
+  assertEqualVectors(expected, result);
+
+  input = makeRowVector({
+      makeNullableFlatVector<double>({0.0, -0.0, 1.0, 2.0}, DOUBLE()),
+  });
+  predicate = "c0 IN ( 0.0 )";
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  expected = makeNullableFlatVector<bool>({true, true, false, false});
+  assertEqualVectors(expected, result);
+
+  input = makeRowVector({
+      makeNullableFlatVector<double>({0.0, -0.0, 1.0, 2.0}, DOUBLE()),
+  });
+  predicate = "c0 IN ( -0.0 )";
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  expected = makeNullableFlatVector<bool>({true, true, false, false});
+  assertEqualVectors(expected, result);
 }
 
 TEST_F(InPredicateTest, double) {
@@ -491,8 +513,6 @@ TEST_F(InPredicateTest, float) {
 
   // InList has Null
   // Multiple non-null, using BigintValuesUsingHashTable
-  // TODO: CAST(1.2 AS REAL), CAST(1.2 AS REAL) captured a bug in
-  // BigintValuesUsingBitmask, it will be fixed in separate diff
   predicate = "c0 IN ( CAST(1.2 AS REAL), CAST(1.3 AS REAL), null )";
   result = evaluate<SimpleVector<bool>>(predicate, input);
   expected = makeNullableFlatVector<bool>({true, std::nullopt, std::nullopt});
@@ -529,5 +549,146 @@ TEST_F(InPredicateTest, float) {
   predicate = "c0 IN ( CAST(1.2 AS REAL), CAST(1.3 AS REAL) )";
   result = evaluate<SimpleVector<bool>>(predicate, input);
   expected = makeNullableFlatVector<bool>({false});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, bigIntDuplicateWithBigintRange) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2}, BIGINT()),
+  });
+  std::string predicate = "c0 IN ( 2, 2, 2, 2 )";
+  auto expected = makeNullableFlatVector<bool>({false, true});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NOT IN
+  input = makeRowVector({
+      makeFlatVector<int64_t>({3, 4, 5}, BIGINT()),
+  });
+  predicate = "c0 NOT IN ( 4, 4, 4, 4 )";
+  expected = makeNullableFlatVector<bool>({true, false, true});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NULL
+  input = makeRowVector({
+      makeFlatVector<int64_t>({3, 4, 5}, BIGINT()),
+  });
+  predicate = "c0 IN ( 4, 4, 4, 4, null )";
+  expected = makeNullableFlatVector<bool>({std::nullopt, true, std::nullopt});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, bigIntDuplicateWithBigintValuesUsingBitmask) {
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>({1, 2, 5}, BIGINT()),
+  });
+  std::string predicate = "c0 IN ( 1, 2, 2, 3, 4 )";
+  auto expected = makeNullableFlatVector<bool>({true, true, false});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NULL
+  input = makeRowVector({
+      makeFlatVector<int64_t>({0, 4, 5}, BIGINT()),
+  });
+  predicate = "c0 IN ( 1, 3, 4, 4, 4, 5, null )";
+  expected = makeNullableFlatVector<bool>({std::nullopt, true, true});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+}
+
+// Filter.cpp range check logic (uint64_t)range + 1 == values.size()
+// will have correctness issue, if there is no dedupe logic
+TEST_F(InPredicateTest, bigIntDuplicateWithContinuousBlock) {
+  auto input = makeRowVector({
+      makeNullableFlatVector<int64_t>({3}, BIGINT()),
+  });
+  auto predicate = "c0 IN ( 1, 2, 2, 4 )";
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  auto expected = makeNullableFlatVector<bool>({false});
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, doubleDuplicateWithFloatingPointRange) {
+  auto input = makeRowVector({
+      makeFlatVector<double>({1.2, 2.3}, DOUBLE()),
+  });
+  std::string predicate = "c0 IN ( 1.2, 1.2, null )";
+  auto expected = makeNullableFlatVector<bool>({true, std::nullopt});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, doubleDuplicateWithBigintValuesUsingHashTable) {
+  auto input = makeRowVector({
+      makeFlatVector<double>({1.2, 4.5}, DOUBLE()),
+  });
+  std::string predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4 )";
+  auto expected = makeNullableFlatVector<bool>({true, false});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NULL
+  input = makeRowVector({
+      makeFlatVector<double>({1.2, 4.5}, DOUBLE()),
+  });
+  predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4, null )";
+  expected = makeNullableFlatVector<bool>({true, std::nullopt});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NaN
+  input = makeRowVector({
+      makeFlatVector<double>({std::nan(""), std::nan("")}, DOUBLE()),
+  });
+  predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4 )";
+  expected = makeNullableFlatVector<bool>({false, false});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // NaN with null
+  input = makeRowVector({
+      makeFlatVector<double>({std::nan(""), std::nan("")}, DOUBLE()),
+  });
+  predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4, null )";
+  expected = makeNullableFlatVector<bool>({std::nullopt, std::nullopt});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // Inf, -Inf
+  input = makeRowVector({
+      makeFlatVector<double>(
+          {std::numeric_limits<double>::infinity(),
+           -std::numeric_limits<double>::infinity()},
+          DOUBLE()),
+  });
+  predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4 )";
+  expected = makeNullableFlatVector<bool>({false, false});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+
+  // Inf, -Inf with null
+  input = makeRowVector({
+      makeFlatVector<double>(
+          {std::numeric_limits<double>::infinity(),
+           -std::numeric_limits<double>::infinity()},
+          DOUBLE()),
+  });
+  predicate = "c0 IN ( 1.2, 1.2, 2.3, 3.4, null )";
+  expected = makeNullableFlatVector<bool>({std::nullopt, std::nullopt});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, floatDuplicateWithFloatingPointRange) {
+  // No Null
+  auto input = makeRowVector({
+      makeNullableFlatVector<float>({1.2, 2.3}, REAL()),
+  });
+  std::string predicate = "c0 IN ( CAST(1.2 AS REAL), CAST(1.2 AS REAL) )";
+  auto expected = makeNullableFlatVector<bool>({true, false});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
   assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
Previously, the InPredicate constant list did not handle duplicates, which causes correctness issues for Integer types, FloatingPoint types, etc.
This diff will help to avoid implementing individual dedupe logic for each internal data structures such as BigintValuesUsingBitmask, BigintValuesUsingHashTable, BigIntRange, FloatingPointRange, etc

Reviewed By: Yuhta

Differential Revision: D47784943

