### PR TITLE
Add array_max Spark Function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -27,6 +27,18 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
+.. function:: array_max(array(E)) -> E
+
+    Returns the maximum value of input array.
+    The result matches the type of the elements.
+    NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.
+    NaN is greater than any non-NaN elements for double/float type. ::
+
+        SELECT array_max(ARRAY [1, 2, 3]); -- 3
+        SELECT array_max(ARRAY [-1, -2, -2]); -- -1
+        SELECT array_max(ARRAY [-1, -2, NULL]); -- NULL
+        SELECT array_max(ARRAY []); -- NULL
+
 .. function:: array_min(array(E)) -> E
 
     Returns the minimum value of input array. 

--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -27,6 +27,19 @@ Array Functions
 
         SELECT array_intersect(array(1, 2, 3), array(1, 3, 5)); -- [1,3]
 
+.. function:: array_min(array(E)) -> E
+
+    Returns the minimum value of input array. 
+    The result matches the type of the elements.
+    NULL elements are skipped. If array is empty, or contains only NULL elements, NULL is returned.
+    NaN is greater than any non-NaN elements for double/float type. ::
+
+        SELECT array_min(ARRAY [1, 2, 3]); -- 1
+        SELECT array_min(ARRAY [-1, -2, -2]); -- -2
+        SELECT array_min(ARRAY [-1, -2, NULL]); -- -2
+        SELECT array_min(ARRAY [NULL, NULL]); -- NULL
+        SELECT array_min(ARRAY []); -- NULL
+
 .. spark:function:: array_sort(array(E)) -> array(E)
 
     Returns an array which has the sorted order of the input array(E). The elements of array(E) must

--- a/velox/functions/sparksql/ArrayFunction.h
+++ b/velox/functions/sparksql/ArrayFunction.h
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cmath>
+#include <type_traits>
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions::sparksql {
+template <typename TExecCtx, bool isMax>
+struct ArrayMinMaxFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecCtx);
+
+  template <typename T>
+  void update(T& currentValue, const T& candidateValue) {
+    // NaN is greater than any non-NaN elements for double/float type.
+    if constexpr (std::is_floating_point_v<T>) {
+      if constexpr (isMax) {
+        if (std::isnan(candidateValue) ||
+            (!std::isnan(currentValue) && candidateValue > currentValue)) {
+          currentValue = candidateValue;
+        }
+      } else {
+        if (std::isnan(currentValue) ||
+            (!std::isnan(candidateValue) && candidateValue < currentValue)) {
+          currentValue = candidateValue;
+        }
+      }
+      return;
+    }
+
+    if constexpr (isMax) {
+      if (candidateValue > currentValue) {
+        currentValue = candidateValue;
+      }
+    } else {
+      if (candidateValue < currentValue) {
+        currentValue = candidateValue;
+      }
+    }
+  }
+
+  template <typename TReturn, typename TInput>
+  void assign(TReturn& out, const TInput& value) {
+    out = value;
+  }
+
+  void assign(out_type<Varchar>& out, const arg_type<Varchar>& value) {
+    // TODO: reuse strings once support landed.
+    out.resize(value.size());
+    if (value.size() != 0) {
+      std::memcpy(out.data(), value.data(), value.size());
+    }
+  }
+
+  template <typename TReturn, typename TInput>
+  FOLLY_ALWAYS_INLINE bool call(TReturn& out, const TInput& array) {
+    // Result is null if array is empty.
+    if (array.size() == 0) {
+      return false;
+    }
+
+    if (!array.mayHaveNulls()) {
+      // Input array does not have nulls.
+      auto currentValue = *array[0];
+      for (auto i = 1; i < array.size(); i++) {
+        update(currentValue, array[i].value());
+      }
+      assign(out, currentValue);
+      return true;
+    }
+
+    auto it = array.begin();
+    // NULL elements are skipped.
+    while (it != array.end() && !it->has_value()) {
+      ++it;
+    }
+    // If array contains only NULL elements, NULL is returned.
+    if (it == array.end()) {
+      return false;
+    }
+
+    auto currentValue = it->value();
+    ++it;
+    while (it != array.end()) {
+      if (it->has_value()) {
+        update(currentValue, it->value());
+      }
+      ++it;
+    }
+
+    assign(out, currentValue);
+    return true;
+  }
+};
+
+template <typename TExecCtx>
+struct ArrayMinFunction : public ArrayMinMaxFunction<TExecCtx, false> {};
+
+template <typename TExecCtx>
+struct ArrayMaxFunction : public ArrayMinMaxFunction<TExecCtx, true> {};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -21,6 +21,7 @@
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
+#include "velox/functions/sparksql/ArrayFunction.h"
 #include "velox/functions/sparksql/ArraySort.h"
 #include "velox/functions/sparksql/Bitwise.h"
 #include "velox/functions/sparksql/CompareFunctionsNullSafe.h"
@@ -68,6 +69,12 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
 }
 
 namespace sparksql {
+
+template <typename T>
+inline void registerArrayMinMaxFunctions(const std::string& prefix) {
+  registerFunction<ArrayMinFunction, T, Array<T>>({prefix + "array_min"});
+  registerFunction<ArrayMaxFunction, T, Array<T>>({prefix + "array_max"});
+}
 
 void registerFunctions(const std::string& prefix) {
   registerFunction<RandFunction, double>({prefix + "rand"});
@@ -213,6 +220,18 @@ void registerFunctions(const std::string& prefix) {
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});
+
+  registerArrayMinMaxFunctions<int8_t>(prefix);
+  registerArrayMinMaxFunctions<int16_t>(prefix);
+  registerArrayMinMaxFunctions<int32_t>(prefix);
+  registerArrayMinMaxFunctions<int64_t>(prefix);
+  registerArrayMinMaxFunctions<int128_t>(prefix);
+  registerArrayMinMaxFunctions<float>(prefix);
+  registerArrayMinMaxFunctions<double>(prefix);
+  registerArrayMinMaxFunctions<bool>(prefix);
+  registerArrayMinMaxFunctions<Varchar>(prefix);
+  registerArrayMinMaxFunctions<Timestamp>(prefix);
+  registerArrayMinMaxFunctions<Date>(prefix);
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/ArrayMaxTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMaxTest.cpp
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayMaxTest : public SparkFunctionBaseTest {
+ protected:
+  void testArrayMax(const VectorPtr& input, const VectorPtr& expected) {
+    auto result = evaluate<BaseVector>("array_max(C0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  }
+};
+
+TEST_F(ArrayMaxTest, booleanWithNulls) {
+  auto input = makeNullableArrayVector<bool>(
+      {{true, false},
+       {true},
+       {false},
+       {},
+       {true, false, true, std::nullopt},
+       {std::nullopt, true, false, true},
+       {false, false, false},
+       {true, true, true}});
+
+  auto expected = makeNullableFlatVector<bool>(
+      {true, true, false, std::nullopt, true, true, false, true});
+
+  testArrayMax(input, expected);
+}
+
+TEST_F(ArrayMaxTest, booleanNoNulls) {
+  auto input = makeNullableArrayVector<bool>(
+      {{true, false},
+       {true},
+       {false},
+       {},
+       {false, false, false},
+       {true, true, true}});
+
+  auto expected = makeNullableFlatVector<bool>(
+      {true, true, false, std::nullopt, false, true});
+
+  testArrayMax(input, expected);
+}
+
+TEST_F(ArrayMaxTest, varcharWithNulls) {
+  auto input = makeNullableArrayVector<StringView>({
+      {"red"_sv, "blue"_sv},
+      {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv},
+      {},
+      {"red"_sv, "purple"_sv, "green"_sv},
+  });
+
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red"_sv, "yellow"_sv, std::nullopt, "red"_sv});
+
+  testArrayMax(input, expected);
+}
+
+TEST_F(ArrayMaxTest, varcharNoNulls) {
+  auto input = makeArrayVector<StringView>({
+      {"red"_sv, "blue"_sv},
+      {"blue"_sv, "yellow"_sv, "orange"_sv},
+      {},
+      {"red"_sv, "purple"_sv, "green"_sv},
+  });
+
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red"_sv, "yellow"_sv, std::nullopt, "red"_sv});
+
+  testArrayMax(input, expected);
+}
+
+// Test non-inlined (> 12 length) nullable strings.
+TEST_F(ArrayMaxTest, longVarcharWithNulls) {
+  auto input = makeNullableArrayVector<StringView>({
+      {"red shiny car ahead"_sv, "blue clear sky above"_sv},
+      {std::nullopt,
+       "blue clear sky above"_sv,
+       "yellow rose flowers"_sv,
+       "orange beautiful sunset"_sv},
+      {},
+      {"red shiny car ahead"_sv,
+       "purple is an elegant color"_sv,
+       "green plants make us happy"_sv},
+  });
+
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red shiny car ahead"_sv,
+       "yellow rose flowers"_sv,
+       std::nullopt,
+       "red shiny car ahead"_sv});
+
+  testArrayMax(input, expected);
+}
+
+// Test non-inlined (> 12 length) strings.
+TEST_F(ArrayMaxTest, longVarcharNoNulls) {
+  auto input = makeNullableArrayVector<StringView>({
+      {"red shiny car ahead"_sv, "blue clear sky above"_sv},
+      {"blue clear sky above"_sv,
+       "yellow rose flowers"_sv,
+       "orange beautiful sunset"_sv},
+      {},
+      {"red shiny car ahead"_sv,
+       "purple is an elegant color"_sv,
+       "green plants make us happy"_sv},
+  });
+
+  auto expected = makeNullableFlatVector<StringView>(
+      {"red shiny car ahead"_sv,
+       "yellow rose flowers"_sv,
+       std::nullopt,
+       "red shiny car ahead"_sv});
+
+  testArrayMax(input, expected);
+}
+
+template <typename Type>
+class ArrayMaxIntegralTest : public FunctionBaseTest {
+ public:
+  using T = typename Type::NativeType::NativeType;
+
+  void testArrayMax(const VectorPtr& input, const VectorPtr& expected) {
+    auto result =
+        evaluate<SimpleVector<T>>("array_max(C0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  }
+
+  void testWithNulls() {
+    auto input = makeNullableArrayVector<T>(
+        {{std::numeric_limits<T>::min(),
+          0,
+          1,
+          2,
+          3,
+          std::numeric_limits<T>::max()},
+         {std::numeric_limits<T>::max(),
+          3,
+          2,
+          1,
+          0,
+          -1,
+          std::numeric_limits<T>::min()},
+         {101, 102, 103, std::numeric_limits<T>::max(), std::nullopt},
+         {std::nullopt, -1, -2, -3, std::numeric_limits<T>::min()},
+         {},
+         {std::nullopt}});
+
+    auto expected = makeNullableFlatVector<T>(
+        {std::numeric_limits<T>::max(),
+         std::numeric_limits<T>::max(),
+         std::numeric_limits<T>::max(),
+         -1,
+         std::nullopt,
+         std::nullopt});
+
+    testArrayMax(input, expected);
+  }
+
+  void testNoNulls() {
+    auto input = makeArrayVector<T>(
+        {{std::numeric_limits<T>::min(), 0, 1, 2, 3, 4},
+         {std::numeric_limits<T>::max(), 3, 2, 1, 0, -1, -2},
+         {std::numeric_limits<T>::max(),
+          101,
+          102,
+          103,
+          104,
+          105,
+          std::numeric_limits<T>::max()},
+         {}});
+
+    auto expected = makeNullableFlatVector<T>(
+        {4,
+         std::numeric_limits<T>::max(),
+         std::numeric_limits<T>::max(),
+         std::nullopt});
+
+    testArrayMax(input, expected);
+  }
+};
+
+template <typename Type>
+class ArrayMaxFloatingPointTest : public FunctionBaseTest {
+ public:
+  using T = typename Type::NativeType::NativeType;
+  static constexpr T kMin = std::numeric_limits<T>::min();
+  static constexpr T kMax = std::numeric_limits<T>::max();
+  static constexpr T kNaN = std::numeric_limits<T>::quiet_NaN();
+
+  void testArrayMax(VectorPtr input, VectorPtr expected) {
+    auto result =
+        evaluate<SimpleVector<T>>("array_max(C0)", makeRowVector({input}));
+    assertEqualVectors(expected, result);
+  }
+
+  void testWithNulls() {
+    auto input = makeNullableArrayVector<T>(
+        {{0.0000, 0.00001},
+         {std::nullopt, 1.1, 1.11, -2.2, -1.0, kMin},
+         {kMin, -0.0001, -0.0002, -0.0003, kMax, kNaN},
+         {},
+         {kMin, 1.1, 1.22222, 1.33, std::nullopt},
+         {-0.00001, -0.0002, 0.0001}});
+
+    auto expected = makeNullableFlatVector<T>(
+        {0.00001, 1.11, kNaN, std::nullopt, 1.33, 0.0001});
+    testArrayMax(input, expected);
+  }
+
+  void testNoNulls() {
+    auto input = makeArrayVector<T>(
+        {{0.0000, 0.00001},
+         {kMax, 1.1, 1.11, -2.2, -1.0, kMin},
+         {kMin, -0.0001, kNaN, -0.0002, -0.0003, kMax},
+         {},
+         {1.1, 1.22222, 1.33},
+         {-0.00001, -0.0002, 0.0001}});
+
+    auto expected = makeNullableFlatVector<T>(
+        {0.00001, kMax, kNaN, std::nullopt, 1.33, 0.0001});
+    testArrayMax(input, expected);
+  }
+};
+
+TYPED_TEST_SUITE(ArrayMaxIntegralTest, FunctionBaseTest::IntegralTypes);
+
+TYPED_TEST(ArrayMaxIntegralTest, arrayMaxNullable) {
+  this->testWithNulls();
+}
+
+TYPED_TEST(ArrayMaxIntegralTest, arrayMax) {
+  this->testNoNulls();
+}
+
+TYPED_TEST_SUITE(
+    ArrayMaxFloatingPointTest,
+    FunctionBaseTest::FloatingPointTypes);
+
+TYPED_TEST(ArrayMaxFloatingPointTest, arrayMaxNullable) {
+  this->testWithNulls();
+}
+
+TYPED_TEST(ArrayMaxFloatingPointTest, arrayMax) {
+  this->testNoNulls();
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/ArrayMinTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayMinTest.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits>
+#include <optional>
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+using namespace facebook::velox::functions::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayMinTest : public SparkFunctionBaseTest {
+ protected:
+  template <typename T, typename TExpected = T>
+  void testExpr(
+      const VectorPtr& expected,
+      const std::string& expression,
+      const std::vector<VectorPtr>& input) {
+    auto result =
+        evaluate<SimpleVector<TExpected>>(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename T>
+  void testIntNullable() {
+    auto arrayVector = makeNullableArrayVector<T>(
+        {{-1, 0, 1, 2, 3, 4},
+         {4, 3, 2, 1, std::nullopt, 0, -1, -2},
+         {-5, -4, -3, -2, -1},
+         {101, 102, 103, 104, std::nullopt},
+         {std::nullopt, -1, -2, std::nullopt, -3, -4},
+         {},
+         {std::nullopt, std::nullopt}});
+    auto expected = makeNullableFlatVector<T>(
+        {-1, -2, -5, 101, -4, std::nullopt, std::nullopt});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  template <typename T>
+  void testInt() {
+    auto arrayVector = makeArrayVector<T>(
+        {{-1, 0, 1, 2, 3, 4},
+         {4, 3, 2, 1, 0, -1, -2},
+         {-5, -4, -3, -2, -1},
+         {101, 102, 103, 104, 105},
+         {}});
+    auto expected = makeNullableFlatVector<T>({-1, -2, -5, 101, std::nullopt});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testInLineVarcharNullable() {
+    using S = StringView;
+
+    auto arrayVector = makeNullableArrayVector<S>({
+        {S("red"), S("blue")},
+        {std::nullopt, S("blue"), S("yellow"), S("orange")},
+        {},
+        {std::nullopt, std::nullopt},
+        {S("red"), S("purple"), S("green")},
+    });
+    auto expected = makeNullableFlatVector<S>(
+        {S("blue"), S("blue"), std::nullopt, std::nullopt, S("green")});
+    testExpr<S>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testVarcharNullable() {
+    using S = StringView;
+    // use > 12 length string to avoid inlining
+    auto arrayVector = makeNullableArrayVector<S>({
+        {S("red shiny car ahead"), S("blue clear sky above")},
+        {std::nullopt,
+         S("blue clear sky above"),
+         S("yellow rose flowers"),
+         S("orange beautiful sunset")},
+        {},
+        {std::nullopt, std::nullopt},
+        {S("red shiny car ahead"),
+         S("purple is an elegant color"),
+         S("green plants make us happy")},
+    });
+    auto expected = makeNullableFlatVector<S>(
+        {S("blue clear sky above"),
+         S("blue clear sky above"),
+         std::nullopt,
+         std::nullopt,
+         S("green plants make us happy")});
+    testExpr<S>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testBoolNullable() {
+    auto arrayVector = makeNullableArrayVector<bool>(
+        {{true, false},
+         {true},
+         {false},
+         {},
+         {std::nullopt, std::nullopt},
+         {true, false, true, std::nullopt},
+         {std::nullopt, true, false, true},
+         {false, false, false},
+         {true, true, true}});
+
+    auto expected = makeNullableFlatVector<bool>(
+        {false,
+         true,
+         false,
+         std::nullopt,
+         std::nullopt,
+         false,
+         false,
+         false,
+         true});
+    testExpr<bool>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  void testBool() {
+    auto arrayVector = makeArrayVector<bool>(
+        {{true, false},
+         {true},
+         {false},
+         {},
+         {false, false, false},
+         {true, true, true}});
+
+    auto expected = makeNullableFlatVector<bool>(
+        {false, true, false, std::nullopt, false, true});
+    testExpr<bool>(expected, "array_min(C0)", {arrayVector});
+  }
+
+  template <typename T>
+  void testNumNullable() {
+    constexpr T kNaN = std::numeric_limits<T>::quiet_NaN();
+    auto arrayVector = makeNullableArrayVector<T>(
+        {{-1.0, 0.0, 1.0, kNaN, 2.0, 3.0, 4.0},
+         {4.0, 3.0, 2.0, 1.0, std::nullopt, 0.0, -1.0, -2.0, kNaN},
+         {-5.0, -4.0, -3.0, -2.0, -1.0},
+         {101.0, 102.0, 103.0, 104.0, std::nullopt},
+         {std::nullopt, -1.0, -2.0, std::nullopt, -3.0, -4.0},
+         {},
+         {std::nullopt, std::nullopt},
+         {kNaN, std::nullopt, -1.0, kNaN, -2.0},
+         {std::nullopt, kNaN}});
+    auto expected = makeNullableFlatVector<T>(
+        {-1.0,
+         -2.0,
+         -5.0,
+         101.0,
+         -4.0,
+         std::nullopt,
+         std::nullopt,
+         -2.0,
+         kNaN});
+    testExpr<T>(expected, "array_min(C0)", {arrayVector});
+  }
+};
+
+TEST_F(ArrayMinTest, intArrays) {
+  testIntNullable<int8_t>();
+  testIntNullable<int16_t>();
+  testIntNullable<int32_t>();
+  testIntNullable<int64_t>();
+  testInt<int8_t>();
+  testInt<int16_t>();
+  testInt<int32_t>();
+  testInt<int64_t>();
+}
+
+TEST_F(ArrayMinTest, varcharArrays) {
+  testInLineVarcharNullable();
+  testVarcharNullable();
+}
+
+TEST_F(ArrayMinTest, boolArrays) {
+  testBoolNullable();
+  testBool();
+}
+
+TEST_F(ArrayMinTest, numArrays) {
+  testNumNullable<float>();
+  testNumNullable<double>();
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
   ArraySortTest.cpp
+  ArrayMaxTest.cpp
   ArrayMinTest.cpp
   BitwiseTest.cpp
   CompareNullSafeTests.cpp

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_test
   ArithmeticTest.cpp
   ArraySortTest.cpp
+  ArrayMinTest.cpp
   BitwiseTest.cpp
   CompareNullSafeTests.cpp
   DateTimeFunctionsTest.cpp


### PR DESCRIPTION
In presto, array_max returns NULL when input contains any NULL element.
In spark, NULL elements are skipped. If the array is empty or contains only NULL elements, NULL is returned.

Spark 3.2 ref: https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L1852