### PR TITLE
Upgrade zlib to 1.3

### DIFF
--- a/build/fbcode_builder/manifests/zlib
+++ b/build/fbcode_builder/manifests/zlib
@@ -12,10 +12,10 @@ zlib-devel
 zlib-static
 
 [download]
-url = https://zlib.net/zlib-1.2.13.tar.gz
-sha256 = b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
+url = https://zlib.net/zlib-1.3.tar.gz
+sha256 = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
 
 [build]
 builder = cmake
-subdir = zlib-1.2.13
+subdir = zlib-1.3
 patchfile = zlib_dont_build_more_than_needed.patch


### PR DESCRIPTION
Summary:
As of today, zlib 1.2.13 is no more:

```
$ with-proxy wget https://zlib.net/zlib-1.2.13.tar.gz
--2023-08-18 18:01:43--  https://zlib.net/zlib-1.2.13.tar.gz
Resolving fwdproxy (fwdproxy)... 2401:db00:12ff:ff13:face:b00c:0:1e10
Connecting to fwdproxy (fwdproxy)|2401:db00:12ff:ff13:face:b00c:0:1e10|:8080... connected.
Proxy request sent, awaiting response... 404 Not Found
2023-08-18 18:01:43 ERROR 404: Not Found.
```

It's causing CI failures: https://www.internalfb.com/intern/sandcastle/job/36028798043461030

This diff updates to the latest version to fix the errors.

As of today, zlib 1.13 is the new hotness: https://zlib.net/

{F1072264715}

Reviewed By: ASchneidman

Differential Revision: D48490699

