### PR TITLE
Make seek before prefetch compatible in DwrfRowReader

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -168,10 +168,9 @@ class DwrfRowReader : public StrideIndexProvider,
       prefetchedStripeStates_;
 
   // Currently, seek logic relies on reloading the stripe every time the row is
-  // seeked to, even if the row was present in the already loaded stripe. These
-  // are temporary flags to disallow seek and prefetch on same reader, until we
-  // implement a good way to support both.
-  bool seekHasOccurred_{false};
+  // seeked to, even if the row was present in the already loaded stripe. This
+  // is a temporary flag to disable seek on a reader which has already
+  // prefetched, until we implement a good way to support both.
   bool prefetchHasOccurred_{false};
 
   // Used to indicate which stripes are finished loading. If stripeLoadBatons[i]

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -122,7 +122,10 @@ class DwrfRowReader : public StrideIndexProvider,
   int64_t nextReadSize(uint64_t size) override;
 
  private:
-  bool fetch(uint32_t stripeIndex);
+  // Represents the status of a stripe being fetched.
+  enum class FetchStatus { NOT_STARTED, IN_PROGRESS, FINISHED, ERROR };
+
+  FetchResult fetch(uint32_t stripeIndex);
   FetchResult prefetch(uint32_t stripeToFetch);
 
   // footer
@@ -175,9 +178,9 @@ class DwrfRowReader : public StrideIndexProvider,
   // is posted, it means the ith stripe has finished loading
   std::vector<std::unique_ptr<folly::Baton<>>> stripeLoadBatons_;
 
-  // Used to indicate which stripes have had a load command issued. If
-  // loaded_[i] is true, it means stripe i is in the process of being loaded
-  folly::Synchronized<std::vector<bool>> loadRequestIssued_;
+  // Indicates the status of load requests. The ith element in
+  // stripeLoadStatuses_ represents the status of the ith stripe.
+  folly::Synchronized<std::vector<FetchStatus>> stripeLoadStatuses_;
 
   // Used to lock when altering state in startNextStripe
   std::mutex startNextStripeMutex_;

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -115,7 +115,7 @@ class DwrfRowReader : public StrideIndexProvider,
 
   void safeFetchNextStripe();
 
-  bool prefetch(uint32_t stripeToFetch);
+  std::optional<std::vector<PrefetchUnit>> prefetchUnits() override;
 
   int64_t nextRowNumber() override;
 
@@ -123,6 +123,7 @@ class DwrfRowReader : public StrideIndexProvider,
 
  private:
   bool fetch(uint32_t stripeIndex);
+  FetchResult prefetch(uint32_t stripeToFetch);
 
   // footer
   std::vector<uint64_t> firstRowOfStripe;

--- a/velox/dwio/dwrf/reader/StripeReaderBase.h
+++ b/velox/dwio/dwrf/reader/StripeReaderBase.h
@@ -35,9 +35,9 @@ class StripeReaderBase {
       const std::shared_ptr<ReaderBase>& reader,
       const proto::StripeFooter* footer)
       : reader_{reader},
-        footer_{const_cast<proto::StripeFooter*>(footer)},
         handler_{std::make_unique<encryption::DecryptionHandler>(
             reader_->getDecryptionHandler())},
+        footer_{const_cast<proto::StripeFooter*>(footer)},
         canLoad_{false} {
     // The footer is expected to be arena allocated and to stay
     // live for the lifetime of 'this'.
@@ -110,11 +110,11 @@ class StripeReaderBase {
   }
 
  private:
-  std::shared_ptr<ReaderBase> reader_;
+  const std::shared_ptr<ReaderBase> reader_;
+  const std::unique_ptr<encryption::DecryptionHandler> handler_;
   std::unique_ptr<dwio::common::BufferedInput> stripeInput_;
-  proto::StripeFooter* footer_ = nullptr;
-  std::unique_ptr<encryption::DecryptionHandler> handler_;
   std::optional<uint32_t> lastStripeIndex_;
+  proto::StripeFooter* footer_ = nullptr;
   bool canLoad_{true};
 
   // Map containing stripe blobs which have already been loaded.


### PR DESCRIPTION
Summary: Remove checks blocking seek and prefetch- previous iterations were having issues so it was disabled, but validation service is showing this working fine.

Differential Revision: D48802923

