### PR TITLE
Track number of rows processed in Window::getOutput

### DIFF
--- a/velox/exec/Window.h
+++ b/velox/exec/Window.h
@@ -122,7 +122,10 @@ class Window : public Operator {
   // Computes the result vector for a single output block. The result
   // consists of all the input columns followed by the results of the
   // window function.
-  void callApplyLoop(vector_size_t numOutputRows, const RowVectorPtr& result);
+  // @return The number of rows processed in the loop.
+  vector_size_t callApplyLoop(
+      vector_size_t numOutputRows,
+      const RowVectorPtr& result);
 
   // Converts WindowNode::Frame to Window::WindowFrame.
   WindowFrame createWindowFrame(


### PR DESCRIPTION
Streaming window needs the number of rows processed in the getOutput() call for
the result vector. Not all received rows might be assigned to a partition yet.
In fact, the last partition is always open until noMoreInput is received. So
getOutput() can only process all closed partitions which is less than the
number of input rows.