### PR TITLE
Make field not found error a velox error and check valid construction of fieldReference

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -243,6 +243,12 @@ class FieldAccessTypedExpr : public ITypedExpr {
       : ITypedExpr{std::move(type), {std::move(input)}},
         name_(std::move(name)),
         isInputColumn_(dynamic_cast<const InputTypedExpr*>(inputs()[0].get())) {
+    auto rowType = asRowType(inputs()[0]->type());
+    VELOX_CHECK(rowType, "Input of field access must have a row type.")
+    VELOX_CHECK(
+        rowType->getChildIdxIfExists(name_).has_value(),
+        fmt::format(
+            "Field {} not found in type {}.", name_, rowType->toString()));
   }
 
   const std::string& name() const {

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -31,7 +31,20 @@ class FieldReference : public SpecialForm {
             field,
             inputs.empty() ? true : false,
             false /* trackCpuUsage */),
-        field_(field) {}
+        field_(field) {
+    if (!inputs.empty()) {
+      VELOX_CHECK(
+          inputs.size() == 1, "Field reference can have a max of 1 input.")
+
+      // Check that field exists in the input row type.
+      auto rowType = asRowType(inputs[0]->type());
+      VELOX_CHECK(rowType, "Input of field reference must be a row type.")
+      VELOX_CHECK(
+          rowType->getChildIdxIfExists(field_).has_value(),
+          fmt::format(
+              "Field {} not found in type {}.", field_, rowType->toString()));
+    }
+  }
 
   const std::string& field() const {
     return field_;

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -353,7 +353,7 @@ const TypePtr& RowType::findChild(folly::StringPiece name) const {
   if (idx) {
     return children_[*idx];
   }
-  VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
+  VELOX_FAIL(makeFieldNotFoundErrorMessage(name, names_));
 }
 
 bool RowType::containsChild(std::string_view name) const {


### PR DESCRIPTION
Summary:
Field not found error ideally should be caught during compilation before the expression runs.
if it was encountered when the expression is evaluated it should not be something
that is hidden by try, hence its type should not be veloxUserError but rather
VeloxError. Since VeloxUserErrors are those that are expected to be hidden by a
try.
This adds checks to catch this issue asap, and change the error type to VeloxError.
A follow up diff should assert that we catch such issue for input row field
referenced during query compilations if do not do that already.

Differential Revision: D47853552

