### PR TITLE
Use compareVectors instead of assertEqualVectors when checking that input vectors did not change

### DIFF
--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -162,8 +162,10 @@ ResultOrError ExpressionVerifier::verify(
 
     exec::EvalCtx evalCtxCommon(execCtx_, &exprSetCommon, inputRowVector.get());
     exprSetCommon.eval(rows, evalCtxCommon, commonEvalResult);
-    assertEqualVectors(copy, inputRowVector);
-
+    {
+      SelectivityVector rows(copy->size());
+      compareVectors(copy, inputRowVector, rows);
+    }
   } catch (const VeloxUserError&) {
     if (!canThrow) {
       LOG(ERROR)
@@ -191,7 +193,10 @@ ResultOrError ExpressionVerifier::verify(
 
     auto copy = createCopy(rowVector);
     exprSetSimplified.eval(rows, evalCtxSimplified, simplifiedEvalResult);
-    assertEqualVectors(copy, rowVector);
+    {
+      SelectivityVector rows(copy->size());
+      compareVectors(copy, rowVector, rows);
+    }
 
   } catch (const VeloxUserError&) {
     exceptionSimplifiedPtr = std::current_exception();


### PR DESCRIPTION
Summary:
assertEqualVectors does not halt the program when running as a guest.
hence when it happen we do not know the context (Seed, expression ..etc)

This happened recently
https://github.com/facebookincubator/velox/issues/5880

Reviewed By: kagamiori

Differential Revision: D47854638

