### PR TITLE
Add different Cuda memory types and copy meter

### DIFF
--- a/velox/common/base/Semaphore.h
+++ b/velox/common/base/Semaphore.h
@@ -55,6 +55,11 @@ class Semaphore {
     }
   }
 
+  int32_t count() {
+    std::lock_guard<std::mutex> l(mutex_);
+    return count_;
+  }
+
  private:
   std::mutex mutex_;
   std::condition_variable cv_;

--- a/velox/experimental/wave/common/Cuda.cu
+++ b/velox/experimental/wave/common/Cuda.cu
@@ -43,10 +43,46 @@ class CudaManagedAllocator : public GpuAllocator {
     cudaFree(ptr);
   }
 };
+
+class CudaDeviceAllocator : public GpuAllocator {
+ public:
+  void* allocate(size_t size) override {
+    void* ret;
+    CUDA_CHECK(cudaMalloc(&ret, size));
+    return ret;
+  }
+
+  void free(void* ptr, size_t /*size*/) override {
+    cudaFree(ptr);
+  }
+};
+
+class CudaHostAllocator : public GpuAllocator {
+ public:
+  void* allocate(size_t size) override {
+    void* ret;
+    CUDA_CHECK(cudaMallocHost(&ret, size));
+    return ret;
+  }
+
+  void free(void* ptr, size_t /*size*/) override {
+    cudaFreeHost(ptr);
+  };
+};
+
 } // namespace
 
 GpuAllocator* getAllocator(Device* /*device*/) {
   static auto* allocator = new CudaManagedAllocator();
+  return allocator;
+}
+
+GpuAllocator* getDeviceAllocator(Device* /*device*/) {
+  static auto* allocator = new CudaDeviceAllocator();
+  return allocator;
+}
+GpuAllocator* getHostAllocator(Device* /*device*/) {
+  static auto* allocator = new CudaHostAllocator();
   return allocator;
 }
 
@@ -76,6 +112,30 @@ void Stream::wait() {
 void Stream::prefetch(Device* device, void* ptr, size_t size) {
   CUDA_CHECK(cudaMemPrefetchAsync(
       ptr, size, device ? device->deviceId : cudaCpuDeviceId, stream_->stream));
+}
+
+void Stream::hostToDeviceAsync(
+    void* deviceAddress,
+    const void* hostAddress,
+    size_t size) {
+  CUDA_CHECK(cudaMemcpyAsync(
+      deviceAddress,
+      hostAddress,
+      size,
+      cudaMemcpyHostToDevice,
+      stream_->stream));
+}
+
+void Stream::deviceToHostAsync(
+    void* hostAddress,
+    const void* deviceAddress,
+    size_t size) {
+  CUDA_CHECK(cudaMemcpyAsync(
+      hostAddress,
+      deviceAddress,
+      size,
+      cudaMemcpyDeviceToHost,
+      stream_->stream));
 }
 
 namespace {

--- a/velox/experimental/wave/common/Cuda.h
+++ b/velox/experimental/wave/common/Cuda.h
@@ -50,6 +50,14 @@ class Stream {
   /// to 'device'.
   void prefetch(Device* device, void* address, size_t size);
 
+  // Enqueues a copy from host to device.
+  void
+  hostToDeviceAsync(void* deviceAddress, const void* hostAddress, size_t size);
+
+  // Enqueues a copy from device to host.
+  void
+  deviceToHostAsync(void* hostAddress, const void* deviceAddress, size_t size);
+
   /// Adds a callback to be invoked after pending processing is done.
   void addCallback(std::function<void()> callback);
 
@@ -132,7 +140,14 @@ class GpuAllocator {
   UniquePtr<T[]> allocate(size_t n);
 };
 
+// Returns an allocator that produces unified memory.
 GpuAllocator* getAllocator(Device* device);
+
+// Returns an allocator that produces device memory on current device.
+GpuAllocator* getDeviceAllocator(Device* device);
+
+/// Returns an allocator that produces pinned host memory.
+GpuAllocator* getHostAllocator(Device* device);
 
 class GpuAllocator::Deleter {
  public:

--- a/velox/experimental/wave/common/tests/BlockTest.cu
+++ b/velox/experimental/wave/common/tests/BlockTest.cu
@@ -40,4 +40,21 @@ void BlockTestStream::testBoolToIndices(
   CUDA_CHECK(cudaGetLastError());
 }
 
+__global__ void sum64(int64_t* numbers, int64_t* results) {
+  extern __shared__ __align__(
+      alignof(cub::BlockReduce<int64_t, 256>::TempStorage)) char smem[];
+  int32_t idx = blockIdx.x;
+  blockSum<256>(
+      [&]() { return numbers[idx * 256 + threadIdx.x]; }, smem, results);
+}
+
+void BlockTestStream::testSum64(
+    int32_t numBlocks,
+    int64_t* numbers,
+    int64_t* results) {
+  auto tempBytes = sizeof(typename cub::BlockReduce<int64_t, 256>::TempStorage);
+  sum64<<<numBlocks, 256, tempBytes, stream_->stream>>>(numbers, results);
+  CUDA_CHECK(cudaGetLastError());
+}
+
 } // namespace facebook::velox::wave

--- a/velox/experimental/wave/common/tests/BlockTest.h
+++ b/velox/experimental/wave/common/tests/BlockTest.h
@@ -34,6 +34,10 @@ class BlockTestStream : public Stream {
       int32_t* sizes,
       int64_t* times);
 
+  // calculates the sum over blocks of 256 int64s and returns the result for
+  // numbers[i * 256] ... numbers[(i + 1) * 256 - 1] inclusive  in results[i].
+  void testSum64(int32_t numBlocks, int64_t* numbers, int64_t* results);
+
   /// Sorts 'rows'[i] using ids[i] as keys and stores the sorted order in
   /// 'result[i]'.
   // void dedup(int32_t numBlocks, uint16_t** ids, uint16_t** rows, uint16_t**

--- a/velox/experimental/wave/common/tests/CMakeLists.txt
+++ b/velox/experimental/wave/common/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_test(velox_wave_common_test velox_wave_common_test)
 target_link_libraries(
   velox_wave_common_test
   velox_wave_common
+  velox_memory
   velox_time
   velox_exception
   gtest

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -16,14 +16,21 @@
 
 #include <iostream>
 
+#include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/init/Init.h>
-
 #include <gtest/gtest.h>
+#include "velox/buffer/Buffer.h"
+#include "velox/common/base/AsyncSource.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/SelectivityInfo.h"
 #include "velox/common/base/Semaphore.h"
 #include "velox/common/base/SimdUtil.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/common/memory/MmapAllocator.h"
 #include "velox/common/time/Timer.h"
 #include "velox/experimental/wave/common/GpuArena.h"
+#include "velox/experimental/wave/common/tests/BlockTest.h"
 #include "velox/experimental/wave/common/tests/CudaTest.h"
 
 DEFINE_int32(num_streams, 0, "Number of paralll streams");
@@ -44,16 +51,420 @@ DEFINE_bool(
     prefetch,
     true,
     "Use prefetch to move unified memory to device at start and to host at end");
+DEFINE_int32(num_threads, 1, "Threads in reduce test");
+DEFINE_int64(working_size, 100000000, "Bytes in flight per thread");
+DEFINE_int32(num_columns, 10, "Columns in reduce test");
+DEFINE_int32(num_rows, 100000, "Batch size in reduce test");
+DEFINE_int32(num_batches, 100, "Batches in reduce test");
 
+DEFINE_int64(
+    memcpy_bytes_per_thread,
+    1000000,
+    "Unit size of memcpy per thread");
+
+DEFINE_string(mode, "all", "Mode for reduce test memory transfers.");
+
+DEFINE_bool(enable_bm, false, "Enable custom and long running tests");
 using namespace facebook::velox;
 using namespace facebook::velox::wave;
 
+// Dataset for data transfer test.
+struct DataBatch {
+  std::vector<BufferPtr> columns;
+  // Sum of the int64s in buffers. Numbers below the size() of each are added
+  // up.
+  int64_t sum{0};
+  int64_t byteSize;
+  int64_t dataSize;
+};
+
+std::unique_ptr<folly::CPUThreadPoolExecutor> globalSyncExecutor;
+
+folly::CPUThreadPoolExecutor* syncExecutor() {
+  return globalSyncExecutor.get();
+}
+
+constexpr int32_t kBlockSize = 256;
+
+struct ArenaSet {
+  std::unique_ptr<GpuArena> unified;
+  std::unique_ptr<GpuArena> device;
+  std::unique_ptr<GpuArena> host;
+};
+
+struct RunStats {
+  std::string mode;
+  int32_t runId{-1};
+  int32_t batchMB{0};
+  int32_t numColumns{0};
+  int32_t numRows{0};
+  int32_t numThreads{0};
+  int32_t workPerThread{0};
+  float gbs{0};
+  float resultClocks{0};
+  int32_t copyPerThread{0};
+
+  std::string toString() const {
+    return fmt::format(
+        "{} GB/s {} {}x{} rows ({}MB)  {} on thread, {} threads copy={}",
+        gbs,
+        mode,
+        numColumns,
+        numRows,
+        (numColumns * numRows * sizeof(int64_t)) >> 20,
+        workPerThread,
+        numThreads,
+        copyPerThread);
+  }
+};
+
+/// Base class modeling processing a batch of data. Inits, continues and tests
+/// for ready.
+class ProcessBatchBase {
+ public:
+  virtual ~ProcessBatchBase() = default;
+  // Starts processing 'batch'. Use isReady() to check for result.
+  virtual void init(
+      DataBatch* data,
+      GpuArena* unifiedArena,
+      GpuArena* deviceArena,
+      GpuArena* hostArena,
+      folly::CPUThreadPoolExecutor* executor) {
+    data_ = data;
+    unifiedArena_ = unifiedArena;
+    deviceArena_ = deviceArena;
+    hostArena_ = hostArena;
+    executor_ = executor;
+    numRows_ = data_->columns[0]->size() / sizeof(int64_t);
+    numBlocks_ = bits::roundUp(numRows_, 256) / 256;
+  }
+
+  DataBatch* batch() {
+    return data_;
+  }
+  // Returns true if ready and sets 'result'. Returns false if pending. If
+  // 'wait' is true, blocks until ready.
+  virtual bool isReady(int64_t& result, bool wait) = 0;
+
+  auto resultClocks() const {
+    return resultClocks_;
+  }
+
+ protected:
+  Device* device_{getDevice()};
+  DataBatch* data_{nullptr};
+  int32_t numBlocks_;
+  int32_t numRows_;
+
+  GpuArena* unifiedArena_{nullptr};
+  GpuArena* deviceArena_{nullptr};
+  GpuArena* hostArena_{nullptr};
+  folly::CPUThreadPoolExecutor* executor_{nullptr};
+  std::vector<WaveBufferPtr> deviceBuffers_;
+  std::vector<int64_t*> deviceArrays_;
+  WaveBufferPtr result_;
+  WaveBufferPtr hostResult_;
+  int64_t sum_{0};
+  std::vector<std::unique_ptr<BlockTestStream>> streams_;
+  std::vector<std::unique_ptr<Event>> events_;
+  Semaphore sem_{0};
+  int32_t toAcquire_{0};
+  float resultClocks_{0};
+};
+
+class ProcessUnifiedN : public ProcessBatchBase {
+ public:
+  void init(
+      DataBatch* data,
+      GpuArena* unifiedArena,
+      GpuArena* deviceArena,
+      GpuArena* hostArena,
+      folly::CPUThreadPoolExecutor* executor) override {
+    ProcessBatchBase::init(
+        data, unifiedArena, deviceArena, hostArena, executor);
+    result_ =
+        unifiedArena->allocate<int64_t>(data_->columns.size() * numBlocks_);
+    deviceBuffers_.resize(data->columns.size());
+    streams_.resize(deviceBuffers_.size());
+    events_.resize(deviceBuffers_.size());
+    toAcquire_ = data->columns.size();
+    for (auto i = 0; i < data_->columns.size(); ++i) {
+      deviceBuffers_[i] =
+          unifiedArena->allocate<char>(data_->columns[i]->size());
+      executor_->add([i, this]() {
+        setDevice(device_);
+        /*simd::*/ memcpy(
+            deviceBuffers_[i]->as<char>(),
+            data_->columns[i]->as<char>(),
+            data_->columns[i]->size());
+        streams_[i] = std::make_unique<BlockTestStream>();
+        streams_[i]->prefetch(
+            device_, deviceBuffers_[i]->as<char>(), data_->columns[i]->size());
+        auto resultIndex = i * numBlocks_;
+        streams_[i]->testSum64(
+            numBlocks_,
+            deviceBuffers_[i]->as<int64_t>(),
+            result_->as<int64_t>() + resultIndex);
+        events_[i] = std::make_unique<Event>();
+        events_[i]->record(*streams_[i]);
+        sem_.release();
+      });
+    }
+  }
+
+  bool isReady(int64_t& result, bool wait) override {
+    if (toAcquire_) {
+      if (wait) {
+        while (toAcquire_) {
+          sem_.acquire();
+          --toAcquire_;
+        }
+      } else {
+        while (toAcquire_) {
+          if (sem_.count() == 0) {
+            return false;
+          }
+          sem_.acquire();
+          --toAcquire_;
+        }
+      }
+    }
+    for (auto i = 0; i < events_.size(); ++i) {
+      if (wait) {
+        events_[i]->wait();
+      } else {
+        if (!events_[i]->query()) {
+          return false;
+        }
+      }
+    }
+    int64_t sum = 0;
+    auto resultPtr = result_->as<int64_t>();
+    auto numResults = data_->columns.size() * numBlocks_;
+    SelectivityInfo info;
+    {
+      SelectivityTimer s(info, 1);
+      for (auto i = 0; i < numResults; ++i) {
+        sum += resultPtr[i];
+      }
+    }
+    resultClocks_ = info.timeToDropValue();
+    result = sum;
+    return true;
+  }
+};
+
+class ProcessUnifiedCudaCopy : public ProcessBatchBase {
+ public:
+  void init(
+      DataBatch* data,
+      GpuArena* unifiedArena,
+      GpuArena* deviceArena,
+      GpuArena* hostArena,
+      folly::CPUThreadPoolExecutor* executor) override {
+    ProcessBatchBase::init(
+        data, unifiedArena, deviceArena, hostArena, executor);
+    result_ =
+        unifiedArena->allocate<int64_t>(data_->columns.size() * numBlocks_);
+    deviceBuffers_.resize(data->columns.size());
+    streams_.resize(deviceBuffers_.size());
+    events_.resize(deviceBuffers_.size());
+    for (auto i = 0; i < data_->columns.size(); ++i) {
+      deviceBuffers_[i] =
+          unifiedArena->allocate<char>(data_->columns[i]->size());
+
+      streams_[i] = std::make_unique<BlockTestStream>();
+      streams_[i]->hostToDeviceAsync(
+          deviceBuffers_[i]->as<char>(),
+          data->columns[i]->as<char>(),
+          data_->columns[i]->size());
+      auto resultIndex = i * numBlocks_;
+      streams_[i]->testSum64(
+          numBlocks_,
+          deviceBuffers_[i]->as<int64_t>(),
+          result_->as<int64_t>() + resultIndex);
+      events_[i] = std::make_unique<Event>();
+      events_[i]->record(*streams_[i]);
+    }
+  }
+
+  bool isReady(int64_t& result, bool wait) override {
+    for (auto i = 0; i < events_.size(); ++i) {
+      if (wait) {
+        events_[i]->wait();
+      } else {
+        if (!events_[i]->query()) {
+          return false;
+        }
+      }
+    }
+    int64_t sum = 0;
+    auto resultPtr = result_->as<int64_t>();
+    auto numResults = data_->columns.size() * numBlocks_;
+    for (auto i = 0; i < numResults; ++i) {
+      sum += resultPtr[i];
+    }
+    result = sum;
+    return true;
+  }
+};
+
+class ProcessDeviceCoalesced : public ProcessBatchBase {
+ public:
+  void init(
+      DataBatch* data,
+      GpuArena* unifiedArena,
+      GpuArena* deviceArena,
+      GpuArena* hostArena,
+      folly::CPUThreadPoolExecutor* executor) override {
+    ProcessBatchBase::init(
+        data, unifiedArena, deviceArena, hostArena, executor);
+    result_ =
+        deviceArena->allocate<int64_t>(data_->columns.size() * numBlocks_);
+    hostResult_ =
+        hostArena->allocate<int64_t>(data_->columns.size() * numBlocks_);
+    streams_.resize(1);
+    streams_[0] = std::make_unique<BlockTestStream>();
+
+    events_.resize(1);
+    int64_t total = 0;
+    for (auto i = 0; i < data_->columns.size(); ++i) {
+      total += data->columns[i]->size();
+    }
+
+    transfer_ = hostArena->allocate<char>(total);
+    compute_ = deviceArena->allocate<char>(total);
+    auto destination = transfer_->as<char>();
+    int32_t firstToCopy = 0;
+    int64_t copySize = 0;
+    auto targetCopySize = FLAGS_memcpy_bytes_per_thread;
+    int32_t numThreads = 0;
+    for (auto i = 0; i < data_->columns.size(); ++i) {
+      auto columnSize = data->columns[i]->size();
+      copySize += columnSize;
+      if (copySize >= targetCopySize && i < data_->columns.size() - 1) {
+        ++numThreads;
+        executor->add([i, firstToCopy, destination, this]() {
+          copyColumns(firstToCopy, i + 1, destination, true);
+        });
+        destination += copySize;
+        copySize = 0;
+        firstToCopy = i + 1;
+      }
+    }
+    toAcquire_ = 1;
+    syncExecutor()->add([firstToCopy, numThreads, destination, total, this]() {
+      copyColumns(firstToCopy, data_->columns.size(), destination, false);
+      for (auto i = 0; i < numThreads; ++i) {
+        sem_.acquire();
+      }
+      streams_[0]->hostToDeviceAsync(
+          compute_->as<char>(), transfer_->as<char>(), total);
+      streams_[0]->testSum64(
+          numBlocks_ * data_->columns.size(),
+          compute_->as<int64_t>(),
+          result_->as<int64_t>());
+      streams_[0]->deviceToHostAsync(
+          hostResult_->as<int64_t>(),
+          result_->as<int64_t>(),
+          data_->columns.size() * numBlocks_ * sizeof(int64_t));
+      events_[0] = std::make_unique<Event>();
+      events_[0]->record(*streams_[0]);
+      syncSem_.release();
+    });
+  }
+
+  bool isReady(int64_t& result, bool wait) override {
+    if (toAcquire_) {
+      if (wait) {
+        syncSem_.acquire();
+        --toAcquire_;
+      } else {
+        if (syncSem_.count() == 0) {
+          return false;
+        }
+        syncSem_.acquire();
+        --toAcquire_;
+      }
+    }
+    if (wait) {
+      events_[0]->wait();
+    } else {
+      if (!events_[0]->query()) {
+        return false;
+      }
+    }
+    int64_t sum = 0;
+    auto resultPtr = hostResult_->as<int64_t>();
+    auto numResults = data_->columns.size() * numBlocks_;
+    for (auto i = 0; i < numResults; ++i) {
+      sum += resultPtr[i];
+    }
+    result = sum;
+    return true;
+  }
+
+ private:
+  void
+  copyColumns(int32_t begin, int32_t end, char* destination, bool release) {
+    for (auto i = begin; i < end; ++i) {
+      memcpy(
+          destination,
+          data_->columns[i]->as<char>(),
+          data_->columns[i]->size());
+      destination += data_->columns[i]->size();
+    }
+    if (release) {
+      sem_.release();
+    }
+  }
+
+  WaveBufferPtr transfer_;
+  WaveBufferPtr compute_;
+  WaveBufferPtr hostResult_;
+  Semaphore syncSem_{0};
+};
+
 class CudaTest : public testing::Test {
  protected:
+  static constexpr int64_t kArenaQuantum = 512 << 20;
+
   void SetUp() override {
     device_ = getDevice();
     setDevice(device_);
     allocator_ = getAllocator(device_);
+    deviceAllocator_ = getDeviceAllocator(device_);
+    hostAllocator_ = getHostAllocator(device_);
+  }
+
+  void setupMemory(int64_t capacity = 16UL << 30) {
+    static bool inited = false;
+    if (!globalSyncExecutor) {
+      globalSyncExecutor = std::make_unique<folly::CPUThreadPoolExecutor>(10);
+    }
+
+    if (inited) {
+      return;
+    }
+    inited = true;
+    memory::MemoryManagerOptions options;
+    options.capacity = capacity;
+    memory::MmapAllocator::Options opts{(uint64_t)options.capacity};
+    mmapAllocator_ = std::make_shared<memory::MmapAllocator>(opts);
+    memory::MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
+
+    options.allocator = mmapAllocator_.get();
+    manager_ = &memory::MemoryManager::getInstance(options);
+  }
+
+  void waitFinish() {
+    if (executor_) {
+      executor_->join();
+    }
+    if (globalSyncExecutor) {
+      globalSyncExecutor->join();
+      globalSyncExecutor = nullptr;
+    }
   }
 
   void streamTest(
@@ -194,8 +605,172 @@ class CudaTest : public testing::Test {
       }
     }
   }
+
+  void createData(int32_t numBatches, int32_t numColumns, int32_t numRows) {
+    batches_.clear();
+    if (!batchPool_) {
+      batchPool_ = memory::addDefaultLeafMemoryPool();
+    }
+    int32_t sequence = 1;
+    for (auto i = 0; i < numBatches; ++i) {
+      auto batch = std::make_unique<DataBatch>();
+      for (auto j = 0; j < numColumns; ++j) {
+        auto buffer = AlignedBuffer::allocate<int64_t>(
+            numRows, batchPool_.get(), sequence);
+        batch->byteSize += buffer->capacity();
+        batch->dataSize += buffer->size();
+        batch->columns.push_back(buffer);
+        batch->sum += numRows * sequence;
+        ++sequence;
+      }
+      batches_.push_back(std::move(batch));
+    }
+  }
+
+  DataBatch* getBatch() {
+    auto number = ++batchIndex_;
+    if (number > batches_.size()) {
+      return nullptr;
+    }
+    return batches_[number - 1].get();
+  }
+
+  //
+  void processBatches(
+      int64_t workingSize,
+      GpuArena* unifiedArena,
+      GpuArena* deviceArena,
+      GpuArena* hostArena,
+      std::function<std::unique_ptr<ProcessBatchBase>()> factory,
+      RunStats& stats) {
+    int64_t pendingSize = 0;
+    std::deque<std::unique_ptr<ProcessBatchBase>> work;
+    for (;;) {
+      int64_t result;
+      auto* batch = getBatch();
+      if (!batch) {
+        for (auto& item : work) {
+          item->isReady(result, true);
+          stats.resultClocks += item->resultClocks();
+          EXPECT_EQ(item->batch()->sum, result);
+          processedBytes_ += item->batch()->dataSize;
+          pendingSize -= item->batch()->byteSize;
+          item.reset();
+        }
+        return;
+      }
+      if (pendingSize > workingSize) {
+        auto* item = work.front().get();
+        item->isReady(result, true);
+        pendingSize -= item->batch()->byteSize;
+        processedBytes_ += item->batch()->dataSize;
+        stats.resultClocks += item->resultClocks();
+        EXPECT_EQ(result, item->batch()->sum);
+        work.pop_front();
+      }
+      auto item = factory();
+      item->init(batch, unifiedArena, deviceArena, hostArena, executor_.get());
+      pendingSize += batch->byteSize;
+      work.push_back(std::move(item));
+      if (work.front()->isReady(result, false)) {
+        EXPECT_EQ(result, work.front()->batch()->sum);
+        pendingSize -= work.front()->batch()->byteSize;
+        processedBytes_ += work.front()->batch()->dataSize;
+        work.pop_front();
+      }
+    }
+  }
+
+  static std::unique_ptr<ProcessBatchBase> makeWork(const std::string& mode) {
+    std::unique_ptr<ProcessBatchBase> ptr;
+    if (mode == "unified") {
+      ptr.reset(new ProcessUnifiedN());
+    } else if (mode == "device") {
+      ptr.reset(new ProcessUnifiedCudaCopy());
+    } else if (mode == "devicecoalesced") {
+      ptr.reset(new ProcessDeviceCoalesced());
+    } else {
+      VELOX_FAIL("Bad mode {}", mode);
+    }
+    return ptr;
+  }
+
+  float reduceTest(
+      const std::string& mode,
+      int32_t numThreads,
+      int64_t workingSize,
+      RunStats& stats) {
+    std::vector<std::thread> threads;
+    threads.reserve(numThreads);
+    auto start = getCurrentTimeMicro();
+    processedBytes_ = 0;
+    batchIndex_ = 0;
+    auto factory = [mode]() { return makeWork(mode); };
+    for (int32_t i = 0; i < numThreads; ++i) {
+      threads.push_back(std::thread([&]() {
+        std::unique_ptr<GpuArena> unifiedArena;
+        std::unique_ptr<GpuArena> deviceArena;
+        std::unique_ptr<GpuArena> hostArena;
+        auto arenas = getArenas();
+        processBatches(
+            workingSize,
+            arenas->unified.get(),
+            arenas->device.get(),
+            arenas->host.get(),
+            factory,
+            stats);
+        releaseArenas(std::move(arenas));
+      }));
+    }
+    for (auto& thread : threads) {
+      thread.join();
+    }
+
+    auto time = getCurrentTimeMicro() - start;
+    float gbs = (processedBytes_ / 1024.0) / time;
+    std::cout << time << "us " << gbs << " GB/s"
+              << " res clks=" << stats.resultClocks << std::endl;
+    stats.gbs = gbs;
+    return gbs;
+  }
+
+  std::unique_ptr<ArenaSet> getArenas() {
+    {
+      std::lock_guard<std::mutex> l(mutex_);
+      if (!arenas_.empty()) {
+        auto value = std::move(arenas_.back());
+        arenas_.pop_back();
+        return value;
+      }
+    }
+    auto arenas = std::make_unique<ArenaSet>();
+    arenas->unified = std::make_unique<GpuArena>(kArenaQuantum, allocator_);
+    arenas->device =
+        std::make_unique<GpuArena>(kArenaQuantum, deviceAllocator_);
+    arenas->host = std::make_unique<GpuArena>(kArenaQuantum, hostAllocator_);
+    return arenas;
+  }
+
+  void releaseArenas(std::unique_ptr<ArenaSet> arenas) {
+    std::lock_guard<std::mutex> l(mutex_);
+    arenas_.push_back(std::move(arenas));
+  }
+
+  std::shared_ptr<memory::MmapAllocator> mmapAllocator_;
+  memory::MemoryManager* manager_{nullptr};
+  std::shared_ptr<memory::MemoryPool> batchPool_;
+  std::vector<std::unique_ptr<DataBatch>> batches_;
+  std::atomic<int32_t> batchIndex_{0};
+  std::atomic<int64_t> processedBytes_{0};
   Device* device_;
   GpuAllocator* allocator_;
+  GpuAllocator* deviceAllocator_;
+  GpuAllocator* hostAllocator_;
+  std::unique_ptr<folly::CPUThreadPoolExecutor> executor_;
+  std::vector<RunStats> stats_;
+  // Serializes common resources for multithread tests, e.g. 'arenas_'
+  std::mutex mutex_;
+  std::vector<std::unique_ptr<ArenaSet>> arenas_;
 };
 
 TEST_F(CudaTest, stream) {
@@ -231,6 +806,95 @@ TEST_F(CudaTest, custom) {
       FLAGS_prefetch,
       FLAGS_use_callbacks,
       FLAGS_sync_streams);
+}
+
+TEST_F(CudaTest, copyReduce) {
+  setupMemory();
+  executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(64);
+  createData(
+      FLAGS_num_batches, FLAGS_num_columns, bits::roundUp(FLAGS_num_rows, 256));
+  std::vector<std::string> modes = {"unified", "device", "devicecoalesced"};
+  bool any = false;
+  for (auto& mode : modes) {
+    if (FLAGS_mode == "all" || FLAGS_mode == mode) {
+      any = true;
+      RunStats stats;
+      stats.mode = mode;
+      stats.numColumns = batches_[0]->columns.size();
+      stats.numRows = batches_[0]->columns[0]->size() / sizeof(int64_t);
+      stats.numThreads = FLAGS_num_threads;
+      stats.workPerThread = FLAGS_working_size / batches_[0]->dataSize;
+      reduceTest(mode, FLAGS_num_threads, FLAGS_working_size, stats);
+      std::cout << stats.toString() << std::endl;
+    }
+  }
+  if (!any) {
+    FAIL() << "Bad mode " << FLAGS_mode;
+  }
+  waitFinish();
+}
+
+TEST_F(CudaTest, reduceMatrix) {
+  constexpr int64_t kTestGB = 20;
+  if (!FLAGS_enable_bm) {
+    return;
+  }
+
+  std::vector<std::string> modes = {/*"unified", "device",*/ "devicecoalesced"};
+  std::vector<int32_t> batchMBValues = {30, 100};
+  std::vector<int32_t> numThreadsValues = {1, 2, 3};
+  std::vector<int32_t> workPerThreadValues = {2, 4};
+  std::vector<int32_t> numColumnsValues = {10, 100, 300};
+  std::vector<int32_t> copyPerThreadValues = {300000, 1000000};
+  setupMemory((kTestGB + 1) << 30);
+  executor_ = std::make_unique<folly::CPUThreadPoolExecutor>(64);
+  for (auto batchMB : batchMBValues) {
+    for (auto numColumns : numColumnsValues) {
+      auto numBatches = (kTestGB << 30) / (batchMB << 20);
+      auto batchSize = (kTestGB << 30) / numBatches / 2;
+      auto columnSize = batchSize / numColumns;
+      auto numRows = bits::roundUp(columnSize / sizeof(int64_t), kBlockSize);
+      batches_.clear();
+      createData(numBatches, numColumns, numRows);
+      for (int64_t workPerThread : workPerThreadValues) {
+        auto workSize =
+            workPerThread * batches_[0]->columns[0]->size() * numColumns;
+        for (auto numThreads : numThreadsValues) {
+          for (auto& mode : modes) {
+            if (batchMB <= 10 && numColumns > 10 && mode != "devicecoalesced") {
+              continue;
+            }
+            std::vector<int32_t> zero = {0};
+            auto& copySizes =
+                mode == "devicecoalesced" ? copyPerThreadValues : zero;
+            for (auto copy : copySizes) {
+              stats_.emplace_back();
+              auto& run = stats_.back();
+              run.mode = mode;
+              run.numThreads = numThreads;
+              run.workPerThread = workPerThread;
+              run.numColumns = numColumns;
+              run.numRows = numRows;
+              run.copyPerThread = copy;
+              reduceTest(mode, numThreads, workSize, run);
+              std::cout << run.toString() << std::endl;
+            }
+          }
+        }
+      }
+    }
+  }
+  std::sort(
+      stats_.begin(),
+      stats_.end(),
+      [](const RunStats& left, const RunStats& right) {
+        return left.gbs > right.gbs;
+      });
+  std::cout << std::endl << "***Result, highest throughput first:" << std::endl;
+  for (auto& stats : stats_) {
+    std::cout << stats.toString() << std::endl;
+  }
+  waitFinish();
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Adds allocators for device and host memory. Adds a test for different types of host to device transfer. Memory is transferred by prefetch, copy or staging into pinned and explicyt copy into device memory. A reduction is made on the device and the result is transferred back to host. This is done with overlapping transfers from one or mire threads with different numbers of simulated columns and different batch sizes.