### PR TITLE
Add isOrderable and isComparable for Type

### DIFF
--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -370,6 +370,18 @@ const TypePtr& RowType::findChild(folly::StringPiece name) const {
   VELOX_USER_FAIL(makeFieldNotFoundErrorMessage(name, names_));
 }
 
+bool RowType::isOrderable() const {
+  return std::all_of(children_.cbegin(), children_.cend(), [](const auto& c) {
+    return c->isOrderable();
+  });
+}
+
+bool RowType::isComparable() const {
+  return std::all_of(children_.cbegin(), children_.cend(), [](const auto& c) {
+    return c->isOrderable();
+  });
+}
+
 bool RowType::containsChild(std::string_view name) const {
   return getChildIdxIfExists(std::string(name)).has_value();
 }

--- a/velox/type/Type.cpp
+++ b/velox/type/Type.cpp
@@ -371,15 +371,17 @@ const TypePtr& RowType::findChild(folly::StringPiece name) const {
 }
 
 bool RowType::isOrderable() const {
-  return std::all_of(children_.cbegin(), children_.cend(), [](const auto& c) {
-    return c->isOrderable();
-  });
+  return std::all_of(
+      children_.cbegin(), children_.cend(), [](const auto& child) {
+        return child->isOrderable();
+      });
 }
 
 bool RowType::isComparable() const {
-  return std::all_of(children_.cbegin(), children_.cend(), [](const auto& c) {
-    return c->isOrderable();
-  });
+  return std::all_of(
+      children_.cbegin(), children_.cend(), [](const auto& child) {
+        return child->isComparable();
+      });
 }
 
 bool RowType::containsChild(std::string_view name) const {

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -455,9 +455,17 @@ class Type : public Tree<const TypePtr>, public velox::ISerializable {
 
   virtual bool isPrimitiveType() const = 0;
 
-  virtual bool isOrderable() const = 0;
-
+  /// Returns true if equality relationship is defined for the values of this
+  /// type, i.e. a == b is defined and returns true, false or null. For example,
+  /// scalar types are usually comparable and complex types are comparable if
+  /// their nested types are.
   virtual bool isComparable() const = 0;
+
+  /// Returns true if less than relationship is defined for the values of this
+  /// type, i.e. a <= b returns true or false. For example, scalar types are
+  /// usually orderable, arrays and structs are orderable if their nested types
+  /// are, while map types are not orderable.
+  virtual bool isOrderable() const = 0;
 
   /// Returns unique logical type name. It can be
   /// different from the physical type name returned by 'kindName()'.
@@ -779,10 +787,6 @@ class UnknownType : public TypeBase<TypeKind::UNKNOWN> {
 
   size_t cppSizeInBytes() const override {
     return 0;
-  }
-
-  bool isOrderable() const override {
-    return false;
   }
 
   bool equivalent(const Type& other) const override {

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -880,7 +880,7 @@ TEST(TypeTest, orderableComparable) {
 
   rowType = ROW({INTEGER(), mapType});
   EXPECT_FALSE(rowType->isOrderable());
-  EXPECT_FALSE(rowType->isComparable());
+  EXPECT_TRUE(rowType->isComparable());
 
   // Decimal types.
   auto shortDecimal = DECIMAL(10, 5);

--- a/velox/type/tests/TypeTest.cpp
+++ b/velox/type/tests/TypeTest.cpp
@@ -845,3 +845,68 @@ TEST(TypeTest, unionWith) {
   ASSERT_TRUE(
       childRowType1->unionWith(childRowType1)->equivalent(*resultRowType2));
 }
+
+TEST(TypeTest, orderableComparable) {
+  // Scalar type.
+  EXPECT_TRUE(INTEGER()->isOrderable());
+  EXPECT_TRUE(INTEGER()->isComparable());
+  EXPECT_TRUE(REAL()->isOrderable());
+  EXPECT_TRUE(REAL()->isComparable());
+  EXPECT_TRUE(VARCHAR()->isOrderable());
+  EXPECT_TRUE(VARCHAR()->isComparable());
+  EXPECT_TRUE(BIGINT()->isOrderable());
+  EXPECT_TRUE(BIGINT()->isComparable());
+  EXPECT_TRUE(DOUBLE()->isOrderable());
+  EXPECT_TRUE(DOUBLE()->isComparable());
+
+  // Map type.
+  auto mapType = MAP(INTEGER(), REAL());
+  EXPECT_FALSE(mapType->isOrderable());
+  EXPECT_TRUE(mapType->isComparable());
+
+  // Array type.
+  auto arrayType = ARRAY(INTEGER());
+  EXPECT_TRUE(arrayType->isOrderable());
+  EXPECT_TRUE(arrayType->isComparable());
+
+  arrayType = ARRAY(mapType);
+  EXPECT_FALSE(arrayType->isOrderable());
+  EXPECT_TRUE(arrayType->isComparable());
+
+  // Row type.
+  auto rowType = ROW({INTEGER(), REAL()});
+  EXPECT_TRUE(rowType->isOrderable());
+  EXPECT_TRUE(rowType->isComparable());
+
+  rowType = ROW({INTEGER(), mapType});
+  EXPECT_FALSE(rowType->isOrderable());
+  EXPECT_FALSE(rowType->isComparable());
+
+  // Decimal types.
+  auto shortDecimal = DECIMAL(10, 5);
+  EXPECT_TRUE(shortDecimal->isOrderable());
+  EXPECT_TRUE(shortDecimal->isComparable());
+
+  auto longDecimal = DECIMAL(30, 5);
+  EXPECT_TRUE(longDecimal->isOrderable());
+  EXPECT_TRUE(longDecimal->isComparable());
+
+  // Function type.
+  auto functionType = std::make_shared<FunctionType>(
+      std::vector<TypePtr>{BIGINT(), VARCHAR()}, BOOLEAN());
+  EXPECT_FALSE(functionType->isOrderable());
+  EXPECT_FALSE(functionType->isComparable());
+
+  // Mixed.
+  mapType = MAP(INTEGER(), functionType);
+  EXPECT_FALSE(mapType->isOrderable());
+  EXPECT_FALSE(mapType->isComparable());
+
+  arrayType = ARRAY(mapType);
+  EXPECT_FALSE(arrayType->isOrderable());
+  EXPECT_FALSE(arrayType->isComparable());
+
+  rowType = ROW({INTEGER(), mapType});
+  EXPECT_FALSE(rowType->isOrderable());
+  EXPECT_FALSE(rowType->isComparable());
+}


### PR DESCRIPTION
In Presto, input to min/max/array_sort is restricted to orderable types. For example, MAP type is not orderable. Velox currently allows MAP inputs. 
This PR extends the Velox Type class to add `isOrderable()` and `isComparable()` methods.

Part of https://github.com/facebookincubator/velox/issues/6718 and https://github.com/facebookincubator/velox/issues/6712