### PR TITLE
Improve ReaderTest.cpp: re-use and lazy load strings

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -100,7 +100,6 @@ uint64_t DwrfRowReader::seekToRow(uint64_t rowNumber) {
     return 0;
   }
 
-  std::unique_lock<std::mutex> lock(prefetchAndSeekMutex_);
   DWIO_ENSURE(
       !prefetchHasOccurred_,
       "Prefetch already called. Currently, seek after prefetch is disallowed in DwrfRowReader");
@@ -536,10 +535,7 @@ DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
 
 DwrfRowReader::FetchResult DwrfRowReader::prefetch(uint32_t stripeToFetch) {
   DWIO_ENSURE(stripeToFetch < lastStripe && stripeToFetch >= 0);
-
-  std::unique_lock<std::mutex> lock(prefetchAndSeekMutex_);
   prefetchHasOccurred_ = true;
-  lock.unlock();
 
   VLOG(1) << "Unlocked lock and calling fetch for " << stripeToFetch
           << ", thread " << std::this_thread::get_id();
@@ -561,8 +557,6 @@ void DwrfRowReader::safeFetchNextStripe() {
 }
 
 void DwrfRowReader::startNextStripe() {
-  // This method should only be called synchronously
-  std::unique_lock<std::mutex> lock(startNextStripeMutex_);
   if (newStripeReadyForRead || currentStripe >= lastStripe) {
     return;
   }

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -151,40 +151,25 @@ class DwrfRowReader : public StrideIndexProvider,
     std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache;
   };
 
-  /*
-  Lock hierarchy is as such:
-  - Any synchronized member can be read to or written from when
-  prefetchAndSeekMutex_ is held, through the client calling other functions
-  asynchronously during a call to seekToRow or prefetch.
-  - loadRequestIssued_ is locked for write, prefetchedStripeStates_ is locked
-  for read and write, and a baton is posted when startNextStripeMutex_ is held.
-  - Any of the synchronized members can be acquired while another synchronized
-  member has been acquired, via asynchronous calls to startNextStripe() or
-  prefetch()
-  */
-
+  // stripeLoadStatuses_ and prefetchedStripeStates_ will never be acquired
+  // simultaneously on the same thread.
   // Key is stripe index
   folly::Synchronized<folly::F14FastMap<uint32_t, PrefetchedStripeState>>
       prefetchedStripeStates_;
-
-  // Currently, seek logic relies on reloading the stripe every time the row is
-  // seeked to, even if the row was present in the already loaded stripe. This
-  // is a temporary flag to disable seek on a reader which has already
-  // prefetched, until we implement a good way to support both.
-  bool prefetchHasOccurred_{false};
-
-  // Used to indicate which stripes are finished loading. If stripeLoadBatons[i]
-  // is posted, it means the ith stripe has finished loading
-  std::vector<std::unique_ptr<folly::Baton<>>> stripeLoadBatons_;
 
   // Indicates the status of load requests. The ith element in
   // stripeLoadStatuses_ represents the status of the ith stripe.
   folly::Synchronized<std::vector<FetchStatus>> stripeLoadStatuses_;
 
-  // Used to lock when altering state in startNextStripe
-  std::mutex startNextStripeMutex_;
-  // Used to ensure we do not issue a prefetch during a seek, or vice versa
-  std::mutex prefetchAndSeekMutex_;
+  // Currently, seek logic relies on reloading the stripe every time the row is
+  // seeked to, even if the row was present in the already loaded stripe. This
+  // is a temporary flag to disable seek on a reader which has already
+  // prefetched, until we implement a good way to support both.
+  std::atomic<bool> prefetchHasOccurred_{false};
+
+  // Used to indicate which stripes are finished loading. If stripeLoadBatons[i]
+  // is posted, it means the ith stripe has finished loading
+  std::vector<std::unique_ptr<folly::Baton<>>> stripeLoadBatons_;
 
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -66,6 +66,8 @@ std::unique_ptr<BufferedInput> createFileBufferedInput(
       std::make_shared<LocalReadFile>(path), pool);
 }
 
+// This relies on schema and data inside of our fm_small and fm_large orc files,
+// and is not composeable with other schema/datas
 void verifyFlatMapReading(
     DwrfRowReader* rowReader,
     const int32_t seeks[],

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -866,8 +866,6 @@ TEST(TestReader, testStatsCallbackFiredWithFiltering) {
 
   do {
     bool result = rowReader->next(1000, batch);
-    LOG(INFO) << "In loop: total key streams is " << totalKeyStreamsAggregate
-              << " selected key streams is " << selectedKeyStreamsAggregate;
     if (!result) {
       break;
     }
@@ -956,8 +954,6 @@ TEST(TestReader, testStatsCallbackFiredWithoutFiltering) {
 
   do {
     bool result = rowReader->next(1000, batch);
-    LOG(INFO) << "In loop: total key streams is " << totalKeyStreamsAggregate
-              << " selected key streams is " << selectedKeyStreamsAggregate;
     if (!result) {
       break;
     }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -661,7 +661,6 @@ TEST(TestRowReaderPrefetch, testFirstStripeNotLoadedWithEagerLoadingOff) {
   // batch size is set as 1000 in reading
   std::array<int32_t, 5> seeks;
   seeks.fill(0);
-  const std::array<int32_t, 4> expectedBatchSize{300, 300, 300, 100};
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setEagerFirstStripeLoad(false);


### PR DESCRIPTION
Summary:
I like [DAMP](https://enterprisecraftsmanship.com/posts/dry-damp-unit-tests/) principles for unit tests. However much of the repeated code made individual tests less readable, not more. Hopefully this makes the file a bit more readable.

- Stop re-declaring `fmSmall`/`fmLarge` in every test, and make them conform to the same file suffix as `structFile`
- Lazy load

Differential Revision: D49038101

