### PR TITLE
Enhance ExchangeClient to maintain a cap on ExchangeQueue size

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -32,9 +32,9 @@ class ExchangeClient {
       memory::MemoryPool* pool,
       int64_t maxQueuedBytes)
       : destination_(destination),
+        maxQueuedBytes_{maxQueuedBytes},
         pool_(pool),
-        queue_(std::make_shared<ExchangeQueue>()),
-        maxQueuedBytes_{maxQueuedBytes} {
+        queue_(std::make_shared<ExchangeQueue>()) {
     VELOX_CHECK_NOT_NULL(pool_);
     VELOX_CHECK(
         destination >= 0,
@@ -73,12 +73,33 @@ class ExchangeClient {
   std::string toJsonString() const;
 
  private:
+  // A list of sources to request data from and how much to request from each
+  // (in bytes).
+  struct RequestSpec {
+    std::vector<std::shared_ptr<ExchangeSource>> sources;
+    int64_t maxBytes;
+  };
+
+  int64_t getAveragePageSize();
+
+  int32_t getNumSourcesToRequestLocked(int64_t averagePageSize);
+
+  RequestSpec pickSourcesToRequest();
+
+  RequestSpec pickSourcesToRequestLocked();
+
+  int32_t countPendingSourcesLocked();
+
+  void request(const RequestSpec& requestSpec);
+
   const int destination_;
+  const int64_t maxQueuedBytes_;
   memory::MemoryPool* const pool_;
   std::shared_ptr<ExchangeQueue> queue_;
-  const int64_t maxQueuedBytes_;
   std::unordered_set<std::string> taskIds_;
   std::vector<std::shared_ptr<ExchangeSource>> sources_;
+  bool allSourcesSupportFlowControl_{true};
+  uint32_t nextSourceIndex_{0};
   bool closed_{false};
 };
 

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -39,6 +39,11 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool);
 
+  /// Temporary API to indicate whether 'request(maxBytes)' API is supported.
+  virtual bool supportsFlowControl() const {
+    return false;
+  }
+
   // Returns true if there is no request to the source pending or if
   // this should be retried. If true, the caller is expected to call
   // request(). This is expected to be called while holding lock over
@@ -48,10 +53,27 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // threads from issuing the same request.
   virtual bool shouldRequestLocked() = 0;
 
+  virtual bool isRequestPendingLocked() const {
+    return requestPending_;
+  }
+
   // Requests the producer to generate more data. Call only if shouldRequest()
   // was true. The object handles its own lifetime by acquiring a
   // shared_from_this() pointer if needed.
-  virtual void request() = 0;
+  virtual void request() {
+    VELOX_UNSUPPORTED();
+  }
+
+  /// Requests the producer to generate up to 'maxBytes' more data.
+  /// Returns a future that completes when producer responds either with 'data'
+  /// or with a message indicating that all data has been already produced or
+  /// data will take more time to produce. Legacy ExchangeSources return empty
+  /// future and keep fetching data until it arrives or no-more-data message is
+  /// received.
+  virtual ContinueFuture request(uint32_t maxBytes) {
+    request();
+    return ContinueFuture::makeEmpty();
+  }
 
   // Close the exchange source. May be called before all data
   // has been received and proessed. This can happen in case

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -105,7 +105,7 @@ TEST_F(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
   VELOX_ASSERT_THROW(
       client.addRemoteTaskId(std::string(1024, 'x')),
       "Failed to create ExchangeSource: Testing error. "
-      "Task ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.");
+      "Task ID: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.");
 }
 
 TEST_F(ExchangeClientTest, stats) {
@@ -137,19 +137,63 @@ TEST_F(ExchangeClientTest, stats) {
     pageBytes.push_back(pageSize);
   }
 
-  // ExchangeSource should have fetched first page and placed it into the queue.
-  // Once we fetch this page from the queue, the ExchangeSource will go fetch
-  // the remaining 2 pages.
-
   fetchPages(client, 3);
 
   auto stats = client.stats();
-  EXPECT_EQ(pageBytes[1] + pageBytes[2], stats.at("peakBytes").sum);
+  EXPECT_EQ(totalBytes, stats.at("peakBytes").sum);
   EXPECT_EQ(data.size(), stats.at("numReceivedPages").sum);
   EXPECT_EQ(totalBytes / data.size(), stats.at("averageReceivedPageBytes").sum);
 
   task->requestCancel();
   bufferManager_->removeTask(taskId);
+}
+
+// Test scenario where fetching data from all sources at once would exceed queue
+// size. Verify that ExchangeClient is fetching data only from a few sources at
+// a time to avoid exceeding the limit.
+TEST_F(ExchangeClientTest, flowControl) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(10'000, [](auto row) { return row; }),
+  });
+
+  auto page = toSerializedPage(data);
+
+  // Set limit at 3.5 pages.
+  ExchangeClient client(17, pool(), page->size() * 3.5);
+
+  auto plan = test::PlanBuilder()
+                  .values({data})
+                  .partitionedOutput({"c0"}, 100)
+                  .planNode();
+  // Make 10 tasks.
+  std::vector<std::shared_ptr<Task>> tasks;
+  for (auto i = 0; i < 10; ++i) {
+    auto taskId = fmt::format("local://t{}", i);
+    auto task = makeTask(taskId, plan, 17);
+
+    bufferManager_->initializeTask(
+        task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
+
+    // Enqueue 3 pages.
+    for (auto j = 0; j < 3; ++j) {
+      enqueue(taskId, 17, data);
+    }
+
+    tasks.push_back(task);
+    client.addRemoteTaskId(taskId);
+  }
+
+  fetchPages(client, 3 * tasks.size());
+
+  auto stats = client.stats();
+  EXPECT_LE(stats.at("peakBytes").sum, page->size() * 4);
+  EXPECT_EQ(30, stats.at("numReceivedPages").sum);
+  EXPECT_EQ(page->size(), stats.at("averageReceivedPageBytes").sum);
+
+  for (auto& task : tasks) {
+    task->requestCancel();
+    bufferManager_->removeTask(task->taskId());
+  }
 }
 
 } // namespace

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1568,7 +1568,7 @@ TEST_F(MultiFragmentTest, maxBytes) {
     task->updateOutputBuffers(1, true);
 
     // Allow for data to accumulate.
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(std::chrono::seconds(2));
 
     DataFetcher fetcher(taskId, 0, maxBytes);
     fetcher.fetch().wait();


### PR DESCRIPTION
ExchangeClient may be used to fetch data from a large number of upstream tasks.
If ExchangeClient tried to fetch data from all these tasks at once, the
ExchangeQueue may receive too much data at once and run out of memory.

This change adds logic to ExchangeClient to request data from a limited number
of sources at a time to make sure ExchangeQueue doesn't accumulate too much
data.

Relevant code in Presto: presto-main/src/main/java/com/facebook/presto/operator/ExchangeClient.java

More context: https://github.com/prestodb/presto/pull/13452

See #6005