### PR TITLE
Clean up BaseVector::addNulls API

### DIFF
--- a/velox/dwio/common/tests/utils/DataSetBuilder.cpp
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.cpp
@@ -106,7 +106,7 @@ DataSetBuilder& DataSetBuilder::withAllNullsForField(
   for (RowVectorPtr batch : *batches_) {
     auto fieldValues = getChildBySubfield(batch.get(), field);
     SelectivityVector rows(fieldValues->size());
-    fieldValues->addNulls(nullptr, rows);
+    fieldValues->addNulls(rows);
   }
 
   return *this;
@@ -122,7 +122,7 @@ DataSetBuilder& DataSetBuilder::withNullsForField(
     if (nullsPercent == 0) {
       fieldValues->clearNulls(rows);
     } else if (nullsPercent >= 100) {
-      fieldValues->addNulls(nullptr, rows);
+      fieldValues->addNulls(rows);
     } else {
       std::vector<vector_size_t> nonNullRows =
           getSomeNonNullRowNumbers(fieldValues, 23);

--- a/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
+++ b/velox/experimental/codegen/vector_function/GeneratedVectorFunction-inl.h
@@ -201,7 +201,7 @@ class GeneratedVectorFunction : public GeneratedVectorFunctionBase {
            GeneratedCodeConfig::isDefaultNullStrict) &&
           !GeneratedCode::hasFilter) {
         // preset all with nulls, only if it's projection only
-        child->addNulls(nullptr, rows);
+        child->addNulls(rows);
       } else {
         // preset all not nulls
         child->mutableRawNulls();

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -98,8 +98,8 @@ TEST(TestConcat, EvalConcatFunction) {
 
   in1->resize(rowLength);
   in2->resize(rowLength);
-  in1->addNulls(nullptr, rows);
-  in2->addNulls(nullptr, rows);
+  in1->addNulls(rows);
+  in2->addNulls(rows);
 
   std::vector<VectorPtr> in{in1, in2};
   auto queryCtx = std::make_shared<core::QueryCtx>();

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -35,7 +35,7 @@ TEST(VectorReader, ReadDoublesVectors) {
   SelectivityVector selectivityVector(vectorSize);
   selectivityVector.setAll();
   in1->resize(vectorSize);
-  in1->addNulls(nullptr, selectivityVector);
+  in1->addNulls(selectivityVector);
   VectorReader<DoubleType, OutputReaderConfig<false, false>> writer(in1);
   VectorReader<DoubleType, InputReaderConfig<false, false>> reader(in1);
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -394,7 +394,7 @@ VectorPtr CastExpr::applyRow(
     if (matchNotFound) {
       // Create a vector for null for this child
       context.ensureWritable(rows, toChildType, outputChild);
-      outputChild->addNulls(nullptr, rows);
+      outputChild->addNulls(rows);
     } else {
       const auto& inputChild = input->children()[fromChildrenIndex];
       if (toChildType == inputChild->type()) {

--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -264,7 +264,7 @@ void ConjunctExpr::updateResult(
       &values,
       &nulls)) {
     case BooleanMix::kAllNull:
-      result->addNulls(nullptr, *activeRows);
+      result->addNulls(*activeRows);
       return;
     case BooleanMix::kAllFalse:
       if (isAnd_) {

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -2008,7 +2008,7 @@ class NullArrayFunction : public exec::VectorFunction {
       VectorPtr& result) const override {
     // This function returns a vector of all nulls
     BaseVector::ensureWritable(rows, ARRAY(VARCHAR()), context.pool(), result);
-    result->addNulls(nullptr, rows);
+    result->addNulls(rows);
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -376,16 +376,14 @@ void BaseVector::copyNulls(
 }
 
 void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
+  if (bits == nullptr || !rows.hasSelections()) {
+    return;
+  }
   VELOX_CHECK(isNullsWritable());
   VELOX_CHECK(length_ >= rows.end());
   ensureNulls();
   auto target = nulls_->asMutable<uint64_t>();
   const uint64_t* selected = rows.asRange().bits();
-  if (!bits) {
-    // A 1 in rows makes a 0 in nulls.
-    bits::andWithNegatedBits(target, selected, rows.begin(), rows.end());
-    return;
-  }
   // A 0 in bits with a 1 in rows makes a 0 in nulls.
   bits::forEachWord(
       rows.begin(),
@@ -398,13 +396,27 @@ void BaseVector::addNulls(const uint64_t* bits, const SelectivityVector& rows) {
       });
 }
 
-void BaseVector::clearNulls(const SelectivityVector& rows) {
+void BaseVector::addNulls(const SelectivityVector& nullRows) {
+  if (!nullRows.hasSelections()) {
+    return;
+  }
+  VELOX_CHECK(isNullsWritable());
+  VELOX_CHECK(length_ >= nullRows.end());
+  ensureNulls();
+  auto target = nulls_->asMutable<uint64_t>();
+  const uint64_t* selected = nullRows.asRange().bits();
+  // A 1 in rows makes a 0 in nulls.
+  bits::andWithNegatedBits(target, selected, nullRows.begin(), nullRows.end());
+  return;
+}
+
+void BaseVector::clearNulls(const SelectivityVector& nonNullRows) {
   VELOX_CHECK(isNullsWritable());
   if (!nulls_) {
     return;
   }
 
-  if (rows.isAllSelected() && rows.end() == length_) {
+  if (nonNullRows.isAllSelected() && nonNullRows.end() == length_) {
     nulls_ = nullptr;
     rawNulls_ = nullptr;
     nullCount_ = 0;
@@ -414,9 +426,9 @@ void BaseVector::clearNulls(const SelectivityVector& rows) {
   auto rawNulls = nulls_->asMutable<uint64_t>();
   bits::orBits(
       rawNulls,
-      rows.asRange().bits(),
-      std::min(length_, rows.begin()),
-      std::min(length_, rows.end()));
+      nonNullRows.asRange().bits(),
+      std::min(length_, nonNullRows.begin()),
+      std::min(length_, nonNullRows.end()));
   nullCount_ = std::nullopt;
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -415,12 +415,20 @@ class BaseVector {
     return !nulls_ || (nulls_->isMutable());
   }
 
-  // Sets null when 'nulls' has null value for a row in 'rows'
-  virtual void addNulls(const uint64_t* bits, const SelectivityVector& rows);
+  // Sets null when 'nulls' has a null value for active rows in 'rows'.
+  // Is a no-op 'nulls' is a nullptr or 'rows' has no selections.
+  virtual void addNulls(
+      const uint64_t* FOLLY_NULLABLE nulls,
+      const SelectivityVector& rows);
 
-  // Clears null when 'nulls' has non-null value for a row in 'rows'
-  virtual void clearNulls(const SelectivityVector& rows);
+  // Sets nulls for all active row in 'nullRows'. Is a no-op if nullRows has no
+  // selections.
+  virtual void addNulls(const SelectivityVector& nullRows);
 
+  // Clears nulls for all active rows in 'nonNullRows'
+  virtual void clearNulls(const SelectivityVector& nonNullRows);
+
+  // Clears nulls for all row indices in range [begin, end).
   virtual void clearNulls(vector_size_t begin, vector_size_t end);
 
   void clearAllNulls() {

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -292,6 +292,10 @@ class ConstantVector final : public SimpleVector<T> {
     }
   }
 
+  void addNulls(const SelectivityVector& /*rows*/) override {
+    VELOX_FAIL("addNulls not supported");
+  }
+
   std::optional<int32_t> compare(
       const BaseVector* other,
       vector_size_t index,

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -216,7 +216,7 @@ void FlatVector<T>::copyValuesAndNulls(
     }
   } else if (source->isConstantEncoding()) {
     if (source->isNullAt(0)) {
-      BaseVector::addNulls(nullptr, rows);
+      BaseVector::addNulls(rows);
       return;
     }
     auto constant = source->asUnchecked<ConstantVector<T>>();

--- a/velox/vector/SequenceVector.h
+++ b/velox/vector/SequenceVector.h
@@ -172,6 +172,10 @@ class SequenceVector : public SimpleVector<T> {
     throw std::runtime_error("addNulls not supported");
   }
 
+  void addNulls(const SelectivityVector& rows) override {
+    throw std::runtime_error("addNulls not supported");
+  }
+
   std::string toString(vector_size_t index) const override {
     if (BaseVector::isNullAt(index)) {
       return "null";


### PR DESCRIPTION
Currently the `BaseVector::addNulls(const uint64_t* bits,
const SelectivityVector& rows)` API has 2 vastly different behaviors
based on its input. If 'bits' in non-null then it sets nulls marked in
'bits' only for active rows in 'row'. However, if 'bits' is null then
it marks all selected rows in 'rows' as null. This is very confusing
as method comment itself only specifies the former behavior and the
expectation would be that if 'bits' is a nullptr, then there are no
nulls to add. This difference can result in silent bugs that only
surface if 'bits' is sometimes null and sometimes not. I have
therefore separated the two behaviors in two separate APIs.

Also, I traced all usages of this API up the usage hierarchy to ensure
its used correctly. Fortunately, till now, all uses that pass a 'bits'
variable seem to only call it when bits is non-null and other usages
that expect the latter behavior pass an explicit nullptr.