### PR TITLE
Add new HashWindowBuild for using a HashTable based window partitioning

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(
   HashPartitionFunction.cpp
   HashProbe.cpp
   HashTable.cpp
+  HashWindowBuild.cpp
   JoinBridge.cpp
   Limit.cpp
   LocalPartition.cpp

--- a/velox/exec/HashWindowBuild.cpp
+++ b/velox/exec/HashWindowBuild.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/HashWindowBuild.h"
+
+namespace facebook::velox::exec {
+
+HashWindowBuild::HashWindowBuild(
+    const std::shared_ptr<const core::WindowNode>& windowNode,
+    velox::memory::MemoryPool* pool)
+    : WindowBuild(windowNode, pool),
+      inputType_(windowNode->sources()[0]->outputType()),
+      comparator_(
+          inputType_,
+          windowNode->sortingKeys(),
+          windowNode->sortingOrders(),
+          data_.get()) {
+  const auto& keys = windowNode->partitionKeys();
+  const auto numKeys = keys.size();
+
+  if (numKeys > 0) {
+    Accumulator accumulator{true, sizeof(SortedRows), false, 1, [](auto) {}};
+
+    table_ = std::make_unique<HashTable<false>>(
+        createVectorHashers(inputType_, keys),
+        std::vector<Accumulator>{accumulator},
+        std::vector<TypePtr>{},
+        false, // allowDuplicates
+        false, // isJoinBuild
+        false, // hasProbedFlag
+        0, // minTableSizeForParallelJoinBuild
+        pool);
+    sortedRowsOffset_ = table_->rows()->columnAt(numKeys).offset();
+    lookup_ = std::make_unique<HashLookup>(table_->hashers());
+  } else {
+    allocator_ = std::make_unique<HashStringAllocator>(pool);
+    singlePartition_ =
+        std::make_unique<SortedRows>(allocator_.get(), comparator_);
+  }
+}
+
+void HashWindowBuild::addInput(RowVectorPtr input) {
+  const auto numInput = input->size();
+
+  for (auto i = 0; i < inputType_->size(); ++i) {
+    decodedInputVectors_[i].decode(*input->childAt(i));
+  }
+
+  if (table_) {
+    SelectivityVector rows(numInput);
+    lookup_->reset(numInput);
+    table_->prepareForProbe(*lookup_, input, rows, false);
+    table_->groupProbe(*lookup_);
+
+    // Initialize new partitions.
+    initializeNewPartitions();
+
+    // Process input rows. For each row, lookup the partition. Add the
+    // new row to the partition. The SortedRows priority queue will
+    // insert the row maintaining the order of the ORDER BY keys.
+    for (auto i = 0; i < numInput; ++i) {
+      auto& partition = sortedRowsAt(lookup_->hits[i]);
+      addRowToPartition(input, i, partition);
+    }
+  } else {
+    for (auto i = 0; i < numInput; ++i) {
+      addRowToPartition(input, i, *singlePartition_);
+    }
+  }
+}
+
+void HashWindowBuild::initializeNewPartitions() {
+  for (auto index : lookup_->newGroups) {
+    new (lookup_->hits[index] + sortedRowsOffset_)
+        SortedRows(table_->stringAllocator(), comparator_);
+  }
+}
+
+void HashWindowBuild::addRowToPartition(
+    const RowVectorPtr& input,
+    vector_size_t index,
+    SortedRows& partition) {
+  char* newRow = data_->newRow();
+  for (auto col = 0; col < input->childrenSize(); ++col) {
+    data_->store(decodedInputVectors_[col], index, newRow, col);
+  }
+
+  auto& sortedRows = partition.rows;
+  sortedRows.push(newRow);
+}
+
+bool HashWindowBuild::hasNextPartition() {
+  if (!noMoreInput_) {
+    // HashBuild not completed so no partitions available.
+    return false;
+  }
+
+  currentSortedRows_ = nextSortedRows();
+  if (!currentSortedRows_) {
+    return false;
+  }
+
+  return true;
+}
+
+std::unique_ptr<WindowPartition> HashWindowBuild::nextPartition() {
+  VELOX_CHECK(noMoreInput_, "No window partitions available");
+  VELOX_CHECK(currentSortedRows_, "All window partitions consumed");
+
+  partitionSortedRows_.clear();
+  auto numSortedRows = currentSortedRows_->rows.size();
+  partitionSortedRows_.reserve(numSortedRows);
+  for (auto i = 0; i < numSortedRows; i++) {
+    partitionSortedRows_.push_back(currentSortedRows_->rows.top());
+    currentSortedRows_->rows.pop();
+  }
+  std::reverse(partitionSortedRows_.begin(), partitionSortedRows_.end());
+
+  auto windowPartition = std::make_unique<WindowPartition>(
+      data_.get(), inputColumns_, sortKeyInfo_);
+
+  auto partition =
+      folly::Range(partitionSortedRows_.data(), partitionSortedRows_.size());
+  windowPartition->resetPartition(partition);
+
+  return windowPartition;
+}
+
+HashWindowBuild::SortedRows* HashWindowBuild::nextSortedRows() {
+  if (!table_) {
+    if (!currentPartition_) {
+      currentPartition_ = 0;
+      return singlePartition_.get();
+    }
+    return nullptr;
+  }
+
+  if (!currentPartition_) {
+    numPartitions_ = table_->listAllRows(
+        &partitionIt_,
+        partitions_.size(),
+        RowContainer::kUnlimited,
+        partitions_.data());
+    if (numPartitions_ == 0) {
+      // No more partitions.
+      return nullptr;
+    }
+
+    currentPartition_ = 0;
+  } else {
+    ++currentPartition_.value();
+    if (currentPartition_ >= numPartitions_) {
+      currentPartition_.reset();
+      return nextSortedRows();
+    }
+  }
+
+  return &sortedRowsAt(partitions_[currentPartition_.value()]);
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/HashWindowBuild.h
+++ b/velox/exec/HashWindowBuild.h
@@ -1,0 +1,117 @@
+
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/exec/HashTable.h"
+#include "velox/exec/RowContainer.h"
+#include "velox/exec/WindowBuild.h"
+
+namespace facebook::velox::exec {
+
+// This WindowBuild class uses a HashTable to obtain Window partitions
+// The input rows are hashed by Window partition keys.
+// Each Window partition row has an Accumulator which is a priority
+// queue of pointers to the rows in it. The priority queue
+// uses the sorting keys of the Window partition to
+// order the rows in it.
+// All input rows are seen before any partitions are processed for
+// output.
+class HashWindowBuild : public WindowBuild {
+ public:
+  HashWindowBuild(
+      const std::shared_ptr<const core::WindowNode>& windowNode,
+      velox::memory::MemoryPool* pool);
+
+  bool needsInput() override {
+    return !noMoreInput_;
+  }
+
+  void addInput(RowVectorPtr input) override;
+
+  void noMoreInput() override {
+    noMoreInput_ = true;
+  }
+
+  bool hasNextPartition() override;
+
+  std::unique_ptr<WindowPartition> nextPartition() override;
+
+ private:
+  // A priority queue to keep track of rows for a given partition.
+  struct SortedRows {
+    struct Compare {
+      RowComparator& comparator;
+
+      bool operator()(const char* lhs, const char* rhs) {
+        return comparator(lhs, rhs);
+      }
+    };
+
+    std::priority_queue<char*, std::vector<char*, StlAllocator<char*>>, Compare>
+        rows;
+
+    SortedRows(HashStringAllocator* allocator, RowComparator& comparator)
+        : rows{{comparator}, StlAllocator<char*>(allocator)} {}
+  };
+
+  void initializeNewPartitions();
+
+  // Adds input row to a partition or discards the row.
+  void addRowToPartition(
+      const RowVectorPtr& input,
+      vector_size_t index,
+      SortedRows& partition);
+
+  SortedRows& sortedRowsAt(char* group) {
+    return *reinterpret_cast<SortedRows*>(group + sortedRowsOffset_);
+  }
+
+  SortedRows* nextSortedRows();
+
+  const RowTypePtr inputType_;
+  RowComparator comparator_;
+
+  // Hash table to keep track of partitions. Not used if there are no
+  // partitioning keys. For each partition, stores an instance of SortedRows
+  // struct.
+  std::unique_ptr<BaseHashTable> table_;
+  std::unique_ptr<HashLookup> lookup_;
+  int32_t sortedRowsOffset_;
+
+  // SortedRows struct to keep track of rows for a single partition, when
+  // there are no partitioning keys.
+  std::unique_ptr<HashStringAllocator> allocator_;
+  std::unique_ptr<SortedRows> singlePartition_;
+
+  // Number of partitions to fetch from a HashTable in a single listAllRows
+  // call.
+  static const size_t kPartitionBatchSize = 100;
+
+  // The below variables are populated for the listAllRows call.
+  BaseHashTable::RowsIterator partitionIt_;
+  std::vector<char*> partitions_{kPartitionBatchSize};
+  size_t numPartitions_{0};
+
+  std::optional<int32_t> currentPartition_;
+  SortedRows* currentSortedRows_;
+  std::vector<char*> partitionSortedRows_;
+
+  bool noMoreInput_ = false;
+};
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Window.cpp
+++ b/velox/exec/Window.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/Window.h"
+#include "velox/exec/HashWindowBuild.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/SortWindowBuild.h"
 #include "velox/exec/Task.h"
@@ -31,7 +32,7 @@ Window::Window(
           windowNode->id(),
           "Window"),
       numInputColumns_(windowNode->sources()[0]->outputType()->size()),
-      windowBuild_(std::make_unique<SortWindowBuild>(windowNode, pool())),
+      windowBuild_(std::make_unique<HashWindowBuild>(windowNode, pool())),
       windowNode_(windowNode),
       currentPartition_(nullptr),
       stringAllocator_(pool()) {}

--- a/velox/functions/prestosql/window/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/window/benchmarks/CMakeLists.txt
@@ -11,16 +11,27 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-if(${VELOX_BUILD_TESTING})
-  add_subdirectory(tests)
-endif()
 
-if(${VELOX_ENABLE_BENCHMARKS})
-  add_subdirectory(benchmarks)
-endif()
+set(BENCHMARK_DEPENDENCIES_NO_FUNC
+    fmt::fmt
+    velox_dwio_common_exception
+    velox_functions_test_lib
+    velox_exec
+    velox_exec_test_lib
+    velox_vector_test_lib
+    gflags::gflags
+    Folly::folly
+    ${FOLLY_BENCHMARK})
 
-add_library(velox_window CumeDist.cpp FirstLastValue.cpp LeadLag.cpp Ntile.cpp
-                         WindowFunctionsRegistration.cpp)
+set(BENCHMARK_DEPENDENCIES
+    velox_window
+    velox_aggregates
+    velox_hive_connector
+    velox_functions_prestosql
+    velox_functions_lib
+    velox_vector_fuzzer
+    ${BENCHMARK_DEPENDENCIES_NO_FUNC})
 
-target_link_libraries(velox_window velox_buffer velox_exec
-                      velox_functions_window Folly::folly)
+add_executable(velox_windows_benchmarks WindowBenchmark.cpp)
+
+target_link_libraries(velox_windows_benchmarks ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/window/benchmarks/WindowBenchmark.cpp
+++ b/velox/functions/prestosql/window/benchmarks/WindowBenchmark.cpp
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <fmt/format.h>
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include <string>
+
+#include "velox/exec/tests/utils/Cursor.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/functions/prestosql/window/WindowFunctionsRegistration.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+DEFINE_int64(fuzzer_seed, 99887766, "Seed for random input dataset generator");
+
+using namespace facebook::velox;
+using namespace facebook::velox::connector::hive;
+using namespace facebook::velox::exec::test;
+
+static constexpr int32_t kNumVectors = 100;
+static constexpr int32_t kRowsPerVector = 10'000;
+
+namespace {
+
+class WindowBenchmark : public HiveConnectorTestBase {
+ public:
+  explicit WindowBenchmark() {
+    HiveConnectorTestBase::SetUp();
+
+    aggregate::prestosql::registerAllAggregateFunctions();
+    window::prestosql::registerAllWindowFunctions();
+
+    inputType_ = ROW({
+        {"k_array", INTEGER()},
+        {"k_norm", INTEGER()},
+        {"k_hash", INTEGER()},
+        {"k_sort", INTEGER()},
+        {"i32", INTEGER()},
+        {"i64", BIGINT()},
+        {"f32", REAL()},
+        {"f64", DOUBLE()},
+        {"i32_halfnull", INTEGER()},
+        {"i64_halfnull", BIGINT()},
+        {"f32_halfnull", REAL()},
+        {"f64_halfnull", DOUBLE()},
+    });
+
+    VectorFuzzer::Options opts;
+    opts.vectorSize = kRowsPerVector;
+    opts.nullRatio = 0;
+    VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
+
+    std::vector<RowVectorPtr> vectors;
+    for (auto i = 0; i < kNumVectors; ++i) {
+      std::vector<VectorPtr> children;
+
+      // Generate key with a small number of unique values from a small range
+      // (0-16).
+      children.emplace_back(makeFlatVector<int32_t>(
+          kRowsPerVector, [](auto row) { return row % 17; }));
+
+      // Generate key with a small number of unique values from a large range
+      // (300 total values).
+      children.emplace_back(
+          makeFlatVector<int32_t>(kRowsPerVector, [](auto row) {
+            if (row % 3 == 0) {
+              return std::numeric_limits<int32_t>::max() - row % 100;
+            } else if (row % 3 == 1) {
+              return row % 100;
+            } else {
+              return std::numeric_limits<int32_t>::min() + row % 100;
+            }
+          }));
+
+      // Generate key with many unique values from a large range (500K total
+      // values).
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+
+      // Generate a column with increasing values to get a deterministic sort
+      // order.
+      children.emplace_back(makeFlatVector<int32_t>(
+          kRowsPerVector, [](auto row) { return row; }));
+
+      // Generate random values without nulls.
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+      children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+      children.emplace_back(fuzzer.fuzzFlat(REAL()));
+      children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+
+      // Generate random values with nulls.
+
+      opts.nullRatio = 0.5; // 50%
+      fuzzer.setOptions(opts);
+
+      children.emplace_back(fuzzer.fuzzFlat(INTEGER()));
+      children.emplace_back(fuzzer.fuzzFlat(BIGINT()));
+      children.emplace_back(fuzzer.fuzzFlat(REAL()));
+      children.emplace_back(fuzzer.fuzzFlat(DOUBLE()));
+
+      vectors.emplace_back(makeRowVector(inputType_->names(), children));
+    }
+
+    filePath_ = TempFilePath::create();
+    writeToFile(filePath_->path, vectors);
+  }
+
+  ~WindowBenchmark() override {
+    HiveConnectorTestBase::TearDown();
+  }
+
+  void TestBody() override {}
+
+  // Enhance this function to include a frame clause.
+  void run(const std::string& key, const std::string& aggregate) {
+    folly::BenchmarkSuspender suspender;
+
+    std::string functionSql = fmt::format(
+        "{} over (partition by {} order by k_sort)", aggregate, key);
+    auto plan = PlanBuilder()
+                    .tableScan(inputType_)
+                    .window({functionSql})
+                    .planFragment();
+
+    vector_size_t numResultRows = 0;
+    auto task = makeTask(plan, numResultRows);
+
+    task->addSplit("0", exec::Split(makeHiveConnectorSplit(filePath_->path)));
+    task->noMoreSplits("0");
+
+    suspender.dismiss();
+
+    exec::Task::start(task, 1);
+    auto& executor = folly::QueuedImmediateExecutor::instance();
+    auto future = task->stateChangeFuture(60'000'000).via(&executor);
+    future.wait();
+
+    folly::doNotOptimizeAway(numResultRows);
+  }
+
+  std::shared_ptr<exec::Task> makeTask(
+      core::PlanFragment plan,
+      vector_size_t& numResultRows) {
+    return exec::Task::create(
+        "t",
+        std::move(plan),
+        0,
+        std::make_shared<core::QueryCtx>(executor_.get()),
+        [&](auto vector, auto* /*future*/) {
+          if (vector) {
+            numResultRows += vector->size();
+          }
+          return exec::BlockingReason::kNotBlocked;
+        });
+  }
+
+ private:
+  RowTypePtr inputType_;
+  std::shared_ptr<TempFilePath> filePath_;
+};
+
+std::unique_ptr<WindowBenchmark> benchmark;
+
+void doRun(uint32_t, const std::string& key, const std::string& aggregate) {
+  benchmark->run(key, aggregate);
+}
+
+#define WINDOW_AGG_BENCHMARKS(_name_, _key_)       \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_INTEGER_##_key_,                    \
+      #_key_,                                      \
+      fmt::format("{}(i32)", (#_name_)));          \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_BIGINT_##_key_,                     \
+      #_key_,                                      \
+      fmt::format("{}(i64)", (#_name_)));          \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_REAL_##_key_,                       \
+      #_key_,                                      \
+      fmt::format("{}(f32)", (#_name_)));          \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_DOUBLE_##_key_,                     \
+      #_key_,                                      \
+      fmt::format("{}(f64)", (#_name_)));          \
+  BENCHMARK_DRAW_LINE();                           \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_INTEGER_NULLS_##_key_,              \
+      #_key_,                                      \
+      fmt::format("{}(i32_halfnull)", (#_name_))); \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_BIGINT_NULLS_##_key_,               \
+      #_key_,                                      \
+      fmt::format("{}(i64_halfnull)", (#_name_))); \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_REAL_NULLS_##_key_,                 \
+      #_key_,                                      \
+      fmt::format("{}(f32_halfnull)", (#_name_))); \
+  BENCHMARK_NAMED_PARAM(                           \
+      doRun,                                       \
+      _name_##_DOUBLE_NULLS_##_key_,               \
+      #_key_,                                      \
+      fmt::format("{}(f64_halfnull)", (#_name_))); \
+  BENCHMARK_DRAW_LINE();                           \
+  BENCHMARK_DRAW_LINE();
+
+// Count(1) aggregate.
+BENCHMARK_NAMED_PARAM(doRun, count_k_array, "k_array", "count(1)");
+BENCHMARK_NAMED_PARAM(doRun, count_k_norm, "k_norm", "count(1)");
+BENCHMARK_NAMED_PARAM(doRun, count_k_hash, "k_hash", "count(1)");
+BENCHMARK_DRAW_LINE();
+
+// Count aggregate.
+WINDOW_AGG_BENCHMARKS(count, k_array)
+WINDOW_AGG_BENCHMARKS(count, k_norm)
+WINDOW_AGG_BENCHMARKS(count, k_hash)
+BENCHMARK_DRAW_LINE();
+
+// Sum aggregate.
+WINDOW_AGG_BENCHMARKS(sum, k_array)
+WINDOW_AGG_BENCHMARKS(sum, k_norm)
+WINDOW_AGG_BENCHMARKS(sum, k_hash)
+BENCHMARK_DRAW_LINE();
+
+// Avg aggregate.
+WINDOW_AGG_BENCHMARKS(avg, k_array)
+WINDOW_AGG_BENCHMARKS(avg, k_norm)
+WINDOW_AGG_BENCHMARKS(avg, k_hash)
+BENCHMARK_DRAW_LINE();
+
+// Min aggregate.
+WINDOW_AGG_BENCHMARKS(min, k_array)
+WINDOW_AGG_BENCHMARKS(min, k_norm)
+WINDOW_AGG_BENCHMARKS(min, k_hash)
+BENCHMARK_DRAW_LINE();
+
+// Max aggregate.
+WINDOW_AGG_BENCHMARKS(max, k_array)
+WINDOW_AGG_BENCHMARKS(max, k_norm)
+WINDOW_AGG_BENCHMARKS(max, k_hash)
+BENCHMARK_DRAW_LINE();
+
+// Stddev aggregate.
+WINDOW_AGG_BENCHMARKS(stddev, k_array)
+WINDOW_AGG_BENCHMARKS(stddev, k_norm)
+WINDOW_AGG_BENCHMARKS(stddev, k_hash)
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+
+  benchmark = std::make_unique<WindowBenchmark>();
+  folly::runBenchmarks();
+  benchmark.reset();
+  return 0;
+}

--- a/velox/functions/prestosql/window/tests/LeadLagTest.cpp
+++ b/velox/functions/prestosql/window/tests/LeadLagTest.cpp
@@ -287,7 +287,8 @@ TEST_P(LeadLagTest, emptyFrames) {
   std::vector<std::optional<int64_t>> expectedWindow;
 
   auto assertResults = [&](const std::string& functionSql) {
-    auto queryInfo = buildWindowQuery({data}, functionSql, "", kEmptyFrame);
+    auto queryInfo =
+        buildWindowQuery({data}, functionSql, "order by c0", kEmptyFrame);
     auto expected = makeRowVector({
         data->childAt(0),
         makeNullableFlatVector<int64_t>(expectedWindow),


### PR DESCRIPTION
For Window operator the most performance critical code path is partitioning and sorting the input rows as per the Window function partitioning spec. 

There are multiple algorithms to fine tune the window partitioning build step. e.g. A single sort across all the input rows with (partition keys + sort keys) combination (the current implementation). Another strategy used by Spark assumes a sorted input stream from a prior step and simply identifies partition key column changes to build the Window partitions.

A third strategy is to use a HashTable to identify the partitions. There is extra work to compute a hash value for partition keys for each row. But the advantages of this approach are :

- The sorts of partitions are self-contained within each partition. 
- Each partition rows are kept pre-sorted in a priority queue so a massive sort after noMoreInput is not required. 

Removing this sort eliminates a computationally expensive and blocking step in the Window operator logic. This makes the runtime more efficient and robust. The benchmark run shows that even with basic runs HashWindowBuild performs as well as SortWindowBuild.

Implementation :
The Window operator code is modularized to abstract a WindowBuild class to plug these different algorithms. This PR implements a HashWindowBuild that splits input data into partitions using a HashTable. Each partition entry in the HashTable maintains a priority queue of the row pointers ordered as per the ORDER BY spec of the partition.