### PR TITLE
Fix ArbitraryBuffer::empty()

### DIFF
--- a/velox/exec/PartitionedOutputBuffer.h
+++ b/velox/exec/PartitionedOutputBuffer.h
@@ -48,7 +48,7 @@ class ArbitraryBuffer {
  public:
   /// Returns true if this arbitrary buffer has no buffered pages.
   bool empty() const {
-    return pages_.empty() || hasNoMoreData();
+    return pages_.empty() || (pages_.size() == 1 && pages_.back() == nullptr);
   }
 
   /// Returns true if this arbitrary buffer will not receive any new pages from

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -422,6 +422,8 @@ TEST_F(PartitionedOutputBufferManagerTest, arbitrayBuffer) {
     ASSERT_EQ(
         buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[false]]");
     buffer.noMoreData();
+    ASSERT_FALSE(buffer.empty());
+    ASSERT_TRUE(buffer.hasNoMoreData());
     ASSERT_EQ(
         buffer.toString(), "[ARBITRARY_BUFFER PAGES[2] NO MORE DATA[true]]");
     pages = buffer.getPages(1'000'000'000);


### PR DESCRIPTION
`ArbitraryBuffer::empty()` returns true if there is no buffered page, 
including two cases: no page exists, and only an end-marker exists. 
For scenarios where the arbitrary buffer is marked as "no-more-data"
but there are still buffered pages in it, it should return false.

Because it is not a public API, this fix will not affect current users.