### PR TITLE
Fix StringBuffer re-use in PrestoSerializer

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -251,6 +251,12 @@ class EvalCtx {
       const VectorPtr& localResult,
       const SelectivityVector& rows,
       VectorPtr& result) const {
+#ifndef NDEBUG
+    if (localResult != nullptr) {
+      // Make sure local/temporary vectors have consistent state.
+      localResult->validate();
+    }
+#endif
     if (result && !isFinalSelection() && *finalSelection() != rows) {
       BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
       result->copy(localResult.get(), rows, nullptr);

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -344,6 +344,14 @@ bool isFlat(const BaseVector& vector) {
       encoding == VectorEncoding::Simple::CONSTANT);
 }
 
+inline void checkResultInternalState(VectorPtr& result) {
+#ifndef NDEBUG
+  if (result != nullptr) {
+    result->validate();
+  }
+#endif
+}
+
 } // namespace
 
 template <typename EvalArg>
@@ -763,6 +771,7 @@ void Expr::eval(
   if (supportsFlatNoNullsFastPath_ && context.throwOnError() &&
       context.inputFlatNoNulls() && rows.countSelected() < 1'000) {
     evalFlatNoNulls(rows, context, result, parentExprSet);
+    checkResultInternalState(result);
     return;
   }
 
@@ -775,6 +784,7 @@ void Expr::eval(
 
   if (!rows.hasSelections()) {
     checkOrSetEmptyResult(type(), context.pool(), result);
+    checkResultInternalState(result);
     return;
   }
 
@@ -818,10 +828,12 @@ void Expr::eval(
 
   if (inputs_.empty()) {
     evalAll(rows, context, result);
+    checkResultInternalState(result);
     return;
   }
 
   evalEncodings(rows, context, result);
+  checkResultInternalState(result);
 }
 
 template <typename TEval>

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -359,6 +359,9 @@ BufferPtr findOrAllocateStringBuffer(
     }
   }
   if (smallestBuffer) {
+    if (smallestBuffer->size() < size) {
+      smallestBuffer->setSize(size);
+    }
     return smallestBuffer;
   }
 

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -851,6 +851,16 @@ void BaseVector::prepareForReuse() {
   this->resetDataDependentFlags(nullptr);
 }
 
+void BaseVector::validate(const VectorValidateOptions& options) const {
+  if (nulls_ != nullptr) {
+    auto bytes = byteSize<bool>(size());
+    VELOX_CHECK_GE(nulls_->size(), bytes);
+  }
+  if (options.callback) {
+    options.callback(*this);
+  }
+}
+
 namespace {
 
 size_t typeSize(const Type& type) {

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -52,6 +52,17 @@ class VectorPool;
 class BaseVector;
 using VectorPtr = std::shared_ptr<BaseVector>;
 
+// Set of options that validate() accepts.
+struct VectorValidateOptions {
+  // If set to true then an unloaded lazy vector is loaded and validate is
+  // called on the loaded vector. NOTE: loading a vector is non-trivial and
+  // can modify how it's handled by downstream code-paths.
+  bool loadLazy = false;
+
+  // Any optional checks you want to execute on the vector.
+  std::function<void(const BaseVector&)> callback;
+};
+
 /**
  * Base class for all columnar-based vectors of any type.
  */
@@ -755,6 +766,11 @@ class BaseVector {
   void disableMemo() {
     memoDisabled_ = true;
   }
+
+  /// Used to check internal state of a vector like sizes of the buffers,
+  /// enclosed child vectors, values in indices. Currently, its only used in
+  /// debug builds to check the result of expressions and some interim results.
+  virtual void validate(const VectorValidateOptions& options = {}) const;
 
  protected:
   /// Returns a brief summary of the vector. The default implementation includes

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -192,6 +192,8 @@ class RowVector : public BaseVector {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;
@@ -317,6 +319,10 @@ struct ArrayVectorBase : BaseVector {
       VectorPtr* targetKeys,
       const BaseVector* sourceKeys);
 
+  void validateArrayVectorBase(
+      const VectorValidateOptions& options,
+      vector_size_t minChildVectorSize) const;
+
  private:
   BufferPtr
   ensureIndices(BufferPtr& buf, const vector_size_t*& raw, vector_size_t size) {
@@ -437,6 +443,8 @@ class ArrayVector : public ArrayVectorBase {
   }
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
+
+  void validate(const VectorValidateOptions& options) const override;
 
  private:
   VectorPtr elements_;
@@ -586,6 +594,8 @@ class MapVector : public ArrayVectorBase {
   }
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
+
+  void validate(const VectorValidateOptions& options) const override;
 
  protected:
   virtual void resetDataDependentFlags(const SelectivityVector* rows) override {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -318,6 +318,20 @@ class ConstantVector final : public SimpleVector<T> {
     return false;
   }
 
+  void validate(const VectorValidateOptions& options) const override {
+    // Do not call BaseVector's validate() since the nulls buffer has
+    // a fixed size for constant vectors.
+    if (options.callback) {
+      options.callback(*this);
+    }
+    if (valueVector_ != nullptr) {
+      if (!isNull_) {
+        VELOX_CHECK_LT(index_, valueVector_->size());
+      }
+      valueVector_->validate(options);
+    }
+  }
+
  protected:
   std::string toSummaryString() const override {
     std::stringstream out;

--- a/velox/vector/DictionaryVector-inl.h
+++ b/velox/vector/DictionaryVector-inl.h
@@ -29,26 +29,7 @@ void DictionaryVector<T>::setInternalState() {
   // Sanity check indices for non-null positions. Enabled in debug mode only to
   // avoid performance hit in production.
 #ifndef NDEBUG
-  for (auto i = 0; i < BaseVector::length_; ++i) {
-    const bool isNull =
-        BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
-    if (isNull) {
-      continue;
-    }
-
-    // Verify index for a non-null position. It must be >= 0 and < size of the
-    // base vector.
-    VELOX_DCHECK_GE(
-        rawIndices_[i],
-        0,
-        "Dictionary index must be greater than zero. Index: {}.",
-        i);
-    VELOX_DCHECK_LT(
-        rawIndices_[i],
-        dictionaryValues_->size(),
-        "Dictionary index must be less than base vector's size. Index: {}.",
-        i);
-  }
+  validate({});
 #endif
 
   if (isLazyNotLoaded(*dictionaryValues_)) {
@@ -203,6 +184,34 @@ VectorPtr DictionaryVector<T>::slice(vector_size_t offset, vector_size_t length)
       valueVector(),
       BaseVector::sliceBuffer(
           *INTEGER(), indices_, offset, length, this->pool_));
+}
+
+template <typename T>
+void DictionaryVector<T>::validate(const VectorValidateOptions& options) const {
+  SimpleVector<T>::validate(options);
+  auto indicesByteSize =
+      BaseVector::byteSize<vector_size_t>(BaseVector::length_);
+  VELOX_CHECK_GE(indices_->size(), indicesByteSize);
+  for (auto i = 0; i < BaseVector::length_; ++i) {
+    const bool isNull =
+        BaseVector::rawNulls_ && bits::isBitNull(BaseVector::rawNulls_, i);
+    if (isNull) {
+      continue;
+    }
+    // Verify index for a non-null position. It must be >= 0 and < size of the
+    // base vector.
+    VELOX_CHECK_GE(
+        rawIndices_[i],
+        0,
+        "Dictionary index must be greater than zero. Index: {}.",
+        i);
+    VELOX_CHECK_LT(
+        rawIndices_[i],
+        dictionaryValues_->size(),
+        "Dictionary index must be less than base vector's size. Index: {}.",
+        i);
+  }
+  dictionaryValues_->validate(options);
 }
 
 } // namespace velox

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -202,6 +202,8 @@ class DictionaryVector : public SimpleVector<T> {
 
   VectorPtr slice(vector_size_t offset, vector_size_t length) const override;
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   // return the dictionary index for the specified vector index.
   inline vector_size_t getDictionaryIndex(vector_size_t idx) const {

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -498,5 +498,42 @@ void FlatVector<StringView>::copyRanges(
   }
 }
 
+// For strings, we also verify if they point to valid memory locations inside
+// the string buffers.
+template <>
+void FlatVector<StringView>::validate(
+    const VectorValidateOptions& options) const {
+  SimpleVector<StringView>::validate(options);
+  auto byteSize = BaseVector::byteSize<StringView>(BaseVector::size());
+  if (byteSize == 0) {
+    return;
+  }
+  VELOX_CHECK_NOT_NULL(values_);
+  VELOX_CHECK_GE(values_->size(), byteSize);
+  auto rawValues = values_->as<StringView>();
+
+  for (auto i = 0; i < BaseVector::length_; ++i) {
+    if (isNullAt(i)) {
+      continue;
+    }
+    auto stringView = rawValues[i];
+    if (!stringView.isInline()) {
+      bool isValid = false;
+      for (const auto& buffer : stringBuffers_) {
+        auto start = buffer->as<char>();
+        if (stringView.data() >= start &&
+            stringView.data() < start + buffer->size()) {
+          isValid = true;
+          break;
+        }
+      }
+      VELOX_CHECK(
+          isValid,
+          "String view at idx {} points outside of the string buffers",
+          i)
+    }
+  }
+}
+
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/FlatVector.h
+++ b/velox/vector/FlatVector.h
@@ -430,6 +430,15 @@ class FlatVector final : public SimpleVector<T> {
   /// mutable. Resizes the buffer to zero to allow for reuse instead of append.
   void prepareForReuse() override;
 
+  void validate(const VectorValidateOptions& options) const override {
+    SimpleVector<T>::validate(options);
+    auto byteSize = BaseVector::byteSize<T>(BaseVector::size());
+    if (byteSize > 0) {
+      VELOX_CHECK_NOT_NULL(values_);
+      VELOX_CHECK_GE(values_->size(), byteSize);
+    }
+  }
+
  private:
   void copyValuesAndNulls(
       const BaseVector* source,
@@ -506,6 +515,10 @@ template <>
 void FlatVector<StringView>::copyRanges(
     const BaseVector* source,
     const folly::Range<const CopyRange*>& ranges);
+
+template <>
+void FlatVector<StringView>::validate(
+    const VectorValidateOptions& options) const;
 
 template <>
 void FlatVector<bool>::copyValuesAndNulls(

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -224,4 +224,12 @@ void LazyVector::ensureLoadedRows(
   ensureLoadedRowsImpl(vector, decoded, rows, baseRows);
 }
 
+void LazyVector::validate(const VectorValidateOptions& options) const {
+  if (isLoaded() || options.loadLazy) {
+    auto loadedVector = this->loadedVector();
+    VELOX_CHECK_NOT_NULL(loadedVector);
+    loadedVector->validate(options);
+  }
+}
+
 } // namespace facebook::velox

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -269,6 +269,8 @@ class LazyVector : public BaseVector {
       DecodedVector& decoded,
       SelectivityVector& baseRows);
 
+  void validate(const VectorValidateOptions& options) const override;
+
  private:
   static void ensureLoadedRowsImpl(
       VectorPtr& vector,


### PR DESCRIPTION
Summary:
When generating a string flatvector from a presto page, the presto
serializer looks for an existing stringBuffer in the FlatVector to
re-use for appending values. It does that by finding the smallest
available buffer that has enough 'capacity' to accommodate all the
values in the incoming presto page. However, currently it does not
update the 'size' the of buffer which it ends up re-using. This
results in all the newly appended stringView's pointing outside the
'size' but within the 'capacity' of the buffer. This patch fixes
this discrepancy.

Test Plan:
- Added Unit test.
- Passing presto e2e tests that failed prior to this change (when #5885 is included):
TestPrestoNativeJoinQueries>AbstractTestNativeJoinQueries.testLeftJoin
TestPrestoNativeJoinQueries>AbstractTestNativeJoinQueries.testAntiJoin
TestPrestoNativeJoinQueries>AbstractTestNativeJoinQueries.testSemiJoin
TestPrestoNativeTpchQueriesParquetUsingJSON>AbstractTestNativeTpchQueries.testTpchQ10
TestPrestoNativeTpchQueriesParquetUsingJSON>AbstractTestNativeTpchQueries.testTpchQ21

Differential Revision: D48800168

