### PR TITLE
Fix BytesRange::testBytesRange

### DIFF
--- a/velox/type/Filter.cpp
+++ b/velox/type/Filter.cpp
@@ -1145,35 +1145,11 @@ bool BytesRange::testBytesRange(
   if (hasNull && nullAllowed_) {
     return true;
   }
-
-  if (min.has_value() && max.has_value() && min.value() == max.value()) {
-    return testBytes(min->data(), min->length());
-  }
-
-  if (lowerUnbounded_) {
-    // min > upper_
-    return min.has_value() &&
-        compareRanges(min->data(), min->length(), upper_) < 0;
-  }
-
-  if (upperUnbounded_) {
-    // max < lower_
-    return max.has_value() &&
-        compareRanges(max->data(), max->length(), lower_) > 0;
-  }
-
-  // min > upper_
-  if (min.has_value() &&
-      compareRanges(min->data(), min->length(), upper_) > 0) {
-    return false;
-  }
-
-  // max < lower_
-  if (max.has_value() &&
-      compareRanges(max->data(), max->length(), lower_) < 0) {
-    return false;
-  }
-  return true;
+  // clang-format off
+  return
+    (lowerUnbounded_ || !max.has_value() || compareRanges(max->data(), max->length(), lower_) >=  !!lowerExclusive_) &&
+    (upperUnbounded_ || !min.has_value() || compareRanges(min->data(), min->length(), upper_) <= -!!upperExclusive_);
+  // clang-format on
 }
 
 bool BytesValues::testBytesRange(

--- a/velox/type/tests/FilterTest.cpp
+++ b/velox/type/tests/FilterTest.cpp
@@ -810,6 +810,7 @@ TEST(FilterTest, bytesRange) {
   EXPECT_FALSE(filter->testBytes("b", 1));
   EXPECT_FALSE(filter->testBytes("c", 1));
   EXPECT_TRUE(filter->testBytes(nullptr, 0));
+  EXPECT_FALSE(filter->testBytesRange("b", "c", false));
 
   // <= b
   filter = lessThanOrEqual("b");
@@ -817,6 +818,7 @@ TEST(FilterTest, bytesRange) {
   EXPECT_TRUE(filter->testBytes("b", 1));
   EXPECT_FALSE(filter->testBytes("c", 1));
   EXPECT_TRUE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytesRange("b", "c", false));
 
   // >= b
   filter = greaterThanOrEqual("b");
@@ -824,6 +826,7 @@ TEST(FilterTest, bytesRange) {
   EXPECT_TRUE(filter->testBytes("b", 1));
   EXPECT_TRUE(filter->testBytes("c", 1));
   EXPECT_FALSE(filter->testBytes(nullptr, 0));
+  EXPECT_TRUE(filter->testBytesRange("a", "b", false));
 
   // > b
   filter = greaterThan("b");
@@ -831,6 +834,7 @@ TEST(FilterTest, bytesRange) {
   EXPECT_FALSE(filter->testBytes("b", 1));
   EXPECT_TRUE(filter->testBytes("c", 1));
   EXPECT_FALSE(filter->testBytes(nullptr, 0));
+  EXPECT_FALSE(filter->testBytesRange("a", "b", false));
 
   // < ''
   filter = lessThan("");


### PR DESCRIPTION
Summary:
`BytesRange::testBytesRange` was wrong when the filter boundary is not
exclusive and ranges overlap on that boundary point.

Differential Revision: D47874425

