### PR TITLE
Avoid re-computing normalized keys in HashTable::groupProbe

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -610,7 +610,8 @@ class HashTable : public BaseHashTable {
   // VectorHashers.
   void clearUseRange(std::vector<bool>& useRange);
 
-  void rehash();
+  // 'initNormalizedKeys' is passed to 'insertBatch'.
+  void rehash(bool initNormalizedKeys);
   void storeKeys(HashLookup& lookup, vector_size_t row);
 
   void storeRowPointer(int32_t index, uint64_t hash, char* row);
@@ -619,13 +620,22 @@ class HashTable : public BaseHashTable {
   // a power of 2.
   void allocateTables(uint64_t size);
 
-  void checkSize(int32_t numNew);
+  // 'initNormalizedKeys' is passed to 'rehash', if it's false and table
+  // is in normalized keys mode, the keys are retrieved from the row
+  // and the hash is made from this, without recomputing the normalized key.
+  void checkSize(int32_t numNew, bool initNormalizedKeys);
 
   // Computes hash numbers of the appropriate hash mode for 'groups',
   // stores these in 'hashes' and inserts the groups using
-  // insertForJoin or insertForGroupBy.
-  bool
-  insertBatch(char** groups, int32_t numGroups, raw_vector<uint64_t>& hashes);
+  // insertForJoin or insertForGroupBy. 'initNormalizedKeys' is passed to
+  // 'hashRows', if it's false and table is in normalized keys mode,
+  // the keys are retrieved from the row and the hash is made from this,
+  // without recomputing the normalized key.
+  bool insertBatch(
+      char** groups,
+      int32_t numGroups,
+      raw_vector<uint64_t>& hashes,
+      bool initNormalizedKeys);
 
   // Inserts 'numGroups' entries into 'this'. 'groups' point to
   // contents in a RowContainer owned by 'this'. 'hashes' are the hash

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -610,7 +610,6 @@ class HashTable : public BaseHashTable {
   // VectorHashers.
   void clearUseRange(std::vector<bool>& useRange);
 
-  // 'initNormalizedKeys' is passed to 'insertBatch'.
   void rehash(bool initNormalizedKeys);
   void storeKeys(HashLookup& lookup, vector_size_t row);
 
@@ -620,17 +619,15 @@ class HashTable : public BaseHashTable {
   // a power of 2.
   void allocateTables(uint64_t size);
 
-  // 'initNormalizedKeys' is passed to 'rehash', if it's false and table
-  // is in normalized keys mode, the keys are retrieved from the row
-  // and the hash is made from this, without recomputing the normalized key.
+  // 'initNormalizedKeys' is passed to 'rehash' --> 'rehash' --> 'insertBatch'.
+  // If it's false and the table is in normalized keys mode,
+  // the keys are retrieved from the row and the hash is made
+  // from this, without recomputing the normalized key.
   void checkSize(int32_t numNew, bool initNormalizedKeys);
 
   // Computes hash numbers of the appropriate hash mode for 'groups',
   // stores these in 'hashes' and inserts the groups using
-  // insertForJoin or insertForGroupBy. 'initNormalizedKeys' is passed to
-  // 'hashRows', if it's false and table is in normalized keys mode,
-  // the keys are retrieved from the row and the hash is made from this,
-  // without recomputing the normalized key.
+  // insertForJoin or insertForGroupBy.
   bool insertBatch(
       char** groups,
       int32_t numGroups,


### PR DESCRIPTION
Optimize aggregation in normalized-key hash mode by skipping redundant
computation of the normalized keys.

HashTable<ignoreNullKeys>::groupProbe calls checkSize, which may change the size
of the hash table and trigger a re-hash. In normalized-key mode, the rehash
doesn't need to recompute normalized keys.

Fixes #6405