### PR TITLE
Free up spill memory when a spill run finishes

### DIFF
--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -232,6 +232,8 @@ class Spiller {
 
     void clear() {
       rows.clear();
+      // Clears the memory allocated in rows after a spill run finishes.
+      rows.shrink_to_fit();
       numBytes = 0;
       sorted = false;
     }


### PR DESCRIPTION
In arbitration test, we found the spilling memory doesn't free up
after spilling runs and keeps growing until the spiller gets destroyed.
The memory growth comes from the spill run data structure which
is std::vector back up by memory pool STL allocator. We discovered
the memory growth from the reported spilling memory usage from
the singleton spilling memory pool.
This PR fixes this by calling shrink_to_fit after clearing the vector