### PR TITLE
Ensure encoding layers are initialized when loading lazy vectors

### DIFF
--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -120,7 +120,7 @@ void LazyVector::ensureLoadedRowsImpl(
         decodedChild.decode(*child, baseRows, false);
         ensureLoadedRowsImpl(child, decodedChild, baseRows, childRows);
       }
-      decoded.base()->loadedVector();
+      vector->loadedVector();
     }
     return;
   }


### PR DESCRIPTION
This fixes a bug where when an input contains a vector of the form
Dictionary(Row(LazyChild)), the dictionary layer remain un-initialized
after loading the row vector.

Test Plan:
Added a unit test