### PR TITLE
Fix use after free in exchange client

### DIFF
--- a/velox/exec/ExchangeClient.h
+++ b/velox/exec/ExchangeClient.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <memory>
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/exec/ExchangeQueue.h"
 #include "velox/exec/ExchangeSource.h"
@@ -23,7 +24,7 @@ namespace facebook::velox::exec {
 
 // Handle for a set of producers. This may be shared by multiple Exchanges, one
 // per consumer thread.
-class ExchangeClient {
+class ExchangeClient : std::enable_shared_from_this<ExchangeClient> {
  public:
   static constexpr int32_t kDefaultMaxQueuedBytes = 32 << 20; // 32 MB.
   static constexpr int32_t kDefaultMaxWaitSeconds = 2;

--- a/velox/exec/MergeSource.cpp
+++ b/velox/exec/MergeSource.cpp
@@ -17,6 +17,7 @@
 #include "velox/exec/MergeSource.h"
 
 #include <boost/circular_buffer.hpp>
+#include <memory>
 #include "velox/exec/Merge.h"
 #include "velox/vector/VectorStream.h"
 
@@ -122,7 +123,7 @@ class MergeExchangeSource : public MergeSource {
       int destination,
       memory::MemoryPool* FOLLY_NONNULL pool)
       : mergeExchange_(mergeExchange),
-        client_(std::make_unique<ExchangeClient>(
+        client_(std::make_shared<ExchangeClient>(
             taskId,
             destination,
             pool,
@@ -185,7 +186,7 @@ class MergeExchangeSource : public MergeSource {
 
  private:
   MergeExchange* const mergeExchange_;
-  std::unique_ptr<ExchangeClient> client_;
+  std::shared_ptr<ExchangeClient> client_;
   std::unique_ptr<ByteStream> inputStream_;
   std::unique_ptr<SerializedPage> currentPage_;
   bool atEnd_ = false;


### PR DESCRIPTION
Summary:
This is the stack trace we see:

```
   @ 000000001026ee2d folly::symbolizer::(anonymous namespace)::signalHandler(int, siginfo_t*, void*)
                       ./fbcode/folly/experimental/symbolizer/SignalHandler.cpp:449
    @ 000000000004459f (unknown)
    @ 000000000009df20 ___pthread_mutex_lock
    @ 000000000ccf3dfc facebook::velox::exec::ExchangeQueue::setError(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
                       ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/x86_64-facebook-linux/bits/gthr-default.h:749
    @ 000000000cd6b515 void folly::detail::function::FunctionTraits<void (folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*)>::callSmall<folly::futures::detail::Core<folly::Unit>::setCallback<folly::Future<folly::Unit>::thenErrorImpl<std::exception, facebook::velox::exec::ExchangeClient::request(facebook::velox::exec::ExchangeClient::RequestSpec const&)::$_1>(folly::tag_t<std::exception>, facebook::velox::exec::ExchangeClient::request(facebook::velox::exec::ExchangeClient::RequestSpec const&)::$_1&&, folly::futures::detail::InlineContinuation) &&::{lambda(folly::Executor::KeepAlive<folly::Executor>&&, folly::Try<folly::Unit>&&)#1}>(folly::Future<folly::Unit>::thenErrorImpl<std::exception, facebook::velox::exec::ExchangeClient::request(facebook::velox::exec::ExchangeClient::RequestSpec const&)::$_1>(folly::tag_t<std::exception>, facebook::velox::exec::ExchangeClient::request(facebook::velox::exec::ExchangeClient::RequestSpec const&)::$_1&&, folly::futures::detail::InlineContinuation) &&::{lambda(folly::Executor::KeepAlive<folly::Executor>&&, folly::Try<folly::Unit>&&)#1}&&, std::shared_ptr<folly::RequestContext>&&, folly::futures::detail::InlineContinuation)::{lambda(folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*)#1}>(folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*, folly::detail::function::Data&)
                       ./fbcode/velox/exec/ExchangeClient.cpp:141
    @ 000000000365ce48 folly::futures::detail::CoreBase::doCallback(folly::Executor::KeepAlive<folly::Executor>&&, folly::futures::detail::State)::$_0::operator()(folly::Executor::KeepAlive<folly::Executor>&&)
                       ./fbcode/folly/Function.h:374
    @ 00000000041a3846 folly::QueuedImmediateExecutor::add(folly::Function<void ()>)
                       ./fbcode/folly/Function.h:374
    @ 000000000365c854 folly::futures::detail::CoreBase::doCallback(folly::Executor::KeepAlive<folly::Executor>&&, folly::futures::detail::State)
                       ./fbcode/folly/Executor.h:186
    @ 000000000365c6c2 folly::futures::detail::Core<folly::Unit>::setResult(folly::Try<folly::Unit>&&)
                       ./fbcode/folly/futures/detail/Core.cpp:510
    @ 000000000365c351 folly::Promise<folly::Unit>::~Promise()
                       ./fbcode/folly/futures/Promise-inl.h:33
    @ 0000000005e6f18a facebook::velox::VeloxPromise<folly::Unit>::~VeloxPromise()
                       ./fbcode/velox/common/future/VeloxPromise.h:43
    @ 000000000d50c04c facebook::presto::PrestoExchangeSource::~PrestoExchangeSource()
                       ./fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h:27
    @ 000000000d50c1bd facebook::presto::PrestoExchangeSource::~PrestoExchangeSource()
                       ./fbcode/github/presto-trunk/presto-native-execution/presto_cpp/main/PrestoExchangeSource.h:27
    @ 00000000036d08ce std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_slow_last_use()
                       ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/shared_ptr_base.h:202
    @ 000000000d516870 folly::futures::detail::CoreCallbackState<folly::Unit, facebook::presto::PrestoExchangeSource::abortResults()::$_7>::setTry(folly::Executor::KeepAlive<folly::Executor>&&, folly::Try<folly::Unit>&&)
                       ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/shared_ptr_base.h:192
    @ 000000000d516588 void folly::detail::function::FunctionTraits<void (folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*)>::callSmall<folly::futures::detail::Core<folly::Unit>::setCallback<folly::Future<folly::Unit>::thenErrorImpl<std::exception, facebook::presto::PrestoExchangeSource::abortResults()::$_7>(folly::tag_t<std::exception>, facebook::presto::PrestoExchangeSource::abortResults()::$_7&&, folly::futures::detail::InlineContinuation) &&::{lambda(folly::Executor::KeepAlive<folly::Executor>&&, folly::Try<folly::Unit>&&)#1}>(folly::Future<folly::Unit>::thenErrorImpl<std::exception, facebook::presto::PrestoExchangeSource::abortResults()::$_7>(folly::tag_t<std::exception>, facebook::presto::PrestoExchangeSource::abortResults()::$_7&&, folly::futures::detail::InlineContinuation) &&::{lambda(folly::Executor::KeepAlive<folly::Executor>&&, folly::Try<folly::Unit>&&)#1}&&, std::shared_ptr<folly::RequestContext>&&, folly::futures::detail::InlineContinuation)::{lambda(folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*)#1}>(folly::futures::detail::CoreBase&, folly::Executor::KeepAlive<folly::Executor>&&, folly::exception_wrapper*, folly::detail::function::Data&)
                       ./fbcode/folly/futures/Future-inl.h:1140
    @ 000000000365ce48 folly::futures::detail::CoreBase::doCallback(folly::Executor::KeepAlive<folly::Executor>&&, folly::futures::detail::State)::$_0::operator()(folly::Executor::KeepAlive<folly::Executor>&&)
                       ./fbcode/folly/Function.h:374
    @ 00000000037fe8e3 folly::ThreadPoolExecutor::runTask(std::shared_ptr<folly::ThreadPoolExecutor::Thread> const&, folly::ThreadPoolExecutor::Task&&)
                       ./fbcode/folly/Function.h:374
    @ 0000000004c7a9f1 void folly::detail::function::FunctionTraits<void ()>::callBig<folly::IOThreadPoolExecutor::add(folly::Function<void ()>, std::chrono::duration<long, std::ratio<1l, 1000l> >, folly::Function<void ()>)::$_0>(folly::detail::function::Data&)
                       ./fbcode/folly/executors/IOThreadPoolExecutor.cpp:162
    @ 0000000003f8ceb6 folly::EventBase::loopMain(int, bool)
                       ./fbcode/folly/Function.h:374
    @ 000000000401b1cd folly::EventBase::loop()
                       ./fbcode/folly/io/async/EventBase.cpp:345
    @ 000000000401af25 folly::EventBase::loopForever()
                       ./fbcode/folly/io/async/EventBase.cpp:565
    @ 0000000004c796f4 folly::IOThreadPoolExecutor::threadRun(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)
                       ./fbcode/folly/executors/IOThreadPoolExecutor.cpp:253
    @ 0000000004aa353c void folly::detail::function::FunctionTraits<void ()>::callSmall<std::_Bind<void (folly::ThreadPoolExecutor::*(folly::ThreadPoolExecutor*, std::shared_ptr<folly::ThreadPoolExecutor::Thread>))(std::shared_ptr<folly::ThreadPoolExecutor::Thread>)> >(folly::detail::function::Data&)
                       ./fbcode/third-party-buck/platform010/build/libgcc/include/c++/trunk/bits/invoke.h:74
    @ 00000000000df4e4 execute_native_thread_routine
    @ 000000000009ac0e start_thread
    @ 000000000012d1db __clone3
    ```

We see a segv in queue->setError method, which is likely due to using already deleted queue_ shared ptr. This PR copies it instead.

Differential Revision: D48972447


