### PR TITLE
Check column selector against requested type in struct reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -65,7 +65,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
             .sequence = encodingKey.sequence,
             .inMapDecoder = nullptr,
             .keySelectionCallback = nullptr});
-    VELOX_CHECK(cs.shouldReadNode(childDataType->id));
+    VELOX_CHECK(cs.shouldReadNode(childRequestedType->id));
     addChild(SelectiveDwrfReader::build(
         childRequestedType, childDataType, childParams, *childSpec));
     childSpec->setSubscript(children_.size() - 1);

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -853,7 +853,6 @@ class RowType : public TypeBase<TypeKind::ROW> {
 
   const std::shared_ptr<const Type>& findChild(folly::StringPiece name) const;
 
-  // Note: Internally does a linear search on all child names, cost is O(N).
   bool containsChild(std::string_view name) const;
 
   uint32_t getChildIdx(const std::string& name) const;


### PR DESCRIPTION
Summary:
The `ColumnSelector` is constructed using schema type not the file
type, so when we check against it, we also need to use schema type.  This was
causing assertion failure when a struct column in file has more fields than the
column in schema (i.e. we drop some fields during schema evolution).

Differential Revision: D47897341

