### PR TITLE
Add add_months Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -7,6 +7,13 @@ Convenience Extraction Functions
 
 These functions support TIMESTAMP and DATE input types.
 
+.. spark:function:: add_months(startDate, numMonths) -> integer
+
+    Returns the date that is ``numMonths`` after ``startDate``.
+    When ``numMonths`` is zero returns ``startDate`` unmodified.
+    When ``numMonths`` is negative subtracts that many months from the ``startDate``.
+    Throws an error when inputs lead to int overflow, eg, add_months('2023-07-10', -2147483648).
+
 .. spark:function:: date_add(start_date, num_days) -> date
 
     Returns the date that is num_days after start_date.
@@ -109,3 +116,4 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: year(x) -> integer
 
     Returns the year from ``x``.
+    

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -10,16 +10,18 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: add_months(startDate, numMonths) -> date
 
     Returns the date that is ``numMonths`` after ``startDate``.
-    Adjusts result to a valid one, considering some months don't have 29th, 30th or 31th
-    day. For example, returns '2015-02-28' adjusted for add_months('2015-01-30', 1) instead
-    of '2015-02-30'.
-    Allows ``numMonths`` to be zero or negative. Throws an error when inputs lead to int
-    overflow, e.g., add_months('2023-07-10', -2147483648). ::
+    Adjusts result to a valid one, considering months have different total days, and especially
+    February has 28 days in common year but 29 days in leap year.
+    For example, add_months('2015-01-30', 1) returns '2015-02-28', because 28th is the last day
+    in February of 2015.
+    ``numMonths`` can be zero or negative. Throws an error when inputs lead to int overflow,
+    e.g., add_months('2023-07-10', -2147483648). ::
 
         SELECT add_months('2015-01-01', 10); -- '2015-11-01'
         SELECT add_months('2015-01-30', 1); -- '2015-02-28'
         SELECT add_months('2015-01-30', 0); -- '2015-01-30'
         SELECT add_months('2015-01-30', -2); -- '2014-11-30'
+        SELECT add_months('2015-03-31', -1); -- '2015-02-28'
 
 .. spark:function:: date_add(start_date, num_days) -> date
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -7,12 +7,19 @@ Convenience Extraction Functions
 
 These functions support TIMESTAMP and DATE input types.
 
-.. spark:function:: add_months(startDate, numMonths) -> integer
+.. spark:function:: add_months(startDate, numMonths) -> date
 
     Returns the date that is ``numMonths`` after ``startDate``.
-    When ``numMonths`` is zero returns ``startDate`` unmodified.
-    When ``numMonths`` is negative subtracts that many months from the ``startDate``.
-    Throws an error when inputs lead to int overflow, eg, add_months('2023-07-10', -2147483648).
+    Adjusts result to a valid one, considering some months don't have 29th, 30th or 31th
+    day. For example, returns '2015-02-28' adjusted for add_months('2015-01-30', 1) instead
+    of '2015-02-30'.
+    Allows ``numMonths`` to be zero or negative. Throws an error when inputs lead to int
+    overflow, e.g., add_months('2023-07-10', -2147483648). ::
+
+        SELECT add_months('2015-01-01', 10); -- '2015-11-01'
+        SELECT add_months('2015-01-30', 1); -- '2015-02-28'
+        SELECT add_months('2015-01-30', 0); -- '2015-01-30'
+        SELECT add_months('2015-01-30', -2); -- '2014-11-30'
 
 .. spark:function:: date_add(start_date, num_days) -> date
 
@@ -116,4 +123,3 @@ These functions support TIMESTAMP and DATE input types.
 .. spark:function:: year(x) -> integer
 
     Returns the year from ``x``.
-    

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -68,6 +68,20 @@ std::tm getDateTime(int32_t days) {
   return dateTime;
 }
 
+FOLLY_ALWAYS_INLINE int getYear(const std::tm& time) {
+  // tm_year: years since 1900.
+  return 1900 + time.tm_year;
+}
+
+FOLLY_ALWAYS_INLINE int getMonth(const std::tm& time) {
+  // tm_mon: months since January – [0, 11].
+  return 1 + time.tm_mon;
+}
+
+FOLLY_ALWAYS_INLINE int getDay(const std::tm& time) {
+  return time.tm_mday;
+}
+
 template <typename T>
 struct InitSessionTimezone {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -342,42 +342,36 @@ template <typename T>
 struct AddMonthsFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE int getYear(const std::tm& time) {
-    return 1900 + time.tm_year;
-  }
-
-  FOLLY_ALWAYS_INLINE int getMonth(const std::tm& time) {
-    return 1 + time.tm_mon;
-  }
-
-  FOLLY_ALWAYS_INLINE int getDay(const std::tm& time) {
-    return time.tm_mday;
-  }
-
   FOLLY_ALWAYS_INLINE void call(
       out_type<Date>& result,
-      const arg_type<Date>& date,
-      const int32_t value) {
-    auto dateTime = getDateTime(date);
-    auto year = getYear(dateTime);
-    auto month = getMonth(dateTime);
-    auto day = getDay(dateTime);
+      const arg_type<Date>& startDate,
+      int32_t numMonths) {
+    auto dateTime = getDateTime(startDate);
+    auto startYear = getYear(dateTime);
+    auto startMonth = getMonth(dateTime);
+    auto startDay = getDay(dateTime);
 
-    int64_t m = month - 1 + value;
-    int64_t y = (m >= 0 ? m : m - 11) / 12;
-    auto dm = static_cast<int32_t>(m - y * 12 + 1);
-    auto dy = year + y;
+    // Similar to handling number in base 12, makes startMonth in range [0, 11].
+    int64_t monthAdded = startMonth - 1 + numMonths;
+    // Year offset used to adjust month/year when monthAdded not in range
+    // [0, 11].
+    int64_t yearOffset = (monthAdded >= 0 ? monthAdded : monthAdded - 11) / 12;
+    // Adjusts monthAdded to natural month in range [1, 12].
+    auto month = static_cast<int32_t>(monthAdded - yearOffset * 12 + 1);
+    // Adjusts year.
+    auto year = startYear + yearOffset;
 
-    auto lastDay = util::getMaxDayOfMonth(dy, dm);
-    auto daysSinceEpoch =
-        util::daysSinceEpochFromDate(dy, dm, lastDay < day ? lastDay : day);
+    auto lastDay = util::getMaxDayOfMonth(year, month);
+    // Adjusts day to valid one.
+    auto day = lastDay < startDay ? lastDay : startDay;
+    auto daysSinceEpoch = util::daysSinceEpochFromDate(
+        year, month, lastDay < startDay ? lastDay : startDay);
     VELOX_USER_CHECK_EQ(
         daysSinceEpoch,
         (int32_t)daysSinceEpoch,
-        "Integer overflow in add_months({}-{}-{})",
-        year,
-        month,
-        day);
+        "Integer overflow in add_months({}, {})",
+        DATE()->toString(startDate),
+        numMonths);
     result = daysSinceEpoch;
   }
 };

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <common/base/Exceptions.h>
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -350,7 +350,7 @@ struct AddMonthsFunction {
 
     // Similar to handling number in base 12. Here, month - 1 makes it in
     // [0, 11] range.
-    int64_t monthAdded = month - 1 + numMonths;
+    int64_t monthAdded = (int64_t)month - 1 + numMonths;
     // Used to adjust month/year when monthAdded is not in [0, 11] range.
     int64_t yearOffset = (monthAdded >= 0 ? monthAdded : monthAdded - 11) / 12;
     // Adjusts monthAdded to natural month number in [1, 12] range.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -240,6 +240,8 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<DateDiffFunction, int32_t, Date, Date>(
       {prefix + "datediff"});
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
+  registerFunction<AddMonthsFunction, Date, Date, int32_t>(
+      {prefix + "add_months"});
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
-
-#include <type/Type.h>
-#include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/tz/TimeZoneMap.h"

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -26,6 +26,10 @@ namespace facebook::velox::functions::sparksql::test {
 namespace {
 
 class DateTimeFunctionsTest : public SparkFunctionBaseTest {
+ public:
+  static constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
+  static constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
+
  protected:
   void setQueryTimeZone(const std::string& timeZone) {
     queryCtx_->testingOverrideConfigUnsafe({
@@ -182,7 +186,6 @@ TEST_F(DateTimeFunctionsTest, makeDate) {
   EXPECT_EQ(makeDate(1920, 1, 25), DATE()->toDays("1920-01-25"));
   EXPECT_EQ(makeDate(-10, 1, 30), DATE()->toDays("-0010-01-30"));
 
-  constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
   auto errorMessage = fmt::format("Date out of range: {}-12-15", kMax);
   VELOX_ASSERT_THROW(makeDate(kMax, 12, 15), errorMessage);
 
@@ -253,8 +256,6 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
   EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
 
   // Check for minimum and maximum tests.
-  constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
-  constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
   EXPECT_EQ(parseDate("5881580-07-11"), dateAdd(parseDate("1970-01-01"), kMax));
   EXPECT_EQ(
       parseDate("1969-12-31"), dateAdd(parseDate("-5877641-06-23"), kMax));
@@ -286,8 +287,6 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("2020-02-29"), dateSub("2019-02-28", -366));
 
   // Check for minimum and maximum tests.
-  constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
-  constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
   EXPECT_EQ(parseDate("-5877641-06-23"), dateSub("1969-12-31", kMax));
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("5881580-07-11", kMax));
   EXPECT_EQ(parseDate("1970-01-01"), dateSub("-5877641-06-23", kMin));
@@ -409,10 +408,6 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
 }
 
 TEST_F(DateTimeFunctionsTest, addMonths) {
-  const auto parseDate = [](const std::string& dateString) {
-    return DATE()->toDays(dateString);
-  };
-
   const auto addMonths = [&](const std::string& dateString, int32_t value) {
     return evaluateOnce<int32_t, int32_t>(
         "add_months(c0, c1)",
@@ -426,12 +421,13 @@ TEST_F(DateTimeFunctionsTest, addMonths) {
   EXPECT_EQ(addMonths("2015-01-31", 24), parseDate("2017-01-31"));
   EXPECT_EQ(addMonths("2015-01-31", 8), parseDate("2015-09-30"));
   EXPECT_EQ(addMonths("2015-01-30", 0), parseDate("2015-01-30"));
+  // The last day of Feb. 2016 is 29th.
   EXPECT_EQ(addMonths("2016-03-30", -1), parseDate("2016-02-29"));
+  // The last day of Feb. 2015 is 28th.
+  EXPECT_EQ(addMonths("2015-03-31", -1), parseDate("2015-02-28"));
   EXPECT_EQ(addMonths("2015-01-30", -2), parseDate("2014-11-30"));
   EXPECT_EQ(addMonths("2015-04-20", -24), parseDate("2013-04-20"));
 
-  constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
-  constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
   VELOX_ASSERT_THROW(
       addMonths("2023-07-10", kMin),
       fmt::format("Integer overflow in add_months(2023-07-10, {})", kMin));


### PR DESCRIPTION
`add_months` : Returns the date that is `num_months` after `start_date`.

ref in spark 3.2 https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1808