### PR TITLE
Fix trim with leaf invalid unicodes.

### DIFF
--- a/velox/functions/lib/string/StringImpl.h
+++ b/velox/functions/lib/string/StringImpl.h
@@ -332,9 +332,13 @@ FOLLY_ALWAYS_INLINE std::array<int64_t, 2> unicodeWhitespaceCodes() {
 ///  8192, 8193, 8194, 8195, 8196, 8197, 8198, 8200, 8201, 8202, 8232, 8233, 8287,
 ///  12288]
 // clang-format on
+// This function need to handle invalid codepoints with out crashing.
 FOLLY_ALWAYS_INLINE bool isUnicodeWhiteSpace(utf8proc_int32_t codePoint) {
   static const auto kAsciiCodes = asciiWhitespaceCodes();
   static const auto kUnicodeCodes = unicodeWhitespaceCodes();
+  if (codePoint < 0) {
+    return false;
+  }
 
   if (codePoint < 5'000) {
     if (codePoint > 32) {
@@ -491,7 +495,7 @@ FOLLY_ALWAYS_INLINE void trimUnicodeWhiteSpace(
           input.data() + curStartPos,
           input.data() + input.size(),
           codePointSize);
-      if (!isUnicodeWhiteSpace(codePoint)) {
+      if (codePoint == -1 || !isUnicodeWhiteSpace(codePoint)) {
         break;
       }
       curStartPos += codePointSize;

--- a/velox/functions/lib/string/tests/StringImplTest.cpp
+++ b/velox/functions/lib/string/tests/StringImplTest.cpp
@@ -639,3 +639,7 @@ TEST_F(StringImplTest, utf8proc_codepoint) {
       -1);
   EXPECT_EQ(size, 4);
 }
+
+TEST_F(StringImplTest, isUnicodeWhiteSpace) {
+  EXPECT_FALSE(isUnicodeWhiteSpace(-1));
+}

--- a/velox/functions/prestosql/tests/TrimFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/TrimFunctionsTest.cpp
@@ -180,6 +180,11 @@ TEST_F(TrimFunctionsTest, trim) {
   EXPECT_EQ(expectedComplexStr, trim(complexStr));
   EXPECT_EQ(
       "Ψ\xFF\xFFΣΓΔA", trim("\u2028 \r \t \nΨ\xFF\xFFΣΓΔA \u2028 \r \t \n"));
+
+  EXPECT_EQ("\xFF\xFF", trim("\u2028 \r \t \n\xFF\xFF \u2028 \r \t \n"));
+
+  // Invalid unicode at the start and end of the string.
+  EXPECT_EQ("\xFF\xFF", trim("\xFF\xFF"));
 }
 
 TEST_F(TrimFunctionsTest, ltrim) {
@@ -219,6 +224,9 @@ TEST_F(TrimFunctionsTest, ltrim) {
 
   EXPECT_EQ(expectedComplexStr, ltrim(complexStr));
   EXPECT_EQ("Ψ\xFF\xFFΣΓΔA", ltrim("  \u2028 \r \t \n   Ψ\xFF\xFFΣΓΔA"));
+
+  // Invalid unicode at the start and end of the string.
+  EXPECT_EQ("\xFF\xFF", ltrim("\xFF\xFF"));
 }
 
 TEST_F(TrimFunctionsTest, rtrim) {
@@ -258,6 +266,9 @@ TEST_F(TrimFunctionsTest, rtrim) {
 
   EXPECT_EQ(expectedComplexStr, rtrim(complexStr));
   EXPECT_EQ("     Ψ\xFF\xFFΣΓΔA", rtrim("     Ψ\xFF\xFFΣΓΔA \u2028 \r \t \n"));
+
+  // Invalid unicode at the start and end of the string.
+  EXPECT_EQ("\xFF\xFF", rtrim("\xFF\xFF"));
 }
 
 TEST_F(TrimFunctionsTest, trimCustomCharacters) {


### PR DESCRIPTION
Summary:
Recent change to isUnicodeWhiteSpace makes it seg fault if negative number is passed to it.
function could call isUnicodeWhiteSpace with -1 when the input is invalid unicode.
I also added explicit check in trim not to call it with invalid, but its good to have the checks in both places.

Fixes #6679 
Differential Revision: D49510430


