### PR TITLE
Add experimental gflag to enable legacy cast output format

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -437,6 +437,13 @@ TEST_F(CastExprTest, basics) {
       {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
       {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0});
   testCast<bool, std::string>("string", {true, false}, {"true", "false"});
+
+  gflags::FlagSaver flagSaver;
+  FLAGS_experimental_enable_legacy_cast = true;
+  testCast<double, std::string>(
+      "string",
+      {1.888, 2.5, 3.6, 100.44, -100.101, 1.0, -2.0},
+      {"1.888", "2.5", "3.6", "100.44", "-100.101", "1", "-2"});
 }
 
 TEST_F(CastExprTest, stringToTimestamp) {

--- a/velox/type/CMakeLists.txt
+++ b/velox/type/CMakeLists.txt
@@ -20,6 +20,7 @@ add_subdirectory(fbhive)
 
 add_library(
   velox_type
+  Conversions.cpp
   DecimalUtil.cpp
   DoubleUtil.cpp
   Filter.cpp

--- a/velox/type/Conversions.cpp
+++ b/velox/type/Conversions.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/type/Conversions.h"
+
+DEFINE_bool(
+    experimental_enable_legacy_cast,
+    false,
+    "Experimental feature flag for backward compatibility with previous output"
+    " format of type conversions used for casting. This is a temporary solution"
+    " that aims to facilitate a seamless transition for users who rely on the"
+    " legacy behavior and hence can change in the future.");

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -24,6 +24,8 @@
 #include "velox/type/TimestampConversion.h"
 #include "velox/type/Type.h"
 
+DECLARE_bool(experimental_enable_legacy_cast);
+
 namespace facebook::velox::util {
 
 template <TypeKind KIND, typename = void, bool TRUNCATE = false>
@@ -382,7 +384,8 @@ struct Converter<TypeKind::VARCHAR, void, TRUNCATE> {
   static std::string cast(const T& val) {
     if constexpr (std::is_same_v<T, double> || std::is_same_v<T, float>) {
       auto stringValue = folly::to<std::string>(val);
-      if (stringValue.find(".") == std::string::npos &&
+      if (!FLAGS_experimental_enable_legacy_cast &&
+          stringValue.find(".") == std::string::npos &&
           isdigit(stringValue[stringValue.length() - 1])) {
         stringValue += ".0";
       }


### PR DESCRIPTION
This change adds a new experimental gflag
"experimental_enable_legacy_cast" which serves as a temporary
solution that aims to facilitate a seamless transition for users
who rely on the legacy behavior and hence can change in the future.
Currently it only affects cast(double/real to varchar).

Test Plan:
Added a unit test.