### PR TITLE
Fix: SimpleVector<ComplexType>::compare null handling.

### DIFF
--- a/velox/vector/SimpleVector.h
+++ b/velox/vector/SimpleVector.h
@@ -402,14 +402,9 @@ inline std::optional<int32_t> SimpleVector<ComplexType>::compare(
       << "Attempting to compare vectors not of the same type";
 
   bool otherNull = other->isNullAt(otherIndex);
-  if (isNullAt(index)) {
-    if (otherNull) {
-      return 0;
-    }
-    return flags.nullsFirst ? -1 : 1;
-  }
-  if (otherNull) {
-    return flags.nullsFirst ? 1 : -1;
+  bool isNull = isNullAt(index);
+  if (isNull || otherNull) {
+    return BaseVector::compareNulls(isNull, otherNull, flags);
   }
 
   auto otherWrappedIndex = other->wrappedIndex(otherIndex);


### PR DESCRIPTION
Summary:
All compare functions should call
  BaseVector::compareNulls(isNull, otherNull, flags);
to compare nulls when found in any of the inputs looks like this function was not updated. This resulted in a
fuzzer found bug, since the flattened vectors call different functions. More precisely the existing logic does not
handle flags correctly, namely stopAtNulls.
This fixes https://github.com/facebookincubator/velox/issues/6150

Reviewed By: bikramSingh91

Differential Revision: D48455293

