### PR TITLE
Reduce MAX_LINK_JOBS for linux-pr-fuzzer-run

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -552,7 +552,7 @@ jobs:
               git push
             fi
 
-  
+
 
   linux-pr-fuzzer-run:
     executor: build
@@ -581,7 +581,7 @@ jobs:
       - run:
           name: "Build"
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4 EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
Summary:
Reduce MAX_LINK_JOBS to 4 to mitigate the following repetitive error

collect2: fatal error: ld terminated with signal 9 [Killed]

Differential Revision: D48448908

