### PR TITLE
pass down the scan table schema type to parquet column reader

### DIFF
--- a/velox/dwio/parquet/reader/BooleanColumnReader.h
+++ b/velox/dwio/parquet/reader/BooleanColumnReader.h
@@ -25,14 +25,15 @@ class BooleanColumnReader : public dwio::common::SelectiveByteRleColumnReader {
  public:
   using ValueType = bool;
   BooleanColumnReader(
-      const std::shared_ptr<const dwio::common::TypeWithId>& nodeType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      std::shared_ptr<const dwio::common::TypeWithId> dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveByteRleColumnReader(
-            nodeType->type(),
+            requestedType->type(),
             params,
             scanSpec,
-            nodeType) {}
+            std::move(dataType)) {}
 
   void seekToRowGroup(uint32_t index) override {
     SelectiveByteRleColumnReader::seekToRowGroup(index);

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -74,7 +74,7 @@ class PageReader {
   /// levels.
   void decodeRepDefs(int32_t numTopLevelRows);
 
-  /// Returns lengths and/or nulls   from 'begin' to 'end' for the level of
+  /// Returns lengths and/or nulls from 'begin' to 'end' for the level of
   /// 'info' using 'mode'. 'maxItems' is the maximum number of nulls and lengths
   /// to produce. 'lengths' is only filled for mode kList. 'nulls' is filled
   /// from bit position 'nullsStartIndex'. Returns the number of lengths/nulls

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -34,6 +34,7 @@ namespace facebook::velox::parquet {
 
 // static
 std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     ParquetParams& params,
     common::ScanSpec& scanSpec) {
@@ -46,30 +47,30 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     case TypeKind::TINYINT:
     case TypeKind::HUGEINT:
       return std::make_unique<IntegerColumnReader>(
-          dataType, dataType, params, scanSpec);
+          requestedType, dataType, params, scanSpec);
 
     case TypeKind::REAL:
       return std::make_unique<FloatingPointColumnReader<float, float>>(
-          dataType->type(), dataType, params, scanSpec);
+          requestedType->type(), dataType, params, scanSpec);
     case TypeKind::DOUBLE:
       return std::make_unique<FloatingPointColumnReader<double, double>>(
-          dataType->type(), dataType, params, scanSpec);
+          requestedType->type(), dataType, params, scanSpec);
 
     case TypeKind::ROW:
-      return std::make_unique<StructColumnReader>(dataType, params, scanSpec);
+      return std::make_unique<StructColumnReader>(requestedType, dataType, params, scanSpec);
 
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
       return std::make_unique<StringColumnReader>(dataType, params, scanSpec);
 
     case TypeKind::ARRAY:
-      return std::make_unique<ListColumnReader>(dataType, params, scanSpec);
+      return std::make_unique<ListColumnReader>(requestedType, dataType, params, scanSpec);
 
     case TypeKind::MAP:
-      return std::make_unique<MapColumnReader>(dataType, params, scanSpec);
+      return std::make_unique<MapColumnReader>(requestedType, dataType, params, scanSpec);
 
     case TypeKind::BOOLEAN:
-      return std::make_unique<BooleanColumnReader>(dataType, params, scanSpec);
+      return std::make_unique<BooleanColumnReader>(requestedType, dataType, params, scanSpec);
 
     default:
       VELOX_FAIL(

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -57,20 +57,24 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
           requestedType->type(), dataType, params, scanSpec);
 
     case TypeKind::ROW:
-      return std::make_unique<StructColumnReader>(requestedType, dataType, params, scanSpec);
+      return std::make_unique<StructColumnReader>(
+          requestedType, dataType, params, scanSpec);
 
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
       return std::make_unique<StringColumnReader>(dataType, params, scanSpec);
 
     case TypeKind::ARRAY:
-      return std::make_unique<ListColumnReader>(requestedType, dataType, params, scanSpec);
+      return std::make_unique<ListColumnReader>(
+          requestedType, dataType, params, scanSpec);
 
     case TypeKind::MAP:
-      return std::make_unique<MapColumnReader>(requestedType, dataType, params, scanSpec);
+      return std::make_unique<MapColumnReader>(
+          requestedType, dataType, params, scanSpec);
 
     case TypeKind::BOOLEAN:
-      return std::make_unique<BooleanColumnReader>(requestedType, dataType, params, scanSpec);
+      return std::make_unique<BooleanColumnReader>(
+          requestedType, dataType, params, scanSpec);
 
     default:
       VELOX_FAIL(

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -42,6 +42,7 @@ class ParquetColumnReader {
   /// Builds a reader tree producing 'dataType'. The metadata is in 'params'.
   /// The filters and pruning are in 'scanSpec'.
   static std::unique_ptr<dwio::common::SelectiveColumnReader> build(
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -30,6 +30,8 @@ DEFINE_int32(
 
 namespace facebook::velox::parquet {
 
+using dwio::common::ColumnSelector;
+
 /// Metadata and options for reading Parquet.
 class ReaderBase {
  public:
@@ -636,8 +638,10 @@ ParquetRowReader::ParquetRowReader(
     return; // TODO
   }
   ParquetParams params(pool_, readerBase_->fileMetaData());
-
+  auto columnSelector = std::make_shared<ColumnSelector>(
+          ColumnSelector::apply(options_.getSelector(), readerBase_->schema()));
   columnReader_ = ParquetColumnReader::build(
+      columnSelector->getSchemaWithId(),
       readerBase_->schemaWithId(), // Id is schema id
       params,
       *options_.getScanSpec());

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -639,7 +639,7 @@ ParquetRowReader::ParquetRowReader(
   }
   ParquetParams params(pool_, readerBase_->fileMetaData());
   auto columnSelector = std::make_shared<ColumnSelector>(
-          ColumnSelector::apply(options_.getSelector(), readerBase_->schema()));
+      ColumnSelector::apply(options_.getSelector(), readerBase_->schema()));
   columnReader_ = ParquetColumnReader::build(
       columnSelector->getSchemaWithId(),
       readerBase_->schemaWithId(), // Id is schema id

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -120,8 +120,8 @@ MapColumnReader::MapColumnReader(
   DWIO_ENSURE_EQ(fileType_->id(), dataType->id(), "working on the same node");
   auto& keyChildType = requestedType->childAt(0);
   auto& elementChildType = requestedType->childAt(1);
-  keyReader_ =
-      ParquetColumnReader::build(keyChildType, fileType_->childAt(0), params, *scanSpec.children()[0]);
+  keyReader_ = ParquetColumnReader::build(
+      keyChildType, fileType_->childAt(0), params, *scanSpec.children()[0]);
   elementReader_ = ParquetColumnReader::build(
       elementChildType, fileType_->childAt(1), params, *scanSpec.children()[1]);
   reinterpret_cast<const ParquetTypeWithId*>(dataType.get())
@@ -228,8 +228,8 @@ ListColumnReader::ListColumnReader(
           params,
           scanSpec) {
   auto& childType = requestedType->childAt(0);
-  child_ =
-      ParquetColumnReader::build(childType, fileType_->childAt(0), params, *scanSpec.children()[0]);
+  child_ = ParquetColumnReader::build(
+      childType, fileType_->childAt(0), params, *scanSpec.children()[0]);
   reinterpret_cast<const ParquetTypeWithId*>(dataType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {child_.get()};

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -108,21 +108,23 @@ void ensureRepDefs(
 }
 
 MapColumnReader::MapColumnReader(
-    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
     : dwio::common::SelectiveMapColumnReader(
           requestedType,
-          requestedType,
+          dataType,
           params,
           scanSpec) {
+  DWIO_ENSURE_EQ(fileType_->id(), dataType->id(), "working on the same node");
   auto& keyChildType = requestedType->childAt(0);
   auto& elementChildType = requestedType->childAt(1);
   keyReader_ =
-      ParquetColumnReader::build(keyChildType, params, *scanSpec.children()[0]);
+      ParquetColumnReader::build(keyChildType, fileType_->childAt(0), params, *scanSpec.children()[0]);
   elementReader_ = ParquetColumnReader::build(
-      elementChildType, params, *scanSpec.children()[1]);
-  reinterpret_cast<const ParquetTypeWithId*>(requestedType.get())
+      elementChildType, fileType_->childAt(1), params, *scanSpec.children()[1]);
+  reinterpret_cast<const ParquetTypeWithId*>(dataType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {keyReader_.get(), elementReader_.get()};
 }
@@ -216,18 +218,19 @@ void MapColumnReader::filterRowGroups(
 }
 
 ListColumnReader::ListColumnReader(
-    std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+    const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
     : dwio::common::SelectiveListColumnReader(
           requestedType,
-          requestedType,
+          dataType,
           params,
           scanSpec) {
   auto& childType = requestedType->childAt(0);
   child_ =
-      ParquetColumnReader::build(childType, params, *scanSpec.children()[0]);
-  reinterpret_cast<const ParquetTypeWithId*>(requestedType.get())
+      ParquetColumnReader::build(childType, fileType_->childAt(0), params, *scanSpec.children()[0]);
+  reinterpret_cast<const ParquetTypeWithId*>(dataType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {child_.get()};
 }

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -56,7 +56,8 @@ class RepeatedLengths {
 class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
  public:
   MapColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 
@@ -111,7 +112,8 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
 class ListColumnReader : public dwio::common::SelectiveListColumnReader {
  public:
   ListColumnReader(
-      std::shared_ptr<const dwio::common::TypeWithId> requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
+      const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);
 

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -20,18 +20,21 @@
 namespace facebook::velox::parquet {
 
 StructColumnReader::StructColumnReader(
+    const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
     ParquetParams& params,
     common::ScanSpec& scanSpec)
-    : SelectiveStructColumnReader(dataType, dataType, params, scanSpec) {
+    : SelectiveStructColumnReader(requestedType, dataType, params, scanSpec) {
   auto& childSpecs = scanSpec_->stableChildren();
   for (auto i = 0; i < childSpecs.size(); ++i) {
+    auto childSpec = childSpecs[i];
     if (childSpecs[i]->isConstant()) {
       continue;
     }
-    auto childDataType = fileType_->childByName(childSpecs[i]->fieldName());
-
-    addChild(ParquetColumnReader::build(childDataType, params, *childSpecs[i]));
+    auto childDataType = fileType_->childByName(childSpec->fieldName());
+    auto childRequestedType =
+        requestedType_->childByName(childSpec->fieldName());
+    addChild(ParquetColumnReader::build(childRequestedType, childDataType, params, *childSpec));
     childSpecs[i]->setSubscript(children_.size() - 1);
   }
   auto type = reinterpret_cast<const ParquetTypeWithId*>(fileType_.get());

--- a/velox/dwio/parquet/reader/StructColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StructColumnReader.cpp
@@ -34,7 +34,8 @@ StructColumnReader::StructColumnReader(
     auto childDataType = fileType_->childByName(childSpec->fieldName());
     auto childRequestedType =
         requestedType_->childByName(childSpec->fieldName());
-    addChild(ParquetColumnReader::build(childRequestedType, childDataType, params, *childSpec));
+    addChild(ParquetColumnReader::build(
+        childRequestedType, childDataType, params, *childSpec));
     childSpecs[i]->setSubscript(children_.size() - 1);
   }
   auto type = reinterpret_cast<const ParquetTypeWithId*>(fileType_.get());

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -24,6 +24,7 @@ namespace facebook::velox::parquet {
 class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
  public:
   StructColumnReader(
+      const std::shared_ptr<const dwio::common::TypeWithId>& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& dataType,
       ParquetParams& params,
       common::ScanSpec& scanSpec);


### PR DESCRIPTION
pass down the scan table schema to parquet column reader


Details:


currently, the requestedType, which is available in [ParquetColumnReader.cpp](https://github.com/facebookincubator/velox/blob/517e3e3a0c8308c96ca068444dfeee37204f7773/velox/dwio/parquet/reader/ParquetColumnReader.cpp#L37C60-L37C68), are set based on the schema present in the parquet file (file data type) instead of scan table schema.

The issue occurs when the expected output of the TableScan differs from the schema of the parquet file. Spark's data format for some types differs from Parquet's format. Similar to schema evolution, when the type differs, Spark performs an implicit conversion. The conversions that Spark performs can be seen in [ParquetVectorUpdaterFactory.java](https://github.com/apache/spark/blob/6ca45c52b7416e7b3520dc902cb24f060c7c72dd/sql/core/src/main/java/org/apache/spark/sql/execution/datasources/parquet/ParquetVectorUpdaterFactory.java#L67C3-L185C6).


This PR fix the issue by setting requestedType` with scan table schema data type to parquet column reader.

It's a follow PR of this PR https://github.com/facebookincubator/velox/pull/5786 to address the issue by following the comments of @Yuhta 

Please check detail context from https://github.com/facebookincubator/velox/pull/5786


This update is one of the modifications necessary for issue https://github.com/facebookincubator/velox/issues/5770.

