### PR TITLE
Ensure RowVector::resize also resizes the children.

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -61,13 +61,12 @@ void SelectiveStructColumnReaderBase::next(
       numValues -= bits::countBits(mutation->deletedRows, 0, numValues);
     }
 
+    auto resultRowVector = std::dynamic_pointer_cast<RowVector>(result);
     // no readers
     // This can be either count(*) query or a query that select only
     // constant columns (partition keys or columns missing from an old file
     // due to schema evolution)
-    result->resize(numValues);
-
-    auto resultRowVector = std::dynamic_pointer_cast<RowVector>(result);
+    resultRowVector->setSize(numValues);
     auto& childSpecs = scanSpec_->children();
     for (auto& childSpec : childSpecs) {
       VELOX_CHECK(childSpec->isConstant());
@@ -319,7 +318,7 @@ void SelectiveStructColumnReaderBase::getValues(
         std::move(children));
   }
   auto* resultRow = static_cast<RowVector*>(result->get());
-  resultRow->resize(rows.size());
+  resultRow->setSize(rows.size());
   if (!rows.size()) {
     return;
   }

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -277,8 +277,10 @@ struct VectorWriter<Row<T...>> : public VectorWriterBase {
 
   void ensureSize(size_t size) override {
     if (size > rowVector_->size()) {
+      // Note order is important here, we resize children first to ensure
+      // data_ is cached and are not reset when rowVector resizes them.
+      resizeVectorWriters<0>(size);
       rowVector_->resize(size, /*setNotNull*/ false);
-      resizeVectorWriters<0>(rowVector_->size());
     }
   }
 
@@ -706,10 +708,10 @@ struct VectorWriter<DynamicRow, void> : public VectorWriterBase {
 
   void ensureSize(size_t size) override {
     if (size > rowVector_->size()) {
-      rowVector_->resize(size, /*setNotNull*/ false);
       for (int i = 0; i < writer_.childrenCount_; ++i) {
         writer_.childrenWriters_[i]->ensureSize(size);
       }
+      rowVector_->resize(size, /*setNotNull*/ false);
     }
   }
 

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -289,6 +289,8 @@ TEST_F(MapFromEntriesTest, arrayOfDictionaryRowOfNulls) {
   RowVectorPtr rowVector =
       makeRowVector({makeFlatVector<int32_t>(0), makeFlatVector<int32_t>(0)});
   rowVector->resize(4);
+  rowVector->childAt(0)->resize(0);
+  rowVector->childAt(1)->resize(0);
   for (int i = 0; i < rowVector->size(); i++) {
     rowVector->setNull(i, true);
   }
@@ -324,7 +326,8 @@ TEST_F(MapFromEntriesTest, arrayOfConstantRowOfNulls) {
       makeRowVector({makeFlatVector<int32_t>(0), makeFlatVector<int32_t>(0)});
   rowVector->resize(1);
   rowVector->setNull(0, true);
-
+  rowVector->childAt(0)->resize(0);
+  rowVector->childAt(1)->resize(0);
   EXPECT_EQ(rowVector->childAt(0)->size(), 0);
   EXPECT_EQ(rowVector->childAt(1)->size(), 0);
 

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -596,6 +596,24 @@ void RowVector::validate(const VectorValidateOptions& options) const {
   }
 }
 
+void RowVector::resize(vector_size_t newSize, bool setNotNull) {
+  BaseVector::resize(newSize, setNotNull);
+
+  // Resize all the children.
+  for (auto& child : children_) {
+    if (child) {
+      if (child->isLazy()) {
+        VELOX_FAIL("Resize on a lazy vector is not allowed");
+      }
+      child->resize(newSize, setNotNull);
+    }
+  }
+}
+
+void RowVector::setSize(vector_size_t newSize) {
+  BaseVector::resize(newSize);
+}
+
 void ArrayVectorBase::checkRanges() const {
   std::unordered_map<vector_size_t, vector_size_t> seenElements;
   seenElements.reserve(size());

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -196,6 +196,15 @@ class RowVector : public BaseVector {
 
   void validate(const VectorValidateOptions& options) const override;
 
+  void resize(vector_size_t newSize, bool setNotNull = true) override;
+
+  /// This is required for SelectiveStructReader,
+  /// which requires that the parent be resized, without
+  /// affecting the children. The Reader ensures that the
+  /// resultant rows will be copyable. Use resize()
+  /// unless you have very good reasons to use setSize().
+  void setSize(vector_size_t newSize);
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1443,6 +1443,88 @@ TEST_F(VectorTest, wrapInConstantWithCopy) {
   }
 }
 
+TEST_F(VectorTest, rowResize) {
+  auto testRowResize = [&](std::vector<VectorPtr> children, bool setNotNull) {
+    auto rowVector = vectorMaker_.rowVector(children);
+    auto oldSize = rowVector->size();
+    auto newSize = oldSize * 2;
+
+    rowVector->resize(newSize, setNotNull);
+
+    EXPECT_EQ(rowVector->size(), newSize);
+
+    for (auto& child : children) {
+      EXPECT_EQ(child->size(), newSize);
+    }
+
+    if (setNotNull) {
+      for (int i = oldSize; i < newSize; i++) {
+        EXPECT_EQ(rowVector->isNullAt(i), !setNotNull);
+        for (auto& child : children) {
+          EXPECT_EQ(child->isNullAt(i), !setNotNull);
+        }
+      }
+    }
+  };
+
+  // FlatVectors.
+  testRowResize(
+      {vectorMaker_.flatVector<int32_t>(10),
+       vectorMaker_.flatVector<int64_t>(10)},
+      false);
+
+  testRowResize(
+      {vectorMaker_.flatVector<int32_t>(10),
+       vectorMaker_.flatVector<double>(10)},
+      true);
+
+  testRowResize({vectorMaker_.flatVector<StringView>(10)}, true);
+  testRowResize({vectorMaker_.flatVector<StringView>(10)}, false);
+
+  // Dictionaries.
+  testRowResize(
+      {BaseVector::wrapInDictionary(
+          nullptr,
+          makeIndices(10, [](auto row) { return row; }),
+          10,
+          BaseVector::wrapInDictionary(
+              nullptr,
+              makeIndices(10, [](auto row) { return row; }),
+              10,
+              vectorMaker_.flatVector<int32_t>(10)))},
+      true);
+
+  // Constants.
+  auto constant = BaseVector::wrapInConstant(
+      10,
+      5,
+      vectorMaker_.arrayVector<int32_t>(
+          10,
+          [](auto row) { return row % 5 + 1; },
+          [](auto row, auto index) { return row * 2 + index; }));
+  testRowResize({constant}, true);
+
+  // Complex Types.
+  testRowResize(
+      {vectorMaker_.arrayVector<int32_t>(
+           10,
+           [](auto row) { return row % 5 + 1; },
+           [](auto row, auto index) { return row * 2 + index; }),
+       vectorMaker_.mapVector<int64_t, double>(
+           10,
+           [](auto row) { return row % 5 + 1; },
+           [](auto /*row*/, auto index) { return index; },
+           [](auto row, auto index) { return row * 2 + index + 0.01; })},
+      true);
+
+  // Resize on lazy children will result in an exception.
+  auto rowWithLazyChild = makeRowVector({vectorMaker_.lazyFlatVector<int32_t>(
+      10,
+      [&](vector_size_t i) { return i % 5; },
+      [](vector_size_t i) { return i % 7 == 0; })});
+  EXPECT_THROW(rowWithLazyChild->resize(20), VeloxException);
+}
+
 TEST_F(VectorTest, wrapConstantInDictionary) {
   // Wrap Constant in Dictionary with no extra nulls. Expect Constant.
   auto indices = makeIndices(10, [](auto row) { return row % 2; });


### PR DESCRIPTION
Currently when we call resize on a rowVector we do not resize its children. This creates problems for example in ContainerRowSerde where we resize the parent row (but the children still have the old size) and the new rows are not set to null. In general ensuring children are of same size as parent in resize helps to ensure vector is in a valid state. 