### PR TITLE
Fix index mapping bugs in contains, array_position and subscript Presto functions

### DIFF
--- a/velox/expression/tests/ExpressionFuzzerTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerTest.cpp
@@ -61,10 +61,6 @@ int main(int argc, char** argv) {
       "in",
       "element_at",
       "width_bucket",
-      // https://github.com/facebookincubator/velox/issues/6346
-      "contains",
-      "subscript",
-      "array_position",
   };
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   return FuzzerRunner::run(

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -414,6 +414,7 @@ class SubscriptImpl : public exec::Subscript {
     exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
     auto mapKeysDecoded = mapKeysHolder.get();
     auto mapKeysBase = mapKeysDecoded->base();
+    auto mapKeysIndices = mapKeysDecoded->indices();
 
     // Get index vector (second argument).
     exec::LocalDecodedVector indexHolder(context, *indexArg, rows);
@@ -433,7 +434,8 @@ class SubscriptImpl : public exec::Subscript {
       bool found = false;
       auto searchIndex = searchIndices[row];
       for (auto i = 0; i < size; i++) {
-        if (mapKeysBase->equalValueAt(searchBase, offset + i, searchIndex)) {
+        if (mapKeysBase->equalValueAt(
+                searchBase, mapKeysIndices[offset + i], searchIndex)) {
           rawIndices[row] = offset + i;
           found = true;
           break;

--- a/velox/functions/prestosql/ArrayContains.cpp
+++ b/velox/functions/prestosql/ArrayContains.cpp
@@ -92,7 +92,7 @@ void applyComplexType(
   auto indices = arrayDecoded.indices();
 
   auto elementsBase = elementsDecoded.base();
-
+  auto elementIndices = elementsDecoded.indices();
   auto searchBase = searchDecoded.base();
   auto searchIndices = searchDecoded.indices();
 
@@ -104,10 +104,10 @@ void applyComplexType(
 
     auto searchIndex = searchIndices[row];
     for (auto i = 0; i < size; i++) {
-      if (elementsBase->isNullAt(offset + i)) {
+      if (elementsDecoded.isNullAt(offset + i)) {
         foundNull = true;
       } else if (elementsBase->equalValueAt(
-                     searchBase, offset + i, searchIndex)) {
+                     searchBase, elementIndices[offset + i], searchIndex)) {
         flatResult.set(row, true);
         return;
       }

--- a/velox/functions/prestosql/ArrayPosition.cpp
+++ b/velox/functions/prestosql/ArrayPosition.cpp
@@ -117,7 +117,7 @@ template <
 void applyTypedFirstMatch(
     const SelectivityVector& rows,
     DecodedVector& arrayDecoded,
-    const DecodedVector& elementsDecoded,
+    DecodedVector& elementsDecoded,
     DecodedVector& searchDecoded,
     FlatVector<int64_t>& flatResult) {
   auto baseArray = arrayDecoded.base()->as<ArrayVector>();
@@ -126,6 +126,7 @@ void applyTypedFirstMatch(
   auto indices = arrayDecoded.indices();
 
   auto elementsBase = elementsDecoded.base();
+  auto elementIndices = elementsDecoded.indices();
 
   auto searchBase = searchDecoded.base();
   auto searchIndices = searchDecoded.indices();
@@ -137,8 +138,9 @@ void applyTypedFirstMatch(
 
     int i;
     for (i = 0; i < size; i++) {
-      if (!elementsBase->isNullAt(offset + i) &&
-          elementsBase->equalValueAt(searchBase, offset + i, searchIndex)) {
+      if (!elementsDecoded.isNullAt(offset + i) &&
+          elementsBase->equalValueAt(
+              searchBase, elementIndices[offset + i], searchIndex)) {
         flatResult.set(row, i + 1);
         break;
       }
@@ -298,7 +300,7 @@ void applyTypedWithInstance(
     const SelectivityVector& rows,
     exec::EvalCtx& context,
     DecodedVector& arrayDecoded,
-    const DecodedVector& elementsDecoded,
+    DecodedVector& elementsDecoded,
     DecodedVector& searchDecoded,
     const DecodedVector& instanceDecoded,
     FlatVector<int64_t>& flatResult) {
@@ -308,7 +310,7 @@ void applyTypedWithInstance(
   auto indices = arrayDecoded.indices();
 
   auto elementsBase = elementsDecoded.base();
-
+  auto elementIndices = elementsDecoded.indices();
   auto searchBase = searchDecoded.base();
   auto searchIndices = searchDecoded.indices();
 
@@ -331,8 +333,9 @@ void applyTypedWithInstance(
 
     int i;
     for (i = startIndex; i != endIndex; i += step) {
-      if (!elementsBase->isNullAt(offset + i) &&
-          elementsBase->equalValueAt(searchBase, offset + i, searchIndex)) {
+      if (!elementsDecoded.isNullAt(offset + i) &&
+          elementsBase->equalValueAt(
+              searchBase, elementIndices[offset + i], searchIndex)) {
         --instance;
         if (instance == 0) {
           flatResult.set(row, i + 1);

--- a/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
+++ b/velox/functions/prestosql/benchmarks/ArrayPositionBasic.h
@@ -64,7 +64,7 @@ template <
 void applyTypedFirstMatch(
     const SelectivityVector& rows,
     DecodedVector& arrayDecoded,
-    const DecodedVector& elementsDecoded,
+    DecodedVector& elementsDecoded,
     DecodedVector& searchDecoded,
     FlatVector<int64_t>& flatResult) {
   auto baseArray = arrayDecoded.base()->as<ArrayVector>();
@@ -73,7 +73,7 @@ void applyTypedFirstMatch(
   auto indices = arrayDecoded.indices();
 
   auto elementsBase = elementsDecoded.base();
-
+  auto elementIndices = elementsDecoded.indices();
   auto searchBase = searchDecoded.base();
   auto searchIndices = searchDecoded.indices();
 
@@ -84,8 +84,9 @@ void applyTypedFirstMatch(
 
     int i;
     for (i = 0; i < size; i++) {
-      if (!elementsBase->isNullAt(offset + i) &&
-          elementsBase->equalValueAt(searchBase, offset + i, searchIndex)) {
+      if (!elementsDecoded.isNullAt(offset + i) &&
+          elementsBase->equalValueAt(
+              searchBase, elementIndices[offset + i], searchIndex)) {
         flatResult.set(row, i + 1);
         break;
       }
@@ -154,7 +155,7 @@ template <
 void applyTypedWithInstance(
     const SelectivityVector& rows,
     DecodedVector& arrayDecoded,
-    const DecodedVector& elementsDecoded,
+    DecodedVector& elementsDecoded,
     DecodedVector& searchDecoded,
     const DecodedVector& instanceDecoded,
     FlatVector<int64_t>& flatResult) {
@@ -164,6 +165,7 @@ void applyTypedWithInstance(
   auto indices = arrayDecoded.indices();
 
   auto elementsBase = elementsDecoded.base();
+  auto elementIndices = elementsDecoded.indices();
 
   auto searchBase = searchDecoded.base();
   auto searchIndices = searchDecoded.indices();
@@ -186,8 +188,9 @@ void applyTypedWithInstance(
 
     int i;
     for (i = startIndex; i != endIndex; i += step) {
-      if (!elementsBase->isNullAt(offset + i) &&
-          elementsBase->equalValueAt(searchBase, offset + i, searchIndex)) {
+      if (!elementsDecoded.isNullAt(offset + i) &&
+          elementsBase->equalValueAt(
+              searchBase, elementIndices[offset + i], searchIndex)) {
         --instance;
         if (instance == 0) {
           flatResult.set(row, i + 1);

--- a/velox/functions/prestosql/tests/ArrayContainsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayContainsTest.cpp
@@ -104,24 +104,21 @@ TEST_F(ArrayContainsTest, integerWithNulls) {
 }
 
 TEST_F(ArrayContainsTest, varcharNoNulls) {
-  std::vector<std::string> colors = {
-      "red", "green", "blue", "yellow", "orange", "purple"};
-
-  using S = StringView;
-
   auto arrayVector = makeArrayVector<StringView>({
-      {S("red"), S("blue")},
-      {S("blue"), S("yellow"), S("orange")},
+      {"red"_sv, "blue"_sv},
+      {"blue"_sv, "yellow"_sv, "orange"_sv},
       {},
-      {S("red"), S("purple"), S("green")},
+      {"red"_sv, "purple"_sv, "green"_sv},
   });
 
-  testContains<StringView>(arrayVector, "red", {true, false, false, true});
-  testContains<StringView>(arrayVector, "blue", {true, true, false, false});
-  testContains<StringView>(arrayVector, "yellow", {false, true, false, false});
-  testContains<StringView>(arrayVector, "green", {false, false, false, true});
+  testContains<StringView>(arrayVector, "red"_sv, {true, false, false, true});
+  testContains<StringView>(arrayVector, "blue"_sv, {true, true, false, false});
   testContains<StringView>(
-      arrayVector, "crimson red", {false, false, false, false});
+      arrayVector, "yellow"_sv, {false, true, false, false});
+  testContains<StringView>(
+      arrayVector, "green"_sv, {false, false, false, true});
+  testContains<StringView>(
+      arrayVector, "crimson red"_sv, {false, false, false, false});
   testContains(
       arrayVector,
       std::optional<StringView>(std::nullopt),
@@ -129,26 +126,22 @@ TEST_F(ArrayContainsTest, varcharNoNulls) {
 }
 
 TEST_F(ArrayContainsTest, varcharWithNulls) {
-  std::vector<std::string> colors = {
-      "red", "green", "blue", "yellow", "orange", "purple"};
-
-  using S = StringView;
-
   auto arrayVector = makeNullableArrayVector<StringView>({
-      {S("red"), S("blue")},
-      {std::nullopt, S("blue"), S("yellow"), S("orange")},
+      {"red"_sv, "blue"_sv},
+      {std::nullopt, "blue"_sv, "yellow"_sv, "orange"_sv},
       {},
-      {S("red"), S("purple"), S("green")},
+      {"red"_sv, "purple"_sv, "green"_sv},
   });
 
   testContains<StringView>(
-      arrayVector, "red", {true, std::nullopt, false, true});
-  testContains<StringView>(arrayVector, "blue", {true, true, false, false});
-  testContains<StringView>(arrayVector, "yellow", {false, true, false, false});
+      arrayVector, "red"_sv, {true, std::nullopt, false, true});
+  testContains<StringView>(arrayVector, "blue"_sv, {true, true, false, false});
   testContains<StringView>(
-      arrayVector, "green", {false, std::nullopt, false, true});
+      arrayVector, "yellow"_sv, {false, true, false, false});
   testContains<StringView>(
-      arrayVector, "crimson red", {false, std::nullopt, false, false});
+      arrayVector, "green"_sv, {false, std::nullopt, false, true});
+  testContains<StringView>(
+      arrayVector, "crimson red"_sv, {false, std::nullopt, false, false});
   testContains(
       arrayVector,
       std::optional<StringView>(std::nullopt),
@@ -324,8 +317,7 @@ TEST_F(ArrayContainsTest, dictionaryEncodingElements) {
       makeArrayVector<int64_t>({{1, 2, 3, 4}, {3, 4, 5}, {10, 9, 8, 7}});
   auto baseVectorSize = baseVector->size();
   const vector_size_t kTopLevelVectorSize = baseVectorSize * 2;
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kTopLevelVectorSize, pool_.get());
+  BufferPtr indices = allocateIndices(kTopLevelVectorSize, pool_.get());
   auto rawIndices = indices->asMutable<vector_size_t>();
   for (size_t i = 0; i < kTopLevelVectorSize; ++i) {
     rawIndices[i] = i % baseVectorSize;

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -68,7 +68,7 @@ class ArrayPositionTest : public FunctionBaseTest {
       assertEqualVectors(
           makeNullableFlatVector<int64_t>(expected), instanceResult);
     } else {
-      auto result = evaluate<SimpleVector<int64_t>>(
+      auto result = evaluate(
           "array_position(c0, c1)", makeRowVector({arrayVector, constSearch}));
       assertEqualVectors(makeNullableFlatVector<int64_t>(expected), result);
     }
@@ -884,8 +884,7 @@ TEST_F(ArrayPositionTest, dictionaryEncodingElements) {
       {{1, 2, 3, 4}, {3, 4, 5}, {1, 2, 3, 4}, {10, 9, 8, 7}});
   auto baseVectorSize = baseVector->size();
   const vector_size_t kTopLevelVectorSize = baseVectorSize * 2;
-  BufferPtr indices =
-      AlignedBuffer::allocate<vector_size_t>(kTopLevelVectorSize, pool_.get());
+  BufferPtr indices = allocateIndices(kTopLevelVectorSize, pool_.get());
   auto rawIndices = indices->asMutable<vector_size_t>();
   for (size_t i = 0; i < kTopLevelVectorSize; ++i) {
     rawIndices[i] = i % baseVectorSize;

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -52,14 +52,14 @@ class ArrayPositionTest : public FunctionBaseTest {
   }
 
   void testPosition(
-      ArrayVectorPtr arrayVector,
-      std::vector<int64_t> search,
+      const ArrayVectorPtr& arrayVector,
+      const std::vector<int64_t>& search,
       const std::vector<std::optional<int64_t>>& expected,
       std::optional<int64_t> instanceOpt = std::nullopt) {
-    auto constSearch = BaseVector::wrapInConstant(
-        1, 0, makeArrayVector<int64_t>({std::move(search)}));
+    auto constSearch =
+        BaseVector::wrapInConstant(1, 0, makeArrayVector<int64_t>({search}));
     if (instanceOpt.has_value()) {
-      auto instanceResult = evaluate<SimpleVector<int64_t>>(
+      auto instanceResult = evaluate(
           "array_position(c0, c1, c2)",
           makeRowVector(
               {arrayVector,

--- a/velox/functions/prestosql/tests/ArrayPositionTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayPositionTest.cpp
@@ -51,6 +51,29 @@ class ArrayPositionTest : public FunctionBaseTest {
         makeNullableFlatVector<int64_t>(expected));
   }
 
+  void testPosition(
+      ArrayVectorPtr arrayVector,
+      std::vector<int64_t> search,
+      const std::vector<std::optional<int64_t>>& expected,
+      std::optional<int64_t> instanceOpt = std::nullopt) {
+    auto constSearch = BaseVector::wrapInConstant(
+        1, 0, makeArrayVector<int64_t>({std::move(search)}));
+    if (instanceOpt.has_value()) {
+      auto instanceResult = evaluate<SimpleVector<int64_t>>(
+          "array_position(c0, c1, c2)",
+          makeRowVector(
+              {arrayVector,
+               constSearch,
+               makeConstant(instanceOpt.value(), arrayVector->size())}));
+      assertEqualVectors(
+          makeNullableFlatVector<int64_t>(expected), instanceResult);
+    } else {
+      auto result = evaluate<SimpleVector<int64_t>>(
+          "array_position(c0, c1)", makeRowVector({arrayVector, constSearch}));
+      assertEqualVectors(makeNullableFlatVector<int64_t>(expected), result);
+    }
+  }
+
   template <typename T>
   void testPositionDictEncoding(
       const TwoDimVector<T>& array,
@@ -834,4 +857,45 @@ TEST_F(ArrayPositionTest, invalidInstance) {
   result = evaluate("try(array_position(c0, 1, 0))", input);
   assertEqualVectors(makeNullConstant(TypeKind::BIGINT, 2), result);
 }
+
+TEST_F(ArrayPositionTest, topLevelCardinalityGreaterThanBase) {
+  // ArrayVector with ConstantVector<Array> elements.
+  auto baseVector = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4},
+       {3, 4, 5},
+       {},
+       {5, 6, 7, 8, 9},
+       {1, 2, 3, 4},
+       {10, 9, 8, 7}});
+  const vector_size_t kTopLevelCardinality = baseVector->size() * 2;
+  auto constantVector =
+      BaseVector::wrapInConstant(kTopLevelCardinality, 0, baseVector);
+  auto arrayVector = makeArrayVector({0, 2, 7}, constantVector);
+
+  testPosition(arrayVector, {1, 2, 3, 4}, {1, 1, 1});
+  testPosition(arrayVector, {3, 4, 5}, {0, 0, 0});
+  testPosition(arrayVector, {1, 2, 3, 4}, {1, 1, 1}, 1);
+  testPosition(arrayVector, {1, 2, 3, 4}, {2, 5, kTopLevelCardinality - 7}, -1);
+}
+
+TEST_F(ArrayPositionTest, topLevelCardinalityLessThanBase) {
+  // ArrayVector with ConstantVector<Array> elements.
+  auto baseVector = makeArrayVector<int64_t>(
+      {{1, 2, 3, 4},
+       {3, 4, 5},
+       {},
+       {5, 6, 7, 8, 9},
+       {1, 2, 3, 4},
+       {10, 9, 8, 7}});
+  const vector_size_t kTopLevelCardinality = baseVector->size() / 2;
+  auto constantVector =
+      BaseVector::wrapInConstant(kTopLevelCardinality, 0, baseVector);
+  auto arrayVector = makeArrayVector({0, 2}, constantVector);
+
+  testPosition(arrayVector, {1, 2, 3, 4}, {1, 1}, std::nullopt);
+  testPosition(arrayVector, {3, 4, 5}, {0, 0}, std::nullopt);
+  testPosition(arrayVector, {1, 2, 3, 4}, {1, 1}, 1);
+  testPosition(arrayVector, {1, 2, 3, 4}, {2, 1}, -1);
+}
+
 } // namespace


### PR DESCRIPTION
Fixes #6346

The cardinality of a top-level vector, such as`ConstantVector<ComplextType>`, may be greater than its base vector, so we should use elementsDecoded and its indices to process each element.