### PR TITLE
Fix MemoryPool::allocateContiguous naming

### DIFF
--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -537,17 +537,17 @@ const std::vector<MachinePageCount>& MemoryPoolImpl::sizeClasses() const {
 }
 
 void MemoryPoolImpl::allocateContiguous(
-    MachinePageCount maxPages,
+    MachinePageCount numPages,
     ContiguousAllocation& out,
-    MachinePageCount numPages) {
+    MachinePageCount maxPages) {
   CHECK_AND_INC_MEM_OP_STATS(Allocs);
   if (!out.empty()) {
     INC_MEM_OP_STATS(Frees);
   }
-  VELOX_CHECK_GT(maxPages, 0);
+  VELOX_CHECK_GT(numPages, 0);
   DEBUG_RECORD_FREE(out);
   if (!allocator_->allocateContiguous(
-          maxPages,
+          numPages,
           nullptr,
           out,
           [this](int64_t allocBytes, bool preAlloc) {
@@ -557,7 +557,7 @@ void MemoryPoolImpl::allocateContiguous(
               release(allocBytes);
             }
           },
-          numPages)) {
+          maxPages)) {
     VELOX_CHECK(out.empty());
     VELOX_MEM_ALLOC_ERROR(fmt::format(
         "{} failed with {} pages from {}", __FUNCTION__, numPages, toString()));

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -277,8 +277,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// Makes a large contiguous mmap of 'numPages'. The new mapped
   /// pages are returned in 'out' on success. Any formly mapped pages
   /// referenced by 'out' is unmapped in all the cases even if the
-  /// allocation fails. If 'numPages' is not given, this defaults to
-  /// 'maxPages'. 'maxPages' gives the size of the mmap in
+  /// allocation fails. If 'maxPages' is not given, this defaults to
+  /// 'numPages'. 'maxPages' gives the size of the mmap in
   /// addresses. 'numPages' gives the amount to declare as
   /// used. growContiguous() is used to increase the
   /// reservation up to 'maxPages'. This allows reserving a large
@@ -287,9 +287,9 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   /// the number of huge pages  can be set according to an assumption of large
   /// utilization.
   virtual void allocateContiguous(
-      MachinePageCount maxPages,
+      MachinePageCount numPages,
       ContiguousAllocation& out,
-      MachinePageCount numPages = 0) = 0;
+      MachinePageCount maxPages = 0) = 0;
 
   /// Frees contiguous 'allocation'. 'allocation' is empty on return.
   virtual void freeContiguous(ContiguousAllocation& allocation) = 0;
@@ -568,9 +568,9 @@ class MemoryPoolImpl : public MemoryPool {
   const std::vector<MachinePageCount>& sizeClasses() const override;
 
   void allocateContiguous(
-      MachinePageCount maxPages,
+      MachinePageCount numPages,
       ContiguousAllocation& out,
-      MachinePageCount numPages = 0) override;
+      MachinePageCount maxPages = 0) override;
 
   void freeContiguous(ContiguousAllocation& allocation) override;
 


### PR DESCRIPTION
The parameter names of the mentioned method is mal-ordered. This PR corrects them