### PR TITLE
Improve ReaderTest.cpp: re-use and lazy load schema

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -100,7 +100,6 @@ uint64_t DwrfRowReader::seekToRow(uint64_t rowNumber) {
     return 0;
   }
 
-  std::unique_lock<std::mutex> lock(prefetchAndSeekMutex_);
   DWIO_ENSURE(
       !prefetchHasOccurred_,
       "Prefetch already called. Currently, seek after prefetch is disallowed in DwrfRowReader");
@@ -536,10 +535,7 @@ DwrfRowReader::FetchResult DwrfRowReader::fetch(uint32_t stripeIndex) {
 
 DwrfRowReader::FetchResult DwrfRowReader::prefetch(uint32_t stripeToFetch) {
   DWIO_ENSURE(stripeToFetch < lastStripe && stripeToFetch >= 0);
-
-  std::unique_lock<std::mutex> lock(prefetchAndSeekMutex_);
   prefetchHasOccurred_ = true;
-  lock.unlock();
 
   VLOG(1) << "Unlocked lock and calling fetch for " << stripeToFetch
           << ", thread " << std::this_thread::get_id();
@@ -561,8 +557,6 @@ void DwrfRowReader::safeFetchNextStripe() {
 }
 
 void DwrfRowReader::startNextStripe() {
-  // This method should only be called synchronously
-  std::unique_lock<std::mutex> lock(startNextStripeMutex_);
   if (newStripeReadyForRead || currentStripe >= lastStripe) {
     return;
   }

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -151,40 +151,25 @@ class DwrfRowReader : public StrideIndexProvider,
     std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache;
   };
 
-  /*
-  Lock hierarchy is as such:
-  - Any synchronized member can be read to or written from when
-  prefetchAndSeekMutex_ is held, through the client calling other functions
-  asynchronously during a call to seekToRow or prefetch.
-  - loadRequestIssued_ is locked for write, prefetchedStripeStates_ is locked
-  for read and write, and a baton is posted when startNextStripeMutex_ is held.
-  - Any of the synchronized members can be acquired while another synchronized
-  member has been acquired, via asynchronous calls to startNextStripe() or
-  prefetch()
-  */
-
+  // stripeLoadStatuses_ and prefetchedStripeStates_ will never be acquired
+  // simultaneously on the same thread.
   // Key is stripe index
   folly::Synchronized<folly::F14FastMap<uint32_t, PrefetchedStripeState>>
       prefetchedStripeStates_;
-
-  // Currently, seek logic relies on reloading the stripe every time the row is
-  // seeked to, even if the row was present in the already loaded stripe. This
-  // is a temporary flag to disable seek on a reader which has already
-  // prefetched, until we implement a good way to support both.
-  bool prefetchHasOccurred_{false};
-
-  // Used to indicate which stripes are finished loading. If stripeLoadBatons[i]
-  // is posted, it means the ith stripe has finished loading
-  std::vector<std::unique_ptr<folly::Baton<>>> stripeLoadBatons_;
 
   // Indicates the status of load requests. The ith element in
   // stripeLoadStatuses_ represents the status of the ith stripe.
   folly::Synchronized<std::vector<FetchStatus>> stripeLoadStatuses_;
 
-  // Used to lock when altering state in startNextStripe
-  std::mutex startNextStripeMutex_;
-  // Used to ensure we do not issue a prefetch during a seek, or vice versa
-  std::mutex prefetchAndSeekMutex_;
+  // Currently, seek logic relies on reloading the stripe every time the row is
+  // seeked to, even if the row was present in the already loaded stripe. This
+  // is a temporary flag to disable seek on a reader which has already
+  // prefetched, until we implement a good way to support both.
+  std::atomic<bool> prefetchHasOccurred_{false};
+
+  // Used to indicate which stripes are finished loading. If stripeLoadBatons[i]
+  // is posted, it means the ith stripe has finished loading
+  std::vector<std::unique_ptr<folly::Baton<>>> stripeLoadBatons_;
 
   // column selector
   std::shared_ptr<dwio::common::ColumnSelector> columnSelector_;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -66,6 +66,8 @@ std::unique_ptr<BufferedInput> createFileBufferedInput(
       std::make_shared<LocalReadFile>(path), pool);
 }
 
+// This relies on schema and data inside of our fm_small and fm_large orc files,
+// and is not composeable with other schema/datas
 void verifyFlatMapReading(
     DwrfRowReader* rowReader,
     const int32_t seeks[],

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -61,6 +61,19 @@ const std::string& getFMLargeFile() {
   static const std::string fmLargeFile_ = getExampleFilePath("fm_large.orc");
   return fmLargeFile_;
 }
+
+// RowType for fmSmallFile and fmLargeFile
+const std::shared_ptr<const RowType>& getFlatmapSchema() {
+  static const std::shared_ptr<const RowType> schema_ =
+      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
+          id:int,\
+      map1:map<int, array<float>>,\
+      map2:map<string, map<smallint,bigint>>,\
+      map3:map<int,int>,\
+      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
+      memo:string>"));
+  return schema_;
+}
 } // namespace
 
 TEST(TestReader, testWriterVersions) {
@@ -234,15 +247,7 @@ void verifyFlatMapReading(
 
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setReturnFlatVector(returnFlatVector);
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(file, readerOpts.getMemoryPool()), readerOpts);
   auto rowReaderOwner = reader->createRowReader(rowReaderOpts);
@@ -432,15 +437,7 @@ TEST(TestRowReaderPfetch, testSeekBeforePrefetch) {
 
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -471,15 +468,7 @@ TEST(TestRowReaderPrefetch, testPrefetchAndStartNextStripeInterleaved) {
   ReaderOptions readerOpts{defaultPool.get()};
   readerOpts.setFilePreloadThreshold(0);
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -543,15 +532,7 @@ TEST(TestRowReaderPrefetch, testParallelPrefetch) {
   const std::array<int32_t, 4> expectedBatchSize{300, 300, 300, 100};
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -585,15 +566,7 @@ TEST(TestRowReaderPrefetch, testParallelPrefetchNoPreload) {
   readerOpts.setFilePreloadThreshold(0);
   readerOpts.setDirectorySizeGuess(4);
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMLargeFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -630,15 +603,7 @@ TEST(TestRowReaderPrefetch, testNoEagerFirstStripeLoad) {
   // tests in this file accordingly.
   ASSERT_TRUE(rowReaderOpts.getEagerFirstStripeLoad());
   rowReaderOpts.setEagerFirstStripeLoad(false);
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -663,15 +628,7 @@ TEST(TestRowReaderPrefetch, testFirstStripeNotLoadedWithEagerLoadingOff) {
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setEagerFirstStripeLoad(false);
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-  rowReaderOpts.select(std::make_shared<ColumnSelector>(requestedType));
+  rowReaderOpts.select(std::make_shared<ColumnSelector>(getFlatmapSchema()));
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
       readerOpts);
@@ -721,17 +678,10 @@ TEST(TestReader, testReadFlatMapWithKeyFilters) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
   // set map key filter for map1 we only need key=1, and map2 only key-1
   auto cs = std::make_shared<ColumnSelector>(
-      requestedType, std::vector<std::string>{"map1#[1]", "map2#[\"key-1\"]"});
+      getFlatmapSchema(),
+      std::vector<std::string>{"map1#[1]", "map2#[\"key-1\"]"});
   rowReaderOpts.select(cs);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
@@ -781,16 +731,8 @@ TEST(TestReader, testReadFlatMapWithKeyRejectList) {
   // file has schema: a int, b struct<a:int, b:float, c:string>, c float
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
   auto cs = std::make_shared<ColumnSelector>(
-      requestedType, std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
+      getFlatmapSchema(), std::vector<std::string>{"map1#[\"!2\",\"!3\"]"});
   rowReaderOpts.select(cs);
   auto reader = DwrfReader::create(
       createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
@@ -826,18 +768,9 @@ TEST(TestReader, testReadFlatMapWithKeyRejectList) {
 
 TEST(TestReader, testStatsCallbackFiredWithFiltering) {
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-
   // Apply feature projection
   auto cs = std::make_shared<ColumnSelector>(
-      requestedType, std::vector<std::string>{"map2#[\"key-1\"]"});
+      getFlatmapSchema(), std::vector<std::string>{"map2#[\"key-1\"]"});
   rowReaderOpts.select(cs);
 
   uint64_t totalKeyStreamsAggregate = 0;
@@ -872,25 +805,13 @@ TEST(TestReader, testStatsCallbackFiredWithFiltering) {
 }
 
 TEST(TestReader, testEstimatedSize) {
-  const std::string fmSmall(getExampleFilePath("fm_small.orc"));
-
-  auto requestedType =
-      asRowType(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-
   ReaderOptions readerOpts{defaultPool.get()};
-
   {
     auto reader = DwrfReader::create(
         createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
         readerOpts);
     auto cs = std::make_shared<ColumnSelector>(
-        requestedType, std::vector<std::string>{"map2"});
+        getFlatmapSchema(), std::vector<std::string>{"map2"});
     RowReaderOptions rowReaderOpts;
     rowReaderOpts.select(cs);
 
@@ -903,7 +824,7 @@ TEST(TestReader, testEstimatedSize) {
         createFileBufferedInput(getFMSmallFile(), readerOpts.getMemoryPool()),
         readerOpts);
     auto cs = std::make_shared<ColumnSelector>(
-        requestedType, std::vector<std::string>{"id"});
+        getFlatmapSchema(), std::vector<std::string>{"id"});
     RowReaderOptions rowReaderOpts;
     rowReaderOpts.select(cs);
     auto rowReader = reader->createRowReader(rowReaderOpts);
@@ -913,18 +834,9 @@ TEST(TestReader, testEstimatedSize) {
 
 TEST(TestReader, testStatsCallbackFiredWithoutFiltering) {
   RowReaderOptions rowReaderOpts;
-  std::shared_ptr<const RowType> requestedType =
-      std::dynamic_pointer_cast<const RowType>(HiveTypeParser().parse("struct<\
-          id:int,\
-      map1:map<int, array<float>>,\
-      map2:map<string, map<smallint,bigint>>,\
-      map3:map<int,int>,\
-      map4:map<int,struct<field1:int,field2:float,field3:string>>,\
-      memo:string>"));
-
   // Don't apply feature projection here
   auto cs = std::make_shared<ColumnSelector>(
-      requestedType, std::vector<std::string>{"map2"});
+      getFlatmapSchema(), std::vector<std::string>{"map2"});
   rowReaderOpts.select(cs);
 
   uint64_t totalKeyStreamsAggregate = 0;

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -866,8 +866,6 @@ TEST(TestReader, testStatsCallbackFiredWithFiltering) {
 
   do {
     bool result = rowReader->next(1000, batch);
-    LOG(INFO) << "In loop: total key streams is " << totalKeyStreamsAggregate
-              << " selected key streams is " << selectedKeyStreamsAggregate;
     if (!result) {
       break;
     }
@@ -956,8 +954,6 @@ TEST(TestReader, testStatsCallbackFiredWithoutFiltering) {
 
   do {
     bool result = rowReader->next(1000, batch);
-    LOG(INFO) << "In loop: total key streams is " << totalKeyStreamsAggregate
-              << " selected key streams is " << selectedKeyStreamsAggregate;
     if (!result) {
       break;
     }

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -661,7 +661,6 @@ TEST(TestRowReaderPrefetch, testFirstStripeNotLoadedWithEagerLoadingOff) {
   // batch size is set as 1000 in reading
   std::array<int32_t, 5> seeks;
   seeks.fill(0);
-  const std::array<int32_t, 4> expectedBatchSize{300, 300, 300, 100};
   ReaderOptions readerOpts{defaultPool.get()};
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setEagerFirstStripeLoad(false);


### PR DESCRIPTION
Summary: - Extract some common `RowType`s we were using for flatmap files, and lazy load them

Differential Revision: D49123443

