### PR TITLE
Introduce BaseVector::toCopyRanges

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3201,6 +3201,7 @@ TEST_F(ExprTest, addNulls) {
         nullptr,
         kSize,
         std::vector<VectorPtr>({a, b}));
+    row->setNull(kSize - 1, true);
     VectorPtr result = row;
     exec::Expr::addNulls(rows, rawNulls, context, row->type(), result);
     ASSERT_NE(result.get(), row.get());

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -389,19 +389,7 @@ class BaseVector {
   virtual void copy(
       const BaseVector* source,
       const SelectivityVector& rows,
-      const vector_size_t* toSourceRow) {
-    rows.applyToSelected([&](vector_size_t row) {
-      auto sourceRow = toSourceRow ? toSourceRow[row] : row;
-      if (sourceRow >= source->size()) {
-        return;
-      }
-      if (source->isNullAt(sourceRow)) {
-        setNull(row, true);
-      } else {
-        copy(source, row, sourceRow, 1);
-      }
-    });
-  }
+      const vector_size_t* toSourceRow);
 
   // Utility for making a deep copy of a whole vector.
   static VectorPtr copy(const BaseVector& vector) {
@@ -428,6 +416,11 @@ class BaseVector {
     vector_size_t targetIndex;
     vector_size_t count;
   };
+
+  /// Converts SelectivityVetor into a list of CopyRanges having sourceIndex ==
+  /// targetIndex. Aims to produce as few ranges as possible. If all rows are
+  /// selected, returns a single range.
+  static std::vector<CopyRange> toCopyRanges(const SelectivityVector& rows);
 
   // Copy multiple ranges at once.  This is more efficient than calling `copy`
   // multiple times, especially for ARRAY, MAP, and VARCHAR.


### PR DESCRIPTION
`BaseVector::copy(const BaseVector* source, const SelectivityVector& rows, const vector_size_t* toSourceRow)` 
used to copy values one at a time making it very slow to copy complex type values. 

Introduce BaseVector::toCopyRanges to convert SelectivityVector to a list of copy ranges 
and use that to copy in bulk.