### PR TITLE
Add abort API to Writer interface

### DIFF
--- a/velox/dwio/common/Writer.h
+++ b/velox/dwio/common/Writer.h
@@ -43,7 +43,7 @@ class Writer {
    */
   virtual void write(const VectorPtr& data) = 0;
 
-  /*
+  /**
    * Forces the writer to flush data to the file.
    * Does not close the writer.
    */
@@ -54,6 +54,12 @@ class Writer {
    *  Data can no longer be written.
    */
   virtual void close() = 0;
+
+  /**
+   *  Aborts the writing by closing the writer and dropping everything.
+   *  Data can no longer be written.
+   */
+  virtual void abort() = 0;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -494,6 +494,10 @@ void Writer::close() {
   writerBase_->close();
 }
 
+void Writer::abort() {
+  writerBase_->abort();
+}
+
 dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
   std::map<std::string, std::string> configs;
   if (options.compressionKind.has_value()) {

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -118,6 +118,8 @@ class Writer : public dwio::common::Writer {
 
   virtual void close() override;
 
+  virtual void abort() override;
+
   void setLowMemoryMode();
 
   uint64_t flushTimeMemoryUsageEstimate(

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -261,6 +261,10 @@ void Writer::close() {
   arrowContext_->stagingChunks.clear();
 }
 
+void Writer::abort() {
+  VELOX_NYI("abort function for Parquet writer is not supported yet");
+}
+
 parquet::WriterOptions getParquetOptions(
     const dwio::common::WriterOptions& options) {
   parquet::WriterOptions parquetOptions;

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -129,6 +129,8 @@ class Writer : public dwio::common::Writer {
   // live until destruction of 'this'.
   void close() override;
 
+  void abort() override;
+
  private:
   // Pool for 'stream_'.
   std::shared_ptr<memory::MemoryPool> pool_;


### PR DESCRIPTION
Add abort API to Writer interface.
Difference between close() and abort(): 
close() would finish encoding, flush out and write summary (metadata) to disk. 
abort() only needs to stop write and drop everything.

For dwrf writer, it would abort the writing by closing the writer.
For parquet writer, it would throw unsupported error.