### PR TITLE
Zero-out accumulators in Aggregate::destroy

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -312,6 +312,20 @@ class Aggregate {
   }
 
   template <typename T>
+  void destroyAccumulator(char* group) const {
+    auto accumulator = value<T>(group);
+    std::destroy_at(accumulator);
+    memset(accumulator, 0, sizeof(T));
+  }
+
+  template <typename T>
+  void destroyAccumulators(folly::Range<char**> groups) const {
+    for (auto group : groups) {
+      destroyAccumulator<T>(group);
+    }
+  }
+
+  template <typename T>
   static uint64_t* getRawNulls(T* vector) {
     if (vector->mayHaveNulls()) {
       BufferPtr nulls = vector->mutableNulls(vector->size());

--- a/velox/exec/SimpleAggregateAdapter.h
+++ b/velox/exec/SimpleAggregateAdapter.h
@@ -287,15 +287,15 @@ class SimpleAggregateAdapter : public Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      auto accumulator = value<typename FUNC::AccumulatorType>(group);
-      if constexpr (accumulator_custom_destroy_) {
+    if constexpr (accumulator_custom_destroy_) {
+      for (auto group : groups) {
+        auto accumulator = value<typename FUNC::AccumulatorType>(group);
         if (!isNull(group)) {
           accumulator->destroy(allocator_);
         }
       }
-      std::destroy_at(accumulator);
     }
+    destroyAccumulators<typename FUNC::AccumulatorType>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -200,10 +200,7 @@ class ApproxDistinctAggregate : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      // All accumulators are default constructed also for nulls.
-      std::destroy_at(value<HllAccumulator>(group));
-    }
+    destroyAccumulators<HllAccumulator>(groups);
   }
 
   void addRawInput(

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -81,9 +81,7 @@ struct ApproxMostFrequentAggregate : exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      std::destroy_at(value<Accumulator<T>>(group));
-    }
+    destroyAccumulators<Accumulator<T>>(groups);
   }
 
   void addRawInput(

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -322,10 +322,7 @@ class HistogramAggregate : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      auto groupMap = value<AccumulatorType>(group);
-      std::destroy_at(groupMap);
-    }
+    destroyAccumulators<AccumulatorType>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -269,14 +269,14 @@ class MapUnionSumAggregate : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto* group : groups) {
-      if constexpr (std::is_same_v<K, StringView>) {
+    if constexpr (std::is_same_v<K, StringView>) {
+      for (auto* group : groups) {
         if (!isNull(group)) {
           value<AccumulatorType>(group)->strings.free(*allocator_);
         }
       }
-      std::destroy_at(value<AccumulatorType>(group));
     }
+    destroyAccumulators<AccumulatorType>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -701,9 +701,7 @@ class MinMaxNAggregateBase : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      std::destroy_at(value(group));
-    }
+    destroyAccumulators<AccumulatorType>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -797,10 +797,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
   }
 
   void destroy(folly::Range<char**> groups) override {
-    for (auto group : groups) {
-      auto* accumulator = Aggregate::value<AccumulatorType>(group);
-      std::destroy_at(accumulator);
-    }
+    destroyAccumulators<AccumulatorType>(groups);
   }
 
  private:

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -322,7 +322,7 @@ class MultiMapAggAggregate : public exec::Aggregate {
     for (auto* group : groups) {
       auto accumulator = value<AccumulatorType>(group);
       accumulator->free(*allocator_);
-      std::destroy_at(accumulator);
+      destroyAccumulator<AccumulatorType>(group);
     }
   }
 


### PR DESCRIPTION
To make it easier to catch double-free issues in aggregations, zero-out memory used by 
the accumulator in Aggregate::destroy.

See #6224