### PR TITLE
Make Buffer::isMutable() check Buffer::unique()

### DIFF
--- a/velox/buffer/tests/BufferTest.cpp
+++ b/velox/buffer/tests/BufferTest.cpp
@@ -66,14 +66,13 @@ TEST_F(BufferTest, testAlignedBuffer) {
         buffer->asMutable<uint8_t>() + buffer->capacity() - testStringLength,
         testString,
         testStringLength);
-    buffer->setIsMutable(false);
     other = buffer;
     EXPECT_EQ(pool_->currentBytes(), pool_->preferredSize(sizeWithHeader));
-    EXPECT_THROW(other->setIsMutable(true), VeloxException);
+
     AlignedBuffer::reallocate<char>(&other, size * 3, 'e');
     EXPECT_NE(other, buffer);
+
     // No longer multiply referenced.
-    other->setIsMutable(true);
     EXPECT_GE(other->capacity(), 3 * size);
     EXPECT_EQ(other->size(), 3 * size);
     EXPECT_EQ(
@@ -204,7 +203,6 @@ TEST_F(BufferTest, testBufferView) {
   EXPECT_EQ(buffer->capacity(), sizeof(data));
   EXPECT_EQ(pin.pinCount, 1);
   EXPECT_FALSE(buffer->isMutable());
-  EXPECT_THROW(buffer->setIsMutable(true), VeloxException);
   {
     BufferPtr other = buffer;
     EXPECT_EQ(pin.pinCount, 1);

--- a/velox/dwio/common/BufferUtil.h
+++ b/velox/dwio/common/BufferUtil.h
@@ -25,7 +25,7 @@ inline void ensureCapacity(
     BufferPtr& data,
     size_t capacity,
     velox::memory::MemoryPool* pool) {
-  if (!data || !data->unique() || !data->isMutable() ||
+  if (!data || !data->isMutable() ||
       data->capacity() < BaseVector::byteSize<T>(capacity)) {
     data = AlignedBuffer::allocate<T>(capacity, pool);
   }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -384,7 +384,7 @@ class BaseVector {
   // This does not guarantee the existence of the nulls buffer, if using this
   // within BaseVector you still may need to call ensureNulls.
   virtual bool isNullsWritable() const {
-    return !nulls_ || (nulls_->unique() && nulls_->isMutable());
+    return !nulls_ || (nulls_->isMutable());
   }
 
   // Sets null when 'nulls' has null value for a row in 'rows'

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -813,11 +813,11 @@ void ArrayVector::ensureWritable(const SelectivityVector& rows) {
 }
 
 bool ArrayVector::isWritable() const {
-  if (offsets_ && !(offsets_->unique() && offsets_->isMutable())) {
+  if (offsets_ && !offsets_->isMutable()) {
     return false;
   }
 
-  if (sizes_ && !(sizes_->unique() && sizes_->isMutable())) {
+  if (sizes_ && !sizes_->isMutable()) {
     return false;
   }
 
@@ -838,13 +838,13 @@ void zeroOutBuffer(BufferPtr buffer) {
 void ArrayVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
-  if (!(offsets_->unique() && offsets_->isMutable())) {
+  if (!offsets_->isMutable()) {
     offsets_ = nullptr;
   } else {
     zeroOutBuffer(offsets_);
   }
 
-  if (!(sizes_->unique() && sizes_->isMutable())) {
+  if (!sizes_->isMutable()) {
     sizes_ = nullptr;
   } else {
     zeroOutBuffer(sizes_);
@@ -1102,11 +1102,11 @@ void MapVector::ensureWritable(const SelectivityVector& rows) {
 }
 
 bool MapVector::isWritable() const {
-  if (offsets_ && !(offsets_->unique() && offsets_->isMutable())) {
+  if (offsets_ && !offsets_->isMutable()) {
     return false;
   }
 
-  if (sizes_ && !(sizes_->unique() && sizes_->isMutable())) {
+  if (sizes_ && !sizes_->isMutable()) {
     return false;
   }
 
@@ -1123,13 +1123,13 @@ uint64_t MapVector::estimateFlatSize() const {
 void MapVector::prepareForReuse() {
   BaseVector::prepareForReuse();
 
-  if (!(offsets_->unique() && offsets_->isMutable())) {
+  if (!offsets_->isMutable()) {
     offsets_ = nullptr;
   } else {
     zeroOutBuffer(offsets_);
   }
 
-  if (!(sizes_->unique() && sizes_->isMutable())) {
+  if (!sizes_->isMutable()) {
     sizes_ = nullptr;
   } else {
     zeroOutBuffer(sizes_);

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -328,7 +328,9 @@ struct ArrayVectorBase : BaseVector {
  private:
   BufferPtr
   ensureIndices(BufferPtr& buf, const vector_size_t*& raw, vector_size_t size) {
-    if (buf && buf->isMutable() &&
+    // TODO: change this to isMutable(). See
+    // https://github.com/facebookincubator/velox/issues/6562.
+    if (buf && !buf->isView() &&
         buf->capacity() >= size * sizeof(vector_size_t)) {
       return buf;
     }

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -131,7 +131,9 @@ class DictionaryVector : public SimpleVector<T> {
   }
 
   BufferPtr mutableIndices(vector_size_t size) {
-    if (indices_ && indices_->isMutable() &&
+    // TODO: change this to isMutable(). See
+    // https://github.com/facebookincubator/velox/issues/6562.
+    if (indices_ && !indices_->isView() &&
         indices_->capacity() >= size * sizeof(vector_size_t)) {
       return indices_;
     }

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -233,7 +233,7 @@ void FlatVector<StringView>::prepareForReuse() {
 
   // Check values buffer. Keep the buffer if singly-referenced and mutable.
   // Reset otherwise.
-  if (values_ && !(values_->unique() && values_->isMutable())) {
+  if (values_ && !values_->isMutable()) {
     values_ = nullptr;
     rawValues_ = nullptr;
   }
@@ -242,7 +242,7 @@ void FlatVector<StringView>::prepareForReuse() {
   // not too large.
   if (!stringBuffers_.empty()) {
     auto& firstBuffer = stringBuffers_.front();
-    if (firstBuffer->unique() && firstBuffer->isMutable() &&
+    if (firstBuffer->isMutable() &&
         firstBuffer->capacity() <= kMaxStringSizeForReuse) {
       firstBuffer->setSize(0);
       setStringBuffers({firstBuffer});
@@ -285,7 +285,7 @@ void FlatVector<StringView>::setNoCopy(
     const vector_size_t idx,
     const StringView& value) {
   VELOX_DCHECK(idx < BaseVector::length_);
-  VELOX_DCHECK(values_->isMutable());
+  VELOX_DCHECK(!values_->isView());
   rawValues_[idx] = value;
   if (BaseVector::nulls_) {
     BaseVector::setNull(idx, false);

--- a/velox/vector/tests/IsWritableVectorTest.cpp
+++ b/velox/vector/tests/IsWritableVectorTest.cpp
@@ -62,12 +62,12 @@ class IsWritableVectorTest : public testing::Test {
       ASSERT_FALSE(BaseVector::isVectorWritable(vector));
     }
 
-    // Set buffer to no longer be mutable.
-    buffer->setIsMutable(false);
+    // Make buffer multiply-referenced so it's no longer be mutable.
+    auto copy = buffer;
     ASSERT_TRUE(vector->isNullsWritable());
     ASSERT_FALSE(BaseVector::isVectorWritable(vector));
 
-    buffer->setIsMutable(true);
+    copy = nullptr;
 
     // Make sure nothing gets left unwritable.
     ASSERT_TRUE(vector->isNullsWritable());


### PR DESCRIPTION
Summary:
A buffer should only be mutated if it is uniquely referenced, but Buffer::isMutable() 
doesn't check the uniqueness. Misuse of Buffer::isMutable() caused bugs that 
affected the correctness of expression evaluation (https://github.com/facebookincubator/velox/issues/5883). 
This diff makes the following changes:
1. Makes Buffer::isMutable() check Buffer::unique() as well. Existing callsites 
that check both `isMutable() && unique()` are replaced with the the new isMutable(). 
Existing callsites that check only `isMutable()` are replaced with the equivalent API 
isView(). 
2. Remove Buffer::mutable_ is to avoid confusion.

Differential Revision: D48632030

