### PR TITLE
Fail if inputs contain nested nulls in min/max/min_by/max_by Presto aggregates

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -107,6 +107,7 @@ General Aggregate Functions
 .. function:: max(x) -> [same as input]
 
     Returns the maximum value of all input values.
+    ``x`` must not contains nulls when it is complex type.
 
 .. function:: max(x, n) -> array<[same as x]>
 
@@ -116,6 +117,7 @@ General Aggregate Functions
 .. function:: min(x) -> [same as input]
 
     Returns the minimum value of all input values.
+    ``x`` must not contains nulls when it is complex type.
 
 .. function:: min(x, n) -> array<[same as x]>
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -280,8 +280,10 @@ const T MinAggregate<T>::kInitialValue_ = MinMaxTrait<T>::max();
 
 class NonNumericMinMaxAggregateBase : public exec::Aggregate {
  public:
-  explicit NonNumericMinMaxAggregateBase(const TypePtr& resultType)
-      : exec::Aggregate(resultType) {}
+  explicit NonNumericMinMaxAggregateBase(
+      const TypePtr& resultType,
+      bool throwOnNestedNulls)
+      : exec::Aggregate(resultType), throwOnNestedNulls_(throwOnNestedNulls) {}
 
   int32_t accumulatorFixedWidthSize() const override {
     return sizeof(SingleValueAccumulator);
@@ -377,9 +379,10 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     }
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (decoded.isNullAt(i)) {
+      if (checkNulls(decoded, i)) {
         return;
       }
+
       auto accumulator = value<SingleValueAccumulator>(groups[i]);
       if (!accumulator->hasValue() ||
           compareTest(compare(accumulator, decoded, i))) {
@@ -399,8 +402,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     auto baseVector = decoded.base();
 
     if (decoded.isConstantMapping()) {
-      if (decoded.isNullAt(0)) {
-        // nothing to do; all values are nulls
+      if (checkNulls(decoded, 0)) {
         return;
       }
 
@@ -414,21 +416,53 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
     auto accumulator = value<SingleValueAccumulator>(group);
     rows.applyToSelected([&](vector_size_t i) {
-      if (decoded.isNullAt(i)) {
+      if (checkNulls(decoded, i)) {
         return;
       }
+
       if (!accumulator->hasValue() ||
           compareTest(compare(accumulator, decoded, i))) {
         accumulator->write(baseVector, indices[i], allocator_);
       }
     });
   }
+
+  FOLLY_ALWAYS_INLINE static void checkNestedNull(
+      const DecodedVector& decoded,
+      vector_size_t index) {
+    VELOX_USER_CHECK(
+        !decoded.base()->containsNullAt(index),
+        fmt::format(
+            "{} comparison not supported for values that contain nulls",
+            mapTypeKindToName(decoded.base()->typeKind())));
+  }
+
+  bool checkNulls(const DecodedVector& decoded, vector_size_t index) {
+    if (decoded.isNullAt(index)) {
+      return true;
+    }
+
+    if (throwOnNestedNulls_) {
+      VELOX_USER_CHECK(
+          !decoded.base()->containsNullAt(index),
+          fmt::format(
+              "{} comparison not supported for values that contain nulls",
+              mapTypeKindToName(decoded.base()->typeKind())));
+    }
+
+    return false;
+  }
+
+ private:
+  bool throwOnNestedNulls_;
 };
 
 class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {
  public:
-  explicit NonNumericMaxAggregate(const TypePtr& resultType)
-      : NonNumericMinMaxAggregateBase(resultType) {}
+  explicit NonNumericMaxAggregate(
+      const TypePtr& resultType,
+      bool throwOnNestedNulls)
+      : NonNumericMinMaxAggregateBase(resultType, throwOnNestedNulls) {}
 
   void addRawInput(
       char** groups,
@@ -469,8 +503,10 @@ class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {
 
 class NonNumericMinAggregate : public NonNumericMinMaxAggregateBase {
  public:
-  explicit NonNumericMinAggregate(const TypePtr& resultType)
-      : NonNumericMinMaxAggregateBase(resultType) {}
+  explicit NonNumericMinAggregate(
+      const TypePtr& resultType,
+      bool throwOnNestedNulls)
+      : NonNumericMinMaxAggregateBase(resultType, throwOnNestedNulls) {}
 
   void addRawInput(
       char** groups,
@@ -910,6 +946,7 @@ exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         const bool nAgg = !resultType->equivalent(*argTypes[0]);
+        bool throwOnNestedNulls = velox::exec::isRawInput(step);
 
         if (nAgg) {
           // We have either 2 arguments: T, bigint (partial aggregation)
@@ -967,13 +1004,14 @@ exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
             case TypeKind::VARBINARY:
               [[fallthrough]];
             case TypeKind::VARCHAR:
-              [[fallthrough]];
+              return std::make_unique<TNonNumeric>(inputType, false);
             case TypeKind::ARRAY:
               [[fallthrough]];
             case TypeKind::MAP:
               [[fallthrough]];
             case TypeKind::ROW:
-              return std::make_unique<TNonNumeric>(inputType);
+              return std::make_unique<TNonNumeric>(
+                  inputType, throwOnNestedNulls);
             default:
               VELOX_CHECK(
                   false,

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -427,16 +427,6 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     });
   }
 
-  FOLLY_ALWAYS_INLINE static void checkNestedNull(
-      const DecodedVector& decoded,
-      vector_size_t index) {
-    VELOX_USER_CHECK(
-        !decoded.base()->containsNullAt(index),
-        fmt::format(
-            "{} comparison not supported for values that contain nulls",
-            mapTypeKindToName(decoded.base()->typeKind())));
-  }
-
   bool checkNulls(const DecodedVector& decoded, vector_size_t index) {
     if (decoded.isNullAt(index)) {
       return true;
@@ -454,7 +444,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
   }
 
  private:
-  bool throwOnNestedNulls_;
+  const bool throwOnNestedNulls_;
 };
 
 class NonNumericMaxAggregate : public NonNumericMinMaxAggregateBase {
@@ -946,7 +936,7 @@ exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<exec::Aggregate> {
         const bool nAgg = !resultType->equivalent(*argTypes[0]);
-        bool throwOnNestedNulls = velox::exec::isRawInput(step);
+        const bool throwOnNestedNulls = velox::exec::isRawInput(step);
 
         if (nAgg) {
           // We have either 2 arguments: T, bigint (partial aggregation)

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -397,25 +397,13 @@ TEST_F(MinMaxTest, arrayCheckNulls) {
       }),
   });
 
-  auto expectedMin = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2},
-      }),
-  });
-
-  auto expectedMax = makeRowVector({
-      makeArrayVector<int64_t>({
-          {6, 7},
-      }),
-  });
-
-  VELOX_ASSERT_THROW(
-      testAggregations({data}, {}, {"min(c0)"}, {expectedMin}),
-      "ARRAY comparison not supported for values that contain nulls");
-
-  VELOX_ASSERT_THROW(
-      testAggregations({data}, {}, {"max(c0)"}, {expectedMax}),
-      "ARRAY comparison not supported for values that contain nulls");
+  for (const auto& expr : {"min(c0)", "max(c0)"}) {
+    auto plan =
+        PlanBuilder().values({data}).singleAggregation({}, {expr}).planNode();
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "ARRAY comparison not supported for values that contain nulls");
+  }
 }
 
 TEST_F(MinMaxTest, rowCheckNull) {
@@ -434,24 +422,13 @@ TEST_F(MinMaxTest, rowCheckNull) {
       }),
   });
 
-  auto expectedMin = makeRowVector({
-      makeRowVector(
-          {makeFlatVector<StringView>({"a"_sv}),
-           makeFlatVector<StringView>({"aa"_sv})}),
-  });
-
-  auto expectedMax = makeRowVector({
-      makeRowVector(
-          {makeFlatVector<StringView>({"c"_sv}),
-           makeFlatVector<StringView>({"cc"_sv})}),
-  });
-
-  VELOX_ASSERT_THROW(
-      testAggregations({data}, {}, {"min(c0)"}, {expectedMin}),
-      "ROW comparison not supported for values that contain nulls");
-  VELOX_ASSERT_THROW(
-      testAggregations({data}, {}, {"max(c0)"}, {expectedMax}),
-      "ROW comparison not supported for values that contain nulls");
+  for (const auto& expr : {"min(c0)", "max(c0)"}) {
+    auto plan =
+        PlanBuilder().values({data}).singleAggregation({}, {expr}).planNode();
+    VELOX_ASSERT_THROW(
+        AssertQueryBuilder(plan).copyResults(pool()),
+        "ROW comparison not supported for values that contain nulls");
+  }
 }
 
 class MinMaxNTest : public functions::aggregate::test::AggregationTestBase {


### PR DESCRIPTION
In terms of min/max, processing a single stream of values [1, 2], [2, 3], [3, null], [3, 4] goes like this:

- acc = [1, 2]
- compare(acc, [2, 3]) -> keep acc = [1, 2]
- compare (acc, [3, null]) -> detect that 1 < 3 and do not continue comparing 2 with null - > keep acc = [1, 2]

But processing 2 streams: ([1, 2], [2, 3]) and ([3, null], [3, 4]) goes differently. When processing 2nd stream:

- acc = [3, null]
- compare (acc, [3, 4]) triggers comparison null v. 4 and fails.

For example,

```SQL
presto> select min(col0) from (values (array [1, 2]), (array [2, 3]), (array [3, null]), (array [3, 4])) as tbl(col0);
 _col0
--------
 [1, 2]
(1 row)
```
But it will fail if I break them into two aggregates,
```SQL
presto> select min(col0) from (values (array [1, 2]), (array [2, 3])) as tbl(col0);
 _col0
--------
 [1, 2]
(1 row)

presto> select min(col0) from (values (array [3, null]), (array [3, 4])) as tbl(col0);
Query 20230919_044628_00012_6yp5g failed: ARRAY comparison not supported for arrays with null elements
```

This behavior is problematic because when a query runs on a cluster it can go either way and therefore, the same query may either succeed or fail. Failures are intermittent and non-deterministic.

We need to make sure that the query always fails to make the query always fail, to make it more semantically clear. This PR adds a check that all inputs to min/max (and other similar functions) do not contain nested nulls before serializing them to the accumulator. 

Part of #6314