### PR TITLE
Add query config to allow validation of output from every operator

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -269,6 +269,14 @@ class QueryConfig {
   static constexpr const char* kMinTableRowsForParallelJoinBuild =
       "min_table_rows_for_parallel_join_build";
 
+  /// If set to true, then during execution of tasks, the output vectors of
+  /// every operator are validated for consistency. This is an expensive check
+  /// so should only be used for debugging. It can help debug issues where
+  /// malformed vector cause failures or crashes by helping identify which
+  /// operator is generating them.
+  static constexpr const char* kValidateOutputFromOperators =
+      "debug.validate_output_from_operators";
+
   uint64_t maxPartialAggregationMemoryUsage() const {
     static constexpr uint64_t kDefault = 1L << 24;
     return get<uint64_t>(kMaxPartialAggregationMemory, kDefault);
@@ -553,6 +561,10 @@ class QueryConfig {
 
   uint32_t minTableRowsForParallelJoinBuild() const {
     return get<uint32_t>(kMinTableRowsForParallelJoinBuild, 1'000);
+  }
+
+  bool validateOutputFromOperators() const {
+    return get<bool>(kValidateOutputFromOperators, false);
   }
 
   template <typename T>

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -81,6 +81,12 @@ Generic Configuration
      - integer
      - 1000
      - The minimum number of table rows that can trigger the parallel hash join table build.
+   * - debug.validate_output_from_operators
+     - bool
+     - false
+     - If set to true, then during execution of tasks, the output vectors of every operator are validated for consistency.
+       This is an expensive check so should only be used for debugging. It can help debug issues where malformed vector
+       cause failures or crashes by helping identify which operator is generating them.
 
 .. _expression-evaluation-conf:
 

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -75,6 +75,18 @@ std::optional<column_index_t> getIdentityProjection(
   return std::nullopt;
 }
 
+void validateOperatorResult(RowVectorPtr& result, Operator& op) {
+  try {
+    result->validate({});
+  } catch (const std::exception& e) {
+    VELOX_FAIL(
+        "Output validation failed for [operator: {}, plan node ID: {}]: {}",
+        op.operatorType(),
+        op.planNodeId(),
+        e.what());
+  }
+}
+
 thread_local DriverThreadContext* driverThreadCtx{nullptr};
 } // namespace
 
@@ -479,7 +491,7 @@ StopReason Driver::runInternal(
               needsInput = nextOp->needsInput(), nextOp, "needsInput");
           if (needsInput) {
             uint64_t resultBytes = 0;
-            RowVectorPtr result;
+            RowVectorPtr intermediateResult;
             {
               auto timer = createDeltaCpuWallTimer(
                   [op, this](const CpuWallTiming& deltaTiming) {
@@ -487,22 +499,27 @@ StopReason Driver::runInternal(
                     op->stats().wlock()->getOutputTiming.add(deltaTiming);
                   });
               RuntimeStatWriterScopeGuard statsWriterGuard(op);
-              CALL_OPERATOR(result = op->getOutput(), op, "getOutput");
-              if (result) {
+              CALL_OPERATOR(
+                  intermediateResult = op->getOutput(), op, "getOutput");
+              if (intermediateResult) {
                 VELOX_CHECK(
-                    result->size() > 0,
+                    intermediateResult->size() > 0,
                     "Operator::getOutput() must return nullptr or "
                     "a non-empty vector: {}",
                     op->operatorType());
-                resultBytes = result->estimateFlatSize();
+                if (ctx_->queryConfig().validateOutputFromOperators()) {
+                  validateOperatorResult(intermediateResult, *op);
+                }
+                resultBytes = intermediateResult->estimateFlatSize();
                 {
                   auto lockedStats = op->stats().wlock();
-                  lockedStats->addOutputVector(resultBytes, result->size());
+                  lockedStats->addOutputVector(
+                      resultBytes, intermediateResult->size());
                 }
               }
             }
             pushdownFilters(i);
-            if (result) {
+            if (intermediateResult) {
               auto timer = createDeltaCpuWallTimer(
                   [nextOp, this](const CpuWallTiming& timing) {
                     auto selfDelta = processLazyTiming(*nextOp, timing);
@@ -510,14 +527,16 @@ StopReason Driver::runInternal(
                   });
               {
                 auto lockedStats = nextOp->stats().wlock();
-                lockedStats->addInputVector(resultBytes, result->size());
+                lockedStats->addInputVector(
+                    resultBytes, intermediateResult->size());
               }
               RuntimeStatWriterScopeGuard statsWriterGuard(nextOp);
               TestValue::adjust(
                   "facebook::velox::exec::Driver::runInternal::addInput",
                   nextOp);
 
-              CALL_OPERATOR(nextOp->addInput(result), nextOp, "addInput");
+              CALL_OPERATOR(
+                  nextOp->addInput(intermediateResult), nextOp, "addInput");
 
               // The next iteration will see if operators_[i + 1] has
               // output now that it got input.
@@ -577,6 +596,9 @@ StopReason Driver::runInternal(
                   "Operator::getOutput() must return nullptr or "
                   "a non-empty vector: {}",
                   op->operatorType());
+              if (ctx_->queryConfig().validateOutputFromOperators()) {
+                validateOperatorResult(result, *op);
+              }
               {
                 auto lockedStats = op->stats().wlock();
                 lockedStats->addOutputVector(


### PR DESCRIPTION
This change adds a new query config
'debug.validate_output_from_operators' which when set to true
calls validate() on the output vector of every operator.