### PR TITLE
Register row_constructor as FunctionCallToSpecialForm

### DIFF
--- a/velox/expression/CMakeLists.txt
+++ b/velox/expression/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(
   LambdaExpr.cpp
   VectorFunction.cpp
   RegisterSpecialForm.cpp
+  RowConstructor.cpp
   SimpleFunctionRegistry.cpp
   SpecialFormRegistry.cpp
   SwitchExpr.cpp

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -671,7 +671,8 @@ TypePtr CastCallToSpecialForm::resolveType(
 ExprPtr CastCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool trackCpuUsage) {
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
   VELOX_CHECK_EQ(
       compiledChildren.size(),
       1,
@@ -689,7 +690,8 @@ TypePtr TryCastCallToSpecialForm::resolveType(
 ExprPtr TryCastCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool trackCpuUsage) {
+    bool trackCpuUsage,
+    const core::QueryConfig& /*config*/) {
   VELOX_CHECK_EQ(
       compiledChildren.size(),
       1,

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -293,7 +293,8 @@ class CastCallToSpecialForm : public FunctionCallToSpecialForm {
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) override;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
 };
 
 class TryCastCallToSpecialForm : public FunctionCallToSpecialForm {
@@ -303,7 +304,8 @@ class TryCastCallToSpecialForm : public FunctionCallToSpecialForm {
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) override;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
 };
 } // namespace facebook::velox::exec
 

--- a/velox/expression/CoalesceExpr.cpp
+++ b/velox/expression/CoalesceExpr.cpp
@@ -110,7 +110,8 @@ TypePtr CoalesceCallToSpecialForm::resolveType(
 ExprPtr CoalesceCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool /* trackCpuUsage */) {
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& /*config*/) {
   bool inputsSupportFlatNoNullsFastPath =
       Expr::allSupportFlatNoNullsFastPath(compiledChildren);
   return std::make_shared<CoalesceExpr>(

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -307,7 +307,8 @@ TypePtr ConjunctCallToSpecialForm::resolveType(
 ExprPtr ConjunctCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool /* trackCpuUsage */) {
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& /*config*/) {
   bool inputsSupportFlatNoNullsFastPath =
       Expr::allSupportFlatNoNullsFastPath(compiledChildren);
 

--- a/velox/expression/ConjunctExpr.h
+++ b/velox/expression/ConjunctExpr.h
@@ -108,7 +108,8 @@ class ConjunctCallToSpecialForm : public FunctionCallToSpecialForm {
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) override;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
 
  private:
   bool isAnd_;

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -37,7 +37,6 @@ using core::TypedExprPtr;
 
 const char* const kAnd = "and";
 const char* const kOr = "or";
-const char* const kRowConstructor = "row_constructor";
 
 struct ITypedExprHasher {
   size_t operator()(const ITypedExpr* expr) const {
@@ -218,43 +217,18 @@ std::vector<TypePtr> getTypes(const std::vector<ExprPtr>& exprs) {
   return types;
 }
 
-ExprPtr getRowConstructorExpr(
-    const core::QueryConfig& config,
-    const TypePtr& type,
-    std::vector<ExprPtr>&& compiledChildren,
-    bool trackCpuUsage) {
-  static auto rowConstructorVectorFunction =
-      vectorFunctionFactories().withRLock([&config](auto& functionMap) {
-        auto functionIterator = functionMap.find(exec::kRowConstructor);
-        return functionIterator->second.factory(
-            exec::kRowConstructor, {}, config);
-      });
-
-  return std::make_shared<Expr>(
-      type,
-      std::move(compiledChildren),
-      rowConstructorVectorFunction,
-      "row_constructor",
-      trackCpuUsage);
-}
-
 ExprPtr getSpecialForm(
     const core::QueryConfig& config,
     const std::string& name,
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
     bool trackCpuUsage) {
-  if (name == kRowConstructor) {
-    return getRowConstructorExpr(
-        config, type, std::move(compiledChildren), trackCpuUsage);
-  }
-
   // If we just check the output of constructSpecialForm we'll have moved
   // compiledChildren, and if the function isn't a special form we'll still need
   // compiledChildren. Splitting the check in two avoids this use after move.
   if (isFunctionCallToSpecialFormRegistered(name)) {
     return constructSpecialForm(
-        name, type, std::move(compiledChildren), trackCpuUsage);
+        name, type, std::move(compiledChildren), trackCpuUsage, config);
   }
 
   return nullptr;
@@ -408,8 +382,12 @@ ExprPtr compileRewrittenExpression(
   auto inputTypes = getTypes(compiledInputs);
   bool isConstantExpr = false;
   if (dynamic_cast<const core::ConcatTypedExpr*>(expr.get())) {
-    result = getRowConstructorExpr(
-        config, resultType, std::move(compiledInputs), trackCpuUsage);
+    result = getSpecialForm(
+        config,
+        "row_constructor",
+        resultType,
+        std::move(compiledInputs),
+        trackCpuUsage);
   } else if (auto cast = dynamic_cast<const core::CastTypedExpr*>(expr.get())) {
     VELOX_CHECK(!compiledInputs.empty());
     auto castExpr = std::make_shared<CastExpr>(

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -22,6 +22,7 @@
 #include "velox/expression/Expr.h"
 #include "velox/expression/FieldReference.h"
 #include "velox/expression/LambdaExpr.h"
+#include "velox/expression/RowConstructor.h"
 #include "velox/expression/SimpleFunctionRegistry.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
@@ -384,7 +385,7 @@ ExprPtr compileRewrittenExpression(
   if (dynamic_cast<const core::ConcatTypedExpr*>(expr.get())) {
     result = getSpecialForm(
         config,
-        "row_constructor",
+        RowConstructorCallToSpecialForm::kRowConstructor,
         resultType,
         std::move(compiledInputs),
         trackCpuUsage);

--- a/velox/expression/FunctionCallToSpecialForm.cpp
+++ b/velox/expression/FunctionCallToSpecialForm.cpp
@@ -35,13 +35,14 @@ ExprPtr constructSpecialForm(
     const std::string& functionName,
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool trackCpuUsage) {
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
   auto specialForm = specialFormRegistry().getSpecialForm(functionName);
   if (specialForm == nullptr) {
     return nullptr;
   }
 
   return specialForm->constructSpecialForm(
-      type, std::move(compiledChildren), trackCpuUsage);
+      type, std::move(compiledChildren), trackCpuUsage, config);
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/FunctionCallToSpecialForm.h
+++ b/velox/expression/FunctionCallToSpecialForm.h
@@ -35,7 +35,8 @@ class FunctionCallToSpecialForm {
   virtual ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) = 0;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) = 0;
 };
 
 /// Returns the output Type of the SpecialForm associated with the functionName
@@ -52,5 +53,10 @@ ExprPtr constructSpecialForm(
     const std::string& functionName,
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool trackCpuUsage);
+    bool trackCpuUsage,
+    const core::QueryConfig& config);
+
+/// Returns true iff a FunctionCallToSpeicalForm object has been registered for
+/// the given functionName.
+bool isFunctionCallToSpecialFormRegistered(const std::string& functionName);
 } // namespace facebook::velox::exec

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -45,6 +45,7 @@ void registerFunctionCallToSpecialForms() {
   registerFunctionCallToSpecialForm(
       "try", std::make_unique<TryCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
-      "row_constructor", std::make_unique<RowConstructorCallToSpecialForm>());
+      RowConstructorCallToSpecialForm::kRowConstructor,
+      std::make_unique<RowConstructorCallToSpecialForm>());
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/RegisterSpecialForm.cpp
+++ b/velox/expression/RegisterSpecialForm.cpp
@@ -21,6 +21,7 @@
 #include "velox/expression/CoalesceExpr.h"
 #include "velox/expression/ConjunctExpr.h"
 #include "velox/expression/FunctionCallToSpecialForm.h"
+#include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
 #include "velox/expression/SwitchExpr.h"
 #include "velox/expression/TryExpr.h"
@@ -43,5 +44,7 @@ void registerFunctionCallToSpecialForms() {
       "switch", std::make_unique<SwitchCallToSpecialForm>());
   registerFunctionCallToSpecialForm(
       "try", std::make_unique<TryCallToSpecialForm>());
+  registerFunctionCallToSpecialForm(
+      "row_constructor", std::make_unique<RowConstructorCallToSpecialForm>());
 }
 } // namespace facebook::velox::exec

--- a/velox/expression/RowConstructor.cpp
+++ b/velox/expression/RowConstructor.cpp
@@ -19,8 +19,6 @@
 
 namespace facebook::velox::exec {
 
-const char* const kRowConstructor = "row_constructor";
-
 TypePtr RowConstructorCallToSpecialForm::resolveType(
     const std::vector<TypePtr>& argTypes) {
   auto numInput = argTypes.size();
@@ -39,7 +37,7 @@ ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
     std::vector<ExprPtr>&& compiledChildren,
     bool trackCpuUsage,
     const core::QueryConfig& config) {
-  static auto rowConstructorVectorFunction =
+  auto rowConstructorVectorFunction =
       vectorFunctionFactories().withRLock([&config, &name](auto& functionMap) {
         auto functionIterator = functionMap.find(name);
         return functionIterator->second.factory(name, {}, config);
@@ -59,7 +57,7 @@ ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
     bool trackCpuUsage,
     const core::QueryConfig& config) {
   return constructSpecialForm(
-      exec::kRowConstructor,
+      kRowConstructor,
       type,
       std::move(compiledChildren),
       trackCpuUsage,

--- a/velox/expression/RowConstructor.cpp
+++ b/velox/expression/RowConstructor.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/RowConstructor.h"
+#include "velox/expression/VectorFunction.h"
+
+namespace facebook::velox::exec {
+
+const char* const kRowConstructor = "row_constructor";
+
+TypePtr RowConstructorCallToSpecialForm::resolveType(
+    const std::vector<TypePtr>& argTypes) {
+  auto numInput = argTypes.size();
+  std::vector<std::string> names(numInput);
+  std::vector<TypePtr> types(numInput);
+  for (auto i = 0; i < numInput; i++) {
+    types[i] = argTypes[i];
+    names[i] = fmt::format("c{}", i + 1);
+  }
+  return ROW(std::move(names), std::move(types));
+}
+
+ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
+    const std::string& name,
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
+  static auto rowConstructorVectorFunction =
+      vectorFunctionFactories().withRLock([&config, &name](auto& functionMap) {
+        auto functionIterator = functionMap.find(name);
+        return functionIterator->second.factory(name, {}, config);
+      });
+
+  return std::make_shared<Expr>(
+      type,
+      std::move(compiledChildren),
+      rowConstructorVectorFunction,
+      name,
+      trackCpuUsage);
+}
+
+ExprPtr RowConstructorCallToSpecialForm::constructSpecialForm(
+    const TypePtr& type,
+    std::vector<ExprPtr>&& compiledChildren,
+    bool trackCpuUsage,
+    const core::QueryConfig& config) {
+  return constructSpecialForm(
+      exec::kRowConstructor,
+      type,
+      std::move(compiledChildren),
+      trackCpuUsage,
+      config);
+}
+} // namespace facebook::velox::exec

--- a/velox/expression/RowConstructor.h
+++ b/velox/expression/RowConstructor.h
@@ -19,32 +19,7 @@
 #include "velox/expression/SpecialForm.h"
 
 namespace facebook::velox::exec {
-
-const char* const kCoalesce = "coalesce";
-
-class CoalesceExpr : public SpecialForm {
- public:
-  CoalesceExpr(
-      TypePtr type,
-      std::vector<ExprPtr>&& inputs,
-      bool inputsSupportFlatNoNullsFastPath);
-
-  void evalSpecialForm(
-      const SelectivityVector& rows,
-      EvalCtx& context,
-      VectorPtr& result) override;
-
- private:
-  void computePropagatesNulls() override {
-    propagatesNulls_ = false;
-  }
-
-  static TypePtr resolveType(const std::vector<TypePtr>& argTypes);
-
-  friend class CoalesceCallToSpecialForm;
-};
-
-class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
+class RowConstructorCallToSpecialForm : public FunctionCallToSpecialForm {
  public:
   TypePtr resolveType(const std::vector<TypePtr>& argTypes) override;
 
@@ -53,6 +28,13 @@ class CoalesceCallToSpecialForm : public FunctionCallToSpecialForm {
       std::vector<ExprPtr>&& compiledChildren,
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
-};
 
+ protected:
+  ExprPtr constructSpecialForm(
+      const std::string& name,
+      const TypePtr& type,
+      std::vector<ExprPtr>&& compiledChildren,
+      bool trackCpuUsage,
+      const core::QueryConfig& config);
+};
 } // namespace facebook::velox::exec

--- a/velox/expression/RowConstructor.h
+++ b/velox/expression/RowConstructor.h
@@ -29,6 +29,8 @@ class RowConstructorCallToSpecialForm : public FunctionCallToSpecialForm {
       bool trackCpuUsage,
       const core::QueryConfig& config) override;
 
+  static constexpr const char* kRowConstructor = "row_constructor";
+
  protected:
   ExprPtr constructSpecialForm(
       const std::string& name,

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -272,7 +272,8 @@ TypePtr SwitchCallToSpecialForm::resolveType(
 ExprPtr SwitchCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool /* trackCpuUsage */) {
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& /*config*/) {
   bool inputsSupportFlatNoNullsFastPath =
       Expr::allSupportFlatNoNullsFastPath(compiledChildren);
   return std::make_shared<SwitchExpr>(

--- a/velox/expression/SwitchExpr.h
+++ b/velox/expression/SwitchExpr.h
@@ -71,7 +71,8 @@ class SwitchCallToSpecialForm : public FunctionCallToSpecialForm {
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) override;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
 };
 
 class IfCallToSpecialForm : public SwitchCallToSpecialForm {

--- a/velox/expression/TryExpr.cpp
+++ b/velox/expression/TryExpr.cpp
@@ -165,7 +165,8 @@ TypePtr TryCallToSpecialForm::resolveType(
 ExprPtr TryCallToSpecialForm::constructSpecialForm(
     const TypePtr& type,
     std::vector<ExprPtr>&& compiledChildren,
-    bool /* trackCpuUsage */) {
+    bool /* trackCpuUsage */,
+    const core::QueryConfig& /*config*/) {
   VELOX_CHECK_EQ(
       compiledChildren.size(),
       1,

--- a/velox/expression/TryExpr.h
+++ b/velox/expression/TryExpr.h
@@ -61,7 +61,8 @@ class TryCallToSpecialForm : public FunctionCallToSpecialForm {
   ExprPtr constructSpecialForm(
       const TypePtr& type,
       std::vector<ExprPtr>&& compiledChildren,
-      bool trackCpuUsage) override;
+      bool trackCpuUsage,
+      const core::QueryConfig& config) override;
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
+++ b/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
@@ -37,6 +37,7 @@ class FunctionCallToSpecialFormTest : public testing::Test,
   static void SetUpTestCase() {
     registerFunctionCallToSpecialForms();
   }
+  const core::QueryConfig config_{{}};
 };
 
 TEST_F(FunctionCallToSpecialFormTest, andCall) {
@@ -52,7 +53,8 @@ TEST_F(FunctionCallToSpecialFormTest, andCall) {
            vectorMaker_.constantVector<bool>({true})),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<bool>({false}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
 }
 
@@ -66,7 +68,8 @@ TEST_F(FunctionCallToSpecialFormTest, castCall) {
       DOUBLE(),
       {std::make_shared<ConstantExpr>(
           vectorMaker_.constantVector<int32_t>({0}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const CastExpr&));
 }
 
@@ -81,7 +84,8 @@ TEST_F(FunctionCallToSpecialFormTest, coalesceCall) {
       INTEGER(),
       {std::make_shared<ConstantExpr>(
           vectorMaker_.constantVector<int32_t>({0}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const CoalesceExpr&));
 }
 
@@ -101,7 +105,8 @@ TEST_F(FunctionCallToSpecialFormTest, ifCall) {
            vectorMaker_.constantVector<int32_t>({0})),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<int32_t>({1}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const SwitchExpr&));
 }
 
@@ -118,7 +123,8 @@ TEST_F(FunctionCallToSpecialFormTest, orCall) {
            vectorMaker_.constantVector<bool>({true})),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<bool>({false}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const ConjunctExpr&));
 }
 
@@ -142,7 +148,8 @@ TEST_F(FunctionCallToSpecialFormTest, switchCall) {
            vectorMaker_.constantVector<int32_t>({1})),
        std::make_shared<ConstantExpr>(
            vectorMaker_.constantVector<int32_t>({2}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const SwitchExpr&));
 }
 
@@ -157,7 +164,8 @@ TEST_F(FunctionCallToSpecialFormTest, tryCall) {
       INTEGER(),
       {std::make_shared<ConstantExpr>(
           vectorMaker_.constantVector<int32_t>({0}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(typeid(*specialForm), typeid(const TryExpr&));
 }
 
@@ -172,6 +180,7 @@ TEST_F(FunctionCallToSpecialFormTest, notASpecialForm) {
       INTEGER(),
       {std::make_shared<ConstantExpr>(
           vectorMaker_.constantVector<int32_t>({0}))},
-      false);
+      false,
+      config_);
   ASSERT_EQ(specialForm, nullptr);
 }

--- a/velox/functions/FunctionRegistry.cpp
+++ b/velox/functions/FunctionRegistry.cpp
@@ -108,18 +108,6 @@ std::shared_ptr<const Type> resolveFunctionOrCallableSpecialForm(
 std::shared_ptr<const Type> resolveCallableSpecialForm(
     const std::string& functionName,
     const std::vector<TypePtr>& argTypes) {
-  // TODO Replace with struct_pack
-  if (functionName == "row_constructor") {
-    auto numInput = argTypes.size();
-    std::vector<TypePtr> types(numInput);
-    std::vector<std::string> names(numInput);
-    for (auto i = 0; i < numInput; i++) {
-      types[i] = argTypes[i];
-      names[i] = fmt::format("c{}", i + 1);
-    }
-    return ROW(std::move(names), std::move(types));
-  }
-
   return exec::resolveTypeForSpecialForm(functionName, argTypes);
 }
 

--- a/velox/parse/TypeResolver.cpp
+++ b/velox/parse/TypeResolver.cpp
@@ -56,18 +56,6 @@ TypePtr resolveType(
     const std::vector<std::shared_ptr<const core::ITypedExpr>>& inputs,
     const std::shared_ptr<const core::CallExpr>& expr,
     bool nullOnFailure) {
-  // TODO Replace with struct_pack
-  if (expr->getFunctionName() == "row_constructor") {
-    auto numInput = inputs.size();
-    std::vector<TypePtr> types(numInput);
-    std::vector<std::string> names(numInput);
-    for (auto i = 0; i < numInput; i++) {
-      types[i] = inputs[i]->type();
-      names[i] = fmt::format("c{}", i + 1);
-    }
-    return ROW(std::move(names), std::move(types));
-  }
-
   std::vector<TypePtr> inputTypes;
   inputTypes.reserve(inputs.size());
   for (auto& input : inputs) {


### PR DESCRIPTION
`row_constructor` is a normal SpecialForm, but treat specially in `resolveCallableSpecialForm`, so make it registered as other SpecialForm.

Besides, Spark function named_struct which is row_constructor in Presto need to be registered in spark folder. We can extend `RowConstructorCallToSpecialForm` to easily register `NamedStructCallToSpecialForm`

Relevant PR: https://github.com/facebookincubator/velox/pull/5649