### PR TITLE
Add key_type/mapped_type typedefs to MapView

### DIFF
--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -785,6 +785,9 @@ class MapView {
     const value_reader_t* valueReader_;
   };
 
+  using key_type = const KeyAccessor;
+  using mapped_type = const ValueAccessor;
+
   using Iterator = IndexBasedIterator<ElementAccessor>;
 
   Iterator begin() const {


### PR DESCRIPTION
Summary: At least mapped_type is necessary for compatibility with folly/MapUtil.h; may as well add key_type while we are here.

Differential Revision: D48131896

