### PR TITLE
Handle exception from remote split

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1775,7 +1775,13 @@ ContinueFuture Task::terminate(TaskState terminalState) {
   for (auto& [planNodeId, splits] : remainingRemoteSplits) {
     auto client = getExchangeClient(planNodeId);
     for (auto& split : splits.first) {
-      addRemoteSplit(planNodeId, split);
+      try {
+        addRemoteSplit(planNodeId, split);
+      } catch (VeloxRuntimeError& ex) {
+        LOG(WARNING)
+            << "Failed to add remaining remote splits during task termination: "
+            << ex.what();
+      }
     }
     if (splits.second) {
       client->noMoreRemoteTasks();

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -194,6 +194,8 @@ std::unique_ptr<ExchangeSource> createLocalExchangeSource(
   if (strncmp(taskId.c_str(), "local://", 8) == 0) {
     return std::make_unique<LocalExchangeSource>(
         taskId, destination, std::move(queue), pool);
+  } else if (strncmp(taskId.c_str(), "bad://", 6) == 0) {
+    throw std::runtime_error("Testing error");
   }
   return nullptr;
 }


### PR DESCRIPTION
During task termination, if there are remote splits remaining, they
will need to be added to the task before the task ends. However, if
`addRemoteSplit` throw an exception. The task termination process will
be interrupted and the cleanup afterward will not be able to execute.
This is problematic when there is unfinished blocked Join operator in
the task, as it relies on `bridge->cancel()` at the end of the task
termination process to clean its unfilfulled promise. If exception
happens, `bridge->cancel()` will not be called and the driver cannot be
cleaned up, resulting in zombie task hanging.

This change handles possible exception from `addRemoteSplit` so that the
cleanup logic will be executed properly to prevent zombie tasks.