### PR TITLE
rename edenscm to sapling

### DIFF
--- a/build/fbcode_builder/manifests/eden
+++ b/build/fbcode_builder/manifests/eden
@@ -90,7 +90,7 @@ fbcode/configerator/structs/scm/hg/public_autocargo = configerator/structs/scm/h
 ^fbcode/common/rust/shed(?!/public_autocargo).*/Cargo\.toml$
 ^fbcode/configerator/structs/scm/hg(?!/public_autocargo).*/Cargo\.toml$
 ^fbcode/eden/fs(?!/public_autocargo).*/Cargo\.toml$
-^fbcode/eden/scm(?!/public_autocargo|/edenscmnative).*/Cargo\.toml$
+^fbcode/eden/scm(?!/public_autocargo|/saplingnative).*/Cargo\.toml$
 ^.*/facebook/.*$
 ^.*/fb/.*$
 


### PR DESCRIPTION
Summary:
This is phase 1 of "sapling" rename. Later we will move out of the "eden" directory.

These were the high level steps I took:
1. "hg mv edenscm sapling" + "hg mv edenscmnative saplingnative"
2. s/edenscm/sapling/g
3. s/EdenSCM/Sapling/g
4. Update autocargo config
5. Update mercurialshim.py to support "edenscm" as legacy module (this is the critical part that keeps backwards compat w/ extensions and hooks that import from "edenscm")

Reviewed By: sggutier

Differential Revision: D49326692


