### PR TITLE
Update the offset when we filter out all values of a Row column in SelectiveStructColumnReader

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -125,6 +125,8 @@ void SelectiveStructColumnReaderBase::read(
         activeRows, kind == velox::common::FilterKind::kIsNull, false);
     if (outputRows_.empty()) {
       recordParentNullsInChildren(offset, rows);
+      lazyVectorReadOffset_ = offset;
+      readOffset_ = offset + rows.back() + 1;
       return;
     }
     activeRows = outputRows_;


### PR DESCRIPTION
Summary:
SelectiveStructColumnReader has logic to exit early if none of the values pass a pushed down filter.
Unfortunately, we're missing the updates to the offsets when we do this.  This results in us either trying to re-
skip the values in the children when we read the next batch or reading to far ahed in the nulls buffer for the
Row which leads to attempting to read off the end of the buffer when we get to the end of the stripe.

The fix is just to make sure we update the offsets before returning.

Differential Revision: D49285600


