### PR TITLE
Alternate API to Register FileSystem

### DIFF
--- a/velox/common/file/FileSystems.cpp
+++ b/velox/common/file/FileSystems.cpp
@@ -49,6 +49,24 @@ void registerFileSystem(
   registeredFileSystems().emplace_back(schemeMatcher, fileSystemGenerator);
 }
 
+// Overloaded version of registerFileSystem, for fileSystem which do not require
+// config object to be passed on each instance of getFileSystem. Once config is
+// passed to registerFileSystem, the config object will be re-used for all the
+// subsequent calls to getFileSystem.
+void registerFileSystem(
+    const std::function<bool(std::string_view)> schemeMatcher,
+    const std::function<std::shared_ptr<FileSystem>(
+        std::shared_ptr<const Config>,
+        std::string_view)> fileSystemGenerator,
+    const std::shared_ptr<const Config> config) {
+  registerFileSystem(
+      schemeMatcher,
+      [&config, &fileSystemGenerator](
+          std::shared_ptr<const Config> /*unused*/, std::string_view path) {
+        return fileSystemGenerator(config, path);
+      });
+}
+
 std::shared_ptr<FileSystem> getFileSystem(
     std::string_view filePath,
     std::shared_ptr<const Config> properties) {


### PR DESCRIPTION
File system is initialised when the fist invocation to filesystem is made. As not all classes have access to the connector config, they call getFileSystem with nullptr in pace of connector config. The side-effect of this being, if this happens to be first invocation of filesystem, the filesystem instance gets initialised incorrectly.

Some filesystems require do not require config object to be passed on each invocation of getFileSystem, this PR adds a new registerFileSystem API. Once config is passed to registerFileSystem, the config object will be re-used for all the subsequent calls to getFileSystem.