### PR TITLE
Fix the linking problem of simdjson

### DIFF
--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp
                                  SIMDJsonExtractor.cpp)
 
 target_link_libraries(velox_functions_json velox_exception Folly::folly
-                      simdjson)
+        simdjson::simdjson)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/json/CMakeLists.txt
+++ b/velox/functions/prestosql/json/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(velox_functions_json JsonExtractor.cpp JsonPathTokenizer.cpp
                                  SIMDJsonExtractor.cpp)
 
 target_link_libraries(velox_functions_json velox_exception Folly::folly
-        simdjson::simdjson)
+                      simdjson::simdjson)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_link_libraries(velox_functions_prestosql velox_functions_prestosql_impl
-                      velox_is_null_functions simdjson)
+        velox_is_null_functions simdjson::simdjson)
 
 set_property(TARGET velox_functions_prestosql PROPERTY JOB_POOL_COMPILE
                                                        high_memory_pool)

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -38,7 +38,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 target_link_libraries(velox_functions_prestosql velox_functions_prestosql_impl
-        velox_is_null_functions simdjson::simdjson)
+                      velox_is_null_functions simdjson::simdjson)
 
 set_property(TARGET velox_functions_prestosql PROPERTY JOB_POOL_COMPILE
                                                        high_memory_pool)


### PR DESCRIPTION
Summary:
When velox was used as a third-party library and `SIMDJsonExtractor` was used, it failed when running json function tests. We found that `-DSIMDJSON_THREADS_ENABLED=1` was not configured when generating libvelox_functions_json.a. We fix it by changing "simdjson" to "simdjson::simdjson" in target_link_libraries.

Fixes https://github.com/facebookincubator/velox/issues/6564