### PR TITLE
Disallow testing of opaque-typed functions in expression fuzzer

### DIFF
--- a/velox/expression/tests/ExpressionFuzzer.cpp
+++ b/velox/expression/tests/ExpressionFuzzer.cpp
@@ -287,7 +287,7 @@ bool isSupportedSignature(const exec::FunctionSignature& signature) {
   // Not supporting lambda functions, or functions using decimal and
   // timestamp with time zone types.
   return !(
-      useTypeName(signature, "function") ||
+      useTypeName(signature, "opaque") || useTypeName(signature, "function") ||
       useTypeName(signature, "long_decimal") ||
       useTypeName(signature, "short_decimal") ||
       useTypeName(signature, "decimal") ||


### PR DESCRIPTION
Summary:
This diff makes expression fuzzer skip functions that use opaque type.

Differential Revision: D49554686


