### PR TITLE
Remove check for nulls in DictionaryVector::wrappedIndex()

### DIFF
--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -164,10 +164,7 @@ class DictionaryVector : public SimpleVector<T> {
     return dictionaryValues_->wrappedVector();
   }
 
-  // Should not be called if the index is null in the top level dictionary
-  // vector.
   vector_size_t wrappedIndex(vector_size_t index) const override {
-    VELOX_CHECK(!BaseVector::isNullAt(index));
     return dictionaryValues_->wrappedIndex(rawIndices_[index]);
   }
 


### PR DESCRIPTION
Summary:
A check is added recently requiring that DictionaryVector::wrappedIndex() is not called on indices where the dictionary vector is null. This check is too general since we have legit callsites of this function on null rows in the ContainerRowSerde class. This causes min() and max() aggregation functions to fail in the fuzzer test. This diff removes this check until we're able to identify and change all callers of wrappedIndex() to follow that expectation.

This diff fixes https://github.com/facebookincubator/velox/issues/6393.

Reviewed By: laithsakka

Differential Revision: D48914410


