### PR TITLE
Add ability to serialize input vector and sql if expression evaluation crashes

### DIFF
--- a/velox/common/process/ThreadDebugInfo.h
+++ b/velox/common/process/ThreadDebugInfo.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <functional>
 #include <string>
 
 namespace facebook::velox::process {
@@ -25,6 +26,8 @@ namespace facebook::velox::process {
 struct ThreadDebugInfo {
   std::string queryId_;
   std::string taskId_;
+  // Callback to invoke when the debug info is to be dumped. Can be empty.
+  std::function<void()> callback_;
 };
 
 // A RAII class to store thread local debug information.

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -41,7 +41,7 @@ DriverCtx::DriverCtx(
       splitGroupId(_splitGroupId),
       partitionId(_partitionId),
       task(_task),
-      threadDebugInfo({task->queryCtx()->queryId(), task->taskId()}) {}
+      threadDebugInfo({task->queryCtx()->queryId(), task->taskId(), nullptr}) {}
 
 const core::QueryConfig& DriverCtx::queryConfig() const {
   return task->queryCtx()->queryConfig();

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -546,7 +546,7 @@ void Task::start(
     uint32_t maxDrivers,
     uint32_t concurrentSplitGroups) {
   facebook::velox::process::ThreadDebugInfo threadDebugInfo{
-      self->queryCtx()->queryId(), self->taskId_};
+      self->queryCtx()->queryId(), self->taskId_, nullptr};
   facebook::velox::process::ScopedThreadDebugInfo scopedInfo(threadDebugInfo);
   try {
     VELOX_CHECK_GE(


### PR DESCRIPTION
Summary:
This adds an experimental flag
'experimental_velox_save_input_on_fatal_signal' that when set to
true, serializes the input vector data and all the SQL expressions
in the ExprSet that is currently executing whenever a fatal signal
is encountered. Enabling this flag makes the signal handler async
signal unsafe, so it should only be used for debugging purposes.

Differential Revision: D48891649


