### PR TITLE
Refactor dwio and common io modules [1/n]

### DIFF
--- a/velox/common/io/CMakeLists.txt
+++ b/velox/common/io/CMakeLists.txt
@@ -11,16 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(base)
-add_subdirectory(caching)
-add_subdirectory(compression)
-add_subdirectory(config)
-add_subdirectory(encode)
-add_subdirectory(file)
-add_subdirectory(hyperloglog)
-add_subdirectory(io)
-add_subdirectory(memory)
-add_subdirectory(process)
-add_subdirectory(serialization)
-add_subdirectory(time)
-add_subdirectory(testutil)
+add_library(velox_common_io CachedBufferedInput.cpp)
+
+target_include_directories(velox_common_io PRIVATE ${Protobuf_INCLUDE_DIRS})
+
+target_link_libraries(velox_common_io xsimd Folly::folly glog::glog)

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -20,7 +20,7 @@
 #include <unordered_map>
 
 #include "velox/common/caching/AsyncDataCache.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
+#include "velox/common/io/CachedBufferedInput.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
 #include "velox/expression/FieldReference.h"
@@ -917,14 +917,13 @@ HiveDataSource::createBufferedInput(
   if (cache_) {
     return std::make_unique<dwio::common::CachedBufferedInput>(
         fileHandle.file,
-        dwio::common::MetricsLog::voidLog(),
         fileHandle.uuid.id(),
         cache_,
         Connector::getTracker(scanId_, readerOpts.loadQuantum()),
         fileHandle.groupId.id(),
         ioStats_,
         executor_,
-        readerOpts);
+        pool_);
   }
   return std::make_unique<dwio::common::BufferedInput>(
       fileHandle.file,

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(
   BitConcatenation.cpp
   BitPackDecoder.cpp
   BufferedInput.cpp
-  CachedBufferedInput.cpp
   CacheInputStream.cpp
   ColumnSelector.cpp
   DataBufferHolder.cpp
@@ -64,6 +63,7 @@ target_link_libraries(
   velox_buffer
   velox_caching
   velox_common_compression
+  velox_common_io
   velox_dwio_common_compression
   velox_dwio_common_encryption
   velox_dwio_common_exception

--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -16,10 +16,10 @@
 
 #include <folly/executors/QueuedImmediateExecutor.h>
 
+#include "velox/common/io/CachedBufferedInput.h"
 #include "velox/common/process/TraceContext.h"
 #include "velox/common/time/Timer.h"
 #include "velox/dwio/common/CacheInputStream.h"
-#include "velox/dwio/common/CachedBufferedInput.h"
 
 using ::facebook::velox::common::Region;
 

--- a/velox/dwio/common/MetricsLog.h
+++ b/velox/dwio/common/MetricsLog.h
@@ -40,7 +40,8 @@ class MetricsLog {
     STREAM_BUNDLE,
     GROUP,
     BLOCK,
-    TEST
+    TEST,
+    UNKNOWN
   };
 
   virtual ~MetricsLog() = default;
@@ -159,6 +160,8 @@ class MetricsLog {
         return "BLOCK";
       case MetricsType::TEST:
         return "TEST";
+      case MetricsType::UNKNOWN:
+        return "UNKNOWN";
     }
   }
 


### PR DESCRIPTION
dwio modules and common io modules are interwined. This is 1/n PR attempting to refactor common-io libararies out from dwio.

Current module design in: 
![Untitled-2023-09-22-1659](https://github.com/facebookincubator/velox/assets/159288/ab58a515-a3c4-4350-90c4-ee0b9f5ded9f)

Approach to refactoring is:
Start from top to bottom of the hierarchy, and move classes to correct folder.
- common/io = for all common io related classes like InputStream, cache objects, etc.
- dwio/commons = for io classes related to data-warehouse

In this PR,
- CachedBufferedInput has been moved to velox/common/io folder, without the change to namespace.
- CachedBufferedInput has been de-coupled from MetricsLog, MetricsType and ReaderOptions.

In subsequent PR, I will move IoStatistics, Excception, StreamIdentifier. Towards the end, will move namespaces where necessary.