### PR TITLE
Fix handling of nested nulls in min and max Presto aggregates

### DIFF
--- a/velox/exec/tests/AggregationFuzzerRunner.h
+++ b/velox/exec/tests/AggregationFuzzerRunner.h
@@ -111,9 +111,6 @@ class AggregationFuzzerRunner {
           {"min_by", ""},
           {"map_union_sum", "array_sort(map_keys({}))"},
           {"multimap_agg", "transform_values({}, (k, v) -> array_sort(v))"},
-          // https://github.com/facebookincubator/velox/issues/6314
-          {"min", ""},
-          {"max", ""},
           // TODO: Skip result verification of companion functions that return
           // complex types that contain floating-point fields for now, until we
           // fix

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -49,6 +49,18 @@ bool SingleValueAccumulator::hasValue() const {
   return start_.header != nullptr;
 }
 
+std::optional<int32_t> SingleValueAccumulator::compare(
+    const DecodedVector& decoded,
+    vector_size_t index,
+    CompareFlags compareFlags) const {
+  VELOX_CHECK_NOT_NULL(start_.header);
+
+  ByteStream stream;
+  HashStringAllocator::prepareRead(start_.header, stream);
+  return exec::ContainerRowSerde::compareWithNulls(
+      stream, decoded, index, compareFlags);
+}
+
 int32_t SingleValueAccumulator::compare(
     const DecodedVector& decoded,
     vector_size_t index) const {

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -34,6 +34,16 @@ struct SingleValueAccumulator {
   bool hasValue() const;
 
   /// Returns 0 if stored and new values are equal; <0 if stored value is less
+  /// then new value; >0 if stored value is greater than new value. If
+  /// flags.nullHandlingMode is StopAtNull, returns std::nullopt
+  /// in case of null array elements, map values, and struct fields.
+  /// If flags.nullHandlingMode is NoStop then NULL is considered equal to NULL.
+  std::optional<int32_t> compare(
+      const DecodedVector& decoded,
+      vector_size_t index,
+      CompareFlags compareFlags) const;
+
+  /// Returns 0 if stored and new values are equal; <0 if stored value is less
   /// then new value; >0 if stored value is greater than new value.
   ///
   /// The caller needs to ensure that hasValue() is true before calling this

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <common/base/tests/GTestUtils.h>
 #include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
 
@@ -278,6 +279,100 @@ TEST_F(MinMaxTest, maxLongDecimal) {
 
 TEST_F(MinMaxTest, minLongDecimal) {
   doTest(min, DECIMAL(38, 19));
+}
+
+TEST_F(MinMaxTest, array) {
+  auto data = makeRowVector({
+      makeNullableArrayVector<int64_t>({
+          {1, 2, 3},
+          {std::nullopt, 2},
+          {6, 7, 8},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  VELOX_ASSERT_THROW(
+      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
+      "ARRAY comparison not supported for values that contain nulls");
+
+  data = makeRowVector({
+      makeNullableArrayVector<int64_t>({
+          {1, 2, 3},
+          {3, 2},
+          {6, 7, 8},
+      }),
+  });
+  testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected});
+}
+
+TEST_F(MinMaxTest, map) {
+  auto data = makeRowVector({
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{1, 1}, {2, 2}}},
+          {{{1, 1}, {2, std::nullopt}}},
+          {{{4, 50}}},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeMapVector<int64_t, int64_t>({{{1, 1}, {2, 2}}}),
+      makeMapVector<int64_t, int64_t>({{{4, 50}}}),
+  });
+
+  VELOX_ASSERT_THROW(
+      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
+      "MAP comparison not supported for values that contain nulls");
+
+  data = makeRowVector({
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{1, 1}, {2, 2}}},
+          {{{1, 1}, {2, 3}}},
+          {{{4, 50}}},
+      }),
+  });
+
+  testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected});
+}
+
+TEST_F(MinMaxTest, row) {
+  auto data = makeRowVector({
+      makeRowVector({
+          makeNullableFlatVector<StringView>({
+              "abc"_sv,
+              std::nullopt,
+              "efg"_sv,
+          }),
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeRowVector({makeFlatVector<StringView>({"abc"_sv})}),
+      makeRowVector({makeFlatVector<StringView>({"efg"_sv})}),
+  });
+
+  VELOX_ASSERT_THROW(
+      testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected}),
+      "ROW comparison not supported for values that contain nulls");
+
+  data = makeRowVector({
+      makeRowVector({
+          makeNullableFlatVector<StringView>({
+              "abc"_sv,
+              "ef"_sv,
+              "efg"_sv,
+          }),
+      }),
+  });
+
+  testAggregations({data}, {}, {"min(c0)", "max(c0)"}, {expected});
 }
 
 class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {


### PR DESCRIPTION
In Presto, min and max check for null array elements, map values, and struct fields and throw, but in Velox, they don't. For example, the following SQL should throw an exception, "**ARRAY comparison not supported for arrays with null elements**".
```SQL
SELECT min(col0) FROM (VALUES (array [1, 2, 3, 4]), (array [null, 1])) AS t(col0) 
```

This PR adds a comparison method in `SingleValueAccumulator` using the method added in https://github.com/facebookincubator/velox/pull/6419 to make `min/max` aggregate functions that compare values of complex types able to detect cases when complex type values contain nulls, making the following guarantees,

- ARRAY comparison is not supported for arrays with null elements
- ROW comparison is not supported for fields with null elements
- MAP comparison is not supported for null value elements

Part of https://github.com/facebookincubator/velox/issues/6314