### PR TITLE
Use Connector Memory Pool in HiveDataSink for FileSink

### DIFF
--- a/velox/common/file/FileSystems.h
+++ b/velox/common/file/FileSystems.h
@@ -36,7 +36,7 @@ namespace facebook::velox::filesystems {
 /// such as S3.
 struct FileOptions {
   std::unordered_map<std::string, std::string> values;
-  memory::MemoryPool* pool{nullptr};
+  std::shared_ptr<memory::MemoryPool> leafPool{nullptr};
 };
 
 /// An abstract FileSystem

--- a/velox/connectors/hive/HiveDataSink.cpp
+++ b/velox/connectors/hive/HiveDataSink.cpp
@@ -497,12 +497,17 @@ uint32_t HiveDataSink::appendWriter(const HiveWriterId& id) {
   options.compressionKind = insertTableHandle_->compressionKind();
   options.setMemoryReclaimer = connectorQueryCtx_->setMemoryReclaimer();
   ioStats_.emplace_back(std::make_shared<dwio::common::IoStatistics>());
+  // TODO: we need to set memory reclaimer of the created leaf memory pool to
+  // integrate with memory arbitrator later.
+  auto fileSinkPool =
+      connectorQueryCtx_->connectorMemoryPool()->addLeafChild("fileSink");
+
   auto writer = writerFactory_->createWriter(
       dwio::common::FileSink::create(
           writePath,
           {.bufferWrite = false,
            .connectorProperties = connectorProperties_,
-           .pool = connectorQueryCtx_->memoryPool(),
+           .leafPool = fileSinkPool,
            .metricLogger = dwio::common::MetricsLog::voidLog(),
            .stats = ioStats_.back().get()}),
       options);

--- a/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/RegisterS3FileSystem.cpp
@@ -66,7 +66,7 @@ s3WriteFileSinkGenerator() {
       auto fileSystem =
           filesystems::getFileSystem(fileURI, options.connectorProperties);
       return std::make_unique<dwio::common::WriteFileSink>(
-          fileSystem->openFileForWrite(fileURI, {{}, options.pool}),
+          fileSystem->openFileForWrite(fileURI, {{}, options.leafPool}),
           fileURI,
           options.metricLogger,
           options.stats);

--- a/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
+++ b/velox/connectors/hive/storage_adapters/s3fs/S3WriteFile.h
@@ -50,7 +50,7 @@ class S3WriteFile : public WriteFile {
   S3WriteFile(
       const std::string& path,
       Aws::S3::S3Client* client,
-      memory::MemoryPool* pool);
+      const std::shared_ptr<memory::MemoryPool>& leafPool);
 
   /// Appends data to the end of the file.
   /// Uploads a part on reaching part size limit.

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -188,7 +188,7 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(hiveConfig);
   auto pool = memory::defaultMemoryManager().addLeafPool("S3FileSystemTest");
-  auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get()});
+  auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool});
   auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
   std::string dataContent =
       "Dance me to your beauty with a burning violin"

--- a/velox/dwio/common/FileSink.cpp
+++ b/velox/dwio/common/FileSink.cpp
@@ -179,7 +179,7 @@ void LocalFileSink::write(std::vector<DataBuffer<char>>& buffers) {
 }
 
 MemorySink::MemorySink(size_t capacity, const Options& options)
-    : FileSink{"MemorySink", options}, data_{*options.pool, capacity} {}
+    : FileSink{"MemorySink", options}, data_{*options.leafPool, capacity} {}
 
 void MemorySink::write(std::vector<DataBuffer<char>>& buffers) {
   writeImpl(buffers, [&](auto& buffer) {

--- a/velox/dwio/common/FileSink.h
+++ b/velox/dwio/common/FileSink.h
@@ -40,7 +40,8 @@ class FileSink : public Closeable {
     /// Connector properties are required to create a FileSink on FileSystems
     /// such as S3.
     const std::shared_ptr<const Config>& connectorProperties{nullptr};
-    memory::MemoryPool* pool{nullptr};
+    /// FileSink pool must be a leaf pool.
+    const std::shared_ptr<memory::MemoryPool>& leafPool{nullptr};
     MetricsLogPtr metricLogger{MetricsLog::voidLog()};
     IoStatistics* stats{nullptr};
   };
@@ -48,7 +49,7 @@ class FileSink : public Closeable {
   FileSink(std::string name, const Options& options)
       : name_{std::move(name)},
         connectorProperties_{options.connectorProperties},
-        pool_(options.pool),
+        leafPool_(options.leafPool),
         metricLogger_{options.metricLogger},
         stats_{options.stats},
         size_{0} {}
@@ -107,7 +108,7 @@ class FileSink : public Closeable {
 
   const std::string name_;
   const std::shared_ptr<const Config> connectorProperties_;
-  memory::MemoryPool* const pool_;
+  std::shared_ptr<memory::MemoryPool> const leafPool_;
   const MetricsLogPtr metricLogger_;
   IoStatistics* const stats_;
 


### PR DESCRIPTION
Writer uses the connector memory pool.
FileSink used by the writer must also use the connector memory pool instead of the operator memory pool.