### PR TITLE
Limit output page size to 1MB in PartitionedOutput

### DIFF
--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -85,9 +85,9 @@ class Destination {
   // the same time. This is done for each batch so that the average
   // batch size for each converges.
   void setTargetSizePct() {
-    // Flush at  70 to 120% of target row or byte count.
+    // Flush at 70 to 120% of target row or byte count.
     targetSizePct_ = 70 + (folly::Random::rand32(rng_) % 50);
-    targetNumRows_ = (10000 * targetSizePct_) / 100;
+    targetNumRows_ = (10'000 * targetSizePct_) / 100;
   }
 
   const std::string taskId_;


### PR DESCRIPTION
PartitionedOutput operator used to cap the page size at
max_page_partitioning_buffer_size (default: 32MB) divided by the number of
partitions. With 32 partitions, the cap was 1MB. With 1 partition, the cap was
32MB. 

This change makes sure that the cap never exceeds 1MB regardless of the number
of partitions. 1 partition -> 1MB. 2 partitions -> 1MB. 32 partitions -> 1MB.
64 partitions -> 0.5MB.

This change allows PartitionedOutputBufferManager::getData() to honor maxBytes
argument with roughly 1MB granularity. 

See #6005 