### PR TITLE
Fix the overflow of numWrittenRows field of HiveWriterInfo

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -342,7 +342,7 @@ struct HiveWriterInfo {
       : writerParameters(std::move(parameters)) {}
 
   const HiveWriterParameters writerParameters;
-  vector_size_t numWrittenRows = 0;
+  int64_t numWrittenRows = 0;
 };
 
 /// Identifies a hive writer.


### PR DESCRIPTION
Observed overflow of the numWrittenRows field of HiveWriterInfo. So change it from vector_size_t to int64_t. This field is included in the serialized string returned by HiveDataSink::finish().