### PR TITLE
No need for explicit reuse of condition vector.

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -273,7 +273,11 @@ class EvalCtx {
     return execCtx_->getVector(type, size);
   }
 
+  // Return true if the vector was moved to the pool.
   bool releaseVector(VectorPtr& vector) {
+    if (!vector) {
+      return false;
+    }
     return execCtx_->releaseVector(vector);
   }
 


### PR DESCRIPTION
Summary:
Reusing the condition vector has the side effect of copying overhead if the consumer calls ensureWritable without checking finalSelection which is not not common!
The diff disables reuse when the condition is not flat. The diff also resize condition to the minimal needed size to avoid not needed copying for rows that spans remainingRows->end().

Differential Revision: D49294479

