### PR TITLE
Allow a VARBINARY constant to be saved as a __complex_constant

### DIFF
--- a/velox/expression/ConstantExpr.cpp
+++ b/velox/expression/ConstantExpr.cpp
@@ -211,13 +211,18 @@ void appendSqlLiteral(
           "Type not supported yet: {}", vector.type()->toString());
   }
 }
+
+bool canBeExpressedInSQL(const TypePtr& type) {
+  return type->isPrimitiveType() && type != VARBINARY();
+}
+
 } // namespace
 
 std::string ConstantExpr::toSql(
     std::vector<VectorPtr>* complexConstants) const {
   VELOX_CHECK_NOT_NULL(sharedConstantValue_);
   std::ostringstream out;
-  if (complexConstants && !sharedConstantValue_->type()->isPrimitiveType()) {
+  if (complexConstants && !canBeExpressedInSQL(sharedConstantValue_->type())) {
     int idx = complexConstants->size();
     out << "__complex_constant(c" << idx << ")";
     complexConstants->push_back(sharedConstantValue_);


### PR DESCRIPTION
This allows a VARBINARY constant to be serialized as a __complex_constant
when Expression Verifier serializes an expression on failure. This
enables us to reproduce the failure using ExpressionRunner. Otherwise,
it would throw an error while serializing.

Test Plan:
Added a test case