### PR TITLE
Fix: CheckDuplicateKeys should not receive rows with null keys.

### DIFF
--- a/velox/functions/lib/CheckDuplicateKeys.cpp
+++ b/velox/functions/lib/CheckDuplicateKeys.cpp
@@ -32,6 +32,9 @@ void checkDuplicateKeys(
     auto offset = offsets[row];
     auto size = sizes[row];
     for (auto i = 1; i < size; i++) {
+      VELOX_DCHECK(
+          !mapKeys->isNullAt(offset + i - 1),
+          "checkDuplicateKeys should not receive null keys");
       if (mapKeys->equalValueAt(mapKeys.get(), offset + i, offset + i - 1)) {
         auto duplicateKey = mapKeys->wrappedVector()->toString(
             mapKeys->wrappedIndex(offset + i));

--- a/velox/functions/lib/CheckDuplicateKeys.h
+++ b/velox/functions/lib/CheckDuplicateKeys.h
@@ -21,7 +21,8 @@
 namespace facebook::velox::functions {
 
 /// Check map keys for duplicates. Mark rows with duplicate keys as 'failed' in
-/// the 'context'.
+/// the 'context'. Rows with null keys should not be passed to this function and
+/// should have been removed from rows.
 void checkDuplicateKeys(
     const MapVectorPtr& mapVector,
     const SelectivityVector& rows,

--- a/velox/functions/prestosql/MapFromEntries.cpp
+++ b/velox/functions/prestosql/MapFromEntries.cpp
@@ -84,6 +84,7 @@ class MapFromEntriesFunction : public exec::VectorFunction {
     auto valueRowVector = decodedValueVector->base()->as<RowVector>();
     auto keyValueVector = valueRowVector->childAt(0);
 
+    exec::LocalSelectivityVector remianingRows(context, rows);
     BufferPtr changedSizes = nullptr;
     vector_size_t* mutableSizes = nullptr;
 
@@ -118,6 +119,8 @@ class MapFromEntriesFunction : public exec::VectorFunction {
       });
     }
 
+    context.deselectErrors(*remianingRows.get());
+
     VectorPtr wrappedKeys;
     VectorPtr wrappedValues;
     if (decodedValueVector->isIdentityMapping()) {
@@ -146,7 +149,7 @@ class MapFromEntriesFunction : public exec::VectorFunction {
         wrappedKeys,
         wrappedValues);
 
-    checkDuplicateKeys(mapVector, rows, context);
+    checkDuplicateKeys(mapVector, *remianingRows, context);
     return mapVector;
   }
 };

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -164,7 +164,10 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_->wrappedVector();
   }
 
+  // Should not be called if the index is null in the top level dictionary
+  // vector.
   vector_size_t wrappedIndex(vector_size_t index) const override {
+    VELOX_CHECK(!BaseVector::isNullAt(index));
     return dictionaryValues_->wrappedIndex(rawIndices_[index]);
   }
 


### PR DESCRIPTION
Summary:
This fix https://github.com/facebookincubator/velox/issues/6301

CheckDuplicateKeys calls toString on the base vector value to generate an error message. 
If the key is null this can cause a Velox runtime error in the case of accessing a dictionary 
vector with added nulls and 0 sizes base vector!
- This function does not need to process null keys, calls should remove rows with null keys 
before calling this function.
- Users should not access wrappedIndex(index) when the top level dict is null at index.
- The diff also change MapFromEntries and Map functions to remove rows with nulls keys before
calling CheckDuplicateKeys. TransformKeys will be updated in a separate PR.

Differential Revision: D48797877

