### PR TITLE
Fix bug in RowVector::copyRanges null setting

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -273,7 +273,8 @@ void RowVector::copyRanges(
     if (rawNulls_) {
       auto* rawNulls = mutableRawNulls();
       for (auto& r : ranges) {
-        bits::fillBits(rawNulls, r.targetIndex, r.count, bits::kNotNull);
+        bits::fillBits(
+            rawNulls, r.targetIndex, r.targetIndex + r.count, bits::kNotNull);
       }
     }
     auto* rowSource = source->loadedVector()->as<RowVector>();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -2587,3 +2587,26 @@ TEST_F(VectorTest, toCopyRanges) {
   rows.updateBounds();
   testRoundTrip();
 }
+
+TEST_F(VectorTest, rowCopyRanges) {
+  RowVectorPtr RowVectorDest = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2}), makeFlatVector<int32_t>({1, 2})});
+  RowVectorPtr RowVectorSrc = makeRowVector(
+      {makeFlatVector<int32_t>({3, 4}), makeFlatVector<int32_t>({3, 4})});
+  std::vector<BaseVector::CopyRange> baseRanges{{
+      .sourceIndex = 0,
+      .targetIndex = 2,
+      .count = 2,
+  }};
+  RowVectorDest->resize(4);
+
+  // Make sure nulls overwritten.
+  RowVectorDest->setNull(2, true);
+  RowVectorDest->setNull(3, true);
+
+  RowVectorDest->copyRanges(RowVectorSrc.get(), baseRanges);
+  auto expected = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4}),
+       makeFlatVector<int32_t>({1, 2, 3, 4})});
+  test::assertEqualVectors(expected, RowVectorDest);
+}


### PR DESCRIPTION
Summary:
bits::fillBits API was passing count instead of end index.
Fixes
https://github.com/facebookincubator/velox/issues/6442

Differential Revision: D49025589


