### PR TITLE
Avoid duplicate reading for small parquet files

### DIFF
--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -122,6 +122,14 @@ class BufferedInput {
     return std::make_unique<BufferedInput>(input_, pool_);
   }
 
+  std::unique_ptr<SeekableInputStream> readFile(
+      uint64_t length,
+      LogType logType) {
+    enqueue({0, length});
+    load(logType);
+    return readBuffer(0, length);
+  }
+
   const std::shared_ptr<ReadFile>& getReadFile() const {
     return input_->getReadFile();
   }

--- a/velox/dwio/common/BufferedInput.h
+++ b/velox/dwio/common/BufferedInput.h
@@ -122,12 +122,10 @@ class BufferedInput {
     return std::make_unique<BufferedInput>(input_, pool_);
   }
 
-  std::unique_ptr<SeekableInputStream> readFile(
-      uint64_t length,
-      LogType logType) {
-    enqueue({0, length});
-    load(logType);
-    return readBuffer(0, length);
+  std::unique_ptr<SeekableInputStream> loadCompleteFile() {
+    auto stream = enqueue({0, input_->getLength()});
+    load(dwio::common::LogType::FILE);
+    return stream;
   }
 
   const std::shared_ptr<ReadFile>& getReadFile() const {

--- a/velox/dwio/parquet/reader/ParquetData.cpp
+++ b/velox/dwio/parquet/reader/ParquetData.cpp
@@ -123,4 +123,22 @@ dwio::common::PositionProvider ParquetData::seekToRowGroup(uint32_t index) {
   return dwio::common::PositionProvider(empty);
 }
 
+std::pair<int64_t, int64_t> ParquetData::getRowGroupRegion(
+    uint32_t index) const {
+  auto& rowGroup = rowGroups_[index];
+
+  VELOX_CHECK_GT(rowGroup.columns.size(), 0);
+  auto fileOffset = rowGroup.__isset.file_offset ? rowGroup.file_offset
+      : rowGroup.columns[0].meta_data.__isset.dictionary_page_offset
+      ? rowGroup.columns[0].meta_data.dictionary_page_offset
+      : rowGroup.columns[0].meta_data.data_page_offset;
+  VELOX_CHECK_GT(fileOffset, 0);
+
+  auto length = rowGroup.__isset.total_compressed_size
+      ? rowGroup.total_compressed_size
+      : rowGroup.total_byte_size;
+
+  return {fileOffset, length};
+}
+
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -55,7 +55,7 @@ class ParquetData : public dwio::common::FormatData {
   /// Prepares to read data for 'index'th row group.
   void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
 
-  /// Positions 'this' at 'index'th row group. enqueueRowGroup must be called
+  /// Positions 'this' at 'index'th row group. loadRowGroup must be called
   /// first. The returned PositionProvider is empty and should not be used.
   /// Other formats may use it.
   dwio::common::PositionProvider seekToRowGroup(uint32_t index) override;
@@ -173,22 +173,7 @@ class ParquetData : public dwio::common::FormatData {
   }
 
   // Returns the <offset, length> of the row group.
-  std::pair<int64_t, int64_t> getRowGroupRegion(uint32_t index) const {
-    auto& rowGroup = rowGroups_[index];
-
-    VELOX_CHECK_GT(rowGroup.columns.size(), 0);
-    auto fileOffset = rowGroup.__isset.file_offset ? rowGroup.file_offset
-        : rowGroup.columns[0].meta_data.__isset.dictionary_page_offset
-        ? rowGroup.columns[0].meta_data.dictionary_page_offset
-        : rowGroup.columns[0].meta_data.data_page_offset;
-    VELOX_CHECK_GT(fileOffset, 0);
-
-    auto length = rowGroup.__isset.total_compressed_size
-        ? rowGroup.total_compressed_size
-        : rowGroup.total_byte_size;
-
-    return {fileOffset, length};
-  }
+  std::pair<int64_t, int64_t> getRowGroupRegion(uint32_t index) const;
 
  private:
   /// True if 'filter' may have hits for the column of 'this' according to the

--- a/velox/dwio/parquet/reader/ParquetData.h
+++ b/velox/dwio/parquet/reader/ParquetData.h
@@ -186,7 +186,6 @@ class ParquetData : public dwio::common::FormatData {
     auto length = rowGroup.__isset.total_compressed_size
         ? rowGroup.total_compressed_size
         : rowGroup.total_byte_size;
-    VELOX_CHECK_GT(length, 0);
 
     return {fileOffset, length};
   }

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -574,21 +574,13 @@ void ReaderBase::scheduleRowGroups(
       currentGroup + 1 < rowGroupIds.size() ? rowGroupIds[currentGroup + 1] : 0;
   auto input = inputs_[thisGroup].get();
   if (!input) {
-    auto newInput = reader.enqueueRowGroup(thisGroup, input_);
-    if (newInput != input_) {
-      newInput->load(dwio::common::LogType::STRIPE);
-    }
-    inputs_[thisGroup] = std::move(newInput);
+    inputs_[thisGroup] = reader.enqueueRowGroup(thisGroup, input_);
   }
   for (auto counter = 0; counter < FLAGS_parquet_prefetch_rowgroups;
        ++counter) {
     if (nextGroup) {
       if (inputs_.count(nextGroup) != 0) {
-        auto newInput = reader.enqueueRowGroup(thisGroup, input_);
-        if (newInput != input_) {
-          newInput->load(dwio::common::LogType::STRIPE);
-        }
-        inputs_[nextGroup] = std::move(newInput);
+        inputs_[nextGroup] = reader.enqueueRowGroup(thisGroup, input_);
       }
     } else {
       break;

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -574,13 +574,13 @@ void ReaderBase::scheduleRowGroups(
       currentGroup + 1 < rowGroupIds.size() ? rowGroupIds[currentGroup + 1] : 0;
   auto input = inputs_[thisGroup].get();
   if (!input) {
-    inputs_[thisGroup] = reader.enqueueRowGroup(thisGroup, input_);
+    inputs_[thisGroup] = reader.loadRowGroup(thisGroup, input_);
   }
   for (auto counter = 0; counter < FLAGS_parquet_prefetch_rowgroups;
        ++counter) {
     if (nextGroup) {
       if (inputs_.count(nextGroup) != 0) {
-        inputs_[nextGroup] = reader.enqueueRowGroup(thisGroup, input_);
+        inputs_[nextGroup] = reader.loadRowGroup(thisGroup, input_);
       }
     } else {
       break;

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -87,8 +87,7 @@ void enqueueChildren(
     dwio::common::BufferedInput& input) {
   auto children = reader->children();
   if (children.empty()) {
-    reader->formatData().as<ParquetData>().enqueueRowGroup(index, input);
-    return;
+    return reader->formatData().as<ParquetData>().enqueueRowGroup(index, input);
   }
   for (auto* child : children) {
     enqueueChildren(child, index, input);

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -101,6 +101,10 @@ StructColumnReader::enqueueRowGroup(
   // Or else create a new input.
   auto newInput = isRowGroupBuffered(index, *input) ? input : input->clone();
   enqueueRowGroup0(index, *newInput);
+  // If a new input was created, then load it.
+  if (newInput != input) {
+    newInput->load(dwio::common::LogType::STRIPE);
+  }
   return newInput;
 }
 

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -33,8 +33,12 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
   void seekToRowGroup(uint32_t index) override;
 
-  /// Creates the streams for 'rowGroup in 'input'. Does not load yet.
-  void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
+  /// Creates the streams for 'rowGroup'. Checks whether row 'rowGroup'
+  /// has been buffered in 'input'. If true, return the input. Or else creates
+  /// the streams in a new input. Does not load yet.
+  std::shared_ptr<dwio::common::BufferedInput> enqueueRowGroup(
+      uint32_t index,
+      const std::shared_ptr<dwio::common::BufferedInput>& input);
 
   // No-op in Parquet. All readers switch row groups at the same time, there is
   // no on-demand skipping to a new row group.
@@ -64,6 +68,10 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
  private:
   dwio::common::SelectiveColumnReader* findBestLeaf();
+
+  void enqueueRowGroup0(uint32_t index, dwio::common::BufferedInput& input);
+
+  bool isRowGroupBuffered(uint32_t index, dwio::common::BufferedInput& input);
 
   // Leaf column reader used for getting nullability information for
   // 'this'. This is nullptr for the root of a table.

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -36,7 +36,7 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
   /// Creates the streams for 'rowGroup'. Checks whether row 'rowGroup'
   /// has been buffered in 'input'. If true, return the input. Or else creates
   /// the streams in a new input and loads.
-  std::shared_ptr<dwio::common::BufferedInput> enqueueRowGroup(
+  std::shared_ptr<dwio::common::BufferedInput> loadRowGroup(
       uint32_t index,
       const std::shared_ptr<dwio::common::BufferedInput>& input);
 
@@ -69,7 +69,7 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
  private:
   dwio::common::SelectiveColumnReader* findBestLeaf();
 
-  void enqueueRowGroup0(uint32_t index, dwio::common::BufferedInput& input);
+  void enqueueRowGroup(uint32_t index, dwio::common::BufferedInput& input);
 
   bool isRowGroupBuffered(uint32_t index, dwio::common::BufferedInput& input);
 

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -35,7 +35,7 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
 
   /// Creates the streams for 'rowGroup'. Checks whether row 'rowGroup'
   /// has been buffered in 'input'. If true, return the input. Or else creates
-  /// the streams in a new input. Does not load yet.
+  /// the streams in a new input and loads.
   std::shared_ptr<dwio::common::BufferedInput> enqueueRowGroup(
       uint32_t index,
       const std::shared_ptr<dwio::common::BufferedInput>& input);


### PR DESCRIPTION
For small parquet files, when loading footer, the whole file is already read to memory, no need to read file again when loading data.
Before this change:
![image](https://github.com/facebookincubator/velox/assets/52736607/964a1b01-5654-408f-af9c-c67f8d2b99f3)

After this change:
![image](https://github.com/facebookincubator/velox/assets/52736607/1bd1cb20-95af-42c6-afe6-af9cb3b525fd)
