### PR TITLE
Allow truncating fraction part in cast(decimal as integer)

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -76,8 +76,8 @@ class QueryConfig {
   static constexpr const char* kCastMatchStructByName =
       "cast_match_struct_by_name";
 
-  // This flags forces the cast from float/double to integer to be performed by
-  // truncating the decimal part instead of rounding.
+  // If set, cast from float/double/decimal to integer truncates the decimal
+  // part, otherwise rounds.
   static constexpr const char* kCastToIntByTruncate = "cast_to_int_by_truncate";
 
   /// Used for backpressure to block local exchange producers when the local

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -108,7 +108,7 @@ Expression Evaluation Configuration
    * - cast_to_int_by_truncate
      - bool
      - false
-     - This flags forces the cast from float/double to integer to be performed by truncating the decimal part instead of rounding.
+     - This flags forces the cast from float/double/decimal to integer to be performed by truncating the decimal part instead of rounding.
 
 Memory Management
 -----------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -268,6 +268,25 @@ Invalid examples
   SELECT cast('nan' as bigint); -- Invalid argument
   SELECT cast('infinity' as bigint); -- Invalid argument
 
+From decimal
+^^^^^^^^^^^^
+
+By default, the decimal part is rounded. If cast_to_int_by_truncate is enabled, the decimal part will be truncated for casting to an integer.
+
+Valid examples
+
+::
+
+  SELECT cast(2.56 decimal(6, 2) as integer); -- 2 /* cast_to_int_by_truncate enabled */
+  SELECT cast(2.56 decimal(6, 2) as integer); -- 3 /* cast_to_int_by_truncate disabled */
+  SELECT cast(3.46 decimal(6, 2) as integer); -- 3
+
+Invalid examples
+
+::
+  
+  SELECT cast(214748364890 decimal(12, 2) as integer); -- Out of range
+
 Cast to Boolean
 ---------------
 

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -246,14 +246,19 @@ VectorPtr CastExpr::applyDecimalToIntegralCast(
   const auto precisionScale = getDecimalPrecisionScale(*fromType);
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
   const auto scaleFactor = DecimalUtil::kPowersOfTen[precisionScale.second];
+  const auto castToIntByTruncate =
+      context.execCtx()->queryCtx()->queryConfig().isCastToIntByTruncate();
   applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
     auto value = simpleInput->valueAt(row);
     auto integralPart = value / scaleFactor;
-    auto fractionPart = value % scaleFactor;
-    auto sign = value >= 0 ? 1 : -1;
-    bool needsRoundUp =
-        (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));
-    integralPart += needsRoundUp ? sign : 0;
+    if (!castToIntByTruncate) {
+      auto fractionPart = value % scaleFactor;
+      auto sign = value >= 0 ? 1 : -1;
+      bool needsRoundUp =
+          (scaleFactor != 1) && (sign * fractionPart >= (scaleFactor >> 1));
+      integralPart += needsRoundUp ? sign : 0;
+    }
+
     if (integralPart > std::numeric_limits<To>::max() ||
         integralPart < std::numeric_limits<To>::min()) {
       if (setNullInResultAtError()) {

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -295,6 +295,7 @@ class CastExprTest : public functions::test::CastBaseTest {
 
   template <typename T>
   void testDecimalToIntegralCasts() {
+    setCastIntByTruncate(false);
     auto shortFlat = makeNullableFlatVector<int64_t>(
         {-300,
          -260,
@@ -352,6 +353,41 @@ class CastExprTest : public functions::test::CastBaseTest {
              55,
              55 /* 55.49 rounds to 55*/,
              56 /* 55.99 rounds to 56*/,
+             69,
+             72,
+             std::nullopt}));
+
+    setCastIntByTruncate(true);
+    testComplexCast(
+        "c0",
+        shortFlat,
+        makeNullableFlatVector<T>(
+            {-3,
+             -2 /*-2.6 truncated to -2*/,
+             -2 /*-2.3 truncated to -2*/,
+             -2,
+             -1,
+             0,
+             55,
+             57 /*57.49 truncated to 57*/,
+             57 /*57.55 truncated to 57*/,
+             69,
+             72,
+             std::nullopt}));
+
+    testComplexCast(
+        "c0",
+        longFlat,
+        makeNullableFlatVector<T>(
+            {-3,
+             -2 /*-2.55 truncated to -2*/,
+             -2 /*-2.45 truncated to -2*/,
+             -2,
+             -1,
+             0,
+             55,
+             55 /* 55.49 truncated to 55*/,
+             55 /* 55.99 truncated to 55*/,
              69,
              72,
              std::nullopt}));


### PR DESCRIPTION
By default, `cast(2.56 Decimal(6, 2) as int)` return 3, but Spark returns 2.

Update CAST expression to check cast_to_int_by_truncate configuration property
and if set truncate the decimal. This logic already applies to CAST from REAL
and DOUBLE.