### PR TITLE
Checkpoint FileInfoMap to SSD

### DIFF
--- a/velox/common/caching/AsyncDataCache.cpp
+++ b/velox/common/caching/AsyncDataCache.cpp
@@ -601,6 +601,9 @@ AsyncDataCache::AsyncDataCache(
   for (auto i = 0; i < kNumShards; ++i) {
     shards_.push_back(std::make_unique<CacheShard>(this));
   }
+  if (ssdCache_) {
+    ssdCache_->readFileInfoMapCheckpoint();
+  }
 }
 
 AsyncDataCache::~AsyncDataCache() {}

--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -110,6 +110,7 @@ struct RawFileCacheKey {
     return offset == other.offset && fileNum == other.fileNum;
   }
 };
+
 } // namespace facebook::velox::cache
 
 namespace std {
@@ -509,6 +510,12 @@ struct CacheStats {
   // Sum of scores of evicted entries. This serves to infer an average
   // lifetime for entries in cache.
   int64_t sumEvictScore{};
+  // Min age of entries since the raw file was opened to load the cache.
+  int64_t entryAgeSecsMin{std::numeric_limits<int64_t>::max()};
+  // Max age of entries since the raw file was opened to load the cache.
+  int64_t entryAgeSecsMax{};
+  // Average age of entries since the raw file was opened to load the cache.
+  int64_t entryAgeSecsAvg{};
 
   std::shared_ptr<SsdCacheStats> ssdStats = nullptr;
 };
@@ -687,6 +694,8 @@ class AsyncDataCache : public memory::Cache {
   /// Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+  /// Returns snapshot of the aggregated stats from all shards and the stats of
+  /// SSD cache if used.
   CacheStats refreshStats() const;
 
   std::string toString() const;

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_library(
   velox_caching
   FileIds.cpp
+  FileInfoMap.cpp
   StringIdMap.cpp
   AsyncDataCache.cpp
   ScanTracker.cpp

--- a/velox/common/caching/FileInfoMap.cpp
+++ b/velox/common/caching/FileInfoMap.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/FileInfoMap.h"
+
+namespace facebook::velox::cache {
+
+std::shared_ptr<FileInfoMap> FileInfoMap::instance_ = nullptr;
+
+// static
+void FileInfoMap::create() {
+  if (!instance_) {
+    instance_ = std::make_shared<FileInfoMap>();
+  }
+}
+
+// static
+void FileInfoMap::release() {
+  if (instance_ != nullptr) {
+    instance_ = nullptr;
+  }
+}
+
+bool FileInfoMap::addOpenFileInfo(uint64_t fileNum, int64_t openTimeSec) {
+  return fileMap_.emplace(fileNum, RawFileInfo{openTimeSec, false}).second;
+}
+
+const RawFileInfo* FileInfoMap::find(uint64_t fileNum) const {
+  const auto it = fileMap_.find(fileNum);
+  if (it == fileMap_.cend()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+RawFileInfo* FileInfoMap::find(uint64_t fileNum) {
+  auto it = fileMap_.find(fileNum);
+  if (it == fileMap_.end()) {
+    return nullptr;
+  }
+  return &it->second;
+}
+
+void FileInfoMap::resetInCache() {
+  for (auto& [_, fileInfo] : fileMap_) {
+    fileInfo.inCache = false;
+  }
+}
+
+void FileInfoMap::deleteNotInCache() {
+  for (auto it = fileMap_.begin(); it != fileMap_.end();) {
+    if (!it->second.inCache) {
+      it = fileMap_.erase(it);
+    } else {
+      it++;
+    }
+  }
+}
+
+void FileInfoMap::forEach(
+    std::function<void(uint64_t, RawFileInfo&)> function) {
+  for (auto& [fileNum, rawFileInfo] : fileMap_) {
+    function(fileNum, rawFileInfo);
+  }
+}
+
+folly::SharedMutex& FileInfoMap::mutex() {
+  return fileMapMutex_;
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/FileInfoMap.h
+++ b/velox/common/caching/FileInfoMap.h
@@ -95,6 +95,11 @@ class FileInfoMap {
     return function(*this);
   }
 
+  // For unit test only.
+  const folly::F14FastMap<uint64_t, RawFileInfo>& getMap() const {
+    return fileMap_;
+  }
+
  private:
   // A singleton instance.
   static std::shared_ptr<FileInfoMap> instance_;

--- a/velox/common/caching/FileInfoMap.h
+++ b/velox/common/caching/FileInfoMap.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/time/Timer.h"
+
+#include "folly/SharedMutex.h"
+#include "folly/container/F14Map.h"
+
+namespace facebook::velox::cache {
+struct RawFileInfo {
+  int64_t openTimeSec;
+  bool inCache;
+
+  bool operator==(const RawFileInfo& other) {
+    return openTimeSec == other.openTimeSec && inCache == other.inCache;
+  }
+};
+
+/// Return a process-wide map of file id to file info.
+class FileInfoMap {
+ public:
+  /// Return the process-wide FileInfoMap singleton instance.
+  static std::shared_ptr<FileInfoMap> getInstance() {
+    return instance_;
+  }
+
+  /// Create a singleton instance of FileInfoMap.
+  static void create();
+
+  static void release();
+
+  /// Whether an instance of FileInfoMap has been created or not.
+  static bool exists() {
+    return instance_ != nullptr;
+  }
+
+  /// Add file opening info for fileNum and return true if fileNum is not in the
+  /// map. If the map already includes fileNum, no action will happen and return
+  /// false.
+  bool addOpenFileInfo(
+      uint64_t fileNum,
+      int64_t openTimeSec = getCurrentTimeSec());
+
+  const RawFileInfo* find(uint64_t fileNum) const;
+
+  RawFileInfo* find(uint64_t fileNum);
+
+  /// Reset the RawFileInfo flag, inCache, to false for all entries.
+  void resetInCache();
+
+  /// Remove all entries with the RawFileInfo flag inCache false.
+  void deleteNotInCache();
+
+  int64_t size() {
+    return fileMap_.size();
+  }
+
+  void clear() {
+    fileMap_.clear();
+  }
+
+  /// For every map entry, run function. The map key fileNum and map value
+  /// RawFileInfo are passed to the function.
+  void forEach(std::function<void(uint64_t, RawFileInfo&)> function);
+
+  /// Return a SharedMutex guarding the FileInfoMap instance. It can be used to
+  /// acquire a read/write lock on the FileInfoMap instance.
+  folly::SharedMutex& mutex();
+
+  /// Run function with a read lock on the FileInfoMap instance.
+  template <typename T>
+  T withRLock(std::function<T(FileInfoMap&)> function) {
+    folly::SharedMutex::ReadHolder rl(fileMapMutex_);
+    return function(*this);
+  }
+
+  /// Run function with a write lock on the FileInfoMap instance.
+  template <typename T>
+  T withWLock(std::function<T(FileInfoMap&)> function) {
+    folly::SharedMutex::WriteHolder wl(fileMapMutex_);
+    return function(*this);
+  }
+
+ private:
+  // A singleton instance.
+  static std::shared_ptr<FileInfoMap> instance_;
+
+  folly::SharedMutex fileMapMutex_;
+  folly::F14FastMap<uint64_t, RawFileInfo> fileMap_{};
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -129,7 +129,7 @@ void SsdCache::write(std::vector<CachePin> pins) {
   writesInProgress_.fetch_sub(numNoStore);
 }
 
-SsdCacheStats SsdCache::stats() const {
+SsdCacheStats SsdCache::refreshStats() const {
   SsdCacheStats stats;
   for (auto& file : files_) {
     file->updateStats(stats);
@@ -144,7 +144,7 @@ void SsdCache::clear() {
 }
 
 std::string SsdCache::toString() const {
-  auto data = stats();
+  auto data = refreshStats();
   uint64_t capacity = maxBytes();
   std::stringstream out;
   out << "Ssd cache IO: Write " << (data.bytesWritten >> 20) << "MB read "

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -76,6 +76,12 @@ class SsdCache {
   /// have returned true.
   void write(std::vector<CachePin> pins);
 
+  /// Evict all entries with their raw file open time prior to
+  /// maxFileOpenTime in seconds. It assumes the global FileInfoMap contains all
+  /// the corresponding raw files and thus requires FileInfoMap to be locked. It
+  /// synchronously processes all SSD files in parallel.
+  void applyTtl(int64_t maxFileOpenTime);
+
   /// Returns stats aggregated from all shards.
   SsdCacheStats refreshStats() const;
 

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -77,7 +77,7 @@ class SsdCache {
   void write(std::vector<CachePin> pins);
 
   /// Returns stats aggregated from all shards.
-  SsdCacheStats stats() const;
+  SsdCacheStats refreshStats() const;
 
   FileGroupStats& groupStats() const {
     return *groupStats_;

--- a/velox/common/caching/SsdFile.cpp
+++ b/velox/common/caching/SsdFile.cpp
@@ -122,12 +122,14 @@ SsdFile::SsdFile(
     const std::string& filename,
     int32_t shardId,
     int32_t maxRegions,
+    SsdCache* ssdCache,
     int64_t checkpointIntervalBytes,
     bool disableFileCow,
     folly::Executor* executor)
     : fileName_(filename),
       maxRegions_(maxRegions),
       shardId_(shardId),
+      ssdCache_(ssdCache),
       checkpointIntervalBytes_(checkpointIntervalBytes),
       executor_(executor) {
   int32_t oDirect = 0;
@@ -432,6 +434,7 @@ void SsdFile::write(std::vector<CachePin>& pins) {
   if ((checkpointIntervalBytes_ > 0) &&
       (bytesAfterCheckpoint_ >= checkpointIntervalBytes_)) {
     checkpoint();
+    ssdCache_->makeFileInfoMapCheckpoint();
   }
 }
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -195,6 +195,7 @@ class SsdFile {
       const std::string& filename,
       int32_t shardId,
       int32_t maxRegions,
+      SsdCache* ssdCache,
       int64_t checkpointInternalBytes = 0,
       bool disableFileCow = false,
       folly::Executor* executor = nullptr);
@@ -366,6 +367,8 @@ class SsdFile {
   // offset and the end of the region. This is subscripted with the region
   // index. The regionIndex times kRegionSize is an offset into the file.
   std::vector<uint32_t> regionSizes_;
+
+  SsdCache* const ssdCache_;
 
   // Indices of regions available for writing new entries.
   std::vector<int32_t> writableRegions_;

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -135,6 +135,10 @@ struct SsdCacheStats {
     bytesCached = tsanAtomicValue(other.bytesCached);
     numPins = tsanAtomicValue(other.numPins);
 
+    entryAgeSecsMin = tsanAtomicValue(other.entryAgeSecsMin);
+    entryAgeSecsMax = tsanAtomicValue(other.entryAgeSecsMax);
+    entryAgeSecsAvg = tsanAtomicValue(other.entryAgeSecsAvg);
+
     openFileErrors = tsanAtomicValue(other.openFileErrors);
     openCheckpointErrors = tsanAtomicValue(other.openCheckpointErrors);
     openLogErrors = tsanAtomicValue(other.openLogErrors);
@@ -153,6 +157,10 @@ struct SsdCacheStats {
   tsan_atomic<uint64_t> entriesCached{0};
   tsan_atomic<uint64_t> bytesCached{0};
   tsan_atomic<int32_t> numPins{0};
+
+  tsan_atomic<uint64_t> entryAgeSecsMin{std::numeric_limits<uint64_t>::max()};
+  tsan_atomic<uint64_t> entryAgeSecsMax{0};
+  tsan_atomic<uint64_t> entryAgeSecsAvg{0};
 
   tsan_atomic<uint32_t> openFileErrors{0};
   tsan_atomic<uint32_t> openCheckpointErrors{0};
@@ -238,6 +246,9 @@ class SsdFile {
 
   // Adds 'stats_' to 'stats'.
   void updateStats(SsdCacheStats& stats) const;
+
+  // Adds entry age stats to 'stats'.
+  void updateEntryAgeStats(SsdCacheStats& stats) const;
 
   // Resets this' to a post-construction empty state. See SsdCache::clear().
   void clear();

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -644,7 +644,7 @@ TEST_F(AsyncDataCacheTest, ssd) {
   // write does not wait for the workload.
   runThreads(16, [&](int32_t /*i*/) { loadLoop(0, kSsdBytes, 11); });
   LOG(INFO) << "Stats after first pass: " << cache_->toString();
-  auto ssdStats = cache_->ssdCache()->stats();
+  auto ssdStats = cache_->ssdCache()->refreshStats();
   ASSERT_LE(kRamBytes, ssdStats.bytesWritten);
 
   // We allow writes to proceed faster.
@@ -653,7 +653,7 @@ TEST_F(AsyncDataCacheTest, ssd) {
   // 13 batch loads.
   runThreads(16, [&](int32_t /*i*/) { loadLoop(0, kSsdBytes, 13); });
   LOG(INFO) << "Stats after second pass:" << cache_->toString();
-  ssdStats = cache_->ssdCache()->stats();
+  ssdStats = cache_->ssdCache()->refreshStats();
   ASSERT_LE(kRamBytes, ssdStats.bytesRead);
 
   // We re-read the second half and add another half capacity of new entries. We
@@ -665,7 +665,7 @@ TEST_F(AsyncDataCacheTest, ssd) {
 
   // Wait for writes to finish and make a checkpoint.
   cache_->ssdCache()->shutdown();
-  auto ssdStatsAfterShutdown = cache_->ssdCache()->stats();
+  auto ssdStatsAfterShutdown = cache_->ssdCache()->refreshStats();
   ASSERT_GT(ssdStatsAfterShutdown.bytesWritten, ssdStats.bytesWritten);
   ASSERT_GT(ssdStatsAfterShutdown.bytesRead, ssdStats.bytesRead);
 
@@ -687,7 +687,7 @@ TEST_F(AsyncDataCacheTest, ssd) {
   });
   LOG(INFO) << "State after starting 3/4 shards from checkpoint: "
             << cache_->toString();
-  const auto ssdStatsFromCP = cache_->ssdCache()->stats();
+  const auto ssdStatsFromCP = cache_->ssdCache()->refreshStats();
   ASSERT_EQ(ssdStatsFromCP.readCheckpointErrors, 1);
 }
 

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -17,8 +17,10 @@ add_test(simple_lru_cache_test simple_lru_cache_test)
 target_link_libraries(simple_lru_cache_test gtest gtest_main glog::glog
                       gflags::gflags Folly::folly)
 
-add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
-                                SsdFileTest.cpp SsdFileTrackerTest.cpp)
+add_executable(
+  velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp SsdCacheTest.cpp
+                   SsdFileTest.cpp SsdFileTrackerTest.cpp)
+add_test(velox_cache_test velox_cache_test)
 add_test(velox_cache_test velox_cache_test)
 target_link_libraries(
   velox_cache_test

--- a/velox/common/caching/tests/SsdCacheTest.cpp
+++ b/velox/common/caching/tests/SsdCacheTest.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/base/Fs.h"
+#include "velox/common/caching/FileIds.h"
+#include "velox/common/caching/FileInfoMap.h"
+#include "velox/common/file/FileSystems.h"
+#include "velox/exec/tests/utils/TempFilePath.h"
+
+#include "gtest/gtest.h"
+
+#include <fcntl.h>
+#ifdef linux
+#include <linux/fs.h>
+#endif // linux
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec::test;
+
+namespace facebook::velox::cache {
+
+class SsdCacheTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::filesystems::registerLocalFileSystem();
+  }
+};
+
+TEST_F(SsdCacheTest, fileInfoMapCheckpoint) {
+  auto tempPath = TempFilePath::create();
+  SsdCache ssd(tempPath->path, 1 << 20, 2, nullptr, 128 << 10, true);
+  FileInfoMap::create();
+
+  for (auto i = 0; i < 1000; i++) {
+    auto fileNum = fileIds().makeId(fmt::format("file{}", i));
+    FileInfoMap::getInstance()->addOpenFileInfo(fileNum);
+  }
+  auto fileMapBefore = FileInfoMap::getInstance()->getMap();
+
+  // Test writing the file info map checkpoint and successfully reading back the
+  // file info map.
+  {
+    ssd.makeFileInfoMapCheckpoint();
+    FileInfoMap::getInstance()->clear();
+    ssd.readFileInfoMapCheckpoint();
+
+    auto fileMapAfter = FileInfoMap::getInstance()->getMap();
+    ASSERT_EQ(fileMapBefore.size(), fileMapAfter.size());
+    ASSERT_TRUE(std::all_of(
+        fileMapAfter.begin(),
+        fileMapAfter.end(),
+        [&fileMapBefore](auto& entry) {
+          return fileMapBefore.at(entry.first) == entry.second;
+        }));
+  }
+  {
+    // Test clearing the file info map and deleting the checkpoint file if the
+    // read is broken.
+    auto checkpointPath =
+        tempPath->path + SsdCache::kFileInfoMapCheckpointExtension;
+    auto fd = open(checkpointPath.c_str(), O_WRONLY);
+    ftruncate(fd, 100);
+    FileInfoMap::getInstance()->clear();
+    ssd.readFileInfoMapCheckpoint();
+    close(fd);
+
+    auto fileMapAfter = FileInfoMap::getInstance()->getMap();
+    ASSERT_EQ(fileMapAfter.size(), 0);
+    ASSERT_FALSE(fs::exists(checkpointPath));
+  }
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/tests/SsdFileTest.cpp
+++ b/velox/common/caching/tests/SsdFileTest.cpp
@@ -65,6 +65,7 @@ class SsdFileTest : public testing::Test {
         fmt::format("{}/ssdtest", tempDirectory_->path),
         0, // shardId
         bits::roundUp(ssdBytes, SsdFile::kRegionSize) / SsdFile::kRegionSize,
+        nullptr, // ssdCache
         0, // checkpointInternalBytes
         setNoCowFlag);
   }

--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -20,6 +20,10 @@ namespace facebook::velox {
 
 using namespace std::chrono;
 
+size_t getCurrentTimeSec() {
+  return duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+}
+
 size_t getCurrentTimeMs() {
   return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
       .count();

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -69,6 +69,9 @@ class ClockTimer {
   uint64_t start_;
 };
 
+// Returns the current epoch time in seconds.
+size_t getCurrentTimeSec();
+
 /// Returns the current epoch time in milliseconds.
 size_t getCurrentTimeMs();
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -714,7 +714,7 @@ class TableWriteMergeNode : public PlanNode {
   /// 'outputType' specifies the type to store the metadata of table write
   /// output which contains the following columns: 'numWrittenRows', 'fragment'
   /// and 'tableCommitContext'.
-#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+  //#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   TableWriteMergeNode(
       const PlanNodeId& id,
       RowTypePtr outputType,
@@ -723,7 +723,7 @@ class TableWriteMergeNode : public PlanNode {
         aggregationNode_(nullptr),
         sources_{std::move(source)},
         outputType_(std::move(outputType)) {}
-#endif
+  //#endif
 
   TableWriteMergeNode(
       const PlanNodeId& id,


### PR DESCRIPTION
Make checkpoint for the FileInfoMap to an SSD file every time
an SSD cache shard is checkpointed. Restore FileInfoMap from
the checkpoint SSD file if it exists during system start.