### PR TITLE
Support accessing sub-fields by index

### DIFF
--- a/velox/core/Expressions.cpp
+++ b/velox/core/Expressions.cpp
@@ -61,6 +61,7 @@ void ITypedExpr::registerSerDe() {
   registry.Register("CastTypedExpr", core::CastTypedExpr::create);
   registry.Register("ConcatTypedExpr", core::ConcatTypedExpr::create);
   registry.Register("ConstantTypedExpr", core::ConstantTypedExpr::create);
+  registry.Register("DereferenceTypedExpr", core::DereferenceTypedExpr::create);
   registry.Register("FieldAccessTypedExpr", core::FieldAccessTypedExpr::create);
   registry.Register("InputTypedExpr", core::InputTypedExpr::create);
   registry.Register("LambdaTypedExpr", core::LambdaTypedExpr::create);
@@ -149,6 +150,26 @@ TypedExprPtr FieldAccessTypedExpr::create(
     return std::make_shared<FieldAccessTypedExpr>(
         std::move(type), std::move(inputs[0]), name);
   }
+}
+
+folly::dynamic DereferenceTypedExpr::serialize() const {
+  auto obj = ITypedExpr::serializeBase("DereferenceTypedExpr");
+  obj["fieldIndex"] = index_;
+  return obj;
+}
+
+// static
+TypedExprPtr DereferenceTypedExpr::create(
+    const folly::dynamic& obj,
+    void* context) {
+  auto type = core::deserializeType(obj, context);
+  auto inputs = deserializeInputs(obj, context);
+  VELOX_CHECK_EQ(inputs.size(), 1);
+
+  uint32_t index = obj["fieldIndex"].asInt();
+
+  return std::make_shared<DereferenceTypedExpr>(
+      std::move(type), std::move(inputs[0]), index);
 }
 
 folly::dynamic ConcatTypedExpr::serialize() const {

--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -51,14 +51,15 @@ TEST_F(TypedExprSerDeTest, input) {
 }
 
 TEST_F(TypedExprSerDeTest, fieldAccess) {
-  auto expression = std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a");
+  std::shared_ptr<ITypedExpr> expression =
+      std::make_shared<FieldAccessTypedExpr>(BIGINT(), "a");
   testSerde(expression);
 
-  expression = std::make_shared<FieldAccessTypedExpr>(
+  expression = std::make_shared<DereferenceTypedExpr>(
       VARCHAR(),
       std::make_shared<FieldAccessTypedExpr>(
           ROW({"a", "b"}, {VARCHAR(), BOOLEAN()}), "ab"),
-      "a");
+      0);
   testSerde(expression);
 }
 

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -499,6 +499,11 @@ ExprPtr compileRewrittenExpression(
       captureFieldReference(fieldReference.get(), expr.get(), scope);
     }
     result = fieldReference;
+  } else if (
+      auto dereference =
+          dynamic_cast<const core::DereferenceTypedExpr*>(expr.get())) {
+    result = std::make_shared<FieldReference>(
+        expr->type(), std::move(compiledInputs), dereference->index());
   } else if (auto row = dynamic_cast<const core::InputTypedExpr*>(expr.get())) {
     VELOX_UNSUPPORTED("InputTypedExpr '{}' is not supported", row->toString());
   } else if (

--- a/velox/expression/ExprToSubfieldFilter.cpp
+++ b/velox/expression/ExprToSubfieldFilter.cpp
@@ -50,37 +50,42 @@ T singleValue(const VectorPtr& vector) {
   return simpleVector->valueAt(0);
 }
 
-const core::FieldAccessTypedExpr* asField(
-    const core::ITypedExpr* expr,
-    int index) {
-  return dynamic_cast<const core::FieldAccessTypedExpr*>(
-      expr->inputs()[index].get());
-}
-
 const core::CallTypedExpr* asCall(const core::ITypedExpr* expr) {
   return dynamic_cast<const core::CallTypedExpr*>(expr);
 }
 
-bool toSubfield(
-    const core::FieldAccessTypedExpr* field,
-    common::Subfield& subfield) {
+bool toSubfield(const core::ITypedExpr* field, common::Subfield& subfield) {
   std::vector<std::unique_ptr<common::Subfield::PathElement>> path;
   for (auto* current = field;;) {
-    path.push_back(
-        std::make_unique<common::Subfield::NestedField>(current->name()));
+    if (auto* fieldAccess =
+            dynamic_cast<const core::FieldAccessTypedExpr*>(current)) {
+      path.push_back(
+          std::make_unique<common::Subfield::NestedField>(fieldAccess->name()));
+    } else if (
+        auto* dereference =
+            dynamic_cast<const core::DereferenceTypedExpr*>(current)) {
+      const auto& name = dereference->name();
+      // When the field name is empty string, it typically means that the field
+      // name was not set in the parent type.
+      if (name == "") {
+        return false;
+      }
+      path.push_back(std::make_unique<common::Subfield::NestedField>(name));
+    } else if (!dynamic_cast<const core::InputTypedExpr*>(current)) {
+      return false;
+    } else {
+      break;
+    }
+
     if (current->inputs().empty()) {
       break;
     }
     if (current->inputs().size() != 1) {
       return false;
     }
-    auto* parent = current->inputs()[0].get();
-    current = dynamic_cast<const core::FieldAccessTypedExpr*>(parent);
+    current = current->inputs()[0].get();
     if (!current) {
-      if (!dynamic_cast<const core::InputTypedExpr*>(parent)) {
-        return false;
-      }
-      break;
+      return false;
     }
   }
   std::reverse(path.begin(), path.end());
@@ -455,71 +460,58 @@ std::unique_ptr<common::Filter> leafCallToSubfieldFilter(
     common::Subfield& subfield,
     core::ExpressionEvaluator* evaluator,
     bool negated) {
+  if (call.inputs().empty()) {
+    return nullptr;
+  }
+
+  const auto* leftSide = call.inputs()[0].get();
+
   if (call.name() == "eq") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated ? makeNotEqualFilter(call.inputs()[1], evaluator)
-                       : makeEqualFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated ? makeNotEqualFilter(call.inputs()[1], evaluator)
+                     : makeEqualFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "neq") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated ? makeEqualFilter(call.inputs()[1], evaluator)
-                       : makeNotEqualFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated ? makeEqualFilter(call.inputs()[1], evaluator)
+                     : makeNotEqualFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "lte") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated ? makeGreaterThanFilter(call.inputs()[1], evaluator)
-                       : makeLessThanOrEqualFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated ? makeGreaterThanFilter(call.inputs()[1], evaluator)
+                     : makeLessThanOrEqualFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "lt") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated
-            ? makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator)
-            : makeLessThanFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated ? makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator)
+                     : makeLessThanFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "gte") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated
-            ? makeLessThanFilter(call.inputs()[1], evaluator)
-            : makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated
+          ? makeLessThanFilter(call.inputs()[1], evaluator)
+          : makeGreaterThanOrEqualFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "gt") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return negated ? makeLessThanOrEqualFilter(call.inputs()[1], evaluator)
-                       : makeGreaterThanFilter(call.inputs()[1], evaluator);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return negated ? makeLessThanOrEqualFilter(call.inputs()[1], evaluator)
+                     : makeGreaterThanFilter(call.inputs()[1], evaluator);
     }
   } else if (call.name() == "between") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return makeBetweenFilter(
-            call.inputs()[1], call.inputs()[2], evaluator, negated);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return makeBetweenFilter(
+          call.inputs()[1], call.inputs()[2], evaluator, negated);
     }
   } else if (call.name() == "in") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        return makeInFilter(call.inputs()[1], evaluator, negated);
-      }
+    if (toSubfield(leftSide, subfield)) {
+      return makeInFilter(call.inputs()[1], evaluator, negated);
     }
   } else if (call.name() == "is_null") {
-    if (auto field = asField(&call, 0)) {
-      if (toSubfield(field, subfield)) {
-        if (negated) {
-          return isNotNull();
-        }
-        return isNull();
+    if (toSubfield(leftSide, subfield)) {
+      if (negated) {
+        return isNotNull();
       }
+      return isNull();
     }
   }
   return nullptr;

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -33,6 +33,19 @@ class FieldReference : public SpecialForm {
             false /* trackCpuUsage */),
         field_(field) {}
 
+  FieldReference(
+      TypePtr type,
+      const std::vector<ExprPtr>& inputs,
+      int32_t index)
+      : SpecialForm(
+            std::move(type),
+            inputs,
+            inputs.at(0)->type()->asRow().nameOf(index),
+            false, /* supportsFlatNoNullsFastPath */
+            false /* trackCpuUsage */),
+        field_(inputs.at(0)->type()->asRow().nameOf(index)),
+        index_(index) {}
+
   const std::string& field() const {
     return field_;
   }

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -230,5 +230,24 @@ TEST_F(ExprToSubfieldFilterTest, userError) {
   ASSERT_FALSE(filter);
 }
 
+TEST_F(ExprToSubfieldFilterTest, dereferenceWithEmptyField) {
+  auto call = std::make_shared<core::CallTypedExpr>(
+      BOOLEAN(),
+      std::vector<core::TypedExprPtr>{
+          std::make_shared<core::DereferenceTypedExpr>(
+              REAL(),
+              std::make_shared<core::FieldAccessTypedExpr>(
+                  ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}}),
+                  std::make_shared<core::InputTypedExpr>(ROW(
+                      {{"c0",
+                        ROW({{"", DOUBLE()}, {"", REAL()}, {"", BIGINT()}})}})),
+                  "c0"),
+              1)},
+      "is_null");
+  Subfield subfield;
+  auto filter = leafCallToSubfieldFilter(*call, subfield, evaluator());
+  ASSERT_FALSE(filter);
+}
+
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -95,10 +95,10 @@ TEST_F(SimpleComparisonMatcherTest, basic) {
     if (lessThan.has_value()) {
       ASSERT_EQ(lessThan.value(), comparison->isLessThen);
 
-      auto field = dynamic_cast<const core::FieldAccessTypedExpr*>(
+      auto field = dynamic_cast<const core::DereferenceTypedExpr*>(
           comparison->expr.get());
       ASSERT_TRUE(field != nullptr);
-      ASSERT_EQ("f", field->name());
+      ASSERT_EQ(0, field->index());
     }
   };
 

--- a/velox/parse/Expressions.cpp
+++ b/velox/parse/Expressions.cpp
@@ -245,10 +245,15 @@ TypedExprPtr Expressions::inferTypes(
     auto input = children.at(0)->type();
     auto& row = input->asRow();
     auto childIndex = row.getChildIdx(fae->getFieldName());
-    return std::make_shared<FieldAccessTypedExpr>(
-        input->childAt(childIndex),
-        children.at(0),
-        std::string{fae->getFieldName()});
+    if (fae->isRootColumn()) {
+      return std::make_shared<FieldAccessTypedExpr>(
+          input->childAt(childIndex),
+          children.at(0),
+          std::string{fae->getFieldName()});
+    } else {
+      return std::make_shared<DereferenceTypedExpr>(
+          input->childAt(childIndex), children.at(0), childIndex);
+    }
   }
   if (auto fun = std::dynamic_pointer_cast<const CallExpr>(expr)) {
     return createWithImplicitCast(fun, std::move(children));

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -71,7 +71,9 @@ class Subfield {
 
   class NestedField final : public PathElement {
    public:
-    explicit NestedField(const std::string& name) : name_(name) {}
+    explicit NestedField(const std::string& name) : name_(name) {
+      VELOX_USER_CHECK_NE(name, "", "NestedFields must have non-empty names.");
+    }
 
     SubfieldKind kind() const override {
       return kNestedField;


### PR DESCRIPTION
Summary:
This diff adds a new ITypedExpr DereferenceTypedExpr which accesses a subfield of a Row by field index
(unlike FieldAccessTypedExpr which only allows accessing fields by name).

This is particularly useful for cases where the RowType was defined without names and so they all default to
empty string, making it impossible to access any field but the first one, but is generally useful for any cases
where field names are for some reason not unique.

I hope that we can eventually use FieldAccessTypedExpr specifically for accessing top level columns, while
DereferenceTypedExpr is used for accessing subfields.  This will simplify logic in the compiler, for example,
where today we have to check if a FieldAccessTypedExpr is an input column or not.  In general, I split the two
classes for this reason as well as making it easy to tell what's available (Dereference always has index, while
FieldAccess always has name).

Differential Revision: D48665326

