### PR TITLE
Avoid copying result in FieldReference in common case

### DIFF
--- a/velox/exec/tests/FilterProjectTest.cpp
+++ b/velox/exec/tests/FilterProjectTest.cpp
@@ -15,8 +15,10 @@
  */
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/OperatorTestBase.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
 
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
@@ -321,4 +323,89 @@ TEST_F(FilterProjectTest, projectAndIdentityOverLazy) {
                   .project({"c0 < 10 AND c1 < 10", "c1"})
                   .planNode();
   assertQuery(plan, "SELECT c0 < 10 AND c1 < 10, c1 FROM tmp");
+}
+
+// Verify that nulls on nested parent are propagated to child without copying
+// the child.  Note that null on top level columns are handled separately in
+// Expr::evalWithNulls; this happens only once per expression tree so we are not
+// optimizing that code.  We are testing the optimization of potentially more
+// expensive case of FieldReference::evalSpecialForm here.
+TEST_F(FilterProjectTest, nestedFieldReference) {
+  auto vector = makeRowVector({
+      makeRowVector({
+          makeRowVector(
+              {
+                  makeRowVector({
+                      makeFlatVector<int32_t>(10, folly::identity),
+                  }),
+              },
+              [](auto i) { return i % 2 == 0; }),
+      }),
+  });
+  // Project c0.c0.c0.c0.  Duck DB fails to parse such an expression.
+  std::shared_ptr<const core::IExpr> expr = std::make_shared<core::InputExpr>();
+  for (int i = 0; i < 4; ++i) {
+    std::vector<std::shared_ptr<const core::IExpr>> inputs;
+    inputs.push_back(expr);
+    expr = std::make_shared<core::FieldAccessExpr>(
+        "c0", std::nullopt, std::move(inputs));
+  }
+  CursorParameters params;
+  params.planNode =
+      PlanBuilder().values({vector}).projectExpressions({expr}).planNode();
+  params.copyResult = false;
+  TaskCursor cursor(params);
+  ASSERT_TRUE(cursor.moveNext());
+  auto result = cursor.current();
+  auto* actual = result->as<RowVector>()->childAt(0).get();
+  const BaseVector* expected = vector.get();
+  for (int i = 0; i < 4; ++i) {
+    expected = expected->as<RowVector>()->childAt(0).get();
+  }
+  ASSERT_EQ(*actual->type(), *expected->type());
+  ASSERT_EQ(actual, expected);
+  for (int i = 0; i < actual->size(); ++i) {
+    ASSERT_EQ(actual->isNullAt(i), i % 2 == 0);
+  }
+}
+
+// Verify the optimization of avoiding copy in null propagation does not break
+// the case when the field is shared between multiple parents.
+TEST_F(FilterProjectTest, nestedFieldReferenceSharedChild) {
+  auto shared = makeFlatVector<int64_t>(10, folly::identity);
+  auto vector = makeRowVector({
+      makeRowVector({
+          makeRowVector({shared}, [](auto i) { return i % 2 == 0; }),
+          makeRowVector({shared}, [](auto i) { return i % 3 == 0; }),
+      }),
+  });
+  // coalesce(c0.c0.c0, 0) + coalesce(c0.c1.c0, 0).  Duck DB fails to infer the
+  // correct type.
+  std::shared_ptr<const core::IExpr> expr;
+  std::vector<std::shared_ptr<const core::IExpr>> plusInputs;
+  for (int j = 0; j < 2; ++j) {
+    expr = std::make_shared<core::InputExpr>();
+    std::vector<std::shared_ptr<const core::IExpr>> inputs;
+    for (int i = 0; i < 3; ++i) {
+      inputs.push_back(expr);
+      expr = std::make_shared<core::FieldAccessExpr>(
+          i == 1 && j == 1 ? "c1" : "c0", std::nullopt, std::move(inputs));
+    }
+    inputs.push_back(expr);
+    expr = std::make_shared<core::ConstantExpr>(
+        BIGINT(), variant(0ll), std::nullopt);
+    inputs.push_back(expr);
+    expr = std::make_shared<core::CallExpr>(
+        "coalesce", std::move(inputs), std::nullopt);
+    plusInputs.push_back(expr);
+  }
+  expr = std::make_shared<core::CallExpr>(
+      "plus", std::move(plusInputs), std::nullopt);
+  auto plan =
+      PlanBuilder().values({vector}).projectExpressions({expr}).planNode();
+  auto expected = makeFlatVector<int64_t>(10);
+  for (int i = 0; i < 10; ++i) {
+    expected->set(i, (i % 2 == 0 ? 0 : i) + (i % 3 == 0 ? 0 : i));
+  }
+  AssertQueryBuilder(plan).assertResults(makeRowVector({expected}));
 }

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -147,9 +147,10 @@ TaskCursor::TaskCursor(const CursorParameters& params)
       params.destination,
       std::move(queryCtx),
       // consumer
-      [queue](RowVectorPtr vector, velox::ContinueFuture* future) {
-        if (!vector) {
-          return queue->enqueue(nullptr, future);
+      [queue, copyResult = params.copyResult](
+          RowVectorPtr vector, velox::ContinueFuture* future) {
+        if (!vector || !copyResult) {
+          return queue->enqueue(vector, future);
         }
         // Make sure to load lazy vector if not loaded already.
         for (auto& child : vector->children()) {

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -52,6 +52,8 @@ struct CursorParameters {
   /// Spilling directory, if not empty, then the task's spilling directory would
   /// be built from it.
   std::string spillDirectory;
+
+  bool copyResult = true;
 };
 
 class TaskQueue {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -228,6 +228,12 @@ class PlanBuilder {
   /// will produce projected columns named sum_ab, c and p2.
   PlanBuilder& project(const std::vector<std::string>& projections);
 
+  /// Variation of project that takes untyped expressions.  Used for access
+  /// deeply nested types, in which case Duck DB often fails to parse or infer
+  /// the type.
+  PlanBuilder& projectExpressions(
+      const std::vector<std::shared_ptr<const core::IExpr>>& projections);
+
   /// Similar to project() except 'optionalProjections' could be empty and the
   /// function will skip creating a ProjectNode in that case.
   PlanBuilder& optionalProject(

--- a/velox/expression/FieldReference.h
+++ b/velox/expression/FieldReference.h
@@ -83,6 +83,12 @@ class FieldReference : public SpecialForm {
   void
   apply(const SelectivityVector& rows, EvalCtx& context, VectorPtr& result);
 
+  bool addNullsFast(
+      const SelectivityVector& rows,
+      EvalCtx& context,
+      VectorPtr& result,
+      const RowVector* row);
+
   const std::string field_;
   int32_t index_ = -1;
 };


### PR DESCRIPTION
Summary:
In `FieldReference::evalSpecialForm`, we copy the child vector unconditionally (because it is referenced in both parent vector and `result` vector) in order to add nulls on it .  This is particularly inefficient for nested structs.  Fix this by allowing adding null in-place if the child is uniquely owned by the parent.

There is another place in `Expr::evalWithNulls` that we also make a copy of the column, but it is done only once for each top level column, so it is relatively less expensive comparing to `FieldReference` which is also copying on each internal vector.  Still there is some chance to further optimize it.

Differential Revision: D49400857

