### PR TITLE
Remove exception type conversion from Converions.h

### DIFF
--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -151,38 +151,26 @@ struct Converter<
   }
 
   static T cast(folly::StringPiece v) {
-    try {
-      if constexpr (TRUNCATE) {
-        return convertStringToInt(v);
-      } else {
-        return folly::to<T>(v);
-      }
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(e.what());
+    if constexpr (TRUNCATE) {
+      return convertStringToInt(v);
+    } else {
+      return folly::to<T>(v);
     }
   }
 
   static T cast(const StringView& v) {
-    try {
-      if constexpr (TRUNCATE) {
-        return convertStringToInt(folly::StringPiece(v));
-      } else {
-        return folly::to<T>(folly::StringPiece(v));
-      }
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(e.what());
+    if constexpr (TRUNCATE) {
+      return convertStringToInt(folly::StringPiece(v));
+    } else {
+      return folly::to<T>(folly::StringPiece(v));
     }
   }
 
   static T cast(const std::string& v) {
-    try {
-      if constexpr (TRUNCATE) {
-        return convertStringToInt(v);
-      } else {
-        return folly::to<T>(v);
-      }
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(e.what());
+    if constexpr (TRUNCATE) {
+      return convertStringToInt(v);
+    } else {
+      return folly::to<T>(v);
     }
   }
 
@@ -322,11 +310,7 @@ struct Converter<
 
   template <typename From>
   static T cast(const From& v) {
-    try {
-      return folly::to<T>(v);
-    } catch (const std::exception& e) {
-      VELOX_USER_FAIL(e.what());
-    }
+    return folly::to<T>(v);
   }
 
   static T cast(folly::StringPiece v) {


### PR DESCRIPTION
Summary:
The `cast` function does not provide any guarantee that the thrown
exception is from type VeloxUserError, in fact. The cast always check
the type and rewrap the exception thrown by cast with a detailed message.

Furthermore some cast function call have this conversions while others
do not. This end up adding overhead for try_cast since two Velox
exceptions end up being constructed, in addition to one throw that's
not needed.

before:
cast_int##try_cast_invalid_nan                           754.36ms 1.33
cast_int##tryexpr_cast_invalid_nan                           1.36s   737.45m

after:
cast_int##try_cast_invalid_nan                                382.07ms 2.62
cast_int##tryexpr_cast_invalid_nan                        759.02ms      1.32

Differential Revision: D47877386

