### PR TITLE
Move data sink creation into table writer initialize method

### DIFF
--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -109,6 +109,8 @@ class TableWriter : public Operator {
     return BlockingReason::kNotBlocked;
   }
 
+  void initialize() override;
+
   void addInput(RowVectorPtr input) override;
 
   void noMoreInput() override {


### PR DESCRIPTION
Data sink creation need to allocate memory from pool and had been moved
out of table writer constructor. This PR moves this table writer initialize()
method to simplify the relevant processing.