### PR TITLE
Add last_day_of_month Presto Function

### DIFF
--- a/velox/docs/functions/presto/datetime.rst
+++ b/velox/docs/functions/presto/datetime.rst
@@ -187,6 +187,10 @@ arbitrary large timestamps.
 
     Returns the hour of the day from ``x``. The value ranges from 0 to 23.
 
+.. function:: last_day_of_month(x) -> date
+
+    Returns the last day of the month.
+
 .. function:: millisecond(x) -> int64
 
     Returns the millisecond of the second from ``x``.

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -330,6 +330,34 @@ struct DayFunction : public InitSessionTimezone<T>,
   }
 };
 
+template <typename T>
+struct LastDayOfMonthFunction : public InitSessionTimezone<T>,
+                                public TimestampWithTimezoneSupport<T> {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Timestamp>& timestamp) {
+    auto dt = getDateTime(timestamp, this->timeZone_);
+    result = util::lastDayOfMonthSinceEpochFromDate(dt);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<Date>& date) {
+    auto dt = getDateTime(date);
+    result = util::lastDayOfMonthSinceEpochFromDate(dt);
+  }
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Date>& result,
+      const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
+    auto timestamp = this->toTimestamp(timestampWithTimezone);
+    auto dt = getDateTime(timestamp, nullptr);
+    result = util::lastDayOfMonthSinceEpochFromDate(dt);
+  }
+};
+
 namespace {
 
 bool isIntervalWholeDays(int64_t milliseconds) {

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -92,6 +92,12 @@ void registerSimpleFunctions(const std::string& prefix) {
   registerFunction<HourFunction, int64_t, Date>({prefix + "hour"});
   registerFunction<HourFunction, int64_t, TimestampWithTimezone>(
       {prefix + "hour"});
+  registerFunction<LastDayOfMonthFunction, Date, Timestamp>(
+      {prefix + "last_day_of_month"});
+  registerFunction<LastDayOfMonthFunction, Date, Date>(
+      {prefix + "last_day_of_month"});
+  registerFunction<LastDayOfMonthFunction, Date, TimestampWithTimezone>(
+      {prefix + "last_day_of_month"});
   registerFunction<MinuteFunction, int64_t, Timestamp>({prefix + "minute"});
   registerFunction<MinuteFunction, int64_t, Date>({prefix + "minute"});
   registerFunction<MinuteFunction, int64_t, TimestampWithTimezone>(

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3609,27 +3609,23 @@ TEST_F(DateTimeFunctionsTest, lastDayOfMonthDate) {
     return lastDayFunc(DATE()->toDays(dateStr));
   };
 
-  const auto parseDateStr = [&](const StringView& dateStr) {
-    return DATE()->toDays(dateStr);
-  };
-
   EXPECT_EQ(std::nullopt, lastDayFunc(std::nullopt));
-  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01"));
-  EXPECT_EQ(parseDateStr("2008-02-29"), lastDay("2008-02-01"));
-  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01"));
-  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01"));
-  EXPECT_EQ(parseDateStr("2023-03-31"), lastDay("2023-03-11"));
-  EXPECT_EQ(parseDateStr("2023-04-30"), lastDay("2023-04-21"));
-  EXPECT_EQ(parseDateStr("2023-05-31"), lastDay("2023-05-09"));
-  EXPECT_EQ(parseDateStr("2023-06-30"), lastDay("2023-06-01"));
-  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-31"));
-  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-31"));
-  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-11"));
-  EXPECT_EQ(parseDateStr("2023-08-31"), lastDay("2023-08-01"));
-  EXPECT_EQ(parseDateStr("2023-09-30"), lastDay("2023-09-09"));
-  EXPECT_EQ(parseDateStr("2023-10-31"), lastDay("2023-10-01"));
-  EXPECT_EQ(parseDateStr("2023-11-30"), lastDay("2023-11-11"));
-  EXPECT_EQ(parseDateStr("2023-12-31"), lastDay("2023-12-12"));
+  EXPECT_EQ(parseDate("1970-01-31"), lastDay("1970-01-01"));
+  EXPECT_EQ(parseDate("2008-02-29"), lastDay("2008-02-01"));
+  EXPECT_EQ(parseDate("2023-02-28"), lastDay("2023-02-01"));
+  EXPECT_EQ(parseDate("2023-02-28"), lastDay("2023-02-01"));
+  EXPECT_EQ(parseDate("2023-03-31"), lastDay("2023-03-11"));
+  EXPECT_EQ(parseDate("2023-04-30"), lastDay("2023-04-21"));
+  EXPECT_EQ(parseDate("2023-05-31"), lastDay("2023-05-09"));
+  EXPECT_EQ(parseDate("2023-06-30"), lastDay("2023-06-01"));
+  EXPECT_EQ(parseDate("2023-07-31"), lastDay("2023-07-31"));
+  EXPECT_EQ(parseDate("2023-07-31"), lastDay("2023-07-31"));
+  EXPECT_EQ(parseDate("2023-07-31"), lastDay("2023-07-11"));
+  EXPECT_EQ(parseDate("2023-08-31"), lastDay("2023-08-01"));
+  EXPECT_EQ(parseDate("2023-09-30"), lastDay("2023-09-09"));
+  EXPECT_EQ(parseDate("2023-10-31"), lastDay("2023-10-01"));
+  EXPECT_EQ(parseDate("2023-11-30"), lastDay("2023-11-11"));
+  EXPECT_EQ(parseDate("2023-12-31"), lastDay("2023-12-12"));
 }
 
 TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestamp) {
@@ -3641,40 +3637,32 @@ TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestamp) {
     return lastDayFunc(util::fromTimestampString(dateStr));
   };
 
-  const auto parseDateStr = [&](const StringView& dateStr) {
-    return DATE()->toDays(dateStr);
-  };
-
   setQueryTimeZone("Pacific/Apia");
 
   EXPECT_EQ(std::nullopt, lastDayFunc(std::nullopt));
-  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01 20:23:00.007"));
-  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01 12:00:00.001"));
-  EXPECT_EQ(parseDateStr("2008-02-29"), lastDay("2008-02-01 12:00:00"));
-  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01 23:59:59.999"));
-  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01 12:00:00"));
-  EXPECT_EQ(parseDateStr("2023-03-31"), lastDay("2023-03-11 12:00:00"));
+  EXPECT_EQ(parseDate("1970-01-31"), lastDay("1970-01-01 20:23:00.007"));
+  EXPECT_EQ(parseDate("1970-01-31"), lastDay("1970-01-01 12:00:00.001"));
+  EXPECT_EQ(parseDate("2008-02-29"), lastDay("2008-02-01 12:00:00"));
+  EXPECT_EQ(parseDate("2023-02-28"), lastDay("2023-02-01 23:59:59.999"));
+  EXPECT_EQ(parseDate("2023-02-28"), lastDay("2023-02-01 12:00:00"));
+  EXPECT_EQ(parseDate("2023-03-31"), lastDay("2023-03-11 12:00:00"));
 }
 
 TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestampWithTimezone) {
-  const auto parseDateStr = [&](const StringView& dateStr) {
-    return DATE()->toDays(dateStr);
-  };
-
   EXPECT_EQ(
-      parseDateStr("1970-01-31"),
+      parseDate("1970-01-31"),
       evaluateWithTimestampWithTimezone<int32_t>(
           "last_day_of_month(c0)", 0, "+00:00"));
   EXPECT_EQ(
-      parseDateStr("1969-12-31"),
+      parseDate("1969-12-31"),
       evaluateWithTimestampWithTimezone<int32_t>(
           "last_day_of_month(c0)", 0, "-02:00"));
   EXPECT_EQ(
-      parseDateStr("2008-02-29"),
+      parseDate("2008-02-29"),
       evaluateWithTimestampWithTimezone<int32_t>(
           "last_day_of_month(c0)", 1201881600000, "+02:00"));
   EXPECT_EQ(
-      parseDateStr("2008-01-31"),
+      parseDate("2008-01-31"),
       evaluateWithTimestampWithTimezone<int32_t>(
           "last_day_of_month(c0)", 1201795200000, "-02:00"));
 }

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3629,7 +3629,7 @@ TEST_F(DateTimeFunctionsTest, lastDayOfMonthDate) {
 }
 
 TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestamp) {
-  const auto lastDayFunc = [&](const std::optional<Timestamp> date) {
+  const auto lastDayFunc = [&](const std::optional<Timestamp>& date) {
     return evaluateOnce<int32_t>("last_day_of_month(c0)", date);
   };
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -3598,3 +3598,83 @@ TEST_F(DateTimeFunctionsTest, castDateToTimestamp) {
       Timestamp(-18297 * kSecondsInDay, 0),
       castDateToTimestamp(DATE()->toDays("1919-11-28")));
 }
+
+TEST_F(DateTimeFunctionsTest, lastDayOfMonthDate) {
+  const auto lastDayFunc = [&](const std::optional<int32_t> date) {
+    return evaluateOnce<int32_t, int32_t>(
+        "last_day_of_month(c0)", {date}, {DATE()});
+  };
+
+  const auto lastDay = [&](const StringView& dateStr) {
+    return lastDayFunc(DATE()->toDays(dateStr));
+  };
+
+  const auto parseDateStr = [&](const StringView& dateStr) {
+    return DATE()->toDays(dateStr);
+  };
+
+  EXPECT_EQ(std::nullopt, lastDayFunc(std::nullopt));
+  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01"));
+  EXPECT_EQ(parseDateStr("2008-02-29"), lastDay("2008-02-01"));
+  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01"));
+  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01"));
+  EXPECT_EQ(parseDateStr("2023-03-31"), lastDay("2023-03-11"));
+  EXPECT_EQ(parseDateStr("2023-04-30"), lastDay("2023-04-21"));
+  EXPECT_EQ(parseDateStr("2023-05-31"), lastDay("2023-05-09"));
+  EXPECT_EQ(parseDateStr("2023-06-30"), lastDay("2023-06-01"));
+  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-31"));
+  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-31"));
+  EXPECT_EQ(parseDateStr("2023-07-31"), lastDay("2023-07-11"));
+  EXPECT_EQ(parseDateStr("2023-08-31"), lastDay("2023-08-01"));
+  EXPECT_EQ(parseDateStr("2023-09-30"), lastDay("2023-09-09"));
+  EXPECT_EQ(parseDateStr("2023-10-31"), lastDay("2023-10-01"));
+  EXPECT_EQ(parseDateStr("2023-11-30"), lastDay("2023-11-11"));
+  EXPECT_EQ(parseDateStr("2023-12-31"), lastDay("2023-12-12"));
+}
+
+TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestamp) {
+  const auto lastDayFunc = [&](const std::optional<Timestamp> date) {
+    return evaluateOnce<int32_t>("last_day_of_month(c0)", date);
+  };
+
+  const auto lastDay = [&](const StringView& dateStr) {
+    return lastDayFunc(util::fromTimestampString(dateStr));
+  };
+
+  const auto parseDateStr = [&](const StringView& dateStr) {
+    return DATE()->toDays(dateStr);
+  };
+
+  setQueryTimeZone("Pacific/Apia");
+
+  EXPECT_EQ(std::nullopt, lastDayFunc(std::nullopt));
+  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01 20:23:00.007"));
+  EXPECT_EQ(parseDateStr("1970-01-31"), lastDay("1970-01-01 12:00:00.001"));
+  EXPECT_EQ(parseDateStr("2008-02-29"), lastDay("2008-02-01 12:00:00"));
+  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01 23:59:59.999"));
+  EXPECT_EQ(parseDateStr("2023-02-28"), lastDay("2023-02-01 12:00:00"));
+  EXPECT_EQ(parseDateStr("2023-03-31"), lastDay("2023-03-11 12:00:00"));
+}
+
+TEST_F(DateTimeFunctionsTest, lastDayOfMonthTimestampWithTimezone) {
+  const auto parseDateStr = [&](const StringView& dateStr) {
+    return DATE()->toDays(dateStr);
+  };
+
+  EXPECT_EQ(
+      parseDateStr("1970-01-31"),
+      evaluateWithTimestampWithTimezone<int32_t>(
+          "last_day_of_month(c0)", 0, "+00:00"));
+  EXPECT_EQ(
+      parseDateStr("1969-12-31"),
+      evaluateWithTimestampWithTimezone<int32_t>(
+          "last_day_of_month(c0)", 0, "-02:00"));
+  EXPECT_EQ(
+      parseDateStr("2008-02-29"),
+      evaluateWithTimestampWithTimezone<int32_t>(
+          "last_day_of_month(c0)", 1201881600000, "+02:00"));
+  EXPECT_EQ(
+      parseDateStr("2008-01-31"),
+      evaluateWithTimestampWithTimezone<int32_t>(
+          "last_day_of_month(c0)", 1201795200000, "-02:00"));
+}

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -517,6 +517,13 @@ bool isValidDayOfYear(int32_t year, int32_t dayOfYear) {
   return true;
 }
 
+int64_t lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime) {
+  auto year = dateTime.tm_year + 1900;
+  auto month = dateTime.tm_mon + 1;
+  auto day = util::getMaxDayOfMonth(year, month);
+  return util::daysSinceEpochFromDate(year, month, day);
+}
+
 int32_t getMaxDayOfMonth(int32_t year, int32_t month) {
   return isLeapYear(year) ? kLeapDays[month] : kNormalDays[month];
 }

--- a/velox/type/TimestampConversion.h
+++ b/velox/type/TimestampConversion.h
@@ -55,6 +55,9 @@ bool isValidDayOfYear(int32_t year, int32_t dayOfYear);
 // Returns max day of month for inputted month of inputted year
 int32_t getMaxDayOfMonth(int32_t year, int32_t month);
 
+// Returns last day of month since unix epoch (1970-01-01).
+int64_t lastDayOfMonthSinceEpochFromDate(const std::tm& dateTime);
+
 /// Date conversions.
 
 /// Returns the (signed) number of days since unix epoch (1970-01-01).


### PR DESCRIPTION
last_day_of_month(x) → date[#](https://prestodb.io/docs/current/functions/datetime.html?highlight=last_day_of_month#last_day_of_month)
Returns the last day of the month.