### PR TITLE
Add WindowBuild to abstract the RowContainer used for Window operator 

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
   RowContainer.cpp
   RowNumber.cpp
   SortedAggregations.cpp
+  SortWindowBuild.cpp
   Spill.cpp
   SpillOperatorGroup.cpp
   Spiller.cpp
@@ -74,6 +75,7 @@ add_library(
   Values.cpp
   VectorHasher.cpp
   Window.cpp
+  WindowBuild.cpp
   WindowFunction.cpp
   WindowPartition.cpp
   AssignUniqueId.cpp

--- a/velox/exec/SortWindowBuild.cpp
+++ b/velox/exec/SortWindowBuild.cpp
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/SortWindowBuild.h"
+
+namespace facebook::velox::exec {
+
+SortWindowBuild::SortWindowBuild(
+    const std::shared_ptr<const core::WindowNode>& windowNode,
+    velox::memory::MemoryPool* pool)
+    : WindowBuild(windowNode, pool) {
+  allKeyInfo_.reserve(partitionKeyInfo_.size() + sortKeyInfo_.size());
+  allKeyInfo_.insert(
+      allKeyInfo_.cend(), partitionKeyInfo_.begin(), partitionKeyInfo_.end());
+  allKeyInfo_.insert(
+      allKeyInfo_.cend(), sortKeyInfo_.begin(), sortKeyInfo_.end());
+  partitionStartRows_.resize(0);
+}
+
+void SortWindowBuild::addInput(RowVectorPtr input) {
+  for (auto col = 0; col < input->childrenSize(); ++col) {
+    decodedInputVectors_[col].decode(*input->childAt(col));
+  }
+
+  // Add all the rows into the RowContainer.
+  for (auto row = 0; row < input->size(); ++row) {
+    char* newRow = data_->newRow();
+
+    for (auto col = 0; col < input->childrenSize(); ++col) {
+      data_->store(decodedInputVectors_[col], row, newRow, col);
+    }
+  }
+  numRows_ += input->size();
+}
+
+void SortWindowBuild::computePartitionStartRows() {
+  partitionStartRows_.reserve(numRows_);
+  auto partitionCompare = [&](const char* lhs, const char* rhs) -> bool {
+    return compareRowsWithKeys(lhs, rhs, partitionKeyInfo_);
+  };
+
+  // Using a sequential traversal to find changing partitions.
+  // This algorithm is inefficient and can be changed
+  // i) Use a binary search kind of strategy.
+  // ii) If we use a Hashtable instead of a full sort then the count
+  // of rows in the partition can be directly used.
+  partitionStartRows_.push_back(0);
+
+  VELOX_CHECK_GT(sortedRows_.size(), 0);
+  for (auto i = 1; i < sortedRows_.size(); i++) {
+    if (partitionCompare(sortedRows_[i - 1], sortedRows_[i])) {
+      partitionStartRows_.push_back(i);
+    }
+  }
+
+  // Setting the startRow of the (last + 1) partition to be returningRows.size()
+  // to help for last partition related calculations.
+  partitionStartRows_.push_back(sortedRows_.size());
+}
+
+void SortWindowBuild::sortPartitions() {
+  // This is a very inefficient but easy implementation to order the input rows
+  // by partition keys + sort keys.
+  // Sort the pointers to the rows in RowContainer (data_) instead of sorting
+  // the rows.
+  sortedRows_.resize(numRows_);
+  RowContainerIterator iter;
+  data_->listRows(&iter, numRows_, sortedRows_.data());
+
+  std::sort(
+      sortedRows_.begin(),
+      sortedRows_.end(),
+      [this](const char* leftRow, const char* rightRow) {
+        return compareRowsWithKeys(leftRow, rightRow, allKeyInfo_);
+      });
+
+  computePartitionStartRows();
+}
+
+void SortWindowBuild::noMoreInput() {
+  if (numRows_ == 0) {
+    return;
+  }
+  // At this point we have seen all the input rows. The operator is
+  // being prepared to output rows now.
+  // To prepare the rows for output in SortWindowBuild they need to
+  // be separated into partitions and sort by ORDER BY keys within
+  // the partition. This will order the rows for getOutput().
+  sortPartitions();
+}
+
+std::unique_ptr<WindowPartition> SortWindowBuild::nextPartition() {
+  VELOX_CHECK(partitionStartRows_.size() > 0, "No window partitions available")
+
+  currentPartition_++;
+  VELOX_CHECK(
+      currentPartition_ <= partitionStartRows_.size() - 2,
+      "All window partitions consumed");
+
+  auto windowPartition = std::make_unique<WindowPartition>(
+      data_.get(), inputColumns_, sortKeyInfo_);
+  // There is partition data available now.
+  auto partitionSize = partitionStartRows_[currentPartition_ + 1] -
+      partitionStartRows_[currentPartition_];
+  auto partition = folly::Range(
+      sortedRows_.data() + partitionStartRows_[currentPartition_],
+      partitionSize);
+  windowPartition->resetPartition(partition);
+
+  return windowPartition;
+}
+
+bool SortWindowBuild::hasNextPartition() {
+  return partitionStartRows_.size() > 0 &&
+      currentPartition_ < int(partitionStartRows_.size() - 2);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/SortWindowBuild.h
+++ b/velox/exec/SortWindowBuild.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/WindowBuild.h"
+
+namespace facebook::velox::exec {
+
+// Sorts input data of the Window by {partition keys, sort keys}
+// to identify window partitions. This sort fully orders
+// rows as needed for window function computation.
+class SortWindowBuild : public WindowBuild {
+ public:
+  SortWindowBuild(
+      const std::shared_ptr<const core::WindowNode>& windowNode,
+      velox::memory::MemoryPool* pool);
+
+  bool needsInput() override {
+    // No partitions are available yet, so can consume input rows.
+    return partitionStartRows_.size() == 0;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override;
+
+  bool hasNextPartition() override;
+
+  std::unique_ptr<WindowPartition> nextPartition() override;
+
+ private:
+  // Main sorting function loop done after all input rows are received
+  // by WindowBuild.
+  void sortPartitions();
+
+  // Function to compute the partitionStartRows_ structure.
+  // partitionStartRows_ is vector of the starting rows index
+  // of each partition in the data. This is an auxiliary
+  // structure that helps simplify the window function computations.
+  void computePartitionStartRows();
+
+  // allKeyInfo_ is a combination of (partitionKeyInfo_ and sortKeyInfo_).
+  // It is used to perform a full sorting of the input rows to be able to
+  // separate partitions and sort the rows in it. The rows are output in
+  // this order by the operator.
+  std::vector<std::pair<column_index_t, core::SortOrder>> allKeyInfo_;
+
+  // Vector of pointers to each input row in the data_ RowContainer.
+  // The rows are sorted by partitionKeys + sortKeys. This total
+  // ordering can be used to split partitions (with the correct
+  // order by) for the processing.
+  std::vector<char*> sortedRows_;
+
+  // This is a vector that gives the index of the start row
+  // (in sortedRows_) of each partition in the RowContainer data_.
+  // This auxiliary structure helps demarcate partitions.
+  std::vector<vector_size_t> partitionStartRows_;
+
+  // Current partition being output. Used to construct WindowPartitions
+  // during resetPartition.
+  vector_size_t currentPartition_ = -1;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -15,32 +15,10 @@
  */
 #include "velox/exec/Window.h"
 #include "velox/exec/OperatorUtils.h"
+#include "velox/exec/SortWindowBuild.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
-
-namespace {
-void initKeyInfo(
-    const RowTypePtr& type,
-    const std::vector<core::FieldAccessTypedExprPtr>& keys,
-    const std::vector<core::SortOrder>& orders,
-    std::vector<std::pair<column_index_t, core::SortOrder>>& keyInfo) {
-  const core::SortOrder defaultPartitionSortOrder(true, true);
-
-  keyInfo.reserve(keys.size());
-  for (auto i = 0; i < keys.size(); ++i) {
-    auto channel = exprToChannel(keys[i].get(), type);
-    VELOX_CHECK(
-        channel != kConstantChannel,
-        "Window doesn't allow constant partition or sort keys");
-    if (i < orders.size()) {
-      keyInfo.push_back(std::make_pair(channel, orders[i]));
-    } else {
-      keyInfo.push_back(std::make_pair(channel, defaultPartitionSortOrder));
-    }
-  }
-}
-}; // namespace
 
 Window::Window(
     int32_t operatorId,
@@ -53,36 +31,13 @@ Window::Window(
           windowNode->id(),
           "Window"),
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
-      data_(std::make_unique<RowContainer>(
-          windowNode->sources()[0]->outputType()->children(),
-          pool())),
-      decodedInputVectors_(numInputColumns_),
+      windowBuild_(std::make_unique<SortWindowBuild>(windowNode, pool())),
+      currentPartition_(nullptr),
       stringAllocator_(pool()) {
   auto inputType = windowNode->sources()[0]->outputType();
-  initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
-  initKeyInfo(
-      inputType,
-      windowNode->sortingKeys(),
-      windowNode->sortingOrders(),
-      sortKeyInfo_);
-  allKeyInfo_.reserve(partitionKeyInfo_.size() + sortKeyInfo_.size());
-  allKeyInfo_.insert(
-      allKeyInfo_.cend(), partitionKeyInfo_.begin(), partitionKeyInfo_.end());
-  allKeyInfo_.insert(
-      allKeyInfo_.cend(), sortKeyInfo_.begin(), sortKeyInfo_.end());
-
-  std::vector<exec::RowColumn> inputColumns;
-  for (int i = 0; i < inputType->children().size(); i++) {
-    inputColumns.push_back(data_->columnAt(i));
-  }
-  // The WindowPartition is structured over all the input columns data.
-  // Individual functions access its input argument column values from it.
-  // The RowColumns are copied by the WindowPartition, so its fine to use
-  // a local variable here.
-  windowPartition_ =
-      std::make_unique<WindowPartition>(inputColumns, inputType->children());
-
   createWindowFunctions(windowNode, inputType, driverCtx->queryConfig());
+
+  createPeerAndFrameBuffers();
 }
 
 Window::WindowFrame Window::createWindowFrame(
@@ -170,44 +125,14 @@ void Window::createWindowFunctions(
 }
 
 void Window::addInput(RowVectorPtr input) {
-  for (auto col = 0; col < input->childrenSize(); ++col) {
-    decodedInputVectors_[col].decode(*input->childAt(col));
-  }
-
-  // Add all the rows into the RowContainer.
-  for (auto row = 0; row < input->size(); ++row) {
-    char* newRow = data_->newRow();
-
-    for (auto col = 0; col < input->childrenSize(); ++col) {
-      data_->store(decodedInputVectors_[col], row, newRow, col);
-    }
-  }
+  windowBuild_->addInput(input);
   numRows_ += input->size();
-}
-
-inline bool Window::compareRowsWithKeys(
-    const char* lhs,
-    const char* rhs,
-    const std::vector<std::pair<column_index_t, core::SortOrder>>& keys) {
-  if (lhs == rhs) {
-    return false;
-  }
-  for (auto& key : keys) {
-    if (auto result = data_->compare(
-            lhs,
-            rhs,
-            key.first,
-            {key.second.isNullsFirst(), key.second.isAscending(), false})) {
-      return result < 0;
-    }
-  }
-  return false;
 }
 
 void Window::createPeerAndFrameBuffers() {
   // TODO: This computation needs to be revised. It only takes into account
   // the input columns size. We need to also account for the output columns.
-  numRowsPerOutput_ = outputBatchRows(data_->estimateRowSize());
+  numRowsPerOutput_ = outputBatchRows(windowBuild_->estimateRowSize());
 
   peerStartBuffer_ = AlignedBuffer::allocate<vector_size_t>(
       numRowsPerOutput_, operatorCtx_->pool());
@@ -230,79 +155,25 @@ void Window::createPeerAndFrameBuffers() {
   }
 }
 
-void Window::computePartitionStartRows() {
-  // Randomly assuming that max 10000 partitions are in the data.
-  partitionStartRows_.reserve(numRows_);
-  auto partitionCompare = [&](const char* lhs, const char* rhs) -> bool {
-    return compareRowsWithKeys(lhs, rhs, partitionKeyInfo_);
-  };
-
-  // Using a sequential traversal to find changing partitions.
-  // This algorithm is inefficient and can be changed
-  // i) Use a binary search kind of strategy.
-  // ii) If we use a Hashtable instead of a full sort then the count
-  // of rows in the partition can be directly used.
-  partitionStartRows_.push_back(0);
-
-  VELOX_CHECK_GT(sortedRows_.size(), 0);
-  for (auto i = 1; i < sortedRows_.size(); i++) {
-    if (partitionCompare(sortedRows_[i - 1], sortedRows_[i])) {
-      partitionStartRows_.push_back(i);
-    }
-  }
-
-  // Setting the startRow of the (last + 1) partition to be returningRows.size()
-  // to help for last partition related calculations.
-  partitionStartRows_.push_back(sortedRows_.size());
-}
-
-void Window::sortPartitions() {
-  // This is a very inefficient but easy implementation to order the input rows
-  // by partition keys + sort keys.
-  // Sort the pointers to the rows in RowContainer (data_) instead of sorting
-  // the rows.
-  sortedRows_.resize(numRows_);
-  RowContainerIterator iter;
-  data_->listRows(&iter, numRows_, sortedRows_.data());
-
-  std::sort(
-      sortedRows_.begin(),
-      sortedRows_.end(),
-      [this](const char* leftRow, const char* rightRow) {
-        return compareRowsWithKeys(leftRow, rightRow, allKeyInfo_);
-      });
-
-  computePartitionStartRows();
-
-  currentPartition_ = 0;
-}
-
 void Window::noMoreInput() {
   Operator::noMoreInput();
   // No data.
   if (numRows_ == 0) {
-    finished_ = true;
     return;
   }
-
-  // At this point we have seen all the input rows. We can start
-  // outputting rows now.
-  // However, some preparation is needed. The rows should be
-  // separated into partitions and sort by ORDER BY keys within
-  // the partition. This will order the rows for getOutput().
-  sortPartitions();
-  createPeerAndFrameBuffers();
+  windowBuild_->noMoreInput();
 }
 
-void Window::callResetPartition(vector_size_t partitionNumber) {
+void Window::callResetPartition() {
   partitionOffset_ = 0;
-  auto partitionSize = partitionStartRows_[partitionNumber + 1] -
-      partitionStartRows_[partitionNumber];
-  auto partition = folly::Range(
-      sortedRows_.data() + partitionStartRows_[partitionNumber], partitionSize);
-  windowPartition_->resetPartition(partition);
-  for (int i = 0; i < windowFunctions_.size(); i++) {
-    windowFunctions_[i]->resetPartition(windowPartition_.get());
+  peerStartRow_ = 0;
+  peerEndRow_ = 0;
+  currentPartition_ = nullptr;
+  if (windowBuild_->hasNextPartition()) {
+    currentPartition_ = windowBuild_->nextPartition();
+    for (int i = 0; i < windowFunctions_.size(); i++) {
+      windowFunctions_[i]->resetPartition(currentPartition_.get());
+    }
   }
 }
 
@@ -312,7 +183,6 @@ template <typename T>
 void updateKRowsOffsetsColumn(
     bool isKPreceding,
     const VectorPtr& value,
-    vector_size_t firstPartitionRow,
     vector_size_t startRow,
     vector_size_t numRows,
     vector_size_t* rawFrameBounds) {
@@ -331,8 +201,8 @@ void updateKRowsOffsetsColumn(
   // moves ahead.
   int precedingFactor = isKPreceding ? -1 : 1;
   for (auto i = 0; i < numRows; i++) {
-    rawFrameBounds[i] = (startRow + i) +
-        vector_size_t(precedingFactor * offsets[i]) - firstPartitionRow;
+    rawFrameBounds[i] =
+        (startRow + i) + vector_size_t(precedingFactor * offsets[i]);
   }
 }
 
@@ -344,21 +214,19 @@ void Window::updateKRowsFrameBounds(
     vector_size_t startRow,
     vector_size_t numRows,
     vector_size_t* rawFrameBounds) {
-  auto firstPartitionRow = partitionStartRows_[currentPartition_];
 
   if (frameArg.index == kConstantChannel) {
     auto constantOffset = frameArg.constant.value();
-    auto startValue = startRow +
-        (isKPreceding ? -constantOffset : constantOffset) - firstPartitionRow;
+    auto startValue =
+        startRow + (isKPreceding ? -constantOffset : constantOffset);
     std::iota(rawFrameBounds, rawFrameBounds + numRows, startValue);
   } else {
-    windowPartition_->extractColumn(
+    currentPartition_->extractColumn(
         frameArg.index, partitionOffset_, numRows, 0, frameArg.value);
     if (frameArg.value->typeKind() == TypeKind::INTEGER) {
       updateKRowsOffsetsColumn<int32_t>(
           isKPreceding,
           frameArg.value,
-          firstPartitionRow,
           startRow,
           numRows,
           rawFrameBounds);
@@ -366,7 +234,6 @@ void Window::updateKRowsFrameBounds(
       updateKRowsOffsetsColumn<int64_t>(
           isKPreceding,
           frameArg.value,
-          firstPartitionRow,
           startRow,
           numRows,
           rawFrameBounds);
@@ -382,8 +249,6 @@ void Window::updateFrameBounds(
     const vector_size_t* rawPeerStarts,
     const vector_size_t* rawPeerEnds,
     vector_size_t* rawFrameBounds) {
-  auto firstPartitionRow = partitionStartRows_[currentPartition_];
-  auto lastPartitionRow = partitionStartRows_[currentPartition_ + 1] - 1;
   auto windowType = windowFrame.type;
   auto boundType = isStartBound ? windowFrame.startType : windowFrame.endType;
   auto frameArg = isStartBound ? windowFrame.start : windowFrame.end;
@@ -393,8 +258,7 @@ void Window::updateFrameBounds(
       std::fill_n(rawFrameBounds, numRows, 0);
       break;
     case core::WindowNode::BoundType::kUnboundedFollowing:
-      std::fill_n(
-          rawFrameBounds, numRows, lastPartitionRow - firstPartitionRow);
+      std::fill_n(rawFrameBounds, numRows, currentPartition_->numRows() - 1);
       break;
     case core::WindowNode::BoundType::kCurrentRow: {
       if (windowType == core::WindowNode::WindowType::kRange) {
@@ -404,12 +268,8 @@ void Window::updateFrameBounds(
       } else {
         // Fills the frameBound buffer with increasing value of row indices
         // (corresponding to CURRENT ROW) from the startRow of the current
-        // output buffer. The startRow has to be adjusted relative to the
-        // partition start row.
-        std::iota(
-            rawFrameBounds,
-            rawFrameBounds + numRows,
-            startRow - firstPartitionRow);
+        // output buffer.
+        std::iota(rawFrameBounds, rawFrameBounds + numRows, startRow);
       }
       break;
     }
@@ -471,15 +331,9 @@ void computeValidFrames(
 
 }; // namespace
 
-void Window::callApplyForPartitionRows(
+void Window::computePeerAndFrameBuffers(
     vector_size_t startRow,
-    vector_size_t endRow,
-    const std::vector<VectorPtr>& result,
-    vector_size_t resultOffset) {
-  if (partitionStartRows_[currentPartition_] == startRow) {
-    callResetPartition(currentPartition_);
-  }
-
+    vector_size_t endRow) {
   vector_size_t numRows = endRow - startRow;
   vector_size_t numFuncs = windowFunctions_.size();
 
@@ -504,39 +358,8 @@ void Window::callApplyForPartitionRows(
     rawFrameEnds.push_back(rawFrameEnd);
   }
 
-  auto peerCompare = [&](const char* lhs, const char* rhs) -> bool {
-    return compareRowsWithKeys(lhs, rhs, sortKeyInfo_);
-  };
-  auto firstPartitionRow = partitionStartRows_[currentPartition_];
-  auto lastPartitionRow = partitionStartRows_[currentPartition_ + 1] - 1;
-  for (auto i = startRow, j = 0; i < endRow; i++, j++) {
-    // When traversing input partition rows, the peers are the rows
-    // with the same values for the ORDER BY clause. These rows
-    // are equal in some ways and affect the results of ranking functions.
-    // This logic exploits the fact that all rows between the peerStartRow_
-    // and peerEndRow_ have the same values for peerStartRow_ and peerEndRow_.
-    // So we can compute them just once and reuse across the rows in that peer
-    // interval. Note: peerStartRow_ and peerEndRow_ can be maintained across
-    // getOutput calls.
-
-    // Compute peerStart and peerEnd rows for the first row of the partition or
-    // when past the previous peerGroup.
-    if (i == firstPartitionRow || i >= peerEndRow_) {
-      peerStartRow_ = i;
-      peerEndRow_ = i;
-      while (peerEndRow_ <= lastPartitionRow) {
-        if (peerCompare(sortedRows_[peerStartRow_], sortedRows_[peerEndRow_])) {
-          break;
-        }
-        peerEndRow_++;
-      }
-    }
-
-    // Peer buffer values should be offsets from the start of the partition
-    // as WindowFunction only sees one partition at a time.
-    rawPeerStarts[j] = peerStartRow_ - firstPartitionRow;
-    rawPeerEnds[j] = peerEndRow_ - 1 - firstPartitionRow;
-  }
+  std::tie(peerStartRow_, peerEndRow_) = currentPartition_->computePeerBuffers(
+      startRow, endRow, peerStartRow_, peerEndRow_, rawPeerStarts, rawPeerEnds);
 
   for (auto i = 0; i < numFuncs; i++) {
     const auto& windowFrame = windowFrames_[i];
@@ -567,15 +390,36 @@ void Window::callApplyForPartitionRows(
       // Ranking functions do not care about frames. So the function decides
       // further what to do with empty frames.
       computeValidFrames(
-          lastPartitionRow - firstPartitionRow,
+          currentPartition_->numRows() - 1,
           numRows,
           rawFrameStarts[i],
           rawFrameEnds[i],
           validFrames_[i]);
     }
   }
+}
 
-  // Invoke the apply method for the WindowFunctions.
+void Window::getInputColumns(
+    vector_size_t startRow,
+    vector_size_t endRow,
+    vector_size_t resultOffset,
+    const RowVectorPtr& result) {
+  auto numRows = endRow - startRow;
+  for (int i = 0; i < numInputColumns_; ++i) {
+    currentPartition_->extractColumn(
+        i, partitionOffset_, numRows, resultOffset, result->childAt(i));
+  }
+}
+
+void Window::callApplyForPartitionRows(
+    vector_size_t startRow,
+    vector_size_t endRow,
+    vector_size_t resultOffset,
+    const RowVectorPtr& result) {
+  getInputColumns(startRow, endRow, resultOffset, result);
+
+  computePeerAndFrameBuffers(startRow, endRow);
+  vector_size_t numFuncs = windowFunctions_.size();
   for (auto w = 0; w < numFuncs; w++) {
     windowFunctions_[w]->apply(
         peerStartBuffer_,
@@ -584,46 +428,52 @@ void Window::callApplyForPartitionRows(
         frameEndBuffers_[w],
         validFrames_[w],
         resultOffset,
-        result[w]);
+        result->childAt(numInputColumns_ + w));
   }
 
+  vector_size_t numRows = endRow - startRow;
   numProcessedRows_ += numRows;
   partitionOffset_ += numRows;
-  if (endRow == partitionStartRows_[currentPartition_ + 1]) {
-    currentPartition_++;
-  }
 }
 
 void Window::callApplyLoop(
     vector_size_t numOutputRows,
-    const std::vector<VectorPtr>& windowOutputs) {
+    const RowVectorPtr& result) {
   // Compute outputs by traversing as many partitions as possible. This
   // logic takes care of partial partitions output also.
-
   vector_size_t resultIndex = 0;
   vector_size_t numOutputRowsLeft = numOutputRows;
+
+  // This function requires that the currentPartition_ is available for output.
+  VELOX_DCHECK_NOT_NULL(currentPartition_);
   while (numOutputRowsLeft > 0) {
     auto rowsForCurrentPartition =
-        partitionStartRows_[currentPartition_ + 1] - numProcessedRows_;
+        currentPartition_->numRows() - partitionOffset_;
     if (rowsForCurrentPartition <= numOutputRowsLeft) {
       // Current partition can fit completely in the output buffer.
       // So output all its rows.
       callApplyForPartitionRows(
-          numProcessedRows_,
-          numProcessedRows_ + rowsForCurrentPartition,
-          windowOutputs,
-          resultIndex);
+          partitionOffset_,
+          partitionOffset_ + rowsForCurrentPartition,
+          resultIndex,
+          result);
       resultIndex += rowsForCurrentPartition;
       numOutputRowsLeft -= rowsForCurrentPartition;
+      callResetPartition();
+      if (!currentPartition_) {
+        // The WindowBuild doesn't have any more partitions to process right
+        // now. So break until the next getOutput call.
+        break;
+      }
     } else {
       // Current partition can fit only partially in the output buffer.
       // Call apply for the rows that can fit in the buffer and break from
       // outputting.
       callApplyForPartitionRows(
-          numProcessedRows_,
-          numProcessedRows_ + numOutputRowsLeft,
-          windowOutputs,
-          resultIndex);
+          partitionOffset_,
+          partitionOffset_ + numOutputRowsLeft,
+          resultIndex,
+          result);
       numOutputRowsLeft = 0;
       break;
     }
@@ -631,41 +481,35 @@ void Window::callApplyLoop(
 }
 
 RowVectorPtr Window::getOutput() {
-  if (finished_ || !noMoreInput_) {
+  if (numRows_ == 0) {
     return nullptr;
   }
 
   auto numRowsLeft = numRows_ - numProcessedRows_;
+  if (numRowsLeft == 0) {
+    return nullptr;
+  }
+
+  if (!currentPartition_) {
+    callResetPartition();
+    if (!currentPartition_) {
+      // WindowBuild doesn't have a partition to output.
+      return nullptr;
+    }
+  }
+
   auto numOutputRows = std::min(numRowsPerOutput_, numRowsLeft);
   auto result = std::dynamic_pointer_cast<RowVector>(
       BaseVector::create(outputType_, numOutputRows, operatorCtx_->pool()));
 
-  // Set all passthrough input columns.
-  for (int i = 0; i < numInputColumns_; ++i) {
-    data_->extractColumn(
-        sortedRows_.data() + numProcessedRows_,
-        numOutputRows,
-        i,
-        result->childAt(i));
-  }
-
-  // Construct vectors for the window function output columns.
-  std::vector<VectorPtr> windowOutputs;
-  windowOutputs.reserve(windowFunctions_.size());
   for (int i = numInputColumns_; i < outputType_->size(); i++) {
     auto output = BaseVector::create(
         outputType_->childAt(i), numOutputRows, operatorCtx_->pool());
-    windowOutputs.emplace_back(std::move(output));
+    result->childAt(i) = output;
   }
 
   // Compute the output values of window functions.
-  callApplyLoop(numOutputRows, windowOutputs);
-
-  for (int j = numInputColumns_; j < outputType_->size(); j++) {
-    result->childAt(j) = windowOutputs[j - numInputColumns_];
-  }
-
-  finished_ = (numProcessedRows_ == sortedRows_.size());
+  callApplyLoop(numOutputRows, result);
   return result;
 }
 

--- a/velox/exec/WindowBuild.cpp
+++ b/velox/exec/WindowBuild.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/WindowBuild.h"
+
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+namespace {
+void initKeyInfo(
+    const RowTypePtr& type,
+    const std::vector<core::FieldAccessTypedExprPtr>& keys,
+    const std::vector<core::SortOrder>& orders,
+    std::vector<std::pair<column_index_t, core::SortOrder>>& keyInfo) {
+  const core::SortOrder defaultPartitionSortOrder(true, true);
+
+  keyInfo.reserve(keys.size());
+  for (auto i = 0; i < keys.size(); ++i) {
+    auto channel = exprToChannel(keys[i].get(), type);
+    VELOX_CHECK(
+        channel != kConstantChannel,
+        "Window doesn't allow constant partition or sort keys");
+    if (i < orders.size()) {
+      keyInfo.push_back(std::make_pair(channel, orders[i]));
+    } else {
+      keyInfo.push_back(std::make_pair(channel, defaultPartitionSortOrder));
+    }
+  }
+}
+}; // namespace
+
+WindowBuild::WindowBuild(
+    const std::shared_ptr<const core::WindowNode>& windowNode,
+    velox::memory::MemoryPool* pool)
+    : numInputColumns_(windowNode->sources()[0]->outputType()->size()),
+      data_(std::make_unique<RowContainer>(
+          windowNode->sources()[0]->outputType()->children(),
+          pool)),
+      decodedInputVectors_(windowNode->sources()[0]->outputType()->size()) {
+  auto inputType = windowNode->sources()[0]->outputType();
+  for (int i = 0; i < inputType->children().size(); i++) {
+    inputColumns_.push_back(data_->columnAt(i));
+  }
+
+  initKeyInfo(inputType, windowNode->partitionKeys(), {}, partitionKeyInfo_);
+  initKeyInfo(
+      inputType,
+      windowNode->sortingKeys(),
+      windowNode->sortingOrders(),
+      sortKeyInfo_);
+}
+
+bool WindowBuild::compareRowsWithKeys(
+    const char* lhs,
+    const char* rhs,
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& keys) {
+  if (lhs == rhs) {
+    return false;
+  }
+  for (auto& key : keys) {
+    if (auto result = data_->compare(
+            lhs,
+            rhs,
+            key.first,
+            {key.second.isNullsFirst(), key.second.isAscending(), false})) {
+      return result < 0;
+    }
+  }
+  return false;
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/WindowBuild.h
+++ b/velox/exec/WindowBuild.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/WindowPartition.h"
+
+namespace facebook::velox::exec {
+
+// The Window operator needs to see all input rows, and separate them into
+// partitions based on a partitioning key. There are many approaches to do
+// this. e.g with a full-sort, HashTable, streaming etc. This abstraction
+// is used by the Window operator to hold the input rows and provide
+// partitions to it for processing. Varied implementations of the
+// WindowBuild can use different algorithms.
+class WindowBuild {
+ public:
+  WindowBuild(
+      const std::shared_ptr<const core::WindowNode>& windowNode,
+      velox::memory::MemoryPool* pool);
+
+  virtual ~WindowBuild() = default;
+
+  // The Window operator invokes this function to check if the WindowBuild can
+  // accept input. The Streaming Window build doesn't accept input if it has a
+  // partition to output.
+  virtual bool needsInput() = 0;
+
+  // Adds new input rows to the WindowBuild.
+  virtual void addInput(RowVectorPtr input) = 0;
+
+  // The Window operator invokes this function to indicate that no
+  // more input rows will be passed from the Window operator to the
+  // WindowBuild.
+  // When using a sort based build, all input rows need to be
+  // seen before any partitions are determined. So this function is
+  // used to indicate to the WindowBuild that it can proceed with
+  // building partitions.
+  virtual void noMoreInput() = 0;
+
+  // Returns true if a new Window partition is available for the Window
+  // operator to consume.
+  virtual bool hasNextPartition() = 0;
+
+  // The Window operator invokes this function to get the next Window partition
+  // to pass along to the WindowFunction. The WindowPartition has APIs to access
+  // the underlying columns of Window partition data.
+  // Check hasNextPartition() before invoking this function. This function fails
+  // if called when no partition is available.
+  virtual std::unique_ptr<WindowPartition> nextPartition() = 0;
+
+  // Returns the average size of input rows in bytes stored in the
+  // data container of the WindowBuild.
+  std::optional<int64_t> estimateRowSize() {
+    return data_->estimateRowSize();
+  }
+
+ protected:
+  bool compareRowsWithKeys(
+      const char* lhs,
+      const char* rhs,
+      const std::vector<std::pair<column_index_t, core::SortOrder>>& keys);
+
+  // The below 2 vectors represent the ChannelIndex of the partition keys
+  // and the order by keys. These keyInfo are used for sorting by those
+  // key combinations during the processing.
+  // partitionKeyInfo_ is used to separate partitions in the rows.
+  // sortKeyInfo_ is used to identify peer rows in a partition.
+  std::vector<std::pair<column_index_t, core::SortOrder>> partitionKeyInfo_;
+  std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
+
+  const vector_size_t numInputColumns_;
+
+  // The RowContainer holds all the input rows in WindowBuild.
+  std::unique_ptr<RowContainer> data_;
+
+  // The decodedInputVectors_ are reused across addInput() calls to decode
+  // the partition and sort keys for the above RowContainer.
+  std::vector<DecodedVector> decodedInputVectors_;
+
+  // RowColumns for window build used to construct WindowPartition.
+  std::vector<exec::RowColumn> inputColumns_;
+
+  // Number of input rows.
+  vector_size_t numRows_ = 0;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/WindowPartition.cpp
+++ b/velox/exec/WindowPartition.cpp
@@ -18,9 +18,10 @@
 namespace facebook::velox::exec {
 
 WindowPartition::WindowPartition(
+    RowContainer* data,
     const std::vector<exec::RowColumn>& columns,
-    const std::vector<TypePtr>& /* argTypes */)
-    : columns_(columns) {}
+    const std::vector<std::pair<column_index_t, core::SortOrder>>& sortKeyInfo)
+    : data_(data), columns_(columns), sortKeyInfo_(sortKeyInfo) {}
 
 void WindowPartition::resetPartition(const folly::Range<char**>& rows) {
   partition_ = rows;
@@ -106,6 +107,68 @@ WindowPartition::extractNulls(
       bits::findFirstBit((*nulls)->as<uint64_t>(), 0, framesSize) >= 0;
   return foundNull ? std::make_optional(std::make_pair(minFrame, framesSize))
                    : std::nullopt;
+}
+
+bool WindowPartition::compareRowsWithSortKeys(const char* lhs, const char* rhs)
+    const {
+  if (lhs == rhs) {
+    return false;
+  }
+  for (auto& key : sortKeyInfo_) {
+    if (auto result = data_->compare(
+            lhs,
+            rhs,
+            key.first,
+            {key.second.isNullsFirst(), key.second.isAscending(), false})) {
+      return result < 0;
+    }
+  }
+  return false;
+}
+
+std::pair<vector_size_t, vector_size_t> WindowPartition::computePeerBuffers(
+    vector_size_t start,
+    vector_size_t end,
+    vector_size_t prevPeerStart,
+    vector_size_t prevPeerEnd,
+    vector_size_t* rawPeerStarts,
+    vector_size_t* rawPeerEnds) const {
+  auto peerCompare = [&](const char* lhs, const char* rhs) -> bool {
+    return compareRowsWithSortKeys(lhs, rhs);
+  };
+
+  VELOX_CHECK_LE(end, numRows());
+
+  auto lastPartitionRow = numRows() - 1;
+  auto peerStart = prevPeerStart;
+  auto peerEnd = prevPeerEnd;
+  for (auto i = start, j = 0; i < end; i++, j++) {
+    // When traversing input partition rows, the peers are the rows
+    // with the same values for the ORDER BY clause. These rows
+    // are equal in some ways and affect the results of ranking functions.
+    // This logic exploits the fact that all rows between the peerStart
+    // and peerEnd have the same values for rawPeerStarts and rawPeerEnds.
+    // So we can compute them just once and reuse across the rows in that peer
+    // interval. Note: peerStart and peerEnd can be maintained across
+    // getOutput calls. Hence, they are returned to the caller.
+
+    if (i == 0 || i >= peerEnd) {
+      // Compute peerStart and peerEnd rows for the first row of the partition
+      // or when past the previous peerGroup.
+      peerStart = i;
+      peerEnd = i;
+      while (peerEnd <= lastPartitionRow) {
+        if (peerCompare(partition_[peerStart], partition_[peerEnd])) {
+          break;
+        }
+        peerEnd++;
+      }
+    }
+
+    rawPeerStarts[j] = peerStart;
+    rawPeerEnds[j] = peerEnd - 1;
+  }
+  return {peerStart, peerEnd};
 }
 
 } // namespace facebook::velox::exec

--- a/velox/exec/WindowPartition.h
+++ b/velox/exec/WindowPartition.h
@@ -25,9 +25,18 @@
 namespace facebook::velox::exec {
 class WindowPartition {
  public:
+  /// The WindowPartition is used by the Window operator and WindowFunction
+  /// objects to access the underlying data and columns of a partition of rows.
+  /// The WindowPartition is constructed by WindowBuild from the input data.
+  /// 'data' : Underlying RowContainer of the WindowBuild.
+  /// 'columns' : Input rows of 'data' used for accessing column data from it.
+  /// 'sortKeyInfo' : Order by columns used by the the Window operator. Used to
+  /// get peer rows from the input partition.
   WindowPartition(
+      RowContainer* data,
       const std::vector<exec::RowColumn>& columns,
-      const std::vector<TypePtr>& types);
+      const std::vector<std::pair<column_index_t, core::SortOrder>>&
+          sortKeyInfo);
 
   /// Returns the number of rows in the current WindowPartition.
   vector_size_t numRows() const {
@@ -79,21 +88,48 @@ class WindowPartition {
       const BufferPtr& frameEnds,
       BufferPtr* nulls) const;
 
+  /// Sets in 'rawPeerStarts' and in 'rawPeerEnds' the peer start and peer end
+  /// offsets of the rows between 'start' and 'end' of the current partition.
+  /// 'peer' row are all the rows having the same value of the order by columns
+  /// as the current row.
+  /// computePeerBuffers is called multiple times for each partition. It is
+  /// called in sequential order of start to end rows.
+  /// The peerStarts/peerEnds of the startRow could be same as the last row in
+  /// the previous call to computePeerBuffers (if they have the same order by
+  /// keys). So peerStart and peerEnd of the last row of this call are returned
+  /// to be passed as prevPeerStart and prevPeerEnd to the subsequent
+  /// call to computePeerBuffers.
+  std::pair<vector_size_t, vector_size_t> computePeerBuffers(
+      vector_size_t start,
+      vector_size_t end,
+      vector_size_t prevPeerStart,
+      vector_size_t prevPeerEnd,
+      vector_size_t* rawPeerStarts,
+      vector_size_t* rawPeerEnds) const;
+
  private:
-  // This is a copy of the input RowColumn objects that are used for
+  bool compareRowsWithSortKeys(const char* lhs, const char* rhs) const;
+
+  // The RowContainer associated with the partition.
+  // It is owned by the WindowBuild that creates the partition.
+  RowContainer* data_;
+
+  // Copy of the input RowColumn objects that are used for
   // accessing the partition row columns. These RowColumn objects
-  // index into the Window Operator RowContainer and can retrieve
-  // the column values.
+  // index into RowContainer data_ above and can retrieve the column values.
   // The order of these columns is the same as that of the input row
   // of the Window operator. The WindowFunctions know the
   // corresponding indexes of their input arguments into this vector.
   // They will request for column vector values at the respective index.
   std::vector<exec::RowColumn> columns_;
 
-  // This folly::Range is for the partition rows iterator provided by the
+  // folly::Range is for the partition rows iterator provided by the
   // Window operator. The pointers are to rows from a RowContainer owned
   // by the operator. We can assume these are valid values for the lifetime
   // of WindowPartition.
   folly::Range<char**> partition_;
+
+  // ORDER BY column info for this partition.
+  const std::vector<std::pair<column_index_t, core::SortOrder>> sortKeyInfo_;
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
The current Window operator included logic for : 

- Storing input data for the window operator in a RowContainer
- Building partitions when no more input rows are left
- Generating output rows by calling window functions

Doing all this in a single class made it difficult to implement more specialized approaches for splitting input partitions. Specifically, for Spark we wanted to implement some customizations. In Spark, input data is available in an ordered stream, so it can split partitions on the go.

This PR abstracts in a class called `WindowBuild` the first 2 bullets above. So the Window operator now forwards input rows to WindowBuild by calling its `addInput()` API. It can also signal noMoreInput using `WindowBuild::noMoreInput()`. The WindowBuild is responsible to split partitions from the input rows. 

On the output side, the Window operator gets partitions from `WindowBuild` using `nextPartition` API. The Window operator then invokes window functions for these partition rows and returns the output rows to the Driver framework.

This separation helps us to use varied algorithms for building partitions from Window operator. The window function invocation parts to build output can be reused across the different implementations. 