### PR TITLE
Copy input vectors in Values operator

### DIFF
--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -573,6 +573,10 @@ class BaseVector {
     VELOX_UNSUPPORTED("Vector is not a wrapper");
   }
 
+  // Returns a loaded version of the current vector, resolving potential lazy
+  // evaluation.
+  // Note that specializations of this method are not guaranteed to be
+  // thread-safe.
   virtual BaseVector* loadedVector() {
     return this;
   }


### PR DESCRIPTION
Summary:
In case Values operator is parallelizable (only used for tests), copy
the input vectors. Vectors are not thread-safe, so different threads calling
loadedVector() can trigger race conditions.

Differential Revision: D49696960


