### PR TITLE
Fix fuzzer error reproduction for dereference

### DIFF
--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -143,4 +143,25 @@ void FieldReference::evalSpecialFormSimplified(
   }
 }
 
+std::string FieldReference::toString(bool recursive) const {
+  std::stringstream out;
+  if (!inputs_.empty() && recursive) {
+    appendInputs(out);
+    out << ".";
+  }
+  out << name();
+  return out.str();
+}
+
+std::string FieldReference::toSql(
+    std::vector<VectorPtr>* complexConstants) const {
+  std::stringstream out;
+  if (!inputs_.empty()) {
+    appendInputsSql(out, complexConstants);
+    out << ".";
+  }
+  out << "\"" << name() << "\"";
+  return out.str();
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -61,6 +61,11 @@ class FieldReference : public SpecialForm {
       EvalCtx& context,
       VectorPtr& result) override;
 
+  std::string toString(bool recursive = true) const override;
+
+  std::string toSql(
+      std::vector<VectorPtr>* complexConstants = nullptr) const override;
+
  private:
   const std::string field_;
   int32_t index_ = -1;


### PR DESCRIPTION
Summary:
When a dereference expression "c0"."c1" fails in expression fuzzer, the fuzzer
currently saves an expression "c1"("c0") which is not valid. This diff fixes this
problem by adding FieldReference::toSql(). This diff also adds FieldReference::toString().

Reviewed By: laithsakka

Differential Revision: D47823242

