### PR TITLE
Handle inner-most lazy layer of input vector in CastExpr

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -600,6 +600,10 @@ void CastExpr::apply(
     auto peeledEncoding = PeeledEncoding::peel(
         {input}, *nonNullRows, localDecoded, true, peeledVectors);
     VELOX_CHECK_EQ(peeledVectors.size(), 1);
+    if (peeledVectors[0]->isLazy()) {
+      peeledVectors[0] =
+          peeledVectors[0]->as<LazyVector>()->loadedVectorShared();
+    }
     auto newRows =
         peeledEncoding->translateToInnerRows(*nonNullRows, newRowsHolder);
     // Save context and set the peel.

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1907,5 +1907,23 @@ TEST_F(CastExprTest, tryCastDoesNotHideInputsAndExistingErrors) {
     }
   }
 }
+
+TEST_F(CastExprTest, lazyInput) {
+  auto lazy =
+      vectorMaker_.lazyFlatVector<int64_t>(5, [](auto row) { return row; });
+  auto indices = makeIndices({0, 1, 2, 3, 4});
+  auto dictionary = BaseVector::wrapInDictionary(nullptr, indices, 5, lazy);
+  dictionary->loadedVector();
+  auto data = makeRowVector(
+      {dictionary,
+       makeNullableFlatVector<int64_t>(
+           {std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt,
+            std::nullopt})});
+
+  evaluate("cast(switch(gt(c0, c1), c1, c0) as double)", data);
+}
 } // namespace
 } // namespace facebook::velox::test


### PR DESCRIPTION
Summary: PeeledEncoding doesn't peel off inner-most lazy layer, so CastExpr can get a lazy vector after peeling. But the current code assumes that the vector after peeling is always a simple vector and this caused crashes. This diff fixes this bug by loading the vector after peeling if it is lazy.

We determined to handle unpeeled lazy layer in CastExpr instead of PeeledEncoding. See the conversation here for context: https://github.com/facebookincubator/velox/pull/6343.

Differential Revision: D48890110

