### PR TITLE
Fix several HyperLogLog correctness issues

### DIFF
--- a/velox/common/hyperloglog/DenseHll.cpp
+++ b/velox/common/hyperloglog/DenseHll.cpp
@@ -139,7 +139,7 @@ void DenseHll::initialize(int8_t indexBitLength) {
 
 void DenseHll::insertHash(uint64_t hash) {
   auto index = computeIndex(hash, indexBitLength_);
-  auto value = computeValue(hash, indexBitLength_);
+  auto value = numberOfLeadingZeros(hash, indexBitLength_) + 1;
   insert(index, value);
 }
 

--- a/velox/common/hyperloglog/HllUtils.h
+++ b/velox/common/hyperloglog/HllUtils.h
@@ -44,10 +44,8 @@ inline void checkMaxStandardError(double error) {
 }
 
 inline int8_t toIndexBitLength(double maxStandardError) {
-  return (8 * sizeof(int) -
-          __builtin_clz(
-              std::ceil(1.0816 / (maxStandardError * maxStandardError)))) -
-      1;
+  int buckets = std::ceil(1.0816 / (maxStandardError * maxStandardError));
+  return 8 * sizeof(int) - __builtin_clz(buckets - 1);
 }
 
 /// Returns first 'indexBitLength' bits of a hash.
@@ -55,13 +53,13 @@ inline uint32_t computeIndex(uint64_t hash, int indexBitLength) {
   return hash >> (64 - indexBitLength);
 }
 
-/// Returns number of contiguous zeros after 'indexBitLength' bits in the 'hash'
-/// + 1.
-inline int8_t computeValue(uint64_t hash, int indexBitLength) {
-  // Place a 1 in the LSB to preserve the original number of
-  // leading zeros if the hash happens to be 0.
-  uint64_t v = (hash << indexBitLength) | (1L << (indexBitLength - 1));
-  return __builtin_clzl(v) + 1;
+/// Returns number of contiguous zeros after 'indexBitLength' bits in the
+/// 'hash'.
+inline int numberOfLeadingZeros(uint64_t hash, int indexBitLength) {
+  // Place a 1 in the LSB to preserve the original number of leading zeros if
+  // the hash happens to be 0.
+  return __builtin_clzl(
+      (hash << indexBitLength) | (1L << (indexBitLength - 1)));
 }
 
 /// Estimates cardinality using Linear Counting algorithm.

--- a/velox/common/hyperloglog/SparseHll.cpp
+++ b/velox/common/hyperloglog/SparseHll.cpp
@@ -71,7 +71,7 @@ common::InputByteStream initializeInputStream(const char* serialized) {
 
 bool SparseHll::insertHash(uint64_t hash) {
   auto index = computeIndex(hash, kIndexBitLength);
-  auto value = computeValue(hash, kIndexBitLength);
+  auto value = numberOfLeadingZeros(hash, kIndexBitLength);
 
   auto entry = encode(index, value);
   auto position = searchIndex(index, entries_);
@@ -231,15 +231,15 @@ void SparseHll::toDense(DenseHll& denseHll) const {
   for (auto i = 0; i < entries_.size(); i++) {
     auto entry = entries_[i];
     auto index = entry >> (32 - indexBitLength);
+    auto shiftedValue = entry << indexBitLength;
+    auto zeros = shiftedValue == 0 ? 32 : __builtin_clz(shiftedValue);
 
-    auto zeros = __builtin_clz(entry << indexBitLength);
-
-    // If zeros > kIndexBitLength - indexBitLength, it means all those bits were
-    // zeros, so look at the entry value, which contains the number of leading 0
-    // *after* kIndexBitLength.
+    // If zeros >= kIndexBitLength - indexBitLength, it means all those bits
+    // were zeros, so look at the entry value, which contains the number of
+    // leading 0 *after* kIndexBitLength.
     auto bits = kIndexBitLength - indexBitLength;
-    if (zeros > bits) {
-      zeros = bits + decodeValue(entry) - 1;
+    if (zeros >= bits) {
+      zeros = bits + decodeValue(entry);
     }
 
     denseHll.insert(index, zeros + 1);

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -195,6 +195,20 @@ TEST_P(SparseHllToDenseTest, toDense) {
   ASSERT_EQ(serialize(denseHll), serialize(expectedHll));
 }
 
+TEST_P(SparseHllToDenseTest, testNumberOfZeros) {
+  auto indexBitLength = GetParam();
+  for (int i = 0; i < 64 - indexBitLength; ++i) {
+    auto hash = 1ull << i;
+    SparseHll sparseHll(&allocator_);
+    sparseHll.insertHash(hash);
+    DenseHll expectedHll(indexBitLength, &allocator_);
+    expectedHll.insertHash(hash);
+    DenseHll denseHll(indexBitLength, &allocator_);
+    sparseHll.toDense(denseHll);
+    ASSERT_EQ(serialize(denseHll), serialize(expectedHll));
+  }
+}
+
 INSTANTIATE_TEST_SUITE_P(
     SparseHllToDenseTest,
     SparseHllToDenseTest,


### PR DESCRIPTION
Summary:
Fix several correctness issues that make the result of HyperLogLog
slightly less accurate and different from the result in Java Presto.

1. Fix the calculation of index bit length from error bound by rounding up the
   bucket number to power of two instead of rounding down.

2. When the value part in hash are all zeros and the entry value happens to have
   the same number of leading zeros as the difference of bit index length
   between sparse and dense accumulator, we failed to count the leading zero
   information for that entry.

3. In `SparseHll` we used to keep leading zeros plus one as entry value, this is
   inconsistent with Presto Java and caused difference when we read back
   serialized `SparseHll` written by Java Presto.

Differential Revision: D48104447

