### PR TITLE
Ignore input with null N in min/max/min_by/max_by Presto aggregates 

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -535,9 +535,11 @@ struct MinMaxNAccumulator {
   }
 
   void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
-    VELOX_USER_CHECK(
-        !decodedN.isNullAt(row),
-        "second argument of max/min must be a positive integer");
+    // Null N is ignored.
+    if (decodedN.isNullAt(row)) {
+      return;
+    }
+
     const auto newN = decodedN.valueAt<int64_t>(row);
     VELOX_USER_CHECK_GT(
         newN, 0, "second argument of max/min must be a positive integer");
@@ -610,7 +612,7 @@ class MinMaxNAggregateBase : public exec::Aggregate {
     decodedN_.decode(*args[1], rows);
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decodedValue_.isNullAt(i)) {
+      if (decodedValue_.isNullAt(i) || decodedN_.isNullAt(i)) {
         return;
       }
 
@@ -650,7 +652,8 @@ class MinMaxNAggregateBase : public exec::Aggregate {
 
     auto tracker = trackRowSize(group);
     rows.applyToSelected([&](vector_size_t i) {
-      if (!decodedValue_.isNullAt(i)) {
+      // Null value && N are ignored.
+      if (!decodedValue_.isNullAt(i) && !decodedN_.isNullAt(i)) {
         addRawInput(group, i);
       }
     });

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -535,7 +535,7 @@ struct MinMaxNAccumulator {
   }
 
   void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
-    // Null N is ignored.
+    // Skip null N.
     if (decodedN.isNullAt(row)) {
       return;
     }
@@ -652,7 +652,7 @@ class MinMaxNAggregateBase : public exec::Aggregate {
 
     auto tracker = trackRowSize(group);
     rows.applyToSelected([&](vector_size_t i) {
-      // Null value && N are ignored.
+      // Skip null value or N.
       if (!decodedValue_.isNullAt(i) && !decodedN_.isNullAt(i)) {
         addRawInput(group, i);
       }

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -105,9 +105,11 @@ struct MinMaxByNAccumulator {
   }
 
   void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
-    VELOX_USER_CHECK(
-        !decodedN.isNullAt(row),
-        "third argument of max_by/min_by must be a positive integer");
+    // Null N is ignored.
+    if (decodedN.isNullAt(row)) {
+      return;
+    }
+
     const auto newN = decodedN.valueAt<int64_t>(row);
     VELOX_USER_CHECK_GT(
         newN, 0, "third argument of max_by/min_by must be a positive integer");
@@ -738,7 +740,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     decodedN_.decode(*args[2], rows);
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decodedComparison_.isNullAt(i)) {
+      if (decodedComparison_.isNullAt(i) || decodedN_.isNullAt(i)) {
         return;
       }
 
@@ -777,7 +779,7 @@ class MinMaxByNAggregate : public exec::Aggregate {
     validateN(args[2], rows, accumulator);
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (!decodedComparison_.isNullAt(i)) {
+      if (!decodedComparison_.isNullAt(i) && !decodedN_.isNullAt(i)) {
         addRawInput(group, i);
       }
     });

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -105,7 +105,7 @@ struct MinMaxByNAccumulator {
   }
 
   void checkAndSetN(DecodedVector& decodedN, vector_size_t row) {
-    // Null N is ignored.
+    // Skip null N.
     if (decodedN.isNullAt(row)) {
       return;
     }

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1466,6 +1466,42 @@ TEST_F(MinMaxByNTest, globalWithNullCompare) {
       {data}, {}, {"min_by(c0, c1, 3)", "max_by(c0, c1, 4)"}, {expected});
 }
 
+TEST_F(MinMaxByNTest, globalWithNullN) {
+  // Rows with null 'compare' should be ignored.
+  auto data = makeRowVector(
+      {makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
+       makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+       makeNullableFlatVector<int64_t>(
+           {3, std::nullopt, 3, 3, 3, std::nullopt, 3})});
+
+  auto expected = makeRowVector({
+      makeNullableArrayVector<int32_t>({
+          {7, 5, 4},
+      }),
+      makeNullableArrayVector<int32_t>({
+          {1, 3, 4},
+      }),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1, c2)", "max_by(c0, c1, c2)"}, {expected});
+
+  // All 'N' are null.
+  data = makeRowVector({
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
+      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeNullConstant(TypeKind::BIGINT, 7),
+  });
+
+  expected = makeRowVector({
+      makeAllNullArrayVector(1, INTEGER()),
+      makeAllNullArrayVector(1, INTEGER()),
+  });
+
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1, c2)", "max_by(c0, c1, c2)"}, {expected});
+}
+
 TEST_F(MinMaxByNTest, sortedGlobal) {
   auto data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
@@ -1627,6 +1663,56 @@ TEST_F(MinMaxByNTest, groupByWithNullCompare) {
 
   testAggregations(
       {data}, {"c0"}, {"min_by(c1, c2, 3)", "max_by(c1, c2, 4)"}, {expected});
+}
+
+TEST_F(MinMaxByNTest, groupByWithNullN) {
+  // Rows with null 'N' should be ignored.
+  auto data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2, 1, 2, 1}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
+      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeNullableFlatVector<int64_t>(
+          {3, std::nullopt, 3, 3, std::nullopt, 3, 3}),
+  });
+
+  auto expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeArrayVector<int32_t>({
+          {7, 3, 1},
+          {6, 4},
+      }),
+      makeArrayVector<int32_t>({
+          {1, 3, 7},
+          {4, 6},
+      }),
+  });
+
+  testAggregations(
+      {data}, {"c0"}, {"min_by(c1, c2, c3)", "max_by(c1, c2, c3)"}, {expected});
+
+  // All 'N' values are null for one group.
+  data = makeRowVector({
+      makeFlatVector<int16_t>({1, 2, 1, 2, 1, 2, 1}),
+      makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
+      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeNullableFlatVector<int64_t>(
+          {3, std::nullopt, 3, std::nullopt, std::nullopt, std::nullopt, 3}),
+  });
+
+  expected = makeRowVector({
+      makeFlatVector<int16_t>({1, 2}),
+      makeNullableArrayVector<int32_t>({
+          {{7, 3, 1}},
+          std::nullopt,
+      }),
+      makeNullableArrayVector<int32_t>({
+          {{1, 3, 7}},
+          std::nullopt,
+      }),
+  });
+
+  testAggregations(
+      {data}, {"c0"}, {"min_by(c1, c2, c3)", "max_by(c1, c2, c3)"}, {expected});
 }
 
 TEST_F(MinMaxByNTest, sortedGroupBy) {

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1470,15 +1470,15 @@ TEST_F(MinMaxByNTest, globalWithNullN) {
   // Rows with null 'compare' should be ignored.
   auto data = makeRowVector(
       {makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
-       makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+       makeFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
        makeNullableFlatVector<int64_t>(
            {3, std::nullopt, 3, 3, 3, std::nullopt, 3})});
 
   auto expected = makeRowVector({
-      makeNullableArrayVector<int32_t>({
+      makeArrayVector<int32_t>({
           {7, 5, 4},
       }),
-      makeNullableArrayVector<int32_t>({
+      makeArrayVector<int32_t>({
           {1, 3, 4},
       }),
   });
@@ -1489,7 +1489,7 @@ TEST_F(MinMaxByNTest, globalWithNullN) {
   // All 'N' are null.
   data = makeRowVector({
       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
       makeNullConstant(TypeKind::BIGINT, 7),
   });
 
@@ -1670,7 +1670,7 @@ TEST_F(MinMaxByNTest, groupByWithNullN) {
   auto data = makeRowVector({
       makeFlatVector<int16_t>({1, 2, 1, 2, 1, 2, 1}),
       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
       makeNullableFlatVector<int64_t>(
           {3, std::nullopt, 3, 3, std::nullopt, 3, 3}),
   });
@@ -1694,7 +1694,7 @@ TEST_F(MinMaxByNTest, groupByWithNullN) {
   data = makeRowVector({
       makeFlatVector<int16_t>({1, 2, 1, 2, 1, 2, 1}),
       makeFlatVector<int32_t>({1, 2, 3, 4, 5, 6, 7}),
-      makeNullableFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
+      makeFlatVector<int64_t>({77, 66, 55, 44, 33, 22, 11}),
       makeNullableFlatVector<int64_t>(
           {3, std::nullopt, 3, std::nullopt, std::nullopt, std::nullopt, 3}),
   });


### PR DESCRIPTION
Presto ignores input rows with null values of N. Velox used to throw.