### PR TITLE
compare function return types when sorting signatures

### DIFF
--- a/velox/expression/tests/FuzzerToolkit.cpp
+++ b/velox/expression/tests/FuzzerToolkit.cpp
@@ -49,6 +49,8 @@ void sortCallableSignatures(std::vector<CallableSignature>& signatures) {
                 return lhs.args[i]->toString() < rhs.args[i]->toString();
               }
             }
+
+            return lhs.returnType->toString() < rhs.returnType->toString();
           }
           return lhs.args.size() < rhs.args.size();
         }


### PR DESCRIPTION
Summary:
Today, when we setup the ExpressionFuzzer we sort the list of signatures.  Currently we do this by
comparing the names, the number of arguments, and the argument types.

Unfortunately, cast throws and wrench in the works, and while this would normally be sufficient, we can have
two cast calls where all of these are equal, but the signatures have different return types.  (Oddly there's a
comment above in the code saying that the return types will be compared even though they aren't).

I tracked down an issue reproducing a failure using a given seed to this.

Differential Revision: D48762001

