### PR TITLE
Support toIntermediate() in SimpleAggregateAdapter

### DIFF
--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -121,11 +121,25 @@ class SimpleAggregateAdapter : public Aggregate {
       std::void_t<decltype(T::use_external_memory_)>>
       : std::integral_constant<bool, T::use_external_memory_> {};
 
+  // Whether the accumulator type defines its destroy() method or not. If it is
+  // defined, we call the accumulator's destroy() in
+  // SimpleAggregateAdapter::destroy().
   template <typename T, typename = void>
   struct accumulator_custom_destroy : std::false_type {};
 
   template <typename T>
   struct accumulator_custom_destroy<T, std::void_t<decltype(&T::destroy)>>
+      : std::true_type {};
+
+  // Whether the function defines its toIntermediate() method or not. If it is
+  // defined, SimpleAggregateAdapter::supportToIntermediate() returns true.
+  // Otherwise, SimpleAggregateAdapter::supportToIntermediate() returns false
+  // and SimpleAggregateAdapter::toIntermediate() is empty.
+  template <typename T, typename = void>
+  struct support_to_intermediate : std::false_type {};
+
+  template <typename T>
+  struct support_to_intermediate<T, std::void_t<decltype(&T::toIntermediate)>>
       : std::true_type {};
 
   static constexpr bool aggregate_default_null_behavior_ =
@@ -139,6 +153,9 @@ class SimpleAggregateAdapter : public Aggregate {
 
   static constexpr bool accumulator_custom_destroy_ =
       accumulator_custom_destroy<typename FUNC::AccumulatorType>::value;
+
+  static constexpr bool support_to_intermediate_ =
+      support_to_intermediate<FUNC>::value;
 
   bool isFixedSize() const override {
     return accumulator_is_fixed_size_;
@@ -197,6 +214,31 @@ class SimpleAggregateAdapter : public Aggregate {
 
     addSingleGroupRawInputImpl(
         group, rows, std::make_index_sequence<FUNC::InputType::size_>{});
+  }
+
+  bool supportsToIntermediate() const override {
+    return support_to_intermediate_;
+  }
+
+  void toIntermediate(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      VectorPtr& result) const override {
+    if constexpr (support_to_intermediate_) {
+      std::vector<DecodedVector> inputDecoded{args.size()};
+      for (column_index_t i = 0; i < args.size(); ++i) {
+        inputDecoded[i].decode(*args[i], rows);
+      }
+
+      toIntermediateImpl(
+          inputDecoded,
+          rows,
+          result,
+          std::make_index_sequence<FUNC::InputType::size_>{});
+    } else {
+      VELOX_UNREACHABLE(
+          "toIntermediate should only be called when support_to_intermediate_ is true.");
+    }
   }
 
   // Add intermediate results to accumulators. If the simple aggregation
@@ -375,6 +417,53 @@ class SimpleAggregateAdapter : public Aggregate {
           clearNull(group);
         }
       });
+    }
+  }
+
+  template <std::size_t... Is>
+  void toIntermediateImpl(
+      const std::vector<DecodedVector>& inputDecoded,
+      const SelectivityVector& rows,
+      VectorPtr& result,
+      std::index_sequence<Is...>) const {
+    std::tuple<VectorReader<typename FUNC::InputType::template type_at<Is>>...>
+        readers{&inputDecoded[Is]...};
+
+    VELOX_CHECK(result);
+    result->ensureWritable(rows);
+    auto* rawNulls = result->mutableRawNulls();
+    bits::fillBits(rawNulls, 0, result->size(), bits::kNull);
+
+    constexpr auto intermediateKind =
+        SimpleTypeTrait<typename FUNC::IntermediateType>::typeKind;
+    auto* flatResult =
+        result->as<typename KindToFlatVector<intermediateKind>::type>();
+    exec::VectorWriter<typename FUNC::IntermediateType> writer;
+    writer.init(*flatResult);
+
+    if constexpr (aggregate_default_null_behavior_) {
+      rows.applyToSelected([&](auto row) {
+        writer.setOffset(row);
+        // If any input is null, we ignore the whole row.
+        if (!(std::get<Is>(readers).isSet(row) && ...)) {
+          writer.commitNull();
+          return;
+        }
+        bool nonNull = FUNC::toIntermediate(
+            writer.current(), std::get<Is>(readers)[row]...);
+        writer.commit(nonNull);
+      });
+      writer.finish();
+    } else {
+      rows.applyToSelected([&](auto row) {
+        writer.setOffset(row);
+        bool nonNull = FUNC::toIntermediate(
+            writer.current(),
+            OptionalAccessor<typename FUNC::InputType::template type_at<Is>>{
+                &std::get<Is>(readers), (int64_t)row}...);
+        writer.commit(nonNull);
+      });
+      writer.finish();
     }
   }
 

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -61,6 +61,17 @@ class ArrayAggAggregate {
 
   static constexpr bool default_null_behavior_ = false;
 
+  static bool toIntermediate(
+      exec::out_type<Array<Generic<T1>>>& out,
+      exec::optional_arg_type<Generic<T1>> in) {
+    if (in.has_value()) {
+      out.add_item().copy_from(in.value());
+    } else {
+      out.add_null();
+    }
+    return true;
+  }
+
   struct AccumulatorType {
     ValueList elements_;
 

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -87,7 +87,7 @@ class ArrayAggAggregate {
         HashStringAllocator* allocator,
         exec::optional_arg_type<Array<Generic<T1>>> other) {
       if (!other.has_value()) {
-        return true;
+        return false;
       }
       for (auto element : other.value()) {
         elements_.appendValue(element, allocator);
@@ -98,7 +98,7 @@ class ArrayAggAggregate {
     bool writeFinalResult(
         bool nonNullGroup,
         exec::out_type<Array<Generic<T1>>>& out) {
-      if (!nonNullGroup || elements_.size() == 0) {
+      if (!nonNullGroup) {
         return false;
       }
       copyValueListToArrayWriter(out, elements_);
@@ -110,7 +110,7 @@ class ArrayAggAggregate {
         exec::out_type<Array<Generic<T1>>>& out) {
       // If the group's accumulator is null, the corresponding intermediate
       // result is null too.
-      if (!nonNullGroup || elements_.size() == 0) {
+      if (!nonNullGroup) {
         return false;
       }
       copyValueListToArrayWriter(out, elements_);

--- a/velox/exec/tests/SimpleAverageAggregate.cpp
+++ b/velox/exec/tests/SimpleAverageAggregate.cpp
@@ -42,6 +42,13 @@ class AverageAggregate {
   using OutputType =
       std::conditional_t<std::is_same_v<T, float>, float, double>;
 
+  static bool toIntermediate(
+      exec::out_type<Row<double, int64_t>>& out,
+      exec::arg_type<T> in) {
+    out.copy_from(std::make_tuple(static_cast<double>(in), 1));
+    return true;
+  }
+
   struct AccumulatorType {
     double sum_;
     int64_t count_;


### PR DESCRIPTION
Summary:
Add support for toIntermediate() in SimpleAggregateAdapter. The UDAF
author defines an optional function toIntermediate(out, in) that converts
a raw input value to an intermediate value. If this function is not defined,
the UDAF returns false in Aggregate::supportToIntermediate() such that
GroupingSet won't call its toIntermediate() functions.

Differential Revision: D48456095

