### PR TITLE
Introduce applyToCodePoints helper function

### DIFF
--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -269,17 +269,15 @@ TEST_F(StringImplTest, stringToCodePoints) {
   testStringToCodePoints("\u840C", {0x840C});
 
   VELOX_ASSERT_THROW(
-      testStringToCodePoints("\xA9", {}),
-      "Invalid UTF-8 encoding in characters");
+      testStringToCodePoints("\xA9", {}), "Invalid UTF-8 encoding in: ");
   VELOX_ASSERT_THROW(
-      testStringToCodePoints("ü\xA9", {}),
-      "Invalid UTF-8 encoding in characters");
+      testStringToCodePoints("ü\xA9", {}), "Invalid UTF-8 encoding in: ");
   VELOX_ASSERT_THROW(
       testStringToCodePoints("ü\xA9hello wooooorld", {}),
-      "Invalid UTF-8 encoding in characters");
+      "Invalid UTF-8 encoding in: ");
   VELOX_ASSERT_THROW(
       testStringToCodePoints("ü\xA9hello wooooooooorrrrrld", {}),
-      "Invalid UTF-8 encoding in characters");
+      "Invalid UTF-8 encoding in: ");
 }
 
 TEST_F(StringImplTest, stringPosition) {

--- a/velox/functions/prestosql/tests/StringFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/StringFunctionsTest.cpp
@@ -1149,13 +1149,13 @@ TEST_F(StringFunctionsTest, unicodeLevenshteinDistance) {
 TEST_F(StringFunctionsTest, invalidLevenshteinDistance) {
   VELOX_ASSERT_THROW(
       levenshteinDistance("a\xA9ü", "hello world"),
-      "Invalid UTF-8 encoding in characters");
+      "Invalid UTF-8 encoding in: ");
   VELOX_ASSERT_THROW(
       levenshteinDistance("Ψ\xFF\xFFΣΓΔA", "abc"),
-      "Invalid UTF-8 encoding in characters");
+      "Invalid UTF-8 encoding in: ");
   VELOX_ASSERT_THROW(
       levenshteinDistance("ab", "AΔΓΣ\xFF\xFFΨ"),
-      "Invalid UTF-8 encoding in characters");
+      "Invalid UTF-8 encoding in: ");
 
   VELOX_ASSERT_THROW(
       levenshteinDistance(std::string(1001, 'h'), std::string(1001, 'o')),


### PR DESCRIPTION
Introduce applyToCodePoints helper function to simplify logic that processes
UTF-8 strings one code point at a time.