### PR TITLE
Revert D49546239: Multisect successfully blamed "D49546239: Fix undefined behavior in bitwise_arithmetic_shift_right" for test or build failures

### DIFF
--- a/velox/functions/prestosql/Bitwise.h
+++ b/velox/functions/prestosql/Bitwise.h
@@ -79,12 +79,16 @@ struct BitwiseXorFunction {
 
 template <typename T>
 struct BitwiseArithmeticShiftRightFunction {
-  // Only support bigint inputs.
-  FOLLY_ALWAYS_INLINE void
-  call(int64_t& result, int64_t number, int64_t shift) {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE
+#if defined(__clang__)
+      __attribute__((no_sanitize("integer")))
+#endif
+      bool
+      call(int64_t& result, TInput number, TInput shift) {
     VELOX_USER_CHECK_GE(shift, 0, "Shift must be positive")
-    shift = shift % 64;
     result = number >> shift;
+    return true;
   }
 };
 

--- a/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/BitwiseFunctionsRegistration.cpp
@@ -42,11 +42,8 @@ void registerBitwiseFunctions(const std::string& prefix) {
   registerBitwiseBinaryIntegral<BitwiseOrFunction>({prefix + "bitwise_or"});
   registerBitwiseBinaryIntegral<BitwiseXorFunction>({prefix + "bitwise_xor"});
   registerBitwiseBinaryIntegral<BitCountFunction>({prefix + "bit_count"});
-  registerFunction<
-      BitwiseArithmeticShiftRightFunction,
-      int64_t,
-      int64_t,
-      int64_t>({prefix + "bitwise_arithmetic_shift_right"});
+  registerBitwiseBinaryIntegral<BitwiseArithmeticShiftRightFunction>(
+      {prefix + "bitwise_arithmetic_shift_right"});
   registerBitwiseBinaryIntegral<BitwiseLeftShiftFunction>(
       {prefix + "bitwise_left_shift"});
   registerBitwiseBinaryIntegral<BitwiseRightShiftFunction>(

--- a/velox/functions/prestosql/tests/BitwiseTest.cpp
+++ b/velox/functions/prestosql/tests/BitwiseTest.cpp
@@ -61,9 +61,10 @@ class BitwiseTest : public functions::test::FunctionBaseTest {
     return evaluateOnce<int64_t>("bit_count(c0, c1)", num, bits);
   }
 
+  template <typename T>
   std::optional<int64_t> bitwiseArithmeticShiftRight(
-      std::optional<int64_t> a,
-      std::optional<int64_t> b) {
+      std::optional<T> a,
+      std::optional<T> b) {
     return evaluateOnce<int64_t>(
         "bitwise_arithmetic_shift_right(c0, c1)", a, b);
   }
@@ -249,33 +250,33 @@ TEST_F(BitwiseTest, bitwiseXor) {
 }
 
 TEST_F(BitwiseTest, arithmeticShiftRight) {
-  EXPECT_EQ(bitwiseArithmeticShiftRight(1, 1), 0);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(3, 1), 1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(-3, 1), -2);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(3, 0), 3);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(3, 3), 0);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(-1, 2), -1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(-1, 2), -1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(-100, 65), -50);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(-100, 66), -25);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(1, 1), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(3, 1), 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-3, 1), -2);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(3, 0), 3);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(3, 3), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-1, 2), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-1, 2), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-100, 65), -50);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(-100, 66), -25);
 
   VELOX_ASSERT_THROW(
-      bitwiseArithmeticShiftRight(3, -1), "Shift must be positive");
+      bitwiseArithmeticShiftRight<int32_t>(3, -1), "Shift must be positive");
 
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin16, kMax16), -1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax16, kMax16), 0);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax16, 1), kMax16 >> 1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin16, 1), kMin16 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int16_t>(kMin16, kMax16), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int16_t>(kMax16, kMax16), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int16_t>(kMax16, 1), kMax16 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int16_t>(kMin16, 1), kMin16 >> 1);
 
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin32, kMax32), -1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax32, kMax32), 0);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax32, 1), kMax32 >> 1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin32, 1), kMin32 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(kMin32, kMax32), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(kMax32, kMax32), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(kMax32, 1), kMax32 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int32_t>(kMin32, 1), kMin32 >> 1);
 
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin64, kMax64), -1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax64, kMax64), 0);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMax64, 1), kMax64 >> 1);
-  EXPECT_EQ(bitwiseArithmeticShiftRight(kMin64, 1), kMin64 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int64_t>(kMin64, kMax64), -1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int64_t>(kMax64, kMax64), 0);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int64_t>(kMax64, 1), kMax64 >> 1);
+  EXPECT_EQ(bitwiseArithmeticShiftRight<int64_t>(kMin64, 1), kMin64 >> 1);
 }
 
 TEST_F(BitwiseTest, rightShiftArithmetic) {


### PR DESCRIPTION
Summary:
This diff is reverting D49546239
D49546239: Fix undefined behavior in bitwise_arithmetic_shift_right by laithsakka has been identified to be causing the following test or build failures:

Tests affected:
- [stylus/xstream/query/integration_test:e2e_test_builtin - test_bitwise (stylus.xstream.query.integration_test.e2e_test_builtin.XStreamBuiltinTest)](https://www.internalfb.com/intern/test/562950055334827/)

Here's the Multisect link:
https://www.internalfb.com/multisect/3139628
Here are the tasks that are relevant to this breakage:

We're generating a revert to back out the changes in this diff, please note the backout may land if someone accepts it.

If you believe this diff has been generated in error you may Commandeer and Abandon it.

Reviewed By: laithsakka

Differential Revision: D49673433


