### PR TITLE
Fix NestedLoopJoinProbe operator finishing before handing mismatch data to the last prober.

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -75,6 +75,13 @@ BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {
       [[fallthrough]];
     case ProbeOperatorState::kFinish:
       return BlockingReason::kNotBlocked;
+    case ProbeOperatorState::kWaitForPeers:
+      if (future_.valid()) {
+        *future = std::move(future_);
+        return BlockingReason::kWaitForJoinProbe;
+      }
+      setState(ProbeOperatorState::kFinish);
+      return BlockingReason::kNotBlocked;
     case ProbeOperatorState::kWaitForBuild: {
       VELOX_CHECK(!buildVectors_.has_value());
       if (!getBuildData(future)) {
@@ -120,7 +127,8 @@ void NestedLoopJoinProbe::addInput(RowVectorPtr input) {
 }
 
 RowVectorPtr NestedLoopJoinProbe::getOutput() {
-  if (isFinished()) {
+  if (state_ == ProbeOperatorState::kFinish ||
+      state_ == ProbeOperatorState::kWaitForPeers) {
     return nullptr;
   }
   RowVectorPtr output{nullptr};
@@ -278,13 +286,13 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
   std::vector<ContinuePromise> promises;
   std::vector<std::shared_ptr<Driver>> peers;
   if (!operatorCtx_->task()->allPeersFinished(
-          planNodeId(), operatorCtx_->driver(), nullptr, promises, peers)) {
-    setState(ProbeOperatorState::kFinish);
+          planNodeId(), operatorCtx_->driver(), &future_, promises, peers)) {
+    VELOX_CHECK(future_.valid());
+    setState(ProbeOperatorState::kWaitForPeers);
     return;
   }
 
   lastProbe_ = true;
-  VELOX_CHECK(promises.empty());
   // From now on, buildIndex_ is used to indexing into buildMismatched_
   VELOX_CHECK_EQ(buildIndex_, 0);
   for (auto& peer : peers) {
@@ -298,6 +306,9 @@ void NestedLoopJoinProbe::beginBuildMismatch() {
   peers.clear();
   for (auto& matched : buildMatched_) {
     matched.updateBounds();
+  }
+  for (auto& promise : promises) {
+    promise.setValue();
   }
 }
 

--- a/velox/exec/ProbeOperatorState.h
+++ b/velox/exec/ProbeOperatorState.h
@@ -36,11 +36,17 @@ enum class ProbeOperatorState {
   kWaitForBuild = 0,
   /// The running state that join the probe input with the build table.
   kRunning = 1,
-  /// Wait for all the peer probe operators to finish processing inputs. This
-  /// state only applies when disk spilling is enabled. The last finished
-  /// operator will notify the build operators to build the next hash table from
-  /// the spilled data. Then all the peer probe operators will wait for the next
-  /// hash table to build.
+  /// This state has different meaning in hash / nested loop join probe.
+  /// For hash probe: Wait for all the peer probe operators to finish processing
+  /// inputs.
+  /// This state only applies when disk spilling is enabled. The last finished
+  /// operator will notify the build operators to build the next hash table
+  /// from the spilled data. Then all the peer probe operators will wait for
+  /// the next hash table to build.
+  /// For nested loop join probe: When doing right/full join, after the
+  /// completion of emitting matching and probe-side mismatching data, non-last
+  /// operators wait for the last probe operator to take over build-side
+  /// mismatching data.
   kWaitForPeers = 2,
   /// The finishing state.
   kFinish = 3,

--- a/velox/exec/ProbeOperatorState.h
+++ b/velox/exec/ProbeOperatorState.h
@@ -36,14 +36,14 @@ enum class ProbeOperatorState {
   kWaitForBuild = 0,
   /// The running state that join the probe input with the build table.
   kRunning = 1,
-  /// This state has different meaning in hash / nested loop join probe.
-  /// For hash probe: Wait for all the peer probe operators to finish processing
+  /// This state has different handlings for hash and nested loop join probe.
+  /// For hash probe, wait for all the peer probe operators to finish processing
   /// inputs.
   /// This state only applies when disk spilling is enabled. The last finished
   /// operator will notify the build operators to build the next hash table
   /// from the spilled data. Then all the peer probe operators will wait for
   /// the next hash table to build.
-  /// For nested loop join probe: When doing right/full join, after the
+  /// For nested loop join probe, when doing right/full join, after the
   /// completion of emitting matching and probe-side mismatching data, non-last
   /// operators wait for the last probe operator to take over build-side
   /// mismatching data.

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -24,23 +24,6 @@ using namespace facebook::velox::exec::test;
 
 class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
-  const std::string probeKeyName_{"t0"};
-  const std::string buildKeyName_{"u0"};
-  RowTypePtr probeType_{ROW({{probeKeyName_, BIGINT()}})};
-  RowTypePtr buildType_{ROW({{buildKeyName_, BIGINT()}})};
-  std::vector<std::string> comparisons_{"=", "<", "<=", "<>"};
-  std::vector<core::JoinType> joinTypes_{
-      core::JoinType::kInner,
-      core::JoinType::kLeft,
-      core::JoinType::kRight,
-      core::JoinType::kFull};
-  std::vector<std::string> outputLayout_{probeKeyName_, buildKeyName_};
-  std::string joinConditionStr_{probeKeyName_ + " {} " + buildKeyName_};
-  std::string queryStr_{fmt::format(
-      "SELECT {0}, {1} FROM t {{}} JOIN u ON t.{0} {{}} u.{1}",
-      probeKeyName_,
-      buildKeyName_)};
-
   void setProbeType(const RowTypePtr& probeType) {
     probeType_ = probeType;
   }
@@ -128,6 +111,24 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
       }
     }
   }
+
+ protected:
+  const std::string probeKeyName_{"t0"};
+  const std::string buildKeyName_{"u0"};
+  RowTypePtr probeType_{ROW({{probeKeyName_, BIGINT()}})};
+  RowTypePtr buildType_{ROW({{buildKeyName_, BIGINT()}})};
+  std::vector<std::string> comparisons_{"=", "<", "<=", "<>"};
+  std::vector<core::JoinType> joinTypes_{
+      core::JoinType::kInner,
+      core::JoinType::kLeft,
+      core::JoinType::kRight,
+      core::JoinType::kFull};
+  std::vector<std::string> outputLayout_{probeKeyName_, buildKeyName_};
+  std::string joinConditionStr_{probeKeyName_ + " {} " + buildKeyName_};
+  std::string queryStr_{fmt::format(
+      "SELECT {0}, {1} FROM t {{}} JOIN u ON t.{0} {{}} u.{1}",
+      probeKeyName_,
+      buildKeyName_)};
 };
 
 TEST_F(NestedLoopJoinTest, basic) {

--- a/velox/exec/tests/NestedLoopJoinTest.cpp
+++ b/velox/exec/tests/NestedLoopJoinTest.cpp
@@ -24,26 +24,22 @@ using namespace facebook::velox::exec::test;
 
 class NestedLoopJoinTest : public HiveConnectorTestBase {
  protected:
-  RowTypePtr probeType_;
-  RowTypePtr buildType_;
-  std::vector<std::string> comparisons_;
-  std::vector<core::JoinType> joinTypes_;
-  std::string joinConditionStr_;
-  std::string queryStr_;
-
-  void SetUp() override {
-    HiveConnectorTestBase::SetUp();
-    probeType_ = ROW({{"t0", BIGINT()}});
-    buildType_ = ROW({{"u0", BIGINT()}});
-    comparisons_ = {"=", "<", "<=", "<>"};
-    joinTypes_ = {
-        core::JoinType::kInner,
-        core::JoinType::kLeft,
-        core::JoinType::kRight,
-        core::JoinType::kFull};
-    joinConditionStr_ = "t0 {} u0";
-    queryStr_ = "SELECT t0, u0 FROM t {} JOIN u ON t.t0 {} u.u0";
-  }
+  const std::string probeKeyName_{"t0"};
+  const std::string buildKeyName_{"u0"};
+  RowTypePtr probeType_{ROW({{probeKeyName_, BIGINT()}})};
+  RowTypePtr buildType_{ROW({{buildKeyName_, BIGINT()}})};
+  std::vector<std::string> comparisons_{"=", "<", "<=", "<>"};
+  std::vector<core::JoinType> joinTypes_{
+      core::JoinType::kInner,
+      core::JoinType::kLeft,
+      core::JoinType::kRight,
+      core::JoinType::kFull};
+  std::vector<std::string> outputLayout_{probeKeyName_, buildKeyName_};
+  std::string joinConditionStr_{probeKeyName_ + " {} " + buildKeyName_};
+  std::string queryStr_{fmt::format(
+      "SELECT {0}, {1} FROM t {{}} JOIN u ON t.{0} {{}} u.{1}",
+      probeKeyName_,
+      buildKeyName_)};
 
   void setProbeType(const RowTypePtr& probeType) {
     probeType_ = probeType;
@@ -57,12 +53,20 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
     comparisons_ = std::move(comparisons);
   }
 
+  void setOutputLayout(std::vector<std::string> outputLayout) {
+    outputLayout_ = std::move(outputLayout);
+  }
+
   void setJoinConditionStr(std::string joinConditionStr) {
     joinConditionStr_ = std::move(joinConditionStr);
   }
 
   void setQueryStr(std::string queryStr) {
     queryStr_ = std::move(queryStr);
+  }
+
+  void setJoinTypes(std::vector<core::JoinType> joinTypes) {
+    joinTypes_ = std::move(joinTypes);
   }
 
   template <typename T>
@@ -77,19 +81,19 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
         size, [start](auto row) { return start + row; });
   }
 
+  void runSingleAndMultiDriverTest(
+      const std::vector<RowVectorPtr>& probeVectors,
+      const std::vector<RowVectorPtr>& buildVectors) {
+    runTest(probeVectors, buildVectors, 1);
+    runTest(probeVectors, buildVectors, 4);
+  }
+
   void runTest(
       const std::vector<RowVectorPtr>& probeVectors,
       const std::vector<RowVectorPtr>& buildVectors,
-      int32_t numDrivers = 1) {
-    if (numDrivers == 1) {
-      createDuckDbTable("t", probeVectors);
-      createDuckDbTable("u", buildVectors);
-    } else {
-      auto allProbeVectors = makeCopies(probeVectors, numDrivers);
-      auto allBuildVectors = makeCopies(buildVectors, numDrivers);
-      createDuckDbTable("t", allProbeVectors);
-      createDuckDbTable("u", allBuildVectors);
-    }
+      int32_t numDrivers) {
+    createDuckDbTable("t", probeVectors);
+    createDuckDbTable("u", buildVectors);
 
     CursorParameters params;
     params.maxDrivers = numDrivers;
@@ -105,13 +109,15 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
 
         params.planNode =
             PlanBuilder(planNodeIdGenerator)
-                .values(probeVectors, numDrivers > 1)
+                .values(probeVectors)
+                .localPartition({probeKeyName_})
                 .nestedLoopJoin(
                     PlanBuilder(planNodeIdGenerator)
-                        .values(buildVectors, numDrivers > 1)
+                        .values(buildVectors)
+                        .localPartition({buildKeyName_})
                         .planNode(),
                     fmt::format(fmt::runtime(joinConditionStr_), comparison),
-                    {"t0", "u0"},
+                    outputLayout_,
                     joinType)
                 .planNode();
 
@@ -127,19 +133,19 @@ class NestedLoopJoinTest : public HiveConnectorTestBase {
 TEST_F(NestedLoopJoinTest, basic) {
   auto probeVectors = makeBatches(20, 5, probeType_, pool_.get());
   auto buildVectors = makeBatches(18, 5, buildType_, pool_.get());
-  runTest(probeVectors, buildVectors);
+  runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
 
 TEST_F(NestedLoopJoinTest, emptyProbe) {
   auto probeVectors = makeBatches(0, 5, probeType_, pool_.get());
   auto buildVectors = makeBatches(18, 5, buildType_, pool_.get());
-  runTest(probeVectors, buildVectors);
+  runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
 
 TEST_F(NestedLoopJoinTest, emptyBuild) {
   auto probeVectors = makeBatches(20, 5, probeType_, pool_.get());
   auto buildVectors = makeBatches(0, 5, buildType_, pool_.get());
-  runTest(probeVectors, buildVectors);
+  runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
 
 TEST_F(NestedLoopJoinTest, basicCrossJoin) {
@@ -373,30 +379,12 @@ TEST_F(NestedLoopJoinTest, zeroColumnBuild) {
   assertQuery(op, "SELECT * FROM t");
 }
 
-TEST_F(NestedLoopJoinTest, parallel) {
-  auto probeVectors = makeBatches(10, 5, probeType_, pool_.get());
-  auto buildVectors = makeBatches(7, 5, buildType_, pool_.get());
-  runTest(probeVectors, buildVectors, 5);
-}
-
 TEST_F(NestedLoopJoinTest, bigintArray) {
   auto probeVectors = makeBatches(1000, 5, probeType_, pool_.get());
   auto buildVectors = makeBatches(900, 5, buildType_, pool_.get());
-  createDuckDbTable("t", probeVectors);
-  createDuckDbTable("u", buildVectors);
-
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .values(probeVectors)
-          .nestedLoopJoin(
-              PlanBuilder(planNodeIdGenerator).values(buildVectors).planNode(),
-              "t0 = u0",
-              {"t0", "u0"},
-              core::JoinType::kFull)
-          .planNode();
-
-  assertQuery(plan, "SELECT t0, u0 FROM t FULL JOIN u ON t.t0 = u.u0");
+  setComparisons({"="});
+  setJoinTypes({core::JoinType::kFull});
+  runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }
 
 TEST_F(NestedLoopJoinTest, allTypes) {
@@ -430,5 +418,5 @@ TEST_F(NestedLoopJoinTest, allTypes) {
       "t0 {0} u0 AND t1 {0} u1 AND t2 {0} u2 AND t3 {0} u3 AND t4 {0} u4 AND t5 {0} u5 AND t6 {0} u6");
   setQueryStr(
       "SELECT t0, u0 FROM t {0} JOIN u ON t.t0 {1} u0 AND t1 {1} u1 AND t2 {1} u2 AND t3 {1} u3 AND t4 {1} u4 AND t5 {1} u5 AND t6 {1} u6");
-  runTest(probeVectors, buildVectors);
+  runSingleAndMultiDriverTest(probeVectors, buildVectors);
 }


### PR DESCRIPTION
Fixes #6223.

Currently non-last probe operators set state to finish when they complete emitting probe side mismatch data. This makes last probe operator unable to fetch build side mismatch data if the driver has destroyed them.
This fix makes non-last probe operators enter kWaitForPeers state when they complete emitting probe side mismatch data, which will block them until the last probe operator fetches the build side mismatch data and sets the promise, so they can finish.
Also in the nested loop join test, the `runTest` function, which is the fundamental for most of the test, has been upgraded to run both single and multi-driver setups, and is renamed to `runSingleAndMultiDriverTest`.