### PR TITLE
Fix PartitionedOutput operator for no-columns output

### DIFF
--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -142,22 +142,28 @@ PartitionedOutput::PartitionedOutput(
 
 void PartitionedOutput::initializeInput(RowVectorPtr input) {
   input_ = std::move(input);
-  if (outputChannels_.empty()) {
+  if (outputType_->size() == 0) {
+    output_ = std::make_shared<RowVector>(
+        input_->pool(),
+        outputType_,
+        nullptr /*nulls*/,
+        input_->size(),
+        std::vector<VectorPtr>{});
+  } else if (outputChannels_.empty()) {
     output_ = input_;
   } else {
     std::vector<VectorPtr> outputColumns;
     outputColumns.reserve(outputChannels_.size());
-    for (auto& i : outputChannels_) {
+    for (auto i : outputChannels_) {
       outputColumns.push_back(input_->childAt(i));
     }
 
     output_ = std::make_shared<RowVector>(
         input_->pool(),
         outputType_,
-        input_->nulls(),
+        nullptr /*nulls*/,
         input_->size(),
-        outputColumns,
-        input_->getNullCount());
+        outputColumns);
   }
 }
 


### PR DESCRIPTION
PartitionedOutput operator didn't handle no-columns output correctly. It
produced same columns as input in this case. This caused failures in downstream
Exchange operator due to schema mismatch. Exchange operator expected
no-columns, but serialized page contained some columns.

```
Reason: Tried to read 1095914049 bytes, larger than what's remained in source 330190 bytes. Source details: ByteStream[lastRangeEnd 330236, 1 ranges (position/size) [(46/330236 current)]]
Retriable: False
Function: computeChecksum
File: /Users/mbasmanova/cpp/velox-1/velox/serializers/PrestoSerializer.cpp
Line: 57
```

Fixes #5976