### PR TITLE
Add SparkSQL url_decode function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -214,3 +214,10 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
     Returns string with all characters changed to uppercase. ::
 
         SELECT upper('SparkSql'); -- SPARKSQL
+
+.. spark:function:: url_decode(string) -> string
+
+    An implementation for spark url_decode function avaliable since Spark-3.4.0.
+    Decodes `string` in 'application/x-www-form-urlencoded' format using UTF-8 encoding scheme. ::
+
+        SELECT url_decode('https%3A%2F%2Fspark.apache.org'); -- https://spark.apache.org

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -209,6 +209,9 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<TranslateFunction, Varchar, Varchar, Varchar, Varchar>(
       {prefix + "translate"});
 
+  registerFunction<UrlDecoderFunction, Varchar, Varchar>(
+      {prefix + "url_decode"});
+
   // Register array sort functions.
   exec::registerStatefulVectorFunction(
       prefix + "array_sort", arraySortSignatures(), makeArraySort);


### PR DESCRIPTION
Decodes input string in 'application/x-www-form-urlencoded' format using UTF-8 encoding scheme.

Spark ref. [link](https://github.com/apache/spark/blob/474f64a88502fe242654eb85c7cb5a1514c710e9/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/urlExpressions.scala#L74).