### PR TITLE
Fix handling of exceptions in try_cast from Json

### DIFF
--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -706,6 +706,7 @@ void castFromJson(
       try {
         object = folly::parseJson(inputVector->valueAt(row));
       } catch (const std::exception& e) {
+        writer.commitNull();
         VELOX_USER_FAIL("Not a JSON input: {}", inputVector->valueAt(row));
       }
 
@@ -715,12 +716,14 @@ void castFromJson(
         try {
           castFromJsonTyped<kind>(object, writer.current());
         } catch (const VeloxException& ve) {
+          writer.commitNull();
           VELOX_USER_FAIL(
               "Cannot cast from Json value {} to {}: {}",
               inputVector->valueAt(row),
               result.type()->toString(),
               ve.message());
         } catch (const std::exception& e) {
+          writer.commitNull();
           VELOX_USER_FAIL(
               "Cannot cast from Json value {} to {}: {}",
               inputVector->valueAt(row),


### PR DESCRIPTION
Summary: try_cast from Json to complex types used to throw when there are exceptions during casting from the first row. The reason is that in this situation, castFromJson() calls add_item() of the top-level complex-type writer before its child generic writer is casted. VectorWriter<Generic<T>> doesn't allow this use case before this fix.

Differential Revision: D48370227

