### PR TITLE
Do not rely on has_null column statistics

### DIFF
--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -313,8 +313,7 @@ bool testFilter(
     dwio::common::ColumnStatistics* stats,
     uint64_t totalRows,
     const TypePtr& type) {
-  bool mayHaveNull =
-      stats->hasNull().has_value() ? stats->hasNull().value() : true;
+  bool mayHaveNull = true;
 
   // Has-null statistics is often not set. Hence, we supplement it with
   // number-of-values statistic to detect no-null columns more often.
@@ -325,11 +324,7 @@ bool testFilter(
       // Column is all null.
       return filter->testNull();
     }
-
-    if (stats->getNumberOfValues().value() == totalRows) {
-      // Column has no nulls.
-      mayHaveNull = false;
-    }
+    mayHaveNull = stats->getNumberOfValues().value() < totalRows;
   }
 
   if (!mayHaveNull && filter->kind() == common::FilterKind::kIsNull) {

--- a/velox/dwio/common/Statistics.h
+++ b/velox/dwio/common/Statistics.h
@@ -98,7 +98,12 @@ class ColumnStatistics {
   }
 
   /**
-   * Get whether column has null value
+   * Get whether column has null value.
+   *
+   * WARNING: Some writer implementation does not take ancestor nulls into
+   * account, so this value should not be trusted.  Check whether
+   * `getNumberOfValues()' is smaller than the row group size is a more accurate
+   * way.
    */
   std::optional<bool> hasNull() const {
     return hasNull_;


### PR DESCRIPTION
Summary:
Some writer implementation does not take ancestors nulls into account
so this value is inaccurate.  Presto Java is not relying on this metadata
either.

Differential Revision: D49278491


