### PR TITLE
Upgrade folly to v2023.08.07.00 for MacOS

### DIFF
--- a/CMake/resolve_dependency_modules/folly/CMakeLists.txt
+++ b/CMake/resolve_dependency_modules/folly/CMakeLists.txt
@@ -14,9 +14,9 @@
 project(Folly)
 cmake_minimum_required(VERSION 3.14)
 
-set(VELOX_FOLLY_BUILD_VERSION v2022.11.14.00)
+set(VELOX_FOLLY_BUILD_VERSION v2023.08.07.00)
 set(VELOX_FOLLY_BUILD_SHA256_CHECKSUM
-    b249436cb61b6dfd5288093565438d8da642b07ae021191a4042b221bc1bdc0e)
+    103d9454ac03dfbfa846b90a4b1b444df1cecc7a9d16caa1a4abd93460f7b422)
 set(VELOX_FOLLY_SOURCE_URL
     "https://github.com/facebook/folly/archive/${VELOX_FOLLY_BUILD_VERSION}.tar.gz"
 )

--- a/scripts/setup-circleci.sh
+++ b/scripts/setup-circleci.sh
@@ -75,7 +75,7 @@ wget_and_untar https://github.com/fmtlib/fmt/archive/8.0.1.tar.gz fmt &
 wget_and_untar https://archive.apache.org/dist/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz hadoop
 wget_and_untar https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz protobuf &
 
-FB_OS_VERSION="v2022.11.14.00"
+FB_OS_VERSION="v2023.08.07.00"
 
 wget_and_untar https://github.com/facebook/folly/archive/${FB_OS_VERSION}.tar.gz folly &
 wget_and_untar https://github.com/facebookincubator/fizz/archive/refs/tags/${FB_OS_VERSION}.tar.gz fizz &

--- a/scripts/setup-macos.sh
+++ b/scripts/setup-macos.sh
@@ -34,7 +34,7 @@ source $SCRIPTDIR/setup-helper-functions.sh
 NPROC=$(getconf _NPROCESSORS_ONLN)
 
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
-MACOS_DEPS="ninja flex bison cmake ccache protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@1.1"
+MACOS_DEPS="ninja flex bison cmake ccache protobuf@21 icu4c boost gflags glog libevent lz4 lzo snappy xz zstd openssl@3"
 
 function run_and_time {
   time "$@" || (echo "Failed to run $* ." ; exit 1 )
@@ -93,8 +93,8 @@ function install_fmt {
 }
 
 function install_folly {
-  github_checkout facebook/folly "v2022.11.14.00"
-  OPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) \
+  github_checkout facebook/folly "v2023.08.07.00"
+  OPENSSL_ROOT_DIR=$(brew --prefix openssl@3) \
   cmake_install -DBUILD_TESTS=OFF -DFOLLY_HAVE_INT128_T=ON
 }
 

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -23,10 +23,20 @@ source $SCRIPTDIR/setup-helper-functions.sh
 CPU_TARGET="${CPU_TARGET:-avx}"
 COMPILER_FLAGS=$(get_cxx_flags "$CPU_TARGET")
 export COMPILER_FLAGS
-FB_OS_VERSION=v2022.11.14.00
+FB_OS_VERSION=v2023.08.07.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
+
+function install_gflags {
+  github_checkout gflags/gflags "2.2.2"
+  cmake_install -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+}
+#
+#function install_glog {
+#  github_checkout google/glog "0.6.0"
+#  cmake_install -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_gflags_LIB=ON
+}
 
 # Install all velox and folly dependencies. 
 # The is an issue on 22.04 where a version conflict prevents glog install,
@@ -45,9 +55,8 @@ sudo --preserve-env apt update && sudo --preserve-env apt install -y libunwind-d
   libboost-all-dev \
   libicu-dev \
   libdouble-conversion-dev \
-  libgoogle-glog-dev \
   libbz2-dev \
-  libgflags-dev \
+  libgoogle-glog-dev \
   libgmock-dev \
   libevent-dev \
   liblz4-dev \

--- a/scripts/setup-velox-torcharrow.sh
+++ b/scripts/setup-velox-torcharrow.sh
@@ -79,7 +79,7 @@ function wget_and_untar {
 wget_and_untar https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz gflags
 wget_and_untar https://ftp.openssl.org/source/openssl-1.1.1k.tar.gz openssl &
 wget_and_untar https://boostorg.jfrog.io/artifactory/main/release/1.69.0/source/boost_1_69_0.tar.gz boost &
-wget_and_untar https://github.com/facebook/folly/archive/v2022.11.14.00.tar.gz folly &
+wget_and_untar https://github.com/facebook/folly/archive/v2023.08.07.00.tar.gz folly &
 wget_and_untar https://github.com/fmtlib/fmt/archive/refs/tags/8.0.1.tar.gz fmt &
 
 wait

--- a/velox/benchmarks/basic/ComparisonConjunct.cpp
+++ b/velox/benchmarks/basic/ComparisonConjunct.cpp
@@ -175,7 +175,7 @@ BENCHMARK(conjunctsNested) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<ComparisonBenchmark>(1'000);

--- a/velox/benchmarks/basic/DecodedVector.cpp
+++ b/velox/benchmarks/basic/DecodedVector.cpp
@@ -188,7 +188,7 @@ BENCHMARK(decodeDictionary5Nested) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<DecodedVectorBenchmark>(10'000);

--- a/velox/benchmarks/basic/FeatureNormalization.cpp
+++ b/velox/benchmarks/basic/FeatureNormalization.cpp
@@ -110,7 +110,7 @@ BENCHMARK(normalizeConstant) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<FeatureNormailzationBenchmark>();

--- a/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeFunctionsBenchmark.cpp
@@ -233,7 +233,7 @@ BENCHMARK(tpchQuery20) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv, true);
+  folly::Init(&argc, &argv, true);
   benchmark = std::make_unique<LikeFunctionsBenchmark>();
   folly::runBenchmarks();
   benchmark.reset();

--- a/velox/benchmarks/basic/Preproc.cpp
+++ b/velox/benchmarks/basic/Preproc.cpp
@@ -444,7 +444,7 @@ BENCHMARK(allFusedWithNulls) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   benchmark = std::make_unique<PreprocBenchmark>();
   // Verify that benchmark calculations are correct.

--- a/velox/benchmarks/basic/SelectivityVector.cpp
+++ b/velox/benchmarks/basic/SelectivityVector.cpp
@@ -164,7 +164,7 @@ BENCHMARK(sumSelectivity1PerCent) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<SelectivityVectorBenchmark>(10'000);

--- a/velox/benchmarks/basic/SimpleArithmetic.cpp
+++ b/velox/benchmarks/basic/SimpleArithmetic.cpp
@@ -343,7 +343,7 @@ BENCHMARK(plusCheckedLarge) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<SimpleArithmeticBenchmark>();

--- a/velox/benchmarks/basic/SimpleCastExpr.cpp
+++ b/velox/benchmarks/basic/SimpleCastExpr.cpp
@@ -106,7 +106,7 @@ BENCHMARK(castTimestampDateAdjustTimeZone) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   benchmark = std::make_unique<SimpleCastBenchmark>();
   folly::runBenchmarks();

--- a/velox/benchmarks/basic/VectorCompare.cpp
+++ b/velox/benchmarks/basic/VectorCompare.cpp
@@ -110,7 +110,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmark = std::make_unique<VectorCompareBenchmark>(1000);

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -128,7 +128,7 @@ BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -110,7 +110,7 @@ DEFINE_BENCHMARKS(row)
 } // namespace facebook::velox
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   using namespace facebook::velox;
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   VELOX_CHECK_LE(FLAGS_slice_size, kVectorSize);

--- a/velox/benchmarks/tpch/TpchBenchmarkMain.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmarkMain.cpp
@@ -23,6 +23,6 @@ int main(int argc, char** argv) {
   std::string kUsage(
       "This program benchmarks TPC-H queries. Run 'velox_tpch_benchmark -helpon=TpchBenchmark' for available options.\n");
   gflags::SetUsageMessage(kUsage);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   tpchBenchmarkMain();
 }

--- a/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
+++ b/velox/benchmarks/unstable/MemoryAllocationBenchmark.cpp
@@ -435,7 +435,7 @@ BENCHMARK_RELATIVE_MULTI(MmapReallocateMix64) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   // TODO: add to run benchmark as a standalone program with multithreading as
   // well as actual memory access to trigger minor page faults in OS which traps
   // into kernel context to setup physical pages for the lazy-mapped virtual

--- a/velox/common/base/benchmarks/BitUtilBenchmark.cpp
+++ b/velox/common/base/benchmarks/BitUtilBenchmark.cpp
@@ -191,7 +191,7 @@ BENCHMARK_RELATIVE_MULTI(forEachBitFirstBitFalse) {
 } // namespace facebook
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/common/base/tests/Memcpy.cpp
+++ b/velox/common/base/tests/Memcpy.cpp
@@ -58,7 +58,7 @@ struct CopyCallable {
 
 int main(int argc, char** argv) {
   constexpr int32_t kAlignment = folly::hardware_destructive_interference_size;
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   auto chunk = bits::roundUp(
       std::max<int64_t>(FLAGS_bytes / FLAGS_threads, kAlignment), kAlignment);
   int64_t bytes = chunk * FLAGS_threads;

--- a/velox/common/base/tests/StatsReporterTest.cpp
+++ b/velox/common/base/tests/StatsReporterTest.cpp
@@ -130,7 +130,7 @@ folly::Singleton<BaseStatsReporter> reporter([]() {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   facebook::velox::BaseStatsReporter::registered = true;
   return RUN_ALL_TESTS();
 }

--- a/velox/common/file/benchmark/ReadBenchmarkMain.cpp
+++ b/velox/common/file/benchmark/ReadBenchmarkMain.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox;
 // and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
 // data.
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   ReadBenchmark bm;
   bm.initialize();
   bm.run();

--- a/velox/common/memory/tests/MemoryPoolBenchmark.cpp
+++ b/velox/common/memory/tests/MemoryPoolBenchmark.cpp
@@ -239,7 +239,7 @@ BENCHMARK(FlatSticks, iters) {
 }
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
+++ b/velox/connectors/fuzzer/tests/FuzzerConnectorTest.cpp
@@ -124,6 +124,6 @@ TEST_F(FuzzerConnectorTest, reproducible) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -267,7 +267,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
 
   benchmarkFew = std::make_unique<HivePartitionFunctionBenchmark>(1'000);

--- a/velox/connectors/hive/storage_adapters/gcs/benchmark/GCSReadBenchmarkMain.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/benchmark/GCSReadBenchmarkMain.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox;
 // and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
 // data.
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   GCSReadBenchmark bm;
   bm.initialize();
   bm.run();

--- a/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/benchmark/S3ReadBenchmarkMain.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox;
 // and the IO throughput is 100 MBps, then it takes 10 seconds to just read the
 // data.
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   S3ReadBenchmark bm;
   bm.initialize();
   bm.run();

--- a/velox/connectors/tpch/tests/SpeedTest.cpp
+++ b/velox/connectors/tpch/tests/SpeedTest.cpp
@@ -179,7 +179,7 @@ class TpchSpeedTest {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
 
   TpchSpeedTest speedTest;
   speedTest.run(

--- a/velox/connectors/tpch/tests/TpchConnectorTest.cpp
+++ b/velox/connectors/tpch/tests/TpchConnectorTest.cpp
@@ -287,6 +287,6 @@ TEST_F(TpchConnectorTest, orderDateCount) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/BitPackDecoderBenchmark.cpp
@@ -412,7 +412,7 @@ void naiveDecodeBitsLE(
 }
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // Populate uint32 buffer
 

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -53,7 +53,7 @@ BENCHMARK(ChainedBufferOps, iters) {
 }
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/common/tests/IntDecoderBenchmark.cpp
+++ b/velox/dwio/common/tests/IntDecoderBenchmark.cpp
@@ -939,7 +939,7 @@ BENCHMARK_RELATIVE(decodeNew_64) {
 }
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // Populate uint16 buffer
   buffer_u16.resize(kNumElements);

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -410,6 +410,6 @@ TEST_F(E2EFilterTest, mutationCornerCases) {
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -130,7 +130,7 @@ BENCHMARK(FloatColumnWriterBenchmark10000) {
 }
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -204,7 +204,7 @@ BENCHMARK_RELATIVE(GenerateAutoIdNew_64) {
 }
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -113,6 +113,6 @@ TEST_F(ParquetTpchTest, Q22) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
+++ b/velox/dwio/parquet/tests/reader/E2EFilterTest.cpp
@@ -616,6 +616,6 @@ TEST_F(E2EFilterTest, combineRowGroup) {
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -374,7 +374,7 @@ PARQUET_BENCHMARKS_NO_FILTER(ARRAY(BIGINT()), List);
 // TODO: Add all data types
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -446,6 +446,6 @@ TEST_F(ParquetTableScanTest, readAsLowerCase) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/dwio/parquet/tests/thrift/ThriftTransportTest.cpp
+++ b/velox/dwio/parquet/tests/thrift/ThriftTransportTest.cpp
@@ -106,6 +106,6 @@ TEST_F(ThriftTransportTest, bufferedOutOfBoundry) {
 // Define main so that gflags get processed.
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/examples/OperatorExtensibility.cpp
+++ b/velox/examples/OperatorExtensibility.cpp
@@ -160,7 +160,7 @@ class DuplicateRowTranslator : public exec::Operator::PlanNodeTranslator {
 };
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // Fourth, we register the custom plan translator. We're now ready to use our
   // operator in a query plan.

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -42,7 +42,7 @@ using exec::test::HiveConnectorTestBase;
 int main(int argc, char** argv) {
   // Velox Tasks/Operators are based on folly's async framework, so we need to
   // make sure we initialize it first.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // Default memory allocator used throughout this example.
   auto pool = memory::addDefaultLeafMemoryPool();

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -31,7 +31,7 @@ using namespace facebook::velox::dwrf;
 // Used to compare the ORC data read by DWRFReader against apache-orc repo.
 // Usage: velox_example_scan_orc {orc_file_path}
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   if (argc < 2) {
     return 1;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -331,7 +331,7 @@ BENCHMARK(localFlat10k) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();

--- a/velox/exec/benchmarks/FilterProjectBenchmark.cpp
+++ b/velox/exec/benchmarks/FilterProjectBenchmark.cpp
@@ -266,7 +266,7 @@ class FilterProjectBenchmark : public VectorTestBase {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -611,7 +611,7 @@ void combineResults(
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   memory::MmapAllocator::Options options;
   options.capacity = 10UL << 30;
   options.useMmapArena = true;

--- a/velox/exec/benchmarks/MergeBenchmark.cpp
+++ b/velox/exec/benchmarks/MergeBenchmark.cpp
@@ -54,7 +54,7 @@ BENCHMARK_RELATIVE(wideArray) {
 }
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   MergeTestBase test;
   test.seed(1);

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -178,7 +178,7 @@ BENCHMARK_RELATIVE(computeValueIdsFlatStrings) {
 }
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
 

--- a/velox/exec/tests/AggregationRunnerTest.cpp
+++ b/velox/exec/tests/AggregationRunnerTest.cpp
@@ -65,7 +65,7 @@ static void checkDirForExpectedFiles() {
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   if (!FLAGS_aggregation_fuzzer_repro_path.empty()) {
     checkDirForExpectedFiles();

--- a/velox/exec/tests/JoinFuzzerTest.cpp
+++ b/velox/exec/tests/JoinFuzzerTest.cpp
@@ -33,7 +33,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return JoinFuzzerRunner::run(initialSeed);

--- a/velox/exec/tests/Main.cpp
+++ b/velox/exec/tests/Main.cpp
@@ -24,6 +24,6 @@ int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   // Signal handler required for ThreadDebugInfoTest
   facebook::velox::process::addDefaultFatalSignalHandler();
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // TODO: List of the functions that at some point crash or fail and need to
   // be fixed before we can enable. Constant argument of bloom_filter_agg cause

--- a/velox/exec/tests/VeloxIn10MinDemo.cpp
+++ b/velox/exec/tests/VeloxIn10MinDemo.cpp
@@ -290,7 +290,7 @@ void VeloxIn10MinDemo::run() {
 }
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
 
   VeloxIn10MinDemo demo;
   demo.run();

--- a/velox/experimental/codegen/benchmark/CodegenBenchmarks.cpp
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmarks.cpp
@@ -24,7 +24,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::codegen;
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   CodegenBenchmark benchmark;
 

--- a/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
+++ b/velox/expression/benchmarks/CallNullFreeBenchmark.cpp
@@ -312,7 +312,7 @@ BENCHMARK_MULTI(simpleMinIntegerNullFreeFastPath) {
 } // namespace facebook::velox::functions
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   facebook::velox::functions::CallNullFreeBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/expression/benchmarks/CastBenchmark.cpp
+++ b/velox/expression/benchmarks/CastBenchmark.cpp
@@ -151,7 +151,7 @@ BENCHMARK_MULTI(largeStructNested) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/expression/benchmarks/TryBenchmark.cpp
+++ b/velox/expression/benchmarks/TryBenchmark.cpp
@@ -185,7 +185,7 @@ BENCHMARK_MULTI(divideAllExceptions) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/expression/benchmarks/VariadicBenchmark.cpp
+++ b/velox/expression/benchmarks/VariadicBenchmark.cpp
@@ -194,7 +194,7 @@ BENCHMARK_MULTI(simpleVariadicLotsOfArgs) {
 } // namespace facebook::velox::functions
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   facebook::velox::functions::VariadicBenchmark benchmark;
   benchmark.test();
   folly::runBenchmarks();

--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -48,7 +48,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // TODO: List of the functions that at some point crash or fail and need to
   // be fixed before we can enable.

--- a/velox/expression/tests/ExpressionRunnerTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerTest.cpp
@@ -165,7 +165,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   if (!FLAGS_fuzzer_repro_path.empty()) {
     checkDirForExpectedFiles();

--- a/velox/expression/tests/SparkExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/SparkExpressionFuzzerTest.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
   // Calls common init functions in the necessary order, initializing
   // singletons, installing proper signal handlers for better debugging
   // experience, and initialize glog and gflags.
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   // The following list are the Spark UDFs that hit issues
   // For rlike you need the following combo in the only list:

--- a/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/ApproxMostFrequentStreamSummaryBenchmark.cpp
@@ -115,7 +115,7 @@ BENCHMARK_NAMED_PARAM(merge, capacity2048, 1e6, 2048)
 } // namespace facebook::velox::functions
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
+++ b/velox/functions/lib/benchmarks/KllSketchBenchmark.cpp
@@ -188,7 +188,7 @@ BENCHMARK_RELATIVE_NAMED_PARAM(mergeKllSketch, 1e6x80, 1e6, 80);
 } // namespace facebook::velox::functions::kll::test
 
 int main(int argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/lib/benchmarks/Re2FunctionsBenchmarks.cpp
+++ b/velox/functions/lib/benchmarks/Re2FunctionsBenchmarks.cpp
@@ -103,7 +103,7 @@ void registerRe2Functions() {
 } // namespace facebook::velox::functions::test
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   facebook::velox::functions::test::registerRe2Functions();
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/benchmarks/SimpleAggregates.cpp
@@ -268,7 +268,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   benchmark = std::make_unique<SimpleAggregatesBenchmark>();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/aggregates/tests/Main.cpp
+++ b/velox/functions/prestosql/aggregates/tests/Main.cpp
@@ -18,6 +18,6 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayContainsBenchmark.cpp
@@ -67,7 +67,7 @@ VELOX_UDF_END();
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   functions::prestosql::registerArrayFunctions();
 
   registerFunction<

--- a/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayMinMaxBenchmark.cpp
@@ -46,7 +46,7 @@ void registerTestSimpleFunctions() {
 using namespace facebook::velox;
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   functions::prestosql::registerArrayFunctions();
 
   functions::registerTestVectorFunctionBasic();

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBenchmark.cpp
@@ -222,7 +222,7 @@ BENCHMARK_RELATIVE(vectorBasicIntegerWithInstance) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArraySumBenchmark.cpp
@@ -27,7 +27,7 @@ using namespace facebook::velox::exec;
 using namespace facebook::velox::functions;
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   functions::prestosql::registerArrayFunctions();
   registerFunction<ArraySumFunction, int64_t, Array<int32_t>>(

--- a/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayWriterBenchmark.cpp
@@ -275,7 +275,7 @@ BENCHMARK_MULTI(std_reference) {
 } // namespace facebook::velox::exec
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   facebook::velox::exec::ArrayWriterBenchmark benchmark;
   benchmark.test();

--- a/velox/functions/prestosql/benchmarks/BitwiseBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/BitwiseBenchmark.cpp
@@ -154,7 +154,7 @@ BENCHMARK_RELATIVE(bitwise_shift_left) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/CardinalityBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/CardinalityBenchmark.cpp
@@ -238,7 +238,7 @@ BENCHMARK(vectorConditional) {
 }
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   LOG(ERROR) << "Seed: " << seed;
   {

--- a/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/CompareBenchmark.cpp
@@ -180,7 +180,7 @@ BENCHMARK_MULTI(Gt_Velox) {
 } // namespace facebook::velox::functions::test
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ComparisonsBenchmark.cpp
@@ -109,7 +109,7 @@ BENCHMARK_RELATIVE(simd_tinyint_eq) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ConcatBenchmark.cpp
@@ -137,7 +137,7 @@ BENCHMARK_MULTI(flattenAndConstantFold, n) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   LOG(ERROR) << "Seed: " << seed;
   {

--- a/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/DateTimeBenchmark.cpp
@@ -200,7 +200,7 @@ BENCHMARK(second) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/InBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/InBenchmark.cpp
@@ -129,7 +129,7 @@ BENCHMARK_RELATIVE(in1K) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -474,7 +474,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace facebook::velox::functions::prestosql
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/MapBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapBenchmark.cpp
@@ -83,7 +83,7 @@ BENCHMARK_MULTI(flatKeys, n) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapInputBenchmark.cpp
@@ -434,7 +434,7 @@ BENCHMARK_RELATIVE(nestedMapSumVectorFunctionMapView) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   MapInputBenchmark benchmark;
   if (benchmark.testMapSum() && benchmark.testNestedMapSum()) {

--- a/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/MapWriterBenchmarks.cpp
@@ -255,7 +255,7 @@ BENCHMARK(simple_general, n) {
 } // namespace facebook::velox::exec
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   facebook::velox::exec::MapWriterBenchmark benchmark;
   benchmark.test();

--- a/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapZipWithBenchmark.cpp
@@ -123,7 +123,7 @@ BENCHMARK_MULTI(dictionaryKeys, n) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   LOG(ERROR) << "Seed: " << seed;
   {

--- a/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NestedArrayWriterBenchmark.cpp
@@ -194,7 +194,7 @@ BENCHMARK_MULTI(simple) {
 } // namespace facebook::velox::exec
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   facebook::velox::exec::NestedArrayWriterBenchmark benchmark;
   benchmark.test();

--- a/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/NotBenchmark.cpp
@@ -79,7 +79,7 @@ BENCHMARK_RELATIVE(vectorizedNot) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/Row.cpp
+++ b/velox/functions/prestosql/benchmarks/Row.cpp
@@ -73,7 +73,7 @@ BENCHMARK(copyMostlyConst) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/RowWriterBenchmark.cpp
@@ -220,7 +220,7 @@ BENCHMARK_MULTI(complex_row) {
 } // namespace facebook::velox::exec
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   facebook::velox::exec::RowWriterBenchmark benchmark;
   benchmark.test();

--- a/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/SimpleSubscriptBenchmark.cpp
@@ -352,7 +352,7 @@ BENCHMARK(ArraySubscript_ArrayRowIntInt) {
 }
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   benchmark = std::make_unique<SimpleSubscriptBenchmark>();
   benchmark->test();
   folly::runBenchmarks();

--- a/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
+++ b/velox/functions/prestosql/benchmarks/StringAsciiUTFFunctionBenchmarks.cpp
@@ -185,7 +185,7 @@ BENCHMARK_RELATIVE(aciiRPad) {
 // asciiUpper                                        98.22%    68.98ms    14.50
 //============================================================================
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/StringWriterBenchmark.cpp
@@ -178,7 +178,7 @@ BENCHMARK_MULTI(array_of_string) {
 } // namespace facebook::velox::exec
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   facebook::velox::exec::StringWriterBenchmark benchmark;
   benchmark.test();

--- a/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/URLBenchmark.cpp
@@ -300,7 +300,7 @@ BENCHMARK_RELATIVE(velox_param) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/WidthBucketBenchmark.cpp
@@ -111,7 +111,7 @@ BENCHMARK_RELATIVE(widthBucket) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ZipBenchmark.cpp
@@ -111,7 +111,7 @@ BENCHMARK_MULTI(NeqSizeFlatFlat) {
 } // namespace facebook::velox::functions::test
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/functions/prestosql/benchmarks/ZipWithBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ZipWithBenchmark.cpp
@@ -136,7 +136,7 @@ BENCHMARK_MULTI(fast, n) {
 } // namespace
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   LOG(ERROR) << "Seed: " << seed;
   {

--- a/velox/functions/prestosql/window/tests/Main.cpp
+++ b/velox/functions/prestosql/window/tests/Main.cpp
@@ -18,6 +18,6 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
+++ b/velox/functions/remote/client/tests/RemoteFunctionTest.cpp
@@ -180,6 +180,6 @@ VELOX_INSTANTIATE_TEST_SUITE_P(
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/functions/sparksql/aggregates/tests/Main.cpp
+++ b/velox/functions/sparksql/aggregates/tests/Main.cpp
@@ -18,6 +18,6 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/functions/sparksql/benchmarks/In.cpp
+++ b/velox/functions/sparksql/benchmarks/In.cpp
@@ -124,7 +124,7 @@ void registerInFunctions() {
 } // namespace facebook::velox::functions::sparksql
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   facebook::velox::functions::registerPrestoIn();
   facebook::velox::functions::sparksql::registerInFunctions();
   facebook::velox::functions::registerArrayConstructor();

--- a/velox/functions/sparksql/window/tests/Main.cpp
+++ b/velox/functions/sparksql/window/tests/Main.cpp
@@ -18,6 +18,6 @@
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -173,7 +173,7 @@ BENCHMARK_NAMED_PARAM_MULTI(
 } // namespace facebook::spark::benchmarks
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -289,7 +289,7 @@ SERDE_BENCHMARKS(
 } // namespace facebook::velox::row
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -509,6 +509,6 @@ TEST_F(VeloxSubstraitRoundTripTest, dateType) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -823,6 +823,6 @@ TEST_F(TpchGenTestCustomerTest, reproducible) {
 
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  folly::init(&argc, &argv, false);
+  folly::Init(&argc, &argv, false);
   return RUN_ALL_TESTS();
 }

--- a/velox/type/tests/FilterBenchmark.cpp
+++ b/velox/type/tests/FilterBenchmark.cpp
@@ -70,7 +70,7 @@ BENCHMARK_RELATIVE(simdSparse) {
 int32_t main(int32_t argc, char* argv[]) {
   constexpr int32_t kNumValues = 1000000;
   constexpr int32_t kFilterValues = 1000;
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   std::vector<int64_t> filterValues;
   filterValues.reserve(kFilterValues);

--- a/velox/type/tests/NegatedBigintRangeBenchmark.cpp
+++ b/velox/type/tests/NegatedBigintRangeBenchmark.cpp
@@ -118,7 +118,7 @@ DEFINE_RANGE_BENCHMARKS(9000)
 DEFINE_RANGE_BENCHMARKS(9900)
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   constexpr int32_t kNumValues = 1000000;
   constexpr int64_t distinctVals = 20001; // -10000 to 10000
   const std::vector<int64_t> pctZeros = {0, 1, 5, 10, 50, 90, 95, 99, 100};

--- a/velox/type/tests/NegatedBytesRangeBenchmark.cpp
+++ b/velox/type/tests/NegatedBytesRangeBenchmark.cpp
@@ -129,7 +129,7 @@ DEFINE_BENCHMARKS(100, 94)
 DEFINE_BENCHMARKS(100, 98)
 
 int32_t main(int32_t argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   constexpr int32_t kNumValues = 1000000;
   constexpr int32_t kStringPoolSize = 20000;
   const std::vector<int32_t> stringLengths = {2, 3, 5, 10, 100};

--- a/velox/type/tests/NegatedBytesValuesBenchmark.cpp
+++ b/velox/type/tests/NegatedBytesValuesBenchmark.cpp
@@ -121,7 +121,7 @@ DEFINE_BENCHMARKS(100, 1000)
 DEFINE_BENCHMARKS(100, 10000)
 
 int32_t main(int32_t argc, char* argv[]) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   constexpr int32_t k_num_values = 1000000;
   constexpr int32_t k_string_pool_size = 20000;
   const std::vector<int32_t> string_lengths = {1, 2, 5, 10, 100};

--- a/velox/type/tests/NegatedValuesFilterBenchmark.cpp
+++ b/velox/type/tests/NegatedValuesFilterBenchmark.cpp
@@ -125,7 +125,7 @@ int32_t main(int32_t argc, char* argv[]) {
       1000, 1000, 10000, 10, 1000, 1000, 1000};
   std::vector<std::vector<int64_t>> rejectedValues;
 
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   rejectedValues.reserve(kFilterSizes.size());
   for (auto i = 0; i < kFilterSizes.size(); ++i) {

--- a/velox/type/tests/StringViewBenchmark.cpp
+++ b/velox/type/tests/StringViewBenchmark.cpp
@@ -53,7 +53,7 @@ BENCHMARK_PARAM(runStringViewCreate, NON_INLINE_SIZE);
 } // namespace facebook::velox
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -351,7 +351,7 @@ BENCHMARK_MULTI(copyStructNonContiguous) {
 } // namespace facebook::velox
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
 
   folly::runBenchmarks();
   return 0;

--- a/velox/vector/benchmarks/NthBitBenchmark.cpp
+++ b/velox/vector/benchmarks/NthBitBenchmark.cpp
@@ -117,7 +117,7 @@ BENCHMARK_RELATIVE_PARAM(BM_setNthBit_shift_false_unsigned, 1000000);
 BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
+++ b/velox/vector/benchmarks/SelectivityVectorBenchmark.cpp
@@ -308,7 +308,7 @@ BENCHMARK_DRAW_LINE();
 // buck run @mode/opt-clang-thinlto \
 //   velox/vector/benchmarks:selectivity_vector_benchmark
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
+++ b/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
@@ -467,7 +467,7 @@ BENCHMARK_DRAW_LINE();
 } // namespace facebook::velox::test
 
 int main(int argc, char** argv) {
-  folly::init(&argc, &argv);
+  folly::Init(&argc, &argv);
   folly::runBenchmarks();
   return 0;
 }


### PR DESCRIPTION
Existing folly version uses OpenSSL@1.1, but setup-macos.sh would install OpenSSL@3 as a dependency of Python. This causes the "make" process failed with message "Undefined symbols for architecture x86_64: "_EVP_MD_get_size"" because _EVP_MD_get_size was defined in OpenSSL@1.1 and was replaced by _EVP_MD_size in OpenSSL@3. CMake tries to link against OpenSSL@3 and therefore the error.

Since the latest folly version is already on OpenSSL@3, upgrading folly to the latest version solves the problem. This commit upgrades Velox folly dependency to version v2023.08.07.00.