### PR TITLE
Deprecate -velox-private for velox parquet reader/writer

### DIFF
--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -26,7 +26,7 @@
 #include "velox/external/duckdb/parquet-amalgamation.hpp"
 #include "velox/vector/TypeAliases.h"
 
-#include <arrow/util/rle_encoding.h> // @manual
+#include <arrow/util/rle_encoding.h>
 #include <folly/Benchmark.h>
 #include <folly/Random.h>
 #include <folly/init/Init.h>

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -16,9 +16,9 @@
 
 #include "velox/vector/arrow/Bridge.h"
 
-#include <arrow/c/bridge.h> // @manual
-#include <arrow/table.h> // @manual
-#include <parquet/arrow/writer.h> // @manual
+#include <arrow/c/bridge.h>
+#include <arrow/table.h>
+#include <parquet/arrow/writer.h>
 #include "velox/dwio/parquet/writer/Writer.h"
 
 namespace facebook::velox::parquet {


### PR DESCRIPTION
Summary: Parquet supported now for apache-arrow (megarepo)

Reviewed By: Yuhta

Differential Revision: D47920640

