### PR TITLE
Add parse_url Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -97,6 +97,14 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT overlay('Spark SQL', 'tructured', 2, 4); -- "Structured SQL"
         SELECT overlay('Spark SQL', '_', -6, 3); -- "_Sql"
 
+.. spark:function:: parse_url(url, partToExtract[, key]) -> string
+
+   Extracts a part from a URL.
+   ::
+        SELECT parse_url('http://spark.apache.org/path?query=1', 'HOST'); -- spark.apache.org
+        SELECT parse_url('http://spark.apache.org/path?query=1', 'QUERY'); -- query=1
+        SELECT parse_url('http://spark.apache.org/path?query=1', 'QUERY', "query"); -- 1
+
 .. spark:function:: replace(string, search, replace) -> string
 
     Replaces all occurrences of `search` with `replace`. ::

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -34,6 +34,7 @@
 #include "velox/functions/sparksql/RegisterCompare.h"
 #include "velox/functions/sparksql/Size.h"
 #include "velox/functions/sparksql/String.h"
+#include "velox/functions/sparksql/URLFunctions.h"
 
 namespace facebook::velox::functions {
 
@@ -215,6 +216,11 @@ void registerFunctions(const std::string& prefix) {
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});
+
+  registerFunction<ParseUrlFunction, Varchar, Varchar, Varchar>(
+      {prefix + "parse_url"});
+  registerFunction<ParseUrlFunction, Varchar, Varchar, Varchar, Varchar>(
+      {prefix + "parse_url"});
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/URLFunctions.h
+++ b/velox/functions/sparksql/URLFunctions.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <boost/regex.hpp>
+#include <cctype>
+#include "velox/functions/Macros.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+FOLLY_ALWAYS_INLINE StringView submatch(const boost::cmatch& match, int idx) {
+  const auto& sub = match[idx];
+  return StringView(sub.first, sub.length());
+}
+
+template <typename TInString>
+bool parse(const TInString& rawUrl, boost::cmatch& match) {
+  static const boost::regex kUriRegex(
+      "(([a-zA-Z][a-zA-Z0-9+.-]*):)?" // scheme:
+      "([^?#]*)" // authority and path
+      "(?:\\?([^#]*))?" // ?query
+      "(?:#(.*))?"); // #fragment
+
+  return boost::regex_match(
+      rawUrl.data(), rawUrl.data() + rawUrl.size(), match, kUriRegex);
+}
+} // namespace
+
+template <typename T>
+struct ParseUrlFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  static constexpr int kProto = 2;
+  static constexpr int kAuthPath = 3;
+  static constexpr int kQuery = 4;
+  static constexpr int kRef = 5;
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract) {
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      return false;
+    }
+
+    if (partToExtract == "PROTOCOL") {
+      auto proto = submatch(match, kProto);
+      if (proto.empty()) {
+        return false;
+      }
+      result.setNoCopy(proto);
+      return true;
+    }
+
+    if (partToExtract == "QUERY") {
+      auto query = submatch(match, kQuery);
+      if (query.empty()) {
+        return false;
+      }
+      result.setNoCopy(query);
+      return true;
+    }
+
+    if (partToExtract == "REF") {
+      auto ref = submatch(match, kRef);
+      if (ref.empty()) {
+        return false;
+      }
+      result.setNoCopy(ref);
+      return true;
+    }
+
+    boost::cmatch authAndPathMatch;
+    boost::cmatch authorityMatch;
+    bool hasAuthority = false;
+    if (!matchAuthorityAndPath(
+            match, authAndPathMatch, authorityMatch, hasAuthority)) {
+      return false;
+    }
+
+    if (partToExtract == "HOST") {
+      if (!hasAuthority) {
+        return false;
+      }
+      result.setNoCopy(submatch(authorityMatch, 3));
+      return true;
+    }
+
+    if (partToExtract == "PATH") {
+      auto path = submatch(match, kAuthPath);
+      if (hasAuthority) {
+        path = submatch(authAndPathMatch, 2);
+      }
+      result.setNoCopy(path);
+      return true;
+    }
+
+    // Path[?Query].
+    if (partToExtract == "FILE") {
+      auto path = submatch(match, kAuthPath);
+      if (hasAuthority) {
+        path = submatch(authAndPathMatch, 2);
+      }
+      auto query = submatch(match, kQuery);
+      result = path;
+      if (!query.empty()) {
+        result += "?";
+        result += query;
+      }
+      return true;
+    }
+
+    // Username[:Password].
+    if (partToExtract == "USERINFO") {
+      if (!hasAuthority) {
+        return false;
+      }
+      auto username = submatch(authorityMatch, 1);
+      auto password = submatch(authorityMatch, 2);
+      result = username;
+      if (!password.empty()) {
+        result += ":";
+        result += password;
+      }
+      return result.size();
+    }
+
+    // [Userinfo@]Host[:Port].
+    if (partToExtract == "AUTHORITY") {
+      if (!hasAuthority) {
+        return false;
+      }
+      auto username = submatch(authorityMatch, 1);
+      auto password = submatch(authorityMatch, 2);
+      if (!username.empty() || !password.empty()) {
+        result = username;
+        if (!password.empty()) {
+          result += ":";
+          result += password;
+        }
+        result += "@";
+      }
+      result += submatch(authorityMatch, 3);
+      auto port = submatch(authorityMatch, 4);
+      if (!port.empty()) {
+        result += ":";
+        result += port;
+      }
+      return result.size();
+    }
+
+    return false;
+  }
+
+  FOLLY_ALWAYS_INLINE bool call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& url,
+      const arg_type<Varchar>& partToExtract,
+      const arg_type<Varchar>& key) {
+    // Only "QUERY" support the third parameter.
+    if (partToExtract != "QUERY") {
+      return false;
+    }
+    if (key.empty()) {
+      return false;
+    }
+
+    boost::cmatch match;
+    if (!parse(url, match)) {
+      return false;
+    }
+
+    // Parse query string.
+    static const boost::regex kQueryParamRegex(
+        "(^|&)" // start of query or start of parameter "&"
+        "([^=&]*)=?" // parameter name and "=" if value is expected
+        "([^=&]*)" // parameter value
+        "(?=(&|$))" // forward reference, next should be end of query or
+                    // start of next parameter
+    );
+
+    auto query = submatch(match, kQuery);
+    const boost::cregex_iterator begin(
+        query.data(), query.data() + query.size(), kQueryParamRegex);
+    boost::cregex_iterator end;
+
+    for (auto it = begin; it != end; ++it) {
+      if (it->length(2) != 0) { // key shouldn't be empty.
+        auto k = submatch((*it), 2);
+        if (key.compare(k) == 0) {
+          auto value = submatch((*it), 3);
+          result.setNoCopy(value);
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+ private:
+  FOLLY_ALWAYS_INLINE bool matchAuthorityAndPath(
+      const boost::cmatch& urlMatch,
+      boost::cmatch& authAndPathMatch,
+      boost::cmatch& authorityMatch,
+      bool& hasAuthority) {
+    static const boost::regex kAuthorityAndPathRegex("//([^/]*)(/.*)?");
+    auto authorityAndPath = submatch(urlMatch, kAuthPath);
+    if (!boost::regex_match(
+            authorityAndPath.begin(),
+            authorityAndPath.end(),
+            authAndPathMatch,
+            kAuthorityAndPathRegex)) {
+      // Does not start with //, doesn't have authority.
+      hasAuthority = false;
+      return true;
+    }
+
+    static const boost::regex kAuthorityRegex(
+        "(?:([^@:]*)(?::([^@]*))?@)?" // username, password.
+        "(\\[[^\\]]*\\]|[^\\[:]*)" // host (IP-literal (e.g. '['+IPv6+']',
+        // dotted-IPv4, or named host).
+        "(?::(\\d*))?"); // port.
+
+    const auto authority = authAndPathMatch[1];
+    if (!boost::regex_match(
+            authority.first,
+            authority.second,
+            authorityMatch,
+            kAuthorityRegex)) {
+      return false; // Invalid URI Authority.
+    }
+
+    hasAuthority = true;
+    return true;
+  }
+};
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   SortArrayTest.cpp
   SplitFunctionsTest.cpp
   StringTest.cpp
+  URLFunctionsTest.cpp
   XxHash64Test.cpp)
 
 add_test(velox_functions_spark_test velox_functions_spark_test)

--- a/velox/functions/sparksql/tests/URLFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/URLFunctionsTest.cpp
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <gmock/gmock.h>
+#include <optional>
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+
+namespace {
+std::optional<std::string> operator+(
+    const std::optional<std::string>& opt1,
+    const std::optional<std::string>& opt2) {
+  if (!opt1.has_value()) {
+    return opt2;
+  }
+  if (!opt2.has_value()) {
+    return opt1;
+  }
+  return opt1.value() + opt2.value();
+}
+
+std::optional<std::string> operator&(
+    const std::optional<std::string>& opt1,
+    const std::optional<std::string>& opt2) {
+  if (!opt1.has_value() || !opt2.has_value()) {
+    return std::nullopt;
+  }
+  return opt1.value() + opt2.value();
+}
+
+class URLFunctionsTest
+    : public functions::sparksql::test::SparkFunctionBaseTest {
+ protected:
+  void validate(
+      const std::optional<std::string>& url,
+      const std::optional<std::string>& expectedProtocol,
+      const std::optional<std::string>& expectedUserinfo,
+      const std::optional<std::string>& expectedHost,
+      const std::optional<std::string>& expectedPort,
+      const std::optional<std::string>& expectedPath,
+      const std::optional<std::string>& expectedQuery,
+      const std::optional<std::string>& expectedRef) {
+    const auto parseUrl = [&](const std::optional<std::string>& partToExtract)
+        -> std::optional<std::string> {
+      std::cout << "TEST:" << url.value() << "-> " << partToExtract.value()
+                << std::endl;
+      return evaluateOnce<std::string>("parse_url(c0, c1)", url, partToExtract);
+    };
+
+    EXPECT_EQ(parseUrl("PROTOCOL"), expectedProtocol);
+
+    EXPECT_EQ(parseUrl("USERINFO"), expectedUserinfo);
+    EXPECT_EQ(parseUrl("HOST"), expectedHost);
+    auto expectedAuthority =
+        (expectedUserinfo & "@") + expectedHost + (":" & expectedPort);
+    EXPECT_EQ(parseUrl("AUTHORITY"), expectedAuthority);
+
+    EXPECT_EQ(parseUrl("PATH"), expectedPath);
+    EXPECT_EQ(parseUrl("QUERY"), expectedQuery);
+
+    auto expectedFile = expectedPath + ("?" & expectedQuery);
+    EXPECT_EQ(parseUrl("FILE"), expectedFile);
+
+    EXPECT_EQ(parseUrl("REF"), expectedRef);
+  }
+};
+
+TEST_F(URLFunctionsTest, validateURL) {
+  validate(
+      "http://user:pass@example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      "user:pass",
+      "example.com",
+      "8080",
+      "/path1/p.php",
+      "k1=v1&k2=v2",
+      "Ref1");
+  validate(
+      "HTTP://example.com/path1/p.php",
+      "HTTP",
+      std::nullopt,
+      "example.com",
+      std::nullopt,
+      "/path1/p.php",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "http://example.com:8080/path1/p.php?k1=v1&k2=v2#Ref1",
+      "http",
+      std::nullopt,
+      "example.com",
+      "8080",
+      "/path1/p.php",
+      "k1=v1&k2=v2",
+      "Ref1");
+  validate(
+      "https://username@example.com",
+      "https",
+      "username",
+      "example.com",
+      std::nullopt,
+      "",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "https:/auth/login.html",
+      "https",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      "/auth/login.html",
+      std::nullopt,
+      std::nullopt);
+  validate(
+      "foo",
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      std::nullopt,
+      "foo",
+      std::nullopt,
+      std::nullopt);
+}
+
+TEST_F(URLFunctionsTest, validateParameter) {
+  const auto checkParseUrlWithKey =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& key) {
+        const std::optional<std::string>& partToExtract = "QUERY";
+        EXPECT_EQ(
+            evaluateOnce<std::string>(
+                "parse_url(c0, c1, c2)", url, partToExtract, key),
+            expected);
+      };
+
+  checkParseUrlWithKey(
+      "v2", "http://example.com/path1/p.php?k1=v1&k2=v2#Ref1", "k2");
+  checkParseUrlWithKey(
+      "v1", "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k1");
+  checkParseUrlWithKey(
+      "", "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1", "k3");
+  checkParseUrlWithKey(
+      std::nullopt,
+      "http://example.com/path1/p.php?k1=v1&k2=v2&k3&k4#Ref1",
+      "k6");
+  checkParseUrlWithKey(std::nullopt, "foo", "");
+}
+
+TEST_F(URLFunctionsTest, sparkUT) {
+  const auto checkParseUrl =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& partToExtract) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>("parse_url(c0, c1)", url, partToExtract),
+            expected);
+      };
+  const auto checkParseUrlWithKey =
+      [&](const std::optional<std::string>& expected,
+          const std::optional<std::string>& url,
+          const std::optional<std::string>& partToExtract,
+          const std::optional<std::string>& key) {
+        EXPECT_EQ(
+            evaluateOnce<std::string>(
+                "parse_url(c0, c1, c2)", url, partToExtract, key),
+            expected);
+      };
+
+  checkParseUrl(
+      "spark.apache.org", "http://spark.apache.org/path?query=1", "HOST");
+  checkParseUrl("/path", "http://spark.apache.org/path?query=1", "PATH");
+  checkParseUrl("query=1", "http://spark.apache.org/path?query=1", "QUERY");
+  checkParseUrl("Ref", "http://spark.apache.org/path?query=1#Ref", "REF");
+  checkParseUrl("http", "http://spark.apache.org/path?query=1", "PROTOCOL");
+  checkParseUrl(
+      "/path?query=1", "http://spark.apache.org/path?query=1", "FILE");
+  checkParseUrl(
+      "spark.apache.org:8080",
+      "http://spark.apache.org:8080/path?query=1",
+      "AUTHORITY");
+  checkParseUrl(
+      "userinfo", "http://userinfo@spark.apache.org/path?query=1", "USERINFO");
+  checkParseUrlWithKey(
+      "1", "http://spark.apache.org/path?query=1", "QUERY", "query");
+
+  // Null checking.
+  checkParseUrl(std::nullopt, std::nullopt, "HOST");
+  checkParseUrl(
+      std::nullopt, "http://spark.apache.org/path?query=1", std::nullopt);
+  checkParseUrl(std::nullopt, std::nullopt, std::nullopt);
+  checkParseUrl(std::nullopt, "test", "HOST");
+  checkParseUrl(std::nullopt, "http://spark.apache.org/path?query=1", "NO");
+  checkParseUrl(
+      std::nullopt, "http://spark.apache.org/path?query=1", "USERINFO");
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "HOST", "query");
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "QUERY", "quer");
+  checkParseUrlWithKey(
+      std::nullopt,
+      "http://spark.apache.org/path?query=1",
+      "QUERY",
+      std::nullopt);
+  checkParseUrlWithKey(
+      std::nullopt, "http://spark.apache.org/path?query=1", "QUERY", "");
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
presto has a bunch of `url_extract_xxx` functions, copy these implementations to construct the `parse_url` and then adjust according to spark semantic.

spark ref:  https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1461