### PR TITLE
Release the extra reserved memory in aggregation after processing input

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -421,6 +421,8 @@ void HashAggregation::noMoreInput() {
   groupingSet_->noMoreInput();
   recordSpillStats();
   Operator::noMoreInput();
+  // Release the extra reserved memory right after processing all the inputs.
+  pool()->release();
 }
 
 bool HashAggregation::isFinished() {


### PR DESCRIPTION
There might be unused memory reservation after processing input
in aggregation op and free up those unused resource.