### PR TITLE
Fix flaky async data cache test

### DIFF
--- a/velox/common/caching/AsyncDataCache.h
+++ b/velox/common/caching/AsyncDataCache.h
@@ -469,46 +469,46 @@ class CoalescedLoad {
 // this struct to provide a snapshot of state.
 struct CacheStats {
   // Total size in 'tinyData_'
-  int64_t tinySize{};
+  int64_t tinySize{0};
   // Total size in 'data_'
-  int64_t largeSize{};
+  int64_t largeSize{0};
   // Unused capacity in 'tinyData_'.
-  int64_t tinyPadding{};
+  int64_t tinyPadding{0};
   // Unused capacity in 'data_'.
-  int64_t largePadding{};
+  int64_t largePadding{0};
   // Total number of entries.
-  int32_t numEntries{};
+  int32_t numEntries{0};
   // Number of entries that do not cache anything.
-  int32_t numEmptyEntries{};
+  int32_t numEmptyEntries{0};
   // Number of entries pinned for shared access.
-  int32_t numShared{};
+  int32_t numShared{0};
   // Number of entries pinned for exclusive access.
-  int32_t numExclusive{};
+  int32_t numExclusive{0};
   // Number of entries that are being or have been prefetched but have not been
   // hit.
-  int32_t numPrefetch{};
+  int32_t numPrefetch{0};
   // Total size of entries in prefetch state.
-  int64_t prefetchBytes{};
+  int64_t prefetchBytes{0};
   // Number of hits (saved IO). The first hit to a prefetched entry does not
   // count.
-  int64_t numHit{};
+  int64_t numHit{0};
   // Sum of sizes of entries counted in 'numHit'.
-  int64_t hitBytes{};
+  int64_t hitBytes{0};
   // Number of new entries created.
-  int64_t numNew{};
+  int64_t numNew{0};
   // Number of times a valid entry was removed in order to make space.
-  int64_t numEvict{};
+  int64_t numEvict{0};
   // Number of entries considered for evicting.
-  int64_t numEvictChecks{};
+  int64_t numEvictChecks{0};
   // Number of times a user waited for an entry to transit from exclusive to
   // shared mode.
-  int64_t numWaitExclusive{};
+  int64_t numWaitExclusive{0};
   // Cumulative clocks spent in allocating or freeing memory for backing cache
   // entries.
-  uint64_t allocClocks{};
+  uint64_t allocClocks{0};
   // Sum of scores of evicted entries. This serves to infer an average
   // lifetime for entries in cache.
-  int64_t sumEvictScore{};
+  int64_t sumEvictScore{0};
 
   std::shared_ptr<SsdCacheStats> ssdStats = nullptr;
 
@@ -604,30 +604,30 @@ class CacheShard {
   std::vector<std::unique_ptr<AsyncDataCacheEntry>> freeEntries_;
 
   // Index in 'entries_' for the next eviction candidate.
-  uint32_t clockHand_{};
+  uint32_t clockHand_{0};
   // Number of gets since last stats sampling.
-  uint32_t eventCounter_{};
+  uint32_t eventCounter_{0};
   // Maximum retainable entry score(). Anything above this is evictable.
   int32_t evictionThreshold_{kNoThreshold};
   // Cumulative count of cache hits.
-  uint64_t numHit_{};
+  uint64_t numHit_{0};
   // Sum of bytes in cache hits.
-  uint64_t hitBytes_{};
+  uint64_t hitBytes_{0};
   // Cumulative count of hits on entries held in exclusive mode.
-  uint64_t numWaitExclusive_{};
+  uint64_t numWaitExclusive_{0};
   // Cumulative count of new entry creation.
-  uint64_t numNew_{};
+  uint64_t numNew_{0};
   // Count of entries evicted.
-  uint64_t numEvict_{};
+  uint64_t numEvict_{0};
   // Count of entries considered for eviction. This divided by
   // 'numEvict_' measured efficiency of eviction.
-  uint64_t numEvictChecks_{};
+  uint64_t numEvictChecks_{0};
   // Sum of evict scores. This divided by 'numEvict_' correlates to
   // time data stays in cache.
-  uint64_t sumEvictScore_{};
+  uint64_t sumEvictScore_{0};
   // Tracker of time spent in allocating/freeing MemoryAllocator space
   // for backing cached data.
-  std::atomic<uint64_t> allocClocks_;
+  std::atomic<uint64_t> allocClocks_{0};
 };
 
 class AsyncDataCache : public memory::Cache {


### PR DESCRIPTION
The flakiness seems due to uninitialized value on certain compilation platform.