### PR TITLE
Fix Lambda functions generating invalid result vector

### DIFF
--- a/velox/functions/lib/LambdaFunctionUtil.h
+++ b/velox/functions/lib/LambdaFunctionUtil.h
@@ -87,4 +87,10 @@ MapVectorPtr flattenMap(
     const SelectivityVector& rows,
     const VectorPtr& vector,
     DecodedVector& decodedVector);
+
+// Makes a copy of the original nulls in 'vector' and adds nulls for unselected
+// rows in 'rows'
+BufferPtr addNullsForUnselectedRows(
+    const VectorPtr& vector,
+    const SelectivityVector& rows);
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArraySort.cpp
+++ b/velox/functions/prestosql/ArraySort.cpp
@@ -314,10 +314,13 @@ class ArraySortLambdaFunction : public exec::VectorFunction {
     auto sortedElements = BaseVector::wrapInDictionary(
         nullptr, indices, newNumElements, flatArray->elements());
 
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatArray, rows);
+
     VectorPtr localResult = std::make_shared<ArrayVector>(
         flatArray->pool(),
         flatArray->type(),
-        flatArray->nulls(),
+        std::move(newNulls),
         flatArray->size(),
         flatArray->offsets(),
         flatArray->sizes(),

--- a/velox/functions/prestosql/FilterFunctions.cpp
+++ b/velox/functions/prestosql/FilterFunctions.cpp
@@ -153,10 +153,12 @@ class ArrayFilterFunction : public FilterFunctionBase {
                                              numSelected,
                                              std::move(elements))
                                        : nullptr;
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatArray, rows);
     auto localResult = std::make_shared<ArrayVector>(
         flatArray->pool(),
         flatArray->type(),
-        flatArray->nulls(),
+        std::move(newNulls),
         rows.end(),
         std::move(resultOffsets),
         std::move(resultSizes),
@@ -218,10 +220,12 @@ class MapFilterFunction : public FilterFunctionBase {
                                            numSelected,
                                            std::move(values))
                                      : nullptr;
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatMap, rows);
     auto localResult = std::make_shared<MapVector>(
         flatMap->pool(),
         outputType,
-        flatMap->nulls(),
+        std::move(newNulls),
         rows.end(),
         std::move(resultOffsets),
         std::move(resultSizes),

--- a/velox/functions/prestosql/MapZipWith.cpp
+++ b/velox/functions/prestosql/MapZipWith.cpp
@@ -191,6 +191,13 @@ class MapZipWithFunction : public exec::VectorFunction {
           &mergedValues);
     }
 
+    // Set nulls for rows not present in 'rows'.
+    bits::andBits(
+        mergeResults.rawNewNulls,
+        rows.asRange().bits(),
+        rows.begin(),
+        rows.end());
+
     auto localResult = std::make_shared<MapVector>(
         context.pool(),
         outputType,

--- a/velox/functions/prestosql/Transform.cpp
+++ b/velox/functions/prestosql/Transform.cpp
@@ -78,10 +78,13 @@ class TransformFunction : public exec::VectorFunction {
           &newElements);
     }
 
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatArray, rows);
+
     VectorPtr localResult = std::make_shared<ArrayVector>(
         flatArray->pool(),
         outputType,
-        flatArray->nulls(),
+        std::move(newNulls),
         flatArray->size(),
         flatArray->offsets(),
         flatArray->sizes(),

--- a/velox/functions/prestosql/TransformKeys.cpp
+++ b/velox/functions/prestosql/TransformKeys.cpp
@@ -79,10 +79,13 @@ class TransformKeysFunction : public exec::VectorFunction {
           &transformedKeys);
     }
 
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatMap, rows);
+
     auto localResult = std::make_shared<MapVector>(
         flatMap->pool(),
         outputType,
-        flatMap->nulls(),
+        std::move(newNulls),
         flatMap->size(),
         flatMap->offsets(),
         flatMap->sizes(),

--- a/velox/functions/prestosql/TransformValues.cpp
+++ b/velox/functions/prestosql/TransformValues.cpp
@@ -78,10 +78,13 @@ class TransformValuesFunction : public exec::VectorFunction {
           &transformedValues);
     }
 
+    // Set nulls for rows not present in 'rows'.
+    BufferPtr newNulls = addNullsForUnselectedRows(flatMap, rows);
+
     auto localResult = std::make_shared<MapVector>(
         flatMap->pool(),
         outputType,
-        flatMap->nulls(),
+        std::move(newNulls),
         flatMap->size(),
         flatMap->offsets(),
         flatMap->sizes(),

--- a/velox/functions/prestosql/ZipWith.cpp
+++ b/velox/functions/prestosql/ZipWith.cpp
@@ -182,6 +182,8 @@ class ZipWithFunction : public exec::VectorFunction {
         decodedInputs.decodedRight->mayHaveNulls()) {
       nulls = allocateNulls(rows.end(), pool);
       rawNulls = nulls->asMutable<uint64_t>();
+      // Set nulls for rows not present in 'rows'.
+      memcpy(rawNulls, rows.asRange().bits(), bits::nbytes(rows.end()));
     }
 
     auto leftSizes = decodedInputs.baseLeft->rawSizes();


### PR DESCRIPTION
Currently Lambda functions directly reuse the nulls vector from the
input complex vector to generate the result vector. This can end up
creating result vectors that have invalid internal state (invalid
offset index) for rows that are not active in the input selectivity
vector. This change fixes this by ensuring that the nulls buffer used
to generate the result has all the unselected rows nulled out which
means any invalid values in offsets or sizes buffers for those rows
is irrelevant.

Test Plan:
Added unit tests for some lambda functions where it is simpler to
replicate  input data that encounters the failing condition.