### PR TITLE
Fix the handling of StringView in MinMaxByAggregate

### DIFF
--- a/velox/functions/lib/aggregates/CMakeLists.txt
+++ b/velox/functions/lib/aggregates/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_functions_aggregates SingleValueAccumulator.cpp
-                                       AverageAggregateBase.cpp)
+                                       AverageAggregateBase.cpp ValueSet.cpp)
 
 target_link_libraries(velox_functions_aggregates velox_exec
                       velox_presto_serializer Folly::folly)

--- a/velox/functions/lib/aggregates/ValueSet.cpp
+++ b/velox/functions/lib/aggregates/ValueSet.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/functions/lib/aggregates/ValueSet.h"
+#include "velox/exec/ContainerRowSerde.h"
+
+namespace facebook::velox::aggregate {
+
+void ValueSet::write(
+    const BaseVector& vector,
+    vector_size_t index,
+    HashStringAllocator::Position& position) const {
+  ByteStream stream(allocator_);
+  if (position.header == nullptr) {
+    position = allocator_->newWrite(stream);
+  } else {
+    allocator_->extendWrite(position, stream);
+  }
+
+  exec::ContainerRowSerde::serialize(vector, index, stream);
+  allocator_->finishWrite(stream, 0);
+}
+
+StringView ValueSet::write(const StringView& value) const {
+  if (value.isInline()) {
+    return value;
+  }
+
+  const auto size = value.size();
+
+  auto* header = allocator_->allocate(size);
+  auto* start = header->begin();
+
+  memcpy(start, value.data(), size);
+  return StringView(start, size);
+}
+
+void ValueSet::read(
+    BaseVector* vector,
+    vector_size_t index,
+    const HashStringAllocator::Header* header) const {
+  VELOX_CHECK_NOT_NULL(header);
+
+  ByteStream stream;
+  HashStringAllocator::prepareRead(header, stream);
+  exec::ContainerRowSerde::deserialize(stream, index, vector);
+}
+
+void ValueSet::free(HashStringAllocator::Header* header) const {
+  VELOX_CHECK_NOT_NULL(header);
+  allocator_->free(header);
+}
+
+void ValueSet::free(const StringView& value) const {
+  if (!value.isInline()) {
+    auto* header = HashStringAllocator::headerOf(value.data());
+    allocator_->free(header);
+  }
+}
+
+} // namespace facebook::velox::aggregate

--- a/velox/functions/lib/aggregates/ValueSet.h
+++ b/velox/functions/lib/aggregates/ValueSet.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::aggregate {
+
+class ValueSet {
+ public:
+  explicit ValueSet(HashStringAllocator* allocator) : allocator_(allocator) {}
+
+  // Serialize a value in `vector` at `index` to memory allocated via
+  // `allocator`. Update `position` to the start address of the written data.
+  // Notice that the caller is responsible for freeing up all the space written
+  // through this function.
+  void write(
+      const BaseVector& vector,
+      vector_size_t index,
+      HashStringAllocator::Position& position) const;
+
+  StringView write(const StringView& value) const;
+
+  // Deserialize the data written in memory at `position` to `vector` at
+  // `index`.
+  void read(
+      BaseVector* vector,
+      vector_size_t index,
+      const HashStringAllocator::Header* header) const;
+
+  void free(HashStringAllocator::Header* header) const;
+
+  void free(const StringView& value) const;
+
+ private:
+  HashStringAllocator* allocator_;
+};
+
+} // namespace facebook::velox::aggregate


### PR DESCRIPTION
Summary:
min_by and max_by functions allow the second argument to be strings, but their accumnulator classes don't handle StringViews correctly for the argument. This causes memory issues during aggregation. This diff fixes this issue by adding support for the StringView as the second argument to min_by and max_by.

This diff fixes https://github.com/facebookincubator/velox/issues/5830.

Differential Revision: D47858415

