### PR TITLE
Make RowReader prefetch use Reader::FetchResult

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -115,7 +115,7 @@ class DwrfRowReader : public StrideIndexProvider,
 
   void safeFetchNextStripe();
 
-  bool prefetch(uint32_t stripeToFetch);
+  std::optional<std::vector<PrefetchUnit>> prefetchUnits() override;
 
   int64_t nextRowNumber() override;
 
@@ -123,6 +123,7 @@ class DwrfRowReader : public StrideIndexProvider,
 
  private:
   bool fetch(uint32_t stripeIndex);
+  FetchResult prefetch(uint32_t stripeToFetch);
 
   // footer
   std::vector<uint64_t> firstRowOfStripe;

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -35,9 +35,9 @@ class StripeReaderBase {
       const std::shared_ptr<ReaderBase>& reader,
       const proto::StripeFooter* footer)
       : reader_{reader},
-        footer_{const_cast<proto::StripeFooter*>(footer)},
         handler_{std::make_unique<encryption::DecryptionHandler>(
             reader_->getDecryptionHandler())},
+        footer_{const_cast<proto::StripeFooter*>(footer)},
         canLoad_{false} {
     // The footer is expected to be arena allocated and to stay
     // live for the lifetime of 'this'.
@@ -110,11 +110,11 @@ class StripeReaderBase {
   }
 
  private:
-  std::shared_ptr<ReaderBase> reader_;
+  const std::shared_ptr<ReaderBase> reader_;
+  const std::unique_ptr<encryption::DecryptionHandler> handler_;
   std::unique_ptr<dwio::common::BufferedInput> stripeInput_;
-  proto::StripeFooter* footer_ = nullptr;
-  std::unique_ptr<encryption::DecryptionHandler> handler_;
   std::optional<uint32_t> lastStripeIndex_;
+  proto::StripeFooter* footer_ = nullptr;
   bool canLoad_{true};
 
   // Map containing stripe blobs which have already been loaded.


### PR DESCRIPTION
Summary: This makes prefetch private and exposes prefetch functionality via `prefetchUnits()` api from `Reader`. We wrap the true/false return value of prefetch to fetched/already fetched. Followup diff will add logic for the 3rd `kInProgress` as well.

Differential Revision: D48691228

