### PR TITLE
Fix the race between task termination and join table build

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -457,4 +457,8 @@ void HashAggregation::close() {
   output_ = nullptr;
   groupingSet_.reset();
 }
+
+void HashAggregation::abort() {
+  close();
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -47,6 +47,8 @@ class HashAggregation : public Operator {
 
   void close() override;
 
+  void abort() override;
+
  private:
   void updateRuntimeStats();
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -716,6 +716,8 @@ bool HashBuild::finishHashBuild() {
     return false;
   }
 
+  TestValue::adjust("facebook::velox::exec::HashBuild::finishHashBuild", this);
+
   auto promisesGuard = folly::makeGuard([&]() {
     // Realize the promises so that the other Drivers (which were not
     // the last to finish) can continue from the barrier and finish.
@@ -736,7 +738,7 @@ bool HashBuild::finishHashBuild() {
     for (auto& peer : peers) {
       auto op = peer->findOperator(planNodeId());
       HashBuild* build = dynamic_cast<HashBuild*>(op);
-      VELOX_CHECK(build);
+      VELOX_CHECK_NOT_NULL(build);
       if (build->joinHasNullKeys_) {
         joinHasNullKeys_ = true;
         if (isAntiJoin(joinType_) && nullAware_ && !joinNode_->filter()) {
@@ -1055,8 +1057,8 @@ void HashBuild::reclaim(uint64_t /*unused*/) {
   }
 }
 
-void HashBuild::close() {
-  Operator::close();
+void HashBuild::abort() {
+  Operator::abort();
 
   // Free up major memory usage.
   joinBridge_.reset();

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -79,7 +79,7 @@ class HashBuild final : public Operator {
 
   void reclaim(uint64_t targetBytes) override;
 
-  void close() override;
+  void abort() override;
 
  private:
   void setState(State state);

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1408,8 +1408,8 @@ void HashProbe::setRunning() {
   setState(ProbeOperatorState::kRunning);
 }
 
-void HashProbe::close() {
-  Operator::close();
+void HashProbe::abort() {
+  Operator::abort();
 
   // Free up major memory usage.
   joinBridge_.reset();

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -64,7 +64,7 @@ class HashProbe : public Operator {
     return false;
   }
 
-  void close() override;
+  void abort() override;
 
   void clearDynamicFilters() override;
 

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -499,7 +499,7 @@ void Operator::MemoryReclaimer::abort(memory::MemoryPool* pool) {
       driver->state().isTerminated);
   VELOX_CHECK(driver->task()->isCancelled());
 
-  // Calls operator close to free up major memory usage.
-  op_->close();
+  // Calls operator abort to free up major memory usage.
+  op_->abort();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -378,6 +378,15 @@ class Operator : public BaseRuntimeStatWriter {
     operatorCtx_->pool()->release();
   }
 
+  /// Invoked by memory arbitrator to free up operator's resource immediately on
+  /// memory abort, and the query will stop running after this call.
+  ///
+  /// NOTE: we don't expect any access to this operator except close method
+  /// call.
+  virtual void abort() {
+    close();
+  }
+
   // Returns true if 'this' never has more output rows than input rows.
   virtual bool isFilter() const {
     return false;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -410,8 +410,8 @@ void OrderBy::prepareOutput() {
   }
 }
 
-void OrderBy::close() {
-  Operator::close();
+void OrderBy::abort() {
+  Operator::abort();
 
   output_ = nullptr;
   spiller_.reset();

--- a/velox/exec/OrderBy.h
+++ b/velox/exec/OrderBy.h
@@ -58,7 +58,7 @@ class OrderBy : public Operator {
 
   void reclaim(uint64_t targetBytes) override;
 
-  void close() override;
+  void abort() override;
 
  private:
   // Checks if input will fit in the existing memory and increases


### PR DESCRIPTION
There is a race condition between task termination and hash join table build
in multi driver setup.
Here is the event sequence that cause the race condition:
T1. All hash build operator finish processing inputs;
T2. One of the hash build operator takes care of the join table build from all
      the peer operators, and all the other build operators stop execution;
T3: An external task abort event to terminate the task which close all the
      stoped drivers. The driver close will close operator which mutate the
      operator state;
T4:  The last hash build operator start building the join table and run into
       segment fault when access table from the other operators.

The race condition is always there but we recently change close method
of spillable operators to free up major memory resources in their close
method including hash build operator. As the memory abort leverage close
method to free up major memory resources so it can be called by both
memory abort and async task termination code path. The memory abort
execution path is safe to close and mutate any operator state as we guarantee
the query won't execute after internal memory aborted. But there is no such
guarantee for async task termination such as the hash build race condition
described above. And it is very hard to exclude such race condition except
explicit task level locking to protect the cross operator access. Instead, we
add new abort method for operator which called by memory abort execution 
path. The previous close only touch very few operator fields. In most cases,
a closed operator will be destroyed soon after the last pending driver reference
drops.

This PR add unit test to reproduce the race condition and verify the fix.