### PR TITLE
Remove ExchangeQueue::minBytes

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -107,9 +107,11 @@ std::unique_ptr<SerializedPage> ExchangeClient::next(
     if (*atEnd) {
       return page;
     }
-    if (page && queue_->totalBytes() > queue_->minBytes()) {
+
+    if (page && queue_->totalBytes() > maxQueuedBytes_) {
       return page;
     }
+
     // There is space for more data, send requests to sources with no pending
     // request.
     for (auto& source : sources_) {

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -25,15 +25,16 @@ namespace facebook::velox::exec {
 // per consumer thread.
 class ExchangeClient {
  public:
-  static constexpr int32_t kDefaultMinSize = 32 << 20; // 32 MB.
+  static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
 
   ExchangeClient(
       int destination,
       memory::MemoryPool* pool,
-      int64_t minSize = kDefaultMinSize)
+      int64_t maxQueuedBytes)
       : destination_(destination),
         pool_(pool),
-        queue_(std::make_shared<ExchangeQueue>(minSize)) {
+        queue_(std::make_shared<ExchangeQueue>()),
+        maxQueuedBytes_{maxQueuedBytes} {
     VELOX_CHECK_NOT_NULL(pool_);
     VELOX_CHECK(
         destination >= 0,
@@ -75,6 +76,7 @@ class ExchangeClient {
   const int destination_;
   memory::MemoryPool* const pool_;
   std::shared_ptr<ExchangeQueue> queue_;
+  const int64_t maxQueuedBytes_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
   bool closed_{false};

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<SerializedPage> ExchangeQueue::dequeueLocked(
   VELOX_CHECK(future);
   if (!error_.empty()) {
     *atEnd = true;
-    throw std::runtime_error(error_);
+    VELOX_FAIL(error_);
   }
   if (queue_.empty()) {
     if (atEnd_) {

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -73,7 +73,11 @@ class SerializedPage {
 // for input.
 class ExchangeQueue {
  public:
-  explicit ExchangeQueue(int64_t minBytes) : minBytes_(minBytes) {}
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  explicit ExchangeQueue(int64_t /*minBytes*/) {}
+
+  ExchangeQueue() = default;
+#endif
 
   ~ExchangeQueue() {
     clearAllPromises();
@@ -103,13 +107,6 @@ class ExchangeQueue {
   // Returns the total bytes held by SerializedPages in 'this'.
   uint64_t totalBytes() const {
     return totalBytes_;
-  }
-
-  // Returns the target size for totalBytes(). An exchange client
-  // should not fetch more data until the queue totalBytes() is below
-  // minBytes().
-  uint64_t minBytes() const {
-    return minBytes_;
   }
 
   void addSourceLocked() {
@@ -167,9 +164,5 @@ class ExchangeQueue {
   std::string error_;
   // Total size of SerializedPages in queue.
   uint64_t totalBytes_{0};
-
-  // If 'totalBytes_' < 'minBytes_', an exchange should request more data from
-  // producers.
-  const uint64_t minBytes_;
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -122,7 +122,10 @@ class MergeExchangeSource : public MergeSource {
       int destination,
       memory::MemoryPool* FOLLY_NONNULL pool)
       : mergeExchange_(mergeExchange),
-        client_(std::make_unique<ExchangeClient>(destination, pool)) {
+        client_(std::make_unique<ExchangeClient>(
+            destination,
+            pool,
+            ExchangeClient::kDefaultMaxQueuedBytes)) {
     client_->addRemoteTaskId(taskId);
     client_->noMoreRemoteTasks();
   }

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -32,7 +32,7 @@ TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
         throw std::runtime_error("Testing error");
       });
 
-  ExchangeClient client(1, pool.get());
+  ExchangeClient client(1, pool.get(), ExchangeClient::kDefaultMaxQueuedBytes);
   VELOX_ASSERT_THROW(
       client.addRemoteTaskId("task.1.2.3"),
       "Failed to create ExchangeSource: Testing error. Task ID: task.1.2.3.");


### PR DESCRIPTION
ExchangeQueue::minBytes() value was used only by the ExchangeClient. Moved it there.