### PR TITLE
Pass task ID to ExchangeClient to use in log messages

### DIFF
--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -235,6 +235,7 @@ std::string ExchangeClient::toString() const {
 
 std::string ExchangeClient::toJsonString() const {
   folly::dynamic obj = folly::dynamic::object;
+  obj["taskId"] = taskId_;
   obj["closed"] = closed_;
   folly::dynamic clientsObj = folly::dynamic::object;
   int index = 0;

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -28,18 +28,18 @@ class ExchangeClient {
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
 
   ExchangeClient(
+      std::string taskId,
       int destination,
       memory::MemoryPool* pool,
       int64_t maxQueuedBytes)
-      : destination_(destination),
+      : taskId_{std::move(taskId)},
+        destination_(destination),
         maxQueuedBytes_{maxQueuedBytes},
         pool_(pool),
         queue_(std::make_shared<ExchangeQueue>()) {
     VELOX_CHECK_NOT_NULL(pool_);
-    VELOX_CHECK(
-        destination >= 0,
-        "Exchange client destination must be greater than zero, got {}",
-        destination);
+    VELOX_CHECK_GE(
+        destination, 0, "Exchange client destination must not be negative");
   }
 
   ~ExchangeClient();
@@ -92,6 +92,8 @@ class ExchangeClient {
 
   void request(const RequestSpec& requestSpec);
 
+  // Handy for ad-hoc logging.
+  const std::string taskId_;
   const int destination_;
   const int64_t maxQueuedBytes_;
   memory::MemoryPool* const pool_;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -123,6 +123,7 @@ class MergeExchangeSource : public MergeSource {
       memory::MemoryPool* FOLLY_NONNULL pool)
       : mergeExchange_(mergeExchange),
         client_(std::make_unique<ExchangeClient>(
+            taskId,
             destination,
             pool,
             ExchangeClient::kDefaultMaxQueuedBytes)) {

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -2342,6 +2342,7 @@ void Task::createExchangeClient(
   // Low-water mark for filling the exchange queue is 1/2 of the per worker
   // buffer size of the producers.
   exchangeClients_[pipelineId] = std::make_shared<ExchangeClient>(
+      taskId_,
       destination_,
       addExchangeClientPool(planNodeId, pipelineId),
       queryCtx()->queryConfig().maxExchangeBufferSize());

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -96,7 +96,7 @@ TEST_F(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {
         throw std::runtime_error("Testing error");
       });
 
-  ExchangeClient client(1, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
+  ExchangeClient client("t", 1, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
   VELOX_ASSERT_THROW(
       client.addRemoteTaskId("task.1.2.3"),
       "Failed to create ExchangeSource: Testing error. Task ID: task.1.2.3.");
@@ -125,7 +125,8 @@ TEST_F(ExchangeClientTest, stats) {
   bufferManager_->initializeTask(
       task, core::PartitionedOutputNode::Kind::kPartitioned, 100, 16);
 
-  ExchangeClient client(17, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
+  ExchangeClient client(
+      "t", 17, pool(), ExchangeClient::kDefaultMaxQueuedBytes);
   client.addRemoteTaskId(taskId);
 
   // Enqueue 3 pages.
@@ -159,7 +160,7 @@ TEST_F(ExchangeClientTest, flowControl) {
   auto page = toSerializedPage(data);
 
   // Set limit at 3.5 pages.
-  ExchangeClient client(17, pool(), page->size() * 3.5);
+  ExchangeClient client("flow.control", 17, pool(), page->size() * 3.5);
 
   auto plan = test::PlanBuilder()
                   .values({data})


### PR DESCRIPTION
It is convenient to include task ID in log messages to help separate messages
for different tasks when running multiple tasks concurrently (like in
Prestissimo).