### PR TITLE
Fix corner case bug in VectorHasher.

### DIFF
--- a/velox/exec/VectorHasher.h
+++ b/velox/exec/VectorHasher.h
@@ -311,6 +311,10 @@ class VectorHasher {
 
   std::string toString() const;
 
+  size_t numUniqueValues() const {
+    return uniqueValues_.size();
+  }
+
  private:
   static constexpr uint32_t kStringASRangeMaxSize = 7;
   static constexpr uint32_t kStringBufferUnitSize = 1024;
@@ -415,7 +419,7 @@ class VectorHasher {
       unique.setId(uniqueValues_.size() + 1);
       if (uniqueValues_.insert(unique).second) {
         if (uniqueValues_.size() > kMaxDistinct) {
-          distinctOverflow_ = true;
+          setDistinctOverflow();
         }
       }
     }
@@ -515,6 +519,10 @@ class VectorHasher {
 
   void copyStringToLocal(const UniqueValue* unique);
 
+  void setDistinctOverflow();
+
+  void setRangeOverflow();
+
   static inline bool
   isNullAt(const char* group, int32_t nullByte, uint8_t nullMask) {
     return (group[nullByte] & nullMask) != 0;
@@ -613,7 +621,7 @@ inline uint64_t VectorHasher::valueId(StringView value) {
   copyStringToLocal(&*pair.first);
   if (!rangeOverflow_) {
     if (size > kStringASRangeMaxSize) {
-      rangeOverflow_ = true;
+      setRangeOverflow();
     } else {
       updateRange(stringAsNumber(data, size));
     }


### PR DESCRIPTION
Summary:
VectorHasher could go into rangeOverflow_ mode while having hasRange_ true.
As a result mayUseValueIds() was returning true even with distinctOverflow_ being true.
distinctOverflow_ being true means we are no longer using that VectorHasher.
Due to mayUseValueIds() returning true the HashBuild was still adding rows to
the VectorHasher and from every batch a single row would leak into the underlying
F14Map w/o string data being backed by saving it in the VectorHasher.
When F14Map was rehashing - it detected the discrepancy in the 7-bit tag and aborted.
The issue is quite rare.

We fix by:
- Whenever we go into rangeOverflow_ mode we also set hasRange_ to false, thus fixing the bug.
- We clean unnecessary data when going to distinctOverflow_.

Differential Revision: D49449425


