### PR TITLE
Fix potential crash in DwrfReader::updateColumnNamesFromTableSchema().

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -795,9 +795,10 @@ TypePtr updateColumnNames(
     const TypePtr& tableType,
     const std::string& fileFieldName,
     const std::string& tableFieldName) {
-  // Check type equality.
+  // Check type kind equality. If not equal, no point to continue down the tree.
   if (fileType->kind() != tableType->kind()) {
     logTypeInequality(*fileType, *tableType, fileFieldName, tableFieldName);
+    return fileType;
   }
 
   // For leaf types we return type as is.

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -3186,6 +3186,17 @@ TEST_F(TableScanTest, readMissingFieldsInMap) {
       ASSERT_TRUE(val->isNullAt(j));
     }
   }
+
+  // Scan with type mismatch in the 1st item (map vs integer). We should throw.
+  rowType = ROW({"i1", "a2"}, {{INTEGER(), ARRAY(structType)}});
+
+  op = PlanBuilder()
+           .tableScan(rowType, {}, "", rowType)
+           .project({"i1"})
+           .planNode();
+
+  EXPECT_THROW(
+      AssertQueryBuilder(op).split(split).copyResults(pool()), VeloxUserError);
 }
 
 // Tests various projections of top level columns using the output type passed


### PR DESCRIPTION
Summary:
When type kind is not equal and one of them non-primitive we would
crash accessing null type pointer after dynamic cast.
Fix is to bail out from going down the type tree whenever type kind is different.
The bug sneaked in, when we replaced throw() by log(1) in type checking code.

Differential Revision: D49338549


