### PR TITLE
Fix ConstantTypedExpr should compre equality not equivalence of types

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -77,6 +77,7 @@ class ConstantTypedExpr : public ITypedExpr {
   size_t localHash() const override {
     static const size_t kBaseHash =
         std::hash<const char*>()("ConstantTypedExpr");
+
     return bits::hashMix(
         kBaseHash,
         hasValueVector() ? valueVector_->hashValueAt(0) : value_.hash());
@@ -128,7 +129,7 @@ class ConstantTypedExpr : public ITypedExpr {
       return false;
     }
 
-    if (!this->type()->equivalent(*casted->type())) {
+    if (*this->type() != *casted->type()) {
       return false;
     }
 

--- a/velox/core/tests/ConstantTypedExprTest.cpp
+++ b/velox/core/tests/ConstantTypedExprTest.cpp
@@ -56,11 +56,15 @@ TEST(ConstantTypedExprTest, null) {
 
   EXPECT_TRUE(*makeNull(DOUBLE()) == *makeNull(DOUBLE()));
   EXPECT_TRUE(*makeNull(ARRAY(DOUBLE())) == *makeNull(ARRAY(DOUBLE())));
-  EXPECT_TRUE(
-      *makeNull(ROW({"a", "b"}, {INTEGER(), REAL()})) ==
-      *makeNull(ROW({"x", "y"}, {INTEGER(), REAL()})));
+
   EXPECT_TRUE(*makeNull(JSON()) == *makeNull(JSON()));
   EXPECT_TRUE(
       *makeNull(MAP(VARCHAR(), JSON())) == *makeNull(MAP(VARCHAR(), JSON())));
+
+  EXPECT_FALSE(*makeNull(JSON()) == *makeNull(VARCHAR()));
+  EXPECT_FALSE(
+      *makeNull(ROW({"a", "b"}, {INTEGER(), REAL()})) ==
+      *makeNull(ROW({"x", "y"}, {INTEGER(), REAL()})));
 }
+
 } // namespace facebook::velox::core::test


### PR DESCRIPTION
Summary:
During query compilation, if two expressions are equal they are
considered shared expressions. This should be valid only if types
matches precisely.

Fix https://github.com/facebookincubator/velox/issues/5846 and
hopefully the non-reproducable
https://github.com/facebookincubator/velox/issues/5835

Reviewed By: bikramSingh91

Differential Revision: D47851125

