### PR TITLE
Back out "Fix round Presto function"

### DIFF
--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -44,12 +44,10 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
-  static const TNum kInf = std::numeric_limits<TNum>::infinity();
   if (number < 0) {
-    return (std::round(std::nextafter(number, -kInf) * factor * -1) / factor) *
-        -1;
+    return (std::round(number * factor * -1) / factor) * -1;
   }
-  return std::round(std::nextafter(number, kInf) * factor) / factor;
+  return std::round(number * factor) / factor;
 }
 
 // This is used by Velox for floating points plus.

--- a/velox/functions/prestosql/tests/RoundTest.cpp
+++ b/velox/functions/prestosql/tests/RoundTest.cpp
@@ -59,20 +59,30 @@ class RoundTest : public functions::test::FunctionBaseTest {
   }
 
   template <typename T>
-  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatAndDoubleData() {
-    return {{1.122112, 0, 1},         {1.129, 1, 1.1},
-            {1.129, 2, 1.13},         {1.0 / 3, 0, 0.0},
-            {1.0 / 3, 1, 0.3},        {1.0 / 3, 2, 0.33},
-            {1.0 / 3, 6, 0.333333},   {-1.122112, 0, -1},
-            {-1.129, 1, -1.1},        {-1.129, 2, -1.13},
-            {-1.129, 2, -1.13},       {-1.0 / 3, 0, 0.0},
-            {-1.0 / 3, 1, -0.3},      {-1.0 / 3, 2, -0.33},
-            {-1.0 / 3, 6, -0.333333}, {1.0, -1, 0.0},
-            {0.0, -2, 0.0},           {-1.0, -3, 0.0},
-            {11111.0, -1, 11110.0},   {11111.0, -2, 11100.0},
-            {11111.0, -3, 11000.0},   {11111.0, -4, 10000.0},
-            {0.575, 2, 0.58},         {0.574, 2, 0.57},
-            {-0.575, 2, -0.58},       {-0.574, 2, -0.57}};
+  std::vector<std::tuple<T, int32_t, T>> testRoundWithDecFloatData() {
+    return {
+        {1.122112, 0, 1},
+        {1.129, 1, 1.1},
+        {1.129, 2, 1.13},
+        {1.0 / 3, 0, 0.0},
+        {1.0 / 3, 1, 0.3},
+        {1.0 / 3, 2, 0.33},
+        {1.0 / 3, 10, 0.3333333333},
+        {-1.122112, 0, -1},
+        {-1.129, 1, -1.1},
+        {-1.129, 2, -1.13},
+        {-1.129, 2, -1.13},
+        {-1.0 / 3, 0, 0.0},
+        {-1.0 / 3, 1, -0.3},
+        {-1.0 / 3, 2, -0.33},
+        {-1.0 / 3, 10, -0.3333333333},
+        {1.0, -1, 0.0},
+        {0.0, -2, 0.0},
+        {-1.0, -3, 0.0},
+        {11111.0, -1, 11110.0},
+        {11111.0, -2, 11100.0},
+        {11111.0, -3, 11000.0},
+        {11111.0, -4, 10000.0}};
   }
 
   template <typename T>
@@ -104,8 +114,9 @@ TEST_F(RoundTest, round) {
 }
 
 TEST_F(RoundTest, roundWithDecimal) {
-  runRoundWithDecimalTest<float>(testRoundWithDecFloatAndDoubleData<float>());
-  runRoundWithDecimalTest<double>(testRoundWithDecFloatAndDoubleData<double>());
+  runRoundWithDecimalTest<float>(testRoundWithDecFloatData<float>());
+  runRoundWithDecimalTest<double>(testRoundWithDecFloatData<double>());
+
   runRoundWithDecimalTest<int64_t>(testRoundWithDecIntegralData<int64_t>());
   runRoundWithDecimalTest<int32_t>(testRoundWithDecIntegralData<int32_t>());
   runRoundWithDecimalTest<int16_t>(testRoundWithDecIntegralData<int16_t>());


### PR DESCRIPTION
Summary:
The behavior of `round(0.575. 2) == 0.58` is Spark specific, should not change it in Presto function.

Original commit changeset: 8b5612915646

Original Phabricator Diff: D47992817

Differential Revision: D48055636

