### PR TITLE
Fix PartitionIdGenerator for BOOLEAN partition keys

### DIFF
--- a/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
@@ -189,4 +189,61 @@ TEST_F(PartitionIdGeneratorTest, limitOfPartitionNumber) {
       fmt::format("Exceeded limit of {} distinct partitions.", maxPartitions));
 }
 
+TEST_F(PartitionIdGeneratorTest, supportedPartitionKeyTypes) {
+  // Test on supported key types.
+  {
+    PartitionIdGenerator idGenerator(
+        ROW({
+            VARCHAR(),
+            BOOLEAN(),
+            VARBINARY(),
+            TINYINT(),
+            SMALLINT(),
+            INTEGER(),
+            BIGINT(),
+        }),
+        {0, 1, 2, 3, 4, 5, 6},
+        100,
+        pool());
+
+    auto input = makeRowVector({
+        makeNullableFlatVector<StringView>(
+            {"Left", std::nullopt, "Right"}, VARCHAR()),
+        makeNullableFlatVector<bool>({true, false, std::nullopt}),
+        makeFlatVector<StringView>(
+            {"proton", "neutron", "electron"}, VARBINARY()),
+        makeNullableFlatVector<int8_t>({1, 2, std::nullopt}),
+        makeNullableFlatVector<int16_t>({1, 2, std::nullopt}),
+        makeNullableFlatVector<int32_t>({1, std::nullopt, 2}),
+        makeNullableFlatVector<int64_t>({std::nullopt, 1, 2}),
+    });
+
+    raw_vector<uint64_t> ids;
+    idGenerator.run(input, ids);
+
+    EXPECT_TRUE(ids[0] == 0);
+    EXPECT_TRUE(ids[1] == 1);
+    EXPECT_TRUE(ids[2] == 2);
+  }
+
+  // Test unsupported partition key types.
+  {
+    auto input = makeRowVector({
+        makeConstant<float>(1.0, 1),
+        makeConstant<double>(1.0, 1),
+        makeConstant<Timestamp>(Timestamp::fromMillis(1639426440000), 1),
+        makeArrayVector<int32_t>({{1, 2, 3}}),
+        makeMapVector<int16_t, int16_t>({{{1, 2}}}),
+    });
+
+    for (column_index_t i = 1; i < input->childrenSize(); i++) {
+      VELOX_ASSERT_THROW(
+          PartitionIdGenerator(asRowType(input->type()), {i}, 100, pool()),
+          fmt::format(
+              "Unsupported partition type: {}.",
+              input->childAt(i)->type()->toString()));
+    }
+  }
+}
+
 } // namespace facebook::velox::connector::hive


### PR DESCRIPTION
For BOOLEAN type, change PartitionIdGenerator to call VectorHasher::enableValueRange() instead of enableValueIds() during rehash. For BOOLEAN type VectorHasher only supports isRange mode. Calling enableValueIds on BOOLEAN vector throws error currently.

Also add validation to the PartitionIdGenerator constructor for current support for partition key types. It is based on VectorHasher support for value id types. We currently do not support all partition types supported by Presto, ex., double.