### PR TITLE
Make sure resultNulls_ is allocated

### DIFF
--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.cpp
@@ -72,6 +72,13 @@ void SelectiveTimestampColumnReader::read(
   VELOX_CHECK(
       !scanSpec_->valueHook(),
       "Selective reader for TIMESTAMP doesn't support aggregation pushdown yet");
+  if (!resultNulls_ || !resultNulls_->unique() ||
+      resultNulls_->capacity() * 8 < rows.size()) {
+    // Make sure a dedicated resultNulls_ is allocated with enough capacity as
+    // RleDecoder always assumes it is available.
+    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), &memoryPool_);
+    rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
+  }
   bool isDense = rows.back() == rows.size() - 1;
   if (isDense) {
     readHelper<true>(scanSpec_->filter(), rows);

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -19,7 +19,6 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
-#include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/PartitionedOutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
@@ -314,6 +313,72 @@ TEST_F(TableScanTest, columnPruning) {
 
   op = tableScanNode(ROW({"c3", "c0"}, {REAL(), BIGINT()}));
   assertQuery(op, {filePath}, "SELECT c3, c0 FROM tmp");
+}
+
+TEST_F(TableScanTest, timestamp) {
+  vector_size_t size = 10'000;
+  auto rowVector = makeRowVector(
+      {makeFlatVector<int64_t>(size, [](vector_size_t row) { return row; }),
+       makeFlatVector<Timestamp>(
+           size,
+           [](vector_size_t row) {
+             return Timestamp(
+                 row, (row % 1000) * Timestamp::kNanosecondsInMillisecond);
+           },
+           [](vector_size_t row) {
+             return row % 5 == 0; /* null every 5 rows */
+           })});
+
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, {rowVector});
+  createDuckDbTable({rowVector});
+
+  auto dataColumns = ROW({"c0", "c1"}, {BIGINT(), TIMESTAMP()});
+  auto op = tableScanNode(dataColumns);
+  assertQuery(op, {filePath}, "SELECT c0, c1 FROM tmp");
+
+  op = PlanBuilder(pool_.get())
+           .tableScan(
+               ROW({"c0", "c1"}, {BIGINT(), TIMESTAMP()}),
+               {"c1 is null"},
+               "",
+               dataColumns)
+           .planNode();
+  assertQuery(op, {filePath}, "SELECT c0, c1 FROM tmp WHERE c1 is null");
+
+  op = PlanBuilder(pool_.get())
+           .tableScan(
+               ROW({"c0", "c1"}, {BIGINT(), TIMESTAMP()}),
+               {"c1 < '1970-01-01 01:30:00'::TIMESTAMP"},
+               "",
+               dataColumns)
+           .planNode();
+  assertQuery(
+      op,
+      {filePath},
+      "SELECT c0, c1 FROM tmp WHERE c1 < timestamp '1970-01-01 01:30:00'");
+
+  op = PlanBuilder(pool_.get())
+           .tableScan(ROW({"c0"}, {BIGINT()}), {}, "", dataColumns)
+           .planNode();
+  assertQuery(op, {filePath}, "SELECT c0 FROM tmp");
+
+  op = PlanBuilder(pool_.get())
+           .tableScan(ROW({"c0"}, {BIGINT()}), {"c1 is null"}, "", dataColumns)
+           .planNode();
+  assertQuery(op, {filePath}, "SELECT c0 FROM tmp WHERE c1 is null");
+
+  op = PlanBuilder(pool_.get())
+           .tableScan(
+               ROW({"c0"}, {BIGINT()}),
+               {"c1 < timestamp'1970-01-01 01:30:00'"},
+               "",
+               dataColumns)
+           .planNode();
+  assertQuery(
+      op,
+      {filePath},
+      "SELECT c0 FROM tmp WHERE c1 < timestamp'1970-01-01 01:30:00'");
 }
 
 TEST_F(TableScanTest, subfieldPruningRowType) {

--- a/velox/expression/ExprToSubfieldFilter.h
+++ b/velox/expression/ExprToSubfieldFilter.h
@@ -398,7 +398,7 @@ between(const Timestamp& min, const Timestamp& max, bool nullAllowed = false) {
 }
 
 inline std::unique_ptr<common::TimestampRange> lessThan(
-    Timestamp& max,
+    Timestamp max,
     bool nullAllowed = false) {
   --max;
   return std::make_unique<common::TimestampRange>(
@@ -413,7 +413,7 @@ inline std::unique_ptr<common::TimestampRange> lessThanOrEqual(
 }
 
 inline std::unique_ptr<common::TimestampRange> greaterThan(
-    Timestamp& min,
+    Timestamp min,
     bool nullAllowed = false) {
   ++min;
   return std::make_unique<common::TimestampRange>(


### PR DESCRIPTION
Summary: When the column is not projected out, `rawResultNulls_` is not initialized and there's no need to fill the nulls.

Differential Revision: D49249897


