### PR TITLE
Support TTL for AsyncDataCache and SsdCache

### DIFF
--- a/velox/common/caching/CacheTTLController.h
+++ b/velox/common/caching/CacheTTLController.h
@@ -72,6 +72,8 @@ class CacheTTLController {
   /// Compute age related stats of the cached files.
   CacheAgeStats getCacheAgeStats() const;
 
+  void applyTTL(int64_t ttlSecs);
+
  private:
   /// A process-wide singleton instance of CacheTTLController.
   static std::unique_ptr<CacheTTLController> instance_;
@@ -79,6 +81,8 @@ class CacheTTLController {
  private:
   // Prevent creating a random instance of CacheTTLController.
   explicit CacheTTLController(AsyncDataCache& cache) : cache_(cache) {}
+
+  folly::F14FastSet<uint64_t> getAndMarkAgedOutFiles(int64_t maxOpenTimeSecs);
 
   /// Clean up file entries with removeInProgress true but keep entries for
   /// fileNums in filesToRetain.

--- a/velox/common/caching/SsdCache.cpp
+++ b/velox/common/caching/SsdCache.cpp
@@ -135,6 +135,29 @@ void SsdCache::write(std::vector<CachePin> pins) {
   writesInProgress_.fetch_sub(numNoStore);
 }
 
+bool SsdCache::removeFileEntries(
+    const folly::F14FastSet<uint64_t>& filesToRemove,
+    folly::F14FastSet<uint64_t>& filesRetained) {
+  if (!startWrite()) {
+    return false;
+  }
+
+  bool success = true;
+  for (auto i = 0; i < numShards_; i++) {
+    try {
+      success &= files_[i]->removeFileEntries(filesToRemove, filesRetained);
+    } catch (const std::exception& e) {
+      VELOX_SSD_CACHE_LOG(ERROR)
+          << "Error removing file entries from SSD shard "
+          << files_[i]->shardId() << ": " << e.what();
+      success = false;
+    }
+    --writesInProgress_;
+  }
+
+  return success;
+}
+
 SsdCacheStats SsdCache::stats() const {
   SsdCacheStats stats;
   for (auto& file : files_) {

--- a/velox/common/caching/SsdCache.h
+++ b/velox/common/caching/SsdCache.h
@@ -76,6 +76,14 @@ class SsdCache {
   /// have returned true.
   void write(std::vector<CachePin> pins);
 
+  /// Remove cached    entries from all SsdFiles for files in the fileNum set
+  /// 'filesToRemove'. If successful, return true, and 'filesRetained' contains
+  /// entries that should not be removed, ex., from pinned regions. Otherwise,
+  /// return false and 'filesRetained' could be ignored.
+  bool removeFileEntries(
+      const folly::F14FastSet<uint64_t>& filesToRemove,
+      folly::F14FastSet<uint64_t>& filesRetained);
+
   /// Returns stats aggregated from all shards.
   SsdCacheStats stats() const;
 

--- a/velox/common/caching/SsdFile.h
+++ b/velox/common/caching/SsdFile.h
@@ -132,7 +132,10 @@ struct SsdCacheStats {
     entriesRead = tsanAtomicValue(other.entriesRead);
     bytesRead = tsanAtomicValue(other.bytesRead);
     entriesCached = tsanAtomicValue(other.entriesCached);
+    regionsCached = tsanAtomicValue(other.regionsCached);
     bytesCached = tsanAtomicValue(other.bytesCached);
+    entriesAgedOut = tsanAtomicValue(other.entriesAgedOut);
+    regionsAgedOut = tsanAtomicValue(other.regionsAgedOut);
     numPins = tsanAtomicValue(other.numPins);
 
     openFileErrors = tsanAtomicValue(other.openFileErrors);
@@ -151,7 +154,10 @@ struct SsdCacheStats {
   tsan_atomic<uint64_t> entriesRead{0};
   tsan_atomic<uint64_t> bytesRead{0};
   tsan_atomic<uint64_t> entriesCached{0};
+  tsan_atomic<uint64_t> regionsCached{0};
   tsan_atomic<uint64_t> bytesCached{0};
+  tsan_atomic<uint64_t> entriesAgedOut{0};
+  tsan_atomic<uint64_t> regionsAgedOut{0};
   tsan_atomic<int32_t> numPins{0};
 
   tsan_atomic<uint32_t> openFileErrors{0};
@@ -245,6 +251,14 @@ class SsdFile {
   // Deletes the backing file. Used in testing.
   void deleteFile();
 
+  /// Remove cached entries of files in the fileNum set 'filesToRemove'. If
+  /// successful, return true, and 'filesRetained' contains entries that should
+  /// not be removed, ex., from pinned regions. Otherwise, return false and
+  /// 'filesRetained' could be ignored.
+  bool removeFileEntries(
+      const folly::F14FastSet<uint64_t>& filesToRemove,
+      folly::F14FastSet<uint64_t>& filesRetained);
+
   // Writes a checkpoint state that can be recovered from. The
   // checkpoint is serialized on 'mutex_'. If 'force' is false,
   // rechecks that at least 'checkpointIntervalBytes_' have been
@@ -263,6 +277,8 @@ class SsdFile {
   static constexpr int64_t kCheckpointMapMarker = 0xfffffffffffffffe;
   // Magic number at end of completed checkpoint file.
   static constexpr int64_t kCheckpointEndMarker = 0xcbedf11e;
+
+  static constexpr int kMaxErasedSizePct = 50;
 
   // Increments the pin count of the region of 'offset'. Caller must hold
   // 'mutex_'.
@@ -343,6 +359,8 @@ class SsdFile {
   // offset and the end of the region. This is subscripted with the region
   // index. The regionIndex times kRegionSize is an offset into the file.
   std::vector<uint32_t> regionSizes_;
+
+  std::vector<uint32_t> erasedRegionSizes_;
 
   // Indices of regions available for writing new entries.
   std::vector<int32_t> writableRegions_;

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "folly/experimental/EventCount.h"
+#include "velox/common/base/Semaphore.h"
 #include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/caching/CacheTTLController.h"
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/caching/SsdCache.h"
 #include "velox/common/file/FileSystems.h"
@@ -131,9 +133,14 @@ class AsyncDataCacheTest : public testing::Test {
   void loadOne(uint64_t fileNum, Request& request, bool injectError);
 
   // Brings the data for the ranges in 'requests' into cache. The individual
-  // entries should be accessed with loadOne().
-  void
-  loadBatch(uint64_t fileNum, std::vector<Request>& requests, bool injectError);
+  // entries should be accessed with loadOne(). 'requests' are handled with one
+  // TestingCoalescedSsdLoad and one TestingCoalescedLoad. Call
+  // semaphore.acquire() twice if needing to wait for the two loads to finish.
+  void loadBatch(
+      uint64_t fileNum,
+      std::vector<Request>& requests,
+      bool injectError,
+      Semaphore* semaphore = nullptr);
 
   // Gets a pin on each of 'requests' individually. This checks the contents via
   // cache_'s verifyHook.
@@ -145,6 +152,8 @@ class AsyncDataCacheTest : public testing::Test {
       loadOne(fileNum, request, injectError);
     }
   }
+
+  void loadNFiles(int32_t numFiles, std::vector<int64_t> offsets);
 
   // Loads a sequence of entries from a number of files. Looks up a
   // number of entries, then loads the ones that nobody else is
@@ -388,7 +397,8 @@ void AsyncDataCacheTest::loadOne(
 void AsyncDataCacheTest::loadBatch(
     uint64_t fileNum,
     std::vector<Request>& requests,
-    bool injectError) {
+    bool injectError,
+    Semaphore* semaphore) {
   // Pattern for loading a set of buffers from a file: Divide the requested
   // ranges between already loaded and loadable from storage.
   std::vector<Request*> fromStorage;
@@ -421,13 +431,18 @@ void AsyncDataCacheTest::loadBatch(
     }
     auto load = std::make_shared<TestingCoalescedLoad>(
         std::move(keys), std::move(sizes), cache_, injectError);
-    executor()->add([load]() {
+    executor()->add([load, semaphore]() {
       try {
         load->loadOrFuture(nullptr);
       } catch (const std::exception& e) {
         // Expecting error, ignore.
       };
+      if (semaphore) {
+        semaphore->release();
+      }
     });
+  } else if (semaphore) {
+    semaphore->release();
   }
 
   if (!fromSsd.empty()) {
@@ -445,13 +460,46 @@ void AsyncDataCacheTest::loadBatch(
         std::move(ssdPins),
         cache_,
         injectError);
-    executor()->add([load]() {
+    executor()->add([load, semaphore]() {
       try {
         load->loadOrFuture(nullptr);
       } catch (const std::exception& e) {
         // Expecting error, ignore.
       };
+      if (semaphore) {
+        semaphore->release();
+      }
     });
+  } else if (semaphore) {
+    semaphore->release();
+  }
+}
+
+void AsyncDataCacheTest::loadNFiles(
+    int32_t numFiles,
+    std::vector<int64_t> offsets) {
+  Semaphore semaphore(0);
+
+  std::vector<Request> batch;
+  int32_t numLoads = 0;
+  for (auto file = 0; file < numFiles; ++file) {
+    auto fileNum = filenames_[file].id();
+    if (auto instance = CacheTTLController::getInstance()) {
+      instance->addOpenFileInfo(fileNum);
+    }
+    for (auto i = 0; i < offsets.size() - 1; i++) {
+      batch.emplace_back(offsets[i], offsets[i + 1] - offsets[i]);
+      if (batch.size() == 8 || i == (offsets.size() - 2)) {
+        loadBatch(fileNum, batch, false, &semaphore);
+        batch.clear();
+        numLoads +=
+            2; // One TestingCoalescedSsdLoad and one TestingCoalescedLoad.
+      }
+    }
+  }
+
+  for (auto i = 0; i < numLoads; i++) {
+    semaphore.acquire();
   }
 }
 
@@ -806,6 +854,7 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
   stats.numEvict = 463;
   stats.numEvictChecks = 348;
   stats.numWaitExclusive = 244;
+  stats.numAgedOut = 10;
   stats.allocClocks = 1320;
   stats.sumEvictScore = 123;
   ASSERT_EQ(
@@ -813,7 +862,7 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
       "Cache size: 2.56KB tinySize: 257B large size: 2.31KB\n"
       "Cache entries: 100 read pins: 30 write pins: 20 pinned shared: 10.00MB pinned exclusive: 10.00MB\n"
       " num write wait: 244 empty entries: 20\n"
-      "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348\n"
+      "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348 aged out: 10\n"
       "Prefetch entries: 30 bytes: 100B\n"
       "Alloc Megaclocks 0");
 
@@ -825,7 +874,7 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
       "Cache size: 0B tinySize: 0B large size: 0B\n"
       "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
       " num write wait: 0 empty entries: 0\n"
-      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
       "Alloc Megaclocks 0\n"
       "Allocated pages: 0 cached pages: 0\n"
@@ -849,7 +898,7 @@ TEST_F(AsyncDataCacheTest, cacheStats) {
       "Cache size: 0B tinySize: 0B large size: 0B\n"
       "Cache entries: 0 read pins: 0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n"
       " num write wait: 0 empty entries: 0\n"
-      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 aged out: 0\n"
       "Prefetch entries: 0 bytes: 0B\n"
       "Alloc Megaclocks 0\n"
       "Allocated pages: 0 cached pages: 0\n";
@@ -1061,5 +1110,41 @@ DEBUG_ONLY_TEST_F(AsyncDataCacheTest, shrinkWithSsdWrite) {
   ASSERT_EQ(stats.numEntries, 0);
   ASSERT_EQ(stats.numEmptyEntries, numEntries);
 }
+
+#ifndef NDEBUG
+DEBUG_ONLY_TEST_F(AsyncDataCacheTest, ttl) {
+  constexpr uint64_t kRamBytes = 32 << 20;
+  constexpr uint64_t kSsdBytes = 128UL << 20;
+
+  initializeCache(kRamBytes, kSsdBytes);
+  CacheTTLController::create(*cache_);
+
+  std::vector<int64_t> offsets(32);
+  std::generate(offsets.begin(), offsets.end(), [&, n = 0]() mutable {
+    return n += (kRamBytes / kNumFiles / offsets.size());
+  });
+
+  ScopedTestTime stt;
+  auto loadTime1 = getCurrentTimeSec();
+  auto loadTime2 = loadTime1 + 100;
+
+  stt.setCurrentTestTimeSec(loadTime1);
+  loadNFiles(filenames_.size() * 2 / 3, offsets);
+  auto statsT1 = cache_->refreshStats();
+
+  stt.setCurrentTestTimeSec(loadTime2);
+  loadNFiles(filenames_.size(), offsets);
+  auto statsT2 = cache_->refreshStats();
+
+  runThreads(2, [&](int32_t /*i*/) {
+    CacheTTLController::getInstance()->applyTTL(
+        getCurrentTimeSec() - loadTime1 - 2);
+  });
+
+  auto statsTtl = cache_->refreshStats();
+  EXPECT_EQ(statsTtl.numAgedOut, statsT1.numEntries);
+  EXPECT_EQ(statsTtl.ssdStats->entriesAgedOut, statsT1.ssdStats->entriesCached);
+}
+#endif
 
 // TODO: add concurrent fuzzer test.

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -601,9 +601,9 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "tinySize: 0B large size: 0B\nCache entries: 0 read pins: "
                     "0 write pins: 0 pinned shared: 0B pinned exclusive: 0B\n "
                     "num write wait: 0 empty entries: 0\nCache access miss: 0 "
-                    "hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\nPrefetch"
-                    " entries: 0 bytes: 0B\nAlloc Megaclocks 0\nAllocated pages: 0"
-                    " cached pages: 0\n",
+                    "hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0 "
+                    "aged out: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks 0\n"
+                    "Allocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());
           } else {
@@ -636,7 +636,7 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
                     "read pins: 0 write pins: 0 pinned shared: 0B pinned "
                     "exclusive: 0B\n num write wait: 0 empty entries: 0\nCache "
                     "access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction "
-                    "checks: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
+                    "checks: 0 aged out: 0\nPrefetch entries: 0 bytes: 0B\nAlloc Megaclocks"
                     " 0\nAllocated pages: 0 cached pages: 0\n",
                     isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
                 ex.message());


### PR DESCRIPTION
Support cache TTL for AsyncDataCache and SsdCache. CacheTTLController
derives a list of files with age greater than the given ttl in seconds, and
remove cache entries loaded from the aged out files. File age uses
the raw file open time as the start time, which is tracked by
CacheTTLController.