### PR TITLE
Spill all to disk to simplify query oom on output processing

### DIFF
--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -21,7 +21,7 @@
 #include "velox/common/compression/Compression.h"
 
 namespace facebook::velox::common {
-// Specifies the config for spilling.
+/// Specifies the config for spilling.
 struct SpillConfig {
   SpillConfig(
       const std::string& _filePath,
@@ -33,6 +33,7 @@ struct SpillConfig {
       uint8_t _startPartitionBit,
       uint8_t _joinPartitionBits,
       uint8_t _aggregationPartitionBits,
+      bool _aggregationSpillAll,
       int32_t _maxSpillLevel,
       int32_t _testSpillPct,
       const std::string& _compressionKind)
@@ -47,6 +48,7 @@ struct SpillConfig {
         startPartitionBit(_startPartitionBit),
         joinPartitionBits(_joinPartitionBits),
         aggregationPartitionBits(_aggregationPartitionBits),
+        aggregationSpillAll(_aggregationSpillAll),
         maxSpillLevel(_maxSpillLevel),
         testSpillPct(_testSpillPct),
         compressionKind(common::stringToCompressionKind(_compressionKind)) {}
@@ -81,36 +83,42 @@ struct SpillConfig {
   /// generating too many small spilled files.
   uint64_t minSpillRunSize;
 
-  // Executor for spilling. If nullptr spilling writes on the Driver's thread.
+  /// Executor for spilling. If nullptr spilling writes on the Driver's thread.
   folly::Executor* executor; // Not owned.
 
-  // The spillable memory reservation growth percentage of the current
-  // reservation size.
+  /// The spillable memory reservation growth percentage of the current
+  /// reservation size.
   int32_t spillableReservationGrowthPct;
 
-  // Used to calculate spill partition number.
+  /// Used to calculate spill partition number.
   uint8_t startPartitionBit;
 
-  // Used to calculate the spill hash partition number for hash join with
-  // 'startPartitionBit'.
+  /// Used to calculate the spill hash partition number for hash join with
+  /// 'startPartitionBit'.
   uint8_t joinPartitionBits;
 
-  // Used to calculate the spill hash partition number for aggregation with
-  // 'startPartitionBit'.
+  /// Used to calculate the spill hash partition number for aggregation with
+  /// 'startPartitionBit'.
   uint8_t aggregationPartitionBits;
 
-  // The max allowed spilling level with zero being the initial spilling
-  // level. This only applies for hash build spilling which needs recursive
-  // spilling when the build table is too big. If it is set to -1, then there
-  // is no limit and then some extreme large query might run out of spilling
-  // partition bits at the end.
+  /// If true and spilling has been triggered during the input processing, the
+  /// spiller will spill all the remaining in-memory state to disk before output
+  /// processing. This is to simplify the aggregation query OOM prevention in
+  /// output processing stage.
+  bool aggregationSpillAll;
+
+  /// The max allowed spilling level with zero being the initial spilling
+  /// level. This only applies for hash build spilling which needs recursive
+  /// spilling when the build table is too big. If it is set to -1, then there
+  /// is no limit and then some extreme large query might run out of spilling
+  /// partition bits at the end.
   int32_t maxSpillLevel;
 
-  // Percentage of input batches to be spilled for testing. 0 means no
-  // spilling for test.
+  /// Percentage of input batches to be spilled for testing. 0 means no
+  /// spilling for test.
   int32_t testSpillPct;
 
-  // CompressionKind when spilling, CompressionKind_NONE means no compression.
+  /// CompressionKind when spilling, CompressionKind_NONE means no compression.
   common::CompressionKind compressionKind;
 };
 } // namespace facebook::velox::common

--- a/velox/common/testutil/tests/SpillConfigTest.cpp
+++ b/velox/common/testutil/tests/SpillConfigTest.cpp
@@ -35,6 +35,7 @@ TEST(SpillConfig, spillLevel) {
       kInitialBitOffset,
       kNumPartitionsBits,
       0,
+      false,
       0,
       0,
       "none");
@@ -118,6 +119,7 @@ TEST(SpillConfig, spillLevelLimit) {
         testData.startBitOffset,
         testData.numBits,
         0,
+        false,
         testData.maxSpillLevel,
         0,
         "none");

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -219,6 +219,12 @@ class QueryConfig {
   static constexpr const char* kAggregationSpillPartitionBits =
       "aggregation_spiller_partition_bits";
 
+  /// If true and spilling has been triggered during the input processing, the
+  /// spiller will spill all the remaining in-memory state to disk before output
+  /// processing. This is to simplify the aggregation query OOM prevention in
+  /// output processing stage.
+  static constexpr const char* kAggregationSpillAll = "aggregation_spill_all";
+
   static constexpr const char* kSpillableReservationGrowthPct =
       "spillable_reservation_growth_pct";
 
@@ -446,6 +452,10 @@ class QueryConfig {
     constexpr uint8_t kMaxBits = 3;
     return std::min(
         kMaxBits, get<uint8_t>(kAggregationSpillPartitionBits, kDefaultBits));
+  }
+
+  bool aggregationSpillAll() const {
+    return get<bool>(kAggregationSpillAll, false);
   }
 
   uint64_t maxSpillFileSize() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -192,6 +192,12 @@ Spilling
      - integer
      - 0
      - Maximum amount of memory in bytes that a final aggregation can use before spilling. 0 means unlimited.
+   * - aggregation_spill_all
+     - boolean
+     - false
+     - If true and spilling has been triggered during the input processing, the spiller will spill all the remaining
+     - in-memory state to disk before output processing. This is to simplify the aggregation query OOM prevention in
+     - output processing stage.
    * - join_spill_memory_threshold
      - integer
      - 0

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -121,6 +121,7 @@ std::optional<common::SpillConfig> DriverCtx::makeSpillConfig(
       queryConfig.spillStartPartitionBit(),
       queryConfig.joinSpillPartitionBits(),
       queryConfig.aggregationSpillPartitionBits(),
+      queryConfig.aggregationSpillAll(),
       queryConfig.maxSpillLevel(),
       queryConfig.testingSpillPct(),
       queryConfig.spillCompressionKind());

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -105,6 +105,9 @@ class GroupingSet {
     return spiller_->stats();
   }
 
+  /// Returns true if spilling has triggered on this grouping set.
+  bool hasSpilled() const;
+
   /// Returns the hashtable stats.
   HashTableStats hashTableStats() const {
     return table_ ? table_->stats() : HashTableStats{};

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -309,10 +309,12 @@ void HashAggregation::updateRuntimeStats() {
 }
 
 void HashAggregation::recordSpillStats() {
-  const auto spillStatsOr = groupingSet_->spilledStats();
+  auto spillStatsOr = groupingSet_->spilledStats();
   if (!spillStatsOr.has_value()) {
     return;
   }
+  VELOX_CHECK_EQ(spillStatsOr.value().spillRuns, 0);
+  spillStatsOr.value().spillRuns = numSpillRuns_;
   Operator::recordSpillStats(spillStatsOr.value());
 }
 

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -145,7 +145,7 @@ class SpillFile {
 struct SpillStats {
   /// The number of times that spilling runs on an operator.
   uint64_t spillRuns{0};
-  // The number of bytes in memory to spill
+  /// The number of bytes in memory to spill
   uint64_t spilledInputBytes{0};
   /// The number of bytes spilled to disks.
   ///

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -283,6 +283,7 @@ TEST_F(SortBufferTest, batchOutput) {
         0,
         0,
         0,
+        false,
         0,
         100, //  testSpillPct
         "none");
@@ -376,6 +377,7 @@ TEST_F(SortBufferTest, spill) {
         0,
         0,
         0,
+        false,
         0,
         0,
         "none");


### PR DESCRIPTION
In Meta internal arbitration and spilling test, we found if a query has
spilled, then it is very likely the remaining state in-memory takes non-trivial
amount of memory which is close to the query memory limit during the
output processing, and it is very likely causing oom during that stage and
we don't support spilling in the middle of output processing.
The followup is to (1) add spilling support during the output processing,
(2) add spilling support during the output processing with mixed of spilled
and in-memory state. And then remove this limitation.
