### PR TITLE
Add schema to parquet writer options

### DIFF
--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -157,6 +157,7 @@ class ParquetTestBase : public testing::Test, public test::VectorTestBase {
       std::function<
           std::unique_ptr<facebook::velox::parquet::DefaultFlushPolicy>()>
           flushPolicy,
+      const RowTypePtr& rowType,
       facebook::velox::common::CompressionKind compressionKind =
           facebook::velox::common::CompressionKind_NONE) {
     facebook::velox::parquet::WriterOptions options;
@@ -164,7 +165,7 @@ class ParquetTestBase : public testing::Test, public test::VectorTestBase {
     options.flushPolicyFactory = flushPolicy;
     options.compression = compressionKind;
     return std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), options);
+        std::move(sink), options, rowType);
   }
 
   std::vector<RowVectorPtr> createBatches(

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/dwio/common/tests/E2EFilterTestBase.h"
 #include "velox/dwio/parquet/reader/ParquetReader.h"
 #include "velox/dwio/parquet/writer/Writer.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <folly/init/Init.h>
 
@@ -27,7 +28,7 @@ using namespace facebook::velox::parquet;
 
 using dwio::common::MemorySink;
 
-class E2EFilterTest : public E2EFilterTestBase {
+class E2EFilterTest : public E2EFilterTestBase, public test::VectorTestBase {
  protected:
   void SetUp() override {
     E2EFilterTestBase::SetUp();
@@ -53,13 +54,13 @@ class E2EFilterTest : public E2EFilterTestBase {
   }
 
   void writeToMemory(
-      const TypePtr&,
+      const TypePtr& type,
       const std::vector<RowVectorPtr>& batches,
       bool forRowGroupSkip = false) override {
     auto sink = std::make_unique<MemorySink>(
         200 * 1024 * 1024, FileSink::Options{.pool = leafPool_.get()});
     sinkPtr_ = sink.get();
-    options_.memoryPool = rootPool_.get();
+    options_.memoryPool = E2EFilterTestBase::rootPool_.get();
     int32_t flushCounter = 0;
     options_.flushPolicyFactory = [&]() {
       return std::make_unique<LambdaFlushPolicy>(
@@ -71,7 +72,7 @@ class E2EFilterTest : public E2EFilterTestBase {
     };
 
     writer_ = std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), options_);
+        std::move(sink), options_, asRowType(type));
     for (auto& batch : batches) {
       writer_->write(batch);
     }
@@ -92,7 +93,7 @@ class E2EFilterTest : public E2EFilterTestBase {
 };
 
 TEST_F(E2EFilterTest, writerMagic) {
-  rowType_ = ROW({INTEGER()});
+  rowType_ = ROW({"c0"}, {INTEGER()});
   std::vector<RowVectorPtr> batches;
   batches.push_back(std::static_pointer_cast<RowVector>(
       test::BatchMaker::createBatch(rowType_, 20000, *leafPool_, nullptr, 0)));
@@ -561,7 +562,7 @@ TEST_F(E2EFilterTest, varbinaryDictionary) {
 TEST_F(E2EFilterTest, largeMetadata) {
   rowsInRowGroup_ = 1;
 
-  rowType_ = ROW({INTEGER()});
+  rowType_ = ROW({"c0"}, {INTEGER()});
   std::vector<RowVectorPtr> batches;
   batches.push_back(std::static_pointer_cast<RowVector>(
       test::BatchMaker::createBatch(rowType_, 1000, *leafPool_, nullptr, 0)));
@@ -598,7 +599,7 @@ TEST_F(E2EFilterTest, date) {
 
 TEST_F(E2EFilterTest, combineRowGroup) {
   rowsInRowGroup_ = 5;
-  rowType_ = ROW({INTEGER()});
+  rowType_ = ROW({"c0"}, {INTEGER()});
   std::vector<RowVectorPtr> batches;
   for (int i = 0; i < 5; i++) {
     batches.push_back(std::static_pointer_cast<RowVector>(
@@ -613,6 +614,29 @@ TEST_F(E2EFilterTest, combineRowGroup) {
   auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
   EXPECT_EQ(parquetReader.numberOfRowGroups(), 1);
   EXPECT_EQ(parquetReader.numberOfRows(), 5);
+}
+
+TEST_F(E2EFilterTest, configurableWriteSchema) {
+  auto rowType = ROW({"c0", "c1"}, {INTEGER(), ROW({"c2"}, {INTEGER()})});
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 5; i++) {
+    batches.push_back(makeRowVector(
+        {"c0", "c1"},
+        {makeFlatVector<int32_t>(std::vector<int32_t>{100}),
+         makeRowVector(
+             {"c2"}, {makeFlatVector<int32_t>(std::vector<int32_t>{100})})}));
+  }
+
+  auto newType =
+      ROW({"int32", "struct"}, {INTEGER(), ROW({"struct_c0"}, {INTEGER()})});
+  writeToMemory(newType, batches, false);
+  std::string_view data(sinkPtr_->data(), sinkPtr_->size());
+  dwio::common::ReaderOptions readerOpts{leafPool_.get()};
+  auto input = std::make_unique<BufferedInput>(
+      std::make_shared<InMemoryReadFile>(data), readerOpts.getMemoryPool());
+  auto reader = makeReader(readerOpts, std::move(input));
+  auto parquetReader = dynamic_cast<ParquetReader&>(*reader.get());
+  EXPECT_EQ(parquetReader.rowType()->toString(), newType->toString());
 }
 
 // Define main so that gflags get processed.

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -39,7 +39,9 @@ const double kFilterErrorMargin = 0.2;
 
 class ParquetReaderBenchmark {
  public:
-  explicit ParquetReaderBenchmark(bool disableDictionary)
+  explicit ParquetReaderBenchmark(
+      bool disableDictionary,
+      const RowTypePtr& rowType)
       : disableDictionary_(disableDictionary) {
     rootPool_ =
         memory::defaultMemoryManager().addRootPool("ParquetReaderBenchmark");
@@ -56,7 +58,7 @@ class ParquetReaderBenchmark {
     }
     options.memoryPool = rootPool_.get();
     writer_ = std::make_unique<facebook::velox::parquet::Writer>(
-        std::move(sink), options);
+        std::move(sink), options, rowType);
   }
 
   ~ParquetReaderBenchmark() {}
@@ -272,7 +274,7 @@ void run(
     uint8_t nullsRateX100,
     uint32_t nextSize,
     bool disableDictionary) {
-  ParquetReaderBenchmark benchmark(disableDictionary);
+  ParquetReaderBenchmark benchmark(disableDictionary, asRowType(type));
   BIGINT()->toString();
   benchmark.readSingleColumn(
       columnName, type, 0, filterRateX100, nullsRateX100, nextSize);

--- a/velox/dwio/parquet/tests/writer/SinkTests.cpp
+++ b/velox/dwio/parquet/tests/writer/SinkTests.cpp
@@ -23,14 +23,18 @@ using namespace facebook::velox::parquet;
 class SinkTest : public ParquetTestBase {};
 
 TEST_F(SinkTest, close) {
-  auto batches = createBatches(ROW({INTEGER(), VARCHAR()}), 2, 3);
+  auto rowType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});
+  auto batches = createBatches(rowType, 2, 3);
   auto filePath = fs::path(fmt::format("{}/test_close.txt", tempPath_->path));
   auto sink = createSink(filePath.string());
   auto sinkPtr = sink.get();
-  auto writer = createWriter(std::move(sink), [&]() {
-    return std::make_unique<LambdaFlushPolicy>(
-        kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
-  });
+  auto writer = createWriter(
+      std::move(sink),
+      [&]() {
+        return std::make_unique<LambdaFlushPolicy>(
+            kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
+      },
+      rowType);
 
   for (auto& batch : batches) {
     writer->write(batch);
@@ -49,14 +53,18 @@ TEST_F(SinkTest, close) {
 }
 
 TEST_F(SinkTest, abort) {
-  auto batches = createBatches(ROW({INTEGER(), VARCHAR()}), 2, 3);
+  auto rowType = ROW({"c0", "c1"}, {INTEGER(), VARCHAR()});
+  auto batches = createBatches(rowType, 2, 3);
   auto filePath = fs::path(fmt::format("{}/test_abort.txt", tempPath_->path));
   auto sink = createSink(filePath.string());
   auto sinkPtr = sink.get();
-  auto writer = createWriter(std::move(sink), [&]() {
-    return std::make_unique<LambdaFlushPolicy>(
-        kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
-  });
+  auto writer = createWriter(
+      std::move(sink),
+      [&]() {
+        return std::make_unique<LambdaFlushPolicy>(
+            kRowsInRowGroup, kBytesInRowGroup, [&]() { return false; });
+      },
+      rowType);
 
   for (auto& batch : batches) {
     writer->write(batch);

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -168,7 +168,6 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
     const std::string& name = "") {
   if (type.isRow()) {
     auto rowType = type.asRow();
-    // Update rowType itselef name.
     auto newField = field->WithName(name);
     auto structType =
         std::dynamic_pointer_cast<::arrow::StructType>(newField->type());
@@ -181,7 +180,6 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
     }
     return newField->WithType(::arrow::struct_(newFields));
   } else if (type.isArray()) {
-    // Update arrayType itselef name.
     auto newField = field->WithName(name);
     auto listType =
         std::dynamic_pointer_cast<::arrow::BaseListType>(newField->type());
@@ -191,7 +189,6 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
         ::arrow::list(updateFieldNameRecursive(elementField, *elementType)));
   } else if (type.isMap()) {
     auto mapType = type.asMap();
-    // Update arrayType itselef name.
     auto newField = field->WithName(name);
     auto arrowMapType =
         std::dynamic_pointer_cast<::arrow::MapType>(newField->type());
@@ -203,8 +200,9 @@ std::shared_ptr<::arrow::Field> updateFieldNameRecursive(
         ::arrow::map(newKeyField->type(), newValueField->type()));
   } else if (name != "") {
     return field->WithName(name);
-  } else
+  } else {
     return field;
+  }
 }
 
 } // namespace

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -255,26 +255,10 @@ dwio::common::StripeProgress getStripeProgress(
  *
  * This method assumes each input `ColumnarBatch` have same schema.
  */
-void Writer::write(const VectorPtr& dataToWrite) {
+void Writer::write(const VectorPtr& data) {
   VELOX_USER_CHECK(
-      dataToWrite->type()->equivalent(*schema_),
+      data->type()->equivalent(*schema_),
       "The file schema type should be equal with the input rowvector type.");
-  auto data = std::dynamic_pointer_cast<RowVector>(dataToWrite);
-  VELOX_CHECK_NULL(data->nulls());
-
-  // VELOX_CHECK_EQ(
-  //     schema_.use_count(),
-  //     1,
-  //     "The schema_ should be singly-referenced before calling the
-  //     BaseVector::setType() method");
-  // auto children = schema_->children();
-  // for (int i = 0; i < children.size(); i++) {
-  //   VELOX_CHECK_EQ(
-  //       children[i].use_count(),
-  //       1,
-  //       "The children vectors type of schema_ should be singly-referenced
-  //       before calling the BaseVector::setType() method");
-  // }
 
   data->setType(schema_);
 

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -106,15 +106,18 @@ class Writer : public dwio::common::Writer {
   // Constructs a writer with output to 'sink'. A new row group is
   // started every 'rowsInRowGroup' top level rows. 'pool' is used for
   // temporary memory. 'properties' specifies Parquet-specific
-  // options.
+  // options. 'schema' specifies the file's overall schema, and it is always
+  // non-null.
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
       const WriterOptions& options,
-      std::shared_ptr<memory::MemoryPool> pool);
+      std::shared_ptr<memory::MemoryPool> pool,
+      RowTypePtr schema);
 
   Writer(
       std::unique_ptr<dwio::common::FileSink> sink,
-      const WriterOptions& options);
+      const WriterOptions& options,
+      RowTypePtr schema);
 
   ~Writer() override = default;
 
@@ -146,6 +149,8 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<ArrowContext> arrowContext_;
 
   std::unique_ptr<DefaultFlushPolicy> flushPolicy_;
+
+  const RowTypePtr schema_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {


### PR DESCRIPTION
Here is the schema information for the TPCH `supplier `table.
```
root
 |-- s_suppkey: long (nullable = true)  
 |-- s_name: string (nullable = true) 
 |-- s_address: string (nullable = true)  
 |-- s_nationkey: long (nullable = true)  
 |-- s_phone: string (nullable = true)  
 |-- s_acctbal: double (nullable = true)  
 |-- s_comment: string (nullable = true)  
```

 When we write the `supplier `table into a parquet file using velox parquet writer in Gluten, we encounter the incorrect schema issue.

```
root
 |-- n0_0: long (nullable = true)
 |-- n0_1: string (nullable = true)
 |-- n0_2: string (nullable = true)
 |-- n0_3: long (nullable = true)
 |-- n0_4: string (nullable = true)
 |-- n0_5: double (nullable = true)
 |-- n0_6: string (nullable = true)
```

The reason for this is that the schema is inferred from the record batch. To address this, this PR introduces a schema into the `WriterOption`. This allows us to pass the appropriate schema to the Parquet writer.