### PR TITLE
Register In predicate with arguments types (date, array<integer>)

### DIFF
--- a/velox/functions/prestosql/InPredicate.cpp
+++ b/velox/functions/prestosql/InPredicate.cpp
@@ -127,8 +127,9 @@ createFloatingPointValuesFilter(
       if (values[i] == float{}) {
         values[i] = 0;
       }
-      intValues[i] = reinterpret_cast<const int32_t&>(values[i]); // silently promote to int64
-    }else{
+      intValues[i] = reinterpret_cast<const int32_t&>(
+          values[i]); // silently promote to int64
+    } else {
       if (values[i] == double{}) {
         values[i] = 0;
       }
@@ -322,6 +323,13 @@ class InPredicate : public exec::VectorFunction {
                                   .argumentType("array(unknown)")
                                   .build());
     }
+    // logical type: Date
+    signatures.emplace_back(exec::FunctionSignatureBuilder()
+                                .returnType("boolean")
+                                .argumentType("date")
+                                .argumentType("array(integer)")
+                                .build());
+
     return signatures;
   }
 


### PR DESCRIPTION
Summary:
DATE is logical type, its physical type is INTEGER

Test: 
`presto:tpch> SELECT ORDERDATE FROM orders WHERE CAST(ORDERDATE AS DATE) IN (CAST('1997-07-29' AS DATE), CAST('1993-03-13' AS DATE)) LIMIT 10;`

Previously, same query will fail with error message:
`Query xxxx failed:  Scalar function in not registered with arguments: (DATE, ARRAY<INTEGER>). Found function registered with the following signatures:
((boolean,array(boolean)) -> boolean)
...`


PS : One irrelevant format format change is included due to format-check rule
