### PR TITLE
Use index based Table->File columns mapping.

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -141,6 +141,11 @@ std::string HiveConfig::gcsCredentials(const Config* config) {
 }
 
 // static.
+bool HiveConfig::isOrcUseColumnNames(const Config* config) {
+  return config->get<bool>(kOrcUseColumnNames, false);
+}
+
+// static.
 bool HiveConfig::isFileColumnNamesReadAsLowerCase(const Config* config) {
   return config->get<bool>(kFileColumnNamesReadAsLowerCase, false);
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -89,6 +89,9 @@ class HiveConfig {
   // The GCS service account configuration as json string
   static constexpr const char* kGCSCredentials = "hive.gcs.credentials";
 
+  // Map table field names to file field names using names, not indices.
+  static constexpr const char* kOrcUseColumnNames = "hive.orc.use-column-names";
+
   // Read the source file column name as lower case.
   static constexpr const char* kFileColumnNamesReadAsLowerCase =
       "file_column_names_read_as_lower_case";
@@ -133,6 +136,8 @@ class HiveConfig {
   static std::string gcsScheme(const Config* config);
 
   static std::string gcsCredentials(const Config* config);
+
+  static bool isOrcUseColumnNames(const Config* config);
 
   static bool isFileColumnNamesReadAsLowerCase(const Config* config);
 

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -83,6 +83,9 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
   options.setFileColumnNamesReadAsLowerCase(
       HiveConfig::isFileColumnNamesReadAsLowerCase(
           connectorQueryCtx->config()));
+  options.setUseColumnNamesForColumnMapping(
+      HiveConfig::isOrcUseColumnNames(connectorQueryCtx->config()));
+
   return std::make_unique<HiveDataSource>(
       outputType,
       tableHandle,

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -390,7 +390,8 @@ class ReaderOptions {
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
   uint64_t directorySizeGuess{kDefaultDirectorySizeGuess};
   uint64_t filePreloadThreshold{kDefaultFilePreloadThreshold};
-  bool fileColumnNamesReadAsLowerCase = false;
+  bool fileColumnNamesReadAsLowerCase{false};
+  bool useColumnNamesForColumnMapping_{false};
 
  public:
   static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
@@ -406,10 +407,7 @@ class ReaderOptions {
         fileFormat(FileFormat::UNKNOWN),
         fileSchema(nullptr),
         autoPreloadLength(DEFAULT_AUTO_PRELOAD_SIZE),
-        prefetchMode(PrefetchMode::PREFETCH),
-        fileColumnNamesReadAsLowerCase(false) {
-    // PASS
-  }
+        prefetchMode(PrefetchMode::PREFETCH) {}
 
   ReaderOptions& operator=(const ReaderOptions& other) {
     tailLocation = other.tailLocation;
@@ -427,6 +425,7 @@ class ReaderOptions {
     directorySizeGuess = other.directorySizeGuess;
     filePreloadThreshold = other.filePreloadThreshold;
     fileColumnNamesReadAsLowerCase = other.fileColumnNamesReadAsLowerCase;
+    useColumnNamesForColumnMapping_ = other.useColumnNamesForColumnMapping_;
     maxCoalesceDistance_ = other.maxCoalesceDistance_;
     maxCoalesceBytes_ = other.maxCoalesceBytes_;
     return *this;
@@ -458,13 +457,8 @@ class ReaderOptions {
    * For "dwrf" format, a default schema is derived from the file.
    * For "rc" format, there is no default schema.
    */
-  ReaderOptions& setFileSchema(
-      const std::shared_ptr<const velox::RowType>& schema) {
-    if (schema != nullptr) {
-      fileSchema = schema;
-    } else {
-      fileSchema = nullptr;
-    }
+  ReaderOptions& setFileSchema(const RowTypePtr& schema) {
+    fileSchema = schema;
     return *this;
   }
 
@@ -539,9 +533,13 @@ class ReaderOptions {
     return *this;
   }
 
-  ReaderOptions& setFileColumnNamesReadAsLowerCase(
-      bool fileColumnNamesReadAsLowerCaseMode) {
-    fileColumnNamesReadAsLowerCase = fileColumnNamesReadAsLowerCaseMode;
+  ReaderOptions& setFileColumnNamesReadAsLowerCase(bool flag) {
+    fileColumnNamesReadAsLowerCase = flag;
+    return *this;
+  }
+
+  ReaderOptions& setUseColumnNamesForColumnMapping(bool flag) {
+    useColumnNamesForColumnMapping_ = flag;
     return *this;
   }
 
@@ -617,6 +615,10 @@ class ReaderOptions {
 
   bool isFileColumnNamesReadAsLowerCase() const {
     return fileColumnNamesReadAsLowerCase;
+  }
+
+  bool isUseColumnNamesForColumnMapping() const {
+    return useColumnNamesForColumnMapping_;
   }
 };
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -730,7 +730,110 @@ DwrfReader::DwrfReader(
           options.getFileFormat() == FileFormat::ORC ? FileFormat::ORC
                                                      : FileFormat::DWRF,
           options.isFileColumnNamesReadAsLowerCase())),
-      options_(options) {}
+      options_(options) {
+  // If we are not using column names to map table columns to file columns, then
+  // we use indices. In that case we need to ensure the names completely match,
+  // because we are still mapping columns by names further down the code.
+  // So we rename column names in the file schema to match table schema.
+  // We test the options to have 'fileSchema' (actually table schema) as most of
+  // the unit tests fail to provide it.
+  if ((not options_.isUseColumnNamesForColumnMapping()) and
+      (options_.getFileSchema() != nullptr)) {
+    updateColumnNamesFromTableSchema();
+  }
+}
+
+namespace {
+void logTypeInequality(
+    const Type& fileType,
+    const Type& tableType,
+    const std::string& fileFieldName,
+    const std::string& tableFieldName) {
+  VLOG(1) << "Type of the File field '" << fileFieldName
+          << "' does not match the type of the Table field '" << tableFieldName
+          << "': [" << fileType.toString() << "] vs [" << tableType.toString()
+          << "]";
+}
+
+// Forward declaration for general type tree recursion function.
+TypePtr updateColumnNames(
+    const TypePtr& fileType,
+    const TypePtr& tableType,
+    const std::string& fileFieldName,
+    const std::string& tableFieldName);
+
+// Non-primitive type tree recursion function.
+template <typename T>
+TypePtr updateColumnNames(const TypePtr& fileType, const TypePtr& tableType) {
+  auto fileRowType = std::dynamic_pointer_cast<const T>(fileType);
+  auto tableRowType = std::dynamic_pointer_cast<const T>(tableType);
+
+  std::vector<std::string> newFileFieldNames{fileRowType->names()};
+  std::vector<TypePtr> newFileFieldTypes{fileRowType->children()};
+
+  for (auto childIdx = 0; childIdx < tableRowType->size(); ++childIdx) {
+    if (childIdx >= fileRowType->size()) {
+      break;
+    }
+
+    newFileFieldTypes[childIdx] = updateColumnNames(
+        fileRowType->childAt(childIdx),
+        tableRowType->childAt(childIdx),
+        fileRowType->nameOf(childIdx),
+        tableRowType->nameOf(childIdx));
+
+    newFileFieldNames[childIdx] = tableRowType->nameOf(childIdx);
+  }
+
+  return std::make_shared<const T>(
+      std::move(newFileFieldNames), std::move(newFileFieldTypes));
+}
+
+// General type tree recursion function.
+TypePtr updateColumnNames(
+    const TypePtr& fileType,
+    const TypePtr& tableType,
+    const std::string& fileFieldName,
+    const std::string& tableFieldName) {
+  // Check type equality.
+  if (fileType->kind() != tableType->kind()) {
+    logTypeInequality(*fileType, *tableType, fileFieldName, tableFieldName);
+  }
+
+  // For leaf types we return type as is.
+  if (fileType->isPrimitiveType()) {
+    return fileType;
+  }
+
+  std::vector<std::string> fileFieldNames{fileType->size()};
+  std::vector<TypePtr> fileFieldTypes{fileType->size()};
+
+  if (fileType->isRow()) {
+    return updateColumnNames<RowType>(fileType, tableType);
+  }
+
+  if (fileType->isMap()) {
+    return updateColumnNames<MapType>(fileType, tableType);
+  }
+
+  if (fileType->isArray()) {
+    return updateColumnNames<ArrayType>(fileType, tableType);
+  }
+
+  // We should not be here.
+  VLOG(1) << "Unexpected table type during column names update for File field '"
+          << fileFieldName << "': [" << fileType->toString() << "]";
+  return fileType;
+}
+} // namespace
+
+void DwrfReader::updateColumnNamesFromTableSchema() {
+  const auto& tableSchema = options_.getFileSchema();
+  const auto& fileSchema = readerBase_->getSchema();
+  auto newSchema = std::dynamic_pointer_cast<const RowType>(
+      updateColumnNames(fileSchema, tableSchema, "", ""));
+  readerBase_->setSchema(newSchema);
+}
 
 std::unique_ptr<StripeInformation> DwrfReader::getStripe(
     uint32_t stripeIndex) const {

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -350,6 +350,11 @@ class DwrfReader : public dwio::common::Reader {
       const dwio::common::ReaderOptions& options);
 
  private:
+  // Ensures that files column names match the ones from the table schema using
+  // column indices.
+  void updateColumnNamesFromTableSchema();
+
+ private:
   std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::ReaderOptions options_;
 

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -119,8 +119,12 @@ class ReaderBase {
     return *footer_;
   }
 
-  const std::shared_ptr<const RowType>& getSchema() const {
+  const RowTypePtr& getSchema() const {
     return schema_;
+  }
+
+  void setSchema(RowTypePtr& newSchema) {
+    schema_ = newSchema;
   }
 
   const std::shared_ptr<const dwio::common::TypeWithId>& getSchemaWithId()

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -17,6 +17,7 @@
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/common/testutil/TestValue.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
@@ -3039,32 +3040,45 @@ TEST_F(TableScanTest, readMissingFieldsInArray) {
   }
 }
 
-// Tests queries that use that read more row fields than exist in the data in a
-// map.
+// Tests queries that read more row fields than exist in the data in a map and
+// array.
 TEST_F(TableScanTest, readMissingFieldsInMap) {
   vector_size_t size = 1'000;
-  auto rowVector = makeRowVector({
+  auto valuesVector = makeRowVector({
       makeFlatVector<int64_t>(size * 4, [](auto row) { return row; }),
-      makeFlatVector<int64_t>(size * 4, [](auto row) { return row; }),
+      makeFlatVector<int32_t>(size * 4, [](auto row) { return row; }),
   });
   auto keysVector =
       makeFlatVector<int64_t>(size * 4, [](auto row) { return row % 4; });
   std::vector<vector_size_t> offsets;
-  for (int i = 0; i < size; i++) {
+  for (auto i = 0; i < size; i++) {
     offsets.push_back(i * 4);
   }
-  auto mapVector = makeMapVector(offsets, keysVector, rowVector);
+  auto mapVector = makeMapVector(offsets, keysVector, valuesVector);
+  auto arrayVector = makeArrayVector(offsets, valuesVector);
 
   auto filePath = TempFilePath::create();
-  writeToFile(filePath->path, {makeRowVector({mapVector})});
-  // Create a row type with additional fields not present in the file.
-  auto rowType = makeRowType(
-      {MAP(BIGINT(), makeRowType({BIGINT(), BIGINT(), BIGINT(), BIGINT()}))});
+  writeToFile(filePath->path, {makeRowVector({mapVector, arrayVector})});
 
-  // Query all the fields.
+  // Create a row type with additional fields in the structure not present in
+  // the file ('c' and 'd') and with all columns having different names than in
+  // the file.
+  auto structType =
+      ROW({"a", "b", "c", "d"}, {BIGINT(), INTEGER(), DOUBLE(), REAL()});
+  auto rowType =
+      ROW({"m1", "a2"}, {{MAP(BIGINT(), structType), ARRAY(structType)}});
+
   auto op = PlanBuilder()
-                .tableScan(rowType)
-                .project({"c0[0].c0", "c0[1].c1", "c0[2].c2", "c0[3].c3"})
+                .tableScan(rowType, {}, "", rowType)
+                .project(
+                    {"m1[0].a",
+                     "m1[1].b",
+                     "m1[2].c",
+                     "m1[3].d",
+                     "a2[1].a",
+                     "a2[2].b",
+                     "a2[3].c",
+                     "a2[4].d"})
                 .planNode();
 
   auto split = makeHiveConnectorSplit(filePath->path);
@@ -3073,23 +3087,88 @@ TEST_F(TableScanTest, readMissingFieldsInMap) {
   ASSERT_EQ(result->size(), size);
   auto rows = result->as<RowVector>();
   ASSERT_TRUE(rows);
-  ASSERT_EQ(rows->childrenSize(), 4);
+  ASSERT_EQ(rows->childrenSize(), 8);
   // The fields that exist in the data should be present and correct.
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 8; i += 4) {
     auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
     ASSERT_TRUE(val);
     ASSERT_EQ(val->size(), size);
-    for (int j = 0; j < size; j++) {
+    for (auto j = 0; j < size; j++) {
       ASSERT_FALSE(val->isNullAt(j));
-      ASSERT_EQ(val->valueAt(j), j * 4 + i);
+      ASSERT_EQ(val->valueAt(j), j * 4);
+    }
+  }
+  for (int i = 1; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<int32_t>>();
+    ASSERT_TRUE(val);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_FALSE(val->isNullAt(j));
+      ASSERT_EQ(val->valueAt(j), j * 4 + 1);
     }
   }
   // The fields that don't exist in the data should be null.
-  for (int i = 2; i < 4; i++) {
-    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
+  for (int i = 2; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<double>>();
     ASSERT_TRUE(val);
     ASSERT_EQ(val->size(), size);
-    for (int j = 0; j < size; j++) {
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+  for (int i = 3; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<float>>();
+    ASSERT_TRUE(val);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+
+  // Now run query with column mapping using names - we should not be able to
+  // find any names.
+  result = AssertQueryBuilder(op)
+               .connectorConfig(
+                   kHiveConnectorId,
+                   connector::hive::HiveConfig::kOrcUseColumnNames,
+                   "true")
+               .split(split)
+               .copyResults(pool());
+
+  ASSERT_EQ(result->size(), size);
+  rows = result->as<RowVector>();
+  ASSERT_TRUE(rows);
+  ASSERT_EQ(rows->childrenSize(), 8);
+
+  for (int i = 0; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
+    ASSERT_TRUE(val != nullptr);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+  for (int i = 1; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<int32_t>>();
+    ASSERT_TRUE(val != nullptr);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+  for (int i = 2; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<double>>();
+    ASSERT_TRUE(val != nullptr);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+  for (int i = 3; i < 8; i += 4) {
+    auto val = rows->childAt(i)->as<SimpleVector<float>>();
+    ASSERT_TRUE(val != nullptr);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
       ASSERT_TRUE(val->isNullAt(j));
     }
   }
@@ -3161,7 +3240,7 @@ TEST_F(TableScanTest, tableScanProjections) {
   testQueryRow({3, 2});
 }
 
-// Tests queries that use that read more row fields than exist in the data, and
+// Tests queries that read more row fields than exist in the data, and
 // read additional columns besides just the row.
 TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
   vector_size_t size = 1'000;
@@ -3180,18 +3259,20 @@ TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
 
   auto filePath = TempFilePath::create();
   writeToFile(filePath->path, {rowVector});
-  // Create a row type with additional fields not present in the file.
-  auto rowType = makeRowType(
-      {makeRowType({BIGINT(), BIGINT(), BIGINT(), BIGINT()}),
-       INTEGER(),
-       DOUBLE(),
-       BOOLEAN(),
-       VARCHAR()});
+
+  // Create a row type with additional fields in the structure not present in
+  // the file ('c' and 'd') and with all columns having different names than in
+  // the file.
+  auto structType =
+      ROW({"a", "b", "c", "d"}, {BIGINT(), BIGINT(), BIGINT(), BIGINT()});
+  auto rowType =
+      ROW({"st1", "i2", "d3", "b4", "c4"},
+          {{structType, INTEGER(), DOUBLE(), BOOLEAN(), VARCHAR()}});
 
   auto op =
       PlanBuilder()
-          .tableScan(rowType)
-          .project({"c0.c0", "c0.c1", "c0.c2", "c0.c3", "c1", "c2", "c3", "c4"})
+          .tableScan(rowType, {}, "", rowType)
+          .project({"st1.a", "st1.b", "st1.c", "st1.d", "i2", "d3", "b4", "c4"})
           .planNode();
 
   auto split = makeHiveConnectorSplit(filePath->path);
@@ -3248,6 +3329,59 @@ TEST_F(TableScanTest, readMissingFieldsWithMoreColumns) {
   ASSERT_TRUE(stringCol);
   ASSERT_EQ(stringCol->size(), size);
   for (int j = 0; j < size; j++) {
+    ASSERT_FALSE(stringCol->isNullAt(j));
+    ASSERT_EQ(stringCol->valueAt(j), fruitViews[j % fruitViews.size()]);
+  }
+
+  // Now run query with column mapping using names - we should not be able to
+  // find any names, except for the last string column.
+  result = AssertQueryBuilder(op)
+               .connectorConfig(
+                   kHiveConnectorId,
+                   connector::hive::HiveConfig::kOrcUseColumnNames,
+                   "true")
+               .split(split)
+               .copyResults(pool());
+
+  ASSERT_EQ(result->size(), size);
+  rows = result->as<RowVector>();
+  ASSERT_TRUE(rows);
+  ASSERT_EQ(rows->childrenSize(), 8);
+
+  for (int i = 0; i < 4; i++) {
+    auto val = rows->childAt(i)->as<SimpleVector<int64_t>>();
+    ASSERT_TRUE(val != nullptr);
+    ASSERT_EQ(val->size(), size);
+    for (auto j = 0; j < size; j++) {
+      ASSERT_TRUE(val->isNullAt(j));
+    }
+  }
+
+  intCol = rows->childAt(4)->as<SimpleVector<int32_t>>();
+  ASSERT_TRUE(intCol != nullptr);
+  ASSERT_EQ(intCol->size(), size);
+  for (auto j = 0; j < size; j++) {
+    ASSERT_TRUE(intCol->isNullAt(j));
+  }
+
+  doubleCol = rows->childAt(5)->as<SimpleVector<double>>();
+  ASSERT_TRUE(doubleCol != nullptr);
+  ASSERT_EQ(doubleCol->size(), size);
+  for (auto j = 0; j < size; j++) {
+    ASSERT_TRUE(doubleCol->isNullAt(j));
+  }
+
+  boolCol = rows->childAt(6)->as<SimpleVector<bool>>();
+  ASSERT_TRUE(boolCol != nullptr);
+  ASSERT_EQ(boolCol->size(), size);
+  for (auto j = 0; j < size; j++) {
+    ASSERT_TRUE(boolCol->isNullAt(j));
+  }
+
+  stringCol = rows->childAt(7)->as<SimpleVector<StringView>>();
+  ASSERT_TRUE(stringCol != nullptr);
+  ASSERT_EQ(stringCol->size(), size);
+  for (auto j = 0; j < size; j++) {
     ASSERT_FALSE(stringCol->isNullAt(j));
     ASSERT_EQ(stringCol->valueAt(j), fruitViews[j % fruitViews.size()]);
   }

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -778,6 +778,11 @@ class ArrayType : public TypeBase<TypeKind::ARRAY> {
  public:
   explicit ArrayType(std::shared_ptr<const Type> child);
 
+  explicit ArrayType(
+      std::vector<std::string>&& /*names*/,
+      std::vector<std::shared_ptr<const Type>>&& types)
+      : ArrayType(types[0]) {}
+
   const std::shared_ptr<const Type>& elementType() const {
     return child_;
   }
@@ -786,7 +791,19 @@ class ArrayType : public TypeBase<TypeKind::ARRAY> {
     return 1;
   }
 
+  std::vector<std::shared_ptr<const Type>> children() const {
+    return {child_};
+  }
+
+  std::vector<std::string> names() const {
+    return {"element"};
+  }
+
   const std::shared_ptr<const Type>& childAt(uint32_t idx) const override;
+
+  const char* nameOf(uint32_t idx) const {
+    return idx == 0 ? "element" : "<invalid>";
+  }
 
   std::string toString() const override;
 
@@ -809,6 +826,11 @@ class MapType : public TypeBase<TypeKind::MAP> {
       std::shared_ptr<const Type> keyType,
       std::shared_ptr<const Type> valueType);
 
+  explicit MapType(
+      std::vector<std::string>&& /*names*/,
+      std::vector<std::shared_ptr<const Type>>&& types)
+      : MapType(types[0], types[1]) {}
+
   const std::shared_ptr<const Type>& keyType() const {
     return keyType_;
   }
@@ -821,9 +843,21 @@ class MapType : public TypeBase<TypeKind::MAP> {
     return 2;
   }
 
+  std::vector<std::shared_ptr<const Type>> children() const {
+    return {keyType_, valueType_};
+  }
+
+  std::vector<std::string> names() const {
+    return {"key", "value"};
+  }
+
   std::string toString() const override;
 
   const std::shared_ptr<const Type>& childAt(uint32_t idx) const override;
+
+  const char* nameOf(uint32_t idx) const {
+    return idx == 0 ? "key" : idx == 1 ? "value" : "<invalid>";
+  }
 
   bool equivalent(const Type& other) const override;
 


### PR DESCRIPTION
Summary:
Presto by default uses index based column mapping.
It has a connector config prop "hive.orc.use-column-names" to use names.
Make Velox use index based column mapping by default.
For this we simply rename fields in the file schema using table schema.
We also check the type compatibility of the fields.
Underneath the code still uses the name mapping, but since we adjusted
field names in the file schema using indices, it is equivalent to index mapping.
In the future the internal code might hande this on its own and this workaround
with column renaming might not be needed.
If "hive.orc.use-column-names" is passed - we don't perform renaming and
work as before.
GH issue: https://github.com/facebookincubator/velox/issues/6466

Differential Revision: D49117889


