### PR TITLE
De-flake and enable MultiFragmentTest::exchangeStatsOnFailure

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -606,7 +606,13 @@ void Driver::initializeOperatorStats(std::vector<OperatorStats>& stats) {
   }
 }
 
-void Driver::addStatsToTask() {
+void Driver::closeOperators() {
+  // Close operators.
+  for (auto& op : operators_) {
+    op->close();
+  }
+
+  // Add operator stats to the task.
   for (auto& op : operators_) {
     auto stats = op->stats(true);
     stats.memoryStats.update(op->pool());
@@ -623,10 +629,7 @@ void Driver::close() {
   if (!isOnThread() && !isTerminated()) {
     LOG(FATAL) << "Driver::close is only allowed from the Driver's thread";
   }
-  for (auto& op : operators_) {
-    op->close();
-  }
-  addStatsToTask();
+  closeOperators();
   closed_ = true;
   Task::removeDriver(ctx_->task, this);
 }
@@ -634,10 +637,7 @@ void Driver::close() {
 void Driver::closeByTask() {
   VELOX_CHECK(isOnThread());
   VELOX_CHECK(isTerminated());
-  addStatsToTask();
-  for (auto& op : operators_) {
-    op->close();
-  }
+  closeOperators();
   closed_ = true;
 }
 

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -275,7 +275,8 @@ class Driver : public std::enable_shared_from_this<Driver> {
 
   void initializeOperatorStats(std::vector<OperatorStats>& stats);
 
-  void addStatsToTask();
+  // Close operators and add operator stats to the task.
+  void closeOperators();
 
   // Returns true if all operators between the source and 'aggregation' are
   // order-preserving and do not increase cardinality.


### PR DESCRIPTION
Summary:
Fix race condition in LocalExchangeSource between close() and async request
processing.

Fix inconsistency in Driver::close and Driver::closeByTask. One of them updated
stats after closing the operators, then other one before. Now both paths close
operators first, then update stats.

Differential Revision: D48229758

