### PR TITLE
Skip header rows in TEXTFILE reader

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -538,6 +538,12 @@ HiveDataSource::HiveDataSource(
   rowReaderOpts_.setScanSpec(scanSpec_);
   rowReaderOpts_.setMetadataFilter(metadataFilter_);
 
+  auto skipRowsIt = hiveTableHandle->tableParameters().find(
+      dwio::common::TableParameter::kSkipHeaderLineCount);
+  if (skipRowsIt != hiveTableHandle->tableParameters().end()) {
+    rowReaderOpts_.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
+  }
+
   ioStats_ = std::make_shared<dwio::common::IoStatistics>();
 }
 

--- a/velox/connectors/hive/TableHandle.cpp
+++ b/velox/connectors/hive/TableHandle.cpp
@@ -108,13 +108,15 @@ HiveTableHandle::HiveTableHandle(
     bool filterPushdownEnabled,
     SubfieldFilters subfieldFilters,
     const core::TypedExprPtr& remainingFilter,
-    const RowTypePtr& dataColumns)
+    const RowTypePtr& dataColumns,
+    const std::unordered_map<std::string, std::string>& tableParameters)
     : ConnectorTableHandle(std::move(connectorId)),
       tableName_(tableName),
       filterPushdownEnabled_(filterPushdownEnabled),
       subfieldFilters_(std::move(subfieldFilters)),
       remainingFilter_(remainingFilter),
-      dataColumns_(dataColumns) {}
+      dataColumns_(dataColumns),
+      tableParameters_(tableParameters) {}
 
 std::string HiveTableHandle::toString() const {
   std::stringstream out;

--- a/velox/connectors/hive/TableHandle.h
+++ b/velox/connectors/hive/TableHandle.h
@@ -120,7 +120,8 @@ class HiveTableHandle : public ConnectorTableHandle {
       bool filterPushdownEnabled,
       SubfieldFilters subfieldFilters,
       const core::TypedExprPtr& remainingFilter,
-      const RowTypePtr& dataColumns = nullptr);
+      const RowTypePtr& dataColumns = nullptr,
+      const std::unordered_map<std::string, std::string>& tableParameters = {});
 
   const std::string& tableName() const {
     return tableName_;
@@ -143,6 +144,10 @@ class HiveTableHandle : public ConnectorTableHandle {
     return dataColumns_;
   }
 
+  const std::unordered_map<std::string, std::string>& tableParameters() const {
+    return tableParameters_;
+  }
+
   std::string toString() const override;
 
   folly::dynamic serialize() const override;
@@ -159,6 +164,7 @@ class HiveTableHandle : public ConnectorTableHandle {
   const SubfieldFilters subfieldFilters_;
   const core::TypedExprPtr remainingFilter_;
   const RowTypePtr dataColumns_;
+  const std::unordered_map<std::string, std::string> tableParameters_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -93,6 +93,10 @@ class SerDeOptions {
   ~SerDeOptions() = default;
 };
 
+struct TableParameter {
+  static constexpr const char* kSkipHeaderLineCount = "skip.header.line.count";
+};
+
 /**
  * Options for creating a RowReader.
  */
@@ -124,6 +128,7 @@ class RowReaderOptions {
       facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
       keySelectionCallback_;
   bool eagerFirstStripeLoad = true;
+  uint64_t skipRows_ = 0;
 
  public:
   RowReaderOptions() noexcept
@@ -328,6 +333,14 @@ class RowReaderOptions {
       void(facebook::velox::dwio::common::flatmap::FlatMapKeySelectionStats)>
   getKeySelectionCallback() const {
     return keySelectionCallback_;
+  }
+
+  void setSkipRows(uint64_t skipRows) {
+    skipRows_ = skipRows;
+  }
+
+  bool getSkipRows() const {
+    return skipRows_;
   }
 
   const std::shared_ptr<folly::Executor>& getDecodingExecutor() const {


### PR DESCRIPTION
Summary: Table metadata has a parameter `skip.header.line.count` which controls how many rows are header rows. This parameter needs to be passed into TEXTFILE reader so that it can skip the header rows accordingly.

Differential Revision: D49573677


