### PR TITLE
Fix missing footer issue for ParquetReaderBenchmark

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -68,6 +68,7 @@ class ParquetReaderBenchmark {
       writer_->write(batch);
     }
     writer_->flush();
+    writer_->close();
   }
 
   FilterSpec createFilterSpec(


### PR DESCRIPTION
The last unflushed batch in the output stream and footer are written in Writer::close(). Without calling close(), ParquetReaderBenchmark:: writeToFile() won't write the file completely. This commit fixes this problem by adding the close() call at the end of writeToFile().