### PR TITLE
Fix integer overflow in avg and simple_avg companion functions

### DIFF
--- a/velox/exec/tests/SimpleAverageAggregate.cpp
+++ b/velox/exec/tests/SimpleAverageAggregate.cpp
@@ -65,7 +65,7 @@ class AverageAggregate {
     // wrapped in InputType.
     void addInput(HashStringAllocator* /*allocator*/, exec::arg_type<T> data) {
       sum_ += data;
-      count_++;
+      count_ = checkedPlus<int64_t>(count_, 1);
     }
 
     // combine expects one parameter of exec::arg_type<IntermediateType>.
@@ -78,7 +78,7 @@ class AverageAggregate {
       VELOX_CHECK(other.at<0>().has_value());
       VELOX_CHECK(other.at<1>().has_value());
       sum_ += other.at<0>().value();
-      count_ += other.at<1>().value();
+      count_ = checkedPlus<int64_t>(count_, other.at<1>().value());
     }
 
     bool writeFinalResult(exec::out_type<OutputType>& out) {

--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -247,7 +247,8 @@ class AverageAggregateBase : public exec::Aggregate {
       exec::Aggregate::clearNull(group);
     }
     accumulator(group)->sum += value;
-    accumulator(group)->count += 1;
+    accumulator(group)->count =
+        checkedPlus<int64_t>(accumulator(group)->count, 1);
   }
 
   template <bool tableHasNulls = true>
@@ -256,7 +257,8 @@ class AverageAggregateBase : public exec::Aggregate {
       exec::Aggregate::clearNull(group);
     }
     accumulator(group)->sum += sum;
-    accumulator(group)->count += count;
+    accumulator(group)->count =
+        checkedPlus<int64_t>(accumulator(group)->count, count);
   }
 
   inline SumCount<TAccumulator>* accumulator(char* group) {
@@ -374,7 +376,9 @@ class AverageAggregateBase : public exec::Aggregate {
               !baseSumDecoded.isNullAt(decodedIndex) &&
               !baseCountDecoded.isNullAt(decodedIndex));
         }
-        totalCount += baseCountDecoded.template valueAt<int64_t>(decodedIndex);
+        totalCount = checkedPlus<int64_t>(
+            totalCount,
+            baseCountDecoded.template valueAt<int64_t>(decodedIndex));
         totalSum += baseSumDecoded.template valueAt<TAccumulator>(decodedIndex);
       });
       updateNonNullValue(group, totalCount, totalSum);


### PR DESCRIPTION
Summary: This diff fixes https://github.com/facebookincubator/velox/issues/6344.

Differential Revision: D48851009

