### PR TITLE
Add support for lazy vector in some BaseVector APIs

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -536,10 +536,7 @@ void BaseVector::ensureWritable(
   auto resultType = result->type();
   bool isUnknownType = resultType->containsUnknown();
   if (result->encoding() == VectorEncoding::Simple::LAZY) {
-    // TODO Figure out how to allow memory reuse for a newly loaded vector.
-    // LazyVector holds a reference to loaded vector, hence, unique() check
-    // below will never pass.
-    VELOX_NYI();
+    result = BaseVector::loadedVectorShared(result);
   }
   if (result.unique() && !isUnknownType) {
     switch (result->encoding()) {
@@ -809,6 +806,12 @@ void BaseVector::flattenVector(VectorPtr& vector) {
       auto* mapVector = vector->asUnchecked<MapVector>();
       BaseVector::flattenVector(mapVector->mapKeys());
       BaseVector::flattenVector(mapVector->mapValues());
+      return;
+    }
+    case VectorEncoding::Simple::LAZY: {
+      auto loadedVector =
+          vector->asUnchecked<LazyVector>()->loadedVectorShared();
+      BaseVector::flattenVector(loadedVector);
       return;
     }
     default:

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -486,6 +486,9 @@ class BaseVector {
   //
   // Use SelectivityVector::empty() to make the 'result' writable and preserve
   // all current values.
+  //
+  // If 'result' is a lazy vector, then caller needs to ensure it is unique in
+  // order to re-use the loaded vector. Otherwise, a copy would be created.
   static void ensureWritable(
       const SelectivityVector& rows,
       const TypePtr& type,

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2310,6 +2310,13 @@ TEST_F(VectorTest, flattenVector) {
   VectorPtr row = makeRowVector({flat, array, map});
   test(row, true);
 
+  VectorPtr lazy = std::make_shared<LazyVector>(
+      pool_.get(),
+      INTEGER(),
+      flat->size(),
+      std::make_unique<TestingLoader>(flat));
+  test(lazy, true);
+
   // Constant
   VectorPtr constant = BaseVector::wrapInConstant(100, 1, flat);
   test(constant, false);


### PR DESCRIPTION
This adds support for handling lazy vectors in ensureWritable and
flattenVector. This gap was exposed by #6168 and are codepaths
that can be encountered during expression eval.

Fixes: #6168

Test Plan:
Added a unit test