### PR TITLE
Fix circular dependency on velox_dwio_common

### DIFF
--- a/velox/codegen/CMakeLists.txt
+++ b/velox/codegen/CMakeLists.txt
@@ -16,6 +16,5 @@ add_library(velox_codegen Codegen.cpp)
 if(${VELOX_CODEGEN_SUPPORT})
   target_link_libraries(velox_codegen velox_experimental_codegen)
 else()
-  target_link_libraries(velox_codegen velox_core velox_exec velox_expression
-                        glog::glog)
+  target_link_libraries(velox_codegen velox_core velox_expression glog::glog)
 endif()

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -22,25 +22,37 @@ elseif(${VELOX_BUILD_TEST_UTILS})
 endif()
 
 add_library(
-  velox_dwio_common
-  BitConcatenation.cpp
-  BitPackDecoder.cpp
+  velox_dwio_common_base
   BufferedInput.cpp
   CachedBufferedInput.cpp
   CacheInputStream.cpp
-  ColumnSelector.cpp
   DataBufferHolder.cpp
+  FileSink.cpp
+  InputStream.cpp
+  IoStatistics.cpp
+  OutputStream.cpp
+  SeekableInputStream.cpp)
+target_link_libraries(
+  velox_dwio_common_base
+  velox_dwio_common_exception
+  velox_buffer
+  velox_caching
+  velox_exception
+  velox_memory
+  Folly::folly)
+
+add_library(
+  velox_dwio_common
+  BitConcatenation.cpp
+  BitPackDecoder.cpp
+  ColumnSelector.cpp
   DecoderUtil.cpp
   DirectDecoder.cpp
   DwioMetricsLog.cpp
-  FileSink.cpp
   FlatMapHelper.cpp
-  InputStream.cpp
   IntDecoder.cpp
-  IoStatistics.cpp
   MetadataFilter.cpp
   Options.cpp
-  OutputStream.cpp
   Range.cpp
   Reader.cpp
   ReaderFactory.cpp
@@ -50,7 +62,6 @@ add_library(
   SelectiveColumnReader.cpp
   SelectiveRepeatedColumnReader.cpp
   SelectiveStructColumnReader.cpp
-  SeekableInputStream.cpp
   TypeUtils.cpp
   TypeWithId.cpp
   WriterFactory.cpp
@@ -61,16 +72,11 @@ target_include_directories(velox_dwio_common PRIVATE ${Protobuf_INCLUDE_DIRS})
 
 target_link_libraries(
   velox_dwio_common
-  velox_buffer
-  velox_caching
   velox_common_compression
+  velox_dwio_common_base
   velox_dwio_common_compression
   velox_dwio_common_encryption
-  velox_dwio_common_exception
-  velox_exception
   velox_expression
-  velox_memory
   velox_exec
   Boost::regex
-  Folly::folly
   glog::glog)

--- a/velox/dwio/common/compression/CMakeLists.txt
+++ b/velox/dwio/common/compression/CMakeLists.txt
@@ -15,5 +15,11 @@
 add_library(velox_dwio_common_compression Compression.cpp PagedInputStream.cpp
                                           PagedOutputStream.cpp)
 
-target_link_libraries(velox_dwio_common_compression velox_dwio_common xsimd
-                      gtest Folly::folly)
+target_link_libraries(
+  velox_dwio_common_compression
+  velox_dwio_common_base
+  velox_dwio_common_exception
+  velox_common_compression
+  xsimd
+  gtest
+  Folly::folly)


### PR DESCRIPTION
This fixes a circular dependency. The newer `velox_dwio_common_compression` doesn't need to link to `velox_dwio_common`of which it is also a part.