### PR TITLE
Revert "Fail benchmark job on regression (#5850)"

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -193,7 +193,8 @@ jobs:
           ./scripts/benchmark-runner.py compare \
                 --baseline_path ${BASELINE_OUTPUT_PATH} \
                 --contender_path ${CONTENDER_OUTPUT_PATH} \
-                --recursive 
+                --recursive \
+                --do_not_fail
           echo "::endgroup::"
 
       - name: "Save PR number"


### PR DESCRIPTION
This reverts commit 4f7e304494be69f158d86802b8836563f5b52985.

It creates too much noise after all.