### PR TITLE
Fix VectorMaer.lazyFlatVector default loader vector size.

### DIFF
--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -115,7 +115,8 @@ class VectorMaker {
             };
           }
 
-          return flatVector<T>(size, selectiveValueAt, selectiveIsNullAt);
+          return flatVector<T>(
+              rowSet.back() + 1, selectiveValueAt, selectiveIsNullAt);
         }));
   }
 


### PR DESCRIPTION
Summary:
The loader need to only load vectors up to  rowSet.back() + 1 and the loader does not have context on
The original lazy vector size.
The lazy vector need to handle the gap after loading the vector.

Differential Revision: D49379633


