### PR TITLE
Track the file ages for AyncDataCache and SsdCache

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -701,6 +701,8 @@ class AsyncDataCache : public memory::Cache {
   /// Returns true if there is an entry for 'key'. Updates access time.
   bool exists(RawFileCacheKey key) const;
 
+  /// Returns snapshot of the aggregated stats from all shards and the stats of
+  /// SSD cache if used.
   CacheStats refreshStats() const;
 
   /// If 'details' is true, returns the stats of the backing memory allocator

--- a/velox/common/caching/CMakeLists.txt
+++ b/velox/common/caching/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_library(
   velox_caching
+  CacheTTLController.cpp
   FileIds.cpp
   StringIdMap.cpp
   AsyncDataCache.cpp

--- a/velox/common/caching/CacheTTLController.cpp
+++ b/velox/common/caching/CacheTTLController.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/CacheTTLController.h"
+
+namespace facebook::velox::cache {
+
+std::unique_ptr<CacheTTLController> CacheTTLController::instance_ = nullptr;
+
+bool CacheTTLController::addOpenFileInfo(
+    uint64_t fileNum,
+    int64_t openTimeSec) {
+  auto lockedFileMap = fileInfoMap_.wlock();
+  auto it = lockedFileMap->find(fileNum);
+  if (it == lockedFileMap->end() || it->second.removeInProgress) {
+    lockedFileMap->insert_or_assign(fileNum, RawFileInfo{openTimeSec, false});
+    return true;
+  }
+  return false;
+}
+
+CacheAgeStats CacheTTLController::getCacheAgeStats() const {
+  auto lockedFileMap = fileInfoMap_.rlock();
+
+  if (lockedFileMap->empty()) {
+    return CacheAgeStats{.maxAgeSecs = 0};
+  }
+
+  // Use the oldest file open time to calculate the max possible age of cache
+  // entries loaded from the files.
+  int64_t minOpenTime = std::numeric_limits<int64_t>::max();
+  for (auto it = lockedFileMap->cbegin(); it != lockedFileMap->cend(); it++) {
+    minOpenTime = std::min<int64_t>(minOpenTime, it->second.openTimeSec);
+  }
+
+  int64_t maxAge = getCurrentTimeSec() - minOpenTime;
+  return CacheAgeStats{.maxAgeSecs = std::max<int64_t>(maxAge, 0)};
+}
+
+void CacheTTLController::cleanUp(
+    const folly::F14FastSet<uint64_t>& filesToRetain) {
+  fileInfoMap_.withWLock([&](auto& fileMap) {
+    auto it = fileMap.begin();
+    while (it != fileMap.end()) {
+      if (!it->second.removeInProgress) {
+        it++;
+        continue;
+      }
+      if (filesToRetain.count(it->first) > 0) {
+        it->second.removeInProgress = false;
+        it++;
+        continue;
+      }
+      it = fileMap.erase(it);
+    }
+  });
+}
+
+void CacheTTLController::reset() {
+  fileInfoMap_.withWLock([](auto& fileMap) {
+    for (auto& [_, fileInfo] : fileMap) {
+      fileInfo.removeInProgress = false;
+    }
+  });
+}
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/CacheTTLController.h
+++ b/velox/common/caching/CacheTTLController.h
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/common/time/Timer.h"
+
+#include "folly/Synchronized.h"
+#include "folly/container/F14Map.h"
+#include "folly/container/F14Set.h"
+
+namespace facebook::velox::cache {
+
+class AsyncDataCache;
+
+struct RawFileInfo {
+  int64_t openTimeSec;
+  bool removeInProgress;
+
+  bool operator==(const RawFileInfo& other) {
+    return openTimeSec == other.openTimeSec &&
+        removeInProgress == other.removeInProgress;
+  }
+};
+
+struct CacheAgeStats {
+  // Age in seconds of the oldest opened file loaded to the caches.
+  int64_t maxAgeSecs{0};
+};
+
+/// A process-wide singleton to handle TTL of AsyncDataCache and SsdCache.
+class CacheTTLController {
+ public:
+  /// Create and return a singleton instance of CacheTTLController.
+  static CacheTTLController* create(AsyncDataCache& cache) {
+    if (instance_ == nullptr) {
+      instance_ =
+          std::unique_ptr<CacheTTLController>(new CacheTTLController(cache));
+    }
+    return instance_.get();
+  }
+
+  /// Return the process-wide singleton instance of CacheTTLController if it has
+  /// been created. Otherwise, return nullptr.
+  static CacheTTLController* getInstance() {
+    if (instance_ == nullptr) {
+      return nullptr;
+    }
+    return instance_.get();
+  }
+
+  /// Add file opening info for a file identified by fileNum. Return true if a
+  /// new file entry is inserted, or if the existing file entry is updated
+  /// while cache deletion for the file is in progress. Return false otherwise
+  /// if the existing file entry is not updated.
+  bool addOpenFileInfo(
+      uint64_t fileNum,
+      int64_t openTimeSec = getCurrentTimeSec());
+
+  /// Compute age related stats of the cached files.
+  CacheAgeStats getCacheAgeStats() const;
+
+ private:
+  /// A process-wide singleton instance of CacheTTLController.
+  static std::unique_ptr<CacheTTLController> instance_;
+
+ private:
+  // Prevent creating a random instance of CacheTTLController.
+  explicit CacheTTLController(AsyncDataCache& cache) : cache_(cache) {}
+
+  /// Clean up file entries with removeInProgress true but keep entries for
+  /// fileNums in filesToRetain.
+  void cleanUp(const folly::F14FastSet<uint64_t>& filesToRetain);
+
+  void reset();
+
+  AsyncDataCache& cache_;
+
+  /// A Map of fileNum to RawFileInfo.
+  folly::Synchronized<folly::F14FastMap<uint64_t, RawFileInfo>> fileInfoMap_;
+};
+
+} // namespace facebook::velox::cache

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -17,8 +17,9 @@ add_test(simple_lru_cache_test simple_lru_cache_test)
 target_link_libraries(simple_lru_cache_test PRIVATE Folly::folly glog::glog
                                                     gtest gtest_main)
 
-add_executable(velox_cache_test StringIdMapTest.cpp AsyncDataCacheTest.cpp
-                                SsdFileTest.cpp SsdFileTrackerTest.cpp)
+add_executable(
+  velox_cache_test AsyncDataCacheTest.cpp CacheTTLControllerTest.cpp
+                   SsdFileTest.cpp SsdFileTrackerTest.cpp StringIdMapTest.cpp)
 add_test(velox_cache_test velox_cache_test)
 target_link_libraries(
   velox_cache_test

--- a/velox/common/caching/tests/CacheTTLControllerTest.cpp
+++ b/velox/common/caching/tests/CacheTTLControllerTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/caching/CacheTTLController.h"
+
+#include "gtest/gtest.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/caching/AsyncDataCache.h"
+#include "velox/common/caching/SsdCache.h"
+#include "velox/common/memory/MmapAllocator.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+namespace facebook::velox::cache {
+
+class CacheTTLControllerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    allocator_ = std::make_shared<MmapAllocator>(
+        MmapAllocator::Options{.capacity = 1024L * 1024L});
+    cache_ = AsyncDataCache::create(allocator_.get());
+    MemoryAllocator::setDefaultInstance(allocator_.get());
+  }
+
+  std::shared_ptr<MemoryAllocator> allocator_;
+  std::shared_ptr<AsyncDataCache> cache_;
+};
+
+TEST_F(CacheTTLControllerTest, addOpenFileInfo) {
+  CacheTTLController::create(*cache_);
+
+  EXPECT_TRUE(CacheTTLController::getInstance()->addOpenFileInfo(123L));
+  EXPECT_FALSE(CacheTTLController::getInstance()->addOpenFileInfo(123L));
+
+  EXPECT_TRUE(CacheTTLController::getInstance()->addOpenFileInfo(456L));
+}
+
+TEST_F(CacheTTLControllerTest, getCacheAgeStats) {
+  CacheTTLController::create(*cache_);
+
+  int64_t fileOpenTime = getCurrentTimeSec();
+  for (auto i = 0; i < 1000; i++) {
+    CacheTTLController::getInstance()->addOpenFileInfo(i, fileOpenTime + i);
+  }
+
+  int64_t current = getCurrentTimeSec();
+  EXPECT_GE(
+      CacheTTLController::getInstance()->getCacheAgeStats().maxAgeSecs,
+      current - fileOpenTime);
+}
+} // namespace facebook::velox::cache

--- a/velox/common/time/Timer.cpp
+++ b/velox/common/time/Timer.cpp
@@ -36,6 +36,10 @@ ScopedTestTime::~ScopedTestTime() {
   enabled_ = false;
 }
 
+void ScopedTestTime::setCurrentTestTimeSec(size_t currentTimeSec) {
+  setCurrentTestTimeMicro(currentTimeSec * 1000000);
+}
+
 void ScopedTestTime::setCurrentTestTimeMs(size_t currentTimeMs) {
   setCurrentTestTimeMicro(currentTimeMs * 1000);
 }
@@ -44,12 +48,21 @@ void ScopedTestTime::setCurrentTestTimeMicro(size_t currentTimeUs) {
   testTimeUs_ = currentTimeUs;
 }
 
+std::optional<size_t> ScopedTestTime::getCurrentTestTimeSec() {
+  return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000000L)
+                                 : testTimeUs_;
+}
 std::optional<size_t> ScopedTestTime::getCurrentTestTimeMs() {
   return testTimeUs_.has_value() ? std::make_optional(*testTimeUs_ / 1000L)
                                  : testTimeUs_;
 }
 std::optional<size_t> ScopedTestTime::getCurrentTestTimeMicro() {
   return testTimeUs_;
+}
+
+size_t getCurrentTimeSec() {
+  return ScopedTestTime::getCurrentTestTimeSec().value_or(
+      duration_cast<seconds>(system_clock::now().time_since_epoch()).count());
 }
 
 size_t getCurrentTimeMs() {
@@ -64,6 +77,11 @@ size_t getCurrentTimeMicro() {
           .count());
 }
 #else
+
+size_t getCurrentTimeSec() {
+  return duration_cast<seconds>(system_clock::now().time_since_epoch()).count();
+}
+
 size_t getCurrentTimeMs() {
   return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
       .count();

--- a/velox/common/time/Timer.h
+++ b/velox/common/time/Timer.h
@@ -70,6 +70,9 @@ class ClockTimer {
   uint64_t start_;
 };
 
+// Returns the current epoch time in seconds.
+size_t getCurrentTimeSec();
+
 /// Returns the current epoch time in milliseconds.
 size_t getCurrentTimeMs();
 
@@ -83,9 +86,11 @@ class ScopedTestTime {
   ScopedTestTime();
   ~ScopedTestTime();
 
+  void setCurrentTestTimeSec(size_t currentTimeSec);
   void setCurrentTestTimeMs(size_t currentTimeMs);
   void setCurrentTestTimeMicro(size_t currentTimeUs);
 
+  static std::optional<size_t> getCurrentTestTimeSec();
   static std::optional<size_t> getCurrentTestTimeMs();
   static std::optional<size_t> getCurrentTestTimeMicro();
 


### PR DESCRIPTION
Use the file open time to calculate the age of AsyncDataCache
and SsdCache entries that are loaded from the file. Tracking this
enables us to expose the metrics maxAge possible of cache entries.

Add a process-wide singleton CacheTTLController to handle the TTL
of AsyncDataCache and SsdCache and track the required info. It
currently adds the file open time when a new file handle is opened. It
also calculates the maxAge for cache entries.