### PR TITLE
Fix flaky AllPartitionedOutputBufferManagerTest.multiFetchers

### DIFF
--- a/velox/exec/PartitionedOutputBuffer.cpp
+++ b/velox/exec/PartitionedOutputBuffer.cpp
@@ -480,12 +480,6 @@ bool PartitionedOutputBuffer::isFinishedLocked() {
   if (isBroadcast() && !noMoreBuffers_) {
     return false;
   }
-  if (isArbitrary()) {
-    VELOX_CHECK_NOT_NULL(arbitraryBuffer_);
-    if (!arbitraryBuffer_->empty()) {
-      return false;
-    }
-  }
   for (auto& buffer : buffers_) {
     if (buffer != nullptr) {
       return false;


### PR DESCRIPTION
Arbitrary output buffer doesn't need to wait for all the
pending buffers to be consumed if all the destinations
have been removed