### PR TITLE
Deprecate -velox-private for benchmark

### DIFF
--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -26,7 +26,7 @@
 #include "velox/external/duckdb/parquet-amalgamation.hpp"
 #include "velox/vector/TypeAliases.h"
 
-#include <arrow/util/rle_encoding.h> // @manual
+#include <arrow/util/rle_encoding.h>
 #include <folly/Benchmark.h>
 #include <folly/Random.h>
 #include <folly/init/Init.h>


### PR DESCRIPTION
Summary: Parquet in apache-arrow (megarepo) enabled now

Reviewed By: Yuhta

Differential Revision: D47920251

