### PR TITLE
Add decimals support for min_by and max_by functions

### DIFF
--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -567,6 +567,9 @@ std::unique_ptr<exec::Aggregate> create(
     case TypeKind::BIGINT:
       return std::make_unique<Aggregate<W, int64_t, isMaxFunc, Comparator>>(
           resultType);
+    case TypeKind::HUGEINT:
+      return std::make_unique<Aggregate<W, int128_t, isMaxFunc, Comparator>>(
+          resultType);
     case TypeKind::REAL:
       return std::make_unique<Aggregate<W, float, isMaxFunc, Comparator>>(
           resultType);
@@ -625,6 +628,9 @@ std::unique_ptr<exec::Aggregate> create(
           resultType, compareType, errorMessage);
     case TypeKind::BIGINT:
       return create<Aggregate, isMaxFunc, Comparator, int64_t>(
+          resultType, compareType, errorMessage);
+    case TypeKind::HUGEINT:
+      return create<Aggregate, isMaxFunc, Comparator, int128_t>(
           resultType, compareType, errorMessage);
     case TypeKind::REAL:
       return create<Aggregate, isMaxFunc, Comparator, float>(

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -701,6 +701,7 @@ VELOX_DEFINE_SCALAR_ACCESSOR(BOOLEAN);
 VELOX_DEFINE_SCALAR_ACCESSOR(TINYINT);
 VELOX_DEFINE_SCALAR_ACCESSOR(SMALLINT);
 VELOX_DEFINE_SCALAR_ACCESSOR(BIGINT);
+VELOX_DEFINE_SCALAR_ACCESSOR(HUGEINT);
 VELOX_DEFINE_SCALAR_ACCESSOR(REAL);
 VELOX_DEFINE_SCALAR_ACCESSOR(DOUBLE);
 VELOX_DEFINE_SCALAR_ACCESSOR(TIMESTAMP);
@@ -858,6 +859,8 @@ TypePtr fromKindToScalerType(TypeKind kind) {
       return BIGINT();
     case TypeKind::INTEGER:
       return INTEGER();
+    case TypeKind::HUGEINT:
+      return HUGEINT();
     case TypeKind::REAL:
       return REAL();
     case TypeKind::VARCHAR:
@@ -990,6 +993,7 @@ const SingletonTypeMap& singletonBuiltInTypes() {
       {"SMALLINT", SMALLINT()},
       {"INTEGER", INTEGER()},
       {"BIGINT", BIGINT()},
+      {"HUGEINT", HUGEINT()},
       {"REAL", REAL()},
       {"DOUBLE", DOUBLE()},
       {"VARCHAR", VARCHAR()},

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -244,9 +244,13 @@ std::string variant::toJson(const TypePtr& type) const {
       folly::json::escapeString(str, target, getOpts());
       return target;
     }
-    case TypeKind::HUGEINT:
-      VELOX_CHECK(type && type->isLongDecimal());
-      return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+    case TypeKind::HUGEINT: {
+      if (type && type->isLongDecimal()) {
+        return DecimalUtil::toString(value<TypeKind::HUGEINT>(), type);
+      } else {
+        return std::to_string(value<TypeKind::HUGEINT>());
+      }
+    }
     case TypeKind::TINYINT:
       [[fallthrough]];
     case TypeKind::SMALLINT:

--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -627,7 +627,7 @@ struct VariantConverter {
         // assumptions. Block converting timestamp to integer, double and
         // std::string types. The callers should implement their own conversion
         //  from value.
-        VELOX_NYI();
+        return convert<TypeKind::HUGEINT, ToKind>(value);
       default:
         VELOX_NYI();
     }

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -288,7 +288,7 @@ void fuzzFlatPrimitiveImpl(
       if (vector->type()->isLongDecimal()) {
         flatVector->set(i, randLongDecimal(vector->type(), rng));
       } else {
-        VELOX_NYI();
+        flatVector->set(i, rand<TCpp>(rng));
       }
     } else {
       flatVector->set(i, rand<TCpp>(rng));


### PR DESCRIPTION
This PR adds min_by and max_by function signatures for DECIMAL logical type. Also, adds `HUGEINT` to the list of compare types. This is required to cover long decimal functions.
Testing:
Included HUGEINT in the map of RowTypes in MinMaxByAggregateTest.
