### PR TITLE
Add simple PlanBuilder::tableWrite API

### DIFF
--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -242,6 +242,13 @@ class PlanBuilder {
   /// function will skip creating a FilterNode in that case.
   PlanBuilder& optionalFilter(const std::string& optionalFilter);
 
+  /// Adds a TableWriteNode to write all input columns into an unpartitioned
+  /// unbucketed Hive table without collecting statistics using DWRF file format
+  /// without compression.
+  ///
+  /// @param outputDirectoryPath Path to a directory to write data to.
+  PlanBuilder& tableWrite(const std::string& outputDirectoryPath);
+
   /// Adds a TableWriteNode.
   ///
   /// @param inputColumns A subset of input columns to write.


### PR DESCRIPTION
Add a simple API to add TableWriteNode to write into unpartitioned unbucketed
table without collecting statistics using DWRF file format without compression.

This API takes single argument: directory to write the data to. 

```
  auto plan = PlanBuilder()
                  .tableScan(rowType)
                  .tableWrite(targetDirectoryPath->path)
                  .planNode();
```