### PR TITLE
Fix lazy vector handeling in FieldReference

### DIFF
--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -69,6 +69,10 @@ void FieldReference::evalSpecialForm(
       peeledEncoding = PeeledEncoding::peel(
           {input}, *nonNullRows, localDecoded, true, peeledVectors);
       VELOX_CHECK_NOT_NULL(peeledEncoding);
+      if (peeledVectors[0]->isLazy()) {
+        peeledVectors[0] =
+            peeledVectors[0]->as<LazyVector>()->loadedVectorShared();
+      }
       VELOX_CHECK(peeledVectors[0]->encoding() == VectorEncoding::Simple::ROW);
       row = peeledVectors[0]->as<const RowVector>();
     } else {


### PR DESCRIPTION
Summary:
Currently, if FieldReference receives an input with encoding over it,
it expects a non-lazy vector and throws an exception if it
encounters a lazy. This fix ensures that it can handle the case
where it receives a lazy instead.

Differential Revision: D49293989


