### PR TITLE
Add support for token based access to filesystem

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -61,6 +61,16 @@ std::shared_ptr<FileSystem> getFileSystem(
   VELOX_FAIL("No registered file system matched with file path '{}'", filePath);
 }
 
+std::vector<std::shared_ptr<filesystems::FileSystem>>
+getRegisteredFileSystems() {
+  std::vector<std::shared_ptr<filesystems::FileSystem>> fileSystems;
+  const auto& filesystems = registeredFileSystems();
+  for (const auto& p : filesystems) {
+    fileSystems.push_back(p.second(nullptr, ""));
+  }
+  return fileSystems;
+}
+
 namespace {
 
 folly::once_flag localFSInstantiationFlag;
@@ -172,6 +182,10 @@ class LocalFileSystem : public FileSystem {
         ec,
         ec.message());
     VLOG(1) << "LocalFileSystem::rmdir " << path;
+  }
+
+  virtual void refreshAccessToken() override {
+    // No-op.
   }
 
   static std::function<bool(std::string_view)> schemeMatcher() {

--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -82,6 +82,10 @@ class FileSystem {
   /// recursively). Throws velox exception on failure.
   virtual void rmdir(std::string_view path) = 0;
 
+  /// Refresh access token used to access the file system.
+  /// This is a no-op if no access token is needed.
+  virtual void refreshAccessToken() = 0;
+
  protected:
   std::shared_ptr<const Config> config_;
 };
@@ -89,6 +93,10 @@ class FileSystem {
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filename,
     std::shared_ptr<const Config> config);
+
+/// Get all the registered file systems
+std::vector<std::shared_ptr<filesystems::FileSystem>>
+getRegisteredFileSystems();
 
 /// FileSystems must be registered explicitly.
 /// The registration function takes two parameters:

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -28,3 +28,8 @@ target_link_libraries(
   gtest
   gtest_main
   gmock)
+
+add_executable(velox_file_system_test FileSystemTest.cpp)
+add_test(velox_file_system_test velox_file_system_test)
+
+target_link_libraries(velox_file_system_test velox_file gmock gtest gtest_main)

--- a/velox/common/file/tests/FileSystemTest.cpp
+++ b/velox/common/file/tests/FileSystemTest.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "velox/common/file/File.h"
+#include "velox/common/file/FileSystems.h"
+
+using namespace facebook::velox;
+
+TEST(FileSystemTest, registeredFileSystem) {
+  EXPECT_EQ(0, filesystems::getRegisteredFileSystems().size());
+
+  filesystems::registerLocalFileSystem();
+  EXPECT_EQ(1, filesystems::getRegisteredFileSystems().size());
+
+  filesystems::registerLocalFileSystem();
+  EXPECT_EQ(2, filesystems::getRegisteredFileSystems().size());
+}

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.cpp
@@ -329,5 +329,9 @@ void GCSFileSystem::rmdir(std::string_view path) {
   VELOX_UNSUPPORTED("rmdir for GCS not implemented");
 }
 
+void GCSFileSystem::refreshAccessToken() {
+  VELOX_UNSUPPORTED("refreshAccessToken for GCS not implemented");
+}
+
 }; // namespace filesystems
 }; // namespace facebook::velox

--- a/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h
@@ -66,6 +66,9 @@ class GCSFileSystem : public FileSystem {
   // Unsupported
   void rmdir(std::string_view path) override;
 
+  // Unsupported
+  void refreshAccessToken() override;
+
  protected:
   class Impl;
   std::shared_ptr<Impl> impl_;

--- a/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
+++ b/velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h
@@ -84,6 +84,10 @@ class HdfsFileSystem : public FileSystem {
     VELOX_UNSUPPORTED("rmdir for HDFS not implemented");
   }
 
+  void refreshAccessToken() override {
+    VELOX_UNSUPPORTED("refreshAccessToken for S3 not implemented");
+  }
+
   static bool isHdfsFile(std::string_view filename);
 
   /// The given filePath is used to infer hdfs endpoint. If hdfs identity is

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h
@@ -68,6 +68,10 @@ class S3FileSystem : public FileSystem {
     VELOX_UNSUPPORTED("rmdir for S3 not implemented");
   }
 
+  void refreshAccessToken() override {
+    VELOX_UNSUPPORTED("refreshAccessToken for S3 not implemented");
+  }
+
   std::string getLogLevelName() const;
 
  protected:


### PR DESCRIPTION
Some filesystem have token based authorization model. Add refreshAccessToken method to allow filesystem to implement their token fetch mechanism.