### PR TITLE
Do not throw exception in SIMDJsonExtractor parse and extract

### DIFF
--- a/velox/common/base/Macros.h
+++ b/velox/common/base/Macros.h
@@ -33,3 +33,8 @@
 #define VELOX_UNSUPPRESS_RETURN_LOCAL_ADDR_WARNING \
   _Pragma("GCC diagnostic pop");
 #endif
+
+#define VELOX_CONCAT(x, y) x##y
+// Need this extra layer to expand __COUNTER__.
+#define VELOX_VARNAME_IMPL(x, y) VELOX_CONCAT(x, y)
+#define VELOX_VARNAME(x) VELOX_VARNAME_IMPL(x, __COUNTER__)

--- a/velox/common/testutil/TestValue.h
+++ b/velox/common/testutil/TestValue.h
@@ -20,6 +20,7 @@
 #include <unordered_map>
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Macros.h"
 
 namespace facebook::velox::common::testutil {
 
@@ -109,11 +110,8 @@ inline void TestValue::adjust(
     void* testData) {}
 #endif
 
-#define VELOX_CONCAT(x, y) __##x##y
-#define VELOX_VARNAME(x) VELOX_CONCAT(x, Obj)
-
 #define SCOPED_TESTVALUE_SET(point, ...)                              \
   ::facebook::velox::common::testutil::ScopedTestValue VELOX_VARNAME( \
-      __LINE__)(point, ##__VA_ARGS__)
+      _scopedTestValue)(point, ##__VA_ARGS__)
 
 } // namespace facebook::velox::common::testutil

--- a/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
+++ b/velox/functions/prestosql/json/SIMDJsonExtractor.cpp
@@ -42,8 +42,8 @@ namespace facebook::velox::functions::detail {
   return *it.first->second;
 }
 
-simdjson::ondemand::document SIMDJsonExtractor::parse(
-    const simdjson::padded_string& json) {
+simdjson::simdjson_result<simdjson::ondemand::document>
+SIMDJsonExtractor::parse(const simdjson::padded_string& json) {
   thread_local static simdjson::ondemand::parser parser;
   return parser.iterate(json);
 }
@@ -71,23 +71,26 @@ bool SIMDJsonExtractor::tokenize(const std::string& path) {
   return true;
 }
 
-void extractObject(
-    simdjson::ondemand::value& jsonObj,
+bool extractObject(
+    simdjson::ondemand::value& jsonValue,
     const std::string& key,
     std::optional<simdjson::ondemand::value>& ret) {
-  for (auto field : jsonObj.get_object()) {
-    if (field.unescaped_key().value() == key) {
+  SIMDJSON_ASSIGN_OR_RAISE(auto jsonObj, jsonValue.get_object());
+  for (auto field : jsonObj) {
+    SIMDJSON_ASSIGN_OR_RAISE(auto currentKey, field.unescaped_key());
+    if (currentKey == key) {
       ret.emplace(field.value());
-      return;
+      return true;
     }
   }
+  return true;
 }
 
-void extractArray(
+bool extractArray(
     simdjson::ondemand::value& jsonValue,
     const std::string& index,
     std::optional<simdjson::ondemand::value>& ret) {
-  auto jsonArray = jsonValue.get_array();
+  SIMDJSON_ASSIGN_OR_RAISE(auto jsonArray, jsonValue.get_array());
   auto rv = folly::tryTo<int32_t>(index);
   if (rv.hasValue()) {
     auto val = jsonArray.at(rv.value());
@@ -95,5 +98,6 @@ void extractArray(
       ret.emplace(std::move(val));
     }
   }
+  return true;
 }
 } // namespace facebook::velox::functions::detail


### PR DESCRIPTION
Summary: `SIMDJsonExtractor::parse` and `SIMDJsonExtractor::extract` is throwing exception when the input is malformed, which slows down the query a lot.  Optimize the exception away by returning the `simdjson_result` directly and inspect the error code from it.

Differential Revision: D49670929


