### PR TITLE
Reduce tinyData_ memory usage in AsyncDataCache

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -564,6 +564,7 @@ class CacheShard {
   }
 
  private:
+  static constexpr uint32_t kMaxFreeEntries = 1 << 10;
   static constexpr int32_t kNoThreshold = std::numeric_limits<int32_t>::max();
 
   void calibrateThreshold();
@@ -577,6 +578,8 @@ class CacheShard {
   CachePin initEntry(RawFileCacheKey key, AsyncDataCacheEntry* entry);
 
   void freeAllocations(std::vector<memory::Allocation>& allocations);
+
+  void tryAddFreeEntry(std::unique_ptr<AsyncDataCacheEntry>&& entry);
 
   mutable std::mutex mutex_;
   folly::F14FastMap<RawFileCacheKey, AsyncDataCacheEntry*> entryMap_;


### PR DESCRIPTION
Summary:
Main logic is in AsyncDataCache.cpp

1) Call shrink_to_fit() when marking cache entry as free, or reuse it. This actually frees the memory. clear() is not enough.

2) Limit size of async data cache free entries. Introduced AsyncDataCacheConfig which can be populated in clients like Presto based on configs.

Differential Revision: D47880154

