### PR TITLE
Fix: Do not allow nested nulls in keys at map construction.

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -21,7 +21,7 @@ Map Functions
 .. function:: map(array(K), array(V)) -> map(K,V)
    :noindex:
 
-    Returns a map created using the given key/value arrays. ::
+    Returns a map created using the given key/value arrays. Keys are not allowed to be null or to contain nulls. ::
 
         SELECT map(ARRAY[1,3], ARRAY[2,4]); -- {1 -> 2, 3 -> 4}
 
@@ -48,7 +48,7 @@ Map Functions
 
 .. function:: map_from_entries(array(row(K, V))) -> map(K, V)
 
-    Returns a map created from the given array of entries. ::
+    Returns a map created from the given array of entries. Keys are not allowed to be null or to contain nulls. ::
 
         SELECT map_from_entries(ARRAY[(1, 'x'), (2, 'y')]); -- {1 -> 'x', 2 -> 'y'}
 
@@ -104,4 +104,3 @@ Map Functions
         SELECT transform_values(MAP(ARRAY ['a', 'b'], ARRAY [1, 2]), (k, v) -> k || CAST(v as VARCHAR)); -- {a -> a1, b -> b2}
         SELECT transform_values(MAP(ARRAY [1, 2], ARRAY [1.0, 1.4]), -- {1 -> one_1.0, 2 -> two_1.4}
                                 (k, v) -> MAP(ARRAY[1, 2], ARRAY['one', 'two'])[k] || '_' || CAST(v AS VARCHAR));
-

--- a/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
+++ b/velox/functions/prestosql/tests/MapFromEntriesTest.cpp
@@ -396,3 +396,11 @@ TEST_F(MapFromEntriesTest, arrayOfConstantNotNulls) {
         {{{1, 2}}, {{1, 2}}, {{1, 2}}, {{1, 2}}});
   }
 }
+
+TEST_F(MapFromEntriesTest, nestedNullInKeys) {
+  VELOX_ASSERT_THROW(
+      evaluate(
+          "map_from_entries(array_constructor(row_constructor(array_constructor(null), null)))",
+          makeRowVector({makeFlatVector<int32_t>(1)})),
+      "map key cannot be indeterminate");
+}

--- a/velox/functions/prestosql/tests/MapTest.cpp
+++ b/velox/functions/prestosql/tests/MapTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <optional>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/tests/utils/FunctionBaseTest.h"
@@ -374,6 +375,19 @@ TEST_F(MapTest, rowsWithNullsNotPassedToCheckDuplicateKey) {
   auto values = makeNullableArrayVector<int32_t>({{1, 2}, {1, 2}});
 
   ASSERT_NO_THROW(evaluate("try(map(c0, c1))", makeRowVector({keys, values})));
+}
+
+TEST_F(MapTest, nestedNullInKeys) {
+  auto inputWithNestedNulls = makeNullableNestedArrayVector<int32_t>(
+      {{{{{1, std::nullopt}}, {{5, 6}}, std::nullopt}},
+       {{{{
+             3,
+         }},
+         {{7, 8}},
+         std::nullopt}}});
+  VELOX_ASSERT_THROW(
+      evaluate("map(c0, c0)", makeRowVector({inputWithNestedNulls})),
+      "map key cannot be indeterminate");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
Presto does not allow nested nulls in keys in map function
they are also changing map_from_entries to not allow nested
nulls in keys.

Adding the two checks to the Velox functions.

Differential Revision: D49287075


