### PR TITLE
Fix flaky reclaimFromCompletedJoinBuilder test

### DIFF
--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -244,7 +244,7 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
             << "', but received '" << errorMessage << "'.";
       }
     }
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2377,29 +2377,6 @@ std::shared_ptr<SpillOperatorGroup> Task::getSpillOperatorGroupLocked(
   return group;
 }
 
-// static
-void Task::testingWaitForAllTasksToBeDeleted(uint64_t maxWaitUs) {
-  const uint64_t numCreatedTasks = Task::numCreatedTasks();
-  uint64_t numDeletedTasks = Task::numDeletedTasks();
-  uint64_t waitUs = 0;
-  while (numCreatedTasks > numDeletedTasks) {
-    constexpr uint64_t kWaitInternalUs = 1'000;
-    std::this_thread::sleep_for(std::chrono::microseconds(kWaitInternalUs));
-    waitUs += kWaitInternalUs;
-    numDeletedTasks = Task::numDeletedTasks();
-    if (waitUs >= maxWaitUs) {
-      break;
-    }
-  }
-  VELOX_CHECK_EQ(
-      numDeletedTasks,
-      numCreatedTasks,
-      "{} tasks have been created while only {} have been deleted after waiting for {} us",
-      numCreatedTasks,
-      numDeletedTasks,
-      waitUs);
-}
-
 void Task::testingVisitDrivers(const std::function<void(Driver*)>& callback) {
   std::lock_guard<std::mutex> l(mutex_);
   for (int i = 0; i < drivers_.size(); ++i) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -576,12 +576,6 @@ class Task : public std::enable_shared_from_this<Task> {
     return numDriversInPartitionedOutput_ > 0;
   }
 
-  /// Invoked to wait for all the tasks created by the test to be deleted.
-  ///
-  /// NOTE: it is assumed that there is no more task to be created after or
-  /// during this wait call. This is for testing purpose for now.
-  static void testingWaitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
-
   /// Invoked to run provided 'callback' on each alive driver of the task.
   void testingVisitDrivers(const std::function<void(Driver*)>& callback);
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2397,7 +2397,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringOutputProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 
@@ -2492,7 +2492,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -5298,7 +5298,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 
@@ -5403,7 +5403,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputgProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 
@@ -5508,7 +5508,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 } // namespace

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -1123,7 +1123,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }
 
@@ -1219,6 +1219,6 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringInputgProcessing) {
     driverWait.notify();
     taskThread.join();
     task.reset();
-    Task::testingWaitForAllTasksToBeDeleted();
+    waitForAllTasksToBeDeleted();
   }
 }

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -42,6 +42,8 @@ void OperatorTestBase::registerVectorSerde() {
 }
 
 OperatorTestBase::~OperatorTestBase() {
+  // Wait for all the tasks to be deleted.
+  exec::test::waitForAllTasksToBeDeleted();
   // Revert to default process-wide MemoryAllocator.
   memory::MemoryAllocator::setDefaultInstance(nullptr);
 }
@@ -53,7 +55,7 @@ void OperatorTestBase::SetUpTestCase() {
 }
 
 void OperatorTestBase::TearDownTestCase() {
-  Task::testingWaitForAllTasksToBeDeleted();
+  waitForAllTasksToBeDeleted();
 }
 
 void OperatorTestBase::SetUp() {
@@ -172,7 +174,7 @@ core::TypedExprPtr OperatorTestBase::parseExpr(
 
   // Wait for the task to go.
   task.reset();
-  Task::testingWaitForAllTasksToBeDeleted();
+  waitForAllTasksToBeDeleted();
 
   // If a spilling directory was set, ensure it was removed after the task is
   // gone.

--- a/velox/exec/tests/utils/QueryAssertions.h
+++ b/velox/exec/tests/utils/QueryAssertions.h
@@ -131,6 +131,18 @@ bool waitForTaskDriversToFinish(
     exec::Task* task,
     uint64_t maxWaitMicros = 1'000'000);
 
+/// Invoked to wait for all the tasks created by the test to be deleted.
+///
+/// NOTE: it is assumed that there is no more task to be created after or
+/// during this wait call. This is for testing purpose for now.
+void waitForAllTasksToBeDeleted(uint64_t maxWaitUs = 3'000'000);
+
+/// Similar to above test utility except waiting for a specific number of
+/// tasks to be deleted.
+void waitForAllTasksToBeDeleted(
+    uint64_t expectedDeletedTasks,
+    uint64_t maxWaitUs);
+
 std::shared_ptr<Task> assertQuery(
     const core::PlanNodePtr& plan,
     const std::string& duckDbSql,

--- a/velox/vector/tests/utils/VectorTestBase.cpp
+++ b/velox/vector/tests/utils/VectorTestBase.cpp
@@ -16,8 +16,6 @@
 
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
-#include "velox/exec/Task.h"
-
 namespace facebook::velox::test {
 
 BufferPtr makeIndicesInReverse(vector_size_t size, memory::MemoryPool* pool) {
@@ -44,8 +42,6 @@ BufferPtr makeIndices(
 }
 
 VectorTestBase::~VectorTestBase() {
-  // Wait for all the tasks to be deleted.
-  exec::Task::testingWaitForAllTasksToBeDeleted();
   // Reset the executor to wait for all the async activities to finish.
   executor_.reset();
 }


### PR DESCRIPTION
Fix flaky reclaimFromCompletedJoinBuilder test by ensuring
the task has been destroyed.
The test passed 400 iterations internally.

Fixes #6049