### PR TITLE
Add datediff Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -13,6 +13,13 @@ These functions support TIMESTAMP and DATE input types.
     If num_days is a negative value then these amount of days will be
     deducted from start_date.
 
+.. spark:function:: date_diff(endDate, startDate) -> integer
+    Returns the number of days from startDate to endDate. 
+    ``datediff`` is` an alias for ``date_diff``::
+
+    SELECT date_diff('2009-07-31', '2009-07-30'); -- 1
+    SELECT date_diff('2009-07-30', '2009-07-31'); -- -1
+
 .. spark:function:: date_sub(start_date, num_days) -> date
 
     Returns the date that is num_days before start_date. According to the inputs,

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -13,13 +13,13 @@ These functions support TIMESTAMP and DATE input types.
     If num_days is a negative value then these amount of days will be
     deducted from start_date.
 
-.. spark:function:: date_diff(endDate, startDate) -> integer
+.. spark:function:: datediff(endDate, startDate) -> integer
 
-    Returns the number of days from startDate to endDate.
-    ``datediff`` is an alias for ``date_diff``. ::
+    Returns the number of days from startDate to endDate. Only DATE type is allowed
+    for input. ::
 
-        SELECT date_diff('2009-07-31', '2009-07-30'); -- 1
-        SELECT date_diff('2009-07-30', '2009-07-31'); -- -1
+        SELECT datediff('2009-07-31', '2009-07-30'); -- 1
+        SELECT datediff('2009-07-30', '2009-07-31'); -- -1
 
 .. spark:function:: date_sub(start_date, num_days) -> date
 

--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -14,11 +14,12 @@ These functions support TIMESTAMP and DATE input types.
     deducted from start_date.
 
 .. spark:function:: date_diff(endDate, startDate) -> integer
-    Returns the number of days from startDate to endDate. 
-    ``datediff`` is` an alias for ``date_diff``::
 
-    SELECT date_diff('2009-07-31', '2009-07-30'); -- 1
-    SELECT date_diff('2009-07-30', '2009-07-31'); -- -1
+    Returns the number of days from startDate to endDate.
+    ``datediff`` is an alias for ``date_diff``. ::
+
+        SELECT date_diff('2009-07-31', '2009-07-30'); -- 1
+        SELECT date_diff('2009-07-30', '2009-07-31'); -- -1
 
 .. spark:function:: date_sub(start_date, num_days) -> date
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -325,9 +325,9 @@ struct DateDiffFunction {
 
   FOLLY_ALWAYS_INLINE bool call(
       int32_t& result,
-      const arg_type<Date>& date1,
-      const arg_type<Date>& date2) {
-    int64_t value = diffDate(DateTimeUnit::kDay, date2, date1);
+      const arg_type<Date>& endDate,
+      const arg_type<Date>& startDate) {
+    int64_t value = diffDate(DateTimeUnit::kDay, startDate, endDate);
     if (value != (int32_t)value) {
       VELOX_UNSUPPORTED("integer overflow");
     }

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -326,7 +326,13 @@ struct DateDiffFunction {
   FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
       const arg_type<Date>& endDate,
-      const arg_type<Date>& startDate) {
+      const arg_type<Date>& startDate)
+#if defined(__has_feature)
+#if __has_feature(__address_sanitizer__)
+      __attribute__((__no_sanitize__("signed-integer-overflow")))
+#endif
+#endif
+  {
     result = endDate - startDate;
   }
 };

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -323,7 +323,7 @@ template <typename T>
 struct DateDiffFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE bool call(
+  FOLLY_ALWAYS_INLINE void call(
       int32_t& result,
       const arg_type<Date>& endDate,
       const arg_type<Date>& startDate) {
@@ -332,7 +332,6 @@ struct DateDiffFunction {
       VELOX_UNSUPPORTED("integer overflow");
     }
     result = (int32_t)value;
-    return true;
   }
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -327,11 +327,7 @@ struct DateDiffFunction {
       int32_t& result,
       const arg_type<Date>& endDate,
       const arg_type<Date>& startDate) {
-    int64_t value = diffDate(DateTimeUnit::kDay, startDate, endDate);
-    if (value != (int32_t)value) {
-      VELOX_UNSUPPORTED("integer overflow");
-    }
-    result = (int32_t)value;
+    result = endDate - startDate;
   }
 };
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -319,4 +319,20 @@ struct DayOfWeekFunction : public InitSessionTimezone<T>,
   }
 };
 
+template <typename T>
+struct DateDiffFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE bool call(
+      int32_t& result,
+      const arg_type<Date>& date1,
+      const arg_type<Date>& date2) {
+    int64_t value = diffDate(DateTimeUnit::kDay, date2, date1);
+    if (value != (int32_t)value) {
+      VELOX_UNSUPPORTED("integer overflow");
+    }
+    result = (int32_t)value;
+    return true;
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -232,7 +232,10 @@ void registerFunctions(const std::string& prefix) {
       Varchar>({prefix + "unix_timestamp", prefix + "to_unix_timestamp"});
   registerFunction<MakeDateFunction, Date, int32_t, int32_t, int32_t>(
       {prefix + "make_date"});
-
+  registerFunction<DateDiffFunction, int32_t, Date, Date>(
+      {prefix + "date_diff"});
+  registerFunction<DateDiffFunction, int32_t, Date, Date>(
+      {prefix + "datediff"});
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -233,8 +233,6 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<MakeDateFunction, Date, int32_t, int32_t, int32_t>(
       {prefix + "make_date"});
   registerFunction<DateDiffFunction, int32_t, Date, Date>(
-      {prefix + "date_diff"});
-  registerFunction<DateDiffFunction, int32_t, Date, Date>(
       {prefix + "datediff"});
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
 

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -383,12 +383,6 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
   const auto dateDiff = [&](std::optional<int32_t> endDate,
                             std::optional<int32_t> startDate) {
     return evaluateOnce<int32_t, int32_t>(
-        "date_diff(c0, c1)", {endDate, startDate}, {DATE(), DATE()});
-  };
-
-  const auto dateDiffAlias = [&](std::optional<int32_t> endDate,
-                                 std::optional<int32_t> startDate) {
-    return evaluateOnce<int32_t, int32_t>(
         "datediff(c0, c1)", {endDate, startDate}, {DATE(), DATE()});
   };
 
@@ -404,12 +398,10 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
   EXPECT_EQ(
       -737790, dateDiff(parseDate("2020-02-29"), parseDate("4040-02-29")));
 
-  // Negative year.
+  // Overflowed result, consistent with spark.
   EXPECT_EQ(
       2147474628,
       dateDiff(parseDate("-5877641-06-23"), parseDate("1994-09-12")));
-
-  EXPECT_EQ(0, dateDiffAlias(parseDate("1994-04-20"), parseDate("1994-04-20")));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -391,23 +391,20 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
     return evaluateOnce<int32_t, int32_t>(
         "datediff(c0, c1)", {endDate, startDate}, {DATE(), DATE()});
   };
-  // Check null behaviors
-  EXPECT_EQ(std::nullopt, dateDiff(1, std::nullopt));
-  EXPECT_EQ(std::nullopt, dateDiff(std::nullopt, 0));
 
-  // Simple tests
+  // Simple tests.
   EXPECT_EQ(-1, dateDiff(parseDate("2019-02-28"), parseDate("2019-03-01")));
   EXPECT_EQ(-358, dateDiff(parseDate("2019-02-28"), parseDate("2020-02-21")));
   EXPECT_EQ(0, dateDiff(parseDate("1994-04-20"), parseDate("1994-04-20")));
 
-  // Account for the last day of a year-month
+  // Account for the last day of a year-month.
   EXPECT_EQ(395, dateDiff(parseDate("2020-02-29"), parseDate("2019-01-30")));
 
-  // Check Large date
+  // Check Large date.
   EXPECT_EQ(
       -737790, dateDiff(parseDate("2020-02-29"), parseDate("4040-02-29")));
 
-  // Negative year
+  // Negative year.
   EXPECT_EQ(
       2147474628,
       dateDiff(parseDate("-5877641-06-23"), parseDate("1994-09-12")));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -380,16 +380,16 @@ TEST_F(DateTimeFunctionsTest, dayofWeekTs) {
 }
 
 TEST_F(DateTimeFunctionsTest, dateDiffDate) {
-  const auto dateDiff = [&](std::optional<int32_t> date1,
-                            std::optional<int32_t> date2) {
+  const auto dateDiff = [&](std::optional<int32_t> endDate,
+                            std::optional<int32_t> startDate) {
     return evaluateOnce<int32_t, int32_t>(
-        "date_diff(c0, c1)", {date1, date2}, {DATE(), DATE()});
+        "date_diff(c0, c1)", {endDate, startDate}, {DATE(), DATE()});
   };
 
-  const auto dateDiffAlias = [&](std::optional<int32_t> date1,
-                                 std::optional<int32_t> date2) {
+  const auto dateDiffAlias = [&](std::optional<int32_t> endDate,
+                                 std::optional<int32_t> startDate) {
     return evaluateOnce<int32_t, int32_t>(
-        "datediff(c0, c1)", {date1, date2}, {DATE(), DATE()});
+        "datediff(c0, c1)", {endDate, startDate}, {DATE(), DATE()});
   };
   // Check null behaviors
   EXPECT_EQ(std::nullopt, dateDiff(1, std::nullopt));

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -413,9 +413,6 @@ TEST_F(DateTimeFunctionsTest, dateDiffDate) {
       dateDiff(parseDate("-5877641-06-23"), parseDate("1994-09-12")));
 
   EXPECT_EQ(0, dateDiffAlias(parseDate("1994-04-20"), parseDate("1994-04-20")));
-
-  // Exception
-  // VELOX_ASSERT_THROW(dateDiff(0, 9999999999), "integer overflow");
 }
 
 } // namespace


### PR DESCRIPTION
Presto date_diff function:

Returns timestamp2 - timestamp1 expressed in terms of unit. 
```    
date_diff(unit, timestamp1, timestamp2) → bigint
```

Spark datediff function：

datediff(endDate, startDate) ->int
```
Returns the number of days from startDate to endDate.
```

Spark's implementation: [link](https://github.com/apache/spark/blob/branch-3.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L2280-L2282C1)