### PR TITLE
Ability to trace File System calls.

### DIFF
--- a/velox/common/process/TraceContext.h
+++ b/velox/common/process/TraceContext.h
@@ -49,6 +49,15 @@ struct TraceData {
 // difficult to figure out from stacks in a core dump.
 class TraceContext {
  public:
+  /// Well-known traces.
+  static constexpr const char* kFileSystemOpenFileForRead{
+      "FileSystem::openFileForRead"};
+  static constexpr const char* kFileSystemOpenFileForWrite{
+      "FileSystem::openFileForWrite"};
+  static constexpr const char* kFilePRead{"File::pread"};
+  static constexpr const char* kFileAppend{"File::append"};
+  static constexpr const char* kFileFlush{"File::flush"};
+
   // Starts a trace context. isTemporary is false if this is a generic
   // operation for which records should be kept for the lifetime of
   // the process, like opening a file. This is true if we are


### PR DESCRIPTION
Summary:
Ability to trace file system calls, when needed, so we can collect data
on how many of them are in-flight, max ms, etc.
The planned use of the traces:
1. In presto_cpp collect counters in the periodic task.
2. In presto_cpp create a server operation that will return current traces.

Why do we need this?
We've been observing some deadlocks and hangs in file system and need ways to debug this.

Note, that we aren't tracing any FileSystem implementations in this PR yet.

Differential Revision: D49674829


