### PR TITLE
Add HashStringAllocator::Header::toString() to help debugging

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -56,6 +56,33 @@ void markAsFree(HashStringAllocator::Header* FOLLY_NONNULL header) {
 }
 } // namespace
 
+std::string HashStringAllocator::Header::toString() {
+  std::ostringstream out;
+  if (isFree()) {
+    out << "|free| ";
+  }
+  if (isContinued()) {
+    out << "|multipart| ";
+  }
+  out << "size: " << size();
+  if (isContinued()) {
+    auto next = nextContinued();
+    out << " [" << next->size();
+    while (next->isContinued()) {
+      next = next->nextContinued();
+      out << ", " << next->size();
+    }
+    out << "]";
+  }
+  if (isPreviousFree()) {
+    out << ", previous is free (" << *previousFreeSize(this) << " bytes)";
+  }
+  if (next() == nullptr) {
+    out << ", at end";
+  }
+  return out.str();
+}
+
 HashStringAllocator::~HashStringAllocator() {
   clear();
 }

--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -142,6 +142,8 @@ class HashStringAllocator : public StreamArena {
       return *reinterpret_cast<Header**>(end() - kContinuedPtrSize);
     }
 
+    std::string toString();
+
    private:
     uint32_t data_;
   };


### PR DESCRIPTION
Add a method to print details about an allocated block of memory to help debugging.