### PR TITLE
Add default memory reclaimer and set it for exchange client

### DIFF
--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(
   LocalPartition.cpp
   LocalPlanner.cpp
   MarkDistinct.cpp
+  MemoryReclaimer.cpp
   Merge.cpp
   MergeJoin.cpp
   MergeSource.cpp

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -323,8 +323,14 @@ class Driver : public std::enable_shared_from_this<Driver> {
     return blockingReason_;
   }
 
-  static std::shared_ptr<Driver> testingCreate() {
-    return std::shared_ptr<Driver>(new Driver());
+  static std::shared_ptr<Driver> testingCreate(
+      std::unique_ptr<DriverCtx> ctx = nullptr) {
+    auto driver = new Driver();
+    if (ctx != nullptr) {
+      ctx->driver = driver;
+      driver->ctx_ = std::move(ctx);
+    }
+    return std::shared_ptr<Driver>(driver);
   }
 
  private:

--- a/velox/exec/MemoryReclaimer.cpp
+++ b/velox/exec/MemoryReclaimer.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MemoryReclaimer.h"
+
+#include "velox/exec/Driver.h"
+#include "velox/exec/Task.h"
+
+namespace facebook::velox::exec {
+std::unique_ptr<memory::MemoryReclaimer> DefaultMemoryReclaimer::create() {
+  return std::unique_ptr<MemoryReclaimer>(new DefaultMemoryReclaimer());
+}
+
+void DefaultMemoryReclaimer::enterArbitration() {
+  DriverThreadContext* driverThreadCtx = driverThreadContext();
+  if (FOLLY_UNLIKELY(driverThreadCtx == nullptr)) {
+    // Skips the driver suspension handling if this memory arbitration
+    // request is not issued from a driver thread.
+    return;
+  }
+
+  Driver* const driver = driverThreadCtx->driverCtx.driver;
+  if (driver->task()->enterSuspended(driver->state()) != StopReason::kNone) {
+    // There is no need for arbitration if the associated task has already
+    // terminated.
+    VELOX_FAIL("Terminate detected when entering suspension");
+  }
+}
+
+void DefaultMemoryReclaimer::leaveArbitration() noexcept {
+  DriverThreadContext* driverThreadCtx = driverThreadContext();
+  if (FOLLY_UNLIKELY(driverThreadCtx == nullptr)) {
+    // Skips the driver suspension handling if this memory arbitration
+    // request is not issued from a driver thread.
+    return;
+  }
+  Driver* const driver = driverThreadCtx->driverCtx.driver;
+  driver->task()->leaveSuspended(driver->state());
+}
+} // namespace facebook::velox::exec

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/base/Exceptions.h"
+#include "velox/common/memory/MemoryArbitrator.h"
+
+namespace facebook::velox::exec {
+/// Provides the default memory reclaimer implementation for velox task
+/// execution.
+class DefaultMemoryReclaimer : public memory::MemoryReclaimer {
+ public:
+  virtual ~DefaultMemoryReclaimer() = default;
+
+  static std::unique_ptr<MemoryReclaimer> create();
+
+  void enterArbitration() override;
+
+  void leaveArbitration() noexcept override;
+
+ protected:
+  DefaultMemoryReclaimer() = default;
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -622,6 +622,13 @@ class Task : public std::enable_shared_from_this<Task> {
   std::unique_ptr<memory::MemoryReclaimer> createNodeReclaimer(
       bool isHashJoinNode) const;
 
+  // Creates a memory reclaimer instance for an exchange client if the task
+  // memory pool has set memory reclaimer. We don't support to reclaim memory
+  // from an exchange client, and the customized reclaimer is used to handle
+  // memory arbitration request initiated under the driver execution context.
+  std::unique_ptr<memory::MemoryReclaimer> createExchangeClientReclaimer()
+      const;
+
   // Creates a memory reclaimer instance for this task. If the query memory
   // pool doesn't set memory reclaimer, then the function simply returns null.
   // Otherwise, it creates a customized memory reclaimer for this task.

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(
   LimitTest.cpp
   LocalPartitionTest.cpp
   Main.cpp
+  MemoryReclaimerTest.cpp
   MergeJoinTest.cpp
   MergeTest.cpp
   MultiFragmentTest.cpp

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/exec/MemoryReclaimer.h"
+#include "velox/common/memory/MemoryPool.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::memory;
+
+class MemoryReclaimerTest : public OperatorTestBase {
+ protected:
+  MemoryReclaimerTest() : pool_(memory::addDefaultLeafMemoryPool()) {
+    const auto seed =
+        std::chrono::system_clock::now().time_since_epoch().count();
+    rng_.seed(seed);
+    LOG(INFO) << "Random seed: " << seed;
+
+    rowType_ = ROW({"c0", "c1"}, {{INTEGER(), VARCHAR()}});
+    VectorFuzzer fuzzer{{}, pool_.get()};
+
+    std::vector<RowVectorPtr> values = {fuzzer.fuzzRow(rowType_)};
+    core::PlanFragment fakePlanFragment;
+    const core::PlanNodeId id{"0"};
+    fakePlanFragment.planNode = std::make_shared<core::ValuesNode>(id, values);
+
+    fakeTask_ = Task::create(
+        "MemoryReclaimerTest",
+        std::move(fakePlanFragment),
+        0,
+        std::make_shared<core::QueryCtx>());
+  }
+
+  void SetUp() override {}
+
+  void TearDown() override {}
+
+  const std::shared_ptr<memory::MemoryPool> pool_;
+  RowTypePtr rowType_;
+  std::shared_ptr<Task> fakeTask_;
+  folly::Random::DefaultGenerator rng_;
+};
+
+TEST_F(MemoryReclaimerTest, enterArbitrationTest) {
+  for (const auto& underDriverContext : {false, true}) {
+    SCOPED_TRACE(fmt::format("underDriverContext: {}", underDriverContext));
+
+    auto reclaimer = DefaultMemoryReclaimer::create();
+    auto driver = Driver::testingCreate(
+        std::make_unique<DriverCtx>(fakeTask_, 0, 0, 0, 0));
+    if (underDriverContext) {
+      driver->state().setThread();
+      ScopedDriverThreadContext scopedDriverThreadCtx{*driver->driverCtx()};
+      reclaimer->enterArbitration();
+      ASSERT_TRUE(driver->state().isOnThread());
+      ASSERT_TRUE(driver->state().isSuspended);
+      reclaimer->leaveArbitration();
+      ASSERT_TRUE(driver->state().isOnThread());
+      ASSERT_FALSE(driver->state().isSuspended);
+    } else {
+      reclaimer->enterArbitration();
+      ASSERT_FALSE(driver->state().isOnThread());
+      ASSERT_FALSE(driver->state().isSuspended);
+      reclaimer->leaveArbitration();
+    }
+  }
+}


### PR DESCRIPTION
Prestissimo-on-Spark might trigger memory allocation from exchange client memory pool
used by exchange source to allocate buffer to read data from remote storage. This is
different than streaming shuffle which only allocate buffer to copy the shuffled data from
network thread on return path.
This PR adds the default memory reclaimer which supports to put a driver thread in suspension
state and set it for exchange client.