### PR TITLE
Update zstd to the latest release

### DIFF
--- a/build/fbcode_builder/manifests/zstd
+++ b/build/fbcode_builder/manifests/zstd
@@ -13,12 +13,12 @@ libzstd-devel
 libzstd
 
 [download]
-url = https://github.com/facebook/zstd/releases/download/v1.4.5/zstd-1.4.5.tar.gz
-sha256 = 98e91c7c6bf162bf90e4e70fdbc41a8188b9fa8de5ad840c401198014406ce9e
+url = https://github.com/facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz
+sha256 = 9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4
 
 [build]
 builder = cmake
-subdir = zstd-1.4.5/build/cmake
+subdir = zstd-1.5.5/build/cmake
 
 # The zstd cmake build explicitly sets the install name
 # for the shared library in such a way that cmake discards


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/folly/pull/2053

X-link: https://github.com/facebookincubator/zstrong/pull/546

1.4.5 is many years old, update the the latest release when we build zstd.

Reviewed By: chadaustin, Cyan4973

Differential Revision: D48172737

