### PR TITLE
Minor refactor for Registry class

### DIFF
--- a/velox/common/serialization/tests/CMakeLists.txt
+++ b/velox/common/serialization/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_serialization_test TestRegistry.cpp SerializableTest.cpp)
+add_executable(velox_serialization_test RegistryTest.cpp SerializableTest.cpp)
 add_test(velox_serialization_test velox_serialization_test)
 
 target_link_libraries(

--- a/velox/common/serialization/tests/RegistryTest.cpp
+++ b/velox/common/serialization/tests/RegistryTest.cpp
@@ -18,9 +18,8 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/serialization/Registry.h"
 
-using namespace ::facebook::velox;
+namespace facebook::velox {
 
-namespace {
 TEST(Registry, SmartPointerFactoryWithNoArgument) {
   Registry<size_t, std::unique_ptr<size_t>()> registry;
 
@@ -51,4 +50,5 @@ TEST(Registry, ValueFactoryWithArguments) {
   EXPECT_TRUE(registry.Has(key));
   EXPECT_EQ(registry.Create(key, 1, 1), 2);
 }
-} // namespace
+
+} // namespace facebook::velox


### PR DESCRIPTION
1. Fixed typo: `registerutex_`->`registerMutex_`;
2. Use nested namespace definition;
3. Following clang-tidy's suggestion, mark the deleted member function 
   as `public` to get a better error message.
4. Add `explicit` to single-argument constructor.
5. Replace old-style comments.