### PR TITLE
Optimize global reduce_agg aggregation

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -127,7 +127,9 @@ General Aggregate Functions
     takes the current state, initially ``initialState``, and returns the new state.
     ``combineFunction`` will be invoked to combine two states into a new state.
     The final state is returned. Throws an error if ``initialState`` is NULL or
-    ``inputFunction`` or ``combineFunction`` returns a NULL.::
+    ``inputFunction`` or ``combineFunction`` returns a NULL.
+
+    Note that reduce_agg doesn't support evaluation over sorted inputs.::
 
         -- Compute sum (for illustration purposes only; use SUM aggregate function in production queries).
         SELECT id, reduce_agg(value, 0, (a, b) -> a + b, (a, b) -> a + b)

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -26,18 +26,65 @@ namespace {
 using ReduceAggAccumulator = functions::aggregate::SingleValueAccumulator;
 
 // clang-format off
-//  TODO: reduce_agg aggregate function doesn't lend itself well to vectorized
+//  reduce_agg aggregate function doesn't lend itself well to vectorized
 //  execution as it is effectively a data-dependent loop. It is hard to avoid
-//  evaluating lambda expressions on small number of rows at a time. This
-//  particular implementation doesn't try very hard and simply evaluates lambda
-//  expressions one row at a time. A relatively straightforward improvement
-//  could be similar to the algorithm implemented in the 'reduce' scalar lambda
-//  function.
+//  evaluating lambda expressions on small number of rows at a time. An original
+//  implementation didn't try very hard and simply evaluated lambda
+//  expressions one row at a time. This implementation is optimized to evaluate
+//  expressions ~log2(n) times, where n is the number of rows in the batch in
+//  case of global aggregation and maximum cardinality of a single group in the
+//  batch in case of group by.
+//
+//   Consider global aggregation over dataset {1, 2, 3, 4, 5, 6,..100}.
+//
+//   The original implementation went like so:
+//
+//   s0 - initialValue, s - state of the only group. f - inputFunction.
+//
+//   s = s0
+//   s = f(s, 1)
+//   s = f(s, 2)
+//   s = f(s, 3)
+//   s = f(s, 4)
+//   s = f(s, 5)
+//   ...
+//
+//   The inputFunction lambda expression was evaluated 100 times, once per row.
+//
+//   This implementation goes like this:
+//
+//   f - inputFunction, g - combineFunction
+//
+//   Convert all inputs into states using inputFunction and initialValue:
+//
+//   [s1, s2, s3, s4, s5,..s100] = f([s0, s0, s0, s0, s0,..], [1, 2, 3, 4, 5,..100])
+//
+//   Combine 100 states into 50:
+//
+//   [s1, s2,...s50] = g([s1, s2,...s50], [s51, s52,...s100])
+//
+//   Combine these 50 states into 25 states:
+//
+//   [s1, s2,...s25] = g([s1, s2,...s25], [s26, s27,...s50])
+//
+//   Combine these 25 states into 13 (12 + 1) states:
+//
+//   [s1, s2,...s12] = g([s1, s2,...s12], [s13, s14,...s24])
+//   s13 = s25
+//
+//   Continue in this manner until all states are combined. This requires only
+//   log2(100), ~7, expression evaluations.
+//
+//   Note: When adding a batch of rows to a non-empty accumulator, the
+//   accumulated state is appended to the list of initial states. In the
+//   example above, we would get 101 states to combine.
+//
+//   Group by applies this technique to each group.
 //
 //   Consider dataset {1, 10, 2, 20, 3} where values 1, 2, 3 belong to group 1
 //   and values 10, 20 belong to group 2.
 //
-//   This implementation goes like so:
+//   The original implementation went like so:
 //
 //   s0 - initialValue, s1 - state for group 1, s2 - state for group 2.
 //
@@ -49,71 +96,45 @@ using ReduceAggAccumulator = functions::aggregate::SingleValueAccumulator;
 //   s2 = f(s2, 20)
 //   s1 = f(s1, 3)
 //
-//   The inputFunction lambda expression is evaluated 5 times, once per row.
+//   The inputFunction lambda expression was evaluated 5 times, once per row.
 //
-//   A more efficient approach would be to evaluate a set of rows that contains
-//   one row per group.
+//   This implementation converts all inputs into states using inputFunction
+//   and initialValue, then combines multiple pairs of states similar to global
+//   aggregation.
 //
-//   s1 = s0
-//   s2 = s0
+//   First, put rows that belong to same groups together.
 //
-//   [s1, s2] = f([s1, s2], [1, 10])
-//   [s1, s2] = f([s1, s2], [2, 20])
-//   s1 = f(s1, 3)
+//   [1, 2, 3, 10, 30]
 //
-//   Here, inputFunction lambda expression is evaluated only 3 times (compared
-//   to 5 times above).
+//   Convert values into states:
 //
-//   Global aggregation would go slightly differently.
+//   [s1, s2, s3, s4, s5] -> f([s0, s0, s0, s0, s0], [1, 2, 3, 10, 30])
 //
-//   Consider dataset {1, 2, 3, 4, 5, 6,..100}.
+//   Combine states within each group:
 //
-//   This implementation goes like so:
+//   [s1, s2] = g([s1, s4], [s2, s5])
+//   s3 = s3 // extra state for group 1
 //
-//   s0 - initialValue, s - state of the only group.
+//   We have 2 states for group 1 (s1, s3) and 1 state for group 2 (s2).
+//   Group 2 is done. We proceed to combine states for group 1.
 //
-//   s = s0
-//   s = f(s, 1)
-//   s = f(s, 2)
-//   s = f(s, 3)
-//   s = f(s, 4)
-//   s = f(s, 5)
-//   ...
+//   s1 = g([s1], [s3])
 //
-//   The inputFunction lambda expression is evaluated 100 times, once per row.
+//   In this example, inputFunction lambda expression is evaluated once and
+//   combineFunction is evaluated twice (compared to evaluating inputFunction 5
+//   times above).
 //
-//   A more efficient approach would be:
+//   Note: When adding a batch of rows to non-empty accumulators, the
+//   accumulated states are added to the list of initial states above.
 //
-//   f - inputFunction, g - combineFunction
+// Note: This more efficient algorithm doesn't support applying reduce_agg
+// to sorted inputs.
 //
-//   Convert all inputs into states:
-//
-//   [s1, s2, s3, s4, s5,..s100] = f([s0, s0, s0, s0, s0,..], [1, 2, 3, 4, 5,..100])
-//
-//   Combine 100 states into 50:
-//
-//   [s1, s2,...s50] = g([s1, s3,...s99], [s2, s4,...s100])
-//
-//   Combine these 50 states into 25 states:
-//
-//   [s1, s2,...s25] = g([s1, s3,...s49], [s2, s4,...s50])
-//
-//   Continue in this manner until all states are combined. This requires only
-//   log2(100), ~7, expression evaluations.
-//
-// Note that the more efficient algorithm for global aggregation doesn't support
-// applying reduce_agg to sorted inputs.
-//
-// Also, note that the more efficient algorithm for global aggregation can be
-// used in a group-by as well. Each evaluation of the lambda could be reducing
-// the cardinality of each group by a factor of 2. This would be require
-// log2(max-group-cardinality) evaluations.
-//
-// A common use case for reduce_agg is to compute a product of input values.
+// TODO A common use case for reduce_agg is to compute a product of input values.
 //
 //   reduce_agg(x, 1, (a, b) -> (a * b), (a, b) -> (a * b))
 //
-// In this case, the best option is to identify this pattern and invoke
+// In this case, the best option would be to identify this pattern and invoke
 // specialized 'product(x)' aggregate function instead.
 //
 // clang-format on
@@ -171,115 +192,16 @@ class ReduceAgg : public exec::Aggregate {
       char** groups,
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
-      bool /*unused*/) override {
-    const auto& lambda = initializeInputLambda();
-
-    const auto& input = args[0];
-    const auto& initialValue = args[1];
-
-    auto* pool = allocator_->pool();
-    const auto lambdaInputType = lambda->signature();
-
-    const auto& stateType = lambdaInputType->childAt(0);
-    VectorPtr state = BaseVector::create(stateType, 1, pool);
-
-    auto lambdaInput = makeLambdaInput(lambdaInputType, 1, state, nullptr);
-
-    SelectivityVector singleRow(1);
-
-    BufferPtr indices = allocateIndices(1, pool);
-    auto* rawIndices = indices->asMutable<vector_size_t>();
-
-    VectorPtr newState;
-
-    rows.applyToSelected([&](auto row) {
-      if (input->isNullAt(row)) {
-        return;
-      }
-
-      auto* group = groups[row];
-      auto& accumulator = *value<ReduceAggAccumulator>(group);
-      if (!accumulator.hasValue()) {
-        // Copy initial value.
-        VELOX_USER_CHECK(
-            !initialValue->isNullAt(row),
-            "Initial value in reduce_agg cannot be null")
-        auto tracker = trackRowSize(group);
-        accumulator.write(initialValue.get(), row, allocator_);
-      }
-
-      accumulator.read(state, 0);
-
-      rawIndices[0] = row;
-      lambdaInput->children()[1] =
-          BaseVector::wrapInDictionary(nullptr, indices, 1, input);
-
-      expressionEvaluator_->evaluate(
-          inputExprSet_.get(), singleRow, *lambdaInput, newState);
-
-      VELOX_USER_CHECK(
-          !newState->isNullAt(0),
-          "Lambda expressions in reduce_agg should not return null for non-null inputs")
-
-      auto tracker = trackRowSize(group);
-      accumulator.write(newState.get(), 0, allocator_);
-    });
+      bool /*mayPushdown*/) override {
+    add(groups, rows, args, true /*rowInput*/);
   }
 
   void addIntermediateResults(
       char** groups,
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
-      bool mayPushdown) override {
-    const auto& lambda = initializeCombineLambda();
-
-    const auto& input = args[0];
-
-    auto* pool = allocator_->pool();
-    const auto lambdaInputType = lambda->signature();
-
-    const auto& stateType = lambdaInputType->childAt(0);
-    VectorPtr state = BaseVector::create(stateType, 1, pool);
-
-    auto lambdaInput = makeLambdaInput(lambdaInputType, 1, state, nullptr);
-
-    SelectivityVector singleRow(1);
-
-    BufferPtr indices = allocateIndices(1, pool);
-    auto* rawIndices = indices->asMutable<vector_size_t>();
-
-    VectorPtr newState;
-
-    rows.applyToSelected([&](auto row) {
-      if (input->isNullAt(row)) {
-        return;
-      }
-
-      auto* group = groups[row];
-      auto& accumulator = *value<ReduceAggAccumulator>(group);
-      if (!accumulator.hasValue()) {
-        // Copy input.
-        auto tracker = trackRowSize(group);
-        accumulator.write(input.get(), row, allocator_);
-        return;
-      }
-
-      accumulator.read(state, 0);
-
-      rawIndices[0] = row;
-      lambdaInput->children()[1] =
-          BaseVector::wrapInDictionary(nullptr, indices, 1, input);
-
-      expressionEvaluator_->evaluate(
-          combineExprSet_.get(), singleRow, *lambdaInput, newState);
-
-      VELOX_USER_CHECK(
-          !newState->isNullAt(0),
-          "Lambda expressions in reduce_agg should not return null for non-null inputs")
-
-      auto tracker = trackRowSize(group);
-      accumulator.write(newState.get(), 0, allocator_);
-    });
+      bool /*mayPushdown*/) override {
+    add(groups, rows, args, false /*rowInput*/);
   }
 
   void addSingleGroupRawInput(
@@ -287,19 +209,39 @@ class ReduceAgg : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool /*unused*/) override {
-    verifyInitialValueArg(args[1], rows);
+    const auto& input = args[0];
 
-    const auto& lambda = initializeInputLambda();
-
-    auto tracker = trackRowSize(group);
-    auto& accumulator = *value<ReduceAggAccumulator>(group);
-    if (!accumulator.hasValue()) {
-      // Copy initial value.
-      accumulator.write(args[1].get(), rows.begin(), allocator_);
+    auto nonNullIndices = collectNonNullRows(input, rows);
+    if (nonNullIndices->size() == 0) {
+      // Nothing to do. All input values are null.
+      return;
     }
 
-    applyLambda(
-        accumulator, args[0], rows, std::nullopt, lambda, *inputExprSet_);
+    const auto& initialValue = args[1];
+    verifyInitialValueArg(initialValue, rows);
+
+    const auto& lambda = initializeInputLambda();
+    const auto& lambdaInputType = lambda->signature();
+
+    // Convert non-null input values into 'state' values by applying
+    // inputFunction to a pair of (value, initialValue).
+    const auto numRows = nonNullIndices->size() / sizeof(vector_size_t);
+    auto nonNullInput =
+        BaseVector::wrapInDictionary(nullptr, nonNullIndices, numRows, input);
+    auto initialState = BaseVector::wrapInDictionary(
+        nullptr, nonNullIndices, numRows, initialValue);
+
+    auto lambdaInput =
+        makeLambdaInput(lambdaInputType, numRows, initialState, nonNullInput);
+
+    SelectivityVector nonNullRows(numRows);
+    VectorPtr combined;
+    expressionEvaluator_->evaluate(
+        inputExprSet_.get(), nonNullRows, *lambdaInput, combined);
+
+    checkStatesNotNull(combined, numRows);
+
+    addSingleGroup(combined, numRows, group);
   }
 
   void addSingleGroupIntermediateResults(
@@ -307,37 +249,19 @@ class ReduceAgg : public exec::Aggregate {
       const SelectivityVector& rows,
       const std::vector<VectorPtr>& args,
       bool mayPushdown) override {
-    auto& accumulator = *value<ReduceAggAccumulator>(group);
+    const auto& input = args[0];
 
-    std::optional<vector_size_t> skipRow;
-    if (!accumulator.hasValue()) {
-      // Copy first non-null value.
-      rows.testSelected([&](auto row) {
-        if (args[0]->isNullAt(row)) {
-          return true;
-        }
-
-        auto tracker = trackRowSize(group);
-        accumulator.write(args[0].get(), row, allocator_);
-        skipRow = row;
-        return false;
-      });
-    }
-
-    // All input values are null.
-    if (!accumulator.hasValue()) {
+    auto nonNullIndices = collectNonNullRows(input, rows);
+    if (nonNullIndices->size() == 0) {
+      // Nothing to do. All input values are null.
       return;
     }
 
-    // No rows left to process.
-    if (skipRow.has_value() && skipRow.value() == rows.end()) {
-      return;
-    }
+    auto numRows = nonNullIndices->size() / sizeof(vector_size_t);
+    auto combined =
+        BaseVector::wrapInDictionary(nullptr, nonNullIndices, numRows, input);
 
-    const auto& lambda = initializeCombineLambda();
-
-    auto tracker = trackRowSize(group);
-    applyLambda(accumulator, args[0], rows, skipRow, lambda, *combineExprSet_);
+    addSingleGroup(combined, numRows, group);
   }
 
   bool supportsToIntermediate() const override {
@@ -412,55 +336,6 @@ class ReduceAgg : public exec::Aggregate {
         std::vector<VectorPtr>{firstArg, secondArg});
   }
 
-  void applyLambda(
-      ReduceAggAccumulator& accumulator,
-      const VectorPtr& input,
-      const SelectivityVector& rows,
-      std::optional<vector_size_t> skipRow,
-      const core::LambdaTypedExprPtr& lambda,
-      exec::ExprSet& exprSet) {
-    auto* pool = allocator_->pool();
-
-    const auto lambdaInputType = lambda->signature();
-
-    const auto& stateType = lambdaInputType->childAt(0);
-    VectorPtr state = BaseVector::create(stateType, 1, pool);
-    accumulator.read(state, 0);
-
-    auto lambdaInput = makeLambdaInput(lambdaInputType, 1, state, nullptr);
-
-    SelectivityVector singleRow(1);
-
-    BufferPtr indices = allocateIndices(1, pool);
-    auto* rawIndices = indices->asMutable<vector_size_t>();
-
-    rows.applyToSelected([&](vector_size_t row) {
-      if (skipRow.has_value() && row <= skipRow.value()) {
-        return;
-      }
-
-      if (input->isNullAt(row)) {
-        return;
-      }
-
-      rawIndices[0] = row;
-      lambdaInput->children()[1] =
-          BaseVector::wrapInDictionary(nullptr, indices, 1, input);
-
-      VectorPtr newState;
-      expressionEvaluator_->evaluate(
-          &exprSet, singleRow, *lambdaInput, newState);
-
-      VELOX_USER_CHECK(
-          !newState->isNullAt(0),
-          "Lambda expressions in reduce_agg should not return null for non-null inputs");
-
-      lambdaInput->children()[0] = newState;
-    });
-
-    accumulator.write(lambdaInput->children()[0].get(), 0, allocator_);
-  }
-
   static void verifyInitialValueArg(
       const VectorPtr& arg,
       const SelectivityVector& rows) {
@@ -468,6 +343,10 @@ class ReduceAgg : public exec::Aggregate {
 
     VELOX_USER_CHECK(
         !arg->isNullAt(firstRow), "Initial value in reduce_agg cannot be null");
+
+    if (arg->isConstantEncoding()) {
+      return;
+    }
 
     rows.applyToSelected([&](vector_size_t row) {
       if (!arg->equalValueAt(arg.get(), firstRow, row)) {
@@ -506,6 +385,396 @@ class ReduceAgg : public exec::Aggregate {
     const auto& lambda = lambdaExpressions_[index];
     VELOX_CHECK_NOT_NULL(lambda);
     return lambda;
+  }
+
+  // Combines 'numRows' states from 'input' with an optional 'accumulator' state
+  // and writes the result back to the accumulator.
+  void addSingleGroup(VectorPtr& input, vector_size_t numRows, char* group) {
+    // Combine 'input' states and an optional 'accumulator' state into one.
+    vector_size_t numCombined = numRows;
+    auto& accumulator = *value<ReduceAggAccumulator>(group);
+    if (accumulator.hasValue()) {
+      prepareToAppendOne(input, numRows);
+      accumulator.read(input, numRows);
+      ++numCombined;
+    }
+
+    if (numCombined > 1) {
+      input = combine(input, numCombined);
+    }
+
+    auto tracker = trackRowSize(group);
+    accumulator.write(input.get(), 0, allocator_);
+  }
+
+  BufferPtr collectNonNullRows(
+      const VectorPtr& input,
+      const SelectivityVector& rows) {
+    BufferPtr indices = allocateIndices(rows.size(), allocator_->pool());
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+
+    vector_size_t i = 0;
+    rows.applyToSelected([&](auto row) {
+      if (!input->isNullAt(row)) {
+        rawIndices[i++] = row;
+      }
+    });
+
+    indices->setSize(sizeof(vector_size_t) * i);
+    return indices;
+  }
+
+  void checkStatesNotNull(const VectorPtr& states, vector_size_t size) {
+    if (!states->mayHaveNulls()) {
+      return;
+    }
+
+    for (auto i = 0; i < size; ++i) {
+      VELOX_USER_CHECK(
+          !states->isNullAt(i),
+          "Lambda expressions in reduce_agg should not return null for non-null inputs");
+    }
+  }
+
+  void checkStatesNotNull(
+      const VectorPtr& states,
+      const SelectivityVector& rows) {
+    if (!states->mayHaveNulls()) {
+      return;
+    }
+
+    rows.applyToSelected([&](auto row) {
+      VELOX_USER_CHECK(
+          !states->isNullAt(row),
+          "Lambda expressions in reduce_agg should not return null for non-null inputs");
+    });
+  }
+
+  void prepareToAppendOne(VectorPtr& vector, vector_size_t size) {
+    SelectivityVector extraRow(size + 1, false);
+    extraRow.setValid(size, true);
+    extraRow.updateBounds();
+
+    BaseVector::ensureWritable(
+        extraRow, vector->type(), allocator_->pool(), vector);
+  }
+
+  // Maps a group pointer to a pair of zero-based unique group index and a
+  // number of rows in the group.
+  using GroupMap = folly::F14FastMap<
+      char*,
+      std::pair<int32_t, int32_t>,
+      std::hash<char*>,
+      std::equal_to<char*>>;
+
+  void populateGroupCountsAndOffsets(
+      const GroupMap& groups,
+      std::vector<vector_size_t>& groupCounts,
+      std::vector<vector_size_t>& groupOffsets) {
+    for (const auto& [group, indexAndCount] : groups) {
+      groupCounts[indexAndCount.first] = indexAndCount.second;
+    }
+
+    vector_size_t offset = 0;
+    for (auto i = 0; i < groupCounts.size(); ++i) {
+      groupOffsets[i] = offset;
+      offset += groupCounts[i];
+    }
+  }
+
+  VectorPtr toStates(
+      const VectorPtr& input,
+      const VectorPtr& initialState,
+      const BufferPtr& groupedIndices,
+      const SelectivityVector& rows) {
+    const auto& lambda = initializeInputLambda();
+    const auto lambdaInputType = lambda->signature();
+
+    const auto numRows = rows.size();
+    auto lambdaInput = makeLambdaInput(
+        lambdaInputType,
+        numRows,
+        BaseVector::wrapInDictionary(
+            nullptr, groupedIndices, numRows, initialState),
+        BaseVector::wrapInDictionary(nullptr, groupedIndices, numRows, input));
+
+    VectorPtr states;
+    expressionEvaluator_->evaluate(
+        inputExprSet_.get(), rows, *lambdaInput, states);
+
+    checkStatesNotNull(states, rows);
+    return states;
+  }
+
+  void copyAccumulatorStates(
+      VectorPtr& states,
+      const SelectivityVector& groupRows,
+      const std::vector<char*>& groups,
+      std::vector<vector_size_t>& groupOffsets) {
+    SelectivityVector accumulatorRows(groupRows.size());
+    accumulatorRows.deselect(groupRows);
+
+    BaseVector::ensureWritable(
+        accumulatorRows, states->type(), allocator_->pool(), states);
+
+    const auto numGroups = groups.size();
+    for (auto i = 0; i < numGroups; ++i) {
+      auto* group = groups[i];
+      auto& accumulator = *value<ReduceAggAccumulator>(group);
+      if (accumulator.hasValue()) {
+        accumulator.read(states, groupOffsets[i]);
+        ++groupOffsets[i];
+      }
+    }
+  }
+
+  void add(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool rawInput) {
+    const auto& input = args[0];
+    auto* pool = allocator_->pool();
+
+    // Figure out a list of unique groups and number of entries per group.
+    GroupMap uniqueGroups;
+
+    vector_size_t numAccumulators = 0;
+    vector_size_t numNotNull = 0;
+    vector_size_t groupIndex = 0;
+
+    rows.applyToSelected([&](auto row) {
+      if (input->isNullAt(row)) {
+        return;
+      }
+
+      auto* group = groups[row];
+      ++numNotNull;
+
+      auto [it, ok] = uniqueGroups.insert({group, {groupIndex, 1}});
+      if (ok) {
+        ++groupIndex;
+        auto& accumulator = *value<ReduceAggAccumulator>(group);
+        if (accumulator.hasValue()) {
+          ++(it->second).second;
+          ++numAccumulators;
+        }
+      } else {
+        ++(it->second).second;
+      }
+    });
+
+    const auto numGroups = uniqueGroups.size();
+
+    std::vector<vector_size_t> groupCounts(numGroups, 0);
+    std::vector<vector_size_t> groupOffsets(numGroups, 0);
+    populateGroupCountsAndOffsets(uniqueGroups, groupCounts, groupOffsets);
+
+    // Place rows from the same group together. Add one more row at the end of
+    // each group for 'accumulator'.
+    const auto numStates = numNotNull + numAccumulators;
+
+    BufferPtr groupedIndices = allocateIndices(numStates, pool);
+    auto* rawGroupedIndices = groupedIndices->asMutable<vector_size_t>();
+
+    SelectivityVector groupRows(numStates, false);
+    rows.applyToSelected([&](auto row) {
+      if (input->isNullAt(row)) {
+        return;
+      }
+
+      auto* group = groups[row];
+      auto groupIndex = uniqueGroups.at(group).first;
+      auto offset = groupOffsets[groupIndex];
+
+      rawGroupedIndices[offset] = row;
+      groupRows.setValid(offset, true);
+      ++groupOffsets[groupIndex];
+    });
+    groupRows.updateBounds();
+
+    VectorPtr states;
+    if (rawInput) {
+      // Convert values into states. Append 'accumulator' state to groups as
+      // needed.
+      const auto& initialValue = args[1];
+      states = toStates(input, initialValue, groupedIndices, groupRows);
+    } else {
+      states = BaseVector::wrapInDictionary(
+          nullptr, groupedIndices, numStates, input);
+    }
+
+    std::vector<char*> indexedGroups(numGroups);
+    for (const auto& [group, indexAndCount] : uniqueGroups) {
+      indexedGroups[indexAndCount.first] = group;
+    }
+
+    // Append accumulators.
+    if (numAccumulators > 0) {
+      copyAccumulatorStates(states, groupRows, indexedGroups, groupOffsets);
+    }
+
+    // Restore offsets.
+    for (auto i = 0; i < numGroups; ++i) {
+      groupOffsets[i] -= groupCounts[i];
+    }
+
+    // Recursively combine states into one state per group and write to
+    // accumulators.
+    combine(states, numStates, indexedGroups, groupOffsets, groupCounts);
+  }
+
+  // Combine multiple per-group states into one state per group and write final
+  // states to the accumulators.
+  //
+  // @param states Per-group states to combine. All states from the same group
+  // appear together starting at groupOffsets[i] and going for groupCounts[i].
+  // @param groups Group pointer to lookup accumulators. The order of groups
+  // here matches 'groupOffsets' and 'groupCounts'.
+  // @param groupOffsets Offsets in 'states' vector for the start of the group.
+  // @param groupCounts Number of group entries in 'states' vector.
+  void combine(
+      const VectorPtr& states,
+      vector_size_t size,
+      const std::vector<char*>& groups,
+      std::vector<vector_size_t>& groupOffsets,
+      std::vector<vector_size_t>& groupCounts) {
+    const auto numGroups = groupOffsets.size();
+
+    BufferPtr leftIndices = allocateIndices(size, allocator_->pool());
+    auto rawLeftIndices = leftIndices->asMutable<vector_size_t>();
+    BufferPtr rightIndices = allocateIndices(size, allocator_->pool());
+    auto rawRightIndices = rightIndices->asMutable<vector_size_t>();
+
+    vector_size_t totalCount = 0;
+    SelectivityVector rows(size, false);
+
+    std::vector<vector_size_t> extraRowNumbers(size, 0);
+
+    for (auto i = 0; i < numGroups; ++i) {
+      // Split each group that has > 1 state in half.
+      auto count = groupCounts[i];
+      auto offset = groupOffsets[i];
+
+      // Update offset.
+      groupOffsets[i] = totalCount;
+
+      if (count == 0) {
+        continue;
+      }
+
+      if (count == 1) {
+        // Write the combined state to accumulator.
+        auto group = groups[i];
+        auto& accumulator = *value<ReduceAggAccumulator>(group);
+
+        auto tracker = trackRowSize(group);
+        accumulator.write(states.get(), offset, allocator_);
+
+        --groupCounts[i];
+        continue;
+      }
+
+      auto halfSize = count / 2;
+
+      for (auto j = 0; j < halfSize; ++j) {
+        rawLeftIndices[totalCount] = offset + j;
+        rawRightIndices[totalCount] = offset + halfSize + j;
+        rows.setValid(totalCount, true);
+        ++totalCount;
+      }
+
+      if (count % 2 == 1) {
+        // Leave space for the 'extra' state.
+        extraRowNumbers[totalCount] = offset + count - 1;
+        ++totalCount;
+      }
+
+      // Update count.
+      groupCounts[i] = totalCount - groupOffsets[i];
+    }
+    rows.updateBounds();
+
+    if (!rows.hasSelections()) {
+      // No group has more than 1 entry.
+      return;
+    }
+
+    // Combine states.
+    const auto& lambda = initializeCombineLambda();
+
+    const auto lambdaInputType = lambda->signature();
+
+    auto lambdaInput = makeLambdaInput(
+        lambdaInputType,
+        totalCount,
+        BaseVector::wrapInDictionary(nullptr, leftIndices, totalCount, states),
+        BaseVector::wrapInDictionary(
+            nullptr, rightIndices, totalCount, states));
+
+    VectorPtr combined;
+    expressionEvaluator_->evaluate(
+        combineExprSet_.get(), rows, *lambdaInput, combined);
+
+    checkStatesNotNull(combined, rows);
+
+    // Copy 'extra' states.
+    if (rows.countSelected() != totalCount) {
+      SelectivityVector extraRows(totalCount);
+      extraRows.deselect(rows);
+
+      BaseVector::ensureWritable(
+          extraRows, combined->type(), allocator_->pool(), combined);
+
+      combined->copy(states.get(), extraRows, extraRowNumbers.data());
+    }
+
+    // Keep combining.
+    combine(combined, totalCount, groups, groupOffsets, groupCounts);
+  }
+
+  // Combine first 'size' states into one.
+  VectorPtr combine(const VectorPtr& states, vector_size_t size) {
+    VELOX_CHECK_GT(size, 1);
+
+    const auto& lambda = initializeCombineLambda();
+
+    auto* pool = allocator_->pool();
+    const auto lambdaInputType = lambda->signature();
+
+    // [size/2, size) indices.
+    const auto halfSize = size / 2;
+    BufferPtr indices = allocateIndices(halfSize, pool);
+    auto* rawIndices = indices->asMutable<vector_size_t>();
+    std::iota(rawIndices, rawIndices + halfSize, halfSize);
+
+    auto lambdaInput = makeLambdaInput(
+        lambdaInputType,
+        halfSize,
+        states,
+        BaseVector::wrapInDictionary(nullptr, indices, halfSize, states));
+
+    SelectivityVector rows(halfSize);
+    VectorPtr combined;
+    expressionEvaluator_->evaluate(
+        combineExprSet_.get(), rows, *lambdaInput, combined);
+
+    checkStatesNotNull(combined, halfSize);
+
+    const bool hasExtraState = (size % 2 == 1);
+    const vector_size_t numCombined = halfSize + (hasExtraState ? 1 : 0);
+
+    if (numCombined == 1) {
+      return combined;
+    }
+
+    if (hasExtraState) {
+      // Add 'extra' state to 'combined'.
+      prepareToAppendOne(combined, halfSize);
+      combined->copy(states.get(), halfSize, size - 1, 1);
+    }
+
+    return combine(combined, numCombined);
   }
 
   mutable std::unique_ptr<exec::ExprSet> inputExprSet_;

--- a/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
@@ -34,7 +34,7 @@ class ReduceAggTest : public functions::aggregate::test::AggregationTestBase {
 
   std::vector<RowVectorPtr> fuzzData() {
     VectorFuzzer::Options opts;
-    opts.vectorSize = 1'000;
+    opts.vectorSize = 10'000;
     opts.nullRatio = 0.1;
     VectorFuzzer fuzzer(opts, pool());
 


### PR DESCRIPTION
Summary:
Optimize global reduce_agg to evaluate lambda expressions log2(n) times where n is number of rows. The original implementation evaluates expressions n times.

Add benchmark. Initially, reduce_agg is 60x slower than sum. After optimization it is "only" 4x slower.

Before:

```
============================================================================
[...]l/aggregates/benchmarks/ReduceAgg.cpp     relative  time/iter   iters/s
============================================================================
reduce_agg                                                   1.14s   873.85m
sum                                             67438.%     1.70ms    589.31
```

After:

```
============================================================================
[...]l/aggregates/benchmarks/ReduceAgg.cpp     relative  time/iter   iters/s
============================================================================
reduce_agg                                                  6.16ms    162.39
sum                                             360.26%     1.71ms    585.03
```

Differential Revision: D49192172


