### PR TITLE
Reduce expression fuzzer logging

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -856,8 +856,8 @@ core::TypedExprPtr ExpressionFuzzer::generateExpression(
     }
   }
   if (!expression) {
-    LOG(INFO) << "Couldn't find a proper function to return '"
-              << returnType->toString() << "'. Returning a constant instead.";
+    VLOG(1) << "Couldn't find a proper function to return '"
+            << returnType->toString() << "'. Returning a constant instead.";
     return generateArgConstant(returnType);
   }
   expressionBank_.insert(expression);

--- a/velox/expression/tests/ExpressionVerifier.cpp
+++ b/velox/expression/tests/ExpressionVerifier.cpp
@@ -28,18 +28,15 @@ void logRowVector(const RowVectorPtr& rowVector) {
   if (rowVector == nullptr) {
     return;
   }
-  LOG(INFO) << rowVector->childrenSize() << " vectors as input:";
+  VLOG(1) << rowVector->childrenSize() << " vectors as input:";
   for (const auto& child : rowVector->children()) {
-    LOG(INFO) << "\t" << child->toString(/*recursive=*/true);
+    VLOG(1) << "\t" << child->toString(/*recursive=*/true);
   }
 
-  if (VLOG_IS_ON(1)) {
-    LOG(INFO) << "RowVector contents (" << rowVector->type()->toString()
-              << "):";
+  VLOG(1) << "RowVector contents (" << rowVector->type()->toString() << "):";
 
-    for (vector_size_t i = 0; i < rowVector->size(); ++i) {
-      LOG(INFO) << "\tAt " << i << ": " << rowVector->toString(i);
-    }
+  for (vector_size_t i = 0; i < rowVector->size(); ++i) {
+    VLOG(1) << "\tAt " << i << ": " << rowVector->toString(i);
   }
 }
 namespace {
@@ -58,14 +55,12 @@ void compareVectors(
     const SelectivityVector& rows) {
   // Print vector contents if in verbose mode.
   size_t vectorSize = left->size();
-  if (VLOG_IS_ON(1)) {
-    LOG(INFO) << "== Result contents (common vs. simple): ";
-    rows.applyToSelected([&](vector_size_t row) {
-      LOG(INFO) << fmt::format(
-          "At {} [ {} vs {} ]", row, left->toString(row), right->toString(row));
-    });
-    LOG(INFO) << "===================";
-  }
+  VLOG(1) << "== Result contents (common vs. simple): ";
+  rows.applyToSelected([&](vector_size_t row) {
+    VLOG(1) << fmt::format(
+        "At {} [ {} vs {} ]", row, left->toString(row), right->toString(row));
+  });
+  VLOG(1) << "===================";
 
   rows.applyToSelected([&](vector_size_t row) {
     VELOX_CHECK(
@@ -154,7 +149,7 @@ ResultOrError ExpressionVerifier::verify(
     if (!columnsToWrapInLazy.empty()) {
       inputRowVector =
           VectorFuzzer::fuzzRowChildrenToLazy(rowVector, columnsToWrapInLazy);
-      LOG(INFO) << "Modified inputs for common eval path: ";
+      VLOG(1) << "Modified inputs for common eval path: ";
       logRowVector(inputRowVector);
     }
 

--- a/velox/expression/tests/FuzzerToolkit.cpp
+++ b/velox/expression/tests/FuzzerToolkit.cpp
@@ -98,6 +98,7 @@ void compareExceptions(
       std::rethrow_exception(simplifiedPtr);
     }
   }
+  LOG(INFO) << "Excpetions match.";
 }
 
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary: Make expression fuzzer tests print out input vectors and message from failed expression generation only when we set `--v=1`.

Differential Revision: D48442190

