### PR TITLE
E2E Wave base

### DIFF
--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -56,6 +56,17 @@ class FilterProject : public Operator {
     exprs_->clear();
   }
 
+  /// Data for accelerator conversion.
+  struct Export {
+    const ExprSet* exprs;
+    bool hasFilter;
+    const std::vector<IdentityProjection>* resultProjections;
+  };
+
+  Export exprsAndProjection() const {
+    return Export{exprs_.get(), hasFilter_, &resultProjections_};
+  }
+
  private:
   // Tests if 'numProcessedRows_' equals to the length of input_ and clears
   // outstanding references to input_ if done. Returns true if getOutput

--- a/velox/exec/Values.h
+++ b/velox/exec/Values.h
@@ -46,6 +46,14 @@ class Values : public SourceOperator {
     return current_;
   }
 
+  const std::vector<RowVectorPtr> values() const {
+    return values_;
+  }
+
+  int32_t roundsLeft() const {
+    return roundsLeft_;
+  }
+
  private:
   std::vector<RowVectorPtr> values_;
   int32_t current_ = 0;

--- a/velox/experimental/gpu/tests/HashTableTest.cu
+++ b/velox/experimental/gpu/tests/HashTableTest.cu
@@ -749,6 +749,10 @@ int main(int argc, char** argv) {
   assert(__builtin_popcount(FLAGS_table_size) == 1);
   assert(FLAGS_table_size % kBlockSize == 0);
   CUDA_CHECK_FATAL(cudaSetDevice(FLAGS_device));
+  cudaDeviceProp prop;
+  CUDA_CHECK_FATAL(cudaGetDeviceProperties(&prop, FLAGS_device));
+  printf("Device : %s\n", prop.name);
+
   if (FLAGS_partitioned) {
     if (FLAGS_use_tags) {
       runPartitioned<true>();

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -53,8 +53,19 @@ class Stream {
   /// Adds a callback to be invoked after pending processing is done.
   void addCallback(std::function<void()> callback);
 
+  auto stream() const {
+    return stream_.get();
+  }
+
+  /// Mutable reference to arbitrary non-owned user data. Can be used for
+  /// tagging streams when scheduling.
+  void*& userData() {
+    return userData_;
+  }
+
  protected:
   std::unique_ptr<StreamImpl> stream_;
+  void* userData_{nullptr};
 
   friend class Event;
 };

--- a/velox/experimental/wave/exec/CMakeLists.txt
+++ b/velox/experimental/wave/exec/CMakeLists.txt
@@ -12,6 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(common)
-add_subdirectory(exec)
-add_subdirectory(vector)
+add_library(
+  velox_wave_exec
+  ExprKernel.cu
+  ToWave.cpp
+  WaveOperator.cpp
+  Vectors.cpp
+  Values.cpp
+  WaveDriver.cpp
+  Wave.cpp
+  Project.cpp)
+
+set_target_properties(velox_wave_exec PROPERTIES CUDA_ARCHITECTURES native)
+
+target_link_libraries(velox_wave_exec velox_wave_vector velox_wave_common
+                      velox_exception velox_common_base velox_exec)
+
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()

--- a/velox/experimental/wave/exec/ExprKernel.cu
+++ b/velox/experimental/wave/exec/ExprKernel.cu
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveCore.cuh"
+#include "velox/experimental/wave/common/CudaUtil.cuh"
+
+namespace facebook::velox::wave {
+
+template <typename T>
+__device__ inline T opFunc_kPlus(T left, T right) {
+  return left + right;
+}
+
+template <typename T, typename OpFunc>
+__device__ inline void binaryOpKernel(
+    OpFunc func,
+    IBinary& op,
+    int32_t blockBase,
+    char* shared,
+    BlockStatus* status) {}
+
+__device__ void filterKernel(
+    const IFilter& filter,
+    int32_t blockBase,
+    char* shared,
+    int32_t& numRows) {
+  auto* flags = filter.flags;
+  if (flags->nulls) {
+    boolBlockToIndices<kBlockSize>(
+        [&]() -> uint8_t {
+          return threadIdx.x >= numRows
+              ? 0
+              : flatValue<uint8_t>(flags->base, blockBase) &
+                  flatValue<uint8_t>(flags->nulls, blockBase);
+        },
+        blockBase,
+        filter.indices + blockBase,
+        shared,
+        numRows);
+  } else {
+    boolBlockToIndices<kBlockSize>(
+        [&]() -> uint8_t {
+          return threadIdx.x >= numRows
+              ? 0
+              : flatValue<uint8_t>(flags->base, blockBase);
+        },
+        blockBase,
+        filter.indices + blockBase,
+        shared,
+        numRows);
+  }
+}
+
+__device__ void wrapKernel(IWrap& wrap, int32_t blockBase, int32_t& numRows) {}
+
+#define OP_MIX(op, t) \
+  static_cast<OpCode>(static_cast<int32_t>(t) + 8 * static_cast<int32_t>(op))
+
+#define BINARY_TYPES(opCode, OP)                             \
+  case OP_MIX(opCode, ScalarType::kInt32):                   \
+    binaryOpKernel<int32_t>(                                 \
+        [](auto left, auto right) { return left OP right; }, \
+        instruction->_.binary,                               \
+        blockBase,                                           \
+        shared,                                              \
+        status);                                             \
+    break;
+
+__global__ void waveBaseKernel(
+    ThreadBlockProgram** programs,
+    int32_t* baseIndices,
+    BlockStatus* blockStatusArray) {
+  using ScanAlgorithm = cub::BlockScan<int, 256, cub::BLOCK_SCAN_RAKING>;
+  extern __shared__ __align__(
+      alignof(typename ScanAlgorithm::TempStorage)) char shared[];
+  auto* program = programs[blockIdx.x];
+  auto* status = &blockStatusArray[blockIdx.x];
+  int32_t blockBase = (blockIdx.x - baseIndices[blockIdx.x]) * blockDim.x;
+  for (auto i = 0; i < program->numInstructions; ++i) {
+    auto instruction = program->instructions[i];
+    switch (instruction->opCode) {
+      case OpCode::kFilter:
+        filterKernel(instruction->_.filter, blockBase, shared, status->numRows);
+        break;
+
+      case OpCode::kWrap:
+        wrapKernel(instruction->_.wrap, blockBase, status->numRows);
+        break;
+
+        BINARY_TYPES(OpCode::kPlus, +);
+    }
+  }
+}
+
+  void WaveKernelStream::call(Stream* alias, int32_t numBlocks, ThreadBlockProgram** programs, int32_t* baseIndices, BlockStatus* status, int32_t sharedSize) {
+    waveBaseKernel<<<numBlocks, kBlockSize, sharedSize, alias ? alias->stream()->stream : stream()->stream>>>(programs, baseIndices, status);
+ }
+
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/ExprKernel.h
+++ b/velox/experimental/wave/exec/ExprKernel.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "velox/experimental/wave/common/Cuda.h"
+#include "velox/experimental/wave/vector/Operand.h"
+
+/// Wave common instruction set. Instructions run a thread block wide
+/// and offer common operations like arithmetic, conditionals,
+/// filters, hash lookups, etc. Several vectorized operators can fuse
+/// into one instruction stream. Instruction streams may use shared
+/// memory depending on the instruction mix. The shared memory is to
+/// be allocated dynamically at kernel invocation.
+namespace facebook::velox::wave {
+
+/// Mixed with opcode to switch between instantiations of instructions for
+/// different types.
+enum class ScalarType {
+  kInt32,
+  kInt64,
+  kReal,
+  kDouble,
+  kString,
+};
+
+/// Opcodes for common instruction set. First all instructions that
+/// do not have operand type variants, then all the ones that
+/// do. For type templated instructions, the case label is opcode *
+/// numTypes + type, so these must be last in oredr not to conflict.
+enum class OpCode {
+  // First all OpCodes that have no operand type specialization.
+  kFilter = 0,
+  kWrap,
+
+  // From here, only OpCodes that have variants for scalar types.
+  kPlus,
+  kMinus,
+  kTimes,
+  kDivide,
+  kEquals,
+  kLT,
+  kLTE,
+  kGT,
+  kGTE,
+  kNE,
+
+};
+
+struct IBinary {
+  Operand* left;
+  Operand* right;
+  Operand* result;
+  // If set, apply operation to lanes where there is a non-zero byte in this.
+  Operand* predicate;
+  // If true, inverts the meaning of 'predicate', so that the operation is
+  // perfformed on lanes with a zero byte bit. Xored with predicate[idx].
+  uint8_t invert;
+};
+
+struct IFilter {
+  Operand* flags;
+  int32_t* indices;
+};
+
+struct IWrap {
+  // The indices to wrap on top of 'columns'.
+  Operand* indices;
+
+  // Number of items in 'columns', 'targetColumns', 'nuwIndices',
+  // 'mayShareIndices'.
+  int32_t numColumns;
+
+  // The columns to wrap.
+  Operand** columns;
+  // The post wrap columns. If the original is not wrapped, these
+  // have the base of original and indices to wrap and posssibly new
+  // nulls from 'newNulls'. If the original is wrapped and
+  // newIndices[i] is non-nullptr, the combined indices from the
+  // existing wrap and 'indices are stored in
+  // 'newIndices'. 'newIndices[i]' is the indices of
+  // targetColumn[i]. If 'newIndices[i]' is nullptr, the new indices
+  // overwrite the indices in 'column[i]' and the indices are
+  // referenced from targetColunns[i]'.
+  Operand** targetColumns;
+
+  Operand** newIndices;
+
+  // If mayShareIndices[i]' is an index of a previous entry in 'columns' and
+  // columns[mayshareIndices[i]] shares indices of columns[i], then
+  // targetColumns[i] has indices of targetColumn[mayShareIndices[i]]. If the
+  // wrappings were not the same, indices are obtained from newIndices[i].
+  int32_t mayShareIndices;
+};
+
+struct Instruction {
+  OpCode opCode;
+  union {
+    IBinary binary;
+    IFilter filter;
+    IWrap wrap;
+  } _;
+};
+
+///
+enum class ErrorCode : int32_t {
+  // All operations completed.
+  kOk,
+
+  // Catchall for runtime errors.
+  kError
+};
+
+/// Contains a count of active lanes and a per lane error code.
+struct BlockStatus {
+  int32_t numRows{0};
+  ErrorCode errors[kBlockSize];
+};
+
+struct ThreadBlockProgram {
+  // Shared memory needed for block. The kernel is launched with max of this
+  // across the ThreadBlockPrograms.
+  int32_t sharedMemorySize{0};
+  int32_t numInstructions;
+
+  Instruction** instructions;
+};
+/// A stream for invoking ExprKernel.
+class WaveKernelStream : public Stream {
+ public:
+  /// Enqueus an invocation of ExprKernel for 'numBlocks' blocks. 'programs[i]'
+  /// is the program for blockIdx.x == i. 'blockIdx.x - baseIndices[i] is the
+  /// starting index for the TB in its set of peer TBs all running the same
+  /// program. 'status' is set to the return status of the corresponding TB.
+  /// 'sharedSize' is the per TB bytes shared memory to be reserved at launch.
+  void call(
+      Stream* alias,
+      int32_t numBlocks,
+      ThreadBlockProgram** programs,
+      int32_t* bases,
+      BlockStatus* status,
+      int32_t sharedSize);
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Filter.h
+++ b/velox/experimental/wave/exec/Filter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+class Filter : public WaveOperator {
+ public:
+  Filter(RowTypePtr inputType, exec::ExprSet exprSet);
+
+ private:
+  std::vector<Subfield> input_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Instruction.h
+++ b/velox/experimental/wave/exec/Instruction.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/exec/ExprKernel.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::wave {
+/// Abstract representation of Wave instructions. These translate to a device
+/// side ThreadBlockProgram right before execution.
+
+struct AbstractOperand {
+  AbstractOperand(int32_t id, const TypePtr& type, std::string label)
+      : id(id), type(type), label(label) {}
+
+  AbstractOperand(const AbstractOperand& other, int32_t id)
+      : id(id), type(other.type), label(other.label) {}
+
+  const int32_t id;
+
+  // Operand type.
+  TypePtr type;
+
+  // Label for debugging, e.g. column name or Expr::toString output.
+  std::string label;
+
+  // Vector with constant value, else nullptr.
+  VectorPtr constant;
+
+  // True if bits in nulls or boolean values are as a bit field. Need widening
+  // to byte on device.
+  bool flagsAsBits{false};
+};
+
+struct AbstractInstruction {
+  AbstractInstruction(OpCode opCode) : opCode(opCode) {}
+
+  OpCode opCode;
+};
+
+struct AbstractFilter : public AbstractInstruction {
+  AbstractOperand* flags;
+  AbstractOperand* indices;
+};
+
+struct AbstractWrap : public AbstractInstruction {
+  AbstractOperand indices;
+  std::vector<AbstractOperand*> source;
+  std::vector<AbstractOperand*> target;
+
+  void addWrap(AbstractOperand* sourceOp, AbstractOperand* targetOp = nullptr) {
+    if (std::find(source.begin(), source.end(), sourceOp) != source.end()) {
+      return;
+    }
+    source.push_back(sourceOp);
+    target.push_back(targetOp ? targetOp : sourceOp);
+  }
+};
+
+struct AbstractBinary : public AbstractInstruction {
+  AbstractBinary(
+      OpCode opCode,
+      AbstractOperand* left,
+      AbstractOperand* right,
+      AbstractOperand* result)
+      : AbstractInstruction(opCode), left(left), right(right), result(result) {}
+
+  AbstractOperand* left;
+  AbstractOperand* right;
+  AbstractOperand* result;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/OperandSet.h
+++ b/velox/experimental/wave/exec/OperandSet.h
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::velox::wave {
+using OperandId = int32_t;
+
+/// Set of OperandId . Uses the id() as an index into a bitmap.
+class OperandSet {
+ public:
+  /// True if id of 'object' is in 'this'.
+  bool contains(int32_t id) const {
+    return id < bits_.size() * 64 && velox::bits::isBitSet(bits_.data(), id);
+  }
+
+  bool operator==(const OperandSet& other) const;
+
+  /// Returns hash code depending on set bits. The allocated size does not
+  /// affect the hash, only set bits. Works with == to allow use as a key of
+  /// hash table.
+  size_t hash() const {
+    size_t result = 0;
+    for (auto word : bits_) {
+      if (word) {
+        result ^= word;
+      }
+      return result * 121 ^ (result >> 9);
+    }
+  }
+
+  // True if no members.
+  bool empty() const {
+    for (auto word : bits_) {
+      if (word) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Inserts id of 'object'.
+  void add(OperandId id) {
+    ensureSize(id);
+    velox::bits::setBit(bits_.data(), id);
+  }
+
+  /// Returns the number of ids below 'id'.
+  int32_t ordinal(int32_t id) {
+    return bits::countBits(bits_.data(), 0, id);
+  }
+
+  /// Returns true if 'this' is a subset of 'super'.
+  bool isSubset(const OperandSet& super) const;
+
+  /// Erases id of 'object'.
+  void erase(OperandId id) {
+    if (id < bits_.size() * 64) {
+      velox::bits::clearBit(bits_.data(), id);
+    }
+  }
+
+  void except(const OperandSet& other) {
+    velox::bits::forEachSetBit(
+        other.bits_.data(), 0, other.bits_.size() * 64, [&](auto id) {
+          if (id < bits_.size() * 64) {
+            velox::bits::clearBit(bits_.data(), id);
+          }
+        });
+  }
+
+  /// Adds all ids in 'other'.
+  void unionSet(const OperandSet& other);
+
+  /// Erases all ids not in 'other'.
+  void intersect(const OperandSet& other);
+
+  /// Applies 'func' to each object in 'this'.
+  template <typename Func>
+  void forEach(Func func) const {
+    velox::bits::forEachSetBit(
+        bits_.data(), 0, bits_.size() * 64, [&](auto i) { func(i); });
+  }
+
+  size_t size() const {
+    return bits::countBits(
+        bits_.data(), 0, sizeof(bits_[0]) * 8 * bits_.size());
+  }
+
+ private:
+  void ensureSize(int32_t id) {
+    ensureWords(velox::bits::nwords(id + 1));
+  }
+
+  void ensureWords(int32_t size) {
+    if (bits_.size() < size) {
+      bits_.resize(size);
+    }
+  }
+
+  // A one bit corresponds to the id of each member.
+  std::vector<uint64_t> bits_;
+};
+
+template <typename V>
+inline bool isZero(const V& bits, size_t begin, size_t end) {
+  for (size_t i = begin; i < end; ++i) {
+    if (bits[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool OperandSet::operator==(const OperandSet& other) const {
+  // The sets are equal if they have the same bits set. Trailing words of zeros
+  // do not count.
+  auto l1 = bits_.size();
+  auto l2 = other.bits_.size();
+  for (unsigned i = 0; i < l1 && i < l2; ++i) {
+    if (bits_[i] != other.bits_[i]) {
+      return false;
+    }
+  }
+  if (l1 < l2) {
+    return isZero(other.bits_, l1, l2);
+  }
+  if (l2 < l1) {
+    return isZero(bits_, l2, l1);
+  }
+  return true;
+}
+
+inline bool OperandSet::isSubset(const OperandSet& super) const {
+  auto l1 = bits_.size();
+  auto l2 = super.bits_.size();
+  for (unsigned i = 0; i < l1 && i < l2; ++i) {
+    if (bits_[i] & ~super.bits_[i]) {
+      return false;
+    }
+  }
+  if (l2 < l1) {
+    return isZero(bits_, l2, l1);
+  }
+  return true;
+}
+
+struct OperandSetHasher {
+  size_t operator()(const OperandSet& set) const {
+    return set.hash();
+  }
+};
+
+struct OperandSetComparer {
+  bool operator()(const OperandSet& left, const OperandSet& right) const {
+    return left == right;
+  }
+};
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Project.cpp
+++ b/velox/experimental/wave/exec/Project.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/Project.h"
+
+namespace facebook::velox::wave {
+
+void Project::schedule(WaveStream& stream, int32_t maxRows) {}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+class Project : public WaveOperator {
+ public:
+  Project(
+      CompileState& state,
+      RowTypePtr outputType,
+      std::vector<ProgramPtr> programs)
+      : WaveOperator(state, outputType), programs_(std::move(programs)) {}
+
+  void schedule(WaveStream& stream, int32_t maxRows = 0) override;
+
+ private:
+  std::vector<ProgramPtr> programs_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -1,0 +1,251 @@
+
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/ToWave.h"
+#include "velox/exec/FilterProject.h"
+#include "velox/experimental/wave/exec/Values.h"
+#include "velox/experimental/wave/exec/WaveDriver.h"
+#include "velox/expression/ConstantExpr.h"
+#include "velox/expression/FieldReference.h"
+
+DEFINE_int64(velox_wave_arena_unit_size, 1 << 30, "Per Driver GPU memory size");
+
+namespace facebook::velox::wave {
+
+using exec::Expr;
+
+common::Subfield* CompileState::toSubfield(const Expr& expr) {
+  std::string name = expr.toString();
+  return toSubfield(name);
+}
+
+common::Subfield* CompileState::toSubfield(const std::string& name) {
+  auto it = subfields_.find(name);
+  if (it == subfields_.end()) {
+    auto field = std::make_unique<common::Subfield>(name);
+    auto result = field.get();
+    subfields_[name] = std::move(field);
+    return result;
+  }
+  return it->second.get();
+}
+
+// true if expr translates to Subfield path.
+bool isField(const Expr& expr) {
+  if (auto* field = dynamic_cast<const exec::FieldReference*>(&expr)) {
+    return (expr.inputs().empty());
+  }
+  return false;
+}
+
+Value CompileState::toValue(const Expr& expr) {
+  if (isField(expr)) {
+    auto* subfield = toSubfield(expr);
+    return Value(subfield);
+  }
+  return Value(&expr);
+}
+
+AbstractOperand* CompileState::newOperand(AbstractOperand& other) {
+  auto newOp = std::make_unique<AbstractOperand>(other, operandCounter_++);
+  operands_.push_back(std::move(newOp));
+  return operands_.back().get();
+}
+
+AbstractOperand* CompileState::newOperand(
+    const TypePtr& type,
+    const std::string& label) {
+  operands_.push_back(
+      std::make_unique<AbstractOperand>(operandCounter_++, type, ""));
+  auto op = operands_.back().get();
+  return op;
+}
+
+AbstractOperand* CompileState::addIdentityProjections(
+    Value value,
+    Program* definedIn) {
+  AbstractOperand* result = nullptr;
+  for (auto i = 0; i < operators_.size(); ++i) {
+    if (auto operand = operators_[i]->defines(value)) {
+      result = operand;
+      continue;
+    }
+    if (!result) {
+      continue;
+    }
+    if (auto wrap = operators_[i]->findWrap()) {
+      if (operators_[i]->isExpanding()) {
+        auto newResult = newOperand(*result);
+        wrap->addWrap(result, newResult);
+        result = newResult;
+      } else {
+        wrap->addWrap(result);
+      }
+    }
+  }
+}
+
+AbstractOperand* CompileState::findCurrentValue(Value value) {
+  auto it = projectedTo_.find(value);
+  if (it == projectedTo_.end()) {
+    auto originIt = definedBy_.find(value);
+    if (originIt == definedBy_.end()) {
+      return nullptr;
+    }
+
+    auto& program = definedIn_[originIt->second];
+    VELOX_CHECK(program);
+    return addIdentityProjections(value, program.get());
+  }
+}
+
+std::optional<OpCode> binaryOpCode(const Expr& expr) {
+  auto& name = expr.name();
+  if (name == "PLUS") {
+    return OpCode::kPlus;
+  }
+  return std::nullopt;
+}
+
+AbstractOperand* CompileState::addExpr(const Expr& expr) {
+  auto value = toValue(expr);
+  auto current = findCurrentValue(value);
+  if (current) {
+    return current;
+  }
+
+  if (auto* field = dynamic_cast<const exec::FieldReference*>(&expr)) {
+    std::string name = expr.name();
+    return currentProgram_->findOperand(Value(&expr));
+  } else if (auto* constant = dynamic_cast<const exec::ConstantExpr*>(&expr)) {
+    VELOX_UNSUPPORTED("No constants");
+  } else if (dynamic_cast<const exec::SpecialForm*>(&expr)) {
+    VELOX_UNSUPPORTED("No special forms");
+  }
+  auto opCode = binaryOpCode(expr);
+  if (!opCode.has_value()) {
+    VELOX_UNSUPPORTED("Expr not supported: {}", expr.toString());
+  }
+  auto result = newOperand(expr.type(), "r");
+  currentProgram_->instructions_.push_back(std::make_unique<AbstractBinary>(
+      opCode.value(),
+      addExpr(*expr.inputs()[0]),
+      addExpr(*expr.inputs()[1]),
+      result));
+  return result;
+}
+
+void CompileState::addExprSet(
+    const exec::ExprSet& exprSet,
+    int32_t begin,
+    int32_t end) {
+  for (auto i = begin; i < end; ++i) {
+    addExpr(*exprSet.exprs()[i]);
+  }
+}
+
+void CompileState::addFilterProject(exec::Operator* op) {
+  auto filterProject = reinterpret_cast<exec::FilterProject*>(op);
+  auto data = filterProject->exprsAndProjection();
+  VELOX_CHECK(!data.hasFilter);
+  std::vector<ProgramPtr> programs;
+}
+
+bool CompileState::reserveMemory() {
+  if (arena_) {
+    return true;
+  }
+  auto* allocator = getAllocator(getDevice());
+  arena_ =
+      std::make_unique<GpuArena>(FLAGS_velox_wave_arena_unit_size, allocator);
+  return true;
+}
+
+bool CompileState::addOperator(
+    exec::Operator* op,
+    int32_t& nodeIndex,
+    RowTypePtr& outputType) {
+  auto& name = op->stats().rlock()->operatorType;
+  if (name == "Values") {
+    if (!reserveMemory()) {
+      return false;
+    }
+    operators_.push_back(std::make_unique<Values>(
+        *this,
+        *reinterpret_cast<const core::ValuesNode*>(
+            driverFactory_.planNodes[nodeIndex].get())));
+    outputType = driverFactory_.planNodes[nodeIndex]->outputType();
+    return true;
+  } else if (name == "FilterProject") {
+    if (!reserveMemory()) {
+      return false;
+    }
+    addFilterProject(op);
+  } else {
+    return false;
+  }
+  return true;
+}
+
+bool CompileState::compile() {
+  auto operators = driver_.operators();
+  auto& nodes = driverFactory_.planNodes;
+
+  int32_t first = 0;
+  int32_t operatorIndex = 0;
+  int32_t nodeIndex = 0;
+  RowTypePtr outputType;
+  for (; operatorIndex < operators.size(); ++operatorIndex) {
+    if (!addOperator(operators[operatorIndex], nodeIndex, outputType)) {
+      break;
+    }
+    ++nodeIndex;
+  }
+  if (operators_.empty()) {
+    return false;
+  }
+
+  auto waveOpUnique = std::make_unique<WaveDriver>(
+      driver_.driverCtx(),
+      outputType,
+      operators[first]->planNodeId(),
+      operators[first]->operatorId(),
+      std::move(arena_),
+      std::move(operators_),
+      std::move(subfields_),
+      std::move(operands_));
+  auto waveOp = waveOpUnique.get();
+  std::vector<std::unique_ptr<exec::Operator>> added;
+  added.push_back(std::move(waveOpUnique));
+  auto replaced = driverFactory_.replaceOperators(
+      driver_, first, operatorIndex, std::move(added));
+  waveOp->setReplaced(std::move(replaced));
+  return true;
+}
+
+bool waveDriverAdapter(
+    const exec::DriverFactory& factory,
+    exec::Driver& driver) {
+  CompileState state(factory, driver);
+  return state.compile();
+}
+
+void registerWave() {
+  exec::DriverAdapter waveAdapter{"Wave", waveDriverAdapter};
+  exec::DriverFactory::registerAdapter(waveAdapter);
+}
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/ToWave.h
+++ b/velox/experimental/wave/exec/ToWave.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::velox::wave {
+
+using SubfieldMap =
+    folly::F14FastMap<std::string, std::unique_ptr<common::Subfield>>;
+
+class CompileState {
+ public:
+  CompileState(const exec::DriverFactory& driverFactory, exec::Driver& driver)
+      : driverFactory_(driverFactory), driver_(driver) {}
+
+  // Replaces sequences of Operators in the Driver given at construction with
+  // Wave equivalents. Returns true if the Driver was changed.
+  bool compile();
+
+  common::Subfield* toSubfield(const exec::Expr& expr);
+
+  common::Subfield* toSubfield(const std::string& name);
+
+  AbstractOperand* newOperand(AbstractOperand& other);
+
+  AbstractOperand* newOperand(
+      const TypePtr& type,
+      const std::string& label = "");
+
+  Value toValue(const exec::Expr& expr);
+
+  AbstractOperand* addIdentityProjections(Value value, Program* definedIn);
+  AbstractOperand* findCurrentValue(Value value);
+  AbstractOperand* addExpr(const exec::Expr& expr);
+
+  void addExprSet(const exec::ExprSet& set, int32_t begin, int32_t end);
+
+ private:
+  bool
+  addOperator(exec::Operator* op, int32_t& nodeIndex, RowTypePtr& outputType);
+
+  void addFilterProject(exec::Operator* op);
+  bool reserveMemory();
+
+  std::unique_ptr<GpuArena> arena_;
+  // The operator and output operand where the Value is first defined.
+  folly::F14FastMap<Value, AbstractOperand*, ValueHasher, ValueComparer>
+      definedBy_;
+
+  // The Operand where Value is available after all projections placed to date.
+  folly::F14FastMap<Value, AbstractOperand*, ValueHasher, ValueComparer>
+      projectedTo_;
+
+  folly::F14FastMap<AbstractOperand*, std::shared_ptr<Program>> definedIn_;
+
+  // The programs that cam be added to. Any programs from previous operators
+  // after which there is no cardinality change or shuffle.
+  folly::F14FastMap<Value, std::shared_ptr<Program>, ValueHasher, ValueComparer>
+      openPrograms_;
+
+  const exec::DriverFactory& driverFactory_;
+  exec::Driver& driver_;
+  SubfieldMap subfields_;
+
+  // All AbstractOperands. Handed off to WaveDriver after plan conversion.
+  std::vector<std::unique_ptr<AbstractOperand>> operands_;
+
+  // The Wave operators generated so far.
+  std::vector<std::unique_ptr<WaveOperator>> operators_;
+
+  // The program being generated.
+  std::shared_ptr<Program> currentProgram_;
+
+  // Sequence number for operands.
+  int32_t operandCounter_{0};
+};
+
+/// Registers adapter to add Wave operators to Drivers.
+void registerWave();
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Values.cpp
+++ b/velox/experimental/wave/exec/Values.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/Values.h"
+#include "velox/experimental/wave/exec/Vectors.h"
+#include "velox/experimental/wave/exec/WaveDriver.h"
+
+namespace facebook::velox::wave {
+
+Values::Values(CompileState& state, const core::ValuesNode& values)
+    : WaveOperator(state, values.outputType()),
+      values_(values.values()),
+      roundsLeft_(values.repeatTimes()) {}
+
+int32_t Values::canAdvance() {
+  if (current_ < values_.size()) {
+    return values_[current_]->size();
+  }
+  if (roundsLeft_ > 1) {
+    return values_[0]->size();
+  }
+  return 0;
+}
+
+void Values::schedule(WaveStream& stream, int32_t maxRows) {
+  RowVectorPtr data;
+  if (current_ == values_.size()) {
+    VELOX_CHECK_GE(roundsLeft_, 1);
+    current_ = 1;
+    data = values_[0];
+    --roundsLeft_;
+
+  } else {
+    data = values_[current_++];
+  }
+  VELOX_CHECK_LE(data->size(), maxRows);
+
+  std::vector<const BaseVector*> sources;
+  for (auto i = 0; i < subfields_.size(); ++i) {
+    sources.push_back(data->childAt(i).get());
+  }
+  vectorsToDevice(
+      folly::Range(sources.data(), sources.size()), outputIds_, stream);
+}
+
+std::string Values::toString() const {
+  return "Values";
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Values.h
+++ b/velox/experimental/wave/exec/Values.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "velox/core/PlanNode.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+class Values : public WaveOperator {
+ public:
+  Values(CompileState& state, const core::ValuesNode& values);
+
+  int32_t canAdvance() override;
+
+  void schedule(WaveStream& stream, int32_t maxRows = 0) override;
+
+  vector_size_t outputSize() const override {
+    // Must not be called before schedule().
+    VELOX_CHECK_LT(0, current_);
+    return values_[current_ - 1]->size();
+  }
+
+  std::string toString() const override;
+
+ private:
+  std::vector<RowVectorPtr> values_;
+  int32_t current_ = 0;
+  size_t roundsLeft_ = 1;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Vectors.cpp
+++ b/velox/experimental/wave/exec/Vectors.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/Vectors.h"
+
+namespace facebook::velox::wave {
+
+WaveVectorPtr allocateWaveVector(const BaseVector* source, GpuArena& arena) {
+  auto result = WaveVector::create(source->type(), arena);
+  result->resize(source->size(), source->mayHaveNulls());
+  return result;
+}
+
+void ensureWaveVector(
+    WaveVectorPtr& waveVector,
+    const BaseVector* vector,
+    GpuArena& arena) {
+  if (!waveVector) {
+    waveVector = allocateWaveVector(vector, arena);
+  } else {
+    waveVector->resize(vector->size(), vector->mayHaveNulls());
+  }
+}
+
+void ensureWaveVector(
+    WaveVectorPtr& waveVector,
+    const TypePtr& type,
+    vector_size_t size,
+    bool nullable,
+    GpuArena& arena) {
+  if (!waveVector) {
+    waveVector = WaveVector::create(type, arena);
+  }
+  waveVector->resize(size, nullable);
+}
+
+void ensureVectors(
+    folly::Range<vector_size_t*> sizes,
+    const std::vector<TypePtr>& types,
+    folly::Range<bool*> nullable,
+    std::vector<WaveVectorPtr> vectors,
+    folly::Range<Operand*> operands,
+    GpuArena& arena) {
+  if (vectors.size() < operands.size()) {
+    vectors.resize(operands.size());
+  }
+  for (auto i = 0; i < operands.size(); ++i) {
+    vector_size_t size = sizes.size() > i ? sizes[i] : sizes.back();
+    bool isNullable = nullable.empty() ? true
+        : nullable.size() > i          ? nullable[i]
+                                       : nullable.back();
+    ensureWaveVector(vectors[i], types[i], size, isNullable, arena);
+    vectors[i]->toOperand(&operands[i]);
+  }
+}
+
+void transferVector(
+    const BaseVector* source,
+    int32_t index,
+    std::vector<Transfer>& transfers,
+    std::vector<WaveVectorPtr>& waveVectors,
+    std::vector<Operand>& operands,
+    GpuArena& arena,
+    int64_t totalBytes) {
+  if (waveVectors.size() <= index) {
+    waveVectors.resize(index + 1);
+  }
+  ensureWaveVector(waveVectors[index], source, arena);
+  if (operands.size() <= index) {
+    operands.resize(index + 1);
+  }
+  waveVectors[index]->toOperand(&operands[index]);
+  auto values = source->values();
+  auto rawNulls = source->rawNulls();
+  if (values) {
+    auto rawValues = values->as<char>();
+    if (source->typeKind() == TypeKind::BOOLEAN) {
+      auto bytes = bits::nbytes(source->size());
+      transfers.emplace_back(
+          rawValues, waveVectors[index]->values<char>(), bytes);
+      totalBytes += bytes;
+    } else {
+      auto bytes = source->size() * source->type()->cppSizeInBytes();
+      transfers.emplace_back(
+          rawValues, waveVectors[index]->values<char>(), bytes);
+      totalBytes += bytes;
+    }
+    if (rawNulls) {
+      auto bytes = bits::nbytes(source->size());
+      transfers.emplace_back(rawNulls, waveVectors[index]->nulls(), bytes);
+      totalBytes += bytes;
+    }
+  }
+}
+
+void vectorsToDevice(
+    folly::Range<const BaseVector**> source,
+    const OperandSet& ids,
+    WaveStream& stream) {
+  std::vector<Transfer> transfers;
+  int64_t bytes = 0;
+  std::vector<Operand> operandVector;
+  std::vector<WaveVectorPtr> waveVectors;
+  auto& arena = stream.arena();
+  for (auto i = 0; i < source.size(); ++i) {
+    transferVector(
+        source[i], i, transfers, waveVectors, operandVector, arena, bytes);
+  }
+  auto operands = arena.allocate<Operand>(operandVector.size());
+  memcpy(
+      operands->as<Operand>(),
+      operandVector.data(),
+      operandVector.size() * sizeof(Operand));
+  operandVector.clear();
+  Executable::startTransfer(
+      ids,
+      std::move(operands),
+      std::move(waveVectors),
+      std::move(transfers),
+      stream);
+}
+
+// Patches the position 'ofet' in 'code' to be a new uninitialized device
+// array of int32_t of at least 'size' elements.
+void allocateIndirection(
+    GpuArena& arena,
+    vector_size_t size,
+    const WaveBufferPtr& code,
+    int32_t offset);
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Vectors.h
+++ b/velox/experimental/wave/exec/Vectors.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/experimental/wave/exec/OperandSet.h"
+#include "velox/experimental/wave/exec/Wave.h"
+#include "velox/experimental/wave/vector/WaveVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::wave {
+
+void vectorsToDevice(
+    folly::Range<const BaseVector**> source,
+    const OperandSet& ids,
+    WaveStream& stream);
+
+WaveVectorPtr allocateWaveVector(const BaseVector* source, GpuArena& arena);
+
+void ensureWaveVector(
+    WaveVectorPtr& waveVector,
+    const BaseVector* vector,
+    GpuArena& arena);
+
+/// Allocates or resizes WaveVectors / Operands given types, size and
+/// nullability.
+void ensureVectors(
+    folly::Range<vector_size_t*> sizes,
+    const std::vector<TypePtr>& types,
+    folly::Range<bool*> nullable,
+    std::vector<WaveVectorPtr> vectors,
+    folly::Range<Operand*> operands,
+    GpuArena& arena);
+
+// Patches the position at 'offset' in 'code' to be a new uninitialized device
+// array of int32_t of at least 'size' elements.
+void allocateIndirection(
+    GpuArena& arena,
+    vector_size_t size,
+    const WaveBufferPtr& code,
+    int32_t offset);
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Wave.cpp
+++ b/velox/experimental/wave/exec/Wave.cpp
@@ -1,0 +1,243 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/Wave.h"
+
+namespace facebook::velox::wave {
+
+WaveStream::~WaveStream() {
+  for (auto& stream : streams_) {
+    releaseStream(std::move(stream));
+  }
+  for (auto& event : allEvents_) {
+    std::unique_ptr<Event> temp(event);
+    releaseEvent(std::move(temp));
+  }
+}
+
+std::mutex WaveStream::reserveMutex_;
+std::vector<std::unique_ptr<Stream>> WaveStream::streamsForReuse_;
+std::vector<std::unique_ptr<Event>> WaveStream::eventsForReuse_;
+bool WaveStream::exitInited_{false};
+
+Stream* WaveStream::newStream() {
+  auto stream = streamFromReserve();
+  auto id = streams_.size();
+  stream->userData() = reinterpret_cast<void*>(id);
+  auto result = stream.get();
+  streams_.push_back(std::move(stream));
+  lastEvent_.push_back(nullptr);
+  return result;
+}
+
+// static
+void WaveStream::clearReusable() {
+  streamsForReuse_.clear();
+  eventsForReuse_.clear();
+}
+
+// static
+std::unique_ptr<Stream> WaveStream::streamFromReserve() {
+  std::lock_guard<std::mutex> l(reserveMutex_);
+  if (streamsForReuse_.empty()) {
+    auto result = std::make_unique<Stream>();
+    if (!exitInited_) {
+      // Register handler for clearing resources after first call of API.
+      exitInited_ = true;
+      atexit(WaveStream::clearReusable);
+    }
+
+    return result;
+  }
+  auto item = std::move(streamsForReuse_.back());
+  streamsForReuse_.pop_back();
+  return item;
+}
+
+//  static
+void WaveStream::releaseStream(std::unique_ptr<Stream>&& stream) {
+  std::lock_guard<std::mutex> l(reserveMutex_);
+  streamsForReuse_.push_back(std::move(stream));
+}
+Event* WaveStream::newEvent() {
+  auto event = eventFromReserve();
+  auto result = event.release();
+  allEvents_.insert(result);
+  return result;
+}
+
+// static
+std::unique_ptr<Event> WaveStream::eventFromReserve() {
+  std::lock_guard<std::mutex> l(reserveMutex_);
+  if (eventsForReuse_.empty()) {
+    return std::make_unique<Event>();
+  }
+  auto item = std::move(eventsForReuse_.back());
+  eventsForReuse_.pop_back();
+  return item;
+}
+
+//  static
+void WaveStream::releaseEvent(std::unique_ptr<Event>&& event) {
+  std::lock_guard<std::mutex> l(reserveMutex_);
+  eventsForReuse_.push_back(std::move(event));
+}
+
+namespace {
+// Copies from pageable host to unified address. Multithreaded memcpy is
+// probably best.
+void copyData(std::vector<Transfer>& transfers) {
+  // TODO: Put memcpys or ppieces of them on AsyncSource if large enough.
+  for (auto& transfer : transfers) {
+    ::memcpy(transfer.to, transfer.from, transfer.size);
+  }
+}
+} // namespace
+
+void Executable::startTransfer(
+    OperandSet outputOperands,
+    WaveBufferPtr&& operands,
+    std::vector<WaveVectorPtr>&& outputVectors,
+    std::vector<Transfer>&& transfers,
+    WaveStream& waveStream) {
+  auto exe = std::make_unique<Executable>();
+  exe->outputOperands = outputOperands;
+  exe->output = std::move(outputVectors);
+  exe->transfers = std::move(transfers);
+  exe->deviceData = operands;
+  exe->operands = operands->as<Operand>();
+  exe->outputOperands = outputOperands;
+  copyData(exe->transfers);
+  auto* device = waveStream.device();
+  waveStream.installExecutables(
+      folly::Range(&exe, 1),
+      [&](Stream* stream, folly::Range<Executable**> executables) {
+        for (auto& transfer : executables[0]->transfers) {
+          stream->prefetch(device, transfer.to, transfer.size);
+        }
+        waveStream.markLaunch(*stream, *executables[0]);
+      });
+}
+
+void WaveStream::installExecutables(
+    folly::Range<std::unique_ptr<Executable>*> executables,
+    std::function<void(Stream*, folly::Range<Executable**>)> launch) {
+  folly::F14FastMap<
+      OperandSet,
+      std::vector<Executable*>,
+      OperandSetHasher,
+      OperandSetComparer>
+      dependences;
+  for (auto& exeUnique : executables) {
+    executables_.push_back(std::move(exeUnique));
+    auto exe = executables_.back().get();
+    VELOX_CHECK(exe->stream == nullptr);
+    OperandSet streamSet;
+    exe->inputOperands.forEach([&](int32_t id) {
+      auto* source = operandToExecutable_[id];
+      VELOX_CHECK(source != nullptr);
+      auto stream = source->stream;
+      if (stream) {
+        // Compute pending, mark depenedency.
+        auto sid = reinterpret_cast<uintptr_t>(stream->userData());
+        streamSet.add(sid);
+      }
+    });
+    dependences[streamSet].push_back(exe);
+    exe->outputOperands.forEach([&](int32_t id) {
+      VELOX_CHECK_EQ(0, operandToExecutable_.count(id));
+      operandToExecutable_[id] = exe;
+    });
+  }
+
+  // exes with no dependences go on a new stream. Streams with dependent compute
+  // get an event. The dependent computes ggo on new streams that first wait for
+  // the events.
+  folly::F14FastMap<int32_t, Event*> streamEvents;
+  for (auto& pair : dependences) {
+    std::vector<Stream*> required;
+    pair.first.forEach(
+        [&](int32_t id) { required.push_back(streams_[id].get()); });
+    Executable** start = pair.second.data();
+    int32_t count = pair.second.size();
+    auto exes = folly::range(start, start + count);
+    if (required.empty()) {
+      auto stream = newStream();
+      launch(stream, exes);
+    } else {
+      for (auto* req : required) {
+        auto id = reinterpret_cast<uintptr_t>(req->userData());
+        if (streamEvents.count(id) == 0) {
+          auto event = newEvent();
+          lastEvent_[id] = event;
+          event->record(*req);
+          streamEvents[id] = event;
+        }
+      }
+      auto launchStream = newStream();
+      pair.first.forEach(
+          [&](int32_t id) { streamEvents[id]->wait(*launchStream); });
+      launch(launchStream, exes);
+    }
+  }
+}
+
+bool WaveStream::isArrived(
+    const OperandSet& ids,
+    int32_t sleepMicro,
+    int32_t timeoutMicro) {
+  OperandSet waitSet;
+  ids.forEach([&](int32_t id) {
+    auto exe = operandToExecutable_[id];
+    VELOX_CHECK_NOT_NULL(exe);
+    if (!exe->stream) {
+      return;
+    }
+    auto streamId = reinterpret_cast<uintptr_t>(exe->stream->userData());
+    if (!lastEvent_[streamId]) {
+      lastEvent_[streamId] = newEvent();
+      lastEvent_[streamId]->record(*exe->stream);
+    }
+    if (lastEvent_[streamId]->query()) {
+      return;
+    }
+    waitSet.add(streamId);
+  });
+  if (waitSet.empty()) {
+    return true;
+  }
+  if (sleepMicro == -1) {
+    return false;
+  }
+  auto start = getCurrentTimeMicro();
+  int64_t elapsed = 0;
+  while (timeoutMicro == 0 || elapsed < timeoutMicro) {
+    bool ready = true;
+    waitSet.forEach([&](int32_t id) {
+      if (!lastEvent_[id]->query()) {
+        ready = false;
+      }
+    });
+    if (ready) {
+      return true;
+    }
+    std::this_thread::sleep_for(std::chrono::microseconds(sleepMicro));
+    elapsed = getCurrentTimeMicro() - start;
+  }
+  return false;
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/Wave.h
+++ b/velox/experimental/wave/exec/Wave.h
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/exec/Instruction.h"
+#include "velox/experimental/wave/exec/OperandSet.h"
+
+#include "velox/expression/Expr.h"
+#include "velox/type/Subfield.h"
+
+#include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/exec/ExprKernel.h"
+#include "velox/experimental/wave/vector/WaveVector.h"
+namespace facebook::velox::wave {
+
+// A value a kernel can depend on. Either a dedupped exec::Expr or a dedupped
+// subfield. Subfield between operators, Expr inside  an Expr.
+struct Value {
+  Value() = default;
+  Value(const exec::Expr* expr) : expr(expr), subfield(nullptr) {}
+
+  Value(const common::Subfield* subfield) : expr(nullptr), subfield(subfield) {}
+  ~Value() = default;
+
+  bool operator==(const Value& other) const {
+    return expr == other.expr && subfield == other.subfield;
+  }
+
+  const exec::Expr* expr;
+  const common::Subfield* subfield;
+};
+
+struct ValueHasher {
+  size_t operator()(const Value& value) const {
+    return folly::hasher<uint64_t>()(
+               reinterpret_cast<uintptr_t>(value.subfield)) ^
+        folly::hasher<uint64_t>()(reinterpret_cast<uintptr_t>(value.expr));
+  }
+};
+
+struct ValueComparer {
+  bool operator()(const Value& left, const Value& right) const {
+    return left == right;
+  }
+};
+
+struct BufferReference {
+  // Ordinal of the instruction that assigns a value to the Operand.
+  int32_t insruction;
+  // Offset of Operand struct in the executable image.
+  int32_t offset;
+};
+
+struct Transfer {
+  Transfer(const void* from, void* to, size_t size)
+      : from(from), to(to), size(size) {}
+
+  const void* from;
+  void* to;
+  // Transfer size in bytes.
+  size_t size;
+};
+
+class WaveStream;
+class Program;
+
+/// Represents a kernel or data transfer. Many executables can be in one kernel
+/// launch on different thread blocks. Owns the output and intermediate memory
+/// for the thread block program or data transfer this represents. Has a
+/// WaveStream level unique id for each output column. be nulllptr if this
+/// represents data movement only.
+struct Executable {
+  std::unique_ptr<Executable>
+  create(std::shared_ptr<Program> program, int32_t numRows, GpuArena& arena);
+
+  /// Creates a data transfer. The ranges to transfer are associated to this by
+  /// addTransfer().
+  static void startTransfer(
+      OperandSet outputOperands,
+      WaveBufferPtr&& operands,
+      std::vector<WaveVectorPtr>&& outputVectors,
+      std::vector<Transfer>&& transfers,
+      WaveStream& stream);
+
+  ThreadBlockProgram* program{nullptr};
+
+  // All device side memory. Instructions, operands, everything except buffers
+  // for input/intermediate/output buffers.
+  WaveBufferPtr deviceData;
+
+  // Operand ids for inputs.
+  OperandSet inputOperands;
+
+  // Operand ids for outputs.
+  OperandSet outputOperands;
+
+  // Unified memory Operand structs. First input, then output. the instructions
+  // in 'program' reference these. The device side memory is referenced as raw
+  // pointers and its ownership is managed by 'intermediates' and 'output'
+  // below.
+  Operand* operands;
+
+  // Backing memory for intermediate Operands. Free when 'this' arrives. If
+  // scheduling follow up work that is synchronized with arrival of 'this', the
+  // intermediates can be moved to the dependent executable at time of
+  // scheduling.
+  std::vector<WaveVectorPtr> intermediates;
+
+  // Backing device memory   for 'output' Can be moved to intermediates or
+  // output of a dependent executables.
+  std::vector<WaveVectorPtr> output;
+
+  // If this represents data transfer, the ranges to transfer.
+  std::vector<Transfer> transfers;
+
+  // The stream on which this is enqueued. Set by
+  // WaveStream::installExecutables(). Cleared after the kernel containing this
+  // is seen to realize dependent event.
+  Stream* stream{nullptr};
+
+  // Function for returning 'this' to a pool of reusable executables kept by an
+  // operator. The function is expected to move the Executable from the
+  // std::unique_ptr. Otherwise the Executable will be freed by reset of the
+  // unique_ptr.
+  std::function<void(std::unique_ptr<Executable>&)> releaser;
+};
+
+class Program {
+ public:
+  void add(std::unique_ptr<AbstractInstruction> instruction) {
+    instructions_.push_back(std::move(instruction));
+  }
+
+  // Initialized executableImage and relocation infromation and places for
+  // parameters.
+  void prepareForDevice(GpuArena& arena);
+
+  std::unique_ptr<Executable> instantiate(GpuArena& arena);
+
+  // Patches device side 'instance' to reference newly allocated buffers for up
+  // to 'numRows' of result data starting at instruction at 'continuePoint'.
+  void setBuffers(
+      ThreadBlockProgram* instance,
+      int32_t continuePoint,
+      int32_t numRows);
+
+  const std::vector<Value>& dependsOn() const {
+    return dependsOn_;
+  }
+
+  AbstractOperand* findOperand(const Value& value) {
+    return nullptr;
+  }
+
+  std::vector<Value> dependsOn_;
+  folly::F14FastMap<Value, AbstractOperand*, ValueHasher, ValueComparer>
+      produces_;
+  std::vector<std::unique_ptr<AbstractInstruction>> instructions_;
+
+  // Relocation info.The first int is the offset of a pointer in the executable
+  // representation .The secon is the offset it points to inside the
+  // representation.
+  std::vector<std::pair<int32_t, int32_t>> relocation_;
+
+  // FDescribes the places in the executable image that need a WaveBuffer's
+  // address to be patched in before execution.
+  std::vector<BufferReference> buffers;
+  // Bytes to copy to device. The relocations and buffer reference patches given
+  // in 'relocations_' and 'buffers_' must be applied to the image before
+  // starting a kernel interpreting the image.
+  std::vector<uint64_t> executableImage_;
+
+  // The size of the device side contiguous memory for 'this'.
+  int32_t sizeOnDevice_{0};
+};
+
+using ProgramPtr = std::shared_ptr<Program>;
+
+/// Represents consecutive data dependent kernel launches.
+class WaveStream {
+ public:
+  WaveStream(GpuArena& arena) : arena_(arena) {}
+
+  ~WaveStream();
+
+  // Binds operands of each program to inputs from pending programs and if
+  // depending on more than one Wave, adds dependency via events. Each program
+  // [i]is dimensioned to have  sizes[i] max intermediates/results.
+  void startWave(
+      folly::Range<Executable**> programs,
+      folly::Range<int32_t*> sizes);
+
+  GpuArena& arena() {
+    return arena_;
+  }
+
+  Executable* operandExecutable(OperandId id) {
+    auto it = operandToExecutable_.find(id);
+    if (it == operandToExecutable_.end()) {
+      return nullptr;
+    }
+    return it->second;
+  }
+
+  /// Determines the prerequisites for each of 'executables' and calls
+  /// 'launch' for each group of executables with the same
+  /// dependencies. 'launch' gets a stream where the prerequisites are
+  /// enqueued or a stream on which an event wait for multiple
+  /// prerequisites is enqueued for executables with more than one
+  /// prerequisite. 'launch' is responsible for enqueuing the actual
+  /// kernel or data transfer and marking which stream it went to with
+  /// markLaunch(). Takes ownership of 'executables', which are moved out of the
+  /// unique_ptrs.
+  void installExecutables(
+      folly::Range<std::unique_ptr<Executable>*> executables,
+      std::function<void(Stream*, folly::Range<Executable**>)> launch);
+
+  /// The callback from installExecutables must call this to establish relation
+  /// of stream and executable before returning. Normally, the executable is
+  /// launched on the stream given to the callback. In some cases the launch may
+  /// decide to use different streams for different executables and have these
+  /// depend on the first stream.
+  void markLaunch(Stream& stream, Executable& executable) {
+    executable.stream = &stream;
+  }
+
+  // Retuns true if all executables needed to cover 'ids' have arrived. if
+  // 'sleepMicro' is default, returns immediately if not arrived. Otherwise
+  // sleeps 'leepMicros' and rechecks until complete or until 'timeoutMicro' us
+  // have elapsed. timeout 0 means wait indefinitely.
+  bool isArrived(
+      const OperandSet& ids,
+      int32_t sleepMicro = -1,
+      int32_t timeoutMicro = 0);
+
+  Device* device() const {
+    return getDevice();
+  }
+  /// Returns a new stream, assigns it an id and keeps it owned by 'this'. The
+  /// Stream will be returned to the static pool of streams on destruction of
+  /// 'this'.
+  Stream* newStream();
+
+  static std::unique_ptr<Stream> streamFromReserve();
+  static void releaseStream(std::unique_ptr<Stream>&& stream);
+
+ private:
+  Event* newEvent();
+
+  static std::unique_ptr<Event> eventFromReserve();
+  static void releaseEvent(std::unique_ptr<Event>&& event);
+
+  // Preallocated Streams and Events.
+  static std::mutex reserveMutex_;
+  static std::vector<std::unique_ptr<Event>> eventsForReuse_;
+  static std::vector<std::unique_ptr<Stream>> streamsForReuse_;
+  static bool exitInited_;
+
+  static void clearReusable();
+
+  GpuArena& arena_;
+  folly::F14FastMap<OperandId, Executable*> operandToExecutable_;
+  std::vector<std::unique_ptr<Executable>> executables_;
+
+  // Currently active streams, each at the position given by its
+  // stream->userData().
+  std::vector<std::unique_ptr<Stream>> streams_;
+  // The most recent event recorded on the pairwise corresponding element of
+  // 'streams_'.
+  std::vector<Event*> lastEvent_;
+
+  // all events recorded on any stream. Events, once seen realized, are moved
+  // back to reserve from here.
+  folly::F14FastSet<Event*> allEvents_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveCore.cuh
+++ b/velox/experimental/wave/exec/WaveCore.cuh
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/common/Block.cuh"
+#include "velox/experimental/wave/exec/ExprKernel.h"
+
+namespace facebook::velox::wave {
+
+template <typename T>
+__device__ inline T& flatValue(void* base, int32_t blockBase) {
+  return reinterpret_cast<T*>(base)[blockBase + threadIdx.x];
+}
+
+__device__ inline bool isNull(Operand* op, int32_t blockBase) {
+  return op->nulls == nullptr || !op->nulls[blockBase + threadIdx.x];
+}
+
+template <typename T>
+__device__ inline T value(Operand* op, int32_t blockBase, char* shared) {
+  int32_t index = (threadIdx.x + blockBase) & op->indexMask;
+  void* base = op->sharedOffset != Operand::kGlobal ? shared + op->sharedOffset : op->base;
+  if (auto indicesInOp = op->indices) {
+    auto indices = indicesInOp[blockBase / kBlockSize];
+    if (indices) {
+      index = indices[index];
+    }
+  }
+  return reinterpret_cast<const T*>(
+      base)[index];
+}
+
+template <typename T>
+T& flatResult(Operand* op, int32_t blockBase) {
+  reinterpret_cast<T*>(op->base)[blockBase + threadIdx.x];
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveDriver.cpp
+++ b/velox/experimental/wave/exec/WaveDriver.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveDriver.h"
+#include "velox/experimental/wave/exec/Instruction.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+WaveDriver::WaveDriver(
+    exec::DriverCtx* driverCtx,
+    RowTypePtr outputType,
+    core::PlanNodeId planNodeId,
+    int32_t operatorId,
+    std::unique_ptr<GpuArena> arena,
+    std::vector<std::unique_ptr<WaveOperator>> waveOperators,
+    SubfieldMap subfields,
+    std::vector<std::unique_ptr<AbstractOperand>> operands)
+    : exec::SourceOperator(
+          driverCtx,
+          outputType,
+          operatorId,
+          planNodeId,
+          "Wave"),
+      arena_(std::move(arena)),
+      waveOperators_(std::move(waveOperators)),
+      subfields_(std::move(subfields)),
+      operands_(std::move(operands)) {
+  for (auto& op : waveOperators_) {
+    op->setDriver(this);
+  }
+}
+
+RowVectorPtr WaveDriver::getOutput() {
+  for (;;) {
+    startMore();
+    if (streams_.empty()) {
+      finished_ = true;
+      return nullptr;
+    }
+    auto& lastSet = waveOperators_.back()->outputIds();
+    for (auto i = 0; i < streams_.size(); ++i) {
+      auto stream = streams_[i].get();
+      if (stream->isArrived(lastSet)) {
+        auto result = makeResult(*stream, lastSet);
+        if (streamAtEnd(*stream)) {
+          streams_.erase(streams_.begin() + i);
+        }
+        return result;
+      }
+    }
+  }
+}
+
+bool WaveDriver::streamAtEnd(WaveStream& stream) {
+  return true;
+}
+RowVectorPtr WaveDriver::makeResult(
+    WaveStream& stream,
+    const OperandSet& lastSet) {
+  auto& last = *waveOperators_.back();
+  auto& rowType = last.outputType();
+  std::vector<VectorPtr> children(rowType->size());
+  auto result = std::make_shared<RowVector>(
+      operatorCtx_->pool(),
+      rowType,
+      BufferPtr(nullptr),
+      last.outputSize(),
+      std::move(children));
+  int32_t nthChild = 0;
+  lastSet.forEach([&](int32_t id) {
+    auto exe = stream.operandExecutable(id);
+    VELOX_CHECK_NOT_NULL(exe);
+    auto ordinal = exe->outputOperands.ordinal(id);
+    auto waveVector = std::move(exe->output[ordinal]);
+    result->childAt(nthChild++) = waveVector->toVelox(operatorCtx_->pool());
+  });
+  return result;
+}
+
+void WaveDriver::startMore() {
+  auto rows = waveOperators_[0]->canAdvance();
+  if (!rows) {
+    return;
+  }
+  streams_.push_back(std::make_unique<WaveStream>(*arena_));
+  auto& stream = *streams_.back();
+  for (auto i = 0; i < waveOperators_.size(); ++i) {
+    waveOperators_[i]->schedule(stream, rows);
+  }
+  prefetchReturn(stream);
+}
+
+void WaveDriver::prefetchReturn(WaveStream& stream) {
+  // Schedule return buffers from last op to be on host side.
+  auto& last = waveOperators_.back();
+  auto& ids = last->outputIds();
+}
+
+std::string WaveDriver::toString() const {
+  std::stringstream out;
+  out << "{Wave" << std::endl;
+  for (auto& op : waveOperators_) {
+    out << op->toString() << std::endl;
+  }
+  return out.str();
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveDriver.h
+++ b/velox/experimental/wave/exec/WaveDriver.h
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/Operator.h"
+#include "velox/experimental/wave/exec/WaveOperator.h"
+
+namespace facebook::velox::wave {
+
+using SubfieldMap =
+    folly::F14FastMap<std::string, std::unique_ptr<common::Subfield>>;
+
+class WaveDriver : public exec::SourceOperator {
+ public:
+  WaveDriver(
+      exec::DriverCtx* driverCtx,
+      RowTypePtr outputType,
+      core::PlanNodeId planNodeId,
+      int32_t operatorId,
+      std::unique_ptr<GpuArena> arena,
+      std::vector<std::unique_ptr<WaveOperator>> waveOperators,
+      SubfieldMap subfields,
+      std::vector<std::unique_ptr<AbstractOperand>> operands);
+
+  RowVectorPtr getOutput() override;
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override {
+    if (blockingFuture_.valid()) {
+      *future = std::move(blockingFuture_);
+      return blockingReason_;
+    }
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() {
+    return finished_;
+  }
+
+  void setReplaced(std::vector<std::unique_ptr<exec::Operator>> original) {
+    cpuOperators_ = std::move(original);
+  }
+
+  GpuArena& arena() const {
+    return *arena_;
+  }
+
+  std::string toString() const override;
+
+ private:
+  // True if all output from 'stream' is fetched.
+  bool streamAtEnd(WaveStream& stream);
+
+  // Makes a RowVector from the result buffers of the last stage of executables
+  // in 'stream'.
+  RowVectorPtr makeResult(WaveStream& stream, const OperandSet& outputIds);
+
+  // Starts another WaveStream if the source operator indicates it has more data
+  // and there is space in the arena.
+  void startMore();
+
+  // Enqueus a prefetch from device to host for the buffers of output vectors.
+  void prefetchReturn(WaveStream& stream);
+
+  std::unique_ptr<GpuArena> arena_;
+
+  ContinueFuture blockingFuture_{ContinueFuture::makeEmpty()};
+  exec::BlockingReason blockingReason_;
+
+  bool finished_{false};
+
+  // Wave operators replacing 'cpuOperators_' on GPU path.
+  std::vector<std::unique_ptr<WaveOperator>> waveOperators_;
+  // The replaced Operators from the Driver. Can be used for a CPU fallback.
+  std::vector<std::unique_ptr<exec::Operator>> cpuOperators_;
+  // Dedupped Subfields. Handed over by CompileState.
+  SubfieldMap subfields_;
+  // Operands handed over by compilation.
+  std::vector<std::unique_ptr<AbstractOperand>> operands_;
+
+  // The set of currently pending kernel DAGs for this WaveDriver. If
+  // the source operator can produce multiple consecutive batches
+  // before the batch is executed to completion, multiple such batches
+  // can be on device independently of each other. This is bounded by
+  // device memory and the speed at which the source can produce new
+  // batches.
+  std::vector<std::unique_ptr<WaveStream>> streams_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveOperator.cpp
+++ b/velox/experimental/wave/exec/WaveOperator.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/exec/WaveOperator.h"
+#include "velox/experimental/wave/exec/ToWave.h"
+
+namespace facebook::velox::wave {
+
+WaveOperator::WaveOperator(CompileState& state, const RowTypePtr& type)
+    : outputType_(type) {
+  definesSubfields(state, outputType_);
+}
+
+void WaveOperator::definesSubfields(
+    CompileState& state,
+    const TypePtr& type,
+    const std::string& parentPath) {
+  switch (type->kind()) {
+    case TypeKind::ROW: {
+      auto& row = type->as<TypeKind::ROW>();
+      for (auto i = 0; i < type->size(); ++i) {
+        auto& child = row.childAt(i);
+        auto name = row.nameOf(i);
+        auto field = state.toSubfield(name);
+        subfields_.push_back(field);
+        types_.push_back(child);
+        auto operand = state.newOperand(child, name);
+        outputIds_.add(operand->id);
+        defines_[Value(field)] = operand;
+      }
+    }
+      // TODO:Add cases for nested types.
+    default: {
+      return;
+    }
+  }
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveOperator.h
+++ b/velox/experimental/wave/exec/WaveOperator.h
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/experimental/wave/exec/Wave.h"
+#include "velox/experimental/wave/vector/WaveVector.h"
+
+namespace facebook::velox::wave {
+
+class CompileState;
+class WaveDriver;
+
+class WaveOperator {
+ public:
+  WaveOperator(CompileState& state, const RowTypePtr& outputType);
+
+  const RowTypePtr& outputType() const {
+    return outputType_;
+  }
+
+  /// True if may reduce cardinality without duplicating input rows.
+  bool isFilter() {
+    return isFilter_;
+  }
+
+  /// True if a single input can produce zero to multiple outputs.
+  bool isExpanding() const {
+    return isExpanding_;
+  }
+
+  // If 'this' is a cardinality change (filter, join, unnest...),
+  // returns the instruction where the projected through columns get
+  // wrapped. Columns that need to be accessed through the change are
+  // added here.
+  virtual AbstractWrap* findWrap() const {
+    return nullptr;
+  }
+
+  /// Returns how many rows of output are available from 'this'. Source
+  /// operators and cardinality increasing operators must return a correct
+  /// answer if they are ready to produce data. Others should return 0.
+  virtual int32_t canAdvance() {
+    return 0;
+  }
+
+  /// Adds processing for 'this' to 'stream'. If 'maxRows' is given,
+  /// then this is the maximum number of intermediates/result rows
+  /// this can produce. If not given, this defaults to the 'stream's
+  /// current result row count. If the stream is pending and the
+  /// count is not known, then this defaults to the max cardinality
+  /// of the pending work. If the work has arrived, this can be the
+  /// actual cardinality. The first schedule() of each 'stream '
+  /// must specify this count. This is the number returned by
+  /// canAdvance() for a source WaveOperator.
+  virtual void schedule(WaveStream& stream, int32_t maxRows = 0) = 0;
+
+  virtual std::string toString() const = 0;
+
+  void definesSubfields(
+      CompileState& state,
+      const TypePtr& type,
+      const std::string& parentPath = "");
+
+  /// Returns the operand if this is defined by 'this'.
+  AbstractOperand* defines(Value value) {
+    auto it = defines_.find(value);
+    if (it == defines_.end()) {
+      return nullptr;
+    }
+    return it->second;
+  }
+
+  void setDriver(WaveDriver* driver) {
+    driver_ = driver;
+  }
+
+  // Returns the number of non-filtered out result rows. The actual result rows
+  // may be non-contiguous in the result vectors and may need indirection to
+  // access, as seen in output operands of the corresponding executables.
+  virtual vector_size_t outputSize() const = 0;
+
+  const OperandSet& outputIds() const {
+    return outputIds_;
+  }
+
+ protected:
+  WaveDriver* driver_{nullptr};
+
+  // The Subfields that are produced. Different ones can arrive at
+  // different times on different waves. In this list, ordered in
+  // depth first preorder of outputType_. Top struct not listed,
+  // struct columns have the parent before the children.
+  std::vector<const common::Subfield*> subfields_;
+
+  // Pairwise type for each subfield.
+  std::vector<TypePtr> types_;
+
+  // the execution time set of OperandIds.
+  OperandSet outputIds_;
+
+  bool isFilter_{false};
+
+  bool isExpanding_{false};
+
+  RowTypePtr outputType_;
+
+  // The operands that are first defined here.
+  folly::F14FastMap<Value, AbstractOperand*, ValueHasher, ValueComparer>
+      defines_;
+
+  // The operand for values that are projected through 'this'.
+  folly::F14FastMap<Value, AbstractOperand*, ValueHasher, ValueComparer>
+      projects_;
+
+  std::vector<std::shared_ptr<Program>> programs_;
+
+  // Executable instances of 'this'. A Driver may instantiate multiple
+  // executable instances to processs consecutive input batches in parallel.
+  // these are handed off to WaveStream for running, so reside here only when
+  // not enqueued to run.
+  std::vector<std::unique_ptr<Executable>> executables_;
+
+  // Buffers containing unified memory for 'executables_' and all instructions,
+  // operands etc. referenced from these.  This does not include buffers for
+  // intermediate results.
+  std::vector<WaveBufferPtr> executableMemory_;
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/tests/CMakeLists.txt
+++ b/velox/experimental/wave/exec/tests/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_wave_exec_test FilterProjectTest.cpp)
+
+set_target_properties(velox_wave_exec_test PROPERTIES CUDA_ARCHITECTURES native)
+
+add_test(velox_wave_exec_test velox_wave_exec_test)
+
+target_link_libraries(
+  velox_wave_exec_test
+  velox_wave_exec
+  velox_aggregates
+  velox_dwio_common
+  velox_dwio_common_exception
+  velox_dwio_common_test_utils
+  velox_dwio_parquet_reader
+  velox_dwio_parquet_writer
+  velox_exec
+  velox_exec_test_lib
+  velox_functions_json
+  velox_functions_lib
+  velox_functions_prestosql
+  velox_functions_test_lib
+  velox_hive_connector
+  velox_memory
+  velox_serialization
+  velox_test_util
+  velox_type
+  velox_vector
+  velox_vector_fuzzer
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
+  gtest
+  gtest_main
+  gmock
+  Folly::folly
+  gflags::gflags
+  glog::glog
+  fmt::fmt
+  ${FILESYSTEM})

--- a/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
+++ b/velox/experimental/wave/exec/tests/FilterProjectTest.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/dwio/common/tests/utils/BatchMaker.h"
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/experimental/wave/exec/ToWave.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+using facebook::velox::test::BatchMaker;
+
+class FilterProjectTest : public OperatorTestBase {
+ protected:
+  void SetUp() override {
+    wave::registerWave();
+  }
+
+  void assertFilter(
+      const std::vector<RowVectorPtr>& vectors,
+      const std::string& filter = "c1 % 10  > 0") {
+    auto plan = PlanBuilder().values(vectors).filter(filter).planNode();
+
+    assertQuery(plan, "SELECT * FROM tmp WHERE " + filter);
+  }
+
+  void makeNotNull(RowVectorPtr row) {
+    for (auto i = 0; i < row->type()->size(); ++i) {
+      row->childAt(i)->clearNulls(0, row->size());
+    }
+  }
+
+  void assertProject(const std::vector<RowVectorPtr>& vectors) {
+    auto plan = PlanBuilder()
+                    .values(vectors)
+                    .project({"c0", "c1", "c0 + c1"})
+                    .planNode();
+
+    auto task = assertQuery(plan, "SELECT c0, c1, c0 + c1 FROM tmp");
+
+    // A quick sanity check for memory usage reporting. Check that peak total
+    // memory usage for the project node is > 0.
+    auto planStats = toPlanStats(task->taskStats());
+    auto projectNodeId = plan->id();
+    auto it = planStats.find(projectNodeId);
+    ASSERT_TRUE(it != planStats.end());
+    ASSERT_TRUE(it->second.peakMemoryBytes > 0);
+  }
+
+  std::shared_ptr<const RowType> rowType_{
+      ROW({"c0", "c1", "c2", "c3"},
+          {BIGINT(), INTEGER(), SMALLINT(), DOUBLE()})};
+};
+
+TEST_F(FilterProjectTest, roundTrip) {
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 10; ++i) {
+    auto vector = std::dynamic_pointer_cast<RowVector>(
+        BatchMaker::createBatch(rowType_, 100, *pool_));
+    makeNotNull(vector);
+    vectors.push_back(vector);
+  }
+  auto plan = PlanBuilder().values(vectors).planNode();
+  AssertQueryBuilder(plan).assertResults(vectors);
+}
+
+TEST_F(FilterProjectTest, project) {
+  return;
+  std::vector<RowVectorPtr> vectors;
+  for (int32_t i = 0; i < 10; ++i) {
+    auto vector = std::dynamic_pointer_cast<RowVector>(
+        BatchMaker::createBatch(rowType_, 100, *pool_));
+    vectors.push_back(vector);
+  }
+  createDuckDbTable(vectors);
+
+  assertProject(vectors);
+}

--- a/velox/experimental/wave/vector/CMakeLists.txt
+++ b/velox/experimental/wave/vector/CMakeLists.txt
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(common)
-add_subdirectory(exec)
-add_subdirectory(vector)
+add_library(velox_wave_vector WaveVector.cpp)
+target_link_libraries(velox_wave_vector velox_vector velox_common_base)

--- a/velox/experimental/wave/vector/Operand.h
+++ b/velox/experimental/wave/vector/Operand.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/// Types for device side access to device vectors. Separate header
+/// independent of Velox headers, included for both host and device
+/// side files.
+namespace facebook::velox::wave {
+
+// Normal thread block size for Wave kernels
+constexpr int32_t kBlockSize = 256;
+using OperandId = int32_t;
+
+constexpr OperandId kNoOperand = ~0;
+
+/// Describes an operand for a Wave kernel instruction. The same
+/// insttruction is interpreted by multiple thread blocks in the
+/// kernel invocation. When accessing an operand, we have the base
+/// index of the thread block. This is blockIdx.x * blockDim.x if all
+/// thread blocks run the same instructions. When the blocks run
+/// different instruction streams, the base is (blockIdx.x - <index of
+/// first block with this instruction stream>) * blockDim.x. We also have a
+/// shared memory pointer to thread block shared memory. Some operands may come
+/// from thread block shared memory.
+
+struct Operand {
+  static constexpr uint16_t kGlobal = ~0;
+
+  int32_t indexMask{~0};
+
+  // If != !0, this indicates that instead of base, we use the thread block's
+  // shared memry base + 'sharedOffset'.
+  uint16_t sharedOffset{kGlobal};
+
+  // Array of flat base values. Cast to pod type or StringView.
+  void* base;
+
+  // If non-nullptr, provides index into 'base. Subscripted with the
+  // blockIdx - idx of first bllock wit this instruction
+  // stream. Different thread blocks may or may not have indices for
+  // a given operand.
+  int32_t** indices;
+
+  // Array of null indicators. No nulls if nullptr.  A 1 means not-null, for
+  // consistency with Velox.
+  uint8_t* nulls{nullptr};
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/vector/WaveVector.cpp
+++ b/velox/experimental/wave/vector/WaveVector.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/experimental/wave/vector/WaveVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::wave {
+
+void WaveVector::resize(vector_size_t size, bool nullable) {
+  if (size > size_) {
+    int64_t bytes = type_->cppSizeInBytes() * size;
+    if (!values_ || bytes > values_->capacity()) {
+      values_ = arena_->allocateBytes(bytes);
+    }
+    if (nullable) {
+      if (!nulls_ || nulls_->capacity() < size) {
+        nulls_ = arena_->allocateBytes(size);
+      }
+    } else {
+      nulls_.reset();
+    }
+    size_ = size;
+  }
+}
+
+void WaveVector::toOperand(Operand* operand) const {
+  if (encoding_ == VectorEncoding::Simple::CONSTANT) {
+    operand->indexMask = 0;
+    if (nulls_) {
+      operand->nulls = nulls_->as<uint8_t>();
+    } else {
+      operand->nulls = nullptr;
+    }
+    operand->base = values_->as<uint64_t>();
+    return;
+  }
+  if (encoding_ == VectorEncoding::Simple::FLAT) {
+    operand->indexMask = ~0;
+    operand->base = values_->as<int64_t>();
+    operand->base = nulls_ ? nulls_->as<uint8_t>() : nullptr;
+    operand->indices = nullptr;
+  } else {
+    VELOX_UNSUPPORTED();
+  }
+}
+
+template <TypeKind kind>
+static VectorPtr toVeloxTyped(
+    vector_size_t size,
+    velox::memory::MemoryPool* pool,
+    const TypePtr& type,
+    const WaveBufferPtr& values,
+    const WaveBufferPtr& nulls) {
+  using T = typename TypeTraits<kind>::NativeType;
+
+  BufferPtr nullsView;
+  if (nulls) {
+    nullsView = WaveBufferView::create(nulls);
+  }
+  BufferPtr valuesView;
+  if (values) {
+    valuesView = WaveBufferView::create(values);
+  }
+
+  return std::make_shared<FlatVector<T>>(
+      pool,
+      type,
+      std::move(nullsView),
+      size,
+      std::move(valuesView),
+      std::vector<BufferPtr>());
+}
+
+VectorPtr WaveVector::toVelox(memory::MemoryPool* pool) {
+  return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH_ALL(
+      toVeloxTyped, type_->kind(), size_, pool, type_, values_, nulls_);
+}
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/vector/WaveVector.h
+++ b/velox/experimental/wave/vector/WaveVector.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "velox/experimental/wave/common/Buffer.h"
+#include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/vector/Operand.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::velox::wave {
+
+class Loader {
+ public:
+  virtual ~Loader() = default;
+
+  virtual void load(WaveBufferPtr indexBuffer, int32_t begin, int32_t end) = 0;
+
+  /// Notifies 'this' that a load should load, in ddition to the requested rows,
+  /// all rows above the last position given in the load indices.
+  void loadTailOnLoad() {
+    loadTail_ = true;
+  }
+
+ protected:
+  bool loadTail_{false};
+};
+
+/// Represents a vector of device side intermediate results. Vector is
+/// a host side only structure, the WaveBufferPtrs own the device
+/// memory. Unlike Velox vectors, these are statically owned by Wave
+/// operators and represent their last computed output. Buffers may be
+/// shared between these, as with Velox vectors. the values in buffers
+/// become well defined on return of the kernel that computes these.
+class WaveVector {
+ public:
+  static std::unique_ptr<WaveVector> create(
+      const TypePtr& type,
+      GpuArena& arena) {
+    return std::make_unique<WaveVector>(type, arena);
+  }
+
+  // Constructs a vector. Resize can be used to create buffers for a given size.
+  WaveVector(const TypePtr& type, GpuArena& arena)
+      : type_(type), kind_(type_->kind()), arena_(&arena) {}
+
+  const TypePtr& type() const {
+    return type_;
+  }
+
+  vector_size_t size() const {
+    return size_;
+  }
+
+  void resize(vector_size_t sie, bool nullable = true);
+
+  bool mayHaveNulls() const {
+    return nulls_ != nullptr;
+  }
+
+  // Makes sure there is space for nulls. Initial value is undefined.
+  void ensureNulls();
+
+  // Frees all allocated buffers. resize() can be used to populate the buffers
+  // with a selected size.
+  void clear();
+
+  /// Starts computation for a kLazy state vector.
+  void load();
+
+  WaveVector& childAt(int32_t index) {
+    return *children_[index];
+  }
+
+  template <typename T>
+  T* values() {
+    return values_->as<T>();
+  }
+
+  uint8_t* nulls() {
+    if (nulls_) {
+      return nulls_->as<uint8_t>();
+    }
+    return nullptr;
+  }
+
+  /// Returns a Velox vector giving a view on device side data. The device
+  /// buffers stay live while referenced by Velox.
+  VectorPtr toVelox(memory::MemoryPool* pool);
+
+  /// Sets 'operand' to point to the buffers of 'this'.
+  void toOperand(Operand* operand) const;
+
+  std::string toString() const;
+
+ private:
+  // Type of the content.
+  TypePtr type_;
+  TypeKind kind_;
+
+  // Encoding. FLAT, CONSTANT, DICTIONARY, ROW, ARRAY, MAP are possible
+  // values.
+  VectorEncoding::Simple encoding_{VectorEncoding::Simple::FLAT};
+
+  // The arena for allocating buffers.
+  GpuArena* arena_;
+
+  std::unique_ptr<Loader> loader_;
+
+  vector_size_t size_{0};
+
+  // Values array, cast to pod type or StringView
+  WaveBufferPtr values_;
+
+  // Nulls buffer, nullptr if no nulls.
+  WaveBufferPtr nulls_;
+
+  // If dictionary or if wrapped in a selection, vector of indices into
+  // 'values'.
+  WaveBufferPtr indices_;
+
+  // Thread block level sizes. For each kBlockSize values, contains
+  // one int16_t that indicates how many of 'values' or 'indices' have
+  // a value.
+  WaveBufferPtr blockSizes_;
+  // Thread block level pointers inside 'indices_'. the ith entry is nullptr
+  // if the ith thread block has no row number mapping (all rows pass or none
+  // pass).
+  WaveBufferPtr blockIndices_;
+
+  // Lengths and offsets for array/map elements.
+  WaveBufferPtr lengths_;
+  WaveBufferPtr offsets_;
+
+  // Members of a array/map/struct vector.
+  std::vector<std::unique_ptr<WaveVector>> children_;
+};
+
+using WaveVectorPtr = std::unique_ptr<WaveVector>;
+
+struct WaveReleaser {
+  WaveReleaser(WaveBufferPtr buffer) : buffer(std::move(buffer)) {}
+
+  void addRef() const {}
+
+  void release() const {
+    buffer.reset();
+  }
+
+  // BufferView inlines the releaser as const, hence this must have const
+  // methods but must mutate the controlled object.
+  mutable WaveBufferPtr buffer;
+};
+
+// A BufferView for velox::BaseVector for a view on unified memory.
+class WaveBufferView : public BufferView<WaveReleaser> {
+ public:
+  static BufferPtr create(WaveBufferPtr buffer) {
+    return BufferView<WaveReleaser>::create(
+        buffer->as<uint8_t>(), buffer->capacity(), WaveReleaser(buffer));
+  }
+};
+
+} // namespace facebook::velox::wave

--- a/velox/experimental/wave/vector/tests/CMakeLists.txt
+++ b/velox/experimental/wave/vector/tests/CMakeLists.txt
@@ -12,6 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(common)
-add_subdirectory(exec)
-add_subdirectory(vector)
+add_executable(velox_wave_vector_test VectorTest.cpp)
+
+set_target_properties(velox_wave_vector_test PROPERTIES CUDA_ARCHITECTURES
+                                                        native)
+
+add_test(veloxwave__vector_test velox_wave_vector_test)
+
+target_link_libraries(
+  velox_wave_vector_test
+  velox_wave_vector
+  velox_type
+  velox_vector
+  Boost::atomic
+  Boost::context
+  Boost::date_time
+  Boost::filesystem
+  Boost::program_options
+  Boost::regex
+  Boost::thread
+  Boost::system
+  gtest
+  gtest_main
+  gmock
+  Folly::folly
+  gflags::gflags
+  glog::glog
+  fmt::fmt
+  ${FILESYSTEM})


### PR DESCRIPTION
Wave Execution Primitives

- device for registering DriverFactory adapters for accelerator operators.

- Plan transformation for Values operator.

- Cuda unified memory BaseVector analog (WaveVector) 

- Stream for scheduling interdependent data transfers and kernel
- invocations (WaveStream). Tracks dependences between kernel
- invocations and columns (OperandSet consumed / produced by
- Executable).

- exec::Operator extension for running pipelines of Wave operators (WaveDriver).

- Base class for Wave operators (WaveOperator) and sample use for Wave Values.

- Sample Cuda code for Wave programmable kernel (ExprKernel.*). Instructions and Operands.

