### PR TITLE
Suffix private members of StringDictionaryColumnReader

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1040,34 +1040,34 @@ class StringDictionaryColumnReader : public ColumnReader {
  private:
   void loadStrideDictionary();
 
-  BufferPtr dictionaryBlob;
-  BufferPtr dictionaryOffset;
-  BufferPtr inDict;
-  BufferPtr strideDict;
-  BufferPtr strideDictOffset;
+  BufferPtr dictionaryBlob_;
+  BufferPtr dictionaryOffset_;
+  BufferPtr inDict_;
+  BufferPtr strideDict_;
+  BufferPtr strideDictOffset_;
   BufferPtr indices_;
-  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> dictIndex;
-  std::unique_ptr<ByteRleDecoder> inDictionaryReader;
-  std::unique_ptr<dwio::common::SeekableInputStream> strideDictStream;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> dictIndex_;
+  std::unique_ptr<ByteRleDecoder> inDictionaryReader_;
+  std::unique_ptr<dwio::common::SeekableInputStream> strideDictStream_;
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>>
-      strideDictLengthDecoder;
+      strideDictLengthDecoder_;
 
   FlatVectorPtr<StringView> combinedDictionaryValues_;
   FlatVectorPtr<StringView> dictionaryValues_;
 
-  uint64_t dictionaryCount;
-  uint64_t strideDictCount;
-  int64_t lastStrideIndex;
-  size_t positionOffset;
-  size_t strideDictSizeOffset;
+  uint64_t dictionaryCount_;
+  uint64_t strideDictCount_;
+  int64_t lastStrideIndex_;
+  size_t positionOffset_;
+  size_t strideDictSizeOffset_;
 
   std::unique_ptr<dwio::common::SeekableInputStream> indexStream_;
   std::unique_ptr<proto::RowIndex> rowIndex_;
-  const StrideIndexProvider& provider;
+  const StrideIndexProvider& provider_;
 
   // lazy load the dictionary
-  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder;
-  std::unique_ptr<dwio::common::SeekableInputStream> blobStream;
+  std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder_;
+  std::unique_ptr<dwio::common::SeekableInputStream> blobStream_;
   const bool returnFlatVector_;
   bool initialized_{false};
 
@@ -1122,17 +1122,17 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
           stripe,
           streamLabels,
           std::move(flatMapContext)),
-      lastStrideIndex(-1),
-      provider(stripe.getStrideIndexProvider()),
+      lastStrideIndex_(-1),
+      provider_(stripe.getStrideIndexProvider()),
       returnFlatVector_(stripe.getRowReaderOptions().getReturnFlatVector()) {
   EncodingKey encodingKey{nodeType_->id(), flatMapContext_.sequence};
   RleVersion rleVersion =
       convertRleVersion(stripe.getEncoding(encodingKey).kind());
-  dictionaryCount = stripe.getEncoding(encodingKey).dictionarysize();
+  dictionaryCount_ = stripe.getEncoding(encodingKey).dictionarysize();
 
   const auto dataId = encodingKey.forKind(proto::Stream_Kind_DATA);
   bool dictVInts = stripe.getUseVInts(dataId);
-  dictIndex = createRleDecoder</*isSigned*/ false>(
+  dictIndex_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(dataId, streamLabels.label(), true),
       rleVersion,
       memoryPool_,
@@ -1141,14 +1141,14 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
   const auto lenId = encodingKey.forKind(proto::Stream_Kind_LENGTH);
   bool lenVInts = stripe.getUseVInts(lenId);
-  lengthDecoder = createRleDecoder</*isSigned*/ false>(
+  lengthDecoder_ = createRleDecoder</*isSigned*/ false>(
       stripe.getStream(lenId, streamLabels.label(), false),
       rleVersion,
       memoryPool_,
       lenVInts,
       dwio::common::INT_BYTE_SIZE);
 
-  blobStream = stripe.getStream(
+  blobStream_ = stripe.getStream(
       encodingKey.forKind(proto::Stream_Kind_DICTIONARY_DATA),
       streamLabels.label(),
       false);
@@ -1160,15 +1160,15 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
           streamLabels.label(),
           false);
   if (inDictStream) {
-    inDictionaryReader =
+    inDictionaryReader_ =
         createBooleanRleDecoder(std::move(inDictStream), encodingKey);
 
     // stride dictionary only exists if in dictionary exists
-    strideDictStream = stripe.getStream(
+    strideDictStream_ = stripe.getStream(
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY),
         streamLabels.label(),
         true);
-    DWIO_ENSURE_NOT_NULL(strideDictStream, "Stride dictionary is missing");
+    DWIO_ENSURE_NOT_NULL(strideDictStream_, "Stride dictionary is missing");
 
     indexStream_ = stripe.getStream(
         encodingKey.forKind(proto::Stream_Kind_ROW_INDEX),
@@ -1179,7 +1179,7 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
     const auto strideDictLenId =
         encodingKey.forKind(proto::Stream_Kind_STRIDE_DICTIONARY_LENGTH);
     bool strideLenVInt = stripe.getUseVInts(strideDictLenId);
-    strideDictLengthDecoder = createRleDecoder</*isSigned*/ false>(
+    strideDictLengthDecoder_ = createRleDecoder</*isSigned*/ false>(
         stripe.getStream(strideDictLenId, streamLabels.label(), true),
         rleVersion,
         memoryPool_,
@@ -1190,9 +1190,9 @@ StringDictionaryColumnReader::StringDictionaryColumnReader(
 
 uint64_t StringDictionaryColumnReader::skip(uint64_t numValues) {
   numValues = ColumnReader::skip(numValues);
-  dictIndex->skip(numValues);
-  if (inDictionaryReader) {
-    inDictionaryReader->skip(numValues);
+  dictIndex_->skip(numValues);
+  if (inDictionaryReader_) {
+    inDictionaryReader_->skip(numValues);
   }
   return numValues;
 }
@@ -1221,34 +1221,34 @@ BufferPtr StringDictionaryColumnReader::loadDictionary(
 }
 
 void StringDictionaryColumnReader::loadStrideDictionary() {
-  auto nextStride = provider.getStrideIndex();
-  if (nextStride == lastStrideIndex) {
+  auto nextStride = provider_.getStrideIndex();
+  if (nextStride == lastStrideIndex_) {
     return;
   }
 
   // get stride dictionary size and load it if needed
   auto& positions = rowIndex_->entry(nextStride).positions();
-  strideDictCount = positions.Get(strideDictSizeOffset);
-  if (strideDictCount > 0) {
+  strideDictCount_ = positions.Get(strideDictSizeOffset_);
+  if (strideDictCount_ > 0) {
     // seek stride dictionary related streams
     std::vector<uint64_t> pos(
-        positions.begin() + positionOffset, positions.end());
+        positions.begin() + positionOffset_, positions.end());
     dwio::common::PositionProvider pp(pos);
-    strideDictStream->seekToPosition(pp);
-    strideDictLengthDecoder->seekToRowGroup(pp);
+    strideDictStream_->seekToPosition(pp);
+    strideDictLengthDecoder_->seekToRowGroup(pp);
 
     detail::ensureCapacity<int64_t>(
-        strideDictOffset, strideDictCount + 1, &memoryPool_);
-    strideDict = loadDictionary(
-        strideDictCount,
-        *strideDictStream,
-        *strideDictLengthDecoder,
-        strideDictOffset);
+        strideDictOffset_, strideDictCount_ + 1, &memoryPool_);
+    strideDict_ = loadDictionary(
+        strideDictCount_,
+        *strideDictStream_,
+        *strideDictLengthDecoder_,
+        strideDictOffset_);
   } else {
-    strideDict.reset();
+    strideDict_.reset();
   }
 
-  lastStrideIndex = nextStride;
+  lastStrideIndex_ = nextStride;
 
   dictionaryValues_.reset();
   combinedDictionaryValues_.reset();
@@ -1271,13 +1271,13 @@ bool /* FOLLY_ALWAYS_INLINE */ StringDictionaryColumnReader::setOutput(
   if (!inDict || bits::isBitSet(inDict, index)) {
     data = dict;
     offsets = dictOffsets;
-    dictCount = dictionaryCount;
+    dictCount = dictionaryCount_;
   } else {
     DWIO_ENSURE_NOT_NULL(strideDict);
     DWIO_ENSURE_NOT_NULL(strideDictOffsets);
     data = strideDict;
     offsets = strideDictOffsets;
-    dictCount = strideDictCount;
+    dictCount = strideDictCount_;
     hasStrideDict = true;
   }
   DWIO_ENSURE_LT(
@@ -1301,19 +1301,19 @@ void StringDictionaryColumnReader::next(
   ensureInitialized();
 
   const char* strideDictBlob = nullptr;
-  if (inDictionaryReader) {
+  if (inDictionaryReader_) {
     loadStrideDictionary();
-    if (strideDict) {
-      DWIO_ENSURE_NOT_NULL(strideDictOffset);
+    if (strideDict_) {
+      DWIO_ENSURE_NOT_NULL(strideDictOffset_);
 
       // It's possible strideDictBlob is nullptr when stride dictionary only
       // contains empty string. In that case, we need to make sure
       // strideDictBlob point to some valid address, and the last entry of
       // strideDictOffset have value 0.
-      strideDictBlob = strideDict->as<char>();
+      strideDictBlob = strideDict_->as<char>();
       if (!strideDictBlob) {
         strideDictBlob = EMPTY_DICT.data();
-        DWIO_ENSURE_EQ(strideDictOffset->as<int64_t>()[strideDictCount], 0);
+        DWIO_ENSURE_EQ(strideDictOffset_->as<int64_t>()[strideDictCount_], 0);
       }
     }
   }
@@ -1349,17 +1349,17 @@ void StringDictionaryColumnReader::readDictionaryVector(
   }
 
   auto indicesPtr = indices->asMutable<vector_size_t>();
-  dictIndex->nextInts(indicesPtr, numValues, nullsPtr);
+  dictIndex_->nextInts(indicesPtr, numValues, nullsPtr);
   indices->setSize(numValues * sizeof(vector_size_t));
 
   bool hasStrideDict = false;
 
   // load inDictionary
   const char* inDictPtr = nullptr;
-  if (inDictionaryReader) {
-    detail::ensureCapacity<bool>(inDict, numValues, &memoryPool_);
-    inDictionaryReader->next(inDict->asMutable<char>(), numValues, nullsPtr);
-    inDictPtr = inDict->as<char>();
+  if (inDictionaryReader_) {
+    detail::ensureCapacity<bool>(inDict_, numValues, &memoryPool_);
+    inDictionaryReader_->next(inDict_->asMutable<char>(), numValues, nullsPtr);
+    inDictPtr = inDict_->as<char>();
   }
 
   if (nulls) {
@@ -1369,7 +1369,7 @@ void StringDictionaryColumnReader::readDictionaryVector(
           // points to an entry in rowgroup dictionary
         } else {
           // points to an entry in stride dictionary
-          indicesPtr[i] += dictionaryCount;
+          indicesPtr[i] += dictionaryCount_;
           hasStrideDict = true;
         }
       }
@@ -1380,31 +1380,31 @@ void StringDictionaryColumnReader::readDictionaryVector(
         // points to an entry in rowgroup dictionary
       } else {
         // points to an entry in stride dictionary
-        indicesPtr[i] += dictionaryCount;
+        indicesPtr[i] += dictionaryCount_;
         hasStrideDict = true;
       }
     }
   }
 
   VectorPtr dictionaryValues;
-  const auto* dictionaryBlobPtr = dictionaryBlob->as<char>();
-  const auto* dictionaryOffsetsPtr = dictionaryOffset->as<int64_t>();
+  const auto* dictionaryBlobPtr = dictionaryBlob_->as<char>();
+  const auto* dictionaryOffsetsPtr = dictionaryOffset_->as<int64_t>();
   if (hasStrideDict) {
     if (!combinedDictionaryValues_) {
       // TODO Reuse memory
       BufferPtr values = AlignedBuffer::allocate<StringView>(
-          dictionaryCount + strideDictCount, &memoryPool_);
+          dictionaryCount_ + strideDictCount_, &memoryPool_);
       auto* valuesPtr = values->asMutable<StringView>();
-      for (size_t i = 0; i < dictionaryCount; i++) {
+      for (size_t i = 0; i < dictionaryCount_; i++) {
         valuesPtr[i] = StringView(
             dictionaryBlobPtr + dictionaryOffsetsPtr[i],
             dictionaryOffsetsPtr[i + 1] - dictionaryOffsetsPtr[i]);
       }
 
-      const auto* strideDictPtr = strideDict->as<char>();
-      const auto* strideDictOffsetPtr = strideDictOffset->as<int64_t>();
-      for (size_t i = 0; i < strideDictCount; i++) {
-        valuesPtr[dictionaryCount + i] = StringView(
+      const auto* strideDictPtr = strideDict_->as<char>();
+      const auto* strideDictOffsetPtr = strideDictOffset_->as<int64_t>();
+      for (size_t i = 0; i < strideDictCount_; i++) {
+        valuesPtr[dictionaryCount_ + i] = StringView(
             strideDictPtr + strideDictOffsetPtr[i],
             strideDictOffsetPtr[i + 1] - strideDictOffsetPtr[i]);
       }
@@ -1413,9 +1413,9 @@ void StringDictionaryColumnReader::readDictionaryVector(
           &memoryPool_,
           nodeType_->type(),
           BufferPtr(nullptr), // TODO nulls
-          dictionaryCount + strideDictCount /*length*/,
+          dictionaryCount_ + strideDictCount_ /*length*/,
           values,
-          std::vector<BufferPtr>{dictionaryBlob, strideDict});
+          std::vector<BufferPtr>{dictionaryBlob_, strideDict_});
     }
 
     dictionaryValues = combinedDictionaryValues_;
@@ -1423,9 +1423,9 @@ void StringDictionaryColumnReader::readDictionaryVector(
     if (!dictionaryValues_) {
       // TODO Reuse memory
       BufferPtr values =
-          AlignedBuffer::allocate<StringView>(dictionaryCount, &memoryPool_);
+          AlignedBuffer::allocate<StringView>(dictionaryCount_, &memoryPool_);
       auto* valuesPtr = values->asMutable<StringView>();
-      for (size_t i = 0; i < dictionaryCount; i++) {
+      for (size_t i = 0; i < dictionaryCount_; i++) {
         valuesPtr[i] = StringView(
             dictionaryBlobPtr + dictionaryOffsetsPtr[i],
             dictionaryOffsetsPtr[i + 1] - dictionaryOffsetsPtr[i]);
@@ -1435,9 +1435,9 @@ void StringDictionaryColumnReader::readDictionaryVector(
           &memoryPool_,
           nodeType_->type(),
           BufferPtr(nullptr), // TODO nulls
-          dictionaryCount /*length*/,
+          dictionaryCount_ /*length*/,
           values,
-          std::vector<BufferPtr>{dictionaryBlob});
+          std::vector<BufferPtr>{dictionaryBlob_});
     }
     dictionaryValues = dictionaryValues_;
   }
@@ -1481,10 +1481,10 @@ void StringDictionaryColumnReader::readFlatVector(
 
   // load inDictionary
   const char* inDictPtr = nullptr;
-  if (inDictionaryReader) {
-    detail::ensureCapacity<bool>(inDict, numValues, &memoryPool_);
-    inDictionaryReader->next(inDict->asMutable<char>(), numValues, nullsPtr);
-    inDictPtr = inDict->as<char>();
+  if (inDictionaryReader_) {
+    detail::ensureCapacity<bool>(inDict_, numValues, &memoryPool_);
+    inDictionaryReader_->next(inDict_->asMutable<char>(), numValues, nullsPtr);
+    inDictPtr = inDict_->as<char>();
   }
   auto dataPtr = data->asMutable<StringView>();
 
@@ -1493,16 +1493,16 @@ void StringDictionaryColumnReader::readFlatVector(
     indices_ = AlignedBuffer::allocate<int64_t>(numValues, &memoryPool_);
   }
   auto indices = indices_->asMutable<int64_t>();
-  dictIndex->next(indices, numValues, nullsPtr);
+  dictIndex_->next(indices, numValues, nullsPtr);
 
   const char* strideDictPtr = nullptr;
   int64_t* strideDictOffsetPtr = nullptr;
-  if (strideDict) {
-    strideDictPtr = strideDict->as<char>();
-    strideDictOffsetPtr = strideDictOffset->asMutable<int64_t>();
+  if (strideDict_) {
+    strideDictPtr = strideDict_->as<char>();
+    strideDictOffsetPtr = strideDictOffset_->asMutable<int64_t>();
   }
-  auto* dictionaryBlobPtr = dictionaryBlob->as<char>();
-  auto* dictionaryOffsetsPtr = dictionaryOffset->asMutable<int64_t>();
+  auto* dictionaryBlobPtr = dictionaryBlob_->as<char>();
+  auto* dictionaryOffsetsPtr = dictionaryOffset_->asMutable<int64_t>();
   bool hasStrideDict = false;
   const char* strData;
   int64_t strLen;
@@ -1539,9 +1539,9 @@ void StringDictionaryColumnReader::readFlatVector(
       dataPtr[i] = StringView{strData, static_cast<int32_t>(strLen)};
     }
   }
-  std::vector<BufferPtr> stringBuffers = {dictionaryBlob};
+  std::vector<BufferPtr> stringBuffers = {dictionaryBlob_};
   if (hasStrideDict) {
-    stringBuffers.emplace_back(strideDict);
+    stringBuffers.emplace_back(strideDict_);
   }
   if (result) {
     result->setNullCount(nullCount);
@@ -1564,24 +1564,24 @@ void StringDictionaryColumnReader::ensureInitialized() {
   }
 
   detail::ensureCapacity<int64_t>(
-      dictionaryOffset, dictionaryCount + 1, &memoryPool_);
-  dictionaryBlob = loadDictionary(
-      dictionaryCount, *blobStream, *lengthDecoder, dictionaryOffset);
+      dictionaryOffset_, dictionaryCount_ + 1, &memoryPool_);
+  dictionaryBlob_ = loadDictionary(
+      dictionaryCount_, *blobStream_, *lengthDecoder_, dictionaryOffset_);
   dictionaryValues_.reset();
   combinedDictionaryValues_.reset();
 
   // handle in dictionary stream
-  if (inDictionaryReader) {
+  if (inDictionaryReader_) {
     // load stride dictionary offsets
     rowIndex_ = ProtoUtils::readProto<proto::RowIndex>(std::move(indexStream_));
     auto indexStartOffset = flatMapContext_.inMapDecoder
         ? flatMapContext_.inMapDecoder->loadIndices(0)
         : 0;
-    positionOffset = notNullDecoder_
+    positionOffset_ = notNullDecoder_
         ? notNullDecoder_->loadIndices(indexStartOffset)
         : indexStartOffset;
-    size_t offset = strideDictStream->positionSize() + positionOffset;
-    strideDictSizeOffset = strideDictLengthDecoder->loadIndices(offset);
+    size_t offset = strideDictStream_->positionSize() + positionOffset_;
+    strideDictSizeOffset_ = strideDictLengthDecoder_->loadIndices(offset);
   }
   initialized_ = true;
 }


### PR DESCRIPTION
Summary: Private member variables have `_` suffix in our codebase. Let's make consistent.

Differential Revision: D49701923


