### PR TITLE
Fix handling of top level nulls in the input to Reduce function

### DIFF
--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -81,14 +81,14 @@ class ReduceFunction : public exec::VectorFunction {
     const auto& initialState = args[1];
     auto partialResult =
         BaseVector::create(initialState->type(), rows.end(), context.pool());
-    std::vector<bool> isNullArrays(rows.end(), false);
+    std::vector<bool> isNulls(rows.end(), false);
     // Process null and empty arrays.
     auto* rawNulls = flatArray->rawNulls();
     auto* rawSizes = flatArray->rawSizes();
     rows.applyToSelected([&](auto row) {
       if (rawNulls && bits::isBitNull(rawNulls, row)) {
         partialResult->setNull(row, true);
-        isNullArrays[row] = true;
+        isNulls[row] = true;
       } else if (rawSizes[row] == 0) {
         partialResult->copy(initialState.get(), row, row, 1);
       }
@@ -171,7 +171,7 @@ class ReduceFunction : public exec::VectorFunction {
     }
     context.moveOrCopyResult(localResult, rows, result);
     for (int i = 0; i < rows.end(); i++) {
-      if (isNullArrays[i]) {
+      if (isNulls[i]) {
         result->setNull(i, true);
       }
     }

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -81,13 +81,14 @@ class ReduceFunction : public exec::VectorFunction {
     const auto& initialState = args[1];
     auto partialResult =
         BaseVector::create(initialState->type(), rows.end(), context.pool());
-
+    std::vector<bool> isNullArrays(rows.end(), false);
     // Process null and empty arrays.
     auto* rawNulls = flatArray->rawNulls();
     auto* rawSizes = flatArray->rawSizes();
     rows.applyToSelected([&](auto row) {
       if (rawNulls && bits::isBitNull(rawNulls, row)) {
         partialResult->setNull(row, true);
+        isNullArrays[row] = true;
       } else if (rawSizes[row] == 0) {
         partialResult->copy(initialState.get(), row, row, 1);
       }
@@ -169,6 +170,11 @@ class ReduceFunction : public exec::VectorFunction {
           &localResult);
     }
     context.moveOrCopyResult(localResult, rows, result);
+    for (int i = 0; i < rows.end(); i++) {
+      if (isNullArrays[i]) {
+        result->setNull(i, true);
+      }
+    }
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -15,6 +15,7 @@
  */
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/lib/LambdaFunctionUtil.h"
+
 namespace facebook::velox::functions {
 namespace {
 
@@ -171,12 +172,10 @@ class ReduceFunction : public exec::VectorFunction {
           nullptr,
           &localResult);
     }
-    context.moveOrCopyResult(localResult, *nonNullRows, result);
-    for (int i = 0; i < flatArray->size(); i++) {
-      if (flatArray->isNullAt(i)) {
-        result->setNull(i, true);
-      }
+    if (flatArray->rawNulls()) {
+      localResult->addNulls(flatArray->rawNulls(), rows);
     }
+    context.moveOrCopyResult(localResult, rows, result);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -125,21 +125,23 @@ TEST_F(ReduceTest, finalSelection) {
       "reduce(c0, 10, (s, x) -> s + x, s -> row_constructor(s)))",
       input);
 
-  auto expectedResult = makeFlatVector<int64_t>(
-      size,
-      [](auto row) -> int64_t {
-        if (row < 100) {
-          return row;
-        } else {
-          int64_t sum = 10;
-          for (auto i = 0; i < row % 5; i++) {
-            sum += row + i;
-          }
-          return sum;
-        }
-      },
+  auto expectedResult = makeRowVector(
+      {makeFlatVector<int64_t>(
+          size,
+          [](auto row) -> int64_t {
+            if (row < 100) {
+              return row;
+            } else {
+              int64_t sum = 10;
+              for (auto i = 0; i < row % 5; i++) {
+                sum += row + i;
+              }
+              return sum;
+            }
+          },
+          nullEvery(11))},
       nullEvery(11));
-  assertEqualVectors(expectedResult, result->childAt(0));
+  assertEqualVectors(expectedResult, result);
 }
 
 TEST_F(ReduceTest, elementIndicesOverwrite) {

--- a/velox/functions/prestosql/tests/ReduceTest.cpp
+++ b/velox/functions/prestosql/tests/ReduceTest.cpp
@@ -207,6 +207,8 @@ TEST_F(ReduceTest, finalSelectionLargerThanInput) {
 }
 
 TEST_F(ReduceTest, nullArray) {
+  // Verify that NULL array is not passed on to lambda as it should be handled
+  // differently from array with null element
   auto arrayVector = makeNullableArrayVector<int64_t>(
       {std::nullopt, {{1, std::nullopt}}, {{std::nullopt, 2}}, {{1, 2, 3}}});
   auto data = makeRowVector({arrayVector});


### PR DESCRIPTION
Fixes #5768 
Fix handling of top level nulls in the input to Reduce function. Currently, the nulls are being passed as rows to be operated on to the lambda functions in Reduce. This patch fixes this by ensuring only the non null Rows are passed to the lambda and nulls are added to the output.

Test Plan:
Adds a unit test for Reduce function.