### PR TITLE
Clear ExchangeSource factories in MultiFragmentTest::SetUp

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -40,6 +40,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
  protected:
   void SetUp() override {
     HiveConnectorTestBase::SetUp();
+    exec::ExchangeSource::factories().clear();
     exec::ExchangeSource::registerFactory(createLocalExchangeSource);
   }
 


### PR DESCRIPTION
Clear factories that may have been registered by other tests.