### PR TITLE
Fix ByteRleDecoder::skipBytes to avoid reading data and breaking contiguous skips

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -212,7 +212,7 @@ void CacheInputStream::loadSync(Region region) {
     } else {
       // Hit memory cache.
       if (!entry->getAndClearFirstUseFlag()) {
-        ioStats_->ramHit().increment(entry->size());
+        ioStats_->ramHit().increment(region.length);
       }
       return;
     }
@@ -269,7 +269,7 @@ bool CacheInputStream::loadFromSsd(
     throw;
   }
   pin_ = std::move(pins[0]);
-  ioStats_->ssdRead().increment(entry.size());
+  ioStats_->ssdRead().increment(region.length);
   ioStats_->queryThreadIoLatency().increment(usec);
   entry.setExclusiveToShared();
   return true;

--- a/velox/dwio/common/compression/Compression.cpp
+++ b/velox/dwio/common/compression/Compression.cpp
@@ -246,7 +246,11 @@ class ZstdDecompressor : public Decompressor {
   explicit ZstdDecompressor(
       uint64_t blockSize,
       const std::string& streamDebugInfo)
-      : Decompressor{blockSize, streamDebugInfo} {}
+      : Decompressor{blockSize, streamDebugInfo}, context_{ZSTD_createDCtx()} {}
+
+  ~ZstdDecompressor() override {
+    ZSTD_freeDCtx(context_);
+  }
 
   uint64_t decompress(
       const char* src,
@@ -254,8 +258,12 @@ class ZstdDecompressor : public Decompressor {
       char* dest,
       uint64_t destLength) override;
 
-  uint64_t getUncompressedLength(const char* src, uint64_t srcLength)
-      const override;
+  std::pair<int64_t, bool> getDecompressedLength(
+      const char* src,
+      uint64_t srcLength) const override;
+
+ private:
+  ZSTD_DCtx* context_;
 };
 
 uint64_t ZstdDecompressor::decompress(
@@ -263,7 +271,7 @@ uint64_t ZstdDecompressor::decompress(
     uint64_t srcLength,
     char* dest,
     uint64_t destLength) {
-  auto ret = ZSTD_decompress(dest, destLength, src, srcLength);
+  auto ret = ZSTD_decompressDCtx(context_, dest, destLength, src, srcLength);
   DWIO_ENSURE(
       !ZSTD_isError(ret),
       "ZSTD returned an error: ",
@@ -273,7 +281,7 @@ uint64_t ZstdDecompressor::decompress(
   return ret;
 }
 
-uint64_t ZstdDecompressor::getUncompressedLength(
+std::pair<int64_t, bool> ZstdDecompressor::getDecompressedLength(
     const char* src,
     uint64_t srcLength) const {
   auto uncompressedLength = ZSTD_getFrameContentSize(src, srcLength);
@@ -281,14 +289,14 @@ uint64_t ZstdDecompressor::getUncompressedLength(
   // bound
   if (uncompressedLength == ZSTD_CONTENTSIZE_UNKNOWN ||
       uncompressedLength == ZSTD_CONTENTSIZE_ERROR) {
-    return blockSize_;
+    return {blockSize_, false};
   }
   DWIO_ENSURE_LE(
       uncompressedLength,
       blockSize_,
       "Insufficient buffer size. Info: ",
       streamDebugInfo_);
-  return uncompressedLength;
+  return {uncompressedLength, true};
 }
 
 class SnappyDecompressor : public Decompressor {
@@ -304,8 +312,9 @@ class SnappyDecompressor : public Decompressor {
       char* dest,
       uint64_t destLength) override;
 
-  uint64_t getUncompressedLength(const char* src, uint64_t srcLength)
-      const override;
+  std::pair<int64_t, bool> getDecompressedLength(
+      const char* src,
+      uint64_t srcLength) const override;
 };
 
 uint64_t SnappyDecompressor::decompress(
@@ -313,7 +322,7 @@ uint64_t SnappyDecompressor::decompress(
     uint64_t srcLength,
     char* dest,
     uint64_t destLength) {
-  auto length = getUncompressedLength(src, srcLength);
+  auto [length, _] = getDecompressedLength(src, srcLength);
   DWIO_ENSURE_GE(destLength, length);
   DWIO_ENSURE(
       snappy::RawUncompress(src, srcLength, dest),
@@ -322,23 +331,24 @@ uint64_t SnappyDecompressor::decompress(
   return length;
 }
 
-uint64_t SnappyDecompressor::getUncompressedLength(
+std::pair<int64_t, bool> SnappyDecompressor::getDecompressedLength(
     const char* src,
     uint64_t srcLength) const {
   size_t uncompressedLength;
   // in the case when decompression size is not available, return the upper
   // bound
   if (!snappy::GetUncompressedLength(src, srcLength, &uncompressedLength)) {
-    return blockSize_;
+    return {blockSize_, false};
   }
   DWIO_ENSURE_LE(
       uncompressedLength,
       blockSize_,
       "Insufficient buffer size. Info: ",
       streamDebugInfo_);
-  return uncompressedLength;
+  return {uncompressedLength, true};
 }
 
+// TODO: Is this really needed?
 class ZlibDecompressionStream : public PagedInputStream,
                                 private ZlibDecompressor {
  public:
@@ -355,13 +365,18 @@ class ZlibDecompressionStream : public PagedInputStream,
         ZlibDecompressor{blockSize, windowBits, streamDebugInfo, isGzip} {}
   ~ZlibDecompressionStream() override = default;
 
-  bool Next(const void** data, int32_t* size) override;
+  bool readOrSkip(const void** data, int32_t* size) override;
 };
 
-bool ZlibDecompressionStream::Next(const void** data, int32_t* size) {
+bool ZlibDecompressionStream::readOrSkip(const void** data, int32_t* size) {
+  if (data) {
+    VELOX_CHECK_EQ(pendingSkip_, 0);
+  }
   // if the user pushed back, return them the partial buffer
   if (outputBufferLength_) {
-    *data = outputBufferPtr_;
+    if (data) {
+      *data = outputBufferPtr_;
+    }
     *size = static_cast<int32_t>(outputBufferLength_);
     outputBufferPtr_ += outputBufferLength_;
     bytesReturned_ += outputBufferLength_;
@@ -381,7 +396,9 @@ bool ZlibDecompressionStream::Next(const void** data, int32_t* size) {
       static_cast<size_t>(inputBufferPtrEnd_ - inputBufferPtr_),
       remainingLength_);
   if (state_ == State::ORIGINAL) {
-    *data = inputBufferPtr_;
+    if (data) {
+      *data = inputBufferPtr_;
+    }
     *size = static_cast<int32_t>(availSize);
     outputBufferPtr_ = inputBufferPtr_ + availSize;
     outputBufferLength_ = 0;
@@ -393,7 +410,8 @@ bool ZlibDecompressionStream::Next(const void** data, int32_t* size) {
         getName(),
         " Info: ",
         ZlibDecompressor::streamDebugInfo_);
-    prepareOutputBuffer(getUncompressedLength(inputBufferPtr_, availSize));
+    prepareOutputBuffer(
+        getDecompressedLength(inputBufferPtr_, availSize).first);
 
     reset();
     zstream_.next_in =
@@ -432,7 +450,9 @@ bool ZlibDecompressionStream::Next(const void** data, int32_t* size) {
       }
     } while (result != Z_STREAM_END);
     *size = static_cast<int32_t>(blockSize_ - zstream_.avail_out);
-    *data = outputBufferPtr_;
+    if (data) {
+      *data = outputBufferPtr_;
+    }
     outputBufferLength_ = 0;
     outputBufferPtr_ += *size;
   }

--- a/velox/dwio/common/compression/Compression.h
+++ b/velox/dwio/common/compression/Compression.h
@@ -46,14 +46,14 @@ class Compressor {
 class Decompressor {
  public:
   explicit Decompressor(uint64_t blockSize, const std::string& streamDebugInfo)
-      : blockSize_{blockSize}, streamDebugInfo_{streamDebugInfo} {}
+      : blockSize_{static_cast<int64_t>(blockSize)},
+        streamDebugInfo_{streamDebugInfo} {}
 
   virtual ~Decompressor() = default;
 
-  virtual uint64_t getUncompressedLength(
-      const char* /* unused */,
-      uint64_t /* unused */) const {
-    return blockSize_;
+  virtual std::pair<int64_t, bool /* Is the size exact? */>
+  getDecompressedLength(const char* /* src */, uint64_t /* srcLength */) const {
+    return {blockSize_, false};
   }
 
   virtual uint64_t decompress(
@@ -63,7 +63,7 @@ class Decompressor {
       uint64_t destLength) = 0;
 
  protected:
-  uint64_t blockSize_;
+  int64_t blockSize_;
   const std::string streamDebugInfo_;
 };
 

--- a/velox/dwio/common/compression/PagedInputStream.h
+++ b/velox/dwio/common/compression/PagedInputStream.h
@@ -52,10 +52,14 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
 
   bool Next(const void** data, int32_t* size) override;
   void BackUp(int32_t count) override;
+
+  // NOTE: This always returns true.
   bool Skip(int32_t count) override;
+
   google::protobuf::int64 ByteCount() const override {
-    return bytesReturned_;
+    return bytesReturned_ + pendingSkip_;
   }
+
   void seekToPosition(dwio::common::PositionProvider& position) override;
   std::string getName() const override {
     return folly::to<std::string>(
@@ -115,6 +119,8 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // make sure input is contiguous for decompression/decryption
   const char* ensureInput(size_t availableInputBytes);
 
+  virtual bool readOrSkip(const void** data, int32_t* size);
+
   // input stream where to read compressed/encrypted data
   std::unique_ptr<SeekableInputStream> input_;
   memory::MemoryPool& pool_;
@@ -157,7 +163,7 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // The first byte after the last range returned by 'input_->Next()'.
   const char* inputBufferPtrEnd_{nullptr};
 
-  // bytes returned by this stream
+  // Bytes returned or skipped by this stream, not including pendingSkip_.
   uint64_t bytesReturned_{0};
 
   // Size returned by the previous call to Next().
@@ -169,7 +175,11 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // decrypter
   const dwio::common::encryption::Decrypter* decrypter_;
 
+  int64_t pendingSkip_{0};
+
  private:
+  bool skipAllPending();
+
   // Stream Debug Info
   const std::string streamDebugInfo_;
 };

--- a/velox/dwio/dwrf/common/ByteRLE.cpp
+++ b/velox/dwio/dwrf/common/ByteRLE.cpp
@@ -365,16 +365,15 @@ void ByteRleDecoder::seekToRowGroup(
 }
 
 void ByteRleDecoder::skipBytes(size_t count) {
-  size_t consumedBytes = count;
-  while (consumedBytes > 0) {
-    if (bufferStart == bufferEnd) {
-      nextBuffer();
-    }
+  if (bufferStart < bufferEnd) {
     size_t skipSize = std::min(
-        static_cast<size_t>(consumedBytes),
+        static_cast<size_t>(count),
         static_cast<size_t>(bufferEnd - bufferStart));
     bufferStart += skipSize;
-    consumedBytes -= skipSize;
+    count -= skipSize;
+  }
+  if (count > 0) {
+    inputStream->Skip(count);
   }
 }
 


### PR DESCRIPTION
Summary: Also fix the metrics for RAM read bytes and SSD read bytes

Differential Revision: D49614579

