### PR TITLE
Add HashStringAllocator free lists and stats

### DIFF
--- a/velox/common/memory/HashStringAllocator.cpp
+++ b/velox/common/memory/HashStringAllocator.cpp
@@ -310,15 +310,29 @@ void HashStringAllocator::freeRestOfBlock(Header* header, int32_t keepBytes) {
 
 // Free list sizes align with size of containers. + 20 allows for padding for an
 // alignment of 16 bytes.
-int32_t HashStringAllocator::freeListSizes_[kNumFreeLists + 1] = {
+int32_t HashStringAllocator::freeListSizes_[kNumFreeLists + 7] = {
+    30,
+    50,
     72,
     8 * 16 + 20,
+    100,
     16 * 16 + 20,
     32 * 16 + 20,
     64 * 16 + 20,
     128 * 16 + 20,
     std::numeric_limits<int32_t>::max(),
-    std::numeric_limits<int32_t>::max()};
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max(),
+    std::numeric_limits<int32_t>::max(),
+};
+
+// static
+folly::Range<const int32_t*> HashStringAllocator::freeListSizeClasses() {
+  return folly::Range<const int32_t*>(&freeListSizes_[0], kNumFreeLists);
+}
 
 int32_t HashStringAllocator::freeListIndex(int32_t size, uint32_t mask) {
   static_assert(sizeof(freeListSizes_) >= sizeof(xsimd::batch<int32_t>));
@@ -399,6 +413,10 @@ HashStringAllocator::allocateFromFreeList(
     int32_t freeListIndex) {
   constexpr int32_t kMaxCheckedForFit = 5;
   int32_t counter = 0;
+  if (mustHaveSize && largestInFreeList_[freeListIndex] < preferredSize) {
+    return nullptr;
+  }
+  int32_t largestFreeSize = 0;
   Header* largest = nullptr;
   Header* found = nullptr;
   for (auto* item = free_[freeListIndex].next(); item != &free_[freeListIndex];
@@ -413,17 +431,22 @@ HashStringAllocator::allocateFromFreeList(
     if (!largest || size > largest->size()) {
       largest = header;
     }
-    if (!mustHaveSize && ++counter > kMaxCheckedForFit) {
+    ++counter;
+    if (!mustHaveSize && counter > kMaxCheckedForFit) {
       break;
     }
   }
+  numFreeListNoFit_ += counter;
   if (!mustHaveSize && !found) {
     found = largest;
   }
   if (!found) {
+    // We have traversed the complete free list and therefore know the largest
+    // size. Either the list is empty or mustHaveSize is true and there is no
+    // block large enough.
+    largestInFreeList_[freeListIndex] = largest ? largest->size() : 0;
     return nullptr;
   }
-
   --numFree_;
   freeBytes_ -= found->size() + sizeof(Header);
   removeFromFreeList(found);
@@ -479,8 +502,12 @@ void HashStringAllocator::free(Header* _header) {
     } else {
       ++numFree_;
     }
-    auto freeIndex = freeListIndex(header->size());
+    auto freedSize = header->size();
+    auto freeIndex = freeListIndex(freedSize);
     freeNonEmpty_ |= 1 << freeIndex;
+    if (largestInFreeList_[freeIndex] < freedSize) {
+      largestInFreeList_[freeIndex] = freedSize;
+    }
     free_[freeIndex].insert(
         reinterpret_cast<CompactDoubleList*>(header->begin()));
     markAsFree(header);


### PR DESCRIPTION
HashStringAllocator (HSA) keeps free lists for different block sizes. Small size free lists get cluttered with ends of blocks that are too small to use. Time goes into traversing lists only to find that all free blocks are too small. Therefore we keep a max size of free block. This is set when freeing the block and updated whenever failing to find a block that fits. At this time the largest extant size is known and remembered.

We add denser coverage of small sizes by free lists. Workloads show differentiated demand in sizes from 16 to ~100, from small strings.