### PR TITLE
Fix include paths and relink targets in velox/commons

### DIFF
--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -44,7 +44,7 @@ if(${VELOX_ENABLE_PARSE})
 endif()
 
 # hive connector depends on dwio
-if(${VELOX_ENABLE_HIVE_CONNECTOR} OR ${VELOX_BUILD_PYTHON_PACKAGE})
+if(${VELOX_ENABLE_HIVE_CONNECTOR})
   add_subdirectory(dwio)
 endif()
 

--- a/velox/CMakeLists.txt
+++ b/velox/CMakeLists.txt
@@ -44,7 +44,7 @@ if(${VELOX_ENABLE_PARSE})
 endif()
 
 # hive connector depends on dwio
-if(${VELOX_ENABLE_HIVE_CONNECTOR})
+if(${VELOX_ENABLE_HIVE_CONNECTOR} OR ${VELOX_BUILD_PYTHON_PACKAGE})
   add_subdirectory(dwio)
 endif()
 

--- a/velox/benchmarks/CMakeLists.txt
+++ b/velox/benchmarks/CMakeLists.txt
@@ -30,6 +30,8 @@ set(velox_benchmark_deps
 
 add_library(velox_benchmark_builder ExpressionBenchmarkBuilder.cpp)
 target_link_libraries(velox_benchmark_builder ${velox_benchmark_deps})
+# This is a workaround for the use of VectorTestBase.h which includes gtest.h
+target_link_libraries(velox_benchmark_builder gtest)
 
 if(${VELOX_ENABLE_BENCHMARKS})
   add_subdirectory(tpch)

--- a/velox/codegen/Codegen-Stubs.h
+++ b/velox/codegen/Codegen-Stubs.h
@@ -20,7 +20,7 @@
 #endif
 
 #include <filesystem>
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "velox/core/PlanNode.h"
 
 namespace facebook {

--- a/velox/codegen/Codegen-Stubs.h
+++ b/velox/codegen/Codegen-Stubs.h
@@ -19,8 +19,8 @@
 #error "This files shouldn't be included when the codegen is enabled"
 #endif
 
-#include <filesystem>
 #include <glog/logging.h>
+#include <filesystem>
 #include "velox/core/PlanNode.h"
 
 namespace facebook {

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 add_library(velox_exception Exceptions.cpp VeloxException.cpp Exceptions.h)
-target_link_libraries(velox_exception PUBLIC velox_flag_definitions velox_process Folly::folly fmt::fmt gflags::gflags glog::glog)
+target_link_libraries(
+  velox_exception PUBLIC velox_flag_definitions velox_process Folly::folly
+                         fmt::fmt gflags::gflags glog::glog)
 
 add_library(
   velox_common_base
@@ -27,7 +29,10 @@ add_library(
   StatsReporter.cpp
   SuccinctPrinter.cpp)
 
-target_link_libraries(velox_common_base PUBLIC velox_exception Folly::folly fmt::fmt xsimd PRIVATE velox_process glog::glog)
+target_link_libraries(
+  velox_common_base
+  PUBLIC velox_exception Folly::folly fmt::fmt xsimd
+  PRIVATE velox_process glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -13,14 +13,7 @@
 # limitations under the License.
 
 add_library(velox_exception Exceptions.cpp VeloxException.cpp Exceptions.h)
-target_link_libraries(
-  velox_exception
-  velox_flag_definitions
-  velox_process
-  glog::glog
-  Folly::folly
-  fmt::fmt
-  gflags::gflags)
+target_link_libraries(velox_exception PUBLIC velox_flag_definitions velox_process Folly::folly fmt::fmt gflags::gflags glog::glog)
 
 add_library(
   velox_common_base
@@ -34,7 +27,7 @@ add_library(
   StatsReporter.cpp
   SuccinctPrinter.cpp)
 
-target_link_libraries(velox_common_base velox_exception velox_process xsimd)
+target_link_libraries(velox_common_base PUBLIC velox_exception Folly::folly fmt::fmt xsimd PRIVATE velox_process glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/base/benchmarks/CMakeLists.txt
+++ b/velox/common/base/benchmarks/CMakeLists.txt
@@ -13,4 +13,7 @@
 # limitations under the License.
 add_executable(velox_common_base_benchmarks BitUtilBenchmark.cpp)
 
-target_link_libraries(velox_common_base_benchmarks PUBLIC ${FOLLY_BENCHMARK} PRIVATE velox_common_base Folly::folly)
+target_link_libraries(
+  velox_common_base_benchmarks
+  PUBLIC ${FOLLY_BENCHMARK}
+  PRIVATE velox_common_base Folly::folly)

--- a/velox/common/base/benchmarks/CMakeLists.txt
+++ b/velox/common/base/benchmarks/CMakeLists.txt
@@ -13,5 +13,4 @@
 # limitations under the License.
 add_executable(velox_common_base_benchmarks BitUtilBenchmark.cpp)
 
-target_link_libraries(velox_common_base_benchmarks velox_common_base
-                      Folly::folly ${FOLLY_BENCHMARK})
+target_link_libraries(velox_common_base_benchmarks PUBLIC ${FOLLY_BENCHMARK} PRIVATE velox_common_base Folly::folly)

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -31,7 +31,18 @@ add_executable(
 
 add_test(velox_base_test velox_base_test)
 
-target_link_libraries(velox_base_test PRIVATE velox_common_base velox_exception velox_temp_path Boost::filesystem Boost::headers Folly::folly fmt::fmt gflags::gflags gtest gtest_main)
+target_link_libraries(
+  velox_base_test
+  PRIVATE velox_common_base
+          velox_exception
+          velox_temp_path
+          Boost::filesystem
+          Boost::headers
+          Folly::folly
+          fmt::fmt
+          gflags::gflags
+          gtest
+          gtest_main)
 
 add_executable(velox_id_map_test IdMapTest.cpp)
 
@@ -50,4 +61,6 @@ target_link_libraries(
   pthread)
 
 add_executable(velox_memcpy_meter Memcpy.cpp)
-target_link_libraries(velox_memcpy_meter PRIVATE velox_common_base velox_exception velox_time Folly::folly gflags::gflags)
+target_link_libraries(
+  velox_memcpy_meter PRIVATE velox_common_base velox_exception velox_time
+                             Folly::folly gflags::gflags)

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -31,16 +31,7 @@ add_executable(
 
 add_test(velox_base_test velox_base_test)
 
-target_link_libraries(
-  velox_base_test
-  velox_common_base
-  Boost::headers
-  Boost::filesystem
-  gflags::gflags
-  glog::glog
-  gtest
-  gtest_main
-  pthread)
+target_link_libraries(velox_base_test PRIVATE velox_common_base velox_exception velox_temp_path Boost::filesystem Boost::headers Folly::folly fmt::fmt gflags::gflags gtest gtest_main)
 
 add_executable(velox_id_map_test IdMapTest.cpp)
 
@@ -59,4 +50,4 @@ target_link_libraries(
   pthread)
 
 add_executable(velox_memcpy_meter Memcpy.cpp)
-target_link_libraries(velox_memcpy_meter velox_common_base pthread)
+target_link_libraries(velox_memcpy_meter PRIVATE velox_common_base velox_exception velox_time Folly::folly gflags::gflags)

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -21,15 +21,7 @@ add_library(
   SsdCache.cpp
   SsdFile.cpp
   SsdFileTracker.cpp)
-target_link_libraries(
-  velox_caching
-  velox_memory
-  velox_exception
-  velox_file
-  velox_process
-  velox_time
-  glog::glog
-  Folly::folly)
+target_link_libraries(velox_caching PUBLIC velox_common_base velox_exception velox_file velox_memory Folly::folly fmt::fmt gflags::gflags PRIVATE velox_time)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -21,7 +21,16 @@ add_library(
   SsdCache.cpp
   SsdFile.cpp
   SsdFileTracker.cpp)
-target_link_libraries(velox_caching PUBLIC velox_common_base velox_exception velox_file velox_memory Folly::folly fmt::fmt gflags::gflags PRIVATE velox_time)
+target_link_libraries(
+  velox_caching
+  PUBLIC velox_common_base
+         velox_exception
+         velox_file
+         velox_memory
+         Folly::folly
+         fmt::fmt
+         gflags::gflags
+  PRIVATE velox_time)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -31,8 +31,8 @@
 #include <mutex>
 #include <utility>
 
-#include "folly/container/F14Set.h"
 #include <glog/logging.h>
+#include "folly/container/F14Set.h"
 
 #include "velox/common/caching/SimpleLRUCache.h"
 #include "velox/common/process/TraceContext.h"

--- a/velox/common/caching/CachedFactory.h
+++ b/velox/common/caching/CachedFactory.h
@@ -32,7 +32,7 @@
 #include <utility>
 
 #include "folly/container/F14Set.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 #include "velox/common/caching/SimpleLRUCache.h"
 #include "velox/common/process/TraceContext.h"

--- a/velox/common/caching/SimpleLRUCache.h
+++ b/velox/common/caching/SimpleLRUCache.h
@@ -21,7 +21,7 @@
 #include <optional>
 
 #include "folly/container/EvictingCacheMap.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 
 namespace facebook::velox {
 

--- a/velox/common/caching/SimpleLRUCache.h
+++ b/velox/common/caching/SimpleLRUCache.h
@@ -20,8 +20,8 @@
 #include <list>
 #include <optional>
 
-#include "folly/container/EvictingCacheMap.h"
 #include <glog/logging.h>
+#include "folly/container/EvictingCacheMap.h"
 
 namespace facebook::velox {
 

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -14,13 +14,24 @@
 
 add_executable(simple_lru_cache_test SimpleLRUCacheTest.cpp)
 add_test(simple_lru_cache_test simple_lru_cache_test)
-target_link_libraries(simple_lru_cache_test PRIVATE Folly::folly glog::glog gtest gtest_main)
+target_link_libraries(simple_lru_cache_test PRIVATE Folly::folly glog::glog
+                                                    gtest gtest_main)
 
 add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
                                 SsdFileTest.cpp SsdFileTrackerTest.cpp)
 add_test(velox_cache_test velox_cache_test)
-target_link_libraries(velox_cache_test PRIVATE velox_caching velox_file velox_memory velox_temp_path Folly::folly glog::glog gtest gtest_main)
+target_link_libraries(
+  velox_cache_test
+  PRIVATE velox_caching
+          velox_file
+          velox_memory
+          velox_temp_path
+          Folly::folly
+          glog::glog
+          gtest
+          gtest_main)
 
 add_executable(cached_factory_test CachedFactoryTest.cpp)
 add_test(cached_factory_test cached_factory_test)
-target_link_libraries(cached_factory_test PRIVATE velox_process Folly::folly glog::glog gtest gtest_main)
+target_link_libraries(cached_factory_test PRIVATE velox_process Folly::folly
+                                                  glog::glog gtest gtest_main)

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -14,31 +14,13 @@
 
 add_executable(simple_lru_cache_test SimpleLRUCacheTest.cpp)
 add_test(simple_lru_cache_test simple_lru_cache_test)
-target_link_libraries(simple_lru_cache_test gtest gtest_main glog::glog
-                      gflags::gflags Folly::folly)
+target_link_libraries(simple_lru_cache_test PRIVATE Folly::folly glog::glog gtest gtest_main)
 
 add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
                                 SsdFileTest.cpp SsdFileTrackerTest.cpp)
 add_test(velox_cache_test velox_cache_test)
-target_link_libraries(
-  velox_cache_test
-  velox_caching
-  velox_memory
-  velox_exception
-  velox_temp_path
-  gtest
-  gtest_main
-  glog::glog
-  gflags::gflags
-  Folly::folly)
+target_link_libraries(velox_cache_test PRIVATE velox_caching velox_file velox_memory velox_temp_path Folly::folly glog::glog gtest gtest_main)
 
 add_executable(cached_factory_test CachedFactoryTest.cpp)
 add_test(cached_factory_test cached_factory_test)
-target_link_libraries(
-  cached_factory_test
-  velox_caching
-  gtest
-  gtest_main
-  glog::glog
-  gflags::gflags
-  Folly::folly)
+target_link_libraries(cached_factory_test PRIVATE velox_process Folly::folly glog::glog gtest gtest_main)

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -17,4 +17,4 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
-target_link_libraries(velox_common_compression Folly::folly)
+target_link_libraries(velox_common_compression PUBLIC Folly::folly PRIVATE velox_dwio_common_exception velox_exception)

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -17,4 +17,7 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
-target_link_libraries(velox_common_compression PUBLIC Folly::folly PRIVATE velox_dwio_common_exception velox_exception)
+target_link_libraries(
+  velox_common_compression
+  PUBLIC Folly::folly
+  PRIVATE velox_dwio_common_exception velox_exception)

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -20,4 +20,4 @@ add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
 target_link_libraries(
   velox_common_compression
   PUBLIC Folly::folly
-  PRIVATE  velox_exception)
+  PRIVATE velox_exception)

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -20,4 +20,4 @@ add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
 target_link_libraries(
   velox_common_compression
   PUBLIC Folly::folly
-  PRIVATE velox_dwio_common_exception velox_exception)
+  PRIVATE  velox_exception)

--- a/velox/common/compression/tests/CMakeLists.txt
+++ b/velox/common/compression/tests/CMakeLists.txt
@@ -16,5 +16,5 @@ add_executable(velox_common_compression_test CompressionTest.cpp)
 add_test(velox_common_compression_test velox_common_compression_test)
 target_link_libraries(
   velox_common_compression_test
-  PUBLIC velox_link_libs ${TEST_LINK_LIBS}
+  PUBLIC velox_link_libs
   PRIVATE velox_common_compression velox_exception gtest gtest_main)

--- a/velox/common/compression/tests/CMakeLists.txt
+++ b/velox/common/compression/tests/CMakeLists.txt
@@ -14,16 +14,4 @@
 
 add_executable(velox_common_compression_test CompressionTest.cpp)
 add_test(velox_common_compression_test velox_common_compression_test)
-target_link_libraries(
-  velox_common_compression_test
-  velox_common_compression
-  Boost::regex
-  velox_link_libs
-  Folly::folly
-  ${TEST_LINK_LIBS}
-  gflags::gflags
-  gtest
-  gtest_main
-  gmock
-  glog::glog
-  fmt::fmt)
+target_link_libraries(velox_common_compression_test PUBLIC velox_link_libs ${TEST_LINK_LIBS} PRIVATE velox_common_compression velox_exception gtest gtest_main)

--- a/velox/common/compression/tests/CMakeLists.txt
+++ b/velox/common/compression/tests/CMakeLists.txt
@@ -14,4 +14,7 @@
 
 add_executable(velox_common_compression_test CompressionTest.cpp)
 add_test(velox_common_compression_test velox_common_compression_test)
-target_link_libraries(velox_common_compression_test PUBLIC velox_link_libs ${TEST_LINK_LIBS} PRIVATE velox_common_compression velox_exception gtest gtest_main)
+target_link_libraries(
+  velox_common_compression_test
+  PUBLIC velox_link_libs ${TEST_LINK_LIBS}
+  PRIVATE velox_common_compression velox_exception gtest gtest_main)

--- a/velox/common/encode/CMakeLists.txt
+++ b/velox/common/encode/CMakeLists.txt
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 add_library(velox_encode Base64.cpp)
-target_link_libraries(velox_encode Folly::folly)
+target_link_libraries(velox_encode PUBLIC Folly::folly)

--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,10 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file PUBLIC velox_exception Folly::folly PRIVATE velox_common_base fmt::fmt glog::glog)
+target_link_libraries(
+  velox_file
+  PUBLIC velox_exception Folly::folly
+  PRIVATE velox_common_base fmt::fmt glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -15,7 +15,7 @@
 # for generated headers
 include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
-target_link_libraries(velox_file velox_common_base Folly::folly)
+target_link_libraries(velox_file PUBLIC velox_exception Folly::folly PRIVATE velox_common_base fmt::fmt glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/file/benchmark/CMakeLists.txt
+++ b/velox/common/file/benchmark/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_read_benchmark_lib ReadBenchmark.cpp)
 
-target_link_libraries(velox_read_benchmark_lib PUBLIC velox_file velox_time Folly::folly gflags::gflags)
+target_link_libraries(velox_read_benchmark_lib
+                      PUBLIC velox_file velox_time Folly::folly gflags::gflags)
 
 add_executable(velox_read_benchmark ReadBenchmarkMain.cpp)
 

--- a/velox/common/file/benchmark/CMakeLists.txt
+++ b/velox/common/file/benchmark/CMakeLists.txt
@@ -14,9 +14,8 @@
 
 add_library(velox_read_benchmark_lib ReadBenchmark.cpp)
 
-target_link_libraries(velox_read_benchmark_lib velox_file velox_exception
-                      velox_exec_test_lib fmt::fmt Folly::folly)
+target_link_libraries(velox_read_benchmark_lib PUBLIC velox_file velox_time Folly::folly gflags::gflags)
 
 add_executable(velox_read_benchmark ReadBenchmarkMain.cpp)
 
-target_link_libraries(velox_read_benchmark velox_read_benchmark_lib)
+target_link_libraries(velox_read_benchmark PRIVATE velox_read_benchmark_lib)

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -17,4 +17,6 @@ target_link_libraries(velox_file_test_utils PUBLIC velox_file)
 
 add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
-target_link_libraries(velox_file_test PRIVATE velox_file velox_file_test_utils velox_temp_path gmock gtest gtest_main)
+target_link_libraries(
+  velox_file_test PRIVATE velox_file velox_file_test_utils velox_temp_path
+                          gmock gtest gtest_main)

--- a/velox/common/file/tests/CMakeLists.txt
+++ b/velox/common/file/tests/CMakeLists.txt
@@ -13,18 +13,8 @@
 # limitations under the License.
 
 add_library(velox_file_test_utils TestUtils.cpp)
-target_link_libraries(velox_file_test_utils velox_file)
+target_link_libraries(velox_file_test_utils PUBLIC velox_file)
 
 add_executable(velox_file_test FileTest.cpp UtilsTest.cpp)
 add_test(velox_file_test velox_file_test)
-target_link_libraries(
-  velox_file_test
-  velox_file_test_utils
-  velox_file
-  velox_exception
-  velox_exec_test_lib
-  fmt::fmt
-  Folly::folly
-  gtest
-  gtest_main
-  gmock)
+target_link_libraries(velox_file_test PRIVATE velox_file velox_file_test_utils velox_temp_path gmock gtest gtest_main)

--- a/velox/common/hyperloglog/CMakeLists.txt
+++ b/velox/common/hyperloglog/CMakeLists.txt
@@ -18,4 +18,7 @@ endif()
 add_library(velox_common_hyperloglog BiasCorrection.cpp DenseHll.cpp
                                      SparseHll.cpp)
 
-target_link_libraries(velox_common_hyperloglog PUBLIC velox_memory PRIVATE velox_exception)
+target_link_libraries(
+  velox_common_hyperloglog
+  PUBLIC velox_memory
+  PRIVATE velox_exception)

--- a/velox/common/hyperloglog/CMakeLists.txt
+++ b/velox/common/hyperloglog/CMakeLists.txt
@@ -18,4 +18,4 @@ endif()
 add_library(velox_common_hyperloglog BiasCorrection.cpp DenseHll.cpp
                                      SparseHll.cpp)
 
-target_link_libraries(velox_common_hyperloglog velox_memory)
+target_link_libraries(velox_common_hyperloglog PUBLIC velox_memory PRIVATE velox_exception)

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -17,4 +17,6 @@ add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
 add_test(NAME velox_common_hyperloglog_test
          COMMAND velox_common_hyperloglog_test)
 
-target_link_libraries(velox_common_hyperloglog_test PRIVATE velox_common_hyperloglog velox_encode gtest gtest_main)
+target_link_libraries(
+  velox_common_hyperloglog_test PRIVATE velox_common_hyperloglog velox_encode
+                                        gtest gtest_main)

--- a/velox/common/hyperloglog/tests/CMakeLists.txt
+++ b/velox/common/hyperloglog/tests/CMakeLists.txt
@@ -17,5 +17,4 @@ add_executable(velox_common_hyperloglog_test DenseHllTest.cpp SparseHllTest.cpp)
 add_test(NAME velox_common_hyperloglog_test
          COMMAND velox_common_hyperloglog_test)
 
-target_link_libraries(velox_common_hyperloglog_test velox_common_hyperloglog
-                      velox_encode gflags::gflags gtest gtest_main)
+target_link_libraries(velox_common_hyperloglog_test PRIVATE velox_common_hyperloglog velox_encode gtest gtest_main)

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -31,15 +31,8 @@ add_library(
   SharedArbitrator.cpp
   StreamArena.cpp)
 
-target_link_libraries(
-  velox_memory
-  velox_flag_definitions
-  velox_common_base
-  velox_exception
-  velox_test_util
-  re2::re2
-  Folly::folly)
+target_link_libraries(velox_memory PUBLIC velox_common_base velox_exception velox_flag_definitions velox_time velox_type Folly::folly fmt::fmt gflags::gflags glog::glog gtest gtest_main PRIVATE velox_test_util re2::re2)
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  target_link_libraries(velox_memory gtest)
+  target_link_libraries(velox_memory PUBLIC gtest)
 endif()

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -31,7 +31,20 @@ add_library(
   SharedArbitrator.cpp
   StreamArena.cpp)
 
-target_link_libraries(velox_memory PUBLIC velox_common_base velox_exception velox_flag_definitions velox_time velox_type Folly::folly fmt::fmt gflags::gflags glog::glog gtest gtest_main PRIVATE velox_test_util re2::re2)
+target_link_libraries(
+  velox_memory
+  PUBLIC velox_common_base
+         velox_exception
+         velox_flag_definitions
+         velox_time
+         velox_type
+         Folly::folly
+         fmt::fmt
+         gflags::gflags
+         glog::glog
+         gtest
+         gtest_main
+  PRIVATE velox_test_util re2::re2)
 
 if(NOT VELOX_DISABLE_GOOGLETEST)
   target_link_libraries(velox_memory PUBLIC gtest)

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -43,4 +43,3 @@ target_link_libraries(
          gflags::gflags
          glog::glog
   PRIVATE velox_test_util re2::re2)
-

--- a/velox/common/memory/CMakeLists.txt
+++ b/velox/common/memory/CMakeLists.txt
@@ -42,10 +42,5 @@ target_link_libraries(
          fmt::fmt
          gflags::gflags
          glog::glog
-         gtest
-         gtest_main
   PRIVATE velox_test_util re2::re2)
 
-if(NOT VELOX_DISABLE_GOOGLETEST)
-  target_link_libraries(velox_memory PUBLIC gtest)
-endif()

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -27,45 +27,15 @@ add_executable(
   MockSharedArbitratorTest.cpp
   SharedArbitratorTest.cpp)
 
-target_link_libraries(
-  velox_memory_test
-  velox_memory
-  velox_caching
-  velox_exception
-  velox_exec_test_lib
-  velox_test_util
-  velox_vector_fuzzer
-  gtest
-  gtest_main
-  gflags::gflags
-  Folly::folly
-  gmock
-  glog::glog)
+target_link_libraries(velox_memory_test PRIVATE velox_caching velox_common_base velox_exception velox_exec velox_exec_test_lib velox_memory velox_temp_path velox_test_util velox_vector_fuzzer Folly::folly gflags::gflags glog::glog gmock gtest gtest_main re2::re2)
 
 gtest_add_tests(velox_memory_test "" AUTO)
 
 add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
 
-target_link_libraries(
-  velox_fragmentation_benchmark
-  velox_memory
-  glog::glog
-  gtest
-  gtest_main
-  gflags::gflags
-  Folly::folly
-  pthread)
+target_link_libraries(velox_fragmentation_benchmark PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
 
 add_executable(velox_concurrent_allocation_benchmark
                ConcurrentAllocationBenchmark.cpp)
 
-target_link_libraries(
-  velox_concurrent_allocation_benchmark
-  velox_memory
-  glog::glog
-  gtest
-  gtest_main
-  gflags::gflags
-  Folly::folly
-  fmt::fmt
-  pthread)
+target_link_libraries(velox_concurrent_allocation_benchmark PRIVATE velox_memory velox_time)

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -27,15 +27,35 @@ add_executable(
   MockSharedArbitratorTest.cpp
   SharedArbitratorTest.cpp)
 
-target_link_libraries(velox_memory_test PRIVATE velox_caching velox_common_base velox_exception velox_exec velox_exec_test_lib velox_memory velox_temp_path velox_test_util velox_vector_fuzzer Folly::folly gflags::gflags glog::glog gmock gtest gtest_main re2::re2)
+target_link_libraries(
+  velox_memory_test
+  PRIVATE velox_caching
+          velox_common_base
+          velox_exception
+          velox_exec
+          velox_exec_test_lib
+          velox_memory
+          velox_temp_path
+          velox_test_util
+          velox_vector_fuzzer
+          Folly::folly
+          gflags::gflags
+          glog::glog
+          gmock
+          gtest
+          gtest_main
+          re2::re2)
 
 gtest_add_tests(velox_memory_test "" AUTO)
 
 add_executable(velox_fragmentation_benchmark FragmentationBenchmark.cpp)
 
-target_link_libraries(velox_fragmentation_benchmark PRIVATE velox_memory Folly::folly gflags::gflags glog::glog)
+target_link_libraries(
+  velox_fragmentation_benchmark PRIVATE velox_memory Folly::folly
+                                        gflags::gflags glog::glog)
 
 add_executable(velox_concurrent_allocation_benchmark
                ConcurrentAllocationBenchmark.cpp)
 
-target_link_libraries(velox_concurrent_allocation_benchmark PRIVATE velox_memory velox_time)
+target_link_libraries(velox_concurrent_allocation_benchmark PRIVATE velox_memory
+                                                                    velox_time)

--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -15,7 +15,10 @@
 add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
                           TraceContext.cpp)
 
-target_link_libraries(velox_process PUBLIC velox_flag_definitions Folly::folly PRIVATE fmt::fmt gflags::gflags glog::glog)
+target_link_libraries(
+  velox_process
+  PUBLIC velox_flag_definitions Folly::folly
+  PRIVATE fmt::fmt gflags::gflags glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -15,8 +15,7 @@
 add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
                           TraceContext.cpp)
 
-target_link_libraries(velox_process velox_flag_definitions Folly::folly
-                      glog::glog)
+target_link_libraries(velox_process PUBLIC velox_flag_definitions Folly::folly PRIVATE fmt::fmt gflags::gflags glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -16,4 +16,5 @@ add_executable(velox_process_test TraceContextTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 
-target_link_libraries(velox_process_test PRIVATE velox_process fmt::fmt gtest gtest_main)
+target_link_libraries(velox_process_test PRIVATE velox_process fmt::fmt gtest
+                                                 gtest_main)

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -16,11 +16,4 @@ add_executable(velox_process_test TraceContextTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 
-target_link_libraries(
-  velox_process_test
-  velox_process
-  gflags::gflags
-  glog::glog
-  gtest
-  gtest_main
-  pthread)
+target_link_libraries(velox_process_test PRIVATE velox_process fmt::fmt gtest gtest_main)

--- a/velox/common/serialization/CMakeLists.txt
+++ b/velox/common/serialization/CMakeLists.txt
@@ -14,7 +14,8 @@
 
 add_library(velox_serialization DeserializationRegistry.cpp)
 
-target_link_libraries(velox_serialization PUBLIC velox_exception Folly::folly glog::glog)
+target_link_libraries(velox_serialization PUBLIC velox_exception Folly::folly
+                                                 glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/serialization/CMakeLists.txt
+++ b/velox/common/serialization/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 add_library(velox_serialization DeserializationRegistry.cpp)
 
-target_link_libraries(velox_serialization velox_exception)
+target_link_libraries(velox_serialization PUBLIC velox_exception Folly::folly glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/serialization/tests/CMakeLists.txt
+++ b/velox/common/serialization/tests/CMakeLists.txt
@@ -15,4 +15,6 @@
 add_executable(velox_serialization_test TestRegistry.cpp SerializableTest.cpp)
 add_test(velox_serialization_test velox_serialization_test)
 
-target_link_libraries(velox_serialization_test PRIVATE velox_exception velox_serialization Folly::folly glog::glog gtest gtest_main)
+target_link_libraries(
+  velox_serialization_test PRIVATE velox_exception velox_serialization
+                                   Folly::folly glog::glog gtest gtest_main)

--- a/velox/common/serialization/tests/CMakeLists.txt
+++ b/velox/common/serialization/tests/CMakeLists.txt
@@ -15,5 +15,4 @@
 add_executable(velox_serialization_test TestRegistry.cpp SerializableTest.cpp)
 add_test(velox_serialization_test velox_serialization_test)
 
-target_link_libraries(velox_serialization_test velox_serialization
-                      velox_exception gtest gtest_main)
+target_link_libraries(velox_serialization_test PRIVATE velox_exception velox_serialization Folly::folly glog::glog gtest gtest_main)

--- a/velox/common/testutil/CMakeLists.txt
+++ b/velox/common/testutil/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(velox_test_util TestValue.cpp)
-target_link_libraries(velox_test_util velox_common_base)
+target_link_libraries(velox_test_util PUBLIC velox_exception)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ gtest_add_tests(velox_test_util_test "" AUTO)
 
 target_link_libraries(
   velox_test_util_test
+  PRIVATE
   velox_test_util
   velox_exception
   velox_spill_config

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -16,11 +16,5 @@ add_executable(velox_test_util_test TestValueTest.cpp SpillConfigTest.cpp)
 gtest_add_tests(velox_test_util_test "" AUTO)
 
 target_link_libraries(
-  velox_test_util_test
-  PRIVATE
-  velox_test_util
-  velox_exception
-  velox_spill_config
-  velox_exec
-  gtest
-  gtest_main)
+  velox_test_util_test PRIVATE velox_test_util velox_exception
+                               velox_spill_config velox_exec gtest gtest_main)

--- a/velox/common/time/CMakeLists.txt
+++ b/velox/common/time/CMakeLists.txt
@@ -16,4 +16,4 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(velox_time Timer.cpp CpuWallTimer.cpp)
-target_link_libraries(velox_time Folly::folly)
+target_link_libraries(velox_time PUBLIC velox_process Folly::folly fmt::fmt)

--- a/velox/common/time/tests/CMakeLists.txt
+++ b/velox/common/time/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ include(GoogleTest)
 
 add_executable(velox_time_test CpuWallTimerTest.cpp)
 
-target_link_libraries(velox_time_test PRIVATE velox_time glog::glog gtest gtest_main)
+target_link_libraries(velox_time_test PRIVATE velox_time glog::glog gtest
+                                              gtest_main)
 
 gtest_add_tests(velox_time_test "" AUTO)

--- a/velox/common/time/tests/CMakeLists.txt
+++ b/velox/common/time/tests/CMakeLists.txt
@@ -15,13 +15,6 @@ include(GoogleTest)
 
 add_executable(velox_time_test CpuWallTimerTest.cpp)
 
-target_link_libraries(
-  velox_time_test
-  velox_process
-  velox_time
-  gtest
-  gtest_main
-  gflags::gflags
-  glog::glog)
+target_link_libraries(velox_time_test PRIVATE velox_time glog::glog gtest gtest_main)
 
 gtest_add_tests(velox_time_test "" AUTO)

--- a/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "velox/common/file/File.h"
 #include "velox/core/Config.h"
 

--- a/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/examples/GCSFileSystemExample.cpp
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "velox/common/file/File.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
 #include "velox/core/Config.h"
 
 #include <folly/init/Init.h>

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
-#include "connectors/hive/storage_adapters/gcs/GCSUtil.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/FileHandle.h"

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSFileSystemTest.cpp
@@ -15,10 +15,10 @@
  */
 
 #include "velox/connectors/hive/storage_adapters/gcs/GCSFileSystem.h"
-#include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/file/File.h"
 #include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
 #include "velox/core/Config.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 

--- a/velox/connectors/hive/storage_adapters/gcs/tests/GCSUtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/gcs/tests/GCSUtilTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "connectors/hive/storage_adapters/gcs/GCSUtil.h"
+#include "velox/connectors/hive/storage_adapters/gcs/GCSUtil.h"
 
 #include "gtest/gtest.h"
 

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -15,8 +15,8 @@
  */
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
 #include <boost/format.hpp>
-#include <connectors/hive/storage_adapters/hdfs/HdfsReadFile.h>
-#include <connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h>
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
+#include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 #include <gmock/gmock-matchers.h>
 #include <hdfs/hdfs.h>
 #include <atomic>

--- a/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/tests/HdfsFileSystemTest.cpp
@@ -15,8 +15,6 @@
  */
 #include "velox/connectors/hive/storage_adapters/hdfs/HdfsFileSystem.h"
 #include <boost/format.hpp>
-#include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
-#include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 #include <gmock/gmock-matchers.h>
 #include <hdfs/hdfs.h>
 #include <atomic>
@@ -24,6 +22,8 @@
 #include "HdfsMiniCluster.h"
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/storage_adapters/hdfs/HdfsReadFile.h"
+#include "velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.h"
 #include "velox/core/QueryConfig.h"
 #include "velox/exec/tests/utils/TempFilePath.h"
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/connectors/hive/storage_adapters/s3fs/tests/S3Test.h"
 
-#include "gtest/gtest.h"
+#include <gtest/gtest.h>
 
 using namespace facebook::velox;
 

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "connectors/hive/storage_adapters/s3fs/S3Util.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3Util.h"
 
 #include "gtest/gtest.h"
 

--- a/velox/experimental/codegen/CodegenExceptions.h
+++ b/velox/experimental/codegen/CodegenExceptions.h
@@ -17,7 +17,7 @@
 
 #include <exception>
 #include <string>
-#include "fmt/format.h"
+#include <fmt/format.h>
 
 namespace facebook::velox::codegen {
 /// An exception that is thrown during codegen if an expression/data type that

--- a/velox/experimental/codegen/CodegenExceptions.h
+++ b/velox/experimental/codegen/CodegenExceptions.h
@@ -15,9 +15,9 @@
  */
 #pragma once
 
+#include <fmt/format.h>
 #include <exception>
 #include <string>
-#include <fmt/format.h>
 
 namespace facebook::velox::codegen {
 /// An exception that is thrown during codegen if an expression/data type that

--- a/velox/experimental/codegen/CodegenStubs.cpp
+++ b/velox/experimental/codegen/CodegenStubs.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "velox/experimental/codegen/Codegen.h"
 #include "velox/experimental/codegen/CodegenExceptions.h"
 #include "velox/experimental/codegen/CodegenLogger.h"

--- a/velox/experimental/codegen/compiler_utils/Compiler.h
+++ b/velox/experimental/codegen/compiler_utils/Compiler.h
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 #pragma once
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "velox/common/base/Exceptions.h"
 #include "velox/experimental/codegen/compiler_utils/CompilerOptions.h"
 #include "velox/experimental/codegen/external_process/Command.h"

--- a/velox/experimental/codegen/compiler_utils/CompilerOptions.h
+++ b/velox/experimental/codegen/compiler_utils/CompilerOptions.h
@@ -15,10 +15,10 @@
  */
 #pragma once
 
+#include <fmt/format.h>
 #include <google/protobuf/util/json_util.h>
 #include <filesystem>
 #include <string>
-#include <fmt/format.h>
 #include "velox/experimental/codegen/compiler_utils/LibraryDescriptor.h"
 #include "velox/experimental/codegen/proto/ProtoUtils.h"
 #include "velox/experimental/codegen/proto/codegen_proto.pb.h"

--- a/velox/experimental/codegen/compiler_utils/CompilerOptions.h
+++ b/velox/experimental/codegen/compiler_utils/CompilerOptions.h
@@ -18,7 +18,7 @@
 #include <google/protobuf/util/json_util.h>
 #include <filesystem>
 #include <string>
-#include "fmt/format.h"
+#include <fmt/format.h>
 #include "velox/experimental/codegen/compiler_utils/LibraryDescriptor.h"
 #include "velox/experimental/codegen/proto/ProtoUtils.h"
 #include "velox/experimental/codegen/proto/codegen_proto.pb.h"

--- a/velox/experimental/codegen/compiler_utils/LibraryDescriptor.h
+++ b/velox/experimental/codegen/compiler_utils/LibraryDescriptor.h
@@ -22,7 +22,7 @@
 #include <string>
 #include <variant>
 #include <vector>
-#include "fmt/format.h"
+#include <fmt/format.h>
 #include "velox/experimental/codegen/proto/codegen_proto.pb.h"
 #include "velox/experimental/codegen/transform/utils/ranges_utils.h"
 

--- a/velox/experimental/codegen/compiler_utils/LibraryDescriptor.h
+++ b/velox/experimental/codegen/compiler_utils/LibraryDescriptor.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <fmt/format.h>
 #include <google/protobuf/util/json_util.h>
 #include <filesystem>
 #include <fstream>
@@ -22,7 +23,6 @@
 #include <string>
 #include <variant>
 #include <vector>
-#include <fmt/format.h>
 #include "velox/experimental/codegen/proto/codegen_proto.pb.h"
 #include "velox/experimental/codegen/transform/utils/ranges_utils.h"
 

--- a/velox/experimental/codegen/compiler_utils/tests/compiler_utils_test.cpp
+++ b/velox/experimental/codegen/compiler_utils/tests/compiler_utils_test.cpp
@@ -213,7 +213,7 @@ TEST(Compiler, ExternalLibraries) {
 
   auto sourceCode = R"a(
   #include <string>
-  #include "fmt/format.h"
+  #include <fmt/format.h>
   extern "C" {
   std::string f() {
     return fmt::format("test {}",2);

--- a/velox/experimental/codegen/compiler_utils/tests/compiler_utils_test.cpp
+++ b/velox/experimental/codegen/compiler_utils/tests/compiler_utils_test.cpp
@@ -212,8 +212,8 @@ TEST(Compiler, ExternalLibraries) {
           .withAdditionalLinkerObject({FMT_LIB})};
 
   auto sourceCode = R"a(
-  #include <string>
   #include <fmt/format.h>
+  #include <string>
   extern "C" {
   std::string f() {
     return fmt::format("test {}",2);

--- a/velox/experimental/codegen/external_process/subprocess.h
+++ b/velox/experimental/codegen/external_process/subprocess.h
@@ -21,7 +21,7 @@
 #include <vector>
 #include "boost/process.hpp"
 #include "boost/process/extend.hpp"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "velox/experimental/codegen/external_process/Command.h"
 #include "velox/experimental/codegen/external_process/ExternalProcessException.h"
 #include "velox/experimental/codegen/external_process/Filesystem.h"

--- a/velox/experimental/codegen/external_process/subprocess.h
+++ b/velox/experimental/codegen/external_process/subprocess.h
@@ -16,12 +16,12 @@
 
 #pragma once
 
+#include <glog/logging.h>
 #include <filesystem>
 #include <string>
 #include <vector>
 #include "boost/process.hpp"
 #include "boost/process/extend.hpp"
-#include <glog/logging.h>
 #include "velox/experimental/codegen/external_process/Command.h"
 #include "velox/experimental/codegen/external_process/ExternalProcessException.h"
 #include "velox/experimental/codegen/external_process/Filesystem.h"

--- a/velox/experimental/codegen/library_loader/NativeLibraryLoader.h
+++ b/velox/experimental/codegen/library_loader/NativeLibraryLoader.h
@@ -16,12 +16,12 @@
 
 #pragma once
 #include <dlfcn.h>
+#include <fmt/format.h>
 #include <algorithm>
 #include <filesystem>
 #include <map>
 #include <string>
 #include <vector>
-#include <fmt/format.h>
 #include "velox/experimental/codegen/library_loader/FunctionTable.h"
 #include "velox/experimental/codegen/library_loader/NativeLibraryLoader.h"
 #include "velox/experimental/codegen/library_loader/NativeLibraryLoaderException.h"

--- a/velox/experimental/codegen/library_loader/NativeLibraryLoader.h
+++ b/velox/experimental/codegen/library_loader/NativeLibraryLoader.h
@@ -21,7 +21,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include "fmt/format.h"
+#include <fmt/format.h>
 #include "velox/experimental/codegen/library_loader/FunctionTable.h"
 #include "velox/experimental/codegen/library_loader/NativeLibraryLoader.h"
 #include "velox/experimental/codegen/library_loader/NativeLibraryLoaderException.h"

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
 #include <cstdint>
 #include <optional>
 #include <vector>
-#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/VeloxException.h"
 #include "velox/expression/VectorReaders.h"

--- a/velox/expression/tests/ArrayViewTest.cpp
+++ b/velox/expression/tests/ArrayViewTest.cpp
@@ -17,7 +17,7 @@
 #include <cstdint>
 #include <optional>
 #include <vector>
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/VeloxException.h"
 #include "velox/expression/VectorReaders.h"

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
 #include <exception>
 #include <fstream>
 #include <stdexcept>

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -16,7 +16,7 @@
 
 #include <optional>
 #include "folly/container/F14Map.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/VectorReaders.h"

--- a/velox/expression/tests/MapViewTest.cpp
+++ b/velox/expression/tests/MapViewTest.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+#include <glog/logging.h>
 #include <optional>
 #include "folly/container/F14Map.h"
-#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/common/base/Exceptions.h"
 #include "velox/expression/VectorReaders.h"

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "folly/lang/Hint.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"

--- a/velox/expression/tests/SimpleFunctionTest.cpp
+++ b/velox/expression/tests/SimpleFunctionTest.cpp
@@ -18,8 +18,8 @@
 #include <optional>
 #include <string>
 
-#include "folly/lang/Hint.h"
 #include <glog/logging.h>
+#include "folly/lang/Hint.h"
 #include "gtest/gtest.h"
 #include "velox/expression/Expr.h"
 #include "velox/functions/Udf.h"

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/expression/StringWriter.h"
 #include "folly/Range.h"
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 

--- a/velox/expression/tests/StringWriterTest.cpp
+++ b/velox/expression/tests/StringWriterTest.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "velox/expression/StringWriter.h"
-#include "folly/Range.h"
 #include <glog/logging.h>
+#include "folly/Range.h"
 #include "gtest/gtest.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
 

--- a/velox/expression/tests/VariadicViewTest.cpp
+++ b/velox/expression/tests/VariadicViewTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "glog/logging.h"
+#include <glog/logging.h>
 #include "gtest/gtest.h"
 #include "velox/expression/VectorReaders.h"
 #include "velox/functions/Udf.h"

--- a/velox/expression/type_calculation/CMakeLists.txt
+++ b/velox/expression/type_calculation/CMakeLists.txt
@@ -26,5 +26,6 @@ add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${FLEX_INCLUDE_DIRS})
 add_library(velox_type_calculation ${BISON_TypeCalculationParser_OUTPUTS}
-                                   ${FLEX_TypeCalculationScanner_OUTPUTS})
+                                   ${FLEX_TypeCalculationScanner_OUTPUTS}
+                                   Scanner.h TypeCalculation.h)
 target_link_libraries(velox_type_calculation velox_common_base)

--- a/velox/expression/type_calculation/CMakeLists.txt
+++ b/velox/expression/type_calculation/CMakeLists.txt
@@ -25,7 +25,8 @@ add_flex_bison_dependency(TypeCalculationScanner TypeCalculationParser)
 
 include_directories(${PROJECT_BINARY_DIR})
 include_directories(${FLEX_INCLUDE_DIRS})
-add_library(velox_type_calculation ${BISON_TypeCalculationParser_OUTPUTS}
-                                   ${FLEX_TypeCalculationScanner_OUTPUTS}
-                                   Scanner.h TypeCalculation.h)
+add_library(
+  velox_type_calculation
+  ${BISON_TypeCalculationParser_OUTPUTS} ${FLEX_TypeCalculationScanner_OUTPUTS}
+  Scanner.h TypeCalculation.h)
 target_link_libraries(velox_type_calculation velox_common_base)

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -26,12 +26,11 @@ add_library(
   DateTimeFormatter.cpp
   DateTimeFormatterBuilder.cpp
   KllSketch.cpp
-  LambdaFunctionUtil.cpp
   MapConcat.cpp
   Re2Functions.cpp
   StringEncodingUtils.cpp)
 
-target_link_libraries(velox_functions_lib velox_vector re2::re2 Folly::folly)
+target_link_libraries(velox_functions_lib velox_functions_util velox_vector re2::re2 Folly::folly)
 
 add_subdirectory(aggregates)
 add_subdirectory(string)

--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -30,7 +30,8 @@ add_library(
   Re2Functions.cpp
   StringEncodingUtils.cpp)
 
-target_link_libraries(velox_functions_lib velox_functions_util velox_vector re2::re2 Folly::folly)
+target_link_libraries(velox_functions_lib velox_functions_util velox_vector
+                      re2::re2 Folly::folly)
 
 add_subdirectory(aggregates)
 add_subdirectory(string)

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -16,7 +16,7 @@
 
 #include "velox/type/Variant.h"
 #include <cfloat>
-#include "common/encode/Base64.h"
+#include "velox/common/encode/Base64.h"
 #include "folly/json.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/HugeInt.h"

--- a/velox/type/Variant.cpp
+++ b/velox/type/Variant.cpp
@@ -16,8 +16,8 @@
 
 #include "velox/type/Variant.h"
 #include <cfloat>
-#include "velox/common/encode/Base64.h"
 #include "folly/json.h"
+#include "velox/common/encode/Base64.h"
 #include "velox/type/DecimalUtil.h"
 #include "velox/type/HugeInt.h"
 

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -13,9 +13,8 @@
 # limitations under the License.
 add_executable(velox_vector_hash_all_benchmark SimpleVectorHashAllBenchmark.cpp)
 
-target_link_libraries(
-  velox_vector_hash_all_benchmark velox_vector velox_vector_test Folly::folly
-  ${FOLLY_BENCHMARK} fmt::fmt)
+target_link_libraries(velox_vector_hash_all_benchmark velox_vector Folly::folly
+                      ${FOLLY_BENCHMARK} fmt::fmt)
 
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(velox_vector_hash_all_benchmark SimpleVectorHashAllBenchmark.cpp)
 
 target_link_libraries(velox_vector_hash_all_benchmark velox_vector Folly::folly
                       ${FOLLY_BENCHMARK} fmt::fmt)
+# This is a workaround for the use of VectorTestUtils.h which include gtest.h
+target_link_libraries(velox_vector_hash_all_benchmark gtest)
 
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)

--- a/velox/vector/benchmarks/CMakeLists.txt
+++ b/velox/vector/benchmarks/CMakeLists.txt
@@ -13,8 +13,9 @@
 # limitations under the License.
 add_executable(velox_vector_hash_all_benchmark SimpleVectorHashAllBenchmark.cpp)
 
-target_link_libraries(velox_vector_hash_all_benchmark velox_vector Folly::folly
-                      ${FOLLY_BENCHMARK} fmt::fmt)
+target_link_libraries(
+  velox_vector_hash_all_benchmark velox_vector velox_vector_test Folly::folly
+  ${FOLLY_BENCHMARK} fmt::fmt)
 
 add_executable(velox_vector_selectivity_vector_benchmark
                SelectivityVectorBenchmark.cpp)

--- a/velox/vector/tests/utils/CMakeLists.txt
+++ b/velox/vector/tests/utils/CMakeLists.txt
@@ -13,4 +13,4 @@
 # limitations under the License.
 add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
-target_link_libraries(velox_vector_test_lib velox_exec velox_vector)
+target_link_libraries(velox_vector_test_lib velox_exec velox_vector gtest gtest_main)

--- a/velox/vector/tests/utils/CMakeLists.txt
+++ b/velox/vector/tests/utils/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 add_library(velox_vector_test_lib VectorMaker.cpp VectorTestBase.cpp)
 
-target_link_libraries(velox_vector_test_lib velox_exec velox_vector gtest gtest_main)
+target_link_libraries(velox_vector_test_lib velox_exec velox_vector gtest
+                      gtest_main)


### PR DESCRIPTION
The first commits in this PR homogenize includes within velox: 
- use 'absolute' path relative to repo root 
  - use 'velox/connector...' instead of  'connector/...'
- #include 
  - <dependencies_and_std(.h)?> 
  - "velox/..."  
  
This was the case in most of the code base already :)

The last commit is the first part of relinking all targets with scope keywords. I tested the changes locally but we will have to see what ci has to say ^^

cc @pedroerp @kgpai let me know if the change for common is to big, I can make even smaller PRs if you prefer...