### PR TITLE
Enforce that switch expression type and all of its clauses are the same.

### DIFF
--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -48,7 +48,12 @@ SwitchExpr::SwitchExpr(
       [](const ExprPtr& expr) { return expr->type(); });
 
   // Apply type checking.
-  resolveType(inputTypes);
+  auto typeExpected = resolveType(inputTypes);
+  VELOX_CHECK(
+      *typeExpected == *this->type(),
+      "Switch expression type different than then clause. Expected {} but got Actual {}.",
+      typeExpected->toString(),
+      this->type()->toString());
 }
 
 void SwitchExpr::evalSpecialForm(
@@ -230,7 +235,7 @@ TypePtr SwitchExpr::resolveType(const std::vector<TypePtr>& argTypes) {
         "Condition of  SWITCH statement is not bool");
 
     VELOX_CHECK(
-        thenType->equivalent(*expressionType),
+        *thenType == *expressionType,
         "All then clauses of a SWITCH statement must have the same type. "
         "Expected {}, but got {}.",
         expressionType->toString(),
@@ -243,7 +248,7 @@ TypePtr SwitchExpr::resolveType(const std::vector<TypePtr>& argTypes) {
     auto& elseClauseType = argTypes.back();
 
     VELOX_CHECK(
-        elseClauseType->equivalent(*expressionType),
+        *elseClauseType == *expressionType,
         "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
         "Expected {}, but got {}.",
         expressionType->toString(),


### PR DESCRIPTION
Summary:
During execution, results types of expressions like switch and coalesce ca
 be of any of their children types. something like
```
switch(c0, cast(row_constructor(1) as struct(f1 BOOLEAN)),  cast(row_constructor(1) as struct(f2 BOOLEAN)).f1
```
could fail with Velox runtime error (not user error) dynamically based on
the actual switch output type.

This diff makes sure that all of the clauses of the switch expression and
the type of associated with the switch expression are the same (including
field names). Hence such error would be caught statically and won't result
in runtime error.
Velox should receive completely well typed expressions.
A following diff will do the same for coalesce.

Differential Revision: D47814027

