### PR TITLE
Allow creating memory manager with custom arbitrator

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -31,12 +31,12 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
       // TODO: consider to reserve a small amount of memory to compensate for
       //  the unreclaimable cache memory which are pinned by query accesses if
       //  enabled.
-      arbitrator_(MemoryArbitrator::create(MemoryArbitrator::Config{
-          .kind = options.arbitratorKind,
-          .capacity = capacity_,
-          .memoryPoolInitCapacity = options.memoryPoolInitCapacity,
-          .memoryPoolTransferCapacity = options.memoryPoolTransferCapacity,
-          .retryArbitrationFailure = options.retryArbitrationFailure})),
+      arbitrator_(MemoryArbitrator::create(
+          {.kind = options.arbitratorKind,
+           .capacity = options.capacity,
+           .memoryPoolInitCapacity = options.memoryPoolInitCapacity,
+           .memoryPoolTransferCapacity = options.memoryPoolTransferCapacity,
+           .retryArbitrationFailure = options.retryArbitrationFailure})),
       alignment_(std::max(MemoryAllocator::kMinAlignment, options.alignment)),
       checkUsageLeak_(options.checkUsageLeak),
       debugEnabled_(options.debugEnabled),
@@ -58,6 +58,12 @@ MemoryManager::MemoryManager(const MemoryManagerOptions& options)
               .checkUsageLeak = options.checkUsageLeak,
               .debugEnabled = options.debugEnabled})} {
   VELOX_CHECK_NOT_NULL(allocator_);
+  if (arbitrator_ != nullptr) {
+    VELOX_CHECK_EQ(
+        arbitrator_->capacity(),
+        capacity_,
+        "Memory arbitrator and memory manager must have the same capacity");
+  }
   VELOX_USER_CHECK_GE(capacity_, 0);
   MemoryAllocator::alignmentCheck(0, alignment_);
   defaultRoot_->grow(defaultRoot_->maxCapacity());

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -82,8 +82,9 @@ struct MemoryManagerOptions {
 
   /// ================== 'MemoryArbitrator' settings ==================
 
-  /// The string kind of memory arbitrator used in the memory manager. Note that
-  /// the arbitrator will only be created if its kind is set explicitly.
+  /// The string kind of memory arbitrator used in the memory manager.
+  ///
+  /// NOTE: the arbitrator will only be created if its kind is set explicitly.
   /// Otherwise MemoryArbitrator::create returns a nullptr.
   std::string arbitratorKind{};
 

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -82,7 +82,10 @@ struct MemoryManagerOptions {
 
   /// ================== 'MemoryArbitrator' settings ==================
 
-  MemoryArbitrator::Kind arbitratorKind{MemoryArbitrator::Kind::kNoOp};
+  /// The string kind of memory arbitrator used in the memory manager. Note that
+  /// the arbitrator will only be created if its kind is set explicitly.
+  /// Otherwise MemoryArbitrator::create returns a nullptr.
+  std::string arbitratorKind{};
 
   /// The initial memory capacity to reserve for a newly created memory pool.
   uint64_t memoryPoolInitCapacity{256 << 20};

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -16,38 +16,65 @@
 
 #include "velox/common/memory/MemoryArbitrator.h"
 
+#include <utility>
+
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/SharedArbitrator.h"
 
 namespace facebook::velox::memory {
-std::string MemoryArbitrator::kindString(Kind kind) {
-  switch (kind) {
-    case Kind::kNoOp:
-      return "NOOP";
-    case Kind::kShared:
-      return "SHARED";
-    default:
-      return fmt::format("UNKNOWN: {}", static_cast<int>(kind));
-  }
-}
 
-std::ostream& operator<<(
-    std::ostream& out,
-    const MemoryArbitrator::Kind& kind) {
-  out << MemoryArbitrator::kindString(kind);
-  return out;
-}
+namespace {
+class Registry {
+ public:
+  void registerFactory(
+      const std::string& kind,
+      MemoryArbitrator::Factory factory) {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_USER_CHECK(
+        map_.find(kind) == map_.end(),
+        "Arbitrator factory for kind {} already registered",
+        kind)
+    map_[kind] = std::move(factory);
+  }
+
+  MemoryArbitrator::Factory& getFactory(const std::string& kind) {
+    std::lock_guard<std::mutex> l(mutex_);
+    VELOX_USER_CHECK(
+        map_.find(kind) != map_.end(),
+        "Arbitrator factory for kind {} not registered",
+        kind)
+    return map_[kind];
+  }
+
+ private:
+  std::mutex mutex_;
+  std::unordered_map<std::string, MemoryArbitrator::Factory> map_;
+};
+
+Registry registry;
+} // namespace
 
 std::unique_ptr<MemoryArbitrator> MemoryArbitrator::create(
     const Config& config) {
-  switch (config.kind) {
-    case Kind::kNoOp:
-      return nullptr;
-    case Kind::kShared:
-      return std::make_unique<SharedArbitrator>(config);
-    default:
-      VELOX_UNREACHABLE(kindString(config.kind));
+  if (config.kind.empty()) {
+    /// Used to enforce the fixed query memory isolation across running queries.
+    /// When a memory pool exceeds the fixed capacity limit, the query just
+    /// fails with memory capacity exceeded error without arbitration. This is
+    /// used to match the current memory isolation behavior adopted by
+    /// Prestissimo.
+    ///
+    /// TODO: deprecate this legacy policy with kShared policy for Prestissimo
+    /// later.
+    return nullptr;
   }
+  auto& factory = registry.getFactory(config.kind);
+  return factory(config);
+}
+
+void MemoryArbitrator::registerFactory(
+    const std::string& kind,
+    MemoryArbitrator::Factory factory) {
+  registry.registerFactory(kind, std::move(factory));
 }
 
 std::unique_ptr<MemoryReclaimer> MemoryReclaimer::create() {

--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -46,6 +46,11 @@ class Registry {
     return map_[kind];
   }
 
+  bool isFactoryRegistered(const std::string& kind) {
+    std::lock_guard<std::mutex> l(mutex_);
+    return map_.find(kind) != map_.end();
+  }
+
  private:
   std::mutex mutex_;
   std::unordered_map<std::string, MemoryArbitrator::Factory> map_;
@@ -75,6 +80,10 @@ void MemoryArbitrator::registerFactory(
     const std::string& kind,
     MemoryArbitrator::Factory factory) {
   registry.registerFactory(kind, std::move(factory));
+}
+
+bool MemoryArbitrator::isFactoryRegistered(const std::string& kind) {
+  return registry.isFactoryRegistered(kind);
 }
 
 std::unique_ptr<MemoryReclaimer> MemoryReclaimer::create() {

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -91,6 +91,7 @@ class MemoryArbitrator {
   ///
   /// NOTE: if arbitrator kind is not set in 'config', then the function returns
   /// nullptr.
+
   static std::unique_ptr<MemoryArbitrator> create(const Config& config);
 
   virtual std::string kind() = 0;

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -41,13 +41,16 @@ class MemoryPool;
 class MemoryArbitrator {
  public:
 #ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static struct Kind { static std::string kShared; };
+  static struct Kind {
+    static std::string kShared;
+  };
 #endif
 
   struct Config {
-    /// The string kind of this memory arbitrator. Note that the arbitrator
-    /// will only be created if its kind is set explicitly. Otherwise
-    /// MemoryArbitrator::create returns a nullptr.
+    /// The string kind of this memory arbitrator.
+    ///
+    /// NOTE: the arbitrator will only be created if its kind is set explicitly.
+    /// Otherwise MemoryArbitrator::create returns a nullptr.
     std::string kind;
 
     /// The total memory capacity in bytes of all the running queries.

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -41,9 +41,7 @@ class MemoryPool;
 class MemoryArbitrator {
  public:
 #ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
-  static struct Kind {
-    static std::string kShared;
-  };
+  static struct Kind { static std::string kShared; };
 #endif
 
   struct Config {

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -40,30 +40,17 @@ class MemoryPool;
 /// (see Kind definition below).
 class MemoryArbitrator {
  public:
-  /// Defines the kind of memory arbitrators.
-  enum class Kind {
-    /// Used to enforce the fixed query memory isolation across running queries.
-    /// When a memory pool exceeds the fixed capacity limit, the query just
-    /// fails with memory capacity exceeded error without arbitration. This is
-    /// used to match the current memory isolation behavior adopted by
-    /// Prestissimo.
-    ///
-    /// TODO: deprecate this legacy policy with kShared policy for Prestissimo
-    /// later.
-    kNoOp,
-    /// Used to achieve dynamic memory sharing among running queries. When a
-    /// memory pool exceeds its current memory capacity, the arbitrator tries to
-    /// grow its capacity by reclaim the overused memory from the query with
-    /// more memory usage. We can configure memory arbitrator the way to reclaim
-    /// memory. For Prestissimo, we can configure it to reclaim memory by
-    /// aborting a query. For Prestissimo-on-Spark, we can configure it to
-    /// reclaim from a running query through techniques such as disk-spilling,
-    /// partial aggregation or persistent shuffle data flushes.
-    kShared,
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  static struct Kind {
+    static std::string kShared;
   };
+#endif
 
   struct Config {
-    Kind kind{Kind::kNoOp};
+    /// The string kind of this memory arbitrator. Note that the arbitrator
+    /// will only be created if its kind is set explicitly. Otherwise
+    /// MemoryArbitrator::create returns a nullptr.
+    std::string kind;
 
     /// The total memory capacity in bytes of all the running queries.
     ///
@@ -86,12 +73,30 @@ class MemoryArbitrator {
     /// happens to trigger the failed memory arbitration.
     bool retryArbitrationFailure{true};
   };
+
+  using Factory = std::function<std::unique_ptr<MemoryArbitrator>(
+      const MemoryArbitrator::Config& config)>;
+
+  /// Register factory for a specific kind of memory arbitrator.
+  /// MemoryArbitrator::Create looks up the registry to find the factory to
+  /// create arbitrator instance based on the kind specified in arbitrator
+  /// config.
+  static void registerFactory(const std::string& kind, Factory factory);
+
+  /// Invoked by the memory manager to create an instance of memory arbitrator
+  /// based on the kind specified in 'config'. The arbitrator kind must be
+  /// registered through MemoryArbitrator::registerFactory, otherwise the
+  /// function throws a velox user exception error.
+  ///
+  /// NOTE: if arbitrator kind is not set in 'config', then the function returns
+  /// nullptr.
   static std::unique_ptr<MemoryArbitrator> create(const Config& config);
 
-  Kind kind() const {
-    return kind_;
+  virtual std::string kind() = 0;
+
+  uint64_t capacity() const {
+    return capacity_;
   }
-  static std::string kindString(Kind kind);
 
   virtual ~MemoryArbitrator() = default;
 
@@ -158,18 +163,18 @@ class MemoryArbitrator {
 
  protected:
   explicit MemoryArbitrator(const Config& config)
-      : kind_(config.kind),
-        capacity_(config.capacity),
+      : capacity_(config.capacity),
         memoryPoolInitCapacity_(config.memoryPoolInitCapacity),
         memoryPoolTransferCapacity_(config.memoryPoolTransferCapacity) {}
 
-  const Kind kind_;
   const uint64_t capacity_;
   const uint64_t memoryPoolInitCapacity_;
   const uint64_t memoryPoolTransferCapacity_;
 };
 
-std::ostream& operator<<(std::ostream& out, const MemoryArbitrator::Kind& kind);
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+std::string MemoryArbitrator::Kind::kShared{"SHARED"};
+#endif
 
 /// The memory reclaimer interface is used by memory pool to participate in
 /// the memory arbitration execution (enter/leave arbitration process) as well

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -82,6 +82,8 @@ class MemoryArbitrator {
   /// config.
   static void registerFactory(const std::string& kind, Factory factory);
 
+  /// Check if factory is registered for the kind.
+  static bool isFactoryRegistered(const std::string& kind);
   /// Invoked by the memory manager to create an instance of memory arbitrator
   /// based on the kind specified in 'config'. The arbitrator kind must be
   /// registered through MemoryArbitrator::registerFactory, otherwise the

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -542,4 +542,8 @@ void SharedArbitrator::registerFactory() {
         return std::make_unique<SharedArbitrator>(config);
       });
 }
+
+bool SharedArbitrator::isFactoryRegistered() {
+  return MemoryArbitrator::isFactoryRegistered(kind_);
+}
 } // namespace facebook::velox::memory

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -23,7 +23,9 @@
 using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::memory {
+
 namespace {
+
 // Returns the max capacity to grow of memory 'pool'. The calculation is based
 // on a memory pool's max capacity and its current capacity.
 uint64_t maxGrowBytes(const MemoryPool& pool) {
@@ -34,7 +36,13 @@ uint64_t maxGrowBytes(const MemoryPool& pool) {
 uint64_t capacityAfterGrowth(const MemoryPool& pool, uint64_t targetBytes) {
   return pool.capacity() + targetBytes;
 }
+
 } // namespace
+
+SharedArbitrator::SharedArbitrator(const MemoryArbitrator::Config& config)
+    : MemoryArbitrator(config), freeCapacity_(capacity_) {
+  VELOX_CHECK_EQ(kind_, config.kind);
+}
 
 std::string SharedArbitrator::Candidate::toString() const {
   return fmt::format(
@@ -451,7 +459,7 @@ std::string SharedArbitrator::toString() const {
 std::string SharedArbitrator::toStringLocked() const {
   return fmt::format(
       "ARBITRATOR[{}] CAPACITY {} {}",
-      kindString(kind_),
+      kind_,
       succinctBytes(capacity_),
       statsLocked().toString());
 }
@@ -522,5 +530,16 @@ void SharedArbitrator::finishArbitration() {
   if (resumePromise.valid()) {
     resumePromise.setValue();
   }
+}
+
+std::string SharedArbitrator::kind() {
+  return kind_;
+}
+
+void SharedArbitrator::registerFactory() {
+  MemoryArbitrator::registerFactory(
+      kind_, [](const MemoryArbitrator::Config& config) {
+        return std::make_unique<SharedArbitrator>(config);
+      });
 }
 } // namespace facebook::velox::memory

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -35,6 +35,8 @@ class SharedArbitrator : public MemoryArbitrator {
  public:
   static void registerFactory();
 
+  static bool isFactoryRegistered();
+
   explicit SharedArbitrator(const Config& config);
 
   ~SharedArbitrator() override;

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -22,12 +22,20 @@
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::velox::memory {
+
+/// Used to achieve dynamic memory sharing among running queries. When a
+/// memory pool exceeds its current memory capacity, the arbitrator tries to
+/// grow its capacity by reclaim the overused memory from the query with
+/// more memory usage. We can configure memory arbitrator the way to reclaim
+/// memory. For Prestissimo, we can configure it to reclaim memory by
+/// aborting a query. For Prestissimo-on-Spark, we can configure it to
+/// reclaim from a running query through techniques such as disk-spilling,
+/// partial aggregation or persistent shuffle data flushes.
 class SharedArbitrator : public MemoryArbitrator {
  public:
-  explicit SharedArbitrator(const Config& config)
-      : MemoryArbitrator(config), freeCapacity_(capacity_) {
-    VELOX_CHECK_EQ(kind_, Kind::kShared);
-  }
+  static void registerFactory();
+
+  explicit SharedArbitrator(const Config& config);
 
   ~SharedArbitrator() override;
 
@@ -41,7 +49,7 @@ class SharedArbitrator : public MemoryArbitrator {
       uint64_t targetBytes) final;
 
   Stats stats() const final;
-
+  std::string kind() override;
   std::string toString() const final;
 
   // The candidate memory pool stats used by arbitration.
@@ -55,6 +63,9 @@ class SharedArbitrator : public MemoryArbitrator {
   };
 
  private:
+  // The kind string of shared arbitrator.
+  inline static const std::string kind_{"SHARED"};
+
   class ScopedArbitration {
    public:
     ScopedArbitration(MemoryPool* requestor, SharedArbitrator* arbitrator);

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -49,7 +49,9 @@ class SharedArbitrator : public MemoryArbitrator {
       uint64_t targetBytes) final;
 
   Stats stats() const final;
+
   std::string kind() override;
+
   std::string toString() const final;
 
   // The candidate memory pool stats used by arbitration.

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -47,44 +47,88 @@ TEST_F(MemoryArbitrationTest, stats) {
       "STATS[numRequests 2 numAborted 3 numFailures 100 queueTime 230.00ms arbitrationTime 1.02ms shrunkMemory 95.37MB reclaimedMemory 9.77KB maxCapacity 0B freeCapacity 0B]");
 }
 
-TEST_F(MemoryArbitrationTest, kind) {
-  struct {
-    MemoryArbitrator::Kind kind;
-    std::string expectedKindStr;
-
-    std::string debugString() const {
-      return fmt::format("kind:{}, expectedStr:{}", kind, expectedKindStr);
-    }
-  } testSettings[] = {
-      {MemoryArbitrator::Kind::kNoOp, "NOOP"},
-      {MemoryArbitrator::Kind::kShared, "SHARED"},
-      {static_cast<MemoryArbitrator::Kind>(100), "UNKNOWN: 100"}};
-
-  for (const auto& testData : testSettings) {
-    SCOPED_TRACE(testData.debugString());
-    ASSERT_EQ(
-        MemoryArbitrator::kindString(testData.kind), testData.expectedKindStr);
-  }
-}
-
 TEST_F(MemoryArbitrationTest, create) {
-  const std::vector<MemoryArbitrator::Kind> kinds = {
-      MemoryArbitrator::Kind::kNoOp,
-      MemoryArbitrator::Kind::kShared,
-      static_cast<MemoryArbitrator::Kind>(100)};
+  const std::string unknownType = "UNKNOWN";
+  const std::vector<std::string> kinds = {
+      std::string(),
+      unknownType // expect error on unregistered type
+  };
   for (const auto& kind : kinds) {
     MemoryArbitrator::Config config;
     config.capacity = 1 * GB;
     config.kind = kind;
-    if (kind == MemoryArbitrator::Kind::kNoOp) {
+    if (kind.empty()) {
       ASSERT_EQ(MemoryArbitrator::create(config), nullptr);
-    } else if (kind == MemoryArbitrator::Kind::kShared) {
-      auto arbitrator = MemoryArbitrator::create(config);
-      ASSERT_EQ(arbitrator->kind(), kind);
+    } else if (kind == unknownType) {
+      VELOX_ASSERT_THROW(
+          MemoryArbitrator::create(config),
+          "Arbitrator factory for kind UNKNOWN not registered");
     } else {
       VELOX_ASSERT_THROW(MemoryArbitrator::create(config), "");
     }
   }
+}
+
+namespace {
+class FakeTestArbitrator : public MemoryArbitrator {
+ public:
+  explicit FakeTestArbitrator(const Config& config)
+      : MemoryArbitrator(
+            {.kind = config.kind,
+             .capacity = config.capacity,
+             .memoryPoolInitCapacity = config.memoryPoolInitCapacity,
+             .memoryPoolTransferCapacity = config.memoryPoolTransferCapacity,
+             .retryArbitrationFailure = config.retryArbitrationFailure}) {}
+
+  void reserveMemory(MemoryPool* pool, uint64_t bytes) override {
+    VELOX_NYI()
+  }
+
+  void releaseMemory(MemoryPool* pool) override{VELOX_NYI()}
+
+  std::string kind() override {
+    return "USER";
+  }
+
+  bool growMemory(
+      MemoryPool* pool,
+      const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
+      uint64_t targetBytes) override{VELOX_NYI()}
+
+  Stats stats() const override{VELOX_NYI()}
+
+  std::string toString() const override {
+    VELOX_NYI()
+  }
+};
+} // namespace
+
+class MemoryArbitratorFactoryTest : public testing::Test {
+ public:
+ protected:
+  static void SetUpTestCase() {
+    MemoryArbitrator::registerFactory(kind_, factory_);
+  }
+
+ protected:
+  inline static const std::string kind_{"USER"};
+  inline static const MemoryArbitrator::Factory factory_{
+      [](const MemoryArbitrator::Config& config) {
+        return std::make_unique<FakeTestArbitrator>(config);
+      }};
+};
+
+TEST_F(MemoryArbitratorFactoryTest, register) {
+  VELOX_ASSERT_THROW(
+      MemoryArbitrator::registerFactory(kind_, factory_),
+      "Arbitrator factory for kind USER already registered");
+}
+
+TEST_F(MemoryArbitratorFactoryTest, create) {
+  MemoryArbitrator::Config config;
+  config.kind = kind_;
+  auto arbitrator = MemoryArbitrator::create(config);
+  ASSERT_EQ(kind_, arbitrator->kind());
 }
 
 class MemoryReclaimerTest : public testing::Test {

--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -20,6 +20,7 @@
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/memory/SharedArbitrator.h"
 
 DECLARE_int32(velox_memory_num_shared_leaf_pools);
 
@@ -37,7 +38,17 @@ MemoryManager& toMemoryManager(MemoryManager& manager) {
 }
 } // namespace
 
-TEST(MemoryManagerTest, Ctor) {
+class MemoryManagerTest : public testing::Test {
+ public:
+ protected:
+  static void SetUpTestCase() {
+    SharedArbitrator::registerFactory();
+  }
+
+  inline static const std::string arbitratorKind_{"SHARED"};
+};
+
+TEST_F(MemoryManagerTest, Ctor) {
   const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
   {
     MemoryManager manager{};
@@ -70,15 +81,65 @@ TEST(MemoryManagerTest, Ctor) {
     MemoryManagerOptions options;
     const auto capacity = folly::Random::rand32();
     options.capacity = capacity;
-    options.arbitratorKind = MemoryArbitrator::Kind::kShared;
+    std::string arbitratorKind = "SHARED";
+    options.arbitratorKind = arbitratorKind;
     MemoryManager manager{options};
     auto* arbitrator = manager.arbitrator();
-    ASSERT_EQ(arbitrator->kind(), MemoryArbitrator::Kind::kShared);
+    ASSERT_EQ(arbitrator->kind(), arbitratorKind);
     ASSERT_EQ(arbitrator->stats().maxCapacityBytes, capacity);
   }
 }
 
-TEST(MemoryManagerTest, addPool) {
+namespace {
+class FakeTestArbitrator : public MemoryArbitrator {
+ public:
+  FakeTestArbitrator(const Config& config, int64_t capacity)
+      : MemoryArbitrator(
+            {.kind = config.kind,
+             .capacity = capacity,
+             .memoryPoolInitCapacity = config.memoryPoolInitCapacity,
+             .memoryPoolTransferCapacity = config.memoryPoolTransferCapacity,
+             .retryArbitrationFailure = config.retryArbitrationFailure}) {}
+
+  void reserveMemory(MemoryPool* pool, uint64_t bytes) override {
+    VELOX_NYI()
+  }
+
+  void releaseMemory(MemoryPool* pool) override {
+    VELOX_NYI()
+  }
+
+  bool growMemory(
+      MemoryPool* pool,
+      const std::vector<std::shared_ptr<MemoryPool>>& candidatePools,
+      uint64_t targetBytes) override{VELOX_NYI()}
+
+  Stats stats() const override{VELOX_NYI()}
+
+  std::string toString() const override{VELOX_NYI()}
+
+  std::string kind() override {
+    return "FAKE";
+  }
+};
+} // namespace
+
+TEST_F(MemoryManagerTest, createWithCustomArbitrator) {
+  const std::string kindString = "FAKE";
+  MemoryArbitrator::Factory factory =
+      [](const MemoryArbitrator::Config& config) {
+        return std::make_unique<FakeTestArbitrator>(config, 0LL);
+      };
+  MemoryArbitrator::registerFactory(kindString, factory);
+  MemoryManagerOptions options;
+  options.arbitratorKind = kindString;
+  options.capacity = 8L * 1024 * 1024;
+  VELOX_ASSERT_THROW(
+      MemoryManager{options},
+      "Memory arbitrator and memory manager must have the same capacity")
+}
+
+TEST_F(MemoryManagerTest, addPool) {
   MemoryManager manager{};
 
   auto rootPool = manager.addRootPool("duplicateRootPool", kMaxMemory);
@@ -105,10 +166,10 @@ TEST(MemoryManagerTest, addPool) {
   ASSERT_EQ(aggregationPool->capacity(), poolCapacity);
 }
 
-TEST(MemoryManagerTest, addPoolWithArbitrator) {
+TEST_F(MemoryManagerTest, addPoolWithArbitrator) {
   MemoryManagerOptions options;
   options.capacity = 32L << 30;
-  options.arbitratorKind = MemoryArbitrator::Kind::kShared;
+  options.arbitratorKind = arbitratorKind_;
   // The arbitrator capacity will be overridden by the memory manager's
   // capacity.
   options.capacity = options.capacity;
@@ -147,7 +208,7 @@ TEST(MemoryManagerTest, addPoolWithArbitrator) {
   ASSERT_EQ(aggregationPool->capacity(), initialPoolCapacity);
 }
 
-TEST(MemoryManagerTest, defaultMemoryManager) {
+TEST_F(MemoryManagerTest, defaultMemoryManager) {
   auto& managerA = toMemoryManager(defaultMemoryManager());
   auto& managerB = toMemoryManager(defaultMemoryManager());
   const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
@@ -227,7 +288,7 @@ TEST(MemoryHeaderTest, addDefaultLeafMemoryPool) {
   ASSERT_EQ(namedPool->name(), "namedPool");
 }
 
-TEST(MemoryManagerTest, memoryPoolManagement) {
+TEST_F(MemoryManagerTest, memoryPoolManagement) {
   const int alignment = 32;
   MemoryManagerOptions options;
   options.alignment = alignment;
@@ -270,7 +331,7 @@ TEST(MemoryManagerTest, memoryPoolManagement) {
 // TODO: when run sequentially, e.g. `buck run dwio/memory/...`, this has side
 // effects for other tests using process singleton memory manager. Might need to
 // use folly::Singleton for isolation by tag.
-TEST(MemoryManagerTest, globalMemoryManager) {
+TEST_F(MemoryManagerTest, globalMemoryManager) {
   auto& manager = MemoryManager::getInstance();
   auto& managerII = MemoryManager::getInstance();
   const auto kSharedPoolCount = FLAGS_velox_memory_num_shared_leaf_pools;
@@ -326,7 +387,7 @@ TEST(MemoryManagerTest, globalMemoryManager) {
   ASSERT_EQ(manager.numPools(), 0);
 }
 
-TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
+TEST_F(MemoryManagerTest, GlobalMemoryManagerQuota) {
   auto& manager = MemoryManager::getInstance();
   MemoryManager::getInstance({.alignment = 32});
 
@@ -334,7 +395,7 @@ TEST(MemoryManagerTest, GlobalMemoryManagerQuota) {
   ASSERT_EQ(manager.alignment(), coercedManager.alignment());
 }
 
-TEST(MemoryManagerTest, alignmentOptionCheck) {
+TEST_F(MemoryManagerTest, alignmentOptionCheck) {
   struct {
     uint16_t alignment;
     bool expectedSuccess;
@@ -379,7 +440,7 @@ TEST(MemoryManagerTest, alignmentOptionCheck) {
   }
 }
 
-TEST(MemoryManagerTest, concurrentPoolAccess) {
+TEST_F(MemoryManagerTest, concurrentPoolAccess) {
   MemoryManager manager{};
   const int numAllocThreads = 40;
   std::vector<std::thread> allocThreads;
@@ -434,7 +495,7 @@ TEST(MemoryManagerTest, concurrentPoolAccess) {
   ASSERT_EQ(manager.numPools(), 0);
 }
 
-TEST(MemoryManagerTest, quotaEnforcement) {
+TEST_F(MemoryManagerTest, quotaEnforcement) {
   struct {
     int64_t memoryQuotaBytes;
     int64_t smallAllocationBytes;
@@ -507,7 +568,7 @@ TEST(MemoryManagerTest, quotaEnforcement) {
   }
 }
 
-TEST(MemoryManagerTest, testCheckUsageLeak) {
+TEST_F(MemoryManagerTest, testCheckUsageLeak) {
   FLAGS_velox_memory_leak_check_enabled = true;
   auto& manager = MemoryManager::getInstance(
       memory::MemoryManagerOptions{.checkUsageLeak = false});

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -73,6 +73,7 @@ class MemoryPoolTest : public testing::TestWithParam<TestParam> {
 
  protected:
   static void SetUpTestCase() {
+    SharedArbitrator::registerFactory();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -23,6 +23,7 @@
 #include "velox/common/memory/MallocAllocator.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 
 DECLARE_bool(velox_memory_leak_check_enabled);
@@ -3125,7 +3126,7 @@ TEST_P(MemoryPoolTest, maybeReserveFailWithAbort) {
   constexpr int64_t kMB = 1 << 20;
   MemoryManagerOptions options;
   options.capacity = kMaxMemory;
-  options.arbitratorKind = MemoryArbitrator::Kind::kShared;
+  options.arbitratorKind = "SHARED";
   MemoryManager manager{options};
   auto root = manager.addRootPool(
       "maybeReserveFailWithAbort", kMaxSize, MemoryReclaimer::create());

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -346,6 +346,7 @@ MockQuery::~MockQuery() {
 class MockSharedArbitrationTest : public testing::Test {
  protected:
   static void SetUpTestCase() {
+    SharedArbitrator::registerFactory();
     FLAGS_velox_memory_leak_check_enabled = true;
     TestValue::enable();
   }

--- a/velox/common/memory/tests/MockSharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/MockSharedArbitratorTest.cpp
@@ -370,13 +370,14 @@ class MockSharedArbitrationTest : public testing::Test {
     }
     MemoryManagerOptions options;
     options.capacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
-    options.arbitratorKind = MemoryArbitrator::Kind::kShared;
+    std::string arbitratorKind = "SHARED";
+    options.arbitratorKind = arbitratorKind;
     options.capacity = options.capacity;
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.checkUsageLeak = true;
     manager_ = std::make_unique<MemoryManager>(options);
-    ASSERT_EQ(manager_->arbitrator()->kind(), MemoryArbitrator::Kind::kShared);
+    ASSERT_EQ(manager_->arbitrator()->kind(), arbitratorKind);
     arbitrator_ = static_cast<SharedArbitrator*>(manager_->arbitrator());
   }
 

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -24,7 +24,6 @@
 #include "folly/futures/Barrier.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/exec/HashBuild.h"
@@ -250,6 +249,7 @@ class FakeMemoryOperatorFactory : public Operator::PlanNodeTranslator {
 class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
  protected:
   static void SetUpTestCase() {
+    SharedArbitrator::registerFactory();
     exec::test::HiveConnectorTestBase::SetUpTestCase();
     auto fakeOperatorFactory = std::make_unique<FakeMemoryOperatorFactory>();
     fakeOperatorFactory_ = fakeOperatorFactory.get();
@@ -287,14 +287,13 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
       uint64_t memoryPoolTransferCapacity = kMemoryPoolTransferCapacity) {
     MemoryManagerOptions options;
     options.capacity = (memoryCapacity != 0) ? memoryCapacity : kMemoryCapacity;
-    options.arbitratorKind = MemoryArbitrator::Kind::kShared;
+    options.arbitratorKind = "SHARED";
     options.capacity = options.capacity;
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.checkUsageLeak = true;
     memoryManager_ = std::make_unique<MemoryManager>(options);
-    ASSERT_EQ(
-        memoryManager_->arbitrator()->kind(), MemoryArbitrator::Kind::kShared);
+    ASSERT_EQ(memoryManager_->arbitrator()->kind(), "SHARED");
     arbitrator_ = static_cast<SharedArbitrator*>(memoryManager_->arbitrator());
   }
 

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -249,7 +249,6 @@ class FakeMemoryOperatorFactory : public Operator::PlanNodeTranslator {
 class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
  protected:
   static void SetUpTestCase() {
-    SharedArbitrator::registerFactory();
     exec::test::HiveConnectorTestBase::SetUpTestCase();
     auto fakeOperatorFactory = std::make_unique<FakeMemoryOperatorFactory>();
     fakeOperatorFactory_ = fakeOperatorFactory.get();

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -48,7 +48,6 @@ OperatorTestBase::~OperatorTestBase() {
 }
 
 void OperatorTestBase::SetUpTestCase() {
-  memory::SharedArbitrator::registerFactory();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   TestValue::enable();
@@ -59,6 +58,9 @@ void OperatorTestBase::TearDownTestCase() {
 }
 
 void OperatorTestBase::SetUp() {
+  if (!memory::SharedArbitrator::isFactoryRegistered()) {
+    memory::SharedArbitrator::registerFactory();
+  }
   if (!isRegisteredVectorSerde()) {
     this->registerVectorSerde();
   }

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/common/caching/AsyncDataCache.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/SharedArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/DataSink.h"
 #include "velox/exec/Exchange.h"
@@ -47,6 +48,7 @@ OperatorTestBase::~OperatorTestBase() {
 }
 
 void OperatorTestBase::SetUpTestCase() {
+  memory::SharedArbitrator::registerFactory();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   TestValue::enable();


### PR DESCRIPTION
This PR adds a arbitrator factory to memory manager config to allow use of custom memory arbitrators.

See issue https://github.com/facebookincubator/velox/issues/5646. Intel's Gluten project relies on a customized implementation of memory arbitrator to grow/shrink pools with dynamic capacity numbers controlled by Apache Spark. So a listener will be injected to the arbitrator instance.