### PR TITLE
Avoid abort request pool itself if arbitration fails

### DIFF
--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -137,8 +137,11 @@ class SharedArbitrator : public MemoryArbitrator {
   void abort(MemoryPool* pool);
 
   // Invoked to handle the memory arbitration failure to abort the memory pool
-  // with the largest capacity to free up memory.
-  void handleOOM(
+  // with the largest capacity to free up memory. The function returns true on
+  // success and false if the requestor itself has been selected as the victim.
+  // We don't abort the requestor itself but just fails the arbitration to let
+  // the user decide to either proceed with the query or fail it.
+  bool handleOOM(
       MemoryPool* requestor,
       uint64_t targetBytes,
       std::vector<Candidate>& candidates);

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -1393,22 +1393,15 @@ DEBUG_ONLY_TEST_F(
   });
 
   std::thread memThread([&]() {
-    bool queryFailed{false};
-    try {
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .queryCtx(fakeMemoryQueryCtx)
-          .plan(PlanBuilder()
-                    .values(vectors)
-                    .addNode([&](std::string id, core::PlanNodePtr input) {
-                      return std::make_shared<FakeMemoryNode>(id, input);
-                    })
-                    .planNode())
-          .assertResults("SELECT * FROM tmp");
-    } catch (const VeloxRuntimeError& error) {
-      ASSERT_EQ(error.message(), "Aborted for external error");
-      queryFailed = true;
-    }
-    ASSERT_TRUE(queryFailed);
+    AssertQueryBuilder(duckDbQueryRunner_)
+        .queryCtx(fakeMemoryQueryCtx)
+        .plan(PlanBuilder()
+                  .values(vectors)
+                  .addNode([&](std::string id, core::PlanNodePtr input) {
+                    return std::make_shared<FakeMemoryNode>(id, input);
+                  })
+                  .planNode())
+        .assertResults("SELECT * FROM tmp");
   });
   joinThread.join();
   memThread.join();
@@ -1547,22 +1540,15 @@ DEBUG_ONLY_TEST_F(
   });
 
   std::thread memThread([&]() {
-    bool queryFailed{false};
-    try {
-      AssertQueryBuilder(duckDbQueryRunner_)
-          .queryCtx(fakeMemoryQueryCtx)
-          .plan(PlanBuilder()
-                    .values(vectors)
-                    .addNode([&](std::string id, core::PlanNodePtr input) {
-                      return std::make_shared<FakeMemoryNode>(id, input);
-                    })
-                    .planNode())
-          .assertResults("SELECT * FROM tmp");
-    } catch (const VeloxRuntimeError& error) {
-      ASSERT_EQ(error.message(), "Aborted for external error");
-      queryFailed = true;
-    }
-    ASSERT_TRUE(queryFailed);
+    AssertQueryBuilder(duckDbQueryRunner_)
+        .queryCtx(fakeMemoryQueryCtx)
+        .plan(PlanBuilder()
+                  .values(vectors)
+                  .addNode([&](std::string id, core::PlanNodePtr input) {
+                    return std::make_shared<FakeMemoryNode>(id, input);
+                  })
+                  .planNode())
+        .assertResults("SELECT * FROM tmp");
   });
   joinThread.join();
   memThread.join();
@@ -1811,7 +1797,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenMaybeReserveAndTaskAbort) {
                       .localPartition(std::vector<std::string>{})
                       .planNode())
             .copyResults(pool()),
-        "Aborted for external error");
+        "Exceeded memory pool cap");
   });
 
   queryThread.join();


### PR DESCRIPTION
Do not abort the request pool if memory arbitration fails and
let the memory pool throw or handle the failure properly.