### PR TITLE
Make NthValue templated for int or bigint offset use

### DIFF
--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -100,7 +100,7 @@ RowVectorPtr WindowTestBase::makeRandomInputVector(vector_size_t size) {
       {makeRandomInputVector(BIGINT(), size, 0.2),
        makeRandomInputVector(VARCHAR(), size, 0.3),
        makeFlatVector<int64_t>(size, genRandomFrameValue),
-       makeFlatVector<int64_t>(size, genRandomFrameValue)});
+       makeFlatVector<int32_t>(size, genRandomFrameValue)});
 }
 
 void WindowTestBase::testWindowFunction(

--- a/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
+++ b/velox/functions/sparksql/window/tests/SparkWindowTest.cpp
@@ -25,6 +25,7 @@ namespace {
 
 static const std::vector<std::string> kSparkWindowFunctions = {
     std::string("nth_value(c0, 1)"),
+    std::string("nth_value(c0, c3)"),
     std::string("row_number()"),
     std::string("rank()"),
     std::string("dense_rank()")};


### PR DESCRIPTION
NthValue had some type specific code for int and bigint offset parameter. The int and bigint signatures were also not consistent as only constant offsets were supported for integer whereas both constant and column offsets were supported for bigint offset. So there were some engine specific error messages added in the code.

This PR makes the implementation between int and bigint uniform. Velox has the superset of function usage for Presto/Spark.