### PR TITLE
Fix typo in scheduled.yml

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -15,7 +15,7 @@
 name: "Scheduled Fuzzer Jobs"
 
 on:
-  schdule:
+  schedule:
     - cron: '0 3 * * *'
 
 defaults:


### PR DESCRIPTION
Github actions fails to run scheduled jobs because of this. 