### PR TITLE
Add information when write fails in ssd cache.

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -393,7 +393,10 @@ void SsdFile::write(std::vector<CachePin>& pins) {
     VELOX_CHECK_GE(fileSize_, offset + bytes);
     auto rc = folly::pwritev(fd_, iovecs.data(), iovecs.size(), offset);
     if (rc != bytes) {
-      LOG(ERROR) << "Failed to write to SSD: " << folly::errnoStr(errno);
+      LOG(ERROR) << "Failed to write to SSD, file name: " << fileName_
+                 << ", fd: " << fd_ << ", size: " << iovecs.size()
+                 << ", offset: " << offset << ", error code: " << errno
+                 << ", error string:" << folly::errnoStr(errno);
       ++stats_.writeSsdErrors;
       // If the write fails we return without adding the pins to the cache. The
       // entries are unchanged.


### PR DESCRIPTION
Summary:
We are observing a lot of write errors from cache. The error message only contains error code's name (Invalid Argument). To debug further, adding more items in the log. Example log:

```
E0808 13:34:47.343155   916 SsdFile.cpp:396] Failed to write to SSD, file name: /mnt/flash/ssd_cache/async_cache.1, fd: 304, size: 2, offset: 19, error code: 28, error string: No space left on device
```

Reviewed By: xiaoxmeng

Differential Revision: D48167316

