### PR TITLE
Add product Presto aggregate function

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -119,6 +119,14 @@ General Aggregate Functions
     Returns a multimap created from the input ``key`` / ``value`` pairs.
     Each key can be associated with multiple values.
 
+.. function:: product(x) -> bigint|double
+
+    Returns a product of non-NULL input values. If all input values are NULL, the result is NULL.
+
+    Supported types are: TINYINT, SMALLINT, INTEGER, BIGINT, REAL, and DOUBLE.
+
+    Return type is BIGINT for integer inputs and DOUBLE for floating point inputs.
+
 .. function:: set_agg(x) -> array<[same as input]>
 
     Returns an array created from the distinct input ``x`` elements.

--- a/velox/functions/prestosql/aggregates/AggregateNames.h
+++ b/velox/functions/prestosql/aggregates/AggregateNames.h
@@ -48,6 +48,7 @@ const char* const kMerge = "merge";
 const char* const kMin = "min";
 const char* const kMinBy = "min_by";
 const char* const kMultiMapAgg = "multimap_agg";
+const char* const kProduct = "product";
 const char* const kRegrIntercept = "regr_intercept";
 const char* const kRegrSlop = "regr_slope";
 const char* const kSetAgg = "set_agg";

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(
   MultiMapAggAggregate.cpp
   CountAggregate.cpp
   PrestoHasher.cpp
+  ProductAggregate.cpp
   SetAggregates.cpp
   SumAggregate.cpp
   ValueList.cpp

--- a/velox/functions/prestosql/aggregates/ProductAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ProductAggregate.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/SimpleAggregateAdapter.h"
+#include "velox/functions/prestosql/aggregates/AggregateNames.h"
+
+namespace facebook::velox::aggregate::prestosql {
+namespace {
+
+template <typename T, typename U>
+class ProductAggregate {
+ public:
+  using InputType = Row<T>;
+
+  using IntermediateType = U;
+
+  using OutputType = U;
+
+  struct AccumulatorType {
+    U product_{1};
+
+    AccumulatorType() = delete;
+
+    explicit AccumulatorType(HashStringAllocator* /*allocator*/) {}
+
+    void addInput(HashStringAllocator* /*allocator*/, exec::arg_type<T> value) {
+      product_ *= value;
+    }
+
+    void combine(HashStringAllocator* /*allocator*/, exec::arg_type<U> other) {
+      product_ *= other;
+    }
+
+    bool writeFinalResult(exec::out_type<OutputType>& out) {
+      out = product_;
+      return true;
+    }
+
+    bool writeIntermediateResult(exec::out_type<IntermediateType>& out) {
+      out = product_;
+      return true;
+    }
+  };
+
+  static bool toIntermediate(exec::out_type<U>& out, exec::arg_type<T> in) {
+    out = in;
+    return true;
+  }
+};
+
+} // namespace
+
+void registerProductAggregate(const std::string& prefix) {
+  const std::string name = prefix + kProduct;
+
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+
+  for (const auto& inputType : {"tinyint", "smallint", "integer", "bigint"}) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .returnType("bigint")
+                             .intermediateType("bigint")
+                             .argumentType(inputType)
+                             .build());
+  }
+
+  for (const auto& inputType : {"real", "double"}) {
+    signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                             .returnType("double")
+                             .intermediateType("double")
+                             .argumentType(inputType)
+                             .build());
+  }
+
+  exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [name](
+          core::AggregationNode::Step step,
+          const std::vector<TypePtr>& argTypes,
+          const TypePtr& resultType,
+          const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        VELOX_CHECK_LE(
+            argTypes.size(), 1, "{} takes at most one argument", name);
+        auto inputType = argTypes[0];
+        if (exec::isRawInput(step)) {
+          switch (inputType->kind()) {
+            case TypeKind::TINYINT:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<int8_t, int64_t>>>(resultType);
+            case TypeKind::SMALLINT:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<int16_t, int64_t>>>(resultType);
+            case TypeKind::INTEGER:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<int32_t, int64_t>>>(resultType);
+            case TypeKind::BIGINT:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<int64_t, int64_t>>>(resultType);
+            case TypeKind::REAL:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<float, double>>>(resultType);
+            case TypeKind::DOUBLE:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<double, double>>>(resultType);
+            default:
+              VELOX_FAIL(
+                  "Unknown input type for {} aggregation {}",
+                  name,
+                  inputType->kindName());
+          }
+        } else {
+          switch (resultType->kind()) {
+            case TypeKind::BIGINT:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<int64_t, int64_t>>>(resultType);
+            case TypeKind::DOUBLE:
+              return std::make_unique<exec::SimpleAggregateAdapter<
+                  ProductAggregate<double, double>>>(resultType);
+            default:
+              VELOX_FAIL(
+                  "Unsupported result type for final aggregation: {}",
+                  resultType->kindName());
+          }
+        }
+      });
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -40,6 +40,7 @@ extern void registerMultiMapAggAggregate(const std::string& prefix);
 extern void registerSumDataSizeForStatsAggregate(const std::string& prefix);
 extern void registerMinMaxAggregates(const std::string& prefix);
 extern void registerMinMaxByAggregates(const std::string& prefix);
+extern void registerProductAggregate(const std::string& prefix);
 extern void registerSetAggAggregate(const std::string& prefix);
 extern void registerSetUnionAggregate(const std::string& prefix);
 extern void registerSumAggregate(const std::string& prefix);
@@ -69,6 +70,7 @@ void registerAllAggregateFunctions(const std::string& prefix) {
   registerSumDataSizeForStatsAggregate(prefix);
   registerMinMaxAggregates(prefix);
   registerMinMaxByAggregates(prefix);
+  registerProductAggregate(prefix);
   registerSetAggAggregate(prefix);
   registerSetUnionAggregate(prefix);
   registerSumAggregate(prefix);

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ add_executable(
   MapAggTest.cpp
   MapUnionAggregationTest.cpp
   MapUnionSumTest.cpp
+  ProductTest.cpp
   ValueListTest.cpp
   VarianceAggregationTest.cpp
   MaxSizeForStatsTest.cpp

--- a/velox/functions/prestosql/aggregates/tests/ProductTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ProductTest.cpp
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::aggregate::test {
+
+namespace {
+
+class ProductTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+  }
+};
+
+TEST_F(ProductTest, globalEmpty) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(std::vector<int32_t>{}),
+  });
+
+  testAggregations({data}, {}, {"product(c0)"}, "SELECT NULL");
+}
+
+TEST_F(ProductTest, globalNulls) {
+  auto data = makeRowVector({
+      makeAllNullFlatVector<int32_t>(100),
+      makeFlatVector<int32_t>(
+          100, [](auto row) { return row; }, nullEvery(2)),
+  });
+
+  // All nulls.
+  testAggregations({data}, {}, {"product(c0)"}, "SELECT NULL");
+
+  // Every other is null.
+  int64_t product = 1;
+  for (auto i = 1; i < 100; i += 2) {
+    product *= i;
+  }
+
+  auto expected = makeRowVector({
+      makeConstant(product, 1),
+  });
+
+  testAggregations({data}, {}, {"product(c1)"}, {expected});
+}
+
+TEST_F(ProductTest, globalIntegers) {
+  auto data = makeRowVector({
+      makeFlatVector<int8_t>(100, [](auto row) { return row / 7; }),
+      makeFlatVector<int16_t>(100, [](auto row) { return row / 7; }),
+      makeFlatVector<int32_t>(100, [](auto row) { return row / 7; }),
+      makeFlatVector<int64_t>(100, [](auto row) { return row / 7; }),
+  });
+
+  int64_t product = 1;
+  for (int32_t i = 0; i < 100; ++i) {
+    product *= (i / 7);
+  }
+
+  auto expected = makeRowVector({
+      makeFlatVector(std::vector<int64_t>{
+          product,
+      }),
+  });
+
+  testAggregations({data}, {}, {"product(c0)"}, {expected});
+  testAggregations({data}, {}, {"product(c1)"}, {expected});
+  testAggregations({data}, {}, {"product(c2)"}, {expected});
+  testAggregations({data}, {}, {"product(c3)"}, {expected});
+}
+
+TEST_F(ProductTest, groupByNulls) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(100, [](auto row) { return row / 10; }),
+      makeFlatVector<int32_t>(
+          100,
+          [](auto row) { return row; },
+          [](auto row) {
+            // All values in group 3 are null.
+            if (row / 10 == 3) {
+              return true;
+            }
+
+            // Every other value is null.
+            return row % 2 == 0;
+          }),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+      makeFlatVector<int64_t>(
+          10,
+          [](auto row) {
+            int64_t product = 1;
+            for (int32_t i = 1; i < 10; i += 2) {
+              product *= (row * 10 + i);
+            }
+            return product;
+          },
+          [](auto row) { return row == 3; }),
+  });
+
+  testAggregations({data}, {"c0"}, {"product(c1)"}, {expected});
+}
+
+TEST_F(ProductTest, groupByIntegers) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(100, [](auto row) { return row / 10; }),
+      makeFlatVector<int8_t>(100, [](auto row) { return row; }),
+      makeFlatVector<int16_t>(100, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(100, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(100, [](auto row) { return row; }),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+      makeFlatVector<int64_t>(
+          10,
+          [](auto row) {
+            int64_t product = 1;
+            for (int32_t i = 0; i < 10; ++i) {
+              product *= (row * 10 + i);
+            }
+            return product;
+          }),
+  });
+
+  testAggregations({data}, {"c0"}, {"product(c1)"}, {expected});
+  testAggregations({data}, {"c0"}, {"product(c2)"}, {expected});
+  testAggregations({data}, {"c0"}, {"product(c3)"}, {expected});
+  testAggregations({data}, {"c0"}, {"product(c4)"}, {expected});
+}
+
+TEST_F(ProductTest, globalDoubles) {
+  auto data = makeRowVector({
+      makeFlatVector<float>(100, [](auto row) { return row * 0.1 / 7; }),
+      makeFlatVector<double>(100, [](auto row) { return row * 0.1 / 7; }),
+  });
+
+  double product = 1.0;
+  for (int32_t i = 0; i < 100; ++i) {
+    product *= (i * 0.1 / 7);
+  }
+
+  auto expected = makeRowVector({
+      makeFlatVector(std::vector<double>{
+          product,
+      }),
+  });
+
+  testAggregations({data}, {}, {"product(c0)"}, {expected});
+  testAggregations({data}, {}, {"product(c1)"}, {expected});
+}
+
+TEST_F(ProductTest, groupByDoubles) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>(100, [](auto row) { return row / 10; }),
+      makeFlatVector<float>(100, [](auto row) { return row * 0.1; }),
+      makeFlatVector<double>(100, [](auto row) { return row * 0.1; }),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+      makeFlatVector<double>(
+          10,
+          [](auto row) {
+            double product = 1.0;
+            for (int32_t i = 0; i < 10; ++i) {
+              product *= (row + i * 0.1);
+            }
+            return product;
+          }),
+  });
+
+  testAggregations({data}, {"c0"}, {"product(c1)"}, {expected});
+  testAggregations({data}, {"c0"}, {"product(c2)"}, {expected});
+}
+
+} // namespace
+} // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
Computing a product of values is a common use case for reduce_agg lambda aggregate function.

```
reduce_agg(x, 1, (a, b) -> (a * b), (a, b) -> (a * b))
```

Using lambda function for this simple computation is inefficient and unnecessarily complicated. 

Add 'product' aggregate function to optimize this use case. A follow-up PR in
Prestissimo will add logic to translate the above reduce_agg invocation into
product(x).

Use the new simple interface to implement the aggregate function.

Part of #6434