### PR TITLE
Restrict n to <= 10000 in min/max(x,n) Presto aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -544,6 +544,11 @@ struct MinMaxNAccumulator {
     VELOX_USER_CHECK_GT(
         newN, 0, "second argument of max/min must be a positive integer");
 
+    VELOX_USER_CHECK_LE(
+        newN,
+        10'000,
+        "second argument of max/min must be less than or equal to 10000");
+
     if (n) {
       VELOX_USER_CHECK_EQ(
           newN,

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -484,6 +484,14 @@ class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {
         {},
         {"min(c0, c1)", "min(c0, c3)", "max(c0, c2)", "max(c0, c3)"},
         {expected});
+
+    // Second argument of max_n/min_n must be less than or equal to 10000.
+    VELOX_ASSERT_THROW(
+        testAggregations({data}, {}, {"min(c0, 10001)"}, {expected}),
+        "second argument of max/min must be less than or equal to 10000");
+    VELOX_ASSERT_THROW(
+        testAggregations({data}, {}, {"max(c0, 10001)"}, {expected}),
+        "second argument of max/min must be less than or equal to 10000");
   }
 
   template <typename T>


### PR DESCRIPTION
In Presto, min/max(x, n) functions fail if n > 10'000. In Velox, these queries
succeed. Velox needs to match Presto by checking N and throwing an exception
with the message "second argument of max_n/min_n must be less than or equal to
10000" if N >10'000.

Fixes #6709