### PR TITLE
Fix the race between task terminate and memory reclaim

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -27,7 +27,7 @@
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/exec/HashTable.h"
+#include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -1653,11 +1653,180 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, driverInitTriggeredArbitration) {
       .queryCtx(queryCtx)
       .plan(PlanBuilder(planNodeIdGenerator, pool())
                 .values(vectors)
-                // Set filter projection to trigger memory allocation on driver
-                // init.
+                // Set filter projection to trigger memory allocation on
+                // driver init.
                 .project({"1+1+4 as t0", "1+3+3 as t1"})
                 .planNode())
       .assertResults(expectedVector);
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenTaskTerminateAndReclaim) {
+  setupMemory(kMemoryCapacity, 0);
+  const int numVectors = 10;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
+  ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+  // Allocate a large chunk of memory to trigger memory reclaim during the query
+  // execution.
+  auto fakeLeafPool = queryCtx->pool()->addLeafChild("fakeLeaf");
+  const size_t fakeAllocationSize = kMemoryCapacity / 2;
+  Allocation fakeAllocation{
+      fakeLeafPool.get(),
+      fakeLeafPool->allocate(fakeAllocationSize),
+      fakeAllocationSize};
+
+  // Set test injection to enforce memory arbitration based on the fake
+  // allocation size and the total available memory.
+  std::shared_ptr<Task> task;
+  std::atomic<bool> injectAllocationOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Values::getOutput",
+      std::function<void(const exec::Values*)>([&](const exec::Values* values) {
+        if (!injectAllocationOnce.exchange(false)) {
+          return;
+        }
+        task = values->testingOperatorCtx()->task();
+        MemoryPool* pool = values->pool();
+        VELOX_ASSERT_THROW(
+            pool->allocate(kMemoryCapacity * 2 / 3),
+            "Exceeded memory pool cap");
+      }));
+
+  // Set test injection to wait until the reclaim on hash aggregation operator
+  // triggers.
+  folly::EventCount opReclaimStartWait;
+  std::atomic<bool> opReclaimStarted{false};
+  folly::EventCount taskAbortWait;
+  std::atomic<bool> taskAborted{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Operator::MemoryReclaimer::reclaim",
+      std::function<void(MemoryPool*)>(([&](MemoryPool* pool) {
+        const std::string re(".*Aggregation");
+        if (!RE2::FullMatch(pool->name(), re)) {
+          return;
+        }
+        opReclaimStarted = true;
+        opReclaimStartWait.notifyAll();
+        // Wait for task abort to happen before the actual memory reclaim.
+        taskAbortWait.await([&]() { return taskAborted.load(); });
+      })));
+
+  const int numDrivers = 1;
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  std::thread queryThread([&]() {
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .queryCtx(queryCtx)
+            .spillDirectory(spillDirectory->path)
+            .config(core::QueryConfig::kSpillEnabled, "true")
+            .config(core::QueryConfig::kJoinSpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(numDrivers)
+            .plan(PlanBuilder()
+                      .values(vectors)
+                      .localPartition({"c0", "c1"})
+                      .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                      .localPartition(std::vector<std::string>{})
+                      .planNode())
+            .assertResults(
+                "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1"),
+        "Aborted for external error");
+  });
+
+  // Wait for the reclaim on aggregation to be started before the task abort.
+  opReclaimStartWait.await([&]() { return opReclaimStarted.load(); });
+  ASSERT_TRUE(task != nullptr);
+  task->requestAbort().wait();
+
+  // Resume aggregation reclaim to execute.
+  taskAborted = true;
+  taskAbortWait.notifyAll();
+
+  queryThread.join();
+  fakeAllocation.free();
+  task.reset();
+  Task::testingWaitForAllTasksToBeDeleted();
+}
+
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
+  setupMemory(kMemoryCapacity, 0);
+  const int numVectors = 10;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
+  ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+  folly::EventCount aggregationAllocationWait;
+  std::atomic<bool> aggregationAllocationOnce{true};
+  folly::EventCount aggregationAllocationUnblockWait;
+  std::atomic<bool> aggregationAllocationUnblocked{false};
+  std::atomic<MemoryPool*> injectPool{nullptr};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::memory::MemoryPoolImpl::reserveThreadSafe",
+      std::function<void(MemoryPool*)>(([&](MemoryPool* pool) {
+        const std::string re(".*Aggregation");
+        if (!RE2::FullMatch(pool->name(), re)) {
+          return;
+        }
+
+        if (!aggregationAllocationOnce.exchange(false)) {
+          return;
+        }
+        injectPool = pool;
+        aggregationAllocationWait.notifyAll();
+
+        aggregationAllocationUnblockWait.await(
+            [&]() { return aggregationAllocationUnblocked.load(); });
+      })));
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  std::shared_ptr<Task> task;
+  std::thread queryThread([&]() {
+    task = AssertQueryBuilder(duckDbQueryRunner_)
+               .queryCtx(queryCtx)
+               .spillDirectory(spillDirectory->path)
+               .config(core::QueryConfig::kSpillEnabled, "true")
+               .config(core::QueryConfig::kJoinSpillEnabled, "true")
+               .config(core::QueryConfig::kSpillPartitionBits, "2")
+               .plan(PlanBuilder()
+                         .values(vectors)
+                         .localPartition({"c0", "c1"})
+                         .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                         .localPartition(std::vector<std::string>{})
+                         .planNode())
+               .assertResults(
+                   "SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+  });
+
+  aggregationAllocationWait.await(
+      [&]() { return !aggregationAllocationOnce.load(); });
+  ASSERT_TRUE(injectPool != nullptr);
+
+  // Trigger the memory arbitration with memory pool whose associated driver is
+  // running on driver thread.
+  const size_t fakeAllocationSize = arbitrator_->stats().freeCapacityBytes / 2;
+  Allocation fakeAllocation = {
+      injectPool.load(),
+      injectPool.load()->allocate(fakeAllocationSize),
+      fakeAllocationSize};
+
+  aggregationAllocationUnblocked = true;
+  aggregationAllocationUnblockWait.notifyAll();
+
+  queryThread.join();
+  fakeAllocation.free();
+
+  task.reset();
+  Task::testingWaitForAllTasksToBeDeleted();
 }
 
 TEST_F(SharedArbitrationTest, concurrentArbitration) {

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -632,6 +632,7 @@ void Driver::close() {
 }
 
 void Driver::closeByTask() {
+  VELOX_CHECK(isOnThread());
   VELOX_CHECK(isTerminated());
   addStatsToTask();
   for (auto& op : operators_) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -723,31 +723,64 @@ void Task::start(
 
 // static
 void Task::resume(std::shared_ptr<Task> self) {
-  VELOX_CHECK(!self->exception_, "Cannot resume failed task");
-  std::lock_guard<std::mutex> l(self->mutex_);
-  // Setting pause requested must be atomic with the resuming so that
-  // suspended sections do not go back on thread during resume.
-  self->pauseRequested_ = false;
-  for (auto& driver : self->drivers_) {
-    if (driver) {
-      if (driver->state().isSuspended) {
-        // The Driver will come on thread in its own time as long as
-        // the cancel flag is reset. This check needs to be inside 'mutex_'.
-        continue;
+  std::vector<std::shared_ptr<Driver>> offThreadDrivers;
+  {
+    std::lock_guard<std::mutex> l(self->mutex_);
+    // Setting pause requested must be atomic with the resuming so that
+    // suspended sections do not go back on thread during resume.
+    self->pauseRequested_ = false;
+    if (!self->exception_) {
+      for (auto& driver : self->drivers_) {
+        if (driver) {
+          if (driver->state().isSuspended) {
+            // The Driver will come on thread in its own time as long as
+            // the cancel flag is reset. This check needs to be inside 'mutex_'.
+            continue;
+          }
+          if (driver->state().isEnqueued) {
+            // A Driver can wait for a thread and there can be a
+            // pause/resume during the wait. The Driver should not be
+            // enqueued twice.
+            continue;
+          }
+          VELOX_CHECK(!driver->isOnThread() && !driver->isTerminated());
+          if (!driver->state().hasBlockingFuture) {
+            // Do not continue a Driver that is blocked on external
+            // event. The Driver gets enqueued by the promise realization.
+            Driver::enqueue(driver);
+          }
+        }
       }
-      if (driver->state().isEnqueued) {
-        // A Driver can wait for a thread and there can be a
-        // pause/resume during the wait. The Driver should not be
-        // enqueued twice.
-        continue;
-      }
-      VELOX_CHECK(!driver->isOnThread() && !driver->isTerminated());
-      if (!driver->state().hasBlockingFuture) {
-        // Do not continue a Driver that is blocked on external
-        // event. The Driver gets enqueued by the promise realization.
-        Driver::enqueue(driver);
+    } else {
+      // NOTE: no need to resume task execution if the task has been terminated.
+      // But we need to close the drivers which are off threads as task
+      // terminate code path skips closing the off thread drivers if the task
+      // has been requested pause and leave the task resume path to handle. If
+      // a task has been paused, then there might be concurrent memory
+      // arbitration thread to reclaim the memory resource from the off thread
+      // driver operators.
+      for (auto& driver : self->drivers_) {
+        if (driver == nullptr) {
+          continue;
+        }
+        if (driver->isOnThread()) {
+          VELOX_CHECK(driver->isTerminated());
+          continue;
+        }
+        if (driver->isTerminated()) {
+          continue;
+        }
+        driver->state().isTerminated = true;
+        driver->state().setThread();
+        self->driverClosedLocked();
+        offThreadDrivers.push_back(std::move(driver));
       }
     }
+  }
+
+  // Get the stats and free the resources of Drivers that were not on thread.
+  for (auto& driver : offThreadDrivers) {
+    driver->closeByTask();
   }
 }
 
@@ -2121,6 +2154,11 @@ StopReason Task::enterForTerminateLocked(ThreadState& state) {
   if (state.isOnThread() || state.isTerminated) {
     state.isTerminated = true;
     return StopReason::kAlreadyOnThread;
+  }
+  if (pauseRequested_) {
+    // NOTE: if the task has been requested to pause, then we let the task
+    // resume code path to close these off thread drivers.
+    return StopReason::kPause;
   }
   state.isTerminated = true;
   state.setThread();

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -23,7 +23,6 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Aggregate.h"
-#include "velox/exec/HashAggregation.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/RowContainer.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"


### PR DESCRIPTION
There are two race conditions in memory arbitration code path:
1. The race condition between task termination and memory arbitration.
Here is the event flow:
T1 memory arbitration thread pause the task and all drivers are off threads'
T2 memory arbitration thread reclaim memory from one driver at a time by
spilling and continue running;
T3 task termination triggers from some reason and starts to close all the off
thread drivers which in turn close all its operators. The operator close will
mutate the operator state which might cause random segment fault with the
current disk spilling operations issued in T2.
To fix the problem, we shall not close off thread drivers if task has been
requested pause, and let the task resume code path to handle those off thread
drivers;
In followup, we consider to add task termination check point in disk spilling
path to abort early based on offline discussion with @mbasmanova 

2. when a memory enters into memory arbitration, the current code expects it
is always from the driver thread but it is not always true as some operator like
table scan, exchange which have async operations that might run off thread such
as connector executor or http thread pool. So we can't expect the memory
arbitration is always from the driver thread. This PR relax the check a bit.
In followup, we will add property in operator to indicate if it is possible an operator
memory pool will have async memory allocation or not to strict the check a bit.