### PR TITLE
Respect output buffer size limit in aggregation output processing

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -207,7 +207,7 @@ class Aggregate {
   //
   // 'result' and its parts are expected to be singly referenced. If
   // other threads or operators hold references that they would use
-  // after 'result' has been updated by this, effects will b unpredictable.
+  // after 'result' has been updated by this, effects will be unpredictable.
   virtual void
   extractValues(char** groups, int32_t numGroups, VectorPtr* result) = 0;
 

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -645,22 +645,26 @@ const SelectivityVector& GroupingSet::getSelectivityVector(
 }
 
 bool GroupingSet::getOutput(
-    int32_t batchSize,
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes,
     RowContainerIterator& iterator,
     RowVectorPtr& result) {
   if (isGlobal_) {
-    return getGlobalAggregationOutput(batchSize, isPartial_, iterator, result);
+    return getGlobalAggregationOutput(
+        maxOutputRows, isPartial_, iterator, result);
   }
   if (hasSpilled()) {
-    return getOutputWithSpill(batchSize, result);
+    return getOutputWithSpill(maxOutputRows, maxOutputBytes, result);
   }
 
   // @lint-ignore CLANGTIDY
-  char* groups[batchSize];
-  int32_t numGroups =
-      table_ ? table_->rows()->listRows(&iterator, batchSize, groups) : 0;
-  if (!numGroups) {
-    if (table_) {
+  char* groups[maxOutputRows];
+  const int32_t numGroups = table_
+      ? table_->rows()->listRows(
+            &iterator, maxOutputRows, maxOutputBytes, groups)
+      : 0;
+  if (numGroups == 0) {
+    if (table_ != nullptr) {
       table_->clear();
     }
     return false;
@@ -676,7 +680,7 @@ void GroupingSet::extractGroups(
   if (groups.empty()) {
     return;
   }
-  RowContainer& rows = table_ ? *table_->rows() : *rowsWhileReadingSpill_;
+  RowContainer& rows = table_ ? *table_->rows() : *nonSpilledRowContainer_;
   auto totalKeys = rows.keyTypes().size();
   for (int32_t i = 0; i < totalKeys; ++i) {
     auto keyVector = result->childAt(i);
@@ -881,7 +885,8 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
 }
 
 bool GroupingSet::getOutputWithSpill(
-    int32_t batchSize,
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes,
     const RowVectorPtr& result) {
   if (outputPartition_ == -1) {
     mergeArgs_.resize(1);
@@ -906,28 +911,30 @@ bool GroupingSet::getOutputWithSpill(
 
     // Take ownership of the rows and free the hash table. The table will not be
     // needed for producing spill output.
-    rowsWhileReadingSpill_ = table_->moveRows();
+    nonSpilledRowContainer_ = table_->moveRows();
     table_.reset();
     outputPartition_ = 0;
     nonSpilledRows_ = spiller_->finishSpill();
   }
 
-  if (nonSpilledIndex_ < nonSpilledRows_.value().size()) {
-    const size_t numGroups = std::min<vector_size_t>(
-        batchSize, nonSpilledRows_.value().size() - nonSpilledIndex_);
+  if (nonSpilledRowIndex_ < nonSpilledRows_.value().size()) {
+    const int32_t numGroups =
+        numNonSpilledGroupsToExtract(maxOutputRows, maxOutputBytes);
     extractGroups(
         folly::Range<char**>(
-            nonSpilledRows_.value().data() + nonSpilledIndex_, numGroups),
+            nonSpilledRows_.value().data() + nonSpilledRowIndex_, numGroups),
         result);
-    nonSpilledIndex_ += numGroups;
+    nonSpilledRowIndex_ += numGroups;
     return true;
   }
+
   while (outputPartition_ < spiller_->state().maxPartitions()) {
     if (!merge_) {
       merge_ = spiller_->startMerge(outputPartition_);
     }
     // NOTE: 'merge_' might be nullptr if 'outputPartition_' is empty.
-    if (merge_ == nullptr || !mergeNext(batchSize, result)) {
+    if (merge_ == nullptr ||
+        !mergeNext(maxOutputRows, maxOutputBytes, result)) {
       ++outputPartition_;
       merge_ = nullptr;
       continue;
@@ -937,7 +944,29 @@ bool GroupingSet::getOutputWithSpill(
   return false;
 }
 
-bool GroupingSet::mergeNext(int32_t batchSize, const RowVectorPtr& result) {
+size_t GroupingSet::numNonSpilledGroupsToExtract(
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes) const {
+  const size_t maxNumGroups = std::min<vector_size_t>(
+      maxOutputRows, nonSpilledRows_.value().size() - nonSpilledRowIndex_);
+  size_t totalBytes{0};
+  size_t nextRow = nonSpilledRowIndex_;
+  size_t numGroups{0};
+  for (; numGroups < maxNumGroups; ++numGroups, ++nextRow) {
+    const auto rowSize =
+        nonSpilledRowContainer_->rowSize(nonSpilledRows_.value()[nextRow]);
+    if (numGroups > 0 && (totalBytes + rowSize) < maxOutputBytes) {
+      break;
+    }
+    totalBytes += rowSize;
+  }
+  return numGroups;
+}
+
+bool GroupingSet::mergeNext(
+    int32_t maxOutputRows,
+    int32_t maxOutputBytes,
+    const RowVectorPtr& result) {
   for (;;) {
     auto next = merge_->nextWithEquals();
     if (!next.first) {
@@ -951,7 +980,9 @@ bool GroupingSet::mergeNext(int32_t batchSize, const RowVectorPtr& result) {
     updateRow(*next.first, mergeState_);
     nextKeyIsEqual_ = next.second;
     next.first->pop();
-    if (!nextKeyIsEqual_ && mergeRows_->numRows() >= batchSize) {
+    if (!nextKeyIsEqual_ &&
+        ((mergeRows_->numRows() >= maxOutputRows) ||
+         (mergeRows_->allocatedBytes() >= maxOutputBytes))) {
       extractSpillResult(result);
       return true;
     }
@@ -1110,7 +1141,7 @@ void GroupingSet::toIntermediate(
 
 std::optional<int64_t> GroupingSet::estimateRowSize() const {
   const RowContainer* rows =
-      table_ ? table_->rows() : rowsWhileReadingSpill_.get();
+      table_ ? table_->rows() : nonSpilledRowContainer_.get();
   return rows && rows->estimateRowSize() >= 0
       ? std::optional<int64_t>(rows->estimateRowSize())
       : std::nullopt;

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -63,9 +63,12 @@ class GroupingSet {
   bool hasOutput();
 
   /// Called if partial aggregation has reached memory limit or if hasOutput()
-  /// returns true.
+  /// returns true. 'maxOutputRows' and 'maxOutputBytes' specify the max number
+  /// of rows/bytes to return in 'result' respectively. The function stops
+  /// producing output if it exceeds either limit.
   bool getOutput(
-      int32_t batchSize,
+      int32_t maxOutputRows,
+      int32_t maxOutputBytes,
       RowContainerIterator& iterator,
       RowVectorPtr& result);
 
@@ -167,15 +170,22 @@ class GroupingSet {
 
   // Produces output in if spilling has occurred. First produces data
   // from non-spilled partitions, then merges spill runs and unspilled data
-  // form spilled partitions. Returns nullptr when at end. 'batchSize' specifies
-  // the max number of output rows in 'result'.
-  bool getOutputWithSpill(int32_t batchSize, const RowVectorPtr& result);
+  // form spilled partitions. Returns nullptr when at end. 'maxOutputRows' and
+  // 'maxOutputBytes' specifies the max number of output rows and bytes in
+  // 'result'.
+  bool getOutputWithSpill(
+      int32_t maxOutputRows,
+      int32_t maxOutputBytes,
+      const RowVectorPtr& result);
 
   // Reads rows from the current spilled partition until producing a batch of
   // final results in 'result'. Returns false and leaves 'result' empty when
-  // the partition is fully read. 'batchSize' specifies the max number of output
-  // rows in 'result'.
-  bool mergeNext(int32_t batchSize, const RowVectorPtr& result);
+  // the partition is fully read. 'maxOutputRows' and 'maxOutputBytes' specify
+  // the max number of output rows and bytes in 'result'.
+  bool mergeNext(
+      int32_t maxOutputRows,
+      int32_t maxOutputBytes,
+      const RowVectorPtr& result);
 
   // Initializes a new row in 'mergeRows' with the keys from the
   // current element from 'keys'. Accumulators are left in the initial
@@ -203,6 +213,14 @@ class GroupingSet {
   // 'excludeToIntermediate' is true, skip the functions that support
   // 'toIntermediate'.
   std::vector<Accumulator> accumulators(bool excludeToIntermediate);
+
+  // Calculates the number of groups to extract from 'rowsWhileReadingSpill_'
+  // container with rows starting at 'nonSpilledIndex_' in 'nonSpilledRows_'.
+  // 'maxOutputRows' and 'maxOutputBytes' specifies the max number of groups and
+  // bytes to extract.
+  size_t numNonSpilledGroupsToExtract(
+      int32_t maxOutputRows,
+      int32_t maxOutputBytes) const;
 
   std::vector<column_index_t> keyChannels_;
 
@@ -293,14 +311,14 @@ class GroupingSet {
   std::optional<Spiller::SpillRows> nonSpilledRows_;
 
   // Index of first in 'nonSpilledRows_' that has not been added to output.
-  size_t nonSpilledIndex_ = 0;
+  size_t nonSpilledRowIndex_{0};
 
   // Pool of the OperatorCtx. Used for spilling.
   memory::MemoryPool& pool_;
 
-  // The RowContainer of 'table_' is moved here before freeing
-  // 'table_' when starting to read spill output.
-  std::unique_ptr<RowContainer> rowsWhileReadingSpill_;
+  // The RowContainer of 'table_' is moved here before freeing 'table_' when
+  // starting to read spill output.
+  std::unique_ptr<RowContainer> nonSpilledRowContainer_;
 
   // Counts input batches and triggers spilling if folly hash of this % 100 <=
   // 'testSpillPct_';.

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1591,65 +1591,163 @@ TEST_F(AggregationTest, groupingSetsOutput) {
 }
 
 TEST_F(AggregationTest, outputBatchSizeCheckWithSpill) {
-  rowType_ = ROW({"c0", "c1", "c2"}, {INTEGER(), INTEGER(), INTEGER()});
-  VectorFuzzer::Options options;
-  options.vectorSize = 10;
-  VectorFuzzer fuzzer(options, pool());
-  const int32_t numBatches = 10;
-  std::vector<RowVectorPtr> batches;
-  for (int32_t i = 0; i < numBatches; ++i) {
-    batches.push_back(fuzzer.fuzzRow(rowType_));
-  }
+  const int vectorSize = 100;
+  const std::string strValue(1L << 20, 'a');
 
-  auto plan = PlanBuilder()
-                  .values(batches)
-                  .singleAggregation({"c0", "c1"}, {"sum(c2)"})
-                  .planNode();
-  auto results = AssertQueryBuilder(plan).copyResults(pool_.get());
+  RowVectorPtr largeVector = makeRowVector(
+      {makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; }),
+       makeFlatVector<StringView>(
+           vectorSize, [&](auto /*unused*/) { return StringView(strValue); })});
+  auto largeRowType = asRowType(largeVector->type());
 
-  {
+  RowVectorPtr smallVector = makeRowVector(
+      {makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; }),
+       makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; })});
+  auto smallRowType = asRowType(smallVector->type());
+
+  struct {
+    bool smallInput;
+    uint32_t maxOutputRows;
+    uint32_t maxOutputBytes;
+    uint32_t expectedNumOutputVectors;
+
+    std::string debugString() const {
+      return fmt::format(
+          "smallInput: {} maxOutputRows: {}, maxOutputBytes: {}, expectedNumOutputVectors: {}",
+          smallInput,
+          maxOutputRows,
+          succinctBytes(maxOutputBytes),
+          expectedNumOutputVectors);
+    }
+  } testSettings[] = {
+      {true, 1000, 1000'000, 1},
+      {true, 10, 1000'000, 10},
+      {true, 1, 1000'000, 100},
+      {true, 1, 1, 100},
+      {true, 10, 1, 100},
+      {true, 100, 1, 100},
+      {true, 1000, 1, 100},
+      {false, 1000, 1, 100},
+      {false, 1000, 1000'000'000, 1},
+      {false, 100, 1000'000'000, 1},
+      {false, 10, 1000'000'000, 10},
+      {false, 1, 1000'000'000, 100},
+      {false, 1, 1, 100}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::vector<RowVectorPtr> inputs;
+    if (testData.smallInput) {
+      inputs.push_back(smallVector);
+    } else {
+      inputs.push_back(largeVector);
+    }
+    createDuckDbTable(inputs);
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    uint64_t outputBufferSize = 10UL << 20;
-    SCOPED_TRACE(fmt::format("outputBufferSize: {}", outputBufferSize));
+    core::PlanNodeId aggrNodeId;
+    auto task =
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .config(QueryConfig::kSpillEnabled, "true")
+            .config(QueryConfig::kAggregationSpillEnabled, "true")
+            // Set one spill partition to avoid the test flakiness.
+            .config(QueryConfig::kAggregationSpillPartitionBits, "0")
+            // Set the memory trigger limit to be a very small value.
+            .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
+            .config(QueryConfig::kAggregationSpillAll, "true")
+            .config(
+                QueryConfig::kPreferredOutputBatchBytes,
+                std::to_string(testData.maxOutputBytes))
+            .config(
+                QueryConfig::kPreferredOutputBatchRows,
+                std::to_string(testData.maxOutputRows))
+            .plan(PlanBuilder()
+                      .values(inputs)
+                      .singleAggregation({"c0"}, {"array_agg(c1)"})
+                      .capturePlanNodeId(aggrNodeId)
+                      .planNode())
+            .assertResults("SELECT c0, array_agg(c1) FROM tmp GROUP BY 1");
 
-    auto task = AssertQueryBuilder(plan)
-                    .spillDirectory(tempDirectory->path)
-                    .config(
-                        QueryConfig::kPreferredOutputBatchBytes,
-                        std::to_string(outputBufferSize))
-                    .config(QueryConfig::kSpillEnabled, "true")
-                    .config(QueryConfig::kAggregationSpillEnabled, "true")
-                    // Set one spill partition to avoid the test flakiness.
-                    .config(QueryConfig::kAggregationSpillPartitionBits, "0")
-                    // Set the memory trigger limit to be a very small value.
-                    .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
-                    .assertResults(results);
-
-    const auto opStats = task->taskStats().pipelineStats[0].operatorStats[1];
-    ASSERT_EQ(opStats.outputVectors, 1);
+    ASSERT_EQ(
+        toPlanStats(task->taskStats()).at(aggrNodeId).outputVectors,
+        testData.expectedNumOutputVectors);
     OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
   }
-  {
-    auto tempDirectory = exec::test::TempDirectoryPath::create();
-    uint64_t outputBufferSize = 1;
-    SCOPED_TRACE(fmt::format("outputBufferSize: {}", outputBufferSize));
+}
 
-    auto task = AssertQueryBuilder(plan)
-                    .spillDirectory(tempDirectory->path)
-                    .config(
-                        QueryConfig::kPreferredOutputBatchBytes,
-                        std::to_string(outputBufferSize))
-                    .config(QueryConfig::kSpillEnabled, "true")
-                    .config(QueryConfig::kAggregationSpillEnabled, "true")
-                    // Set one spill partition to avoid the test flakiness.
-                    .config(QueryConfig::kAggregationSpillPartitionBits, "0")
-                    // Set the memory trigger limit to be a very small value.
-                    .config(QueryConfig::kAggregationSpillMemoryThreshold, "1")
-                    .assertResults(results);
+TEST_F(AggregationTest, outputBatchSizeCheckWithoutSpill) {
+  const int vectorSize = 100;
+  const std::string strValue(1L << 20, 'a');
 
-    const auto opStats = task->taskStats().pipelineStats[0].operatorStats[1];
-    ASSERT_EQ(opStats.outputVectors, opStats.outputPositions);
-    OperatorTestBase::deleteTaskAndCheckSpillDirectory(task);
+  RowVectorPtr largeVector = makeRowVector(
+      {makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; }),
+       makeFlatVector<StringView>(
+           vectorSize, [&](auto /*unused*/) { return StringView(strValue); })});
+  auto largeRowType = asRowType(largeVector->type());
+
+  RowVectorPtr smallVector = makeRowVector(
+      {makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; }),
+       makeFlatVector<int32_t>(vectorSize, [&](auto row) { return row; })});
+  auto smallRowType = asRowType(smallVector->type());
+
+  struct {
+    bool smallInput;
+    uint32_t maxOutputRows;
+    uint32_t maxOutputBytes;
+    uint32_t expectedNumOutputVectors;
+
+    std::string debugString() const {
+      return fmt::format(
+          "smallInput: {} maxOutputRows: {}, maxOutputBytes: {}, expectedNumOutputVectors: {}",
+          smallInput,
+          maxOutputRows,
+          succinctBytes(maxOutputBytes),
+          expectedNumOutputVectors);
+    }
+  } testSettings[] = {
+      {true, 1000, 1000'000, 1},
+      {true, 10, 1000'000, 10},
+      {true, 1, 1000'000, 100},
+      {true, 1, 1, 100},
+      {true, 10, 1, 100},
+      {true, 100, 1, 100},
+      {true, 1000, 1, 100},
+      {false, 1000, 1, 100},
+      {false, 1000, 1000'000'000, 1},
+      {false, 100, 1000'000'000, 1},
+      {false, 10, 1000'000'000, 10},
+      {false, 1, 1000'000'000, 100},
+      {false, 1, 1, 100}};
+
+  for (const auto& testData : testSettings) {
+    SCOPED_TRACE(testData.debugString());
+
+    std::vector<RowVectorPtr> inputs;
+    if (testData.smallInput) {
+      inputs.push_back(smallVector);
+    } else {
+      inputs.push_back(largeVector);
+    }
+    createDuckDbTable(inputs);
+    core::PlanNodeId aggrNodeId;
+    auto task =
+        AssertQueryBuilder(duckDbQueryRunner_)
+            .config(
+                QueryConfig::kPreferredOutputBatchBytes,
+                std::to_string(testData.maxOutputBytes))
+            .config(
+                QueryConfig::kPreferredOutputBatchRows,
+                std::to_string(testData.maxOutputRows))
+            .plan(PlanBuilder()
+                      .values(inputs)
+                      .singleAggregation({"c0"}, {"array_agg(c1)"})
+                      .capturePlanNodeId(aggrNodeId)
+                      .planNode())
+            .assertResults("SELECT c0, array_agg(c1) FROM tmp GROUP BY 1");
+
+    ASSERT_EQ(
+        toPlanStats(task->taskStats()).at(aggrNodeId).outputVectors,
+        testData.expectedNumOutputVectors);
   }
 }
 


### PR DESCRIPTION
In Meta internal memory arbitration and spilling test, we found query can OOM during
output processing stage. In some query, the first output can generate ~1GB data
with 1000 rows limit set in query config as we don't know the average the row size
(which is based on historical data) on the first output.

This change makes hash aggregation produce output based on the actual data size
instead of historical data based estimation. This prevents aggregation query from
running out of memory on aggregation output stage.