### PR TITLE
Add date_add Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -7,6 +7,12 @@ Convenience Extraction Functions
 
 These functions support TIMESTAMP and DATE input types.
 
+.. spark:function:: date_add(start_date, num_days) -> date
+
+    Returns the date that is num_days after start_date.
+    If num_days is a negative value then these amount of days will be
+    deducted from start_date.
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -16,6 +16,7 @@
 
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
+#include "velox/functions/prestosql/DateTimeImpl.h"
 #include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox::functions::sparksql {
@@ -263,4 +264,15 @@ struct LastDayFunction {
   }
 };
 
+template <typename T>
+struct DateAddFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Date>& date,
+      const int32_t value) {
+    result = addToDate(date, DateTimeUnit::kDay, value);
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -212,6 +212,8 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
 
+  registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
+
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -234,6 +234,8 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
 
   // Check null behaviors
   EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, 1));
+  EXPECT_EQ(std::nullopt, dateAdd(parseDate("2019-02-28"), std::nullopt));
+  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, std::nullopt));
 
   // Check simple tests.
   EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-03-01"), 0));
@@ -246,6 +248,16 @@ TEST_F(DateTimeFunctionsTest, dateAdd) {
   // Check for negative intervals
   EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
   EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
+
+  // Check for minimum and maximum tests.
+  constexpr int32_t kMin = std::numeric_limits<int32_t>::min();
+  constexpr int32_t kMax = std::numeric_limits<int32_t>::max();
+  EXPECT_EQ(parseDate("5881580-07-11"), dateAdd(parseDate("1970-01-01"), kMax));
+  EXPECT_EQ(
+      parseDate("1969-12-31"), dateAdd(parseDate("-5877641-06-23"), kMax));
+  EXPECT_EQ(
+      parseDate("-5877641-06-23"), dateAdd(parseDate("1970-01-01"), kMin));
+  EXPECT_EQ(parseDate("1969-12-31"), dateAdd(parseDate("5881580-07-11"), kMin));
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -225,5 +225,28 @@ TEST_F(DateTimeFunctionsTest, lastDay) {
   EXPECT_EQ(lastDayFunc(std::nullopt), std::nullopt);
 }
 
+TEST_F(DateTimeFunctionsTest, dateAdd) {
+  const auto dateAdd = [&](std::optional<int32_t> date,
+                           std::optional<int32_t> value) {
+    return evaluateOnce<int32_t, int32_t>(
+        "date_add(c0, c1)", {date, value}, {DATE(), INTEGER()});
+  };
+
+  // Check null behaviors
+  EXPECT_EQ(std::nullopt, dateAdd(std::nullopt, 1));
+
+  // Check simple tests.
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-03-01"), 0));
+  EXPECT_EQ(parseDate("2019-03-01"), dateAdd(parseDate("2019-02-28"), 1));
+
+  // Account for the last day of a year-month
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
+  EXPECT_EQ(parseDate("2020-02-29"), dateAdd(parseDate("2019-01-30"), 395));
+
+  // Check for negative intervals
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
+  EXPECT_EQ(parseDate("2019-02-28"), dateAdd(parseDate("2020-02-29"), -366));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
**Spark date_add implementation:**
https://github.com/apache/spark/blob/f67e168acd9c13d27c55807736b7fd7cdf870e29/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L284-L321

**Function semantics:**

Presto semantic:
```
date_add(unit: Date, value: Varchar, x: int64_t) -> x: int64_t
date_add(unit: Timestamp, value: Varchar, x: int64_t) -> x: int64_t
date_add(unit: TimestampWithTimezone, value: Varchar, x: int64_t) -> x: int64_t
```

Spark semantic:
```
date_add(start_date: Date, num_days: Date) -> x: int32_t
```

**Corner cases:**
Null behavior: If the first and/or the second argument is null, the expression will return null.