### PR TITLE
Optimize large chunk memory allocation in stream arena

### DIFF
--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -46,6 +46,11 @@ struct AllocationTraits {
     return bits::roundUp(bytes, kPageSize) / kPageSize;
   }
 
+  /// Returns the round up page bytes.
+  FOLLY_ALWAYS_INLINE static MachinePageCount roundUpPageBytes(uint64_t bytes) {
+    return bits::roundUp(bytes, kPageSize);
+  }
+
   /// The number of pages in a huge page.
   FOLLY_ALWAYS_INLINE static MachinePageCount numPagesInHugePage() {
     VELOX_DCHECK_GE(kHugePageSize, kPageSize);

--- a/velox/common/memory/ByteStream.cpp
+++ b/velox/common/memory/ByteStream.cpp
@@ -18,6 +18,10 @@
 
 namespace facebook::velox {
 
+std::string ByteRange::toString() const {
+  return fmt::format("[{} starting at {}]", succinctBytes(size), position);
+}
+
 size_t ByteStream::size() const {
   if (ranges_.empty()) {
     return 0;

--- a/velox/common/memory/ByteStream.h
+++ b/velox/common/memory/ByteStream.h
@@ -23,14 +23,16 @@
 namespace facebook::velox {
 
 struct ByteRange {
-  // Start of buffer. Not owned.
+  /// Start of buffer. Not owned.
   uint8_t* buffer;
 
-  // Number of bytes or bits starting at 'buffer'.
+  /// Number of bytes or bits starting at 'buffer'.
   int32_t size;
 
-  // Index of next byte/bit to be read/written in 'buffer'.
+  /// Index of next byte/bit to be read/written in 'buffer'.
   int32_t position;
+
+  std::string toString() const;
 };
 
 class OutputStreamListener {

--- a/velox/common/memory/tests/AllocationTest.cpp
+++ b/velox/common/memory/tests/AllocationTest.cpp
@@ -28,6 +28,12 @@ class AllocationTest : public testing::Test {};
 
 TEST_F(AllocationTest, basic) {
   ASSERT_EQ(AllocationTraits::numPagesInHugePage(), 512);
+  ASSERT_EQ(AllocationTraits::roundUpPageBytes(0), 0);
+  ASSERT_EQ(AllocationTraits::roundUpPageBytes(1), AllocationTraits::kPageSize);
+  ASSERT_EQ(
+      AllocationTraits::roundUpPageBytes(4093), AllocationTraits::kPageSize);
+  ASSERT_EQ(
+      AllocationTraits::roundUpPageBytes(4094), AllocationTraits::kPageSize);
 }
 
 // This test is to verify that Allocation doesn't merge different append buffers

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -25,7 +25,8 @@ add_executable(
   MemoryManagerTest.cpp
   MemoryPoolTest.cpp
   MockSharedArbitratorTest.cpp
-  SharedArbitratorTest.cpp)
+  SharedArbitratorTest.cpp
+  StreamArenaTest.cpp)
 
 target_link_libraries(
   velox_memory_test

--- a/velox/common/memory/tests/StreamArenaTest.cpp
+++ b/velox/common/memory/tests/StreamArenaTest.cpp
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/ByteStream.h"
+#include "velox/common/memory/MemoryAllocator.h"
+#include "velox/common/memory/MmapAllocator.h"
+
+#include <gflags/gflags.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::memory;
+
+class StreamArenaTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    constexpr uint64_t kMaxMappedMemory = 64 << 20;
+    MmapAllocator::Options options;
+    options.capacity = kMaxMappedMemory;
+    mmapAllocator_ = std::make_shared<MmapAllocator>(options);
+    MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
+    memoryManager_ = std::make_unique<MemoryManager>(MemoryManagerOptions{
+        .capacity = kMaxMappedMemory,
+        .allocator = MemoryAllocator::getInstance()});
+    pool_ = memoryManager_->addLeafPool("ByteStreamTest");
+    rng_.seed(124);
+  }
+
+  void TearDown() override {
+    MmapAllocator::testingDestroyInstance();
+    MemoryAllocator::setDefaultInstance(nullptr);
+  }
+
+  std::unique_ptr<StreamArena> newArena() {
+    return std::make_unique<StreamArena>(pool_.get());
+  }
+
+  folly::Random::DefaultGenerator rng_;
+  std::shared_ptr<MmapAllocator> mmapAllocator_;
+  std::unique_ptr<MemoryManager> memoryManager_;
+  std::shared_ptr<memory::MemoryPool> pool_;
+};
+
+TEST_F(StreamArenaTest, newRange) {
+  const int largestClassPageSize = 1 << 20;
+  struct {
+    std::vector<uint64_t> requestRangeSizes;
+    std::vector<uint64_t> expectedRangeSizes;
+    uint64_t expectedNonContiguousAllocationSize;
+    uint64_t expectedContiguousAllocationSize;
+
+    std::string debugString() const {
+      return fmt::format(
+          "requestRangeSizes[{}]\nexpectedRangeSizes[{}]\nexpectedNonContiguousAllocationSize[{}]\nexpectedContiguousAllocationSize[{}]\n",
+          folly::join(",", requestRangeSizes),
+          folly::join(",", expectedRangeSizes),
+          succinctBytes(expectedNonContiguousAllocationSize),
+          succinctBytes(expectedContiguousAllocationSize));
+    }
+  } testSettings[] = {
+      {{largestClassPageSize + 1,
+        largestClassPageSize + 1,
+        largestClassPageSize + 1,
+        2 * largestClassPageSize},
+       {largestClassPageSize + AllocationTraits::kPageSize,
+        largestClassPageSize + AllocationTraits::kPageSize,
+        largestClassPageSize + AllocationTraits::kPageSize,
+        2 * largestClassPageSize},
+       0,
+       largestClassPageSize * 5 + AllocationTraits::kPageSize * 3},
+      {{largestClassPageSize - 1,
+        1,
+        largestClassPageSize + 1,
+        largestClassPageSize / 2,
+        1,
+        AllocationTraits::kPageSize + 1,
+        AllocationTraits::kPageSize},
+       {largestClassPageSize - 1,
+        1,
+        largestClassPageSize + AllocationTraits::kPageSize,
+        largestClassPageSize / 2,
+        1,
+        AllocationTraits::kPageSize + 1,
+        AllocationTraits::kPageSize - 2},
+       largestClassPageSize + largestClassPageSize / 2 +
+           AllocationTraits::kPageSize * 2,
+       largestClassPageSize + AllocationTraits::kPageSize}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+    ASSERT_EQ(
+        testData.requestRangeSizes.size(), testData.expectedRangeSizes.size());
+
+    auto arena = newArena();
+    ByteRange range;
+    for (int i = 0; i < testData.requestRangeSizes.size(); ++i) {
+      arena->newRange(testData.requestRangeSizes[i], &range);
+      ASSERT_EQ(range.size, testData.expectedRangeSizes[i]) << range.toString();
+      ASSERT_EQ(range.position, 0);
+      ASSERT_TRUE(range.buffer != nullptr);
+    }
+    ASSERT_EQ(
+        testData.expectedContiguousAllocationSize +
+            testData.expectedNonContiguousAllocationSize,
+        arena->size());
+    const int allocateBytes =
+        AllocationTraits::pageBytes(mmapAllocator_->numAllocated());
+    const int contiguousBytes =
+        AllocationTraits::pageBytes(mmapAllocator_->numExternalMapped());
+    ASSERT_EQ(
+        testData.expectedNonContiguousAllocationSize,
+        allocateBytes - contiguousBytes);
+    ASSERT_EQ(testData.expectedContiguousAllocationSize, contiguousBytes);
+  }
+}
+
+TEST_F(StreamArenaTest, randomRange) {
+  const int numRanges = 30;
+  auto arena = newArena();
+  ByteRange range;
+  for (int i = 0; i < numRanges; ++i) {
+    if (folly::Random::oneIn(4)) {
+      const int requestSize =
+          1 + folly::Random::rand32() % (2 * AllocationTraits::kPageSize);
+      arena->newTinyRange(requestSize, &range);
+      ASSERT_EQ(range.size, requestSize);
+    } else if (folly::Random::oneIn(3)) {
+      const int requestSize =
+          AllocationTraits::pageBytes(pool_->largestSizeClass()) +
+          (folly::Random::rand32() % (4 << 20));
+      arena->newRange(requestSize, &range);
+      ASSERT_EQ(AllocationTraits::roundUpPageBytes(requestSize), range.size);
+    } else {
+      const int requestSize =
+          1 + folly::Random::rand32() % pool_->largestSizeClass();
+      arena->newRange(requestSize, &range);
+      ASSERT_LE(range.size, AllocationTraits::roundUpPageBytes(requestSize));
+    }
+    ASSERT_EQ(range.position, 0);
+    ASSERT_TRUE(range.buffer != nullptr);
+  }
+}
+
+TEST_F(StreamArenaTest, error) {
+  auto arena = newArena();
+  ByteRange range;
+  VELOX_ASSERT_THROW(
+      arena->newTinyRange(0, &range),
+      "StreamArena::newTinyRange can't be zero length");
+  VELOX_ASSERT_THROW(
+      arena->newRange(0, &range), "StreamArena::newRange can't be zero length");
+}


### PR DESCRIPTION
In Meta internal spilling shadowing test, we found the non-contiguous
memory allocations in stream arena is not optimized for large chunk
memory allocation when disk spilling code path to flush serialized data
from VectorStreamGroup to IOBufOutputStream in SpillFileList::flush().
In that case, we already know the total required bytes for IOBufOutputStream
so we can reserve enough space on the initial range. Ideally, there will
be one iobuf flushed to remote storage. However, if IOBufOutputStream
allocate more than the largest class page, then the stream arena will only
returns the first class page (or first page run in non-contiguous memory
allocation) which is guaranteed to be contiguous. Then followup allocations
come with small pieces which is based on each serialized stream sizes.

This PR optimize the large chunk memory allocation in stream arena by allocating
a large contiguous memory instead of non-contiguous memory buffers. Unit
tests are added to cover the new behavior.