### PR TITLE
Round large non-contiguous HashStringAllocator allocs to standarde sizes

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -192,23 +192,19 @@ HashStringAllocator::finishWrite(ByteStream& stream, int32_t numReserveBytes) {
   return {startPosition_, currentPosition};
 }
 
-void HashStringAllocator::newSlab(int32_t size) {
+void HashStringAllocator::newSlab() {
   constexpr int32_t kSimdPadding = simd::kPadding - sizeof(Header);
-  char* run = nullptr;
-  uint64_t available = 0;
-  int32_t needed = std::max<int32_t>(
-      bits::roundUp(
-          size + 2 * sizeof(Header) + kSimdPadding,
-          memory::AllocationTraits::kPageSize),
-      kUnitSize);
-  auto pagesNeeded = memory::AllocationTraits::numPages(needed);
-  // All large allocations are made standalone in pool().
-  VELOX_CHECK_LE(pagesNeeded, pool()->largestSizeClass());
-  if (pool_.allocatedBytes() >= pool_.hugePageThreshold()) {
-    needed = memory::AllocationTraits::kHugePageSize;
-  }
-  run = pool_.allocateFixed(needed);
-  available = needed - sizeof(Header) - kSimdPadding;
+  const int64_t needed = pool_.allocatedBytes() >= pool_.hugePageThreshold()
+      ? memory::AllocationTraits::kHugePageSize
+      : kUnitSize;
+  auto run = pool_.allocateFixed(needed);
+  // We check we got exactly the requested amount. checkConsistency()
+  // depends on slabs made here coinciding with ranges from
+  // AllocationPool::rangeAt(). Sometimes the last range can be
+  // several huge pages for severl huge page sized arenas but
+  // checkConsistency() can interpret that.
+  VELOX_CHECK_EQ(0, pool_.freeBytes());
+  auto available = needed - sizeof(Header) - kSimdPadding;
 
   VELOX_CHECK_NOT_NULL(run);
   VELOX_CHECK_GT(available, 0);
@@ -328,7 +324,7 @@ HashStringAllocator::allocate(int32_t size, bool exactSize) {
   }
   auto header = allocateFromFreeLists(size, exactSize, exactSize);
   if (!header) {
-    newSlab(size);
+    newSlab();
     header = allocateFromFreeLists(size, exactSize, exactSize);
     VELOX_CHECK(header != nullptr);
     VELOX_CHECK_GT(header->size(), 0);

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -357,13 +357,10 @@ class HashStringAllocator : public StreamArena {
 
   void newRange(int32_t bytes, ByteRange* range, bool contiguous);
 
-  // Adds 'bytes' worth of contiguous space to the free list. This
+  // Adds a new standard size slab to the free list. This
   // grows the footprint in MemoryAllocator but does not allocate
-  // anything yet. Throws if fails to grow. The caller typically knows
-  // a cap on memory to allocate and uses this and freeSpace() to make
-  // sure that there is space to accommodate the expected need before
-  // starting to process a batch of input.
-  void newSlab(int32_t size);
+  // anything yet. Throws if fails to grow.
+  void newSlab();
 
   void removeFromFreeList(Header* FOLLY_NONNULL header) {
     VELOX_CHECK(header->isFree());


### PR DESCRIPTION
When a non-contiguous allocation is requested and there are no free blocks in an HSA, we append a new slab of the requested sizes. This slab is rounded up to a standard size in the AllocationPool. We use the requested size instead of the rounded up size to make the new slab. This wastes space at the tail, e.g. we ask for 200K and get 256K. Furthermore when the HSA adds new slabs after this, it fails checkConsistency() because checkConsistency() reads the ranges from allocationPool and expects them to be entirely filled by HSA arenas, This is not the case here because the arena that was added for the 200K string is 200K and not the range of 256K.

Now therefore, we always allocate a standard size, either 64K or 2MB when extending the HSA.

The test appends a few large strings and calls checkConsistency() to chekc the arenas.