### PR TITLE
Fix race between maybeReserve and memory abort

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -103,8 +103,9 @@ void MemoryReclaimer::abort(MemoryPool* pool) {
     // instead of the child pool as the latter always forwards the abort to its
     // root first.
     auto* reclaimer = child->reclaimer();
-    VELOX_CHECK_NOT_NULL(reclaimer);
-    reclaimer->abort(child);
+    if (reclaimer != nullptr) {
+      reclaimer->abort(child);
+    }
     return true;
   });
 }

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -638,6 +638,13 @@ bool MemoryPoolImpl::maybeReserve(uint64_t increment) {
   try {
     reserve(reservationToAdd, true);
   } catch (const std::exception& e) {
+    if (aborted()) {
+      // NOTE: we shall throw to stop the query execution if the root memory
+      // pool has been aborted. It is also unsafe to proceed as the memory abort
+      // code path might have already freed up the memory resource of this
+      // operator while it is under memory arbitration.
+      std::rethrow_exception(std::current_exception());
+    }
     return false;
   }
   return true;

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -1753,6 +1753,71 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenTaskTerminateAndReclaim) {
   Task::testingWaitForAllTasksToBeDeleted();
 }
 
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenMaybeReserveAndTaskAbort) {
+  setupMemory(kMemoryCapacity, 0);
+  const int numVectors = 10;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+
+  auto queryCtx = newQueryCtx(kMemoryCapacity);
+  ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+  // Create a fake query to hold some memory to trigger memory arbitration.
+  auto fakeQueryCtx = newQueryCtx(kMemoryCapacity);
+  auto fakeLeafPool = fakeQueryCtx->pool()->addLeafChild("fakeLeaf");
+  Allocation fakeAllocation{
+      fakeLeafPool.get(),
+      fakeLeafPool->allocate(kMemoryCapacity / 3),
+      kMemoryCapacity / 3};
+
+  std::unique_ptr<Allocation> injectAllocation;
+  std::atomic<bool> injectAllocationOnce{true};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
+      std::function<void(memory::MemoryPool*)>([&](memory::MemoryPool* pool) {
+        if (!injectAllocationOnce.exchange(false)) {
+          return;
+        }
+        // The injection memory allocation (with the given size) makes sure that
+        // maybeReserve fails and abort this query itself.
+        const size_t injectAllocationSize =
+            pool->freeBytes() + arbitrator_->stats().freeCapacityBytes;
+        injectAllocation.reset(new Allocation{
+            fakeLeafPool.get(),
+            fakeLeafPool->allocate(injectAllocationSize),
+            injectAllocationSize});
+      }));
+
+  const int numDrivers = 1;
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  std::thread queryThread([&]() {
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .queryCtx(queryCtx)
+            .spillDirectory(spillDirectory->path)
+            .config(core::QueryConfig::kSpillEnabled, "true")
+            .config(core::QueryConfig::kJoinSpillEnabled, "true")
+            .config(core::QueryConfig::kSpillPartitionBits, "2")
+            .maxDrivers(numDrivers)
+            .plan(PlanBuilder()
+                      .values(vectors)
+                      .localPartition({"c0", "c1"})
+                      .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                      .localPartition(std::vector<std::string>{})
+                      .planNode())
+            .copyResults(pool()),
+        "Aborted for external error");
+  });
+
+  queryThread.join();
+  fakeAllocation.free();
+  injectAllocation->free();
+  Task::testingWaitForAllTasksToBeDeleted();
+}
+
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
   setupMemory(kMemoryCapacity, 0);
   const int numVectors = 10;


### PR DESCRIPTION
There is a race condition between maybeReserve and memory abort which
leads the segment fault during the operator execution. The following is the
event sequence of this race condition:
T1: aggregation operator request memory arbitration by maybeReserve
T2: memory arbitration fails for whatever reason that cause this memory 
       pool to be aborted.
T3: the memory arbitration aborts the query and wait for the query execution
       to stop, that is, no running threads. Note the aggregation driver thread
       which initiates the arbitration is under driver suspension state so it is not
       counted as a running thread.
T4: the memory arbitration abort free up the memory resource from all the
       operators of the aborted query as it has been totally stopped.
T5: however the aggregation thread is not stopped and after the memory
      arbitration fails, maybeReserve will catch the exception and returns false
T6: the aggregation operator will continue the execution after maybeReserve
      fails by triggering disk spilling.
T7: the aggregation operator runs into random segment fault.

We shall throw the exception in maybeReserve if the query pool has been aborted
to stop the query execution. This PR reproduce this race condition and verified
the fix.
In followup, once the integration of memory arbitration and disk spilling becomes
stable. We shall remove the disk spilling after maybeReserve fails as the memory 
arbitration is always able to spill if needs. We might want to keep the threshold
triggered disk spilling as it might be useful to handle some special query shape as
we have found in Meta internal staging tests.
