### PR TITLE
Throw error in FileSink::create when registration is missing

### DIFF
--- a/velox/dwio/common/tests/LocalFileSinkTest.cpp
+++ b/velox/dwio/common/tests/LocalFileSinkTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/Fs.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/exec/tests/utils/TempDirectoryPath.h"
 
@@ -38,6 +39,10 @@ void runTest() {
   localFileSink->close();
 
   EXPECT_TRUE(fs::exists(filePath.string()));
+}
+
+TEST(LocalFileSinkTest, missingRegistration) {
+  VELOX_ASSERT_THROW(runTest(), "FileSink is not registered for file:");
 }
 
 TEST(LocalFileSinkTest, create) {


### PR DESCRIPTION
FileSink::create returns default LocalFileSink. For the S3 scheme, this was silently breaking the functionality
since there was no S3FileSink registered.