### PR TITLE
Fix handling null string in json_extract()

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -256,12 +256,6 @@ struct SIMDJsonExtractFunction {
     }
 
     if (resultSize == 1) {
-      if (results == kNullString) {
-        // If there was only one value mapped to by the path and it was null,
-        // return null directly.
-        return false;
-      }
-
       // If there was only one value mapped to by the path, don't wrap it in an
       // array.
       result.copy_from(results);

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -549,7 +549,7 @@ TEST_F(JsonFunctionsTest, jsonExtract) {
   EXPECT_EQ(
       "3", jsonExtract("{\"x\": {\"a\" : 1, \"b\" : [2, 3]} }", "$.x.b[1]"));
   EXPECT_EQ("2", jsonExtract("[1,2,3]", "$[1]"));
-  EXPECT_EQ(std::nullopt, jsonExtract("[1,null,3]", "$[1]"));
+  EXPECT_EQ("null", jsonExtract("[1,null,3]", "$[1]"));
   EXPECT_EQ(std::nullopt, jsonExtract("INVALID_JSON", "$"));
   VELOX_ASSERT_THROW(jsonExtract("{\"\":\"\"}", ""), "Invalid JSON path");
 


### PR DESCRIPTION
`SIMDJsonExtractFunction` returned null directly when there was only one value mapped to the json path and it was null. However, in Presto, the function returns null string instead of null value for this case.

Fixes #6437