### PR TITLE
Remove all partitions spilled check in hash build

### DIFF
--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -850,9 +850,12 @@ void HashBuild::ensureTableFits(uint64_t numRows) {
     return;
   }
 
+  // TODO: add spilling support here in case of threshold triggered spilling.
+#if 0
   // NOTE: the memory arbitrator must have spilled everything from this hash
   // build operator and all its peers.
   VELOX_CHECK(spiller_->isAllSpilled());
+#endif
 
   // Throw a memory cap exceeded error to fail this query.
   VELOX_MEM_POOL_CAP_EXCEEDED(fmt::format(


### PR DESCRIPTION
If memory arbitration is not enabled, there is no guarantee that
all partitions have been spilled if memory reservation fail. This PR
removes this check to unblock the threshold triggered spilling
test in Meta internally