### PR TITLE
Adds checks for verifying internal state of a vector

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -248,6 +248,12 @@ class EvalCtx {
       const VectorPtr& localResult,
       const SelectivityVector& rows,
       VectorPtr& result) const {
+#ifndef NDEBUG
+    if (localResult != nullptr) {
+      // Make sure local/temporary vectors have consistent state.
+      localResult->validate();
+    }
+#endif
     if (result && !isFinalSelection() && *finalSelection() != rows) {
       BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
       result->copy(localResult.get(), rows, nullptr);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -344,6 +344,14 @@ bool isFlat(const BaseVector& vector) {
       encoding == VectorEncoding::Simple::CONSTANT);
 }
 
+inline void checkResultInternalState(VectorPtr& result) {
+#ifndef NDEBUG
+  if (result != nullptr) {
+    result->validate();
+  }
+#endif
+}
+
 } // namespace
 
 template <typename EvalArg>
@@ -763,6 +771,7 @@ void Expr::eval(
   if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
       context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
     evalFlatNoNulls(rows, context, result, parentExprSet);
+    checkResultInternalState(result);
     return;
   }
 
@@ -775,6 +784,7 @@ void Expr::eval(
 
   if (!rows.hasSelections()) {
     checkOrSetEmptyResult(type(), context.pool(), result);
+    checkResultInternalState(result);
     return;
   }
 
@@ -818,10 +828,12 @@ void Expr::eval(
 
   if (inputs_.empty()) {
     evalAll(rows, context, result);
+    checkResultInternalState(result);
     return;
   }
 
   evalEncodings(rows, context, result);
+  checkResultInternalState(result);
 }
 
 template <typename TEval>

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -167,8 +167,7 @@ struct CombinationsFunction {
 
   static constexpr int32_t kMaxCombinationSize = 5;
   static constexpr int64_t kMaxNumberOfCombinations = 100000;
-  /// TODO: Add ability to re-use strings once reuse_strings_from_arg supports
-  /// reusing strings nested within complex types.
+  static constexpr int32_t reuse_strings_from_arg = 0;
 
   int64_t calculateCombinationCount(
       int64_t inputArraySize,

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -785,6 +785,16 @@ void BaseVector::prepareForReuse() {
   this->resetDataDependentFlags(nullptr);
 }
 
+void BaseVector::validate(const VectorValidateOptions& options) const {
+  if (nulls_ != nullptr) {
+    auto bytes = byteSize<bool>(size());
+    VELOX_CHECK_GE(nulls_->size(), bytes);
+  }
+  if (options.callback) {
+    options.callback(*this);
+  }
+}
+
 namespace {
 
 size_t typeSize(const Type& type) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -52,6 +52,17 @@ class VectorPool;
 class BaseVector;
 using VectorPtr = std::shared_ptr<BaseVector>;
 
+// Set of options that validate() accepts.
+struct VectorValidateOptions {
+  // If set to true then an unloaded lazy vector is loaded and validate is
+  // called on the loaded vector. NOTE: loading a vector is non-trivial and
+  // can modify how it's handled by downstream code-paths.
+  bool loadLazy = false;
+
+  // Any optional checks you want to execute on the vector.
+  std::function<void(const BaseVector&)> callback;
+};
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -755,6 +766,11 @@ class BaseVector {
   void disableMemo() {
     memoDisabled_ = true;
   }
+
+  /// Used to check internal state of a vector like sizes of the buffers,
+  /// enclosed child vectors, values in indices. Currently, its only used in
+  /// debug builds to check the result of expressions and some interim results.
+  virtual void validate(const VectorValidateOptions& options = {}) const;
 
  protected:
   /// Returns a brief summary of the vector. The default implementation includes

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -525,6 +525,15 @@ void ArrayVectorBase::copyRangesImpl(
   }
 }
 
+void RowVector::validate(const VectorValidateOptions& options) const {
+  BaseVector::validate(options);
+  for (auto& child : children_) {
+    if (child != nullptr) {
+      child->validate(options);
+    }
+  }
+}
+
 void ArrayVectorBase::checkRanges() const {
   std::unordered_map<vector_size_t, vector_size_t> seenElements;
   seenElements.reserve(size());
@@ -549,6 +558,40 @@ void ArrayVectorBase::checkRanges() const {
       }
       seenElements.emplace(offset + j, i);
     }
+  }
+}
+
+void ArrayVectorBase::validateArrayVectorBase(
+    const VectorValidateOptions& options,
+    vector_size_t minChildVectorSize) const {
+  BaseVector::validate(options);
+  auto bufferByteSize = byteSize<vector_size_t>(BaseVector::length_);
+  VELOX_CHECK_GE(sizes_->size(), bufferByteSize);
+  VELOX_CHECK_GE(offsets_->size(), bufferByteSize);
+  for (auto i = 0; i < BaseVector::length_; ++i) {
+    const bool isNull =
+        BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
+    if (isNull || rawSizes_[i] == 0) {
+      continue;
+    }
+    // Verify index for a non-null position. It must be >= 0 and < size of the
+    // base vector.
+    VELOX_CHECK_GE(
+        rawSizes_[i],
+        0,
+        "ArrayVectorBase size must be greater than zero. Index: {}.",
+        i);
+    VELOX_CHECK_GE(
+        rawOffsets_[i],
+        0,
+        "ArrayVectorBase offset must be greater than zero. Index: {}.",
+        i)
+    VELOX_CHECK_LT(
+        rawOffsets_[i] + rawSizes_[i] - 1,
+        minChildVectorSize,
+        "ArrayVectorBase must only point to indices within the base "
+        "vector's size. Index: {}.",
+        i);
   }
 }
 
@@ -788,6 +831,11 @@ VectorPtr ArrayVector::slice(vector_size_t offset, vector_size_t length) const {
       sliceBuffer(*INTEGER(), offsets_, offset, length, pool_),
       sliceBuffer(*INTEGER(), sizes_, offset, length, pool_),
       elements_);
+}
+
+void ArrayVector::validate(const VectorValidateOptions& options) const {
+  ArrayVectorBase::validateArrayVectorBase(options, elements_->size());
+  elements_->validate(options);
 }
 
 std::optional<int32_t> MapVector::compare(
@@ -1050,6 +1098,13 @@ VectorPtr MapVector::slice(vector_size_t offset, vector_size_t length) const {
       sliceBuffer(*INTEGER(), sizes_, offset, length, pool_),
       keys_,
       values_);
+}
+
+void MapVector::validate(const VectorValidateOptions& options) const {
+  ArrayVectorBase::validateArrayVectorBase(
+      options, std::min(keys_->size(), values_->size()));
+  keys_->validate(options);
+  values_->validate(options);
 }
 
 } // namespace velox

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -192,6 +192,8 @@ class RowVector : public BaseVector {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;
@@ -317,6 +319,10 @@ struct ArrayVectorBase : BaseVector {
       VectorPtr* targetKeys,
       const BaseVector* sourceKeys);
 
+  void validateArrayVectorBase(
+      const VectorValidateOptions& options,
+      vector_size_t minChildVectorSize) const;
+
  private:
   BufferPtr
   ensureIndices(BufferPtr& buf, const vector_size_t*& raw, vector_size_t size) {
@@ -437,6 +443,8 @@ class ArrayVector : public ArrayVectorBase {
   }
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
+
+  void validate(const VectorValidateOptions& options) const override;
 
  private:
   VectorPtr elements_;
@@ -586,6 +594,8 @@ class MapVector : public ArrayVectorBase {
   }
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
+
+  void validate(const VectorValidateOptions& options) const override;
 
  protected:
   virtual void resetDataDependentFlags(const SelectivityVector* rows) override {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -318,6 +318,20 @@ class ConstantVector final : public SimpleVector<T> {
     return false;
   }
 
+  void validate(const VectorValidateOptions& options) const override {
+    // Do not call BaseVector's validate() since the nulls buffer has
+    // a fixed size for constant vectors.
+    if (options.callback) {
+      options.callback(*this);
+    }
+    if (valueVector_ != nullptr) {
+      if (!isNull_) {
+        VELOX_CHECK_LT(index_, valueVector_->size());
+      }
+      valueVector_->validate(options);
+    }
+  }
+
  protected:
   std::string toSummaryString() const override {
     std::stringstream out;

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -29,26 +29,7 @@ void DictionaryVector<T>::setInternalState() {
   // Sanity check indices for non-null positions. Enabled in debug mode only to
   // avoid performance hit in production.
 #ifndef NDEBUG
-  for (auto i = 0; i < BaseVector::length_; ++i) {
-    const bool isNull =
-        BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
-    if (isNull) {
-      continue;
-    }
-
-    // Verify index for a non-null position. It must be >= 0 and < size of the
-    // base vector.
-    VELOX_DCHECK_GE(
-        rawIndices_[i],
-        0,
-        "Dictionary index must be greater than zero. Index: {}.",
-        i);
-    VELOX_DCHECK_LT(
-        rawIndices_[i],
-        dictionaryValues_->size(),
-        "Dictionary index must be less than base vector's size. Index: {}.",
-        i);
-  }
+  validate({});
 #endif
 
   if (isLazyNotLoaded(*dictionaryValues_)) {
@@ -203,6 +184,34 @@ VectorPtr DictionaryVector<T>::slice(vector_size_t offset, vector_size_t length)
       valueVector(),
       BaseVector::sliceBuffer(
           *INTEGER(), indices_, offset, length, this->pool_));
+}
+
+template <typename T>
+void DictionaryVector<T>::validate(const VectorValidateOptions& options) const {
+  SimpleVector<T>::validate(options);
+  auto indicesByteSize =
+      BaseVector::byteSize<vector_size_t>(BaseVector::length_);
+  VELOX_CHECK_GE(indices_->size(), indicesByteSize);
+  for (auto i = 0; i < BaseVector::length_; ++i) {
+    const bool isNull =
+        BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
+    if (isNull) {
+      continue;
+    }
+    // Verify index for a non-null position. It must be >= 0 and < size of the
+    // base vector.
+    VELOX_CHECK_GE(
+        rawIndices_[i],
+        0,
+        "Dictionary index must be greater than zero. Index: {}.",
+        i);
+    VELOX_CHECK_LT(
+        rawIndices_[i],
+        dictionaryValues_->size(),
+        "Dictionary index must be less than base vector's size. Index: {}.",
+        i);
+  }
+  dictionaryValues_->validate(options);
 }
 
 } // namespace velox

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -199,6 +199,8 @@ class DictionaryVector : public SimpleVector<T> {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   // return the dictionary index for the specified vector index.
   inline vector_size_t getDictionaryIndex(vector_size_t idx) const {

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -498,5 +498,42 @@ void FlatVector<StringView>::copyRanges(
   }
 }
 
+// For strings, we also verify if they point to valid memory locations inside
+// the string buffers.
+template <>
+void FlatVector<StringView>::validate(
+    const VectorValidateOptions& options) const {
+  SimpleVector<StringView>::validate(options);
+  auto byteSize = BaseVector::byteSize<StringView>(BaseVector::size());
+  if (byteSize == 0) {
+    return;
+  }
+  VELOX_CHECK_NOT_NULL(values_);
+  VELOX_CHECK_GE(values_->size(), byteSize);
+  auto rawValues = values_->as<StringView>();
+
+  for (auto i = 0; i < BaseVector::length_; ++i) {
+    if (isNullAt(i)) {
+      continue;
+    }
+    auto stringView = rawValues[i];
+    if (!stringView.isInline()) {
+      bool isValid = false;
+      for (const auto& buffer : stringBuffers_) {
+        auto start = buffer->as<char>();
+        if (stringView.data() >= start &&
+            stringView.data() < start + buffer->size()) {
+          isValid = true;
+          break;
+        }
+      }
+      VELOX_CHECK(
+          isValid,
+          "String view at idx {} points outside of the string buffers",
+          i)
+    }
+  }
+}
+
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -430,6 +430,15 @@ class FlatVector final : public SimpleVector<T> {
   /// mutable. Resizes the buffer to zero to allow for reuse instead of append.
   void prepareForReuse() override;
 
+  void validate(const VectorValidateOptions& options) const override {
+    SimpleVector<T>::validate(options);
+    auto byteSize = BaseVector::byteSize<T>(BaseVector::size());
+    if (byteSize > 0) {
+      VELOX_CHECK_NOT_NULL(values_);
+      VELOX_CHECK_GE(values_->size(), byteSize);
+    }
+  }
+
  private:
   void copyValuesAndNulls(
       const BaseVector* source,

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -224,4 +224,12 @@ void LazyVector::ensureLoadedRows(
   ensureLoadedRowsImpl(vector, decoded, rows, baseRows);
 }
 
+void LazyVector::validate(const VectorValidateOptions& options) const {
+  if (isLoaded() || options.loadLazy) {
+    auto loadedVector = this->loadedVector();
+    VELOX_CHECK_NOT_NULL(loadedVector);
+    loadedVector->validate(options);
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -269,6 +269,8 @@ class LazyVector : public BaseVector {
       DecodedVector& decoded,
       SelectivityVector& baseRows);
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   static void ensureLoadedRowsImpl(
       VectorPtr& vector,


### PR DESCRIPTION
This change adds thorough checks for each vector type, including its
children vectors. These checks verify the validity of buffer sizes
and their values (if applicable), such as nulls, values, and indices,
offsets, etc. Currently, its only used in debug builds on the result
of expressions and the objective is to catch these issues especially
in the expression fuzzer. These checks help clarify expected states
and enforce them, improving overall vector reliability.

This check also found a bug in Combinations(Array<>) udf which is
fixed as a part of this change.

Test Plan:
Ran fuzzer for 1 hour