### PR TITLE
Add spill metric spilledInputBytes

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -274,6 +274,7 @@ void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
 void Operator::recordSpillStats(const SpillStats& spillStats) {
   VELOX_CHECK(noMoreInput_);
   auto lockedStats = stats_.wlock();
+  lockedStats->spilledMemoryBytes += spillStats.spilledMemoryBytes;
   lockedStats->spilledBytes += spillStats.spilledBytes;
   lockedStats->spilledRows += spillStats.spilledRows;
   lockedStats->spilledPartitions += spillStats.spilledPartitions;
@@ -439,6 +440,7 @@ void OperatorStats::add(const OperatorStats& other) {
   }
 
   numDrivers += other.numDrivers;
+  spilledMemoryBytes += other.spilledMemoryBytes;
   spilledBytes += other.spilledBytes;
   spilledRows += other.spilledRows;
   spilledPartitions += other.spilledPartitions;
@@ -467,6 +469,13 @@ void OperatorStats::clear() {
   memoryStats.clear();
 
   runtimeStats.clear();
+
+  numDrivers = 0;
+  spilledMemoryBytes = 0;
+  spilledBytes = 0;
+  spilledRows = 0;
+  spilledPartitions = 0;
+  spilledFiles = 0;
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Operator::MemoryReclaimer::create(

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -274,7 +274,7 @@ void Operator::recordBlockingTime(uint64_t start, BlockingReason reason) {
 void Operator::recordSpillStats(const SpillStats& spillStats) {
   VELOX_CHECK(noMoreInput_);
   auto lockedStats = stats_.wlock();
-  lockedStats->spilledMemoryBytes += spillStats.spilledMemoryBytes;
+  lockedStats->spilledInputBytes += spillStats.spilledInputBytes;
   lockedStats->spilledBytes += spillStats.spilledBytes;
   lockedStats->spilledRows += spillStats.spilledRows;
   lockedStats->spilledPartitions += spillStats.spilledPartitions;
@@ -440,7 +440,7 @@ void OperatorStats::add(const OperatorStats& other) {
   }
 
   numDrivers += other.numDrivers;
-  spilledMemoryBytes += other.spilledMemoryBytes;
+  spilledInputBytes += other.spilledInputBytes;
   spilledBytes += other.spilledBytes;
   spilledRows += other.spilledRows;
   spilledPartitions += other.spilledPartitions;
@@ -471,7 +471,7 @@ void OperatorStats::clear() {
   runtimeStats.clear();
 
   numDrivers = 0;
-  spilledMemoryBytes = 0;
+  spilledInputBytes = 0;
   spilledBytes = 0;
   spilledRows = 0;
   spilledPartitions = 0;

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -126,7 +126,10 @@ struct OperatorStats {
 
   MemoryStats memoryStats;
 
-  // Total bytes written for spilling.
+  // Total bytes in memory for spilling
+  uint64_t spilledMemoryBytes{0};
+
+  // Total bytes written to file for spilling.
   uint64_t spilledBytes{0};
 
   // Total rows written for spilling.

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -127,7 +127,7 @@ struct OperatorStats {
   MemoryStats memoryStats;
 
   // Total bytes in memory for spilling
-  uint64_t spilledMemoryBytes{0};
+  uint64_t spilledInputBytes{0};
 
   // Total bytes written to file for spilling.
   uint64_t spilledBytes{0};

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -71,7 +71,7 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
 
   numSplits += stats.numSplits;
 
-  spilledMemoryBytes += stats.spilledMemoryBytes;
+  spilledInputBytes += stats.spilledInputBytes;
   spilledBytes += stats.spilledBytes;
   spilledRows += stats.spilledRows;
   spilledPartitions += stats.spilledPartitions;
@@ -148,7 +148,7 @@ folly::dynamic toPlanStatsJson(const facebook::velox::exec::TaskStats& stats) {
       stat["numMemoryAllocations"] = operatorStat.second->numMemoryAllocations;
       stat["numDrivers"] = operatorStat.second->numDrivers;
       stat["numSplits"] = operatorStat.second->numSplits;
-      stat["spilledMemoryBytes"] = operatorStat.second->spilledMemoryBytes;
+      stat["spilledInputBytes"] = operatorStat.second->spilledInputBytes;
       stat["spilledBytes"] = operatorStat.second->spilledBytes;
       stat["spilledRows"] = operatorStat.second->spilledRows;
       stat["spilledFiles"] = operatorStat.second->spilledFiles;

--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -71,6 +71,7 @@ void PlanNodeStats::addTotals(const OperatorStats& stats) {
 
   numSplits += stats.numSplits;
 
+  spilledMemoryBytes += stats.spilledMemoryBytes;
   spilledBytes += stats.spilledBytes;
   spilledRows += stats.spilledRows;
   spilledPartitions += stats.spilledPartitions;
@@ -147,6 +148,10 @@ folly::dynamic toPlanStatsJson(const facebook::velox::exec::TaskStats& stats) {
       stat["numMemoryAllocations"] = operatorStat.second->numMemoryAllocations;
       stat["numDrivers"] = operatorStat.second->numDrivers;
       stat["numSplits"] = operatorStat.second->numSplits;
+      stat["spilledMemoryBytes"] = operatorStat.second->spilledMemoryBytes;
+      stat["spilledBytes"] = operatorStat.second->spilledBytes;
+      stat["spilledRows"] = operatorStat.second->spilledRows;
+      stat["spilledFiles"] = operatorStat.second->spilledFiles;
 
       folly::dynamic cs = folly::dynamic::object;
       for (const auto& cstat : operatorStat.second->customStats) {

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -99,6 +99,9 @@ struct PlanNodeStats {
   /// Number of total splits.
   int numSplits{0};
 
+  // Total bytes in memory for spilling
+  uint64_t spilledMemoryBytes{0};
+
   /// Total bytes written for spilling.
   uint64_t spilledBytes{0};
 

--- a/velox/exec/PlanNodeStats.h
+++ b/velox/exec/PlanNodeStats.h
@@ -100,7 +100,7 @@ struct PlanNodeStats {
   int numSplits{0};
 
   // Total bytes in memory for spilling
-  uint64_t spilledMemoryBytes{0};
+  uint64_t spilledInputBytes{0};
 
   /// Total bytes written for spilling.
   uint64_t spilledBytes{0};

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -311,7 +311,7 @@ void SpillState::setPartitionSpilled(int32_t partition) {
   incrementGlobalSpilledPartitionStats();
 }
 
-void SpillState::updateSpilledInputBytes(int32_t partition, uint64_t bytes) {
+void SpillState::updateSpilledInputBytes(uint64_t bytes) {
   auto statsLocked = stats_->wlock();
   statsLocked->spilledInputBytes += bytes;
   updateGlobalSpillMemoryBytes(bytes);
@@ -334,7 +334,7 @@ uint64_t SpillState::appendToPartition(
         pool_,
         stats_);
   }
-  updateSpilledInputBytes(partition, rows->estimateFlatSize());
+  updateSpilledInputBytes(rows->estimateFlatSize());
 
   IndexRange range{0, rows->size()};
   return files_[partition]->write(rows, folly::Range<IndexRange*>(&range, 1));
@@ -639,11 +639,6 @@ void updateGlobalSpillWriteStats(
 void updateGlobalSpillMemoryBytes(uint64_t spilledInputBytes) {
   auto statsLocked = localSpillStats().wlock();
   statsLocked->spilledInputBytes += spilledInputBytes;
-}
-
-void decrementGlobalSpillMemoryBytes(uint64_t spilledInputBytes) {
-  auto statsLocked = localSpillStats().wlock();
-  statsLocked->spilledInputBytes -= spilledInputBytes;
 }
 
 void incrementGlobalSpilledFiles() {

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -652,7 +652,7 @@ class SpillState {
   std::vector<std::string> testingSpilledFilePaths() const;
 
  private:
-  void updateSpilledInputBytes(int32_t partition, uint64_t bytes);
+  void updateSpilledInputBytes(uint64_t bytes);
 
   const RowTypePtr type_;
   const std::string path_;
@@ -700,8 +700,7 @@ void updateGlobalSpillWriteStats(
     uint64_t writeTimeUs);
 // Increment the spill memory bytes.
 void updateGlobalSpillMemoryBytes(uint64_t spilledInputBytes);
-// Decrement the spill memory bytes.
-void decrementGlobalSpillMemoryBytes(uint64_t spilledInputBytes);
+
 /// Increments the spilled files by one.
 void incrementGlobalSpilledFiles();
 

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -146,7 +146,7 @@ struct SpillStats {
   /// The number of times that spilling runs on an operator.
   uint64_t spillRuns{0};
   // The number of bytes in memory to spill
-  uint64_t spilledMemoryBytes{0};
+  uint64_t spilledInputBytes{0};
   /// The number of bytes spilled to disks.
   ///
   /// NOTE: if compression is enabled, this counts the compressed bytes.
@@ -174,7 +174,7 @@ struct SpillStats {
 
   SpillStats(
       uint64_t _spillRuns,
-      uint64_t _spilledMemoryBytes,
+      uint64_t _spilledInputBytes,
       uint64_t _spilledBytes,
       uint64_t _spilledRows,
       uint32_t _spilledPartitions,
@@ -652,7 +652,7 @@ class SpillState {
   std::vector<std::string> testingSpilledFilePaths() const;
 
  private:
-  void updateSpilledMemoryBytes(int32_t partition, uint64_t bytes, bool isAdd);
+  void updateSpilledInputBytes(int32_t partition, uint64_t bytes);
 
   const RowTypePtr type_;
   const std::string path_;
@@ -670,9 +670,6 @@ class SpillState {
   // A file list for each spilled partition. Only partitions that have
   // started spilling have an entry here.
   std::vector<std::unique_ptr<SpillFileList>> files_;
-
-  // Bytes in memory to spill for each partition.
-  std::vector<uint64_t> spilledMemoryBytes_;
 };
 
 /// Generate partition id set from given spill partition set.
@@ -702,9 +699,9 @@ void updateGlobalSpillWriteStats(
     uint64_t flushTimeUs,
     uint64_t writeTimeUs);
 // Increment the spill memory bytes.
-void incrementGlobalSpillMemoryBytes(uint64_t spilledMemoryBytes);
+void updateGlobalSpillMemoryBytes(uint64_t spilledInputBytes);
 // Decrement the spill memory bytes.
-void decrementGlobalSpillMemoryBytes(uint64_t spilledMemoryBytes);
+void decrementGlobalSpillMemoryBytes(uint64_t spilledInputBytes);
 /// Increments the spilled files by one.
 void incrementGlobalSpilledFiles();
 

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -145,6 +145,8 @@ class SpillFile {
 struct SpillStats {
   /// The number of times that spilling runs on an operator.
   uint64_t spillRuns{0};
+  // The number of bytes in memory to spill
+  uint64_t spilledMemoryBytes{0};
   /// The number of bytes spilled to disks.
   ///
   /// NOTE: if compression is enabled, this counts the compressed bytes.
@@ -172,6 +174,7 @@ struct SpillStats {
 
   SpillStats(
       uint64_t _spillRuns,
+      uint64_t _spilledMemoryBytes,
       uint64_t _spilledBytes,
       uint64_t _spilledRows,
       uint32_t _spilledPartitions,
@@ -649,6 +652,8 @@ class SpillState {
   std::vector<std::string> testingSpilledFilePaths() const;
 
  private:
+  void updateSpilledMemoryBytes(int32_t partition, uint64_t bytes, bool isAdd);
+
   const RowTypePtr type_;
   const std::string path_;
   const int32_t maxPartitions_;
@@ -665,6 +670,9 @@ class SpillState {
   // A file list for each spilled partition. Only partitions that have
   // started spilling have an entry here.
   std::vector<std::unique_ptr<SpillFileList>> files_;
+
+  // Bytes in memory to spill for each partition.
+  std::vector<uint64_t> spilledMemoryBytes_;
 };
 
 /// Generate partition id set from given spill partition set.
@@ -693,6 +701,10 @@ void updateGlobalSpillWriteStats(
     uint64_t spilledBytes,
     uint64_t flushTimeUs,
     uint64_t writeTimeUs);
+// Increment the spill memory bytes.
+void incrementGlobalSpillMemoryBytes(uint64_t spilledMemoryBytes);
+// Decrement the spill memory bytes.
+void decrementGlobalSpillMemoryBytes(uint64_t spilledMemoryBytes);
 /// Increments the spilled files by one.
 void incrementGlobalSpilledFiles();
 

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1072,9 +1072,9 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
                     .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats[0].operatorStats[1];
-    ASSERT_EQ(testData.expectSpill, stats.spilledBytes > 0);
     if (testData.expectSpill) {
       ASSERT_GT(stats.spilledRows, 0);
+      ASSERT_GT(stats.spilledMemoryBytes, 0);
       ASSERT_GT(stats.spilledBytes, 0);
       ASSERT_GT(stats.spilledPartitions, 0);
       ASSERT_GT(stats.spilledFiles, 0);
@@ -1087,6 +1087,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
       ASSERT_GT(stats.runtimeStats["spillWriteTime"].sum, 0);
     } else {
       ASSERT_EQ(stats.spilledRows, 0);
+      ASSERT_EQ(stats.spilledMemoryBytes, 0);
       ASSERT_EQ(stats.spilledBytes, 0);
       ASSERT_EQ(stats.spilledPartitions, 0);
       ASSERT_EQ(stats.spilledFiles, 0);
@@ -1219,6 +1220,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
 
     auto stats = task->taskStats().pipelineStats;
     // Check spilled bytes.
+    EXPECT_LT(0, stats[0].operatorStats[1].spilledMemoryBytes);
     EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
     EXPECT_GE(kNumPartitions - 1, stats[0].operatorStats[1].spilledPartitions);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
@@ -1332,6 +1334,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
 
   auto stats = task->taskStats().pipelineStats;
   // Check spilled bytes.
+  EXPECT_LT(0, stats[0].operatorStats[1].spilledMemoryBytes);
   EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
   EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
@@ -1618,6 +1621,8 @@ TEST_F(AggregationTest, distinctWithSpilling) {
                             .planNode())
                   .assertResults("SELECT distinct c0 FROM tmp");
   // Verify that spilling is not triggered.
+  ASSERT_EQ(
+      toPlanStats(task->taskStats()).at(aggrNodeId).spilledMemoryBytes, 0);
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
@@ -1656,6 +1661,8 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
           .assertResults("SELECT c0, c1, sum(c2) FROM tmp GROUP BY c0, c1");
   auto stats = task->taskStats().pipelineStats;
   // Verify that spilling is not triggered.
+  ASSERT_EQ(
+      toPlanStats(task->taskStats()).at(aggrNodeId).spilledMemoryBytes, 0);
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1074,7 +1074,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
     auto stats = task->taskStats().pipelineStats[0].operatorStats[1];
     if (testData.expectSpill) {
       ASSERT_GT(stats.spilledRows, 0);
-      ASSERT_GT(stats.spilledMemoryBytes, 0);
+      ASSERT_GT(stats.spilledInputBytes, 0);
       ASSERT_GT(stats.spilledBytes, 0);
       ASSERT_GT(stats.spilledPartitions, 0);
       ASSERT_GT(stats.spilledFiles, 0);
@@ -1087,7 +1087,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
       ASSERT_GT(stats.runtimeStats["spillWriteTime"].sum, 0);
     } else {
       ASSERT_EQ(stats.spilledRows, 0);
-      ASSERT_EQ(stats.spilledMemoryBytes, 0);
+      ASSERT_EQ(stats.spilledInputBytes, 0);
       ASSERT_EQ(stats.spilledBytes, 0);
       ASSERT_EQ(stats.spilledPartitions, 0);
       ASSERT_EQ(stats.spilledFiles, 0);
@@ -1220,7 +1220,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
 
     auto stats = task->taskStats().pipelineStats;
     // Check spilled bytes.
-    EXPECT_LT(0, stats[0].operatorStats[1].spilledMemoryBytes);
+    EXPECT_LT(0, stats[0].operatorStats[1].spilledInputBytes);
     EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
     EXPECT_GE(kNumPartitions - 1, stats[0].operatorStats[1].spilledPartitions);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
@@ -1334,7 +1334,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
 
   auto stats = task->taskStats().pipelineStats;
   // Check spilled bytes.
-  EXPECT_LT(0, stats[0].operatorStats[1].spilledMemoryBytes);
+  EXPECT_LT(0, stats[0].operatorStats[1].spilledInputBytes);
   EXPECT_LT(0, stats[0].operatorStats[1].spilledBytes);
   EXPECT_EQ(1, stats[0].operatorStats[1].spilledPartitions);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
@@ -1621,8 +1621,7 @@ TEST_F(AggregationTest, distinctWithSpilling) {
                             .planNode())
                   .assertResults("SELECT distinct c0 FROM tmp");
   // Verify that spilling is not triggered.
-  ASSERT_EQ(
-      toPlanStats(task->taskStats()).at(aggrNodeId).spilledMemoryBytes, 0);
+  ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledInputBytes, 0);
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }
@@ -1661,8 +1660,7 @@ TEST_F(AggregationTest, preGroupedAggregationWithSpilling) {
           .assertResults("SELECT c0, c1, sum(c2) FROM tmp GROUP BY c0, c1");
   auto stats = task->taskStats().pipelineStats;
   // Verify that spilling is not triggered.
-  ASSERT_EQ(
-      toPlanStats(task->taskStats()).at(aggrNodeId).spilledMemoryBytes, 0);
+  ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledInputBytes, 0);
   ASSERT_EQ(toPlanStats(task->taskStats()).at(aggrNodeId).spilledBytes, 0);
   OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
 }

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -72,11 +72,13 @@ std::pair<SpillStats, SpillStats> taskSpilledStats(const exec::Task& task) {
   for (auto& pipeline : stats.pipelineStats) {
     for (auto op : pipeline.operatorStats) {
       if (op.operatorType == "HashBuild") {
+        buildStats.spilledMemoryBytes += op.spilledMemoryBytes;
         buildStats.spilledBytes += op.spilledBytes;
         buildStats.spilledRows += op.spilledRows;
         buildStats.spilledPartitions += op.spilledPartitions;
         buildStats.spilledFiles += op.spilledFiles;
       } else if (op.operatorType == "HashProbe") {
+        probeStats.spilledMemoryBytes += op.spilledMemoryBytes;
         probeStats.spilledBytes += op.spilledBytes;
         probeStats.spilledRows += op.spilledRows;
         probeStats.spilledPartitions += op.spilledPartitions;
@@ -625,6 +627,8 @@ class HashJoinBuilder {
         ASSERT_GT(statsPair.second.spilledRows, 0);
         ASSERT_GT(statsPair.first.spilledBytes, 0);
         ASSERT_GT(statsPair.second.spilledBytes, 0);
+        ASSERT_GT(statsPair.first.spilledMemoryBytes, 0);
+        ASSERT_GT(statsPair.second.spilledMemoryBytes, 0);
         ASSERT_GT(statsPair.first.spilledPartitions, 0);
         ASSERT_GT(statsPair.second.spilledPartitions, 0);
         ASSERT_GT(statsPair.first.spilledFiles, 0);
@@ -638,10 +642,12 @@ class HashJoinBuilder {
       // set, the test might trigger spilling by its own.
     } else if (spillDirectory_.empty() && spillMemoryThreshold_ == 0) {
       ASSERT_EQ(statsPair.first.spilledRows, 0);
+      ASSERT_EQ(statsPair.first.spilledMemoryBytes, 0);
       ASSERT_EQ(statsPair.first.spilledBytes, 0);
       ASSERT_EQ(statsPair.first.spilledPartitions, 0);
       ASSERT_EQ(statsPair.first.spilledFiles, 0);
       ASSERT_EQ(statsPair.second.spilledRows, 0);
+      ASSERT_EQ(statsPair.second.spilledBytes, 0);
       ASSERT_EQ(statsPair.second.spilledBytes, 0);
       ASSERT_EQ(statsPair.second.spilledPartitions, 0);
       ASSERT_EQ(statsPair.second.spilledFiles, 0);

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -72,13 +72,13 @@ std::pair<SpillStats, SpillStats> taskSpilledStats(const exec::Task& task) {
   for (auto& pipeline : stats.pipelineStats) {
     for (auto op : pipeline.operatorStats) {
       if (op.operatorType == "HashBuild") {
-        buildStats.spilledMemoryBytes += op.spilledMemoryBytes;
+        buildStats.spilledInputBytes += op.spilledInputBytes;
         buildStats.spilledBytes += op.spilledBytes;
         buildStats.spilledRows += op.spilledRows;
         buildStats.spilledPartitions += op.spilledPartitions;
         buildStats.spilledFiles += op.spilledFiles;
       } else if (op.operatorType == "HashProbe") {
-        probeStats.spilledMemoryBytes += op.spilledMemoryBytes;
+        probeStats.spilledInputBytes += op.spilledInputBytes;
         probeStats.spilledBytes += op.spilledBytes;
         probeStats.spilledRows += op.spilledRows;
         probeStats.spilledPartitions += op.spilledPartitions;
@@ -627,8 +627,8 @@ class HashJoinBuilder {
         ASSERT_GT(statsPair.second.spilledRows, 0);
         ASSERT_GT(statsPair.first.spilledBytes, 0);
         ASSERT_GT(statsPair.second.spilledBytes, 0);
-        ASSERT_GT(statsPair.first.spilledMemoryBytes, 0);
-        ASSERT_GT(statsPair.second.spilledMemoryBytes, 0);
+        ASSERT_GT(statsPair.first.spilledInputBytes, 0);
+        ASSERT_GT(statsPair.second.spilledInputBytes, 0);
         ASSERT_GT(statsPair.first.spilledPartitions, 0);
         ASSERT_GT(statsPair.second.spilledPartitions, 0);
         ASSERT_GT(statsPair.first.spilledFiles, 0);
@@ -642,7 +642,7 @@ class HashJoinBuilder {
       // set, the test might trigger spilling by its own.
     } else if (spillDirectory_.empty() && spillMemoryThreshold_ == 0) {
       ASSERT_EQ(statsPair.first.spilledRows, 0);
-      ASSERT_EQ(statsPair.first.spilledMemoryBytes, 0);
+      ASSERT_EQ(statsPair.first.spilledInputBytes, 0);
       ASSERT_EQ(statsPair.first.spilledBytes, 0);
       ASSERT_EQ(statsPair.first.spilledPartitions, 0);
       ASSERT_EQ(statsPair.first.spilledFiles, 0);

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -42,6 +42,7 @@ SpillStats spilledStats(const exec::Task& task) {
   auto stats = task.taskStats();
   for (auto& pipeline : stats.pipelineStats) {
     for (auto op : pipeline.operatorStats) {
+      spilledStats.spilledMemoryBytes += op.spilledMemoryBytes;
       spilledStats.spilledBytes += op.spilledBytes;
       spilledStats.spilledRows += op.spilledRows;
       spilledStats.spilledPartitions += op.spilledPartitions;
@@ -193,12 +194,14 @@ class OrderByTest : public OperatorTestBase {
       auto task = assertQueryOrdered(params, duckDbSql, sortingKeys);
       auto inputRows = toPlanStats(task->taskStats()).at(orderById).inputRows;
       if (inputRows > 0) {
+        EXPECT_LT(0, spilledStats(*task).spilledMemoryBytes);
         EXPECT_LT(0, spilledStats(*task).spilledBytes);
         EXPECT_EQ(1, spilledStats(*task).spilledPartitions);
         EXPECT_LT(0, spilledStats(*task).spilledFiles);
         // NOTE: the last input batch won't go spilling.
         EXPECT_GT(inputRows, spilledStats(*task).spilledRows);
       } else {
+        EXPECT_EQ(0, spilledStats(*task).spilledMemoryBytes);
         EXPECT_EQ(0, spilledStats(*task).spilledBytes);
       }
       OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
@@ -469,6 +472,7 @@ TEST_F(OrderByTest, spill) {
   ASSERT_GT(stats.spilledRows, 0);
   ASSERT_LT(stats.spilledRows, kNumBatches * kNumRows);
   ASSERT_GT(stats.spilledBytes, 0);
+  ASSERT_GT(stats.spilledMemoryBytes, 0);
   ASSERT_EQ(stats.spilledPartitions, 1);
   ASSERT_EQ(stats.spilledFiles, 2);
   ASSERT_GT(stats.runtimeStats["spillRuns"].count, 0);
@@ -543,6 +547,8 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
             .assertResults(results);
 
     auto stats = task->taskStats().pipelineStats;
+    ASSERT_EQ(
+        testData.expectSpill, stats[0].operatorStats[1].spilledMemoryBytes > 0);
     ASSERT_EQ(testData.expectSpill, stats[0].operatorStats[1].spilledBytes > 0);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -356,9 +356,9 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(
         finalStats.toString(),
         fmt::format(
-            "spillRuns[{}] spilledMemoryBytes[{}] spilledBytes[{}] spilledRows[{}] spilledPartitions[{}] spilledFiles[{}] spillFillTimeUs[{}] spillSortTime[{}] spillSerializationTime[{}] spillDiskWrites[{}] spillFlushTime[{}] spillWriteTime[{}]",
+            "spillRuns[{}] spilledInputBytes[{}] spilledBytes[{}] spilledRows[{}] spilledPartitions[{}] spilledFiles[{}] spillFillTimeUs[{}] spillSortTime[{}] spillSerializationTime[{}] spillDiskWrites[{}] spillFlushTime[{}] spillWriteTime[{}]",
             finalStats.spillRuns,
-            succinctBytes(finalStats.spilledMemoryBytes),
+            succinctBytes(finalStats.spilledInputBytes),
             succinctBytes(finalStats.spilledBytes),
             finalStats.spilledRows,
             finalStats.spilledPartitions,
@@ -686,7 +686,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(SpillTest, spillStats) {
   SpillStats stats1;
   stats1.spillRuns = 100;
-  stats1.spilledMemoryBytes = 2048;
+  stats1.spilledInputBytes = 2048;
   stats1.spilledBytes = 1024;
   stats1.spilledPartitions = 1024;
   stats1.spilledFiles = 1023;
@@ -699,7 +699,7 @@ TEST(SpillTest, spillStats) {
   stats1.spillSerializationTimeUs = 1023;
   SpillStats stats2;
   stats2.spillRuns = 100;
-  stats2.spilledMemoryBytes = 2048;
+  stats2.spilledInputBytes = 2048;
   stats2.spilledBytes = 1024;
   stats2.spilledPartitions = 1025;
   stats2.spilledFiles = 1026;
@@ -725,7 +725,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_TRUE(stats1 <= stats1);
 
   SpillStats delta = stats2 - stats1;
-  ASSERT_EQ(delta.spilledMemoryBytes, 0);
+  ASSERT_EQ(delta.spilledInputBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, 1);
   ASSERT_EQ(delta.spilledFiles, 3);
@@ -737,7 +737,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(delta.spilledRows, 8);
   ASSERT_EQ(delta.spillSerializationTimeUs, 9);
   delta = stats1 - stats2;
-  ASSERT_EQ(delta.spilledMemoryBytes, 0);
+  ASSERT_EQ(delta.spilledInputBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, -1);
   ASSERT_EQ(delta.spilledFiles, -3);
@@ -748,7 +748,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(delta.spillFillTimeUs, -7);
   ASSERT_EQ(delta.spilledRows, -8);
   ASSERT_EQ(delta.spillSerializationTimeUs, -9);
-  stats1.spilledMemoryBytes = 2060;
+  stats1.spilledInputBytes = 2060;
   stats1.spilledBytes = 1030;
   VELOX_ASSERT_THROW(stats1 < stats2, "");
   VELOX_ASSERT_THROW(stats1 > stats2, "");
@@ -761,5 +761,5 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(zeroStats, stats1);
   ASSERT_EQ(
       stats2.toString(),
-      "spillRuns[100] spilledMemoryBytes[2.00KB] spilledBytes[1.00KB] spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] spillFillTimeUs[1.03ms] spillSortTime[1.03ms] spillSerializationTime[1.03ms] spillDiskWrites[1028] spillFlushTime[1.03ms] spillWriteTime[1.03ms]");
+      "spillRuns[100] spilledInputBytes[2.00KB] spilledBytes[1.00KB] spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] spillFillTimeUs[1.03ms] spillSortTime[1.03ms] spillSerializationTime[1.03ms] spillDiskWrites[1028] spillFlushTime[1.03ms] spillWriteTime[1.03ms]");
 }

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -356,8 +356,9 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
     ASSERT_EQ(
         finalStats.toString(),
         fmt::format(
-            "spillRuns[{}] spilledBytes[{}] spilledRows[{}] spilledPartitions[{}] spilledFiles[{}] spillFillTimeUs[{}] spillSortTime[{}] spillSerializationTime[{}] spillDiskWrites[{}] spillFlushTime[{}] spillWriteTime[{}]",
+            "spillRuns[{}] spilledMemoryBytes[{}] spilledBytes[{}] spilledRows[{}] spilledPartitions[{}] spilledFiles[{}] spillFillTimeUs[{}] spillSortTime[{}] spillSerializationTime[{}] spillDiskWrites[{}] spillFlushTime[{}] spillWriteTime[{}]",
             finalStats.spillRuns,
+            succinctBytes(finalStats.spilledMemoryBytes),
             succinctBytes(finalStats.spilledBytes),
             finalStats.spilledRows,
             finalStats.spilledPartitions,
@@ -675,6 +676,7 @@ INSTANTIATE_TEST_SUITE_P(
     SpillTestSuite,
     SpillTest,
     ::testing::Values(
+        common::CompressionKind::CompressionKind_NONE,
         common::CompressionKind::CompressionKind_ZLIB,
         common::CompressionKind::CompressionKind_SNAPPY,
         common::CompressionKind::CompressionKind_ZSTD,
@@ -684,6 +686,7 @@ INSTANTIATE_TEST_SUITE_P(
 TEST(SpillTest, spillStats) {
   SpillStats stats1;
   stats1.spillRuns = 100;
+  stats1.spilledMemoryBytes = 2048;
   stats1.spilledBytes = 1024;
   stats1.spilledPartitions = 1024;
   stats1.spilledFiles = 1023;
@@ -696,6 +699,7 @@ TEST(SpillTest, spillStats) {
   stats1.spillSerializationTimeUs = 1023;
   SpillStats stats2;
   stats2.spillRuns = 100;
+  stats2.spilledMemoryBytes = 2048;
   stats2.spilledBytes = 1024;
   stats2.spilledPartitions = 1025;
   stats2.spilledFiles = 1026;
@@ -721,6 +725,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_TRUE(stats1 <= stats1);
 
   SpillStats delta = stats2 - stats1;
+  ASSERT_EQ(delta.spilledMemoryBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, 1);
   ASSERT_EQ(delta.spilledFiles, 3);
@@ -732,6 +737,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(delta.spilledRows, 8);
   ASSERT_EQ(delta.spillSerializationTimeUs, 9);
   delta = stats1 - stats2;
+  ASSERT_EQ(delta.spilledMemoryBytes, 0);
   ASSERT_EQ(delta.spilledBytes, 0);
   ASSERT_EQ(delta.spilledPartitions, -1);
   ASSERT_EQ(delta.spilledFiles, -3);
@@ -742,6 +748,7 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(delta.spillFillTimeUs, -7);
   ASSERT_EQ(delta.spilledRows, -8);
   ASSERT_EQ(delta.spillSerializationTimeUs, -9);
+  stats1.spilledMemoryBytes = 2060;
   stats1.spilledBytes = 1030;
   VELOX_ASSERT_THROW(stats1 < stats2, "");
   VELOX_ASSERT_THROW(stats1 > stats2, "");
@@ -754,5 +761,5 @@ TEST(SpillTest, spillStats) {
   ASSERT_EQ(zeroStats, stats1);
   ASSERT_EQ(
       stats2.toString(),
-      "spillRuns[100] spilledBytes[1.00KB] spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] spillFillTimeUs[1.03ms] spillSortTime[1.03ms] spillSerializationTime[1.03ms] spillDiskWrites[1028] spillFlushTime[1.03ms] spillWriteTime[1.03ms]");
+      "spillRuns[100] spilledMemoryBytes[2.00KB] spilledBytes[1.00KB] spilledRows[1031] spilledPartitions[1025] spilledFiles[1026] spillFillTimeUs[1.03ms] spillSortTime[1.03ms] spillSerializationTime[1.03ms] spillDiskWrites[1028] spillFlushTime[1.03ms] spillWriteTime[1.03ms]");
 }

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1454,30 +1454,35 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST(SpillerTest, stats) {
   SpillStats sumStats;
   EXPECT_EQ(0, sumStats.spilledRows);
+  EXPECT_EQ(0, sumStats.spilledMemoryBytes);
   EXPECT_EQ(0, sumStats.spilledBytes);
   EXPECT_EQ(0, sumStats.spilledPartitions);
   EXPECT_EQ(0, sumStats.spilledFiles);
 
   SpillStats stats;
   stats.spilledRows = 10;
+  stats.spilledMemoryBytes = 200;
   stats.spilledBytes = 100;
   stats.spilledPartitions = 2;
   stats.spilledFiles = 3;
 
   sumStats += stats;
   EXPECT_EQ(stats.spilledRows, sumStats.spilledRows);
+  EXPECT_EQ(stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
   EXPECT_EQ(stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(stats.spilledFiles, sumStats.spilledFiles);
 
   sumStats += stats;
   EXPECT_EQ(2 * stats.spilledRows, sumStats.spilledRows);
+  EXPECT_EQ(2 * stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
   EXPECT_EQ(2 * stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(2 * stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(2 * stats.spilledFiles, sumStats.spilledFiles);
 
   sumStats += stats;
   EXPECT_EQ(3 * stats.spilledRows, sumStats.spilledRows);
+  EXPECT_EQ(3 * stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
   EXPECT_EQ(3 * stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(3 * stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(3 * stats.spilledFiles, sumStats.spilledFiles);

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -1454,35 +1454,35 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 TEST(SpillerTest, stats) {
   SpillStats sumStats;
   EXPECT_EQ(0, sumStats.spilledRows);
-  EXPECT_EQ(0, sumStats.spilledMemoryBytes);
+  EXPECT_EQ(0, sumStats.spilledInputBytes);
   EXPECT_EQ(0, sumStats.spilledBytes);
   EXPECT_EQ(0, sumStats.spilledPartitions);
   EXPECT_EQ(0, sumStats.spilledFiles);
 
   SpillStats stats;
   stats.spilledRows = 10;
-  stats.spilledMemoryBytes = 200;
+  stats.spilledInputBytes = 200;
   stats.spilledBytes = 100;
   stats.spilledPartitions = 2;
   stats.spilledFiles = 3;
 
   sumStats += stats;
   EXPECT_EQ(stats.spilledRows, sumStats.spilledRows);
-  EXPECT_EQ(stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
+  EXPECT_EQ(stats.spilledInputBytes, sumStats.spilledInputBytes);
   EXPECT_EQ(stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(stats.spilledFiles, sumStats.spilledFiles);
 
   sumStats += stats;
   EXPECT_EQ(2 * stats.spilledRows, sumStats.spilledRows);
-  EXPECT_EQ(2 * stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
+  EXPECT_EQ(2 * stats.spilledInputBytes, sumStats.spilledInputBytes);
   EXPECT_EQ(2 * stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(2 * stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(2 * stats.spilledFiles, sumStats.spilledFiles);
 
   sumStats += stats;
   EXPECT_EQ(3 * stats.spilledRows, sumStats.spilledRows);
-  EXPECT_EQ(3 * stats.spilledMemoryBytes, sumStats.spilledMemoryBytes);
+  EXPECT_EQ(3 * stats.spilledInputBytes, sumStats.spilledInputBytes);
   EXPECT_EQ(3 * stats.spilledBytes, sumStats.spilledBytes);
   EXPECT_EQ(3 * stats.spilledPartitions, sumStats.spilledPartitions);
   EXPECT_EQ(3 * stats.spilledFiles, sumStats.spilledFiles);


### PR DESCRIPTION
Since spill support compression, the metric `spilledBytes` meaning is ambiguous, we need the bytes before spill and the bytes in file.