### PR TITLE
Add support for CAST(DECIMAL as VARCHAR)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -197,7 +197,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      - Y
      - Y
      - Y
-     -
+     - Y
      -
      -
      -
@@ -482,6 +482,10 @@ Valid examples
   SELECT cast(infinity() as varchar); -- 'Infinity'
   SELECT cast(true as varchar); -- 'true'
   SELECT cast(timestamp '1970-01-01 00:00:00' as varchar); -- '1970-01-01T00:00:00.000'
+  SELECT cast(cast(22.51 as DECIMAL(5, 3)) as varchar); -- '22.510'
+  SELECT cast(cast(-22.51 as DECIMAL(4, 2)) as varchar); -- '-22.51'
+  SELECT cast(cast(0.123 as DECIMAL(3, 3)) as varchar); -- '0.123'
+  SELECT cast(cast(1 as DECIMAL(6, 2)) as varchar); -- '1.00'
 
 Cast to TIMESTAMP
 -----------------

--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 #pragma once
+
+#include <charconv>
+
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
 #include "velox/expression/StringWriter.h"
@@ -47,6 +50,81 @@ inline std::exception_ptr makeBadCastException(
       makeErrorMessage(input, row, resultType, errorDetails),
       false));
 };
+
+// Copied from format.h of fmt.
+inline int countDigits(uint128_t n) {
+  int count = 1;
+  for (;;) {
+    if (n < 10) {
+      return count;
+    }
+    if (n < 100) {
+      return count + 1;
+    }
+    if (n < 1000) {
+      return count + 2;
+    }
+    if (n < 10000) {
+      return count + 3;
+    }
+    n /= 10000u;
+    count += 4;
+  }
+}
+
+/// @brief Convert the unscaled value of a decimal to varchar and write to raw
+/// string buffer from start position.
+/// @tparam T The type of input value.
+/// @param unscaledValue The input unscaled value.
+/// @param scale The scale of decimal.
+/// @param maxVarcharSize The estimated max size of a varchar.
+/// @param startPosition The start position to write from.
+/// @return A string view.
+template <typename T>
+StringView convertToStringView(
+    T unscaledValue,
+    int32_t scale,
+    int32_t maxVarcharSize,
+    char* const startPosition) {
+  char* writePosition = startPosition;
+  if (unscaledValue == 0) {
+    *writePosition++ = '0';
+  } else {
+    if (unscaledValue < 0) {
+      *writePosition++ = '-';
+      unscaledValue = -unscaledValue;
+    }
+    auto [position, errorCode] = std::to_chars(
+        writePosition,
+        writePosition + maxVarcharSize,
+        unscaledValue / DecimalUtil::kPowersOfTen[scale]);
+    VELOX_DCHECK_EQ(
+        errorCode,
+        std::errc(),
+        "Failed to cast decimal to varchar: {}",
+        std::make_error_code(errorCode).message());
+    writePosition = position;
+
+    if (scale > 0) {
+      *writePosition++ = '.';
+      uint128_t fraction = unscaledValue % DecimalUtil::kPowersOfTen[scale];
+      // Append leading zeros.
+      int numLeadingZeros = std::max(scale - countDigits(fraction), 0);
+      std::memset(writePosition, '0', numLeadingZeros);
+      writePosition += numLeadingZeros;
+      // Append remaining fraction digits.
+      auto [position, errorCode] = std::to_chars(
+          writePosition, writePosition + maxVarcharSize, fraction);
+      VELOX_DCHECK_EQ(
+          errorCode,
+          std::errc(),
+          "Failed to cast decimal to varchar: {}",
+          std::make_error_code(errorCode).message());
+      writePosition = position;
+    }
+  }
+  return StringView(startPosition, writePosition - startPosition);
+}
 
 } // namespace
 
@@ -306,39 +384,59 @@ VectorPtr CastExpr::applyDecimalToVarcharCast(
     const SelectivityVector& rows,
     const BaseVector& input,
     exec::EvalCtx& context,
-    const TypePtr& fromType,
-    const TypePtr& toType) {
+    const TypePtr& fromType) {
   VectorPtr result;
   context.ensureWritable(rows, VARCHAR(), result);
   (*result).clearNulls(rows);
   const auto simpleInput = input.as<SimpleVector<FromNativeType>>();
+  int precision = getDecimalPrecisionScale(*fromType).first;
+  int scale = getDecimalPrecisionScale(*fromType).second;
+  // A varchar's size is estimated with unscaled value digits, dot, leading
+  // zero, and possible minus sign.
+  int32_t rowSize = precision + 1;
+  if (scale > 0) {
+    ++rowSize; // A dot.
+  }
+  if (precision == scale) {
+    ++rowSize; // Leading zero.
+  }
+
   auto flatResult = result->asFlatVector<StringView>();
+  if (StringView::isInline(rowSize)) {
+    char inlined[StringView::kInlineSize];
+    applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
+      if (simpleInput->isNullAt(row)) {
+        result->setNull(row, true);
+      } else {
+        flatResult->setNoCopy(
+            row,
+            convertToStringView<FromNativeType>(
+                simpleInput->valueAt(row), scale, rowSize, inlined));
+      }
+    });
+    return result;
+  }
 
-  // Calculate the total size of the stringBuffers.
-  size_t totalResultBytes = 0;
-  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
-    if (!simpleInput->isNullAt(row)) {
-      std::string output =
-          DecimalUtil::toString((int128_t)simpleInput->valueAt(row), fromType);
-      totalResultBytes += output.size();
-    }
-  });
+  Buffer* buffer =
+      flatResult->getBufferWithSpace(rows.countSelected() * rowSize);
+  char* rawBuffer = buffer->asMutable<char>() + buffer->size();
 
-  auto rawBuffer = flatResult->getRawStringBufferWithSpace(totalResultBytes);
-  size_t offset = 0;
-  applyToSelectedNoThrowLocal(context, rows, result, [&](int row) {
+  applyToSelectedNoThrowLocal(context, rows, result, [&](vector_size_t row) {
     if (simpleInput->isNullAt(row)) {
       result->setNull(row, true);
     } else {
-      std::string output =
-          DecimalUtil::toString((int128_t)simpleInput->valueAt(row), fromType);
-      const char* start = rawBuffer + offset;
-      auto size = output.size();
-      memcpy(rawBuffer + offset, output.data(), size);
-      offset += size;
-      flatResult->setNoCopy(row, StringView(start, size));
+      auto stringView = convertToStringView<FromNativeType>(
+          simpleInput->valueAt(row), scale, rowSize, rawBuffer);
+      flatResult->setNoCopy(row, stringView);
+      if (!stringView.isInline()) {
+        // If string view is inline, correponding bytes on the raw string buffer
+        // are not needed.
+        rawBuffer += stringView.size();
+      }
     }
   });
+  // Update the exact buffer size.
+  buffer->setSize(rawBuffer - buffer->asMutable<char>());
   return result;
 }
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -518,14 +518,27 @@ void CastExpr::applyPeeled(
   } else if (toType->isLongDecimal()) {
     result = applyDecimal<int128_t>(rows, input, context, fromType, toType);
   } else if (fromType->isDecimal()) {
-    result = VELOX_DYNAMIC_DECIMAL_TYPE_DISPATCH(
-        applyDecimalToPrimitiveCast,
-        fromType,
-        rows,
-        input,
-        context,
-        fromType,
-        toType);
+    switch (toType->kind()) {
+      case TypeKind::VARCHAR:
+        result = VELOX_DYNAMIC_DECIMAL_TYPE_DISPATCH(
+            applyDecimalToVarcharCast,
+            fromType,
+            rows,
+            input,
+            context,
+            fromType,
+            toType);
+        break;
+      default:
+        result = VELOX_DYNAMIC_DECIMAL_TYPE_DISPATCH(
+            applyDecimalToPrimitiveCast,
+            fromType,
+            rows,
+            input,
+            context,
+            fromType,
+            toType);
+    }
   } else {
     switch (toType->kind()) {
       case TypeKind::MAP:

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -526,8 +526,7 @@ void CastExpr::applyPeeled(
             rows,
             input,
             context,
-            fromType,
-            toType);
+            fromType);
         break;
       default:
         result = VELOX_DYNAMIC_DECIMAL_TYPE_DISPATCH(

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -248,6 +248,22 @@ class CastExpr : public SpecialForm {
       const BaseVector& input,
       VectorPtr& result);
 
+  template <typename TOutput>
+  void applyVarCharToDecimalCastKernel(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& toType,
+      VectorPtr castResult);
+
+  template <typename FromNativeType>
+  VectorPtr applyDecimalToVarcharCast(
+      const SelectivityVector& rows,
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const TypePtr& fromType,
+      const TypePtr& toType);
+
   template <TypeKind ToKind>
   void applyCastPrimitivesDispatch(
       const TypePtr& fromType,

--- a/velox/expression/CastExpr.h
+++ b/velox/expression/CastExpr.h
@@ -248,21 +248,12 @@ class CastExpr : public SpecialForm {
       const BaseVector& input,
       VectorPtr& result);
 
-  template <typename TOutput>
-  void applyVarCharToDecimalCastKernel(
-      const SelectivityVector& rows,
-      const BaseVector& input,
-      exec::EvalCtx& context,
-      const TypePtr& toType,
-      VectorPtr castResult);
-
   template <typename FromNativeType>
   VectorPtr applyDecimalToVarcharCast(
       const SelectivityVector& rows,
       const BaseVector& input,
       exec::EvalCtx& context,
-      const TypePtr& fromType,
-      const TypePtr& toType);
+      const TypePtr& fromType);
 
   template <TypeKind ToKind>
   void applyCastPrimitivesDispatch(

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1528,6 +1528,54 @@ TEST_F(CastExprTest, decimalToBool) {
       "c0", longFlat, makeNullableFlatVector<bool>({1, 0, std::nullopt}));
 }
 
+TEST_F(CastExprTest, decimalToVarchar) {
+  auto flatForInline = makeNullableFlatVector<int64_t>(
+      {123456789, -333333333, 0, 5, -9, std::nullopt}, DECIMAL(9, 2));
+  testComplexCast(
+      "c0",
+      flatForInline,
+      makeNullableFlatVector<StringView>(
+          {"1234567.89", "-3333333.33", "0", "0.05", "-0.09", std::nullopt}));
+
+  auto shortFlat = makeNullableFlatVector<int64_t>(
+      {DecimalUtil::kShortDecimalMin,
+       -3,
+       0,
+       55,
+       DecimalUtil::kShortDecimalMax,
+       std::nullopt},
+      DECIMAL(18, 18));
+  testComplexCast(
+      "c0",
+      shortFlat,
+      makeNullableFlatVector<StringView>(
+          {"-0.999999999999999999",
+           "-0.000000000000000003",
+           "0",
+           "0.000000000000000055",
+           "0.999999999999999999",
+           std::nullopt}));
+
+  auto longFlat = makeNullableFlatVector<int128_t>(
+      {DecimalUtil::kLongDecimalMin,
+       0,
+       DecimalUtil::kLongDecimalMax,
+       HugeInt::build(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull),
+       HugeInt::build(0xffff, 0xffffffffffffffff),
+       std::nullopt},
+      DECIMAL(38, 5));
+  testComplexCast(
+      "c0",
+      longFlat,
+      makeNullableFlatVector<StringView>(
+          {"-999999999999999999999999999999999.99999",
+           "0",
+           "999999999999999999999999999999999.99999",
+           "-0.00001",
+           "12089258196146291747.06175",
+           std::nullopt}));
+}
+
 TEST_F(CastExprTest, decimalToDecimal) {
   // short to short, scale up.
   auto shortFlat =


### PR DESCRIPTION
To improve the performance, instead of creating intermediate strings, the 
raw string buffer is pre-allocated to be written directly. Function `std::to_chars`
is used to convert integers into a character string by successively filling
the range. On buffer allocation, instead of calculating the precise size 
from intermediate strings, we pre-allocate sufficient buffer based on an 
estimation with decimal precision and scale, and set the precise size after all 
strings are written.

An alternative implementation used `DecimalUtil::toString` which produced a lot 
of intermediate strings during conversion. Besides, `DecimalUtil::toString` 
was called for the calculation of string buffer size. The optimized implementation
uses `std::to_chars` to convert integer to string and avoid all intermediate strings.
The string buffer size is estimated with decimal precision and scale. As below
benchmarks show, the final performance is improved 4-5x compared with the
previous one.

Cast from decimal to varchar benchmark | cast##cast_short_decimal | cast##cast_long_decimal
-- | -- | --
previous (DecimalUtil::toString) | 45.43ms | 132.09ms
optimized (std::to_chars) | 9.87ms | 35.00ms

