### PR TITLE
Add support for complex types to compare argument of min_by and max_by

### DIFF
--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -61,32 +61,6 @@ std::optional<int32_t> SingleValueAccumulator::compare(
       stream, decoded, index, compareFlags);
 }
 
-int32_t SingleValueAccumulator::compare(
-    const DecodedVector& decoded,
-    vector_size_t index) const {
-  VELOX_CHECK_NOT_NULL(start_.header);
-
-  ByteStream stream;
-  HashStringAllocator::prepareRead(start_.header, stream);
-  return exec::ContainerRowSerde::compare(
-      stream, decoded, index, {true, true, false});
-}
-
-// static
-int32_t SingleValueAccumulator::compare(
-    const SingleValueAccumulator* accumulator,
-    const DecodedVector& decoded,
-    vector_size_t index,
-    CompareFlags compareFlags) {
-  auto result = accumulator->compare(decoded, index, compareFlags);
-  VELOX_USER_CHECK(
-      result.has_value(),
-      fmt::format(
-          "{} comparison not supported for values that contain nulls",
-          mapTypeKindToName(decoded.base()->typeKind())));
-  return result.value();
-}
-
 void SingleValueAccumulator::destroy(HashStringAllocator* allocator) {
   if (start_.header != nullptr) {
     allocator->free(start_.header);

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.cpp
@@ -72,6 +72,21 @@ int32_t SingleValueAccumulator::compare(
       stream, decoded, index, {true, true, false});
 }
 
+// static
+int32_t SingleValueAccumulator::compare(
+    const SingleValueAccumulator* accumulator,
+    const DecodedVector& decoded,
+    vector_size_t index,
+    CompareFlags compareFlags) {
+  auto result = accumulator->compare(decoded, index, compareFlags);
+  VELOX_USER_CHECK(
+      result.has_value(),
+      fmt::format(
+          "{} comparison not supported for values that contain nulls",
+          mapTypeKindToName(decoded.base()->typeKind())));
+  return result.value();
+}
+
 void SingleValueAccumulator::destroy(HashStringAllocator* allocator) {
   if (start_.header != nullptr) {
     allocator->free(start_.header);

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -43,19 +43,6 @@ struct SingleValueAccumulator {
       vector_size_t index,
       CompareFlags compareFlags) const;
 
-  /// Returns 0 if stored and new values are equal; <0 if stored value is less
-  /// then new value; >0 if stored value is greater than new value.
-  ///
-  /// The caller needs to ensure that hasValue() is true before calling this
-  /// method.
-  int32_t compare(const DecodedVector& decoded, vector_size_t index) const;
-
-  static int32_t compare(
-      const SingleValueAccumulator* accumulator,
-      const DecodedVector& decoded,
-      vector_size_t index,
-      CompareFlags compareFlags);
-
   /// Returns memory back to HashStringAllocator.
   void destroy(HashStringAllocator* allocator);
 

--- a/velox/functions/lib/aggregates/SingleValueAccumulator.h
+++ b/velox/functions/lib/aggregates/SingleValueAccumulator.h
@@ -50,6 +50,12 @@ struct SingleValueAccumulator {
   /// method.
   int32_t compare(const DecodedVector& decoded, vector_size_t index) const;
 
+  static int32_t compare(
+      const SingleValueAccumulator* accumulator,
+      const DecodedVector& decoded,
+      vector_size_t index,
+      CompareFlags compareFlags);
+
   /// Returns memory back to HashStringAllocator.
   void destroy(HashStringAllocator* allocator);
 

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(
   BitwiseAggregates.cpp
   BoolAggregates.cpp
   CentralMomentsAggregates.cpp
+  Compare.cpp
   CountIfAggregate.cpp
   CovarianceAggregates.cpp
   ChecksumAggregate.cpp

--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Compare.h"
+
+namespace facebook::velox::aggregate::prestosql {
+
+int32_t compare(
+    const SingleValueAccumulator* accumulator,
+    const DecodedVector& decoded,
+    vector_size_t index) {
+  static const CompareFlags kCompareFlags{
+      true, // nullsFirst
+      true, // ascending
+      false, // equalsOnly
+      CompareFlags::NullHandlingMode::StopAtNull};
+
+  auto result = accumulator->compare(decoded, index, kCompareFlags);
+  VELOX_USER_CHECK(
+      result.has_value(),
+      fmt::format(
+          "{} comparison not supported for values that contain nulls",
+          mapTypeKindToName(decoded.base()->typeKind())));
+  return result.value();
+}
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#include "Compare.h"
+#include "velox/functions/prestosql/aggregates/Compare.h"
+
+using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
 

--- a/velox/functions/prestosql/aggregates/Compare.h
+++ b/velox/functions/prestosql/aggregates/Compare.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox::functions::aggregate;
+
+namespace facebook::velox::aggregate::prestosql {
+
+int32_t compare(
+    const SingleValueAccumulator* accumulator,
+    const DecodedVector& decoded,
+    vector_size_t index);
+
+} // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/Compare.h
+++ b/velox/functions/prestosql/aggregates/Compare.h
@@ -20,12 +20,17 @@
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/vector/DecodedVector.h"
 
-using namespace facebook::velox::functions::aggregate;
-
 namespace facebook::velox::aggregate::prestosql {
 
+/// Compare the new value of the DecodedVector at the given index with the value
+/// stored in the SingleValueAccumulator. Returns 0 if stored and new values are
+/// equal; <0 if stored value is less then new value; >0 if stored value is
+/// greater than new value.
+///
+/// The default nullHandlingMode in Presto is StopAtNull so it will throw an
+/// exception when complex type values contain nulls.
 int32_t compare(
-    const SingleValueAccumulator* accumulator,
+    const velox::functions::aggregate::SingleValueAccumulator* accumulator,
     const DecodedVector& decoded,
     vector_size_t index);
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -382,7 +382,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       }
       auto accumulator = value<SingleValueAccumulator>(groups[i]);
       if (!accumulator->hasValue() ||
-          compareTest(prestosql::compare(accumulator, decoded, i))) {
+          compareTest(compare(accumulator, decoded, i))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
@@ -406,7 +406,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(group);
       if (!accumulator->hasValue() ||
-          compareTest(prestosql::compare(accumulator, decoded, 0))) {
+          compareTest(compare(accumulator, decoded, 0))) {
         accumulator->write(baseVector, indices[0], allocator_);
       }
       return;
@@ -418,7 +418,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
         return;
       }
       if (!accumulator->hasValue() ||
-          compareTest(prestosql::compare(accumulator, decoded, i))) {
+          compareTest(compare(accumulator, decoded, i))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -20,6 +20,7 @@
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/Compare.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -381,8 +382,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       }
       auto accumulator = value<SingleValueAccumulator>(groups[i]);
       if (!accumulator->hasValue() ||
-          compareTest(SingleValueAccumulator::compare(
-              accumulator, decoded, i, kCompareFlags_))) {
+          compareTest(prestosql::compare(accumulator, decoded, i))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
@@ -406,8 +406,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
       auto accumulator = value<SingleValueAccumulator>(group);
       if (!accumulator->hasValue() ||
-          compareTest(SingleValueAccumulator::compare(
-              accumulator, decoded, 0, kCompareFlags_))) {
+          compareTest(prestosql::compare(accumulator, decoded, 0))) {
         accumulator->write(baseVector, indices[0], allocator_);
       }
       return;
@@ -419,19 +418,11 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
         return;
       }
       if (!accumulator->hasValue() ||
-          compareTest(SingleValueAccumulator::compare(
-              accumulator, decoded, i, kCompareFlags_))) {
+          compareTest(prestosql::compare(accumulator, decoded, i))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
   }
-
- private:
-  constexpr static CompareFlags kCompareFlags_{
-      true, // nullsFirst
-      true, // ascending
-      false, // equalsOnly
-      CompareFlags::NullHandlingMode::StopAtNull};
 };
 
 class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -47,13 +47,27 @@ struct Comparator {
       // is less than vector value.
       if constexpr (greaterThan) {
         return !accumulator->hasValue() ||
-            (accumulator->compare(newComparisons, index) < 0);
+            SingleValueAccumulator::compare(
+                dynamic_cast<SingleValueAccumulator*>(accumulator),
+                newComparisons,
+                index,
+                kCompareFlags_) < 0;
       } else {
         return !accumulator->hasValue() ||
-            (accumulator->compare(newComparisons, index) > 0);
+            SingleValueAccumulator::compare(
+                dynamic_cast<SingleValueAccumulator*>(accumulator),
+                newComparisons,
+                index,
+                kCompareFlags_) > 0;
       }
     }
   }
+
+  constexpr static CompareFlags kCompareFlags_{
+      true, // nullsFirst
+      true, // ascending
+      false, // equalsOnly
+      CompareFlags::NullHandlingMode::NoStop};
 };
 
 template <typename T>
@@ -1100,6 +1114,16 @@ template <
     template <typename U, typename V>
     class NAggregate>
 exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
+  // V, C -> row(V, C) -> V.
+  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
+                           .typeVariable("V")
+                           .typeVariable("C")
+                           .returnType("V")
+                           .intermediateType("row(V,C)")
+                           .argumentType("V")
+                           .argumentType("C")
+                           .build());
   const std::vector<std::string> supportedCompareTypes = {
       "boolean",
       "tinyint",
@@ -1111,19 +1135,6 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
       "varchar",
       "date",
       "timestamp"};
-
-  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
-  for (const auto& compareType : supportedCompareTypes) {
-    // V, C -> row(V, C) -> V.
-    signatures.push_back(
-        exec::AggregateFunctionSignatureBuilder()
-            .typeVariable("T")
-            .returnType("T")
-            .intermediateType(fmt::format("row(T,{})", compareType))
-            .argumentType("T")
-            .argumentType(compareType)
-            .build());
-  }
 
   // Add support for all value types to 3-arg version of the aggregate.
   for (const auto& compareType : supportedCompareTypes) {

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -48,16 +48,10 @@ struct Comparator {
       // is less than vector value.
       if constexpr (greaterThan) {
         return !accumulator->hasValue() ||
-            prestosql::compare(
-                dynamic_cast<SingleValueAccumulator*>(accumulator),
-                newComparisons,
-                index) < 0;
+            prestosql::compare(accumulator, newComparisons, index) < 0;
       } else {
         return !accumulator->hasValue() ||
-            prestosql::compare(
-                dynamic_cast<SingleValueAccumulator*>(accumulator),
-                newComparisons,
-                index) > 0;
+            prestosql::compare(accumulator, newComparisons, index) > 0;
       }
     }
   }

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -17,6 +17,7 @@
 #include "velox/functions/lib/aggregates/MinMaxByAggregatesBase.h"
 #include "velox/functions/lib/aggregates/ValueSet.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
+#include "velox/functions/prestosql/aggregates/Compare.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -47,27 +48,19 @@ struct Comparator {
       // is less than vector value.
       if constexpr (greaterThan) {
         return !accumulator->hasValue() ||
-            SingleValueAccumulator::compare(
+            prestosql::compare(
                 dynamic_cast<SingleValueAccumulator*>(accumulator),
                 newComparisons,
-                index,
-                kCompareFlags_) < 0;
+                index) < 0;
       } else {
         return !accumulator->hasValue() ||
-            SingleValueAccumulator::compare(
+            prestosql::compare(
                 dynamic_cast<SingleValueAccumulator*>(accumulator),
                 newComparisons,
-                index,
-                kCompareFlags_) > 0;
+                index) > 0;
       }
     }
   }
-
-  constexpr static CompareFlags kCompareFlags_{
-      true, // nullsFirst
-      true, // ascending
-      false, // equalsOnly
-      CompareFlags::NullHandlingMode::NoStop};
 };
 
 template <typename T>

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -44,16 +44,10 @@ struct SparkComparator {
     } else {
       if constexpr (sparkGreaterThan) {
         return !accumulator->hasValue() ||
-            compare(
-                dynamic_cast<SingleValueAccumulator*>(accumulator),
-                newComparisons,
-                index) <= 0;
+            compare(accumulator, newComparisons, index) <= 0;
       } else {
         return !accumulator->hasValue() ||
-            compare(
-                dynamic_cast<SingleValueAccumulator*>(accumulator),
-                newComparisons,
-                index) >= 0;
+            compare(accumulator, newComparisons, index) >= 0;
       }
     }
   }
@@ -67,13 +61,7 @@ struct SparkComparator {
         true, // ascending
         false, // equalsOnly
         CompareFlags::NullHandlingMode::NoStop};
-
     auto result = accumulator->compare(decoded, index, kCompareFlags);
-    VELOX_USER_CHECK(
-        result.has_value(),
-        fmt::format(
-            "{} comparison not supported for values that contain nulls",
-            mapTypeKindToName(decoded.base()->typeKind())));
     return result.value();
   }
 };

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -59,5 +59,161 @@ TEST_F(MinMaxByAggregateTest, minBy) {
   testAggregations(vectors, {}, {"spark_min_by(c0, c1)"}, expected);
 }
 
+TEST_F(MinMaxByAggregateTest, arrayCompare) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeNullableArrayVector<int64_t>({
+          {4, 5},
+          {std::nullopt, 2},
+          {6, 7, 8},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {4, 5},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+
+  data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeNullableArrayVector<int64_t>({
+          {1, 2, 3},
+          {3, std::nullopt, 4},
+          {6, 7, 8},
+      }),
+  });
+
+  expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+}
+
+TEST_F(MinMaxByAggregateTest, mapCompare) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{1, 1}, {2, 2}}},
+          {{{1, 1}, {2, std::nullopt}}},
+          {{{4, 50}}},
+      }),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {4, 5},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+
+  data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeNullableMapVector<int64_t, int64_t>({
+          {{{1, 1}, {2, 2}}},
+          {{{1, 1}, {2, 3}}},
+          {{{4, 50}}},
+      }),
+  });
+
+  expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+}
+
+TEST_F(MinMaxByAggregateTest, rowCompare) {
+  auto data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeRowVector({makeNullableFlatVector<int32_t>({
+          1,
+          std::nullopt,
+          3,
+      })}),
+  });
+
+  auto expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {4, 5},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+
+  data = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+          {4, 5},
+          {6, 7, 8},
+      }),
+      makeRowVector({makeNullableFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      })}),
+  });
+
+  expected = makeRowVector({
+      makeArrayVector<int64_t>({
+          {1, 2, 3},
+      }),
+      makeArrayVector<int64_t>({
+          {6, 7, 8},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+}
+
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test

--- a/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -83,7 +83,7 @@ TEST_F(MinMaxByAggregateTest, arrayCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 
   data = makeRowVector({
       makeArrayVector<int64_t>({
@@ -108,7 +108,7 @@ TEST_F(MinMaxByAggregateTest, arrayCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 }
 
 TEST_F(MinMaxByAggregateTest, mapCompare) {
@@ -135,7 +135,7 @@ TEST_F(MinMaxByAggregateTest, mapCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 
   data = makeRowVector({
       makeArrayVector<int64_t>({
@@ -160,7 +160,7 @@ TEST_F(MinMaxByAggregateTest, mapCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 }
 
 TEST_F(MinMaxByAggregateTest, rowCompare) {
@@ -187,7 +187,7 @@ TEST_F(MinMaxByAggregateTest, rowCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 
   data = makeRowVector({
       makeArrayVector<int64_t>({
@@ -212,7 +212,7 @@ TEST_F(MinMaxByAggregateTest, rowCompare) {
   });
 
   testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+      {data}, {}, {"spark_min_by(c0, c1)", "spark_max_by(c0, c1)"}, {expected});
 }
 
 } // namespace


### PR DESCRIPTION
In Presto, min_by and max_by functions with complex types for the "compare" parameter throw in case of nested nulls. For example, the following query fails,

```
presto> SELECT min_by(col0, col1) FROM (VALUES (5, array [1, 2]), (4, array [null, 3])) AS tbl(col0, col1);
Query 20230916_120046_00011_28jc9 failed: ARRAY comparison not supported for arrays with null elements
```

However in Spark, that query completes successfully.

```
spark-sql> SELECT min_by(col0, col1) FROM (VALUES (5, array (1, 2)), (4, array (null, 3))) AS tbl(col0, col1);
4
```

Part of https://github.com/facebookincubator/velox/issues/6314