### PR TITLE
Fix getByteRange when it encounters an invalid UTF code point.

### DIFF
--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -431,6 +431,20 @@ TEST_F(StringImplTest, getByteRange) {
     EXPECT_EQ(expectedStartByteIndex, range.first);
     EXPECT_EQ(expectedEndByteIndex, range.second);
   }
+
+  // Test bad unicode strings.
+
+  // This exercises bad unicode byte in determining startByteIndex.
+  std::string badUnicode = "aa\xff  ";
+  auto range = getByteRange<false>(badUnicode.data(), 4, 3);
+  EXPECT_EQ(range.first, 3);
+  EXPECT_EQ(range.second, 6);
+
+  // This exercises bad unicode byte in determining endByteIndex.
+  badUnicode = "\xff aa";
+  range = getByteRange<false>(badUnicode.data(), 1, 3);
+  EXPECT_EQ(range.first, 0);
+  EXPECT_EQ(range.second, 3);
 }
 
 TEST_F(StringImplTest, pad) {
@@ -529,6 +543,11 @@ TEST_F(StringImplTest, pad) {
   runTestUserError("text", -1, "a");
   runTestUserError(
       "text", ((int64_t)std::numeric_limits<int32_t>::max()) + 1, "a");
+  // Additional tests with bad unicode bytes.
+  runTest("abcd\xff \xff ef", 6, "0", "abcd\xff ", "abcd\xff ");
+  runTest(
+      "abcd\xff \xff ef", 11, "0", "0abcd\xff \xff ef", "abcd\xff \xff ef0");
+  runTest("abcd\xff ef", 6, "0", "abcd\xff ", "abcd\xff ");
 }
 
 // Make sure that utf8proc_codepoint returns invalid codepoint (-1) for


### PR DESCRIPTION
Fixes #5877 . 

RPad encounters a segfault when getByterange encounters a bad utf code point ; This is because utf8proc_char_length returns -1 which when added to buffer ptr of current string results in an exception. 
I have validated that the current changes work and compared this with behavior in production presto and ensured they match. I also looked for other uses of utf8proc_char_length and validated that we don't have similar bugs in other uses. 

In spark udfs utf8proc_char_length is used without the check for -1, however all uses of utf8proc_char_length are immediately followed by calls to std::string(stringptr, <char length returned by utf8proc_char_length>) which throws an exception on negative length. Thus spark call points are safe. 