### PR TITLE
Fix the memory budget check in dwrf writer flush control

### DIFF
--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -40,7 +40,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
       MemoryPool::Kind kind,
       std::shared_ptr<MemoryPool> parent,
       int64_t cap = std::numeric_limits<int64_t>::max())
-      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment}},
+      : MemoryPool{name, kind, parent, {.alignment = velox::memory::MemoryAllocator::kMinAlignment, .maxCapacity = cap}},
         capacity_(cap) {}
 
   ~MockMemoryPool() override {
@@ -169,7 +169,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   }
 
   MOCK_CONST_METHOD0(peakBytes, int64_t());
-  MOCK_CONST_METHOD0(getMaxBytes, int64_t());
+  // MOCK_CONST_METHOD0(getMaxBytes, int64_t());
 
   MOCK_METHOD1(updateSubtreeMemoryUsage, int64_t(int64_t));
 

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -218,7 +218,7 @@ class WriterContext : public CompressionBufferPool {
   int64_t getTotalMemoryUsage() const;
 
   int64_t getMemoryBudget() const {
-    return pool_->capacity();
+    return pool_->maxCapacity();
   }
 
   const encryption::EncryptionHandler& getEncryptionHandler() const {


### PR DESCRIPTION
Currently dwrf relies on the capacity limit in dwrf writer pool to detect if it 
needs to flush or not. The capacity limit in dwrf writer pool is actually the
capacity from the associated query root pool as velox doesn't do quota 
enforcement at operator or plan node level. 

But we should not check on the capacity, as with memory arbitrator, 
the capacity is the memory pool's current capacity and is different 
than the max capacity. The former can grow up to max capacity. 
The dwrf writer flush also depends on the control logic in flush policy. 
Without this fix, we might see flush becoming more often with
memory arbitration enabled as the pool's initial capacity could be small.