### PR TITLE
Fast Path for Scalar Flat Map

### DIFF
--- a/velox/dwio/common/tests/utils/DataSetBuilder.cpp
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.cpp
@@ -235,6 +235,76 @@ DataSetBuilder& DataSetBuilder::makeUniformMapKeys(
   return *this;
 }
 
+DataSetBuilder& DataSetBuilder::makeMapStringValues(
+    const common::Subfield& field) {
+  for (auto& batch : *batches_) {
+    auto* map = dwio::common::getChildBySubfield(batch.get(), field)
+                    ->asUnchecked<MapVector>();
+    auto keyKind = map->type()->childAt(0)->kind();
+    auto valueKind = map->type()->childAt(1)->kind();
+    auto offsets = map->rawOffsets();
+    auto sizes = map->rawSizes();
+    int32_t offsetIndex = 0;
+    auto mapSize = map->size();
+    auto getNextOffset = [&]() {
+      while (offsetIndex < mapSize) {
+        if (offsets[offsetIndex] != 0) {
+          return offsets[offsetIndex++];
+        }
+        ++offsetIndex;
+      }
+      return 0;
+    };
+
+    int32_t nextOffset = offsets[0];
+    int32_t nullCounter = 0;
+    auto size = map->mapKeys()->size();
+    if (keyKind == TypeKind::VARCHAR) {
+      if (auto keys = map->mapKeys()->as<FlatVector<StringView>>()) {
+        for (auto i = 0; i < size; ++i) {
+          if (i == nextOffset) {
+            // The first key of every map is fixed. The first value is limited
+            // cardinality so that at least one column of flat map comes out as
+            // dict.
+            std::string str = "dictEncodedValue";
+            keys->set(i, StringView(str));
+            nextOffset = getNextOffset();
+            continue;
+          }
+          if (!keys->isNullAt(i) && i % 3 == 0) {
+            std::string str = keys->valueAt(i);
+            str += "----123456789";
+            keys->set(i, StringView(str));
+          }
+        }
+      }
+    }
+    if (valueKind == TypeKind::VARCHAR) {
+      if (auto values = map->mapValues()->as<FlatVector<StringView>>()) {
+        offsetIndex = 0;
+        nextOffset = offsets[0];
+        for (auto i = 0; i < size; ++i) {
+          if (i == nextOffset) {
+            std::string str = fmt::format("dictEncoded{}", i % 3);
+            values->set(i, StringView(str));
+            if (nullCounter++ % 4 == 0) {
+              values->setNull(i, true);
+            }
+            nextOffset = getNextOffset();
+            continue;
+          }
+          if (!values->isNullAt(i) && i % 3 == 0) {
+            std::string str = values->valueAt(i);
+            str += "----123456789";
+            values->set(i, StringView(str));
+          }
+        }
+      }
+    }
+  }
+  return *this;
+}
+
 std::unique_ptr<std::vector<RowVectorPtr>> DataSetBuilder::build() {
   return std::move(batches_);
 }

--- a/velox/dwio/common/tests/utils/DataSetBuilder.h
+++ b/velox/dwio/common/tests/utils/DataSetBuilder.h
@@ -180,6 +180,10 @@ class DataSetBuilder {
 
   DataSetBuilder& makeUniformMapKeys(const common::Subfield& field);
 
+  // Ensures that there are non-inlined various string sizes in map keys/values
+  // if either key or value is a string.
+  DataSetBuilder& makeMapStringValues(const common::Subfield& field);
+
   std::unique_ptr<std::vector<RowVectorPtr>> build();
 
  private:

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -73,6 +73,7 @@ class E2EFilterTest : public E2EFilterTestBase {
                                : (++flushCounter % flushEveryNBatches_ == 0);
       });
     };
+
     auto sink = std::make_unique<MemorySink>(
         200 * 1024 * 1024,
         dwio::common::FileSink::Options{.pool = leafPool_.get()});
@@ -140,6 +141,9 @@ class E2EFilterTest : public E2EFilterTestBase {
         flatmapNodeIdsAsStruct_[child->id()] = mapFlatColsStructKeys[i];
       }
       config->set(dwrf::Config::FLATTEN_MAP, true);
+      config->set(dwrf::Config::MAP_FLAT_DISABLE_DICT_ENCODING, false);
+      config->set(dwrf::Config::MAP_FLAT_DISABLE_DICT_ENCODING_STRING, false);
+
       config->set<const std::vector<uint32_t>>(
           dwrf::Config::MAP_FLAT_COLS, mapFlatCols);
       config->set<const std::vector<std::vector<std::string>>>(
@@ -373,19 +377,19 @@ TEST_F(E2EFilterTest, flatMapAsStruct) {
       kColumns, [] {}, false, {"long_val"}, 10, true);
 }
 
-TEST_F(E2EFilterTest, flatMap) {
+TEST_F(E2EFilterTest, flatMapScalar) {
   constexpr auto kColumns =
       "long_val:bigint,"
       "long_vals:map<tinyint,bigint>,"
-      "struct_vals:map<varchar,struct<v1:bigint, v2:float>>,"
-      "array_vals:map<tinyint,array<int>>";
-  flatMapColumns_ = {"long_vals", "struct_vals", "array_vals"};
+      "string_vals:map<string,string>";
+  flatMapColumns_ = {"long_vals", "string_vals"};
   auto customize = [this] {
-    dataSetBuilder_->makeUniformMapKeys(Subfield("struct_vals"));
+    dataSetBuilder_->makeUniformMapKeys(Subfield("string_vals"));
+    dataSetBuilder_->makeMapStringValues(Subfield("string_vals"));
   };
   int numCombinations = 5;
 #if defined(__has_feature)
-#if __has_feature(thread_sanitizer)
+#if __has_feature(thread_sanitizer) || __has_feature(__address_sanitizer__)
   numCombinations = 1;
 #endif
 #endif
@@ -396,6 +400,28 @@ TEST_F(E2EFilterTest, flatMap) {
       {"long_val", "long_vals"},
       numCombinations,
       true);
+}
+
+TEST_F(E2EFilterTest, flatMapComplex) {
+  constexpr auto kColumns =
+      "long_val:bigint,"
+      "struct_vals:map<varchar,struct<v1:bigint, v2:float>>,"
+      "array_vals:map<tinyint,array<int>>";
+  flatMapColumns_ = {"struct_vals", "array_vals"};
+  auto customize = [this] {
+    dataSetBuilder_->makeUniformMapKeys(Subfield("struct_vals"));
+  };
+  int numCombinations = 5;
+#if defined(__has_feature)
+#if __has_feature(thread_sanitizer) || __has_feature(__address_sanitizer__)
+  numCombinations = 1;
+#endif
+#endif
+#if !defined(NDEBUG)
+  numCombinations = 1;
+#endif
+  testWithTypes(
+      kColumns, customize, false, {"long_val"}, numCombinations, true);
 }
 
 TEST_F(E2EFilterTest, metadataFilter) {


### PR DESCRIPTION
Flat map decoding for scalar values was extremely bad. The main reason is generating too many intermediate structures (list of copy sources and targets) and calling virtual functions (BaseVector::copy*) to copy.

Now, do all scalar payloads as follows: Generate a row-wise bitmap marking all the items to copy from per-key vectors to direct map values or keys. Generate this column-wise: Every selected row where the key is present sets a bit. The init sets the bits with a stride of distinct keys. So if 100 distinct keys and all rows are selected and all rows have a value for the key, set bits 0, 100, 200 etc to mark that the value is needed. Counting the bits produces the size of the key/valyue vector for the direct map.

As a second pass, loop through the bits in row-wise order. Every set bit means that a value needs to be copied from the row/column of the bit to the next place in the direct map's keys/values.

If the keys or values are strings, there can be constant or dictionary encoding in the values. These are flattened out in the copy.

For scalar key/value types an extra optimization could be to do a gather load - vector store for keys and values. We'll see if we do this later. For now, the acceleration is 4-5x.

Adds a test for string-string flat map to exercise string keys and values inline and not inline. Adds a utility to make not in line strings.