### PR TITLE
Use fully qualified namespace in VELOX_ASSERT_THROW macro

### DIFF
--- a/velox/common/base/tests/GTestUtils.h
+++ b/velox/common/base/tests/GTestUtils.h
@@ -36,7 +36,7 @@
   try {                                                              \
     (expression);                                                    \
     FAIL() << "Expected an exception";                               \
-  } catch (const VeloxException& e) {                                \
+  } catch (const facebook::velox::VeloxException& e) {               \
     ASSERT_TRUE(e.message().find(errorMessage) != std::string::npos) \
         << "Expected error message to contain '" << errorMessage     \
         << "', but received '" << e.message() << "'.";               \


### PR DESCRIPTION
The `VELOX_ASSERT_THROW` macro is very useful and widely used. In order
for Velox users (whose code is not in the `facebook::velox` namespace)
to be able to use this macro, we should use the fully qualified namespace
for `VeloxException` in it.