### PR TITLE
Set memory reclaimer for writer pool to avoid arbitration deadlock

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -56,6 +56,9 @@ class MemoryManager;
 
 constexpr int64_t kMaxMemory = std::numeric_limits<int64_t>::max();
 
+/// Sets the memory reclaimer to the provided memory pool.
+using SetMemoryReclaimer = std::function<void(MemoryPool*)>;
+
 /// This class provides the memory allocation interfaces for a query execution.
 /// Each query execution entity creates a dedicated memory pool object. The
 /// memory pool objects from a query are organized as a tree with four levels

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -495,6 +495,7 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   options.schema = inputType_;
   options.memoryPool = connectorQueryCtx_->connectorMemoryPool();
   options.compressionKind = insertTableHandle_->compressionKind();
+  options.setMemoryReclaimer = connectorQueryCtx_->setMemoryReclaimer();
   ioStats_.emplace_back(std::make_shared<dwio::common::IoStatistics>());
   auto writer = writerFactory_->createWriter(
       dwio::common::FileSink::create(

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -17,7 +17,6 @@
 #include <gtest/gtest.h>
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
-#include <folly/Singleton.h>
 #include <folly/init/Init.h>
 #include "velox/common/base/Fs.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -48,6 +47,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
     connectorQueryCtx_ = std::make_unique<connector::ConnectorQueryCtx>(
         opPool_.get(),
         connectorPool_.get(),
+        nullptr,
         connectorConfig_.get(),
         nullptr,
         nullptr,

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -623,7 +623,8 @@ class ReaderOptions {
 struct WriterOptions {
   TypePtr schema;
   velox::memory::MemoryPool* memoryPool;
-  std::optional<velox::common::CompressionKind> compressionKind = {};
+  velox::memory::SetMemoryReclaimer setMemoryReclaimer{nullptr};
+  std::optional<velox::common::CompressionKind> compressionKind;
 };
 
 } // namespace common

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -65,13 +65,20 @@ Writer::Writer(
       !pool->isLeaf(),
       "Memory pool {} for DWRF writer can't be leaf",
       pool->name());
+  if (options.setMemoryReclaimer != nullptr) {
+    options.setMemoryReclaimer(pool.get());
+  }
   auto handler =
       (options.encryptionSpec ? encryption::EncryptionHandler::create(
                                     schema_,
                                     *options.encryptionSpec,
                                     options.encrypterFactory.get())
                               : nullptr);
-  writerBase_->initContext(options.config, std::move(pool), std::move(handler));
+  writerBase_->initContext(
+      options.config,
+      std::move(pool),
+      options.setMemoryReclaimer,
+      std::move(handler));
   auto& context = writerBase_->getContext();
   context.buildPhysicalSizeAggregators(*schema_);
   if (options.flushPolicyFactory == nullptr) {
@@ -543,6 +550,7 @@ dwrf::WriterOptions getDwrfOptions(const dwio::common::WriterOptions& options) {
   dwrfOptions.config = Config::fromMap(configs);
   dwrfOptions.schema = options.schema;
   dwrfOptions.memoryPool = options.memoryPool;
+  dwrfOptions.setMemoryReclaimer = options.setMemoryReclaimer;
   return dwrfOptions;
 }
 

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -33,6 +33,7 @@ struct WriterOptions {
   std::shared_ptr<const Config> config = std::make_shared<Config>();
   std::shared_ptr<const Type> schema;
   velox::memory::MemoryPool* memoryPool;
+  velox::memory::SetMemoryReclaimer setMemoryReclaimer{nullptr};
   /// The default factory allows the writer to construct the default flush
   /// policy with the configs in its ctor.
   std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory;

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -72,9 +72,14 @@ class WriterBase {
   void initContext(
       const std::shared_ptr<const Config>& config,
       std::shared_ptr<velox::memory::MemoryPool> pool,
+      const velox::memory::SetMemoryReclaimer& setReclaimer = nullptr,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr) {
     context_ = std::make_unique<WriterContext>(
-        config, std::move(pool), sink_->metricsLog(), std::move(handler));
+        config,
+        std::move(pool),
+        setReclaimer,
+        sink_->metricsLog(),
+        std::move(handler));
     writerSink_ = std::make_unique<WriterSink>(
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -20,6 +20,56 @@ namespace facebook::velox::dwrf {
 namespace {
 constexpr uint32_t MIN_INDEX_STRIDE = 1000;
 }
+
+WriterContext::WriterContext(
+    const std::shared_ptr<const Config>& config,
+    std::shared_ptr<memory::MemoryPool> pool,
+    const memory::SetMemoryReclaimer& setReclaimer,
+    const dwio::common::MetricsLogPtr& metricLogger,
+    std::unique_ptr<encryption::EncryptionHandler> handler)
+    : config_{config},
+      pool_{std::move(pool)},
+      dictionaryPool_{pool_->addLeafChild(".dictionary")},
+      outputStreamPool_{pool_->addLeafChild(".compression")},
+      generalPool_{pool_->addLeafChild(".general")},
+      indexEnabled_{getConfig(Config::CREATE_INDEX)},
+      indexStride_{getConfig(Config::ROW_INDEX_STRIDE)},
+      compression_{getConfig(Config::COMPRESSION)},
+      compressionBlockSize_{getConfig(Config::COMPRESSION_BLOCK_SIZE)},
+      shareFlatMapDictionaries_{getConfig(Config::MAP_FLAT_DICT_SHARE)},
+      stripeSizeFlushThreshold_{getConfig(Config::STRIPE_SIZE)},
+      dictionarySizeFlushThreshold_{getConfig(Config::MAX_DICTIONARY_SIZE)},
+      streamSizeAboveThresholdCheckEnabled_{
+          getConfig(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED)},
+      rawDataSizePerBatch_{getConfig(Config::RAW_DATA_SIZE_PER_BATCH)},
+      // Currently logging with no metadata. Might consider populating
+      // metadata with dwio::common::request::AccessDescriptor upstream and
+      // pass down the metric log.
+      metricLogger_{metricLogger},
+      handler_{std::move(handler)} {
+  if (setReclaimer != nullptr) {
+    setReclaimer(dictionaryPool_.get());
+    setReclaimer(outputStreamPool_.get());
+    setReclaimer(generalPool_.get());
+  }
+  const bool forceLowMemoryMode{getConfig(Config::FORCE_LOW_MEMORY_MODE)};
+  const bool disableLowMemoryMode{getConfig(Config::DISABLE_LOW_MEMORY_MODE)};
+  VELOX_CHECK(!(forceLowMemoryMode && disableLowMemoryMode));
+  checkLowMemoryMode_ = !forceLowMemoryMode && !disableLowMemoryMode;
+  if (forceLowMemoryMode) {
+    setLowMemoryMode();
+  }
+  if (handler_ == nullptr) {
+    handler_ = std::make_unique<encryption::EncryptionHandler>();
+  }
+  validateConfigs();
+  VLOG(2) << fmt::format("Compression config: {}", compression_);
+  if (compression_ != common::CompressionKind_NONE) {
+    compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
+        *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
+  }
+}
+
 void WriterContext::validateConfigs() const {
   // the writer is implemented with strong assumption that index is enabled.
   // Things like dictionary encoding will fail if not. Before we clean that up,

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -41,46 +41,10 @@ class WriterContext : public CompressionBufferPool {
   WriterContext(
       const std::shared_ptr<const Config>& config,
       std::shared_ptr<memory::MemoryPool> pool,
+      const memory::SetMemoryReclaimer& setReclaimer = nullptr,
       const dwio::common::MetricsLogPtr& metricLogger =
           dwio::common::MetricsLog::voidLog(),
-      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr)
-      : config_{config},
-        pool_{std::move(pool)},
-        dictionaryPool_{pool_->addLeafChild(".dictionary")},
-        outputStreamPool_{pool_->addLeafChild(".compression")},
-        generalPool_{pool_->addLeafChild(".general")},
-        indexEnabled_{getConfig(Config::CREATE_INDEX)},
-        indexStride_{getConfig(Config::ROW_INDEX_STRIDE)},
-        compression_{getConfig(Config::COMPRESSION)},
-        compressionBlockSize_{getConfig(Config::COMPRESSION_BLOCK_SIZE)},
-        shareFlatMapDictionaries_{getConfig(Config::MAP_FLAT_DICT_SHARE)},
-        stripeSizeFlushThreshold_{getConfig(Config::STRIPE_SIZE)},
-        dictionarySizeFlushThreshold_{getConfig(Config::MAX_DICTIONARY_SIZE)},
-        streamSizeAboveThresholdCheckEnabled_{
-            getConfig(Config::STREAM_SIZE_ABOVE_THRESHOLD_CHECK_ENABLED)},
-        rawDataSizePerBatch_{getConfig(Config::RAW_DATA_SIZE_PER_BATCH)},
-        // Currently logging with no metadata. Might consider populating
-        // metadata with dwio::common::request::AccessDescriptor upstream and
-        // pass down the metric log.
-        metricLogger_{metricLogger},
-        handler_{std::move(handler)} {
-    const bool forceLowMemoryMode{getConfig(Config::FORCE_LOW_MEMORY_MODE)};
-    const bool disableLowMemoryMode{getConfig(Config::DISABLE_LOW_MEMORY_MODE)};
-    VELOX_CHECK(!(forceLowMemoryMode && disableLowMemoryMode));
-    checkLowMemoryMode_ = !forceLowMemoryMode && !disableLowMemoryMode;
-    if (forceLowMemoryMode) {
-      setLowMemoryMode();
-    }
-    if (handler_ == nullptr) {
-      handler_ = std::make_unique<encryption::EncryptionHandler>();
-    }
-    validateConfigs();
-    VLOG(2) << fmt::format("Compression config: {}", compression_);
-    if (compression_ != common::CompressionKind_NONE) {
-      compressionBuffer_ = std::make_unique<dwio::common::DataBuffer<char>>(
-          *generalPool_, compressionBlockSize_ + PAGE_HEADER_SIZE);
-    }
-  }
+      std::unique_ptr<encryption::EncryptionHandler> handler = nullptr);
 
   bool hasStream(const DwrfStreamIdentifier& stream) const {
     return streams_.find(stream) != streams_.end();

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -50,10 +50,12 @@ OperatorCtx::createConnectorQueryCtx(
     const std::string& connectorId,
     const std::string& planNodeId,
     memory::MemoryPool* connectorPool,
+    memory::SetMemoryReclaimer setMemoryReclaimer,
     const common::SpillConfig* spillConfig) const {
   return std::make_shared<connector::ConnectorQueryCtx>(
       pool_,
       connectorPool,
+      std::move(setMemoryReclaimer),
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       spillConfig,
       std::make_unique<SimpleExpressionEvaluator>(

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -226,6 +226,7 @@ class OperatorCtx {
       const std::string& connectorId,
       const std::string& planNodeId,
       memory::MemoryPool* connectorPool,
+      memory::SetMemoryReclaimer setMemoryReclaimer = nullptr,
       const common::SpillConfig* spillConfig = nullptr) const;
 
  private:
@@ -554,12 +555,13 @@ class Operator : public BaseRuntimeStatWriter {
     void abort(memory::MemoryPool* pool, const std::exception_ptr& /* error */)
         override;
 
-   private:
+   protected:
     MemoryReclaimer(const std::shared_ptr<Driver>& driver, Operator* op)
         : driver_(driver), op_(op) {
       VELOX_CHECK_NOT_NULL(op_);
     }
 
+   private:
     // Gets the shared pointer to the associated driver to ensure the liveness
     // of the operator during the memory reclaim operation.
     //


### PR DESCRIPTION
We have integrate the memory pools used internally by file writer with
memory arbitration which can cause memory arbitration deadlock if
file writer initiate the memory arbitration as there is no arbitration enter
handling which puts the driver thread into suspended state. This PR
integrates the memory pool used by file writer with memory arbitration by
passing set memory reclaimer callback in file writer options and hooks with
dwrf writer file format. The callback is lambda function provided by table
writer operator which connects the file writer internal memory pool with the
table writer operator. Note the table writer and all its file writers are single
thread executed. Unit test is added to reproduce the race condition and verify
the fix.
Next will add memory arbitration support in table writer. To simplify the
arbitration control flow, we run arbitration from the table writer operator's
reclaimer to handle the memory reclaim of the table writer and all its open
file writers with one per partition.