### PR TITLE
Remove StripeReaderBase dependency on StripeStreams

### DIFF
--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -61,7 +61,7 @@ class StripeReaderBase {
     return *reader_;
   }
 
-  std::shared_ptr<ReaderBase> readerBaseShared() {
+  const std::shared_ptr<ReaderBase>& readerBaseShared() const {
     return reader_;
   }
 


### PR DESCRIPTION
Summary: Moves StripeStream to rely on state produced by StripeReaderBase, instead of the StripeReaderBase itself

Reviewed By: Yuhta, DanielMunozT

Differential Revision: D48671514

