### PR TITLE
Remove gtest/gtest_prod.h header from GTestMacros.h

### DIFF
--- a/velox/common/base/GTestMacros.h
+++ b/velox/common/base/GTestMacros.h
@@ -21,6 +21,7 @@
 // Replacing it with "nothing" is okay when testing is disabled.
 #define VELOX_FRIEND_TEST(X, Y)
 #else
-#include <gtest/gtest_prod.h>
-#define VELOX_FRIEND_TEST(X, Y) FRIEND_TEST(X, Y)
+// Same as FRIEND_TEST(X, Y) defined in gtest/gtest_prod.h
+#define VELOX_FRIEND_TEST(test_case_name, test_name) \
+  friend class test_case_name##_##test_name##_Test
 #endif


### PR DESCRIPTION
GTestMacros.h is introducing a dependency on gtest library.
Duplicate a macro from gtest_prod.h and avoid this dependency.

Example:
```
In file included from /Users/wypb/data/code/apache/temp/velox/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp:23:
In file included from /Users/wypb/data/code/apache/temp/velox/./velox/dwio/common/DataSink.h:23:
In file included from /Users/wypb/data/code/apache/temp/velox/./velox/dwio/common/DataBuffer.h:22:
In file included from /Users/wypb/data/code/apache/temp/velox/./velox/buffer/Buffer.h:27:
In file included from /Users/wypb/data/code/apache/temp/velox/./velox/common/memory/Memory.h:39:
In file included from /Users/wypb/data/code/apache/temp/velox/./velox/common/memory/Allocation.h:24:
/Users/wypb/data/code/apache/temp/velox/./velox/common/base/GTestMacros.h:24:10: fatal error: 'gtest/gtest_prod.h' file not found
#include <gtest/gtest_prod.h>
         ^~~~~~~~~~~~~~~~~~~~
```