### PR TITLE
Prevent partition output op OOM with fine-grained byte stream allocation

### DIFF
--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -94,11 +94,11 @@ class OStreamOutputStream : public OutputStream {
 /// seeking back to start to write a length header.
 class ByteStream {
  public:
-  // For input.
+  /// For input.
   ByteStream() : isBits_(false), isReverseBitOrder_(false) {}
   virtual ~ByteStream() = default;
 
-  // For output.
+  /// For output.
   ByteStream(
       StreamArena* arena,
       bool isBits = false,
@@ -230,10 +230,16 @@ class ByteStream {
   /// space.
   char* writePosition();
 
+  int32_t testingAllocatedBytes() const {
+    return allocatedBytes_;
+  }
+
   std::string toString() const;
 
  private:
-  void extend(int32_t bytes = memory::AllocationTraits::kPageSize);
+  void extend(int32_t bytes);
+
+  int32_t newRangeSize(int32_t bytes) const;
 
   void updateEnd() {
     if (!ranges_.empty() && current_ == &ranges_.back() &&
@@ -242,7 +248,7 @@ class ByteStream {
     }
   }
 
-  StreamArena* arena_{nullptr};
+  StreamArena* const arena_{nullptr};
 
   // Indicates that position in ranges_ is in bits, not bytes.
   const bool isBits_;
@@ -254,6 +260,8 @@ class ByteStream {
   bool isReversed_ = false;
 
   std::vector<ByteRange> ranges_;
+  // The total number of bytes allocated from 'arena_' in 'ranges_'.
+  int64_t allocatedBytes_{0};
 
   // Pointer to the current element of 'ranges_'.
   ByteRange* current_{nullptr};

--- a/velox/common/memory/StreamArena.h
+++ b/velox/common/memory/StreamArena.h
@@ -20,27 +20,25 @@ namespace facebook::velox {
 
 struct ByteRange;
 
-// An abstract class that holds memory for serialized vector
-// content. A single repartitioning target is one use case: The bytes
-// held are released as a unit when the destination acknowledges
-// receipt. Another use case is a hash table partition that holds
-// complex types as serialized rows.
+/// An abstract class that holds memory for serialized vector content. A single
+/// repartitioning target is one use case: The bytes held are released as a unit
+/// when the destination acknowledges receipt. Another use case is a hash table
+/// partition that holds complex types as serialized rows.
 class StreamArena {
  public:
   explicit StreamArena(memory::MemoryPool* pool);
 
   virtual ~StreamArena() = default;
 
-  // Sets range to refer  to at least one page of writable memory owned by
-  // 'this'. Up to 'numPages' may be  allocated.
+  /// Sets range to the request 'bytes' of writable memory owned by 'this'.
   virtual void newRange(int32_t bytes, ByteRange* range);
 
-  // sets 'range' to point to a small piece of memory owned by this. These alwys
-  // come from the heap. The use case is for headers that may change length
-  // based on data properties, not for bulk data.
+  /// sets 'range' to point to a small piece of memory owned by this. These
+  /// always come from the heap. The use case is for headers that may change
+  /// length based on data properties, not for bulk data.
   virtual void newTinyRange(int32_t bytes, ByteRange* range);
 
-  // Returns the Total size in bytes held by all Allocations.
+  /// Returns the Total size in bytes held by all Allocations.
   virtual size_t size() const {
     return size_;
   }
@@ -51,14 +49,15 @@ class StreamArena {
 
  private:
   memory::MemoryPool* const pool_;
+  const memory::MachinePageCount allocationQuantum_{2};
+
   // All allocations.
   std::vector<std::unique_ptr<memory::Allocation>> allocations_;
   // The allocation from which pages are given out. Moved to 'allocations_' when
   // used up.
   memory::Allocation allocation_;
   int32_t currentRun_ = 0;
-  int32_t currentPage_ = 0;
-  memory::MachinePageCount allocationQuantum_ = 2;
+  int32_t currentOffset_ = 0;
   size_t size_ = 0;
   std::vector<std::string> tinyRanges_;
 };


### PR DESCRIPTION
In Presto batch workload shadowing, we found memory amplification
inside the partition output operator. For each input, the partition output
operator split the input vector into multi sub vectors with each sub vector
goes to a different destination or worker in the cluster. There might be
many workers in a large batch cluster and we assume each input split into
N workers. For each sub vector, partition output operator will create a
vector stream group object for serialization which creates one byte stream
for each sub filed, and all the byte stream objects share the same stream
arena underneath for memory allocations. The latter allocates memory from
the allocator in page granularity (through non-contiguous allocation interface).
For batch workload, the number of sub fields could be large (~300 in some
query), say M sub-fields. For each byte stream, when it allocates a new range
from stream arena. The stream arena rounds up to page granularity, so even
few bytes allocation from a byte stream, the stream arena allocate 1 page. So
we assume each byte stream allocates 1 page from the stream arena at a time.
Then a single input to a partition output operator can cause 4KB * N * M, if
N is 300 and M is 300, the memory allocation could be ~400MB.

To reduce the memory amplification between byte stream and stream arena,
the byte stream object does the round up allocation based on its current
accumulated allocation bytes which incrementally bumping up the actual allocation
size or range size. Correspondingly, the stream arena instead of maintaining  the
next allocation page index in a allocation run, it maintains the next allocation byte
offset and gives the exact request allocation bytes for the new range requested
from byte stream.

With Meta internal experiment, this can prevent the query OOM
in partition output operator.