### PR TITLE
Add mechanism to run non-streaming (blocking) wave operator

### DIFF
--- a/velox/experimental/wave/common/GpuArena.h
+++ b/velox/experimental/wave/common/GpuArena.h
@@ -125,6 +125,7 @@ class GpuArena {
 
   template <typename T>
   WaveBufferPtr allocate(int32_t items) {
+    static_assert(std::is_trivially_destructible_v<T>);
     return allocateBytes(sizeof(T) * items);
   }
 

--- a/velox/experimental/wave/common/Hash.h
+++ b/velox/experimental/wave/common/Hash.h
@@ -101,6 +101,7 @@ struct IntHasher32 {
     } else {
       return twang32From64(val);
     }
+    __builtin_unreachable();
   }
 };
 
@@ -110,6 +111,9 @@ struct Hasher<StringView, uint32_t> {
     return Murmur3::hashBytes(val.data(), val.size(), 42);
   }
 };
+
+template <>
+struct Hasher<int32_t, uint32_t> : IntHasher32<int32_t> {};
 
 template <>
 struct Hasher<int64_t, uint32_t> : IntHasher32<int64_t> {};

--- a/velox/experimental/wave/common/StringView.h
+++ b/velox/experimental/wave/common/StringView.h
@@ -37,6 +37,7 @@ class StringView {
       memcpy(inlineData(), data, len);
     } else {
       assert(len <= kMaxSize);
+      assert(!((uintptr_t)data >> (64 - kSizeBits)));
       data_ |= reinterpret_cast<uintptr_t>(data) << kSizeBits;
     }
   }

--- a/velox/experimental/wave/common/tests/IdMapTest.cu
+++ b/velox/experimental/wave/common/tests/IdMapTest.cu
@@ -61,9 +61,10 @@ IdMapHolder<T> createIdMap(GpuAllocator* allocator, int capacity) {
 template <typename T>
 __global__ void
 runMakeIds(IdMap<T>* idMap, const T* values, int size, int32_t* output) {
-  int offset = blockIdx.x * blockDim.x;
-  size = min(blockDim.x, size - offset);
-  idMap->makeIds(values + offset, size, output + offset);
+  int step = gridDim.x * blockDim.x;
+  for (int i = threadIdx.x + blockIdx.x * blockDim.x; i < size; i += step) {
+    output[i] = idMap->makeId(values[i]);
+  }
 }
 
 template <typename T>

--- a/velox/experimental/wave/exec/ExprKernel.cu
+++ b/velox/experimental/wave/exec/ExprKernel.cu
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include "velox/experimental/wave/exec/ExprKernel.h"
+
+#include "velox/experimental/wave/common/Block.cuh"
 #include "velox/experimental/wave/common/CudaUtil.cuh"
 #include "velox/experimental/wave/exec/WaveCore.cuh"
 

--- a/velox/experimental/wave/exec/ExprKernel.h
+++ b/velox/experimental/wave/exec/ExprKernel.h
@@ -122,7 +122,9 @@ enum class ErrorCode : int32_t {
   kOk,
 
   // Catchall for runtime errors.
-  kError
+  kError,
+
+  kInsuffcientMemory,
 };
 
 /// Contains a count of active lanes and a per lane error code.

--- a/velox/experimental/wave/exec/Filter.h
+++ b/velox/experimental/wave/exec/Filter.h
@@ -24,6 +24,10 @@ class Filter : public WaveOperator {
  public:
   Filter(RowTypePtr inputType, exec::ExprSet exprSet);
 
+  bool isStreaming() const override {
+    return true;
+  }
+
  private:
   std::vector<Subfield> input_;
 };

--- a/velox/experimental/wave/exec/Project.h
+++ b/velox/experimental/wave/exec/Project.h
@@ -26,6 +26,10 @@ class Project : public WaveOperator {
       std::vector<ProgramPtr> programs)
       : WaveOperator(state, outputType), programs_(std::move(programs)) {}
 
+  bool isStreaming() const override {
+    return true;
+  }
+
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 
  private:

--- a/velox/experimental/wave/exec/ToWave.h
+++ b/velox/experimental/wave/exec/ToWave.h
@@ -52,6 +52,10 @@ class CompileState {
 
   void addExprSet(const exec::ExprSet& set, int32_t begin, int32_t end);
 
+  GpuArena& arena() {
+    return *arena_;
+  }
+
  private:
   bool
   addOperator(exec::Operator* op, int32_t& nodeIndex, RowTypePtr& outputType);

--- a/velox/experimental/wave/exec/Values.h
+++ b/velox/experimental/wave/exec/Values.h
@@ -26,6 +26,10 @@ class Values : public WaveOperator {
 
   int32_t canAdvance() override;
 
+  bool isStreaming() const override {
+    return true;
+  }
+
   void schedule(WaveStream& stream, int32_t maxRows = 0) override;
 
   vector_size_t outputSize() const override {

--- a/velox/experimental/wave/exec/WaveCore.cuh
+++ b/velox/experimental/wave/exec/WaveCore.cuh
@@ -16,8 +16,9 @@
 
 #pragma once
 
-#include "velox/experimental/wave/common/Block.cuh"
-#include "velox/experimental/wave/exec/ExprKernel.h"
+#include <cuda_runtime.h> // @manual
+
+#include "velox/experimental/wave/vector/Operand.h"
 
 namespace facebook::velox::wave {
 
@@ -45,8 +46,8 @@ __device__ inline T value(Operand* op, int32_t blockBase, char* shared) {
 }
 
 template <typename T>
-T& flatResult(Operand* op, int32_t blockBase) {
-  reinterpret_cast<T*>(op->base)[blockBase + threadIdx.x];
+__device__ T& flatResult(Operand* op, int32_t blockBase) {
+  return flatValue<T>(op->base, blockBase);
 }
 
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/exec/WaveOperator.h
+++ b/velox/experimental/wave/exec/WaveOperator.h
@@ -44,6 +44,16 @@ class WaveOperator {
     return isExpanding_;
   }
 
+  virtual bool isStreaming() const = 0;
+
+  virtual void enqueue(WaveVectorPtr) {
+    VELOX_FAIL("Override for blocking operator");
+  }
+
+  virtual void flush() {
+    VELOX_FAIL("Override for blocking operator");
+  }
+
   // If 'this' is a cardinality change (filter, join, unnest...),
   // returns the instruction where the projected through columns get
   // wrapped. Columns that need to be accessed through the change are

--- a/velox/experimental/wave/vector/WaveVector.h
+++ b/velox/experimental/wave/vector/WaveVector.h
@@ -84,6 +84,10 @@ class WaveVector {
     return *children_[index];
   }
 
+  void setChildAt(int32_t i, std::unique_ptr<WaveVector> child) {
+    children_[i] = std::move(child);
+  }
+
   template <typename T>
   T* values() {
     return values_->as<T>();


### PR DESCRIPTION
Summary:
Divide wave operators in driver into multiple pipelines; each pipeline starts with either a source operator (e.g. `Values`, `TableScan`) or blocking operator (e.g. `Aggregation`, `HashBuild`).  The rest of the pipeline should be streaming (no mutable state is kept in the operator and current output is solely depending on the current input).

At end of each pipeline, we generate some result vector.  If it is the last pipeline, we convert the result back to CPU vector.  Otherwise we create a `WaveVector` and enqueue it into the starting operator (guaranteed to be blocking) of next pipeline.  Once all the streams finishes enqueuing the results, we flush the enqueued vectors to build up internal states of the blocking operator.

The output of blocking operator is fetched in the same way as a normal source operator by polling `canAdvance`.

Differential Revision: D48606213

