### PR TITLE
Support floating point map key pruning

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -73,6 +73,57 @@ void deduplicate(std::vector<T>& values) {
   values.erase(std::unique(values.begin(), values.end()), values.end());
 }
 
+// Floating point map key subscripts are truncated toward 0 in Presto.  For
+// example given `a' as a map with floating point key, if user queries a[0.99],
+// Presto coordinator will generate a required subfield a[0]; for a[-1.99] it
+// will generate a[-1]; for anything larger than 9223372036854775807, it
+// generates a[9223372036854775807]; for anything smaller than
+// -9223372036854775808 it generates a[-9223372036854775808].
+template <typename T>
+std::unique_ptr<common::Filter> makeFloatingPointMapKeyFilter(
+    const std::vector<int64_t>& subscripts) {
+  std::vector<std::unique_ptr<common::Filter>> filters;
+  for (auto subscript : subscripts) {
+    T lower = subscript;
+    T upper = subscript;
+    bool lowerUnbounded = subscript == std::numeric_limits<int64_t>::min();
+    bool upperUnbounded = subscript == std::numeric_limits<int64_t>::max();
+    bool lowerExclusive = false;
+    bool upperExclusive = false;
+    if (lower <= 0 && !lowerUnbounded) {
+      if (lower > subscript - 1) {
+        lower = subscript - 1;
+      } else {
+        lower = std::nextafter(lower, -std::numeric_limits<T>::infinity());
+      }
+      lowerExclusive = true;
+    }
+    if (upper >= 0 && !upperUnbounded) {
+      if (upper < subscript + 1) {
+        upper = subscript + 1;
+      } else {
+        upper = std::nextafter(upper, std::numeric_limits<T>::infinity());
+      }
+      upperExclusive = true;
+    }
+    if (lowerUnbounded && upperUnbounded) {
+      continue;
+    }
+    filters.push_back(std::make_unique<common::FloatingPointRange<T>>(
+        lower,
+        lowerUnbounded,
+        lowerExclusive,
+        upper,
+        upperUnbounded,
+        upperExclusive,
+        false));
+  }
+  if (filters.size() == 1) {
+    return std::move(filters[0]);
+  }
+  return std::make_unique<common::MultiRange>(std::move(filters), false, false);
+}
+
 // Recursively add subfields to scan spec.
 void addSubfields(
     const Type& type,
@@ -162,7 +213,13 @@ void addSubfields(
         filter = std::make_unique<common::BytesValues>(stringSubscripts, false);
       } else {
         deduplicate(longSubscripts);
-        filter = common::createBigintValues(longSubscripts, false);
+        if (keyType->isReal()) {
+          filter = makeFloatingPointMapKeyFilter<float>(longSubscripts);
+        } else if (keyType->isDouble()) {
+          filter = makeFloatingPointMapKeyFilter<double>(longSubscripts);
+        } else {
+          filter = common::createBigintValues(longSubscripts, false);
+        }
       }
       keys->setFilter(std::move(filter));
       break;

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -214,6 +214,82 @@ TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_allSubscripts) {
   validateNullConstant(*elements->childByName("c0c1"), *BIGINT());
 }
 
+TEST_F(HiveConnectorTest, makeScanSpec_requiredSubfields_doubleMapKey) {
+  auto rowType =
+      ROW({{"c0", MAP(REAL(), BIGINT())}, {"c1", MAP(DOUBLE(), BIGINT())}});
+  auto scanSpec = HiveDataSource::makeScanSpec(
+      rowType,
+      groupSubfields(makeSubfields({"c0[0]", "c1[-1]"})),
+      {},
+      nullptr,
+      pool_.get());
+  auto* keysFilter = scanSpec->childByName("c0")
+                         ->childByName(ScanSpec::kMapKeysFieldName)
+                         ->filter();
+  ASSERT_TRUE(keysFilter);
+  ASSERT_TRUE(applyFilter(*keysFilter, 0.0f));
+  ASSERT_TRUE(applyFilter(*keysFilter, 0.99f));
+  ASSERT_FALSE(applyFilter(*keysFilter, 1.0f));
+  ASSERT_TRUE(applyFilter(*keysFilter, -0.99f));
+  ASSERT_FALSE(applyFilter(*keysFilter, -1.0f));
+  keysFilter = scanSpec->childByName("c1")
+                   ->childByName(ScanSpec::kMapKeysFieldName)
+                   ->filter();
+  ASSERT_TRUE(keysFilter);
+  ASSERT_FALSE(applyFilter(*keysFilter, 0.0));
+  ASSERT_TRUE(applyFilter(*keysFilter, -1.0));
+  ASSERT_TRUE(applyFilter(*keysFilter, -1.99));
+  ASSERT_FALSE(applyFilter(*keysFilter, -2.0));
+
+  // Integer min and max means infinities.
+  scanSpec = HiveDataSource::makeScanSpec(
+      rowType,
+      groupSubfields(makeSubfields(
+          {"c0[-9223372036854775808]", "c1[9223372036854775807]"})),
+      {},
+      nullptr,
+      pool_.get());
+  keysFilter = scanSpec->childByName("c0")
+                   ->childByName(ScanSpec::kMapKeysFieldName)
+                   ->filter();
+  ASSERT_TRUE(applyFilter(*keysFilter, -1e30f));
+  ASSERT_FALSE(applyFilter(*keysFilter, -9223370000000000000.0f));
+  keysFilter = scanSpec->childByName("c1")
+                   ->childByName(ScanSpec::kMapKeysFieldName)
+                   ->filter();
+  ASSERT_TRUE(applyFilter(*keysFilter, 1e100));
+  ASSERT_FALSE(applyFilter(*keysFilter, 9223372036854700000.0));
+  scanSpec = HiveDataSource::makeScanSpec(
+      rowType,
+      groupSubfields(makeSubfields(
+          {"c0[9223372036854775807]", "c0[-9223372036854775808]"})),
+      {},
+      nullptr,
+      pool_.get());
+  keysFilter = scanSpec->childByName("c0")
+                   ->childByName(ScanSpec::kMapKeysFieldName)
+                   ->filter();
+  ASSERT_TRUE(applyFilter(*keysFilter, -1e30f));
+  ASSERT_FALSE(applyFilter(*keysFilter, 0.0f));
+  ASSERT_TRUE(applyFilter(*keysFilter, 1e30f));
+
+  // Unrepresentable values.
+  scanSpec = HiveDataSource::makeScanSpec(
+      rowType,
+      groupSubfields(makeSubfields({"c0[-100000000]", "c0[100000000]"})),
+      {},
+      nullptr,
+      pool_.get());
+  keysFilter = scanSpec->childByName("c0")
+                   ->childByName(ScanSpec::kMapKeysFieldName)
+                   ->filter();
+  ASSERT_TRUE(applyFilter(*keysFilter, -100000000.0f));
+  ASSERT_FALSE(applyFilter(*keysFilter, -100000008.0f));
+  ASSERT_FALSE(applyFilter(*keysFilter, 0.0f));
+  ASSERT_TRUE(applyFilter(*keysFilter, 100000000.0f));
+  ASSERT_FALSE(applyFilter(*keysFilter, 100000008.0f));
+}
+
 TEST_F(HiveConnectorTest, makeScanSpec_filtersNotInRequiredSubfields) {
   auto c0Type = ROW({
       {"c0c0", BIGINT()},


### PR DESCRIPTION
Summary: Floating point key pruning is tricky in Presto because the coordinator is passing truncated values to workers.  We enlarge the filter range to make sure we do not filter out the values we want.

Differential Revision: D49646809


