### PR TITLE
Fix handling failed cast in json_array_contains()

### DIFF
--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -91,12 +91,9 @@ struct SIMDJsonArrayContainsFunction {
           }
         } else if constexpr (std::is_same_v<TInput, int64_t>) {
           if (v.type() == simdjson::ondemand::json_type::number &&
-              ((v.get_number_type() ==
-                    simdjson::ondemand::number_type::signed_integer &&
-                v.get_int64() == value) ||
-               (v.get_number_type() ==
-                    simdjson::ondemand::number_type::unsigned_integer &&
-                v.get_uint64() == value))) {
+              v.get_number_type() ==
+                  simdjson::ondemand::number_type::signed_integer &&
+              v.get_int64() == value) {
             result = true;
             break;
           }
@@ -119,6 +116,15 @@ struct SIMDJsonArrayContainsFunction {
           }
         }
       } catch (const simdjson::simdjson_error& e) {
+        // For bool/int64_t/double type, "get_bool()/get_int64()/get_double()"
+        // may throw an exception if the conversion of json value to the
+        // specified type failed, and the corresponding error code is
+        // "INCORRECT_TYPE" or "NUMBER_ERROR".
+        // If there are multiple json values in the json array, and some of them
+        // cannot be converted to the type of input `value`, it should not
+        // return null directly. It should continue to judge whether there is a
+        // json value that matches the input value, e.g.
+        // jsonArrayContains("[truet, false]", false) => true.
         if (e.error() != simdjson::INCORRECT_TYPE &&
             e.error() != simdjson::NUMBER_ERROR) {
           return false;

--- a/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/JsonFunctionsTest.cpp
@@ -369,6 +369,11 @@ false, false, false, false, false, false, true, false, false, false, false])",
 true, true, true, true, true, true, true, true, true, true, true])",
           false),
       false);
+
+  // Test errors of getting the specified type of json value.
+  // Error code is "INCORRECT_TYPE".
+  EXPECT_EQ(jsonArrayContains<bool>(R"([truet])", false), false);
+  EXPECT_EQ(jsonArrayContains<bool>(R"([truet, false])", false), true);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsBigint) {
@@ -405,8 +410,15 @@ TEST_F(JsonFunctionsTest, jsonArrayContainsBigint) {
           23),
       false);
   EXPECT_EQ(jsonArrayContains<int64_t>(R"([92233720368547758071])", -9), false);
+
+  // Test errors of getting the specified type of json value.
+  // Error code is "INCORRECT_TYPE".
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([-9223372036854775809])", -9), false);
   EXPECT_EQ(
-      jsonArrayContains<int64_t>(R"([92233720368547758071,-9])", -9), true);
+      jsonArrayContains<int64_t>(R"([-9223372036854775809,-9])", -9), true);
+  // Error code is "NUMBER_ERROR".
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([01])", 4), false);
+  EXPECT_EQ(jsonArrayContains<int64_t>(R"([01, 4])", 4), true);
 }
 
 TEST_F(JsonFunctionsTest, jsonArrayContainsDouble) {
@@ -444,6 +456,9 @@ TEST_F(JsonFunctionsTest, jsonArrayContainsDouble) {
           R"([1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5, 1.2, 2.3, 3.4, 4.5])",
           4.3),
       false);
+
+  // Test errors of getting the specified type of json value.
+  // Error code is "NUMBER_ERROR".
   EXPECT_EQ(jsonArrayContains<double>(R"([9.6E400])", 4.2), false);
   EXPECT_EQ(jsonArrayContains<double>(R"([9.6E400,4.2])", 4.2), true);
 }


### PR DESCRIPTION
`SIMDJsonArrayContainsFunction` returned null directly when there was a failure in casting the json element in json array to the corresponding type of the containing value. However, in Presto, the function returns false instead of null for this case.

Fixes #6438