### PR TITLE
Adding support for background cpu time stats

### DIFF
--- a/velox/exec/Exchange.cpp
+++ b/velox/exec/Exchange.cpp
@@ -135,6 +135,10 @@ void Exchange::close() {
   exchangeClient_ = nullptr;
 }
 
+uint64_t Exchange::backgroundCpuTimeMs() const {
+  return exchangeClient_ ? exchangeClient_->backgroundCpuTimeMs() : 0;
+}
+
 void Exchange::recordExchangeClientStats() {
   if (!processSplits_) {
     return;

--- a/velox/exec/Exchange.h
+++ b/velox/exec/Exchange.h
@@ -60,6 +60,8 @@ class Exchange : public SourceOperator {
 
   bool isFinished() override;
 
+  uint64_t backgroundCpuTimeMs() const override;
+
  protected:
   virtual VectorSerde* getSerde();
 

--- a/velox/exec/ExchangeClient.cpp
+++ b/velox/exec/ExchangeClient.cpp
@@ -102,6 +102,15 @@ folly::F14FastMap<std::string, RuntimeMetric> ExchangeClient::stats() const {
   return stats;
 }
 
+uint64_t ExchangeClient::backgroundCpuTimeMs() const {
+  uint64_t backgroundCpuTimeMs = 0;
+  for (const auto& source : sources_) {
+    backgroundCpuTimeMs += source->backgroundCpuTimeMs();
+  }
+
+  return backgroundCpuTimeMs;
+}
+
 std::unique_ptr<SerializedPage> ExchangeClient::next(
     bool* atEnd,
     ContinueFuture* future) {

--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -59,6 +59,8 @@ class ExchangeClient {
   // Closes exchange sources.
   void close();
 
+  uint64_t backgroundCpuTimeMs() const;
+
   // Returns runtime statistics aggregated across all of the exchange sources.
   folly::F14FastMap<std::string, RuntimeMetric> stats() const;
 

--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -72,6 +72,10 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   // Returns runtime statistics.
   virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
 
+  virtual uint64_t backgroundCpuTimeMs() const {
+    return 0L;
+  }
+
   virtual std::string toString() {
     std::stringstream out;
     out << "[ExchangeSource " << taskId_ << ":" << destination_

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -434,6 +434,8 @@ void OperatorStats::add(const OperatorStats& other) {
 
   finishTiming.add(other.finishTiming);
 
+  backgroundTiming.add(other.backgroundTiming);
+
   memoryStats.add(other.memoryStats);
 
   for (const auto& [name, stats] : other.runtimeStats) {
@@ -470,6 +472,8 @@ void OperatorStats::clear() {
   blockedWallNanos = 0;
 
   finishTiming.clear();
+
+  backgroundTiming.clear();
 
   memoryStats.clear();
 

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -124,6 +124,8 @@ struct OperatorStats {
 
   CpuWallTiming finishTiming;
 
+  CpuWallTiming backgroundTiming;
+
   MemoryStats memoryStats;
 
   // Total bytes in memory for spilling
@@ -397,6 +399,15 @@ class Operator : public BaseRuntimeStatWriter {
   virtual void close() {
     input_ = nullptr;
     results_.clear();
+
+    // We are collecting the background CPU time of this operator and storing
+    // its value in OperatorStats.backgroundTiming.
+    const uint64_t backgroundCpuTimeMs = this->backgroundCpuTimeMs();
+    if (backgroundCpuTimeMs > 0) {
+      const CpuWallTiming opBackgroundTiming{1, 0, backgroundCpuTimeMs};
+      stats_.wlock()->backgroundTiming.add(opBackgroundTiming);
+    }
+
     // Release the unused memory reservation on close.
     operatorCtx_->pool()->release();
   }
@@ -434,6 +445,13 @@ class Operator : public BaseRuntimeStatWriter {
   /// read/write access to the stats.
   folly::Synchronized<OperatorStats>& stats() {
     return stats_;
+  }
+
+  // Returns the cpu time (ms) spent by this operator on background activities
+  // which are not running on driver threads. Individual operators will override
+  // this method to report their background CPU time.
+  virtual uint64_t backgroundCpuTimeMs() const {
+    return 0L;
   }
 
   void recordBlockingTime(uint64_t start, BlockingReason reason);

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -999,6 +999,7 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
     EXPECT_EQ(3 * i, operatorStats.outputPositions);
     EXPECT_EQ(i, operatorStats.outputVectors);
     EXPECT_EQ(0, operatorStats.finishTiming.count);
+    EXPECT_EQ(0, operatorStats.backgroundTiming.count);
 
     EXPECT_EQ(1, liveStats[i].numTotalDrivers);
     EXPECT_EQ(0, liveStats[i].numCompletedDrivers);
@@ -1019,6 +1020,8 @@ DEBUG_ONLY_TEST_F(TaskTest, liveStats) {
   EXPECT_EQ(3 * numBatches, operatorStats.outputPositions);
   EXPECT_EQ(numBatches, operatorStats.outputVectors);
   EXPECT_EQ(1, operatorStats.finishTiming.count);
+  // No operators with background CPU time yet.
+  EXPECT_EQ(0, operatorStats.backgroundTiming.count);
 }
 
 TEST_F(TaskTest, outputBufferSize) {


### PR DESCRIPTION
Summary: This diff collects cpu time spent on background threads per executor, storing it in OperatorStats

Differential Revision: D48834043

