### PR TITLE
Add dayofweek Spark Function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -34,6 +34,18 @@ These functions support TIMESTAMP and DATE input types.
 
     SELECT dayofmonth('2009-07-30'); -- 30
 
+.. spark:function:: dayofweek(date/timestamp) -> integer
+
+    Returns the day of the week for date/timestamp (1 = Sunday, 2 = Monday, ..., 7 = Saturday).
+    We can use `dow` as alias for ::
+
+    SELECT dayofweek('2009-07-30'); -- 5
+    SELECT dayofweek('2023-08-22 11:23:00.100'); -- 3
+
+.. function:: dow(x) -> integer
+
+    This is an alias for :func:`day_of_week`.
+
 .. spark:function:: last_day(date) -> date
 
     Returns the last day of the month which the date belongs to.

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -298,4 +298,25 @@ struct DateSubFunction {
   }
 };
 
+template <typename T>
+struct DayOfWeekFunction : public InitSessionTimezone<T>,
+                           public TimestampWithTimezoneSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // 1 = Sunday, 2 = Monday, ..., 7 = Saturday
+  FOLLY_ALWAYS_INLINE int32_t getDayOfWeek(const std::tm& time) {
+    return time.tm_wday + 1;
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      int32_t& result,
+      const arg_type<Timestamp>& timestamp) {
+    result = getDayOfWeek(getDateTime(timestamp, this->timeZone_));
+  }
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    result = getDayOfWeek(getDateTime(date));
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -225,6 +225,11 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<DayOfYearFunction, int64_t, Date>(
       {prefix + "doy", prefix + "dayofyear"});
 
+  registerFunction<DayOfWeekFunction, int32_t, Timestamp>(
+      {prefix + "dow", prefix + "dayofweek"});
+  registerFunction<DayOfWeekFunction, int32_t, Date>(
+      {prefix + "dow", prefix + "dayofweek"});
+
   // Register bloom filter function
   registerFunction<BloomFilterMightContainFunction, bool, Varbinary, int64_t>(
       {prefix + "might_contain"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
 #include "velox/type/tz/TimeZoneMap.h"
@@ -308,6 +307,76 @@ TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   EXPECT_EQ(std::nullopt, day(std::nullopt));
   EXPECT_EQ(30, day(parseDate("2009-07-30")));
   EXPECT_EQ(23, day(parseDate("2023-08-23")));
+}
+
+TEST_F(DateTimeFunctionsTest, dayOfWeekDate) {
+  const auto dayOfWeek = [&](std::optional<int32_t> date,
+                             const std::string& func) {
+    return evaluateOnce<int32_t, int32_t>(
+        fmt::format("{}(c0)", func), {date}, {DATE()});
+  };
+
+  for (const auto& func : {"dayofweek", "dow"}) {
+    EXPECT_EQ(std::nullopt, dayOfWeek(std::nullopt, func));
+    EXPECT_EQ(5, dayOfWeek(0, func));
+    EXPECT_EQ(4, dayOfWeek(-1, func));
+    EXPECT_EQ(7, dayOfWeek(-40, func));
+    EXPECT_EQ(5, dayOfWeek(parseDate("2009-07-30"), func));
+    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-20"), func));
+    EXPECT_EQ(2, dayOfWeek(parseDate("2023-08-21"), func));
+    EXPECT_EQ(3, dayOfWeek(parseDate("2023-08-22"), func));
+    EXPECT_EQ(4, dayOfWeek(parseDate("2023-08-23"), func));
+    EXPECT_EQ(5, dayOfWeek(parseDate("2023-08-24"), func));
+    EXPECT_EQ(6, dayOfWeek(parseDate("2023-08-25"), func));
+    EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26"), func));
+    EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27"), func));
+
+    // test cases from spark's DateExpressionSuite
+    EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06"), func));
+  }
+}
+
+TEST_F(DateTimeFunctionsTest, dayofWeekTs) {
+  const auto dayOfWeek = [&](std::optional<Timestamp> date,
+                             const std::string& func) {
+    return evaluateOnce<int32_t>(fmt::format("{}(c0)", func), date);
+  };
+
+  for (const auto& func : {"dayofweek", "dow"}) {
+    EXPECT_EQ(5, dayOfWeek(Timestamp(0, 0), func));
+    EXPECT_EQ(4, dayOfWeek(Timestamp(-1, 0), func));
+    EXPECT_EQ(
+        1,
+        dayOfWeek(util::fromTimestampString("2023-08-20 20:23:00.001"), func));
+    EXPECT_EQ(
+        2,
+        dayOfWeek(util::fromTimestampString("2023-08-21 21:23:00.030"), func));
+    EXPECT_EQ(
+        3,
+        dayOfWeek(util::fromTimestampString("2023-08-22 11:23:00.100"), func));
+    EXPECT_EQ(
+        4,
+        dayOfWeek(util::fromTimestampString("2023-08-23 22:23:00.030"), func));
+    EXPECT_EQ(
+        5,
+        dayOfWeek(util::fromTimestampString("2023-08-24 15:23:00.000"), func));
+    EXPECT_EQ(
+        6,
+        dayOfWeek(util::fromTimestampString("2023-08-25 03:23:04.000"), func));
+    EXPECT_EQ(
+        7,
+        dayOfWeek(util::fromTimestampString("2023-08-26 01:03:00.300"), func));
+    EXPECT_EQ(
+        1,
+        dayOfWeek(util::fromTimestampString("2023-08-27 01:13:00.000"), func));
+    // test cases from spark's DateExpressionSuite
+    EXPECT_EQ(
+        4, dayOfWeek(util::fromTimestampString("2015-04-08 13:10:15"), func));
+    EXPECT_EQ(
+        7, dayOfWeek(util::fromTimestampString("2017-05-27 13:10:15"), func));
+    EXPECT_EQ(
+        6, dayOfWeek(util::fromTimestampString("1582-10-15 13:10:15"), func));
+  }
 }
 
 } // namespace

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -331,7 +331,7 @@ TEST_F(DateTimeFunctionsTest, dayOfWeekDate) {
     EXPECT_EQ(7, dayOfWeek(parseDate("2023-08-26"), func));
     EXPECT_EQ(1, dayOfWeek(parseDate("2023-08-27"), func));
 
-    // test cases from spark's DateExpressionSuite
+    // test cases from spark's DateExpressionSuite.
     EXPECT_EQ(6, dayOfWeek(util::fromDateString("2011-05-06"), func));
   }
 }
@@ -369,7 +369,7 @@ TEST_F(DateTimeFunctionsTest, dayofWeekTs) {
     EXPECT_EQ(
         1,
         dayOfWeek(util::fromTimestampString("2023-08-27 01:13:00.000"), func));
-    // test cases from spark's DateExpressionSuite
+    // test cases from spark's DateExpressionSuite.
     EXPECT_EQ(
         4, dayOfWeek(util::fromTimestampString("2015-04-08 13:10:15"), func));
     EXPECT_EQ(


### PR DESCRIPTION
[dayofweek](https://spark.apache.org/docs/latest/api/sql/index.html#dayofweek)

dayofweek(date) - Returns the day of the week for date/timestamp (1 = Sunday, 2 = Monday, ..., 7 = Saturday).

Examples:

> SELECT dayofweek('2009-07-30');
 5