### PR TITLE
Optimize nested struct reading

### DIFF
--- a/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
+++ b/velox/dwio/common/SelectiveRepeatedColumnReader.cpp
@@ -64,6 +64,8 @@ void prepareResult(
          (type->kind() == TypeKind::MAP &&
           result->encoding() == VectorEncoding::Simple::MAP)) &&
         result.unique())) {
+    VLOG(1) << "Reallocating result " << type->kind() << " vector of size "
+            << size;
     result = BaseVector::create(type, size, pool);
     return;
   }

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -309,6 +309,8 @@ void SelectiveStructColumnReaderBase::getValues(
   if (auto reused = tryReuseResult(*result)) {
     *result = std::move(reused);
   } else {
+    VLOG(1) << "Reallocating result row vector with " << rowType.size()
+            << " children";
     std::vector<VectorPtr> children(rowType.size());
     fillRowVectorChildren(*result->get()->pool(), rowType, children);
     *result = std::make_shared<RowVector>(
@@ -372,9 +374,11 @@ void SelectiveStructColumnReaderBase::getValues(
           &memoryPool_,
           resultRow->type()->childAt(channel),
           rows.size(),
-          std::move(loader));
+          std::move(loader),
+          std::move(childResult));
     }
   }
+  resultRow->updateContainsLazyNotLoaded();
 }
 
 } // namespace facebook::velox::dwio::common

--- a/velox/vector/LazyVector.cpp
+++ b/velox/vector/LazyVector.cpp
@@ -117,13 +117,14 @@ void LazyVector::ensureLoadedRowsImpl(
     if (decoded.base()->encoding() == VectorEncoding::Simple::ROW &&
         isLazyNotLoaded(*decoded.base())) {
       decoded.unwrapRows(baseRows, rows);
-      auto children = decoded.base()->asUnchecked<RowVector>()->children();
+      auto* rowVector = decoded.base()->asUnchecked<RowVector>();
       DecodedVector decodedChild;
       SelectivityVector childRows;
-      for (auto& child : children) {
+      for (auto child : rowVector->children()) {
         decodedChild.decode(*child, baseRows, false);
         ensureLoadedRowsImpl(child, decodedChild, baseRows, childRows);
       }
+      rowVector->updateContainsLazyNotLoaded();
       vector->loadedVector();
     }
     return;

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -117,14 +117,16 @@ class LazyVector : public BaseVector {
       velox::memory::MemoryPool* pool,
       TypePtr type,
       vector_size_t size,
-      std::unique_ptr<VectorLoader>&& loader)
+      std::unique_ptr<VectorLoader>&& loader,
+      VectorPtr&& vector = nullptr)
       : BaseVector(
             pool,
             std::move(type),
             VectorEncoding::Simple::LAZY,
             BufferPtr(nullptr),
             size),
-        loader_(std::move(loader)) {}
+        loader_(std::move(loader)),
+        vector_(std::move(vector)) {}
 
   void reset(std::unique_ptr<VectorLoader>&& loader, vector_size_t size) {
     BaseVector::length_ = size;


### PR DESCRIPTION
Summary:
1. Optimize `isLazyNotLoaded` and `RowVector::loadedVector` to not recurse into children of RowVector multiple times
2. Allow reader to create a `LazyVector` by reusing a materialized result vector from previous batch

Differential Revision: D49327996


