### PR TITLE
Fix to_base when input is min possible value of int64_t.

### DIFF
--- a/velox/functions/prestosql/tests/ArithmeticTest.cpp
+++ b/velox/functions/prestosql/tests/ArithmeticTest.cpp
@@ -603,6 +603,12 @@ TEST_F(ArithmeticTest, toBase) {
   EXPECT_EQ("20a2", to_base(3578, 12));
   EXPECT_EQ("-20a2", to_base(-3578, 12));
 
+  EXPECT_EQ(
+      "-1104332401304422434310311213",
+      to_base(std::numeric_limits<int64_t>::min(), 5));
+  EXPECT_EQ(
+      "1104332401304422434310311212",
+      to_base(std::numeric_limits<int64_t>::max(), 5));
   ASSERT_THROW(to_base(1, 37), velox::VeloxUserError);
 }
 


### PR DESCRIPTION
Summary:
old implementation used to overflow, use int128_t operations to avoid that.
Fix: https://github.com/facebookincubator/velox/issues/6241

Differential Revision: D48695529

