### PR TITLE
Fix: Make sure switch expr generates vectors that can be dereferenced at rows where errors are thrown

### DIFF
--- a/velox/expression/CastExpr-inl.h
+++ b/velox/expression/CastExpr-inl.h
@@ -96,6 +96,9 @@ void CastExpr::applyToSelectedNoThrowLocal(
       try {
         func(row);
       } catch (const VeloxException& e) {
+        if (!e.isUserError()) {
+          throw;
+        }
         // Avoid double throwing.
         context.setVeloxExceptionError(row, std::current_exception());
       } catch (const std::exception& e) {
@@ -358,7 +361,10 @@ void CastExpr::applyCastPrimitives(
         applyCastKernel<ToKind, FromKind, false /*truncate*/>(
             row, context, inputSimpleVector, resultFlatVector);
 
-      } catch (const VeloxUserError& ue) {
+      } catch (const VeloxException& ue) {
+        if (!ue.isUserError()) {
+          throw;
+        }
         setError(row, ue.message());
       } catch (const std::exception& e) {
         setError(row, e.what());
@@ -370,7 +376,10 @@ void CastExpr::applyCastPrimitives(
       try {
         applyCastKernel<ToKind, FromKind, true /*truncate*/>(
             row, context, inputSimpleVector, resultFlatVector);
-      } catch (const VeloxUserError& ue) {
+      } catch (const VeloxException& ue) {
+        if (!ue.isUserError()) {
+          throw;
+        }
         setError(row, ue.message());
       } catch (const std::exception& e) {
         setError(row, e.what());

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -52,7 +52,10 @@ VectorPtr CastExpr::castFromDate(
           writer.resize(output.size());
           std::memcpy(writer.data(), output.data(), output.size());
           writer.finalize();
-        } catch (const VeloxUserError& ue) {
+        } catch (const VeloxException& ue) {
+          if (!ue.isUserError()) {
+            throw;
+          }
           VELOX_USER_FAIL(
               makeErrorMessage(input, row, toType) + " " + ue.message());
         } catch (const std::exception& e) {
@@ -104,7 +107,10 @@ VectorPtr CastExpr::castToDate(
         try {
           auto inputString = inputVector->valueAt(row);
           resultFlatVector->set(row, DATE()->toDays(inputString));
-        } catch (const VeloxUserError& ue) {
+        } catch (const VeloxException& ue) {
+          if (!ue.isUserError()) {
+            throw;
+          }
           VELOX_USER_FAIL(
               makeErrorMessage(input, row, DATE()) + " " + ue.message());
         } catch (const std::exception& e) {

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -102,6 +102,9 @@ class EvalCtx {
       try {
         func(row);
       } catch (const VeloxException& e) {
+        if (!e.isUserError()) {
+          throw;
+        }
         // Avoid double throwing.
         setVeloxExceptionError(row, std::current_exception());
       } catch (const std::exception& e) {

--- a/velox/expression/SimpleFunctionAdapter.h
+++ b/velox/expression/SimpleFunctionAdapter.h
@@ -219,6 +219,8 @@ class SimpleFunctionAdapter : public VectorFunction {
     if constexpr (FUNC::udf_has_initialize) {
       try {
         unpackInitialize<0>(config, constantInputs);
+      } catch (const VeloxRuntimeError&) {
+        throw;
       } catch (const std::exception& e) {
         initializeException_ = std::current_exception();
       }

--- a/velox/expression/tests/SimpleFunctionInitTest.cpp
+++ b/velox/expression/tests/SimpleFunctionInitTest.cpp
@@ -202,7 +202,7 @@ struct InitAlwaysThrowsFunction {
   void initialize(
       const core::QueryConfig& /*config*/,
       const arg_type<int32_t>* /*first*/) {
-    VELOX_FAIL("Unconditional throw!");
+    VELOX_USER_FAIL("Unconditional throw!");
   }
 
   void call(out_type<int64_t>& out, const arg_type<int32_t>& first) {
@@ -219,7 +219,7 @@ TEST_F(SimpleFunctionInitTest, initException) {
 
   // Ensure this will normally throw if there are active rows.
   auto rowVector = makeRowVector({makeNullableFlatVector<int32_t>({1, 2, 3})});
-  EXPECT_THROW(evaluate("init_throws(c0)", rowVector), VeloxRuntimeError);
+  EXPECT_THROW(evaluate("init_throws(c0)", rowVector), VeloxUserError);
 
   // Shouldn't throw if the input is a Null constant.
   rowVector = makeRowVector({makeNullConstant(TypeKind::INTEGER, 3)});

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -194,6 +194,8 @@ class SubscriptImpl : public exec::Subscript {
       // If index is invalid, capture the error and mark all rows as failed.
       try {
         adjustedIndex = adjustIndex(decodedIndices->valueAt<I>(0));
+      } catch (const VeloxRuntimeError&) {
+        throw;
       } catch (const std::exception& e) {
         context.setErrors(rows, std::current_exception());
         allFailed = true;

--- a/velox/functions/prestosql/Repeat.cpp
+++ b/velox/functions/prestosql/Repeat.cpp
@@ -39,6 +39,8 @@ class RepeatFunction : public exec::VectorFunction {
     if (args[1]->isConstantEncoding()) {
       try {
         localResult = applyConstant(rows, args, outputType, context);
+      } catch (const VeloxRuntimeError&) {
+        throw;
       } catch (const std::exception& e) {
         context.setErrors(rows, std::current_exception());
         return;

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -99,7 +99,7 @@ void castToJson(
   } else {
     context.applyToSelectedNoThrow(rows, [&](auto row) {
       if (inputVector->isNullAt(row)) {
-        VELOX_FAIL("Map keys cannot be null.");
+        VELOX_USER_FAIL("Map keys cannot be null.");
       } else {
         result.clear();
         generateJsonTyped<T, true>(*inputVector, row, result, input.type());
@@ -197,7 +197,7 @@ struct AsJson {
     if (isMapKey && decoded_->mayHaveNulls()) {
       context.applyToSelectedNoThrow(rows, [&](auto row) {
         if (decoded_->isNullAt(row)) {
-          VELOX_FAIL("Cannot cast map with null keys to JSON.");
+          VELOX_USER_FAIL("Cannot cast map with null keys to JSON.");
         }
       });
     }
@@ -716,6 +716,9 @@ void castFromJson(
         try {
           castFromJsonTyped<kind>(object, writer.current());
         } catch (const VeloxException& ve) {
+          if (!ve.isUserError()) {
+            throw;
+          }
           writer.commitNull();
           VELOX_USER_FAIL(
               "Cannot cast from Json value {} to {}: {}",

--- a/velox/functions/remote/client/Remote.cpp
+++ b/velox/functions/remote/client/Remote.cpp
@@ -63,6 +63,8 @@ class RemoteFunction : public exec::VectorFunction {
       VectorPtr& result) const override {
     try {
       applyRemote(rows, args, outputType, context, result);
+    } catch (const VeloxRuntimeError&) {
+      throw;
     } catch (const std::exception&) {
       context.setErrors(rows, std::current_exception());
     }

--- a/velox/vector/tests/TestingAlwaysThrowsFunction.h
+++ b/velox/vector/tests/TestingAlwaysThrowsFunction.h
@@ -18,12 +18,11 @@
 #include "velox/expression/VectorFunction.h"
 
 namespace facebook::velox::test {
-
 template <typename T>
 struct TestingAlwaysThrowsFunction {
   template <typename TResult, typename TInput>
   FOLLY_ALWAYS_INLINE void call(TResult&, const TInput&) {
-    VELOX_FAIL();
+    VELOX_USER_FAIL();
   }
 };
 

--- a/velox/vector/tests/TestingAlwaysThrowsFunction.h
+++ b/velox/vector/tests/TestingAlwaysThrowsFunction.h
@@ -21,8 +21,19 @@ namespace facebook::velox::test {
 template <typename T>
 struct TestingAlwaysThrowsFunction {
   template <typename TResult, typename TInput>
-  FOLLY_ALWAYS_INLINE void call(TResult&, const TInput&) {
+  void call(TResult&, const TInput&) {
     VELOX_USER_FAIL();
+  }
+};
+
+template <typename T>
+struct TestingThrowsAtOddFunction {
+  void call(bool& out, const int64_t& input) {
+    if (input % 2) {
+      VELOX_USER_FAIL();
+    } else {
+      out = 1;
+    }
   }
 };
 


### PR DESCRIPTION
Summary:
When switch expression is evaluated and the output is complex type, for indices where
an error happens, nothing is written on the output vector.

This can result in a vector that is not serializable and cant be dereferenced for those
indices which can result in seg-fault when someone tries to access the data.

We have a rule that vectors should be always serializable for their size, furthermore,
this could lead to error if any expression later on is reading the result for the indices
were we did throw, this diff fixes the issue here. see the issue discussion for more details
This fix:https://github.com/facebookincubator/velox/issues/5878

following fix will update the cast as well to avoid being performed on rows that have errors.

Differential Revision: D48480584

