### PR TITLE
Add driver thread context to fix memory arbitration deadlock

### DIFF
--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -421,6 +421,12 @@ uint64_t SharedArbitrator::reclaim(
   numReclaimedBytes_ += reclaimedBytes - freedBytes;
   numShrunkBytes_ += freedBytes;
   reclaimTimeUs_ += reclaimDurationUs;
+  VELOX_MEM_LOG(INFO) << "Reclaimed from memory pool " << pool->name()
+                      << " with target of " << succinctBytes(targetBytes)
+                      << ", actually reclaimed " << succinctBytes(freedBytes)
+                      << " free memory and "
+                      << succinctBytes(reclaimedBytes - freedBytes)
+                      << " used memory";
   return reclaimedBytes;
 }
 

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -14,12 +14,9 @@
  * limitations under the License.
  */
 #include "velox/exec/OrderBy.h"
-#include "velox/common/testutil/TestValue.h"
 #include "velox/exec/OperatorUtils.h"
 #include "velox/exec/Task.h"
 #include "velox/vector/FlatVector.h"
-
-using facebook::velox::common::testutil::TestValue;
 
 namespace facebook::velox::exec {
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -1313,3 +1313,29 @@ DEBUG_ONLY_TEST_F(DriverTest, driverSuspensionCalledFromOffThread) {
   ASSERT_ANY_THROW(driver->task()->enterSuspended(driver->state()));
   ASSERT_ANY_THROW(driver->task()->leaveSuspended(driver->state()));
 }
+
+DEBUG_ONLY_TEST_F(DriverTest, driverThreadContext) {
+  ASSERT_TRUE(driverThreadContext() == nullptr);
+  std::thread nonDriverThread(
+      [&]() { ASSERT_TRUE(driverThreadContext() == nullptr); });
+  nonDriverThread.join();
+
+  std::atomic<Task*> capturedTask{nullptr};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Values::getOutput",
+      std::function<void(const exec::Values*)>([&](const exec::Values* values) {
+        ASSERT_TRUE(driverThreadContext() != nullptr);
+        capturedTask = driverThreadContext()->driverCtx.task.get();
+      }));
+  std::vector<RowVectorPtr> batches;
+  for (int i = 0; i < 4; ++i) {
+    batches.push_back(
+        makeRowVector({"c0"}, {makeFlatVector<int32_t>({1, 2, 3})}));
+  }
+  createDuckDbTable(batches);
+
+  auto plan = PlanBuilder().values(batches).planNode();
+  auto task = AssertQueryBuilder(plan, duckDbQueryRunner_)
+                  .assertResults("SELECT * FROM tmp");
+  ASSERT_EQ(task.get(), capturedTask);
+}


### PR DESCRIPTION
Meta internal shadowing test discover the following memory use case
can cause memory arbitration deadlock:
T1: opA allocate a buffer
T2: opB from a different driver re-allocate the buffer
T3: opB triggers the memory arbitration and suppose opB's driver is the
      only running driver from the task, and opA's driver is currently off thread
T4: opB memory reclaimer enter arbitration which find out its driver is not
       running so treat it as a memory arbitration issued from non-driver thread
       context so it doesn't put the driver in suspension state.
T5: when task tries to reclaim and hangs in task pause wait as running driver
       thread will never go down to zero.

This PR fix the issue by introducing a DriverThreadContext which contains the
driver ctx of a running driver. It is set to a thread local variable when a driver
starts execution on a driver thread and clears when the driver leaves the driver
thread. And provides to access the thread local variable to help detects if a
thread is running a driver and access the current driver data structure if needs.
First used in operator reclaimer enter arbitration handling to check if needs to
put the driver into suspension state. We simply needs to put the driver into
suspension state if it is set in thread local variable. Later on we might integrate
the per-op state such runtime stats into DriverThreadContext to consolidate
such driver/op execution contexts into one data structure to ease management.

Unit test is added to reproduce the deadlock and verified the fix.