### PR TITLE
Fix dwrf writer output stream flush query oom handling

### DIFF
--- a/velox/common/memory/tests/MemoryManagerTest.cpp
+++ b/velox/common/memory/tests/MemoryManagerTest.cpp
@@ -38,7 +38,6 @@ MemoryManager& toMemoryManager(MemoryManager& manager) {
 } // namespace
 
 class MemoryManagerTest : public testing::Test {
- public:
  protected:
   static void SetUpTestCase() {
     MemoryArbitrator::registerAllFactories();

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -98,11 +98,11 @@ class DataBuffer {
   void reserve(uint64_t capacity) {
     if (capacity <= capacity_) {
       // After resetting the buffer, capacity always resets to zero.
-      DWIO_ENSURE_NOT_NULL(buf_);
+      VELOX_CHECK_NOT_NULL(buf_);
       return;
     }
     if (veloxRef_ != nullptr) {
-      DWIO_RAISE("Can't reserve on a referenced buffer");
+      VELOX_FAIL("Can't reserve on a referenced buffer");
     }
     const auto newSize = sizeInBytes(capacity);
     if (buf_ == nullptr) {
@@ -111,7 +111,7 @@ class DataBuffer {
       buf_ = reinterpret_cast<T*>(
           pool_->reallocate(buf_, sizeInBytes(capacity_), newSize));
     }
-    DWIO_ENSURE(buf_ != nullptr || newSize == 0);
+    VELOX_CHECK(buf_ != nullptr || newSize == 0);
     capacity_ = capacity;
   }
 

--- a/velox/dwio/common/DataBufferHolder.cpp
+++ b/velox/dwio/common/DataBufferHolder.cpp
@@ -15,8 +15,41 @@
  */
 
 #include "velox/dwio/common/DataBufferHolder.h"
+#include "velox/common/testutil/TestValue.h"
+
+using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::dwio::common {
+
+void DataBufferHolder::take(const std::vector<folly::StringPiece>& buffers) {
+  // compute size
+  uint64_t totalSize = 0;
+  for (auto& buf : buffers) {
+    totalSize += buf.size();
+  }
+  if (totalSize == 0) {
+    return;
+  }
+
+  TestValue::adjust(
+      "facebook::velox::dwio::common::DataBufferHolder::take", pool_);
+
+  dwio::common::DataBuffer<char> buf(*pool_, totalSize);
+  auto* data = buf.data();
+  for (auto& buffer : buffers) {
+    const auto size = buffer.size();
+    ::memcpy(data, buffer.begin(), size);
+    data += size;
+  }
+  // If possibly, write content of the data to output immediately. Otherwise,
+  // make a copy and add it to buffer list
+  if (sink_ != nullptr) {
+    sink_->write(std::move(buf));
+  } else {
+    buffers_.push_back(std::move(buf));
+  }
+  size_ += totalSize;
+}
 
 bool DataBufferHolder::tryResize(
     dwio::common::DataBuffer<char>& buffer,
@@ -27,11 +60,11 @@ bool DataBufferHolder::tryResize(
   if (FOLLY_LIKELY(size >= headerSize)) {
     size -= headerSize;
   } else {
-    DWIO_ENSURE_EQ(size, 0);
+    VELOX_CHECK_EQ(size, 0);
   }
 
-  DWIO_ENSURE_LE(size, maxSize_);
-  // If already at max size, return
+  VELOX_CHECK_LE(size, maxSize_);
+  // If already at max size, return.
   if (size == maxSize_) {
     return false;
   }

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -442,7 +442,7 @@ std::unique_ptr<BufferedOutputStream> createCompressor(
     uint8_t pageHeaderSize,
     const Encrypter* encrypter) {
   std::unique_ptr<Compressor> compressor;
-  switch (static_cast<int64_t>(kind)) {
+  switch (kind) {
     case CompressionKind::CompressionKind_NONE:
       if (!encrypter) {
         return std::make_unique<BufferedOutputStream>(bufferHolder);

--- a/velox/dwio/dwrf/common/Config.cpp
+++ b/velox/dwio/dwrf/common/Config.cpp
@@ -57,7 +57,7 @@ Config::Entry<bool> Config::CREATE_INDEX{"hive.exec.orc.create.index", true};
 
 Config::Entry<uint32_t> Config::ROW_INDEX_STRIDE{
     "hive.exec.orc.row.index.stride",
-    10000};
+    10'000};
 
 Config::Entry<proto::ChecksumAlgorithm> Config::CHECKSUM_ALGORITHM{
     "orc.checksum.algorithm",

--- a/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
+++ b/velox/dwio/dwrf/test/DataBufferHolderTests.cpp
@@ -15,18 +15,18 @@
  */
 
 #include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/dwio/common/DataBufferHolder.h"
 
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::memory;
+using facebook::velox::VeloxException;
 
 TEST(DataBufferHolderTests, InputCheck) {
   auto pool = addDefaultLeafMemoryPool();
-  ASSERT_THROW((DataBufferHolder{*pool, 0}), exception::LoggedException);
-  ASSERT_THROW(
-      (DataBufferHolder{*pool, 1024, 2048}), exception::LoggedException);
-  ASSERT_THROW(
-      (DataBufferHolder{*pool, 1024, 1024, 1.1f}), exception::LoggedException);
+  VELOX_ASSERT_THROW((DataBufferHolder{*pool, 0}), "");
+  VELOX_ASSERT_THROW((DataBufferHolder{*pool, 1024, 2048}), "");
+  VELOX_ASSERT_THROW((DataBufferHolder{*pool, 1024, 1024, 1.1f}), "");
 
   { DataBufferHolder holder{*pool, 1024}; }
   { DataBufferHolder holder{*pool, 1024, 512}; }

--- a/velox/dwio/dwrf/utils/BufferedWriter.h
+++ b/velox/dwio/dwrf/utils/BufferedWriter.h
@@ -25,55 +25,90 @@ template <typename T, typename F>
 class BufferedWriter {
  public:
   BufferedWriter(dwio::common::DataBuffer<char>& buffer, F fn)
-      : fn_{fn},
-        buf_{nullptr},
+      : buf_{nullptr},
         start_{reinterpret_cast<T*>(buffer.data())},
-        capacity_{buffer.capacity() / sizeof(T)} {
-    DWIO_ENSURE_GT(capacity_, 0, "invalid capacity");
+        capacity_{buffer.capacity() / sizeof(T)},
+        fn_{std::move(fn)} {
+    VELOX_CHECK_GT(capacity_, 0, "invalid capacity");
   }
 
   BufferedWriter(char* buffer, size_t size, F fn)
-      : fn_{fn},
-        buf_{nullptr},
+      : buf_{nullptr},
         start_{reinterpret_cast<T*>(buffer)},
-        capacity_{size / sizeof(T)} {
-    DWIO_ENSURE_GT(capacity_, 0, "invalid capacity");
+        capacity_{size / sizeof(T)},
+        fn_{std::move(fn)} {
+    VELOX_CHECK_GT(capacity_, 0, "invalid capacity");
   }
 
   BufferedWriter(memory::MemoryPool& pool, size_t size, F fn)
-      : fn_{fn},
-        buf_{std::make_unique<dwio::common::DataBuffer<char>>(pool, size)},
+      : buf_{std::make_unique<dwio::common::DataBuffer<char>>(pool, size)},
         start_{reinterpret_cast<T*>(buf_->data())},
-        capacity_{size / sizeof(T)} {
-    DWIO_ENSURE_GT(capacity_, 0, "invalid capacity");
+        capacity_{size / sizeof(T)},
+        fn_{std::move(fn)} {
+    VELOX_CHECK_GT(capacity_, 0, "invalid capacity");
   }
 
   ~BufferedWriter() {
-    flush();
+    VELOX_CHECK(empty() && closed_, toString());
   }
 
   void add(T t) {
+    VELOX_CHECK(!closed_);
+
     start_[pos_++] = t;
-    if (UNLIKELY(pos_ == capacity_)) {
-      fn_(start_, pos_);
-      pos_ = 0;
+    if (FOLLY_UNLIKELY(full())) {
+      flush();
     }
+    VELOX_CHECK_LT(pos_, capacity_);
   }
 
   void flush() {
-    if (pos_ > 0) {
-      fn_(start_, pos_);
+    VELOX_CHECK(!closed_);
+
+    if (!empty()) {
+      // Ensures 'pos_' to be reset even if the flush fails as we don't retry.
+      const auto flushPos = pos_;
       pos_ = 0;
+      fn_(start_, flushPos);
     }
   }
 
+  /// Invoked to close this buffered writer which flush all its pending buffers.
+  ///
+  /// NOTE: this can only be called once and we don't expect any call on this
+  /// buffered writer after close.
+  void close() {
+    VELOX_CHECK(!closed_);
+    const auto cleanup = folly::makeGuard([this]() { closed_ = true; });
+    flush();
+  }
+
+  std::string toString() const {
+    return fmt::format(
+        "BufferedWriter[pos[{}] capacity[{}] closed[{}]]",
+        pos_,
+        capacity_,
+        closed_);
+  }
+
  private:
-  F fn_;
-  std::unique_ptr<dwio::common::DataBuffer<char>> buf_;
+  // Indicates if this buffered writer has pending data to flush or not.
+  bool empty() const {
+    return pos_ == 0;
+  }
+
+  // Indicates if this buffered writer is full or not.
+  bool full() const {
+    return pos_ == capacity_;
+  }
+
+  const std::unique_ptr<dwio::common::DataBuffer<char>> buf_;
   T* const start_;
   const size_t capacity_;
 
+  F fn_;
   size_t pos_{0};
+  bool closed_{false};
 };
 
 template <typename T, typename F>
@@ -103,6 +138,7 @@ void bufferedWrite(
   for (size_t i = start; i < end; ++i) {
     writer.add(get(i));
   }
+  writer.close();
 }
 
 template <typename T, typename G, typename W>
@@ -117,6 +153,7 @@ void bufferedWrite(
   for (size_t i = start; i < end; ++i) {
     writer.add(get(i));
   }
+  writer.close();
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
+++ b/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/dwio/dwrf/utils/BufferedWriter.h"
+
+using namespace ::testing;
+
+namespace facebook::velox::dwrf::utils {
+namespace {
+using WriteFn = std::function<void(char*, size_t)>;
+using GetFn = std::function<char(size_t)>;
+
+class BufferedWriterTest : public testing::TestWithParam<bool> {
+ protected:
+  BufferedWriterTest()
+      : usePool_(GetParam()),
+        pool_(memory::addDefaultLeafMemoryPool("BufferedWriterTest")) {}
+
+  void SetUp() override {}
+  static void SetUpTestCase() {}
+
+  // Indicates test with buffered writer interface which takes memory pool or
+  // not.
+  const bool usePool_;
+  const std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_P(BufferedWriterTest, Basic) {
+  const int bufferSize = 1024;
+
+  struct {
+    // NOTE: if it is 0, then it is a flush op and if it is -1, then it is a
+    // close op.
+    std::vector<int> addBytes;
+    bool expectedCrashed;
+    int expectedFlushedBytes;
+
+    std::string debugString() const {
+      return fmt::format(
+          "addBytes:{}, expectedCrashed:{}, expectedFlushedBytes:{}",
+          folly::join(",", addBytes),
+          expectedCrashed,
+          expectedFlushedBytes);
+    }
+  } testSettings[] = {
+      {{1, 1, 0}, true, 2},
+      {{1, 0, 1}, true, 2},
+      {{0, 1, 1, 0}, true, 2},
+      {{0, 1, 0, 1}, true, 2},
+      {{0, 1024}, true, 1024},
+      {{1024}, true, 1024},
+      {{1024, 0}, true, 1024},
+      {{1024, 0, 1}, true, 1025},
+      {{1024, 0, 1, 0}, true, 1025},
+      {{1024, 1023}, true, 2047},
+      {{1024, 1024}, true, 2048},
+      {{1024, 0, 1024}, true, 2048},
+      {{1024, 0, 1024, 0, 0}, true, 2048},
+
+      {{1, 1, 0, -1}, false, 2},
+      {{1, 0, 1, -1}, false, 2},
+      {{0, 1, 1, 0, -1}, false, 2},
+      {{0, 1, 0, 1, -1}, false, 2},
+      {{0, 1024, -1}, false, 1024},
+      {{1024, -1}, false, 1024},
+      {{1024, 0, -1}, false, 1024},
+      {{1024, 0, 1, -1}, false, 1025},
+      {{1024, 0, 1, 0, -1}, false, 1025},
+      {{1024, 1023, -1}, false, 2047},
+      {{1024, 1024, -1}, false, 2048},
+      {{1024, 0, 1024, -1}, false, 2048},
+      {{1024, 0, 1024, 0, 0, -1}, false, 2048}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::unique_ptr<dwio::common::DataBuffer<char>> buffer;
+    if (!usePool_) {
+      buffer =
+          std::make_unique<dwio::common::DataBuffer<char>>(*pool_, bufferSize);
+    }
+    size_t flushCount{0};
+    auto writeFn = [&](char* buf, size_t size) { flushCount += size; };
+    std::unique_ptr<BufferedWriter<char, WriteFn>> writer;
+    if (usePool_) {
+      writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+          *pool_, bufferSize, writeFn);
+    } else {
+      writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+          *pool_, bufferSize, writeFn);
+    }
+    ASSERT_EQ(
+        writer->toString(),
+        "BufferedWriter[pos[0] capacity[1024] closed[false]]");
+    for (const auto bytes : testData.addBytes) {
+      if (bytes == 0) {
+        writer->flush();
+        continue;
+      }
+      if (bytes == -1) {
+        writer->close();
+        continue;
+      }
+      for (int i = 0; i < bytes; ++i) {
+        writer->add('a');
+      }
+    }
+    if (testData.expectedCrashed) {
+      EXPECT_DEATH(writer.reset(), "");
+      writer->close();
+    } else {
+      writer.reset();
+    }
+    ASSERT_EQ(flushCount, testData.expectedFlushedBytes);
+  }
+}
+
+TEST_P(BufferedWriterTest, flushFailureTest) {
+  const int bufferSize = 1024;
+  std::unique_ptr<dwio::common::DataBuffer<char>> buffer;
+  if (!usePool_) {
+    buffer =
+        std::make_unique<dwio::common::DataBuffer<char>>(*pool_, bufferSize);
+  }
+  auto writeFailureInjectionFn = [&](char* buf, size_t size) {
+    VELOX_FAIL("flushFailureTest");
+  };
+  std::unique_ptr<BufferedWriter<char, WriteFn>> writer;
+  if (usePool_) {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+        *pool_, bufferSize, writeFailureInjectionFn);
+  } else {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+        *pool_, bufferSize, writeFailureInjectionFn);
+  }
+  for (int i = 0; i < bufferSize - 1; ++i) {
+    writer->add('a');
+  }
+  VELOX_ASSERT_THROW(writer->flush(), "flushFailureTest");
+  writer->close();
+}
+
+TEST_P(BufferedWriterTest, bufferedWrite) {
+  const int bufferSize = 1024;
+
+  auto getFn = [&](size_t index) { return 'a'; };
+
+  struct {
+    int start;
+    int end;
+
+    std::string debugString() const {
+      return fmt::format("start:{}, end:{}", start, end);
+    }
+  } testSettings[] = {
+      {0, 1023},
+      {0, 1024},
+      {0, 1025},
+      {0, 0},
+      {0, 1},
+      {20, 1023},
+      {20, 1024},
+      {20, 1025},
+      {20, 20},
+      {20, 21},
+      {20, 1023 + 1024},
+      {20, 1024 + 1024},
+      {20, 1025 + 1024},
+      {20, 20 + 1024},
+      {20, 21 + 1024}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    size_t flushCount{0};
+    auto writeFn = [&](char* buf, size_t size) { flushCount += size; };
+    std::unique_ptr<BufferedWriter<char, WriteFn>> writer;
+    if (usePool_) {
+      bufferedWrite<char>(
+          *pool_, bufferSize, testData.start, testData.end, getFn, writeFn);
+    } else {
+      std::unique_ptr<dwio::common::DataBuffer<char>> buffer =
+          std::make_unique<dwio::common::DataBuffer<char>>(*pool_, bufferSize);
+      bufferedWrite<char>(
+          *buffer, testData.start, testData.end, getFn, writeFn);
+    }
+    ASSERT_EQ(flushCount, testData.end - testData.start);
+  }
+}
+
+TEST_P(BufferedWriterTest, closeTest) {
+  const int bufferSize = 1024;
+  std::unique_ptr<dwio::common::DataBuffer<char>> buffer;
+  if (!usePool_) {
+    buffer =
+        std::make_unique<dwio::common::DataBuffer<char>>(*pool_, bufferSize);
+  }
+  size_t flushCount{0};
+  auto writeFn = [&](char* buf, size_t size) { flushCount += size; };
+  std::unique_ptr<BufferedWriter<char, WriteFn>> writer;
+  if (usePool_) {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+        *pool_, bufferSize, writeFn);
+  } else {
+    writer = std::make_unique<BufferedWriter<char, WriteFn>>(
+        *pool_, bufferSize, writeFn);
+  }
+  writer->add('a');
+  ASSERT_EQ(
+      writer->toString(),
+      "BufferedWriter[pos[1] capacity[1024] closed[false]]");
+  writer->close();
+  // Verify all the calls on a closed object throw.
+  VELOX_ASSERT_THROW(writer->close(), "");
+  VELOX_ASSERT_THROW(writer->add('a'), "");
+  VELOX_ASSERT_THROW(writer->flush(), "");
+}
+
+VELOX_INSTANTIATE_TEST_SUITE_P(
+    BufferedWriterTestSuite,
+    BufferedWriterTest,
+    testing::ValuesIn({false, true}));
+} // namespace
+} // namespace facebook::velox::dwrf::utils

--- a/velox/dwio/dwrf/utils/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/utils/test/CMakeLists.txt
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_dwio_dwrf_utils_test ProtoUtilsTests.cpp
-                                          BitIteratorTests.cpp)
+add_executable(velox_dwio_dwrf_utils_test
+               ProtoUtilsTests.cpp BitIteratorTests.cpp BufferedWriterTest.cpp)
 
 add_test(velox_dwio_dwrf_utils_test velox_dwio_dwrf_utils_test)
 

--- a/velox/dwio/dwrf/writer/DictionaryEncodingUtils.h
+++ b/velox/dwio/dwrf/writer/DictionaryEncodingUtils.h
@@ -80,7 +80,6 @@ class DictionaryEncodingUtils {
     uint32_t newIndex = 0;
     auto dictLengthWriter =
         createBufferedWriter<uint32_t>(pool, 64 * 1024, lengthFn);
-
     for (uint32_t i = 0; i != numKeys; ++i) {
       auto origIndex = (sort ? sortedIndex[i] : i);
       if (!dropInfrequentKeys || shouldWriteKey(dictEncoder, origIndex)) {
@@ -95,6 +94,7 @@ class DictionaryEncodingUtils {
         inDict[origIndex] = false;
       }
     }
+    dictLengthWriter.close();
 
     return newIndex;
   }

--- a/velox/dwio/dwrf/writer/IndexBuilder.h
+++ b/velox/dwio/dwrf/writer/IndexBuilder.h
@@ -52,8 +52,8 @@ class IndexBuilder : public PositionRecorder {
   }
 
   virtual size_t getEntrySize() const {
-    int32_t size = index_.entry_size() + 1;
-    DWIO_ENSURE_GT(size, 0, "Invalid entry size or missing current entry.");
+    const int32_t size = index_.entry_size() + 1;
+    VELOX_CHECK_GT(size, 0, "Invalid entry size or missing current entry.");
     return size;
   }
 
@@ -92,12 +92,12 @@ class IndexBuilder : public PositionRecorder {
     } else if (index < index_.entry_size()) {
       return index_.mutable_entry(index);
     } else {
-      DWIO_ENSURE_EQ(index, index_.entry_size());
+      VELOX_CHECK_EQ(index, index_.entry_size());
       return &entry_;
     }
   }
 
-  std::unique_ptr<BufferedOutputStream> out_;
+  const std::unique_ptr<BufferedOutputStream> out_;
   proto::RowIndex index_;
   proto::RowIndexEntry entry_;
   std::optional<int32_t> presentStreamOffset_;

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -207,7 +207,6 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
     uint32_t newIndex = 0;
 
     auto dictWriter = createBufferedWriter<Integer>(writeBuffer, fn);
-
     for (uint32_t i = 0; i != numKeys; ++i) {
       auto origIndex = (sort ? sortedIndex[i] : i);
       if (!dropInfrequentKeys || shouldWriteKey(dictEncoder, origIndex)) {
@@ -219,6 +218,7 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
         inDict[origIndex] = false;
       }
     }
+    dictWriter.close();
     return newIndex;
   }
 

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -20,21 +20,20 @@ namespace facebook::velox::dwrf {
 namespace {
 constexpr uint32_t MIN_INDEX_STRIDE = 1000;
 }
-
 void WriterContext::validateConfigs() const {
   // the writer is implemented with strong assumption that index is enabled.
   // Things like dictionary encoding will fail if not. Before we clean that up,
   // always require index to be enabled.
-  DWIO_ENSURE(indexEnabled(), "index is required");
+  VELOX_CHECK(indexEnabled(), "index is required");
   if (indexEnabled()) {
-    DWIO_ENSURE_GE(indexStride_, MIN_INDEX_STRIDE);
+    VELOX_CHECK_GE(indexStride_, MIN_INDEX_STRIDE);
     // Java works with signed integer and setting anything above the int32_max
     // will make the java reader fail.
-    DWIO_ENSURE_LE(indexStride_, INT32_MAX);
+    VELOX_CHECK_LE(indexStride_, INT32_MAX);
   }
-  DWIO_ENSURE_GE(
+  VELOX_CHECK_GE(
       compressionBlockSize_, getConfig(Config::COMPRESSION_BLOCK_SIZE_MIN));
-  DWIO_ENSURE_GE(
+  VELOX_CHECK_GE(
       getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO),
       dwio::common::MIN_PAGE_GROW_RATIO);
 }

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -66,7 +66,7 @@ class WriterContext : public CompressionBufferPool {
         handler_{std::move(handler)} {
     const bool forceLowMemoryMode{getConfig(Config::FORCE_LOW_MEMORY_MODE)};
     const bool disableLowMemoryMode{getConfig(Config::DISABLE_LOW_MEMORY_MODE)};
-    DWIO_ENSURE(!(forceLowMemoryMode && disableLowMemoryMode));
+    VELOX_CHECK(!(forceLowMemoryMode && disableLowMemoryMode));
     checkLowMemoryMode_ = !forceLowMemoryMode && !disableLowMemoryMode;
     if (forceLowMemoryMode) {
       setLowMemoryMode();
@@ -76,8 +76,10 @@ class WriterContext : public CompressionBufferPool {
     }
     validateConfigs();
     VLOG(2) << fmt::format("Compression config: {}", compression_);
-    compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
-        *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
+    if (compression_ != common::CompressionKind_NONE) {
+      compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
+          *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
+    }
   }
 
   bool hasStream(const DwrfStreamIdentifier& stream) const {
@@ -104,8 +106,8 @@ class WriterContext : public CompressionBufferPool {
   // flush policy evaluation and would be more accurate after flush.
   std::unique_ptr<BufferedOutputStream> newStream(
       const DwrfStreamIdentifier& stream) {
-    DWIO_ENSURE(
-        !hasStream(stream), "Stream already exists ", stream.toString());
+    VELOX_CHECK(
+        !hasStream(stream), "Stream already exists: {}", stream.toString());
 
     streams_.emplace(
         std::piecewise_construct,
@@ -176,7 +178,7 @@ class WriterContext : public CompressionBufferPool {
   }
 
   void suppressStream(const DwrfStreamIdentifier& stream) {
-    DWIO_ENSURE(hasStream(stream));
+    VELOX_CHECK(hasStream(stream));
     auto& collector = streams_.at(stream);
     collector.suppress();
   }
@@ -273,15 +275,15 @@ class WriterContext : public CompressionBufferPool {
 
   std::unique_ptr<dwio::common::DataBuffer<char>> getBuffer(
       uint64_t size) override {
-    DWIO_ENSURE_NOT_NULL(compressionBuffer_);
-    DWIO_ENSURE_GE(compressionBuffer_->size(), size);
+    VELOX_CHECK_NOT_NULL(compressionBuffer_);
+    VELOX_CHECK_GE(compressionBuffer_->size(), size);
     return std::move(compressionBuffer_);
   }
 
   void returnBuffer(
       std::unique_ptr<dwio::common::DataBuffer<char>> buffer) override {
-    DWIO_ENSURE_NOT_NULL(buffer);
-    DWIO_ENSURE(!compressionBuffer_);
+    VELOX_CHECK_NOT_NULL(buffer);
+    VELOX_CHECK_NULL(compressionBuffer_);
     compressionBuffer_ = std::move(buffer);
   }
 
@@ -502,43 +504,43 @@ class WriterContext : public CompressionBufferPool {
         break;
       }
       case TypeKind::BOOLEAN:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::TINYINT:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::SMALLINT:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::INTEGER:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::BIGINT:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::HUGEINT:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::REAL:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::DOUBLE:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::VARCHAR:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::VARBINARY:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::TIMESTAMP:
         physicalSizeAggregators_.emplace(
             type.id(), std::make_unique<PhysicalSizeAggregator>(parent));
         break;
       case TypeKind::UNKNOWN:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::FUNCTION:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::OPAQUE:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       case TypeKind::INVALID:
-        [[fallthrough]];
+        FOLLY_FALLTHROUGH;
       default:
-        VELOX_FAIL(fmt::format(
+        VELOX_FAIL(
             "Unexpected type kind {} encountered when building "
             "physical size aggregator for node {}.",
             type.type()->toString(),
-            type.id()));
+            type.id());
     }
   }
 
@@ -578,6 +580,10 @@ class WriterContext : public CompressionBufferPool {
       selectivityVector_->resize(size);
     }
     return *selectivityVector_;
+  }
+
+  dwio::common::DataBuffer<char>* testingCompressionBuffer() const {
+    return compressionBuffer_.get();
   }
 
  private:
@@ -658,19 +664,15 @@ class WriterContext : public CompressionBufferPool {
 
   CpuWallTiming flushTiming_{};
 
-  template <typename TestType>
-  friend class WriterEncodingIndexTest;
   friend class IntegerColumnWriterDirectEncodingIndexTest;
   friend class StringColumnWriterDictionaryEncodingIndexTest;
   friend class StringColumnWriterDirectEncodingIndexTest;
-  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
-  VELOX_FRIEND_TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode);
   // TODO: remove once writer code is consolidated
   template <typename TestType>
   friend class WriterEncodingIndexTest2;
-  friend class IntegerColumnWriterDirectEncodingIndexTest2;
-  friend class StringColumnWriterDictionaryEncodingIndexTest2;
-  friend class StringColumnWriterDirectEncodingIndexTest2;
+
+  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode);
 };
 
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
Current dwrf writer output stream flush could fail because of query oom.
This can cause a couple of issues found in Meta internal presto batch
staging test: (1) compression buffer is not reset in writer context when
stripe flush fails; (2) buffered write object destructor will call flush again
which fails again in object destructor which cause server crashes. The
latter must be fixed or handling properly. We shall just fail the query but
not crash the server. The flush involves memory allocation and it is very 
hard to totally prevent it even with memory arbitration support in Velox.

This PR fixes both issues by (1) catching the exception when data buffer
holder fails to allocate the new buffer to store the compressed new data,
and reset the compression buffer in writer context if it happens; (2) instead
of flushing any pending buffered data in buffered writer dtor, we change to
require the caller to explicitly call flush at the end of buffering data, and
reset the buffered data offset before we start the actual flush (there is no
retry on flush failure) and buffered writer object adds sanity check that all
the pending buffer has been flushed (or at least the corresponding flush has
been triggered).

This PR also avoid creating compression buffer if the dwrf writer hasn't configured
compression plus some code cleanup in dwrf writer.