### PR TITLE
Fix: duckValueAt<TypeKind::VARBINARY> and variantAt<TypeKind::VARBINARY>

### DIFF
--- a/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
+++ b/velox/substrait/tests/VeloxSubstraitRoundTripTest.cpp
@@ -485,7 +485,7 @@ TEST_F(VeloxSubstraitRoundTripTest, arrayLiteral) {
       plan,
       "SELECT array[true, null], array[0, null], array[1, null], "
       "array[2, null], array[3, null], array[4.4, null], array[5.5, null], "
-      "array[6],"
+      "array['6'],"
       "array['1970-01-02T10:17:36.000123000'::TIMESTAMP],"
       "array['1992-01-01'::DATE],"
       "array[INTERVAL 54 MILLISECONDS], "


### PR DESCRIPTION
Summary: duckValueAt should return a blob and not varchar type

Differential Revision: D49073775


