### PR TITLE
Make sure value hook is empty in timestamp column reader

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -106,6 +106,7 @@ void SelectiveTimestampColumnReader::read(
     const uint64_t* incomingNulls) {
   prepareRead<int64_t>(offset, rows, incomingNulls);
   VELOX_CHECK(!scanSpec_->filter());
+  VELOX_CHECK(!scanSpec_->valueHook());
   bool isDense = rows.back() == rows.size() - 1;
   if (isDense) {
     readHelper<true>(rows);


### PR DESCRIPTION
Summary: Block incorrect results caused by: https://github.com/facebookincubator/velox/issues/6297

Differential Revision: D48743985

