### PR TITLE
Add CAST(decimal as bool)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -170,7 +170,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     -
+     - Y
      - Y
      - Y
      -

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -280,7 +280,7 @@ VectorPtr CastExpr::applyDecimalToBooleanCast(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
-    const TypePtr& fromType,
+    const TypePtr& /*fromType*/,
     const TypePtr& toType) {
   VectorPtr result;
   context.ensureWritable(rows, toType, result);

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -231,9 +231,7 @@ class CastExpr : public SpecialForm {
   VectorPtr applyDecimalToBooleanCast(
       const SelectivityVector& rows,
       const BaseVector& input,
-      exec::EvalCtx& context,
-      const TypePtr& fromType,
-      const TypePtr& toType);
+      exec::EvalCtx& context);
 
   template <typename FromNativeType>
   VectorPtr applyDecimalToPrimitiveCast(

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -227,7 +227,7 @@ class CastExpr : public SpecialForm {
       const TypePtr& fromType,
       const TypePtr& toType);
 
-  template <typename FromNativeType, TypeKind ToKind>
+  template <typename FromNativeType>
   VectorPtr applyDecimalToBooleanCast(
       const SelectivityVector& rows,
       const BaseVector& input,

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -227,6 +227,14 @@ class CastExpr : public SpecialForm {
       const TypePtr& fromType,
       const TypePtr& toType);
 
+  template <typename FromNativeType, TypeKind ToKind>
+  VectorPtr applyDecimalToBooleanCast(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
   template <typename FromNativeType>
   VectorPtr applyDecimalToPrimitiveCast(
       const SelectivityVector& rows,

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -221,6 +221,30 @@ class CastExprTest : public functions::test::CastBaseTest {
             {-1e33, 0, 1e33, 1.2089258196146293E19, std::nullopt}));
   }
 
+  void testDecimalToBoolCasts() {
+    auto shortFlat = makeNullableFlatVector<int64_t>(
+        {DecimalUtil::kShortDecimalMin,
+         0,
+         std::nullopt},
+        DECIMAL(18, 18));
+    testComplexCast(
+        "c0",
+        shortFlat,
+        makeNullableFlatVector<bool>(
+            {1, 0, std::nullopt}));
+
+    auto longFlat = makeNullableFlatVector<int128_t>(
+        {DecimalUtil::kLongDecimalMin,
+         0,
+	 std::nullopt},
+        DECIMAL(38, 5));
+    testComplexCast(
+        "c0",
+        longFlat,
+        makeNullableFlatVector<bool>(
+            {1, 0, std::nullopt}));
+  }
+
   template <TypeKind KIND>
   void testDecimalToIntegralCastsOutOfBounds() {
     using NativeType = typename TypeTraits<KIND>::NativeType;
@@ -1357,6 +1381,10 @@ TEST_F(CastExprTest, decimalToIntegralOutOfBoundsSetNullOnFailure) {
 TEST_F(CastExprTest, decimalToFloat) {
   testDecimalToFloatCasts<float>();
   testDecimalToFloatCasts<double>();
+}
+
+TEST_F(CastExprTest, decimalToBool) {
+  testDecimalToBoolCasts();
 }
 
 TEST_F(CastExprTest, decimalToDecimal) {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -221,18 +221,6 @@ class CastExprTest : public functions::test::CastBaseTest {
             {-1e33, 0, 1e33, 1.2089258196146293E19, std::nullopt}));
   }
 
-  void testDecimalToBoolCasts() {
-    auto shortFlat = makeNullableFlatVector<int64_t>(
-        {DecimalUtil::kShortDecimalMin, 0, std::nullopt}, DECIMAL(18, 18));
-    testComplexCast(
-        "c0", shortFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
-
-    auto longFlat = makeNullableFlatVector<int128_t>(
-        {DecimalUtil::kLongDecimalMin, 0, std::nullopt}, DECIMAL(38, 5));
-    testComplexCast(
-        "c0", longFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
-  }
-
   template <TypeKind KIND>
   void testDecimalToIntegralCastsOutOfBounds() {
     using NativeType = typename TypeTraits<KIND>::NativeType;
@@ -1372,7 +1360,15 @@ TEST_F(CastExprTest, decimalToFloat) {
 }
 
 TEST_F(CastExprTest, decimalToBool) {
-  testDecimalToBoolCasts();
+  auto shortFlat = makeNullableFlatVector<int64_t>(
+      {DecimalUtil::kShortDecimalMin, 0, std::nullopt}, DECIMAL(18, 18));
+  testComplexCast(
+      "c0", shortFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
+
+  auto longFlat = makeNullableFlatVector<int128_t>(
+      {DecimalUtil::kLongDecimalMin, 0, std::nullopt}, DECIMAL(38, 5));
+  testComplexCast(
+      "c0", longFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
 }
 
 TEST_F(CastExprTest, decimalToDecimal) {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -223,26 +223,14 @@ class CastExprTest : public functions::test::CastBaseTest {
 
   void testDecimalToBoolCasts() {
     auto shortFlat = makeNullableFlatVector<int64_t>(
-        {DecimalUtil::kShortDecimalMin,
-         0,
-         std::nullopt},
-        DECIMAL(18, 18));
+        {DecimalUtil::kShortDecimalMin, 0, std::nullopt}, DECIMAL(18, 18));
     testComplexCast(
-        "c0",
-        shortFlat,
-        makeNullableFlatVector<bool>(
-            {1, 0, std::nullopt}));
+        "c0", shortFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
 
     auto longFlat = makeNullableFlatVector<int128_t>(
-        {DecimalUtil::kLongDecimalMin,
-         0,
-	 std::nullopt},
-        DECIMAL(38, 5));
+        {DecimalUtil::kLongDecimalMin, 0, std::nullopt}, DECIMAL(38, 5));
     testComplexCast(
-        "c0",
-        longFlat,
-        makeNullableFlatVector<bool>(
-            {1, 0, std::nullopt}));
+        "c0", longFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
   }
 
   template <TypeKind KIND>


### PR DESCRIPTION
Spark and presto has same semantic.
Here is spark [implementation](https://github.com/apache/spark/blob/branch-3.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/Cast.scala#L479-L480)
Here is presto [implementation](https://github.com/prestodb/presto/blob/master/presto-main/src/main/java/com/facebook/presto/type/DecimalCasts.java#L192-L201)

when decimal equal zero return false, otherwise return true.