### PR TITLE
Fix round Presto function

### DIFF
--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,15 +44,13 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
-  double variance = 0.1;
+  static const double kInf = std::numeric_limits<double>::infinity();
   if (number < 0) {
-    return (std::round(
-                std::nextafter(number, number - variance) * factor * -1) /
+    return (std::round(std::nextafter(number, number - kInf) * factor * -1) /
             factor) *
         -1;
   }
-  return std::round(std::nextafter(number, number + variance) * factor) /
-      factor;
+  return std::round(std::nextafter(number, number + kInf) * factor) / factor;
 }
 
 // This is used by Velox for floating points plus.

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,7 +44,7 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
-  static const float kInf = std::numeric_limits<TNum>::infinity();
+  static const TNum kInf = std::numeric_limits<TNum>::infinity();
   if (number < 0) {
     return (std::round(std::nextafter(number, -kInf) * factor * -1) / factor) *
         -1;

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,10 +44,15 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
+  double variance = 0.1;
   if (number < 0) {
-    return (std::round(number * factor * -1) / factor) * -1;
+    return (std::round(
+                std::nextafter(number, number - variance) * factor * -1) /
+            factor) *
+        -1;
   }
-  return std::round(number * factor) / factor;
+  return std::round(std::nextafter(number, number + variance) * factor) /
+      factor;
 }
 
 // This is used by Velox for floating points plus.

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,13 +44,24 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
-  static const double kInf = std::numeric_limits<double>::infinity();
-  if (number < 0) {
-    return (std::round(std::nextafter(number, number - kInf) * factor * -1) /
-            factor) *
-        -1;
+  if constexpr (std::is_floating_point_v<TNum>) {
+    static const float kInf = std::numeric_limits<float>::infinity();
+    if (number < 0) {
+      return (std::round(std::nextafter(number, -kInf) * factor * -1) /
+              factor) *
+          -1;
+    }
+    return std::round(std::nextafter(number, kInf) * factor) / factor;
+
+  } else {
+    static const double kInf = std::numeric_limits<double>::infinity();
+    if (number < 0) {
+      return (std::round(std::nextafter(number, -kInf) * factor * -1) /
+              factor) *
+          -1;
+    }
+    return std::round(std::nextafter(number, kInf) * factor) / factor;
   }
-  return std::round(std::nextafter(number, number + kInf) * factor) / factor;
 }
 
 // This is used by Velox for floating points plus.

--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,24 +44,12 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
-  if constexpr (std::is_floating_point_v<TNum>) {
-    static const float kInf = std::numeric_limits<float>::infinity();
-    if (number < 0) {
-      return (std::round(std::nextafter(number, -kInf) * factor * -1) /
-              factor) *
-          -1;
-    }
-    return std::round(std::nextafter(number, kInf) * factor) / factor;
-
-  } else {
-    static const double kInf = std::numeric_limits<double>::infinity();
-    if (number < 0) {
-      return (std::round(std::nextafter(number, -kInf) * factor * -1) /
-              factor) *
-          -1;
-    }
-    return std::round(std::nextafter(number, kInf) * factor) / factor;
+  static const float kInf = std::numeric_limits<TNum>::infinity();
+  if (number < 0) {
+    return (std::round(std::nextafter(number, -kInf) * factor * -1) / factor) *
+        -1;
   }
+  return std::round(std::nextafter(number, kInf) * factor) / factor;
 }
 
 // This is used by Velox for floating points plus.

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -87,7 +87,11 @@ class RoundTest : public functions::test::FunctionBaseTest {
 
   template <typename T>
   std::vector<std::tuple<T, int32_t, T>> testRoundWithDecDoubleData() {
-    return {{0.575, 2, 0.58}, {0.574, 2, 0.57}};
+    return {
+        {0.575, 2, 0.58},
+        {0.574, 2, 0.57},
+        {-0.575, 2, -0.58},
+        {-0.574, 2, -0.57}};
   }
 
   template <typename T>

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -59,7 +59,7 @@ class RoundTest : public functions::test::FunctionBaseTest {
   }
 
   template <typename T>
-  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatData() {
+  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatAndDoubleData() {
     return {{1.122112, 0, 1},         {1.129, 1, 1.1},
             {1.129, 2, 1.13},         {1.0 / 3, 0, 0.0},
             {1.0 / 3, 1, 0.3},        {1.0 / 3, 2, 0.33},
@@ -70,16 +70,9 @@ class RoundTest : public functions::test::FunctionBaseTest {
             {-1.0 / 3, 6, -0.333333}, {1.0, -1, 0.0},
             {0.0, -2, 0.0},           {-1.0, -3, 0.0},
             {11111.0, -1, 11110.0},   {11111.0, -2, 11100.0},
-            {11111.0, -3, 11000.0},   {11111.0, -4, 10000.0}};
-  }
-
-  template <typename T>
-  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecDoubleData() {
-    return {
-        {0.575, 2, 0.58},
-        {0.574, 2, 0.57},
-        {-0.575, 2, -0.58},
-        {-0.574, 2, -0.57}};
+            {11111.0, -3, 11000.0},   {11111.0, -4, 10000.0},
+            {0.575, 2, 0.58},         {0.574, 2, 0.57},
+            {-0.575, 2, -0.58},       {-0.574, 2, -0.57}};
   }
 
   template <typename T>
@@ -111,11 +104,8 @@ TEST_F(RoundTest, round) {
 }
 
 TEST_F(RoundTest, roundWithDecimal) {
-  runRoundWithDecimalTest<float>(testRoundWithDecFloatData<float>());
-  runRoundWithDecimalTest<double>(testRoundWithDecFloatData<double>());
-  runRoundWithDecimalTest<float>(testRoundWithDecDoubleData<float>());
-  runRoundWithDecimalTest<double>(testRoundWithDecDoubleData<double>());
-
+  runRoundWithDecimalTest<float>(testRoundWithDecFloatAndDoubleData<float>());
+  runRoundWithDecimalTest<double>(testRoundWithDecFloatAndDoubleData<double>());
   runRoundWithDecimalTest<int64_t>(testRoundWithDecIntegralData<int64_t>());
   runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());
   runRoundWithDecimalTest<int16_t>(testRoundWithDecIntegralData<int16_t>());

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -60,29 +60,17 @@ class RoundTest : public functions::test::FunctionBaseTest {
 
   template <typename T>
   std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatData() {
-    return {
-        {1.122112, 0, 1},
-        {1.129, 1, 1.1},
-        {1.129, 2, 1.13},
-        {1.0 / 3, 0, 0.0},
-        {1.0 / 3, 1, 0.3},
-        {1.0 / 3, 2, 0.33},
-        {1.0 / 3, 10, 0.3333333333},
-        {-1.122112, 0, -1},
-        {-1.129, 1, -1.1},
-        {-1.129, 2, -1.13},
-        {-1.129, 2, -1.13},
-        {-1.0 / 3, 0, 0.0},
-        {-1.0 / 3, 1, -0.3},
-        {-1.0 / 3, 2, -0.33},
-        {-1.0 / 3, 10, -0.3333333333},
-        {1.0, -1, 0.0},
-        {0.0, -2, 0.0},
-        {-1.0, -3, 0.0},
-        {11111.0, -1, 11110.0},
-        {11111.0, -2, 11100.0},
-        {11111.0, -3, 11000.0},
-        {11111.0, -4, 10000.0}};
+    return {{1.122112, 0, 1},         {1.129, 1, 1.1},
+            {1.129, 2, 1.13},         {1.0 / 3, 0, 0.0},
+            {1.0 / 3, 1, 0.3},        {1.0 / 3, 2, 0.33},
+            {1.0 / 3, 6, 0.333333},   {-1.122112, 0, -1},
+            {-1.129, 1, -1.1},        {-1.129, 2, -1.13},
+            {-1.129, 2, -1.13},       {-1.0 / 3, 0, 0.0},
+            {-1.0 / 3, 1, -0.3},      {-1.0 / 3, 2, -0.33},
+            {-1.0 / 3, 6, -0.333333}, {1.0, -1, 0.0},
+            {0.0, -2, 0.0},           {-1.0, -3, 0.0},
+            {11111.0, -1, 11110.0},   {11111.0, -2, 11100.0},
+            {11111.0, -3, 11000.0},   {11111.0, -4, 10000.0}};
   }
 
   template <typename T>
@@ -125,6 +113,7 @@ TEST_F(RoundTest, round) {
 TEST_F(RoundTest, roundWithDecimal) {
   runRoundWithDecimalTest<float>(testRoundWithDecFloatData<float>());
   runRoundWithDecimalTest<double>(testRoundWithDecFloatData<double>());
+  runRoundWithDecimalTest<float>(testRoundWithDecDoubleData<float>());
   runRoundWithDecimalTest<double>(testRoundWithDecDoubleData<double>());
 
   runRoundWithDecimalTest<int64_t>(testRoundWithDecIntegralData<int64_t>());

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -86,6 +86,11 @@ class RoundTest : public functions::test::FunctionBaseTest {
   }
 
   template <typename T>
+  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecDoubleData() {
+    return {{0.575, 2, 0.58}};
+  }
+
+  template <typename T>
   std::vector<std::tuple<T, int32_t, T>> testRoundWithDecIntegralData() {
     return {
         {1, 0, 1},
@@ -116,6 +121,7 @@ TEST_F(RoundTest, round) {
 TEST_F(RoundTest, roundWithDecimal) {
   runRoundWithDecimalTest<float>(testRoundWithDecFloatData<float>());
   runRoundWithDecimalTest<double>(testRoundWithDecFloatData<double>());
+  runRoundWithDecimalTest<double>(testRoundWithDecDoubleData<double>());
 
   runRoundWithDecimalTest<int64_t>(testRoundWithDecIntegralData<int64_t>());
   runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -87,7 +87,7 @@ class RoundTest : public functions::test::FunctionBaseTest {
 
   template <typename T>
   std::vector<std::tuple<T, int32_t, T>> testRoundWithDecDoubleData() {
-    return {{0.575, 2, 0.58}};
+    return {{0.575, 2, 0.58}, {0.574, 2, 0.57}};
   }
 
   template <typename T>


### PR DESCRIPTION
std::round will get 0.57 for round(0.575,2). 
But we should get 0.58 in default mode.
Presto round description:
```
round(x, d) → [same as input]
    Returns x rounded to d decimal places.
```

Here is a query which I verified on presto:
```
presto> select round(0.575, 2);
 _col0
-------
 0.580
(1 row)

```
The main reason is that double type "0.575" is actually "0.57499999999999996". So we need use nextafter function to get real value.
