### PR TITLE
Add castFromDateString for different cast behavior

### DIFF
--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -105,6 +105,18 @@ constexpr int32_t kCumulativeYearDays[] = {
 
 namespace {
 
+// Enum to dictate parsing modes for date strings.
+//
+// kStrict: For date string conversion, align with DuckDB's implementation.
+//
+// kNonStrict: For timestamp string conversion, align with DuckDB's
+// implementation.
+//
+// kStandardCast: Strictly processes dates in the [+-](YYYY-MM-DD) format.
+// Align with Presto casting conventions.
+//
+// kNonStandardCast: Like standard but permits missing day/month and allows
+// trailing 'T' or spaces. Align with Spark SQL casting conventions.
 enum class ParseMode { kStrict, kNonStrict, kStandardCast, kNonStandardCast };
 
 inline bool characterIsSpace(char c) {
@@ -576,7 +588,10 @@ castFromDateString(const char* str, size_t len, bool isNonStandardCast) {
                                 : ParseMode::kStandardCast;
   if (!tryParseDateString(str, len, pos, daysSinceEpoch, mode)) {
     VELOX_USER_FAIL(
-        "Unable to parse date value: \"{}\", expected format is (YYYY-MM-DD)",
+        "Unable to parse date value: \"{}\"."
+        "In Spark SQL, valid date string patterns include "
+        "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]; "
+        "while in Presto, the supported pattern is [+-](YYYY-MM-DD).",
         std::string(str, len));
   }
   return daysSinceEpoch;

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -587,12 +587,20 @@ castFromDateString(const char* str, size_t len, bool isNonStandardCast) {
   auto mode = isNonStandardCast ? ParseMode::kNonStandardCast
                                 : ParseMode::kStandardCast;
   if (!tryParseDateString(str, len, pos, daysSinceEpoch, mode)) {
-    VELOX_USER_FAIL(
-        "Unable to parse date value: \"{}\"."
-        "In Spark SQL, valid date string patterns include "
-        "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]; "
-        "while in Presto, the supported pattern is [+-](YYYY-MM-DD).",
-        std::string(str, len));
+    if (isNonStandardCast) {
+      VELOX_USER_FAIL(
+          "Unable to parse date value: \"{}\"."
+          "Valid date string patterns include "
+          "(YYYY, YYYY-MM, YYYY-MM-DD), and any pattern prefixed with [+-]",
+          std::string(str, len));
+
+    } else {
+      VELOX_USER_FAIL(
+          "Unable to parse date value: \"{}\"."
+          "Valid date string pattern is (YYYY-MM-DD), "
+          "and can be prefixed with [+-]",
+          std::string(str, len));
+    }
   }
   return daysSinceEpoch;
 }

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -105,6 +105,8 @@ constexpr int32_t kCumulativeYearDays[] = {
 
 namespace {
 
+enum class ParseMode { kStrict, kNonStrict, kStandardCast, kNonStandardCast };
+
 inline bool characterIsSpace(char c) {
   return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' ||
       c == '\r';
@@ -142,12 +144,17 @@ bool isValidWeekDate(int32_t weekYear, int32_t weekOfYear, int32_t dayOfWeek) {
   return true;
 }
 
+inline bool validDate(int64_t daysSinceEpoch) {
+  return daysSinceEpoch >= std::numeric_limits<int32_t>::min() &&
+      daysSinceEpoch <= std::numeric_limits<int32_t>::max();
+}
+
 bool tryParseDateString(
     const char* buf,
     size_t len,
     size_t& pos,
     int64_t& daysSinceEpoch,
-    bool strict) {
+    ParseMode mode) {
   pos = 0;
   if (len == 0) {
     return false;
@@ -173,7 +180,13 @@ bool tryParseDateString(
     if (pos >= len) {
       return false;
     }
+  } else if (buf[pos] == '+') {
+    pos++;
+    if (pos >= len) {
+      return false;
+    }
   }
+
   if (!characterIsDigit(buf[pos])) {
     return false;
   }
@@ -191,20 +204,39 @@ bool tryParseDateString(
     }
   }
 
+  // No month or day.
+  if (mode == ParseMode::kNonStandardCast && pos == len) {
+    daysSinceEpoch = daysSinceEpochFromDate(year, 1, 1);
+    return validDate(daysSinceEpoch);
+  }
+
   if (pos >= len) {
     return false;
   }
 
   // Fetch the separator.
   sep = buf[pos++];
-  if (sep != ' ' && sep != '-' && sep != '/' && sep != '\\') {
-    // Invalid separator.
-    return false;
+  if (mode == ParseMode::kStandardCast || mode == ParseMode::kNonStandardCast) {
+    // Only '-' is valid for cast.
+    if (sep != '-') {
+      return false;
+    }
+  } else {
+    if (sep != ' ' && sep != '-' && sep != '/' && sep != '\\') {
+      // Invalid separator.
+      return false;
+    }
   }
 
   // Parse the month.
   if (!parseDoubleDigit(buf, len, pos, month)) {
     return false;
+  }
+
+  // No day.
+  if (mode == ParseMode::kNonStandardCast && pos == len) {
+    daysSinceEpoch = daysSinceEpochFromDate(year, month, 1);
+    return validDate(daysSinceEpoch);
   }
 
   if (pos >= len) {
@@ -224,6 +256,35 @@ bool tryParseDateString(
     return false;
   }
 
+  // In standard-cast mode, no more trailing characters.
+  if (mode == ParseMode::kStandardCast) {
+    daysSinceEpoch = daysSinceEpochFromDate(year, month, day);
+
+    if (pos == len) {
+      return validDate(daysSinceEpoch);
+    }
+    return false;
+  }
+
+  // In non-standard cast mode, any optional trailing 'T' or spaces followed
+  // by any optional characters are valid patterns.
+  if (mode == ParseMode::kNonStandardCast) {
+    daysSinceEpoch = daysSinceEpochFromDate(year, month, day);
+
+    if (!validDate(daysSinceEpoch)) {
+      return false;
+    }
+
+    if (pos == len) {
+      return true;
+    }
+
+    if (buf[pos] == 'T' || buf[pos] == ' ') {
+      return true;
+    }
+    return false;
+  }
+
   // Check for an optional trailing " (BC)".
   if (len - pos >= 5 && characterIsSpace(buf[pos]) && buf[pos + 1] == '(' &&
       buf[pos + 2] == 'B' && buf[pos + 3] == 'C' && buf[pos + 4] == ')') {
@@ -239,7 +300,7 @@ bool tryParseDateString(
   }
 
   // In strict mode, check remaining string for non-space characters.
-  if (strict) {
+  if (mode == ParseMode::kStrict) {
     // Skip trailing spaces.
     while (pos < len && characterIsSpace(buf[pos])) {
       pos++;
@@ -498,7 +559,22 @@ int64_t fromDateString(const char* str, size_t len) {
   int64_t daysSinceEpoch;
   size_t pos = 0;
 
-  if (!tryParseDateString(str, len, pos, daysSinceEpoch, true)) {
+  if (!tryParseDateString(str, len, pos, daysSinceEpoch, ParseMode::kStrict)) {
+    VELOX_USER_FAIL(
+        "Unable to parse date value: \"{}\", expected format is (YYYY-MM-DD)",
+        std::string(str, len));
+  }
+  return daysSinceEpoch;
+}
+
+int32_t
+castFromDateString(const char* str, size_t len, bool isNonStandardCast) {
+  int64_t daysSinceEpoch;
+  size_t pos = 0;
+
+  auto mode = isNonStandardCast ? ParseMode::kNonStandardCast
+                                : ParseMode::kStandardCast;
+  if (!tryParseDateString(str, len, pos, daysSinceEpoch, mode)) {
     VELOX_USER_FAIL(
         "Unable to parse date value: \"{}\", expected format is (YYYY-MM-DD)",
         std::string(str, len));
@@ -580,7 +656,8 @@ Timestamp fromTimestampString(const char* str, size_t len) {
   int64_t daysSinceEpoch;
   int64_t microsSinceMidnight;
 
-  if (!tryParseDateString(str, len, pos, daysSinceEpoch, false)) {
+  if (!tryParseDateString(
+          str, len, pos, daysSinceEpoch, ParseMode::kNonStrict)) {
     parserError(str, len);
   }
 

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -81,6 +81,26 @@ inline int64_t fromDateString(const StringView& str) {
   return fromDateString(str.data(), str.size());
 }
 
+/// Cast string to date.
+/// When isNonStandardCast = false, only support "[+-]YYYY-MM-DD" format.
+/// When isNonStandardCast = true, supported date formats include:
+///
+/// `[+-]YYYY*`
+/// `[+-]YYYY*-[M]M`
+/// `[+-]YYYY*-[M]M-[D]D`
+/// `[+-]YYYY*-[M]M-[D]D `
+/// `[+-]YYYY*-[M]M-[D]D *`
+/// `[+-]YYYY*-[M]M-[D]DT*`
+///
+/// Throws VeloxUserError if the format or date is invalid.
+int32_t castFromDateString(const char* buf, size_t len, bool isNonStandardCast);
+
+inline int32_t castFromDateString(
+    const StringView& str,
+    bool isNonStandardCast) {
+  return castFromDateString(str.data(), str.size(), isNonStandardCast);
+}
+
 // Extracts the day of the week from the number of days since epoch
 int32_t extractISODayOfTheWeek(int32_t daysSinceEpoch);
 

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -109,6 +109,45 @@ TEST(DateTimeUtilTest, fromDateStrInvalid) {
   EXPECT_THROW(fromDateString("-1000000"), VeloxUserError);
 }
 
+TEST(DateTimeUtilTest, castFromDateString) {
+  for (bool nonStandard : {true, false}) {
+    EXPECT_EQ(0, castFromDateString("1970-01-01", nonStandard));
+    EXPECT_EQ(3789742, castFromDateString("12345-12-18", nonStandard));
+
+    EXPECT_EQ(1, castFromDateString("+1970-1-2", nonStandard));
+    EXPECT_EQ(1, castFromDateString("+1970-01-2", nonStandard));
+    EXPECT_EQ(1, castFromDateString("+1970-1-02", nonStandard));
+
+    EXPECT_EQ(1, castFromDateString("+1970-01-02", nonStandard));
+    EXPECT_EQ(-719893, castFromDateString("-1-1-1", nonStandard));
+  }
+
+  EXPECT_EQ(3789391, castFromDateString("12345", true));
+  EXPECT_EQ(16495, castFromDateString("2015-03", true));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 ", true));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18 123412", true));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18T", true));
+  EXPECT_EQ(16512, castFromDateString("2015-03-18T123412", true));
+}
+
+TEST(DateTimeUtilTest, castFromDateStringInvalid) {
+  for (bool nonStandard : {true, false}) {
+    EXPECT_THROW(
+        castFromDateString("2015-03-18X", nonStandard), VeloxUserError);
+    EXPECT_THROW(castFromDateString("2015/03/18", nonStandard), VeloxUserError);
+    EXPECT_THROW(castFromDateString("2015.03.18", nonStandard), VeloxUserError);
+    EXPECT_THROW(castFromDateString("20150318", nonStandard), VeloxUserError);
+    EXPECT_THROW(castFromDateString("2015-031-8", nonStandard), VeloxUserError);
+  }
+
+  EXPECT_THROW(castFromDateString("12345", false), VeloxUserError);
+  EXPECT_THROW(castFromDateString("2015-03", false), VeloxUserError);
+  EXPECT_THROW(castFromDateString("2015-03-18 ", false), VeloxUserError);
+  EXPECT_THROW(castFromDateString("2015-03-18 123412", false), VeloxUserError);
+  EXPECT_THROW(castFromDateString("2015-03-18T", false), VeloxUserError);
+  EXPECT_THROW(castFromDateString("2015-03-18T123412", false), VeloxUserError);
+}
+
 TEST(DateTimeUtilTest, fromTimeString) {
   EXPECT_EQ(0, fromTimeString("00:00:00"));
   EXPECT_EQ(0, fromTimeString("00:00:00.00"));


### PR DESCRIPTION
This is a splitting PR from https://github.com/facebookincubator/velox/pull/5844

Since `fromDateString` cannot properly handle different cast behaviors and returns int64_t that may cause overflow of Date type, this PR add `castFromDateString` as a helper function, which can be used for handle different cast from string to date behavior from sparksql and prestosql. 

Below patterns are considered valid to cast from string to date in spark sql functions:

Year only: "YYYY"
Year and month only: "YYYY-MM"
Digits after trailing spaces: "YYYY-MM-DD 123"
Trailing character 'T': "YYYY-MM-DDT"
Digits after 'T': "YYYY-MM-DDT123123"
"[+-]" before any valid pattern.

Below patterns are valid in presto sql:

"[+-]YYYY-MM-DD"