### PR TITLE
Add array_min and array_max Spark functions

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -27,6 +27,17 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
+.. function:: array_max(array(E)) -> E
+
+    Returns maximum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.
+    When E is DOUBLE or REAL, returns NaN if any element is NaN. ::
+
+        SELECT array_max(ARRAY [1, 2, 3]); -- 3
+        SELECT array_max(ARRAY [-1, -2, -2]); -- -1
+        SELECT array_max(ARRAY [-1, -2, NULL]); -- -1
+        SELECT array_max(ARRAY []); -- NULL
+        SELECT array_max(ARRAY [-0.0001, -0.0002, -0.0003, float('nan')]); -- NaN
+
 .. function:: array_min(array(E)) -> E
 
     Returns the minimum value of input array. 
@@ -39,6 +50,7 @@ Array Functions
         SELECT array_min(ARRAY [-1, -2, NULL]); -- -2
         SELECT array_min(ARRAY [NULL, NULL]); -- NULL
         SELECT array_min(ARRAY []); -- NULL
+        SELECT array_min(ARRAY [4.0, float('nan')]) -- 4.0
 
 .. spark:function:: array_sort(array(E)) -> array(E)
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -40,17 +40,16 @@ Array Functions
 
 .. function:: array_min(array(E)) -> E
 
-    Returns the minimum value of input array. 
-    The result matches the type of the elements.
-    NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.
-    NaN is greater than any non-NaN elements for double/float type. ::
+    Returns minimum non-NULL element of the array. Returns NULL if array is empty or all elements are NULL.
+    When E is DOUBLE or REAL, NaN value is considered greater than any non-NaN value. ::
 
         SELECT array_min(ARRAY [1, 2, 3]); -- 1
         SELECT array_min(ARRAY [-1, -2, -2]); -- -2
         SELECT array_min(ARRAY [-1, -2, NULL]); -- -2
         SELECT array_min(ARRAY [NULL, NULL]); -- NULL
         SELECT array_min(ARRAY []); -- NULL
-        SELECT array_min(ARRAY [4.0, float('nan')]) -- 4.0
+        SELECT array_min(ARRAY [4.0, float('nan')]); -- 4.0
+        SELECT array_min(ARRAY [NULL, float('nan')]); -- NaN
 
 .. spark:function:: array_sort(array(E)) -> array(E)
 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -27,6 +27,19 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
+.. function:: array_min(array(E)) -> E
+
+    Returns the minimum value of input array. 
+    The result matches the type of the elements.
+    NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.
+    NaN is greater than any non-NaN elements for double/float type. ::
+
+        SELECT array_min(ARRAY [1, 2, 3]); -- 1
+        SELECT array_min(ARRAY [-1, -2, -2]); -- -2
+        SELECT array_min(ARRAY [-1, -2, NULL]); -- -2
+        SELECT array_min(ARRAY [NULL, NULL]); -- NULL
+        SELECT array_min(ARRAY []); -- NULL
+
 .. spark:function:: array_sort(array(E)) -> array(E)
 
     Returns an array which has the sorted order of the input array(E). The elements of array(E) must

--- a/velox/functions/sparksql/ArrayFunction.h
+++ b/velox/functions/sparksql/ArrayFunction.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cmath>
+#include <type_traits>
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions::sparksql {
+template <typename TExecCtx, bool isMax>
+struct ArrayMinMaxFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecCtx);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  template <typename T>
+  void update(T& currentValue, const T& candidateValue) {
+    // NaN is greater than any non-NaN elements for double/float type.
+    if constexpr (std::is_floating_point_v<T>) {
+      if constexpr (isMax) {
+        if (std::isnan(candidateValue) ||
+            (!std::isnan(currentValue) && candidateValue > currentValue)) {
+          currentValue = candidateValue;
+        }
+      } else {
+        if (std::isnan(currentValue) ||
+            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
+          currentValue = candidateValue;
+        }
+      }
+      return;
+    }
+
+    if constexpr (isMax) {
+      if (candidateValue > currentValue) {
+        currentValue = candidateValue;
+      }
+    } else {
+      if (candidateValue < currentValue) {
+        currentValue = candidateValue;
+      }
+    }
+  }
+
+  template <typename T>
+  void assign(T& out, const T& value) {
+    out = value;
+  }
+
+  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
+    out.setNoCopy(value);
+  }
+
+  template <typename TReturn, typename TInput>
+  bool call(TReturn& out, const TInput& array) {
+    // Result is null if array is empty.
+    if (array.size() == 0) {
+      return false;
+    }
+
+    if (!array.mayHaveNulls()) {
+      // Input array does not have nulls.
+      auto currentValue = *array[0];
+      for (auto i = 1; i < array.size(); i++) {
+        update(currentValue, array[i].value());
+      }
+      assign(out, currentValue);
+      return true;
+    }
+
+    // Try to find the first non-null element.
+    auto it = array.begin();
+    // NULL elements are skipped.
+    while (it != array.end() && !it->has_value()) {
+      ++it;
+    }
+    // If array contains only NULL elements, NULL is returned.
+    if (it == array.end()) {
+      return false;
+    }
+
+    // Now we got the first non-null element.
+    auto currentValue = it->value();
+    ++it;
+    while (it != array.end()) {
+      if (it->has_value()) {
+        update(currentValue, it->value());
+      }
+      ++it;
+    }
+
+    assign(out, currentValue);
+    return true;
+  }
+};
+
+template <typename TExecCtx>
+struct ArrayMinFunction : public ArrayMinMaxFunction<TExecCtx, false> {};
+
+template <typename TExecCtx>
+struct ArrayMaxFunction : public ArrayMinMaxFunction<TExecCtx, true> {};
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/ArrayMinMaxFunction.h
+++ b/velox/functions/sparksql/ArrayMinMaxFunction.h
@@ -20,6 +20,7 @@
 #include "velox/functions/Udf.h"
 
 namespace facebook::velox::functions::sparksql {
+
 template <typename TExecCtx, bool isMax>
 struct ArrayMinMaxFunction {
   VELOX_DEFINE_FUNCTION_TYPES(TExecCtx);
@@ -84,16 +85,15 @@ struct ArrayMinMaxFunction {
 
     // Try to find the first non-null element.
     auto it = array.begin();
-    // NULL elements are skipped.
     while (it != array.end() && !it->has_value()) {
       ++it;
     }
-    // If array contains only NULL elements, NULL is returned.
+    // If array contains only NULL elements, return NULL.
     if (it == array.end()) {
       return false;
     }
 
-    // Now we got the first non-null element.
+    // Now 'it' point to the first non-null element.
     auto currentValue = it->value();
     ++it;
     while (it != array.end()) {

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -23,6 +23,7 @@
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
+#include "velox/functions/sparksql/ArrayFunction.h"
 #include "velox/functions/sparksql/ArraySort.h"
 #include "velox/functions/sparksql/Bitwise.h"
 #include "velox/functions/sparksql/CompareFunctionsNullSafe.h"
@@ -74,6 +75,28 @@ namespace sparksql {
 void registerAllSpecialFormGeneralFunctions() {
   exec::registerFunctionCallToSpecialForms();
 }
+
+namespace {
+template <typename T>
+inline void registerArrayMinMaxFunctions(const std::string& prefix) {
+  registerFunction<ArrayMinFunction, T, Array<T>>({prefix + "array_min"});
+  registerFunction<ArrayMaxFunction, T, Array<T>>({prefix + "array_max"});
+}
+
+inline void registerAllArrayMinMaxFunctions(const std::string& prefix) {
+  registerArrayMinMaxFunctions<int8_t>(prefix);
+  registerArrayMinMaxFunctions<int16_t>(prefix);
+  registerArrayMinMaxFunctions<int32_t>(prefix);
+  registerArrayMinMaxFunctions<int64_t>(prefix);
+  registerArrayMinMaxFunctions<int128_t>(prefix);
+  registerArrayMinMaxFunctions<float>(prefix);
+  registerArrayMinMaxFunctions<double>(prefix);
+  registerArrayMinMaxFunctions<bool>(prefix);
+  registerArrayMinMaxFunctions<Varchar>(prefix);
+  registerArrayMinMaxFunctions<Timestamp>(prefix);
+  registerArrayMinMaxFunctions<Date>(prefix);
+}
+} // namespace
 
 void registerFunctions(const std::string& prefix) {
   registerAllSpecialFormGeneralFunctions();
@@ -239,6 +262,8 @@ void registerFunctions(const std::string& prefix) {
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});
+
+  registerAllArrayMinMaxFunctions(prefix);
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -23,7 +23,7 @@
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
-#include "velox/functions/sparksql/ArrayFunction.h"
+#include "velox/functions/sparksql/ArrayMinMaxFunction.h"
 #include "velox/functions/sparksql/ArraySort.h"
 #include "velox/functions/sparksql/Bitwise.h"
 #include "velox/functions/sparksql/CompareFunctionsNullSafe.h"
@@ -83,7 +83,7 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerFunction<ArrayMaxFunction, T, Array<T>>({prefix + "array_max"});
 }
 
-inline void registerAllArrayMinMaxFunctions(const std::string& prefix) {
+inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerArrayMinMaxFunctions<int8_t>(prefix);
   registerArrayMinMaxFunctions<int16_t>(prefix);
   registerArrayMinMaxFunctions<int32_t>(prefix);
@@ -263,7 +263,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});
 
-  registerAllArrayMinMaxFunctions(prefix);
+  registerArrayMinMaxFunctions(prefix);
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -149,11 +149,13 @@ class ArrayMaxFloatingPointTest : public ArrayMaxTest {
   static constexpr T kNaN = std::numeric_limits<T>::quiet_NaN();
 
   void runTest() {
-    EXPECT_EQ(arrayMax<T>({0.0000, 0.00001}), 0.00001);
-    EXPECT_EQ(arrayMax<T>({std::nullopt, 1.1, 1.11, -2.2, -1.0, kMin}), 1.11);
+    EXPECT_FLOAT_EQ(arrayMax<T>({0.0000, 0.00001}).value(), 0.00001);
+    EXPECT_FLOAT_EQ(
+        arrayMax<T>({std::nullopt, 1.1, 1.11, -2.2, -1.0, kMin}).value(), 1.11);
     EXPECT_EQ(arrayMax<T>({}), std::nullopt);
-    EXPECT_EQ(arrayMax<T>({kMin, 1.1, 1.22222, 1.33, std::nullopt}), 1.33);
-    EXPECT_EQ(arrayMax<T>({-0.00001, -0.0002, 0.0001}), 0.0001);
+    EXPECT_FLOAT_EQ(
+        arrayMax<T>({kMin, 1.1, 1.22222, 1.33, std::nullopt}).value(), 1.33);
+    EXPECT_FLOAT_EQ(arrayMax<T>({-0.00001, -0.0002, 0.0001}).value(), 0.0001);
 
     EXPECT_TRUE(std::isnan(
         arrayMax<T>({kMin, -0.0001, -0.0002, -0.0003, kMax, kNaN}).value()));

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <type/Timestamp.h>
+#include <limits>
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayMaxTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T>
+  std::optional<T> arrayMax(const std::vector<std::optional<T>>& input) {
+    std::vector<std::vector<std::optional<T>>> vec = {input};
+    auto row = makeRowVector({makeNullableArrayVector(vec)});
+    return evaluateOnce<T>("array_max(C0)", row);
+  }
+};
+
+TEST_F(ArrayMaxTest, boolean) {
+  EXPECT_EQ(arrayMax<bool>({true, false}), true);
+  EXPECT_EQ(arrayMax<bool>({true}), true);
+  EXPECT_EQ(arrayMax<bool>({false}), false);
+  EXPECT_EQ(arrayMax<bool>({}), std::nullopt);
+  EXPECT_EQ(arrayMax<bool>({true, false, true, std::nullopt}), true);
+  EXPECT_EQ(arrayMax<bool>({std::nullopt, true, false, true}), true);
+  EXPECT_EQ(arrayMax<bool>({false, false, false}), false);
+  EXPECT_EQ(arrayMax<bool>({true, true, true}), true);
+}
+
+TEST_F(ArrayMaxTest, varchar) {
+  EXPECT_EQ(arrayMax<StringView>({"red"_sv, "blue"_sv}), "red"_sv);
+  EXPECT_EQ(
+      arrayMax<StringView>({std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
+      "yellow"_sv);
+  EXPECT_EQ(arrayMax<StringView>({}), std::nullopt);
+  EXPECT_EQ(arrayMax<StringView>({std::nullopt}), std::nullopt);
+}
+
+// Test non-inlined (> 12 length) nullable strings.
+TEST_F(ArrayMaxTest, longVarchar) {
+  EXPECT_EQ(
+      arrayMax<StringView>(
+          {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
+      "red shiny car ahead"_sv);
+  EXPECT_EQ(
+      arrayMax<StringView>(
+          {std::nullopt,
+           "blue clear sky above"_sv,
+           "yellow rose flowers"_sv,
+           "orange beautiful sunset"_sv}),
+      "yellow rose flowers"_sv);
+  EXPECT_EQ(arrayMax<StringView>({}), std::nullopt);
+  EXPECT_EQ(
+      arrayMax<StringView>(
+          {"red shiny car ahead"_sv,
+           "purple is an elegant color"_sv,
+           "green plants make us happy"_sv}),
+      "red shiny car ahead"_sv);
+}
+
+TEST_F(ArrayMaxTest, date) {
+  auto D = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
+  EXPECT_EQ(
+      arrayMax<int32_t>({D("1970-01-01"), D("2023-08-23")}), D("2023-08-23"));
+  EXPECT_EQ(arrayMax<int32_t>({}), std::nullopt);
+  EXPECT_EQ(
+      arrayMax<int32_t>({D("1970-01-01"), std::nullopt}), D("1970-01-01"));
+}
+
+TEST_F(ArrayMaxTest, timestamp) {
+  auto T = [](int64_t micros) { return Timestamp::fromMicros(micros); };
+  EXPECT_EQ(arrayMax<Timestamp>({T(0), T(1)}), T(1));
+  EXPECT_EQ(
+      arrayMax<Timestamp>({T(0), T(1), Timestamp::max(), Timestamp::min()}),
+      Timestamp::max());
+  EXPECT_EQ(arrayMax<Timestamp>({}), std::nullopt);
+  EXPECT_EQ(arrayMax<Timestamp>({T(0), std::nullopt}), T(0));
+}
+
+template <typename Type>
+class ArrayMaxIntegralTest : public ArrayMaxTest {
+ public:
+  using T = typename Type::NativeType::NativeType;
+
+  void runTest() {
+    EXPECT_EQ(
+        arrayMax<T>(
+            {std::numeric_limits<T>::min(),
+             0,
+             1,
+             2,
+             3,
+             std::numeric_limits<T>::max()}),
+        std::numeric_limits<T>::max());
+    EXPECT_EQ(
+        arrayMax<T>(
+            {std::numeric_limits<T>::max(),
+             3,
+             2,
+             1,
+             0,
+             -1,
+             std::numeric_limits<T>::min()}),
+        std::numeric_limits<T>::max());
+    EXPECT_EQ(
+        arrayMax<T>(
+            {101, 102, 103, std::numeric_limits<T>::max(), std::nullopt}),
+        std::numeric_limits<T>::max());
+    EXPECT_EQ(
+        arrayMax<T>({std::nullopt, -1, -2, -3, std::numeric_limits<T>::min()}),
+        -1);
+    EXPECT_EQ(arrayMax<T>({}), std::nullopt);
+    EXPECT_EQ(arrayMax<T>({std::nullopt}), std::nullopt);
+  }
+};
+
+TYPED_TEST_SUITE(ArrayMaxIntegralTest, FunctionBaseTest::IntegralTypes);
+
+TYPED_TEST(ArrayMaxIntegralTest, basic) {
+  this->runTest();
+}
+
+template <typename Type>
+class ArrayMaxFloatingPointTest : public ArrayMaxTest {
+ public:
+  using T = typename Type::NativeType::NativeType;
+  static constexpr T kMin = std::numeric_limits<T>::lowest();
+  static constexpr T kMax = std::numeric_limits<T>::max();
+  static constexpr T kNaN = std::numeric_limits<T>::quiet_NaN();
+
+  void runTest() {
+    EXPECT_EQ(arrayMax<T>({0.0000, 0.00001}), 0.00001);
+    EXPECT_EQ(arrayMax<T>({std::nullopt, 1.1, 1.11, -2.2, -1.0, kMin}), 1.11);
+    EXPECT_EQ(arrayMax<T>({}), std::nullopt);
+    EXPECT_EQ(arrayMax<T>({kMin, 1.1, 1.22222, 1.33, std::nullopt}), 1.33);
+    EXPECT_EQ(arrayMax<T>({-0.00001, -0.0002, 0.0001}), 0.0001);
+
+    EXPECT_TRUE(std::isnan(
+        arrayMax<T>({kMin, -0.0001, -0.0002, -0.0003, kMax, kNaN}).value()));
+  }
+};
+
+TYPED_TEST_SUITE(
+    ArrayMaxFloatingPointTest,
+    FunctionBaseTest::FloatingPointTypes);
+
+TYPED_TEST(ArrayMaxFloatingPointTest, basic) {
+  this->runTest();
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -48,11 +48,10 @@ TEST_F(ArrayMaxTest, boolean) {
 }
 
 TEST_F(ArrayMaxTest, varchar) {
-  EXPECT_EQ(arrayMax<std::string>({"red"_sv, "blue"_sv}), "red"_sv);
+  EXPECT_EQ(arrayMax<std::string>({"red", "blue"}), "red");
   EXPECT_EQ(
-      arrayMax<std::string>(
-          {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
-      "yellow"_sv);
+      arrayMax<std::string>({std::nullopt, "blue", "yellow", "orange"}),
+      "yellow");
   EXPECT_EQ(arrayMax<std::string>({}), std::nullopt);
   EXPECT_EQ(arrayMax<std::string>({std::nullopt}), std::nullopt);
 }
@@ -60,23 +59,22 @@ TEST_F(ArrayMaxTest, varchar) {
 // Test non-inlined (> 12 length) nullable strings.
 TEST_F(ArrayMaxTest, longVarchar) {
   EXPECT_EQ(
-      arrayMax<std::string>(
-          {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
-      "red shiny car ahead"_sv);
+      arrayMax<std::string>({"red shiny car ahead", "blue clear sky above"}),
+      "red shiny car ahead");
   EXPECT_EQ(
       arrayMax<std::string>(
           {std::nullopt,
-           "blue clear sky above"_sv,
-           "yellow rose flowers"_sv,
-           "orange beautiful sunset"_sv}),
-      "yellow rose flowers"_sv);
+           "blue clear sky above",
+           "yellow rose flowers",
+           "orange beautiful sunset"}),
+      "yellow rose flowers");
   EXPECT_EQ(arrayMax<std::string>({}), std::nullopt);
   EXPECT_EQ(
       arrayMax<std::string>(
-          {"red shiny car ahead"_sv,
-           "purple is an elegant color"_sv,
-           "green plants make us happy"_sv}),
-      "red shiny car ahead"_sv);
+          {"red shiny car ahead",
+           "purple is an elegant color",
+           "green plants make us happy"}),
+      "red shiny car ahead");
 }
 
 TEST_F(ArrayMaxTest, date) {

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -30,8 +30,7 @@ class ArrayMaxTest : public SparkFunctionBaseTest {
  protected:
   template <typename T>
   std::optional<T> arrayMax(const std::vector<std::optional<T>>& input) {
-    std::vector<std::vector<std::optional<T>>> vec = {input};
-    auto row = makeRowVector({makeNullableArrayVector(vec)});
+    auto row = makeRowVector({makeNullableArrayVector({input})});
     return evaluateOnce<T>("array_max(C0)", row);
   }
 };

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -47,30 +47,31 @@ TEST_F(ArrayMaxTest, boolean) {
 }
 
 TEST_F(ArrayMaxTest, varchar) {
-  EXPECT_EQ(arrayMax<StringView>({"red"_sv, "blue"_sv}), "red"_sv);
+  EXPECT_EQ(arrayMax<std::string>({"red"_sv, "blue"_sv}), "red"_sv);
   EXPECT_EQ(
-      arrayMax<StringView>({std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
+      arrayMax<std::string>(
+          {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
       "yellow"_sv);
-  EXPECT_EQ(arrayMax<StringView>({}), std::nullopt);
-  EXPECT_EQ(arrayMax<StringView>({std::nullopt}), std::nullopt);
+  EXPECT_EQ(arrayMax<std::string>({}), std::nullopt);
+  EXPECT_EQ(arrayMax<std::string>({std::nullopt}), std::nullopt);
 }
 
 // Test non-inlined (> 12 length) nullable strings.
 TEST_F(ArrayMaxTest, longVarchar) {
   EXPECT_EQ(
-      arrayMax<StringView>(
+      arrayMax<std::string>(
           {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
       "red shiny car ahead"_sv);
   EXPECT_EQ(
-      arrayMax<StringView>(
+      arrayMax<std::string>(
           {std::nullopt,
            "blue clear sky above"_sv,
            "yellow rose flowers"_sv,
            "orange beautiful sunset"_sv}),
       "yellow rose flowers"_sv);
-  EXPECT_EQ(arrayMax<StringView>({}), std::nullopt);
+  EXPECT_EQ(arrayMax<std::string>({}), std::nullopt);
   EXPECT_EQ(
-      arrayMax<StringView>(
+      arrayMax<std::string>(
           {"red shiny car ahead"_sv,
            "purple is an elegant color"_sv,
            "green plants make us happy"_sv}),
@@ -78,22 +79,23 @@ TEST_F(ArrayMaxTest, longVarchar) {
 }
 
 TEST_F(ArrayMaxTest, date) {
-  auto D = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
+  auto dt = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
   EXPECT_EQ(
-      arrayMax<int32_t>({D("1970-01-01"), D("2023-08-23")}), D("2023-08-23"));
+      arrayMax<int32_t>({dt("1970-01-01"), dt("2023-08-23")}),
+      dt("2023-08-23"));
   EXPECT_EQ(arrayMax<int32_t>({}), std::nullopt);
   EXPECT_EQ(
-      arrayMax<int32_t>({D("1970-01-01"), std::nullopt}), D("1970-01-01"));
+      arrayMax<int32_t>({dt("1970-01-01"), std::nullopt}), dt("1970-01-01"));
 }
 
 TEST_F(ArrayMaxTest, timestamp) {
-  auto T = [](int64_t micros) { return Timestamp::fromMicros(micros); };
-  EXPECT_EQ(arrayMax<Timestamp>({T(0), T(1)}), T(1));
+  auto ts = [](int64_t micros) { return Timestamp::fromMicros(micros); };
+  EXPECT_EQ(arrayMax<Timestamp>({ts(0), ts(1)}), ts(1));
   EXPECT_EQ(
-      arrayMax<Timestamp>({T(0), T(1), Timestamp::max(), Timestamp::min()}),
+      arrayMax<Timestamp>({ts(0), ts(1), Timestamp::max(), Timestamp::min()}),
       Timestamp::max());
   EXPECT_EQ(arrayMax<Timestamp>({}), std::nullopt);
-  EXPECT_EQ(arrayMax<Timestamp>({T(0), std::nullopt}), T(0));
+  EXPECT_EQ(arrayMax<Timestamp>({ts(0), std::nullopt}), ts(0));
 }
 
 template <typename Type>

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayMinTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T, typename TExpected = T>
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result =
+        evaluate<SimpleVector<TExpected>>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename T>
+  void testIntNullable() {
+    auto arrayVector = makeNullableArrayVector<T>(
+        {{-1, 0, 1, 2, 3, 4},
+         {4, 3, 2, 1, std::nullopt, 0, -1, -2},
+         {-5, -4, -3, -2, -1},
+         {101, 102, 103, 104, std::nullopt},
+         {std::nullopt, -1, -2, std::nullopt, -3, -4},
+         {},
+         {std::nullopt, std::nullopt}});
+    auto expected = makeNullableFlatVector<T>(
+        {-1, -2, -5, 101, -4, std::nullopt, std::nullopt});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  template <typename T>
+  void testInt() {
+    auto arrayVector = makeArrayVector<T>(
+        {{-1, 0, 1, 2, 3, 4},
+         {4, 3, 2, 1, 0, -1, -2},
+         {-5, -4, -3, -2, -1},
+         {101, 102, 103, 104, 105},
+         {}});
+    auto expected = makeNullableFlatVector<T>({-1, -2, -5, 101, std::nullopt});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testDateNullable() {
+    auto D = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
+    auto arrayVector = makeNullableArrayVector<int32_t>(
+        {{D("1970-01-01"), D("2023-08-23")},
+         {},
+         {D("1970-01-01"), std::nullopt}},
+        ARRAY(DATE()));
+    auto expected = makeNullableFlatVector<int32_t>(
+        {D("1970-01-01"), std::nullopt, D("1970-01-01")}, DATE());
+    testExpr<int32_t>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testDate() {
+    auto D = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
+    auto arrayVector = makeArrayVector<int32_t>(
+        {{D("1970-01-01"), D("2023-08-23")}, {}}, DATE());
+    auto expected = makeNullableFlatVector<int32_t>(
+        {D("1970-01-01"), std::nullopt}, DATE());
+    testExpr<int32_t>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testInLineVarcharNullable() {
+    using S = StringView;
+
+    auto arrayVector = makeNullableArrayVector<S>({
+        {S("red"), S("blue")},
+        {std::nullopt, S("blue"), S("yellow"), S("orange")},
+        {},
+        {std::nullopt, std::nullopt},
+        {S("red"), S("purple"), S("green")},
+    });
+    auto expected = makeNullableFlatVector<S>(
+        {S("blue"), S("blue"), std::nullopt, std::nullopt, S("green")});
+    testExpr<S>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testVarcharNullable() {
+    using S = StringView;
+    // use > 12 length string to avoid inlining
+    auto arrayVector = makeNullableArrayVector<S>({
+        {S("red shiny car ahead"), S("blue clear sky above")},
+        {std::nullopt,
+         S("blue clear sky above"),
+         S("yellow rose flowers"),
+         S("orange beautiful sunset")},
+        {},
+        {std::nullopt, std::nullopt},
+        {S("red shiny car ahead"),
+         S("purple is an elegant color"),
+         S("green plants make us happy")},
+    });
+    auto expected = makeNullableFlatVector<S>(
+        {S("blue clear sky above"),
+         S("blue clear sky above"),
+         std::nullopt,
+         std::nullopt,
+         S("green plants make us happy")});
+    testExpr<S>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testBoolNullable() {
+    auto arrayVector = makeNullableArrayVector<bool>(
+        {{true, false},
+         {true},
+         {false},
+         {},
+         {std::nullopt, std::nullopt},
+         {true, false, true, std::nullopt},
+         {std::nullopt, true, false, true},
+         {false, false, false},
+         {true, true, true}});
+
+    auto expected = makeNullableFlatVector<bool>(
+        {false,
+         true,
+         false,
+         std::nullopt,
+         std::nullopt,
+         false,
+         false,
+         false,
+         true});
+    testExpr<bool>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testBool() {
+    auto arrayVector = makeArrayVector<bool>(
+        {{true, false},
+         {true},
+         {false},
+         {},
+         {false, false, false},
+         {true, true, true}});
+
+    auto expected = makeNullableFlatVector<bool>(
+        {false, true, false, std::nullopt, false, true});
+    testExpr<bool>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  template <typename T>
+  void testNumNullable() {
+    constexpr T kNaN = std::numeric_limits<T>::quiet_NaN();
+    auto arrayVector = makeNullableArrayVector<T>(
+        {{-1.0, 0.0, 1.0, kNaN, 2.0, 3.0, 4.0},
+         {4.0, 3.0, 2.0, 1.0, std::nullopt, 0.0, -1.0, -2.0, kNaN},
+         {-5.0, -4.0, -3.0, -2.0, -1.0},
+         {101.0, 102.0, 103.0, 104.0, std::nullopt},
+         {std::nullopt, -1.0, -2.0, std::nullopt, -3.0, -4.0},
+         {},
+         {std::nullopt, std::nullopt},
+         {kNaN, std::nullopt, -1.0, kNaN, -2.0},
+         {std::nullopt, kNaN}});
+    auto expected = makeNullableFlatVector<T>(
+        {-1.0,
+         -2.0,
+         -5.0,
+         101.0,
+         -4.0,
+         std::nullopt,
+         std::nullopt,
+         -2.0,
+         kNaN});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+};
+
+TEST_F(ArrayMinTest, intArrays) {
+  testIntNullable<int8_t>();
+  testIntNullable<int16_t>();
+  testIntNullable<int32_t>();
+  testIntNullable<int64_t>();
+  testInt<int8_t>();
+  testInt<int16_t>();
+  testInt<int32_t>();
+  testInt<int64_t>();
+}
+
+TEST_F(ArrayMinTest, varcharArrays) {
+  testInLineVarcharNullable();
+  testVarcharNullable();
+}
+
+TEST_F(ArrayMinTest, boolArrays) {
+  testBoolNullable();
+  testBool();
+}
+
+TEST_F(ArrayMinTest, numArrays) {
+  testNumNullable<float>();
+  testNumNullable<double>();
+}
+
+TEST_F(ArrayMinTest, dateArrays) {
+  testDate();
+  testDateNullable();
+}
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -154,8 +154,9 @@ class ArrayMinFloatingPointTest : public ArrayMinTest {
     EXPECT_EQ(arrayMin<T>({std::nullopt, 1.1, 1.11, -2.2, -1.0, kMin}), kMin);
     EXPECT_EQ(arrayMin<T>({}), std::nullopt);
     EXPECT_EQ(arrayMin<T>({kMin, 1.1, 1.22222, 1.33, std::nullopt}), kMin);
-    EXPECT_EQ(arrayMin<T>({-0.00001, -0.0002, 0.0001}), -0.0002);
-    EXPECT_EQ(arrayMin<T>({-0.0001, -0.0002, kMax, kNaN}), -0.0002);
+    EXPECT_FLOAT_EQ(arrayMin<T>({-0.00001, -0.0002, 0.0001}).value(), -0.0002);
+    EXPECT_FLOAT_EQ(
+        arrayMin<T>({-0.0001, -0.0002, kMax, kNaN}).value(), -0.0002);
   }
 };
 

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -49,30 +49,31 @@ TEST_F(ArrayMinTest, boolean) {
 } // namespace
 
 TEST_F(ArrayMinTest, varchar) {
-  EXPECT_EQ(arrayMin<StringView>({"red"_sv, "blue"_sv}), "blue"_sv);
+  EXPECT_EQ(arrayMin<std::string>({"red"_sv, "blue"_sv}), "blue"_sv);
   EXPECT_EQ(
-      arrayMin<StringView>({std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
+      arrayMin<std::string>(
+          {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
       "blue"_sv);
-  EXPECT_EQ(arrayMin<StringView>({}), std::nullopt);
-  EXPECT_EQ(arrayMin<StringView>({std::nullopt}), std::nullopt);
+  EXPECT_EQ(arrayMin<std::string>({}), std::nullopt);
+  EXPECT_EQ(arrayMin<std::string>({std::nullopt}), std::nullopt);
 }
 
 // Test non-inlined (> 12 length) nullable strings.
 TEST_F(ArrayMinTest, longVarchar) {
   EXPECT_EQ(
-      arrayMin<StringView>(
+      arrayMin<std::string>(
           {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
       "blue clear sky above"_sv);
   EXPECT_EQ(
-      arrayMin<StringView>(
+      arrayMin<std::string>(
           {std::nullopt,
            "blue clear sky above"_sv,
            "yellow rose flowers"_sv,
            "orange beautiful sunset"_sv}),
       "blue clear sky above"_sv);
-  EXPECT_EQ(arrayMin<StringView>({}), std::nullopt);
+  EXPECT_EQ(arrayMin<std::string>({}), std::nullopt);
   EXPECT_EQ(
-      arrayMin<StringView>(
+      arrayMin<std::string>(
           {"red shiny car ahead"_sv,
            "purple is an elegant color"_sv,
            "green plants make us happy"_sv}),
@@ -80,22 +81,23 @@ TEST_F(ArrayMinTest, longVarchar) {
 }
 
 TEST_F(ArrayMinTest, date) {
-  auto D = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
+  auto dt = [](const std::string& dateStr) { return DATE()->toDays(dateStr); };
   EXPECT_EQ(
-      arrayMin<int32_t>({D("1970-01-01"), D("2023-08-23")}), D("1970-01-01"));
+      arrayMin<int32_t>({dt("1970-01-01"), dt("2023-08-23")}),
+      dt("1970-01-01"));
   EXPECT_EQ(arrayMin<int32_t>({}), std::nullopt);
   EXPECT_EQ(
-      arrayMin<int32_t>({D("1970-01-01"), std::nullopt}), D("1970-01-01"));
+      arrayMin<int32_t>({dt("1970-01-01"), std::nullopt}), dt("1970-01-01"));
 }
 
 TEST_F(ArrayMinTest, timestamp) {
-  auto T = [](int64_t micros) { return Timestamp::fromMicros(micros); };
-  EXPECT_EQ(arrayMin<Timestamp>({T(0), T(1)}), T(0));
+  auto ts = [](int64_t micros) { return Timestamp::fromMicros(micros); };
+  EXPECT_EQ(arrayMin<Timestamp>({ts(0), ts(1)}), ts(0));
   EXPECT_EQ(
-      arrayMin<Timestamp>({T(0), T(1), Timestamp::max(), Timestamp::min()}),
+      arrayMin<Timestamp>({ts(0), ts(1), Timestamp::max(), Timestamp::min()}),
       Timestamp::min());
   EXPECT_EQ(arrayMin<Timestamp>({}), std::nullopt);
-  EXPECT_EQ(arrayMin<Timestamp>({T(0), std::nullopt}), T(0));
+  EXPECT_EQ(arrayMin<Timestamp>({ts(0), std::nullopt}), ts(0));
 }
 
 template <typename Type>

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -49,11 +49,10 @@ TEST_F(ArrayMinTest, boolean) {
 } // namespace
 
 TEST_F(ArrayMinTest, varchar) {
-  EXPECT_EQ(arrayMin<std::string>({"red"_sv, "blue"_sv}), "blue"_sv);
+  EXPECT_EQ(arrayMin<std::string>({"red", "blue"}), "blue");
   EXPECT_EQ(
-      arrayMin<std::string>(
-          {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv}),
-      "blue"_sv);
+      arrayMin<std::string>({std::nullopt, "blue", "yellow", "orange"}),
+      "blue");
   EXPECT_EQ(arrayMin<std::string>({}), std::nullopt);
   EXPECT_EQ(arrayMin<std::string>({std::nullopt}), std::nullopt);
 }
@@ -61,23 +60,22 @@ TEST_F(ArrayMinTest, varchar) {
 // Test non-inlined (> 12 length) nullable strings.
 TEST_F(ArrayMinTest, longVarchar) {
   EXPECT_EQ(
-      arrayMin<std::string>(
-          {"red shiny car ahead"_sv, "blue clear sky above"_sv}),
-      "blue clear sky above"_sv);
+      arrayMin<std::string>({"red shiny car ahead", "blue clear sky above"}),
+      "blue clear sky above");
   EXPECT_EQ(
       arrayMin<std::string>(
           {std::nullopt,
-           "blue clear sky above"_sv,
-           "yellow rose flowers"_sv,
-           "orange beautiful sunset"_sv}),
-      "blue clear sky above"_sv);
+           "blue clear sky above",
+           "yellow rose flowers",
+           "orange beautiful sunset"}),
+      "blue clear sky above");
   EXPECT_EQ(arrayMin<std::string>({}), std::nullopt);
   EXPECT_EQ(
       arrayMin<std::string>(
-          {"red shiny car ahead"_sv,
-           "purple is an elegant color"_sv,
-           "green plants make us happy"_sv}),
-      "green plants make us happy"_sv);
+          {"red shiny car ahead",
+           "purple is an elegant color",
+           "green plants make us happy"}),
+      "green plants make us happy");
 }
 
 TEST_F(ArrayMinTest, date) {

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -15,8 +15,9 @@
 add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
-  ArraySortTest.cpp
+  ArrayMaxTest.cpp
   ArrayMinTest.cpp
+  ArraySortTest.cpp
   BitwiseTest.cpp
   CompareNullSafeTests.cpp
   DateTimeFunctionsTest.cpp

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
   ArraySortTest.cpp
+  ArrayMinTest.cpp
   BitwiseTest.cpp
   CompareNullSafeTests.cpp
   DateTimeFunctionsTest.cpp


### PR DESCRIPTION
In presto, `array_min/array_max` returns NULL when input contains any NULL element.
In spark,  NULL elements are skipped. If the array is empty or contains only NULL elements, NULL is returned.

`array_min` Spark 3.2 ref: https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L1779

`array_max` Spark 3.2 ref: https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L1852