### PR TITLE
Add split_to_map Presto function

### DIFF
--- a/velox/docs/functions/presto/string.rst
+++ b/velox/docs/functions/presto/string.rst
@@ -131,6 +131,17 @@ String Functions
     Field indexes start with 1. If the index is larger than the number of fields,
     then null is returned.
 
+.. function:: split_to_map(string, entryDelimiter, keyValueDelimiter) -> map<varchar, varchar>
+
+    Splits ``string`` by ``entryDelimiter`` and ``keyValueDelimiter`` and returns a map.
+    ``entryDelimiter`` splits ``string`` into key-value pairs. ``keyValueDelimiter`` splits
+    each pair into key and value. Note that ``entryDelimiter`` and ``keyValueDelimiter`` are
+    interpreted literally, i.e., as full string matches.
+
+    entryDelimiter and keyValueDelimiter must not be empty and must not be the same.
+
+    Raises an error if there are duplicate keys.
+
 .. function:: strpos(string, substring) -> bigint
 
     Returns the starting position of the first instance of ``substring`` in

--- a/velox/functions/prestosql/SplitToMap.h
+++ b/velox/functions/prestosql/SplitToMap.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "folly/container/F14Set.h"
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions {
+
+template <typename TExecCtx>
+struct SplitToMapFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(TExecCtx);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  void call(
+      out_type<Map<Varchar, Varchar>>& out,
+      const arg_type<Varchar>& input,
+      const arg_type<Varchar>& entryDelimiter,
+      const arg_type<Varchar>& keyValueDelimiter) {
+    VELOX_USER_CHECK(!entryDelimiter.empty(), "entryDelimiter is empty");
+    VELOX_USER_CHECK(!keyValueDelimiter.empty(), "keyValueDelimiter is empty");
+    VELOX_USER_CHECK_NE(
+        entryDelimiter,
+        keyValueDelimiter,
+        "entryDelimiter and keyValueDelimiter must not be the same");
+
+    if (input.empty()) {
+      return;
+    }
+
+    callImpl(
+        out,
+        toStringView(input),
+        toStringView(entryDelimiter),
+        toStringView(keyValueDelimiter));
+  }
+
+ private:
+  static std::string_view toStringView(const arg_type<Varchar>& input) {
+    return std::string_view(input.data(), input.size());
+  }
+
+  void callImpl(
+      out_type<Map<Varchar, Varchar>>& out,
+      std::string_view input,
+      std::string_view entryDelimiter,
+      std::string_view keyValueDelimiter) const {
+    size_t pos = 0;
+
+    folly::F14FastSet<std::string_view> keys;
+
+    auto nextEntryPos = input.find(entryDelimiter, pos);
+    while (nextEntryPos != std::string::npos) {
+      processEntry(
+          out,
+          std::string_view(input.data() + pos, nextEntryPos - pos),
+          keyValueDelimiter,
+          keys);
+
+      pos = nextEntryPos + 1;
+      nextEntryPos = input.find(entryDelimiter, pos);
+    }
+
+    processEntry(
+        out,
+        std::string_view(input.data() + pos, input.size() - pos),
+        keyValueDelimiter,
+        keys);
+  }
+
+  void processEntry(
+      out_type<Map<Varchar, Varchar>>& out,
+      std::string_view entry,
+      std::string_view keyValueDelimiter,
+      folly::F14FastSet<std::string_view>& keys) const {
+    const auto delimiterPos = entry.find(keyValueDelimiter, 0);
+
+    VELOX_USER_CHECK_NE(
+        delimiterPos,
+        std::string::npos,
+        "Key-value delimiter must appear exactly once in each entry. Bad input: '{}'",
+        entry)
+
+    const auto key = std::string_view(entry.data(), delimiterPos);
+    VELOX_USER_CHECK(
+        keys.insert(key).second, "Duplicate keys ({}) are not allowed.", key);
+
+    const auto value = StringView(
+        entry.data() + delimiterPos + 1, entry.size() - delimiterPos - 1);
+
+    auto [keyWriter, valueWriter] = out.add_item();
+    keyWriter.setNoCopy(StringView(key));
+    valueWriter.setNoCopy(value);
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/StringFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/prestosql/RegexpReplace.h"
 #include "velox/functions/prestosql/SplitPart.h"
+#include "velox/functions/prestosql/SplitToMap.h"
 #include "velox/functions/prestosql/StringFunctions.h"
 
 namespace facebook::velox::functions {
@@ -83,6 +84,12 @@ void registerStringFunctions(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_lower, prefix + "lower");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_upper, prefix + "upper");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_split, prefix + "split");
+  registerFunction<
+      SplitToMapFunction,
+      Map<Varchar, Varchar>,
+      Varchar,
+      Varchar,
+      Varchar>({prefix + "split_to_map"});
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat, prefix + "concat");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_replace, prefix + "replace");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reverse, prefix + "reverse");

--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(
   SliceTest.cpp
   SequenceTest.cpp
   SplitTest.cpp
+  SplitToMapTest.cpp
   StringFunctionsTest.cpp
   TransformTest.cpp
   TransformKeysTest.cpp

--- a/velox/functions/prestosql/tests/SplitToMapTest.cpp
+++ b/velox/functions/prestosql/tests/SplitToMapTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
+
+namespace facebook::velox::functions {
+namespace {
+
+class SplitToMapTest : public test::FunctionBaseTest {};
+
+TEST_F(SplitToMapTest, basic) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({
+          "1:10,2:20,3:30,4:",
+          "4:40",
+          "",
+          ":00,1:11,3:33,5:55,7:77",
+      }),
+  });
+
+  auto result = evaluate("split_to_map(c0, ',', ':')", data);
+
+  auto expected = makeMapVector<std::string, std::string>({
+      {{"1", "10"}, {"2", "20"}, {"3", "30"}, {"4", ""}},
+      {{"4", "40"}},
+      {},
+      {{"", "00"}, {"1", "11"}, {"3", "33"}, {"5", "55"}, {"7", "77"}},
+  });
+
+  velox::test::assertEqualVectors(expected, result);
+}
+
+TEST_F(SplitToMapTest, invalidInput) {
+  auto data = makeRowVector({
+      makeFlatVector<std::string>({
+          "1:10,2:20,1:30",
+      }),
+  });
+
+  auto splitToMap = [&](const std::string& entryDelimiter,
+                        const std::string& keyValueDelimiter) {
+    evaluate(
+        fmt::format(
+            "split_to_map(c0, '{}', '{}')", entryDelimiter, keyValueDelimiter),
+        data);
+  };
+
+  VELOX_ASSERT_THROW(
+      splitToMap(".", "."),
+      "entryDelimiter and keyValueDelimiter must not be the same");
+  VELOX_ASSERT_THROW(splitToMap(".", ""), "keyValueDelimiter is empty");
+  VELOX_ASSERT_THROW(splitToMap("", "."), "entryDelimiter is empty");
+  VELOX_ASSERT_THROW(
+      splitToMap(":", ","),
+      "Key-value delimiter must appear exactly once in each entry. Bad input: '1'");
+  VELOX_ASSERT_THROW(
+      splitToMap(",", ":"), "Duplicate keys (1) are not allowed.");
+}
+
+} // namespace
+} // namespace facebook::velox::functions


### PR DESCRIPTION
Fixes #6217

Presto has 2 versions of split_to_map function: https://prestodb.io/docs/current/functions/string.html#split_to_map

This change introduces only one version that takes a string, entry delimiter and key-value delimiter.