### PR TITLE
Fix bug that only subfields are projected out

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -107,7 +107,12 @@ class HiveDataSource : public DataSource {
   dwio::common::ReaderOptions readerOpts_;
   memory::MemoryPool* pool_;
   VectorPtr output_;
+
+  // Output type from file reader.  This is different from outputType_ that it
+  // contains column names before assignment, and columns that only used in
+  // remaining filter.
   RowTypePtr readerOutputType_;
+
   std::unique_ptr<dwio::common::RowReader> rowReader_;
 
  private:


### PR DESCRIPTION
Summary:
When we project an whole column, but only some subfields of it are also used
in remaining filter, only these subfields are projected out instead of the whole
column.

Differential Revision: D49162711


