### PR TITLE
Add current_timezone() presto function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -6,6 +6,10 @@ Date and Time Functions
 
     Returns the current date.
 
+.. function:: current_timezone() -> string
+
+    Returns current timezone in the format defined by IANA.
+
 .. function:: date(x) -> date
 
     This is an alias for ``CAST(x AS date)``.

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -100,6 +100,28 @@ struct TimestampWithTimezoneSupport {
 } // namespace
 
 template <typename T>
+struct CurrentTimezoneFunction : public TimestampWithTimezoneSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  std::string timezoneId;
+
+  FOLLY_ALWAYS_INLINE void initialize(const core::QueryConfig& config) {
+    auto sessionTzName = config.sessionTimezone();
+
+    std::optional<int64_t> sessionTzID;
+    // Set the timezone to the session timezone. If there's
+    // no session timezone, fallback to 0 (GMT).
+    if (!sessionTzName.empty()) {
+      sessionTzID = util::getTimeZoneID(sessionTzName);
+    }
+    timezoneId = std::to_string(sessionTzID.value_or(0));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(out_type<Varchar>& result) {
+    result = timezoneId;
+  }
+};
+template <typename T>
 struct DateFunction : public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -28,6 +28,8 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_unixtime"});
   registerFunction<FromUnixtimeFunction, Timestamp, double>(
       {prefix + "from_unixtime"});
+  registerFunction<CurrentTimezoneFunction, Varchar>(
+      {prefix + "current_timezone"});
   registerFunction<DateFunction, Date, Varchar>({prefix + "date"});
   registerFunction<DateFunction, Date, Timestamp>({prefix + "date"});
   registerFunction<DateFunction, Date, TimestampWithTimezone>(


### PR DESCRIPTION
Implementing `current_timezone()` presto function. 

Resolves https://github.com/facebookincubator/velox/issues/4671