### PR TITLE
Add to_json Spark Function

### DIFF
--- a/velox/docs/functions/spark/json.rst
+++ b/velox/docs/functions/spark/json.rst
@@ -25,3 +25,10 @@ JSON Functions
     Extracts a json object from path::
 
         SELECT get_json_object('{"a":"b"}', '$.a'); -- b
+
+.. spark:function:: to_json(expr[, options]) -> varchar
+
+    Returns a JSON string with a given struct value::
+
+        SELECT to_json(map('a', 1)); -- {"a":1}
+        SELECT to_json(array((map('a', 1)))); -- [{"a":1}]

--- a/velox/functions/sparksql/CMakeLists.txt
+++ b/velox/functions/sparksql/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   CompareFunctionsNullSafe.cpp
   Hash.cpp
   In.cpp
+  Json.cpp
   LeastGreatest.cpp
   Map.cpp
   RegexFunctions.cpp

--- a/velox/functions/sparksql/Json.cpp
+++ b/velox/functions/sparksql/Json.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <functions/prestosql/types/JsonType.h>
+#include "velox/expression/VectorWriters.h"
+
+namespace facebook::velox::functions::sparksql {
+namespace {
+
+class ToJsonFunction : public exec::VectorFunction {
+ public:
+  void apply(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      const TypePtr& outputType,
+      exec::EvalCtx& context,
+      VectorPtr& result) const override {
+    JsonCastOperator::get()->castTo(
+        *args.at(0), context, rows, outputType, result);
+  }
+
+  static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
+    return {
+        exec::FunctionSignatureBuilder()
+            .typeVariable("T")
+            .returnType("varchar")
+            .argumentType("T")
+            .build(),
+    };
+  }
+};
+
+} // namespace
+
+VELOX_DECLARE_VECTOR_FUNCTION(
+    udf_to_json,
+    ToJsonFunction::signatures(),
+    std::make_unique<ToJsonFunction>());
+
+} // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -148,6 +148,7 @@ void registerFunctions(const std::string& prefix) {
       xxhash64WithSeedSignatures(),
       makeXxHash64WithSeed);
   VELOX_REGISTER_VECTOR_FUNCTION(udf_map, prefix + "map");
+  VELOX_REGISTER_VECTOR_FUNCTION(udf_to_json, prefix + "to_json");
 
   // Register 'in' functions.
   registerIn(prefix);

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   SortArrayTest.cpp
   SplitFunctionsTest.cpp
   StringTest.cpp
+  ToJsonTest.cpp
   XxHash64Test.cpp)
 
 add_test(velox_functions_spark_test velox_functions_spark_test)

--- a/velox/functions/sparksql/tests/ToJsonTest.cpp
+++ b/velox/functions/sparksql/tests/ToJsonTest.cpp
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ToJsonTest : public SparkFunctionBaseTest {
+ protected:
+  void testToJson(
+      const std::vector<StringView>& expected,
+      const std::string& expression,
+      const VectorPtr& input) {
+    testToJson(expected, expression, makeRowVector({input}));
+  }
+
+  void testToJson(
+      const std::vector<StringView>& expected,
+      const std::string& expression,
+      const RowVectorPtr& input) {
+    auto result = evaluate(expression, (input));
+    velox::test::assertEqualVectors(
+        makeFlatVector<StringView>(expected), result);
+  }
+};
+
+TEST_F(ToJsonTest, basic) {
+  auto arrayInput = makeNullableArrayVector<int64_t>({
+      {1, 2, 3},
+      {4, 4},
+      {std::nullopt},
+      {std::nullopt, 123},
+      {std::numeric_limits<int64_t>::min(),
+       std::numeric_limits<int64_t>::max()},
+  });
+
+  std::vector<StringView> expected{
+      "[1,2,3]",
+      "[4,4]",
+      "[null]",
+      "[null,123]",
+      "[-9223372036854775808,9223372036854775807]",
+  };
+
+  testToJson(expected, "to_json(c0)", arrayInput);
+
+  arrayInput = makeArrayVector<StringView>({
+      {"hello", "velox!"},
+      {"deadbeaf"},
+      {},
+  });
+
+  expected = {
+      R"(["hello","velox!"])",
+      "[\"deadbeaf\"]",
+      "[]",
+  };
+
+  testToJson(expected, "to_json(c0)", arrayInput);
+
+  auto mapInput = makeMapVector<StringView, int64_t>({
+      {{"k1", 1}, {"k2", 2}},
+      {{"k3", 3}},
+      {},
+  });
+
+  expected = {R"({"k1":1,"k2":2})", R"({"k3":3})", "{}"};
+  testToJson(expected, "to_json(c0)", mapInput);
+
+  auto bigintInput = makeFlatVector<int64_t>({0, 1024, 9527});
+  auto stringInput = makeFlatVector<StringView>({"a", "b", "c"});
+
+  auto rowInput = makeRowVector({"c0", "c1"}, {bigintInput, stringInput});
+  expected = {
+      R"([0,"a"])",
+      R"([1024,"b"])",
+      R"([9527,"c"])",
+  };
+  testToJson(expected, "to_json(c0)", makeRowVector({rowInput}));
+}
+
+TEST_F(ToJsonTest, complex) {
+  auto arrayInput = makeArrayVector<StringView>({
+      {"hello", "velox!"},
+      {"deadbeaf"},
+      {},
+  });
+  auto mapInput = makeMapVector<StringView, int64_t>({
+      {{"k1", 1}, {"k2", 2}},
+      {{"k3", 3}},
+      {},
+  });
+  auto bigintInput = makeFlatVector<int64_t>({0, 1024, 9527});
+  auto rowInput =
+      makeRowVector({"c0", "c1", "c2"}, {bigintInput, arrayInput, mapInput});
+  std::vector<StringView> expected = {
+      R"([0,["hello","velox!"],{"k1":1,"k2":2}])",
+      R"([1024,["deadbeaf"],{"k3":3}])",
+      "[9527,[],{}]",
+  };
+  testToJson(expected, "to_json(c0)", makeRowVector({rowInput}));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
[to_json](https://spark.apache.org/docs/latest/api/sql/index.html#to_json)

to_json(expr[, options]) - Returns a JSON string with a given struct value