### PR TITLE
Fix segfault in HashTable::loadTag()

### DIFF
--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -280,7 +280,7 @@ class BaseHashTable {
 #endif
 #endif
   static TagVector
-  loadTags(uint8_t* tags, int32_t tagIndex) {
+  loadTags(uint8_t* tags, int64_t tagIndex) {
     // Cannot use xsimd::batch::unaligned here because we need to skip TSAN.
     auto src = tags + tagIndex;
 #if XSIMD_WITH_SSE2
@@ -772,7 +772,7 @@ class HashTable : public BaseHashTable {
   }
 
   // Returns the tag vector for bucket at 'bucketOffset'.
-  TagVector loadTags(int32_t bucketOffset) const {
+  TagVector loadTags(int64_t bucketOffset) const {
     return BaseHashTable::loadTags(
         reinterpret_cast<uint8_t*>(table_), bucketOffset);
   }


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/20032

When the number of unique entries in the HashTable crosses int32 max, the offset param passed to HashTable::loadTags() method gets downcast to int32. This leads to segmentation fault as the offset is corrupted.

Added a repro test which is currently disabled. It takes really long time to complete and will likely get timed out on CircleCI.