### PR TITLE
Fix PeeledEncoding to peel off inner-most Lazy layer

### DIFF
--- a/velox/expression/PeeledEncoding.cpp
+++ b/velox/expression/PeeledEncoding.cpp
@@ -121,6 +121,7 @@ bool PeeledEncoding::peelInternal(
       if (leaf->isLazy() && leaf->asUnchecked<LazyVector>()->isLoaded()) {
         auto lazy = leaf->asUnchecked<LazyVector>();
         leaf = lazy->loadedVectorShared();
+        setPeeled(leaf, fieldIndex, peeledVectors);
       }
       if (!constantFields.empty() && constantFields[fieldIndex]) {
         setPeeled(leaf, fieldIndex, maybePeeled);


### PR DESCRIPTION
Summary:
For vectors like dictionary(lazy(flat)), PeeledEncoding doesn't peel off the inner-most lazy layer. This is because the peeling loop doesn't update peeledVector[i] with the loaded lazy vector in the peeling loop, so after the peeling process stops, the remaining code returns peeledVector[i] that is a lazy vector. This caused a crash in CastExpr that expect simple vector after peeling but got a lazy vector.

This diff fixes this issue by replacing peeledVector[i] with the loaded vector once the loading happens.

Differential Revision: D48814919

