### PR TITLE
Ensure WarmStorageFileSystem created with FileSystemTimeoutConfig.

### DIFF
--- a/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
+++ b/velox/connectors/hive/storage_adapters/hdfs/RegisterHdfsFileSystem.cpp
@@ -78,7 +78,8 @@ hdfsWriteFileSinkGenerator() {
         if (HdfsFileSystem::isHdfsFile(fileURI)) {
           std::string pathSuffix =
               getHdfsPath(fileURI, HdfsFileSystem::kScheme);
-          auto fileSystem = filesystems::getFileSystem(fileURI, nullptr);
+          auto fileSystem =
+              filesystems::getFileSystem(fileURI, options.connectorProperties);
           return std::make_unique<dwio::common::WriteFileSink>(
               fileSystem->openFileForWrite(pathSuffix),
               fileURI,


### PR DESCRIPTION
Summary:
We use warm_storage::getDefaultFileSystemTimeoutConfig(), which
means 'no timeout' for anything.
At the same time we create custom FileSystemTimeoutConfig, which timeouts
conming from the config file (with default values). But it wasn't used.
So, use it now and log the values.

Also, emsure HdfsFileSystem get config in the same way as other file systems.

Differential Revision: D49606585


