### PR TITLE
[ORC]Fix crash problem when reading orc files with null data

### DIFF
--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -139,6 +139,7 @@ void HiveConnectorFactory::initialize() {
   static bool once = []() {
     dwio::common::registerFileSinks();
     dwrf::registerDwrfReaderFactory();
+    dwrf::registerOrcReaderFactory();
     dwrf::registerDwrfWriterFactory();
 // Meta's buck build system needs this check.
 #ifdef VELOX_ENABLE_PARQUET

--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -299,7 +299,9 @@ class SelectiveColumnReader {
         values_->capacity());
 
     anyNulls_ = true;
-    bits::setNull(rawResultNulls_, numValues_);
+    if (!returnReaderNulls_) {
+      bits::setNull(rawResultNulls_, numValues_);
+    }
     // Set the default value at the nominal width of the reader but
     // calculate the index based on the actual width of the
     // data. These may differ for integer and dictionary readers.

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -426,7 +426,8 @@ class FooterWrapper : public ProtoWrapperBase {
 
   // TODO: ORC has not supported column statistics yet
   int statisticsSize() const {
-    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->statistics_size() : 0;
+    return format_ == DwrfFormat::kDwrf ? dwrfPtr()->statistics_size()
+                                        : orcPtr()->statistics_size();
   }
 
   const ::google::protobuf::RepeatedPtrField<
@@ -438,7 +439,6 @@ class FooterWrapper : public ProtoWrapperBase {
 
   const ::facebook::velox::dwrf::proto::ColumnStatistics& statistics(
       int index) const {
-    VELOX_CHECK_EQ(format_, DwrfFormat::kDwrf);
     return dwrfPtr()->statistics(index);
   }
 

--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -1064,8 +1064,16 @@ void registerDwrfReaderFactory() {
   dwio::common::registerReaderFactory(std::make_shared<DwrfReaderFactory>());
 }
 
+void registerOrcReaderFactory() {
+  dwio::common::registerReaderFactory(std::make_shared<OrcReaderFactory>());
+}
+
 void unregisterDwrfReaderFactory() {
   dwio::common::unregisterReaderFactory(dwio::common::FileFormat::DWRF);
+}
+
+void unregisterOrcReaderFactory() {
+  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::ORC);
 }
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -372,8 +372,23 @@ class DwrfReaderFactory : public dwio::common::ReaderFactory {
   }
 };
 
+class OrcReaderFactory : public dwio::common::ReaderFactory {
+ public:
+  OrcReaderFactory() : ReaderFactory(dwio::common::FileFormat::ORC) {}
+
+  std::unique_ptr<dwio::common::Reader> createReader(
+      std::unique_ptr<dwio::common::BufferedInput> input,
+      const dwio::common::ReaderOptions& options) override {
+    return DwrfReader::create(std::move(input), options);
+  }
+};
+
 void registerDwrfReaderFactory();
 
+void registerOrcReaderFactory();
+
 void unregisterDwrfReaderFactory();
+
+void unregisterOrcReaderFactory();
 
 } // namespace facebook::velox::dwrf


### PR DESCRIPTION
I have an ORC table, and the query results through presto are as follows:
```
presto:tpch_velox> select * from data_with_null;
  id
------
 NULL
    1
    2
(3 rows)
```
but when I use velox to read this table, the worker will crash and the following exception will appear:
```
I0908 05:55:31.340974   182 DwrfReader.cpp:436] [DWRF] Load read plan for stripe 1
*** Aborted at 1694145331 (Unix time, try 'date -d @1694145331') ***
*** Signal 11 (SIGSEGV) (0x0) received by PID 32 (pthread TID 0x7f1c2affd700) (linux TID 90) (code: address not mapped to object), stack trace: ***
(error retrieving stack trace)
```
After I use `InstallFailureSignalHandler` to handle the `SIGSEGV` signal, I get the following exception stack:
```
*** Aborted at 1695038496 (unix time) try "date -d @1695038496" if you are using GNU date ***
PC: @                0x0 facebook::velox::BaseStatsReporter::registered
*** SIGSEGV (@0x0) received by PID 16625 (TID 0x16f5eb000) stack trace: ***
    @        0x192a86a24 _sigtramp
    @        0x100f1a3a4 facebook::velox::bits::setNull()
    @        0x106b13bc8 facebook::velox::dwio::common::SelectiveColumnReader::addNull<>()
    @        0x106e729a4 facebook::velox::dwio::common::ExtractToReader<>::addNull<>()
    @        0x106e72978 facebook::velox::dwio::common::ColumnVisitor<>::addNull()
    @        0x106e7294c facebook::velox::dwio::common::ColumnVisitor<>::filterPassedForNull()
    @        0x106e71ea4 facebook::velox::dwio::common::ColumnVisitor<>::processNull()
    @        0x106bbb2e4 facebook::velox::dwrf::RleDecoderV2<>::readWithVisitor<>()
    @        0x106bb75cc facebook::velox::dwio::common::SelectiveColumnReader::decodeWithVisitor<>()
    @        0x106bb2464 facebook::velox::dwrf::SelectiveIntegerDirectColumnReader::readWithVisitor<>()
    @        0x106bb0ca8 facebook::velox::dwio::common::SelectiveIntegerColumnReader::readHelper<>()
    @        0x106b43540 facebook::velox::dwio::common::SelectiveIntegerColumnReader::processFilter<>()
    @        0x106b42e1c facebook::velox::dwio::common::SelectiveIntegerColumnReader::readCommon<>()
    @        0x106b42a28 facebook::velox::dwrf::SelectiveIntegerDirectColumnReader::read()
    @        0x102aaa848 facebook::velox::dwio::common::ColumnLoader::loadInternal()
    @        0x106264e4c facebook::velox::VectorLoader::load()
    @        0x106266394 facebook::velox::LazyVector::load()
    @        0x106265f98 facebook::velox::LazyVector::ensureLoadedRowsImpl()
    @        0x106265568 facebook::velox::LazyVector::ensureLoadedRows()
    @        0x102c6e3f4 facebook::velox::exec::loadColumns()
    @        0x102c27dc8 facebook::velox::exec::CallbackSink::addInput()
    @        0x102b62468 facebook::velox::exec::Driver::runInternal()
    @        0x102b6440c facebook::velox::exec::Driver::run()
    @        0x102b6a2b4 facebook::velox::exec::Driver::enqueue()::$_1::operator()()
```
 I have tested other types and all have this problem. By analyzing the code, I found that when we use the avx CPU architecture, [useBulkPath() of SelectiveColumnReader#prepareNulls will return true](https://github.com/facebookincubator/velox/blob/main/velox/dwio/common/SelectiveColumnReader.cpp#L102-L112), which will cause the `rawResultNulls_` variable not to be initialized, but [this line of code](https://github.com/facebookincubator/velox/blob/main/velox/dwio/common/SelectiveColumnReader.h#L302) of `SelectiveColumnReader#addNull` will call `bits::setNull( rawResultNulls_, numValues_)`, which causes an exception.
