### PR TITLE
Ensure BaseVector::copy only accepts rows valid in source

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -688,36 +688,21 @@ void BaseVector::copy(
     const BaseVector* source,
     const SelectivityVector& rows,
     const vector_size_t* toSourceRow) {
-  // Check if there are rows that do not exist in 'source'. Remove these from
-  // 'ranges'.
-  // TODO Update the callers and remove this logic.
-
+  if (!rows.hasSelections()) {
+    return;
+  }
   std::vector<CopyRange> ranges;
   if (toSourceRow == nullptr) {
-    if (source->size() < rows.end()) {
-      SelectivityVector trimmedRows = rows;
-      trimmedRows.setValidRange(source->size(), rows.end(), false);
-      trimmedRows.updateBounds();
-
-      ranges = toCopyRanges(trimmedRows);
-    } else {
-      ranges = toCopyRanges(rows);
-    }
+    VELOX_CHECK_GE(source->size(), rows.end());
+    ranges = toCopyRanges(rows);
   } else {
     ranges.reserve(rows.end());
     rows.applyToSelected([&](vector_size_t row) {
       const auto sourceRow = toSourceRow[row];
-      if (sourceRow >= source->size()) {
-        return;
-      }
+      VELOX_DCHECK_GT(source->size(), sourceRow);
       ranges.push_back({sourceRow, row, 1});
     });
   }
-
-  if (ranges.empty()) {
-    return;
-  }
-
   copyRanges(source, ranges);
 }
 

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -440,7 +440,8 @@ class BaseVector {
 
   // Sets the rows of 'this' given by 'rows' to
   // 'source.valueAt(toSourceRow ? toSourceRow[row] : row)', where
-  // 'row' iterates over 'rows'.
+  // 'row' iterates over 'rows'. All active 'row' in 'rows' must map to a valid
+  // row in the 'source'.
   virtual void copy(
       const BaseVector* source,
       const SelectivityVector& rows,

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -187,6 +187,9 @@ void RowVector::copy(
 
   // Copy non-null values.
   SelectivityVector nonNullRows = rows;
+  if (!toSourceRow) {
+    VELOX_CHECK_GE(source->size(), rows.end());
+  }
 
   DecodedVector decodedSource(*source);
   if (decodedSource.isIdentityMapping()) {
@@ -194,6 +197,7 @@ void RowVector::copy(
       auto rawNulls = source->rawNulls();
       rows.applyToSelected([&](auto row) {
         auto idx = toSourceRow ? toSourceRow[row] : row;
+        VELOX_DCHECK_GT(source->size(), idx);
         if (bits::isBitNull(rawNulls, idx)) {
           nonNullRows.setValid(row, false);
         }
@@ -218,6 +222,7 @@ void RowVector::copy(
     if (nulls) {
       rows.applyToSelected([&](auto row) {
         auto idx = toSourceRow ? toSourceRow[row] : row;
+        VELOX_DCHECK_GT(source->size(), idx);
         if (bits::isBitNull(nulls, idx)) {
           nonNullRows.setValid(row, false);
         }


### PR DESCRIPTION
Fixes #6591
Found 2 bugs so far:
Addressed in #6967 and #6968
Depends on those fixes for a clean run of unit tests and fuzzer

Differential Revision: D49341013


