### PR TITLE
Add field separators as parameter in Subfield

### DIFF
--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -18,8 +18,10 @@
 
 namespace facebook::velox::common {
 
-Subfield::Subfield(const std::string& path) {
-  Tokenizer tokenizer(path);
+Subfield::Subfield(
+    const std::string& path,
+    const std::shared_ptr<Separators>& separators) {
+  Tokenizer tokenizer(path, separators);
   VELOX_CHECK(tokenizer.hasNext(), "Column name is missing: {}", path);
 
   auto firstElement = tokenizer.next();

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -29,6 +29,29 @@ enum SubfieldKind {
   kLongSubscript
 };
 
+// Contains field name separators to be used in Tokenizer.
+struct Separators {
+  static const std::shared_ptr<Separators>& get() {
+    static const std::shared_ptr<Separators> instance =
+        std::make_shared<Separators>();
+    return instance;
+  }
+
+  bool isSeparator(char c) const {
+    return (
+        c == closeBracket || c == dot || c == openBracket || c == quote ||
+        c == wildCard);
+  }
+
+  char backSlash = '\\';
+  char closeBracket = ']';
+  char dot = '.';
+  char openBracket = '[';
+  char quote = '\"';
+  char wildCard = '*';
+  char unicodeCaret = '^';
+};
+
 class Subfield {
  public:
   class PathElement {
@@ -195,7 +218,10 @@ class Subfield {
   };
 
  public:
-  explicit Subfield(const std::string& path);
+  // Separators: the customized separators to tokenize field name.
+  explicit Subfield(
+      const std::string& path,
+      const std::shared_ptr<Separators>& separators = Separators::get());
 
   explicit Subfield(std::vector<std::unique_ptr<PathElement>>&& path);
 

--- a/velox/type/Tokenizer.h
+++ b/velox/type/Tokenizer.h
@@ -35,22 +35,20 @@ class Tokenizer {
     kFailed,
   };
 
-  explicit Tokenizer(const std::string& path);
+  // Separators: the customized separators to tokenize field name.
+  explicit Tokenizer(
+      const std::string& path,
+      const std::shared_ptr<Separators>& separators);
 
   bool hasNext();
 
   std::unique_ptr<Subfield::PathElement> next();
 
  private:
-  const char DOT = '.';
-  const char QUOTE = '\"';
-  const char BACKSLASH = '\\';
-  const char WILDCARD = '*';
-  const char OPEN_BRACKET = '[';
-  const char CLOSE_BRACKET = ']';
-  const char UNICODE_CARET = '^';
-
   const std::string path_;
+  // Customized separators to tokenize field name.
+  std::shared_ptr<Separators> separators_;
+
   int index_;
   State state;
   bool firstSegment = true;
@@ -59,6 +57,10 @@ class Tokenizer {
   bool hasNextCharacter();
 
   std::unique_ptr<Subfield::PathElement> computeNext();
+
+  // Returns whether the expected char is a separator and
+  // can be found.
+  bool tryMatchSeparator(char expected);
 
   void match(char expected);
 

--- a/velox/type/tests/SubfieldTest.cpp
+++ b/velox/type/tests/SubfieldTest.cpp
@@ -20,9 +20,10 @@
 using namespace facebook::velox::common;
 
 std::vector<std::unique_ptr<Subfield::PathElement>> tokenize(
-    const std::string& path) {
+    const std::string& path,
+    const std::shared_ptr<Separators>& separators = Separators::get()) {
   std::vector<std::unique_ptr<Subfield::PathElement>> elements;
-  Tokenizer tokenizer(path);
+  Tokenizer tokenizer(path, separators);
   while (tokenizer.hasNext()) {
     elements.push_back(tokenizer.next());
   }
@@ -47,8 +48,10 @@ TEST(SubfieldTest, invalidPaths) {
   assertInvalidSubfield("a[2].[3].", "Invalid subfield path: a[2].^[3].");
 }
 
-void testColumnName(const std::string& name) {
-  auto elements = tokenize(name);
+void testColumnName(
+    const std::string& name,
+    const std::shared_ptr<Separators>& separators = Separators::get()) {
+  auto elements = tokenize(name, separators);
   EXPECT_EQ(elements.size(), 1);
   EXPECT_EQ(*elements[0].get(), Subfield::NestedField(name));
 }
@@ -59,6 +62,9 @@ TEST(SubfieldTest, columnNamesWithSpecialCharacters) {
   testColumnName("a/b/c:12");
   testColumnName("@basis");
   testColumnName("@basis|city_id");
+  auto separators = std::make_shared<Separators>();
+  separators->dot = '\0';
+  testColumnName("city.id@address:number/date|day$a-b$10_bucket", separators);
 }
 
 std::vector<std::unique_ptr<Subfield::PathElement>> createElements() {


### PR DESCRIPTION
In Velox tokenizer, some characters, eg. DOT, are treated as separation 
characters by default. But in Spark, DOT is treated as a regular character when 
it exists in column name.This PR added field separators as a parameter of 
Subfield to allow configurable behaviors. Separation happens when the input 
char is a separator and can be found in the path. Otherwise, the char is not 
used to tokenize.