### PR TITLE
Add macro to add prefix for ssd cache logging to help debug

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -21,6 +21,7 @@
 #include <fmt/format.h>
 #include <folly/chrono/Hardware.h>
 #include <folly/futures/SharedPromise.h>
+#include "folly/GLog.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/common/base/CoalesceIo.h"
 #include "velox/common/base/Portability.h"
@@ -32,6 +33,11 @@
 #include "velox/common/memory/MemoryAllocator.h"
 
 namespace facebook::velox::cache {
+
+#define VELOX_CACHE_LOG_PREFIX "[CACHE] "
+#define VELOX_CACHE_LOG(severity) LOG(severity) << VELOX_CACHE_LOG_PREFIX
+#define VELOX_CACHE_LOG_EVERY_MS(severity, ms) \
+  FB_LOG_EVERY_MS(severity, ms) << VELOX_CACHE_LOG_PREFIX
 
 class AsyncDataCache;
 class CacheShard;

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -113,13 +113,14 @@ void SsdCache::write(std::vector<CachePin> pins) {
       } catch (const std::exception& e) {
         // Catch so as not to miss updating 'writesInProgress_'. Could
         // theoretically happen for std::bad_alloc or such.
-        LOG(INFO) << "Ignoring error in SsdFile::write: " << e.what();
+        VELOX_SSD_CACHE_LOG(WARNING)
+            << "Ignoring error in SsdFile::write: " << e.what();
       }
       if (--writesInProgress_ == 0) {
         // Typically occurs every few GB. Allows detecting unusually slow rates
         // from failing devices.
-        LOG(INFO) << fmt::format(
-            "SSDCA: Wrote {}MB, {} MB/s",
+        VELOX_SSD_CACHE_LOG(INFO) << fmt::format(
+            "Wrote {}MB, {} MB/s",
             bytes >> 20,
             static_cast<float>(bytes) / (getCurrentTimeMicro() - startTimeUs));
       }

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -20,6 +20,10 @@
 
 namespace facebook::velox::cache {
 
+#define VELOX_SSD_CACHE_LOG_PREFIX "[SSDCA] "
+#define VELOX_SSD_CACHE_LOG(severity) \
+  LOG(severity) << VELOX_SSD_CACHE_LOG_PREFIX
+
 class SsdCache {
  public:
   /// Constructs a cache with backing files at path 'filePrefix'.<ordinal>.

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -164,7 +164,7 @@ individual measures are sorted and de-duplicated.
    * - aggregateNames
      - Names for the output columns for the measures.
    * - aggregates
-     - One or more measures to compute. Each measure specifies an expression, e.g. count(1), sum(a), avg(b), optional boolean input column that's used to mask out rows for this particular measure, optional list of input columns to sort by before computing the measure, an optional flag to indicate that inputs must be de-deduplicated before computing the measure. Expressions must be in the form of aggregate function calls over input columns directly, e.g. sum(c) is ok, but sum(c + d) is not.
+     - One or more measures to compute. Each measure specifies an expression, e.g. count(1), sum(a), avg(b), optional boolean input column that's used to mask out rows for this particular measure, optional list of input columns to sort by before computing the measure, an optional flag to indicate that inputs must be deduplicated before computing the measure. Expressions must be in the form of aggregate function calls over input columns directly, e.g. sum(c) is ok, but sum(c + d) is not.
    * - ignoreNullKeys
      - A boolean flag indicating whether the aggregation should drop rows with nulls in any of the grouping keys. Used to avoid unnecessary processing for an aggregation followed by an inner join on the grouping keys.
 


### PR DESCRIPTION
Add VELOX_CACHE_LOG/VELOX_CACHE_LOG_EVERY_MS
with prefix "[CACHE] " for in-memory cache logging (AsyncDataCache)
Add VELOX_SSD_CACHE_LOG with prefix "[SSDCA] " for ssd cache
logging
Fix a typo in operator.rst
