### PR TITLE
Remove libmnl dependency for fboss

### DIFF
--- a/build/fbcode_builder/manifests/fboss
+++ b/build/fbcode_builder/manifests/fboss
@@ -27,7 +27,6 @@ zstd
 fatal
 fbthrift
 iproute2
-libmnl
 libusb
 libcurl
 libnl


### PR DESCRIPTION
Summary:
libmnl-static has not been used for fboss in centos8. It is not
available in centos9. fboss builds fine without limnl dependency

Differential Revision: D49380161


