### PR TITLE
Add support for global agg with no aggregates

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -117,9 +117,9 @@ AggregationNode::AggregationNode(
   //    SELECT sum(c) FROM t
   // Empty aggregates are used in distinct:
   //    SELECT distinct(b, c) FROM t GROUP BY a
-  VELOX_CHECK(
-      !groupingKeys_.empty() || !aggregates_.empty(),
-      "Aggregation must specify either grouping keys or aggregates");
+  // Sometimes there are no grouping keys and no aggregations:
+  //    WITH a AS (SELECT sum(x) from t)
+  //    SELECT y FROM a, UNNEST(array[1, 2,3]) as u(y)
 
   std::unordered_set<std::string> groupingKeyNames;
   groupingKeyNames.reserve(groupingKeys.size());

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -77,8 +77,8 @@ HashAggregation::HashAggregation(
               ? driverCtx->makeSpillConfig(operatorId)
               : std::nullopt),
       isPartialOutput_(isPartialOutput(aggregationNode->step())),
-      isDistinct_(aggregationNode->aggregates().empty()),
       isGlobal_(aggregationNode->groupingKeys().empty()),
+      isDistinct_(!isGlobal_ && aggregationNode->aggregates().empty()),
       maxExtendedPartialAggregationMemoryUsage_(
           driverCtx->queryConfig().maxExtendedPartialAggregationMemoryUsage()),
       maxPartialAggregationMemoryUsage_(

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -72,8 +72,8 @@ class HashAggregation : public Operator {
   void recordSpillStats();
 
   const bool isPartialOutput_;
-  const bool isDistinct_;
   const bool isGlobal_;
+  const bool isDistinct_;
   const int64_t maxExtendedPartialAggregationMemoryUsage_;
 
   int64_t maxPartialAggregationMemoryUsage_;

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2494,4 +2494,22 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
   }
 }
 
+TEST_F(AggregationTest, noAggregationsNoGroupingKeys) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3}),
+  });
+
+  auto plan = PlanBuilder()
+                  .values({data})
+                  .partialAggregation({}, {})
+                  .finalAggregation()
+                  .planNode();
+
+  auto result = AssertQueryBuilder(plan).copyResults(pool());
+
+  // 1 row.
+  ASSERT_EQ(result->size(), 1);
+  // Zero columns.
+  ASSERT_EQ(result->type()->size(), 0);
+}
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
Add support for a weird query shape that has an aggregation with no grouping keys and no aggregates.

```
with a as (select sum(nationkey) from tpch.tiny.nation) select x from a, unnest(array[1, 2,3]) as t(x)

Fragment 0 [SINGLE]
     - Output[x] => [field:integer]
             x := field (1:91)
         - Unnest[replicate=, unnest=expr_5:array(integer)] => [field:integer]
             - Project[projectLocality = LOCAL] => [expr_5:array(integer)]
                     expr_5 := [Block: position count: 3; size: 84 bytes]
                 - LocalExchange[ROUND_ROBIN] () => []
                     - Aggregate(FINAL) => []
                         - LocalExchange[SINGLE] () => []
                             - RemoteSource[1] => []

 Fragment 1 [SOURCE]
     - Aggregate(PARTIAL) => []
         - TableScan[TableHandle {connectorId='tpch', connectorHandle='nation:sf0.01', layout='Optional[nation:sf0.01]'}, grouped = false] => []
```

These queries used to fail with 

`VeloxRuntimeError: !groupingKeys_.empty() || !aggregates_.empty() Aggregation must specify either grouping keys or aggregates`