### PR TITLE
Increase default value of abandon_partial_aggregation_min_rows to 100K

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -249,7 +249,7 @@ class QueryConfig {
   }
 
   int32_t abandonPartialAggregationMinRows() const {
-    return get<int32_t>(kAbandonPartialAggregationMinRows, 10000);
+    return get<int32_t>(kAbandonPartialAggregationMinRows, 100'000);
   }
 
   int32_t abandonPartialAggregationMinPct() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -29,7 +29,7 @@ Generic Configuration
        average row size is known and preferred_output_batch_bytes is used to compute the number of output rows.
    * - abandon_partial_aggregation_min_rows
      - integer
-     - 10000
+     - 100,000
      - Min number of rows when we check if a partial aggregation is not reducing the cardinality well and might be
        a subject to being abandoned.
    * - abandon_partial_aggregation_min_pct


### PR DESCRIPTION
The original value of 10K rows is too small.

Partial aggregation often comes right after table scan which produces batches of 10K rows. 
We need to see a few batches (10) before deciding to abandon partial aggregation.

CC: @rui-mo 