### PR TITLE
Extend FunctionSignature to allow exclusions

### DIFF
--- a/velox/exec/AggregateCompanionSignatures.cpp
+++ b/velox/exec/AggregateCompanionSignatures.cpp
@@ -222,7 +222,8 @@ FunctionSignaturePtr CompanionSignatures::extractFunctionSignature(
       /*argumentTypes*/
       std::vector<TypeSignature>{signature->intermediateType()},
       /*constantArguments*/ std::vector<bool>{false},
-      /*variableArity*/ false);
+      /*variableArity*/ false,
+      /*isExcluded*/ false);
 }
 
 std::string CompanionSignatures::extractFunctionNameWithSuffix(

--- a/velox/exec/tests/FunctionSignatureBuilderTest.cpp
+++ b/velox/exec/tests/FunctionSignatureBuilderTest.cpp
@@ -251,4 +251,12 @@ TEST_F(FunctionSignatureBuilderTest, toString) {
   ASSERT_EQ("(varchar) -> varbinary -> bigint", toString({signature}));
 
   ASSERT_EQ("foo(BIGINT, VARCHAR)", toString("foo", {BIGINT(), VARCHAR()}));
+
+  // Excluded signature.
+  signature = FunctionSignatureBuilder()
+                  .exclude()
+                  .returnType("bigint")
+                  .argumentType("integer")
+                  .build();
+  ASSERT_EQ("exclude (integer) -> bigint", toString({signature}));
 }

--- a/velox/expression/FunctionSignature.cpp
+++ b/velox/expression/FunctionSignature.cpp
@@ -88,6 +88,9 @@ std::string FunctionSignature::argumentsToString() const {
 
 std::string FunctionSignature::toString() const {
   std::ostringstream out;
+  if (isExcluded()) {
+    out << "exclude ";
+  }
   out << "(" << argumentsToString() << ") -> " << returnType_.toString();
   return out.str();
 }
@@ -248,12 +251,14 @@ FunctionSignature::FunctionSignature(
     TypeSignature returnType,
     std::vector<TypeSignature> argumentTypes,
     std::vector<bool> constantArguments,
-    bool variableArity)
+    bool variableArity,
+    bool isExcluded)
     : variables_{std::move(variables)},
       returnType_{std::move(returnType)},
       argumentTypes_{std::move(argumentTypes)},
       constantArguments_{std::move(constantArguments)},
-      variableArity_{variableArity} {
+      variableArity_{variableArity},
+      isExcluded_(isExcluded) {
   validate(variables_, returnType_, argumentTypes_, constantArguments_);
 }
 
@@ -271,7 +276,8 @@ FunctionSignaturePtr FunctionSignatureBuilder::build() {
       returnType_.value(),
       std::move(argumentTypes_),
       std::move(constantArguments_),
-      variableArity_);
+      variableArity_,
+      isExcluded_);
 }
 
 std::shared_ptr<AggregateFunctionSignature>

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -127,7 +127,8 @@ class FunctionSignature {
       TypeSignature returnType,
       std::vector<TypeSignature> argumentTypes,
       std::vector<bool> constantArguments,
-      bool variableArity);
+      bool variableArity,
+      bool isExcluded);
 
   virtual ~FunctionSignature() = default;
 
@@ -145,6 +146,10 @@ class FunctionSignature {
 
   bool variableArity() const {
     return variableArity_;
+  }
+
+  bool isExcluded() const {
+    return isExcluded_;
   }
 
   virtual std::string toString() const;
@@ -172,6 +177,7 @@ class FunctionSignature {
   const std::vector<TypeSignature> argumentTypes_;
   const std::vector<bool> constantArguments_;
   const bool variableArity_;
+  const bool isExcluded_;
 };
 
 using FunctionSignaturePtr = std::shared_ptr<FunctionSignature>;
@@ -190,7 +196,8 @@ class AggregateFunctionSignature : public FunctionSignature {
             std::move(returnType),
             std::move(argumentTypes),
             std::move(constantArguments),
-            variableArity),
+            variableArity,
+            false),
         intermediateType_{std::move(intermediateType)} {}
 
   const TypeSignature& intermediateType() const {
@@ -296,6 +303,11 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
+  FunctionSignatureBuilder& exclude() {
+    isExcluded_ = true;
+    return *this;
+  }
+
   FunctionSignaturePtr build();
 
  private:
@@ -304,6 +316,7 @@ class FunctionSignatureBuilder {
   std::vector<TypeSignature> argumentTypes_;
   std::vector<bool> constantArguments_;
   bool variableArity_{false};
+  bool isExcluded_{false};
 };
 
 /// Convenience class for creating AggregageFunctionSignature instances.

--- a/velox/expression/VectorFunction.cpp
+++ b/velox/expression/VectorFunction.cpp
@@ -44,6 +44,17 @@ std::shared_ptr<const Type> resolveVectorFunction(
   if (auto vectorFunctionSignatures =
           exec::getVectorFunctionSignatures(functionName)) {
     for (const auto& signature : vectorFunctionSignatures.value()) {
+      if (signature->isExcluded()) {
+        exec::SignatureBinder binder(*signature, argTypes);
+        if (binder.tryBind()) {
+          return nullptr;
+        }
+      }
+    }
+    for (const auto& signature : vectorFunctionSignatures.value()) {
+      if (signature->isExcluded()) {
+        continue;
+      }
       exec::SignatureBinder binder(*signature, argTypes);
       if (binder.tryBind()) {
         return binder.tryResolveReturnType();


### PR DESCRIPTION
Summary:
Some UDFs have loose function signatures while the UDFs throw runtime errors on unsupported types. E.g., https://github.com/facebookincubator/velox/pull/5973 is allowing element_at() to take map inputs with complex-typed keys. It relaxed the argument type in the function signature to `map(K, V)` while the function body checks that `K` cannot be timestamp. This is not ideal for two reasons:
1. Function calls with unsupported input types should be rejected during expression compilation rather than during expression evaluation.
2. This unsupported-type error during expression evaluation cannot be suppressed by try() and hence fails the retry-with-try in fuzzer tests.

This diff extend FunctionSignature to allow expressing that a signature is excluded from the signatures of a function. E.g., The following signatures indicate that the function support any input types except varchar.
```
std::vector<std::shared_ptr<exec::FunctionSignature>> signatures{
  exec::FunctionSignatureBuilder()
            .typeVariable("T")
            .returnType("T")
            .argumentType("T")
            .build(),
  exec::FunctionSignatureBuilder()
            .exclude()
            .returnType("varchar")
            .argumentType("varchar")
            .build()
};
```

This diff only adds the extension to FunctionSignature but not AggregateFunctionSignature. The extension is not integrated in the simple scalar function registration API yet. Support in fuzzer to avoid generating excluded argument types will be added in a following diff.

Differential Revision: D48401859

