### PR TITLE
Reduce peak memory usage by roughly half in HiveDataSource

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -681,6 +681,9 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
   configureRowReaderOptions(
       rowReaderOpts_,
       ROW(std::vector<std::string>(fileType->names()), std::move(columnTypes)));
+  // NOTE: we firstly reset the finished 'rowReader_' of previous split before
+  // setting up for the next one to avoid doubling the peak memory usage.
+  rowReader_.reset();
   rowReader_ = createRowReader(rowReaderOpts_);
 }
 


### PR DESCRIPTION
Directly assigning to rowReader_ will create a moment when current and previous allocated memory co-exist. Free the previously allocated memory first by reset() and then create the new one solves the problem. The fix reduces peak memory usage by half in certain scenarios and removed "false" peak memory usage pattern in TableScan stage