### PR TITLE
Add checksum to SsdCache entries

### DIFF
--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -31,7 +31,8 @@ SsdCache::SsdCache(
     int32_t numShards,
     folly::Executor* executor,
     int64_t checkpointIntervalBytes,
-    bool disableFileCow)
+    bool disableFileCow,
+    bool enableChecksum)
     : filePrefix_(filePrefix),
       numShards_(numShards),
       groupStats_(std::make_unique<FileGroupStats>()),
@@ -56,7 +57,9 @@ SsdCache::SsdCache(
         i,
         fileMaxRegions,
         checkpointIntervalBytes / numShards,
-        disableFileCow));
+        disableFileCow,
+        nullptr,
+        enableChecksum));
   }
 }
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -45,7 +45,8 @@ class SsdCache {
       int32_t numShards,
       folly::Executor* executor,
       int64_t checkpointIntervalBytes = 0,
-      bool disableFileCow = false);
+      bool disableFileCow = false,
+      bool enableChecksum = false);
 
   // Returns the shard corresponding to 'fileId'. 'fileId' is a
   //  file id from e.g. FileCacheKey.


### PR DESCRIPTION
Summary: Add checksum when reading/writing entries from ssd cache.

Differential Revision: D48447498

