### PR TITLE
Add kAbandonPartialAggregationMinMemory config for partial aggregation flush

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -99,6 +99,9 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialAggregationMinRows =
       "abandon_partial_aggregation_min_rows";
 
+  static constexpr const char* kAbandonPartialAggregationMinMemory =
+      "min_abandon_partial_aggregation_memory";
+
   static constexpr const char* kAbandonPartialAggregationMinPct =
       "abandon_partial_aggregation_min_pct";
 
@@ -250,6 +253,11 @@ class QueryConfig {
 
   int32_t abandonPartialAggregationMinRows() const {
     return get<int32_t>(kAbandonPartialAggregationMinRows, 10000);
+  }
+
+  uint64_t abandonPartialAggregationMinMemoryUsage() const {
+    static constexpr uint64_t kDefault = 0;
+    return get<uint64_t>(kAbandonPartialAggregationMinMemory, kDefault);
   }
 
   int32_t abandonPartialAggregationMinPct() const {

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -85,6 +85,8 @@ HashAggregation::HashAggregation(
           driverCtx->queryConfig().maxPartialAggregationMemoryUsage()),
       abandonPartialAggregationMinRows_(
           driverCtx->queryConfig().abandonPartialAggregationMinRows()),
+      abandonPartialAggregationMinMemory_(
+          driverCtx->queryConfig().abandonPartialAggregationMinMemoryUsage()),
       abandonPartialAggregationMinPct_(
           driverCtx->queryConfig().abandonPartialAggregationMinPct()) {
   VELOX_CHECK(pool()->trackUsage());
@@ -187,7 +189,8 @@ HashAggregation::HashAggregation(
 
 bool HashAggregation::abandonPartialAggregationEarly(int64_t numOutput) const {
   VELOX_CHECK(isPartialOutput_ && !isGlobal_);
-  return numInputRows_ > abandonPartialAggregationMinRows_ &&
+  return groupingSet_->allocatedBytes() > abandonPartialAggregationMinMemory_ &&
+      numInputRows_ > abandonPartialAggregationMinRows_ &&
       100 * numOutput / numInputRows_ >= abandonPartialAggregationMinPct_;
 }
 

--- a/velox/exec/HashAggregation.h
+++ b/velox/exec/HashAggregation.h
@@ -91,6 +91,10 @@ class HashAggregation : public Operator {
   // aggregation.
   const int32_t abandonPartialAggregationMinRows_;
 
+  // Minimum size of memory usage in bytes to see before deciding to give up on
+  // partial aggregation.
+  const uint64_t abandonPartialAggregationMinMemory_;
+
   // Min unique rows pct for partial aggregation. If more than this many rows
   // are unique, the partial aggregation is not worthwhile.
   const int32_t abandonPartialAggregationMinPct_;


### PR DESCRIPTION
To fix https://github.com/facebookincubator/velox/issues/6035, add kAbandonPartialAggregationMinMemory config for partial aggregation flush. With this config, `abandonPartialAggregationEarly` can be set as true only when the allocated memory is larger than this limit.