### PR TITLE
Fix exec::Strings  allocation pattern

### DIFF
--- a/velox/common/memory/HashStringAllocator.h
+++ b/velox/common/memory/HashStringAllocator.h
@@ -335,6 +335,11 @@ class HashStringAllocator : public StreamArena {
     return cumulativeBytes_;
   }
 
+  // Returns the starting sizes of free lists. Allocating one of these
+  // sizes will always be fast because all elements of the free list
+  // in question will fit.
+  static folly::Range<const int32_t*> freeListSizes();
+
   // Checks the free space accounting and consistency of
   // Headers. Throws when detects corruption. Returns the number of allocated
   // payload bytes, excluding headers, continue links and other overhead.
@@ -362,6 +367,9 @@ class HashStringAllocator : public StreamArena {
   // match the size progression for growing F14 containers. Static array of
   // exactly 8 ints for simd.
   static int32_t freeListSizes_[HashStringAllocator::kNumFreeLists + 1];
+
+  // The largest size present in each free list.
+  int32_t largestInFreeList_[HashStringAllocator::kNumFreeLists + 1] = {};
 
   void newRange(int32_t bytes, ByteRange* range, bool contiguous);
 

--- a/velox/exec/Strings.h
+++ b/velox/exec/Strings.h
@@ -32,7 +32,7 @@ struct Strings {
 
   /// Maximum size of a string passed to 'append'. Used to calculate the amount
   /// of space to reserve for future strings.
-  size_t maxStringSize = 0;
+  int32_t maxStringSize = 0;
 
   /// Copies the string into contiguous memory allocated via
   /// HashStringAllocator. Returns StringView over the copy.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(
   SplitToStringTest.cpp
   SqlTest.cpp
   StreamingAggregationTest.cpp
+  StringsTest.cpp
   TableScanTest.cpp
   TableWriteTest.cpp
   TaskListenerTest.cpp

--- a/velox/exec/tests/StringsTest.cpp
+++ b/velox/exec/tests/StringsTest.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/Strings.h"
+#include "velox/common/memory/HashStringAllocator.h"
+
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::aggregate::prestosql;
+
+namespace {
+
+class StringsTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    pool_ = memory::addDefaultLeafMemoryPool();
+    allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
+  }
+
+  // Appends a string and records the string and result for verification.
+  void append(Strings& strings, const std::string& str) {
+    appended_.push_back(str);
+    views_.push_back(strings.append(StringView(str), *allocator_));
+    check();
+  }
+
+  // Checks all appended strings are unchanged.
+  void check() {
+    for (auto i = 0; i < appended_.size(); ++i) {
+      EXPECT_EQ(
+          0,
+          memcmp(appended_[i].data(), views_[i].data(), appended_[i].size()));
+    }
+  }
+
+  std::vector<std::string> appended_;
+  std::vector<StringView> views_;
+
+  std::shared_ptr<memory::MemoryPool> pool_;
+  std::unique_ptr<HashStringAllocator> allocator_;
+};
+
+TEST_F(StringsTest, basic) {
+  constexpr int32_t kHeader = sizeof(HashStringAllocator::Header);
+  // next pointer, 8 leading bytes, and header.
+  constexpr int32_t kOverhead = 16 + kHeader;
+  Strings strings;
+  std::string s13 = "0123456789abc";
+  std::string s16 = "0123456789abcdef";
+  std::string large;
+  large.resize(1000);
+  // Initialize allocator. Start counting cumulative from post-init baseline.
+  allocator_->allocate(24);
+  auto sizes = HashStringAllocator::freeListSizes();
+
+  int32_t expectedBytes =
+      allocator_->cumulativeBytes() + sizes[0] + kHeader - 8;
+  append(strings, StringView(s13));
+  EXPECT_EQ(expectedBytes, allocator_->cumulativeBytes());
+
+  append(strings, StringView(s16));
+  append(strings, StringView(s16));
+  // 13 + 2 * 16 should fit in the first allocation of 72.
+  EXPECT_EQ(expectedBytes, allocator_->cumulativeBytes());
+
+  // Now we allocate one more and expect to have 8x16 bytes of payload without
+  // more allocation.
+  expectedBytes += sizes[1] + kHeader;
+  for (auto i = 0; i < 7; ++i) {
+    append(strings, StringView(s16));
+  }
+  EXPECT_EQ(expectedBytes, allocator_->cumulativeBytes());
+
+  expectedBytes += kOverhead + large.size();
+  append(strings, StringView(large));
+  EXPECT_EQ(expectedBytes, allocator_->cumulativeBytes());
+
+  // If the largest size is much larger than overhead, the next
+  // allocation will be a multiple of the allocated size instead. 4 *
+  // 13 + 16 overhead = 68 rounds up to first size.
+  expectedBytes += sizes[0] + kHeader;
+  append(strings, StringView(s13));
+  EXPECT_EQ(expectedBytes, allocator_->cumulativeBytes());
+}
+
+} // namespace


### PR DESCRIPTION
Fix exec::Strings  allocation pattern

the Strings collection is used for variable length payload data in
aggregates. It would previously allocate the exact size needed to
cover the string and the next pointer and the 8 byte gap at the head
of a continued HashStrigAllocator allocation. Each append to Strings
would make a single string. These are typically small, e.g. 15-20b of
string and 16b of overhead.

This falls in the smallest allocation class of HashStringAllocator,
under 72b. Making many such small allocations causes ends of blocks to
be added to the smallest free list. The ends are 17-27b and are always
too small for the smallest possible allocation from Strings, which is
13 + 16 = 29b. The allocations from Strings also always fall in the
smallest class but loop through 30+K of ends of blocks that are too
small. This makes all the time go to scanning the free list.

Now therefore, one fix is to make Strings allocate larger blocks,
e.g. 4 * max string size, which was the original intent, but never did
work. This causes ends of blocks still to be created from time to time
but they go to the small list which Strings does not use, except for
the first two allocations. Strings is also thereby slightly more
efficient since it does not incur the 16b overhead for every single
string.

We round up sizes to the minimum size of HashStringAllocator free
lists. This means no scanning through free lists since all blocks will
be large enough.

We track the largest size available in each free list of
HashStringAllocator. This is updated when an entry is added. This is
not updated when removing an entry. After traversing the whole free
list and failing to find a fit, we know the largest size and update
the record.
