### PR TITLE
Add Add Operator::initialize API to handle customized operation init

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -259,6 +259,10 @@ class Driver : public std::enable_shared_from_this<Driver> {
   /// operator must produce data that will be returned to caller.
   RowVectorPtr next(std::shared_ptr<BlockingState>& blockingState);
 
+  /// Invoked to initialize the operators from this driver once on its first
+  /// execution.
+  void initializeOperators();
+
   bool isOnThread() const {
     return state_.isOnThread();
   }
@@ -356,6 +360,9 @@ class Driver : public std::enable_shared_from_this<Driver> {
   }
 
   std::unique_ptr<DriverCtx> ctx_;
+
+  bool operatorsInitialized_{false};
+
   std::atomic_bool closed_{false};
 
   // Set via Task and serialized by Task's mutex.

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -135,6 +135,11 @@ std::unique_ptr<JoinBridge> Operator::joinBridgeFromPlanNode(
   return nullptr;
 }
 
+void Operator::initialize() {
+  VELOX_CHECK(!initialized_);
+  initialized_ = true;
+}
+
 // static
 OperatorSupplier Operator::operatorSupplierFromPlanNode(
     const core::PlanNodePtr& planNode) {


### PR DESCRIPTION
Add operator init API to handle heavy customized operator initialization
work such as memory pool allocations. The operator init is called by
driver operator init method when the driver starts execution for the first
time. This is required as memory allocation can trigger memory arbitration
which might grab the task lock for memory reclamation. This can cause
deadlock as the driver creation is under the lock (see [PR](https://github.com/facebookincubator/velox/pull/6395) for details.
Later on, we will add memory usage check after driver creation to enforce
there is no memory allocations from memory pool on driver creation under
the task lock.