### PR TITLE
reduce fuzzer run MAX_LINK_JOBS to 4

### DIFF
--- a/.circleci/dist_compile.yml
+++ b/.circleci/dist_compile.yml
@@ -105,7 +105,7 @@ commands:
       - run:
           name: Build
           command: |
-            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=6
+            make debug NUM_THREADS=16 MAX_HIGH_MEM_JOBS=8 MAX_LINK_JOBS=4
             ccache -s
           no_output_timeout: 1h
       - run:


### PR DESCRIPTION
Summary: CircleCi running out of memory.

Differential Revision: D49233704


