### PR TITLE
Add spilling performance benchmark

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -72,33 +72,34 @@ class MemoryArbitrator {
   using Factory = std::function<std::unique_ptr<MemoryArbitrator>(
       const MemoryArbitrator::Config& config)>;
 
-  /// Register factory for a specific kind of memory arbitrator.
+  /// Register factory for a specific 'kind' of memory arbitrator
   /// MemoryArbitrator::Create looks up the registry to find the factory to
   /// create arbitrator instance based on the kind specified in arbitrator
   /// config.
+  ///
+  /// NOTE: we only allow the same 'kind' of memory arbitrator to be registered
+  /// once. The function throws an error if 'kind' is already registered.
   static void registerFactory(const std::string& kind, Factory factory);
 
-  /// Unregister the registered factory for this kind. The arbitrator kind must
-  /// be registered through MemoryArbitrator::registerFactory, otherwise the
-  /// function throws a velox user exception error.
+  /// Unregister the registered factory for a specifc kind.
+  ///
+  /// NOTE: the function throws if the specified arbitrator 'kind' is not
+  /// registered.
   static void unregisterFactory(const std::string& kind);
 
-  /// Register all memory arbitrator factories including the shared
-  /// arbitrator implementation.
+  /// Register all the supported memory arbitrator kinds.
   static void registerAllFactories();
 
-  /// Unregister all memory arbitrator factories including the shared
-  /// arbitrator implementation.
+  /// Unregister all the supported memory arbitrator kinds.
   static void unregisterAllFactories();
 
   /// Invoked by the memory manager to create an instance of memory arbitrator
   /// based on the kind specified in 'config'. The arbitrator kind must be
-  /// registered through MemoryArbitrator::registerFactory, otherwise the
+  /// registered through MemoryArbitrator::registerFactory(), otherwise the
   /// function throws a velox user exception error.
   ///
   /// NOTE: if arbitrator kind is not set in 'config', then the function returns
-  /// nullptr.
-
+  /// nullptr, and the memory arbitration function is disabled.
   static std::unique_ptr<MemoryArbitrator> create(const Config& config);
 
   virtual std::string kind() = 0;

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -46,12 +46,12 @@ std::string memoryPoolAbortMessage(
   VELOX_CHECK(requestor->isRoot());
   if (requestor == victim) {
     out << "\nFailed memory pool '" << victim->name()
-        << "' aborted by itself when tried to grow " << growBytes
-        << " bytes.\n";
+        << "' aborted by itself when tried to grow " << succinctBytes(growBytes)
+        << "\n";
   } else {
     out << "\nFailed memory pool '" << victim->name()
         << "' aborted when requestor '" << requestor->name()
-        << "' tried to grow " << growBytes << " bytes.\n";
+        << "' tried to grow " << succinctBytes(growBytes) << "\n";
   }
   out << "Memory usage of the failed memory pool:\n"
       << victim->treeMemoryUsage();

--- a/velox/common/testutil/TestValue.h
+++ b/velox/common/testutil/TestValue.h
@@ -47,8 +47,8 @@ class TestValue {
       const std::string& injectionPoint,
       std::function<void(T*)> injectionCb);
 
-  /// Invoked by the test code to unregisterFactory a callback hook at the
-  /// specified execution point.
+  /// Invoked by the test code to unregister a callback hook at the specified
+  /// execution point.
   static void clear(const std::string& injectionPoint);
 
   /// Invoked by the production code to try to invoke the test callback hook

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -853,7 +853,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig_->maxFileSize,
         spillConfig_->minSpillRunSize,
         spillConfig_->compressionKind,
-        Spiller::spillPool(),
+        Spiller::pool(),
         spillConfig_->executor);
   }
   spiller_->spill(targetRows, targetBytes);

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -97,8 +97,11 @@ class GroupingSet {
   void spill(int64_t targetRows, int64_t targetBytes);
 
   /// Returns the spiller stats including total bytes and rows spilled so far.
-  Spiller::Stats spilledStats() const {
-    return spiller_ != nullptr ? spiller_->stats() : Spiller::Stats{};
+  std::optional<SpillStats> spilledStats() const {
+    if (spiller_ == nullptr) {
+      return std::nullopt;
+    }
+    return spiller_->stats();
   }
 
   /// Returns the hashtable stats.

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -262,12 +262,11 @@ void HashAggregation::updateRuntimeStats() {
 }
 
 void HashAggregation::recordSpillStats() {
-  const auto spillStats = groupingSet_->spilledStats();
-  auto lockedStats = stats_.wlock();
-  lockedStats->spilledBytes = spillStats.spilledBytes;
-  lockedStats->spilledRows = spillStats.spilledRows;
-  lockedStats->spilledPartitions = spillStats.spilledPartitions;
-  lockedStats->spilledFiles = spillStats.spilledFiles;
+  const auto spillStatsOr = groupingSet_->spilledStats();
+  if (!spillStatsOr.has_value()) {
+    return;
+  }
+  Operator::recordSpillStats(spillStatsOr.value());
 }
 
 void HashAggregation::prepareOutput(vector_size_t size) {
@@ -419,8 +418,8 @@ RowVectorPtr HashAggregation::getOutput() {
 
 void HashAggregation::noMoreInput() {
   groupingSet_->noMoreInput();
-  recordSpillStats();
   Operator::noMoreInput();
+  recordSpillStats();
   // Release the extra reserved memory right after processing all the inputs.
   pool()->release();
 }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -220,7 +220,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       spillConfig.maxFileSize,
       spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
-      Spiller::spillPool(),
+      Spiller::pool(),
       spillConfig.executor);
 
   const int32_t numPartitions = spiller_->hashBits().numPartitions();
@@ -774,28 +774,18 @@ bool HashBuild::finishHashBuild() {
   std::vector<std::unique_ptr<BaseHashTable>> otherTables;
   otherTables.reserve(peers.size());
   SpillPartitionSet spillPartitions;
-  Spiller::Stats spillStats;
   for (auto* build : otherBuilds) {
     VELOX_CHECK_NOT_NULL(build->table_);
     otherTables.push_back(std::move(build->table_));
     if (build->spiller_ != nullptr) {
-      spillStats += build->spiller_->stats();
       build->spiller_->finishSpill(spillPartitions);
+      build->recordSpillStats();
     }
   }
 
   if (spiller_ != nullptr) {
-    spillStats += spiller_->stats();
-
-    {
-      auto lockedStats = stats_.wlock();
-      lockedStats->spilledBytes += spillStats.spilledBytes;
-      lockedStats->spilledRows += spillStats.spilledRows;
-      lockedStats->spilledPartitions += spillStats.spilledPartitions;
-      lockedStats->spilledFiles += spillStats.spilledFiles;
-    }
-
     spiller_->finishSpill(spillPartitions);
+    recordSpillStats();
 
     // Verify all the spilled partitions are not empty as we won't spill on
     // an empty one.
@@ -822,6 +812,13 @@ bool HashBuild::finishHashBuild() {
   // table build.
   pool()->release();
   return true;
+}
+
+void HashBuild::recordSpillStats() {
+  VELOX_CHECK_NOT_NULL(spiller_);
+  const auto spillStats = spiller_->stats();
+  VELOX_CHECK_EQ(spillStats.spillSortTimeUs, 0);
+  Operator::recordSpillStats(spillStats);
 }
 
 void HashBuild::ensureTableFits(uint64_t numRows) {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -116,6 +116,8 @@ class HashBuild final : public Operator {
     return spillConfig_.has_value() ? &spillConfig_.value() : nullptr;
   }
 
+  void recordSpillStats();
+
   // Indicates if the input is read from spill data or not.
   bool isInputFromSpill() const;
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -247,7 +247,7 @@ void HashProbe::maybeSetupSpillInput(
       spillConfig.maxFileSize,
       spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
-      Spiller::spillPool(),
+      Spiller::pool(),
       spillConfig.executor);
   // Set the spill partitions to the corresponding ones at the build side. The
   // hash probe operator itself won't trigger any spilling.
@@ -1358,6 +1358,7 @@ void HashProbe::noMoreInputInternal() {
     VELOX_CHECK_EQ(
         spillInputPartitionIds_.size(), spiller_->spilledPartitionSet().size());
     spiller_->finishSpill(spillPartitionSet_);
+    recordSpillStats();
   }
 
   // Setup spill partition data.
@@ -1390,6 +1391,14 @@ void HashProbe::noMoreInputInternal() {
   VELOX_CHECK(promises.empty());
   VELOX_CHECK(hasSpillData || peers.empty());
   lastProber_ = true;
+}
+
+void HashProbe::recordSpillStats() {
+  VELOX_CHECK_NOT_NULL(spiller_);
+  const auto spillStats = spiller_->stats();
+  VELOX_CHECK_EQ(spillStats.spillSortTimeUs, 0);
+  VELOX_CHECK_EQ(spillStats.spillFillTimeUs, 0);
+  Operator::recordSpillStats(spillStats);
 }
 
 bool HashProbe::isFinished() {

--- a/velox/exec/HashProbe.h
+++ b/velox/exec/HashProbe.h
@@ -218,6 +218,8 @@ class HashProbe : public Operator {
   // next hash table from the spilled data.
   void noMoreInputInternal();
 
+  void recordSpillStats();
+
   // Returns the index of the 'match' column in the output for semi project
   // joins.
   VectorPtr& matchColumn() const {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -584,10 +584,13 @@ class Operator : public BaseRuntimeStatWriter {
   uint32_t outputBatchRows(
       std::optional<uint64_t> averageRowSize = std::nullopt) const;
 
+  /// Invoked to record spill stats in operator stats.
+  void recordSpillStats(const SpillStats& spillStats);
+
   const std::unique_ptr<OperatorCtx> operatorCtx_;
   const RowTypePtr outputType_;
-  // Contains the disk spilling related configs if spilling is enabled (e.g.
-  // the fs dir path to store spill files), otherwise null.
+  /// Contains the disk spilling related configs if spilling is enabled (e.g.
+  /// the fs dir path to store spill files), otherwise null.
   const std::optional<Spiller::Config> spillConfig_;
 
   folly::Synchronized<OperatorStats> stats_;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -244,7 +244,7 @@ void OrderBy::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig.maxFileSize,
         spillConfig.minSpillRunSize,
         spillConfig.compressionKind,
-        Spiller::spillPool(),
+        Spiller::pool(),
         spillConfig.executor);
     VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
   }
@@ -296,15 +296,9 @@ void OrderBy::noMoreInput() {
 
 void OrderBy::recordSpillStats() {
   VELOX_CHECK_NOT_NULL(spiller_);
-  VELOX_CHECK(noMoreInput_);
-
   const auto spillStats = spiller_->stats();
-  auto lockedStats = stats_.wlock();
-  lockedStats->spilledBytes = spillStats.spilledBytes;
-  lockedStats->spilledRows = spillStats.spilledRows;
-  lockedStats->spilledPartitions = spillStats.spilledPartitions;
-  lockedStats->spilledFiles = spillStats.spilledFiles;
-  VELOX_DCHECK_LE(lockedStats->spilledPartitions, 1);
+  VELOX_CHECK_LE(spillStats.spilledPartitions, 1);
+  Operator::recordSpillStats(spillStats);
 }
 
 RowVectorPtr OrderBy::getOutput() {

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -244,3 +244,22 @@ add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp)
 target_link_libraries(
   velox_simple_aggregate_test velox_simple_aggregate velox_exec
   velox_functions_aggregates_test_lib gtest gtest_main)
+
+add_library(velox_spiller_benchmark_base SpillerBenchmarkBase.cpp)
+
+target_link_libraries(velox_spiller_benchmark_base velox_exec
+                      velox_exec_test_lib velox_memory velox_vector_fuzzer)
+
+add_executable(velox_spiller_benchmark SpillerBenchmark.cpp)
+
+target_link_libraries(
+  velox_spiller_benchmark
+  velox_exec
+  velox_exec_test_lib
+  velox_spiller_benchmark_base
+  velox_vector_fuzzer
+  glog::glog
+
+  gflags::gflags
+  Folly::folly
+  pthread)

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -103,7 +103,7 @@ class HashJoinBridgeTest : public testing::Test,
           std::vector<CompareFlags>({}),
           tempDir_->path + "/Spill",
           common::CompressionKind_NONE,
-          *pool_));
+          pool_.get()));
       // Create a fake file to avoid too many exception logs in test when spill
       // file deletion fails.
       createFile(files.back()->testingFilePath());

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -64,19 +64,67 @@ std::function<void(Task* task)> makeAddSplit(
   };
 }
 
-// Returns aggregated spilled stats by 'task'.
-Spiller::Stats taskSpilledStats(const exec::Task& task) {
-  Spiller::Stats spilledStats;
+// Returns aggregated spilled stats by build and probe operators from 'task'.
+std::pair<SpillStats, SpillStats> taskSpilledStats(const exec::Task& task) {
+  SpillStats buildStats;
+  SpillStats probeStats;
   auto stats = task.taskStats();
   for (auto& pipeline : stats.pipelineStats) {
     for (auto op : pipeline.operatorStats) {
-      spilledStats.spilledBytes += op.spilledBytes;
-      spilledStats.spilledRows += op.spilledRows;
-      spilledStats.spilledPartitions += op.spilledPartitions;
-      spilledStats.spilledFiles += op.spilledFiles;
+      if (op.operatorType == "HashBuild") {
+        buildStats.spilledBytes += op.spilledBytes;
+        buildStats.spilledRows += op.spilledRows;
+        buildStats.spilledPartitions += op.spilledPartitions;
+        buildStats.spilledFiles += op.spilledFiles;
+      } else if (op.operatorType == "HashProbe") {
+        probeStats.spilledBytes += op.spilledBytes;
+        probeStats.spilledRows += op.spilledRows;
+        probeStats.spilledPartitions += op.spilledPartitions;
+        probeStats.spilledFiles += op.spilledFiles;
+      }
     }
   }
-  return spilledStats;
+  return {buildStats, probeStats};
+}
+
+// Returns aggregated spilled runtime stats by build and probe operators from
+// 'task'.
+void verifyTaskSpilledRuntimeStats(const exec::Task& task, bool expectedSpill) {
+  auto stats = task.taskStats();
+  for (auto& pipeline : stats.pipelineStats) {
+    for (auto op : pipeline.operatorStats) {
+      if ((op.operatorType == "HashBuild") ||
+          (op.operatorType == "HashProbe")) {
+        if (!expectedSpill) {
+          ASSERT_EQ(op.runtimeStats["spillFillTime"].count, 0);
+          ASSERT_EQ(op.runtimeStats["spillSortTime"].count, 0);
+          ASSERT_EQ(op.runtimeStats["spillSerializationTime"].count, 0);
+          ASSERT_EQ(op.runtimeStats["spillFlushTime"].count, 0);
+          ASSERT_EQ(op.runtimeStats["spillDiskWrites"].count, 0);
+          ASSERT_EQ(op.runtimeStats["spillWriteTime"].count, 0);
+        } else {
+          if (op.operatorType == "HashBuild") {
+            ASSERT_GT(op.runtimeStats["spillFillTime"].sum, 0);
+          } else {
+            ASSERT_EQ(op.runtimeStats["spillFillTime"].sum, 0);
+          }
+          ASSERT_EQ(op.runtimeStats["spillSortTime"].sum, 0);
+          ASSERT_GT(op.runtimeStats["spillSerializationTime"].sum, 0);
+          ASSERT_GE(op.runtimeStats["spillFlushTime"].sum, 0);
+          // NOTE: spill flush might take less than one microsecond.
+          ASSERT_GE(
+              op.runtimeStats["spillSerializationTime"].count,
+              op.runtimeStats["spillFlushTime"].count);
+          ASSERT_GT(op.runtimeStats["spillDiskWrites"].sum, 0);
+          ASSERT_GE(op.runtimeStats["spillWriteTime"].sum, 0);
+          // NOTE: spill flush might take less than one microsecond.
+          ASSERT_GE(
+              op.runtimeStats["spillDiskWrites"].count,
+              op.runtimeStats["spillWriteTime"].count);
+        }
+      }
+    }
+  }
 }
 
 static uint64_t getOutputPositions(
@@ -120,8 +168,9 @@ std::pair<int32_t, int32_t> numTaskSpillFiles(const exec::Task& task) {
       }
       if (operatorStat.operatorType == "HashBuild") {
         numBuildFiles += operatorStat.runtimeStats["spillFileSize"].count;
-      } else {
-        VELOX_CHECK_EQ(operatorStat.operatorType, "HashProbe");
+        continue;
+      }
+      if (operatorStat.operatorType == "HashProbe") {
         numProbeFiles += operatorStat.runtimeStats["spillFileSize"].count;
       }
     }
@@ -220,8 +269,8 @@ class HashJoinBuilder {
     // NOTE: there is one value node copy per driver thread and if the value
     // node is not parallelizable, then the associated driver pipeline will be
     // single threaded. 'allProbeVectors_' contains the value vectors fed to
-    // all the hash probe drivers, which will be used to populate the duckdb as
-    // well.
+    // all the hash probe drivers, which will be used to populate the duckdb
+    // as well.
     allProbeVectors_ = makeCopies(probeVectors_, numDrivers_);
     return *this;
   }
@@ -264,8 +313,8 @@ class HashJoinBuilder {
     // NOTE: there is one value node copy per driver thread and if the value
     // node is not parallelizable, then the associated driver pipeline will be
     // single threaded. 'allBuildVectors_' contains the value vectors fed to
-    // all the hash build drivers, which will be used to populate the duckdb as
-    // well.
+    // all the hash build drivers, which will be used to populate the duckdb
+    // as well.
     allBuildVectors_ = makeCopies(buildVectors_, numDrivers_);
     return *this;
   }
@@ -457,8 +506,9 @@ class HashJoinBuilder {
     }
     // NOTE: we generate a number of vectors with a fresh new fuzzer init with
     // the same fix seed. The purpose is to ensure we have sufficient match if
-    // we use the row type for both build and probe inputs. Here we shuffle the
-    // built vectors to introduce some randomness during the join execution.
+    // we use the row type for both build and probe inputs. Here we shuffle
+    // the built vectors to introduce some randomness during the join
+    // execution.
     if (shuffle) {
       shuffleBatches(vectors);
     }
@@ -566,24 +616,34 @@ class HashJoinBuilder {
         injectSpill ? fmt::format("With Max Spill Level: {}", maxSpillLevel)
                     : "Without Spill");
     auto task = builder.assertResults(referenceQuery_);
-    const auto spillStats = taskSpilledStats(*task);
+    const auto statsPair = taskSpilledStats(*task);
     if (injectSpill) {
       if (checkSpillStats_) {
-        ASSERT_GT(spillStats.spilledRows, 0);
-        ASSERT_GT(spillStats.spilledBytes, 0);
-        ASSERT_GT(spillStats.spilledPartitions, 0);
-        ASSERT_GT(spillStats.spilledFiles, 0);
+        ASSERT_GT(statsPair.first.spilledRows, 0);
+        ASSERT_GT(statsPair.second.spilledRows, 0);
+        ASSERT_GT(statsPair.first.spilledBytes, 0);
+        ASSERT_GT(statsPair.second.spilledBytes, 0);
+        ASSERT_GT(statsPair.first.spilledPartitions, 0);
+        ASSERT_GT(statsPair.second.spilledPartitions, 0);
+        ASSERT_GT(statsPair.first.spilledFiles, 0);
+        ASSERT_GT(statsPair.second.spilledFiles, 0);
         if (maxSpillLevel != -1) {
           ASSERT_EQ(maxHashBuildSpillLevel(*task), maxSpillLevel);
         }
+        verifyTaskSpilledRuntimeStats(*task, true);
       }
-      // NOTE: if 'spillDirectory_' is not empty and spill threshold is not set,
-      // the test might trigger spilling by its own.
+      // NOTE: if 'spillDirectory_' is not empty and spill threshold is not
+      // set, the test might trigger spilling by its own.
     } else if (spillDirectory_.empty() && spillMemoryThreshold_ == 0) {
-      ASSERT_EQ(spillStats.spilledRows, 0);
-      ASSERT_EQ(spillStats.spilledBytes, 0);
-      ASSERT_EQ(spillStats.spilledPartitions, 0);
-      ASSERT_EQ(spillStats.spilledFiles, 0);
+      ASSERT_EQ(statsPair.first.spilledRows, 0);
+      ASSERT_EQ(statsPair.first.spilledBytes, 0);
+      ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+      ASSERT_EQ(statsPair.first.spilledFiles, 0);
+      ASSERT_EQ(statsPair.second.spilledRows, 0);
+      ASSERT_EQ(statsPair.second.spilledBytes, 0);
+      ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+      ASSERT_EQ(statsPair.second.spilledFiles, 0);
+      verifyTaskSpilledRuntimeStats(*task, false);
     }
     // Customized test verification.
     if (testVerifier_ != nullptr) {
@@ -622,7 +682,8 @@ class HashJoinBuilder {
 
   uint64_t spillMemoryThreshold_{0};
   bool injectSpill_{true};
-  // If not set, then the test will run the test with different settings: 0, 2.
+  // If not set, then the test will run the test with different settings:
+  // 0, 2.
   std::optional<int32_t> maxSpillLevel_;
   bool checkSpillStats_{true};
 
@@ -819,12 +880,17 @@ TEST_P(MultiThreadedHashJoinTest, emptyBuild) {
         .referenceQuery(
             "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           // Check the hash probe has processed probe input rows.
           if (finishOnEmpty) {
             ASSERT_EQ(getInputPositions(task, 1), 0);
@@ -842,8 +908,33 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbe) {
       .keyTypes({BIGINT()})
       .probeVectors(0, 5)
       .buildVectors(1500, 5)
+      .checkSpillStats(false)
       .referenceQuery(
           "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
+      .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+        const auto statsPair = taskSpilledStats(*task);
+        if (hasSpill) {
+          ASSERT_GT(statsPair.first.spilledRows, 0);
+          ASSERT_GT(statsPair.first.spilledBytes, 0);
+          ASSERT_GT(statsPair.first.spilledPartitions, 0);
+          ASSERT_GT(statsPair.first.spilledFiles, 0);
+          // There is no spilling at empty probe side.
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_GT(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+        } else {
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
+        }
+      })
       .run();
 }
 
@@ -859,11 +950,15 @@ TEST_P(MultiThreadedHashJoinTest, emptyProbeWithSpillMemoryThreshold) {
       .referenceQuery(
           "SELECT t_k0, t_data, u_k0, u_data FROM t, u WHERE t_k0 = u_k0")
       .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-        const auto spillStats = taskSpilledStats(*task);
-        ASSERT_GT(spillStats.spilledRows, 0);
-        ASSERT_GT(spillStats.spilledBytes, 0);
-        ASSERT_GT(spillStats.spilledPartitions, 0);
-        ASSERT_GT(spillStats.spilledFiles, 0);
+        const auto statsPair = taskSpilledStats(*task);
+        ASSERT_GT(statsPair.first.spilledRows, 0);
+        ASSERT_GT(statsPair.first.spilledBytes, 0);
+        ASSERT_GT(statsPair.first.spilledPartitions, 0);
+        ASSERT_GT(statsPair.first.spilledFiles, 0);
+        ASSERT_EQ(statsPair.second.spilledRows, 0);
+        ASSERT_EQ(statsPair.second.spilledBytes, 0);
+        ASSERT_GT(statsPair.second.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.second.spilledFiles, 0);
       })
       .run();
 }
@@ -1003,7 +1098,8 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithNull) {
 }
 
 TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithLargeOutput) {
-  // Build the identical left and right vectors to generate large join outputs.
+  // Build the identical left and right vectors to generate large join
+  // outputs.
   std::vector<RowVectorPtr> probeVectors =
       makeBatches(4, [&](uint32_t /*unused*/) {
         return makeRowVector(
@@ -1186,12 +1282,17 @@ TEST_P(MultiThreadedHashJoinTest, innerJoinWithEmptyBuild) {
         .joinOutputLayout({"c1"})
         .referenceQuery("SELECT null LIMIT 0")
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
           // Check the hash probe has processed probe input rows.
           if (finishOnEmpty) {
@@ -1367,12 +1468,17 @@ TEST_P(MultiThreadedHashJoinTest, rightSemiJoinFilterWithEmptyBuild) {
         .referenceQuery(
             "SELECT u.u1 FROM u WHERE u.u0 IN (SELECT t0 FROM t) AND u.u0 < 0")
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
           // Check the hash probe has processed probe input rows.
           if (finishOnEmpty) {
@@ -1716,14 +1822,19 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilter) {
       .referenceQuery(
           "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE t0 = u0 AND t1 <> u1)")
       .checkSpillStats(false)
-      .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
-        // Verify spilling is not triggered in case of null-aware anti-join with
-        // filter.
-        const auto spillStats = taskSpilledStats(*task);
-        ASSERT_EQ(spillStats.spilledRows, 0);
-        ASSERT_EQ(spillStats.spilledBytes, 0);
-        ASSERT_EQ(spillStats.spilledPartitions, 0);
-        ASSERT_EQ(spillStats.spilledFiles, 0);
+      .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+        // Verify spilling is not triggered in case of null-aware anti-join
+        // with filter.
+        const auto statsPair = taskSpilledStats(*task);
+        ASSERT_EQ(statsPair.first.spilledRows, 0);
+        ASSERT_EQ(statsPair.first.spilledBytes, 0);
+        ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.first.spilledFiles, 0);
+        ASSERT_EQ(statsPair.second.spilledRows, 0);
+        ASSERT_EQ(statsPair.second.spilledBytes, 0);
+        ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+        ASSERT_EQ(statsPair.second.spilledFiles, 0);
+        verifyTaskSpilledRuntimeStats(*task, false);
         ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
       })
       .run();
@@ -1766,14 +1877,19 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndEmptyBuild) {
         .referenceQuery(
             "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE u0 < 0 AND u.u0 = t.t0)")
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
           // Verify spilling is not triggered in case of null-aware anti-join
           // with filter.
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1818,14 +1934,19 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterAndNullKey) {
         .joinOutputLayout({"t0", "t1"})
         .referenceQuery(referenceSql)
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
           // Verify spilling is not triggered in case of null-aware anti-join
           // with filter.
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1866,14 +1987,19 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
         .joinOutputLayout({"t0", "t1"})
         .referenceQuery(referenceSql)
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
           // Verify spilling is not triggered in case of null-aware anti-join
           // with filter.
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1911,14 +2037,19 @@ TEST_P(MultiThreadedHashJoinTest, nullAwareAntiJoinWithFilterOnNullableColumn) {
         .joinOutputLayout({"t0", "t1"})
         .referenceQuery(referenceSql)
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
           // Verify spilling is not triggered in case of null-aware anti-join
           // with filter.
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -1957,11 +2088,12 @@ TEST_P(MultiThreadedHashJoinTest, antiJoin) {
   std::vector<std::string> filters({
       "u1 > t1",
       "u1 * t1 > 0",
-      // This filter is true on rows without a match. It should not prevent the
-      // row from being returned.
+      // This filter is true on rows without a match. It should not prevent
+      // the row from being returned.
       "coalesce(u1, t1, 0::integer) is not null",
       // This filter throws if evaluated on rows without a match. The join
-      // should not evaluate filter on those rows and therefore should not fail.
+      // should not evaluate filter on those rows and therefore should not
+      // fail.
       "t1 / coalesce(u1, 0::integer) is not null",
   });
   for (const std::string& filter : filters) {
@@ -2017,12 +2149,17 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
         .referenceQuery(
             "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE u0 < 0 AND u.u0 = t.t0)")
         .checkSpillStats(false)
-        .verifier([&](const std::shared_ptr<Task>& task, bool hasSpill) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_EQ(spillStats.spilledRows, 0);
-          ASSERT_EQ(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 0);
-          ASSERT_EQ(spillStats.spilledFiles, 0);
+        .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_EQ(statsPair.first.spilledRows, 0);
+          ASSERT_EQ(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.first.spilledFiles, 0);
+          ASSERT_EQ(statsPair.second.spilledRows, 0);
+          ASSERT_EQ(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+          ASSERT_EQ(statsPair.second.spilledFiles, 0);
+          verifyTaskSpilledRuntimeStats(*task, false);
           ASSERT_EQ(maxHashBuildSpillLevel(*task), -1);
         })
         .run();
@@ -2031,7 +2168,8 @@ TEST_P(MultiThreadedHashJoinTest, antiJoinWithFilterAndEmptyBuild) {
 
 TEST_P(MultiThreadedHashJoinTest, leftJoin) {
   // Left side keys are [0, 1, 2,..20].
-  // Use 3-rd column as row number to allow for asserting the order of results.
+  // Use 3-rd column as row number to allow for asserting the order of
+  // results.
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
@@ -2155,7 +2293,8 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithEmptyBuild) {
 
 TEST_P(MultiThreadedHashJoinTest, leftJoinWithNoJoin) {
   // Left side keys are [0, 1, 2,..10].
-  // Use 3-rd column as row number to allow for asserting the order of results.
+  // Use 3-rd column as row number to allow for asserting the order of
+  // results.
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
@@ -2212,7 +2351,8 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithNoJoin) {
 
 TEST_P(MultiThreadedHashJoinTest, leftJoinWithAllMatch) {
   // Left side keys are [0, 1, 2,..10].
-  // Use 3-rd column as row number to allow for asserting the order of results.
+  // Use 3-rd column as row number to allow for asserting the order of
+  // results.
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
@@ -2270,7 +2410,8 @@ TEST_P(MultiThreadedHashJoinTest, leftJoinWithAllMatch) {
 
 TEST_P(MultiThreadedHashJoinTest, leftJoinWithFilter) {
   // Left side keys are [0, 1, 2,..10].
-  // Use 3-rd column as row number to allow for asserting the order of results.
+  // Use 3-rd column as row number to allow for asserting the order of
+  // results.
   std::vector<RowVectorPtr> probeVectors = mergeBatches(
       makeBatches(
           3,
@@ -4390,8 +4531,8 @@ TEST_F(HashJoinTest, memoryUsage) {
 }
 
 /// Test an edge case in producing small output batches where the logic to
-/// calculate the set of probe-side rows to load lazy vectors for was triggering
-/// a crash.
+/// calculate the set of probe-side rows to load lazy vectors for was
+/// triggering a crash.
 TEST_F(HashJoinTest, smallOutputBatchSize) {
   // Setup probe data with 50 non-null matching keys followed by 50 null
   // keys: 1, 2, 1, 2,...null, null.
@@ -4459,21 +4600,23 @@ TEST_F(HashJoinTest, spillFileSize) {
           if (!hasSpill) {
             return;
           }
-          const auto stats = taskSpilledStats(*task);
-          const int32_t numPartitions = stats.spilledPartitions;
+          const auto statsPair = taskSpilledStats(*task);
+          const int32_t numPartitions = statsPair.first.spilledPartitions;
+          ASSERT_EQ(statsPair.second.spilledPartitions, numPartitions);
           const auto fileSizes = numTaskSpillFiles(*task);
           if (spillFileSize != 1) {
             ASSERT_EQ(fileSizes.first, numPartitions);
           } else {
             ASSERT_GT(fileSizes.first, numPartitions);
           }
+          verifyTaskSpilledRuntimeStats(*task, true);
         })
         .run();
   }
 }
 
-// The test is to verify if the hash build reservation has been released on task
-// error.
+// The test is to verify if the hash build reservation has been released on
+// task error.
 DEBUG_ONLY_TEST_F(HashJoinTest, buildReservationReleaseCheck) {
   std::vector<RowVectorPtr> probeVectors =
       makeBatches(1, [&](int32_t /*unused*/) {
@@ -4675,13 +4818,19 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
           .referenceQuery(
               "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1")
           .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-            const auto spillStats = taskSpilledStats(*task);
+            const auto statsPair = taskSpilledStats(*task);
             if (testData.expectedReclaimable) {
-              ASSERT_GT(spillStats.spilledBytes, 0);
-              ASSERT_EQ(spillStats.spilledPartitions, 4);
+              ASSERT_GT(statsPair.first.spilledBytes, 0);
+              ASSERT_EQ(statsPair.first.spilledPartitions, 4);
+              ASSERT_GT(statsPair.second.spilledBytes, 0);
+              ASSERT_EQ(statsPair.second.spilledPartitions, 4);
+              verifyTaskSpilledRuntimeStats(*task, true);
             } else {
-              ASSERT_EQ(spillStats.spilledBytes, 0);
-              ASSERT_EQ(spillStats.spilledPartitions, 0);
+              ASSERT_EQ(statsPair.first.spilledBytes, 0);
+              ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+              ASSERT_EQ(statsPair.second.spilledBytes, 0);
+              ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+              verifyTaskSpilledRuntimeStats(*task, false);
             }
           })
           .run();
@@ -4807,9 +4956,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
         .referenceQuery(
             "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1")
         .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_GT(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 4);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_GT(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 4);
+          ASSERT_GT(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 4);
+          verifyTaskSpilledRuntimeStats(*task, true);
         })
         .run();
   });
@@ -4928,9 +5080,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
           .referenceQuery(
               "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1")
           .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-            const auto spillStats = taskSpilledStats(*task);
-            ASSERT_EQ(spillStats.spilledBytes, 0);
-            ASSERT_EQ(spillStats.spilledPartitions, 0);
+            const auto statsPair = taskSpilledStats(*task);
+            ASSERT_EQ(statsPair.first.spilledBytes, 0);
+            ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+            ASSERT_EQ(statsPair.second.spilledBytes, 0);
+            ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+            verifyTaskSpilledRuntimeStats(*task, false);
           })
           .run();
     });
@@ -5041,9 +5196,12 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
           .referenceQuery(
               "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1")
           .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-            const auto spillStats = taskSpilledStats(*task);
-            ASSERT_EQ(spillStats.spilledBytes, 0);
-            ASSERT_EQ(spillStats.spilledPartitions, 0);
+            const auto statsPair = taskSpilledStats(*task);
+            ASSERT_EQ(statsPair.first.spilledBytes, 0);
+            ASSERT_EQ(statsPair.first.spilledPartitions, 0);
+            ASSERT_EQ(statsPair.second.spilledBytes, 0);
+            ASSERT_EQ(statsPair.second.spilledPartitions, 0);
+            verifyTaskSpilledRuntimeStats(*task, false);
           })
           .run();
     });
@@ -5175,9 +5333,11 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
         .referenceQuery(
             "SELECT t_k1, t_k2, t_v1, u_k1, u_k2, u_v1 FROM t, u WHERE t.t_k1 = u.u_k1")
         .verifier([&](const std::shared_ptr<Task>& task, bool /*unused*/) {
-          const auto spillStats = taskSpilledStats(*task);
-          ASSERT_GT(spillStats.spilledBytes, 0);
-          ASSERT_EQ(spillStats.spilledPartitions, 4);
+          const auto statsPair = taskSpilledStats(*task);
+          ASSERT_GT(statsPair.first.spilledBytes, 0);
+          ASSERT_EQ(statsPair.first.spilledPartitions, 4);
+          ASSERT_GT(statsPair.second.spilledBytes, 0);
+          ASSERT_EQ(statsPair.second.spilledPartitions, 4);
         })
         .run();
   });

--- a/velox/exec/tests/SpillerBenchmark.cpp
+++ b/velox/exec/tests/SpillerBenchmark.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <deque>
+
+#include "velox/exec/tests/SpillerBenchmarkBase.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+using namespace facebook::velox::exec;
+
+int main(int argc, char* argv[]) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  serializer::presto::PrestoVectorSerde::registerVectorSerde();
+  filesystems::registerLocalFileSystem();
+  auto test =
+      std::make_unique<facebook::velox::exec::test::JoinSpillInputTest>();
+  test->setUp();
+  test->run();
+  test->printStats();
+  test->cleanup();
+  return 0;
+}

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/tests/SpillerBenchmarkBase.h"
+
+DEFINE_string(
+    spiller_benchmark_path,
+    "",
+    "The file directory path for spilling");
+DEFINE_uint64(
+    spiller_benchmark_max_spill_file_size,
+    1 << 30,
+    "The max spill file size");
+DEFINE_uint64(
+    spiller_benchmark_min_spill_run_size,
+    1 << 30,
+    "The file directory path for spiller benchmark");
+DEFINE_uint32(
+    spiller_benchmark_num_spill_vectors,
+    10'000,
+    "The number of vectors for spilling");
+DEFINE_uint32(
+    spiller_benchmark_spill_vector_size,
+    1'000,
+    "The number of rows per each spill vector");
+DEFINE_string(
+    spiller_benchmark_compression_kind,
+    "none",
+    "The compression kind to compress spill rows before write to disk");
+DEFINE_uint32(
+    spiller_benchmark_spill_executor_size,
+    std::thread::hardware_concurrency(),
+    "The spiller executor size in number of threads");
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+using namespace facebook::velox::memory;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+namespace {
+static const int kNumSampleVectors = 100;
+}
+
+void JoinSpillInputTest::setUp() {
+  rootPool_ = defaultMemoryManager().addRootPool("JoinSpillInputTest");
+  pool_ = rootPool_->addLeafChild("JoinSpillInputTest");
+
+  rowType_ =
+      ROW({"c0", "c1", "c2", "c3", "c4"},
+          {INTEGER(), BIGINT(), VARCHAR(), VARBINARY(), DOUBLE()});
+
+  numInputVectors_ = FLAGS_spiller_benchmark_num_spill_vectors;
+  inputVectorSize_ = FLAGS_spiller_benchmark_spill_vector_size;
+  {
+    VectorFuzzer::Options options;
+    options.vectorSize = inputVectorSize_;
+    vectorFuzzer_ = std::make_unique<VectorFuzzer>(options, pool_.get());
+  }
+  rowVectors_.reserve(kNumSampleVectors);
+  for (int i = 0; i < kNumSampleVectors; ++i) {
+    rowVectors_.push_back(vectorFuzzer_->fuzzRow(rowType_));
+  }
+
+  if (FLAGS_spiller_benchmark_spill_executor_size != 0) {
+    executor_ = std::make_unique<folly::IOThreadPoolExecutor>(
+        FLAGS_spiller_benchmark_spill_executor_size,
+        std::make_shared<folly::NamedThreadFactory>("Spiller"));
+  }
+  if (FLAGS_spiller_benchmark_path.empty()) {
+    tempDir_ = exec::test::TempDirectoryPath::create();
+    spillDir_ = tempDir_->path;
+  } else {
+    spillDir_ = FLAGS_spiller_benchmark_path;
+  }
+  fs_ = filesystems::getFileSystem(spillDir_, {});
+  fs_->mkdir(spillDir_);
+
+  spiller_ = std::make_unique<Spiller>(
+      exec::Spiller::Type::kHashJoinProbe,
+      rowType_,
+      HashBitRange{29, 29},
+      fmt::format("{}/{}", spillDir_, "JoinSpillInputTest"),
+      FLAGS_spiller_benchmark_max_spill_file_size,
+      FLAGS_spiller_benchmark_min_spill_run_size,
+      stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
+      Spiller::pool(),
+      executor_.get());
+  spiller_->setPartitionsSpilled({0});
+}
+
+void JoinSpillInputTest::run() {
+  MicrosecondTimer timer(&executionTimeUs_);
+  for (auto i = 0; i < numInputVectors_; ++i) {
+    spiller_->spill(0, rowVectors_[i % kNumSampleVectors]);
+  }
+}
+
+void JoinSpillInputTest::printStats() {
+  LOG(INFO) << "total execution time: " << succinctMicros(executionTimeUs_);
+  LOG(INFO) << numInputVectors_ << " vectors each with " << inputVectorSize_
+            << " rows have been processed";
+  const auto memStats = pool_->stats();
+  LOG(INFO) << "peak memory usage[" << succinctBytes(memStats.peakBytes)
+            << "] cumulative memory usage["
+            << succinctBytes(memStats.cumulativeBytes) << "]";
+  LOG(INFO) << spiller_->stats().toString();
+  // List files under file path.
+  SpillPartitionSet partitionSet;
+  spiller_->finishSpill(partitionSet);
+  VELOX_CHECK_EQ(partitionSet.size(), 1);
+  const auto files = fs_->list(spillDir_);
+  for (const auto& file : files) {
+    auto rfile = fs_->openFileForRead(file);
+    LOG(INFO) << "spilled file " << file << " size "
+              << succinctBytes(rfile->size());
+  }
+}
+
+void JoinSpillInputTest::cleanup() {
+  LOG(INFO) << "Remove spill dir: " << spillDir_;
+  fs_->rmdir(spillDir_);
+}
+} // namespace facebook::velox::exec::test

--- a/velox/exec/tests/SpillerBenchmarkBase.h
+++ b/velox/exec/tests/SpillerBenchmarkBase.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include "velox/common/compression/Compression.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/common/memory/MmapAllocator.h"
+#include "velox/common/time/Timer.h"
+#include "velox/exec/Spiller.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+#include "velox/serializers/PrestoSerializer.h"
+#include "velox/type/Type.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DECLARE_string(spiller_benchmark_path);
+DECLARE_uint64(spiller_benchmark_max_spill_file_size);
+DECLARE_uint64(spiller_benchmark_min_spill_run_size);
+DECLARE_uint32(spiller_benchmark_num_input_vectors);
+DECLARE_uint32(spiller_benchmark_input_vector_size);
+DECLARE_string(spiller_benchmark_compression_kind);
+DECLARE_uint32(spiller_benchmark_spill_executor_size);
+
+using namespace facebook::velox;
+using namespace facebook::velox::common;
+using namespace facebook::velox::memory;
+using namespace facebook::velox::exec;
+
+namespace facebook::velox::exec::test {
+// This test measures the spill input overhead in spill join & probe.
+class JoinSpillInputTest {
+ public:
+  JoinSpillInputTest() = default;
+
+  /// Sets up the test.
+  void setUp();
+
+  /// Runs the test.
+  void run();
+
+  /// Prints out the measured test stats.
+  void printStats();
+
+  /// Cleans up the test.
+  void cleanup();
+
+ private:
+  std::shared_ptr<MemoryPool> rootPool_;
+  std::shared_ptr<MemoryPool> pool_;
+  RowTypePtr rowType_;
+  uint32_t numInputVectors_;
+  uint32_t inputVectorSize_;
+  std::unique_ptr<VectorFuzzer> vectorFuzzer_;
+  std::vector<RowVectorPtr> rowVectors_;
+  std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
+  std::shared_ptr<exec::test::TempDirectoryPath> tempDir_;
+  std::string spillDir_;
+  std::shared_ptr<filesystems::FileSystem> fs_;
+  std::unique_ptr<Spiller> spiller_;
+  // Stats.
+  uint64_t executionTimeUs_{0};
+};
+} // namespace facebook::velox::exec::test

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -34,6 +34,7 @@ struct Timestamp {
  public:
   enum class Precision : int { kMilliseconds = 3, kNanoseconds = 9 };
   static constexpr int64_t kMillisecondsInSecond = 1'000;
+  static constexpr int64_t kNanosecondsInMicrosecond = 1'000;
   static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
 
   // Limit the range of seconds to avoid some problems. Seconds should be


### PR DESCRIPTION
- Add more spill stats to break down the spill write path and collect
   both per-query and global (aggregated stats across all queries) stats.
   The per-query stats is reported through task runtime stats and the
   latter are collected in a global stats (shared by thread id)
- Refactor spiller internal stats collection mechanism.
- Add hash probe spill stats collection
- Change hash build to report stats at operator level
- Add spill input performance benchmark

Followup will report the global stats through stats (like ODS in Meta)
mechanism by Prestissimo