### PR TITLE
Make VectorHasher analyze more optimally

### DIFF
--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -247,7 +247,7 @@ bool VectorHasher::makeValueIdsDecoded(
 
   bool success = true;
   int decodedBaseVisited = 0;
-  rows.testSelected([&](vector_size_t row) {
+  rows.testSelected([&](vector_size_t row) INLINE_LAMBDA {
     if constexpr (mayHaveNulls) {
       if (decoded_.isNullAt(row)) {
         if (multiplier_ == 1) {

--- a/velox/exec/VectorHasher.cpp
+++ b/velox/exec/VectorHasher.cpp
@@ -270,7 +270,9 @@ bool VectorHasher::makeValueIdsDecoded(
           success = false;
         }
       }
-      result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
+      if (success) {
+        result[row] = multiplier_ == 1 ? id : result[row] + multiplier_ * id;
+      }
     } else {
       if (id == 0) {
         id = kUnmappable;
@@ -279,8 +281,7 @@ bool VectorHasher::makeValueIdsDecoded(
       }
     }
 
-    bool shouldContinue = success || decodedBaseVisited < cachedHashes_.size();
-    return shouldContinue;
+    return success || decodedBaseVisited < cachedHashes_.size();
   });
 
   return success;

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -193,7 +193,7 @@ BENCHMARK(computeValueIdsLowCardinalityLargeBatchSize) {
   for (int i = 0; i < 10; i++) {
     raw_vector<uint64_t> hashes(batchSize);
     SelectivityVector rows(batchSize);
-    VectorHasher hasher(CppToType<int64_t>::create(), 0);
+    VectorHasher hasher(BIGINT(), 0);
     hasher.decode(*values, rows);
     suspender.dismiss();
 

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -213,16 +213,14 @@ BENCHMARK(computeValueIdsLowCardinalityNotAllUsed) {
   BenchmarkBase base;
 
   auto data = base.vectorMaker().flatVector<int64_t>(
-      cardinality, [](vector_size_t row) { return row; }, nullptr);
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(batchSize, base.pool_.get());
+      cardinality, [](vector_size_t row) { return row; });
+  BufferPtr indices = allocateIndices(batchSize, base.pool_.get());
   auto rawIndices = indices->asMutable<vector_size_t>();
   // Assign indices such that array is reversed.
   for (size_t i = 0; i < batchSize; ++i) {
     rawIndices[i] = i % (cardinality - 1);
   }
-  auto values = BaseVector::wrapInDictionary(
-      BufferPtr(nullptr), indices, batchSize, data);
+  auto values = BaseVector::wrapInDictionary(nullptr, indices, batchSize, data);
 
   for (int i = 0; i < 10; i++) {
     raw_vector<uint64_t> hashes(batchSize);


### PR DESCRIPTION
### Description

Currently, for computeValueIds, VectorHasher consumes the entire input, either successfully hashing all values, or if an unhashable value is encountered, VectorHasher will still consume the entirety of the rest of the input in "AnalyzeValue" mode. So that subsequently, a "workable" new hashmode can be picked and rehash.

In the "fail to hash, analyze the remaining values" code path, current implementation is not optimal. Because current implementation calls "AnalyzeValue" on all values of the input vector. The optimal algorithm would only analyze the remaining values of input until "all unique values" of the "inner-most"/"decoded.base()" have been visited.

In low cardinality large batchsize workloads, this results in Nx improvement where if cardinality = C, batchSize = B, N = B / C.

In all other cases, this optimization is no worse than current implementation.

Real life workload example:

Age (say 0 y/o to 80 y/o)column of some large population (say 20mil). Even using batchSize of 1024, this optimization would result in 12.8x (1024/80)speed-up of computeValueIds.

Benchmark result:

```
============================================================================
[...]/benchmarks/VectorHasherBenchmark.cpp     relative  time/iter   iters/s
============================================================================
computeValueIdsLowCardinalityLargeBatchSize                  9.90s   101.00m
computeValueIdsLowCardinalityLargeBatchSizeOpt 1.0028e+05%     9.87ms    101.28
computeValueIdsLowCardinalityNotAllUsed                      7.33s   136.34m
computeValueIdsLowCardinalityNotAllUsedOpt      858.03%   854.81ms      1.17
```


@mbasmanova @oerling 
