### PR TITLE
Add logic operators to MemoryArbitrator::Stats

### DIFF
--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -170,9 +170,31 @@ class MemoryArbitrator {
     /// The free memory capacity in bytes.
     uint64_t freeCapacityBytes{0};
 
+    Stats(
+        uint64_t _numRequests,
+        uint64_t _numAborted,
+        uint64_t _numFailures,
+        uint64_t _queueTimeUs,
+        uint64_t _arbitrationTimeUs,
+        uint64_t _numShrunkBytes,
+        uint64_t _numReclaimedBytes,
+        uint64_t _maxCapacityBytes,
+        uint64_t _freeCapacityBytes);
+
+    Stats() = default;
+
+    Stats operator-(const Stats& other) const;
+    bool operator==(const Stats& other) const;
+    bool operator!=(const Stats& other) const;
+    bool operator<(const Stats& other) const;
+    bool operator>(const Stats& other) const;
+    bool operator>=(const Stats& other) const;
+    bool operator<=(const Stats& other) const;
+
     /// Returns the debug string of this stats.
     std::string toString() const;
   };
+
   virtual Stats stats() const = 0;
 
   /// Returns the debug string of this memory arbitrator.
@@ -188,6 +210,12 @@ class MemoryArbitrator {
   const uint64_t memoryPoolInitCapacity_;
   const uint64_t memoryPoolTransferCapacity_;
 };
+
+FOLLY_ALWAYS_INLINE std::ostream& operator<<(
+    std::ostream& o,
+    const MemoryArbitrator::Stats& stats) {
+  return o << stats.toString();
+}
 
 /// The memory reclaimer interface is used by memory pool to participate in
 /// the memory arbitration execution (enter/leave arbitration process) as well

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -117,6 +117,35 @@ TEST_F(MemoryArbitrationTest, queryMemoryCapacity) {
   }
 }
 
+TEST_F(MemoryArbitrationTest, arbitratorStats) {
+  MemoryArbitrator::Stats anchorStats(5, 5, 5, 5, 5, 5, 5, 5, 5);
+  MemoryArbitrator::Stats largeStats(8, 8, 8, 8, 8, 8, 8, 8, 8);
+  ASSERT_TRUE(!(anchorStats == largeStats));
+  ASSERT_TRUE(anchorStats != largeStats);
+  ASSERT_TRUE(anchorStats < largeStats);
+  ASSERT_TRUE(!(anchorStats > largeStats));
+  ASSERT_TRUE(anchorStats <= largeStats);
+  ASSERT_TRUE(!(anchorStats >= largeStats));
+  auto delta = largeStats - anchorStats;
+  ASSERT_EQ(delta, MemoryArbitrator::Stats(3, 3, 3, 3, 3, 3, 3, 8, 8));
+
+  MemoryArbitrator::Stats smallStats(2, 2, 2, 2, 2, 2, 2, 2, 2);
+  ASSERT_TRUE(!(anchorStats == smallStats));
+  ASSERT_TRUE(anchorStats != smallStats);
+  ASSERT_TRUE(!(anchorStats < smallStats));
+  ASSERT_TRUE(anchorStats > smallStats);
+  ASSERT_TRUE(!(anchorStats <= smallStats));
+  ASSERT_TRUE(anchorStats >= smallStats);
+
+  MemoryArbitrator::Stats invalidStats(2, 2, 2, 2, 2, 8, 8, 8, 8);
+  ASSERT_TRUE(!(anchorStats == invalidStats));
+  ASSERT_TRUE(anchorStats != invalidStats);
+  ASSERT_THROW(anchorStats < invalidStats, VeloxException);
+  ASSERT_THROW(anchorStats > invalidStats, VeloxException);
+  ASSERT_THROW(anchorStats <= invalidStats, VeloxException);
+  ASSERT_THROW(anchorStats >= invalidStats, VeloxException);
+}
+
 namespace {
 class FakeTestArbitrator : public MemoryArbitrator {
  public:


### PR DESCRIPTION
The logic operators will be used for metrics maintaining and exporting in Presto native.