### PR TITLE
Prioritize productive sources in Exchange

### DIFF
--- a/velox/exec/ExchangeSource.h
+++ b/velox/exec/ExchangeSource.h
@@ -39,18 +39,19 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
       std::shared_ptr<ExchangeQueue> queue,
       memory::MemoryPool* pool);
 
-  /// Temporary API to indicate whether 'request(maxBytes)' API is supported.
-  virtual bool supportsFlowControl() const {
-    VELOX_UNREACHABLE();
+  /// Temporary API to indicate whether 'request(maxBytes, maxWaitSeconds)' API
+  /// is supported.
+  virtual bool supportsFlowControlV2() const {
+    return false;
   }
 
-  // Returns true if there is no request to the source pending or if
-  // this should be retried. If true, the caller is expected to call
-  // request(). This is expected to be called while holding lock over
-  // queue_.mutex(). This sets the status of 'this' to be pending. The
-  // caller is thus expected to call request() without holding a lock over
-  // queue_.mutex(). This pattern prevents multiple exchange consumer
-  // threads from issuing the same request.
+  /// Returns true if there is no request to the source pending or if
+  /// this should be retried. If true, the caller is expected to call
+  /// request(). This is expected to be called while holding lock over
+  /// queue_.mutex(). This sets the status of 'this' to be pending. The
+  /// caller is thus expected to call request() without holding a lock over
+  /// queue_.mutex(). This pattern prevents multiple exchange consumer
+  /// threads from issuing the same request.
   virtual bool shouldRequestLocked() = 0;
 
   virtual bool isRequestPendingLocked() const {
@@ -61,15 +62,36 @@ class ExchangeSource : public std::enable_shared_from_this<ExchangeSource> {
   /// Returns a future that completes when producer responds either with 'data'
   /// or with a message indicating that all data has been already produced or
   /// data will take more time to produce.
-  virtual ContinueFuture request(uint32_t maxBytes) = 0;
+  virtual ContinueFuture request(uint32_t /*maxBytes*/) {
+    VELOX_NYI();
+  }
 
-  // Close the exchange source. May be called before all data
-  // has been received and proessed. This can happen in case
-  // of an error or an operator like Limit aborting the query
-  // once it received enough data.
+  struct Response {
+    /// Size of the response in bytes. Zero means response didn't contain any
+    /// data.
+    const int64_t bytes;
+
+    /// Boolean indicating that there will be no more data.
+    const bool atEnd;
+  };
+
+  /// Requests the producer to generate up to 'maxBytes' more data and reply
+  /// within 'maxWaitSeconds'. Returns a future that completes when producer
+  /// responds either with 'data' or with a message indicating that all data has
+  /// been already produced or data will take more time to produce.
+  virtual folly::SemiFuture<Response> request(
+      uint32_t /*maxBytes*/,
+      uint32_t /*maxWaitSeconds*/) {
+    VELOX_NYI();
+  }
+
+  /// Close the exchange source. May be called before all data
+  /// has been received and processed. This can happen in case
+  /// of an error or an operator like Limit aborting the query
+  /// once it received enough data.
   virtual void close() = 0;
 
-  // Returns runtime statistics.
+  /// Returns runtime statistics.
   virtual folly::F14FastMap<std::string, int64_t> stats() const = 0;
 
   virtual uint64_t backgroundCpuTimeMs() const {

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -29,6 +29,10 @@ class LocalExchangeSource : public exec::ExchangeSource {
       memory::MemoryPool* pool)
       : ExchangeSource(taskId, destination, queue, pool) {}
 
+  bool supportsFlowControlV2() const override {
+    return true;
+  }
+
   bool shouldRequestLocked() override {
     if (atEnd_) {
       return false;
@@ -36,19 +40,22 @@ class LocalExchangeSource : public exec::ExchangeSource {
     return !requestPending_.exchange(true);
   }
 
-  ContinueFuture request(uint32_t maxBytes) override {
+  folly::SemiFuture<Response> request(
+      uint32_t maxBytes,
+      uint32_t /*maxWaitSeconds*/) override {
     ++numRequests_;
 
-    auto [promise, future] =
-        makeVeloxContinuePromiseContract("LocalExchangeSource::request");
+    auto promise = VeloxPromise<Response>("LocalExchangeSource::request");
+    auto future = promise.getSemiFuture();
+
     if (numRequests_ % 2 == 0) {
       {
         std::lock_guard<std::mutex> l(queue_->mutex());
         requestPending_ = false;
       }
       // Simulate no-data.
-      promise.setValue();
-      return std::move(future);
+      promise.setValue(Response{0, false});
+      return future;
     }
 
     promise_ = std::move(promise);
@@ -79,18 +86,21 @@ class LocalExchangeSource : public exec::ExchangeSource {
           }
           std::vector<std::unique_ptr<SerializedPage>> pages;
           bool atEnd = false;
+          int64_t totalBytes = 0;
           for (auto& inputPage : data) {
             if (!inputPage) {
               atEnd = true;
               // Keep looping, there could be extra end markers.
               continue;
             }
+            totalBytes += inputPage->length();
             inputPage->unshare();
             pages.push_back(
                 std::make_unique<SerializedPage>(std::move(inputPage)));
             inputPage = nullptr;
           }
           numPages_ += pages.size();
+          totalBytes_ += totalBytes;
 
           try {
             common::testutil::TestValue::adjust(
@@ -102,7 +112,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
           }
 
           int64_t ackSequence;
-          ContinuePromise requestPromise;
+          VeloxPromise<Response> requestPromise;
           {
             std::vector<ContinuePromise> queuePromises;
             {
@@ -130,11 +140,11 @@ class LocalExchangeSource : public exec::ExchangeSource {
           }
 
           if (!requestPromise.isFulfilled()) {
-            requestPromise.setValue();
+            requestPromise.setValue(Response{totalBytes, atEnd_});
           }
         });
 
-    return std::move(future);
+    return future;
   }
 
   void close() override {
@@ -145,18 +155,21 @@ class LocalExchangeSource : public exec::ExchangeSource {
   }
 
   folly::F14FastMap<std::string, int64_t> stats() const override {
-    return {{"localExchangeSource.numPages", numPages_}};
+    return {
+        {"localExchangeSource.numPages", numPages_},
+        {"localExchangeSource.totalBytes", totalBytes_},
+    };
   }
 
  private:
   bool checkSetRequestPromise() {
-    ContinuePromise promise;
+    VeloxPromise<Response> promise;
     {
       std::lock_guard<std::mutex> l(queue_->mutex());
       promise = std::move(promise_);
     }
     if (promise.valid() && !promise.isFulfilled()) {
-      promise.setValue();
+      promise.setValue(Response{0, false});
       return true;
     }
 
@@ -165,7 +178,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
 
   // Records the total number of pages fetched from sources.
   int64_t numPages_{0};
-  ContinuePromise promise_{ContinuePromise::makeEmpty()};
+  uint64_t totalBytes_{0};
+  VeloxPromise<Response> promise_{VeloxPromise<Response>::makeEmpty()};
   int32_t numRequests_{0};
 };
 


### PR DESCRIPTION
PR #5953 introduced a mechanism to maintain a cap on ExchangeQueue size. This
mechanism limits the number of ExchangeSources that are requested at once. This
makes some queries very slow. For example, one query that used to finish in < 2
minutes now takes 1.5 hours.

In this pathological case, each upstream worker produces data only for one
output buffer. Say, worker 1 produces data for buffer 1, worker 2 for buffer
2,... worker N for buffer N. Each worker produces data for one buffer and no
data for remaining N-1 buffers.

Each downstream worker pulls data from the same output buffer from all upstream
workers. E.g. downstream worker 1 pulls data from buffer 1 from all of N
upstream workers. It receives data only from worker 1, the remaining N-1
workers return no data.

If N is relatively large, say 200, the downstream worker requests data from a
subset of workers at a time (32). Each worker takes 2s to respond with no data.
It takes 12s to request data from each worker and receive first package from
the only worker that has data. It takes another 12s to request data from
the "right" worker again. If the worker has 300 packages total and it takes 12s
to receive each package, the query runs for an hour.

This change helps fix this issue by prioritizing requesting data from sources
that returned data from the most recent request.

To do that, we introduce new ExchangeSource::request API that returns a
SemiFuture<Response> with Response struct containing number of bytes received
from the producer and a boolean indicating whether the producer is at end.

We also add maxWaitSeconds parameter to 'request' API to allow (in the future)
for controlling how quickly a producer should wait before responding with no
data.

See #6005