### PR TITLE
Extract LocalExchangeSource into a separate file

### DIFF
--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -312,8 +312,6 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
     return folly::toPrettyJson(obj);
   }
 
-  static void registerFactory();
-
   static bool registerFactory(Factory factory) {
     factories().push_back(factory);
     return true;
@@ -478,8 +476,3 @@ class Exchange : public SourceOperator {
 };
 
 } // namespace facebook::velox::exec
-
-#define VELOX_REGISTER_EXCHANGE_SOURCE_METHOD_DEFINITION(class, function) \
-  void class ::registerFactory() {                                        \
-    facebook::velox::exec::ExchangeSource::registerFactory((function));   \
-  }

--- a/velox/exec/TaskStructs.h
+++ b/velox/exec/TaskStructs.h
@@ -25,7 +25,6 @@ namespace facebook::velox::exec {
 class Driver;
 class JoinBridge;
 class LocalExchangeMemoryManager;
-class LocalExchangeSource;
 class MergeSource;
 class MergeJoinSource;
 class Split;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -21,6 +21,7 @@
 #include "velox/exec/Exchange.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -306,19 +307,19 @@ Counters flat50Counters;
 Counters deep50Counters;
 Counters localFlat10kCounters;
 
-BENCHMARK(exchanegeFlat10k) {
+BENCHMARK(exchangeFlat10k) {
   bm.run(flat10k, FLAGS_width, FLAGS_task_width, flat10kCounters);
 }
 
-BENCHMARK_RELATIVE(exchanegeFlat50) {
+BENCHMARK_RELATIVE(exchangeFlat50) {
   bm.run(flat50, FLAGS_width, FLAGS_task_width, flat50Counters);
 }
 
-BENCHMARK(exchanegeDeep10k) {
+BENCHMARK(exchangeDeep10k) {
   bm.run(deep10k, FLAGS_width, FLAGS_task_width, deep10kCounters);
 }
 
-BENCHMARK_RELATIVE(exchanegeDeep50) {
+BENCHMARK_RELATIVE(exchangeDeep50) {
   bm.run(deep50, FLAGS_width, FLAGS_task_width, deep50Counters);
 }
 
@@ -335,7 +336,7 @@ int main(int argc, char** argv) {
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
-  exec::ExchangeSource::registerFactory();
+  exec::ExchangeSource::registerFactory(exec::test::createLocalExchangeSource);
   std::vector<std::string> flatNames = {"c0"};
   std::vector<TypePtr> flatTypes = {BIGINT()};
   std::vector<TypePtr> typeSelection = {

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   AssertQueryBuilder.cpp
   Cursor.cpp
   HiveConnectorTestBase.cpp
+  LocalExchangeSource.cpp
   OperatorTestBase.cpp
   PlanBuilder.cpp
   QueryAssertions.cpp

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/exec/PartitionedOutputBufferManager.h"
+
+namespace facebook::velox::exec::test {
+namespace {
+
+class LocalExchangeSource : public exec::ExchangeSource {
+ public:
+  LocalExchangeSource(
+      const std::string& taskId,
+      int destination,
+      std::shared_ptr<exec::ExchangeQueue> queue,
+      memory::MemoryPool* pool)
+      : ExchangeSource(taskId, destination, queue, pool) {}
+
+  bool shouldRequestLocked() override {
+    if (atEnd_) {
+      return false;
+    }
+    return !requestPending_.exchange(true);
+  }
+
+  void request() override {
+    auto buffers = PartitionedOutputBufferManager::getInstance().lock();
+    VELOX_CHECK_NOT_NULL(buffers, "invalid PartitionedOutputBufferManager");
+    VELOX_CHECK(requestPending_);
+    auto requestedSequence = sequence_;
+    auto self = shared_from_this();
+    buffers->getData(
+        taskId_,
+        destination_,
+        kMaxBytes,
+        sequence_,
+        // Since this lambda may outlive 'this', we need to capture a
+        // shared_ptr to the current object (self).
+        [self, requestedSequence, buffers, this](
+            std::vector<std::unique_ptr<folly::IOBuf>> data, int64_t sequence) {
+          if (requestedSequence > sequence) {
+            VLOG(2) << "Receives earlier sequence than requested: task "
+                    << taskId_ << ", destination " << destination_
+                    << ", requested " << sequence << ", received "
+                    << requestedSequence;
+            int64_t nExtra = requestedSequence - sequence;
+            VELOX_CHECK(nExtra < data.size());
+            data.erase(data.begin(), data.begin() + nExtra);
+            sequence = requestedSequence;
+          }
+          std::vector<std::unique_ptr<SerializedPage>> pages;
+          bool atEnd = false;
+          for (auto& inputPage : data) {
+            if (!inputPage) {
+              atEnd = true;
+              // Keep looping, there could be extra end markers.
+              continue;
+            }
+            inputPage->unshare();
+            pages.push_back(
+                std::make_unique<SerializedPage>(std::move(inputPage)));
+            inputPage = nullptr;
+          }
+          numPages_ += pages.size();
+          int64_t ackSequence;
+          {
+            std::vector<ContinuePromise> promises;
+            {
+              std::lock_guard<std::mutex> l(queue_->mutex());
+              requestPending_ = false;
+              for (auto& page : pages) {
+                queue_->enqueueLocked(std::move(page), promises);
+              }
+              if (atEnd) {
+                queue_->enqueueLocked(nullptr, promises);
+                atEnd_ = true;
+              }
+              ackSequence = sequence_ = sequence + pages.size();
+            }
+            for (auto& promise : promises) {
+              promise.setValue();
+            }
+          }
+          // Outside of queue mutex.
+          if (atEnd_) {
+            buffers->deleteResults(taskId_, destination_);
+          } else {
+            buffers->acknowledge(taskId_, destination_, ackSequence);
+          }
+        });
+  }
+
+  void close() override {
+    auto buffers = PartitionedOutputBufferManager::getInstance().lock();
+    buffers->deleteResults(taskId_, destination_);
+  }
+
+  folly::F14FastMap<std::string, int64_t> stats() const override {
+    return {{"localExchangeSource.numPages", numPages_}};
+  }
+
+ private:
+  static constexpr uint64_t kMaxBytes = 32 * 1024 * 1024; // 32 MB
+
+  // Records the total number of pages fetched from sources.
+  int64_t numPages_{0};
+};
+
+} // namespace
+
+std::unique_ptr<ExchangeSource> createLocalExchangeSource(
+    const std::string& taskId,
+    int destination,
+    std::shared_ptr<ExchangeQueue> queue,
+    memory::MemoryPool* pool) {
+  if (strncmp(taskId.c_str(), "local://", 8) == 0) {
+    return std::make_unique<LocalExchangeSource>(
+        taskId, destination, std::move(queue), pool);
+  }
+  return nullptr;
+}
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/LocalExchangeSource.h
+++ b/velox/exec/tests/utils/LocalExchangeSource.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/exec/Exchange.h"
+
+namespace facebook::velox::exec::test {
+
+/// Given taskId that starts with local:// returns an instance of ExchangeSource
+/// that fetches data from local PartitionedoutputBufferManager.
+std::unique_ptr<exec::ExchangeSource> createLocalExchangeSource(
+    const std::string& taskId,
+    int destination,
+    std::shared_ptr<exec::ExchangeQueue> queue,
+    memory::MemoryPool* pool);
+
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -34,8 +34,6 @@ using namespace facebook::velox::common::testutil;
 namespace facebook::velox::exec::test {
 
 OperatorTestBase::OperatorTestBase() {
-  using memory::MemoryAllocator;
-  facebook::velox::exec::ExchangeSource::registerFactory();
   parse::registerTypeResolver();
 }
 


### PR DESCRIPTION
LocalExchangeSource is a test-only class. Move it out of exec/Exchange.cpp into
a separate .h/.cpp files under test directory.