### PR TITLE
Add GPU memory and API basics

### DIFF
--- a/velox/experimental/wave/CMakeLists.txt
+++ b/velox/experimental/wave/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_subdirectory(common)

--- a/velox/experimental/wave/common/Buffer.cpp
+++ b/velox/experimental/wave/common/Buffer.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+
+namespace facebook::velox::wave {
+
+void Buffer::release() {
+  if (referenceCount_.fetch_sub(1) == 1) {
+    arena_->free(this);
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Buffer.h
+++ b/velox/experimental/wave/common/Buffer.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <boost/intrusive_ptr.hpp>
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::wave {
+
+class GpuArena;
+
+/// Each area of device or universal memory in Wave has a unique
+/// host side control block with reference and pin counts. If
+/// unpinned, the memory is not currently accessed by a kernel and
+/// can be moved. When moving, it suffices to update the pointer in
+/// Buffer. These are managed via WaveBufferPtr. When the reference count goes
+/// to 0, the memory is returned to 'arena' and the Buffer is added to the
+/// Buffer free list.
+class Buffer {
+ public:
+  template <typename T>
+  T* as() {
+    reinterpret_cast<T*>(ptr_);
+  }
+
+  size_t capacity() const {
+    return capacity_;
+  }
+
+  size_t size() const {
+    return size_;
+  }
+
+  void setSize(size_t newSize) {
+    VELOX_DCHECK_LE(newSize, capacity_);
+    size_ = newSize;
+  }
+
+  void pin() {
+    ++pinCount_;
+  }
+
+  bool unpin() {
+    VELOX_DCHECK_LT(0, pinCount_);
+    return --pinCount_ == 0;
+  }
+
+  bool isPinned() const {
+    return 0 != pinCount_;
+  }
+
+  void addRef() {
+    referenceCount_.fetch_add(1);
+  }
+
+  int refCount() const {
+    return referenceCount_;
+  }
+
+  void release();
+
+ private:
+  // Number of WaveBufferPtrs referencing 'this'.
+  std::atomic<int32_t> referenceCount_{0};
+
+  // Number of pins. Incremented when passing to a kernel, decremented
+  // when the kernel returns. If 0 pins, o compute is proceeding and
+  // the memory owned by 'this' can be moved.
+  std::atomic<int32_t> pinCount_{0};
+
+  // Pointer to device/universal memory. If 'referenceCount_' is 0, this is the
+  // host pointer to the next  free Buffer in 'arena_'.
+  void* ptr_{nullptr};
+
+  // Byte size of memory held by 'ptr_'. Undefined if 'referenceCount_' is 0.
+  int64_t capacity_{0};
+
+  // Number of bytes used. Must be <= 'capacity_'.
+  int64_t size_{0};
+
+  // The containeing arena.
+  GpuArena* arena_{nullptr};
+
+  friend class GpuArena;
+};
+
+using WaveBufferPtr = boost::intrusive_ptr<Buffer>;
+
+static inline void intrusive_ptr_add_ref(Buffer* buffer) {
+  buffer->addRef();
+}
+
+static inline void intrusive_ptr_release(Buffer* buffer) {
+  buffer->release();
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/CMakeLists.txt
+++ b/velox/experimental/wave/common/CMakeLists.txt
@@ -1,0 +1,22 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(velox_wave_common GpuArena.cpp Buffer.cpp Cuda.cu Exception.cpp)
+
+set_target_properties(velox_wave_common PROPERTIES CUDA_ARCHITECTURES native)
+
+target_link_libraries(velox_wave_common velox_exception velox_common_base)
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_runtime.h>
+#include <fmt/format.h>
+#include "velox/experimental/wave/common/Cuda.h"
+#include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/Exception.h"
+
+namespace facebook::velox::wave {
+
+void cudaCheck(cudaError_t err, const char* file, int line) {
+  if (err == cudaSuccess) {
+    return;
+  }
+  waveError(
+      fmt::format("Cuda error: {}:{} {}", file, line, cudaGetErrorString(err)));
+}
+
+namespace {
+class CudaManagedAllocator : public GpuAllocator {
+ public:
+  void* allocate(size_t size) override {
+    void* ret;
+    CUDA_CHECK(cudaMallocManaged(&ret, size));
+    return ret;
+  }
+
+  void free(void* ptr, size_t /*size*/) override {
+    cudaFree(ptr);
+  }
+};
+} // namespace
+
+GpuAllocator* getAllocator(Device* /*device*/) {
+  static auto* allocator = new CudaManagedAllocator();
+  return allocator;
+}
+
+// Always returns device 0.
+Device* getDevice(int32_t /*preferredDevice*/) {
+  static Device device(0);
+  return &device;
+}
+
+void setDevice(Device* device) {
+  CUDA_CHECK(cudaSetDevice(device->deviceId));
+}
+
+Stream::Stream() {
+  stream = std::make_unique<StreamImpl>();
+  CUDA_CHECK(cudaStreamCreate(&stream->stream));
+}
+
+Stream::~Stream() {
+  cudaStreamDestroy(stream->stream);
+}
+
+void Stream::wait() {
+  CUDA_CHECK(cudaStreamSynchronize(stream->stream));
+}
+
+void Stream::prefetch(Device* device, void* ptr, size_t size) {
+  CUDA_CHECK(cudaMemPrefetchAsync(
+      ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream->stream));
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <memory>
+
+/// Contains wrappers for common Cuda objects. Wave does not directly
+/// include Cuda headers because of interference with BitUtils.h and
+/// SimdUtils.h.
+namespace facebook::velox::wave {
+
+struct Device {
+  explicit Device(int32_t id) : deviceId(id) {}
+
+  int32_t deviceId;
+};
+
+/// Checks that the machine has the right capability and returns a Device
+/// struct. If 'preferredId' is given tries to return  a Device on that device
+/// id.
+Device* getDevice(int32_t preferredId = -1);
+/// Binds subsequent Cuda operations of the calling thread to 'device'.
+void setDevice(Device* device);
+
+struct StreamImpl;
+
+struct Stream {
+  Stream();
+  virtual ~Stream();
+
+  /// Waits  until the stream is completed.
+  void wait();
+
+  /// Enqueus a prefetch. Prefetches to host if 'device' is nullptr, otherwise
+  /// to 'device'.
+  void prefetch(Device* device, void* address, size_t size);
+  std::unique_ptr<StreamImpl> stream;
+};
+
+// Abstract class wrapping device or universal address memory allocation.
+class GpuAllocator {
+ public:
+  virtual ~GpuAllocator() = default;
+
+  // Returns a pointer to at least 'bytes' of universal or device memory,
+  // depending on specific allocator. The size can be rounded up. The alignment
+  // is to 8 bytes.
+  virtual void* allocate(size_t bytes) = 0;
+
+  /// Frees a pointer from allocate(). 'size' must correspond to the size given
+  /// to allocate(). A Memory must be freed to the same allocator it came from.
+  virtual void free(void* ptr, size_t bytes) = 0;
+};
+
+GpuAllocator* getAllocator(Device* device);
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/CudaUtil.cuh
+++ b/velox/experimental/wave/common/CudaUtil.cuh
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+/// Utilities header to include in Cuda code for Velox Wave. Do not combine with
+/// Velox *.h.n
+namespace facebook::velox::wave {
+
+void cudaCheck(cudaError_t err, const char* file, int line);
+
+#define CUDA_CHECK(e) ::facebook::velox::wave::cudaCheck(e, __FILE__, __LINE__)
+
+template <typename T, typename U>
+constexpr inline T roundUp(T value, U factor) {
+  return (value + (factor - 1)) / factor * factor;
+}
+
+struct StreamImpl {
+  cudaStream_t stream;
+};
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Exception.cpp
+++ b/velox/experimental/wave/common/Exception.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/Exception.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::velox::wave {
+void waveError(const std::string& str) {
+  VELOX_FAIL(str);
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Exception.h
+++ b/velox/experimental/wave/common/Exception.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <glog/logging.h>
+#include <string>
+#include "folly/GLog.h"
+
+#define VELOX_WAVE_LOG_PREFIX "WAVE"
+#define VELOX_WAVE_LOG(severity) LOG(severity) << VELOX_WAVE_LOG_PREFIX
+#define VELOX_WAVE_LOG_EVERY_MS(severity, ms) \
+  FB_LOG_EVERY_MS(severity, ms) << VELOX_WAVE_LOG_PREFIX
+
+namespace facebook::velox::wave {
+/// Throws a VeloxException with 'message'.
+void waveError(const std::string& message);
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/GpuArena.cpp
+++ b/velox/experimental/wave/common/GpuArena.cpp
@@ -1,0 +1,365 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/GpuArena.h"
+#include <sstream>
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/base/SuccinctPrinter.h"
+#include "velox/experimental/wave/common/Exception.h"
+
+namespace facebook::velox::wave {
+
+uint64_t GpuSlab::roundBytes(uint64_t bytes) {
+  return bits::nextPowerOfTwo(bytes);
+}
+
+GpuSlab::GpuSlab(void* ptr, size_t capacityBytes, GpuAllocator* allocator)
+    : address_(reinterpret_cast<uint8_t*>(ptr)),
+      byteSize_(capacityBytes),
+      allocator_(allocator) {
+  addFreeBlock(reinterpret_cast<uint64_t>(address_), byteSize_);
+  freeBytes_ = byteSize_;
+}
+
+GpuSlab::~GpuSlab() {
+  allocator_->free(address_, byteSize_);
+}
+
+void* GpuSlab::allocate(uint64_t bytes) {
+  if (bytes == 0) {
+    return nullptr;
+  }
+  bytes = roundBytes(bytes);
+
+  // First match in the list that can give this many bytes
+  auto lookupItr = freeLookup_.lower_bound(bytes);
+  if (lookupItr == freeLookup_.end()) {
+    VELOX_WAVE_LOG_EVERY_MS(WARNING, 1000)
+        << "Cannot find a free block that is large enough to allocate " << bytes
+        << " bytes. Current arena freeBytes " << freeBytes_ << " & lookup table"
+        << freeLookupStr();
+    return nullptr;
+  }
+
+  freeBytes_ -= bytes;
+  auto address = *(lookupItr->second.begin());
+  auto curFreeBytes = lookupItr->first;
+  void* result = reinterpret_cast<void*>(address);
+  if (curFreeBytes == bytes) {
+    removeFreeBlock(address, curFreeBytes);
+    return result;
+  }
+  addFreeBlock(address + bytes, curFreeBytes - bytes);
+  removeFreeBlock(address, curFreeBytes);
+  return result;
+}
+
+void GpuSlab::free(void* address, uint64_t bytes) {
+  if (address == nullptr || bytes == 0) {
+    return;
+  }
+  bytes = roundBytes(bytes);
+  freeBytes_ += bytes;
+
+  const auto curAddr = reinterpret_cast<uint64_t>(address);
+  auto curIter = addFreeBlock(curAddr, bytes);
+  auto prevIter = freeList_.end();
+  uint64_t prevAddr;
+  uint64_t prevBytes;
+  bool mergePrev = false;
+  if (curIter != freeList_.begin()) {
+    prevIter = std::prev(curIter);
+    prevAddr = prevIter->first;
+    prevBytes = prevIter->second;
+    auto prevEndAddr = prevAddr + prevBytes;
+    VELOX_CHECK_LE(
+        prevEndAddr,
+        curAddr,
+        "New free node (addr:{} size:{}) overlaps with previous free node (addr:{} size:{}) in free list",
+        curAddr,
+        bytes,
+        prevAddr,
+        prevBytes);
+    mergePrev = prevEndAddr == curAddr;
+  }
+
+  auto nextItr = std::next(curIter);
+  uint64_t nextAddr;
+  uint64_t nextBytes;
+  bool mergeNext = false;
+  if (nextItr != freeList_.end()) {
+    nextAddr = nextItr->first;
+    nextBytes = nextItr->second;
+    auto curEndAddr = curAddr + bytes;
+    VELOX_CHECK_LE(
+        curEndAddr,
+        nextAddr,
+        "New free node (addr:{} size:{}) overlaps with next free node (addr:{} size:{}) in free list",
+        curAddr,
+        bytes,
+        nextAddr,
+        nextBytes);
+    mergeNext = (curEndAddr == nextAddr);
+  }
+
+  if (!mergePrev && !mergeNext) {
+    return;
+  }
+
+  if (mergePrev) {
+    removeFreeBlock(curIter);
+    removeFromLookup(prevAddr, prevBytes);
+    auto newFreeSize = curAddr - prevAddr + bytes;
+    if (mergeNext) {
+      removeFreeBlock(nextItr);
+      newFreeSize = nextAddr - prevAddr + nextBytes;
+    }
+    freeList_[prevIter->first] = newFreeSize;
+    freeLookup_[newFreeSize].emplace(prevAddr);
+    return;
+  }
+
+  if (mergeNext) {
+    VELOX_DCHECK(!mergePrev);
+    removeFreeBlock(nextItr);
+    removeFromLookup(curAddr, bytes);
+    const auto newFreeSize = nextAddr - curAddr + nextBytes;
+    freeList_[curIter->first] = newFreeSize;
+    freeLookup_[newFreeSize].emplace(curAddr);
+  }
+}
+
+void GpuSlab::removeFromLookup(uint64_t addr, uint64_t bytes) {
+  freeLookup_[bytes].erase(addr);
+  if (freeLookup_[bytes].empty()) {
+    freeLookup_.erase(bytes);
+  }
+}
+
+std::map<uint64_t, uint64_t>::iterator GpuSlab::addFreeBlock(
+    uint64_t address,
+    uint64_t bytes) {
+  auto insertResult = freeList_.emplace(address, bytes);
+  VELOX_CHECK(
+      insertResult.second,
+      "Trying to free a memory space that is already freed. Already in free list address {} size {}. Attempted to free address {} size {}",
+      address,
+      freeList_[address],
+      address,
+      bytes);
+  freeLookup_[bytes].emplace(address);
+  return insertResult.first;
+}
+
+void GpuSlab::removeFreeBlock(uint64_t addr, uint64_t bytes) {
+  freeList_.erase(addr);
+  removeFromLookup(addr, bytes);
+}
+
+void GpuSlab::removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& iter) {
+  removeFromLookup(iter->first, iter->second);
+  freeList_.erase(iter);
+}
+
+bool GpuSlab::checkConsistency() const {
+  uint64_t numErrors = 0;
+  auto arenaEndAddress = reinterpret_cast<uint64_t>(address_) + byteSize_;
+  auto iter = freeList_.begin();
+  auto end = freeList_.end();
+  int64_t freeListTotalBytes = 0;
+  while (iter != end) {
+    // Lookup list should contain the address
+    auto freeLookupIter = freeLookup_.find(iter->second);
+    if (freeLookupIter == freeLookup_.end() ||
+        freeLookupIter->second.find(iter->first) ==
+            freeLookupIter->second.end()) {
+      LOG(WARNING)
+          << "GpuSlab::checkConsistency(): freeLookup_ out of sync: Not "
+             "containing item from freeList_ {addr:"
+          << iter->first << ", size:" << iter->second << "}";
+      numErrors++;
+    }
+
+    // Verify current free block end
+    auto blockEndAddress = iter->first + iter->second;
+    if (blockEndAddress > arenaEndAddress) {
+      LOG(WARNING)
+          << "GpuSlab::checkConsistency(): freeList_ out of sync: Block "
+             "extruding arena boundary {addr:"
+          << iter->first << ", size:" << iter->second << "}";
+      numErrors++;
+    }
+
+    // Verify next free block not overlapping
+    auto next = std::next(iter);
+    if (next != end && blockEndAddress > next->first) {
+      LOG(ERROR)
+          << "GpuSlab::checkConsistency(): freeList_ out of sync: Overlapping"
+             " blocks {addr:"
+          << iter->first << ", size:" << iter->second
+          << "} {addr:" << next->first << ", size:" << next->second << "}";
+      numErrors++;
+    }
+
+    freeListTotalBytes += iter->second;
+    iter++;
+  }
+
+  // Check consistency of lookup list
+  int64_t freeLookupTotalBytes = 0;
+  for (auto freeIter = freeLookup_.begin(); freeIter != freeLookup_.end();
+       freeIter++) {
+    if (freeIter->second.empty()) {
+      LOG(ERROR)
+          << "GpuSlab::checkConsistency(): freeLookup_ out of sync: Empty "
+             "address list for size "
+          << freeIter->first;
+      numErrors++;
+    }
+    freeLookupTotalBytes += (freeIter->first * freeIter->second.size());
+  }
+
+  // Check consistency of freeList_ and freeLookup_ in terms of bytes
+  if (freeListTotalBytes != freeLookupTotalBytes ||
+      freeListTotalBytes != freeBytes_) {
+    LOG(WARNING)
+        << "GpuSlab::checkConsistency(): free bytes out of sync: freeListTotalBytes "
+        << freeListTotalBytes << " freeLookupTotalBytes "
+        << freeLookupTotalBytes << " freeBytes_ " << freeBytes_;
+    numErrors++;
+  }
+
+  if (numErrors) {
+    LOG(ERROR) << "GpuSlab::checkConsistency(): " << numErrors << " errors";
+  }
+  return numErrors == 0;
+}
+
+std::string GpuSlab::freeLookupStr() {
+  std::stringstream lookupStr;
+  for (auto itr = freeLookup_.begin(); itr != freeLookup_.end(); ++itr) {
+    lookupStr << "\n{" << itr->first << "->[";
+    for (auto itrInner = itr->second.begin(); itrInner != itr->second.end();
+         itrInner++) {
+      lookupStr << *itrInner << ", ";
+    }
+    lookupStr << "]}\n";
+  }
+  return lookupStr.str();
+}
+
+std::string GpuSlab::toString() const {
+  return fmt::format(
+      "GpuSlab[byteSize[{}] address[{}] freeBytes[{}] freeList[{}]]]",
+      succinctBytes(byteSize_),
+      reinterpret_cast<uint64_t>(address_),
+      succinctBytes(freeBytes_),
+      freeList_.size());
+}
+
+GpuArena::Buffers::Buffers() {
+  memset(&buffers[0], 0, sizeof(buffers));
+}
+
+GpuArena::GpuArena(uint64_t singleArenaCapacity, GpuAllocator* allocator)
+    : singleArenaCapacity_(singleArenaCapacity), allocator_(allocator) {
+  auto arena = std::make_shared<GpuSlab>(
+      allocator_->allocate(singleArenaCapacity),
+      singleArenaCapacity,
+      allocator_);
+  arenas_.emplace(reinterpret_cast<uint64_t>(arena->address()), arena);
+  currentArena_ = arena;
+}
+
+WaveBufferPtr GpuArena::getBuffer(void* ptr, size_t size) {
+  auto result = firstFreeBuffer_;
+  if (!result) {
+    allBuffers_.push_back(std::make_unique<Buffers>());
+    auto* buffers = allBuffers_.back().get();
+    for (int32_t i = (sizeof(*buffers) / sizeof(Buffer)) - 1; i >= 0; --i) {
+      buffers->buffers[i].ptr_ = firstFreeBuffer_;
+      firstFreeBuffer_ = &buffers->buffers[i];
+    }
+    result = firstFreeBuffer_;
+  }
+  firstFreeBuffer_ = reinterpret_cast<Buffer*>(result->ptr_);
+  result->arena_ = this;
+  result->ptr_ = ptr;
+  result->size_ = size;
+  result->capacity_ = size;
+  return result;
+}
+
+WaveBufferPtr GpuArena::allocate(uint64_t bytes) {
+  bytes = GpuSlab::roundBytes(bytes);
+  std::lock_guard<std::mutex> l(mutex_);
+  auto* result = currentArena_->allocate(bytes);
+  if (result != nullptr) {
+    return getBuffer(result, bytes);
+  }
+  for (auto pair : arenas_) {
+    if (pair.second == currentArena_ || pair.second->freeBytes() < bytes) {
+      continue;
+    }
+    result = pair.second->allocate(bytes);
+    if (result) {
+      currentArena_ = pair.second;
+      return getBuffer(result, bytes);
+    }
+  }
+
+  // If first allocation fails we create a new GpuSlab for another attempt. If
+  // it ever fails again then it means requested bytes is larger than a single
+  // GpuSlab's capacity. No further attempts will happen.
+  auto newArena = std::make_shared<GpuSlab>(
+      allocator_->allocate(singleArenaCapacity_),
+      singleArenaCapacity_,
+      allocator_);
+  arenas_.emplace(reinterpret_cast<uint64_t>(newArena->address()), newArena);
+  currentArena_ = newArena;
+  result = currentArena_->allocate(bytes);
+  if (result) {
+    return getBuffer(result, bytes);
+  }
+  VELOX_FAIL("Failed to allocate {} bytes of universal address space", bytes);
+}
+
+void GpuArena::free(Buffer* buffer) {
+  const uint64_t addressU64 = reinterpret_cast<uint64_t>(buffer->ptr_);
+  VELOX_CHECK_EQ(0, buffer->referenceCount_);
+  VELOX_CHECK_EQ(0, buffer->pinCount_);
+  std::lock_guard<std::mutex> l(mutex_);
+  VELOX_CHECK(!arenas_.empty());
+
+  auto iter = arenas_.lower_bound(addressU64);
+  if (iter == arenas_.end() || iter->first != addressU64) {
+    VELOX_CHECK(iter != arenas_.begin());
+    --iter;
+    VELOX_CHECK_GE(
+        iter->first + singleArenaCapacity_, addressU64 + buffer->size_);
+  }
+  iter->second->free(buffer->ptr_, buffer->size_);
+  if (iter->second->empty() && iter->second != currentArena_) {
+    arenas_.erase(iter);
+  }
+  buffer->ptr_ = firstFreeBuffer_;
+  buffer->size_ = 0;
+  buffer->capacity_ = 0;
+  firstFreeBuffer_ = buffer;
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/Cuda.h"
+
+namespace facebook::velox::wave {
+
+/// A contiguous range slab of device or universal memory for
+/// backing small allocations. The caller is responsible for
+/// serializing access across threads.
+class GpuSlab {
+ public:
+  static constexpr int64_t kMinCapacityBytes = 128 * 1024 * 1024; // 128M
+
+  GpuSlab(void* address, size_t capacityBytes, GpuAllocator* allocator);
+
+  ~GpuSlab();
+
+  // Returns an address for at least 'bytes' of memory inside this slab, nullptr
+  // if there is no contiguous run of at least 'bytes'.
+  void* FOLLY_NULLABLE allocate(uint64_t bytes);
+
+  /// Frees an area returned by allocate().
+  void free(void* address, uint64_t bytes);
+
+  void* address() const {
+    return reinterpret_cast<void*>(address_);
+  }
+
+  uint64_t byteSize() const {
+    return byteSize_;
+  }
+
+  const std::map<uint64_t, uint64_t>& freeList() const {
+    return freeList_;
+  }
+
+  const std::map<uint64_t, std::unordered_set<uint64_t>>& freeLookup() const {
+    return freeLookup_;
+  }
+
+  uint64_t freeBytes() {
+    return freeBytes_;
+  }
+
+  bool empty() {
+    return freeBytes_ == byteSize_;
+  }
+
+  /// Checks internal consistency of this GpuSlab. Returns true if OK. May
+  /// return false if there are concurrent alocations and frees during the
+  /// consistency check. This is a false positive but not dangerous. This is for
+  /// test only
+  bool checkConsistency() const;
+
+  /// translate lookup table to a string for debugging purpose only.
+  std::string freeLookupStr();
+
+  std::string toString() const;
+  // Rounds up size to the next power of 2.
+  static uint64_t roundBytes(uint64_t bytes);
+
+ private:
+  std::map<uint64_t, uint64_t>::iterator addFreeBlock(
+      uint64_t addr,
+      uint64_t bytes);
+
+  void removeFromLookup(uint64_t addr, uint64_t bytes);
+
+  void removeFreeBlock(uint64_t addr, uint64_t bytes);
+
+  void removeFreeBlock(std::map<uint64_t, uint64_t>::iterator& itr);
+
+  // Starting address of this slab.
+  uint8_t* address_;
+
+  // Total size of this slab.
+  const uint64_t byteSize_;
+
+  std::atomic<uint64_t> freeBytes_;
+
+  // A sorted list with each entry mapping from free block address to size of
+  // the free block
+  std::map<uint64_t, uint64_t> freeList_;
+
+  // A sorted look up structure that stores the block size as key and a set of
+  // addresses of that size as value.
+  std::map<uint64_t, std::unordered_set<uint64_t>> freeLookup_;
+
+  GpuAllocator* const allocator_;
+};
+
+/// A class that manages a set of GpuSlabs. It is able to adapt itself by
+/// growing the number of its managed GpuSlab's when extreme memory
+/// fragmentation happens.
+class GpuArena {
+ public:
+  GpuArena(uint64_t singleArenaCapacity, GpuAllocator* allocator);
+
+  WaveBufferPtr allocate(uint64_t bytes);
+
+  void free(Buffer* buffer);
+
+  const std::map<uint64_t, std::shared_ptr<GpuSlab>>& slabs() const {
+    return arenas_;
+  }
+
+ private:
+  // A preallocated array of Buffer handles for memory of 'this'.
+  struct Buffers {
+    Buffers();
+    std::array<Buffer, 1024> buffers;
+  };
+
+  // Returns a new reference counting pointer to a new Buffer initialized to
+  // 'ptr' and 'size'.
+  WaveBufferPtr getBuffer(void* ptr, size_t size);
+
+  // Serializes all activity in 'this'.
+  std::mutex mutex_;
+
+  // All buffers referencing memory from 'this'. All must be locatable for e.g.
+  // compaction.
+  std::vector<std::unique_ptr<Buffers>> allBuffers_;
+
+  // Head of Buffer free list.
+  Buffer* firstFreeBuffer_{nullptr};
+
+  // Capacity in bytes for a single GpuSlab managed by this.
+  const uint64_t singleArenaCapacity_;
+
+  GpuAllocator* const allocator_;
+
+  // A sorted list of GpuSlab by its initial address
+  std::map<uint64_t, std::shared_ptr<GpuSlab>> arenas_;
+
+  // All allocations should come from this GpuSlab. When it is no longer able
+  // to handle allocations it will be updated to a newly created GpuSlab.
+  std::shared_ptr<GpuSlab> currentArena_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_wave_common_test GpuArenaTest.cpp CudaTest.cpp CudaTest.cu)
+
+set_target_properties(velox_wave_common_test PROPERTIES CUDA_ARCHITECTURES
+                                                        native)
+
+add_test(velox_wave_common_test velox_wave_common_test)
+
+target_link_libraries(
+  velox_wave_common_test
+  velox_wave_common
+  velox_exception
+  gtest
+  gtest_main
+  gflags::gflags
+  Folly::folly)

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/tests/CudaTest.h"
+#include <gtest/gtest.h>
+#include "velox/common/base/BitUtil.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::wave;
+
+class CudaTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    device_ = getDevice();
+    setDevice(device_);
+    allocator_ = getAllocator(device_);
+  }
+  Device* device_;
+  GpuAllocator* allocator_;
+};
+
+TEST_F(CudaTest, stream) {
+  constexpr int32_t kSize = 1000000;
+  TestStream stream;
+  auto ints =
+      reinterpret_cast<int32_t*>(allocator_->allocate(kSize * sizeof(int32_t)));
+  for (auto i = 0; i < kSize; ++i) {
+    ints[i] = i;
+  }
+  stream.prefetch(device_, ints, kSize * sizeof(int32_t));
+  stream.addOne(ints, kSize);
+  stream.prefetch(nullptr, ints, kSize * sizeof(int32_t));
+  stream.wait();
+  for (auto i = 0; i < kSize; ++i) {
+    ASSERT_EQ(ints[i], i + 1);
+  }
+  allocator_->free(ints, sizeof(int32_t) * kSize);
+}

--- a/velox/experimental/wave/common/tests/CudaTest.cu
+++ b/velox/experimental/wave/common/tests/CudaTest.cu
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/tests/CudaTest.h"
+
+namespace facebook::velox::wave {
+
+__global__ void addOneKernel(int32_t* numbers, int32_t size) {
+  auto index = blockDim.x * blockIdx.x + threadIdx.x;
+  if (index < size) {
+    ++numbers[index];
+  }
+}
+
+void TestStream::addOne(int32_t* numbers, int32_t size) {
+  auto numBlocks = roundUp(size, 256) / 256;
+  addOneKernel<<<numBlocks, 256, 0, stream->stream>>>(numbers, size);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CudaTest.h
+++ b/velox/experimental/wave/common/tests/CudaTest.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/common/Cuda.h"
+
+/// Sample header for testing Cuda.h
+
+namespace facebook::velox::wave {
+
+class TestStream : public Stream {
+ public:
+  // Queues a kernel to add 1 to numbers[0...size - 1].
+  void addOne(int32_t* numbers, int size);
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/GpuArenaTest.cpp
+++ b/velox/experimental/wave/common/tests/GpuArenaTest.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/common/GpuArena.h"
+#include <folly/Random.h>
+#include <gtest/gtest.h>
+#include "velox/common/base/BitUtil.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::wave;
+
+class TestingGpuAllocator : public GpuAllocator {
+ public:
+  void* allocate(size_t bytes) override {
+    return malloc(bytes);
+  }
+
+  void free(void* ptr, size_t /*size*/) override {
+    ::free(ptr);
+  }
+};
+
+class GpuArenaTest : public testing::Test {
+ public:
+  // 32 MB arena space
+  static constexpr uint64_t kArenaCapacityBytes = 1l << 25;
+
+ protected:
+  void SetUp() override {
+    rng_.seed(1);
+    allocator_ = std::make_unique<TestingGpuAllocator>();
+  }
+
+  void* allocateAndPad(GpuSlab* arena, uint64_t bytes) {
+    void* buffer = arena->allocate(bytes);
+    memset(buffer, 0xff, bytes);
+    return buffer;
+  }
+
+  void unpadAndFree(GpuSlab* arena, void* buffer, uint64_t bytes) {
+    memset(buffer, 0x00, bytes);
+    arena->free(buffer, bytes);
+  }
+
+  uint64_t randomPowTwo(uint64_t lowerBound, uint64_t upperBound) {
+    lowerBound = bits::nextPowerOfTwo(lowerBound);
+    auto attemptedUpperBound = bits::nextPowerOfTwo(upperBound);
+    upperBound = attemptedUpperBound == upperBound ? upperBound
+                                                   : attemptedUpperBound / 2;
+    uint64_t moveSteps;
+    if (lowerBound == 0) {
+      uint64_t one = 1;
+      moveSteps =
+          (folly::Random::rand64(
+               bits::countLeadingZeros(one) + 1 -
+                   bits::countLeadingZeros(upperBound),
+               rng_) +
+           1);
+      return moveSteps == 0 ? 0 : (1l << (moveSteps - 1));
+    }
+    moveSteps =
+        (folly::Random::rand64(
+             bits::countLeadingZeros(lowerBound) -
+                 bits::countLeadingZeros(upperBound),
+             rng_) +
+         1);
+    return lowerBound << moveSteps;
+  }
+
+  folly::Random::DefaultGenerator rng_;
+  std::unique_ptr<TestingGpuAllocator> allocator_;
+};
+
+TEST_F(GpuArenaTest, slab) {
+  // 0 Byte lower bound for revealing edge cases.
+  const uint64_t kAllocLowerBound = 0;
+
+  // 1 KB upper bound
+  const uint64_t kAllocUpperBound = 1l << 10;
+  std::unique_ptr<GpuSlab> arena = std::make_unique<GpuSlab>(
+      allocator_->allocate(kArenaCapacityBytes),
+      kArenaCapacityBytes,
+      allocator_.get());
+  memset(arena->address(), 0x00, kArenaCapacityBytes);
+
+  std::unordered_map<uint64_t, uint64_t> allocations;
+
+  // First phase allocate only
+  for (size_t i = 0; i < 1000; i++) {
+    auto bytes = randomPowTwo(kAllocLowerBound, kAllocUpperBound);
+    allocations.emplace(
+        reinterpret_cast<uint64_t>(allocateAndPad(arena.get(), bytes)), bytes);
+  }
+  EXPECT_TRUE(arena->checkConsistency());
+
+  // Second phase alloc and free called in an interleaving way
+  for (size_t i = 0; i < 10000; i++) {
+    auto bytes = randomPowTwo(kAllocLowerBound, kAllocUpperBound);
+    allocations.emplace(
+        reinterpret_cast<uint64_t>(allocateAndPad(arena.get(), bytes)), bytes);
+
+    auto itrToFree = allocations.begin();
+    auto bytesFree = itrToFree->second;
+    unpadAndFree(
+        arena.get(), reinterpret_cast<void*>(itrToFree->first), bytesFree);
+    allocations.erase(itrToFree);
+  }
+  EXPECT_TRUE(arena->checkConsistency());
+
+  // Third phase free only
+  auto itr = allocations.begin();
+  while (itr != allocations.end()) {
+    auto bytes = itr->second;
+    unpadAndFree(arena.get(), reinterpret_cast<void*>(itr->first), bytes);
+    itr++;
+  }
+  EXPECT_TRUE(arena->checkConsistency());
+}
+
+TEST_F(GpuArenaTest, buffers) {
+  auto arena = std::make_unique<GpuArena>(1 << 20, allocator_.get());
+  std::vector<WaveBufferPtr> buffers;
+  for (auto i = 0; i < 5000; ++i) {
+    buffers.push_back(arena->allocate(1024));
+  }
+  EXPECT_EQ(5, arena->slabs().size());
+  // We clear some of the first allocated buffers.
+  buffers.erase(buffers.begin(), buffers.begin() + 2300);
+  EXPECT_EQ(3, arena->slabs().size());
+  // Allocate some more. Check that slabs  with unuused capacity get used before
+  // making new ones.
+  for (auto i = 0; i < 100; ++i) {
+    buffers.push_back(arena->allocate(1024));
+  }
+  EXPECT_EQ(3, arena->slabs().size());
+  for (auto i = 0; i < 500; ++i) {
+    buffers.push_back(arena->allocate(1024));
+  }
+  EXPECT_EQ(4, arena->slabs().size());
+
+  // We clear all and expect one arena to be left at the end.
+  buffers.clear();
+  EXPECT_EQ(1, arena->slabs().size());
+}


### PR DESCRIPTION
Adds an arena for managing device or universal memory for query execution on accelerators. Code modified from MmapArena.*. The std::maps will be replaced by a SIMD tree for performance later.

Adds a wrapper for Cuda concepts. The Cuda headers will not be included in CPU code and the Velox headers will not be included in kernel code. Adds a test for the patttern of making a specialized stream for an interface between the C++ and Cuda code so that the Cuda headers are not included in C++.