### PR TITLE
Add check to prevent memory pool allocation during driver creation

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -470,6 +470,12 @@ RowVectorPtr Task::next(ContinueFuture* future) {
     drivers.reserve(numDriversUngrouped_);
     createSplitGroupStateLocked(kUngroupedGroupId);
     createDriversLocked(self, kUngroupedGroupId, drivers);
+    if (self->pool_->stats().currentBytes != 0) {
+      VELOX_FAIL(
+          "Unexpected memory pool allocations during task[{}] driver initialization: {}",
+          self->taskId_,
+          self->pool_->treeMemoryUsage());
+    }
 
     drivers_ = std::move(drivers);
   }
@@ -665,6 +671,12 @@ void Task::start(
       drivers.reserve(self->numDriversUngrouped_);
       self->createSplitGroupStateLocked(kUngroupedGroupId);
       self->createDriversLocked(self, kUngroupedGroupId, drivers);
+      if (self->pool_->stats().currentBytes != 0) {
+        VELOX_FAIL(
+            "Unexpected memory pool allocations during task[{}] driver initialization: {}",
+            self->taskId_,
+            self->pool_->treeMemoryUsage());
+      }
 
       // Prevent the connecting structures from being cleaned up before all
       // split groups are finished during the grouped execution mode.

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -33,155 +33,7 @@ using namespace facebook::velox;
 using namespace facebook::velox::common::testutil;
 
 namespace facebook::velox::exec::test {
-
-class TaskTest : public HiveConnectorTestBase {
- protected:
-  static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>
-  executeSingleThreaded(
-      core::PlanFragment plan,
-      const std::unordered_map<std::string, std::vector<std::string>>&
-          filePaths = {}) {
-    auto task = Task::create(
-        "single.execution.task.0", plan, 0, std::make_shared<core::QueryCtx>());
-
-    for (const auto& [nodeId, paths] : filePaths) {
-      for (const auto& path : paths) {
-        task->addSplit(nodeId, exec::Split(makeHiveConnectorSplit(path)));
-      }
-      task->noMoreSplits(nodeId);
-    }
-
-    VELOX_CHECK(task->supportsSingleThreadedExecution());
-
-    vector_size_t numRows = 0;
-    std::vector<RowVectorPtr> results;
-    for (;;) {
-      auto result = task->next();
-      if (!result) {
-        break;
-      }
-
-      for (auto& child : result->children()) {
-        child->loadedVector();
-      }
-      results.push_back(result);
-      numRows += result->size();
-    }
-
-    VELOX_CHECK(waitForTaskCompletion(task.get()));
-
-    auto planNodeStats = toPlanStats(task->taskStats());
-    VELOX_CHECK(planNodeStats.count(plan.planNode->id()));
-    VELOX_CHECK_EQ(numRows, planNodeStats.at(plan.planNode->id()).outputRows);
-    VELOX_CHECK_EQ(
-        results.size(), planNodeStats.at(plan.planNode->id()).outputVectors);
-
-    return {task, results};
-  }
-};
-
-TEST_F(TaskTest, wrongPlanNodeForSplit) {
-  auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
-      "test",
-      "file:/tmp/abc",
-      facebook::velox::dwio::common::FileFormat::DWRF,
-      0,
-      100);
-
-  auto plan = PlanBuilder()
-                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
-                  .project({"a * a", "b + b"})
-                  .planFragment();
-
-  auto task = Task::create(
-      "task-1",
-      std::move(plan),
-      0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
-
-  // Add split for the source node.
-  task->addSplit("0", exec::Split(folly::copy(connectorSplit)));
-
-  // Add an empty split.
-  task->addSplit("0", exec::Split());
-
-  // Try to add split for a non-source node.
-  auto errorMessage =
-      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 1 doesn't refer to such plan node.";
-  VELOX_ASSERT_THROW(
-      task->addSplit("1", exec::Split(folly::copy(connectorSplit))),
-      errorMessage)
-
-  VELOX_ASSERT_THROW(
-      task->addSplitWithSequence(
-          "1", exec::Split(folly::copy(connectorSplit)), 3),
-      errorMessage)
-
-  VELOX_ASSERT_THROW(task->setMaxSplitSequenceId("1", 9), errorMessage)
-
-  VELOX_ASSERT_THROW(task->noMoreSplits("1"), errorMessage)
-
-  VELOX_ASSERT_THROW(task->noMoreSplitsForGroup("1", 5), errorMessage)
-
-  // Try to add split for non-existent node.
-  errorMessage =
-      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 12 doesn't refer to such plan node.";
-  VELOX_ASSERT_THROW(
-      task->addSplit("12", exec::Split(folly::copy(connectorSplit))),
-      errorMessage)
-
-  VELOX_ASSERT_THROW(
-      task->addSplitWithSequence(
-          "12", exec::Split(folly::copy(connectorSplit)), 3),
-      errorMessage)
-
-  VELOX_ASSERT_THROW(task->setMaxSplitSequenceId("12", 9), errorMessage)
-
-  VELOX_ASSERT_THROW(task->noMoreSplits("12"), errorMessage)
-
-  VELOX_ASSERT_THROW(task->noMoreSplitsForGroup("12", 5), errorMessage)
-
-  // Try to add split for a Values source node.
-  plan =
-      PlanBuilder()
-          .values({makeRowVector(ROW({"a", "b"}, {INTEGER(), DOUBLE()}), 10)})
-          .project({"a * a", "b + b"})
-          .planFragment();
-
-  auto valuesTask = Task::create(
-      "task-2",
-      std::move(plan),
-      0,
-      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
-  errorMessage =
-      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
-  VELOX_ASSERT_THROW(
-      valuesTask->addSplit("0", exec::Split(folly::copy(connectorSplit))),
-      errorMessage)
-}
-
-TEST_F(TaskTest, duplicatePlanNodeIds) {
-  auto plan = PlanBuilder()
-                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
-                  .hashJoin(
-                      {"a"},
-                      {"a1"},
-                      PlanBuilder()
-                          .tableScan(ROW({"a1", "b1"}, {INTEGER(), DOUBLE()}))
-                          .planNode(),
-                      "",
-                      {"b", "b1"})
-                  .planFragment();
-
-  VELOX_ASSERT_THROW(
-      Task::create(
-          "task-1",
-          std::move(plan),
-          0,
-          std::make_shared<core::QueryCtx>(driverExecutor_.get())),
-      "Plan node IDs must be unique. Found duplicate ID: 0.")
-}
-
+namespace {
 // A test join node whose build is skewed in terms of process time. The driver
 // id 0 processes slower than other drivers if paralelism greater than 1
 class TestSkewedJoinNode : public core::PlanNode {
@@ -392,6 +244,363 @@ class TestSkewedJoinBridgeTranslator
     return nullptr;
   }
 };
+
+class ExternalBlocker {
+ public:
+  folly::SemiFuture<folly::Unit> continueFuture() {
+    if (isBlocked_) {
+      auto [promise, future] = makeVeloxContinuePromiseContract();
+      continuePromise_ = std::move(promise);
+      return std::move(future);
+    }
+    return folly::SemiFuture<folly::Unit>();
+  }
+
+  void unblock() {
+    if (isBlocked_) {
+      continuePromise_.setValue();
+      isBlocked_ = false;
+    }
+  }
+
+  void block() {
+    isBlocked_ = true;
+  }
+
+  bool isBlocked() const {
+    return isBlocked_;
+  }
+
+ private:
+  bool isBlocked_ = false;
+  folly::Promise<folly::Unit> continuePromise_;
+};
+
+// A test node that normally just re-project/passthrough the output from input
+// When the node is blocked by external even (via externalBlocker), the operator
+// will signal kBlocked. The pipeline can ONLY proceed again when it is
+// unblocked externally.
+class TestExternalBlockableNode : public core::PlanNode {
+ public:
+  TestExternalBlockableNode(
+      const core::PlanNodeId& id,
+      core::PlanNodePtr source,
+      std::shared_ptr<ExternalBlocker> externalBlocker)
+      : PlanNode(id),
+        sources_{std::move(source)},
+        externalBlocker_(std::move(externalBlocker)) {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "external blocking node";
+  }
+
+  ExternalBlocker* externalBlocker() const {
+    return externalBlocker_.get();
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+  std::shared_ptr<ExternalBlocker> externalBlocker_;
+};
+
+class TestExternalBlockableOperator : public exec::Operator {
+ public:
+  TestExternalBlockableOperator(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const TestExternalBlockableNode> node)
+      : Operator(
+            driverCtx,
+            node->outputType(),
+            operatorId,
+            node->id(),
+            "ExternalBlockable"),
+        externalBlocker_(node->externalBlocker()) {}
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr input) override {
+    input_ = std::move(input);
+  }
+
+  RowVectorPtr getOutput() override {
+    // If this operator is signaled to be blocked externally
+    if (externalBlocker_->isBlocked()) {
+      continueFuture_ = externalBlocker_->continueFuture();
+      return nullptr;
+    }
+    auto output = std::move(input_);
+    input_ = nullptr;
+    return output;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* future) override {
+    if (continueFuture_.valid()) {
+      *future = std::move(continueFuture_);
+      return exec::BlockingReason::kWaitForConsumer;
+    }
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_;
+  }
+
+ private:
+  RowVectorPtr input_;
+  ExternalBlocker* externalBlocker_;
+  folly::SemiFuture<folly::Unit> continueFuture_;
+};
+
+class TestExternalBlockableTranslator
+    : public exec::Operator::PlanNodeTranslator {
+  std::unique_ptr<exec::Operator> toOperator(
+      exec::DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto castedNode =
+            std::dynamic_pointer_cast<const TestExternalBlockableNode>(node)) {
+      return std::make_unique<TestExternalBlockableOperator>(
+          id, ctx, castedNode);
+    }
+    return nullptr;
+  }
+};
+
+// A test node creates operator that allocate memory from velox memory pool on
+// construction.
+class TestBadMemoryNode : public core::PlanNode {
+ public:
+  TestBadMemoryNode(const core::PlanNodeId& id, core::PlanNodePtr source)
+      : PlanNode(id), sources_{std::move(source)} {}
+
+  const RowTypePtr& outputType() const override {
+    return sources_[0]->outputType();
+  }
+
+  const std::vector<core::PlanNodePtr>& sources() const override {
+    return sources_;
+  }
+
+  std::string_view name() const override {
+    return "bad memory node";
+  }
+
+ private:
+  void addDetails(std::stringstream& /* stream */) const override {}
+
+  std::vector<core::PlanNodePtr> sources_;
+};
+
+class TestBadMemoryOperator : public exec::Operator {
+ public:
+  TestBadMemoryOperator(
+      int32_t operatorId,
+      exec::DriverCtx* driverCtx,
+      std::shared_ptr<const TestBadMemoryNode> node)
+      : Operator(
+            driverCtx,
+            node->outputType(),
+            operatorId,
+            node->id(),
+            "BadMemory") {
+    pool()->allocateNonContiguous(1, allocation_);
+  }
+
+  bool needsInput() const override {
+    return !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr /*unused*/) override {}
+
+  RowVectorPtr getOutput() override {
+    return nullptr;
+  }
+
+  exec::BlockingReason isBlocked(ContinueFuture* /*unused*/) override {
+    return exec::BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return noMoreInput_;
+  }
+
+ private:
+  memory::Allocation allocation_;
+};
+
+class TestBadMemoryTranslator : public exec::Operator::PlanNodeTranslator {
+  std::unique_ptr<exec::Operator> toOperator(
+      exec::DriverCtx* ctx,
+      int32_t id,
+      const core::PlanNodePtr& node) override {
+    if (auto castedNode =
+            std::dynamic_pointer_cast<const TestBadMemoryNode>(node)) {
+      return std::make_unique<TestBadMemoryOperator>(id, ctx, castedNode);
+    }
+    return nullptr;
+  }
+};
+} // namespace
+class TaskTest : public HiveConnectorTestBase {
+ protected:
+  static std::pair<std::shared_ptr<exec::Task>, std::vector<RowVectorPtr>>
+  executeSingleThreaded(
+      core::PlanFragment plan,
+      const std::unordered_map<std::string, std::vector<std::string>>&
+          filePaths = {}) {
+    auto task = Task::create(
+        "single.execution.task.0", plan, 0, std::make_shared<core::QueryCtx>());
+
+    for (const auto& [nodeId, paths] : filePaths) {
+      for (const auto& path : paths) {
+        task->addSplit(nodeId, exec::Split(makeHiveConnectorSplit(path)));
+      }
+      task->noMoreSplits(nodeId);
+    }
+
+    VELOX_CHECK(task->supportsSingleThreadedExecution());
+
+    vector_size_t numRows = 0;
+    std::vector<RowVectorPtr> results;
+    for (;;) {
+      auto result = task->next();
+      if (!result) {
+        break;
+      }
+
+      for (auto& child : result->children()) {
+        child->loadedVector();
+      }
+      results.push_back(result);
+      numRows += result->size();
+    }
+
+    VELOX_CHECK(waitForTaskCompletion(task.get()));
+
+    auto planNodeStats = toPlanStats(task->taskStats());
+    VELOX_CHECK(planNodeStats.count(plan.planNode->id()));
+    VELOX_CHECK_EQ(numRows, planNodeStats.at(plan.planNode->id()).outputRows);
+    VELOX_CHECK_EQ(
+        results.size(), planNodeStats.at(plan.planNode->id()).outputVectors);
+
+    return {task, results};
+  }
+};
+
+TEST_F(TaskTest, wrongPlanNodeForSplit) {
+  auto connectorSplit = std::make_shared<connector::hive::HiveConnectorSplit>(
+      "test",
+      "file:/tmp/abc",
+      facebook::velox::dwio::common::FileFormat::DWRF,
+      0,
+      100);
+
+  auto plan = PlanBuilder()
+                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
+                  .project({"a * a", "b + b"})
+                  .planFragment();
+
+  auto task = Task::create(
+      "task-1",
+      std::move(plan),
+      0,
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+
+  // Add split for the source node.
+  task->addSplit("0", exec::Split(folly::copy(connectorSplit)));
+
+  // Add an empty split.
+  task->addSplit("0", exec::Split());
+
+  // Try to add split for a non-source node.
+  auto errorMessage =
+      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 1 doesn't refer to such plan node.";
+  VELOX_ASSERT_THROW(
+      task->addSplit("1", exec::Split(folly::copy(connectorSplit))),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(
+      task->addSplitWithSequence(
+          "1", exec::Split(folly::copy(connectorSplit)), 3),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(task->setMaxSplitSequenceId("1", 9), errorMessage)
+
+  VELOX_ASSERT_THROW(task->noMoreSplits("1"), errorMessage)
+
+  VELOX_ASSERT_THROW(task->noMoreSplitsForGroup("1", 5), errorMessage)
+
+  // Try to add split for non-existent node.
+  errorMessage =
+      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 12 doesn't refer to such plan node.";
+  VELOX_ASSERT_THROW(
+      task->addSplit("12", exec::Split(folly::copy(connectorSplit))),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(
+      task->addSplitWithSequence(
+          "12", exec::Split(folly::copy(connectorSplit)), 3),
+      errorMessage)
+
+  VELOX_ASSERT_THROW(task->setMaxSplitSequenceId("12", 9), errorMessage)
+
+  VELOX_ASSERT_THROW(task->noMoreSplits("12"), errorMessage)
+
+  VELOX_ASSERT_THROW(task->noMoreSplitsForGroup("12", 5), errorMessage)
+
+  // Try to add split for a Values source node.
+  plan =
+      PlanBuilder()
+          .values({makeRowVector(ROW({"a", "b"}, {INTEGER(), DOUBLE()}), 10)})
+          .project({"a * a", "b + b"})
+          .planFragment();
+
+  auto valuesTask = Task::create(
+      "task-2",
+      std::move(plan),
+      0,
+      std::make_shared<core::QueryCtx>(driverExecutor_.get()));
+  errorMessage =
+      "Splits can be associated only with leaf plan nodes which require splits. Plan node ID 0 doesn't refer to such plan node.";
+  VELOX_ASSERT_THROW(
+      valuesTask->addSplit("0", exec::Split(folly::copy(connectorSplit))),
+      errorMessage)
+}
+
+TEST_F(TaskTest, duplicatePlanNodeIds) {
+  auto plan = PlanBuilder()
+                  .tableScan(ROW({"a", "b"}, {INTEGER(), DOUBLE()}))
+                  .hashJoin(
+                      {"a"},
+                      {"a1"},
+                      PlanBuilder()
+                          .tableScan(ROW({"a1", "b1"}, {INTEGER(), DOUBLE()}))
+                          .planNode(),
+                      "",
+                      {"b", "b1"})
+                  .planFragment();
+
+  VELOX_ASSERT_THROW(
+      Task::create(
+          "task-1",
+          std::move(plan),
+          0,
+          std::make_shared<core::QueryCtx>(driverExecutor_.get())),
+      "Plan node IDs must be unique. Found duplicate ID: 0.")
+}
 
 // This test simulates the following execution sequence that potentially can
 // cause a deadlock:
@@ -622,140 +831,6 @@ TEST_F(TaskTest, singleThreadedCrossJoin) {
     assertEqualResults({expectedResult}, results);
   }
 }
-
-class ExternalBlocker {
- public:
-  folly::SemiFuture<folly::Unit> continueFuture() {
-    if (isBlocked_) {
-      auto [promise, future] = makeVeloxContinuePromiseContract();
-      continuePromise_ = std::move(promise);
-      return std::move(future);
-    }
-    return folly::SemiFuture<folly::Unit>();
-  }
-
-  void unblock() {
-    if (isBlocked_) {
-      continuePromise_.setValue();
-      isBlocked_ = false;
-    }
-  }
-
-  void block() {
-    isBlocked_ = true;
-  }
-
-  bool isBlocked() const {
-    return isBlocked_;
-  }
-
- private:
-  bool isBlocked_ = false;
-  folly::Promise<folly::Unit> continuePromise_;
-};
-
-// A test node that normally just re-project/passthrough the output from input
-// When the node is blocked by external even (via externalBlocker), the operator
-// will signal kBlocked. The pipeline can ONLY proceed again when it is
-// unblocked externally.
-class TestExternalBlockableNode : public core::PlanNode {
- public:
-  TestExternalBlockableNode(
-      const core::PlanNodeId& id,
-      core::PlanNodePtr source,
-      std::shared_ptr<ExternalBlocker> externalBlocker)
-      : PlanNode(id),
-        sources_{std::move(source)},
-        externalBlocker_(std::move(externalBlocker)) {}
-
-  const RowTypePtr& outputType() const override {
-    return sources_[0]->outputType();
-  }
-
-  const std::vector<core::PlanNodePtr>& sources() const override {
-    return sources_;
-  }
-
-  std::string_view name() const override {
-    return "external blocking node";
-  }
-
-  ExternalBlocker* externalBlocker() const {
-    return externalBlocker_.get();
-  }
-
- private:
-  void addDetails(std::stringstream& /* stream */) const override {}
-
-  std::vector<core::PlanNodePtr> sources_;
-  std::shared_ptr<ExternalBlocker> externalBlocker_;
-};
-
-class TestExternalBlockableOperator : public exec::Operator {
- public:
-  TestExternalBlockableOperator(
-      int32_t operatorId,
-      exec::DriverCtx* driverCtx,
-      std::shared_ptr<const TestExternalBlockableNode> node)
-      : Operator(
-            driverCtx,
-            node->outputType(),
-            operatorId,
-            node->id(),
-            "ExternalBlockable"),
-        externalBlocker_(node->externalBlocker()) {}
-
-  bool needsInput() const override {
-    return !noMoreInput_;
-  }
-
-  void addInput(RowVectorPtr input) override {
-    input_ = std::move(input);
-  }
-
-  RowVectorPtr getOutput() override {
-    // If this operator is signaled to be blocked externally
-    if (externalBlocker_->isBlocked()) {
-      continueFuture_ = externalBlocker_->continueFuture();
-      return nullptr;
-    }
-    auto output = std::move(input_);
-    input_ = nullptr;
-    return output;
-  }
-
-  exec::BlockingReason isBlocked(ContinueFuture* future) override {
-    if (continueFuture_.valid()) {
-      *future = std::move(continueFuture_);
-      return exec::BlockingReason::kWaitForConsumer;
-    }
-    return exec::BlockingReason::kNotBlocked;
-  }
-
-  bool isFinished() override {
-    return noMoreInput_;
-  }
-
- private:
-  RowVectorPtr input_;
-  ExternalBlocker* externalBlocker_;
-  folly::SemiFuture<folly::Unit> continueFuture_;
-};
-
-class TestExternalBlockableTranslator
-    : public exec::Operator::PlanNodeTranslator {
-  std::unique_ptr<exec::Operator> toOperator(
-      exec::DriverCtx* ctx,
-      int32_t id,
-      const core::PlanNodePtr& node) override {
-    if (auto castedNode =
-            std::dynamic_pointer_cast<const TestExternalBlockableNode>(node)) {
-      return std::make_unique<TestExternalBlockableOperator>(
-          id, ctx, castedNode);
-    }
-    return nullptr;
-  }
-};
 
 TEST_F(TaskTest, singleThreadedExecutionExternalBlockable) {
   exec::Operator::registerOperator(
@@ -1203,4 +1278,31 @@ DEBUG_ONLY_TEST_F(TaskTest, raceBetweenTaskPauseAndTerminate) {
   taskThread.join();
 }
 
+TEST_F(TaskTest, driverCreationMemoryAllocationCheck) {
+  exec::Operator::registerOperator(std::make_unique<TestBadMemoryTranslator>());
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(1'000, [](auto row) { return row; }),
+  });
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .addNode([&](std::string id, core::PlanNodePtr input) mutable {
+            return std::make_shared<TestBadMemoryNode>(id, input);
+          })
+          .planFragment();
+  for (bool singleThreadExecution : {false, true}) {
+    SCOPED_TRACE(fmt::format("singleThreadExecution: ", singleThreadExecution));
+    auto badTask = Task::create(
+        "driverCreationMemoryAllocationCheck",
+        plan,
+        0,
+        std::make_shared<core::QueryCtx>());
+    if (singleThreadExecution) {
+      VELOX_ASSERT_THROW(
+          Task::start(badTask, 1), "Unexpected memory pool allocations");
+    } else {
+      VELOX_ASSERT_THROW(badTask->next(), "Unexpected memory pool allocations");
+    }
+  }
+}
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
The memory pool allocation during driver creation can cause deadlock if memory arbitration
is triggered as explained in [PR](https://github.com/facebookincubator/velox/pull/6395), we shall use lazy operation initialization if possible
This PR adds to check the memory pool allocation is zero and log out query pool memory
usage distribution if happens. Add driverCreationMemoryAllocationCheck verifies the check