### PR TITLE
Add ContainerRowSerde::compareWithNulls API

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -411,14 +411,14 @@ std::optional<int32_t> compare<TypeKind::ROW>(
 
     if (leftNull || rightNull) {
       auto result = BaseVector::compareNulls(leftNull, rightNull, flags);
-      if (result && *result == 0) {
+      if (result.has_value() && result.value() == 0) {
         continue;
       }
       return result;
     }
 
     auto result = compareSwitch(left, *child, wrappedIndex, flags);
-    if (result && *result == 0) {
+    if (result.has_value() && result.value() == 0) {
       continue;
     }
     return result;
@@ -446,14 +446,14 @@ std::optional<int32_t> compareArrays(
 
     if (leftNull || rightNull) {
       auto result = BaseVector::compareNulls(leftNull, rightNull, flags);
-      if (result && *result == 0) {
+      if (result.has_value() && result.value() == 0) {
         continue;
       }
       return result;
     }
 
     auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
-    if (result && *result == 0) {
+    if (result.has_value() && result.value() == 0) {
       continue;
     }
     return result;
@@ -481,14 +481,14 @@ std::optional<int32_t> compareArrayIndices(
 
     if (leftNull || rightNull) {
       auto result = BaseVector::compareNulls(leftNull, rightNull, flags);
-      if (result && *result == 0) {
+      if (result.has_value() && result.value() == 0) {
         continue;
       }
       return result;
     }
 
     auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
-    if (result && *result == 0) {
+    if (result.has_value() && result.value() == 0) {
       continue;
     }
     return result;
@@ -526,7 +526,7 @@ std::optional<int32_t> compare<TypeKind::MAP>(
   std::vector<vector_size_t> indices(size);
   auto rightIndices = map->sortedKeyIndices(wrappedIndex);
   auto result = compareArrayIndices(left, *map->mapKeys(), rightIndices, flags);
-  if (result && *result == 0) {
+  if (result.has_value() && result.value() == 0) {
     return compareArrayIndices(left, *map->mapValues(), rightIndices, flags);
   }
   return result;

--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -526,10 +526,10 @@ std::optional<int32_t> compare<TypeKind::MAP>(
   std::vector<vector_size_t> indices(size);
   auto rightIndices = map->sortedKeyIndices(wrappedIndex);
   auto result = compareArrayIndices(left, *map->mapKeys(), rightIndices, flags);
-  if (result.has_value() && result.value() != 0) {
-    return result;
+  if (result && *result == 0) {
+    return compareArrayIndices(left, *map->mapValues(), rightIndices, flags);
   }
-  return compareArrayIndices(left, *map->mapValues(), rightIndices, flags);
+  return result;
 }
 
 std::optional<int32_t> compareSwitch(

--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -326,19 +326,18 @@ void deserializeSwitch(
 }
 
 // Comparison of serialization and vector.
-int compareSwitch(
+std::optional<int32_t> compareSwitch(
     ByteStream& stream,
     const BaseVector& vector,
     vector_size_t index,
     CompareFlags flags);
 
 template <TypeKind Kind>
-int32_t compare(
+std::optional<int32_t> compare(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
   using T = typename TypeTraits<Kind>::NativeType;
   auto rightValue = right.asUnchecked<SimpleVector<T>>()->valueAt(index);
   auto leftValue = left.read<T>();
@@ -373,37 +372,56 @@ int compareStringAsc(
 }
 
 template <>
-int compare<TypeKind::VARCHAR>(
+std::optional<int32_t> compare<TypeKind::VARCHAR>(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto result = compareStringAsc(left, right, index, flags.equalsOnly);
   return flags.ascending ? result : result * -1;
 }
 
 template <>
-int compare<TypeKind::VARBINARY>(
+std::optional<int32_t> compare<TypeKind::VARBINARY>(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto result = compareStringAsc(left, right, index, flags.equalsOnly);
   return flags.ascending ? result : result * -1;
 }
 
+std::optional<std::optional<int32_t>>
+compareNulls(bool leftNull, bool rightNull, CompareFlags flags) {
+  switch (flags.nullHandlingMode) {
+    case CompareFlags::NullHandlingMode::StopAtNull:
+      return std::make_optional<std::optional<int32_t>>(std::nullopt);
+    case CompareFlags::NullHandlingMode::NoStop:
+    default:
+      break;
+  }
+
+  if (leftNull && rightNull) {
+    return std::nullopt;
+  }
+
+  if (leftNull) {
+    return {{flags.nullsFirst ? -1 : 1}};
+  }
+
+  if (rightNull) {
+    return {{flags.nullsFirst ? 1 : -1}};
+  }
+
+  VELOX_UNREACHABLE();
+}
+
 template <>
-int compare<TypeKind::ROW>(
+std::optional<int32_t> compare<TypeKind::ROW>(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto row = right.wrappedVector()->asUnchecked<RowVector>();
   auto wrappedIndex = right.wrappedIndex(index);
   VELOX_CHECK_EQ(row->encoding(), VectorEncoding::Simple::ROW);
@@ -415,31 +433,28 @@ int compare<TypeKind::ROW>(
     auto child = row->childAt(i);
     auto leftNull = bits::isBitSet(nulls.data(), i);
     auto rightNull = child->isNullAt(wrappedIndex);
-    if (leftNull && rightNull) {
+
+    if (leftNull || rightNull) {
+      if (auto result = compareNulls(leftNull, rightNull, flags)) {
+        return result.value();
+      }
       continue;
     }
-    if (leftNull) {
-      return flags.nullsFirst ? -1 : 1;
-    }
-    if (rightNull) {
-      return flags.nullsFirst ? 1 : -1;
-    }
+
     auto result = compareSwitch(left, *child, wrappedIndex, flags);
-    if (result) {
+    if (result.has_value() && result.value() != 0) {
       return result;
     }
   }
   return 0;
 }
 
-int32_t compareArrays(
+std::optional<int32_t> compareArrays(
     ByteStream& left,
-    BaseVector& elements,
+    const BaseVector& elements,
     vector_size_t offset,
     vector_size_t rightSize,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   int leftSize = left.read<int32_t>();
   if (leftSize != rightSize && flags.equalsOnly) {
     return flags.ascending ? 1 : -1;
@@ -451,29 +466,27 @@ int32_t compareArrays(
     auto elementIndex = elements.wrappedIndex(offset + i);
     bool leftNull = bits::isBitSet(leftNulls.data(), i);
     bool rightNull = wrappedElements->isNullAt(elementIndex);
-    if (leftNull) {
-      if (rightNull) {
-        continue;
+
+    if (leftNull || rightNull) {
+      if (auto result = compareNulls(leftNull, rightNull, flags)) {
+        return result.value();
       }
-      return flags.nullsFirst ? -1 : 1;
-    } else if (rightNull) {
-      return flags.nullsFirst ? 1 : -1;
+      continue;
     }
-    int result = compareSwitch(left, *wrappedElements, elementIndex, flags);
-    if (result) {
+
+    auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
+    if (result.has_value() && result.value() != 0) {
       return result;
     }
   }
   return flags.ascending ? (leftSize - rightSize) : (rightSize - leftSize);
 }
 
-int32_t compareArrayIndices(
+std::optional<int32_t> compareArrayIndices(
     ByteStream& left,
-    BaseVector& elements,
+    const BaseVector& elements,
     folly::Range<const vector_size_t*> rightIndices,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   int32_t leftSize = left.read<int32_t>();
   int32_t rightSize = rightIndices.size();
   if (leftSize != rightSize && flags.equalsOnly) {
@@ -486,16 +499,16 @@ int32_t compareArrayIndices(
     auto elementIndex = elements.wrappedIndex(rightIndices[i]);
     bool leftNull = bits::isBitSet(leftNulls.data(), i);
     bool rightNull = wrappedElements->isNullAt(elementIndex);
-    if (leftNull) {
-      if (rightNull) {
-        continue;
+
+    if (leftNull || rightNull) {
+      if (auto result = compareNulls(leftNull, rightNull, flags)) {
+        return result.value();
       }
-      return flags.nullsFirst ? -1 : 1;
-    } else if (rightNull) {
-      return flags.nullsFirst ? 1 : -1;
+      continue;
     }
-    int result = compareSwitch(left, *wrappedElements, elementIndex, flags);
-    if (result) {
+
+    auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
+    if (result.has_value() && result.value() != 0) {
       return result;
     }
   }
@@ -503,13 +516,11 @@ int32_t compareArrayIndices(
 }
 
 template <>
-int compare<TypeKind::ARRAY>(
+std::optional<int32_t> compare<TypeKind::ARRAY>(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto array = right.wrappedVector()->asUnchecked<ArrayVector>();
   VELOX_CHECK_EQ(array->encoding(), VectorEncoding::Simple::ARRAY);
   auto wrappedIndex = right.wrappedIndex(index);
@@ -522,13 +533,11 @@ int compare<TypeKind::ARRAY>(
 }
 
 template <>
-int compare<TypeKind::MAP>(
+std::optional<int32_t> compare<TypeKind::MAP>(
     ByteStream& left,
     const BaseVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto map = right.wrappedVector()->asUnchecked<MapVector>();
   VELOX_CHECK_EQ(map->encoding(), VectorEncoding::Simple::MAP);
   auto wrappedIndex = right.wrappedIndex(index);
@@ -536,19 +545,17 @@ int compare<TypeKind::MAP>(
   std::vector<vector_size_t> indices(size);
   auto rightIndices = map->sortedKeyIndices(wrappedIndex);
   auto result = compareArrayIndices(left, *map->mapKeys(), rightIndices, flags);
-  if (result) {
+  if (result.has_value() && result.value() != 0) {
     return result;
   }
   return compareArrayIndices(left, *map->mapValues(), rightIndices, flags);
 }
 
-int32_t compareSwitch(
+std::optional<int32_t> compareSwitch(
     ByteStream& stream,
     const BaseVector& vector,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   return VELOX_DYNAMIC_TYPE_DISPATCH(
       compare, vector.typeKind(), stream, vector, index, flags);
 }
@@ -582,8 +589,6 @@ int32_t compare(
     ByteStream& right,
     const Type* /*type*/,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   using T = typename TypeTraits<Kind>::NativeType;
   T leftValue = left.read<T>();
   T rightValue = right.read<T>();
@@ -597,8 +602,6 @@ int32_t compare<TypeKind::VARCHAR>(
     ByteStream& right,
     const Type* /*type*/,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   std::string leftStorage;
   std::string rightStorage;
   StringView leftValue = readStringView(left, leftStorage);
@@ -613,8 +616,6 @@ int32_t compare<TypeKind::VARBINARY>(
     ByteStream& right,
     const Type* /*type*/,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   std::string leftStorage;
   std::string rightStorage;
   StringView leftValue = readStringView(left, leftStorage);
@@ -628,8 +629,6 @@ int32_t compareArrays(
     ByteStream& right,
     const Type* elementType,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto leftSize = left.read<int32_t>();
   auto rightSize = right.read<int32_t>();
   if (flags.equalsOnly && leftSize != rightSize) {
@@ -664,8 +663,6 @@ int32_t compare<TypeKind::ROW>(
     ByteStream& right,
     const Type* type,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   const auto& rowType = type->as<TypeKind::ROW>();
   int size = rowType.size();
   auto leftNulls = readNulls(left, size);
@@ -696,8 +693,6 @@ int32_t compare<TypeKind::ARRAY>(
     ByteStream& right,
     const Type* type,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   return compareArrays(left, right, type->childAt(0).get(), flags);
 }
 
@@ -707,8 +702,6 @@ int32_t compare<TypeKind::MAP>(
     ByteStream& right,
     const Type* type,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   auto result = compareArrays(left, right, type->childAt(0).get(), flags);
   if (result) {
     return result;
@@ -721,8 +714,6 @@ int32_t compareSwitch(
     ByteStream& right,
     const Type* type,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-
   return VELOX_DYNAMIC_TYPE_DISPATCH(
       compare, type->kind(), left, right, type, flags);
 }
@@ -825,8 +816,7 @@ int32_t ContainerRowSerde::compare(
     const DecodedVector& right,
     vector_size_t index,
     CompareFlags flags) {
-  VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
-  return compareSwitch(left, *right.base(), right.index(index), flags);
+  return compareSwitch(left, *right.base(), right.index(index), flags).value();
 }
 
 // static
@@ -838,6 +828,15 @@ int32_t ContainerRowSerde::compare(
   VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
 
   return compareSwitch(left, right, type, flags);
+}
+
+// static
+std::optional<int32_t> ContainerRowSerde::compareWithNulls(
+    ByteStream& left,
+    const DecodedVector& right,
+    vector_size_t index,
+    CompareFlags flags) {
+  return compareSwitch(left, *right.base(), right.index(index), flags);
 }
 
 // static

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -32,21 +32,29 @@ class ContainerRowSerde {
   static void
   deserialize(ByteStream& in, vector_size_t index, BaseVector* result);
 
+  /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
+  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
+  /// support null-safe equal.
   static int32_t compare(
       ByteStream& left,
       const DecodedVector& right,
       vector_size_t index,
       CompareFlags flags);
 
+  /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
+  /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
+  /// support null-safe equal.
   static int32_t compare(
       ByteStream& left,
       ByteStream& right,
       const Type* type,
       CompareFlags flags);
 
-  /// Return std::nullopt if encountered in NullHandlingMode::StopAtNull mode.
-  /// And return std::optional<int32_t>(0) if both sides are nulls in
-  /// NullHandlingMode::NoStop mode.
+  /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
+  /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
+  /// returns std::nullopt if either 'left' or 'right' value is null or contains
+  /// a null. If flags.nullHandlingMode is NoStop, returns
+  /// std::optional<int32_t>(0) if both sides are nulls
   static std::optional<int32_t> compareWithNulls(
       ByteStream& left,
       const DecodedVector& right,

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -44,6 +44,12 @@ class ContainerRowSerde {
       const Type* type,
       CompareFlags flags);
 
+  static std::optional<int32_t> compareWithNulls(
+      ByteStream& left,
+      const DecodedVector& right,
+      vector_size_t index,
+      CompareFlags flags);
+
   static uint64_t hash(ByteStream& data, const Type* type);
 };
 

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -45,8 +45,8 @@ class ContainerRowSerde {
       CompareFlags flags);
 
   /// Return std::nullopt if encountered in NullHandlingMode::StopAtNull mode.
-  /// Support NullHandlingMode::NoStop mode as well and return
-  /// std::optional<int32_t>(0) if null encountered.
+  /// And return std::optional<int32_t>(0) if both sides are nulls in
+  /// NullHandlingMode::NoStop mode.
   static std::optional<int32_t> compareWithNulls(
       ByteStream& left,
       const DecodedVector& right,

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -44,6 +44,9 @@ class ContainerRowSerde {
       const Type* type,
       CompareFlags flags);
 
+  /// Return std::nullopt if encountered in NullHandlingMode::StopAtNull mode.
+  /// Support NullHandlingMode::NoStop mode as well and return
+  /// std::optional<int32_t>(0) if null encountered.
   static std::optional<int32_t> compareWithNulls(
       ByteStream& left,
       const DecodedVector& right,

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -53,8 +53,8 @@ class ContainerRowSerde {
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. If flags.nullHandlingMode is StopAtNull,
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
-  /// a null. If flags.nullHandlingMode is NoStop, returns
-  /// std::optional<int32_t>(0) if both sides are nulls
+  /// a null. If flags.nullHandlingMode is NoStop then NULL is considered equal
+  /// to NULL.
   static std::optional<int32_t> compareWithNulls(
       ByteStream& left,
       const DecodedVector& right,

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -772,23 +772,6 @@ class BaseVector {
   /// debug builds to check the result of expressions and some interim results.
   virtual void validate(const VectorValidateOptions& options = {}) const;
 
- protected:
-  /// Returns a brief summary of the vector. The default implementation includes
-  /// encoding, type, number of rows and number of nulls.
-  ///
-  /// For example,
-  ///     [FLAT INTEGER: 3 elements, no nulls]
-  ///     [DICTIONARY INTEGER: 5 elements, 1 nulls]
-  virtual std::string toSummaryString() const;
-
-  /*
-   * Allocates or reallocates nulls_ with at least the given size if nulls_
-   * hasn't been allocated yet or has been allocated with a smaller capacity.
-   * Ensures that nulls are writable (mutable and single referenced for
-   * minimumSize).
-   */
-  void ensureNullsCapacity(vector_size_t minimumSize, bool setNotNull = false);
-
   FOLLY_ALWAYS_INLINE static std::optional<int32_t>
   compareNulls(bool thisNull, bool otherNull, CompareFlags flags) {
     DCHECK(thisNull || otherNull);
@@ -813,6 +796,23 @@ class BaseVector {
     VELOX_UNREACHABLE(
         "The function should be called only if one of the inputs is null");
   }
+
+ protected:
+  /// Returns a brief summary of the vector. The default implementation includes
+  /// encoding, type, number of rows and number of nulls.
+  ///
+  /// For example,
+  ///     [FLAT INTEGER: 3 elements, no nulls]
+  ///     [DICTIONARY INTEGER: 5 elements, 1 nulls]
+  virtual std::string toSummaryString() const;
+
+  /*
+   * Allocates or reallocates nulls_ with at least the given size if nulls_
+   * hasn't been allocated yet or has been allocated with a smaller capacity.
+   * Ensures that nulls are writable (mutable and single referenced for
+   * minimumSize).
+   */
+  void ensureNullsCapacity(vector_size_t minimumSize, bool setNotNull = false);
 
   void ensureNulls() {
     ensureNullsCapacity(length_, true);


### PR DESCRIPTION
Presto aggregate functions that compare values of complex types need to detect
cases when complex type values contain nulls. The new
ContainerRowSerde::compareWithNulls API allows to signal the case when complex
type value contains a null.

Part of #6314