### PR TITLE
Check if ICU_SOURCE is set

### DIFF
--- a/CMake/resolve_dependency_modules/re2.cmake
+++ b/CMake/resolve_dependency_modules/re2.cmake
@@ -34,10 +34,12 @@ set(RE2_USE_ICU ON)
 set(RE2_BUILD_TESTING OFF)
 
 FetchContent_MakeAvailable(re2)
-
-if(${ICU_SOURCE} STREQUAL "BUNDLED")
-  # build re2 after icu so the files are available
-  add_dependencies(re2 ICU ICU::uc)
+if(ICU_SOURCE)
+  # empty var will cause a syntax error
+  if(${ICU_SOURCE} STREQUAL "BUNDLED")
+    # build re2 after icu so the files are available
+    add_dependencies(re2 ICU ICU::uc)
+  endif()
 endif()
 
 set(re2_LIBRARIES ${re2_BINARY_DIR}/libre2.a)


### PR DESCRIPTION
Fixes #6090 

When system Boost but bundled re2 is used the empty ICU_SOURCE var will cause a syntax error.