### PR TITLE
Handle missing columns in file that appear only in filter

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -71,9 +71,11 @@ void SelectiveStructColumnReaderBase::next(
     auto& childSpecs = scanSpec_->children();
     for (auto& childSpec : childSpecs) {
       VELOX_CHECK(childSpec->isConstant());
-      auto channel = childSpec->channel();
-      resultRowVector->childAt(channel) =
-          BaseVector::wrapInConstant(numValues, 0, childSpec->constantValue());
+      if (childSpec->projectOut()) {
+        auto channel = childSpec->channel();
+        resultRowVector->childAt(channel) = BaseVector::wrapInConstant(
+            numValues, 0, childSpec->constantValue());
+      }
     }
     return;
   }

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -764,7 +764,7 @@ class TableWriteTest : public HiveConnectorTestBase {
     // Read data from bucketed file on disk into 'rowVector'.
     core::PlanNodeId scanNodeId;
     auto plan = PlanBuilder()
-                    .tableScan(tableSchema_)
+                    .tableScan(tableSchema_, {}, "", tableSchema_)
                     .capturePlanNodeId(scanNodeId)
                     .planNode();
     const auto resultVector =

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -105,10 +105,17 @@ class PlanBuilder {
   /// @param remainingFilter SQL expression for the additional conjunct. May
   /// include multiple columns and SQL functions. The remainingFilter is AND'ed
   /// with all the subfieldFilters.
+  /// @param dataColumns can be different from 'outputType' for the purposes
+  /// of testing queries using missing columns. It is used, if specified, for
+  /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
+  /// types (for all columns) in this argument as opposed to 'outputType', where
+  /// you define the output types only. See 'missingColumns' test in
+  /// 'TableScanTest'.
   PlanBuilder& tableScan(
       const RowTypePtr& outputType,
       const std::vector<std::string>& subfieldFilters = {},
-      const std::string& remainingFilter = "");
+      const std::string& remainingFilter = "",
+      const RowTypePtr& dataColumns = nullptr);
 
   /// Add a TableScanNode to scan a Hive table.
   ///
@@ -125,12 +132,19 @@ class PlanBuilder {
   /// include multiple columns and SQL functions. Should use column name
   /// aliases, not column names in the files. The remainingFilter is AND'ed
   /// with all the subfieldFilters.
+  /// @param dataColumns can be different from 'outputType' for the purposes
+  /// of testing queries using missing columns. It is used, if specified, for
+  /// parseExpr call and as 'dataColumns' for the TableHandle. You supply more
+  /// types (for all columns) in this argument as opposed to 'outputType', where
+  /// you define the output types only. See 'missingColumns' test in
+  /// 'TableScanTest'.
   PlanBuilder& tableScan(
       const std::string& tableName,
       const RowTypePtr& outputType,
       const std::unordered_map<std::string, std::string>& columnAliases = {},
       const std::vector<std::string>& subfieldFilters = {},
-      const std::string& remainingFilter = "");
+      const std::string& remainingFilter = "",
+      const RowTypePtr& dataColumns = nullptr);
 
   /// Add a TableScanNode using a connector-specific table handle and
   /// assignments. Supports any connector, not just Hive connector.


### PR DESCRIPTION
Summary:
The issue ("Columns not found in hive table" error) happens when:
- A partition does not have a column (it was added after the partition was created)
- That column is used in IS NULL filter.
- That columns is not used in projection.

Differential Revision: D48977115


