### PR TITLE
Start tracking peakBytes and average received page size in ExchangeQueue

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -129,7 +129,11 @@ RowVectorPtr Exchange::getOutput() {
 void Exchange::recordStats() {
   auto lockedStats = stats_.wlock();
   for (const auto& [name, value] : exchangeClient_->stats()) {
-    lockedStats->runtimeStats[name].merge(value);
+    if (lockedStats->runtimeStats.count(name) == 0) {
+      lockedStats->runtimeStats.insert({name, value});
+    } else {
+      lockedStats->runtimeStats[name].merge(value);
+    }
   }
 }
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -85,13 +85,21 @@ void ExchangeClient::close() {
 }
 
 folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
-  folly::F14FastMap<std::string, RuntimeMetric> stats;
   std::lock_guard<std::mutex> l(queue_->mutex());
+
+  folly::F14FastMap<std::string, RuntimeMetric> stats;
   for (const auto& source : sources_) {
     for (const auto& [name, value] : source->stats()) {
       stats[name].addValue(value);
     }
   }
+
+  stats["peakBytes"] =
+      RuntimeMetric(queue_->peakBytes(), RuntimeCounter::Unit::kBytes);
+  stats["numReceivedPages"] = RuntimeMetric(queue_->receivedPages());
+  stats["averageReceivedPageBytes"] = RuntimeMetric(
+      queue_->averageReceivedPageBytes(), RuntimeCounter::Unit::kBytes);
+
   return stats;
 }
 

--- a/velox/exec/ExchangeQueue.cpp
+++ b/velox/exec/ExchangeQueue.cpp
@@ -74,7 +74,15 @@ void ExchangeQueue::enqueueLocked(
     }
     return;
   }
+
   totalBytes_ += page->size();
+  if (peakBytes_ < totalBytes_) {
+    peakBytes_ = totalBytes_;
+  }
+
+  ++receivedPages_;
+  receivedBytes_ += page->size();
+
   queue_.push_back(std::move(page));
   if (!promises_.empty()) {
     // Resume one of the waiting drivers.

--- a/velox/exec/ExchangeQueue.h
+++ b/velox/exec/ExchangeQueue.h
@@ -104,9 +104,25 @@ class ExchangeQueue {
       bool* atEnd,
       ContinueFuture* future);
 
-  // Returns the total bytes held by SerializedPages in 'this'.
+  /// Returns the total bytes held by SerializedPages in 'this'.
   uint64_t totalBytes() const {
     return totalBytes_;
+  }
+
+  /// Returns the maximum value of total bytes.
+  uint64_t peakBytes() const {
+    return peakBytes_;
+  }
+
+  /// Returns total number of pages received from all sources.
+  uint64_t receivedPages() const {
+    return receivedPages_;
+  }
+
+  /// Returns an average size of received pages. Returns 0 if hasn't received
+  /// any pages yet.
+  uint64_t averageReceivedPageBytes() const {
+    return receivedPages_ > 0 ? receivedBytes_ / receivedPages_ : 0;
   }
 
   void addSourceLocked() {
@@ -164,5 +180,12 @@ class ExchangeQueue {
   std::string error_;
   // Total size of SerializedPages in queue.
   uint64_t totalBytes_{0};
+  // Number of SerializedPages received.
+  int64_t receivedPages_{0};
+  // Total size of SerializedPages received. Used to calculate an average
+  // expected size.
+  int64_t receivedBytes_{0};
+  // Maximum value of totalBytes_.
+  int64_t peakBytes_{0};
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -16,23 +16,86 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/tests/utils/LocalExchangeSource.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 namespace facebook::velox::exec {
 
 namespace {
 
-TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
-  std::shared_ptr<memory::MemoryPool> rootPool{
-      memory::defaultMemoryManager().addRootPool()};
-  std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
+class ExchangeClientTest : public testing::Test,
+                           public velox::test::VectorTestBase {
+ protected:
+  void SetUp() override {
+    exec::ExchangeSource::factories().clear();
+    exec::ExchangeSource::registerFactory(test::createLocalExchangeSource);
+    if (!isRegisteredVectorSerde()) {
+      velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    }
 
+    bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
+  }
+
+  std::unique_ptr<SerializedPage> toSerializedPage(const RowVectorPtr& vector) {
+    auto data = std::make_unique<VectorStreamGroup>(pool());
+    auto size = vector->size();
+    auto range = IndexRange{0, size};
+    data->createStreamTree(asRowType(vector->type()), size);
+    data->append(vector, folly::Range(&range, 1));
+    auto listener = bufferManager_->newListener();
+    IOBufOutputStream stream(*pool(), listener.get(), data->size());
+    data->flush(&stream);
+    return std::make_unique<SerializedPage>(stream.getIOBuf());
+  }
+
+  std::shared_ptr<Task> makeTask(
+      const std::string& taskId,
+      const core::PlanNodePtr& planNode,
+      int destination) {
+    auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
+    queryCtx->testingOverrideMemoryPool(
+        memory::defaultMemoryManager().addRootPool(queryCtx->queryId()));
+    core::PlanFragment planFragment{planNode};
+    return Task::create(
+        taskId, std::move(planFragment), destination, std::move(queryCtx));
+  }
+
+  int32_t enqueue(
+      const std::string& taskId,
+      int32_t destination,
+      const RowVectorPtr& data) {
+    auto page = toSerializedPage(data);
+    const auto pageSize = page->size();
+    ContinueFuture unused;
+    auto blockingReason =
+        bufferManager_->enqueue(taskId, destination, std::move(page), &unused);
+    VELOX_CHECK(blockingReason == BlockingReason::kNotBlocked);
+    return pageSize;
+  }
+
+  void fetchPages(ExchangeClient& client, int32_t numPages) {
+    for (auto i = 0; i < numPages; ++i) {
+      bool atEnd;
+      ContinueFuture future;
+      auto page = client.next(&atEnd, &future);
+      ASSERT_TRUE(page != nullptr);
+    }
+  }
+
+  std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
+};
+
+TEST_F(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
   ExchangeSource::registerFactory(
       [](const auto& taskId, auto destination, auto queue, auto pool)
           -> std::shared_ptr<ExchangeSource> {
         throw std::runtime_error("Testing error");
       });
 
-  ExchangeClient client(1, pool.get(), ExchangeClient::kDefaultMaxQueuedBytes);
+  ExchangeClient client(1, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
   VELOX_ASSERT_THROW(
       client.addRemoteTaskId("task.1.2.3"),
       "Failed to create ExchangeSource: Testing error. Task ID: task.1.2.3.");
@@ -42,6 +105,50 @@ TEST(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
       client.addRemoteTaskId(std::string(1024, 'x')),
       "Failed to create ExchangeSource: Testing error. "
       "Task ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.");
+}
+
+TEST_F(ExchangeClientTest, stats) {
+  auto data = {
+      makeRowVector({makeFlatVector<int32_t>({1, 2, 3})}),
+      makeRowVector({makeFlatVector<int32_t>({1, 2, 3, 4, 5})}),
+      makeRowVector({makeFlatVector<int32_t>({1, 2})}),
+  };
+
+  auto plan = test::PlanBuilder()
+                  .values(data)
+                  .partitionedOutput({"c0"}, 100)
+                  .planNode();
+  auto taskId = "local://t1";
+  auto task = makeTask(taskId, plan, 17);
+
+  bufferManager_->initializeTask(
+      task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
+
+  ExchangeClient client(17, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
+  client.addRemoteTaskId(taskId);
+
+  // Enqueue 3 pages.
+  std::vector<uint64_t> pageBytes;
+  uint64_t totalBytes = 0;
+  for (auto vector : data) {
+    const auto pageSize = enqueue(taskId, 17, vector);
+    totalBytes += pageSize;
+    pageBytes.push_back(pageSize);
+  }
+
+  // ExchangeSource should have fetched first page and placed it into the queue.
+  // Once we fetch this page from the queue, the ExchangeSource will go fetch
+  // the remaining 2 pages.
+
+  fetchPages(client, 3);
+
+  auto stats = client.stats();
+  EXPECT_EQ(pageBytes[1] + pageBytes[2], stats.at("peakBytes").sum);
+  EXPECT_EQ(data.size(), stats.at("numReceivedPages").sum);
+  EXPECT_EQ(totalBytes / data.size(), stats.at("averageReceivedPageBytes").sum);
+
+  task->requestCancel();
+  bufferManager_->removeTask(taskId);
 }
 
 } // namespace


### PR DESCRIPTION
We would need this information to decide how many ExchangeSources can be
fetching data in parallel and still fit within memory budget.

The new stats are propagated via ExchangeClient to Exchange operator.