### PR TITLE
Fix : try_cast custom types.

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -504,11 +504,40 @@ void CastExpr::applyPeeled(
         "Attempting to cast from {} to itself.",
         fromType->toString());
 
-    if (castToOperator_) {
-      castToOperator_->castTo(input, context, rows, toType, result);
+    auto applyCustomCast = [&]() {
+      if (castToOperator_) {
+        castToOperator_->castTo(input, context, rows, toType, result);
+      } else {
+        castFromOperator_->castFrom(input, context, rows, toType, result);
+      }
+    };
+
+    if (setNullInResultAtError()) {
+      // This can be optimized by passing setNullInResultAtError() to castTo and
+      // castFrom operations.
+
+      ErrorVectorPtr oldErrors;
+      context.swapErrors(oldErrors);
+
+      applyCustomCast();
+
+      if (context.errors()) {
+        auto errors = context.errors();
+        auto rawNulls = result->mutableRawNulls();
+
+        rows.applyToSelected([&](auto row) {
+          if (errors->isIndexInRange(row) && !errors->isNullAt(row)) {
+            bits::setNull(rawNulls, row, true);
+          }
+        });
+      };
+      // Restore original state.
+      context.swapErrors(oldErrors);
+
     } else {
-      castFromOperator_->castFrom(input, context, rows, toType, result);
+      applyCustomCast();
     }
+
   } else if (fromType->isDate()) {
     result = castFromDate(rows, input, context, toType);
   } else if (toType->isDate()) {

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -45,7 +45,7 @@ class JsonCastTest : public functions::test::CastBaseTest {
     auto expectedVector =
         makeNullableFlatVector<JsonNativeType>(expected, JSON());
 
-    testCast<JsonNativeType>(fromType, JSON(), arrayVector, expectedVector);
+    testCast(fromType, JSON(), arrayVector, expectedVector);
   }
 
   template <typename TKey, typename TValue>
@@ -57,7 +57,7 @@ class JsonCastTest : public functions::test::CastBaseTest {
     auto expectedVector =
         makeNullableFlatVector<JsonNativeType>(expected, JSON());
 
-    testCast<JsonNativeType>(fromType, JSON(), mapVector, expectedVector);
+    testCast(fromType, JSON(), mapVector, expectedVector);
   }
 
   template <typename TChild1, typename TChild2, typename TChild3>
@@ -78,7 +78,7 @@ class JsonCastTest : public functions::test::CastBaseTest {
     auto expectedVector =
         makeNullableFlatVector<JsonNativeType>(expected, JSON());
 
-    testCast<JsonNativeType>(fromType, JSON(), rowVector, expectedVector);
+    testCast(fromType, JSON(), rowVector, expectedVector);
   }
 
   // Populates offsets and sizes buffers for making array and map vectors.
@@ -323,8 +323,7 @@ TEST_F(JsonCastTest, fromUnknown) {
   auto input = makeFlatUnknownVector(3);
   auto expected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt}, JSON());
-  evaluateAndVerify<JsonNativeType>(
-      UNKNOWN(), JSON(), makeRowVector({input}), expected);
+  evaluateAndVerify(UNKNOWN(), JSON(), makeRowVector({input}), expected);
 }
 
 TEST_F(JsonCastTest, fromArray) {
@@ -345,7 +344,7 @@ TEST_F(JsonCastTest, fromArray) {
       ARRAY(UNKNOWN()));
   auto arrayOfUnknownElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,null]", "[null,null]"}, JSON());
-  testCast<JsonNativeType>(
+  testCast(
       ARRAY(UNKNOWN()),
       JSON(),
       arrayOfUnknownElements,
@@ -356,7 +355,7 @@ TEST_F(JsonCastTest, fromArray) {
       makeArrayWithDictionaryElements<int64_t>({1, -2, 3, -4, 5, -6, 7}, 2);
   auto arrayOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,-6]", "[5,-4]", "[3,-2]", "[1]"}, JSON());
-  testCast<JsonNativeType>(
+  testCast(
       ARRAY(BIGINT()),
       JSON(),
       arrayOfDictElements,
@@ -370,7 +369,7 @@ TEST_F(JsonCastTest, fromArray) {
           ARRAY(JSON()));
   auto jsonArrayOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,f]", "[e,d]", "[c,b]", "[a]"}, JSON());
-  testCast<JsonNativeType>(
+  testCast(
       ARRAY(JSON()),
       JSON(),
       jsonArrayOfDictElements,
@@ -381,8 +380,7 @@ TEST_F(JsonCastTest, fromArray) {
   auto allNullExpected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       JSON());
-  testCast<JsonNativeType>(
-      ARRAY(BIGINT()), JSON(), allNullArray, allNullExpected);
+  testCast(ARRAY(BIGINT()), JSON(), allNullArray, allNullExpected);
 }
 
 TEST_F(JsonCastTest, fromMap) {
@@ -438,7 +436,7 @@ TEST_F(JsonCastTest, fromMap) {
        R"({"a":null})"},
       JSON());
 
-  testCast<JsonNativeType>(
+  testCast(
       MAP(VARCHAR(), UNKNOWN()),
       JSON(),
       mapOfUnknownValues,
@@ -455,7 +453,7 @@ TEST_F(JsonCastTest, fromMap) {
        R"({"b":2.2,"c":3.14})",
        R"({"a":1100})"},
       JSON());
-  testCast<JsonNativeType>(
+  testCast(
       MAP(VARCHAR(), DOUBLE()),
       JSON(),
       mapOfDictElements,
@@ -467,7 +465,7 @@ TEST_F(JsonCastTest, fromMap) {
   auto jsonMapOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"{f:-6E-10,g:null}", "{d:-4.4,e:null}", "{b:2.2,c:3.14}", "{a:1100}"},
       JSON());
-  testCast<JsonNativeType>(
+  testCast(
       MAP(JSON(), DOUBLE()),
       JSON(),
       jsonMapOfDictElements,
@@ -478,8 +476,7 @@ TEST_F(JsonCastTest, fromMap) {
   auto allNullExpected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       JSON());
-  testCast<JsonNativeType>(
-      MAP(VARCHAR(), BIGINT()), JSON(), allNullMap, allNullExpected);
+  testCast(MAP(VARCHAR(), BIGINT()), JSON(), allNullMap, allNullExpected);
 }
 
 TEST_F(JsonCastTest, fromRow) {
@@ -519,7 +516,7 @@ TEST_F(JsonCastTest, fromRow) {
   auto rowOfUnknownChildrenExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,null]", "[null,null]"}, JSON());
 
-  testCast<JsonNativeType>(
+  testCast(
       ROW({UNKNOWN(), UNKNOWN()}),
       JSON(),
       rowOfUnknownChildren,
@@ -530,7 +527,7 @@ TEST_F(JsonCastTest, fromRow) {
       {{1, 2, 3}, {4, 5, 6}, {7, 8, 9}}, ROW({BIGINT(), BIGINT(), BIGINT()}));
   auto rowOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,null,null]", "[2,5,8]", "[1,4,7]"}, JSON());
-  testCast<JsonNativeType>(
+  testCast(
       ROW({BIGINT(), BIGINT(), BIGINT()}),
       JSON(),
       rowOfDictElements,
@@ -544,7 +541,7 @@ TEST_F(JsonCastTest, fromRow) {
       ROW({JSON(), JSON(), JSON()}));
   auto jsonRowOfDictElementsExpected = makeNullableFlatVector<JsonNativeType>(
       {"[null,null,null]", "[a2,b2,c2]", "[a1,b1,c1]"}, JSON());
-  testCast<JsonNativeType>(
+  testCast(
       ROW({JSON(), JSON(), JSON()}),
       JSON(),
       jsonRowOfDictElements,
@@ -559,8 +556,7 @@ TEST_F(JsonCastTest, fromRow) {
   auto allNullExpected = makeNullableFlatVector<JsonNativeType>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt},
       JSON());
-  testCast<JsonNativeType>(
-      ROW({BIGINT()}), JSON(), allNullRow, allNullExpected);
+  testCast(ROW({BIGINT()}), JSON(), allNullRow, allNullExpected);
 }
 
 TEST_F(JsonCastTest, fromNested) {
@@ -611,7 +607,7 @@ TEST_F(JsonCastTest, fromNested) {
   auto expectedVector =
       makeNullableFlatVector<JsonNativeType>(expected, JSON());
 
-  testCast<JsonNativeType>(
+  testCast(
       ROW({MAP(VARCHAR(), ARRAY(BIGINT())), ARRAY(MAP(VARCHAR(), BIGINT()))}),
       JSON(),
       rowVector,
@@ -622,14 +618,14 @@ TEST_F(JsonCastTest, unsupportedTypes) {
   // Map keys cannot be timestamp.
   auto timestampKeyMap = makeMapVector<Timestamp, int64_t>({{}});
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           MAP(TIMESTAMP(), BIGINT()), JSON(), makeRowVector({timestampKeyMap})),
       "Cannot cast MAP<TIMESTAMP,BIGINT> to JSON");
 
   // All children of row must be of supported types.
   auto invalidTypeRow = makeRowVector({timestampKeyMap});
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           ROW({MAP(TIMESTAMP(), BIGINT())}),
           JSON(),
           makeRowVector({invalidTypeRow})),
@@ -654,7 +650,7 @@ TEST_F(JsonCastTest, unsupportedTypes) {
       nullKeyVector,
       valueVector);
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           MAP(VARCHAR(), BIGINT()), JSON(), makeRowVector({nullKeyMap})),
       "Map keys cannot be null.");
 
@@ -670,7 +666,7 @@ TEST_F(JsonCastTest, unsupportedTypes) {
       arrayKeyVector,
       valueVector);
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           MAP(ARRAY(BIGINT()), BIGINT()), JSON(), makeRowVector({arrayKeyMap})),
       "Cannot cast MAP<ARRAY<BIGINT>,BIGINT> to JSON");
 
@@ -687,13 +683,13 @@ TEST_F(JsonCastTest, unsupportedTypes) {
       jsonKeyVector,
       valueVector);
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           MAP(JSON(), BIGINT()), JSON(), makeRowVector({invalidJsonKeyMap})),
       "Cannot cast map with null keys to JSON");
 
   // Not allowing to cast from json to itself.
   VELOX_ASSERT_THROW(
-      evaluateCast<JsonNativeType>(
+      evaluateCast(
           JSON(),
           JSON(),
           makeRowVector({makeNullableFlatVector<JsonNativeType>(
@@ -879,7 +875,7 @@ TEST_F(JsonCastTest, toArray) {
        {{}},
        std::nullopt});
 
-  testCast<ComplexType>(JSON(), ARRAY(VARCHAR()), data, expected);
+  testCast(JSON(), ARRAY(VARCHAR()), data, expected);
 
   // Tests array that has null at every row.
   data = makeNullableFlatVector<JsonNativeType>(
@@ -887,7 +883,7 @@ TEST_F(JsonCastTest, toArray) {
   expected = makeNullableArrayVector<int64_t>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 
-  testCast<ComplexType>(JSON(), ARRAY(BIGINT()), data, expected);
+  testCast(JSON(), ARRAY(BIGINT()), data, expected);
 }
 
 TEST_F(JsonCastTest, toMap) {
@@ -903,7 +899,7 @@ TEST_F(JsonCastTest, toMap) {
        {{}},
        std::nullopt});
 
-  testCast<ComplexType>(JSON(), MAP(VARCHAR(), VARCHAR()), data, expected);
+  testCast(JSON(), MAP(VARCHAR(), VARCHAR()), data, expected);
 
   // Tests map of non-string keys.
   data = makeNullableFlatVector<JsonNativeType>(
@@ -918,7 +914,7 @@ TEST_F(JsonCastTest, toMap) {
        {{}},
        std::nullopt});
 
-  testCast<ComplexType>(JSON(), MAP(BIGINT(), DOUBLE()), data, expected);
+  testCast(JSON(), MAP(BIGINT(), DOUBLE()), data, expected);
 
   // Tests map that has null at every row.
   data = makeNullableFlatVector<JsonNativeType>(
@@ -926,7 +922,7 @@ TEST_F(JsonCastTest, toMap) {
   expected = makeNullableMapVector<StringView, int64_t>(
       {std::nullopt, std::nullopt, std::nullopt, std::nullopt, std::nullopt});
 
-  testCast<ComplexType>(JSON(), MAP(VARCHAR(), BIGINT()), data, expected);
+  testCast(JSON(), MAP(VARCHAR(), BIGINT()), data, expected);
 
   // Null keys or non-string keys in JSON maps are not allowed.
   testThrow<JsonNativeType, ComplexType>(
@@ -955,7 +951,7 @@ TEST_F(JsonCastTest, toRow) {
   auto child3 =
       makeNullableFlatVector<bool>({true, false, std::nullopt, std::nullopt});
 
-  testCast<ComplexType>(
+  testCast(
       JSON(),
       ROW({BIGINT(), VARCHAR(), BOOLEAN()}),
       array,
@@ -982,7 +978,7 @@ TEST_F(JsonCastTest, toRow) {
   auto child6 = makeNullableFlatVector<bool>(
       {true, true, true, false, false, std::nullopt});
 
-  testCast<ComplexType>(
+  testCast(
       JSON(),
       ROW({"k1", "k2", "k3"}, {BIGINT(), VARCHAR(), BOOLEAN()}),
       map,
@@ -993,7 +989,7 @@ TEST_F(JsonCastTest, toRow) {
   auto nullExpected = makeRowVector(ROW({BIGINT(), DOUBLE()}), 1);
   nullExpected->setNull(0, true);
 
-  testCast<ComplexType>(JSON(), ROW({BIGINT(), DOUBLE()}), null, nullExpected);
+  testCast(JSON(), ROW({BIGINT(), DOUBLE()}), null, nullExpected);
 }
 
 TEST_F(JsonCastTest, toNested) {
@@ -1006,7 +1002,7 @@ TEST_F(JsonCastTest, toNested) {
        {{{{}}}},
        {{}}});
 
-  testCast<ComplexType>(JSON(), ARRAY(ARRAY(VARCHAR())), array, arrayExpected);
+  testCast(JSON(), ARRAY(ARRAY(VARCHAR())), array, arrayExpected);
 
   auto map = makeNullableFlatVector<JsonNativeType>(
       {R"({"1":[1.1,1.2],"2":[2,2.1]})"_sv, R"({"3":null,"4":[4.1,4.2]})"_sv});
@@ -1028,8 +1024,7 @@ TEST_F(JsonCastTest, toNested) {
       sizes,
       keys,
       innerArray);
-  testCast<ComplexType>(
-      JSON(), MAP(VARCHAR(), ARRAY(DOUBLE())), map, mapExpected);
+  testCast(JSON(), MAP(VARCHAR(), ARRAY(DOUBLE())), map, mapExpected);
 }
 
 TEST_F(JsonCastTest, toArrayAndMapOfJson) {
@@ -1040,7 +1035,7 @@ TEST_F(JsonCastTest, toArrayAndMapOfJson) {
       {{"[1,2]"_sv, "[null]"_sv, "null"_sv, "\"3\""_sv}, {"[]"_sv}, {}},
       ARRAY(JSON()));
 
-  testCast<ComplexType>(JSON(), ARRAY(JSON()), array, arrayExpected);
+  testCast(JSON(), ARRAY(JSON()), array, arrayExpected);
 
   // Test casting to map of JSON values.
   auto map = makeNullableFlatVector<JsonNativeType>(
@@ -1057,7 +1052,7 @@ TEST_F(JsonCastTest, toArrayAndMapOfJson) {
        {}},
       MAP(VARCHAR(), JSON()));
 
-  testCast<ComplexType>(JSON(), MAP(VARCHAR(), JSON()), map, mapExpected);
+  testCast(JSON(), MAP(VARCHAR(), JSON()), map, mapExpected);
 
   // The type of map keys is not allowed to be JSON.
   testThrow<JsonNativeType, ComplexType>(
@@ -1211,7 +1206,7 @@ TEST_F(JsonCastTest, tryCastFromJson) {
       JSON());
   auto expectedMap =
       makeNullableMapVector<int64_t, float>({std::nullopt, std::nullopt});
-  evaluateAndVerify<ComplexType>(
+  evaluateAndVerify(
       JSON(), MAP(BIGINT(), REAL()), makeRowVector({data}), expectedMap, true);
 
   // To array(bigint).
@@ -1220,7 +1215,7 @@ TEST_F(JsonCastTest, tryCastFromJson) {
       JSON());
   auto expectedArray =
       makeNullableArrayVector<float>({std::nullopt, std::nullopt});
-  evaluateAndVerify<ComplexType>(
+  evaluateAndVerify(
       JSON(), ARRAY(REAL()), makeRowVector({data}), expectedArray, true);
 
   // To row(bigint).
@@ -1228,21 +1223,20 @@ TEST_F(JsonCastTest, tryCastFromJson) {
       {R"(["101a"])"_sv, R"(["28593278167872960000000a"])"_sv}, JSON());
   auto expectedRow = makeRowVector(
       {makeFlatVector<float>({0, 0})}, [](auto /*row*/) { return true; });
-  evaluateAndVerify<ComplexType>(
+  evaluateAndVerify(
       JSON(), ROW({REAL()}), makeRowVector({data}), expectedRow, true);
 
   // To primitive.
   data = makeFlatVector<JsonNativeType>(
       {R"("101a")"_sv, R"("28593278167872960000000a")"_sv}, JSON());
   auto expected = makeNullableFlatVector<float>({std::nullopt, std::nullopt});
-  evaluateAndVerify<float>(
-      JSON(), REAL(), makeRowVector({data}), expected, true);
+  evaluateAndVerify(JSON(), REAL(), makeRowVector({data}), expected, true);
 
   // Invalid input.
   data = makeFlatVector<JsonNativeType>(
       {R"(["101a"})"_sv, R"(["28593278167872960000000a"})"_sv}, JSON());
   expectedRow = makeRowVector(
       {makeFlatVector<float>({0, 0})}, [](auto /*row*/) { return true; });
-  evaluateAndVerify<ComplexType>(
+  evaluateAndVerify(
       JSON(), ROW({REAL()}), makeRowVector({data}), expectedRow, true);
 }

--- a/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
+++ b/velox/functions/prestosql/tests/TimestampWithTimeZoneCastTest.cpp
@@ -43,8 +43,7 @@ TEST_F(TimestampWithTimeZoneCastTest, fromTimestamp) {
       makeFlatVector<int16_t>({0, 0, 0}));
   expected->setNull(1, true);
 
-  testCast<ComplexType>(
-      TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE(), tsVector, expected);
+  testCast(TIMESTAMP(), TIMESTAMP_WITH_TIME_ZONE(), tsVector, expected);
 }
 
 TEST_F(TimestampWithTimeZoneCastTest, toTimestamp) {
@@ -56,6 +55,5 @@ TEST_F(TimestampWithTimeZoneCastTest, toTimestamp) {
   const auto expected = makeNullableFlatVector<Timestamp>(
       {Timestamp(1996, 0), std::nullopt, Timestamp(19920 - 8 * 3600, 0)});
 
-  testCast<ComplexType>(
-      TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP(), tsWithTZVector, expected);
+  testCast(TIMESTAMP_WITH_TIME_ZONE(), TIMESTAMP(), tsWithTZVector, expected);
 }


### PR DESCRIPTION
Summary:
After cast of custom types is called errors should be translated to nulls and removed
from context.error() when setNullInResultAtError() is true.

Differential Revision: D49424847


