### PR TITLE
Remove unneeded LocalPartitionQueue::producerPromises_

### DIFF
--- a/velox/exec/LocalPartition.cpp
+++ b/velox/exec/LocalPartition.cpp
@@ -64,22 +64,15 @@ void LocalExchangeQueue::addProducer() {
 
 void LocalExchangeQueue::noMoreProducers() {
   std::vector<ContinuePromise> consumerPromises;
-  std::vector<ContinuePromise> producerPromises;
   queue_.withWLock([&](auto& queue) {
     VELOX_CHECK(!noMoreProducers_, "noMoreProducers can be called only once");
     noMoreProducers_ = true;
     if (pendingProducers_ == 0) {
       // No more data will be produced.
       consumerPromises = std::move(consumerPromises_);
-
-      if (queue.empty()) {
-        // All data has been consumed.
-        producerPromises = std::move(producerPromises_);
-      }
     }
   });
   notify(consumerPromises);
-  notify(producerPromises);
 }
 
 BlockingReason LocalExchangeQueue::enqueue(
@@ -118,26 +111,20 @@ BlockingReason LocalExchangeQueue::enqueue(
 
 void LocalExchangeQueue::noMoreData() {
   std::vector<ContinuePromise> consumerPromises;
-  std::vector<ContinuePromise> producerPromises;
   queue_.withWLock([&](auto& queue) {
     VELOX_CHECK_GT(pendingProducers_, 0);
     --pendingProducers_;
     if (noMoreProducers_ && pendingProducers_ == 0) {
       consumerPromises = std::move(consumerPromises_);
-      if (queue.empty()) {
-        producerPromises = std::move(producerPromises_);
-      }
     }
   });
   notify(consumerPromises);
-  notify(producerPromises);
 }
 
 BlockingReason LocalExchangeQueue::next(
     ContinueFuture* future,
     memory::MemoryPool* pool,
     RowVectorPtr* data) {
-  std::vector<ContinuePromise> producerPromises;
   std::vector<ContinuePromise> memoryPromises;
   auto blockingReason = queue_.withWLock([&](auto& queue) {
     *data = nullptr;
@@ -158,14 +145,9 @@ BlockingReason LocalExchangeQueue::next(
     memoryPromises =
         memoryManager_->decreaseMemoryUsage((*data)->estimateFlatSize());
 
-    if (noMoreProducers_ && pendingProducers_ == 0 && queue.empty()) {
-      producerPromises = std::move(producerPromises_);
-    }
-
     return BlockingReason::kNotBlocked;
   });
   notify(memoryPromises);
-  notify(producerPromises);
   return blockingReason;
 }
 
@@ -182,25 +164,11 @@ bool LocalExchangeQueue::isFinishedLocked(
   return false;
 }
 
-BlockingReason LocalExchangeQueue::isFinished(ContinueFuture* future) {
-  return queue_.withWLock([&](auto& queue) {
-    if (isFinishedLocked(queue)) {
-      return BlockingReason::kNotBlocked;
-    }
-
-    producerPromises_.emplace_back("LocalExchangeQueue::isFinished");
-    *future = producerPromises_.back().getSemiFuture();
-
-    return BlockingReason::kWaitForConsumer;
-  });
-}
-
 bool LocalExchangeQueue::isFinished() {
   return queue_.withWLock([&](auto& queue) { return isFinishedLocked(queue); });
 }
 
 void LocalExchangeQueue::close() {
-  std::vector<ContinuePromise> producerPromises;
   std::vector<ContinuePromise> consumerPromises;
   std::vector<ContinuePromise> memoryPromises;
   queue_.withWLock([&](auto& queue) {
@@ -214,11 +182,9 @@ void LocalExchangeQueue::close() {
       memoryPromises = memoryManager_->decreaseMemoryUsage(freedBytes);
     }
 
-    producerPromises = std::move(producerPromises_);
     consumerPromises = std::move(consumerPromises_);
     closed_ = true;
   });
-  notify(producerPromises);
   notify(consumerPromises);
   notify(memoryPromises);
 }

--- a/velox/exec/LocalPartition.h
+++ b/velox/exec/LocalPartition.h
@@ -82,14 +82,6 @@ class LocalExchangeQueue {
   BlockingReason
   next(ContinueFuture* future, memory::MemoryPool* pool, RowVectorPtr* data);
 
-  /// Used by producers to get notified when all data has been fetched. Returns
-  /// kNotBlocked if all data has been fetched. Otherwise, returns
-  /// kWaitForConsumer and sets future that will be competed when all data is
-  /// fetched. Producers must stay alive until all data has been fetched.
-  /// Otherwise, the memory backing the data may get freed before the data was
-  /// copied into the consumers memory pool.
-  BlockingReason isFinished(ContinueFuture* future);
-
   bool isFinished();
 
   /// Drop remaining data from the queue and notify consumers and producers if
@@ -106,10 +98,6 @@ class LocalExchangeQueue {
   // finished producing, e.g. queue_ is not empty or noMoreProducers_ is true
   // and pendingProducers_ is zero.
   std::vector<ContinuePromise> consumerPromises_;
-  // Satisfied when all data has been fetched and no more data will be produced,
-  // e.g. queue_ is empty, noMoreProducers_ is true and pendingProducers_ is
-  // zero.
-  std::vector<ContinuePromise> producerPromises_;
   int pendingProducers_{0};
   bool noMoreProducers_{false};
   bool closed_{false};


### PR DESCRIPTION
`LocalPartitionQueue::producerPromises_` is used by the producer
(`LocalPartition`) to be notified after all data has been consumed by
`LocalExchange`. But after #4385, `LocalPartition` no longer waits for
`LocalExchange` to drain all data. This also means that after all the
data in the queue has been consumed, there is no need to notify the
producers at all.

So, `LocalPartitionQueue::producerPromises_` is no longer needed, and
its notification to the producers is redundant, we should remove it.

Fixes #6387 