### PR TITLE
Disallow generation of INTERVAL_DAY_TIME type in join fuzzer

### DIFF
--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -60,6 +60,7 @@ class JoinFuzzer {
     opts.stringVariableLength = true;
     opts.stringLength = 100;
     opts.nullRatio = FLAGS_null_ratio;
+    opts.allowIntervalType = false;
     return opts;
   }
 

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -140,6 +140,10 @@ class VectorFuzzer {
     /// vectors. The generated lazy vectors can also have any number of
     /// dictionary layers on top of them.
     bool allowLazyVector{false};
+
+    // If true, randType can generate INTERVAL_DAY_TIME type.
+    // (https://github.com/facebookincubator/velox/issues/6375).
+    bool allowIntervalType{true};
   };
 
   VectorFuzzer(
@@ -339,10 +343,17 @@ class VectorFuzzer {
 
 /// Generates a random type, including maps, vectors, and arrays. maxDepth
 /// limits the maximum level of nesting for complex types. maxDepth <= 1 means
-/// no complex types are allowed.
-TypePtr randType(FuzzerGenerator& rng, int maxDepth = 5);
+/// no complex types are allowed. allowIntervalType indicates whether
+/// INTERVAL_DAY_TIME type can be generated.
+/// (https://github.com/facebookincubator/velox/issues/6375)
+TypePtr
+randType(FuzzerGenerator& rng, int maxDepth = 5, bool allowIntervalType = true);
 
-/// Generates a random ROW type.
-RowTypePtr randRowType(FuzzerGenerator& rng, int maxDepth = 5);
+/// Generates a random ROW type. allowIntervalType indicates whether the ROW
+/// type can contain INTERVAL_DAY_TIME type.
+RowTypePtr randRowType(
+    FuzzerGenerator& rng,
+    int maxDepth = 5,
+    bool allowIntervalType = true);
 
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
When join fuzzer generates INTERVAL_DAY_TIME data, creation of DuckDB
table fails due to Unimplemented type for cast (BIGINT -> INTERVAL)".
This diff disallow generation of INTERVAL_DAY_TIME type in join fuzzer
until we figure out the right way of handling it.

This diff fixes https://github.com/facebookincubator/velox/issues/6375.

Differential Revision: D48876454

