### PR TITLE
feat: PyVelox implementation for Map Vector  

### DIFF
--- a/pyvelox/pyvelox.cpp
+++ b/pyvelox/pyvelox.cpp
@@ -143,6 +143,8 @@ static VectorPtr pyListToVector(
   if (first_kind == velox::TypeKind::INVALID) {
     throw py::value_error(
         "Can't create a Velox vector consisting of only None");
+  } else if (first_kind == velox::TypeKind::ARRAY) {
+    return facebook::velox::core::variantsToVector(variants, pool);
   }
 
   return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(

--- a/pyvelox/pyvelox.cpp
+++ b/pyvelox/pyvelox.cpp
@@ -143,7 +143,9 @@ static VectorPtr pyListToVector(
   if (first_kind == velox::TypeKind::INVALID) {
     throw py::value_error(
         "Can't create a Velox vector consisting of only None");
-  } else if (first_kind == velox::TypeKind::ARRAY) {
+  } else if (
+      first_kind == velox::TypeKind::ARRAY ||
+      first_kind == velox::TypeKind::MAP) {
     return facebook::velox::core::variantsToVector(variants, pool);
   }
 

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -70,7 +70,7 @@ inline velox::variant pyToVariant(const py::handle& obj) {
     std::vector<velox::variant> result;
     for (auto& item : objAsList) {
       result.push_back(pyToVariant(item));
-      if (result.front().kind() != result.back().kind()) {
+      if ((result.front().kind() != result.back().kind()) && !(item.is_none())) {
         throw py::type_error("Array must consist of elements of only one kind");
       }
     }

--- a/pyvelox/pyvelox.h
+++ b/pyvelox/pyvelox.h
@@ -30,6 +30,7 @@
 #include <velox/vector/DictionaryVector.h>
 #include <velox/vector/FlatVector.h>
 #include "folly/json.h"
+#include "velox/vector/VariantToVector.h"
 
 #include "context.h"
 
@@ -64,6 +65,32 @@ inline velox::variant pyToVariant(const py::handle& obj) {
     return pyToVariant<velox::TypeKind::DOUBLE>(obj);
   } else if (py::isinstance<py::str>(obj)) {
     return pyToVariant<velox::TypeKind::VARCHAR>(obj);
+  } else if (py::isinstance<py::list>(obj)) {
+    py::list objAsList = py::cast<py::list>(obj);
+    std::vector<velox::variant> result;
+    for (auto& item : objAsList) {
+      result.push_back(pyToVariant(item));
+      if (result.front().kind() != result.back().kind()) {
+        throw py::type_error("Array must consist of elements of only one kind");
+      }
+    }
+    return velox::variant::array(std::move(result));
+  } else if (py::isinstance<py::dict>(obj)) {
+    py::dict objAsDict = py::cast<py::dict>(obj);
+    std::map<velox::variant, velox::variant> map;
+    for (auto item : objAsDict) {
+      map.emplace(
+          std::make_pair(pyToVariant(item.first), pyToVariant(item.second)));
+    }
+    return velox::variant::map(std::move(map));
+  } else if (py::isinstance<py::tuple>(obj)) {
+    py::tuple objAsTuple = py::cast<py::tuple>(obj);
+    std::vector<velox::variant> elements;
+    elements.reserve(py::len(objAsTuple));
+    for (auto item : objAsTuple) {
+      elements.emplace_back(pyToVariant(item));
+    }
+    return velox::variant::row(std::move(elements));
   } else {
     throw py::type_error("Invalid type of object");
   }
@@ -120,9 +147,6 @@ static VectorPtr variantsToFlatVector(
     const std::vector<velox::variant>& variants,
     facebook::velox::memory::MemoryPool* pool);
 
-static inline VectorPtr pyListToVector(
-    const py::list& list,
-    facebook::velox::memory::MemoryPool* pool);
 
 static inline VectorPtr pyListToVector(
     const py::list& list,
@@ -145,15 +169,41 @@ static VectorPtr createDictionaryVector(
 }
 
 template <typename NativeType>
-static py::object getItemFromSimpleVector(
-    SimpleVectorPtr<NativeType>& vector,
-    vector_size_t idx);
+inline py::object getItemFromSimpleVector(
+    SimpleVectorPtr<NativeType>& v,
+    vector_size_t idx) {
+  checkBounds(v, idx);
+  if (v->isNullAt(idx)) {
+    return py::none();
+  }
+  if constexpr (std::is_same_v<NativeType, velox::StringView>) {
+    const velox::StringView value = v->valueAt(idx);
+    py::str result = std::string_view(value);
+    return result;
+  } else {
+    py::object result = py::cast(v->valueAt(idx));
+    return result;
+  }
+}
 
 template <typename NativeType>
 inline void setItemInFlatVector(
-    FlatVectorPtr<NativeType>& vector,
+    FlatVectorPtr<NativeType>& v,
     vector_size_t idx,
-    py::handle& obj);
+    py::handle& obj) {
+  checkBounds(v, idx);
+
+  velox::variant var = pyToVariant(obj);
+  if (var.kind() == velox::TypeKind::INVALID) {
+    return v->setNull(idx, true);
+  }
+
+  if (var.kind() != v->typeKind()) {
+    throw py::type_error("Attempted to insert value of mismatched types");
+  }
+
+  v->set(idx, NativeType{var.value<NativeType>()});
+}
 
 inline void appendVectors(VectorPtr& u, VectorPtr& v) {
   if (u->typeKind() != v->typeKind()) {
@@ -433,6 +483,32 @@ static void addVectorBindings(
           py::arg("start"),
           py::arg("stop"),
           py::arg("step") = 1);
+
+  py::class_<ArrayVector, ArrayVectorPtr, BaseVector>(
+      m, "ArrayVector", py::module_local(asModuleLocalDefinitions))
+      .def("elements", [](ArrayVectorPtr vec) -> VectorPtr {
+        return vec->elements();
+      });
+
+  py::class_<MapVector, MapVectorPtr, BaseVector>(
+      m, "MapVector", py::module_local(asModuleLocalDefinitions))
+      .def(
+          "mapKeys",
+          [](MapVectorPtr vec) -> VectorPtr { return vec->mapKeys(); })
+      .def("mapValues", [](MapVectorPtr vec) -> VectorPtr {
+        return vec->mapValues();
+      });
+
+  py::class_<RowVector, RowVectorPtr, BaseVector>(
+      m, "RowVector", py::module_local(asModuleLocalDefinitions))
+      .def(
+          "children",
+          [](RowVectorPtr vec) -> std::vector<VectorPtr> {
+            return vec->children();
+          })
+      .def("childAt", [](RowVectorPtr vec, column_index_t idx) -> VectorPtr {
+        return vec->childAt(idx);
+      });
 
   constexpr TypeKind supportedTypes[] = {
       TypeKind::BOOLEAN,

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -166,6 +166,20 @@ class TestVeloxVector(unittest.TestCase):
         for i in range(len(expected_flat)):
             self.assertEqual(expected_flat[i], v1.elements()[i])
 
+        v2 = pv.from_list([[1, 2], [None, None]])
+        self.assertTrue(isinstance(v2, pv.ArrayVector))
+        self.assertTrue(isinstance(v2.elements(), pv.FlatVector_BIGINT))
+        self.assertEqual(len(v2), 2)
+        expected_flat = [1, 2, None, None]
+        self.assertEqual(len(v2.elements()), len(expected_flat))
+        for i in range(len(expected_flat)):
+            self.assertEqual(expected_flat[i], v2.elements()[i])
+
+        with self.assertRaises(TypeError):
+            v = pv.from_list([[1], [1, 2, None]])
+        with self.assertRaises(RuntimeError):
+            v = pv.from_list([[None], [None, None, None]])
+
     def test_to_string(self):
         self.assertEqual(
             str(pv.from_list([1, 2, 3])),

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -178,6 +178,18 @@ class TestVeloxVector(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             v = pv.from_list([[None], [None, None, None]])
 
+    def test_map_vector(self):
+        v = pv.from_list([{"a": 1}, {"b": 2}])
+        self.assertTrue(isinstance(v, pv.MapVector))
+        self.assertTrue(isinstance(v.mapKeys(), pv.FlatVector_VARBINARY))
+        self.assertTrue(isinstance(v.mapValues(), pv.FlatVector_BIGINT))
+        self.assertEqual(len(v), 2)
+        expected_keys = ["a", "b"]
+        expected_values = [1, 2]
+        for i in range(len(v)):
+            self.assertEqual(expected_keys[i], v.mapKeys()[i])
+            self.assertEqual(expected_values[i], v.mapValues()[i])
+
     def test_to_string(self):
         self.assertEqual(
             str(pv.from_list([1, 2, 3])),

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -166,17 +166,15 @@ class TestVeloxVector(unittest.TestCase):
         for i in range(len(expected_flat)):
             self.assertEqual(expected_flat[i], v1.elements()[i])
 
-        v2 = pv.from_list([[1, 2], [None, None]])
+        v2 = pv.from_list([[1], [1, 2, None]])
         self.assertTrue(isinstance(v2, pv.ArrayVector))
         self.assertTrue(isinstance(v2.elements(), pv.FlatVector_BIGINT))
         self.assertEqual(len(v2), 2)
-        expected_flat = [1, 2, None, None]
+        expected_flat = [1, 1, 2, None]
         self.assertEqual(len(v2.elements()), len(expected_flat))
         for i in range(len(expected_flat)):
             self.assertEqual(expected_flat[i], v2.elements()[i])
 
-        with self.assertRaises(TypeError):
-            v = pv.from_list([[1], [1, 2, None]])
         with self.assertRaises(RuntimeError):
             v = pv.from_list([[None], [None, None, None]])
 

--- a/pyvelox/test/test_vector.py
+++ b/pyvelox/test/test_vector.py
@@ -166,61 +166,6 @@ class TestVeloxVector(unittest.TestCase):
         for i in range(len(expected_flat)):
             self.assertEqual(expected_flat[i], v1.elements()[i])
 
-    def test_map_vector(self):
-        v = pv.from_list([{"a": 1}, {"b": 2}])
-        self.assertTrue(isinstance(v, pv.MapVector))
-        self.assertTrue(isinstance(v.mapKeys(), pv.FlatVector_VARBINARY))
-        self.assertTrue(isinstance(v.mapValues(), pv.FlatVector_BIGINT))
-        self.assertEqual(len(v), 2)
-        expected_keys = ["a", "b"]
-        expected_values = [1, 2]
-        for i in range(len(v)):
-            self.assertEqual(expected_keys[i], v.mapKeys()[i])
-            self.assertEqual(expected_values[i], v.mapValues()[i])
-
-    def test_row_vector(self):
-        expected = [(1, "hi", 3), (4, "bye", 6), None, (7, "kek", None)]
-        v = pv.from_list(expected)
-        self.assertTrue(isinstance(v, pv.RowVector))
-        self.assertEqual(len(v.children()), 3)
-        self.assertTrue(isinstance(v.childAt(0), pv.FlatVector_BIGINT))
-        self.assertTrue(isinstance(v.childAt(1), pv.FlatVector_VARBINARY))
-        self.assertTrue(isinstance(v.childAt(2), pv.FlatVector_BIGINT))
-
-        self.assertEqual(len(v), len(expected))
-        for i in range(len(expected)):
-            if expected[i] is None:
-                self.assertTrue(v.isNullAt(i))
-            else:
-                for j in range(3):
-                    self.assertEqual(v.childAt(j)[i], expected[i][j])
-
-    def test_crazy_vector(self):
-        crazy_vector = pv.from_list(
-            [
-                (1000, ["hi", "bye"], [{"a": 1, "b": 2}, {"c": 3, "d": 4}]),
-                (2000, ["good", "morning"], [{"e": 5}]),
-            ]
-        )
-        self.assertTrue(isinstance(crazy_vector, pv.RowVector))
-        self.assertTrue(isinstance(crazy_vector.childAt(0), pv.FlatVector_BIGINT))
-        self.assertTrue(isinstance(crazy_vector.childAt(1), pv.ArrayVector))
-        self.assertTrue(isinstance(crazy_vector.childAt(2), pv.ArrayVector))
-        self.assertTrue(
-            isinstance(crazy_vector.childAt(1).elements(), pv.FlatVector_VARBINARY)
-        )
-        self.assertTrue(isinstance(crazy_vector.childAt(2).elements(), pv.MapVector))
-        self.assertTrue(
-            isinstance(
-                crazy_vector.childAt(2).elements().mapKeys(), pv.FlatVector_VARBINARY
-            )
-        )
-        self.assertTrue(
-            isinstance(
-                crazy_vector.childAt(2).elements().mapValues(), pv.FlatVector_BIGINT
-            )
-        )
-
     def test_to_string(self):
         self.assertEqual(
             str(pv.from_list([1, 2, 3])),

--- a/velox/vector/VariantToVector.cpp
+++ b/velox/vector/VariantToVector.cpp
@@ -77,4 +77,265 @@ ArrayVectorPtr variantArrayToVector(
       pool);
 }
 
+struct NestedTypeCounter {
+  TypeKind kind = TypeKind::UNKNOWN;
+  vector_size_t rowCount = 0;
+  vector_size_t rowsInserted = 0;
+  std::vector<NestedTypeCounter> children;
+  uint8_t precision = 0;
+  uint8_t scale = 0;
+};
+
+static void validateOrSetType(NestedTypeCounter& counter, const variant& v) {
+  if (v.isNull()) // If a row is null, it can be UNKNOWN, INVALID, or matching
+                  // our expected kind
+  {
+    if (v.kind() != TypeKind::UNKNOWN && v.kind() != TypeKind::INVALID &&
+        v.kind() != counter.kind) {
+      throw std::invalid_argument("Variant was of an unexpected kind");
+    }
+    return;
+  } else {
+    if (v.kind() == TypeKind::UNKNOWN || v.kind() == TypeKind::INVALID) {
+      throw std::invalid_argument(
+          "Non-null variant has unknown or invalid kind");
+    }
+    if (v.kind() != counter.kind) {
+      if (counter.kind == TypeKind::UNKNOWN) {
+        counter.kind = v.kind();
+        if (v.kind() == TypeKind::SHORT_DECIMAL) {
+          auto dec = v.value<TypeKind::SHORT_DECIMAL>();
+          counter.precision = dec.precision;
+          counter.scale = dec.scale;
+        } else if (v.kind() == TypeKind::LONG_DECIMAL) {
+          auto dec = v.value<TypeKind::LONG_DECIMAL>();
+          counter.precision = dec.precision;
+          counter.scale = dec.scale;
+        }
+      } else {
+        throw std::invalid_argument("Variant kind doesn't match predecessors");
+      }
+    } else if (v.kind() == TypeKind::SHORT_DECIMAL) {
+      auto dec = v.value<TypeKind::SHORT_DECIMAL>();
+      if (counter.precision != dec.precision || counter.scale != dec.scale) {
+        throw std::invalid_argument(
+            "Mismatch between expected and actual precision and scale");
+      }
+    } else if (v.kind() == TypeKind::LONG_DECIMAL) {
+      auto dec = v.value<TypeKind::LONG_DECIMAL>();
+      if (counter.precision != dec.precision || counter.scale != dec.scale) {
+        throw std::invalid_argument(
+            "Mismatch between expected and actual precision and scale");
+      }
+    }
+  }
+}
+
+static void computeRowCountsAndType(
+    NestedTypeCounter& counter,
+    const variant& v) {
+  validateOrSetType(counter, v);
+  counter.rowCount += 1;
+  if (v.isNull()) {
+    return;
+  }
+  // At this point, we know that v.kind() equals counter.kind
+  switch (counter.kind) {
+    case TypeKind::ROW: {
+      const std::vector<variant>& children = v.row();
+      if (counter.children.size() != children.size()) {
+        if (counter.children.size() == 0) {
+          counter.children.resize(children.size());
+        } else {
+          throw std::invalid_argument("Unexpected number of children");
+        }
+      }
+      for (size_t i = 0; i < children.size(); i++) {
+        computeRowCountsAndType(counter.children[i], children[i]);
+        counter.children[i].rowCount = counter.rowCount;
+      }
+    } break;
+    case TypeKind::ARRAY: {
+      const std::vector<variant>& elements = v.array();
+      counter.children.resize(1);
+      for (const variant& elt : elements) {
+        computeRowCountsAndType(counter.children[0], elt);
+      }
+    } break;
+    case TypeKind::MAP: {
+      const std::map<variant, variant>& elements = v.map();
+      counter.children.resize(2);
+      for (const std::pair<variant, variant> pair : elements) {
+        computeRowCountsAndType(counter.children[0], pair.first);
+        computeRowCountsAndType(counter.children[1], pair.second);
+      }
+    } break;
+    default:
+      // we have a simple type with no children
+      break;
+  }
+}
+
+static VectorPtr allocateVector(
+    const NestedTypeCounter& counter,
+    velox::memory::MemoryPool* pool) {
+  switch (counter.kind) {
+    case TypeKind::ROW: {
+      std::vector<VectorPtr> children;
+      std::vector<TypePtr> types;
+      children.reserve(counter.children.size());
+      types.reserve(counter.children.size());
+      for (auto child_counter : counter.children) {
+        children.push_back(allocateVector(child_counter, pool));
+        types.push_back(children.back()->type());
+      }
+      return std::make_shared<RowVector>(
+          pool,
+          ROW(std::move(types)),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(children));
+    }
+    case TypeKind::ARRAY: {
+      BufferPtr sizes =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      BufferPtr offsets =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      VectorPtr elements = allocateVector(counter.children.at(0), pool);
+      return std::make_shared<ArrayVector>(
+          pool,
+          ARRAY(elements->type()),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(elements));
+    }
+    case TypeKind::MAP: {
+      BufferPtr sizes =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      BufferPtr offsets =
+          AlignedBuffer::allocate<vector_size_t>(counter.rowCount, pool, 0);
+      VectorPtr keys = allocateVector(counter.children.at(0), pool);
+      VectorPtr values = allocateVector(counter.children.at(1), pool);
+      return std::make_shared<MapVector>(
+          pool,
+          MAP(keys->type(), values->type()),
+          /*nulls=*/nullptr,
+          counter.rowCount,
+          std::move(offsets),
+          std::move(sizes),
+          std::move(keys),
+          std::move(values));
+    }
+    default: {
+      TypePtr type;
+      if (counter.kind == TypeKind::SHORT_DECIMAL) {
+        type = SHORT_DECIMAL(counter.precision, counter.scale);
+      } else if (counter.kind == TypeKind::LONG_DECIMAL) {
+        type = LONG_DECIMAL(counter.precision, counter.scale);
+      } else {
+        type = createScalarType(counter.kind);
+      }
+      return BaseVector::create(std::move(type), counter.rowCount, pool);
+    }
+  }
+}
+
+template <TypeKind Kind>
+void setElementInFlatVector(
+    vector_size_t idx,
+    const variant& v,
+    VectorPtr& vector) {
+  using NativeType = typename TypeTraits<Kind>::NativeType;
+  auto asFlat = vector->asFlatVector<NativeType>();
+  if constexpr (
+      Kind == TypeKind::SHORT_DECIMAL || Kind == TypeKind::LONG_DECIMAL) {
+    asFlat->set(idx, NativeType{v.value<NativeType>().value()});
+  } else {
+    asFlat->set(idx, NativeType{v.value<NativeType>()});
+  }
+}
+
+static void incrementChildRowsInserted(NestedTypeCounter& counter) {
+  for (NestedTypeCounter& child : counter.children) {
+    incrementChildRowsInserted(child);
+    child.rowsInserted += 1;
+  }
+}
+
+static void insertVariantIntoVector(
+    NestedTypeCounter& counter,
+    const variant& v,
+    VectorPtr& vector) {
+  if (v.isNull()) {
+    vector->setNull(counter.rowsInserted, true);
+    if (counter.kind == TypeKind::ROW) {
+      incrementChildRowsInserted(counter);
+    }
+  } else
+    switch (counter.kind) {
+      case TypeKind::ROW: {
+        auto asRow = vector->as<RowVector>();
+        const std::vector<variant>& children = v.row();
+        for (size_t i = 0; i < counter.children.size(); i++) {
+          insertVariantIntoVector(
+              counter.children[i], children[i], asRow->childAt(i));
+        }
+        break;
+      }
+      case TypeKind::ARRAY: {
+        auto asArray = vector->as<ArrayVector>();
+        const std::vector<variant>& elements = v.array();
+        vector_size_t offset = 0;
+        if (counter.rowsInserted != 0) {
+          offset = asArray->offsetAt(counter.rowsInserted - 1) +
+              asArray->sizeAt(counter.rowsInserted - 1);
+        }
+        asArray->setOffsetAndSize(
+            counter.rowsInserted, offset, elements.size());
+        for (const variant& elt : elements) {
+          insertVariantIntoVector(
+              counter.children.at(0), elt, asArray->elements());
+        }
+        break;
+      }
+      case TypeKind::MAP: {
+        auto asMap = vector->as<MapVector>();
+        const std::map<variant, variant>& elements = v.map();
+        VectorPtr& keys = asMap->mapKeys();
+        VectorPtr& values = asMap->mapValues();
+        for (const auto& pair : elements) {
+          insertVariantIntoVector(counter.children.at(0), pair.first, keys);
+          insertVariantIntoVector(counter.children.at(1), pair.second, values);
+        }
+        break;
+      }
+      default: {
+        VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+            setElementInFlatVector,
+            counter.kind,
+            counter.rowsInserted,
+            v,
+            vector);
+        break;
+      }
+    }
+  counter.rowsInserted += 1;
+}
+
+VectorPtr variantsToVector(
+    const std::vector<variant>& rows,
+    velox::memory::MemoryPool* pool) {
+  NestedTypeCounter counter;
+  for (const variant& v : rows) {
+    computeRowCountsAndType(counter, v);
+  }
+  VectorPtr resultVector = allocateVector(counter, pool);
+  for (const variant& v : rows) {
+    insertVariantIntoVector(counter, v, resultVector);
+  }
+  return resultVector;
+}
+
 } // namespace facebook::velox::core

--- a/velox/vector/VariantToVector.h
+++ b/velox/vector/VariantToVector.h
@@ -27,10 +27,11 @@ ArrayVectorPtr variantArrayToVector(
     const std::vector<variant>& variantArray,
     velox::memory::MemoryPool* pool);
 
-// Converts an array of variants into the appropriate vector. Each input variant
-// is a row in the final vector.
+// Converts a std::vector of variants into the
+// appropriate velox vector. Each input variant
+// is a member in the final vector.
 VectorPtr variantsToVector(
-    const std::vector<variant>& rows,
+    const std::vector<variant>& variants,
     velox::memory::MemoryPool* pool);
 
 } // namespace facebook::velox::core

--- a/velox/vector/VariantToVector.h
+++ b/velox/vector/VariantToVector.h
@@ -27,4 +27,10 @@ ArrayVectorPtr variantArrayToVector(
     const std::vector<variant>& variantArray,
     velox::memory::MemoryPool* pool);
 
+// Converts an array of variants into the appropriate vector. Each input variant
+// is a row in the final vector.
+VectorPtr variantsToVector(
+    const std::vector<variant>& rows,
+    velox::memory::MemoryPool* pool);
+
 } // namespace facebook::velox::core


### PR DESCRIPTION
This PR implements the support for Map vectors in PyVelox, based on the previous work done by @save-buffer in PR #4113 and by @richtia in PR #4602 on a flat vector encoding.

This contains code also implemented in the PR for Array vectors (#6100), which should be rebased once it gets merged.