### PR TITLE
Add support to compress in spiller

### DIFF
--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -12,5 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()
+
 add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
 target_link_libraries(velox_common_compression Folly::folly)

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -81,7 +81,7 @@ std::string compressionKindToString(CompressionKind kind) {
 }
 
 CompressionKind stringToCompressionKind(const std::string& kind) {
-  const std::unordered_map<std::string, CompressionKind>
+  static const std::unordered_map<std::string, CompressionKind>
       stringToCompressionKindMap = {
           {"none", CompressionKind_NONE},
           {"zlib", CompressionKind_ZLIB},

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -33,6 +33,8 @@ std::unique_ptr<folly::io::Codec> compressionKindToCodec(CompressionKind kind) {
       return getCodec(folly::io::CodecType::ZSTD);
     case CompressionKind_LZ4:
       return getCodec(folly::io::CodecType::LZ4);
+    case CompressionKind_GZIP:
+      return getCodec(folly::io::CodecType::GZIP);
     default:
       VELOX_UNSUPPORTED(
           "Not support {} in folly", compressionKindToString(kind));
@@ -51,6 +53,8 @@ CompressionKind codecTypeToCompressionKind(folly::io::CodecType type) {
       return CompressionKind_ZSTD;
     case folly::io::CodecType::LZ4:
       return CompressionKind_LZ4;
+    case folly::io::CodecType::GZIP:
+      return CompressionKind_GZIP;
     default:
       VELOX_UNSUPPORTED("Not support folly codec type {}", type);
   }

--- a/velox/common/compression/Compression.cpp
+++ b/velox/common/compression/Compression.cpp
@@ -75,4 +75,22 @@ std::string compressionKindToString(CompressionKind kind) {
   }
   return folly::to<std::string>("unknown - ", kind);
 }
+
+CompressionKind stringToCompressionKind(const std::string& kind) {
+  const std::unordered_map<std::string, CompressionKind>
+      stringToCompressionKindMap = {
+          {"none", CompressionKind_NONE},
+          {"zlib", CompressionKind_ZLIB},
+          {"snappy", CompressionKind_SNAPPY},
+          {"lzo", CompressionKind_LZO},
+          {"zstd", CompressionKind_ZSTD},
+          {"lz4", CompressionKind_LZ4},
+          {"gzip", CompressionKind_GZIP}};
+  auto iter = stringToCompressionKindMap.find(kind);
+  if (iter != stringToCompressionKindMap.end()) {
+    return iter->second;
+  } else {
+    VELOX_UNSUPPORTED("Not support compression kind {}", kind);
+  }
+}
 } // namespace facebook::velox::common

--- a/velox/common/compression/Compression.h
+++ b/velox/common/compression/Compression.h
@@ -41,6 +41,8 @@ CompressionKind codecTypeToCompressionKind(folly::io::CodecType type);
  */
 std::string compressionKindToString(CompressionKind kind);
 
+CompressionKind stringToCompressionKind(const std::string& kind);
+
 constexpr uint64_t DEFAULT_COMPRESSION_BLOCK_SIZE = 256 * 1024;
 
 } // namespace facebook::velox::common

--- a/velox/common/compression/tests/CompressionTest.cpp
+++ b/velox/common/compression/tests/CompressionTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/compression/Compression.h"
 
-using namespace facebook::velox::common;
+namespace facebook::velox::common {
 
 class CompressionTest : public testing::Test {};
 
@@ -47,3 +47,16 @@ TEST_F(CompressionTest, compressionKindToCodec) {
       compressionKindToCodec(CompressionKind::CompressionKind_LZO),
       facebook::velox::VeloxException);
 }
+
+TEST_F(CompressionTest, stringToCompressionKind) {
+  EXPECT_EQ(stringToCompressionKind("none"), CompressionKind_NONE);
+  EXPECT_EQ(stringToCompressionKind("zlib"), CompressionKind_ZLIB);
+  EXPECT_EQ(stringToCompressionKind("snappy"), CompressionKind_SNAPPY);
+  EXPECT_EQ(stringToCompressionKind("lzo"), CompressionKind_LZO);
+  EXPECT_EQ(stringToCompressionKind("lz4"), CompressionKind_LZ4);
+  EXPECT_EQ(stringToCompressionKind("zstd"), CompressionKind_ZSTD);
+  EXPECT_EQ(stringToCompressionKind("gzip"), CompressionKind_GZIP);
+  VELOX_ASSERT_THROW(
+      stringToCompressionKind("bz2"), "Not support compression kind bz2");
+}
+} // namespace facebook::velox::common

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -180,6 +180,9 @@ class QueryConfig {
   /// spilled files.
   static constexpr const char* kMinSpillRunSize = "min_spill_run_size";
 
+  static constexpr const char* kSpillCompressionKind =
+      "spill_compression_codec";
+
   static constexpr const char* kSpillStartPartitionBit =
       "spiller_start_partition_bit";
 
@@ -422,6 +425,10 @@ class QueryConfig {
   uint64_t minSpillRunSize() const {
     constexpr uint64_t kDefaultMinSpillRunSize = 256 << 20; // 256MB.
     return get<uint64_t>(kMinSpillRunSize, kDefaultMinSpillRunSize);
+  }
+
+  std::string spillCompressionKind() const {
+    return get<std::string>(kSpillCompressionKind, "none");
   }
 
   /// Returns the spillable memory reservation growth percentage of the previous

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -200,6 +200,13 @@ Spilling
        If the limit is zero, then the spiller always spills a previously spilled partition if it has any data. This is
        to avoid spill from a partition with a small amount of data which might result in generating too many small
        spilled files.
+   * - spill_compression_codec
+     - string
+     - none
+     - The compression codec used to control if compressing data when spilling to files. None means no compression.
+       This is to avoid to take too much storage space.
+       Available options are zlib, snappy, zstd, lz4, gzip.
+       
    * - spiller_start_partition_bit
      - integer
      - 29

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -88,7 +88,8 @@ target_link_libraries(
   velox_codegen
   velox_common_base
   velox_test_util
-  velox_arrow_bridge)
+  velox_arrow_bridge
+  velox_common_compression)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -73,7 +73,8 @@ std::optional<Spiller::Config> DriverCtx::makeSpillConfig(
       queryConfig.joinSpillPartitionBits(),
       queryConfig.aggregationSpillPartitionBits(),
       queryConfig.maxSpillLevel(),
-      queryConfig.testingSpillPct());
+      queryConfig.testingSpillPct(),
+      queryConfig.spillCompressionKind());
 }
 
 std::atomic_uint64_t BlockingState::numBlockedDrivers_{0};

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -851,6 +851,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig_->filePath,
         spillConfig_->maxFileSize,
         spillConfig_->minSpillRunSize,
+        spillConfig_->compressionKind,
         Spiller::spillPool(),
         spillConfig_->executor);
   }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -217,6 +217,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.minSpillRunSize,
+      spillConfig.compressionKind,
       Spiller::spillPool(),
       spillConfig.executor);
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -246,6 +246,7 @@ void HashProbe::maybeSetupSpillInput(
       spillConfig.filePath,
       spillConfig.maxFileSize,
       spillConfig.minSpillRunSize,
+      spillConfig.compressionKind,
       Spiller::spillPool(),
       spillConfig.executor);
   // Set the spill partitions to the corresponding ones at the build side. The

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -243,6 +243,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig.filePath,
         spillConfig.maxFileSize,
         spillConfig.minSpillRunSize,
+        spillConfig.compressionKind,
         Spiller::spillPool(),
         spillConfig.executor);
     VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -92,7 +92,7 @@ WriteFile& SpillFileList::currentOutput() {
 }
 
 uint64_t SpillFileList::flush() {
-  uint64_t totalBytes = 0;
+  uint64_t flushedBytes = 0;
   if (batch_) {
     IOBufOutputStream out(
         pool_, nullptr, std::max<int64_t>(64 * 1024, batch_->size()));
@@ -103,10 +103,10 @@ uint64_t SpillFileList::flush() {
     for (auto& range : *iobuf) {
       file.append(std::string_view(
           reinterpret_cast<const char*>(range.data()), range.size()));
-      totalBytes += range.size();
+      flushedBytes += range.size();
     }
   }
-  return totalBytes;
+  return flushedBytes;
 }
 
 uint64_t SpillFileList::write(

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -571,6 +571,7 @@ class SpillState {
         sortCompareFlags_(sortCompareFlags),
         targetFileSize_(targetFileSize),
         compressionKind_(compressionKind),
+        codec_(compressionKindToCodec(compressionKind)),
         pool_(pool),
         files_(maxPartitions_) {}
 
@@ -590,6 +591,16 @@ class SpillState {
 
   uint64_t targetFileSize() const {
     return targetFileSize_;
+  }
+
+  common::CompressionKind compressionKind() const {
+    return compressionKind_;
+  }
+
+  uint64_t compressedSize(int64_t totalBytes) const {
+    return compressionKind_ == common::CompressionKind_NONE
+        ? totalBytes
+        : codec_->maxCompressedLength(totalBytes);
   }
 
   memory::MemoryPool& pool() const {
@@ -656,6 +667,7 @@ class SpillState {
   const std::vector<CompareFlags> sortCompareFlags_;
   const uint64_t targetFileSize_;
   const common::CompressionKind compressionKind_;
+  const std::unique_ptr<folly::io::Codec> codec_;
 
   memory::MemoryPool& pool_;
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -37,6 +37,7 @@ Spiller::Spiller(
     const std::string& path,
     uint64_t targetFileSize,
     uint64_t minSpillRunSize,
+    common::CompressionKind compressionKind,
     memory::MemoryPool& pool,
     folly::Executor* executor)
     : Spiller(
@@ -50,6 +51,7 @@ Spiller::Spiller(
           path,
           targetFileSize,
           minSpillRunSize,
+          compressionKind,
           pool,
           executor) {
   VELOX_CHECK_EQ(type_, Type::kOrderBy);
@@ -62,6 +64,7 @@ Spiller::Spiller(
     const std::string& path,
     uint64_t targetFileSize,
     uint64_t minSpillRunSize,
+    common::CompressionKind compressionKind,
     memory::MemoryPool& pool,
     folly::Executor* FOLLY_NULLABLE executor)
     : Spiller(
@@ -75,6 +78,7 @@ Spiller::Spiller(
           path,
           targetFileSize,
           minSpillRunSize,
+          compressionKind,
           pool,
           executor) {
   VELOX_CHECK_EQ(type_, Type::kHashJoinProbe);
@@ -91,6 +95,7 @@ Spiller::Spiller(
     const std::string& path,
     uint64_t targetFileSize,
     uint64_t minSpillRunSize,
+    common::CompressionKind compressionKind,
     memory::MemoryPool& pool,
     folly::Executor* executor)
     : type_(type),
@@ -105,6 +110,7 @@ Spiller::Spiller(
           numSortingKeys,
           sortCompareFlags,
           targetFileSize,
+          compressionKind,
           pool),
       pool_(pool),
       executor_(executor) {

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -278,10 +278,10 @@ std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(int32_t partition) {
     int64_t totalBytes = 0;
     size_t written = 0;
     while (written < run.rows.size()) {
-      totalBytes += extractSpillVector(
+      extractSpillVector(
           run.rows, kTargetBatchRows, kTargetBatchBytes, spillVector, written);
-      state_.appendToPartition(partition, spillVector);
-      if (state_.compressedSize(totalBytes) > state_.targetFileSize()) {
+      totalBytes += state_.appendToPartition(partition, spillVector);
+      if (totalBytes > state_.targetFileSize()) {
         break;
       }
     }

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -281,7 +281,7 @@ std::unique_ptr<Spiller::SpillStatus> Spiller::writeSpill(int32_t partition) {
       totalBytes += extractSpillVector(
           run.rows, kTargetBatchRows, kTargetBatchBytes, spillVector, written);
       state_.appendToPartition(partition, spillVector);
-      if (totalBytes > state_.targetFileSize()) {
+      if (state_.compressedSize(totalBytes) > state_.targetFileSize()) {
         break;
       }
     }

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/common/compression/Compression.h"
 #include "velox/exec/HashBitRange.h"
 #include "velox/exec/RowContainer.h"
 
@@ -49,7 +50,8 @@ class Spiller {
         uint8_t _joinPartitionBits,
         uint8_t _aggregationPartitionBits,
         int32_t _maxSpillLevel,
-        int32_t _testSpillPct)
+        int32_t _testSpillPct,
+        const std::string& _compressionKind)
         : filePath(_filePath),
           maxFileSize(
               _maxFileSize == 0 ? std::numeric_limits<int64_t>::max()
@@ -61,7 +63,8 @@ class Spiller {
           joinPartitionBits(_joinPartitionBits),
           aggregationPartitionBits(_aggregationPartitionBits),
           maxSpillLevel(_maxSpillLevel),
-          testSpillPct(_testSpillPct) {}
+          testSpillPct(_testSpillPct),
+          compressionKind(common::stringToCompressionKind(_compressionKind)) {}
 
     /// Returns the hash join spilling level with given 'startBitOffset'.
     ///
@@ -117,6 +120,9 @@ class Spiller {
     // Percentage of input batches to be spilled for testing. 0 means no
     // spilling for test.
     int32_t testSpillPct;
+
+    // CompressionKind when spilling, CompressionKind_NONE means no compression
+    common::CompressionKind compressionKind;
   };
 
   using SpillRows = std::vector<char*, memory::StlAllocator<char*>>;
@@ -133,6 +139,7 @@ class Spiller {
       const std::string& path,
       uint64_t targetFileSize,
       uint64_t minSpillRunSize,
+      common::CompressionKind compressionKind,
       memory::MemoryPool& pool,
       folly::Executor* executor);
 
@@ -143,6 +150,7 @@ class Spiller {
       const std::string& path,
       uint64_t targetFileSize,
       uint64_t minSpillRunSize,
+      common::CompressionKind compressionKind,
       memory::MemoryPool& pool,
       folly::Executor* executor);
 
@@ -157,6 +165,7 @@ class Spiller {
       const std::string& path,
       uint64_t targetFileSize,
       uint64_t minSpillRunSize,
+      common::CompressionKind compressionKind,
       memory::MemoryPool& pool,
       folly::Executor* executor);
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -121,7 +121,7 @@ class Spiller {
     // spilling for test.
     int32_t testSpillPct;
 
-    // CompressionKind when spilling, CompressionKind_NONE means no compression
+    // CompressionKind when spilling, CompressionKind_NONE means no compression.
     common::CompressionKind compressionKind;
   };
 

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -102,6 +102,7 @@ class HashJoinBridgeTest : public testing::Test,
           1,
           std::vector<CompareFlags>({}),
           tempDir_->path + "/Spill",
+          common::CompressionKind_NONE,
           *pool_));
       // Create a fake file to avoid too many exception logs in test when spill
       // file deletion fails.

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -144,7 +144,13 @@ class SpillTest : public testing::Test,
     // the batch number of the vector in the partition. When read back, both
     // partitions produce an ascending sequence of integers without gaps.
     state_ = std::make_unique<SpillState>(
-        spillPath_, numPartitions, 1, compareFlags, targetFileSize, *pool());
+        spillPath_,
+        numPartitions,
+        1,
+        compareFlags,
+        targetFileSize,
+        common::CompressionKind_NONE,
+        *pool());
     EXPECT_EQ(targetFileSize, state_->targetFileSize());
     EXPECT_EQ(numPartitions, state_->maxPartitions());
     EXPECT_EQ(0, state_->spilledPartitions());
@@ -350,7 +356,14 @@ TEST_F(SpillTest, spillTimestamp) {
       Timestamp{1, 17'123'456},
       Timestamp{-1, 17'123'456}};
 
-  SpillState state(spillPath, 1, 1, emptyCompareFlags, 1024, *pool());
+  SpillState state(
+      spillPath,
+      1,
+      1,
+      emptyCompareFlags,
+      1024,
+      common::CompressionKind_NONE,
+      *pool());
   int partitionIndex = 0;
   state.setPartitionSpilled(partitionIndex);
   EXPECT_TRUE(state.isPartitionSpilled(partitionIndex));

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -605,5 +605,8 @@ INSTANTIATE_TEST_SUITE_P(
     SpillTestSuite,
     SpillTest,
     ::testing::Values(
-        common::CompressionKind_NONE,
-        common::CompressionKind_LZ4));
+        common::CompressionKind::CompressionKind_ZLIB,
+        common::CompressionKind::CompressionKind_SNAPPY,
+        common::CompressionKind::CompressionKind_ZSTD,
+        common::CompressionKind::CompressionKind_LZ4,
+        common::CompressionKind::CompressionKind_GZIP));

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -53,9 +53,13 @@ struct TestParam {
   // Specifies the spill executor pool size. If the size is zero, then spill
   // write path is executed inline with spiller control code path.
   int poolSize;
+  common::CompressionKind compressionKind;
 
-  TestParam(Spiller::Type _type, int _poolSize)
-      : type(_type), poolSize(_poolSize) {}
+  TestParam(
+      Spiller::Type _type,
+      int _poolSize,
+      common::CompressionKind _compressionKind)
+      : type(_type), poolSize(_poolSize), compressionKind(_compressionKind) {}
 
   std::string toString() const {
     return fmt::format("{}|{}", Spiller::typeName(type), poolSize);
@@ -68,8 +72,10 @@ struct TestParamsBuilder {
     for (int i = 0; i < Spiller::kNumTypes; ++i) {
       const auto type = static_cast<Spiller::Type>(i);
       if (typesToExclude.find(type) == typesToExclude.end()) {
+        common::CompressionKind compressionKind =
+            static_cast<common::CompressionKind>(Spiller::kNumTypes % 6);
         for (int poolSize : {0, 8}) {
-          params.emplace_back(type, poolSize);
+          params.emplace_back(type, poolSize, compressionKind);
         }
       }
     }
@@ -109,6 +115,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       : param_(param),
         type_(param.type),
         executorPoolSize_(param.poolSize),
+        compressionKind_(param.compressionKind),
         hashBits_(0, type_ == Spiller::Type::kOrderBy ? 0 : 2),
         numPartitions_(hashBits_.numPartitions()),
         statWriter_(std::make_unique<TestRuntimeStatWriter>(stats_)) {
@@ -404,6 +411,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           minSpillRunSize,
+          compressionKind_,
           *pool_,
           executor());
     } else if (type_ == Spiller::Type::kOrderBy) {
@@ -419,6 +427,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           minSpillRunSize,
+          compressionKind_,
           *pool_,
           executor());
     } else {
@@ -433,6 +442,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
           makeError ? "/bad/path" : tempDirPath_->path,
           targetFileSize,
           minSpillRunSize,
+          compressionKind_,
           *pool_,
           executor());
     }
@@ -845,6 +855,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
   const TestParam param_;
   const Spiller::Type type_;
   const int32_t executorPoolSize_;
+  const common::CompressionKind compressionKind_;
   const HashBitRange hashBits_;
   const int32_t numPartitions_;
   std::unordered_map<std::string, RuntimeMetric> stats_;
@@ -1350,7 +1361,8 @@ TEST(SpillerTest, spillLevel) {
       kNumPartitionsBits,
       0,
       0,
-      0);
+      0,
+      "none");
   struct {
     uint8_t bitOffset;
     // Indicates an invalid if 'expectedLevel' is negative.
@@ -1431,7 +1443,8 @@ TEST(SpillerTest, spillLevelLimit) {
         testData.numBits,
         0,
         testData.maxSpillLevel,
-        0);
+        0,
+        "none");
 
     ASSERT_EQ(
         testData.expectedExceeds,

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -441,4 +441,5 @@ INSTANTIATE_TEST_SUITE_P(
         common::CompressionKind::CompressionKind_ZLIB,
         common::CompressionKind::CompressionKind_SNAPPY,
         common::CompressionKind::CompressionKind_ZSTD,
-        common::CompressionKind::CompressionKind_LZ4));
+        common::CompressionKind::CompressionKind_LZ4,
+        common::CompressionKind::CompressionKind_GZIP));


### PR DESCRIPTION
Add the QueryConfig `spill_compression_codec` to control if compressing data when spilling, default is no compression, support all the Velox compression codec.

Resolves: https://github.com/facebookincubator/velox/issues/5313