### PR TITLE
Reduce table write test execution time by half

### DIFF
--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -1244,8 +1244,8 @@ class AllTableWriterTest : public TableWriteTest,
 
 // Runs a pipeline with read + filter + project (with substr) + write.
 TEST_P(AllTableWriterTest, scanFilterProjectWrite) {
-  auto filePaths = makeFilePaths(10);
-  auto vectors = makeVectors(filePaths.size(), 1000);
+  auto filePaths = makeFilePaths(5);
+  auto vectors = makeVectors(filePaths.size(), 500);
   for (int i = 0; i < filePaths.size(); i++) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
@@ -1290,8 +1290,8 @@ TEST_P(AllTableWriterTest, scanFilterProjectWrite) {
 }
 
 TEST_P(AllTableWriterTest, renameAndReorderColumns) {
-  auto filePaths = makeFilePaths(10);
-  auto vectors = makeVectors(filePaths.size(), 1'000);
+  auto filePaths = makeFilePaths(5);
+  auto vectors = makeVectors(filePaths.size(), 500);
   for (int i = 0; i < filePaths.size(); ++i) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
@@ -1345,8 +1345,8 @@ TEST_P(AllTableWriterTest, renameAndReorderColumns) {
 
 // Runs a pipeline with read + write.
 TEST_P(AllTableWriterTest, directReadWrite) {
-  auto filePaths = makeFilePaths(10);
-  auto vectors = makeVectors(filePaths.size(), 1000);
+  auto filePaths = makeFilePaths(5);
+  auto vectors = makeVectors(filePaths.size(), 200);
   for (int i = 0; i < filePaths.size(); i++) {
     writeToFile(filePaths[i]->path, vectors[i]);
   }
@@ -1428,8 +1428,8 @@ TEST_P(AllTableWriterTest, emptyInput) {
 }
 
 TEST_P(AllTableWriterTest, commitStrategies) {
-  auto filePaths = makeFilePaths(10);
-  auto vectors = makeVectors(filePaths.size(), 1000);
+  auto filePaths = makeFilePaths(5);
+  auto vectors = makeVectors(filePaths.size(), 100);
 
   createDuckDbTable(vectors);
 


### PR DESCRIPTION
All test time on clion drops from 2min10s to 55s:

- commitStrategy from 47s to 14s
- directReadWrite from 30s to 8s
- scanFilterProjectWrite from 26s to 11s
- renameAndReorderColumns 9s to 
