### PR TITLE
Fix task termination with reclaim failure

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -100,7 +100,7 @@ uint64_t MemoryReclaimer::reclaim(MemoryPool* pool, uint64_t targetBytes) {
   return reclaimedBytes;
 }
 
-void MemoryReclaimer::abort(MemoryPool* pool) {
+void MemoryReclaimer::abort(MemoryPool* pool, const std::exception_ptr& error) {
   if (pool->kind() == MemoryPool::Kind::kLeaf) {
     VELOX_UNSUPPORTED(
         "Don't support to abort a leaf memory pool {}", pool->name());
@@ -111,7 +111,7 @@ void MemoryReclaimer::abort(MemoryPool* pool) {
     // root first.
     auto* reclaimer = child->reclaimer();
     if (reclaimer != nullptr) {
-      reclaimer->abort(child);
+      reclaimer->abort(child, error);
     }
     return true;
   });

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -240,8 +240,10 @@ class MemoryReclaimer {
   /// query execution when encounters non-recoverable memory reclaim error or
   /// fails to reclaim enough free capacity. The abort is a synchronous
   /// operation and we expect most of used memory to be freed after the abort
-  /// completes.
-  virtual void abort(MemoryPool* pool);
+  /// completes. 'error' should be passed in as the direct cause of the
+  /// abortion. It will be propagated all the way to task level for accurate
+  /// error exposure.
+  virtual void abort(MemoryPool* pool, const std::exception_ptr& error);
 
  protected:
   MemoryReclaimer() = default;

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -34,6 +34,27 @@ uint64_t maxGrowBytes(const MemoryPool& pool) {
 uint64_t capacityAfterGrowth(const MemoryPool& pool, uint64_t targetBytes) {
   return pool.capacity() + targetBytes;
 }
+
+std::string memoryPoolAbortMessage(
+    MemoryPool* victim,
+    MemoryPool* requestor,
+    size_t growBytes) {
+  std::stringstream out;
+  VELOX_CHECK(victim->isRoot());
+  VELOX_CHECK(requestor->isRoot());
+  if (requestor == victim) {
+    out << "\nFailed memory pool '" << victim->name()
+        << "' aborted by itself when tried to grow " << growBytes
+        << " bytes.\n";
+  } else {
+    out << "\nFailed memory pool '" << victim->name()
+        << "' aborted when requestor '" << requestor->name()
+        << "' tried to grow " << growBytes << " bytes.\n";
+  }
+  out << "Memory usage of the failed memory pool:\n"
+      << victim->treeMemoryUsage();
+  return out.str();
+}
 } // namespace
 
 std::string SharedArbitrator::Candidate::toString() const {
@@ -160,7 +181,7 @@ bool SharedArbitrator::growMemory(
   MemoryPool* requestor = pool->root();
   if (FOLLY_UNLIKELY(requestor->aborted())) {
     ++numFailures_;
-    VELOX_MEM_POOL_ABORTED(requestor);
+    VELOX_MEM_POOL_ABORTED("The requestor has already been aborted");
   }
 
   if (FOLLY_UNLIKELY(!ensureCapacity(requestor, targetBytes))) {
@@ -222,7 +243,7 @@ bool SharedArbitrator::ensureCapacity(
   // Check if the requestor has been aborted in reclaim operation above.
   if (requestor->aborted()) {
     ++numFailures_;
-    VELOX_MEM_POOL_ABORTED(requestor);
+    VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted");
   }
   return checkCapacityGrowth(*requestor, targetBytes);
 }
@@ -242,7 +263,12 @@ bool SharedArbitrator::handleOOM(
   VELOX_MEM_LOG(WARNING) << "Aborting victim memory pool " << victim->name()
                          << " to free up memory for requestor "
                          << requestor->name();
-  abort(victim);
+  try {
+    VELOX_MEM_POOL_ABORTED(
+        memoryPoolAbortMessage(victim, requestor, targetBytes));
+  } catch (VeloxRuntimeError& e) {
+    abort(victim, std::current_exception());
+  }
   // Free up all the unused capacity from the aborted memory pool and gives back
   // to the arbitrator.
   incrementFreeCapacity(victim->shrink());
@@ -286,7 +312,7 @@ bool SharedArbitrator::arbitrateMemory(
       requestor, candidates, growTarget - freedBytes);
   if (requestor->aborted()) {
     ++numFailures_;
-    VELOX_MEM_POOL_ABORTED(requestor);
+    VELOX_MEM_POOL_ABORTED("The requestor pool has been aborted.");
   }
 
   VELOX_CHECK(!requestor->aborted());
@@ -369,7 +395,7 @@ uint64_t SharedArbitrator::reclaim(
   } catch (const std::exception& e) {
     VELOX_MEM_LOG(ERROR) << "Failed to reclaim from memory pool "
                          << pool->name() << ", aborting it!";
-    abort(pool);
+    abort(pool, std::current_exception());
     // Free up all the free capacity from the aborted pool as the associated
     // query has failed at this point.
     pool->shrink();
@@ -382,10 +408,12 @@ uint64_t SharedArbitrator::reclaim(
   return reclaimedbytes;
 }
 
-void SharedArbitrator::abort(MemoryPool* pool) {
+void SharedArbitrator::abort(
+    MemoryPool* pool,
+    const std::exception_ptr& error) {
   ++numAborted_;
   try {
-    pool->abort();
+    pool->abort(error);
   } catch (const std::exception& e) {
     VELOX_MEM_LOG(WARNING) << "Failed to abort memory pool "
                            << pool->toString();

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -119,11 +119,12 @@ SharedArbitrator::findCandidateWithLargestCapacity(
       maxCapacity = capacity;
       continue;
     }
-    if (maxCapacity > capacity) {
+    if (capacity < maxCapacity) {
       continue;
     }
-    if (capacity < maxCapacity) {
+    if (capacity > maxCapacity) {
       candidateIdx = i;
+      maxCapacity = capacity;
       continue;
     }
     // With the same amount of capacity, we prefer to kill the requestor itself

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -134,7 +134,7 @@ class SharedArbitrator : public MemoryArbitrator {
   uint64_t reclaim(MemoryPool* pool, uint64_t targetBytes) noexcept;
 
   // Invoked to abort memory 'pool'.
-  void abort(MemoryPool* pool);
+  void abort(MemoryPool* pool, const std::exception_ptr& error);
 
   // Invoked to handle the memory arbitration failure to abort the memory pool
   // with the largest capacity to free up memory. The function returns true on

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -68,14 +68,15 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
   // We look for these lines separately, since their order can change (not sure
   // why).
   std::vector<std::string> expectedTexts = {
-      "Exceeded memory pool cap of 5.00MB with max 5.00MB when requesting 2.00MB, memory manager cap is UNLIMITED"};
+      "Exceeded memory pool cap of 5.00MB with max 5.00MB when requesting "
+      "2.00MB, memory manager cap is UNLIMITED, requestor "
+      "'op.2.0.0.Aggregation' with current usage 3.70MB"};
   std::vector<std::string> expectedDetailedTexts = {
       "node.1 usage 1.00MB peak 1.00MB",
       "op.1.0.0.FilterProject usage 12.00KB peak 12.00KB",
       "node.2 usage 4.00MB peak 4.00MB",
       "op.2.0.0.Aggregation usage 3.70MB peak 3.70MB",
-      "Top 2 leaf memory pool usages:",
-      "Failed memory pool: op.2.0.0.Aggregation: 3.70MB"};
+      "Top 2 leaf memory pool usages:"};
 
   std::vector<RowVectorPtr> data;
   for (auto i = 0; i < 100; ++i) {

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -427,6 +427,10 @@ class MockSharedArbitrationTest : public testing::Test {
       ReclaimInjectionCallback reclaimInjectCb = nullptr,
       ArbitrationInjectionCallback arbitrationInjectCb = nullptr);
 
+  const std::vector<std::shared_ptr<MockTask>>& tasks() const {
+    return tasks_;
+  }
+
   void clearTasks() {
     tasks_.clear();
   }
@@ -893,8 +897,10 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithMemoryReclaim) {
     }
     auto* arbitrateOp = addMemoryOp();
     if (!isLeafReclaimable) {
-      ASSERT_ANY_THROW(arbitrateOp->allocate(allocateSize));
-      ASSERT_EQ(arbitrator_->stats().numFailures, 1);
+      auto leafTask = tasks().front();
+      ASSERT_NO_THROW(arbitrateOp->allocate(allocateSize));
+      ASSERT_NE(leafTask->error(), nullptr);
+      ASSERT_EQ(arbitrator_->stats().numFailures, 0);
       continue;
     }
     arbitrateOp->allocate(allocateSize);

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -38,8 +38,6 @@ using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::memory {
 namespace {
-class MockLeafMemoryReclaimer;
-
 constexpr int64_t KB = 1024L;
 constexpr int64_t MB = 1024L * KB;
 
@@ -47,7 +45,7 @@ constexpr uint64_t kMemoryCapacity = 512 * MB;
 constexpr uint64_t kMemoryPoolInitCapacity = 16 * MB;
 constexpr uint64_t kMemoryPoolTransferCapacity = 8 * MB;
 
-class MockMemoryReclaimer;
+class MemoryReclaimer;
 class MockMemoryOperator;
 
 using ReclaimInjectionCallback =
@@ -59,15 +57,40 @@ struct Allocation {
   size_t size{0};
 };
 
-class MockQuery {
+class MockTask : public std::enable_shared_from_this<MockTask> {
  public:
-  MockQuery(MemoryManager* manager, uint64_t capacity)
-      : root_(manager->addRootPool(
-            fmt::format("RootPool-{}", poolId_++),
-            capacity,
-            MemoryReclaimer::create())) {}
+  MockTask() {}
 
-  ~MockQuery();
+  ~MockTask();
+
+  class MemoryReclaimer : public memory::MemoryReclaimer {
+   public:
+    MemoryReclaimer(const std::shared_ptr<MockTask>& task) : task_(task) {}
+
+    static std::unique_ptr<MemoryReclaimer> create(
+        const std::shared_ptr<MockTask>& task) {
+      return std::make_unique<MemoryReclaimer>(task);
+    }
+
+    void abort(MemoryPool* pool, const std::exception_ptr& error) override {
+      auto task = task_.lock();
+      if (task == nullptr) {
+        return;
+      }
+      task->setError(error);
+      memory::MemoryReclaimer::abort(pool, error);
+    }
+
+   private:
+    std::weak_ptr<MockTask> task_;
+  };
+
+  void initTaskPool(MemoryManager* manager, uint64_t capacity) {
+    root_ = manager->addRootPool(
+        fmt::format("RootPool-{}", poolId_++),
+        capacity,
+        MemoryReclaimer::create(shared_from_this()));
+  }
 
   MemoryPool* pool() const {
     return root_.get();
@@ -92,12 +115,21 @@ class MockQuery {
     }
   }
 
+  std::exception_ptr error() const {
+    return error_;
+  }
+
+  void setError(const std::exception_ptr& error) {
+    error_ = error;
+  }
+
  private:
   inline static std::atomic<int64_t> poolId_{0};
-  const std::shared_ptr<MemoryPool> root_;
+  std::shared_ptr<MemoryPool> root_;
   std::atomic<uint64_t> nextOp_{0};
   std::vector<std::shared_ptr<MemoryPool>> pools_;
   std::vector<std::shared_ptr<MockMemoryOperator>> ops_;
+  std::exception_ptr error_{nullptr};
 };
 
 class MockMemoryOperator {
@@ -107,6 +139,88 @@ class MockMemoryOperator {
   ~MockMemoryOperator() {
     freeAll();
   }
+
+  class MemoryReclaimer : public memory::MemoryReclaimer {
+   public:
+    explicit MemoryReclaimer(
+        std::shared_ptr<MockMemoryOperator> op,
+        bool reclaimable,
+        ReclaimInjectionCallback reclaimInjectCb = nullptr,
+        ArbitrationInjectionCallback arbitrationInjectCb = nullptr)
+        : op_(op),
+          reclaimable_(reclaimable),
+          reclaimInjectCb_(std::move(reclaimInjectCb)),
+          arbitrationInjectCb_(std::move(arbitrationInjectCb)) {}
+
+    bool reclaimableBytes(const MemoryPool& pool, uint64_t& reclaimableBytes)
+        const override {
+      if (!reclaimable_) {
+        return false;
+      }
+      return op_->reclaimableBytes(pool, reclaimableBytes);
+    }
+
+    uint64_t reclaim(MemoryPool* pool, uint64_t targetBytes) override {
+      ++numReclaims_;
+      if (!reclaimable_) {
+        return 0;
+      }
+      if (reclaimInjectCb_ != nullptr) {
+        reclaimInjectCb_(pool, targetBytes);
+      }
+      reclaimTargetBytes_.push_back(targetBytes);
+      return op_->reclaim(pool, targetBytes);
+    }
+
+    void enterArbitration() override {
+      if (arbitrationInjectCb_ != nullptr) {
+        arbitrationInjectCb_();
+      }
+      ++numEnterArbitrations_;
+    }
+
+    void leaveArbitration() noexcept override {
+      ++numLeaveArbitrations_;
+    }
+
+    void abort(MemoryPool* pool, const std::exception_ptr& error) override {
+      ++numAborts_;
+      error_ = error;
+      op_->abort(pool);
+    }
+
+    struct Stats {
+      uint64_t numEnterArbitrations;
+      uint64_t numLeaveArbitrations;
+      uint64_t numReclaims;
+      uint64_t numAborts;
+      std::vector<uint64_t> reclaimTargetBytes;
+    };
+
+    Stats stats() const {
+      Stats stats;
+      stats.numEnterArbitrations = numEnterArbitrations_;
+      stats.numLeaveArbitrations = numLeaveArbitrations_;
+      stats.numReclaims = numReclaims_;
+      stats.reclaimTargetBytes = reclaimTargetBytes_;
+      stats.numAborts = numAborts_;
+      return stats;
+    }
+
+   private:
+    const std::shared_ptr<MockMemoryOperator> op_;
+    const bool reclaimable_;
+    const ReclaimInjectionCallback reclaimInjectCb_;
+    const ArbitrationInjectionCallback arbitrationInjectCb_;
+
+    std::exception_ptr error_;
+
+    std::atomic<uint64_t> numEnterArbitrations_{0};
+    std::atomic<uint64_t> numLeaveArbitrations_{0};
+    std::atomic<uint64_t> numReclaims_{0};
+    std::atomic<uint64_t> numAborts_{0};
+    std::vector<uint64_t> reclaimTargetBytes_;
+  };
 
   void* allocate(uint64_t bytes) {
     VELOX_CHECK_EQ(bytes % pool_->alignment(), 0);
@@ -228,7 +342,7 @@ class MockMemoryOperator {
     return pool_->capacity();
   }
 
-  MockMemoryReclaimer* reclaimer() const;
+  MemoryReclaimer* reclaimer() const;
 
  private:
   mutable std::mutex mu_;
@@ -237,90 +351,11 @@ class MockMemoryOperator {
   std::unordered_map<void*, size_t> allocations_;
 };
 
-class MockMemoryReclaimer : public MemoryReclaimer {
- public:
-  explicit MockMemoryReclaimer(
-      std::shared_ptr<MockMemoryOperator> op,
-      bool reclaimable,
-      ReclaimInjectionCallback reclaimInjectCb = nullptr,
-      ArbitrationInjectionCallback arbitrationInjectCb = nullptr)
-      : op_(op),
-        reclaimable_(reclaimable),
-        reclaimInjectCb_(std::move(reclaimInjectCb)),
-        arbitrationInjectCb_(std::move(arbitrationInjectCb)) {}
-
-  bool reclaimableBytes(const MemoryPool& pool, uint64_t& reclaimableBytes)
-      const override {
-    if (!reclaimable_) {
-      return false;
-    }
-    return op_->reclaimableBytes(pool, reclaimableBytes);
-  }
-
-  uint64_t reclaim(MemoryPool* pool, uint64_t targetBytes) override {
-    ++numReclaims_;
-    if (!reclaimable_) {
-      return 0;
-    }
-    if (reclaimInjectCb_ != nullptr) {
-      reclaimInjectCb_(pool, targetBytes);
-    }
-    reclaimTargetBytes_.push_back(targetBytes);
-    return op_->reclaim(pool, targetBytes);
-  }
-
-  void enterArbitration() override {
-    if (arbitrationInjectCb_ != nullptr) {
-      arbitrationInjectCb_();
-    }
-    ++numEnterArbitrations_;
-  }
-
-  void leaveArbitration() noexcept override {
-    ++numLeaveArbitrations_;
-  }
-
-  void abort(MemoryPool* pool) override {
-    ++numAborts_;
-    op_->abort(pool);
-  }
-
-  struct Stats {
-    uint64_t numEnterArbitrations;
-    uint64_t numLeaveArbitrations;
-    uint64_t numReclaims;
-    uint64_t numAborts;
-    std::vector<uint64_t> reclaimTargetBytes;
-  };
-
-  Stats stats() const {
-    Stats stats;
-    stats.numEnterArbitrations = numEnterArbitrations_;
-    stats.numLeaveArbitrations = numLeaveArbitrations_;
-    stats.numReclaims = numReclaims_;
-    stats.reclaimTargetBytes = reclaimTargetBytes_;
-    stats.numAborts = numAborts_;
-    return stats;
-  }
-
- private:
-  const std::shared_ptr<MockMemoryOperator> op_;
-  const bool reclaimable_;
-  const ReclaimInjectionCallback reclaimInjectCb_;
-  const ArbitrationInjectionCallback arbitrationInjectCb_;
-
-  std::atomic<uint64_t> numEnterArbitrations_{0};
-  std::atomic<uint64_t> numLeaveArbitrations_{0};
-  std::atomic<uint64_t> numReclaims_{0};
-  std::atomic<uint64_t> numAborts_{0};
-  std::vector<uint64_t> reclaimTargetBytes_;
-};
-
-MockMemoryReclaimer* MockMemoryOperator::reclaimer() const {
-  return static_cast<MockMemoryReclaimer*>(pool_->reclaimer());
+MockMemoryOperator::MemoryReclaimer* MockMemoryOperator::reclaimer() const {
+  return static_cast<MockMemoryOperator::MemoryReclaimer*>(pool_->reclaimer());
 }
 
-MockMemoryOperator* MockQuery::addMemoryOp(
+MockMemoryOperator* MockTask::addMemoryOp(
     bool isReclaimable,
     ReclaimInjectionCallback reclaimInjectCb,
     ArbitrationInjectionCallback arbitrationInjectCb) {
@@ -328,7 +363,7 @@ MockMemoryOperator* MockQuery::addMemoryOp(
   pools_.push_back(root_->addLeafChild(
       std::to_string(poolId_++),
       true,
-      std::make_unique<MockMemoryReclaimer>(
+      std::make_unique<MockMemoryOperator::MemoryReclaimer>(
           ops_.back(),
           isReclaimable,
           std::move(reclaimInjectCb),
@@ -337,7 +372,7 @@ MockMemoryOperator* MockQuery::addMemoryOp(
   return ops_.back().get();
 }
 
-MockQuery::~MockQuery() {
+MockTask::~MockTask() {
   for (auto op : ops_) {
     op->freeAll();
   }
@@ -355,7 +390,7 @@ class MockSharedArbitrationTest : public testing::Test {
   }
 
   void TearDown() override {
-    clearQueries();
+    clearTasks();
   }
 
   void setupMemory(
@@ -380,35 +415,37 @@ class MockSharedArbitrationTest : public testing::Test {
     arbitrator_ = static_cast<SharedArbitrator*>(manager_->arbitrator());
   }
 
-  std::shared_ptr<MockQuery> addQuery(int64_t capacity = kMaxMemory) {
-    return std::make_shared<MockQuery>(manager_.get(), capacity);
+  std::shared_ptr<MockTask> addTask(int64_t capacity = kMaxMemory) {
+    auto task = std::make_shared<MockTask>();
+    task->initTaskPool(manager_.get(), capacity);
+    return task;
   }
 
   MockMemoryOperator* addMemoryOp(
-      std::shared_ptr<MockQuery> query = nullptr,
+      std::shared_ptr<MockTask> task = nullptr,
       bool isReclaimable = true,
       ReclaimInjectionCallback reclaimInjectCb = nullptr,
       ArbitrationInjectionCallback arbitrationInjectCb = nullptr);
 
-  void clearQueries() {
-    queries_.clear();
+  void clearTasks() {
+    tasks_.clear();
   }
 
   std::unique_ptr<MemoryManager> manager_;
   SharedArbitrator* arbitrator_;
-  std::vector<std::shared_ptr<MockQuery>> queries_;
+  std::vector<std::shared_ptr<MockTask>> tasks_;
 };
 
 MockMemoryOperator* MockSharedArbitrationTest::addMemoryOp(
-    std::shared_ptr<MockQuery> query,
+    std::shared_ptr<MockTask> task,
     bool isReclaimable,
     ReclaimInjectionCallback reclaimInjectCb,
     ArbitrationInjectionCallback arbitrationInjectCb) {
-  if (query == nullptr) {
-    queries_.push_back(addQuery());
-    query = queries_.back();
+  if (task == nullptr) {
+    tasks_.push_back(addTask());
+    task = tasks_.back();
   }
-  return query->addMemoryOp(
+  return task->addMemoryOp(
       isReclaimable,
       std::move(reclaimInjectCb),
       std::move(arbitrationInjectCb));
@@ -435,7 +472,7 @@ void verifyArbitratorStats(
 }
 
 void verifyReclaimerStats(
-    const MockMemoryReclaimer::Stats& stats,
+    const MockMemoryOperator::MemoryReclaimer::Stats& stats,
     uint64_t numReclaims = 0,
     uint64_t numArbitrations = 0,
     uint64_t reclaimTargetBytes = 0) {
@@ -448,28 +485,48 @@ void verifyReclaimerStats(
 }
 
 TEST_F(MockSharedArbitrationTest, constructor) {
-  std::vector<std::shared_ptr<MockQuery>> queries;
+  std::vector<std::shared_ptr<MockTask>> tasks;
   for (int i = 0; i <= kMemoryCapacity / kMemoryPoolInitCapacity; ++i) {
-    uint64_t poolCapacity = kMemoryCapacity;
-    if (i % 3 == 0) {
-      poolCapacity = 0;
-    } else {
-      poolCapacity = kMaxMemory;
-    }
-    auto query = addQuery(kMemoryCapacity);
-    ASSERT_NE(query->pool()->reclaimer(), nullptr);
+    auto task = addTask(kMemoryCapacity);
+    ASSERT_NE(task->pool()->reclaimer(), nullptr);
     if (i < kMemoryCapacity / kMemoryPoolInitCapacity) {
-      ASSERT_EQ(query->capacity(), kMemoryPoolInitCapacity);
+      ASSERT_EQ(task->capacity(), kMemoryPoolInitCapacity);
     } else {
-      ASSERT_EQ(query->capacity(), 0);
+      ASSERT_EQ(task->capacity(), 0);
     }
-    queries.push_back(std::move(query));
+    tasks.push_back(std::move(task));
   }
   auto stats = arbitrator_->stats();
   verifyArbitratorStats(stats, kMemoryCapacity);
-  queries.clear();
+  tasks.clear();
   stats = arbitrator_->stats();
   verifyArbitratorStats(stats, kMemoryCapacity, kMemoryCapacity);
+}
+
+TEST_F(MockSharedArbitrationTest, arbitrationFailsTask) {
+  auto nonReclaimTask = addTask(384 * MB);
+  auto nonReclaimOp = nonReclaimTask->addMemoryOp(false);
+  auto buf = nonReclaimOp->allocate(384 * MB);
+
+  // growTask is (192 + 128) = 320MB which is less than nonReclaimTask 384MB.
+  // This makes sure nonReclaimTask gets picked as the victim during handleOOM()
+  auto growTask = addTask(192 * MB);
+  auto growOp = growTask->addMemoryOp(false);
+  auto bufGrow = growOp->allocate(128 * MB);
+  EXPECT_NO_THROW(manager_->growPool(growOp->pool(), 64 * MB));
+  ASSERT_NE(nonReclaimTask->error(), nullptr);
+  try {
+    std::rethrow_exception(nonReclaimTask->error());
+  } catch (const VeloxRuntimeError& e) {
+    ASSERT_EQ(velox::error_code::kMemAborted, e.errorCode());
+    ASSERT_TRUE(
+        std::string(e.what()).find("usage 384.00MB peak 384.00MB") !=
+        std::string::npos);
+  } catch (...) {
+    FAIL();
+  }
+  nonReclaimOp->freeAll();
+  growOp->freeAll();
 }
 
 TEST_F(MockSharedArbitrationTest, singlePoolGrowWithoutArbitration) {
@@ -492,7 +549,7 @@ TEST_F(MockSharedArbitrationTest, singlePoolGrowWithoutArbitration) {
       (kMemoryCapacity - kMemoryPoolInitCapacity) /
           kMemoryPoolTransferCapacity);
 
-  clearQueries();
+  clearTasks();
   verifyArbitratorStats(
       arbitrator_->stats(),
       kMemoryCapacity,
@@ -522,9 +579,9 @@ TEST_F(MockSharedArbitrationTest, maxCapacityReserve) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto query = addQuery(testData.maxCapacity);
-    ASSERT_EQ(query->pool()->maxCapacity(), testData.maxCapacity);
-    ASSERT_EQ(query->pool()->capacity(), testData.expectedInitialCapacity);
+    auto task = addTask(testData.maxCapacity);
+    ASSERT_EQ(task->pool()->maxCapacity(), testData.maxCapacity);
+    ASSERT_EQ(task->pool()->capacity(), testData.expectedInitialCapacity);
   }
 }
 
@@ -536,18 +593,18 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     bool isReclaimable;
     uint64_t allocatedBytes;
     uint64_t requestBytes;
-    bool hasOtherQuery;
+    bool hasOtherTask;
     bool expectedSuccess;
     bool expectedReclaimFromOther;
 
     std::string debugString() const {
       return fmt::format(
-          "maxCapacity {} isReclaimable {} allocatedBytes {} requestBytes {} hasOtherQuery {} expectedSuccess {} expectedReclaimFromOther {}",
+          "maxCapacity {} isReclaimable {} allocatedBytes {} requestBytes {} hasOtherTask {} expectedSuccess {} expectedReclaimFromOther {}",
           succinctBytes(maxCapacity),
           isReclaimable,
           succinctBytes(allocatedBytes),
           succinctBytes(requestBytes),
-          hasOtherQuery,
+          hasOtherTask,
           expectedSuccess,
           expectedReclaimFromOther);
     }
@@ -641,13 +698,13 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     SCOPED_TRACE(testData.debugString());
     setupMemory(memCapacity, minPoolCapacity);
 
-    auto requestor = addQuery(testData.maxCapacity);
+    auto requestor = addTask(testData.maxCapacity);
     auto requestorOp = addMemoryOp(requestor, testData.isReclaimable);
     requestorOp->allocate(testData.allocatedBytes);
-    std::shared_ptr<MockQuery> other;
+    std::shared_ptr<MockTask> other;
     MockMemoryOperator* otherOp;
-    if (testData.hasOtherQuery) {
-      other = addQuery();
+    if (testData.hasOtherTask) {
+      other = addTask();
       otherOp = addMemoryOp(other, true);
       otherOp->allocate(memCapacity - testData.allocatedBytes);
     }
@@ -661,13 +718,13 @@ TEST_F(MockSharedArbitrationTest, ensureMemoryPoolMaxCapacity) {
     }
     if (testData.expectedReclaimFromOther) {
       ASSERT_GT(otherOp->reclaimer()->stats().numReclaims, 0);
-    } else if (testData.hasOtherQuery) {
+    } else if (testData.hasOtherTask) {
       ASSERT_EQ(otherOp->reclaimer()->stats().numReclaims, 0);
     }
     if (testData.expectedSuccess &&
         (((testData.allocatedBytes + testData.requestBytes) >
           testData.maxCapacity) ||
-         testData.hasOtherQuery)) {
+         testData.hasOtherTask)) {
       ASSERT_GT(arbitrator_->stats().numReclaimedBytes, 0);
     } else {
       ASSERT_EQ(arbitrator_->stats().numReclaimedBytes, 0);
@@ -711,7 +768,7 @@ TEST_F(MockSharedArbitrationTest, ensureNodeMaxCapacity) {
     SCOPED_TRACE(testData.debugString());
     setupMemory(testData.nodeCapacity);
 
-    auto requestor = addQuery(testData.poolMaxCapacity);
+    auto requestor = addTask(testData.poolMaxCapacity);
     auto requestorOp = addMemoryOp(requestor, testData.isReclaimable);
     requestorOp->allocate(testData.allocatedBytes);
     const auto numRequests = arbitrator_->stats().numRequests;
@@ -783,7 +840,7 @@ TEST_F(MockSharedArbitrationTest, singlePoolGrowCapacityWithArbitration) {
         arbitrator_->stats(), kMemoryCapacity, 0, 63, 0, 8388608);
     verifyReclaimerStats(op->reclaimer()->stats(), 1, 63);
 
-    clearQueries();
+    clearTasks();
     verifyArbitratorStats(
         arbitrator_->stats(), kMemoryCapacity, kMemoryCapacity, 63, 0, 8388608);
   }
@@ -818,7 +875,7 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithCapacityShrink) {
     verifyReclaimerStats(reclaimedOp->reclaimer()->stats(), 0, 11);
     verifyReclaimerStats(arbitrateOp->reclaimer()->stats(), 0, 5);
 
-    clearQueries();
+    clearTasks();
   }
 }
 
@@ -850,7 +907,7 @@ TEST_F(MockSharedArbitrationTest, arbitrateWithMemoryReclaim) {
 
     verifyReclaimerStats(
         reclaimedOp->reclaimer()->stats(), 1, 31, kMemoryPoolTransferCapacity);
-    clearQueries();
+    clearTasks();
   }
 }
 
@@ -860,8 +917,8 @@ TEST_F(MockSharedArbitrationTest, arbitrateBySelfMemoryReclaim) {
     SCOPED_TRACE(fmt::format("isLeafReclaimable {}", isLeafReclaimable));
     const uint64_t memCapacity = 128 * MB;
     setupMemory(memCapacity);
-    std::shared_ptr<MockQuery> query = addQuery(kMemoryCapacity);
-    auto* memOp = addMemoryOp(query, isLeafReclaimable);
+    std::shared_ptr<MockTask> task = addTask(kMemoryCapacity);
+    auto* memOp = addMemoryOp(task, isLeafReclaimable);
     const int allocateSize = 8 * MB;
     while (memOp->pool()->currentBytes() < memCapacity / 2) {
       memOp->allocate(allocateSize);
@@ -910,8 +967,8 @@ TEST_F(MockSharedArbitrationTest, noAbortOnRequestWhenArbitrationFails) {
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     setupMemory(memCapacity, 0);
-    std::shared_ptr<MockQuery> query = addQuery(kMemoryCapacity);
-    auto* memOp = addMemoryOp(query, false);
+    std::shared_ptr<MockTask> task = addTask(kMemoryCapacity);
+    auto* memOp = addMemoryOp(task, false);
     if (testData.initialAllocationSize != 0) {
       memOp->allocate(testData.initialAllocationSize);
     }
@@ -953,7 +1010,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
   const uint64_t memCapacity = 512 * MB;
   const uint64_t minPoolCapacity = 32 * MB;
   const uint64_t minPoolCapacityTransferSize = 8 * MB;
-  const int numQueries = 8;
+  const int numTasks = 8;
   struct {
     bool freeCapacity;
     bool sameSize;
@@ -970,12 +1027,12 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
     setupMemory(memCapacity, minPoolCapacity, minPoolCapacityTransferSize);
     std::vector<MockMemoryOperator*> memOps;
     std::vector<uint64_t> memOpCapacities;
-    for (int i = 0; i < numQueries; ++i) {
+    for (int i = 0; i < numTasks; ++i) {
       auto* memOp = addMemoryOp();
-      int allocationSize = testData.sameSize ? memCapacity / numQueries
+      int allocationSize = testData.sameSize ? memCapacity / numTasks
                                              : minPoolCapacity +
               folly::Random::rand32(rng) %
-                  ((memCapacity / numQueries) - minPoolCapacity);
+                  ((memCapacity / numTasks) - minPoolCapacity);
       allocationSize = allocationSize / MB * MB;
       memOp->allocate(allocationSize);
       if (testData.freeCapacity) {
@@ -991,7 +1048,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, orderedArbitration) {
       ASSERT_EQ(memOp->capacity(), 0);
     }
     ASSERT_EQ(arbitrator_->stats().queueTimeUs, 0);
-    clearQueries();
+    clearTasks();
   }
 }
 
@@ -1136,7 +1193,11 @@ TEST_F(MockSharedArbitrationTest, noArbitratiognFromAbortedPool) {
   auto* reclaimedOp = addMemoryOp();
   ASSERT_EQ(reclaimedOp->capacity(), kMemoryPoolInitCapacity);
   reclaimedOp->allocate(128);
-  reclaimedOp->pool()->abort();
+  try {
+    VELOX_MEM_POOL_ABORTED("Manual abort pool");
+  } catch (VeloxException& e) {
+    reclaimedOp->pool()->abort(std::current_exception());
+  }
   ASSERT_TRUE(reclaimedOp->pool()->aborted());
   ASSERT_TRUE(reclaimedOp->pool()->aborted());
   const int largeAllocationSize = 2 * kMemoryPoolInitCapacity;
@@ -1160,27 +1221,27 @@ TEST_F(MockSharedArbitrationTest, noArbitratiognFromAbortedPool) {
 }
 
 DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
-  const int numOtherQueries = 4;
-  const int otherQueryMemoryCapacity = kMemoryCapacity / 8;
-  const int failedQueryMemoryCapacity = kMemoryCapacity / 2;
+  const int numOtherTasks = 4;
+  const int otherTaskMemoryCapacity = kMemoryCapacity / 8;
+  const int failedTaskMemoryCapacity = kMemoryCapacity / 2;
   struct {
-    bool hasAllocationFromFailedQueryAfterAbort;
-    bool hasAllocationFromOtherQueryAfterAbort;
-    int64_t expectedFailedQueryMemoryCapacity;
-    int64_t expectedFailedQueryMemoryUsage;
-    int64_t expectedOtherQueryMemoryCapacity;
-    int64_t expectedOtherQueryMemoryUsage;
+    bool hasAllocationFromFailedTaskAfterAbort;
+    bool hasAllocationFromOtherTaskAfterAbort;
+    int64_t expectedFailedTaskMemoryCapacity;
+    int64_t expectedFailedTaskMemoryUsage;
+    int64_t expectedOtherTaskMemoryCapacity;
+    int64_t expectedOtherTaskMemoryUsage;
     int64_t expectedFreeCapacity;
 
     std::string debugString() const {
       return fmt::format(
-          "hasAllocationFromFailedQueryAfterAbort {}, hasAllocationFromOtherQueryAfterAbort {} expectedFailedQueryMemoryCapacity {} expectedFailedQueryMemoryUsage {} expectedOtherQueryMemoryCapacity {} expectedOtherQueryMemoryUsage {} expectedFreeCapacity{}",
-          hasAllocationFromFailedQueryAfterAbort,
-          hasAllocationFromOtherQueryAfterAbort,
-          expectedFailedQueryMemoryCapacity,
-          expectedFailedQueryMemoryUsage,
-          expectedOtherQueryMemoryCapacity,
-          expectedOtherQueryMemoryUsage,
+          "hasAllocationFromFailedTaskAfterAbort {}, hasAllocationFromOtherTaskAfterAbort {} expectedFailedTaskMemoryCapacity {} expectedFailedTaskMemoryUsage {} expectedOtherTaskMemoryCapacity {} expectedOtherTaskMemoryUsage {} expectedFreeCapacity{}",
+          hasAllocationFromFailedTaskAfterAbort,
+          hasAllocationFromOtherTaskAfterAbort,
+          expectedFailedTaskMemoryCapacity,
+          expectedFailedTaskMemoryUsage,
+          expectedOtherTaskMemoryCapacity,
+          expectedOtherTaskMemoryUsage,
           expectedFreeCapacity);
     }
   } testSettings[] = {
@@ -1188,74 +1249,71 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
        false,
        0,
        0,
-       otherQueryMemoryCapacity,
-       otherQueryMemoryCapacity,
-       failedQueryMemoryCapacity},
+       otherTaskMemoryCapacity,
+       otherTaskMemoryCapacity,
+       failedTaskMemoryCapacity},
       {true,
        false,
        0,
        0,
-       otherQueryMemoryCapacity,
-       otherQueryMemoryCapacity,
-       failedQueryMemoryCapacity},
+       otherTaskMemoryCapacity,
+       otherTaskMemoryCapacity,
+       failedTaskMemoryCapacity},
       {true,
        true,
        0,
        0,
-       otherQueryMemoryCapacity * 2,
-       otherQueryMemoryCapacity * 2,
+       otherTaskMemoryCapacity * 2,
+       otherTaskMemoryCapacity * 2,
        0},
       {false,
        true,
        0,
        0,
-       otherQueryMemoryCapacity * 2,
-       otherQueryMemoryCapacity * 2,
+       otherTaskMemoryCapacity * 2,
+       otherTaskMemoryCapacity * 2,
        0}};
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
     setupMemory();
 
-    std::vector<std::shared_ptr<MockQuery>> otherQueries;
-    std::vector<MockMemoryOperator*> otherQueryOps;
-    for (int i = 0; i < numOtherQueries; ++i) {
-      otherQueries.push_back(addQuery());
-      otherQueryOps.push_back(addMemoryOp(otherQueries.back(), false));
-      otherQueryOps.back()->allocate(otherQueryMemoryCapacity);
+    std::vector<std::shared_ptr<MockTask>> otherTasks;
+    std::vector<MockMemoryOperator*> otherTaskOps;
+    for (int i = 0; i < numOtherTasks; ++i) {
+      otherTasks.push_back(addTask());
+      otherTaskOps.push_back(addMemoryOp(otherTasks.back(), false));
+      otherTaskOps.back()->allocate(otherTaskMemoryCapacity);
       ASSERT_EQ(
-          otherQueries.back()->pool()->currentBytes(),
-          otherQueryMemoryCapacity);
+          otherTasks.back()->pool()->currentBytes(), otherTaskMemoryCapacity);
     }
-    std::shared_ptr<MockQuery> failedQuery = addQuery();
-    MockMemoryOperator* failedQueryOp = addMemoryOp(
-        failedQuery, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
+    std::shared_ptr<MockTask> failedTask = addTask();
+    MockMemoryOperator* failedTaskOp = addMemoryOp(
+        failedTask, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
           VELOX_FAIL("throw reclaim exception");
         });
-    failedQueryOp->allocate(failedQueryMemoryCapacity);
-    for (int i = 0; i < numOtherQueries; ++i) {
-      ASSERT_EQ(otherQueryOps[0]->pool()->capacity(), otherQueryMemoryCapacity);
+    failedTaskOp->allocate(failedTaskMemoryCapacity);
+    for (int i = 0; i < numOtherTasks; ++i) {
+      ASSERT_EQ(otherTaskOps[0]->pool()->capacity(), otherTaskMemoryCapacity);
     }
-    ASSERT_EQ(failedQueryOp->capacity(), failedQueryMemoryCapacity);
+    ASSERT_EQ(failedTaskOp->capacity(), failedTaskMemoryCapacity);
 
     const auto oldStats = arbitrator_->stats();
     ASSERT_EQ(oldStats.numFailures, 0);
     ASSERT_EQ(oldStats.numAborted, 0);
 
-    const int numFailedQueryAllocationsAfterAbort =
-        testData.hasAllocationFromFailedQueryAfterAbort ? 3 : 0;
-    // If 'hasAllocationFromOtherQueryAfterAbort' is true, then one allocation
-    // from each of the other queries.
+    const int numFailedTaskAllocationsAfterAbort =
+        testData.hasAllocationFromFailedTaskAfterAbort ? 3 : 0;
+    // If 'hasAllocationFromOtherTaskAfterAbort' is true, then one allocation
+    // from each of the other tasks.
     const int numOtherAllocationsAfterAbort =
-        testData.hasAllocationFromOtherQueryAfterAbort ? numOtherQueries : 0;
+        testData.hasAllocationFromOtherTaskAfterAbort ? numOtherTasks : 0;
 
-    // One barrier count is for the initial allocation from the failed query to
+    // One barrier count is for the initial allocation from the failed task to
     // trigger memory arbitration.
     folly::futures::Barrier arbitrationStartBarrier(
-        numFailedQueryAllocationsAfterAbort + numOtherAllocationsAfterAbort +
-        1);
+        numFailedTaskAllocationsAfterAbort + numOtherAllocationsAfterAbort + 1);
     folly::futures::Barrier arbitrationBarrier(
-        numFailedQueryAllocationsAfterAbort + numOtherAllocationsAfterAbort +
-        1);
+        numFailedTaskAllocationsAfterAbort + numOtherAllocationsAfterAbort + 1);
     std::atomic<int> testInjectionCount{0};
     std::atomic<bool> arbitrationStarted{false};
     SCOPED_TESTVALUE_SET(
@@ -1265,7 +1323,7 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
               if (!arbitrationStarted) {
                 return;
               }
-              if (++testInjectionCount <= numFailedQueryAllocationsAfterAbort +
+              if (++testInjectionCount <= numFailedTaskAllocationsAfterAbort +
                       numOtherAllocationsAfterAbort + 1) {
                 arbitrationBarrier.wait().wait();
               }
@@ -1278,310 +1336,309 @@ DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromRequestor) {
               if (!arbitrationStarted.exchange(true)) {
                 arbitrationStartBarrier.wait().wait();
               }
-              if (++testInjectionCount <= numFailedQueryAllocationsAfterAbort +
+              if (++testInjectionCount <= numFailedTaskAllocationsAfterAbort +
                       numOtherAllocationsAfterAbort + 1) {
+                arbitrationBarrier.wait().wait();
+              }
+            })));
+
+    std::vector<std::thread> allocationThreadsAfterAbort;
+    for (int i = 0;
+         i < numFailedTaskAllocationsAfterAbort + numOtherAllocationsAfterAbort;
+         ++i) {
+      allocationThreadsAfterAbort.emplace_back([&, i]() {
+        arbitrationStartBarrier.wait().wait();
+        if (i < numFailedTaskAllocationsAfterAbort) {
+          VELOX_ASSERT_THROW(
+              failedTaskOp->allocate(failedTaskMemoryCapacity), "");
+        } else {
+          otherTaskOps[i - numFailedTaskAllocationsAfterAbort]->allocate(
+              otherTaskMemoryCapacity);
+        }
+      });
+    }
+
+    // Trigger memory arbitration to reclaim from itself which throws.
+    VELOX_ASSERT_THROW(failedTaskOp->allocate(failedTaskMemoryCapacity), "");
+    // Wait for all the allocation threads to complete.
+    for (auto& allocationThread : allocationThreadsAfterAbort) {
+      allocationThread.join();
+    }
+    ASSERT_TRUE(failedTaskOp->pool()->aborted());
+    ASSERT_EQ(
+        failedTaskOp->pool()->currentBytes(),
+        testData.expectedFailedTaskMemoryCapacity);
+    ASSERT_EQ(
+        failedTaskOp->pool()->capacity(),
+        testData.expectedFailedTaskMemoryUsage);
+    ASSERT_EQ(failedTaskOp->reclaimer()->stats().numAborts, 1);
+    ASSERT_EQ(failedTaskOp->reclaimer()->stats().numReclaims, 1);
+
+    const auto newStats = arbitrator_->stats();
+    ASSERT_EQ(
+        newStats.numRequests,
+        oldStats.numRequests + 1 + numFailedTaskAllocationsAfterAbort +
+            numOtherAllocationsAfterAbort);
+    ASSERT_EQ(newStats.numAborted, 1);
+    ASSERT_EQ(newStats.freeCapacityBytes, testData.expectedFreeCapacity);
+    ASSERT_EQ(newStats.numFailures, numFailedTaskAllocationsAfterAbort + 1);
+    ASSERT_EQ(newStats.maxCapacityBytes, kMemoryCapacity);
+    // Check if memory pools have been aborted or not as expected.
+    for (const auto* taskOp : otherTaskOps) {
+      ASSERT_FALSE(taskOp->pool()->aborted());
+      ASSERT_EQ(taskOp->reclaimer()->stats().numAborts, 0);
+      ASSERT_EQ(taskOp->reclaimer()->stats().numReclaims, 0);
+      ASSERT_EQ(
+          taskOp->pool()->capacity(), testData.expectedOtherTaskMemoryCapacity);
+      ASSERT_EQ(
+          taskOp->pool()->currentBytes(),
+          testData.expectedOtherTaskMemoryUsage);
+    }
+
+    VELOX_ASSERT_THROW(failedTaskOp->allocate(failedTaskMemoryCapacity), "");
+    ASSERT_EQ(arbitrator_->stats().numRequests, newStats.numRequests);
+    ASSERT_EQ(arbitrator_->stats().numAborted, 1);
+  }
+}
+
+DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromOtherTask) {
+  const int numNonFailedTasks = 3;
+  const int nonFailTaskMemoryCapacity = kMemoryCapacity / 8;
+  const int failedTaskMemoryCapacity =
+      kMemoryCapacity / 2 + nonFailTaskMemoryCapacity;
+  struct {
+    bool hasAllocationFromFailedTaskAfterAbort;
+    bool hasAllocationFromNonFailedTaskAfterAbort;
+    int64_t expectedFailedTaskMemoryCapacity;
+    int64_t expectedFailedTaskMemoryUsage;
+    int64_t expectedNonFailedTaskMemoryCapacity;
+    int64_t expectedNonFailedTaskMemoryUsage;
+    int64_t expectedFreeCapacity;
+
+    std::string debugString() const {
+      return fmt::format(
+          "hasAllocationFromFailedTaskAfterAbort {}, hasAllocationFromNonFailedTaskAfterAbort {} expectedFailedTaskMemoryCapacity {} expectedFailedTaskMemoryUsage {} expectedNonFailedTaskMemoryCapacity {} expectedNonFailedTaskMemoryUsage {} expectedFreeCapacity {}",
+          hasAllocationFromFailedTaskAfterAbort,
+          hasAllocationFromNonFailedTaskAfterAbort,
+          expectedFailedTaskMemoryCapacity,
+          expectedFailedTaskMemoryUsage,
+          expectedNonFailedTaskMemoryCapacity,
+          expectedNonFailedTaskMemoryUsage,
+          expectedFreeCapacity);
+    }
+  } testSettings[] = {
+      {false,
+       false,
+       0,
+       0,
+       nonFailTaskMemoryCapacity,
+       nonFailTaskMemoryCapacity,
+       failedTaskMemoryCapacity - nonFailTaskMemoryCapacity},
+      {true,
+       false,
+       0,
+       0,
+       nonFailTaskMemoryCapacity,
+       nonFailTaskMemoryCapacity,
+       failedTaskMemoryCapacity - nonFailTaskMemoryCapacity},
+      {true,
+       true,
+       0,
+       0,
+       nonFailTaskMemoryCapacity * 2,
+       nonFailTaskMemoryCapacity * 2,
+       nonFailTaskMemoryCapacity},
+      {false,
+       true,
+       0,
+       0,
+       nonFailTaskMemoryCapacity * 2,
+       nonFailTaskMemoryCapacity * 2,
+       nonFailTaskMemoryCapacity}};
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    setupMemory();
+
+    std::vector<std::shared_ptr<MockTask>> nonFailedTasks;
+    std::vector<MockMemoryOperator*> nonFailedTaskOps;
+    for (int i = 0; i < numNonFailedTasks; ++i) {
+      nonFailedTasks.push_back(addTask());
+      nonFailedTaskOps.push_back(addMemoryOp(nonFailedTasks.back(), false));
+      nonFailedTaskOps.back()->allocate(nonFailTaskMemoryCapacity);
+      ASSERT_EQ(
+          nonFailedTasks.back()->pool()->currentBytes(),
+          nonFailTaskMemoryCapacity);
+    }
+    std::shared_ptr<MockTask> failedTask = addTask();
+    MockMemoryOperator* failedTaskOp = addMemoryOp(
+        failedTask, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
+          VELOX_FAIL("throw reclaim exception");
+        });
+    failedTaskOp->allocate(failedTaskMemoryCapacity);
+    for (int i = 0; i < numNonFailedTasks; ++i) {
+      ASSERT_EQ(
+          nonFailedTasks[0]->pool()->capacity(), nonFailTaskMemoryCapacity)
+          << i;
+    }
+    ASSERT_EQ(failedTaskOp->capacity(), failedTaskMemoryCapacity);
+
+    const auto oldStats = arbitrator_->stats();
+    ASSERT_EQ(oldStats.numFailures, 0);
+    ASSERT_EQ(oldStats.numAborted, 0);
+
+    const int numFailedTaskAllocationsAfterAbort =
+        testData.hasAllocationFromFailedTaskAfterAbort ? 3 : 0;
+    // If 'hasAllocationFromOtherTaskAfterAbort' is true, then one allocation
+    // from each of the other tasks.
+    const int numNonFailedAllocationsAfterAbort =
+        testData.hasAllocationFromNonFailedTaskAfterAbort ? numNonFailedTasks
+                                                          : 0;
+    // One barrier count is for the initial allocation from the failed task to
+    // trigger memory arbitration.
+    folly::futures::Barrier arbitrationStartBarrier(
+        numFailedTaskAllocationsAfterAbort + numNonFailedAllocationsAfterAbort +
+        1);
+    folly::futures::Barrier arbitrationBarrier(
+        numFailedTaskAllocationsAfterAbort + numNonFailedAllocationsAfterAbort +
+        1);
+    std::atomic<int> testInjectionCount{0};
+    std::atomic<bool> arbitrationStarted{false};
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::memory::SharedArbitrator::startArbitration",
+        std::function<void(const MemoryPool*)>(
+            ([&](const MemoryPool* /*unsed*/) {
+              if (!arbitrationStarted) {
+                return;
+              }
+              if (++testInjectionCount <= numFailedTaskAllocationsAfterAbort +
+                      numNonFailedAllocationsAfterAbort + 1) {
+                arbitrationBarrier.wait().wait();
+              }
+            })));
+
+    SCOPED_TESTVALUE_SET(
+        "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
+        std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
+            ([&](const std::vector<SharedArbitrator::Candidate>* /*unused*/) {
+              if (!arbitrationStarted.exchange(true)) {
+                arbitrationStartBarrier.wait().wait();
+              }
+              if (++testInjectionCount <= numFailedTaskAllocationsAfterAbort +
+                      numNonFailedAllocationsAfterAbort + 1) {
                 arbitrationBarrier.wait().wait();
               }
             })));
 
     std::vector<std::thread> allocationThreadsAfterAbort;
     for (int i = 0; i <
-         numFailedQueryAllocationsAfterAbort + numOtherAllocationsAfterAbort;
+         numFailedTaskAllocationsAfterAbort + numNonFailedAllocationsAfterAbort;
          ++i) {
       allocationThreadsAfterAbort.emplace_back([&, i]() {
         arbitrationStartBarrier.wait().wait();
-        if (i < numFailedQueryAllocationsAfterAbort) {
+        if (i < numFailedTaskAllocationsAfterAbort) {
           VELOX_ASSERT_THROW(
-              failedQueryOp->allocate(failedQueryMemoryCapacity), "");
+              failedTaskOp->allocate(failedTaskMemoryCapacity), "");
         } else {
-          otherQueryOps[i - numFailedQueryAllocationsAfterAbort]->allocate(
-              otherQueryMemoryCapacity);
+          nonFailedTaskOps[i - numFailedTaskAllocationsAfterAbort]->allocate(
+              nonFailTaskMemoryCapacity);
         }
       });
     }
 
-    // Trigger memory arbitration to reclaim from itself which throws.
-    VELOX_ASSERT_THROW(failedQueryOp->allocate(failedQueryMemoryCapacity), "");
+    // Trigger memory arbitration to reclaim from failedTask which throws.
+    nonFailedTaskOps[0]->allocate(nonFailTaskMemoryCapacity);
     // Wait for all the allocation threads to complete.
     for (auto& allocationThread : allocationThreadsAfterAbort) {
       allocationThread.join();
     }
-    ASSERT_TRUE(failedQueryOp->pool()->aborted());
+    ASSERT_TRUE(failedTaskOp->pool()->aborted());
     ASSERT_EQ(
-        failedQueryOp->pool()->currentBytes(),
-        testData.expectedFailedQueryMemoryCapacity);
+        failedTaskOp->pool()->currentBytes(),
+        testData.expectedFailedTaskMemoryCapacity);
     ASSERT_EQ(
-        failedQueryOp->pool()->capacity(),
-        testData.expectedFailedQueryMemoryUsage);
-    ASSERT_EQ(failedQueryOp->reclaimer()->stats().numAborts, 1);
-    ASSERT_EQ(failedQueryOp->reclaimer()->stats().numReclaims, 1);
+        failedTaskOp->pool()->capacity(),
+        testData.expectedFailedTaskMemoryUsage);
+    ASSERT_EQ(failedTaskOp->reclaimer()->stats().numAborts, 1);
+    ASSERT_EQ(failedTaskOp->reclaimer()->stats().numReclaims, 1);
 
     const auto newStats = arbitrator_->stats();
     ASSERT_EQ(
         newStats.numRequests,
-        oldStats.numRequests + 1 + numFailedQueryAllocationsAfterAbort +
-            numOtherAllocationsAfterAbort);
-    ASSERT_EQ(newStats.numAborted, 1);
-    ASSERT_EQ(newStats.freeCapacityBytes, testData.expectedFreeCapacity);
-    ASSERT_EQ(newStats.numFailures, numFailedQueryAllocationsAfterAbort + 1);
-    ASSERT_EQ(newStats.maxCapacityBytes, kMemoryCapacity);
-    // Check if memory pools have been aborted or not as expected.
-    for (const auto* queryOp : otherQueryOps) {
-      ASSERT_FALSE(queryOp->pool()->aborted());
-      ASSERT_EQ(queryOp->reclaimer()->stats().numAborts, 0);
-      ASSERT_EQ(queryOp->reclaimer()->stats().numReclaims, 0);
-      ASSERT_EQ(
-          queryOp->pool()->capacity(),
-          testData.expectedOtherQueryMemoryCapacity);
-      ASSERT_EQ(
-          queryOp->pool()->currentBytes(),
-          testData.expectedOtherQueryMemoryUsage);
-    }
-
-    VELOX_ASSERT_THROW(failedQueryOp->allocate(failedQueryMemoryCapacity), "");
-    ASSERT_EQ(arbitrator_->stats().numRequests, newStats.numRequests);
-    ASSERT_EQ(arbitrator_->stats().numAborted, 1);
-  }
-}
-
-DEBUG_ONLY_TEST_F(MockSharedArbitrationTest, failedToReclaimFromOtherQuery) {
-  const int numNonFailedQueries = 3;
-  const int nonFailQueryMemoryCapacity = kMemoryCapacity / 8;
-  const int failedQueryMemoryCapacity =
-      kMemoryCapacity / 2 + nonFailQueryMemoryCapacity;
-  struct {
-    bool hasAllocationFromFailedQueryAfterAbort;
-    bool hasAllocationFromNonFailedQueryAfterAbort;
-    int64_t expectedFailedQueryMemoryCapacity;
-    int64_t expectedFailedQueryMemoryUsage;
-    int64_t expectedNonFailedQueryMemoryCapacity;
-    int64_t expectedNonFailedQueryMemoryUsage;
-    int64_t expectedFreeCapacity;
-
-    std::string debugString() const {
-      return fmt::format(
-          "hasAllocationFromFailedQueryAfterAbort {}, hasAllocationFromNonFailedQueryAfterAbort {} expectedFailedQueryMemoryCapacity {} expectedFailedQueryMemoryUsage {} expectedNonFailedQueryMemoryCapacity {} expectedNonFailedQueryMemoryUsage {} expectedFreeCapacity {}",
-          hasAllocationFromFailedQueryAfterAbort,
-          hasAllocationFromNonFailedQueryAfterAbort,
-          expectedFailedQueryMemoryCapacity,
-          expectedFailedQueryMemoryUsage,
-          expectedNonFailedQueryMemoryCapacity,
-          expectedNonFailedQueryMemoryUsage,
-          expectedFreeCapacity);
-    }
-  } testSettings[] = {
-      {false,
-       false,
-       0,
-       0,
-       nonFailQueryMemoryCapacity,
-       nonFailQueryMemoryCapacity,
-       failedQueryMemoryCapacity - nonFailQueryMemoryCapacity},
-      {true,
-       false,
-       0,
-       0,
-       nonFailQueryMemoryCapacity,
-       nonFailQueryMemoryCapacity,
-       failedQueryMemoryCapacity - nonFailQueryMemoryCapacity},
-      {true,
-       true,
-       0,
-       0,
-       nonFailQueryMemoryCapacity * 2,
-       nonFailQueryMemoryCapacity * 2,
-       nonFailQueryMemoryCapacity},
-      {false,
-       true,
-       0,
-       0,
-       nonFailQueryMemoryCapacity * 2,
-       nonFailQueryMemoryCapacity * 2,
-       nonFailQueryMemoryCapacity}};
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
-    setupMemory();
-
-    std::vector<std::shared_ptr<MockQuery>> nonFailedQueries;
-    std::vector<MockMemoryOperator*> nonFailedQueryOps;
-    for (int i = 0; i < numNonFailedQueries; ++i) {
-      nonFailedQueries.push_back(addQuery());
-      nonFailedQueryOps.push_back(addMemoryOp(nonFailedQueries.back(), false));
-      nonFailedQueryOps.back()->allocate(nonFailQueryMemoryCapacity);
-      ASSERT_EQ(
-          nonFailedQueries.back()->pool()->currentBytes(),
-          nonFailQueryMemoryCapacity);
-    }
-    std::shared_ptr<MockQuery> failedQuery = addQuery();
-    MockMemoryOperator* failedQueryOp = addMemoryOp(
-        failedQuery, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
-          VELOX_FAIL("throw reclaim exception");
-        });
-    failedQueryOp->allocate(failedQueryMemoryCapacity);
-    for (int i = 0; i < numNonFailedQueries; ++i) {
-      ASSERT_EQ(
-          nonFailedQueries[0]->pool()->capacity(), nonFailQueryMemoryCapacity)
-          << i;
-    }
-    ASSERT_EQ(failedQueryOp->capacity(), failedQueryMemoryCapacity);
-
-    const auto oldStats = arbitrator_->stats();
-    ASSERT_EQ(oldStats.numFailures, 0);
-    ASSERT_EQ(oldStats.numAborted, 0);
-
-    const int numFailedQueryAllocationsAfterAbort =
-        testData.hasAllocationFromFailedQueryAfterAbort ? 3 : 0;
-    // If 'hasAllocationFromOtherQueryAfterAbort' is true, then one allocation
-    // from each of the other queries.
-    const int numNonFailedAllocationsAfterAbort =
-        testData.hasAllocationFromNonFailedQueryAfterAbort ? numNonFailedQueries
-                                                           : 0;
-    // One barrier count is for the initial allocation from the failed query to
-    // trigger memory arbitration.
-    folly::futures::Barrier arbitrationStartBarrier(
-        numFailedQueryAllocationsAfterAbort +
-        numNonFailedAllocationsAfterAbort + 1);
-    folly::futures::Barrier arbitrationBarrier(
-        numFailedQueryAllocationsAfterAbort +
-        numNonFailedAllocationsAfterAbort + 1);
-    std::atomic<int> testInjectionCount{0};
-    std::atomic<bool> arbitrationStarted{false};
-    SCOPED_TESTVALUE_SET(
-        "facebook::velox::memory::SharedArbitrator::startArbitration",
-        std::function<void(const MemoryPool*)>(
-            ([&](const MemoryPool* /*unsed*/) {
-              if (!arbitrationStarted) {
-                return;
-              }
-              if (++testInjectionCount <= numFailedQueryAllocationsAfterAbort +
-                      numNonFailedAllocationsAfterAbort + 1) {
-                arbitrationBarrier.wait().wait();
-              }
-            })));
-
-    SCOPED_TESTVALUE_SET(
-        "facebook::velox::memory::SharedArbitrator::sortCandidatesByFreeCapacity",
-        std::function<void(const std::vector<SharedArbitrator::Candidate>*)>(
-            ([&](const std::vector<SharedArbitrator::Candidate>* /*unused*/) {
-              if (!arbitrationStarted.exchange(true)) {
-                arbitrationStartBarrier.wait().wait();
-              }
-              if (++testInjectionCount <= numFailedQueryAllocationsAfterAbort +
-                      numNonFailedAllocationsAfterAbort + 1) {
-                arbitrationBarrier.wait().wait();
-              }
-            })));
-
-    std::vector<std::thread> allocationThreadsAfterAbort;
-    for (int i = 0; i < numFailedQueryAllocationsAfterAbort +
-             numNonFailedAllocationsAfterAbort;
-         ++i) {
-      allocationThreadsAfterAbort.emplace_back([&, i]() {
-        arbitrationStartBarrier.wait().wait();
-        if (i < numFailedQueryAllocationsAfterAbort) {
-          VELOX_ASSERT_THROW(
-              failedQueryOp->allocate(failedQueryMemoryCapacity), "");
-        } else {
-          nonFailedQueryOps[i - numFailedQueryAllocationsAfterAbort]->allocate(
-              nonFailQueryMemoryCapacity);
-        }
-      });
-    }
-
-    // Trigger memory arbitration to reclaim from failedQuery which throws.
-    nonFailedQueryOps[0]->allocate(nonFailQueryMemoryCapacity);
-    // Wait for all the allocation threads to complete.
-    for (auto& allocationThread : allocationThreadsAfterAbort) {
-      allocationThread.join();
-    }
-    ASSERT_TRUE(failedQueryOp->pool()->aborted());
-    ASSERT_EQ(
-        failedQueryOp->pool()->currentBytes(),
-        testData.expectedFailedQueryMemoryCapacity);
-    ASSERT_EQ(
-        failedQueryOp->pool()->capacity(),
-        testData.expectedFailedQueryMemoryUsage);
-    ASSERT_EQ(failedQueryOp->reclaimer()->stats().numAborts, 1);
-    ASSERT_EQ(failedQueryOp->reclaimer()->stats().numReclaims, 1);
-
-    const auto newStats = arbitrator_->stats();
-    ASSERT_EQ(
-        newStats.numRequests,
-        oldStats.numRequests + 1 + numFailedQueryAllocationsAfterAbort +
+        oldStats.numRequests + 1 + numFailedTaskAllocationsAfterAbort +
             numNonFailedAllocationsAfterAbort);
     ASSERT_EQ(newStats.numAborted, 1);
     ASSERT_EQ(newStats.freeCapacityBytes, testData.expectedFreeCapacity);
-    ASSERT_EQ(newStats.numFailures, numFailedQueryAllocationsAfterAbort);
+    ASSERT_EQ(newStats.numFailures, numFailedTaskAllocationsAfterAbort);
     ASSERT_EQ(newStats.maxCapacityBytes, kMemoryCapacity);
     // Check if memory pools have been aborted or not as expected.
-    for (int i = 0; i < nonFailedQueryOps.size(); ++i) {
-      auto* queryOp = nonFailedQueryOps[i];
-      ASSERT_FALSE(queryOp->pool()->aborted());
-      ASSERT_EQ(queryOp->reclaimer()->stats().numAborts, 0);
-      ASSERT_EQ(queryOp->reclaimer()->stats().numReclaims, 0);
+    for (int i = 0; i < nonFailedTaskOps.size(); ++i) {
+      auto* taskOp = nonFailedTaskOps[i];
+      ASSERT_FALSE(taskOp->pool()->aborted());
+      ASSERT_EQ(taskOp->reclaimer()->stats().numAborts, 0);
+      ASSERT_EQ(taskOp->reclaimer()->stats().numReclaims, 0);
       if (i == 0) {
         ASSERT_EQ(
-            queryOp->pool()->capacity(),
-            testData.expectedNonFailedQueryMemoryCapacity +
-                nonFailQueryMemoryCapacity);
+            taskOp->pool()->capacity(),
+            testData.expectedNonFailedTaskMemoryCapacity +
+                nonFailTaskMemoryCapacity);
         ASSERT_EQ(
-            queryOp->pool()->currentBytes(),
-            testData.expectedNonFailedQueryMemoryUsage +
-                nonFailQueryMemoryCapacity);
+            taskOp->pool()->currentBytes(),
+            testData.expectedNonFailedTaskMemoryUsage +
+                nonFailTaskMemoryCapacity);
       } else {
         ASSERT_EQ(
-            queryOp->pool()->capacity(),
-            testData.expectedNonFailedQueryMemoryCapacity);
+            taskOp->pool()->capacity(),
+            testData.expectedNonFailedTaskMemoryCapacity);
         ASSERT_EQ(
-            queryOp->pool()->currentBytes(),
-            testData.expectedNonFailedQueryMemoryUsage);
+            taskOp->pool()->currentBytes(),
+            testData.expectedNonFailedTaskMemoryUsage);
       }
     }
 
-    VELOX_ASSERT_THROW(failedQueryOp->allocate(failedQueryMemoryCapacity), "");
+    VELOX_ASSERT_THROW(failedTaskOp->allocate(failedTaskMemoryCapacity), "");
     ASSERT_EQ(arbitrator_->stats().numRequests, newStats.numRequests);
     ASSERT_EQ(arbitrator_->stats().numAborted, 1);
   }
 }
 
 TEST_F(MockSharedArbitrationTest, memoryPoolAbortThrow) {
-  const int numQueries = 4;
-  const int smallQueryMemoryCapacity = kMemoryCapacity / 8;
-  const int largeQueryMemoryCapacity = kMemoryCapacity / 2;
-  std::vector<std::shared_ptr<MockQuery>> smallQueries;
-  std::vector<MockMemoryOperator*> smallQueryOps;
-  for (int i = 0; i < numQueries; ++i) {
-    smallQueries.push_back(addQuery());
-    smallQueryOps.push_back(addMemoryOp(smallQueries.back(), false));
-    smallQueryOps.back()->allocate(smallQueryMemoryCapacity);
+  const int numTasks = 4;
+  const int smallTaskMemoryCapacity = kMemoryCapacity / 8;
+  const int largeTaskMemoryCapacity = kMemoryCapacity / 2;
+  std::vector<std::shared_ptr<MockTask>> smallTasks;
+  std::vector<MockMemoryOperator*> smallTaskOps;
+  for (int i = 0; i < numTasks; ++i) {
+    smallTasks.push_back(addTask());
+    smallTaskOps.push_back(addMemoryOp(smallTasks.back(), false));
+    smallTaskOps.back()->allocate(smallTaskMemoryCapacity);
   }
-  std::shared_ptr<MockQuery> largeQuery = addQuery();
-  MockMemoryOperator* largeQueryOp = addMemoryOp(
-      largeQuery, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
+  std::shared_ptr<MockTask> largeTask = addTask();
+  MockMemoryOperator* largeTaskOp = addMemoryOp(
+      largeTask, true, [&](MemoryPool* /*unsed*/, uint64_t /*unsed*/) {
         VELOX_FAIL("throw reclaim exception");
       });
-  largeQueryOp->allocate(largeQueryMemoryCapacity);
+  largeTaskOp->allocate(largeTaskMemoryCapacity);
   const auto oldStats = arbitrator_->stats();
   ASSERT_EQ(oldStats.numFailures, 0);
   ASSERT_EQ(oldStats.numAborted, 0);
 
   // Trigger memory arbitration to reclaim from itself which throws.
-  VELOX_ASSERT_THROW(largeQueryOp->allocate(largeQueryMemoryCapacity), "");
+  VELOX_ASSERT_THROW(largeTaskOp->allocate(largeTaskMemoryCapacity), "");
   const auto newStats = arbitrator_->stats();
   ASSERT_EQ(newStats.numRequests, oldStats.numRequests + 1);
   ASSERT_EQ(newStats.numAborted, 1);
-  ASSERT_EQ(newStats.freeCapacityBytes, largeQueryMemoryCapacity);
+  ASSERT_EQ(newStats.freeCapacityBytes, largeTaskMemoryCapacity);
   ASSERT_EQ(newStats.maxCapacityBytes, kMemoryCapacity);
   // Check if memory pools have been aborted or not as expected.
-  for (const auto* queryOp : smallQueryOps) {
-    ASSERT_FALSE(queryOp->pool()->aborted());
-    ASSERT_EQ(queryOp->reclaimer()->stats().numAborts, 0);
-    ASSERT_EQ(queryOp->reclaimer()->stats().numReclaims, 0);
+  for (const auto* taskOp : smallTaskOps) {
+    ASSERT_FALSE(taskOp->pool()->aborted());
+    ASSERT_EQ(taskOp->reclaimer()->stats().numAborts, 0);
+    ASSERT_EQ(taskOp->reclaimer()->stats().numReclaims, 0);
   }
-  ASSERT_TRUE(largeQueryOp->pool()->aborted());
-  ASSERT_EQ(largeQueryOp->reclaimer()->stats().numAborts, 1);
-  ASSERT_EQ(largeQueryOp->reclaimer()->stats().numReclaims, 1);
-  VELOX_ASSERT_THROW(largeQueryOp->allocate(largeQueryMemoryCapacity), "");
+  ASSERT_TRUE(largeTaskOp->pool()->aborted());
+  ASSERT_EQ(largeTaskOp->reclaimer()->stats().numAborts, 1);
+  ASSERT_EQ(largeTaskOp->reclaimer()->stats().numReclaims, 1);
+  VELOX_ASSERT_THROW(largeTaskOp->allocate(largeTaskMemoryCapacity), "");
   ASSERT_EQ(arbitrator_->stats().numRequests, newStats.numRequests);
   ASSERT_EQ(arbitrator_->stats().numAborted, 1);
 }
@@ -1591,14 +1648,14 @@ DEBUG_ONLY_TEST_F(
     freeUnusedCapacityWhenReclaimMemoryPool) {
   setupMemory(kMemoryCapacity, 0);
   const int allocationSize = kMemoryCapacity / 4;
-  std::shared_ptr<MockQuery> reclaimedQuery = addQuery();
-  MockMemoryOperator* reclaimedQueryOp = addMemoryOp(reclaimedQuery);
+  std::shared_ptr<MockTask> reclaimedTask = addTask();
+  MockMemoryOperator* reclaimedTaskOp = addMemoryOp(reclaimedTask);
   // The buffer to free later.
-  void* bufferToFree = reclaimedQueryOp->allocate(allocationSize);
-  reclaimedQueryOp->allocate(kMemoryCapacity - allocationSize);
+  void* bufferToFree = reclaimedTaskOp->allocate(allocationSize);
+  reclaimedTaskOp->allocate(kMemoryCapacity - allocationSize);
 
-  std::shared_ptr<MockQuery> arbitrationQuery = addQuery();
-  MockMemoryOperator* arbitrationQueryOp = addMemoryOp(arbitrationQuery);
+  std::shared_ptr<MockTask> arbitrationTask = addTask();
+  MockMemoryOperator* arbitrationTaskOp = addMemoryOp(arbitrationTask);
   folly::EventCount reclaimWait;
   auto reclaimWaitKey = reclaimWait.prepareWait();
   folly::EventCount reclaimBlock;
@@ -1614,11 +1671,11 @@ DEBUG_ONLY_TEST_F(
 
   std::thread allocThread([&]() {
     // Allocate to trigger arbitration.
-    arbitrationQueryOp->allocate(allocationSize);
+    arbitrationTaskOp->allocate(allocationSize);
   });
 
   reclaimWait.wait(reclaimWaitKey);
-  reclaimedQueryOp->free(bufferToFree);
+  reclaimedTaskOp->free(bufferToFree);
   reclaimBlock.notify();
   allocThread.join();
   const auto stats = arbitrator_->stats();
@@ -1628,16 +1685,16 @@ DEBUG_ONLY_TEST_F(
   // We count the freed capacity in reclaimed bytes.
   ASSERT_EQ(stats.numShrunkBytes, oldStats.numShrunkBytes + allocationSize);
   ASSERT_EQ(stats.numReclaimedBytes, 0);
-  ASSERT_EQ(reclaimedQueryOp->capacity(), kMemoryCapacity - allocationSize);
-  ASSERT_EQ(arbitrationQueryOp->capacity(), allocationSize);
+  ASSERT_EQ(reclaimedTaskOp->capacity(), kMemoryCapacity - allocationSize);
+  ASSERT_EQ(arbitrationTaskOp->capacity(), allocationSize);
 }
 
 DEBUG_ONLY_TEST_F(
     MockSharedArbitrationTest,
     raceBetweenInitialReservationAndArbitration) {
-  std::shared_ptr<MockQuery> arbitrationQuery = addQuery(kMemoryCapacity);
-  MockMemoryOperator* arbitrationQueryOp = addMemoryOp(arbitrationQuery);
-  ASSERT_EQ(arbitrationQuery->pool()->capacity(), kMemoryPoolInitCapacity);
+  std::shared_ptr<MockTask> arbitrationTask = addTask(kMemoryCapacity);
+  MockMemoryOperator* arbitrationTaskOp = addMemoryOp(arbitrationTask);
+  ASSERT_EQ(arbitrationTask->pool()->capacity(), kMemoryPoolInitCapacity);
 
   folly::EventCount arbitrationRun;
   auto arbitrationRunKey = arbitrationRun.prepareWait();
@@ -1654,16 +1711,16 @@ DEBUG_ONLY_TEST_F(
   std::thread allocThread([&]() {
     // Allocate more than its capacity to trigger arbitration which is blocked
     // by the arbitration testvalue injection above.
-    arbitrationQueryOp->allocate(2 * kMemoryPoolInitCapacity);
+    arbitrationTaskOp->allocate(2 * kMemoryPoolInitCapacity);
   });
 
   arbitrationRun.wait(arbitrationRunKey);
 
   // Allocate a new root memory pool and check its initial memory reservation is
   // zero.
-  std::shared_ptr<MockQuery> skipQuery = addQuery(kMemoryCapacity);
-  MockMemoryOperator* skipQueryOp = addMemoryOp(skipQuery);
-  ASSERT_EQ(skipQueryOp->pool()->capacity(), 0);
+  std::shared_ptr<MockTask> skipTask = addTask(kMemoryCapacity);
+  MockMemoryOperator* skipTaskOp = addMemoryOp(skipTask);
+  ASSERT_EQ(skipTaskOp->pool()->capacity(), 0);
 
   arbitrationBlock.notify();
   allocThread.join();
@@ -1699,12 +1756,12 @@ TEST_F(MockSharedArbitrationTest, arbitrationFailure) {
     SCOPED_TRACE(testData.debugString());
 
     setupMemory(maxCapacity, initialCapacity, minTransferCapacity);
-    std::shared_ptr<MockQuery> requestorQuery = addQuery();
-    MockMemoryOperator* requestorOp = addMemoryOp(requestorQuery, false);
+    std::shared_ptr<MockTask> requestorTask = addTask();
+    MockMemoryOperator* requestorOp = addMemoryOp(requestorTask, false);
     requestorOp->allocate(testData.requestorCapacity);
     ASSERT_EQ(requestorOp->capacity(), testData.requestorCapacity);
-    std::shared_ptr<MockQuery> otherQuery = addQuery();
-    MockMemoryOperator* otherOp = addMemoryOp(otherQuery, false);
+    std::shared_ptr<MockTask> otherTask = addTask();
+    MockMemoryOperator* otherOp = addMemoryOp(otherTask, false);
     otherOp->allocate(testData.otherCapacity);
     ASSERT_EQ(otherOp->capacity(), testData.otherCapacity);
 
@@ -1735,20 +1792,20 @@ TEST_F(MockSharedArbitrationTest, arbitrationFailure) {
 }
 
 TEST_F(MockSharedArbitrationTest, concurrentArbitrations) {
-  const int numQueries = 10;
-  const int numOpsPerQuery = 5;
-  std::vector<std::shared_ptr<MockQuery>> queries;
-  queries.reserve(numQueries);
+  const int numTasks = 10;
+  const int numOpsPerTask = 5;
+  std::vector<std::shared_ptr<MockTask>> tasks;
+  tasks.reserve(numTasks);
   std::vector<MockMemoryOperator*> memOps;
-  memOps.reserve(numQueries * numOpsPerQuery);
+  memOps.reserve(numTasks * numOpsPerTask);
   const std::string injectReclaimErrorMessage("Inject reclaim failure");
   const std::string injectArbitrationErrorMessage(
       "Inject enter arbitration failure");
-  for (int i = 0; i < numQueries; ++i) {
-    queries.push_back(addQuery());
-    for (int j = 0; j < numOpsPerQuery; ++j) {
+  for (int i = 0; i < numTasks; ++i) {
+    tasks.push_back(addTask());
+    for (int j = 0; j < numOpsPerTask; ++j) {
       memOps.push_back(addMemoryOp(
-          queries.back(),
+          tasks.back(),
           (j % 3) != 0,
           [&](MemoryPool* /*unused*/, uint64_t /*unused*/) {
             if (folly::Random::oneIn(10)) {
@@ -1766,7 +1823,7 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrations) {
   std::atomic<bool> stopped{false};
 
   std::vector<std::thread> memThreads;
-  for (int i = 0; i < numQueries * numOpsPerQuery; ++i) {
+  for (int i = 0; i < numTasks * numOpsPerTask; ++i) {
     memThreads.emplace_back([&, i, memOp = memOps[i]]() {
       folly::Random::DefaultGenerator rng;
       rng.seed(i);
@@ -1804,14 +1861,14 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrations) {
   for (auto& memThread : memThreads) {
     memThread.join();
   }
-  queries.clear();
+  tasks.clear();
 }
 
 TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
   std::mutex mutex;
-  std::vector<std::shared_ptr<MockQuery>> queries;
-  queries.push_back(addQuery());
-  queries.back()->addMemoryOp();
+  std::vector<std::shared_ptr<MockTask>> tasks;
+  tasks.push_back(addTask());
+  tasks.back()->addMemoryOp();
 
   std::atomic<bool> stopped{false};
 
@@ -1825,23 +1882,23 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
       folly::Random::DefaultGenerator rng;
       rng.seed(i);
       while (!stopped) {
-        std::shared_ptr<MockQuery> query;
+        std::shared_ptr<MockTask> task;
         {
           std::lock_guard<std::mutex> l(mutex);
-          const int index = folly::Random::rand32() % queries.size();
-          query = queries[index];
+          const int index = folly::Random::rand32() % tasks.size();
+          task = tasks[index];
         }
         if (folly::Random::oneIn(4, rng)) {
           if (folly::Random::oneIn(3, rng)) {
-            query->memoryOp()->freeAll();
+            task->memoryOp()->freeAll();
           } else {
-            query->memoryOp()->free();
+            task->memoryOp()->free();
           }
         } else {
           const int allocationPages = AllocationTraits::numPages(
               folly::Random::rand32(rng) % (kMemoryCapacity / 8));
           try {
-            query->memoryOp()->allocate(
+            task->memoryOp()->allocate(
                 AllocationTraits::pageBytes(allocationPages));
           } catch (VeloxException& e) {
             // Ignore memory limit exception and injected error exceptions.
@@ -1860,17 +1917,17 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
     });
   }
 
-  const int maxNumQueries = 64;
+  const int maxNumTasks = 64;
   std::thread controlThread([&]() {
     folly::Random::DefaultGenerator rng;
     rng.seed(1000);
     while (!stopped) {
       {
         std::lock_guard<std::mutex> l(mutex);
-        if ((queries.size() == 1) ||
-            (queries.size() < maxNumQueries && folly::Random::oneIn(4, rng))) {
-          queries.push_back(addQuery());
-          queries.back()->addMemoryOp(
+        if ((tasks.size() == 1) ||
+            (tasks.size() < maxNumTasks && folly::Random::oneIn(4, rng))) {
+          tasks.push_back(addTask());
+          tasks.back()->addMemoryOp(
               !folly::Random::oneIn(3, rng),
               [&](MemoryPool* /*unused*/, uint64_t /*unused*/) {
                 if (folly::Random::oneIn(10)) {
@@ -1883,8 +1940,8 @@ TEST_F(MockSharedArbitrationTest, concurrentArbitrationWithTransientRoots) {
                 }
               });
         } else {
-          const int deleteIndex = folly::Random::rand32(rng) % queries.size();
-          queries.erase(queries.begin() + deleteIndex);
+          const int deleteIndex = folly::Random::rand32(rng) % tasks.size();
+          tasks.erase(tasks.begin() + deleteIndex);
         }
       }
       std::this_thread::sleep_for(std::chrono::microseconds(5));

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -218,11 +218,15 @@ class MockMemoryPool : public velox::memory::MemoryPool {
         velox::memory::MemoryAllocator::kindString(allocator_->kind()));
   }
 
-  void abort() override {
+  void abort(const std::exception_ptr& error) override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 
   bool aborted() const override {
+    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+  }
+
+  std::string treeMemoryUsage() const override {
     VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
   }
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -488,7 +488,9 @@ uint64_t Operator::MemoryReclaimer::reclaim(
   return pool->shrink(targetBytes);
 }
 
-void Operator::MemoryReclaimer::abort(memory::MemoryPool* pool) {
+void Operator::MemoryReclaimer::abort(
+    memory::MemoryPool* pool,
+    const std::exception_ptr& /* error */) {
   std::shared_ptr<Driver> driver = ensureDriver();
   if (FOLLY_UNLIKELY(driver == nullptr)) {
     return;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -517,7 +517,8 @@ class Operator : public BaseRuntimeStatWriter {
 
     uint64_t reclaim(memory::MemoryPool* pool, uint64_t targetBytes) override;
 
-    void abort(memory::MemoryPool* pool) override;
+    void abort(memory::MemoryPool* pool, const std::exception_ptr& /* error */)
+        override;
 
    private:
     MemoryReclaimer(const std::shared_ptr<Driver>& driver, Operator* op)

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1894,7 +1894,8 @@ ContinueFuture Task::taskCompletionFuture(uint64_t maxWaitMicros) {
   // If 'this' is running, the future is realized on timeout or when
   // this no longer is running.
   if (not isRunningLocked()) {
-    return ContinueFuture();
+    return makeFinishFutureLocked(
+        fmt::format("Task::taskCompletionFuture {}", taskId_).data());
   }
   auto [promise, future] = makeVeloxContinuePromiseContract(
       fmt::format("Task::taskCompletionFuture {}", taskId_));
@@ -2439,14 +2440,18 @@ uint64_t Task::MemoryReclaimer::reclaim(
   return memory::MemoryReclaimer::reclaim(pool, targetBytes);
 }
 
-void Task::MemoryReclaimer::abort(memory::MemoryPool* pool) {
+void Task::MemoryReclaimer::abort(
+    memory::MemoryPool* pool,
+    const std::exception_ptr& error) {
   auto task = ensureTask();
   if (FOLLY_UNLIKELY(task == nullptr)) {
     return;
   }
   VELOX_CHECK_EQ(task->pool()->name(), pool->name());
-  task->requestAbort().wait();
-  memory::MemoryReclaimer::abort(pool);
+  task->setError(error);
+  // Set timeout to zero to infinite wait until task completes.
+  task->taskCompletionFuture(0).wait();
+  memory::MemoryReclaimer::abort(pool, error);
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -651,7 +651,8 @@ class Task : public std::enable_shared_from_this<Task> {
 
     uint64_t reclaim(memory::MemoryPool* pool, uint64_t targetBytes) override;
 
-    void abort(memory::MemoryPool* pool) override;
+    void abort(memory::MemoryPool* pool, const std::exception_ptr& error)
+        override;
 
    private:
     explicit MemoryReclaimer(const std::shared_ptr<Task>& task) : task_(task) {


### PR DESCRIPTION
Reclaim failure is propagated to task currently through task's ABORT API which is incorrect because ABORT in task has special meaning that a task is aborted only when external party(user) tells the task to abort. Change the reclaimer to call FAIL API from task and also propagate the corresponding exception to task for better error categorization. Detailed logging is also added upon pool abortion.
This PR also refactored the MockSharedArbitrationTest to be aligned with core codebase. 