### PR TITLE
Add plan inspector for accelerator integration

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -23,6 +23,7 @@
 #include "velox/common/process/ThreadDebugInfo.h"
 #include "velox/common/time/CpuWallTimer.h"
 #include "velox/connectors/Connector.h"
+#include "velox/core/PlanFragment.h"
 #include "velox/core/PlanNode.h"
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Spiller.h"
@@ -400,6 +401,7 @@ using AdaptDriverFunction =
 
 struct DriverAdapter {
   std::string label;
+  std::function<void(const core::PlanFragment&)> inspect;
   AdaptDriverFunction adapt;
 };
 

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -262,6 +262,11 @@ void LocalPlanner::plan(
     std::vector<std::unique_ptr<DriverFactory>>* driverFactories,
     const core::QueryConfig& queryConfig,
     uint32_t maxDrivers) {
+  for (auto& adapter : DriverFactory::adapters) {
+    if (adapter.inspect) {
+      adapter.inspect(planFragment);
+    }
+  }
   detail::plan(
       planFragment.planNode,
       nullptr,

--- a/velox/experimental/wave/exec/ToWave.cpp
+++ b/velox/experimental/wave/exec/ToWave.cpp
@@ -412,7 +412,7 @@ bool waveDriverAdapter(
 }
 
 void registerWave() {
-  exec::DriverAdapter waveAdapter{"Wave", waveDriverAdapter};
+  exec::DriverAdapter waveAdapter{"Wave", {}, waveDriverAdapter};
   exec::DriverFactory::registerAdapter(waveAdapter);
 }
 } // namespace facebook::velox::wave


### PR DESCRIPTION
Summary:
Accelerator implementation can inspect the full fragment, capture the
necessary information before doing transformation in `DriverAdapter`.

Differential Revision: D49164594


