### PR TITLE
Fix ContainerRowSerde::compare for arrays and maps

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -440,9 +440,8 @@ std::optional<int32_t> compareArrays(
   auto leftNulls = readNulls(left, leftSize);
   auto wrappedElements = elements.wrappedVector();
   for (auto i = 0; i < compareSize; ++i) {
-    auto elementIndex = elements.wrappedIndex(offset + i);
     bool leftNull = bits::isBitSet(leftNulls.data(), i);
-    bool rightNull = wrappedElements->isNullAt(elementIndex);
+    bool rightNull = elements.isNullAt(offset + i);
 
     if (leftNull || rightNull) {
       auto result = BaseVector::compareNulls(leftNull, rightNull, flags);
@@ -452,6 +451,7 @@ std::optional<int32_t> compareArrays(
       return result;
     }
 
+    auto elementIndex = elements.wrappedIndex(offset + i);
     auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
     if (result.has_value() && result.value() == 0) {
       continue;
@@ -475,9 +475,8 @@ std::optional<int32_t> compareArrayIndices(
   auto leftNulls = readNulls(left, leftSize);
   auto wrappedElements = elements.wrappedVector();
   for (auto i = 0; i < compareSize; ++i) {
-    auto elementIndex = elements.wrappedIndex(rightIndices[i]);
     bool leftNull = bits::isBitSet(leftNulls.data(), i);
-    bool rightNull = wrappedElements->isNullAt(elementIndex);
+    bool rightNull = elements.isNullAt(rightIndices[i]);
 
     if (leftNull || rightNull) {
       auto result = BaseVector::compareNulls(leftNull, rightNull, flags);
@@ -487,6 +486,7 @@ std::optional<int32_t> compareArrayIndices(
       return result;
     }
 
+    auto elementIndex = elements.wrappedIndex(rightIndices[i]);
     auto result = compareSwitch(left, *wrappedElements, elementIndex, flags);
     if (result.has_value() && result.value() == 0) {
       continue;


### PR DESCRIPTION
ContainerRowSerde::compare crashes or produced incorrect results when processing
arrays or maps with encoded elements, keys or values.

ContainerRowSerde::compare used to access base vector without first checking
that encodings didn't add nulls.

I.e. it used to call v->wrappedVector()->isNullAt(v->wrappedIndex
(index)) without first checking that v->isNullAt(index) is false.  When
v->isNullAt(index) is null v->wrappedIndex(index) may be out of range or
incorrect causing either a crash or wrong results.