### PR TITLE
Add dayofyear,dayofmonth Spark Functions

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -22,6 +22,18 @@ These functions support TIMESTAMP and DATE input types.
 
     num_days can be positive or negative.
 
+.. spark:function:: dayofyear(date) -> integer
+
+    Returns Returns the day of year of the date/timestamp. ::
+
+    SELECT dayofyear('2016-04-09'); -- 100
+
+.. spark:function:: dayofmonth(date) -> integer
+
+    Returns the day of month of the date/timestamp. ::
+
+    SELECT dayofmonth('2009-07-30'); -- 30
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -18,6 +18,7 @@
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
+#include "velox/functions/prestosql/DateTimeFunctions.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
 #include "velox/functions/prestosql/Rand.h"
 #include "velox/functions/prestosql/StringFunctions.h"
@@ -214,6 +215,15 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
+
+  registerFunction<DayFunction, int64_t, Timestamp>(
+      {prefix + "day", prefix + "dayofmonth"});
+  registerFunction<DayFunction, int64_t, Date>(
+      {prefix + "day", prefix + "dayofmonth"});
+  registerFunction<DayOfYearFunction, int64_t, Timestamp>(
+      {prefix + "doy", prefix + "dayofyear"});
+  registerFunction<DayOfYearFunction, int64_t, Date>(
+      {prefix + "doy", prefix + "dayofyear"});
 
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -291,5 +291,24 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
   EXPECT_EQ(parseDate("5881580-07-11"), dateSub("1969-12-31", kMin));
 }
 
+TEST_F(DateTimeFunctionsTest, dayOfYear) {
+  const auto day = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int64_t, int32_t>("dayofyear(c0)", {date}, {DATE()});
+  };
+  EXPECT_EQ(std::nullopt, day(std::nullopt));
+  EXPECT_EQ(100, day(parseDate("2016-04-09")));
+  EXPECT_EQ(235, day(parseDate("2023-08-23")));
+  EXPECT_EQ(1, day(parseDate("1970-01-01")));
+}
+
+TEST_F(DateTimeFunctionsTest, dayOfMonth) {
+  const auto day = [&](std::optional<int32_t> date) {
+    return evaluateOnce<int64_t, int32_t>("dayofmonth(c0)", {date}, {DATE()});
+  };
+  EXPECT_EQ(std::nullopt, day(std::nullopt));
+  EXPECT_EQ(30, day(parseDate("2009-07-30")));
+  EXPECT_EQ(23, day(parseDate("2023-08-23")));
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
Add [**dayofyear**](https://spark.apache.org/docs/latest/api/sql/index.html#dayofyear), [**dayofmonth**](https://spark.apache.org/docs/latest/api/sql/index.html#dayofmonth) Spark Functions.

dayofyear(date) - Returns the day of year of the date/timestamp.

Examples:
```SQL
> SELECT dayofyear('2016-04-09');
 100
```
dayofmonth(date) - Returns the day of month of the date/timestamp.

```SQL
Examples:

> SELECT dayofmonth('2009-07-30');
 30
```

Reuse the implementation of day_of_year and day_of_month of PrestoSQL functions.