### PR TITLE
Move op initialization outside of FilterProject ctor path

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -532,6 +532,8 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   // visitChildren() cost as we don't have to upgrade the weak pointer and copy
   // out the upgraded shared pointers.git
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> children_;
+
+  friend class TestMemoryReclaimer;
 };
 
 std::ostream& operator<<(std::ostream& out, MemoryPool::Kind kind);

--- a/velox/exec/FilterProject.cpp
+++ b/velox/exec/FilterProject.cpp
@@ -52,15 +52,25 @@ FilterProject::FilterProject(
           operatorId,
           project ? project->id() : filter->id(),
           "FilterProject"),
-      hasFilter_(filter != nullptr) {
+      hasFilter_(filter != nullptr),
+      project_(project),
+      filter_(filter) {}
+
+void FilterProject::ensureInitialized() {
+  if (initialized_) {
+    VELOX_CHECK_NULL(filter_);
+    VELOX_CHECK_NULL(project_);
+    return;
+  }
   std::vector<core::TypedExprPtr> allExprs;
   if (hasFilter_) {
-    allExprs.push_back(filter->filter());
+    VELOX_CHECK_NOT_NULL(filter_);
+    allExprs.push_back(filter_->filter());
   }
-  if (project) {
-    const auto& inputType = project->sources()[0]->outputType();
-    for (column_index_t i = 0; i < project->projections().size(); i++) {
-      auto& projection = project->projections()[i];
+  if (project_) {
+    const auto& inputType = project_->sources()[0]->outputType();
+    for (column_index_t i = 0; i < project_->projections().size(); i++) {
+      auto& projection = project_->projections()[i];
       bool identityProjection = checkAddIdentityProjection(
           projection, inputType, i, identityProjections_);
       if (!identityProjection) {
@@ -78,8 +88,8 @@ FilterProject::FilterProject(
   exprs_ = makeExprSetFromFlag(std::move(allExprs), operatorCtx_->execCtx());
 
   if (numExprs_ > 0 && !identityProjections_.empty()) {
-    auto inputType = project ? project->sources()[0]->outputType()
-                             : filter->sources()[0]->outputType();
+    const auto inputType = project_ ? project_->sources()[0]->outputType()
+                                    : filter_->sources()[0]->outputType();
     std::unordered_set<uint32_t> distinctFieldIndices;
     for (auto field : exprs_->distinctFields()) {
       auto fieldIndex = inputType->getChildIdx(field->name());
@@ -92,9 +102,13 @@ FilterProject::FilterProject(
       }
     }
   }
+  initialized_ = true;
+  filter_.reset();
+  project_.reset();
 }
 
 void FilterProject::addInput(RowVectorPtr input) {
+  ensureInitialized();
   input_ = std::move(input);
   numProcessedInputRows_ = 0;
   if (!resultProjections_.empty()) {
@@ -125,6 +139,7 @@ bool FilterProject::isFinished() {
 }
 
 RowVectorPtr FilterProject::getOutput() {
+  ensureInitialized();
   if (allInputProcessed()) {
     return nullptr;
   }

--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -53,7 +53,11 @@ class FilterProject : public Operator {
 
   void close() override {
     Operator::close();
-    exprs_->clear();
+    if (exprs_ != nullptr) {
+      exprs_->clear();
+    } else {
+      VELOX_CHECK(!initialized_);
+    }
   }
 
   /// Data for accelerator conversion.
@@ -66,6 +70,8 @@ class FilterProject : public Operator {
   Export exprsAndProjection() const {
     return Export{exprs_.get(), hasFilter_, &resultProjections_};
   }
+
+  void ensureInitialized();
 
  private:
   // Tests if 'numProcessedRows_' equals to the length of input_ and clears
@@ -86,6 +92,13 @@ class FilterProject : public Operator {
 
   // If true exprs_[0] is a filter and the other expressions are projections
   const bool hasFilter_{false};
+
+  // Cached filter and project node for lazy initialization. After
+  // initialization, they will be reset, and initialized_ will be set to true.
+  std::shared_ptr<const core::ProjectNode> project_;
+  std::shared_ptr<const core::FilterNode> filter_;
+  bool initialized_{false};
+
   std::unique_ptr<ExprSet> exprs_;
   int32_t numExprs_;
 

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -848,6 +848,7 @@ void Task::createDriversLocked(
     std::shared_ptr<Task>& self,
     uint32_t splitGroupId,
     std::vector<std::shared_ptr<Driver>>& out) {
+  TestValue::adjust("facebook::velox::exec::Task::createDriversLocked", this);
   const bool groupedExecutionDrivers = (splitGroupId != kUngroupedGroupId);
   auto& splitGroupState = self->splitGroupStates_[splitGroupId];
   const auto numPipelines = driverFactories_.size();

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -352,6 +352,10 @@ bool CompileState::compile() {
   int32_t nodeIndex = 0;
   RowTypePtr outputType;
   for (; operatorIndex < operators.size(); ++operatorIndex) {
+    if (auto filterProject = dynamic_cast<velox::exec::FilterProject*>(
+            operators[operatorIndex])) {
+      filterProject->ensureInitialized();
+    }
     if (!addOperator(operators[operatorIndex], nodeIndex, outputType)) {
       break;
     }


### PR DESCRIPTION
Currently FilterProject operator initialization is in its constructor path. The constructor uses memory pool to compile expressions. This can lead to deadlock from memory arbitration in the following scenario:
1. T1: TaskManager::createOrUpdateTask()
2. T1: acquired PrestoTask::mutex_;
3. T1: acquired Task::mutex_;
4. T2: Something triggered arbitration, in arbitration calling Task::reclaim() trying to acquire Task::mutex_ but not able to acquire;
5. T1: triggered arbitration during FilterProject operator construction, got in arbitration queue, stuck in arbitration queue because current processing arbitration in T2 cannot proceed

DEADLOCK stuck in arbitration, and queue not able to move forward. Also PrestoTask mutex_ held forever.

The root cause of the above scenario is we hold Task::mutex_ while going into memory arbitration. We shall move the logic that uses memory pool out from the constructor to avoid such scenario.