### PR TITLE
Add next_day Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -49,6 +49,23 @@ These functions support TIMESTAMP and DATE input types.
     ``day`` need to be from 1 to 31, and matches the number of days in each month.
     days of ``year-month-day - 1970-01-01`` need to be in the range of INTEGER type.
 
+.. spark:function:: next_day(start_date, day_of_week) -> date
+   
+    Returns the first date which is later than ``start_date`` and named as indicated.
+    Returns NULL if ``day_of_week`` is an invalid input.
+    ``day_of_week`` must be one of the following (case insensitive):
+    'SU', 'SUN', 'SUNDAY'
+    'MO', 'MON', 'MONDAY'
+    'TU', 'TUE', 'TUESDAY'
+    'WE', 'WED', 'WEDNESDAY'
+    'TH', 'THU', 'THURSDAY'
+    'FR', 'FRI', 'FRIDAY'
+    'SA', 'SAT', 'SATURDAY'
+    ::
+
+        SELECT next_day('2015-01-14', 'TU'); -- 2015-01-20
+        SELECT next_day('2015-01-14', 'NotValid'); -- NULL
+
 .. spark:function:: to_unix_timestamp(string) -> integer
 
     Alias for ``unix_timestamp(string) -> integer``.

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -212,6 +212,7 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "make_date"});
 
   registerFunction<LastDayFunction, Date, Date>({prefix + "last_day"});
+  registerFunction<NextDayFunction, Date, Date, Varchar>({prefix + "next_day"});
 
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});


### PR DESCRIPTION
presto does not have a similar function.

spark 3.2 ref:
https://github.com/apache/spark/blob/v3.2.2/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L1453