### PR TITLE
Add CAST TIMESTAMP WITH TIME ZONE to and from TIMESTAMP

### DIFF
--- a/velox/functions/prestosql/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/tests/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
   SplitTest.cpp
   SplitToMapTest.cpp
   StringFunctionsTest.cpp
+  TimestampWithTimeZoneCastTest.cpp
   TransformTest.cpp
   TransformKeysTest.cpp
   TransformValuesTest.cpp

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/prestosql/tests/CastBaseTest.h"
+#include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+
+using namespace facebook::velox;
+
+class TimestampWithTimeZoneCastTest : public functions::test::CastBaseTest {
+ public:
+  RowVectorPtr makeTimestampWithTimeZoneVector(
+      const VectorPtr& timestamps,
+      const VectorPtr& timezones) {
+    VELOX_CHECK_EQ(timestamps->size(), timezones->size());
+    return std::make_shared<RowVector>(
+        pool(),
+        TIMESTAMP_WITH_TIME_ZONE(),
+        nullptr,
+        timestamps->size(),
+        std::vector<VectorPtr>({timestamps, timezones}));
+  }
+};
+
+TEST_F(TimestampWithTimeZoneCastTest, fromTimestamp) {
+  const auto tsVector = makeNullableFlatVector<Timestamp>(
+      {Timestamp(1996, 0), std::nullopt, Timestamp(19920, 0)});
+  const auto expected = makeTimestampWithTimeZoneVector(
+      makeFlatVector<int64_t>(
+          {1996 * kMillisInSecond, 0, 19920 * kMillisInSecond}),
+      makeFlatVector<int16_t>({0, 0, 0}));
+  expected->setNull(1, true);
+
+  testCast<ComplexType>(
+      TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE(), tsVector, expected);
+}
+
+TEST_F(TimestampWithTimeZoneCastTest, toTimestamp) {
+  const auto tsWithTZVector = makeTimestampWithTimeZoneVector(
+      makeFlatVector<int64_t>(
+          {1996 * kMillisInSecond, 0, 19920 * kMillisInSecond}),
+      makeFlatVector<int16_t>({0, 0, 1825 /*America/Los_Angeles*/}));
+  tsWithTZVector->setNull(1, true);
+  const auto expected = makeNullableFlatVector<Timestamp>(
+      {Timestamp(1996, 0), std::nullopt, Timestamp(19920 - 8 * 3600, 0)});
+
+  testCast<ComplexType>(
+      TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP(), tsWithTZVector, expected);
+}

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.cpp
@@ -14,8 +14,163 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/type/tz/TimeZoneMap.h"
 
 namespace facebook::velox {
+namespace {
+void castFromTimestamp(
+    const SimpleVector<Timestamp>& inputVector,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    RowVector& rowResult) {
+  const auto& config = context.execCtx()->queryCtx()->queryConfig();
+  const auto& sessionTzName = config.sessionTimezone();
+  int64_t sessionTzID = 0;
+  if (!sessionTzName.empty()) {
+    sessionTzID = util::getTimeZoneID(sessionTzName);
+  }
+  const auto adjustTimestampToTimezone = config.adjustTimestampToTimezone();
+
+  auto timestampVector = rowResult.childAt(0)->asFlatVector<int64_t>();
+  auto timezoneVector = rowResult.childAt(1)->asFlatVector<int16_t>();
+  auto rawTsValues = timestampVector->values()->asMutable<int64_t>();
+  auto rawTzValues = timezoneVector->values()->asMutable<int16_t>();
+  timestampVector->clearNulls(rows);
+  timezoneVector->clearNulls(rows);
+
+  context.applyToSelectedNoThrow(rows, [&](auto row) {
+    if (inputVector.isNullAt(row)) {
+      rowResult.setNull(row, true);
+    } else {
+      auto ts = inputVector.valueAt(row);
+      if (!adjustTimestampToTimezone) {
+        // Treat TIMESTAMP as wall time in session time zone. This means that in
+        // order to get its UTC representation we need to shift the value by the
+        // offset of the time zone.
+        ts.toGMT(sessionTzID);
+      }
+      rawTsValues[row] = ts.toMillis();
+      rawTzValues[row] = sessionTzID;
+    }
+  });
+}
+
+template <TypeKind kind>
+void castToTimestampWithTimeZone(
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    RowVector& rowResult) {
+  VELOX_CHECK_EQ(kind, TypeKind::TIMESTAMP)
+  const auto inputVector = input.as<SimpleVector<Timestamp>>();
+  castFromTimestamp(*inputVector, context, rows, rowResult);
+}
+
+void castToTimestamp(
+    const RowVector& inputVector,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    FlatVector<Timestamp>& flatResult) {
+  const auto& config = context.execCtx()->queryCtx()->queryConfig();
+  const auto adjustTimestampToTimezone = config.adjustTimestampToTimezone();
+  const auto timestampVector =
+      inputVector.childAt(0)->as<SimpleVector<int64_t>>();
+  const auto timezoneVector =
+      inputVector.childAt(1)->as<SimpleVector<int16_t>>();
+
+  context.applyToSelectedNoThrow(rows, [&](auto row) {
+    if (inputVector.isNullAt(row)) {
+      flatResult.setNull(row, true);
+    } else {
+      Timestamp ts = Timestamp::fromMillis(timestampVector->valueAt(row));
+      if (!adjustTimestampToTimezone) {
+        // Convert UTC to the given time zone.
+        ts.toTimezone(timezoneVector->valueAt(row));
+      }
+      flatResult.set(row, ts);
+    }
+  });
+}
+
+template <TypeKind kind>
+void castFromTimestampWithTimeZone(
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    BaseVector& result) {
+  VELOX_CHECK_EQ(kind, TypeKind::TIMESTAMP)
+
+  const auto inputVector = input.as<RowVector>();
+  auto flatResult = result.as<FlatVector<Timestamp>>();
+  castToTimestamp(*inputVector, context, rows, *flatResult);
+}
+} // namespace
+
+bool TimestampWithTimeZoneCastOperator::isSupportedFromType(
+    const TypePtr& other) const {
+  switch (other->kind()) {
+    case TypeKind::TIMESTAMP:
+      return true;
+    case TypeKind::VARCHAR:
+      // TODO: support cast from VARCHAR
+    case TypeKind::INTEGER:
+      // TODO: support cast from DATE
+    default:
+      return false;
+  }
+}
+
+bool TimestampWithTimeZoneCastOperator::isSupportedToType(
+    const TypePtr& other) const {
+  switch (other->kind()) {
+    case TypeKind::TIMESTAMP:
+      return true;
+    case TypeKind::VARCHAR:
+      // TODO: support cast to VARCHAR
+    case TypeKind::INTEGER:
+      // TODO: support cast to DATE
+    default:
+      return false;
+  }
+}
+
+void TimestampWithTimeZoneCastOperator::castTo(
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    const TypePtr& resultType,
+    VectorPtr& result) const {
+  context.ensureWritable(rows, resultType, result);
+  auto rowResult = result->as<RowVector>();
+  for (const auto& child : rowResult->children()) {
+    child->resize(rowResult->size());
+  }
+
+  VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      castToTimestampWithTimeZone,
+      input.typeKind(),
+      input,
+      context,
+      rows,
+      *rowResult);
+}
+
+void TimestampWithTimeZoneCastOperator::castFrom(
+    const BaseVector& input,
+    exec::EvalCtx& context,
+    const SelectivityVector& rows,
+    const TypePtr& resultType,
+    VectorPtr& result) const {
+  context.ensureWritable(rows, resultType, result);
+
+  VELOX_DYNAMIC_TYPE_DISPATCH_ALL(
+      castFromTimestampWithTimeZone,
+      result->typeKind(),
+      input,
+      context,
+      rows,
+      *result);
+}
 
 void registerTimestampWithTimeZoneType() {
   registerCustomType(

--- a/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
+++ b/velox/functions/prestosql/types/TimestampWithTimeZoneType.h
@@ -15,10 +15,42 @@
  */
 #pragma once
 
+#include "velox/expression/CastExpr.h"
 #include "velox/type/Type.h"
 #include "velox/vector/VectorTypeUtils.h"
 
 namespace facebook::velox {
+
+class TimestampWithTimeZoneCastOperator : public exec::CastOperator {
+ public:
+  static const std::shared_ptr<const CastOperator>& get() {
+    static const std::shared_ptr<const CastOperator> instance{
+        new TimestampWithTimeZoneCastOperator()};
+
+    return instance;
+  }
+
+  bool isSupportedFromType(const TypePtr& other) const override;
+
+  bool isSupportedToType(const TypePtr& other) const override;
+
+  void castTo(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override;
+
+  void castFrom(
+      const BaseVector& input,
+      exec::EvalCtx& context,
+      const SelectivityVector& rows,
+      const TypePtr& resultType,
+      VectorPtr& result) const override;
+
+ private:
+  TimestampWithTimeZoneCastOperator() = default;
+};
 
 /// Represents timestamp with time zone as a number of milliseconds since epoch
 /// and time zone ID.
@@ -87,9 +119,7 @@ class TimestampWithTimeZoneTypeFactories : public CustomTypeFactories {
 
   // Type casting from and to TimestampWithTimezone is not supported yet.
   exec::CastOperatorPtr getCastOperator() const override {
-    VELOX_NYI(
-        "Casting of {} is not implemented yet.",
-        TIMESTAMP_WITH_TIME_ZONE()->toString());
+    return TimestampWithTimeZoneCastOperator::get();
   }
 };
 


### PR DESCRIPTION
Presto also allows CAST TIMESTAMP WITH TIME ZONE to and from DATE and VARCHAR. 
This functionality is not available yet.
