### PR TITLE
Fix S3FileSystem tests

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+add_library(velox_hive_config OBJECT HiveConfig.cpp)
+
+target_link_libraries(velox_hive_config velox_exception)
+
 add_library(
   velox_hive_connector OBJECT
   FileHandle.cpp

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace facebook::velox {

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -15,7 +15,6 @@
  */
 #pragma once
 
-#include <folly/Optional.h>
 #include <string>
 
 namespace facebook::velox {

--- a/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.cpp
@@ -64,7 +64,7 @@ class S3ReadFile final : public ReadFile {
  public:
   S3ReadFile(const std::string& path, Aws::S3::S3Client* client)
       : client_(client) {
-    bucketAndKeyFromS3Path(path, bucket_, key_);
+    getBucketAndKeyFromS3Path(path, bucket_, key_);
   }
 
   // Gets the length of the file.

--- a/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3Util.h
@@ -77,7 +77,7 @@ inline bool isS3File(const std::string_view filename) {
       isOssFile(filename) || isCosFile(filename) || isCosNFile(filename);
 }
 
-inline void bucketAndKeyFromS3Path(
+inline void getBucketAndKeyFromS3Path(
     const std::string& path,
     std::string& bucket,
     std::string& key) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(
   velox_s3file_test
   velox_file
   velox_s3fs
+  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
@@ -31,9 +32,21 @@ target_link_libraries(
   velox_s3registration_test
   velox_file
   velox_s3fs
+  velox_hive_config
   velox_core
   velox_exec_test_lib
   velox_dwio_common_exception
   velox_exec
+  gtest
+  gtest_main)
+
+add_executable(velox_s3finalize_test S3FileSystemFinalizeTest.cpp)
+add_test(velox_s3finalize_test velox_s3finalize_test)
+target_link_libraries(
+  velox_s3finalize_test
+  velox_s3fs
+  velox_hive_config
+  velox_file
+  velox_core
   gtest
   gtest_main)

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemFinalizeTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemFinalizeTest.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/hive/storage_adapters/s3fs/S3FileSystem.h"
+#include "velox/core/Config.h"
+
+#include "gtest/gtest.h"
+
+using namespace facebook::velox;
+
+TEST(S3FileSystemFinalizeTest, finalize) {
+  auto s3Config = std::make_shared<core::MemConfig>();
+  ASSERT_TRUE(filesystems::initializeS3(s3Config.get()));
+  ASSERT_FALSE(filesystems::initializeS3(s3Config.get()));
+  {
+    filesystems::S3FileSystem s3fs(s3Config);
+    VELOX_ASSERT_THROW(
+        filesystems::finalizeS3(), "Cannot finalize S3 while in use");
+  }
+  filesystems::finalizeS3();
+  VELOX_ASSERT_THROW(
+      filesystems::initializeS3(s3Config.get()),
+      "Attempt to initialize S3 after it has been finalized.");
+}

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -38,6 +38,7 @@ class S3FileSystemTest : public S3Test {
       minioServer_->stop();
       minioServer_ = nullptr;
     }
+    filesystems::finalizeS3();
   }
 };
 
@@ -174,19 +175,4 @@ TEST_F(S3FileSystemTest, logLevel) {
   // It does not change with a new config.
   config["hive.s3.log-level"] = "Trace";
   checkLogLevelName("INFO");
-}
-
-// This test has to be the last one as it invokes finalizeS3.
-TEST_F(S3FileSystemTest, finalize) {
-  auto s3Config = minioServer_->hiveConfig();
-  ASSERT_FALSE(filesystems::initializeS3(s3Config.get()));
-  {
-    filesystems::S3FileSystem s3fs(s3Config);
-    VELOX_ASSERT_THROW(
-        filesystems::finalizeS3(), "Cannot finalize S3 while in use");
-  }
-  filesystems::finalizeS3();
-  VELOX_ASSERT_THROW(
-      filesystems::initializeS3(s3Config.get()),
-      "Attempt to initialize S3 after it has been finalized.");
 }

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3UtilTest.cpp
@@ -104,7 +104,7 @@ TEST(S3UtilTest, s3Path) {
 TEST(S3UtilTest, bucketAndKeyFromS3Path) {
   std::string bucket, key;
   auto path = "bucket/file.txt";
-  bucketAndKeyFromS3Path(path, bucket, key);
+  getBucketAndKeyFromS3Path(path, bucket, key);
   EXPECT_EQ(bucket, "bucket");
   EXPECT_EQ(key, "file.txt");
 }


### PR DESCRIPTION
Fix a build issue with missing HiveConfig symbols.
Move S3FileSystemTest::finalize to its own test to allow running tests individually in S3FileSystemTest