### PR TITLE
Add Cuda Event, Metrics and Utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,6 +342,9 @@ if(${VELOX_ENABLE_GPU})
   enable_language(CUDA)
   # Determine CUDA_ARCHITECTURES automatically.
   cmake_policy(SET CMP0104 NEW)
+  if(CMAKE_BUILD_TYPE MATCHES Debug)
+    add_compile_options("$<$<COMPILE_LANGUAGE:CUDA>:-G>")
+  endif()
 endif()
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/velox/experimental/wave/common/Block.cuh
+++ b/velox/experimental/wave/common/Block.cuh
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cub/block/block_scan.cuh>
+
+/// Utilities for  booleans and indices and thread blocks.
+
+namespace facebook::velox::wave {
+
+template <
+    int32_t blockSize,
+    cub::BlockScanAlgorithm Algorithm = cub::BLOCK_SCAN_RAKING,
+    typename Getter>
+__device__ inline void boolBlockToIndices(
+    Getter getter,
+    int32_t start,
+    int32_t* indices,
+    void* shmem,
+    int32_t& size) {
+  typedef cub::BlockScan<int, blockSize, Algorithm> BlockScanT;
+
+  auto* temp = reinterpret_cast<typename BlockScanT::TempStorage*>(shmem);
+  int data[1];
+  uint8_t flag = getter();
+  data[0] = flag;
+  __syncthreads();
+  int aggregate;
+  BlockScanT(*temp).ExclusiveSum(data, data, aggregate);
+  __syncthreads();
+  if (flag) {
+    indices[data[0]] = threadIdx.x + start;
+  }
+  if (threadIdx.x == 0) {
+    size = aggregate;
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/Buffer.h
+++ b/velox/experimental/wave/common/Buffer.h
@@ -33,7 +33,7 @@ class Buffer {
  public:
   template <typename T>
   T* as() {
-    reinterpret_cast<T*>(ptr_);
+    return reinterpret_cast<T*>(ptr_);
   }
 
   size_t capacity() const {

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -61,21 +61,87 @@ void setDevice(Device* device) {
 }
 
 Stream::Stream() {
-  stream = std::make_unique<StreamImpl>();
-  CUDA_CHECK(cudaStreamCreate(&stream->stream));
+  stream_ = std::make_unique<StreamImpl>();
+  CUDA_CHECK(cudaStreamCreate(&stream_->stream));
 }
 
 Stream::~Stream() {
-  cudaStreamDestroy(stream->stream);
+  cudaStreamDestroy(stream_->stream);
 }
 
 void Stream::wait() {
-  CUDA_CHECK(cudaStreamSynchronize(stream->stream));
+  CUDA_CHECK(cudaStreamSynchronize(stream_->stream));
 }
 
 void Stream::prefetch(Device* device, void* ptr, size_t size) {
   CUDA_CHECK(cudaMemPrefetchAsync(
-      ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream->stream));
+      ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream_->stream));
+}
+
+namespace {
+struct CallbackData {
+  CallbackData(std::function<void()> callback)
+      : callback(std::move(callback)){};
+  std::function<void()> callback;
+};
+
+void readyCallback(void* voidData) {
+  std::unique_ptr<CallbackData> data(reinterpret_cast<CallbackData*>(voidData));
+  data->callback();
+}
+} // namespace
+
+void Stream::addCallback(std::function<void()> callback) {
+  auto cdata = new CallbackData(std::move(callback));
+  CUDA_CHECK(cudaLaunchHostFunc(stream_->stream, readyCallback, cdata));
+}
+
+struct EventImpl {
+  ~EventImpl() {
+    CUDA_CHECK(cudaEventDestroy(event));
+  }
+  cudaEvent_t event;
+};
+
+Event::Event(bool withTime) : hasTiming_(withTime) {
+  event_ = std::make_unique<EventImpl>();
+  CUDA_CHECK(
+      cudaEventCreate(&event_->event, withTime ? 0 : cudaEventDisableTiming));
+}
+
+Event::~Event() {}
+
+void Event::record(Stream& stream) {
+  CUDA_CHECK(cudaEventRecord(event_->event, stream.stream_->stream));
+  recorded_ = true;
+}
+
+void Event::wait() {
+  CUDA_CHECK(cudaEventSynchronize(event_->event));
+}
+
+bool Event::query() const {
+  auto rc = cudaEventQuery(event_->event);
+  if (rc == ::cudaErrorNotReady) {
+    return false;
+  }
+  CUDA_CHECK(rc);
+  return true;
+}
+
+void Event::wait(Stream& stream) {
+  CUDA_CHECK(cudaStreamWaitEvent(stream.stream_->stream, event_->event));
+}
+
+/// Returns time in ms betweene 'this' and an earlier 'start'. Both events must
+/// enable timing.
+float Event::elapsedTime(const Event& start) const {
+  float ms;
+  if (!hasTiming_ || !start.hasTiming_) {
+    waveError("Event timing not enabled");
+  }
+  CUDA_CHECK(cudaEventElapsedTime(&ms, start.event_->event, event_->event));
+  return ms;
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/GpuArena.cpp
+++ b/velox/experimental/wave/common/GpuArena.cpp
@@ -304,7 +304,7 @@ WaveBufferPtr GpuArena::getBuffer(void* ptr, size_t size) {
   return result;
 }
 
-WaveBufferPtr GpuArena::allocate(uint64_t bytes) {
+WaveBufferPtr GpuArena::allocateBytes(uint64_t bytes) {
   bytes = GpuSlab::roundBytes(bytes);
   std::lock_guard<std::mutex> l(mutex_);
   auto* result = currentArena_->allocate(bytes);

--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -121,7 +121,12 @@ class GpuArena {
  public:
   GpuArena(uint64_t singleArenaCapacity, GpuAllocator* allocator);
 
-  WaveBufferPtr allocate(uint64_t bytes);
+  WaveBufferPtr allocateBytes(uint64_t bytes);
+
+  template <typename T>
+  WaveBufferPtr allocate(int32_t items) {
+    return allocateBytes(sizeof(T) * items);
+  }
 
   void free(Buffer* buffer);
 

--- a/velox/experimental/wave/common/tests/BlockTest.cpp
+++ b/velox/experimental/wave/common/tests/BlockTest.cpp
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <iostream>
+
+#include <gtest/gtest.h>
+#include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Semaphore.h"
+#include "velox/common/base/SimdUtil.h"
+#include "velox/common/time/Timer.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/tests/BlockTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::wave;
+
+class BlockTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    device_ = getDevice();
+    setDevice(device_);
+    allocator_ = getAllocator(device_);
+    arena_ = std::make_unique<GpuArena>(1 << 28, allocator_);
+  }
+
+  void prefetch(Stream& stream, WaveBufferPtr buffer) {
+    stream.prefetch(device_, buffer->as<char>(), buffer->capacity());
+  }
+
+  Device* device_;
+  GpuAllocator* allocator_;
+  std::unique_ptr<GpuArena> arena_;
+};
+
+TEST_F(BlockTest, boolToIndices) {
+  /// We make a set of 256 flags and corresponding 256 indices of true flags.
+  constexpr int32_t kNumBlocks = 20480;
+  constexpr int32_t kBlockSize = 256;
+  constexpr int32_t kNumFlags = kBlockSize * kNumBlocks;
+  auto flagsBuffer = arena_->allocate<uint8_t>(kNumFlags);
+  auto indicesBuffer = arena_->allocate<int32_t>(kNumFlags);
+  auto sizesBuffer = arena_->allocate<int32_t>(kNumBlocks);
+  auto timesBuffer = arena_->allocate<int64_t>(kNumBlocks);
+  BlockTestStream stream;
+
+  std::vector<int32_t> referenceIndices(kNumFlags);
+  std::vector<int32_t> referenceSizes(kNumBlocks);
+  uint8_t* flags = flagsBuffer->as<uint8_t>();
+  for (auto i = 0; i < kNumFlags; ++i) {
+    if ((i >> 8) % 17 == 0) {
+      flags[i] = 0;
+    } else if ((i >> 8) % 23 == 0) {
+      flags[i] = 1;
+    } else {
+      flags[i] = (i * 1121) % 73 > 50;
+    }
+  }
+  for (auto b = 0; b < kNumBlocks; ++b) {
+    auto start = b * kBlockSize;
+    int32_t counter = start;
+    for (auto i = 0; i < kBlockSize; ++i) {
+      if (flags[start + i]) {
+        referenceIndices[counter++] = start + i;
+      }
+    }
+    referenceSizes[b] = counter - start;
+  }
+
+  prefetch(stream, flagsBuffer);
+  prefetch(stream, indicesBuffer);
+  prefetch(stream, sizesBuffer);
+
+  auto indicesPointers = arena_->allocate<void*>(kNumBlocks);
+  auto flagsPointers = arena_->allocate<void*>(kNumBlocks);
+  for (auto i = 0; i < kNumBlocks; ++i) {
+    flagsPointers->as<uint8_t*>()[i] = flags + (i * kBlockSize);
+    indicesPointers->as<int32_t*>()[i] =
+        indicesBuffer->as<int32_t>() + (i * kBlockSize);
+  }
+
+  auto startMicros = getCurrentTimeMicro();
+  stream.testBoolToIndices(
+      kNumBlocks,
+      flagsPointers->as<uint8_t*>(),
+      indicesPointers->as<int32_t*>(),
+      sizesBuffer->as<int32_t>(),
+      timesBuffer->as<int64_t>());
+  stream.wait();
+  auto elapsed = getCurrentTimeMicro() - startMicros;
+  for (auto b = 0; b < kNumBlocks; ++b) {
+    ASSERT_EQ(
+        0,
+        ::memcmp(
+            referenceIndices.data() + b * kBlockSize,
+            indicesBuffer->as<int32_t>() + b * kBlockSize,
+            referenceSizes[b] * sizeof(int32_t)));
+    ASSERT_EQ(referenceSizes[b], sizesBuffer->as<int32_t>()[b]);
+  }
+  std::cout << "Flags to indices: " << elapsed << "us, "
+            << kNumFlags / static_cast<float>(elapsed) << " Mrows/s"
+            << std::endl;
+}

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -1,0 +1,43 @@
+#include "velox/experimental/wave/common/Block.cuh"
+#include "velox/experimental/wave/common/CudaUtil.cuh"
+#include "velox/experimental/wave/common/tests/BlockTest.h"
+
+namespace facebook::velox::wave {
+
+using ScanAlgorithm = cub::BlockScan<int, 256, cub::BLOCK_SCAN_RAKING>;
+
+__global__ void boolToIndices(
+    uint8_t** bools,
+    int32_t** indices,
+    int32_t* sizes,
+    int64_t* times) {
+  extern __shared__ __align__(alignof(ScanAlgorithm::TempStorage)) char smem[];
+  int32_t idx = blockIdx.x;
+  // Start cycle timer
+  clock_t start = clock();
+  uint8_t* blockBools = bools[idx];
+  boolBlockToIndices<256>(
+      [&]() { return blockBools[threadIdx.x]; },
+      idx * 256,
+      indices[idx],
+      smem,
+      sizes[idx]);
+  clock_t stop = clock();
+  if (threadIdx.x == 0) {
+    times[idx] = (start > stop) ? start - stop : stop - start;
+  }
+}
+
+void BlockTestStream::testBoolToIndices(
+    int32_t numBlocks,
+    uint8_t** flags,
+    int32_t** indices,
+    int32_t* sizes,
+    int64_t* times) {
+  auto tempBytes = sizeof(typename ScanAlgorithm::TempStorage);
+  boolToIndices<<<numBlocks, 256, tempBytes, stream_->stream>>>(
+      flags, indices, sizes, times);
+  CUDA_CHECK(cudaGetLastError());
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/BlockTest.h
+++ b/velox/experimental/wave/common/tests/BlockTest.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/common/Cuda.h"
+
+/// Sample header for testing Block.cuh
+
+namespace facebook::velox::wave {
+
+class BlockTestStream : public Stream {
+ public:
+  /// In each block of 256 bools in bools[i], counts the number of
+  /// true and writes the indices of true lanes into the corresponding
+  /// indices[i]. Stors the number of true values to sizes[i].
+  void testBoolToIndices(
+      int32_t numBlocks,
+      uint8_t** flags,
+      int32_t** indices,
+      int32_t* sizes,
+      int64_t* times);
+
+  /// Sorts 'rows'[i] using ids[i] as keys and stores the sorted order in
+  /// 'result[i]'.
+  // void dedup(int32_t numBlocks, uint16_t** ids, uint16_t** rows, uint16_t**
+  // resultRows);
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_wave_common_test GpuArenaTest.cpp CudaTest.cpp CudaTest.cu)
+add_executable(velox_wave_common_test GpuArenaTest.cpp CudaTest.cpp CudaTest.cu
+                                      BlockTest.cpp BlockTest.cu)
 
 set_target_properties(velox_wave_common_test PROPERTIES CUDA_ARCHITECTURES
                                                         native)
@@ -22,8 +23,10 @@ add_test(velox_wave_common_test velox_wave_common_test)
 target_link_libraries(
   velox_wave_common_test
   velox_wave_common
+  velox_time
   velox_exception
   gtest
   gtest_main
   gflags::gflags
+  glog::glog
   Folly::folly)

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -14,10 +14,36 @@
  * limitations under the License.
  */
 
-#include "velox/experimental/wave/common/tests/CudaTest.h"
+#include <iostream>
+
+#include <folly/init/Init.h>
+
 #include <gtest/gtest.h>
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Semaphore.h"
+#include "velox/common/base/SimdUtil.h"
+#include "velox/common/time/Timer.h"
 #include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/tests/CudaTest.h"
+
+DEFINE_int32(num_streams, 0, "Number of paralll streams");
+DEFINE_int32(op_size, 0, "Size of invoke kernel (ints read and written)");
+DEFINE_int32(
+    num_ops,
+    0,
+    "Number of consecutive kernel executions on each stream");
+DEFINE_bool(
+    use_callbacks,
+    false,
+    "Queue a host callback after each kernel execution");
+DEFINE_bool(
+    sync_streams,
+    false,
+    "Use events to synchronize all parallel streams before calling the next kernel on each stream.");
+DEFINE_bool(
+    prefetch,
+    true,
+    "Use prefetch to move unified memory to device at start and to host at end");
 
 using namespace facebook::velox;
 using namespace facebook::velox::wave;
@@ -29,24 +55,186 @@ class CudaTest : public testing::Test {
     setDevice(device_);
     allocator_ = getAllocator(device_);
   }
+
+  void streamTest(
+      int32_t numStreams,
+      int32_t numOps,
+      int32_t opSize,
+      bool prefetch,
+      bool useCallbacks,
+      bool syncStreams) {
+    int32_t firstNotify = useCallbacks ? 1 : numOps - 1;
+    constexpr int32_t kBatch = xsimd::batch<int32_t>::size;
+    std::vector<std::unique_ptr<TestStream>> streams;
+    std::vector<std::unique_ptr<Event>> events;
+    std::vector<int32_t*> ints;
+    std::mutex mutex;
+    int32_t initValues[16] = {
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+    auto initVector = xsimd::load_unaligned(&initValues[0]);
+    auto increment = xsimd::broadcast<int32_t>(1);
+    std::vector<int64_t> delay;
+    delay.reserve(numStreams * (numOps + 2));
+
+    auto start = getCurrentTimeMicro();
+    for (auto i = 0; i < numStreams; ++i) {
+      streams.push_back(std::make_unique<TestStream>());
+      ints.push_back(reinterpret_cast<int32_t*>(
+          allocator_->allocate(opSize * sizeof(int32_t))));
+      auto last = ints.back();
+      auto data = initVector;
+      for (auto i = 0; i < opSize; i += kBatch) {
+        data.store_unaligned(last + i);
+        data += increment;
+      }
+    }
+    for (auto i = 0; i < numStreams; ++i) {
+      streams[i]->addCallback([&]() {
+        auto d = getCurrentTimeMicro() - start;
+        {
+          std::lock_guard<std::mutex> l(mutex);
+          delay.push_back(d);
+        }
+      });
+      if (prefetch) {
+        streams[i]->prefetch(device_, ints[i], opSize * sizeof(int32_t));
+      }
+    }
+
+    Semaphore sem(0);
+    for (auto counter = 0; counter < numOps; ++counter) {
+      if (counter > 0 && syncStreams) {
+        waitEach(streams, events);
+      }
+      for (auto i = 0; i < numStreams; ++i) {
+        streams[i]->addOne(ints[i], opSize);
+        if (counter == 0 || counter >= firstNotify) {
+          streams[i]->addCallback([&]() {
+            auto d = getCurrentTimeMicro() - start;
+            {
+              std::lock_guard<std::mutex> l(mutex);
+              delay.push_back(d);
+            }
+            sem.release();
+          });
+        }
+        if (counter == numOps - 1) {
+          if (prefetch) {
+            streams[i]->prefetch(nullptr, ints[i], opSize * sizeof(int32_t));
+          }
+        }
+      }
+      if (syncStreams && counter < numOps - 1) {
+        recordEach(streams, events);
+      }
+    }
+    // Destroy the streams while items pending. Items should finish.
+    streams.clear();
+    for (auto i = 0; i < numStreams * (numOps + 1 - firstNotify); ++i) {
+      sem.acquire();
+    }
+    for (auto i = 0; i < numStreams; ++i) {
+      auto* array = ints[i];
+      auto data = initVector + numOps;
+      xsimd::batch_bool<int32_t> error;
+      error = error ^ error;
+      for (auto j = 0; j < opSize; j += kBatch) {
+        error = error | (data != xsimd::load_unaligned(array + j));
+        data += increment;
+      }
+      ASSERT_EQ(0, simd::toBitMask(error));
+      delay.push_back(getCurrentTimeMicro() - start);
+    }
+    for (auto i = 0; i < numStreams; ++i) {
+      allocator_->free(ints[i], sizeof(int32_t) * opSize);
+    }
+    std::cout << "Delays: ";
+    int32_t counter = 0;
+    for (auto d : delay) {
+      std::cout << d << " ";
+      if (++counter % numStreams == 0) {
+        std::cout << std::endl;
+      }
+    }
+    std::cout << std::endl;
+    float toDeviceMicros = delay[(2 * numStreams) - 1] - delay[0];
+    float inDeviceMicros =
+        delay[delay.size() - numStreams - 1] - delay[numStreams * 2 - 1];
+    float toHostMicros = delay.back() - delay[delay.size() - numStreams];
+    float gbSize =
+        (sizeof(int32_t) * numStreams * static_cast<float>(opSize)) / (1 << 30);
+    std::cout << "to device= " << toDeviceMicros << "us ("
+              << gbSize / (toDeviceMicros / 1000000) << " GB/s)" << std::endl;
+    std::cout << "In device (ex. first pass): " << inDeviceMicros << "us ("
+              << gbSize * (numOps - 1) / (inDeviceMicros / 1000000) << " GB/s)"
+              << std::endl;
+    std::cout << "to host= " << toHostMicros << "us ("
+              << gbSize / (toHostMicros / 1000000) << " GB/s)" << std::endl;
+  }
+
+  void recordEach(
+      std::vector<std::unique_ptr<TestStream>>& streams,
+      std::vector<std::unique_ptr<Event>>& events) {
+    for (auto& stream : streams) {
+      events.push_back(std::make_unique<Event>());
+      events.back()->record(*stream);
+    }
+  }
+
+  // Every stream waits for every event recorded on each stream in the previous
+  // call to recordEach.
+  void waitEach(
+      std::vector<std::unique_ptr<TestStream>>& streams,
+      std::vector<std::unique_ptr<Event>>& events) {
+    auto firstEvent = events.size() - streams.size();
+    for (auto& stream : streams) {
+      for (auto eventIndex = firstEvent; eventIndex < events.size();
+           ++eventIndex) {
+        events[eventIndex]->wait(*stream);
+      }
+    }
+  }
   Device* device_;
   GpuAllocator* allocator_;
 };
 
 TEST_F(CudaTest, stream) {
-  constexpr int32_t kSize = 1000000;
+  constexpr int32_t opSize = 1000000;
   TestStream stream;
-  auto ints =
-      reinterpret_cast<int32_t*>(allocator_->allocate(kSize * sizeof(int32_t)));
-  for (auto i = 0; i < kSize; ++i) {
+  auto ints = reinterpret_cast<int32_t*>(
+      allocator_->allocate(opSize * sizeof(int32_t)));
+  for (auto i = 0; i < opSize; ++i) {
     ints[i] = i;
   }
-  stream.prefetch(device_, ints, kSize * sizeof(int32_t));
-  stream.addOne(ints, kSize);
-  stream.prefetch(nullptr, ints, kSize * sizeof(int32_t));
+  stream.prefetch(device_, ints, opSize * sizeof(int32_t));
+  stream.addOne(ints, opSize);
+  stream.prefetch(nullptr, ints, opSize * sizeof(int32_t));
   stream.wait();
-  for (auto i = 0; i < kSize; ++i) {
+  for (auto i = 0; i < opSize; ++i) {
     ASSERT_EQ(ints[i], i + 1);
   }
-  allocator_->free(ints, sizeof(int32_t) * kSize);
+  allocator_->free(ints, sizeof(int32_t) * opSize);
+}
+
+TEST_F(CudaTest, callback) {
+  streamTest(10, 10, 1024 * 1024, true, false, false);
+}
+
+TEST_F(CudaTest, custom) {
+  if (FLAGS_num_streams == 0) {
+    return;
+  }
+  streamTest(
+      FLAGS_num_streams,
+      FLAGS_num_ops,
+      FLAGS_op_size,
+      FLAGS_prefetch,
+      FLAGS_use_callbacks,
+      FLAGS_sync_streams);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest();
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
 }

--- a/velox/experimental/wave/common/tests/GpuArenaTest.cpp
+++ b/velox/experimental/wave/common/tests/GpuArenaTest.cpp
@@ -134,7 +134,7 @@ TEST_F(GpuArenaTest, buffers) {
   auto arena = std::make_unique<GpuArena>(1 << 20, allocator_.get());
   std::vector<WaveBufferPtr> buffers;
   for (auto i = 0; i < 5000; ++i) {
-    buffers.push_back(arena->allocate(1024));
+    buffers.push_back(arena->allocate<char>(1024));
   }
   EXPECT_EQ(5, arena->slabs().size());
   // We clear some of the first allocated buffers.
@@ -143,11 +143,11 @@ TEST_F(GpuArenaTest, buffers) {
   // Allocate some more. Check that slabs  with unuused capacity get used before
   // making new ones.
   for (auto i = 0; i < 100; ++i) {
-    buffers.push_back(arena->allocate(1024));
+    buffers.push_back(arena->allocate<char>(1024));
   }
   EXPECT_EQ(3, arena->slabs().size());
   for (auto i = 0; i < 500; ++i) {
-    buffers.push_back(arena->allocate(1024));
+    buffers.push_back(arena->allocate<char>(1024));
   }
   EXPECT_EQ(4, arena->slabs().size());
 


### PR DESCRIPTION
Encapsulates Cuda event. Tests timing of callbacks and stream-to-stream synchronization with Cuda events. Adds a generic test for multi-stream operation from one host stream with options for prefetch, synchronization and callbacks.

A host callbakc from Cuda stream is about 100us. A two stream synchronization on device is about 3 us. A 10 stream synchronization on device is about 40 us. The cost to launch a kernel from a stream is about 3 us if it is enqueued beforehand.

Times with GForce 3080 ad 16x PCIE 4.0

Adds a header for common cub applications, initially with a flag array to indices of set positions conversion. More thread block utilities to folllow.