### PR TITLE
Fix circular dependency between velox_dwio_common<->velox_dwio_common…

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -64,7 +64,6 @@ target_link_libraries(
   velox_buffer
   velox_caching
   velox_common_compression
-  velox_dwio_common_compression
   velox_dwio_common_encryption
   velox_dwio_common_exception
   velox_exception

--- a/velox/dwio/dwrf/common/CMakeLists.txt
+++ b/velox/dwio/dwrf/common/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   velox_common_base
   velox_common_compression
   velox_dwio_common
+  velox_dwio_common_compression
   velox_dwio_dwrf_proto
   velox_caching
   Snappy::snappy

--- a/velox/dwio/dwrf/test/utils/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/utils/CMakeLists.txt
@@ -24,7 +24,9 @@ target_link_libraries(
   velox_exception
   velox_memory
   velox_type
-  velox_vector)
+  velox_vector
+  gtest
+  gtest_main)
 
 # older versions of GCC need it to allow std::filesystem
 if(CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   velox_dwio_parquet_thrift
   velox_type
   velox_dwio_common
+  velox_dwio_common_compression
   fmt::fmt
   parquet
   arrow


### PR DESCRIPTION
…_compression

`velox_dwio_common` does not need a dependency on `velox_dwio_common_compression`. The dependency on the latter should be added to the client library that needs them.