### PR TITLE
Separate number of partition configs for join and aggregation spills

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -648,7 +648,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, DISABLED_reclaimFromAggregation) {
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kAggregationSpillEnabled, "true")
-              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
               .queryCtx(aggregationQueryCtx)
               .plan(PlanBuilder()
                         .values(vectors)
@@ -906,7 +906,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimFromJoinBuilder) {
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kJoinSpillEnabled, "true")
-              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
               .queryCtx(joinQueryCtx)
               .plan(PlanBuilder(planNodeIdGenerator)
                         .values(vectors)
@@ -1209,7 +1209,7 @@ DEBUG_ONLY_TEST_F(
               .spillDirectory(spillDirectory->path)
               .config(core::QueryConfig::kSpillEnabled, "true")
               .config(core::QueryConfig::kJoinSpillEnabled, "true")
-              .config(core::QueryConfig::kSpillPartitionBits, "2")
+              .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
               // NOTE: set an extreme large value to avoid non-reclaimable
               // section in test.
               .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
@@ -1364,7 +1364,7 @@ DEBUG_ONLY_TEST_F(
             .spillDirectory(spillDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kJoinSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
             // NOTE: set an extreme large value to avoid non-reclaimable
             // section in test.
             .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
@@ -1518,7 +1518,7 @@ DEBUG_ONLY_TEST_F(
             .spillDirectory(spillDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kJoinSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
             // NOTE: set an extreme large value to avoid non-reclaimable
             // section in test.
             .config(core::QueryConfig::kSpillableReservationGrowthPct, "8000")
@@ -1727,7 +1727,7 @@ DEBUG_ONLY_TEST_F(
             .spillDirectory(spillDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kJoinSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
             .maxDrivers(numDrivers)
             .plan(PlanBuilder()
                       .values(vectors)
@@ -1802,7 +1802,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenMaybeReserveAndTaskAbort) {
             .spillDirectory(spillDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kJoinSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
             .maxDrivers(numDrivers)
             .plan(PlanBuilder()
                       .values(vectors)
@@ -1862,7 +1862,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
                .spillDirectory(spillDirectory->path)
                .config(core::QueryConfig::kSpillEnabled, "true")
                .config(core::QueryConfig::kJoinSpillEnabled, "true")
-               .config(core::QueryConfig::kSpillPartitionBits, "2")
+               .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
                .plan(PlanBuilder()
                          .values(vectors)
                          .localPartition({"c0", "c1"})

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -69,10 +69,9 @@ std::optional<Spiller::Config> DriverCtx::makeSpillConfig(
       queryConfig.minSpillRunSize(),
       task->queryCtx()->spillExecutor(),
       queryConfig.spillableReservationGrowthPct(),
-      HashBitRange(
-          queryConfig.spillStartPartitionBit(),
-          queryConfig.spillStartPartitionBit() +
-              queryConfig.spillPartitionBits()),
+      queryConfig.spillStartPartitionBit(),
+      queryConfig.joinSpillPartitionBits(),
+      queryConfig.aggregationSpillPartitionBits(),
       queryConfig.maxSpillLevel(),
       queryConfig.testingSpillPct());
 }

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -842,9 +842,10 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         rows,
         [&](folly::Range<char**> rows) { table_->erase(rows); },
         ROW(std::move(names), std::move(types)),
-        // Spill up to 8 partitions based on bits starting from 29th of the hash
-        // number. Any from one to three bits would do.
-        spillConfig_->hashBitRange,
+        HashBitRange(
+            spillConfig_->startPartitionBit,
+            spillConfig_->startPartitionBit +
+                spillConfig_->aggregationPartitionBits),
         rows->keyTypes().size(),
         std::vector<CompareFlags>(),
         spillConfig_->filePath,

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -242,7 +242,7 @@ void HashProbe::maybeSetupSpillInput(
       HashBitRange(
           spillInputPartitionIds_.begin()->partitionBitOffset(),
           spillInputPartitionIds_.begin()->partitionBitOffset() +
-              spillConfig.hashBitRange.numBits()),
+              spillConfig.joinPartitionBits),
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.minSpillRunSize,

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -594,15 +594,15 @@ std::string Spiller::toString() const {
       spillFinalized_);
 }
 
-int32_t Spiller::Config::spillLevel(uint8_t startBitOffset) const {
-  const auto numPartitionBits = hashBitRange.numBits();
+int32_t Spiller::Config::joinSpillLevel(uint8_t startBitOffset) const {
+  const auto numPartitionBits = joinPartitionBits;
   VELOX_CHECK_LE(
       startBitOffset + numPartitionBits,
       64,
       "startBitOffset:{} numPartitionsBits:{}",
       startBitOffset,
       numPartitionBits);
-  const int32_t deltaBits = startBitOffset - hashBitRange.begin();
+  const int32_t deltaBits = startBitOffset - startPartitionBit;
   VELOX_CHECK_GE(deltaBits, 0, "deltaBits:{}", deltaBits);
   VELOX_CHECK_EQ(
       deltaBits % numPartitionBits,
@@ -613,14 +613,14 @@ int32_t Spiller::Config::spillLevel(uint8_t startBitOffset) const {
   return deltaBits / numPartitionBits;
 }
 
-bool Spiller::Config::exceedSpillLevelLimit(uint8_t startBitOffset) const {
-  if (startBitOffset + hashBitRange.numBits() > 64) {
+bool Spiller::Config::exceedJoinSpillLevelLimit(uint8_t startBitOffset) const {
+  if (startBitOffset + joinPartitionBits > 64) {
     return true;
   }
   if (maxSpillLevel == -1) {
     return false;
   }
-  return spillLevel(startBitOffset) > maxSpillLevel;
+  return joinSpillLevel(startBitOffset) > maxSpillLevel;
 }
 
 // static

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1178,7 +1178,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
             .config(QueryConfig::kAggregationSpillEnabled, "true")
             .config(QueryConfig::kMinSpillRunSize, std::to_string(1000'000'000))
             .config(
-                QueryConfig::kSpillPartitionBits,
+                QueryConfig::kAggregationSpillPartitionBits,
                 std::to_string(kPartitionsBits))
             .config(
                 QueryConfig::kSpillStartPartitionBit,
@@ -1291,7 +1291,8 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
           .config(QueryConfig::kSpillEnabled, "true")
           .config(QueryConfig::kAggregationSpillEnabled, "true")
           .config(
-              QueryConfig::kSpillPartitionBits, std::to_string(kPartitionsBits))
+              QueryConfig::kAggregationSpillPartitionBits,
+              std::to_string(kPartitionsBits))
           // Set to increase the hash table a little bit to only trigger spill
           // on the partition with most spillable data.
           .config(QueryConfig::kSpillableReservationGrowthPct, "25")
@@ -1536,7 +1537,7 @@ TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
                     .config(QueryConfig::kSpillEnabled, "true")
                     .config(QueryConfig::kAggregationSpillEnabled, "true")
                     // Set one spill partition to avoid the test flakiness.
-                    .config(QueryConfig::kSpillPartitionBits, "0")
+                    .config(QueryConfig::kAggregationSpillPartitionBits, "0")
                     // Set the memory trigger limit to be a very small value.
                     .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
                     .assertResults(results);
@@ -1558,7 +1559,7 @@ TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
                     .config(QueryConfig::kSpillEnabled, "true")
                     .config(QueryConfig::kAggregationSpillEnabled, "true")
                     // Set one spill partition to avoid the test flakiness.
-                    .config(QueryConfig::kSpillPartitionBits, "0")
+                    .config(QueryConfig::kAggregationSpillPartitionBits, "0")
                     // Set the memory trigger limit to be a very small value.
                     .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
                     .assertResults(results);
@@ -1760,18 +1761,19 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
 
     std::thread taskThread([&]() {
       if (testData.spillEnabled) {
-        auto task = AssertQueryBuilder(
-                        PlanBuilder()
-                            .values(batches)
-                            .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
-                            .planNode())
-                        .queryCtx(queryCtx)
-                        .spillDirectory(tempDirectory->path)
-                        .config(QueryConfig::kSpillEnabled, "true")
-                        .config(QueryConfig::kAggregationSpillEnabled, "true")
-                        .config(core::QueryConfig::kSpillPartitionBits, "2")
-                        .maxDrivers(1)
-                        .assertResults(expectedResult);
+        auto task =
+            AssertQueryBuilder(
+                PlanBuilder()
+                    .values(batches)
+                    .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                    .planNode())
+                .queryCtx(queryCtx)
+                .spillDirectory(tempDirectory->path)
+                .config(QueryConfig::kSpillEnabled, "true")
+                .config(QueryConfig::kAggregationSpillEnabled, "true")
+                .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
+                .maxDrivers(1)
+                .assertResults(expectedResult);
       } else {
         auto task = AssertQueryBuilder(
                         PlanBuilder()
@@ -1903,7 +1905,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
         .spillDirectory(tempDirectory->path)
         .config(QueryConfig::kSpillEnabled, "true")
         .config(QueryConfig::kAggregationSpillEnabled, "true")
-        .config(core::QueryConfig::kSpillPartitionBits, "2")
+        .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
         .maxDrivers(1)
         .assertResults(expectedResult);
   });
@@ -2019,7 +2021,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
             .spillDirectory(tempDirectory->path)
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {
@@ -2140,7 +2142,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
             .spillDirectory(tempDirectory->path)
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {
@@ -2254,7 +2256,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
             .spillDirectory(tempDirectory->path)
             .config(QueryConfig::kSpillEnabled, "true")
             .config(QueryConfig::kAggregationSpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .config(core::QueryConfig::kAggregationSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -2807,7 +2807,7 @@ TEST_P(MultiThreadedHashJoinTest, noSpillLevelLimit) {
           "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t.t_k0 = u.u_k0")
       .maxSpillLevel(-1)
       .config(core::QueryConfig::kSpillStartPartitionBit, "48")
-      .config(core::QueryConfig::kSpillPartitionBits, "3")
+      .config(core::QueryConfig::kJoinSpillPartitionBits, "3")
       .checkSpillStats(false)
       .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
         if (!hasSpill) {
@@ -4384,7 +4384,7 @@ TEST_F(HashJoinTest, spillFileSize) {
         .referenceQuery(
             "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t.t_k0 = u.u_k0")
         .config(core::QueryConfig::kSpillStartPartitionBit, "48")
-        .config(core::QueryConfig::kSpillPartitionBits, "3")
+        .config(core::QueryConfig::kJoinSpillPartitionBits, "3")
         .config(
             core::QueryConfig::kMaxSpillFileSize, std::to_string(spillFileSize))
         .checkSpillStats(false)

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -619,7 +619,6 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
             .spillDirectory(tempDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {
@@ -752,7 +751,6 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
         .spillDirectory(tempDirectory->path)
         .config(core::QueryConfig::kSpillEnabled, "true")
         .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-        .config(core::QueryConfig::kSpillPartitionBits, "2")
         .maxDrivers(1)
         .assertResults(expectedResult);
   });
@@ -865,7 +863,6 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
             .spillDirectory(tempDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {
@@ -986,7 +983,6 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
             .spillDirectory(tempDirectory->path)
             .config(core::QueryConfig::kSpillEnabled, "true")
             .config(core::QueryConfig::kOrderBySpillEnabled, "true")
-            .config(core::QueryConfig::kSpillPartitionBits, "2")
             .maxDrivers(1)
             .assertResults(expectedResult);
       } else {

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1340,10 +1340,17 @@ TEST(SpillerTest, stats) {
 TEST(SpillerTest, spillLevel) {
   const uint8_t kInitialBitOffset = 16;
   const uint8_t kNumPartitionsBits = 3;
-  const HashBitRange partitionBits(
-      kInitialBitOffset, kInitialBitOffset + kNumPartitionsBits);
   const Spiller::Config config(
-      "fakeSpillPath", 0, 0, nullptr, 0, partitionBits, 0, 0);
+      "fakeSpillPath",
+      0,
+      0,
+      nullptr,
+      0,
+      kInitialBitOffset,
+      kNumPartitionsBits,
+      0,
+      0,
+      0);
   struct {
     uint8_t bitOffset;
     // Indicates an invalid if 'expectedLevel' is negative.
@@ -1366,9 +1373,10 @@ TEST(SpillerTest, spillLevel) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     if (testData.expectedLevel == -1) {
-      ASSERT_ANY_THROW(config.spillLevel(testData.bitOffset));
+      ASSERT_ANY_THROW(config.joinSpillLevel(testData.bitOffset));
     } else {
-      ASSERT_EQ(config.spillLevel(testData.bitOffset), testData.expectedLevel);
+      ASSERT_EQ(
+          config.joinSpillLevel(testData.bitOffset), testData.expectedLevel);
     }
   }
 }
@@ -1419,12 +1427,14 @@ TEST(SpillerTest, spillLevelLimit) {
         0,
         nullptr,
         0,
-        partitionBits,
+        testData.startBitOffset,
+        testData.numBits,
+        0,
         testData.maxSpillLevel,
         0);
 
     ASSERT_EQ(
         testData.expectedExceeds,
-        config.exceedSpillLevelLimit(testData.bitOffset));
+        config.exceedJoinSpillLevelLimit(testData.bitOffset));
   }
 }


### PR DESCRIPTION
The number of partitions for spilling should be configured separately for hash
join and aggregation. As for now, we shall always spill entire data for hash
aggregation but always partition spilling data for hash join.