### PR TITLE
Avoid copying results in FildReference::evalSpecialForm when it does not need to be preserved.

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -273,7 +273,11 @@ class EvalCtx {
     return execCtx_->getVector(type, size);
   }
 
+  // Return true if the vector was moved to the pool.
   bool releaseVector(VectorPtr& vector) {
+    if (!vector) {
+      return false;
+    }
     return execCtx_->releaseVector(vector);
   }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -245,6 +245,12 @@ class EvalCtx {
     peeledEncoding_ = std::move(peel);
   }
 
+  bool resultShouldBePreserved(
+      const VectorPtr& result,
+      const SelectivityVector& rows) const {
+    return result && !isFinalSelection() && *finalSelection() != rows;
+  }
+
   // Copy "rows" of localResult into results if "result" is partially populated
   // and must be preserved. Copy localResult pointer into result otherwise.
   void moveOrCopyResult(
@@ -257,7 +263,7 @@ class EvalCtx {
       localResult->validate();
     }
 #endif
-    if (result && !isFinalSelection() && *finalSelection() != rows) {
+    if (resultShouldBePreserved(result, rows)) {
       BaseVector::ensureWritable(rows, result->type(), result->pool(), result);
       result->copy(localResult.get(), rows, nullptr);
     } else {

--- a/velox/expression/FieldReference.cpp
+++ b/velox/expression/FieldReference.cpp
@@ -20,13 +20,10 @@
 
 namespace facebook::velox::exec {
 
-void FieldReference::evalSpecialForm(
+void FieldReference::apply(
     const SelectivityVector& rows,
     EvalCtx& context,
     VectorPtr& result) {
-  if (result) {
-    context.ensureWritable(rows, type_, result);
-  }
   const RowVector* row;
   DecodedVector decoded;
   VectorPtr input;
@@ -111,6 +108,15 @@ void FieldReference::evalSpecialForm(
   if (!inputs_.empty() && decoded.mayHaveNulls()) {
     addNulls(rows, decoded.nulls(), context, result);
   }
+}
+
+void FieldReference::evalSpecialForm(
+    const SelectivityVector& rows,
+    EvalCtx& context,
+    VectorPtr& result) {
+  VectorPtr localResult;
+  apply(rows, context, localResult);
+  context.moveOrCopyResult(localResult, rows, result);
 }
 
 void FieldReference::evalSpecialFormSimplified(

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -80,6 +80,9 @@ class FieldReference : public SpecialForm {
       std::vector<VectorPtr>* complexConstants = nullptr) const override;
 
  private:
+  void
+  apply(const SelectivityVector& rows, EvalCtx& context, VectorPtr& result);
+
   const std::string field_;
   int32_t index_ = -1;
 };


### PR DESCRIPTION
Summary: title

Differential Revision: D49299731

