### PR TITLE
Make 'https' the default GCS Scheme

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -132,7 +132,7 @@ std::string HiveConfig::gcsEndpoint(const Config* config) {
 
 // static
 std::string HiveConfig::gcsScheme(const Config* config) {
-  return config->get<std::string>(kGCSScheme, std::string(""));
+  return config->get<std::string>(kGCSScheme, std::string("https"));
 }
 
 // static


### PR DESCRIPTION
The GCS Hive Connector is currently using insecure connection by default. It should behave like S3 and use secure connections by default. This change makes GCS use https as default scheme.

Fixes https://github.com/facebookincubator/velox/issues/6359