### PR TITLE
Add aggregation function name to the error message

### DIFF
--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -118,10 +118,11 @@ HashAggregation::HashAggregation(
       info.intermediateType =
           Aggregate::intermediateType(aggregate.call->name(), argTypes);
     } else {
-      VELOX_CHECK_EQ(
+      VELOX_USER_CHECK_EQ(
           argTypes.size(),
           1,
-          "Intermediate aggregates must have a single argument");
+          "Intermediate aggregates must have a single argument: {}",
+          aggregate.call->name());
       info.intermediateType = argTypes[0];
     }
     // Setup aggregation mask: convert the Variable Reference name to the


### PR DESCRIPTION
Final aggregation for reduce_agg lambda aggregate function fails with this error:

"argTypes.size() == 1 (3 vs. 1) Intermediate aggregates must have a single argument" 

This error message is confusing. Add aggregate function name to help provide some context.

"argTypes.size() == 1 (3 vs. 1) Intermediate aggregates must have a single argument: reduce_agg" 

See #6434