### PR TITLE
Fix BaseVector::resizeIndices

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -308,9 +308,9 @@ void FlatMapColumnReader<T>::next(
   const auto* nullsPtr = nulls ? nulls->as<uint64_t>() : nullptr;
   uint64_t nullCount = nullsPtr ? bits::countNulls(nullsPtr, 0, numValues) : 0;
 
-  if (mapVector) {
-    detail::resetIfNotWritable(result, offsets, lengths);
-  }
+  // Release extra references of keys and values vectors as well as nulls,
+  // offsets and lengths buffers.
+  result.reset();
 
   if (!offsets) {
     offsets = AlignedBuffer::allocate<vector_size_t>(numValues, &memoryPool_);

--- a/velox/serializers/PrestoSerializer.cpp
+++ b/velox/serializers/PrestoSerializer.cpp
@@ -607,8 +607,7 @@ void readRowVector(
             size,
             pool,
             &offsets,
-            const_cast<const vector_size_t**>(&rawOffsets),
-            0);
+            const_cast<const vector_size_t**>(&rawOffsets));
         for (int32_t child = 0; child < i; ++child) {
           rawOffsets[child] = child;
         }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -618,18 +618,6 @@ class BaseVector {
     setNulls(nullptr);
   }
 
-  // Ensures that '*indices' has space for 'size' elements. Sets
-  // elements between the old and new sizes to 'initialValue' if the
-  // new size > old size. If memory is moved, '*raw' is maintained to
-  // point to element 0 of (*indices)->as<vector_size_t>().
-  void resizeIndices(
-      vector_size_t size,
-      BufferPtr* indices,
-      const vector_size_t** raw,
-      std::optional<vector_size_t> initialValue = std::nullopt) {
-    resizeIndices(size, this->pool(), indices, raw, initialValue);
-  }
-
   void
   clearIndices(BufferPtr& indices, vector_size_t start, vector_size_t end) {
     if (start == end) {
@@ -639,12 +627,19 @@ class BaseVector {
     std::fill(data + start, data + end, 0);
   }
 
+  /// Ensures that '*indices' is singly-referenced and has space for 'size'
+  /// elements. Sets elements between the old and new sizes to 0 if
+  /// the new size > old size.
+  ///
+  /// If '*indices' is nullptr, read-only, not uniquely-referenced, or doesn't
+  /// have capacity for 'size' elements allocates new buffer and copies data to
+  /// it. Updates '*raw' to point to element 0 of
+  /// (*indices)->as<vector_size_t>().
   static void resizeIndices(
       vector_size_t size,
       velox::memory::MemoryPool* pool,
       BufferPtr* indices,
-      const vector_size_t** raw,
-      std::optional<vector_size_t> initialValue = std::nullopt);
+      const vector_size_t** raw);
 
   // Makes sure '*buffer' has space for 'size' items of T and is writable. Sets
   // 'raw' to point to the writable contents of '*buffer'.

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -266,17 +266,19 @@ struct ArrayVectorBase : BaseVector {
   }
 
   BufferPtr mutableOffsets(size_t size) {
-    return ensureIndices(offsets_, rawOffsets_, size);
+    BaseVector::resizeIndices(size, pool_, &offsets_, &rawOffsets_);
+    return offsets_;
   }
 
   BufferPtr mutableSizes(size_t size) {
-    return ensureIndices(sizes_, rawSizes_, size);
+    BaseVector::resizeIndices(size, pool_, &sizes_, &rawSizes_);
+    return sizes_;
   }
 
   void resize(vector_size_t size, bool setNotNull = true) override {
     if (BaseVector::length_ < size) {
-      resizeIndices(size, &offsets_, &rawOffsets_);
-      resizeIndices(size, &sizes_, &rawSizes_);
+      BaseVector::resizeIndices(size, pool_, &offsets_, &rawOffsets_);
+      BaseVector::resizeIndices(size, pool_, &sizes_, &rawSizes_);
       clearIndices(sizes_, length_, size);
       // No need to clear offset indices since we set sizes to 0.
     }
@@ -333,19 +335,6 @@ struct ArrayVectorBase : BaseVector {
   void validateArrayVectorBase(
       const VectorValidateOptions& options,
       vector_size_t minChildVectorSize) const;
-
- private:
-  BufferPtr
-  ensureIndices(BufferPtr& buf, const vector_size_t*& raw, vector_size_t size) {
-    // TODO: change this to isMutable(). See
-    // https://github.com/facebookincubator/velox/issues/6562.
-    if (buf && !buf->isView() &&
-        buf->capacity() >= size * sizeof(vector_size_t)) {
-      return buf;
-    }
-    resizeIndices(size, &buf, &raw, 0);
-    return buf;
-  }
 
  protected:
   BufferPtr offsets_;

--- a/velox/vector/DictionaryVector.h
+++ b/velox/vector/DictionaryVector.h
@@ -205,7 +205,8 @@ class DictionaryVector : public SimpleVector<T> {
   /// If setNotNull is false then the values and isNull is undefined.
   void resize(vector_size_t size, bool setNotNull = true) override {
     if (size > BaseVector::length_) {
-      this->resizeIndices(size, &indices_, &rawIndices_);
+      BaseVector::resizeIndices(
+          size, BaseVector::pool(), &indices_, &rawIndices_);
       this->clearIndices(indices_, BaseVector::length_, size);
     }
 


### PR DESCRIPTION
Summary:
BaseVector::resizeIndices didn't check that indices buffer is singly-referenced.
This allowed modifications to shared buffers causing corruptions.

This issue affected Array/MapVector::mutableOffsets/Sizes and
Array/Map/DictionaryVector::resize.

There is a similar issue in FlatVector::mutableValues. Will address in a follow-up.

Part of https://github.com/facebookincubator/velox/issues/6562

Differential Revision: D49413262


