### PR TITLE
Add support for reading orc column statistics

### DIFF
--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -336,6 +336,336 @@ class UserMetadataItemWrapper : public ProtoWrapperBase {
   }
 };
 
+class IntegerStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit IntegerStatisticsWrapper(
+      const proto::IntegerStatistics* intStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, intStatistics) {}
+
+  explicit IntegerStatisticsWrapper(
+      const proto::orc::IntegerStatistics* intStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, intStatistics) {}
+
+  bool hasMinimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_minimum()
+                                        : orcPtr()->has_minimum();
+  }
+
+  int64_t minimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->minimum()
+                                        : orcPtr()->minimum();
+  }
+
+  bool hasMaximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_maximum()
+                                        : orcPtr()->has_maximum();
+  }
+
+  int64_t maximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->maximum()
+                                        : orcPtr()->maximum();
+  }
+
+  bool hasSum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_sum()
+                                        : orcPtr()->has_sum();
+  }
+
+  int64_t sum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->sum() : orcPtr()->sum();
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::IntegerStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::IntegerStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::IntegerStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::IntegerStatistics*>(
+        rawProtoPtr());
+  }
+};
+
+class DoubleStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit DoubleStatisticsWrapper(
+      const proto::DoubleStatistics* doubleStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, doubleStatistics) {}
+
+  explicit DoubleStatisticsWrapper(
+      const proto::orc::DoubleStatistics* doubleStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, doubleStatistics) {}
+
+  bool hasMinimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_minimum()
+                                        : orcPtr()->has_minimum();
+  }
+
+  double minimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->minimum()
+                                        : orcPtr()->minimum();
+  }
+
+  bool hasMaximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_maximum()
+                                        : orcPtr()->has_maximum();
+  }
+
+  double maximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->maximum()
+                                        : orcPtr()->maximum();
+  }
+
+  bool hasSum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_sum()
+                                        : orcPtr()->has_sum();
+  }
+
+  double sum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->sum() : orcPtr()->sum();
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::DoubleStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::DoubleStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::DoubleStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::DoubleStatistics*>(rawProtoPtr());
+  }
+};
+
+class StringStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit StringStatisticsWrapper(
+      const proto::StringStatistics* stringStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, stringStatistics) {}
+
+  explicit StringStatisticsWrapper(
+      const proto::orc::StringStatistics* stringStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, stringStatistics) {}
+
+  bool hasMinimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_minimum()
+                                        : orcPtr()->has_minimum();
+  }
+
+  const std::string& minimum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->minimum()
+                                        : orcPtr()->minimum();
+  }
+
+  bool hasMaximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_maximum()
+                                        : orcPtr()->has_maximum();
+  }
+
+  const std::string& maximum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->maximum()
+                                        : orcPtr()->maximum();
+  }
+
+  bool hasSum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_sum()
+                                        : orcPtr()->has_sum();
+  }
+
+  int64_t sum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->sum() : orcPtr()->sum();
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::StringStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::StringStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::StringStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::StringStatistics*>(rawProtoPtr());
+  }
+};
+
+class BucketStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit BucketStatisticsWrapper(
+      const proto::BucketStatistics* bucketStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, bucketStatistics) {}
+
+  explicit BucketStatisticsWrapper(
+      const proto::orc::BucketStatistics* bucketStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, bucketStatistics) {}
+
+  int countSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->count_size()
+                                        : orcPtr()->count_size();
+  }
+
+  const uint64_t count(int index) const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->count(index)
+                                        : orcPtr()->count(index);
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::BucketStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::BucketStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::BucketStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::BucketStatistics*>(rawProtoPtr());
+  }
+};
+
+class BinaryStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit BinaryStatisticsWrapper(
+      const proto::BinaryStatistics* binaryStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, binaryStatistics) {}
+
+  explicit BinaryStatisticsWrapper(
+      const proto::orc::BinaryStatistics* binaryStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, binaryStatistics) {}
+
+  bool hasSum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_sum()
+                                        : orcPtr()->has_sum();
+  }
+
+  const int64_t sum() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->sum() : orcPtr()->sum();
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::BinaryStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::BinaryStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::BinaryStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::BinaryStatistics*>(rawProtoPtr());
+  }
+};
+
+class ColumnStatisticsWrapper : public ProtoWrapperBase {
+ public:
+  explicit ColumnStatisticsWrapper(
+      const proto::ColumnStatistics* columnStatistics)
+      : ProtoWrapperBase(DwrfFormat::kDwrf, columnStatistics) {}
+
+  explicit ColumnStatisticsWrapper(
+      const proto::orc::ColumnStatistics* columnStatistics)
+      : ProtoWrapperBase(DwrfFormat::kOrc, columnStatistics) {}
+
+  bool hasNumberOfValues() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_numberofvalues()
+                                        : orcPtr()->has_numberofvalues();
+  }
+
+  uint64_t numberOfValues() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->numberofvalues()
+                                        : orcPtr()->numberofvalues();
+  }
+
+  bool hasHasNull() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_hasnull()
+                                        : orcPtr()->has_hasnull();
+  }
+
+  bool hasNull() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->hasnull()
+                                        : orcPtr()->hasnull();
+  }
+
+  bool hasRawSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_rawsize() : false;
+  }
+
+  std::optional<uint64_t> rawSize() const {
+    return format_ == DwrfFormat::kDwrf ? std::optional(dwrfPtr()->rawsize())
+                                        : std::nullopt;
+  }
+
+  bool hasSize() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_size() : false;
+  }
+
+  std::optional<uint64_t> size() const {
+    return format_ == DwrfFormat::kDwrf ? std::optional(dwrfPtr()->size())
+                                        : std::nullopt;
+  }
+
+  bool hasIntStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_intstatistics()
+                                        : orcPtr()->has_intstatistics();
+  }
+
+  IntegerStatisticsWrapper intStatistics() const {
+    return format_ == DwrfFormat::kDwrf
+        ? IntegerStatisticsWrapper(&dwrfPtr()->intstatistics())
+        : IntegerStatisticsWrapper(&orcPtr()->intstatistics());
+  }
+
+  bool hasDoubleStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_doublestatistics()
+                                        : orcPtr()->has_doublestatistics();
+  }
+
+  DoubleStatisticsWrapper doubleStatistics() const {
+    return format_ == DwrfFormat::kDwrf
+        ? DoubleStatisticsWrapper(&dwrfPtr()->doublestatistics())
+        : DoubleStatisticsWrapper(&orcPtr()->doublestatistics());
+  }
+
+  bool hasStringStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_stringstatistics()
+                                        : orcPtr()->has_stringstatistics();
+  }
+
+  StringStatisticsWrapper stringStatistics() const {
+    return format_ == DwrfFormat::kDwrf
+        ? StringStatisticsWrapper(&dwrfPtr()->stringstatistics())
+        : StringStatisticsWrapper(&orcPtr()->stringstatistics());
+  }
+
+  bool hasBucketStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_bucketstatistics()
+                                        : orcPtr()->has_bucketstatistics();
+  }
+
+  BucketStatisticsWrapper bucketStatistics() const {
+    return format_ == DwrfFormat::kDwrf
+        ? BucketStatisticsWrapper(&dwrfPtr()->bucketstatistics())
+        : BucketStatisticsWrapper(&orcPtr()->bucketstatistics());
+  }
+
+  bool hasBinaryStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_binarystatistics()
+                                        : orcPtr()->has_binarystatistics();
+  }
+
+  BinaryStatisticsWrapper binaryStatistics() const {
+    return format_ == DwrfFormat::kDwrf
+        ? BinaryStatisticsWrapper(&dwrfPtr()->binarystatistics())
+        : BinaryStatisticsWrapper(&orcPtr()->binarystatistics());
+  }
+
+  bool hasMapStatistics() const {
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->has_mapstatistics()
+                                        : false;
+  }
+
+  const ::facebook::velox::dwrf::proto::MapStatistics& mapStatistics() const {
+    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
+    return dwrfPtr()->mapstatistics();
+  }
+
+ private:
+  // private helper with no format checking
+  inline const proto::ColumnStatistics* dwrfPtr() const {
+    return reinterpret_cast<const proto::ColumnStatistics*>(rawProtoPtr());
+  }
+  inline const proto::orc::ColumnStatistics* orcPtr() const {
+    return reinterpret_cast<const proto::orc::ColumnStatistics*>(rawProtoPtr());
+  }
+};
+
 class FooterWrapper : public ProtoWrapperBase {
  public:
   explicit FooterWrapper(const proto::Footer* footer)
@@ -424,9 +754,9 @@ class FooterWrapper : public ProtoWrapperBase {
     return dwrfPtr()->stripecacheoffsets();
   }
 
-  // TODO: ORC has not supported column statistics yet
   int statisticsSize() const {
-    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->statistics_size() : 0;
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->statistics_size()
+                                        : orcPtr()->statistics_size();
   }
 
   const ::google::protobuf::RepeatedPtrField<
@@ -436,10 +766,10 @@ class FooterWrapper : public ProtoWrapperBase {
     return dwrfPtr()->statistics();
   }
 
-  const ::facebook::velox::dwrf::proto::ColumnStatistics& statistics(
-      int index) const {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
-    return dwrfPtr()->statistics(index);
+  ColumnStatisticsWrapper statistics(int index) const {
+    return format_ == DwrfFormat::kDwrf
+        ? ColumnStatisticsWrapper(&dwrfPtr()->statistics(index))
+        : ColumnStatisticsWrapper(&orcPtr()->statistics(index));
   }
 
   // TODO: ORC has not supported encryption yet

--- a/velox/dwio/dwrf/common/Statistics.cpp
+++ b/velox/dwio/dwrf/common/Statistics.cpp
@@ -21,74 +21,75 @@ namespace facebook::velox::dwrf {
 using namespace dwio::common;
 
 std::unique_ptr<ColumnStatistics> buildColumnStatisticsFromProto(
-    const proto::ColumnStatistics& s,
+    ColumnStatisticsWrapper stats,
     const StatsContext& statsContext) {
   ColumnStatistics colStats(
-      s.has_numberofvalues() ? std::optional(s.numberofvalues()) : std::nullopt,
-      s.has_hasnull() ? std::optional(s.hasnull()) : std::nullopt,
-      s.has_rawsize() ? std::optional(s.rawsize()) : std::nullopt,
-      s.has_size() ? std::optional(s.size()) : std::nullopt);
+      stats.hasNumberOfValues() ? std::optional(stats.numberOfValues())
+                                : std::nullopt,
+      stats.hasHasNull() ? std::optional(stats.hasNull()) : std::nullopt,
+      stats.hasRawSize() ? stats.rawSize() : std::nullopt,
+      stats.hasSize() ? stats.size() : std::nullopt);
 
   // detailed stats is only defined when has non-null value
-  if (!s.has_numberofvalues() || s.numberofvalues() > 0) {
-    if (s.has_intstatistics()) {
-      const auto& intStats = s.intstatistics();
+  if (!stats.hasNumberOfValues() || stats.numberOfValues() > 0) {
+    if (stats.hasIntStatistics()) {
+      const auto& intStats = stats.intStatistics();
       return std::make_unique<IntegerColumnStatistics>(
           colStats,
-          intStats.has_minimum() ? std::optional(intStats.minimum())
-                                 : std::nullopt,
-          intStats.has_maximum() ? std::optional(intStats.maximum())
-                                 : std::nullopt,
-          intStats.has_sum() ? std::optional(intStats.sum()) : std::nullopt);
-    } else if (s.has_doublestatistics()) {
-      const auto& dStats = s.doublestatistics();
+          intStats.hasMinimum() ? std::optional(intStats.minimum())
+                                : std::nullopt,
+          intStats.hasMaximum() ? std::optional(intStats.maximum())
+                                : std::nullopt,
+          intStats.hasSum() ? std::optional(intStats.sum()) : std::nullopt);
+    } else if (stats.hasDoubleStatistics()) {
+      const auto& dStats = stats.doubleStatistics();
       // Comparing against NaN doesn't make sense, and to prevent downstream
       // from incorrectly using it, need to make sure min/max/sum doens't have
       // NaN.
-      auto hasNan = (dStats.has_minimum() && std::isnan(dStats.minimum())) ||
-          (dStats.has_maximum() && std::isnan(dStats.maximum())) ||
-          (dStats.has_sum() && std::isnan(dStats.sum()));
+      auto hasNan = (dStats.hasMinimum() && std::isnan(dStats.minimum())) ||
+          (dStats.hasMaximum() && std::isnan(dStats.maximum())) ||
+          (dStats.hasSum() && std::isnan(dStats.sum()));
       if (!hasNan) {
         return std::make_unique<DoubleColumnStatistics>(
             colStats,
-            dStats.has_minimum() ? std::optional(dStats.minimum())
-                                 : std::nullopt,
-            dStats.has_maximum() ? std::optional(dStats.maximum())
-                                 : std::nullopt,
-            dStats.has_sum() ? std::optional(dStats.sum()) : std::nullopt);
+            dStats.hasMinimum() ? std::optional(dStats.minimum())
+                                : std::nullopt,
+            dStats.hasMaximum() ? std::optional(dStats.maximum())
+                                : std::nullopt,
+            dStats.hasSum() ? std::optional(dStats.sum()) : std::nullopt);
       }
-    } else if (s.has_stringstatistics()) {
+    } else if (stats.hasStringStatistics()) {
       // DWRF_5_0 is the first version that string stats are saved as UTF8
       // bytes, hence only process string stats for version >= DWRF_5_0
       if (statsContext.writerVersion >= WriterVersion::DWRF_5_0 ||
           statsContext.writerName == kPrestoWriter ||
           statsContext.writerName == kDwioWriter) {
-        const auto& strStats = s.stringstatistics();
+        const auto& strStats = stats.stringStatistics();
         return std::make_unique<StringColumnStatistics>(
             colStats,
-            strStats.has_minimum() ? std::optional(strStats.minimum())
-                                   : std::nullopt,
-            strStats.has_maximum() ? std::optional(strStats.maximum())
-                                   : std::nullopt,
+            strStats.hasMinimum() ? std::optional(strStats.minimum())
+                                  : std::nullopt,
+            strStats.hasMaximum() ? std::optional(strStats.maximum())
+                                  : std::nullopt,
             // In proto, length(sum) is defined as sint. We need to make sure
             // length is not negative
-            (strStats.has_sum() && strStats.sum() >= 0)
+            (strStats.hasSum() && strStats.sum() >= 0)
                 ? std::optional(strStats.sum())
                 : std::nullopt);
       }
-    } else if (s.has_bucketstatistics()) {
-      const auto& bucketStats = s.bucketstatistics();
+    } else if (stats.hasBucketStatistics()) {
+      const auto& bucketStats = stats.bucketStatistics();
       // Need to make sure there is at least one bucket. True count is saved in
       // bucket 0
-      if (bucketStats.count_size() > 0) {
+      if (bucketStats.countSize() > 0) {
         return std::make_unique<BooleanColumnStatistics>(
             colStats, bucketStats.count(0));
       }
-    } else if (s.has_binarystatistics()) {
-      const auto& binStats = s.binarystatistics();
+    } else if (stats.hasBinaryStatistics()) {
+      const auto& binStats = stats.binaryStatistics();
       // In proto, length(sum) is defined as sint. We need to make sure length
       // is not negative
-      if (binStats.has_sum() && binStats.sum() >= 0) {
+      if (binStats.hasSum() && binStats.sum() >= 0) {
         return std::make_unique<BinaryColumnStatistics>(
             colStats, static_cast<uint64_t>(binStats.sum()));
       }

--- a/velox/dwio/dwrf/common/Statistics.h
+++ b/velox/dwio/dwrf/common/Statistics.h
@@ -18,6 +18,7 @@
 
 #include "velox/dwio/common/Statistics.h"
 #include "velox/dwio/dwrf/common/Common.h"
+#include "velox/dwio/dwrf/common/FileMetadata.h"
 #include "velox/dwio/dwrf/common/wrap/dwrf-proto-wrapper.h"
 
 namespace facebook::velox::dwrf {
@@ -39,7 +40,7 @@ struct StatsContext : public dwio::common::StatsContext {
 };
 
 std::unique_ptr<dwio::common::ColumnStatistics> buildColumnStatisticsFromProto(
-    const proto::ColumnStatistics& stats,
+    ColumnStatisticsWrapper stats,
     const StatsContext& statsContext);
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/BinaryStreamReader.h
+++ b/velox/dwio/dwrf/reader/BinaryStreamReader.h
@@ -75,7 +75,7 @@ class BinaryStreamReader {
 
   std::unique_ptr<BinaryStripeStreams> next();
 
-  std::unordered_map<uint32_t, proto::ColumnStatistics> getStatistics() const;
+  std::unordered_map<uint32_t, ColumnStatisticsWrapper> getStatistics() const;
 
   uint32_t getCurrentStripeIndex() const {
     return stripeIndex_;

--- a/velox/dwio/dwrf/reader/DwrfData.cpp
+++ b/velox/dwio/dwrf/reader/DwrfData.cpp
@@ -159,8 +159,8 @@ void DwrfData::filterRowGroups(
   }
   for (auto i = 0; i < index_->entry_size(); i++) {
     const auto& entry = index_->entry(i);
-    auto columnStats =
-        buildColumnStatisticsFromProto(entry.statistics(), *dwrfContext);
+    auto columnStats = buildColumnStatisticsFromProto(
+        ColumnStatisticsWrapper(&entry.statistics()), *dwrfContext);
     if (filter &&
         !testFilter(
             filter, columnStats.get(), rowGroupSize, nodeType_->type())) {

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -60,7 +60,8 @@ FooterStatisticsImpl::FooterStatisticsImpl(
         for (uint32_t statsIndex = 0; statsIndex < stats->statistics_size();
              ++statsIndex) {
           colStats_[node + statsIndex] = buildColumnStatisticsFromProto(
-              stats->statistics(statsIndex), statsContext);
+              ColumnStatisticsWrapper(&stats->statistics(statsIndex)),
+              statsContext);
         }
       }
     }
@@ -244,7 +245,7 @@ std::unique_ptr<ColumnStatistics> ReaderBase::getColumnStatistics(
       "column index out of range");
   StatsContext statsContext(getWriterVersion());
   if (!handler_->isEncrypted(index)) {
-    auto& stats = footer_->statistics(index);
+    auto stats = footer_->statistics(index);
     return buildColumnStatisticsFromProto(stats, statsContext);
   }
 
@@ -255,7 +256,7 @@ std::unique_ptr<ColumnStatistics> ReaderBase::getColumnStatistics(
 
   // if key is not loaded, return plaintext stats
   if (!decrypter.isKeyLoaded()) {
-    auto& stats = footer_->statistics(index);
+    auto stats = footer_->statistics(index);
     return buildColumnStatisticsFromProto(stats, statsContext);
   }
 
@@ -271,7 +272,7 @@ std::unique_ptr<ColumnStatistics> ReaderBase::getColumnStatistics(
   auto stats = readProtoFromString<proto::FileStatistics>(
       group.statistics(nodeIndex), &decrypter);
   return buildColumnStatisticsFromProto(
-      stats->statistics(index - root), statsContext);
+      ColumnStatisticsWrapper(&stats->statistics(index - root)), statsContext);
 }
 
 std::shared_ptr<const Type> ReaderBase::convertType(

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -34,11 +34,20 @@ add_test(velox_dwio_dwrf_buffered_output_stream_test
 target_link_libraries(velox_dwio_dwrf_buffered_output_stream_test
                       velox_link_libs Folly::folly ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_dwrf_column_statistics_test TestColumnStatistics.cpp)
+add_executable(velox_dwio_dwrf_column_statistics_test
+               TestDwrfColumnStatistics.cpp)
 add_test(velox_dwio_dwrf_column_statistics_test
          velox_dwio_dwrf_column_statistics_test)
 
 target_link_libraries(velox_dwio_dwrf_column_statistics_test velox_link_libs
+                      Folly::folly ${TEST_LINK_LIBS})
+
+add_executable(velox_dwio_orc_column_statistics_test
+               TestOrcColumnStatistics.cpp)
+add_test(velox_dwio_orc_column_statistics_test
+         velox_dwio_orc_column_statistics_test)
+
+target_link_libraries(velox_dwio_orc_column_statistics_test velox_link_libs
                       Folly::folly ${TEST_LINK_LIBS})
 
 add_executable(velox_dwio_dwrf_compression_test TestCompression.cpp)

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -124,7 +124,7 @@ void verifyStats(
 
     for (auto count = 0; count < rowIndex->entry_size(); count++) {
       auto stridStatistics = buildColumnStatisticsFromProto(
-          rowIndex->entry(count).statistics(),
+          ColumnStatisticsWrapper(&rowIndex->entry(count).statistics()),
           dwrf::StatsContext(WriterVersion_CURRENT));
       // TODO, take in a lambda to verify the entire statistics instead of Just
       // the rawSize.

--- a/velox/dwio/dwrf/test/E2EWriterTests.cpp
+++ b/velox/dwio/dwrf/test/E2EWriterTests.cpp
@@ -219,10 +219,10 @@ class E2EWriterTests : public Test {
         }
       }
       auto stats = reader->getFooter().statistics(mapTypeId);
-      ASSERT_TRUE(stats.has_mapstatistics());
-      ASSERT_EQ(featureStreamSizes.size(), stats.mapstatistics().stats_size());
-      for (size_t i = 0; i != stats.mapstatistics().stats_size(); ++i) {
-        const auto& entry = stats.mapstatistics().stats(i);
+      ASSERT_TRUE(stats.hasMapStatistics());
+      ASSERT_EQ(featureStreamSizes.size(), stats.mapStatistics().stats_size());
+      for (size_t i = 0; i != stats.mapStatistics().stats_size(); ++i) {
+        const auto& entry = stats.mapStatistics().stats(i);
         ASSERT_TRUE(entry.stats().has_size());
         EXPECT_EQ(
             featureStreamSizes.at(constructKey(entry.key())),

--- a/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestDwrfColumnStatistics.cpp
@@ -1,0 +1,496 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/test/TestColumnStatisticsBase.h"
+#include "velox/type/fbhive/HiveTypeParser.h"
+
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::dwrf;
+using facebook::velox::type::fbhive::HiveTypeParser;
+
+TEST(StatisticsBuilder, size) {
+  testSize();
+}
+
+TEST(StatisticsBuilder, integer) {
+  testInteger();
+}
+
+TEST(StatisticsBuilder, integerMissingStats) {
+  proto::ColumnStatistics proto;
+  auto intProto = proto.mutable_intstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testIntegerMissingStats(columnStatisticsWrapper, intProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, integerEmptyStats) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testIntegerEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, integerOverflow) {
+  testIntegerOverflow();
+}
+
+TEST(StatisticsBuilder, doubles) {
+  testDoubles();
+}
+
+TEST(StatisticsBuilder, doubleMissingStats) {
+  proto::ColumnStatistics proto;
+  auto doubleProto = proto.mutable_doublestatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testDoubleMissingStats(
+      columnStatisticsWrapper, doubleProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, doubleEmptyStats) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testDoubleEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, doubleNaN) {
+  testDoubleNaN();
+}
+
+TEST(StatisticsBuilder, string) {
+  testString();
+}
+
+TEST(StatisticsBuilder, stringMissingStats) {
+  proto::ColumnStatistics proto;
+  auto strProto = proto.mutable_stringstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testStringMissingStats(columnStatisticsWrapper, strProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, stringEmptyStats) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testStringEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, stringLengthThreshold) {
+  testStringLengthThreshold();
+}
+
+TEST(StatisticsBuilder, stringLengthOverflow) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(1);
+  auto strProto = proto.mutable_stringstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testStringLengthOverflow(
+      columnStatisticsWrapper, strProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, boolean) {
+  testBoolean();
+}
+
+TEST(StatisticsBuilder, booleanMissingStats) {
+  proto::ColumnStatistics proto;
+  auto boolProto = proto.mutable_bucketstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBooleanMissingStats(
+      columnStatisticsWrapper, boolProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, booleanEmptyStats) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBooleanEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, basic) {
+  testBasic();
+}
+
+TEST(StatisticsBuilder, basicMissingStats) {
+  proto::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBasicMissingStats(columnStatisticsWrapper);
+}
+
+TEST(StatisticsBuilder, basicHasNull) {
+  proto::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBasicHasNull(columnStatisticsWrapper, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, binary) {
+  testBinary();
+}
+
+TEST(StatisticsBuilder, binaryMissingStats) {
+  proto::ColumnStatistics proto;
+  auto binProto = proto.mutable_binarystatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryMissingStats(columnStatisticsWrapper, binProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, binaryEmptyStats) {
+  proto::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, binaryLengthOverflow) {
+  proto::ColumnStatistics proto;
+  auto binProto = proto.mutable_binarystatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryLengthOverflow(
+      columnStatisticsWrapper, binProto, DwrfFormat::kDwrf);
+}
+
+TEST(StatisticsBuilder, initialSize) {
+  testInitialSize();
+}
+
+proto::KeyInfo createKeyInfo(int64_t key) {
+  proto::KeyInfo keyInfo;
+  keyInfo.set_intkey(key);
+  return keyInfo;
+}
+
+inline bool operator==(
+    const ColumnStatistics& lhs,
+    const ColumnStatistics& rhs) {
+  return (lhs.hasNull() == rhs.hasNull()) &&
+      (lhs.getNumberOfValues() == rhs.getNumberOfValues()) &&
+      (lhs.getRawSize() == rhs.getRawSize());
+}
+
+void checkEntries(
+    const std::vector<ColumnStatistics>& entries,
+    const std::vector<ColumnStatistics>& expectedEntries) {
+  EXPECT_EQ(expectedEntries.size(), entries.size());
+  for (const auto& entry : entries) {
+    EXPECT_NE(
+        std::find_if(
+            expectedEntries.begin(),
+            expectedEntries.end(),
+            [&](const ColumnStatistics& expectedStats) {
+              return expectedStats == entry;
+            }),
+        expectedEntries.end());
+  }
+}
+
+struct TestKeyStats {
+  TestKeyStats(int64_t key, bool hasNull, uint64_t valueCount, uint64_t rawSize)
+      : key{key}, hasNull{hasNull}, valueCount{valueCount}, rawSize{rawSize} {}
+
+  int64_t key;
+  bool hasNull;
+  uint64_t valueCount;
+  uint64_t rawSize;
+};
+
+struct MapStatsAddValueTestCase {
+  explicit MapStatsAddValueTestCase(
+      const std::vector<TestKeyStats>& input,
+      const std::vector<TestKeyStats>& expected)
+      : input{input}, expected{expected} {}
+
+  std::vector<TestKeyStats> input;
+  std::vector<TestKeyStats> expected;
+};
+
+class MapStatisticsBuilderAddValueTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<MapStatsAddValueTestCase> {};
+
+TEST_P(MapStatisticsBuilderAddValueTest, addValues) {
+  auto type = HiveTypeParser{}.parse("map<int, float>");
+  MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+  for (const auto& entry : GetParam().input) {
+    StatisticsBuilder statsBuilder{options};
+    if (entry.hasNull) {
+      statsBuilder.setHasNull();
+    }
+    statsBuilder.increaseValueCount(entry.valueCount);
+    statsBuilder.increaseRawSize(entry.rawSize);
+    mapStatsBuilder.addValues(createKeyInfo(entry.key), statsBuilder);
+  }
+
+  const auto& expectedTestEntries = GetParam().expected;
+  std::vector<ColumnStatistics> expectedEntryStats{};
+  expectedEntryStats.reserve(expectedTestEntries.size());
+  for (const auto& entry : expectedTestEntries) {
+    StatisticsBuilder statsBuilder{options};
+    if (entry.hasNull) {
+      statsBuilder.setHasNull();
+    }
+    statsBuilder.increaseValueCount(entry.valueCount);
+    statsBuilder.increaseRawSize(entry.rawSize);
+    expectedEntryStats.push_back(statsBuilder);
+  }
+
+  std::vector<ColumnStatistics> entryStats;
+  const auto& outputEntries = mapStatsBuilder.getEntryStatistics();
+  entryStats.reserve(outputEntries.size());
+  for (const auto& entry : outputEntries) {
+    entryStats.push_back(*entry.second);
+  }
+
+  checkEntries(entryStats, expectedEntryStats);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MapStatisticsBuilderAddValueTestSuite,
+    MapStatisticsBuilderAddValueTest,
+    testing::Values(
+        MapStatsAddValueTestCase{{}, {}},
+        MapStatsAddValueTestCase{
+            {TestKeyStats{1, false, 1, 21}},
+            {TestKeyStats{1, false, 1, 21}}},
+        MapStatsAddValueTestCase{
+            {TestKeyStats{1, false, 1, 21}, TestKeyStats{1, true, 3, 42}},
+            {TestKeyStats{1, true, 4, 63}}},
+        MapStatsAddValueTestCase{
+            {TestKeyStats{1, false, 1, 21}, TestKeyStats{2, true, 3, 42}},
+            {TestKeyStats{1, false, 1, 21}, TestKeyStats{2, true, 3, 42}}},
+        MapStatsAddValueTestCase{
+            {TestKeyStats{1, false, 1, 21},
+             TestKeyStats{2, false, 3, 42},
+             TestKeyStats{2, false, 3, 42},
+             TestKeyStats{1, true, 1, 42}},
+            {TestKeyStats{1, true, 2, 63}, TestKeyStats{2, false, 6, 84}}}));
+
+struct MapStatsMergeTestCase {
+  std::vector<std::vector<TestKeyStats>> inputs;
+  std::vector<TestKeyStats> expected;
+};
+
+class MapStatisticsBuilderMergeTest
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<MapStatsMergeTestCase> {};
+
+TEST_P(MapStatisticsBuilderMergeTest, addValues) {
+  auto type = HiveTypeParser{}.parse("map<int, float>");
+
+  const auto& inputTestEntries = GetParam().inputs;
+  std::vector<std::unique_ptr<MapStatisticsBuilder>> mapStatsBuilders;
+  mapStatsBuilders.reserve(inputTestEntries.size());
+  for (const auto& input : inputTestEntries) {
+    std::unique_ptr<MapStatisticsBuilder> mapStatsBuilder =
+        std::make_unique<MapStatisticsBuilder>(*type, options);
+    for (const auto& entry : input) {
+      StatisticsBuilder statsBuilder{options};
+      if (entry.hasNull) {
+        statsBuilder.setHasNull();
+      }
+      statsBuilder.increaseValueCount(entry.valueCount);
+      statsBuilder.increaseRawSize(entry.rawSize);
+      mapStatsBuilder->addValues(createKeyInfo(entry.key), statsBuilder);
+    }
+    mapStatsBuilders.push_back(std::move(mapStatsBuilder));
+  }
+
+  MapStatisticsBuilder aggregateMapStatsBuilder{*type, options};
+  for (const auto& mapStatsBuilder : mapStatsBuilders) {
+    aggregateMapStatsBuilder.merge(*mapStatsBuilder);
+  }
+
+  const auto& expectedTestEntries = GetParam().expected;
+  std::vector<ColumnStatistics> expectedEntryStats{};
+  expectedEntryStats.reserve(expectedTestEntries.size());
+  for (const auto& entry : expectedTestEntries) {
+    StatisticsBuilder statsBuilder{options};
+    if (entry.hasNull) {
+      statsBuilder.setHasNull();
+    }
+    statsBuilder.increaseValueCount(entry.valueCount);
+    statsBuilder.increaseRawSize(entry.rawSize);
+    expectedEntryStats.push_back(statsBuilder);
+  }
+
+  std::vector<ColumnStatistics> entryStats;
+  const auto& aggregatedEntries = aggregateMapStatsBuilder.getEntryStatistics();
+  entryStats.reserve(aggregatedEntries.size());
+  for (const auto& entry : aggregatedEntries) {
+    entryStats.push_back(*entry.second);
+  }
+
+  checkEntries(entryStats, expectedEntryStats);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    MapStatisticsBuilderMergeTestSuite,
+    MapStatisticsBuilderMergeTest,
+    testing::Values(
+        MapStatsMergeTestCase{{}, {}},
+        MapStatsMergeTestCase{
+            {{TestKeyStats{1, false, 1, 21}}},
+            {TestKeyStats{1, false, 1, 21}}},
+        MapStatsMergeTestCase{
+            {{}, {TestKeyStats{1, false, 1, 21}}},
+            {TestKeyStats{1, false, 1, 21}}},
+        MapStatsMergeTestCase{
+            {{TestKeyStats{1, false, 1, 21}}, {TestKeyStats{1, true, 3, 42}}},
+            {TestKeyStats{1, true, 4, 63}}},
+        MapStatsMergeTestCase{
+            {{TestKeyStats{1, false, 1, 21}}, {TestKeyStats{2, true, 3, 42}}},
+            {TestKeyStats{1, false, 1, 21}, TestKeyStats{2, true, 3, 42}}},
+        MapStatsMergeTestCase{
+            {{TestKeyStats{1, false, 1, 21}, TestKeyStats{2, false, 3, 42}},
+             {TestKeyStats{2, false, 3, 42}},
+             {TestKeyStats{1, true, 1, 42}}},
+            {TestKeyStats{1, true, 2, 63}, TestKeyStats{2, false, 6, 84}}}));
+
+TEST(MapStatisticsBuilderTest, innerStatsType) {
+  {
+    auto type = HiveTypeParser{}.parse("map<int, float>");
+    MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+    DoubleStatisticsBuilder statsBuilder{options};
+    statsBuilder.addValues(0.1);
+    statsBuilder.addValues(1.0);
+    mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder);
+
+    auto& doubleStats = dynamic_cast<DoubleColumnStatistics&>(
+        *mapStatsBuilder.getEntryStatistics().at(KeyInfo{1}));
+
+    EXPECT_EQ(0.1, doubleStats.getMinimum());
+    EXPECT_EQ(1.0, doubleStats.getMaximum());
+  }
+  {
+    auto type = HiveTypeParser{}.parse("map<bigint, bigint>");
+    MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+    IntegerStatisticsBuilder statsBuilder{options};
+    statsBuilder.addValues(1);
+    statsBuilder.addValues(2);
+    mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder);
+
+    auto& intStats = dynamic_cast<IntegerColumnStatistics&>(
+        *mapStatsBuilder.getEntryStatistics().at(KeyInfo{1}));
+
+    EXPECT_EQ(1, intStats.getMinimum());
+    EXPECT_EQ(2, intStats.getMaximum());
+    EXPECT_EQ(3, intStats.getSum());
+  }
+}
+
+TEST(MapStatisticsBuilderTest, incrementSize) {
+  auto type = HiveTypeParser{}.parse("map<int, float>");
+  MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+  DoubleStatisticsBuilder statsBuilder1{options};
+  statsBuilder1.addValues(0.1);
+  statsBuilder1.addValues(1.0);
+  ASSERT_FALSE(statsBuilder1.getSize().has_value());
+  mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder1);
+  EXPECT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{1})
+                   ->getSize()
+                   .has_value());
+
+  DoubleStatisticsBuilder statsBuilder2{options};
+  statsBuilder2.addValues(0.3);
+  statsBuilder2.addValues(3.0);
+  ASSERT_FALSE(statsBuilder2.getSize().has_value());
+  mapStatsBuilder.addValues(createKeyInfo(2), statsBuilder2);
+  EXPECT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{2})
+                   ->getSize()
+                   .has_value());
+
+  mapStatsBuilder.incrementSize(createKeyInfo(1), 4);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      4,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_FALSE(mapStatsBuilder.getEntryStatistics()
+                   .at(KeyInfo{2})
+                   ->getSize()
+                   .has_value());
+  mapStatsBuilder.incrementSize(createKeyInfo(2), 8);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      4,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{2})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      8,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{2})->getSize().value());
+
+  mapStatsBuilder.incrementSize(createKeyInfo(1), 8);
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{1})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      12,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{1})->getSize().value());
+  ASSERT_TRUE(mapStatsBuilder.getEntryStatistics()
+                  .at(KeyInfo{2})
+                  ->getSize()
+                  .has_value());
+  EXPECT_EQ(
+      8,
+      mapStatsBuilder.getEntryStatistics().at(KeyInfo{2})->getSize().value());
+}
+
+TEST(MapStatisticsBuilderTest, mergeKeyStats) {
+  auto type = HiveTypeParser{}.parse("map<bigint, bigint>");
+  MapStatisticsBuilder mapStatsBuilder{*type, options};
+
+  mapStatsBuilder.incrementSize(createKeyInfo(1), 42);
+  auto& keyStats = dynamic_cast<StatisticsBuilder&>(
+      *mapStatsBuilder.getEntryStatistics().at(KeyInfo{1}));
+  ASSERT_EQ(0, keyStats.getNumberOfValues());
+  ASSERT_TRUE(keyStats.getRawSize().has_value());
+  ASSERT_EQ(0, keyStats.getRawSize().value());
+  ASSERT_TRUE(keyStats.getSize().has_value());
+  ASSERT_EQ(42, keyStats.getSize().value());
+
+  IntegerStatisticsBuilder statsBuilder{options};
+  statsBuilder.addValues(1);
+  statsBuilder.addValues(2);
+  statsBuilder.increaseRawSize(8);
+  mapStatsBuilder.addValues(createKeyInfo(1), statsBuilder);
+
+  keyStats = dynamic_cast<StatisticsBuilder&>(
+      *mapStatsBuilder.getEntryStatistics().at(KeyInfo{1}));
+  ASSERT_EQ(2, keyStats.getNumberOfValues());
+  ASSERT_TRUE(keyStats.getRawSize().has_value());
+  ASSERT_EQ(8, keyStats.getRawSize().value());
+  EXPECT_TRUE(keyStats.getSize().has_value());
+  EXPECT_EQ(42, keyStats.getSize().value());
+}

--- a/velox/dwio/dwrf/test/TestOrcColumnStatistics.cpp
+++ b/velox/dwio/dwrf/test/TestOrcColumnStatistics.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/dwrf/test/TestColumnStatisticsBase.h"
+
+using namespace facebook::velox::dwrf;
+
+TEST(StatisticsBuilder, size) {
+  testSize();
+}
+
+TEST(StatisticsBuilder, integer) {
+  testInteger();
+}
+
+TEST(StatisticsBuilder, integerMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  auto intProto = proto.mutable_intstatistics();
+  testIntegerMissingStats(columnStatisticsWrapper, intProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, integerEmptyStats) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testIntegerEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, integerOverflow) {
+  testIntegerOverflow();
+}
+
+TEST(StatisticsBuilder, doubles) {
+  testDoubles();
+}
+
+TEST(StatisticsBuilder, doubleMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  auto doubleProto = proto.mutable_doublestatistics();
+  testDoubleMissingStats(
+      columnStatisticsWrapper, doubleProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, doubleEmptyStats) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testDoubleEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, doubleNaN) {
+  testDoubleNaN();
+}
+
+TEST(StatisticsBuilder, string) {
+  testString();
+}
+
+TEST(StatisticsBuilder, stringMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  auto strProto = proto.mutable_stringstatistics();
+  testStringMissingStats(columnStatisticsWrapper, strProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, stringEmptyStats) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testStringEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, stringLengthThreshold) {
+  testStringLengthThreshold();
+}
+
+TEST(StatisticsBuilder, stringLengthOverflow) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(1);
+  auto strProto = proto.mutable_stringstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testStringLengthOverflow(columnStatisticsWrapper, strProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, boolean) {
+  testBoolean();
+}
+
+TEST(StatisticsBuilder, booleanMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto boolProto = proto.mutable_bucketstatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBooleanMissingStats(columnStatisticsWrapper, boolProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, booleanEmptyStats) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBooleanEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, basic) {
+  testBasic();
+}
+
+TEST(StatisticsBuilder, basicMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBasicMissingStats(columnStatisticsWrapper);
+}
+
+TEST(StatisticsBuilder, basicHasNull) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBasicHasNull(columnStatisticsWrapper, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, binary) {
+  testBinary();
+}
+
+TEST(StatisticsBuilder, binaryMissingStats) {
+  proto::orc::ColumnStatistics proto;
+  auto binProto = proto.mutable_binarystatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryMissingStats(columnStatisticsWrapper, binProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, binaryEmptyStats) {
+  proto::orc::ColumnStatistics proto;
+  proto.set_numberofvalues(0);
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryEmptyStats(
+      columnStatisticsWrapper, (void*)&proto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, binaryLengthOverflow) {
+  proto::orc::ColumnStatistics proto;
+  auto binProto = proto.mutable_binarystatistics();
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  testBinaryLengthOverflow(columnStatisticsWrapper, binProto, DwrfFormat::kOrc);
+}
+
+TEST(StatisticsBuilder, initialSize) {
+  testInitialSize();
+}
+
+TEST(MapStatistics, orcUnsupportedMapStatistics) {
+  proto::orc::ColumnStatistics proto;
+  auto columnStatisticsWrapper = ColumnStatisticsWrapper(&proto);
+  ASSERT_FALSE(columnStatisticsWrapper.hasMapStatistics());
+  ASSERT_THROW(
+      columnStatisticsWrapper.mapStatistics(),
+      ::facebook::velox::VeloxRuntimeError);
+}

--- a/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
+++ b/velox/dwio/dwrf/writer/StatisticsBuilder.cpp
@@ -115,7 +115,8 @@ std::unique_ptr<dwio::common::ColumnStatistics> StatisticsBuilder::build()
   proto::ColumnStatistics stats;
   toProto(stats);
   StatsContext context{WriterVersion_CURRENT};
-  return buildColumnStatisticsFromProto(stats, context);
+  return buildColumnStatisticsFromProto(
+      ColumnStatisticsWrapper(&stats), context);
 }
 
 std::unique_ptr<StatisticsBuilder> StatisticsBuilder::create(


### PR DESCRIPTION
Currently, the dwrf module only supports reading the column statistics of dwrf format, and does not support reading the column statistics of orc format. When I use velox to read the orc table, the following exception occurs:
```
presto:tpch_velox> create table region_orc with(format = 'ORC') as select * from tpch.sf10.region;
CREATE TABLE: 5 rows

Query 20230804_032253_00003_tubug, FINISHED, 1 node
Splits: 22 total, 22 done (100.00%)
0:35 [5 rows, 0B] [0 rows/s, 0B/s]

presto:tpch_velox> select * from region_orc;

Query 20230804_043524_00023_m8qw7, FAILED, 1 node
Splits: 2 total, 0 done (0.00%)
0:40 [0 rows, 0B] [0 rows/s, 0B/s]

Query 20230804_043524_00023_m8qw7 failed:  Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: vector

presto:tpch_velox> select * from region_orc;
```
with this pr, we support read orc column statistics, than we can read orc data through velox:
```
presto:tpch_velox> select * from region_orc;
 regionkey |    name     |                                                       comment
-----------+-------------+---------------------------------------------------------------------------------------------------------------------
         0 | AFRICA      | lar deposits. blithely final packages cajole. regular waters are final requests. regular accounts are according to
         1 | AMERICA     | hs use ironic, even requests. s
         2 | ASIA        | ges. thinly even pinto beans ca
         3 | EUROPE      | ly final courts cajole furiously final excuse
         4 | MIDDLE EAST | uickly special accounts cajole carefully blithely close requests. carefully final asymptotes haggle furiousl
(5 rows)

Query 20230804_044016_00026_m8qw7, FINISHED, 1 node
Splits: 2 total, 2 done (100.00%)
0:14 [5 rows, 603B] [0 rows/s, 44B/s]

presto:tpch_velox>
```
