### PR TITLE
Fix error of different row field names among Coalesce and Switch arguments

### DIFF
--- a/velox/core/Expressions.h
+++ b/velox/core/Expressions.h
@@ -209,6 +209,9 @@ class CallTypedExpr : public ITypedExpr {
     if (casted->name() != this->name()) {
       return false;
     }
+    if (*casted->type() != *this->type()) {
+      return false;
+    }
     return std::equal(
         this->inputs().begin(),
         this->inputs().end(),
@@ -303,6 +306,9 @@ class FieldAccessTypedExpr : public ITypedExpr {
     if (casted->name_ != this->name_) {
       return false;
     }
+    if (*casted->type() != *this->type()) {
+      return false;
+    }
     return std::equal(
         this->inputs().begin(),
         this->inputs().end(),
@@ -366,6 +372,9 @@ class ConcatTypedExpr : public ITypedExpr {
   bool operator==(const ITypedExpr& other) const override {
     const auto* casted = dynamic_cast<const ConcatTypedExpr*>(&other);
     if (!casted) {
+      return false;
+    }
+    if (*casted->type() != *this->type()) {
       return false;
     }
     return std::equal(
@@ -436,6 +445,9 @@ class LambdaTypedExpr : public ITypedExpr {
   bool operator==(const ITypedExpr& other) const override {
     const auto* casted = dynamic_cast<const LambdaTypedExpr*>(&other);
     if (!casted) {
+      return false;
+    }
+    if (*casted->type() != *this->type()) {
       return false;
     }
     return *signature_ == *casted->signature_ && *body_ == *casted->body_;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -76,13 +76,20 @@ class ExprTest : public testing::Test, public VectorTestBase {
     return parsed;
   }
 
+  // T can be ExprSet or ExprSetSimplified.
+  template <typename T = exec::ExprSet>
+  std::unique_ptr<T> compileExpression(const core::TypedExprPtr& expr) {
+    std::vector<core::TypedExprPtr> expressions = {expr};
+    return std::make_unique<T>(std::move(expressions), execCtx_.get());
+  }
+
+  // T can be ExprSet or ExprSetSimplified.
   template <typename T = exec::ExprSet>
   std::unique_ptr<T> compileExpression(
       const std::string& expr,
       const RowTypePtr& rowType) {
-    std::vector<core::TypedExprPtr> expressions = {
-        parseExpression(expr, rowType)};
-    return std::make_unique<T>(std::move(expressions), execCtx_.get());
+    auto parsedExpression = parseExpression(expr, rowType);
+    return compileExpression<T>(parsedExpression);
   }
 
   std::unique_ptr<exec::ExprSet> compileMultiple(
@@ -4209,6 +4216,89 @@ TEST_F(ExprTest, coalesceRowInputTypesAreTheSame) {
           "Coalesce expression type different than its inputs. Expected ROW<f1:BOOLEAN> but got Actual ROW<c0:BOOLEAN>.",
           e.message());
     }
+  }
+
+  {
+    // Check that operator==() of CallTypedExpr, FieldAccessTypedExpr,
+    // ConcatTypedExpr, and LambdaTypedExpr returns false when result types are
+    // different.
+    auto call1 = std::make_shared<const core::CallTypedExpr>(
+        ROW({"row_field0"}, {BIGINT()}),
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(BIGINT(), "c0")},
+        "foo");
+    auto call2 = std::make_shared<const core::CallTypedExpr>(
+        ROW({""}, {BIGINT()}),
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(BIGINT(), "c0")},
+        "foo");
+    ASSERT_FALSE(*call1 == *call2);
+
+    auto fieldAccess1 = std::make_shared<const core::FieldAccessTypedExpr>(
+        ROW({"row_field0"}, {BIGINT()}), "c0");
+    auto fieldAccess2 = std::make_shared<const core::FieldAccessTypedExpr>(
+        ROW({""}, {BIGINT()}), "c0");
+    ASSERT_FALSE(*fieldAccess1 == *fieldAccess2);
+
+    auto concat1 = std::make_shared<const core::ConcatTypedExpr>(
+        std::vector<std::string>{"row_field0"},
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(
+                BIGINT(), "c0")});
+    auto concat2 = std::make_shared<const core::ConcatTypedExpr>(
+        std::vector<std::string>{""},
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(
+                BIGINT(), "c0")});
+    ASSERT_FALSE(*concat1 == *concat2);
+
+    auto lambda1 = std::make_shared<const core::LambdaTypedExpr>(
+        ROW({"c0"}, {BIGINT()}), call1);
+    auto lambda2 = std::make_shared<const core::LambdaTypedExpr>(
+        ROW({"c0"}, {BIGINT()}), call2);
+    ASSERT_FALSE(*lambda1 == *lambda2);
+  }
+
+  {
+    // cast(concat(c0) as row(row_field0)).row_field0 + coalesce(c1,
+    // concat(c0)).row_field0. The result type of the first concat is
+    // Row<"":bigint> while the result type of the second concat is
+    // Row<"row_field0":bigint>. This is a valid expression, so the expression
+    // compilation should not throw in this situation.
+    core::TypedExprPtr concat = std::make_shared<const core::ConcatTypedExpr>(
+        std::vector<std::string>{"row_field0"},
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(
+                BIGINT(), "c0")});
+    core::TypedExprPtr coalesce = std::make_shared<const core::CallTypedExpr>(
+        ROW({"row_field0"}, {BIGINT()}),
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(
+                ROW({"row_field0"}, {BIGINT()}), "c1"),
+            concat},
+        "coalesce");
+    core::TypedExprPtr dereference =
+        std::make_shared<const core::FieldAccessTypedExpr>(
+            BIGINT(), coalesce, "row_field0");
+    core::TypedExprPtr concat2 = std::make_shared<const core::ConcatTypedExpr>(
+        std::vector<std::string>{""},
+        std::vector<core::TypedExprPtr>{
+            std::make_shared<const core::FieldAccessTypedExpr>(
+                BIGINT(), "c0")});
+    ASSERT_FALSE(*concat == *concat2);
+    core::TypedExprPtr cast = std::make_shared<const core::CallTypedExpr>(
+        ROW({"row_field0"}, {BIGINT()}),
+        std::vector<core::TypedExprPtr>{concat2},
+        "cast");
+    core::TypedExprPtr dereference2 =
+        std::make_shared<const core::FieldAccessTypedExpr>(
+            BIGINT(), cast, "row_field0");
+    core::TypedExprPtr plus = std::make_shared<const core::CallTypedExpr>(
+        BIGINT(),
+        std::vector<core::TypedExprPtr>{dereference2, dereference},
+        "plus");
+
+    ASSERT_NO_THROW(compileExpression(plus));
   }
 }
 } // namespace


### PR DESCRIPTION
Summary:
When an expression has two sub-expressions returning RowTypes that are the same except the field names in their result types, ExprCompiler consider them to be common sub-expression because CallTypedExpr::operator== and ConcatTypedExpr::operator== do not compare the result types. ExprCompiler then makes both sub-expressions point to the the same ExprPtr whose field name matches only one of the sub-expression. This can cause violation of the argument type checks in CoalesceExpr and SwitchExpr that expects all arguments to have the same type including the Row field names. This diff fixes this problem by making CallTypedExpr::operator== and ConcatTypedExpr::operator== compare the result type.

This diff fixes https://github.com/facebookincubator/velox/issues/6219 and https://github.com/facebookincubator/velox/issues/6230.

Differential Revision: D48748002

