### PR TITLE
Fix unsafe fallthrough in fbcode//velox/dwio/dwrf/reader:velox_dwio_dwrf_reader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -2512,6 +2512,7 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
             streamLabels,
             std::move(flatMapContext));
       }
+      [[fallthrough]];
     default:
       DWIO_RAISE("buildReader unhandled type");
   }

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -295,6 +295,7 @@ std::shared_ptr<const Type> ReaderBase::convertType(
         return DECIMAL(
             type.getOrcPtr()->precision(), type.getOrcPtr()->scale());
       }
+      [[fallthrough]];
     case TypeKind::REAL:
     case TypeKind::DOUBLE:
     case TypeKind::VARCHAR:

--- a/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDwrfReader.cpp
@@ -140,6 +140,7 @@ std::unique_ptr<SelectiveColumnReader> SelectiveDwrfReader::build(
         return std::make_unique<SelectiveDecimalColumnReader<int128_t>>(
             requestedType, params, scanSpec);
       }
+      [[fallthrough]];
     default:
       DWIO_RAISE(
           "buildReader unhandled type: " +


### PR DESCRIPTION
Summary: Be explicit in switch statements when there is fall through. T161364219

Differential Revision: D48477777

