### PR TITLE
Add support for IN predicate with REAL types

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -322,6 +322,13 @@ class InPredicate : public exec::VectorFunction {
                                   .argumentType("array(unknown)")
                                   .build());
     }
+    // logical type: Date
+    signatures.emplace_back(exec::FunctionSignatureBuilder()
+                                .returnType("boolean")
+                                .argumentType("date")
+                                .argumentType("array(integer)")
+                                .build());
+
     return signatures;
   }
 

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -691,4 +691,25 @@ TEST_F(InPredicateTest, floatDuplicateWithFloatingPointRange) {
   auto expected = makeNullableFlatVector<bool>({true, false});
   auto result = evaluate<SimpleVector<bool>>(predicate, input);
   assertEqualVectors(expected, result);
+
+  // with null
+  input = makeRowVector({
+      makeNullableFlatVector<float>({1.2, 2.3}, REAL()),
+  });
+  predicate = "c0 IN ( CAST(1.2 AS REAL), CAST(1.2 AS REAL), null )";
+  expected = makeNullableFlatVector<bool>({true, std::nullopt});
+  result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
+}
+
+TEST_F(InPredicateTest, floatDuplicateWithBigintValuesUsingHashTable) {
+  // No Null
+  auto input = makeRowVector({
+      makeNullableFlatVector<float>({1.2, 2.3}, REAL()),
+  });
+  std::string predicate =
+      "c0 IN ( CAST(1.2 AS REAL), CAST(1.2 AS REAL), CAST(1.2 AS REAL), CAST(2.3 AS REAL) )";
+  auto expected = makeNullableFlatVector<bool>({true, true});
+  auto result = evaluate<SimpleVector<bool>>(predicate, input);
+  assertEqualVectors(expected, result);
 }


### PR DESCRIPTION
previously, REAL is handled thru DOUBLE code path. This PR explicitly support REAL type

float is `reinterpret_cast ` to `Int32` and then promote to `Int64`


