### PR TITLE
Add support for Conda Environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,6 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS)
   find_package(FBThrift CONFIG REQUIRED)
 endif()
 
-
 # define processor variable for conditional compilation
 if(${VELOX_CODEGEN_SUPPORT})
   add_compile_definitions(CODEGEN_ENABLED=1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,22 @@ endif()
 # set the project name
 project(velox)
 
+# If we are in an active conda env disable search in system paths and add env to
+# prefix path
+if(DEFINED ENV{CONDA_PREFIX})
+  if(NOT DEFINED ENV{VELOX_DEPENDENCY_SOURCE} OR $ENV{VELOX_DEPENDENCY_SOURCE}
+                                                 STREQUAL "CONDA")
+    message(STATUS "Using Conda environment: $ENV{CONDA_PREFIX}")
+    set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH FALSE)
+    list(APPEND CMAKE_PREFIX_PATH "$ENV{CONDA_PREFIX}")
+    # Override in case it was set to CONDA
+    set(ENV{VELOX_DEPENDENCY_SOURCE} AUTO)
+  elseif(DEFINED ENV{VELOX_DEPENDENCY_SOURCE}
+         AND NOT $ENV{VELOX_DEPENDENCY_SOURCE} STREQUAL "CONDA")
+    message(STATUS "Overriding Conda environment: $ENV{CONDA_PREFIX}")
+  endif()
+endif()
+
 list(PREPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMake"
      "${PROJECT_SOURCE_DIR}/CMake/third-party")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.18)
 
 # the policy allows us to change options without caching
 cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.14)
 
 # the policy allows us to change options without caching
 cmake_policy(SET CMP0077 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,16 +233,6 @@ if(VELOX_ENABLE_REMOTE_FUNCTIONS)
   find_package(FBThrift CONFIG REQUIRED)
 endif()
 
-# Turn on Codegen only for Clang and non Mac systems.
-if((NOT DEFINED VELOX_CODEGEN_SUPPORT)
-   AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-   AND NOT (${CMAKE_SYSTEM_NAME} MATCHES "Darwin"))
-  message(STATUS "Enabling Codegen")
-  set(VELOX_CODEGEN_SUPPORT True)
-else()
-  message(STATUS "Disabling Codegen")
-  set(VELOX_CODEGEN_SUPPORT False)
-endif()
 
 # define processor variable for conditional compilation
 if(${VELOX_CODEGEN_SUPPORT})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ project(velox)
 # If we are in an active conda env disable search in system paths and add env to
 # prefix path
 if(DEFINED ENV{CONDA_PREFIX})
-  if(NOT DEFINED ENV{VELOX_DEPENDENCY_SOURCE} OR $ENV{VELOX_DEPENDENCY_SOURCE}
+  if(NOT DEFINED ENV{VELOX_DEPENDENCY_SOURCE} OR "$ENV{VELOX_DEPENDENCY_SOURCE}"
                                                  STREQUAL "CONDA")
     message(STATUS "Using Conda environment: $ENV{CONDA_PREFIX}")
     set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH FALSE)
@@ -39,7 +39,7 @@ if(DEFINED ENV{CONDA_PREFIX})
     # Override in case it was set to CONDA
     set(ENV{VELOX_DEPENDENCY_SOURCE} AUTO)
   elseif(DEFINED ENV{VELOX_DEPENDENCY_SOURCE}
-         AND NOT $ENV{VELOX_DEPENDENCY_SOURCE} STREQUAL "CONDA")
+         AND NOT "$ENV{VELOX_DEPENDENCY_SOURCE}" STREQUAL "CONDA")
     message(STATUS "Overriding Conda environment: $ENV{CONDA_PREFIX}")
   endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,7 +511,7 @@ include_directories(SYSTEM velox/external/duckdb/tpch/dbgen/include)
 
 # these were previously vendored in third-party/
 if(NOT VELOX_DISABLE_GOOGLETEST)
-  set(gtest_SOURCE BUNDLED)
+  set(gtest_SOURCE AUTO)
   resolve_dependency(gtest)
   set(VELOX_GTEST_INCUDE_DIR
       "${gtest_SOURCE_DIR}/googletest/include"

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ ifdef AZURESDK_ROOT_DIR
 CMAKE_FLAGS += -DAZURESDK_ROOT_DIR=$(AZURESDK_ROOT_DIR)
 endif
 
+ifdef CONDA_PREFIX
+CMAKE_FLAGS += -DCMAKE_PREFIX_PATH=${CONDA_PREFIX}
+CMAKE_FLAGS += -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=FALSE
+endif
+
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1
 ifeq ($(USE_NINJA), 1)

--- a/Makefile
+++ b/Makefile
@@ -50,11 +50,6 @@ ifdef AZURESDK_ROOT_DIR
 CMAKE_FLAGS += -DAZURESDK_ROOT_DIR=$(AZURESDK_ROOT_DIR)
 endif
 
-ifdef CONDA_PREFIX
-CMAKE_FLAGS += -DCMAKE_PREFIX_PATH=${CONDA_PREFIX}
-CMAKE_FLAGS += -DCMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH=FALSE
-endif
-
 # Use Ninja if available. If Ninja is used, pass through parallelism control flags.
 USE_NINJA ?= 1
 ifeq ($(USE_NINJA), 1)

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -31,7 +31,11 @@ dependencies:
   - flex
   - gxx=12 # has to be installed to get clang to work...
   - make
+  - minio-server
   - ninja
+  - nodejs
+  - openjdk=8.*
+  - python=3.8
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
@@ -45,6 +49,7 @@ dependencies:
   - gmock=1.13
   - google-cloud-cpp
   - gtest=1.13
+  - hdfs3
   - libaio
   - libdwarf-dev
   - libevent
@@ -56,6 +61,7 @@ dependencies:
   - lzo
   - openssl=1.1.*
   - re2
+  - simdjson
   - snappy
   - xz
   - zlib

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -1,3 +1,17 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: velox_base
 
 channels:

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -3,15 +3,19 @@ name: velox_base
 channels:
   - conda-forge
 
+variables:
+  CC: clang
+  CXX: clang++
+
 dependencies:
 # tools
   - binutils
   - bison
+  - clangxx
   - cmake
   - ccache
-  - elfutils
   - flex
-  - gxx=12
+  - gxx=12 # has to be installed to get clang to work...
   - make
   - ninja
   - sysroot_linux-64=2.17
@@ -24,7 +28,7 @@ dependencies:
   - gflags=2.2.2
   - glog=0.6.0
   - gmock=1.13
-  - google-cloud-sdk
+  - google-cloud-cpp
   - gtest=1.13
   - libaio
   - libdwarf-dev

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -35,6 +35,7 @@ dependencies:
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
+  - azure-storage-blob
   - boost-cpp
   - bzip2
   - double-conversion

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -25,7 +25,7 @@ dependencies:
 # tools
   - binutils
   - bison
-  - clangxx
+  - clangxx=14
   - cmake
   - ccache
   - flex
@@ -39,7 +39,7 @@ dependencies:
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
-  - azure-storage-blob
+  - azure-storage-blobs-cpp
   - boost-cpp
   - bzip2
   - double-conversion
@@ -49,7 +49,6 @@ dependencies:
   - gmock=1.13
   - google-cloud-cpp
   - gtest=1.13
-  - hdfs3
   - libaio
   - libdwarf-dev
   - libevent
@@ -59,7 +58,7 @@ dependencies:
   - libunwind
   - lz4-c
   - lzo
-  - openssl=1.1.*
+  - openssl=1.1
   - re2
   - simdjson
   - snappy

--- a/scripts/velox_env_linux.yml
+++ b/scripts/velox_env_linux.yml
@@ -1,0 +1,43 @@
+name: velox_base
+
+channels:
+  - conda-forge
+
+dependencies:
+# tools
+  - binutils
+  - bison
+  - cmake
+  - ccache
+  - elfutils
+  - flex
+  - gxx=12
+  - make
+  - ninja
+  - sysroot_linux-64=2.17
+# dependencies
+  - aws-sdk-cpp
+  - boost-cpp
+  - bzip2
+  - double-conversion
+  - fmt=8.0.*
+  - gflags=2.2.2
+  - glog=0.6.0
+  - gmock=1.13
+  - google-cloud-sdk
+  - gtest=1.13
+  - libaio
+  - libdwarf-dev
+  - libevent
+  - libprotobuf=3.21
+  - libsodium
+  - libtool
+  - libunwind
+  - lz4-c
+  - lzo
+  - openssl=1.1.*
+  - re2
+  - snappy
+  - xz
+  - zlib
+  - zstd

--- a/scripts/velox_env_mac.yml
+++ b/scripts/velox_env_mac.yml
@@ -30,13 +30,18 @@ dependencies:
   - ccache
   - flex
   - make
+  - minio-server
   - ninja
+  - nodejs
+  - openjdk=8.*
+  - python=3.8
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
   - azure-storage-blob
   - boost-cpp
   - bzip2
+  - crc32c
   - double-conversion
   - fmt=8.0.*
   - gflags=2.2.2
@@ -44,6 +49,7 @@ dependencies:
   - gmock=1.13
   - google-cloud-cpp
   - gtest=1.13
+  - hdfs3
   - libdwarf-dev
   - libevent
   - libprotobuf=3.21
@@ -54,6 +60,7 @@ dependencies:
   - openssl=1.1.*
   - re2
   - snappy
+  - simdjson
   - xz
   - zlib
   - zstd

--- a/scripts/velox_env_mac.yml
+++ b/scripts/velox_env_mac.yml
@@ -1,0 +1,59 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: velox_base
+
+channels:
+  - conda-forge
+
+variables:
+  CC: clang
+  CXX: clang++
+
+dependencies:
+# tools
+  - binutils
+  - bison
+  - clangxx=14 # pin to something recent'ish to avoid warings on upgrade
+  - cmake
+  - ccache
+  - flex
+  - make
+  - ninja
+  - sysroot_linux-64=2.17
+# dependencies
+  - aws-sdk-cpp
+  - boost-cpp
+  - bzip2
+  - double-conversion
+  - fmt=8.0.*
+  - gflags=2.2.2
+  - glog=0.6.0
+  - gmock=1.13
+  - google-cloud-cpp
+  - gtest=1.13
+  - libdwarf-dev
+  - libevent
+  - libprotobuf=3.21
+  - libsodium
+  - libtool
+  - lz4-c
+  - lzo
+  - openssl=1.1.*
+  - re2
+  - snappy
+  - xz
+  - zlib
+  - zstd
+

--- a/scripts/velox_env_mac.yml
+++ b/scripts/velox_env_mac.yml
@@ -38,7 +38,7 @@ dependencies:
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
-  - azure-storage-blob
+  - azure-storage-blobs-cpp
   - boost-cpp
   - bzip2
   - crc32c
@@ -49,7 +49,6 @@ dependencies:
   - gmock=1.13
   - google-cloud-cpp
   - gtest=1.13
-  - hdfs3
   - libdwarf-dev
   - libevent
   - libprotobuf=3.21

--- a/scripts/velox_env_mac.yml
+++ b/scripts/velox_env_mac.yml
@@ -34,6 +34,7 @@ dependencies:
   - sysroot_linux-64=2.17
 # dependencies
   - aws-sdk-cpp
+  - azure-storage-blob
   - boost-cpp
   - bzip2
   - double-conversion


### PR DESCRIPTION
This PR adds a conda env for linux and adds changes to the make file to prevent cmake from picking up system dependencies and only use the env. Closes #6278 

This PR does not add the env to CI or similar, that should be handled in a follow up.(see #6280 and #6281)

To install the env: `mamba env create -f scripts/velox_env_linux.ym` and `mamba activate velox_base` and then use make as usual. I have used it to successfully build and test  velox with s3 and gcs. 

@kgpai you should be able to try activating *SAN with this env.