### PR TITLE
Lazy table writer init to avoid memory allocation on driver init

### DIFF
--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -125,7 +125,7 @@ class TableWriter : public Operator {
 
   void close() override {
     if (!closed_) {
-      if (dataSink_) {
+      if (dataSink_ != nullptr) {
         dataSink_->close();
       }
       closed_ = true;

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -1345,6 +1345,23 @@ TEST_P(AllTableWriterTest, constantVectors) {
   verifyTableWriterOutput(outputDirectory->path);
 }
 
+TEST_P(AllTableWriterTest, emptyInput) {
+  auto outputDirectory = TempDirectoryPath::create();
+  auto vector = makeConstantVector(0);
+  auto op = createInsertPlan(
+      PlanBuilder().values({vector}),
+      rowType_,
+      outputDirectory->path,
+      partitionedBy_,
+      bucketProperty_,
+      compressionKind_,
+      getNumWriters(),
+      connector::hive::LocationHandle::TableType::kNew,
+      commitStrategy_);
+
+  assertQuery(op, "SELECT 0");
+}
+
 TEST_P(AllTableWriterTest, commitStrategies) {
   auto filePaths = makeFilePaths(10);
   auto vectors = makeVectors(filePaths.size(), 1000);


### PR DESCRIPTION
Move table writer init on first add input to avoid memory allocation
on driver init such as triggers memory arbitration if possible