### PR TITLE
Rename rows_ to ranges_ in detail::Destination

### DIFF
--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -35,16 +35,16 @@ class Destination {
 
   // Resets the destination before starting a new batch.
   void beginBatch() {
-    rows_.clear();
-    row_ = 0;
+    ranges_.clear();
+    rangeIdx_ = 0;
   }
 
   void addRow(vector_size_t row) {
-    rows_.push_back(IndexRange{row, 1});
+    ranges_.push_back(IndexRange{row, 1});
   }
 
   void addRows(const IndexRange& rows) {
-    rows_.push_back(rows);
+    ranges_.push_back(rows);
   }
 
   BlockingReason advance(
@@ -94,10 +94,10 @@ class Destination {
   const int destination_;
   memory::MemoryPool* const pool_;
   uint64_t bytesInCurrent_{0};
-  std::vector<IndexRange> rows_;
+  std::vector<IndexRange> ranges_;
 
-  // First row of 'rows_' that is not appended to 'current_'
-  vector_size_t row_{0};
+  // First range index of 'ranges_' that is not appended to 'current_'.
+  vector_size_t rangeIdx_{0};
   std::unique_ptr<VectorStreamGroup> current_;
   bool finished_{false};
 


### PR DESCRIPTION
The `rows_` member of `detail::Destination` is misleading because it is 
actually a list of `IndexRange`(an `IndexRange` represents a row-range). 
In an `IndexRange`, there may be only one row, but it may also include 
multiple consecutive rows(in the scenario of only one partition). 

To avoid misunderstandings and improve readability, `rows_` is renamed 
to `ranges_`, and `row_` is renamed to `rangeIdx_`.

No functional change in the PR.