### PR TITLE
Fix race between task terminate and threshold triggered spilling

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -318,6 +318,10 @@ class Driver : public std::enable_shared_from_this<Driver> {
     return blockingReason_;
   }
 
+  static std::shared_ptr<Driver> testingCreate() {
+    return std::shared_ptr<Driver>(new Driver());
+  }
+
  private:
   Driver() = default;
 

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -201,6 +201,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
   if (spillPartition == nullptr) {
     spillGroup_->addOperator(
         *this,
+        operatorCtx_->driver()->shared_from_this(),
         [&](const std::vector<Operator*>& operators) { runSpill(operators); });
   } else {
     spillInputReader_ = spillPartition->createReader();


### PR DESCRIPTION
We found the following race condition in threshold triggered join spilling in
Meta internal testing:
T1 one hash build operator has finished and leave the spill group, and the 
     associated driver is off thread and there is no pending driver reference
     except the associated query task;
T2 one hash build operator adds input and triggers the threshold based
     disk spilling;
T3 all the other hash build operators all reaches to the synchronization point
      in spill group to do group spilling
T4 one of the hash build operator is selected to run spilling
T5 there is an external event that caused the query task to terminate
T6 the task terminate process close and destroy the hash build driver stopped
      at T1
T7 the group spilling tries to spill from hash build operator which is destroyed
      at T6, and the process run into crash.

To fix this problem, when we add operator into the spill group, we also store the
driver weak pointer there and upgrade those driver weak pointers to the shared
ones before running spilling. This ensures the operators are alive while spilling.
If any driver has gone (the upgrade fails), the associated query task must have
been terminated at that point, so we simply throw in that case.

Unit test is added to reproduce the race condition and verify the fix.