### PR TITLE
Support UNKNOWN type in arbitrary aggregation

### DIFF
--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -300,6 +300,8 @@ exec::AggregateRegistrationResult registerArbitrary(const std::string& name) {
           case TypeKind::MAP:
             [[fallthrough]];
           case TypeKind::ROW:
+            [[fallthrough]];
+          case TypeKind::UNKNOWN:
             return std::make_unique<NonNumericArbitrary>(inputType);
           default:
             VELOX_FAIL(

--- a/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ArbitraryTest.cpp
@@ -87,34 +87,34 @@ TEST_F(ArbitraryTest, noNulls) {
 
 TEST_F(ArbitraryTest, nulls) {
   auto vectors = {
-      makeRowVector({
-          makeNullableFlatVector<int32_t>({1, 1, 2, 2, 3, 3}),
-          makeNullableFlatVector<int64_t>(
-              {std::nullopt, std::nullopt, std::nullopt, 4, std::nullopt, 5}),
-          makeNullableFlatVector<double>({
-              std::nullopt,
-              0.50,
-              std::nullopt,
-              std::nullopt,
-              0.25,
-              std::nullopt,
-          }),
-      }),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1, 2, 2, 3, 3}),
+           makeNullableFlatVector<int64_t>(
+               {std::nullopt, std::nullopt, std::nullopt, 4, std::nullopt, 5}),
+           makeNullableFlatVector<double>({
+               std::nullopt,
+               0.50,
+               std::nullopt,
+               std::nullopt,
+               0.25,
+               std::nullopt,
+           }),
+           makeNullConstant(TypeKind::UNKNOWN, 6)}),
   };
 
   // Global aggregation.
   testAggregations(
       vectors,
       {},
-      {"arbitrary(c1)", "arbitrary(c2)"},
-      "SELECT * FROM( VALUES (4, 0.50)) AS t");
+      {"arbitrary(c1)", "arbitrary(c2)", "arbitrary(c3)"},
+      "SELECT * FROM( VALUES (4, 0.50, NULL)) AS t");
 
   // Group by aggregation.
   testAggregations(
       vectors,
       {"c0"},
-      {"arbitrary(c1)", "arbitrary(c2)"},
-      "SELECT * FROM(VALUES (1, NULL, 0.50), (2, 4, NULL), (3, 5, 0.25)) AS t");
+      {"arbitrary(c1)", "arbitrary(c2)", "arbitrary(c3)"},
+      "SELECT * FROM(VALUES (1, NULL, 0.50, NULL), (2, 4, NULL, NULL), (3, 5, 0.25, NULL)) AS t");
 }
 
 TEST_F(ArbitraryTest, varchar) {


### PR DESCRIPTION
Summary:
This change adds support for the UNKNOWN type in arbitrary aggregation, it's fairly trivial since
NonNumericArbitrary supports it directly.

Differential Revision: D49241110


