### PR TITLE
Fix spacing in a log line.

### DIFF
--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -396,7 +396,7 @@ void SsdFile::write(std::vector<CachePin>& pins) {
       LOG(ERROR) << "Failed to write to SSD, file name: " << fileName_
                  << ", fd: " << fd_ << ", size: " << iovecs.size()
                  << ", offset: " << offset << ", error code: " << errno
-                 << ", error string:" << folly::errnoStr(errno);
+                 << ", error string: " << folly::errnoStr(errno);
       ++stats_.writeSsdErrors;
       // If the write fails we return without adding the pins to the cache. The
       // entries are unchanged.


### PR DESCRIPTION
Summary: The missing space makes the log line inconsistent. Adding the space here.

Reviewed By: Yuhta

Differential Revision: D48488117

