### PR TITLE
Cast negative float/double to boolean should return true

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -769,6 +769,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<int8_t, bool>("boolean", {-1}, {true}, false);
     testCast<double, bool>("boolean", {1.0}, {true}, false);
     testCast<double, bool>("boolean", {1.1}, {true}, false);
+    testCast<double, bool>("boolean", {0.1}, {true}, false);
+    testCast<double, bool>("boolean", {-0.1}, {true}, false);
+    testCast<double, bool>("boolean", {-1.0}, {true}, false);
     testCast<float, bool>("boolean", {kNan}, {true}, false);
     testCast<float, bool>("boolean", {kInf}, {true}, false);
     testCast<double, bool>("boolean", {0.0000000000001}, {true}, false);
@@ -826,6 +829,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<int8_t, bool>("boolean", {-1}, {true}, false);
     testCast<double, bool>("boolean", {1.0}, {true}, false);
     testCast<double, bool>("boolean", {1.1}, {true}, false);
+    testCast<double, bool>("boolean", {0.1}, {true}, false);
+    testCast<double, bool>("boolean", {-0.1}, {true}, false);
+    testCast<double, bool>("boolean", {-1.0}, {true}, false);
     testCast<float, bool>("boolean", {kNan}, {false}, false);
     testCast<float, bool>("boolean", {kInf}, {true}, false);
     testCast<double, bool>("boolean", {0.0000000000001}, {true}, false);

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -209,6 +209,9 @@ struct Converter<
       if (std::isnan(v)) {
         return 0;
       }
+      if constexpr (std::is_same_v<T, bool>) {
+        return v != 0;
+      }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();
       } else if (v > LimitType::maxLimit()) {
@@ -232,6 +235,9 @@ struct Converter<
     if constexpr (TRUNCATE) {
       if (std::isnan(v)) {
         return 0;
+      }
+      if constexpr (std::is_same_v<T, bool>) {
+        return v != 0;
       }
       if constexpr (std::is_same_v<T, int128_t>) {
         return std::numeric_limits<int128_t>::max();


### PR DESCRIPTION
Whether set expression eval configuration `cast_to_int_by_truncate` to true/false, cast from negative float/double to boolean should always return true. But currently it returns false when `cast_to_int_by_truncate=true`.

This PR fix the wrong result and add tests to cover these cases.