### PR TITLE
Try next larger free list if head is no fit

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -362,15 +362,7 @@ class HashStringAllocator : public StreamArena {
   // anything yet. Throws if fails to grow.
   void newSlab();
 
-  void removeFromFreeList(Header* FOLLY_NONNULL header) {
-    VELOX_CHECK(header->isFree());
-    header->clearFree();
-    auto index = freeListIndex(header->size());
-    reinterpret_cast<CompactDoubleList*>(header->begin())->remove();
-    if (free_[index].empty()) {
-      freeNonEmpty_ &= ~(1 << index);
-    }
-  }
+  void removeFromFreeList(Header* FOLLY_NONNULL header);
 
   /// Allocates a block of specified size. If exactSize is false, the block may
   /// be smaller or larger. Checks free list before allocating new memory.

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -439,5 +439,13 @@ TEST_F(HashStringAllocatorTest, externalLeak) {
   EXPECT_EQ(initialBytes, pool->currentBytes());
 }
 
+TEST_F(HashStringAllocatorTest, freeListOrder) {
+  using HSA = HashStringAllocator;
+
+  std::vector<HSA::Header> headers;
+
+  // **** fill in.
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
HashStringAllocator can hit a worst case if items are freed in dcreasing order of size inside a free list bucket. If one looks for the top size in the bucket, one must travel to the end to find it and it may still not be found. We move the head of the fre list to the place where we stopped the search for the last time. In this way, a situation with all small before all the large will not have to repeatedly go through the small.

So we quit looking after a few tries and move to the larger bucket where any hit will be large enough.