### PR TITLE
Add additional validations for Row Vector.

### DIFF
--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -239,9 +239,10 @@ class ApproxPercentileAggregate : public exec::Aggregate {
           BaseVector::createNullConstant(BOOLEAN(), numGroups, pool);
       rowResult->childAt(kAccuracy) =
           BaseVector::createNullConstant(DOUBLE(), numGroups, pool);
-      for (auto i = 0; i < numGroups; ++i) {
-        rowResult->setNull(i, true);
-      }
+
+      // Set nulls for all rows.
+      auto rawNulls = rowResult->mutableRawNulls();
+      bits::fillBits(rawNulls, 0, rowResult->size(), bits::kNull);
       return;
     }
     auto& values = percentiles_->values;


### PR DESCRIPTION
Ensure we add checks to ensure Row Vector children are validated with respect to the parent. 
We also ensure that in GroupingSet::toIntermediate we recursively resize all the children if the encoding is a ROW - Without this we see several failures in failures in aggregation tests (for e.g reducedAgg Test). We also ensure that ApproxPercentile returns valid rowVector when it has no inputs - i.e it returns a valid null row vector. 
