### PR TITLE
Fix handling of VARBINARY partition keys in Hive Connector

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -259,6 +259,9 @@ velox::variant convertFromString(const std::optional<std::string>& value) {
     if constexpr (ToKind == TypeKind::VARCHAR) {
       return velox::variant(value.value());
     }
+    if constexpr (ToKind == TypeKind::VARBINARY) {
+      return velox::variant::binary((value.value()));
+    }
     auto result = velox::util::Converter<ToKind>::cast(value.value());
 
     return velox::variant(result);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3033,3 +3033,25 @@ TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
     ASSERT_EQ(stringCol->valueAt(j), fruitViews[j % fruitViews.size()]);
   }
 }
+
+TEST_F(TableScanTest, varbinaryToVarchar) {
+  auto vectors = makeVectors(1, 1'000);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, vectors);
+  createDuckDbTable(vectors);
+
+  ColumnHandleMap assignments = {
+      {"a", regularColumn("c0", BIGINT())},
+      {"ds_alias", partitionKey("ds", VARBINARY())}};
+
+  auto split = HiveConnectorSplitBuilder(filePath->path)
+                   .partitionKey("ds", "2021-12-02")
+                   .build();
+
+  auto outputType = ROW({"a", "ds_alias"}, {BIGINT(), VARBINARY()});
+  auto op = PlanBuilder()
+                .tableScan(outputType, makeTableHandle(), assignments)
+                .planNode();
+
+  assertQuery(op, split, "SELECT c0, '2021-12-02' FROM tmp");
+}

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3034,7 +3034,7 @@ TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
   }
 }
 
-TEST_F(TableScanTest, varbinaryToVarchar) {
+TEST_F(TableScanTest, varbinaryPartitionKey) {
   auto vectors = makeVectors(1, 1'000);
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, vectors);


### PR DESCRIPTION
Hive Connector used to throw an error when processing VARBINARY partition keys.

Fixes #6198