### PR TITLE
Allow freeing rowsacross many RowContainers

### DIFF
--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -251,6 +251,11 @@ class RowContainer {
   // variable length data.
   void eraseRows(folly::Range<char**> rows);
 
+  // Copies elements of 'rows'where the char* points to a row inside 'this'  to
+  // 'result' and returns the number copied. 'result' should have space for
+  // 'rows.size()'.
+  int32_t findRows(folly::Range<char**> rows, char** result);
+
   void incrementRowSize(char* FOLLY_NONNULL row, uint64_t bytes) {
     uint32_t* ptr = reinterpret_cast<uint32_t*>(row + rowSizeOffset_);
     uint64_t size = *ptr + bytes;


### PR DESCRIPTION
In freeing rows in RowContainer::eraseRows() allow the RowContainer to filter out the rows that are not allocated from it.  This does ont occur in usual cases in production but does happen in tests where tables composed from multiple containers have a fraction of the data freed.

We add a function to filter out the members of a given container from a set of arbitrary pointers. We optionally apply this in RowContainer::eraseRows().