### PR TITLE
Bump up velox_exec_test timeout limit

### DIFF
--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -99,6 +99,8 @@ add_test(
   COMMAND velox_exec_test
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
+set_tests_properties(velox_exec_test PROPERTIES TIMEOUT 3000)
+
 add_test(
   NAME velox_exec_infra_test
   COMMAND velox_exec_infra_test


### PR DESCRIPTION
velox_exec_test is failing with timeout, reason being sum of different 
test suites, example of test suites that took more than 3 minutes: 
TableScanTest 3minutes, 
SpillTestSuite/SpillTest 4 minutes
HashJoinTest 7 minutes
TableWriterTest 4 minutes

Bump up the test timeout limit.