### PR TITLE
Update code calling HashPartitionFunction::partition to check the return value.

### DIFF
--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -388,11 +388,13 @@ void HashProbe::spillInput(RowVectorPtr& input) {
   const auto numInput = input->size();
   prepareInputIndicesBuffers(
       input->size(), spiller_->state().spilledPartitionSet());
-  spillHashFunction_->partition(*input, spillPartitions_);
+  const auto partitionNum =
+      spillHashFunction_->partition(*input, spillPartitions_);
 
   vector_size_t numNonSpillingInput = 0;
   for (auto row = 0; row < numInput; ++row) {
-    const auto partition = spillPartitions_[row];
+    const auto partition =
+        partitionNum.has_value() ? partitionNum.value() : spillPartitions_[row];
     if (!spiller_->isSpilled(partition)) {
       rawNonSpillInputIndicesBuffer_[numNonSpillingInput++] = row;
       continue;

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -637,10 +637,11 @@ class SpillerTest : public exec::test::RowContainerTestBase {
         0,
         numPartitionInputs_.size() * sizeof(vector_size_t));
 
-    partitionFn.partition(*input, spillPartitions_);
+    const auto partitionNum = partitionFn.partition(*input, spillPartitions_);
 
     for (auto i = 0; i < input->size(); ++i) {
-      auto partition = spillPartitions_[i];
+      const auto partition =
+          partitionNum.has_value() ? partitionNum.value() : spillPartitions_[i];
       spillIndicesBuffers_[partition]
           ->asMutable<vector_size_t>()[numPartitionInputs_[partition]++] = i;
     }


### PR DESCRIPTION
`HashPartitionFunction::partition` returns the partition number if all the computed partitions are identical, leaves `partitions` vector unchanged.
This change updates the following code to check the return value:
- HashProbe
- SpillerTest