### PR TITLE
Enable trailing spaces in standard mode string-to-date conversion

### DIFF
--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -125,7 +125,7 @@ Expression Evaluation Configuration
        For the last two patterns, the trailing ``*`` can represent none or any sequence of characters, e.g:
          * "1970-01-01 123"
          * "1970-01-01 (BC)"
-       Regardless of this setting's value, leading spaces will be trimmed.
+       Regardless of this setting's value, leading and trailing spaces will be trimmed.
 
 Memory Management
 -----------------

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -597,6 +597,7 @@ Valid examples
 ::
 
   SELECT cast('1970-01-01' as date); -- 1970-01-01
+  SELECT cast('1970-01-01 ' as date); -- 1970-01-01
 
 **cast_string_to_date_is_iso_8601=false**
 
@@ -622,7 +623,6 @@ Invalid examples
   SELECT cast('2012-Oct-23' as date); -- Invalid argument
   SELECT cast('2012/10/23' as date); -- Invalid argument
   SELECT cast('2012.10.23' as date); -- Invalid argument
-  SELECT cast('2012-10-23 ' as date); -- Invalid argument
 
 **cast_string_to_date_is_iso_8601=false**
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -694,7 +694,9 @@ TEST_F(CastExprTest, date) {
          "1970-1-02",
          "+1970-01-02",
          "-1-1-1",
+         "1970-01-01 ",
          " 1970-01-01",
+         " 1970-01-01 ",
          std::nullopt},
         {0,
          18262,
@@ -708,6 +710,8 @@ TEST_F(CastExprTest, date) {
          1,
          1,
          -719893,
+         0,
+         0,
          0,
          std::nullopt},
         false,
@@ -778,10 +782,6 @@ TEST_F(CastExprTest, invalidDate) {
       "date", {"2015-03-18T123412"}, {0}, true, false, VARCHAR(), DATE());
   testCast<std::string, int32_t>(
       "date", {"2015-03-18 (BC)"}, {0}, true, false, VARCHAR(), DATE());
-  testCast<std::string, int32_t>(
-      "date", {"1970-01-01 "}, {0}, true, false, VARCHAR(), DATE());
-  testCast<std::string, int32_t>(
-      "date", {" 1970-01-01 "}, {0}, true, false, VARCHAR(), DATE());
 }
 
 TEST_F(CastExprTest, primitiveInvalidCornerCases) {

--- a/velox/type/TimestampConversion.cpp
+++ b/velox/type/TimestampConversion.cpp
@@ -269,6 +269,15 @@ bool tryParseDateString(
   }
 
   if (mode == ParseMode::kStandardCast) {
+    // Skip trailing spaces.
+    while (pos < len && characterIsSpace(buf[pos])) {
+      pos++;
+    }
+    // Check position. if end was not reached, non-space chars remaining.
+    if (pos < len) {
+      return false;
+    }
+
     daysSinceEpoch = daysSinceEpochFromDate(year, month, day);
 
     if (pos == len) {

--- a/velox/type/tests/TimestampConversionTest.cpp
+++ b/velox/type/tests/TimestampConversionTest.cpp
@@ -121,6 +121,8 @@ TEST(DateTimeUtilTest, castFromDateString) {
     EXPECT_EQ(1, castFromDateString("+1970-01-02", isIso8601));
     EXPECT_EQ(-719893, castFromDateString("-1-1-1", isIso8601));
 
+    EXPECT_EQ(0, castFromDateString("1970-01-01 ", isIso8601));
+    EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", isIso8601));
     EXPECT_EQ(0, castFromDateString(" 1970-01-01", isIso8601));
   }
 
@@ -131,9 +133,6 @@ TEST(DateTimeUtilTest, castFromDateString) {
   EXPECT_EQ(16512, castFromDateString("2015-03-18T123123", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18 123142", false));
   EXPECT_EQ(16512, castFromDateString("2015-03-18 (BC)", false));
-
-  EXPECT_EQ(0, castFromDateString("1970-01-01 ", false));
-  EXPECT_EQ(0, castFromDateString(" 1970-01-01 ", false));
 }
 
 TEST(DateTimeUtilTest, castFromDateStringInvalid) {
@@ -177,9 +176,6 @@ TEST(DateTimeUtilTest, castFromDateStringInvalid) {
   testCastFromDateStringInvalid("2015-03-18T", true);
   testCastFromDateStringInvalid("2015-03-18T123412", true);
   testCastFromDateStringInvalid("2015-03-18 (BC)", true);
-
-  testCastFromDateStringInvalid("1970-01-01 ", true);
-  testCastFromDateStringInvalid(" 1970-01-01 ", true);
 }
 
 TEST(DateTimeUtilTest, fromTimeString) {


### PR DESCRIPTION
When implementing Spark's cast varchar to date, we found the current implementation is also incompatible with Presto's.
Presto cast varchar to date allows trailing spaces, but Velox throws exception.

Here's the output from presto:
```
presto:default> SELECT cast('1970-01-01 ' as date);
   _col0
------------
 1970-01-01
(1 row)
```

This PR makes string pattern with trailing spaces valid.