### PR TITLE
Add Type argument to variant::pyToJson

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -399,8 +399,8 @@ class variant {
   std::string toJson(const TypePtr& type = nullptr) const;
 
   /// Used by python binding, do not change signature.
-  std::string pyToJson() const {
-    return toJson();
+  std::string pyToJson(const TypePtr& type) const {
+    return toJson(type);
   }
 
   folly::dynamic serialize() const;


### PR DESCRIPTION
With the introduction of logical types, variant::pyToJson must always consume a type to infer the output.
