### PR TITLE
Fix: add trailing nulls to loaded vector to match lazy vector size.

### DIFF
--- a/velox/dwio/common/ColumnLoader.h
+++ b/velox/dwio/common/ColumnLoader.h
@@ -31,7 +31,11 @@ class ColumnLoader : public velox::VectorLoader {
         version_(version) {}
 
  protected:
-  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override;
+  void loadInternal(
+      RowSet rows,
+      ValueHook* hook,
+      vector_size_t resultSize,
+      VectorPtr* result) override;
 
  private:
   SelectiveStructColumnReaderBase* structReader_;

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -725,7 +725,7 @@ VectorPtr BaseVector::createNullConstant(
 }
 
 // static
-VectorPtr BaseVector::loadedVectorShared(VectorPtr vector) {
+const VectorPtr& BaseVector::loadedVectorShared(const VectorPtr& vector) {
   if (vector->encoding() != VectorEncoding::Simple::LAZY) {
     // If 'vector' is a wrapper, we load any wrapped LazyVector.
     vector->loadedVector();

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -582,7 +582,7 @@ class BaseVector {
     return this;
   }
 
-  static VectorPtr loadedVectorShared(VectorPtr vector);
+  static const VectorPtr& loadedVectorShared(const VectorPtr& vector);
 
   virtual const BufferPtr& values() const {
     VELOX_UNSUPPORTED("Only flat vectors have a values buffer");

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -459,7 +459,8 @@ BaseVector* RowVector::loadedVector() {
     if (!children_[i]) {
       continue;
     }
-    auto newChild = BaseVector::loadedVectorShared(children_[i]);
+    auto& newChild = BaseVector::loadedVectorShared(children_[i]);
+    // This is not needed but can potentially optimize decoding speed later.
     if (children_[i].get() != newChild.get()) {
       children_[i] = newChild;
     }

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -22,7 +22,6 @@
 #include <folly/hash/Hash.h>
 #include <glog/logging.h>
 
-#include <velox/vector/BaseVector.h>
 #include "velox/type/Type.h"
 #include "velox/vector/BaseVector.h"
 #include "velox/vector/LazyVector.h"

--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -539,11 +539,15 @@ class LoadedVectorShim : public VectorLoader {
  public:
   explicit LoadedVectorShim(VectorPtr vector) : vector_(vector) {}
 
-  void loadInternal(RowSet /*rowSet*/, ValueHook* /*hook*/, VectorPtr* result)
-      override {
+  void loadInternal(
+      RowSet /*rowSet*/,
+      ValueHook* /*hook*/,
+      vector_size_t resultSize,
+      VectorPtr* result) override {
     VELOX_CHECK(
         vector_ != nullptr, "This lazy vector should not have been loaded.");
     *result = vector_;
+    VELOX_CHECK_EQ((*result)->size(), resultSize);
   }
 
  private:

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -23,6 +23,7 @@
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/type/Timestamp.h"
+#include "velox/vector/BaseVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/NullsBuilder.h"
 #include "velox/vector/VectorTypeUtils.h"
@@ -306,21 +307,26 @@ class VectorLoaderWrap : public VectorLoader {
  public:
   explicit VectorLoaderWrap(VectorPtr vector) : vector_(vector) {}
 
-  void loadInternal(RowSet rowSet, ValueHook* hook, VectorPtr* result)
-      override {
+  void loadInternal(
+      RowSet rowSet,
+      ValueHook* hook,
+      vector_size_t resultSize,
+      VectorPtr* result) override {
     VELOX_CHECK(!hook, "VectorLoaderWrap doesn't support ValueHook");
     SelectivityVector rows(rowSet.back() + 1, false);
     for (auto row : rowSet) {
       rows.setValid(row, true);
     }
     rows.updateBounds();
-    *result = makeEncodingPreservedCopy(rows);
+    *result = makeEncodingPreservedCopy(rows, resultSize);
   }
 
  private:
   // Returns a copy of 'vector_' while retaining dictionary encoding if present.
   // Multiple dictionary layers are collapsed into one.
-  VectorPtr makeEncodingPreservedCopy(SelectivityVector& rows);
+  VectorPtr makeEncodingPreservedCopy(
+      SelectivityVector& rows,
+      vector_size_t vectorSize);
   VectorPtr vector_;
 };
 
@@ -929,13 +935,17 @@ RowVectorPtr VectorFuzzer::fuzzRowChildrenToLazy(
       std::move(children));
 }
 
-VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(SelectivityVector& rows) {
-  VectorPtr result;
+VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(
+    SelectivityVector& rows,
+    vector_size_t vectorSize) {
   DecodedVector decoded;
   decoded.decode(*vector_, rows, false);
 
   if (decoded.isConstantMapping() || decoded.isIdentityMapping()) {
+    VectorPtr result;
+
     BaseVector::ensureWritable(rows, vector_->type(), vector_->pool(), result);
+    result->resize(vectorSize);
     result->copy(vector_.get(), rows, nullptr);
     return result;
   }
@@ -951,31 +961,35 @@ VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(SelectivityVector& rows) {
   });
   baseRows.updateBounds();
 
+  VectorPtr baseResult;
   BaseVector::ensureWritable(
-      baseRows, baseVector->type(), vector_->pool(), result);
-  result->copy(baseVector, baseRows, nullptr);
+      baseRows, baseVector->type(), vector_->pool(), baseResult);
+  baseResult->copy(baseVector, baseRows, nullptr);
 
-  BufferPtr indices = allocateIndices(rows.end(), vector_->pool());
+  BufferPtr indices = allocateIndices(vectorSize, vector_->pool());
   auto rawIndices = indices->asMutable<vector_size_t>();
   auto decodedIndices = decoded.indices();
   rows.applyToSelected(
       [&](auto row) { rawIndices[row] = decodedIndices[row]; });
 
   BufferPtr nulls = nullptr;
-  if (decoded.nulls()) {
-    if (!baseRows.hasSelections()) {
-      nulls = allocateNulls(rows.end(), vector_->pool(), bits::kNull);
-    } else {
-      nulls = AlignedBuffer::allocate<bool>(rows.end(), vector_->pool());
+  // We fill [rows.end(), vectorSize) with nulls.
+  if (decoded.nulls() || vectorSize > rows.end()) {
+    nulls = allocateNulls(vectorSize, vector_->pool(), bits::kNotNull);
+
+    if (decoded.nulls() && baseRows.hasSelections()) {
       std::memcpy(
           nulls->asMutable<uint64_t>(),
           decoded.nulls(),
           bits::nbytes(rows.end()));
+    } else if (baseRows.hasSelections()) {
+      bits::fillBits(
+          nulls->asMutable<uint64_t>(), 0, rows.end(), bits::kNotNull);
     }
   }
 
   return BaseVector::wrapInDictionary(
-      std::move(nulls), std::move(indices), rows.end(), result);
+      std::move(nulls), std::move(indices), vectorSize, baseResult);
 }
 
 namespace {

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -59,7 +59,11 @@ TEST_F(LazyVectorTest, lazyInDictionary) {
   rows.updateBounds();
   LazyVector::ensureLoadedRows(wrapped, rows);
   EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
-  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
+  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::LAZY);
+  EXPECT_EQ(
+      wrapped->valueVector()->loadedVector()->encoding(),
+      VectorEncoding::Simple::FLAT);
+
   EXPECT_EQ(loadedRows, (std::vector<vector_size_t>{0, 5}));
   assertCopyableVector(wrapped);
 }
@@ -83,6 +87,38 @@ TEST_F(LazyVectorTest, rowVectorWithLazyChild) {
   SelectivityVector rows(rowVector->size(), false);
   LazyVector::ensureLoadedRows(rowVector, rows);
   EXPECT_FALSE(isLazyNotLoaded(*rowVector.get()));
+}
+
+TEST_F(LazyVectorTest, rowVectorWithLazyChildPartiallyLoaded) {
+  constexpr vector_size_t size = 1000;
+  auto columnType = ROW({"a", "b"}, {INTEGER(), INTEGER()});
+
+  auto lazyVectorA = vectorMaker_.lazyFlatVector<int32_t>(
+      size, [&](vector_size_t) { return 2222; });
+  auto lazyVectorB = vectorMaker_.lazyFlatVector<int32_t>(
+      size, [&](vector_size_t) { return 1111; });
+
+  VectorPtr rowVector = makeRowVector({lazyVectorA, lazyVectorB});
+  EXPECT_FALSE(lazyVectorA->isLoaded());
+  EXPECT_TRUE(isLazyNotLoaded(*rowVector.get()));
+
+  // Only load first row, the row vector should still be valid.
+  SelectivityVector rows(1);
+  LazyVector::ensureLoadedRows(rowVector, rows);
+  EXPECT_FALSE(isLazyNotLoaded(*rowVector.get()));
+
+  auto rowVectorPtr = rowVector->asUnchecked<RowVector>();
+  auto child1 = rowVectorPtr->childAt(0);
+  auto child2 = rowVectorPtr->childAt(1);
+
+  EXPECT_FALSE(child1->isNullAt(0));
+  EXPECT_FALSE(child2->isNullAt(0));
+  EXPECT_EQ(child1->loadedVector()->asFlatVector<int32_t>()->valueAt(0), 2222);
+  EXPECT_EQ(child2->loadedVector()->asFlatVector<int32_t>()->valueAt(0), 1111);
+  EXPECT_FALSE(rowVectorPtr->childAt(1)->isNullAt(0));
+
+  EXPECT_EQ(rowVectorPtr->childAt(0)->size(), 1000);
+  EXPECT_EQ(rowVectorPtr->childAt(1)->size(), 1000);
 }
 
 TEST_F(LazyVectorTest, dictionaryOverRowVectorWithLazyChild) {
@@ -247,9 +283,8 @@ TEST_F(LazyVectorTest, dictionaryOverLazyRowVectorWithLazyChildren) {
 
   EXPECT_FALSE(isLazyNotLoaded(*dict.get()));
 
-  // The dictionaries get squashed into a single dictionary.
   RowVector* loadedVector =
-      dict->valueVector()->loadedVector()->as<RowVector>();
+      dict->valueVector()->valueVector()->loadedVector()->as<RowVector>();
   auto child = loadedVector->childAt(0);
   EXPECT_FALSE(child->isLazy());
   assertEqualVectors(child, lazyInnerRowVector);
@@ -396,9 +431,8 @@ TEST_F(LazyVectorTest, lazyInDoubleDictionary) {
   // We have dictionaries over LazyVector. We load for some indices in
   // the top dictionary. The intermediate dictionaries refer to
   // non-loaded items in the base of the LazyVector, including indices
-  // past its end. We check that we end up with one level of
-  // dictionary and have no dictionaries that are invalid by
-  // referring to uninitialized/nonexistent positions.
+  // past its end.
+  // This test make sure the we have valid vector after loading.
   static constexpr int32_t kInnerSize = 100;
   static constexpr int32_t kOuterSize = 1000;
 
@@ -426,44 +460,41 @@ TEST_F(LazyVectorTest, lazyInDoubleDictionary) {
             kOuterSize,
             lazy));
   };
-
-  // We expect a single level of dictionary and rows loaded for kInnerSize first
-  // elements of 'lazy'.
+  SelectivityVector rows(kInnerSize);
 
   // No nulls.
-  auto wrapped = makeWrapped(nullptr);
+  {
+    auto wrapped = makeWrapped(nullptr);
 
-  SelectivityVector rows(kInnerSize);
-  LazyVector::ensureLoadedRows(wrapped, rows);
-  EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
-  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
-  EXPECT_EQ(kInnerSize, loadEnd);
-
-  auto expected =
-      makeFlatVector<int32_t>(kInnerSize, [](auto row) { return row; });
-  assertEqualVectors(wrapped, expected);
+    LazyVector::ensureLoadedRows(wrapped, rows);
+    EXPECT_EQ(kInnerSize, loadEnd);
+    auto expected =
+        makeFlatVector<int32_t>(kInnerSize, [](auto row) { return row; });
+    assertEqualVectors(wrapped, expected);
+  }
 
   // With nulls.
-  wrapped = makeWrapped(makeNulls(kInnerSize, nullEvery(7)));
-  LazyVector::ensureLoadedRows(wrapped, rows);
-  EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
-  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
-  EXPECT_EQ(kInnerSize, loadEnd);
+  {
+    auto wrapped = makeWrapped(makeNulls(kInnerSize, nullEvery(7)));
+    LazyVector::ensureLoadedRows(wrapped, rows);
 
-  expected = makeFlatVector<int32_t>(
-      kInnerSize, [](auto row) { return row; }, nullEvery(7));
-  assertEqualVectors(wrapped, expected);
+    EXPECT_EQ(kInnerSize, loadEnd);
+    auto expected = makeFlatVector<int32_t>(
+        kInnerSize, [](auto row) { return row; }, nullEvery(7));
+    assertEqualVectors(wrapped, expected);
+  }
 
   // With nulls at the end.
-  wrapped = makeWrapped(makeNulls(kInnerSize, nullEvery(3)));
-  LazyVector::ensureLoadedRows(wrapped, rows);
-  EXPECT_EQ(wrapped->encoding(), VectorEncoding::Simple::DICTIONARY);
-  EXPECT_EQ(wrapped->valueVector()->encoding(), VectorEncoding::Simple::FLAT);
-  EXPECT_EQ(kInnerSize - 1, loadEnd);
+  {
+    auto wrapped = makeWrapped(makeNulls(kInnerSize, nullEvery(3)));
+    LazyVector::ensureLoadedRows(wrapped, rows);
 
-  expected = makeFlatVector<int32_t>(
-      kInnerSize, [](auto row) { return row; }, nullEvery(3));
-  assertEqualVectors(wrapped, expected);
+    EXPECT_EQ(kInnerSize - 1, loadEnd);
+
+    auto expected = makeFlatVector<int32_t>(
+        kInnerSize, [](auto row) { return row; }, nullEvery(3));
+    assertEqualVectors(wrapped, expected);
+  }
 }
 
 TEST_F(LazyVectorTest, lazySlice) {
@@ -535,8 +566,9 @@ TEST_F(LazyVectorTest, lazyInDictionaryNoRowsToLoad) {
       lazy);
   SelectivityVector rows(kVectorSize, false);
   LazyVector::ensureLoadedRows(wrapped, rows);
-  auto expected = makeFlatVector<int32_t>(0);
-  assertEqualVectors(expected, wrapped);
+  for (int i = 0; i < wrapped->size(); i++) {
+    EXPECT_TRUE(wrapped->isNullAt(i));
+  }
 }
 
 TEST_F(LazyVectorTest, lazyWithDictionaryInConstant) {

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -40,13 +40,18 @@ class TestingLoader : public VectorLoader {
  public:
   explicit TestingLoader(VectorPtr data) : data_(data), rowCounter_(0) {}
 
-  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
+  void loadInternal(
+      RowSet rows,
+      ValueHook* hook,
+      vector_size_t resultSize,
+      VectorPtr* result) override {
     if (hook) {
       VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
           applyHook, data_->typeKind(), rows, hook);
       return;
     }
     *result = data_;
+    VELOX_CHECK_GE(data_->size(), resultSize);
     rowCounter_ += rows.size();
   }
 
@@ -2038,6 +2043,7 @@ TEST_F(VectorTest, multipleDictionariesOverLazy) {
       indices,
       size,
       BaseVector::wrapInDictionary(nullptr, indices, size, lazy));
+
   dict->loadedVector();
   for (auto i = 0; i < size; i++) {
     ASSERT_EQ(i, dict->as<SimpleVector<int32_t>>()->valueAt(i));

--- a/velox/vector/tests/utils/VectorMaker.h
+++ b/velox/vector/tests/utils/VectorMaker.h
@@ -74,9 +74,17 @@ class SimpleVectorLoader : public VectorLoader {
   explicit SimpleVectorLoader(std::function<VectorPtr(RowSet)> loader)
       : loader_(loader) {}
 
-  void loadInternal(RowSet rows, ValueHook* hook, VectorPtr* result) override {
+  void loadInternal(
+      RowSet rows,
+      ValueHook* hook,
+      vector_size_t resultSize,
+      VectorPtr* result) override {
     VELOX_CHECK(!hook, "SimpleVectorLoader doesn't support ValueHook");
-    *result = loader_(rows);
+    auto& resultRef = *result;
+    resultRef = loader_(rows);
+    if (resultRef->size() < resultSize) {
+      resultRef->resize(resultSize);
+    }
   }
 
  private:


### PR DESCRIPTION
Summary:
LazyVector::ensureLoadedRows() used to be able to replace the input vector with a new vector.
This used to be done to ensure that the output vector is valid when we load less rows than the size
of the lazy vector.

This is problematic because the input to ensureLoadedRows() is not checked to be unique (hence other
references are not not updated) also if there any raw references they are not also updated.

It's hard to make sure there are no raw references obtained to the input of ensureLoadedRows.
For example, this code i invalid because children of row vector are not updated.

```
auto children =(decoded.base()->asUnchecked<RowVector>()) ->children();
DecodedVector decodedChild;
SelectivityVector childRows;
for (auto& child : children) {
decodedChild.decode(*child, baseRows, false);
ensureLoadedRowsImpl(child, decodedChild, baseRows, childRows);
}
```

while it looks easy to fix up there by using a reference instead of copying children pointers, there is
guarantee that those children or any nested vector where ensureLoadedRowsImpl will be called is
unique or does not have a row pointer.

To solve the issue, ensureLoadedRows is changed not to change the input vector, instead if we partially
load a lazy vector we add nulls to make sure the loadedVector has the same size of the containing lazy
vector, this could keep the containing vectors valid without a need to change anything else.

Differential Revision: D49461830

