### PR TITLE
Enable avg_merge and avg_merge_extract functions in aggregation fuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -57,10 +57,6 @@ int main(int argc, char** argv) {
   static const std::unordered_set<std::string> skipFunctions = {
       // https://github.com/facebookincubator/velox/issues/3493
       "stddev_pop",
-      // https://github.com/facebookincubator/velox/issues/6344
-      "avg_merge",
-      "avg_merge_extract_double",
-      "avg_merge_extract_real",
       // Lambda functions are not supported yet.
       "reduce_agg",
   };

--- a/velox/functions/lib/aggregates/AverageAggregateBase.h
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.h
@@ -344,8 +344,8 @@ class AverageAggregateBase : public exec::Aggregate {
               !baseCountDecoded.isNullAt(decodedIndex));
         }
         const auto numRows = rows.countSelected();
-        auto totalCount =
-            baseCountDecoded.template valueAt<int64_t>(decodedIndex) * numRows;
+        auto totalCount = checkedMultiply<int64_t>(
+            baseCountDecoded.template valueAt<int64_t>(decodedIndex), numRows);
         auto totalSum =
             baseSumDecoded.template valueAt<TAccumulator>(decodedIndex) *
             numRows;


### PR DESCRIPTION
Summary: avg_merge, avg_merge_extract_double, and avg_merge_extract_real were added to the skip-function list of aggregation fuzzer due to an integer-overflow bug (https://github.com/facebookincubator/velox/issues/6344). The bug has been fixed, so enabling them again in aggregation fuzzer.

Differential Revision: D49167783


