### PR TITLE
Fix cast(varchar as timestamp) when cast_to_int_by_truncate is true

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -257,24 +257,26 @@ TEST_F(CastExprTest, basics) {
 }
 
 TEST_F(CastExprTest, stringToTimestamp) {
-  testCast<std::string, Timestamp>(
-      "timestamp",
-      {
-          "1970-01-01",
-          "2000-01-01",
-          "1970-01-01 00:00:00",
-          "2000-01-01 12:21:56",
-          "1970-01-01 00:00:00-02:00",
-          std::nullopt,
-      },
-      {
-          Timestamp(0, 0),
-          Timestamp(946684800, 0),
-          Timestamp(0, 0),
-          Timestamp(946729316, 0),
-          Timestamp(7200, 0),
-          std::nullopt,
-      });
+  std::vector<std::optional<std::string>> input{
+      "1970-01-01",
+      "2000-01-01",
+      "1970-01-01 00:00:00",
+      "2000-01-01 12:21:56",
+      "1970-01-01 00:00:00-02:00",
+      std::nullopt,
+  };
+  std::vector<std::optional<Timestamp>> expected{
+      Timestamp(0, 0),
+      Timestamp(946684800, 0),
+      Timestamp(0, 0),
+      Timestamp(946729316, 0),
+      Timestamp(7200, 0),
+      std::nullopt,
+  };
+  testCast<std::string, Timestamp>("timestamp", input, expected);
+
+  setCastIntByTruncate(true);
+  testCast<std::string, Timestamp>("timestamp", input, expected);
 }
 
 TEST_F(CastExprTest, timestampToString) {

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -396,8 +396,8 @@ struct Converter<TypeKind::VARCHAR, void, TRUNCATE> {
 };
 
 // Allow conversions from string to TIMESTAMP type.
-template <>
-struct Converter<TypeKind::TIMESTAMP> {
+template <bool TRUNCATE>
+struct Converter<TypeKind::TIMESTAMP, void, TRUNCATE> {
   using T = typename TypeTraits<TypeKind::TIMESTAMP>::NativeType;
 
   template <typename From>


### PR DESCRIPTION
cast(varchar as timestamp) used to fail with "Conversion to TIMESTAMP is not
supported" when cast_to_int_by_truncate was true. 