### PR TITLE
Improve memory and cache logging

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -511,6 +511,8 @@ struct CacheStats {
   int64_t sumEvictScore{};
 
   std::shared_ptr<SsdCacheStats> ssdStats = nullptr;
+
+  std::string toString() const;
 };
 
 /// Collection of cache entries whose key hashes to the same shard of

--- a/velox/common/caching/tests/AsyncDataCacheTest.cpp
+++ b/velox/common/caching/tests/AsyncDataCacheTest.cpp
@@ -700,3 +700,58 @@ TEST_F(AsyncDataCacheTest, invalidSsdPath) {
           "Ssd path '{}' does not start with '/' that points to local file system.",
           testPath));
 }
+
+TEST_F(AsyncDataCacheTest, cacheStats) {
+  CacheStats stats;
+  stats.tinySize = 234;
+  stats.largeSize = 1024;
+  stats.tinyPadding = 23;
+  stats.largePadding = 1344;
+  stats.numEntries = 100;
+  stats.numExclusive = 20;
+  stats.numShared = 30;
+  stats.numEmptyEntries = 20;
+  stats.numPrefetch = 30;
+  stats.prefetchBytes = 100;
+  stats.numHit = 46;
+  stats.hitBytes = 1374;
+  stats.numNew = 2041;
+  stats.numEvict = 463;
+  stats.numEvictChecks = 348;
+  stats.numWaitExclusive = 244;
+  stats.allocClocks = 1320;
+  stats.sumEvictScore = 123;
+  ASSERT_EQ(
+      stats.toString(),
+      "Cache size: 2.56KB tinySize: 257B large size: 2.31KB\n"
+      "Cache entries: 100 read pins: 30 write pins: 20 num write wait: 244 empty entries: 20\n"
+      "Cache access miss: 2041 hit: 46 hit bytes: 1.34KB eviction: 463 eviction checks: 348\n"
+      "Prefetch entries: 30 bytes: 100B\n"
+      "Alloc Megaclocks 0");
+
+  constexpr uint64_t kRamBytes = 32 << 20;
+  constexpr uint64_t kSsdBytes = 512UL << 20;
+  initializeCache(kRamBytes, kSsdBytes);
+  ASSERT_EQ(
+      cache_->toString(),
+      "AsyncDataCache:\n"
+      "Cache size: 0B tinySize: 0B large size: 0B\n"
+      "Cache entries: 0 read pins: 0 write pins: 0 num write wait: 0 empty entries: 0\n"
+      "Cache access miss: 0 hit: 0 hit bytes: 0B eviction: 0 eviction checks: 0\n"
+      "Prefetch entries: 0 bytes: 0B\n"
+      "Alloc Megaclocks 0\n"
+      "Allocated pages: 0 cached pages: 0\n"
+      "Backing: Memory Allocator[MMAP capacity 16.00KB allocated pages 0 mapped pages 0 external mapped pages 0\n"
+      "[size 1: 0(0MB) allocated 0 mapped]\n"
+      "[size 2: 0(0MB) allocated 0 mapped]\n"
+      "[size 4: 0(0MB) allocated 0 mapped]\n"
+      "[size 8: 0(0MB) allocated 0 mapped]\n"
+      "[size 16: 0(0MB) allocated 0 mapped]\n"
+      "[size 32: 0(0MB) allocated 0 mapped]\n"
+      "[size 64: 0(0MB) allocated 0 mapped]\n"
+      "[size 128: 0(0MB) allocated 0 mapped]\n"
+      "[size 256: 0(0MB) allocated 0 mapped]\n"
+      "]\n"
+      "SSD: Ssd cache IO: Write 0MB read 0MB Size 0GB Occupied 0GB0K entries.\n"
+      "GroupStats: <dummy FileGroupStats>");
+}

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -430,7 +430,10 @@ void* MemoryPoolImpl::allocate(int64_t size) {
   if (FOLLY_UNLIKELY(buffer == nullptr)) {
     release(alignedSize);
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} bytes from {}", __FUNCTION__, size, toString()));
+        "{} failed with {} from {}",
+        __FUNCTION__,
+        succinctBytes(size),
+        toString()));
   }
   DEBUG_RECORD_ALLOC(buffer, size);
   return buffer;
@@ -445,10 +448,10 @@ void* MemoryPoolImpl::allocateZeroFilled(int64_t numEntries, int64_t sizeEach) {
   if (FOLLY_UNLIKELY(buffer == nullptr)) {
     release(alignedSize);
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} entries and {} bytes each from {}",
+        "{} failed with {} entries and {} each from {}",
         __FUNCTION__,
         numEntries,
-        sizeEach,
+        succinctBytes(sizeEach),
         toString()));
   }
   DEBUG_RECORD_ALLOC(buffer, size);
@@ -464,10 +467,10 @@ void* MemoryPoolImpl::reallocate(void* p, int64_t size, int64_t newSize) {
   if (FOLLY_UNLIKELY(newP == nullptr)) {
     release(alignedNewSize);
     VELOX_MEM_ALLOC_ERROR(fmt::format(
-        "{} failed with {} new bytes and {} old bytes from {}",
+        "{} failed with new {} and old {} from {}",
         __FUNCTION__,
-        newSize,
-        size,
+        succinctBytes(newSize),
+        succinctBytes(size),
         toString()));
   }
   DEBUG_RECORD_ALLOC(newP, newSize);

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -880,8 +880,8 @@ class MemoryPoolImpl : public MemoryPool {
         << MemoryAllocator::kindString(allocator_->kind())
         << (trackUsage_ ? " track-usage" : " no-usage-track")
         << (threadSafe_ ? " thread-safe" : " non-thread-safe") << "]<";
-    if (maxCapacity_ != kMaxMemory) {
-      out << "max capacity " << succinctBytes(maxCapacity_) << " ";
+    if (maxCapacity() != kMaxMemory) {
+      out << "max capacity " << succinctBytes(maxCapacity()) << " ";
     } else {
       out << "unlimited max capacity ";
     }

--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -78,7 +78,7 @@ bool MmapAllocator::allocateNonContiguousWithoutRetry(
   if (numAllocated_ + mix.totalPages > capacity_) {
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
         << "Exceeding memory allocator limit when allocate " << mix.totalPages
-        << " pages with capacity of " << capacity_;
+        << " pages with capacity of " << capacity_ << " pages";
     if ((bytesFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(bytesFreed, false);
     }
@@ -87,7 +87,7 @@ bool MmapAllocator::allocateNonContiguousWithoutRetry(
   if (numAllocated_.fetch_add(mix.totalPages) + mix.totalPages > capacity_) {
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
         << "Exceeded memory allocator limit when allocate " << mix.totalPages
-        << " pages with capacity of " << capacity_;
+        << " pages with capacity of " << capacity_ << " pages";
     numAllocated_.fetch_sub(mix.totalPages);
     if ((bytesFreed != 0) && (reservationCB != nullptr)) {
       reservationCB(bytesFreed, false);
@@ -332,7 +332,7 @@ bool MmapAllocator::allocateContiguousImpl(
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
         << "Exceeded memory allocator limit when allocate " << newPages
         << " new pages for total allocation of " << numPages
-        << " pages, the memory allocator capacity is " << capacity_;
+        << " pages, the memory allocator capacity is " << capacity_ << " pages";
     rollbackAllocation(0);
     return false;
   }
@@ -429,7 +429,7 @@ bool MmapAllocator::growContiguousWithoutRetry(
     VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
         << "Exceeded memory allocator limit when adding " << increment
         << " new pages for total allocation of " << allocation.numPages()
-        << " pages, the memory allocator capacity is " << capacity_;
+        << " pages, the memory allocator capacity is " << capacity_ << " pages";
     numAllocated_ -= increment;
     if (reservationCB != nullptr) {
       reservationCB(AllocationTraits::pageBytes(increment), false);

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -192,7 +192,7 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
       std::make_shared<memory::MallocAllocator>(64LL << 20),
       std::vector<std::string>{
           "allocateContiguous failed with .* pages",
-          "unlimited max capacity unlimited capacity used .* available .*",
+          "max capacity 128.00MB unlimited capacity used .* available .*",
           ".* reservation .used .*MB, reserved .*MB, min 0B. counters",
           "allocs .*, frees .*, reserves .*, releases .*, collisions .*"}});
   const memory::MmapAllocator::Options options = {.capacity = 64LL << 20};
@@ -200,7 +200,7 @@ TEST_P(MemoryCapExceededTest, allocatorCapacityExceededError) {
       std::make_shared<memory::MmapAllocator>(options),
       std::vector<std::string>{
           "allocateContiguous failed with .* pages",
-          "unlimited max capacity unlimited capacity used .* available .*",
+          "max capacity 128.00MB unlimited capacity used .* available .*",
           ".* reservation .used .*MB, reserved .*MB, min .*B. counters",
           ".*, frees .*, reserves .*, releases .*, collisions .*"}});
   for (auto& allocExp : allocatorExpectations) {

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -588,10 +588,10 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         if (useMmap_) {
           ASSERT_EQ(
               fmt::format(
-                  "allocate failed with 134217729 bytes from Memory Pool["
+                  "allocate failed with 128.00MB from Memory Pool["
                   "static_quota LEAF root[MemoryCapExceptions] "
-                  "parent[MemoryCapExceptions] MMAP track-usage {}]<unlimited "
-                  "max capacity capacity 256.00MB used 0B available 0B "
+                  "parent[MemoryCapExceptions] MMAP track-usage {}]<max "
+                  "capacity 256.00MB capacity 256.00MB used 0B available 0B "
                   "reservation [used 0B, reserved 0B, min 0B] counters [allocs "
                   "1, frees 0, reserves 0, releases 0, collisions 0])>",
                   isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
@@ -599,10 +599,10 @@ TEST_P(MemoryPoolTest, MemoryCapExceptions) {
         } else {
           ASSERT_EQ(
               fmt::format(
-                  "allocate failed with 134217729 bytes from Memory Pool"
+                  "allocate failed with 128.00MB from Memory Pool"
                   "[static_quota LEAF root[MemoryCapExceptions] "
                   "parent[MemoryCapExceptions] MALLOC track-usage {}]"
-                  "<unlimited max capacity capacity 256.00MB used 0B available "
+                  "<max capacity 256.00MB capacity 256.00MB used 0B available "
                   "0B reservation [used 0B, reserved 0B, min 0B] counters "
                   "[allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
                   isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"),
@@ -2827,7 +2827,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
-          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<unlimited max capacity capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
           useMmap_ ? "MMAP" : "MALLOC",
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(
@@ -2836,7 +2836,7 @@ TEST_P(MemoryPoolTest, statsAndToString) {
   ASSERT_EQ(
       leafChild1->toString(),
       fmt::format(
-          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<unlimited max capacity capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
+          "Memory Pool[leaf-child1 LEAF root[stats] parent[stats] {} track-usage {}]<max capacity 4.00GB capacity 4.00GB used 1.00KB available 1023.00KB reservation [used 1.00KB, reserved 1.00MB, min 0B] counters [allocs 1, frees 0, reserves 0, releases 0, collisions 0])>",
           useMmap_ ? "MMAP" : "MALLOC",
           isLeafThreadSafe_ ? "thread-safe" : "non-thread-safe"));
   ASSERT_EQ(


### PR DESCRIPTION
Improve memory and cache logging to ease debugging:
use succintBytes for byte and add pages when log memory error
refactor cache logging and use it in Prestissimo side for background logging