### PR TITLE
Extract subfields from remaining filter

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -72,10 +72,12 @@ class HiveDataSource : public DataSource {
   // Internal API, made public to be accessible in unit tests.  Do not use in
   // other places.
   static std::shared_ptr<common::ScanSpec> makeScanSpec(
-      const SubfieldFilters& filters,
       const RowTypePtr& rowType,
-      const std::vector<const HiveColumnHandle*>& columnHandles,
-      const std::vector<common::Subfield>& remainingFilterInputs,
+      const folly::F14FastMap<
+          std::string,
+          std::vector<const common::Subfield*>>& outputSubfields,
+      const SubfieldFilters& filters,
+      const RowTypePtr& dataColumns,
       memory::MemoryPool* pool);
 
   // Internal API, made public to be accessible in unit tests.  Do not use in

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -25,6 +25,8 @@
 #include "velox/core/Expressions.h"
 #include "velox/expression/DecodedArgs.h"
 #include "velox/expression/EvalCtx.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/type/Subfield.h"
 #include "velox/vector/SimpleVector.h"
 
 /// GFlag used to enable saving input vector and expression SQL on disk in case
@@ -284,6 +286,12 @@ class Expr {
   void setMultiplyReferenced() {
     isMultiplyReferenced_ = true;
   }
+
+  std::vector<common::Subfield> extractSubfields() const;
+
+  virtual void extractSubfieldsImpl(
+      folly::F14FastMap<std::string, int32_t>* shadowedNames,
+      std::vector<common::Subfield>* subfields) const;
 
   template <typename T>
   const T* as() const {
@@ -836,6 +844,13 @@ class SimpleExpressionEvaluator : public core::ExpressionEvaluator {
   core::QueryCtx* const queryCtx_;
   memory::MemoryPool* const pool_;
   std::unique_ptr<core::ExecCtx> execCtx_;
+};
+
+class Subscript : public exec::VectorFunction {
+ public:
+  virtual bool canPushdown() const {
+    return false;
+  }
 };
 
 } // namespace facebook::velox::exec

--- a/velox/expression/LambdaExpr.cpp
+++ b/velox/expression/LambdaExpr.cpp
@@ -227,4 +227,20 @@ void LambdaExpr::makeTypeWithCapture(EvalCtx& context) {
         ROW(std::move(parameterNames), std::move(parameterTypes));
   }
 }
+
+void LambdaExpr::extractSubfieldsImpl(
+    folly::F14FastMap<std::string, int32_t>* shadowedNames,
+    std::vector<common::Subfield>* subfields) const {
+  for (auto& name : signature_->names()) {
+    (*shadowedNames)[name]++;
+  }
+  body_->extractSubfieldsImpl(shadowedNames, subfields);
+  for (auto& name : signature_->names()) {
+    auto it = shadowedNames->find(name);
+    if (--it->second == 0) {
+      shadowedNames->erase(it);
+    }
+  }
+}
+
 } // namespace facebook::velox::exec

--- a/velox/expression/LambdaExpr.h
+++ b/velox/expression/LambdaExpr.h
@@ -71,6 +71,10 @@ class LambdaExpr : public SpecialForm {
     propagatesNulls_ = false;
   }
 
+  void extractSubfieldsImpl(
+      folly::F14FastMap<std::string, int32_t>* shadowedNames,
+      std::vector<common::Subfield>* subfields) const override;
+
   RowTypePtr signature_;
 
   /// The inner expression that will be applied to the elements of the input

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
 #include "velox/type/Type.h"
 #include "velox/vector/NullsBuilder.h"
@@ -38,7 +39,7 @@ template <
     bool nullOnNegativeIndices,
     bool allowOutOfBound,
     bool indexStartsAtOne>
-class SubscriptImpl : public exec::VectorFunction {
+class SubscriptImpl : public exec::Subscript {
  public:
   void apply(
       const SelectivityVector& rows,

--- a/velox/functions/prestosql/Subscript.cpp
+++ b/velox/functions/prestosql/Subscript.cpp
@@ -25,11 +25,17 @@ namespace {
 /// - does not allow negative indices for arrays
 /// - does not allow out of bounds accesses for arrays (throws)
 /// - index starts at 1 for arrays.
-using SubscriptFunction = SubscriptImpl<
-    /* allowNegativeIndices */ false,
-    /* nullOnNegativeIndices */ false,
-    /* allowOutOfBound */ false,
-    /* indexStartsAtOne */ true>;
+class SubscriptFunction : public SubscriptImpl<
+                              /* allowNegativeIndices */ false,
+                              /* nullOnNegativeIndices */ false,
+                              /* allowOutOfBound */ false,
+                              /* indexStartsAtOne */ true> {
+ public:
+  bool canPushdown() const override {
+    return true;
+  }
+};
+
 } // namespace
 
 VELOX_DECLARE_VECTOR_FUNCTION(

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -298,13 +298,15 @@ TypedExprPtr Expressions::resolveLambdaExpr(
     types.push_back(lambdaInputTypes[i]);
   }
 
-  auto signature = ROW(std::move(names), std::move(types));
+  auto signature =
+      ROW(std::vector<std::string>(names), std::vector<TypePtr>(types));
 
-  names = inputRow->asRow().names();
-  types = inputRow->asRow().children();
-  for (auto i = 0; i < signature->size(); ++i) {
-    names.push_back(signature->names()[i]);
-    types.push_back(signature->childAt(i));
+  auto& inputRowType = inputRow->asRow();
+  for (auto i = 0; i < inputRowType.size(); ++i) {
+    if (!signature->containsChild(inputRowType.names()[i])) {
+      names.push_back(inputRowType.names()[i]);
+      types.push_back(inputRowType.childAt(i));
+    }
   }
 
   auto lambdaRow = ROW(std::move(names), std::move(types));

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <boost/algorithm/string/replace.hpp>
+#include <ostream>
+
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::velox::common {
@@ -268,6 +270,11 @@ class Subfield {
  private:
   std::vector<std::unique_ptr<PathElement>> path_;
 };
+
+inline std::ostream& operator<<(std::ostream& out, const Subfield& subfield) {
+  return out << subfield.toString();
+}
+
 } // namespace facebook::velox::common
 
 namespace std {


### PR DESCRIPTION
Summary:
Also fix a bug when only subfields in a column are filtered, and the
column itself is not projected out, it caused assertions like
`!scanSpec_->children().empty()` to fail.

Differential Revision: D48104479

