### PR TITLE
Fix subfield pruning for remaining expr of projected columns

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -848,7 +848,7 @@ std::shared_ptr<common::ScanSpec> HiveDataSource::makeScanSpec(
     auto& name = rowType->nameOf(i);
     auto& type = rowType->childAt(i);
     auto it = outputSubfields.find(name);
-    if (it == outputSubfields.end()) {
+    if (it != outputSubfields.end()) {
       spec->addFieldRecursively(name, *type, i);
       filterSubfields.erase(name);
       continue;


### PR DESCRIPTION
When remaining expression addresses subfields of a field that is projected out it must not restrict the set of subfields of the field. If the field is not pruned, it stays unpruned and if it is pruned, the new subfields add themselves to the pruned set.