### PR TITLE
Add datediff Spark function 

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -22,6 +22,13 @@ These functions support TIMESTAMP and DATE input types.
 
     num_days can be positive or negative.
 
+.. spark:function:: datediff(endDate, startDate) -> integer
+
+    Returns the number of days from startDate to endDate. ::
+
+    SELECT datediff('2009-07-31', '2009-07-30'); -- 1
+    SELECT datediff('2009-07-30', '2009-07-31'); -- -1
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -298,4 +298,14 @@ struct DateSubFunction {
   }
 };
 
+template <typename T>
+struct DateDiffFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void
+  call(int32_t& result, const arg_type<Date>& to, const arg_type<Date>& from) {
+    result = diffDate(DateTimeUnit::kDay, from, to);
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -214,6 +214,8 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
+  registerFunction<DateDiffFunction, int32_t, Date, Date>(
+      {prefix + "datediff"});
 
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -291,5 +291,22 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("5881580-07-11"), dateSub("1969-12-31", kMin));
 }
 
+TEST_F(DateTimeFunctionsTest, datediff) {
+  const auto dateSubFunc = [&](std::optional<int32_t> from,
+                               std::optional<int32_t> to) {
+    return evaluateOnce<int32_t, int32_t>(
+        "datediff(c0, c1)", {from, to}, {DATE(), DATE()});
+  };
+
+  const auto dateDiff = [&](const std::string& fromStr,
+                            const std::string& toStr) {
+    return dateSubFunc(parseDate(fromStr), parseDate(toStr));
+  };
+
+  EXPECT_EQ(1, dateDiff("2009-07-31", "2009-07-30"));
+  EXPECT_EQ(-1, dateDiff("2009-07-30", "2009-07-31"));
+  EXPECT_EQ(19592, dateDiff("2023-08-23", "1970-01-01"));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
[**datediff**](https://spark.apache.org/docs/3.3.1/api/sql/index.html#datediff)

datediff(endDate, startDate) - Returns the number of days from startDate to endDate.

Examples:
```SQL
> SELECT datediff('2009-07-31', '2009-07-30');
 1

> SELECT datediff('2009-07-30', '2009-07-31');
 -1
```