### PR TITLE
Fix: support unknown in map_from_entries function

### DIFF
--- a/velox/functions/lib/CheckDuplicateKeys.cpp
+++ b/velox/functions/lib/CheckDuplicateKeys.cpp
@@ -21,6 +21,9 @@ void checkDuplicateKeys(
     const MapVectorPtr& mapVector,
     const SelectivityVector& rows,
     exec::EvalCtx& context) {
+  if (rows.end() == 0) {
+    return;
+  }
   static const char* kDuplicateKey = "Duplicate map keys ({}) are not allowed";
 
   MapVector::canonicalize(mapVector);

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -404,3 +404,15 @@ TEST_F(MapFromEntriesTest, nestedNullInKeys) {
           makeRowVector({makeFlatVector<int32_t>(1)})),
       "map key cannot be indeterminate");
 }
+
+TEST_F(MapFromEntriesTest, unknownInputs) {
+  auto expectedType = MAP(UNKNOWN(), UNKNOWN());
+  auto test = [&](const std::string& query) {
+    auto result = evaluate(query, makeRowVector({makeFlatVector<int32_t>(2)}));
+    ASSERT_TRUE(result->type()->equivalent(*expectedType));
+  };
+
+  test("try(map_from_entries(array_constructor(row_constructor(null, null))))");
+  test("try(map_from_entries(array_constructor(null)))");
+  test("try(map_from_entries(null))");
+}


### PR DESCRIPTION
Summary:
presto support
``
try (select MAP_FROM_ENTRIES(ARRAY[Row(null, null)]))
``
and 
``
try (select MAP_FROM_ENTRIES(ARRAY[null]))
``

Differential Revision: D48837795

