### PR TITLE
Enforce that coalesce expression type and all of its inputs are strictly the same

### DIFF
--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -36,7 +36,12 @@ CoalesceExpr::CoalesceExpr(
       [](const ExprPtr& expr) { return expr->type(); });
 
   // Apply type checks.
-  resolveType(inputTypes);
+  auto expectedType = resolveType(inputTypes);
+  VELOX_CHECK(
+      *expectedType == *this->type(),
+      "Coalesce expression type different than its inputs. Expected {} but got Actual {}.",
+      expectedType->toString(),
+      this->type()->toString());
 }
 
 void CoalesceExpr::evalSpecialForm(
@@ -88,7 +93,7 @@ TypePtr CoalesceExpr::resolveType(const std::vector<TypePtr>& argTypes) {
       "COALESCE statements expect to receive at least 1 argument, but did not receive any.");
   for (auto i = 1; i < argTypes.size(); i++) {
     VELOX_USER_CHECK(
-        argTypes[0]->equivalent(*argTypes[i]),
+        *argTypes[0] == *argTypes[i],
         "Inputs to coalesce must have the same type. Expected {}, but got {}.",
         argTypes[0]->toString(),
         argTypes[i]->toString());

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -48,7 +48,12 @@ SwitchExpr::SwitchExpr(
       [](const ExprPtr& expr) { return expr->type(); });
 
   // Apply type checking.
-  resolveType(inputTypes);
+  auto typeExpected = resolveType(inputTypes);
+  VELOX_CHECK(
+      *typeExpected == *this->type(),
+      "Switch expression type different than then clause. Expected {} but got Actual {}.",
+      typeExpected->toString(),
+      this->type()->toString());
 }
 
 void SwitchExpr::evalSpecialForm(
@@ -230,7 +235,7 @@ TypePtr SwitchExpr::resolveType(const std::vector<TypePtr>& argTypes) {
         "Condition of  SWITCH statement is not bool");
 
     VELOX_CHECK(
-        thenType->equivalent(*expressionType),
+        *thenType == *expressionType,
         "All then clauses of a SWITCH statement must have the same type. "
         "Expected {}, but got {}.",
         expressionType->toString(),
@@ -243,7 +248,7 @@ TypePtr SwitchExpr::resolveType(const std::vector<TypePtr>& argTypes) {
     auto& elseClauseType = argTypes.back();
 
     VELOX_CHECK(
-        elseClauseType->equivalent(*expressionType),
+        *elseClauseType == *expressionType,
         "Else clause of a SWITCH statement must have the same type as 'then' clauses. "
         "Expected {}, but got {}.",
         expressionType->toString(),


### PR DESCRIPTION
Summary:
Results types of expressions like switch and coalesce can be of any of their children types. something like

``` coalesce(cast(row_constructor(1) as struct(f1 BOOLEAN)), cast(row_constructor(1) as struct(f2 BOOLEAN)).f1 ```
could fail with Velox runtime error (not user error) dynamically based on the actual coalesce output type. This diff makes sure that all of the inputs of the coalesce expression and the type associated with the coalesce expression are the same (including field names).

Hence such errors would be caught statically and won't result in runtime errors.
Velox should receive completely well typed expressions.

Differential Revision: D47815849

