### PR TITLE
Support Iceberg positional deletes

### DIFF
--- a/velox/benchmarks/tpch/CMakeLists.txt
+++ b/velox/benchmarks/tpch/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(
   velox_dwio_parquet_reader
   velox_dwio_common_test_utils
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_exception
   velox_memory
   velox_process

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -331,7 +331,8 @@ class Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) = 0;
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit) = 0;
 
   // Returns true if addSplit of DataSource can use 'dataSource' from
   // ConnectorSplit in addSplit(). If so, TableScan can preload splits

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -113,7 +113,9 @@ class FuzzerConnector final : public Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& /*columnHandles*/,
-      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> /*connectorSplit*/)
+      override final {
     return std::make_unique<FuzzerDataSource>(
         outputType, tableHandle, connectorQueryCtx->memoryPool());
   }

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   velox_dwio_parquet_reader
   velox_dwio_parquet_writer
   velox_file
+  velox_hive_iceberg_datasource
   velox_hive_partition_function
   velox_s3fs
   velox_hdfs
@@ -42,6 +43,8 @@ add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 target_link_libraries(velox_hive_partition_function velox_core velox_exec)
 
 add_subdirectory(storage_adapters)
+
+add_subdirectory(iceberg)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -51,7 +51,9 @@ class HiveConnector : public Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* connectorQueryCtx) override;
+      ConnectorQueryCtx* connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit)
+      override;
 
   bool supportsSplitPreload() override {
     return true;

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -389,15 +389,16 @@ HiveDataSource::HiveDataSource(
     cache::AsyncDataCache* cache,
     const std::string& scanId,
     folly::Executor* executor,
-    const dwio::common::ReaderOptions& options)
+    const dwio::common::ReaderOptions& options,
+    std::shared_ptr<velox::connector::ConnectorSplit> /*connectorSplit*/)
     : fileHandleFactory_(fileHandleFactory),
       readerOpts_(options),
       pool_(&options.getMemoryPool()),
-      outputType_(outputType),
       expressionEvaluator_(expressionEvaluator),
       cache_(cache),
       scanId_(scanId),
-      executor_(executor) {
+      executor_(executor),
+      outputType_(outputType) {
   // Column handled keyed on the column alias, the name used in the query.
   for (const auto& [canonicalizedName, columnHandle] : columnHandles) {
     auto handle = std::dynamic_pointer_cast<HiveColumnHandle>(columnHandle);

--- a/velox/connectors/hive/benchmarks/CMakeLists.txt
+++ b/velox/connectors/hive/benchmarks/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_hive_partition_function
   velox_memory
   Folly::folly

--- a/velox/connectors/hive/iceberg/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/CMakeLists.txt
@@ -12,30 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set(TEST_LINK_LIBS
-    velox_dwio_common_test_utils
-    velox_vector_test_lib
-    gtest
-    gtest_main
-    gmock
-    gflags::gflags
-    ${GLOG}
-    ${FILESYSTEM})
+add_library(velox_hive_iceberg_datasource OBJECT IcebergSplit.cpp
+                                                 IcebergDataSource.cpp)
 
-add_subdirectory(reader)
-add_subdirectory(thrift)
-
-add_executable(velox_dwio_parquet_tpch_test ParquetTpchTest.cpp)
-add_test(
-  NAME velox_dwio_parquet_tpch_test
-  COMMAND velox_dwio_parquet_tpch_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
-  velox_dwio_parquet_tpch_test
-  velox_dwio_parquet_reader
-  velox_exec_test_lib
-  velox_exec
-  velox_hive_connector
   velox_hive_iceberg_datasource
-  velox_aggregates
-  ${TEST_LINK_LIBS})
+  Folly::folly
+  gtest
+  Boost::headers
+  Boost::filesystem
+  gflags::gflags
+  glog::glog
+  gtest
+  gtest_main
+  xsimd)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/connectors/hive/iceberg/IcebergDataSource.cpp
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergDataSource.h"
+
+#include "velox/connectors/hive/iceberg/IcebergMetadataColumn.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/dwio/common/BufferUtil.h"
+
+using namespace facebook::velox::dwio::common;
+
+namespace facebook::velox::connector::hive::iceberg {
+
+HiveIcebergDataSource::HiveIcebergDataSource(
+    const RowTypePtr& outputType,
+    const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<connector::ColumnHandle>>&
+        columnHandles, // output columns
+    FileHandleFactory* fileHandleFactory,
+    core::ExpressionEvaluator* expressionEvaluator,
+    cache::AsyncDataCache* cache,
+    const std::string& scanId,
+    folly::Executor* executor,
+    const dwio::common::ReaderOptions& options,
+    std::shared_ptr<velox::connector::ConnectorSplit> split)
+    : HiveDataSource(
+          outputType,
+          tableHandle,
+          columnHandles,
+          fileHandleFactory,
+          expressionEvaluator,
+          cache,
+          scanId,
+          executor,
+          options,
+          split),
+      connectorId_(split->connectorId),
+      deleteFileContentsOffset_(0),
+      deleteRowsOffset_(0),
+      numDeleteRowsInSplit_(0) {}
+
+void HiveIcebergDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
+  readOffset_ = 0;
+  deleteFileContents_.clear();
+  deleteFileContentsOffset_ = 0;
+  deleteRowsOffset_ = 0;
+  numDeleteRowsInSplit_ = 0;
+
+  HiveDataSource::addSplit(split);
+
+  firstRowInSplit_ = rowReader_->nextRowNumber();
+
+  // TODO: Deserialize the std::vector<IcebergDeleteFile> deleteFiles. For now
+  // we assume it's already deserialized.
+  std::shared_ptr<HiveIcebergSplit> icebergSplit =
+      std::dynamic_pointer_cast<HiveIcebergSplit>(split);
+
+  auto& deleteFiles = icebergSplit->deleteFiles;
+  for (auto& deleteFile : deleteFiles) {
+    if (deleteFile.content == FileContent::kEqualityDeletes) {
+      readEqualityDeletes(deleteFile);
+    } else if (deleteFile.content == FileContent::kPositionalDeletes) {
+      readPositionalDeletes(deleteFile);
+    }
+  }
+}
+
+uint64_t HiveIcebergDataSource::readNext(uint64_t size) {
+  // The equality deletes should have been put into filter in scanspec. Now we
+  // just need to deal with positional deletes. The deleteFileContents_ contains
+  // the deleted row numbers relative to the start of the file, and we need to
+  // convert them into row numbers relative to the start of the split.
+  Mutation mutation;
+  mutation.deletedRows = nullptr;
+
+  if (numDeleteRowsInSplit_ > 0) {
+    auto numBytes = bits::nbytes(size);
+    dwio::common::ensureCapacity<int8_t>(deleteBitmap_, numBytes, pool_);
+    std::memset((void*)deleteBitmap_->as<int8_t>(), 0L, numBytes);
+
+    while (deleteFileContentsOffset_ < deleteFileContents_.size()) {
+      auto deleteFile = deleteFileContents_[deleteFileContentsOffset_];
+      VectorPtr& posVector = deleteFile->childAt(1);
+      const int64_t* deleteRows =
+          posVector->as<FlatVector<int64_t>>()->rawValues();
+
+      auto deleteRowsOffsetBefore = deleteRowsOffset_;
+      while (deleteRowsOffset_ < posVector->size() &&
+             deleteRows[deleteRowsOffset_] <
+                 firstRowInSplit_ + readOffset_ + size) {
+        bits::setBit(
+            deleteBitmap_->asMutable<uint64_t>(),
+            deleteRows[deleteRowsOffset_] - readOffset_ - firstRowInSplit_);
+        deleteRowsOffset_++;
+      }
+
+      numDeleteRowsInSplit_ -= deleteRowsOffset_ - deleteRowsOffsetBefore;
+      if (deleteRowsOffset_ == posVector->size()) {
+        deleteFileContentsOffset_++;
+        deleteRowsOffset_ = 0;
+      } else {
+        break;
+      }
+    }
+
+    deleteBitmap_->setSize(numBytes);
+    mutation.deletedRows = deleteBitmap_->as<uint64_t>();
+  }
+
+  auto rowsScanned = HiveDataSource::rowReader_->next(size, output_, &mutation);
+  readOffset_ += rowsScanned;
+
+  return rowsScanned;
+}
+
+void HiveIcebergDataSource::readPositionalDeletes(
+    const IcebergDeleteFile& deleteFile) {
+  auto filePathColumn = ICEBERG_DELETE_FILE_PATH_COLUMN();
+  auto positionsColumn = ICEBERG_DELETE_FILE_POSITIONS_COLUMN();
+
+  std::vector<std::string> deleteColumnNames(
+      {filePathColumn->name, positionsColumn->name});
+  std::vector<std::shared_ptr<const Type>> deleteColumnTypes(
+      {filePathColumn->type, positionsColumn->type});
+
+  RowTypePtr deleteRowType =
+      ROW(std::move(deleteColumnNames), std::move(deleteColumnTypes));
+
+  std::unordered_map<std::string, std::shared_ptr<connector::ColumnHandle>>
+      deleteColumnHandles;
+  deleteColumnHandles[filePathColumn->name] =
+      std::make_shared<HiveColumnHandle>(
+          filePathColumn->name,
+          HiveColumnHandle::ColumnType::kRegular,
+          VARCHAR(),
+          VARCHAR());
+  deleteColumnHandles[positionsColumn->name] =
+      std::make_shared<HiveColumnHandle>(
+          positionsColumn->name,
+          HiveColumnHandle::ColumnType::kRegular,
+          BIGINT(),
+          BIGINT());
+
+  openDeletes(deleteFile, deleteRowType, deleteColumnHandles);
+}
+
+void HiveIcebergDataSource::readEqualityDeletes(
+    const IcebergDeleteFile& deleteFile) {
+  VELOX_NYI();
+}
+
+void HiveIcebergDataSource::openDeletes(
+    const IcebergDeleteFile& deleteFile,
+    const RowTypePtr& deleteRowType,
+    const std::unordered_map<
+        std::string,
+        std::shared_ptr<connector::ColumnHandle>>& deleteColumnHandles) {
+  size_t lastPathDelimiterPos = deleteFile.filePath.find_last_of('/');
+  std::string deleteFileName = deleteFile.filePath.substr(
+      lastPathDelimiterPos, deleteFile.filePath.size() - lastPathDelimiterPos);
+
+  SubfieldFilters subfieldFilters = {};
+  auto deleteTableHandle = std::make_shared<HiveTableHandle>(
+      connectorId_, deleteFileName, false, std::move(subfieldFilters), nullptr);
+
+  auto deleteSplit = std::make_shared<HiveConnectorSplit>(
+      connectorId_,
+      deleteFile.filePath,
+      deleteFile.fileFormat,
+      0,
+      deleteFile.fileSizeInBytes);
+
+  auto deleteFileDataSource = std::make_shared<HiveDataSource>(
+      deleteRowType,
+      deleteTableHandle,
+      deleteColumnHandles,
+      fileHandleFactory_,
+      expressionEvaluator_,
+      cache_,
+      scanId_ + deleteFile.filePath,
+      executor_,
+      readerOpts_,
+      deleteSplit);
+
+  deleteFileDataSource->addSplit(deleteSplit);
+
+  ContinueFuture blockingFuture(ContinueFuture::makeEmpty());
+  uint64_t numDeleteRowsInFile = 0;
+  while (true) {
+    std::optional<RowVectorPtr> deletesResult =
+        deleteFileDataSource->next(deleteFile.recordCount, blockingFuture);
+
+    if (!deletesResult.has_value()) {
+      return;
+    }
+
+    auto data = deletesResult.value();
+    if (data) {
+      if (data->size() > 0) {
+        VELOX_CHECK(data->childrenSize() > 0);
+        numDeleteRowsInFile += data->childAt(0)->size();
+
+        data->loadedVector();
+        deleteFileContents_.push_back(data);
+      }
+    } else {
+      numDeleteRowsInSplit_ += numDeleteRowsInFile;
+      VELOX_CHECK(
+          numDeleteRowsInFile == deleteFile.recordCount,
+          "Failed to read Iceberg delete file %s. Supposed to read %lld rows, actual read %lld rows",
+          deleteFile.filePath,
+          deleteFile.recordCount,
+          numDeleteRowsInFile);
+
+      return;
+    }
+  };
+}
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDataSource.h
+++ b/velox/connectors/hive/iceberg/IcebergDataSource.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveDataSource.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+class HiveIcebergDataSource : public HiveDataSource {
+ public:
+  HiveIcebergDataSource(
+      const RowTypePtr& outputType,
+      const std::shared_ptr<connector::ConnectorTableHandle>& tableHandle,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>& columnHandles,
+      FileHandleFactory* fileHandleFactory,
+      core::ExpressionEvaluator* expressionEvaluator,
+      cache::AsyncDataCache* cache,
+      const std::string& scanId,
+      folly::Executor* executor,
+      const dwio::common::ReaderOptions& options,
+      std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit);
+
+  void addSplit(std::shared_ptr<ConnectorSplit> split) override;
+  uint64_t readNext(uint64_t size) override;
+
+ private:
+  void readPositionalDeletes(const IcebergDeleteFile& deleteFile);
+  void readEqualityDeletes(const IcebergDeleteFile& deleteFile);
+  void openDeletes(
+      const IcebergDeleteFile& deleteFile,
+      const RowTypePtr& deleteRowType,
+      const std::unordered_map<
+          std::string,
+          std::shared_ptr<connector::ColumnHandle>>& deleteColumnHandles);
+
+  std::string connectorId_;
+  BufferPtr deleteBitmap_;
+  // The read offset to the beginning of the split in number of rows for the
+  // current batch
+  uint64_t readOffset_;
+  // The file row position for the first row in the split
+  uint64_t firstRowInSplit_;
+  // Materialized delete file contents, one RowVectorPtr for each delete file
+  std::vector<RowVectorPtr> deleteFileContents_;
+  // The index into deleteFileContents_ vector for the current batch
+  uint32_t deleteFileContentsOffset_;
+  // The index within each delete file
+  uint32_t deleteRowsOffset_;
+  // Total number of delete rows in the split
+  uint64_t numDeleteRowsInSplit_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergDeleteFile.h
+++ b/velox/connectors/hive/iceberg/IcebergDeleteFile.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/dwio/common/Options.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+enum class FileContent {
+  kData,
+  kPositionalDeletes,
+  kEqualityDeletes,
+};
+
+struct IcebergDeleteFile {
+  FileContent content;
+  const std::string filePath;
+  dwio::common::FileFormat fileFormat;
+  uint64_t recordCount;
+  uint64_t fileSizeInBytes;
+  // The field ids for the delete columns for equality delete files
+  std::vector<int32_t> equalityFieldIds;
+  // The lower bounds of the in-file positions for the deleted rows, identified
+  // by each column's field id. E.g. The deleted rows for a column with field id
+  // 1 is in range [10, 50], where 10 and 50 are the deleted row positions in
+  // the data file, then lowerBounds would contain entry <1, "10">
+  std::unordered_map<int32_t, std::string> lowerBounds;
+  // The upper bounds of the in-file positions for the deleted rows, identified
+  // by each column's field id. E.g. The deleted rows for a column with field id
+  // 1 is in range [10, 50], then upperBounds will contain entry <1, "50">
+  std::unordered_map<int32_t, std::string> upperBounds;
+
+  IcebergDeleteFile(
+      FileContent _content,
+      const std::string& _filePath,
+      dwio::common::FileFormat _fileFormat,
+      uint64_t _recordCount,
+      uint64_t _fileSizeInBytes,
+      std::vector<int32_t> _equalityFieldIds = {},
+      std::unordered_map<int32_t, std::string> _lowerBounds = {},
+      std::unordered_map<int32_t, std::string> _upperBounds = {})
+      : content(_content),
+        filePath(_filePath),
+        fileFormat(_fileFormat),
+        recordCount(_recordCount),
+        fileSizeInBytes(_fileSizeInBytes),
+        equalityFieldIds(_equalityFieldIds),
+        lowerBounds(_lowerBounds),
+        upperBounds(_upperBounds) {}
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergMetadataColumn.h
+++ b/velox/connectors/hive/iceberg/IcebergMetadataColumn.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/type/Type.h"
+
+#include <string>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+const std::string kIcebergDeleteFilePathColumn = "file_path";
+const std::string kIcebergRowPositionColumn = "pos";
+
+struct IcebergMetadataColumn {
+  int id;
+  std::string name;
+  std::shared_ptr<const Type> type;
+  std::string doc;
+
+  IcebergMetadataColumn(
+      int _id,
+      const std::string& _name,
+      std::shared_ptr<const Type> _type,
+      const std::string& _doc)
+      : id(_id), name(_name), type(_type), doc(_doc) {}
+};
+
+#define ICEBERG_DELETE_FILE_PATH_COLUMN()  \
+  std::make_shared<IcebergMetadataColumn>( \
+      2147483546,                          \
+      kIcebergDeleteFilePathColumn,        \
+      VARCHAR(),                           \
+      "Path of a file in which a deleted row is stored");
+
+#define ICEBERG_DELETE_FILE_POSITIONS_COLUMN() \
+  std::make_shared<IcebergMetadataColumn>(     \
+      2147483545,                              \
+      kIcebergRowPositionColumn,               \
+      BIGINT(),                                \
+      "Ordinal position of a deleted row in the data file");
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.cpp
+++ b/velox/connectors/hive/iceberg/IcebergSplit.cpp
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+HiveIcebergSplit::HiveIcebergSplit(
+    const std::string& _connectorId,
+    const std::string& _filePath,
+    dwio::common::FileFormat _fileFormat,
+    uint64_t _start,
+    uint64_t _length,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        _partitionKeys,
+    std::optional<int32_t> _tableBucketNumber,
+    const std::unordered_map<std::string, std::string>& _customSplitInfo,
+    const std::shared_ptr<std::string>& _extraFileInfo)
+    : HiveConnectorSplit(
+          _connectorId,
+          _filePath,
+          _fileFormat,
+          _start,
+          _length,
+          _partitionKeys,
+          _tableBucketNumber) {
+  // TODO: Deserialize _extraFileInfo to get deleteFiles;
+}
+
+// For tests only
+HiveIcebergSplit::HiveIcebergSplit(
+    const std::string& _connectorId,
+    const std::string& _filePath,
+    dwio::common::FileFormat _fileFormat,
+    uint64_t _start,
+    uint64_t _length,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        _partitionKeys,
+    std::optional<int32_t> _tableBucketNumber,
+    const std::unordered_map<std::string, std::string>& _customSplitInfo,
+    const std::shared_ptr<std::string>& _extraFileInfo,
+    std::vector<IcebergDeleteFile> _deletes)
+    : HiveConnectorSplit(
+          _connectorId,
+          _filePath,
+          _fileFormat,
+          _start,
+          _length,
+          _partitionKeys,
+          _tableBucketNumber,
+          _customSplitInfo,
+          _extraFileInfo),
+      deleteFiles(_deletes) {}
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/IcebergSplit.h
+++ b/velox/connectors/hive/iceberg/IcebergSplit.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergDeleteFile.h"
+
+namespace facebook::velox::connector::hive::iceberg {
+
+struct HiveIcebergSplit : public connector::hive::HiveConnectorSplit {
+  std::vector<IcebergDeleteFile> deleteFiles;
+
+  HiveIcebergSplit(
+      const std::string& connectorId,
+      const std::string& _filePath,
+      dwio::common::FileFormat _fileFormat,
+      uint64_t _start = 0,
+      uint64_t _length = std::numeric_limits<uint64_t>::max(),
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          _partitionKeys = {},
+      std::optional<int32_t> _tableBucketNumber = std::nullopt,
+      const std::unordered_map<std::string, std::string>& _customSplitInfo = {},
+      const std::shared_ptr<std::string>& _extraFileInfo = {});
+
+  // For tests only
+  HiveIcebergSplit(
+      const std::string& connectorId,
+      const std::string& _filePath,
+      dwio::common::FileFormat _fileFormat,
+      uint64_t _start = 0,
+      uint64_t _length = std::numeric_limits<uint64_t>::max(),
+      const std::unordered_map<std::string, std::optional<std::string>>&
+          _partitionKeys = {},
+      std::optional<int32_t> _tableBucketNumber = std::nullopt,
+      const std::unordered_map<std::string, std::string>& _customSplitInfo = {},
+      const std::shared_ptr<std::string>& _extraFileInfo = {},
+      std::vector<IcebergDeleteFile> deletes = {});
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/iceberg/tests/CMakeLists.txt
+++ b/velox/connectors/hive/iceberg/tests/CMakeLists.txt
@@ -11,31 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+add_executable(velox_hive_iceberg_test IcebergReadTest.cpp)
+add_test(velox_hive_iceberg_test velox_hive_iceberg_test)
 
-set(TEST_LINK_LIBS
-    velox_dwio_common_test_utils
-    velox_vector_test_lib
-    gtest
-    gtest_main
-    gmock
-    gflags::gflags
-    ${GLOG}
-    ${FILESYSTEM})
-
-add_subdirectory(reader)
-add_subdirectory(thrift)
-
-add_executable(velox_dwio_parquet_tpch_test ParquetTpchTest.cpp)
-add_test(
-  NAME velox_dwio_parquet_tpch_test
-  COMMAND velox_dwio_parquet_tpch_test
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(
-  velox_dwio_parquet_tpch_test
-  velox_dwio_parquet_reader
-  velox_exec_test_lib
-  velox_exec
+  velox_hive_iceberg_test
   velox_hive_connector
   velox_hive_iceberg_datasource
-  velox_aggregates
-  ${TEST_LINK_LIBS})
+  velox_hive_partition_function
+  velox_hive_iceberg_datasource
+  velox_dwio_common_exception
+  velox_dwio_common_test_utils
+  velox_vector_test_lib
+  velox_exec
+  velox_exec_test_lib
+  gtest
+  gtest_main)

--- a/velox/connectors/hive/iceberg/tests/IcebergReadTest.h
+++ b/velox/connectors/hive/iceberg/tests/IcebergReadTest.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/iceberg/IcebergSplit.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+
+#include <string>
+
+namespace facebook::velox::connector::hive::iceberg {
+
+class IcebergSplitBuilder : public exec::test::HiveConnectorSplitBuilder {
+ public:
+  const std::string kHiveConnectorId = "test-hive";
+
+  IcebergSplitBuilder(std::string filePath)
+      : HiveConnectorSplitBuilder{std::move(filePath)} {}
+
+  IcebergSplitBuilder& deleteFiles(
+      const std::vector<IcebergDeleteFile>& deleteFiles) {
+    deleteFiles_ = deleteFiles;
+    return *this;
+  }
+
+  IcebergSplitBuilder& deleteFile(const IcebergDeleteFile& deleteFile) {
+    deleteFiles_.push_back(std::move(deleteFile));
+    return *this;
+  }
+
+  std::shared_ptr<HiveIcebergSplit> build() const {
+    return std::make_shared<HiveIcebergSplit>(
+        kHiveConnectorId,
+        "file:" + filePath_,
+        fileFormat_,
+        start_,
+        length_,
+        partitionKeys_,
+        tableBucketNumber_,
+        {},
+        {},
+        deleteFiles_);
+  }
+
+ private:
+  std::vector<IcebergDeleteFile> deleteFiles_;
+};
+
+} // namespace facebook::velox::connector::hive::iceberg

--- a/velox/connectors/hive/storage_adapters/gcs/examples/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/CMakeLists.txt
@@ -20,5 +20,6 @@ target_link_libraries(
   velox_gcs
   velox_core
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_dwio_common_exception
   velox_exec)

--- a/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
   velox_gcs
   velox_core
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_dwio_common_exception
   velox_exec
   gmock

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   velox_core
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_dwio_common_exception
   velox_exec
   gtest

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ target_link_libraries(
   velox_core
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_dwio_common_exception
   velox_exec
   gtest

--- a/velox/connectors/hive/tests/CMakeLists.txt
+++ b/velox/connectors/hive/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ add_test(velox_hive_connector_test velox_hive_connector_test)
 target_link_libraries(
   velox_hive_connector_test
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_hive_partition_function
   velox_dwio_common_exception
   velox_vector_fuzzer

--- a/velox/connectors/tests/ConnectorTest.cpp
+++ b/velox/connectors/tests/ConnectorTest.cpp
@@ -33,7 +33,9 @@ class TestConnector : public connector::Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& /* columnHandles */,
-      connector::ConnectorQueryCtx* connectorQueryCtx) override {
+      connector::ConnectorQueryCtx* connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit)
+      override {
     VELOX_NYI();
   }
 

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -140,7 +140,8 @@ class TpchConnector final : public Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& columnHandles,
-      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx) override final {
+      ConnectorQueryCtx* FOLLY_NONNULL connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> split) override final {
     return std::make_unique<TpchDataSource>(
         outputType,
         tableHandle,

--- a/velox/dwio/common/tests/utils/BatchMaker.h
+++ b/velox/dwio/common/tests/utils/BatchMaker.h
@@ -62,6 +62,14 @@ struct BatchMaker {
     std::mt19937 gen{seed};
     return createVector<KIND>(type, size, pool, gen, isNullAt);
   }
+
+  template <TypeKind KIND>
+  static VectorPtr createOrderedVector(
+      const std::shared_ptr<const Type>& type,
+      size_t size,
+      size_t base,
+      memory::MemoryPool& pool,
+      std::function<bool(vector_size_t /*index*/)> isNullAt = nullptr);
 };
 
 } // namespace facebook::velox::test

--- a/velox/dwio/common/tests/utils/DataFiles.h
+++ b/velox/dwio/common/tests/utils/DataFiles.h
@@ -23,4 +23,5 @@ std::string getDataFilePath(
     const std::string& baseDir,
     const std::string& filePath);
 
+uint64_t getFileSize(const std::string& filePath);
 }

--- a/velox/dwio/parquet/tests/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/reader/CMakeLists.txt
@@ -51,6 +51,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_exec
   velox_hive_connector
+  velox_hive_iceberg_datasource
   Folly::folly
   ${FOLLY_BENCHMARK})
 
@@ -81,6 +82,7 @@ target_link_libraries(
   velox_exec_test_lib
   velox_exec
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_link_libs
   ${TEST_LINK_LIBS})
 

--- a/velox/examples/CMakeLists.txt
+++ b/velox/examples/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(
   velox_exec
   velox_exec_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_memory)
 
 add_executable(velox_example_vector_reader_writer VectorReaderWriter.cpp)

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -106,7 +106,8 @@ RowVectorPtr TableScan::getOutput() {
             outputType_,
             tableHandle_,
             columnHandles_,
-            connectorQueryCtx_.get());
+            connectorQueryCtx_.get(),
+            connectorSplit);
         for (const auto& entry : pendingDynamicFilters_) {
           dataSource_->addDynamicFilter(entry.first, entry.second);
         }
@@ -233,7 +234,9 @@ void TableScan::preload(std::shared_ptr<connector::ConnectorSplit> split) {
              },
              &debugString});
 
-        auto ptr = connector->createDataSource(type, table, columns, ctx.get());
+        auto ptr =
+            connector->createDataSource(type, table, columns, ctx.get(), split);
+
         if (task->isCancelled()) {
           return nullptr;
         }

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -142,7 +142,9 @@ class TestConnector : public connector::Connector {
       const std::unordered_map<
           std::string,
           std::shared_ptr<connector::ColumnHandle>>& /* columnHandles */,
-      connector::ConnectorQueryCtx* connectorQueryCtx) override {
+      connector::ConnectorQueryCtx* connectorQueryCtx,
+      std::shared_ptr<velox::connector::ConnectorSplit> connectorSplit)
+      override {
     return std::make_unique<TestDataSource>(connectorQueryCtx->memoryPool());
   }
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_memory
   velox_serialization
   velox_test_util
@@ -152,6 +153,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_test_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_memory
   velox_serialization
   velox_test_util

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -44,6 +44,7 @@ target_link_libraries(
   velox_dwio_common_test_utils
   velox_type_fbhive
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql

--- a/velox/exec/tests/utils/HiveConnectorTestBase.h
+++ b/velox/exec/tests/utils/HiveConnectorTestBase.h
@@ -229,7 +229,7 @@ class HiveConnectorSplitBuilder {
         tableBucketNumber_);
   }
 
- private:
+ protected:
   const std::string filePath_;
   dwio::common::FileFormat fileFormat_{dwio::common::FileFormat::DWRF};
   uint64_t start_{0};

--- a/velox/experimental/codegen/benchmark/CMakeLists.txt
+++ b/velox/experimental/codegen/benchmark/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(
   velox_codegen_utils_resource_path
   velox_codegen_code_generator
   velox_hive_connector
+  velox_hive_iceberg_datasource
   ${FOLLY_BENCHMARK}
   Folly::folly
   Boost::filesystem

--- a/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
+++ b/velox/experimental/codegen/vector_function/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ target_link_libraries(
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_core
   velox_type
   velox_serialization

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -64,8 +64,10 @@ target_link_libraries(
   velox_expression_test
   velox_aggregates
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_dwio_common
   velox_dwio_common_exception
+  velox_dwio_common_test_utils
   velox_exec_test_lib
   velox_expression
   velox_expression_test_utility

--- a/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/benchmarks/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(
   velox_aggregates_simple_aggregates_benchmarks
   velox_aggregates
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_functions_lib
   velox_exec_test_lib
   velox_functions_prestosql

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ target_link_libraries(
   velox_functions_prestosql
   velox_functions_lib
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_simple_aggregate
   velox_type
   velox_vector_fuzzer

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ target_link_libraries(
   velox_functions_aggregates_test_lib
   velox_functions_spark_aggregates
   velox_hive_connector
+  velox_hive_iceberg_datasource
   gflags::gflags
   gtest
   gtest_main)

--- a/velox/substrait/tests/CMakeLists.txt
+++ b/velox/substrait/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ target_link_libraries(
   velox_functions_lib
   velox_functions_prestosql
   velox_hive_connector
+  velox_hive_iceberg_datasource
   velox_type
   velox_serialization
   velox_exec_test_lib


### PR DESCRIPTION
This PR is the first cut to support reading Iceberg tables with positional delete files. 
Design doc: https://github.com/facebookincubator/velox/issues/5977

TODO:
- Delete file deserialization in HiveIcebergSplit. This will be done after the Prestissimo changes are in shape
- File path matching when reading the positional delete files
- Performance optimization to avoid extra conversion from row numbers to bitmap then to row numbers

Catches:
- The velox_hive_iceberg_datasource would be better to be included in velox_hive_connector. But so far it's unclear to me how to do it properly. Suggestions are welcome.