### PR TITLE
Improve normalized key join probe

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -653,22 +653,22 @@ void HashTable<ignoreNullKeys>::joinNormalizedKeyProbe(HashLookup& lookup) {
   int32_t probeIndex = 0;
   int32_t numProbes = lookup.rows.size();
   const vector_size_t* rows = lookup.rows.data();
-  constexpr int32_t probeStep = 64;
-  ProbeState states[probeStep];
+  constexpr int32_t groupSize = 64;
+  ProbeState states[groupSize];
   const uint64_t* keys = lookup.normalizedKeys.data();
   const uint64_t* hashes = lookup.hashes.data();
   char** hits = lookup.hits.data();
   constexpr int32_t kKeyOffset =
       -static_cast<int32_t>(sizeof(normalized_key_t));
-  for (; probeIndex + probeStep <= numProbes; probeIndex += probeStep) {
-    for (int32_t i = 0; i < probeStep; ++i) {
+  for (; probeIndex + groupSize <= numProbes; probeIndex += groupSize) {
+    for (int32_t i = 0; i < groupSize; ++i) {
       int32_t row = rows[probeIndex + i];
       states[i].preProbe(*this, hashes[row], row);
     }
-    for (int32_t i = 0; i < probeStep; ++i) {
+    for (int32_t i = 0; i < groupSize; ++i) {
       states[i].firstProbe(*this, kKeyOffset);
     }
-    for (int32_t i = 0; i < probeStep; ++i) {
+    for (int32_t i = 0; i < groupSize; ++i) {
       hits[states[i].row()] = states[i].joinNormalizedKeyFullProbe(*this, keys);
     }
   }

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -95,26 +95,27 @@ class ProbeState {
     return row_;
   }
 
-  // Use one instruction to load 16 tags
-  // Use another instruction to make 16 copies of the tag being searched for
+  // Use one instruction to make 16 copies of the tag being searched for
   template <typename Table>
   inline void preProbe(const Table& table, uint64_t hash, int32_t row) {
     row_ = row;
-
     bucketOffset_ = table.bucketOffset(hash);
-    tagsInTable_ = BaseHashTable::loadTags(
-        reinterpret_cast<uint8_t*>(table.table_), bucketOffset_);
     auto tag = BaseHashTable::hashTag(hash);
     wantedTags_ = BaseHashTable::TagVector::broadcast(tag);
     group_ = nullptr;
     indexInTags_ = kNotSet;
-    table.incrementTagLoads();
+    __builtin_prefetch(
+        reinterpret_cast<uint8_t*>(table.table_) + bucketOffset_);
   }
 
-  // Use one instruction to compare the tag being searched for to 16 tags
-  // If there is a match, load corresponding data from the table
+  // Use one instruction to load 16 tags. Use another one instruction
+  // to compare the tag being searched for to 16 tags.
+  // If there is a match, load corresponding data from the table.
   template <Operation op = Operation::kProbe, typename Table>
   inline void firstProbe(const Table& table, int32_t firstKey) {
+    tagsInTable_ = BaseHashTable::loadTags(
+        reinterpret_cast<uint8_t*>(table.table_), bucketOffset_);
+    table.incrementTagLoads();
     hits_ = simd::toBitMask(tagsInTable_ == wantedTags_);
     if (hits_) {
       loadNextHit<op>(table, firstKey);
@@ -652,38 +653,30 @@ void HashTable<ignoreNullKeys>::joinNormalizedKeyProbe(HashLookup& lookup) {
   int32_t probeIndex = 0;
   int32_t numProbes = lookup.rows.size();
   const vector_size_t* rows = lookup.rows.data();
-  ProbeState state1;
-  ProbeState state2;
-  ProbeState state3;
-  ProbeState state4;
+  constexpr int32_t probeStep = 64;
+  ProbeState states[probeStep];
   const uint64_t* keys = lookup.normalizedKeys.data();
   const uint64_t* hashes = lookup.hashes.data();
   char** hits = lookup.hits.data();
   constexpr int32_t kKeyOffset =
       -static_cast<int32_t>(sizeof(normalized_key_t));
-  for (; probeIndex + 4 <= numProbes; probeIndex += 4) {
-    int32_t row = rows[probeIndex];
-    state1.preProbe(*this, hashes[row], row);
-    row = rows[probeIndex + 1];
-    state2.preProbe(*this, hashes[row], row);
-    row = rows[probeIndex + 2];
-    state3.preProbe(*this, hashes[row], row);
-    row = rows[probeIndex + 3];
-    state4.preProbe(*this, hashes[row], row);
-    state1.firstProbe(*this, kKeyOffset);
-    state2.firstProbe(*this, kKeyOffset);
-    state3.firstProbe(*this, kKeyOffset);
-    state4.firstProbe(*this, kKeyOffset);
-    hits[state1.row()] = state1.joinNormalizedKeyFullProbe(*this, keys);
-    hits[state2.row()] = state2.joinNormalizedKeyFullProbe(*this, keys);
-    hits[state3.row()] = state3.joinNormalizedKeyFullProbe(*this, keys);
-    hits[state4.row()] = state4.joinNormalizedKeyFullProbe(*this, keys);
+  for (; probeIndex + probeStep <= numProbes; probeIndex += probeStep) {
+    for (int32_t i = 0; i < probeStep; ++i) {
+      int32_t row = rows[probeIndex + i];
+      states[i].preProbe(*this, hashes[row], row);
+    }
+    for (int32_t i = 0; i < probeStep; ++i) {
+      states[i].firstProbe(*this, kKeyOffset);
+    }
+    for (int32_t i = 0; i < probeStep; ++i) {
+      hits[states[i].row()] = states[i].joinNormalizedKeyFullProbe(*this, keys);
+    }
   }
   for (; probeIndex < numProbes; ++probeIndex) {
     int32_t row = rows[probeIndex];
-    state1.preProbe(*this, lookup.hashes[row], row);
-    state1.firstProbe(*this, 0);
-    hits[row] = state1.joinNormalizedKeyFullProbe(*this, keys);
+    states[0].preProbe(*this, lookup.hashes[row], row);
+    states[0].firstProbe(*this, 0);
+    hits[row] = states[0].joinNormalizedKeyFullProbe(*this, keys);
   }
 }
 


### PR DESCRIPTION
Improve normalized key join probe
1. add prefetch command for tags.
2. increase group size from 4 to 64 in `joinNormalizedKeyProbe`.

Fixes #6694