### PR TITLE
Support decimal compare functions on different precisions and scales

### DIFF
--- a/velox/docs/functions/spark/comparison.rst
+++ b/velox/docs/functions/spark/comparison.rst
@@ -78,5 +78,32 @@ Comparison Functions
     Returns true if x is not equal to y. Supports all scalar types. The types
     of x and y must be the same. Corresponds to Spark's operator ``!=``.
 
+.. spark:function:: decimal_lessthan(x, y) -> boolean
 
+    Returns true if x is less than y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``<``.
 
+.. spark:function:: decimal_lessthanorequal(x, y) -> boolean
+
+    Returns true if x is less than y or x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``<=``.
+
+.. spark:function:: decimal_equalto(x, y) -> boolean
+
+    Returns true if x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``==``.
+
+.. spark:function:: decimal_notequalto(x, y) -> boolean
+
+    Returns true if x is not equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``!=``.
+
+.. spark:function:: decimal_greaterthan(x, y) -> boolean
+
+    Returns true if x is greater than y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``>``.
+
+.. spark:function:: decimal_greaterthanorequal(x, y) -> boolean
+
+    Returns true if x is greater than y or x is equal to y. Supports decimal types with different precisions and scales.
+    Corresponds to Spark's operator ``>=``.

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(
   Bitwise.cpp
   Comparisons.cpp
   DecimalArithmetic.cpp
+  DecimalCompare.cpp
   Hash.cpp
   In.cpp
   LeastGreatest.cpp

--- a/velox/functions/sparksql/DecimalCompare.cpp
+++ b/velox/functions/sparksql/DecimalCompare.cpp
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/expression/DecodedArgs.h"
+#include "velox/expression/VectorFunction.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+// Rescale two inputs as the same scale and compare. Returns 0 when a is equal
+// with b. Returns -1 when a is less than b. Returns 1 when a is greater than b.
+template <typename T>
+int32_t rescaleAndCompare(T a, T b, int32_t deltaScale) {
+  T aScaled = a;
+  T bScaled = b;
+  if (deltaScale < 0) {
+    aScaled = a * velox::DecimalUtil::kPowersOfTen[-deltaScale];
+  } else if (deltaScale > 0) {
+    bScaled = b * velox::DecimalUtil::kPowersOfTen[deltaScale];
+  }
+  if (aScaled == bScaled) {
+    return 0;
+  } else if (aScaled < bScaled) {
+    return -1;
+  } else {
+    return 1;
+  }
+}
+
+// Compare two decimals. Rescale one of them if they are of different scales.
+int32_t
+decimalCompare(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+  if (need256) {
+    return rescaleAndCompare<int256_t>(
+        static_cast<int256_t>(a), static_cast<int256_t>(b), deltaScale);
+  }
+  return rescaleAndCompare<int128_t>(a, b, deltaScale);
+}
+
+struct GreaterThan {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) > 0;
+  }
+};
+
+struct GreaterThanOrEqual {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) >= 0;
+  }
+};
+
+struct LessThan {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) < 0;
+  }
+};
+
+struct LessThanOrEqual {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) <= 0;
+  }
+};
+
+struct Equal {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) == 0;
+  }
+};
+
+struct NotEqual {
+  inline static bool
+  apply(int128_t a, int128_t b, int8_t deltaScale, bool need256) {
+    return decimalCompare(a, b, deltaScale, need256) != 0;
+  }
+};
+
+template <typename A, typename B, typename Operation /* Arithmetic operation */>
+class DecimalCompareFunction : public exec::VectorFunction {
+ public:
+  DecimalCompareFunction(
+      uint8_t aPrecision,
+      uint8_t aScale,
+      uint8_t bPrecision,
+      uint8_t bScale)
+      : aPrecision_(aPrecision),
+        bPrecision_(bPrecision),
+        deltaScale_(aScale - bScale),
+        need256_(
+            (deltaScale_ < 0 &&
+             aPrecision_ - deltaScale_ > LongDecimalType::kMaxPrecision) ||
+            (bPrecision_ + deltaScale_ > LongDecimalType::kMaxPrecision)) {}
+
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& resultType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    prepareResults(rows, resultType, context, result);
+
+    // Fast path when the first argument is a flat vector.
+    if (args[0]->isFlatEncoding()) {
+      auto rawA = args[0]->asUnchecked<FlatVector<A>>()->mutableRawValues();
+
+      if (args[1]->isConstantEncoding()) {
+        auto constantB = args[1]->asUnchecked<SimpleVector<B>>()->valueAt(0);
+        context.applyToSelectedNoThrow(rows, [&](auto row) {
+          result->asUnchecked<FlatVector<bool>>()->set(
+              row,
+              Operation::apply(
+                  (int128_t)rawA[row],
+                  (int128_t)constantB,
+                  deltaScale_,
+                  need256_));
+        });
+        return;
+      }
+
+      if (args[1]->isFlatEncoding()) {
+        auto rawB = args[1]->asUnchecked<FlatVector<B>>()->mutableRawValues();
+        context.applyToSelectedNoThrow(rows, [&](auto row) {
+          result->asUnchecked<FlatVector<bool>>()->set(
+              row,
+              Operation::apply(
+                  (int128_t)rawA[row],
+                  (int128_t)rawB[row],
+                  deltaScale_,
+                  need256_));
+        });
+        return;
+      }
+    } else {
+      // Fast path when the first argument is encoded but the second is
+      // constant.
+      exec::DecodedArgs decodedArgs(rows, args, context);
+      auto aDecoded = decodedArgs.at(0);
+      auto aDecodedData = aDecoded->data<A>();
+
+      if (args[1]->isConstantEncoding()) {
+        auto constantB = args[1]->asUnchecked<SimpleVector<B>>()->valueAt(0);
+        context.applyToSelectedNoThrow(rows, [&](auto row) {
+          auto value = aDecodedData[aDecoded->index(row)];
+          result->asUnchecked<FlatVector<bool>>()->set(
+              row,
+              Operation::apply(
+                  (int128_t)value, (int128_t)constantB, deltaScale_, need256_));
+        });
+        return;
+      }
+    }
+
+    // Decode the input in all other cases.
+    exec::DecodedArgs decodedArgs(rows, args, context);
+    auto aDecoded = decodedArgs.at(0);
+    auto bDecoded = decodedArgs.at(1);
+
+    auto aDecodedData = aDecoded->data<A>();
+    auto bDecodedData = bDecoded->data<B>();
+
+    context.applyToSelectedNoThrow(rows, [&](auto row) {
+      auto aValue = aDecodedData[aDecoded->index(row)];
+      auto bValue = bDecodedData[bDecoded->index(row)];
+      result->asUnchecked<FlatVector<bool>>()->set(
+          row,
+          Operation::apply(
+              (int128_t)aValue, (int128_t)bValue, deltaScale_, need256_));
+    });
+  }
+
+ private:
+  void prepareResults(
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const {
+    context.ensureWritable(rows, resultType, result);
+    result->clearNulls(rows);
+  }
+
+  const uint8_t aPrecision_;
+  const uint8_t bPrecision_;
+  const int8_t deltaScale_;
+  // If 256 bits are needed after adjusting the scale.
+  const bool need256_;
+};
+
+template <typename Operation>
+std::shared_ptr<exec::VectorFunction> createDecimalCompareFunction(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs,
+    const core::QueryConfig& /*config*/) {
+  const auto& aType = inputArgs[0].type;
+  const auto& bType = inputArgs[1].type;
+  auto [aPrecision, aScale] = getDecimalPrecisionScale(*aType);
+  auto [bPrecision, bScale] = getDecimalPrecisionScale(*bType);
+  if (aType->isShortDecimal()) {
+    if (bType->isShortDecimal()) {
+      return std::make_shared<
+          DecimalCompareFunction<int64_t, int64_t, Operation>>(
+          aPrecision, aScale, bPrecision, bScale);
+    } else {
+      return std::make_shared<
+          DecimalCompareFunction<int64_t, int128_t, Operation>>(
+          aPrecision, aScale, bPrecision, bScale);
+    }
+  }
+  if (aType->isLongDecimal()) {
+    if (bType->isShortDecimal()) {
+      return std::make_shared<
+          DecimalCompareFunction<int128_t, int64_t, Operation>>(
+          aPrecision, aScale, bPrecision, bScale);
+    } else {
+      return std::make_shared<
+          DecimalCompareFunction<int128_t, int128_t, Operation>>(
+          aPrecision, aScale, bPrecision, bScale);
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+std::vector<std::shared_ptr<exec::FunctionSignature>>
+decimalCompareSignature() {
+  return {exec::FunctionSignatureBuilder()
+              .integerVariable("a_precision")
+              .integerVariable("a_scale")
+              .integerVariable("b_precision")
+              .integerVariable("b_scale")
+              .returnType("boolean")
+              .argumentType("DECIMAL(a_precision, a_scale)")
+              .argumentType("DECIMAL(b_precision, b_scale)")
+              .build()};
+}
+
+} // namespace
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_gt,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<GreaterThan>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_gte,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<GreaterThanOrEqual>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_lt,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<LessThan>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_lte,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<LessThanOrEqual>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_eq,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<Equal>);
+
+VELOX_DECLARE_STATEFUL_VECTOR_FUNCTION(
+    udf_decimal_neq,
+    decimalCompareSignature(),
+    createDecimalCompareFunction<NotEqual>);
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/RegisterCompare.cpp
+++ b/velox/functions/sparksql/RegisterCompare.cpp
@@ -50,6 +50,17 @@ void registerCompareFunctions(const std::string& prefix) {
       {prefix + "between"});
   registerFunction<BetweenFunction, bool, double, double, double>(
       {prefix + "between"});
+  // Decimal comapre functions.
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_decimal_gt, prefix + "decimal_greaterthan");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_decimal_gte, prefix + "decimal_greaterthanorequal");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_lt, prefix + "decimal_lessthan");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_decimal_lte, prefix + "decimal_lessthanorequal");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_decimal_eq, prefix + "decimal_equalto");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_decimal_neq, prefix + "decimal_notequalto");
 }
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/benchmarks/CMakeLists.txt
+++ b/velox/functions/sparksql/benchmarks/CMakeLists.txt
@@ -23,3 +23,7 @@ target_link_libraries(
   velox_vector_fuzzer
   Folly::folly
   ${FOLLY_BENCHMARK})
+
+add_executable(velox_sparksql_benchmarks_compare CompareBenchmark.cpp)
+target_link_libraries(velox_sparksql_benchmarks_compare velox_functions_spark
+                      velox_benchmark_builder velox_vector_test_lib)

--- a/velox/functions/sparksql/benchmarks/CompareBenchmark.cpp
+++ b/velox/functions/sparksql/benchmarks/CompareBenchmark.cpp
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/sparksql/Register.h"
+
+using namespace facebook;
+
+using namespace facebook::velox;
+
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+  functions::sparksql::registerFunctions("");
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  benchmarkBuilder
+      .addBenchmarkSet(
+          "compare", ROW({"c0", "c1"}, {DECIMAL(18, 6), DECIMAL(38, 16)}))
+      .withFuzzerOptions({.vectorSize = 1000, .nullRatio = 0.1})
+      .addExpression("gt", "decimal_greaterthan(c0, c1)")
+      .addExpression(
+          "gt_with_cast", "greaterthan(cast (c0 as decimal(38, 16)), c1)")
+      .addExpression("gte", "decimal_greaterthanorequal(c0, c1)")
+      .addExpression(
+          "gte_with_cast",
+          "greaterthanorequal(cast (c0 as decimal(38, 16)), c1)")
+      .addExpression("lt", "decimal_lessthan(c0, c1)")
+      .addExpression(
+          "lt_with_cast", "lessthan(cast (c0 as decimal(38, 16)), c1)")
+      .addExpression("lte", "decimal_lessthanorequal(c0, c1)")
+      .addExpression(
+          "lte_with_cast", "lessthanorequal(cast (c0 as decimal(38, 16)), c1)")
+      .addExpression("eq", "decimal_equalto(c0, c1)")
+      .addExpression(
+          "eq_with_cast", "equalto(cast (c0 as decimal(38, 16)), c1)")
+      .addExpression("neq", "decimal_notequalto(c0, c1)")
+      .addExpression(
+          "neq_with_cast", "not(equalto(cast (c0 as decimal(38, 16)), c1))")
+      .withIterations(100);
+
+  benchmarkBuilder.registerBenchmarks();
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ComparisonsTest.cpp
   DateTimeFunctionsTest.cpp
   DecimalArithmeticTest.cpp
+  DecimalCompareTest.cpp
   DecimalUtilTest.cpp
   ElementAtTest.cpp
   HashTest.cpp

--- a/velox/functions/sparksql/tests/DecimalCompareTest.cpp
+++ b/velox/functions/sparksql/tests/DecimalCompareTest.cpp
@@ -1,0 +1,622 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class DecimalVectorFunctionsTest : public SparkFunctionBaseTest {
+ protected:
+  void testCompareExpr(
+      const std::string& exprStr,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expectedResult) {
+    auto actual = evaluate(exprStr, makeRowVector(input));
+    velox::test::assertEqualVectors(expectedResult, actual);
+  }
+};
+
+TEST_F(DecimalVectorFunctionsTest, gt) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({false, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, true, false}));
+  testCompareExpr(
+      "decimal_greaterthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, false, false}));
+}
+
+TEST_F(DecimalVectorFunctionsTest, gte) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({true, true, true, false}));
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, true, false}));
+  testCompareExpr(
+      "decimal_greaterthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, false, false}));
+}
+
+TEST_F(DecimalVectorFunctionsTest, eq) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, false, false, false}));
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, false, false, false}));
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({true, false, false, false}));
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({false, false, false, false}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, false, false}));
+  testCompareExpr(
+      "decimal_equalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, false, false}));
+}
+
+TEST_F(DecimalVectorFunctionsTest, neq) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, true, true, true}));
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, true, true, true}));
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({false, true, true, true}));
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, true, true}));
+  testCompareExpr(
+      "decimal_notequalto(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, true, true}));
+}
+
+TEST_F(DecimalVectorFunctionsTest, lt) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({false, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({false, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({false, std::nullopt, false, true}));
+  testCompareExpr(
+      "decimal_lessthan(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, true, true}));
+}
+
+TEST_F(DecimalVectorFunctionsTest, lte) {
+  // Fast path when c1 vector is constant.
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeConstant((int64_t)100, 4, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeConstant((int64_t)100000, 4, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Fast path when vectors are flat.
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeFlatVector<bool>({true, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeFlatVector<int64_t>(
+              {100000, 120000, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // General case when vectors are dictionary-encoded.
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>({100, 120, 130, 350}, DECIMAL(5, 1))),
+      },
+      makeFlatVector<bool>({true, false, false, true}));
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int128_t>(
+                  {10'000'000'000'000'000,
+                   12'000'000'000'000'000,
+                   13'000'000'000'000'000,
+                   35'000'000'000'000'000},
+                  DECIMAL(38, 34))),
+          wrapInDictionary(
+              makeIndices({0, 1, 2, 3}),
+              makeFlatVector<int64_t>(
+                  {100000, 120000, 130000, 350000}, DECIMAL(6, 1))),
+      },
+      makeFlatVector<bool>({true, true, true, true}));
+
+  // Decimal with nulls.
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int64_t>({1000, 2000, 3000, 400}, DECIMAL(6, 2)),
+          makeNullableFlatVector<int64_t>(
+              {100, std::nullopt, 130, 350}, DECIMAL(5, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, false, true}));
+  testCompareExpr(
+      "decimal_lessthanorequal(c0, c1)",
+      {
+          makeFlatVector<int128_t>(
+              {10'000'000'000'000'000,
+               12'000'000'000'000'000,
+               13'000'000'000'000'000,
+               35'000'000'000'000'000},
+              DECIMAL(38, 34)),
+          makeNullableFlatVector<int64_t>(
+              {100000, std::nullopt, 130000, 350000}, DECIMAL(6, 1)),
+      },
+      makeNullableFlatVector<bool>({true, std::nullopt, true, true}));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Spark allows comparison of decimals on different precision and scales, but current Velox generates below error for this case.
> Exception: VeloxUserError
Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: Scalar function greaterthan not registered with arguments: (DECIMAL(24,7), DECIMAL(21,6)). Found function registered with the following signatures:
((T,T) -> boolean)

This PR supports decimal compare functions `>, >=, ==, !=, <, <=` on different precisions and scales. The input decimals are rescaled to the same scale and then compared. For those exceeding the max precision of decimal, int256 is used to store the rescaled value.