### PR TITLE
Fix the problems about closing parquet writer in ParquetReaderBenchmark.cpp

### DIFF
--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -58,7 +58,6 @@ class ParquetReaderBenchmark {
   }
 
   ~ParquetReaderBenchmark() {
-    writer_->close();
   }
 
   void writeToFile(
@@ -68,6 +67,7 @@ class ParquetReaderBenchmark {
       writer_->write(batch);
     }
     writer_->flush();
+    writer_->close();
   }
 
   FilterSpec createFilterSpec(


### PR DESCRIPTION
Solve the problems in ParquetReaderBenchmark.cpp that is related to closing the Parquet writer improperly:
```
root@biday-test-21:~/velox/_build/debug/velox/dwio/parquet/tests/reader# ./velox_dwio_parquet_reader_benchmark
E0811 16:36:51.368777 485799 Exceptions.h:69] Line: /root/velox/velox/dwio/parquet/reader/ParquetReader.cpp:62, Function:loadFileMetaData, Expression: strncmp(copy.data() + readSize - 4, "PAR1", 4) == 0 No magic bytes found at end of the Parquet file, Source: RUNTIME, ErrorCode: INVALID_STATE
terminate called after throwing an instance of 'facebook::velox::VeloxRuntimeError'
  what():  Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: No magic bytes found at end of the Parquet file
Retriable: False
Expression: strncmp(copy.data() + readSize - 4, "PAR1", 4) == 0
Function: loadFileMetaData
File: /root/velox/velox/dwio/parquet/reader/ParquetReader.cpp
Line: 62
```
```
terminate called after throwing an instance of 'facebook::velox::dwio::common::real_jason::LoggedException'
  what():  Exception: VeloxException
Error Source: RUNTIME
Error Code: UNKNOWN
Reason: Cannot write to closed sink.
Retriable: False
Expression: !isClosed()
Function: writeImpl
File: /root/velox/./velox/dwio/common/DataSink.h
Line: 119
Stack trace:
```