### PR TITLE
Fix DecimalUtil::rescaleXXX check overflow

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -86,6 +86,7 @@ class DecimalUtil {
         value);
   }
 
+  // Check if the precision can represent the value.
   template <typename T>
   FOLLY_ALWAYS_INLINE static bool valueInRange(T value, uint8_t precision) {
     return value < kPowersOfTen[precision] && value > -kPowersOfTen[precision];

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -86,6 +86,11 @@ class DecimalUtil {
         value);
   }
 
+  template <typename T>
+  FOLLY_ALWAYS_INLINE static bool valueInRange(T value, uint8_t precision) {
+    return value < kPowersOfTen[precision] && value > -kPowersOfTen[precision];
+  }
+
   /// Helper function to convert a decimal value to string.
   static std::string toString(const int128_t value, const TypePtr& type);
 
@@ -161,8 +166,7 @@ class DecimalUtil {
       }
     }
     // Check overflow.
-    if (rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
-        rescaledValue > DecimalUtil::kPowersOfTen[toPrecision] || isOverflow) {
+    if (!valueInRange(rescaledValue, toPrecision) || isOverflow) {
       VELOX_USER_FAIL(
           "Cannot cast DECIMAL '{}' to DECIMAL({},{})",
           DecimalUtil::toString(inputValue, DECIMAL(fromPrecision, fromScale)),
@@ -181,8 +185,7 @@ class DecimalUtil {
     bool isOverflow = __builtin_mul_overflow(
         rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
     // Check overflow.
-    if (rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
-        rescaledValue > DecimalUtil::kPowersOfTen[toPrecision] || isOverflow) {
+    if (!valueInRange(rescaledValue, toPrecision) || isOverflow) {
       VELOX_USER_FAIL(
           "Cannot cast {} '{}' to DECIMAL({},{})",
           SimpleTypeTrait<TInput>::name,

--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -86,9 +86,11 @@ class DecimalUtil {
         value);
   }
 
-  // Check if the precision can represent the value.
+  // Returns true if the precision can represent the value.
   template <typename T>
-  FOLLY_ALWAYS_INLINE static bool valueInRange(T value, uint8_t precision) {
+  FOLLY_ALWAYS_INLINE static bool valueInPrecisionRange(
+      T value,
+      uint8_t precision) {
     return value < kPowersOfTen[precision] && value > -kPowersOfTen[precision];
   }
 
@@ -167,7 +169,7 @@ class DecimalUtil {
       }
     }
     // Check overflow.
-    if (!valueInRange(rescaledValue, toPrecision) || isOverflow) {
+    if (!valueInPrecisionRange(rescaledValue, toPrecision) || isOverflow) {
       VELOX_USER_FAIL(
           "Cannot cast DECIMAL '{}' to DECIMAL({},{})",
           DecimalUtil::toString(inputValue, DECIMAL(fromPrecision, fromScale)),
@@ -186,7 +188,7 @@ class DecimalUtil {
     bool isOverflow = __builtin_mul_overflow(
         rescaledValue, DecimalUtil::kPowersOfTen[toScale], &rescaledValue);
     // Check overflow.
-    if (!valueInRange(rescaledValue, toPrecision) || isOverflow) {
+    if (!valueInPrecisionRange(rescaledValue, toPrecision) || isOverflow) {
       VELOX_USER_FAIL(
           "Cannot cast {} '{}' to DECIMAL({},{})",
           SimpleTypeTrait<TInput>::name,

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -182,15 +182,15 @@ TEST(DecimalTest, valueInPrecisionRange) {
   ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(1000, 3));
   ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(1234, 3));
   ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int64_t>(
-      DecimalUtil::kShortDecimalMax, 18));
+      DecimalUtil::kShortDecimalMax, ShortDecimalType::kMaxPrecision));
   ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(
-      DecimalUtil::kShortDecimalMax + 1, 18));
+      DecimalUtil::kShortDecimalMax + 1, ShortDecimalType::kMaxPrecision));
   ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int128_t>(
-      DecimalUtil::kLongDecimalMax, 38));
+      DecimalUtil::kLongDecimalMax, LongDecimalType::kMaxPrecision));
   ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int128_t>(
-      DecimalUtil::kLongDecimalMax + 1, 38));
+      DecimalUtil::kLongDecimalMax + 1, LongDecimalType::kMaxPrecision));
   ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int128_t>(
-      DecimalUtil::kLongDecimalMin - 1, 38));
+      DecimalUtil::kLongDecimalMin - 1, LongDecimalType::kMaxPrecision));
 }
 
 } // namespace

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -176,17 +176,20 @@ TEST(DecimalTest, toByteArray) {
   testToByteArray(DecimalUtil::kLongDecimalMax, expected8, 16);
 }
 
-TEST(DecimalTest, valueInRange) {
-  ASSERT_TRUE(DecimalUtil::valueInRange<int64_t>(12, 3));
-  ASSERT_TRUE(
-      DecimalUtil::valueInRange<int64_t>(DecimalUtil::kShortDecimalMax, 18));
-  ASSERT_FALSE(DecimalUtil::valueInRange<int64_t>(
+TEST(DecimalTest, valueInPrecisionRange) {
+  ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int64_t>(12, 3));
+  ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int64_t>(999, 3));
+  ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(1000, 3));
+  ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(1234, 3));
+  ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int64_t>(
+      DecimalUtil::kShortDecimalMax, 18));
+  ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int64_t>(
       DecimalUtil::kShortDecimalMax + 1, 18));
-  ASSERT_TRUE(
-      DecimalUtil::valueInRange<int128_t>(DecimalUtil::kLongDecimalMax, 38));
-  ASSERT_FALSE(DecimalUtil::valueInRange<int128_t>(
+  ASSERT_TRUE(DecimalUtil::valueInPrecisionRange<int128_t>(
+      DecimalUtil::kLongDecimalMax, 38));
+  ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int128_t>(
       DecimalUtil::kLongDecimalMax + 1, 38));
-  ASSERT_FALSE(DecimalUtil::valueInRange<int128_t>(
+  ASSERT_FALSE(DecimalUtil::valueInPrecisionRange<int128_t>(
       DecimalUtil::kLongDecimalMin - 1, 38));
 }
 

--- a/velox/type/tests/DecimalTest.cpp
+++ b/velox/type/tests/DecimalTest.cpp
@@ -176,5 +176,19 @@ TEST(DecimalTest, toByteArray) {
   testToByteArray(DecimalUtil::kLongDecimalMax, expected8, 16);
 }
 
+TEST(DecimalTest, valueInRange) {
+  ASSERT_TRUE(DecimalUtil::valueInRange<int64_t>(12, 3));
+  ASSERT_TRUE(
+      DecimalUtil::valueInRange<int64_t>(DecimalUtil::kShortDecimalMax, 18));
+  ASSERT_FALSE(DecimalUtil::valueInRange<int64_t>(
+      DecimalUtil::kShortDecimalMax + 1, 18));
+  ASSERT_TRUE(
+      DecimalUtil::valueInRange<int128_t>(DecimalUtil::kLongDecimalMax, 38));
+  ASSERT_FALSE(DecimalUtil::valueInRange<int128_t>(
+      DecimalUtil::kLongDecimalMax + 1, 38));
+  ASSERT_FALSE(DecimalUtil::valueInRange<int128_t>(
+      DecimalUtil::kLongDecimalMin - 1, 38));
+}
+
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
The original logic returns incorrect result when `rescaledValue = DecimalUtil::kPowersOfTen[toPrecision]`

```
rescaledValue < -DecimalUtil::kPowersOfTen[toPrecision] ||
        rescaledValue > DecimalUtil::kPowersOfTen[toPrecision]
```