### PR TITLE
Fix crash in ExprCompiler

### DIFF
--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -83,6 +83,8 @@ struct Scope {
   // Deduplicatable ITypedExprs. Only applies within the one scope.
   ExprDedupMap visited;
 
+  std::vector<TypedExprPtr> rewrittenExpressions;
+
   Scope(std::vector<std::string>&& _locals, Scope* _parent, ExprSet* _exprSet)
       : locals(_locals), parent(_parent), exprSet(_exprSet) {}
 
@@ -521,6 +523,9 @@ ExprPtr compileExpression(
     const std::unordered_set<std::string>& flatteningCandidates,
     bool enableConstantFolding) {
   auto rewritten = rewriteExpression(expr);
+  if (rewritten.get() != expr.get()) {
+    scope->rewrittenExpressions.push_back(rewritten);
+  }
   return compileRewrittenExpression(
       rewritten == nullptr ? expr : rewritten,
       scope,


### PR DESCRIPTION
When expression contains array_sort function call, rewriteExpression rewrites it
and returns a different expression. compileRewrittenExpression used to store a
pointer to rewritten expression in F14FastMap, which went out of scope and
resulting in a dangling pointer stored in F14FastMap. Whenever, F14Map needed
to check that entry it causes a crash.

A fix is to store a pointer to the original (before re-write) expression.

New test reproduces the crash.