### PR TITLE
Add Pacific/Kanton, Europe/Kyiv, America/Ciudad_Juarez time zones

### DIFF
--- a/velox/type/tz/TimeZoneDatabase.cpp
+++ b/velox/type/tz/TimeZoneDatabase.cpp
@@ -2257,6 +2257,9 @@ const std::unordered_map<int64_t, std::string>& getTimeZoneDB() {
       {2228, "Europe/Saratov"},
       {2229, "Asia/Qostanay"},
       {2230, "America/Nuuk"},
+      {2231, "Pacific/Kanton"},
+      {2232, "Europe/Kyiv"},
+      {2233, "America/Ciudad_Juarez"},
   };
   return tzDB;
 }

--- a/velox/type/tz/gen_timezone_database.py
+++ b/velox/type/tz/gen_timezone_database.py
@@ -42,11 +42,12 @@ cpp_template = Template(
 //       > velox/type/tz/TimeZoneDatabase.cpp
 //
 // The zone-index.properties file should be the same one used in Presto,
-// Available here : https://github.com/prestodb/presto/blob/master/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties.
+// Available here :
+// https://github.com/prestodb/presto/blob/master/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties.
 // @generated
 
-#include <unordered_map>
 #include <string>
+#include <unordered_map>
 
 namespace facebook::velox::util {
 

--- a/velox/type/tz/tests/TimeZoneMapTest.cpp
+++ b/velox/type/tz/tests/TimeZoneMapTest.cpp
@@ -24,10 +24,16 @@ namespace {
 TEST(TimeZoneMapTest, simple) {
   EXPECT_EQ("America/Los_Angeles", getTimeZoneName(1825));
   EXPECT_EQ("Europe/Moscow", getTimeZoneName(2079));
+  EXPECT_EQ("Pacific/Kanton", getTimeZoneName(2231));
+  EXPECT_EQ("Europe/Kyiv", getTimeZoneName(2232));
+  EXPECT_EQ("America/Ciudad_Juarez", getTimeZoneName(2233));
   EXPECT_EQ("-00:01", getTimeZoneName(840));
 
   EXPECT_EQ(1825, getTimeZoneID("America/Los_Angeles"));
   EXPECT_EQ(2079, getTimeZoneID("Europe/Moscow"));
+  EXPECT_EQ(2231, getTimeZoneID("Pacific/Kanton"));
+  EXPECT_EQ(2232, getTimeZoneID("Europe/Kyiv"));
+  EXPECT_EQ(2233, getTimeZoneID("America/Ciudad_Juarez"));
   EXPECT_EQ(840, getTimeZoneID("-00:01"));
   EXPECT_EQ(0, getTimeZoneID("+00:00"));
 }


### PR DESCRIPTION
Presto 0.282 adds three new timezones: Pacific/Kanton, Europe/Kyiv, America/Ciudad_Juarez: https://github.com/prestodb/presto/pull/19758, So velox should be consistent with it

