### PR TITLE
Fix accidental copy in LocalExchangeQueue::noMoreData

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -119,7 +119,7 @@ BlockingReason LocalExchangeQueue::enqueue(
 void LocalExchangeQueue::noMoreData() {
   std::vector<ContinuePromise> consumerPromises;
   std::vector<ContinuePromise> producerPromises;
-  queue_.withWLock([&](auto queue) {
+  queue_.withWLock([&](auto& queue) {
     VELOX_CHECK_GT(pendingProducers_, 0);
     --pendingProducers_;
     if (noMoreProducers_ && pendingProducers_ == 0) {


### PR DESCRIPTION
Summary: This was likely an oversight, all the other calls to `withWLock` in the file correctly accept a reference.

Differential Revision: D48436544

