### PR TITLE
Fix cyclic dependency velox_exec <-> velox_codegen

### DIFF
--- a/pyvelox/CMakeLists.txt
+++ b/pyvelox/CMakeLists.txt
@@ -34,6 +34,7 @@ if(VELOX_BUILD_PYTHON_PACKAGE)
             velox_exec
             velox_functions_prestosql
             velox_parse_parser
+            velox_parse_utils
             velox_functions_prestosql
             velox_functions_spark)
 

--- a/velox/codegen/CMakeLists.txt
+++ b/velox/codegen/CMakeLists.txt
@@ -16,6 +16,5 @@ add_library(velox_codegen Codegen.cpp)
 if(${VELOX_CODEGEN_SUPPORT})
   target_link_libraries(velox_codegen velox_experimental_codegen)
 else()
-  target_link_libraries(velox_codegen velox_core velox_exec velox_expression
-                        glog::glog)
+  target_link_libraries(velox_codegen velox_core velox_expression glog::glog)
 endif()

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_test(velox_base_test velox_base_test)
 target_link_libraries(
   velox_base_test
   PRIVATE velox_common_base
+          velox_test_util
           velox_time
           velox_status
           velox_exception

--- a/velox/common/caching/tests/CMakeLists.txt
+++ b/velox/common/caching/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ target_link_libraries(
           velox_file
           velox_memory
           velox_temp_path
+          velox_test_util
           Folly::folly
           glog::glog
           gtest

--- a/velox/common/time/tests/CMakeLists.txt
+++ b/velox/common/time/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ include(GoogleTest)
 
 add_executable(velox_time_test CpuWallTimerTest.cpp)
 
-target_link_libraries(velox_time_test PRIVATE velox_time glog::glog gtest
-                                              gtest_main)
+target_link_libraries(velox_time_test PRIVATE velox_exception velox_time
+                                              glog::glog gtest gtest_main)
 
 gtest_add_tests(velox_time_test "" AUTO)

--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -77,4 +77,5 @@ target_link_libraries(
   velox_exec
   Boost::regex
   Folly::folly
-  glog::glog)
+  glog::glog
+  ${Protobuf_LIBRARIES})

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ target_link_libraries(
   velox_e2e_filter_test_base
   velox_functions_prestosql
   velox_parse_parser
+  velox_parse_utils
   velox_vector_test_lib
   velox_link_libs
   Folly::folly

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -348,6 +348,7 @@ target_link_libraries(
   velox_dwrf_e2e_filter_test
   velox_e2e_filter_test_base
   velox_link_libs
+  velox_parse_utils
   velox_test_util
   Folly::folly
   fmt::fmt

--- a/velox/exec/fuzzer/CMakeLists.txt
+++ b/velox/exec/fuzzer/CMakeLists.txt
@@ -29,7 +29,6 @@ target_link_libraries(
   velox_dwio_dwrf_reader
   velox_dwio_dwrf_writer
   velox_type
-  velox_vector_fuzzer
   velox_exec_test_lib
   velox_expression_test_utility
   velox_vector
@@ -38,10 +37,5 @@ target_link_libraries(
 add_library(velox_aggregation_fuzzer AggregationFuzzer.cpp)
 
 target_link_libraries(
-  velox_aggregation_fuzzer
-  velox_type
-  velox_vector_fuzzer
-  velox_exec_test_lib
-  velox_expression_test_utility
-  velox_aggregation_fuzzer_base
-  velox_fuzzer_util)
+  velox_aggregation_fuzzer velox_type velox_exec_test_lib
+  velox_expression_test_utility velox_aggregation_fuzzer_base velox_fuzzer_util)

--- a/velox/exec/tests/utils/CMakeLists.txt
+++ b/velox/exec/tests/utils/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
   velox_exception
   velox_expression
   velox_parse_parser
+  velox_parse_utils
   velox_duckdb_conversion
   velox_dwio_common
   velox_dwio_dwrf_reader
@@ -49,4 +50,5 @@ target_link_libraries(
   velox_tpch_connector
   velox_presto_serializer
   velox_functions_prestosql
-  velox_aggregates)
+  velox_aggregates
+  velox_vector_fuzzer)

--- a/velox/parse/CMakeLists.txt
+++ b/velox/parse/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 add_library(velox_parse_expression Expressions.cpp)
-target_link_libraries(velox_parse_expression velox_type velox_parse_utils
+target_link_libraries(velox_parse_expression velox_type velox_function_registry
                       velox_expression velox_exec)
 
 add_library(velox_parse_parser ExpressionsParser.cpp QueryPlanner.cpp)
@@ -20,8 +20,8 @@ target_link_libraries(velox_parse_parser velox_parse_expression velox_type
                       velox_duckdb_parser)
 
 add_library(velox_parse_utils TypeResolver.cpp)
-target_link_libraries(velox_parse_utils velox_buffer velox_type velox_vector
-                      velox_function_registry)
+target_link_libraries(velox_parse_utils velox_buffer velox_parse_expression
+                      velox_type velox_vector velox_function_registry)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/tpch/gen/dbgen/CMakeLists.txt
+++ b/velox/tpch/gen/dbgen/CMakeLists.txt
@@ -1,3 +1,16 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 cmake_minimum_required(VERSION 3.0.0)
 cmake_policy(SET CMP0063 NEW)
 
@@ -18,6 +31,7 @@ add_library(
   text.cpp)
 
 target_include_directories(velox_dbgen PRIVATE include)
+target_link_libraries(velox_dbgen duckdb)
 
 # Suppress warnings when compiling dbgen.
 target_compile_options(velox_dbgen PRIVATE -w)


### PR DESCRIPTION
When shared library build it turned on (by adding `set(BUILD_SHARED_LIBS ON)` prior to the velox directory in the main `CMakeList.txt`), then it fails with

```
CMake Error: The inter-target dependency graph contains the following strongly connected component (cycle):
  "velox_exec" of type SHARED_LIBRARY
    depends on "velox_codegen" (weak)
  "velox_codegen" of type SHARED_LIBRARY
    depends on "velox_exec" (weak)
At least one of these targets is not a STATIC_LIBRARY. 
```

After resolving the dependency various modules fail due to missing symbols.

```
/usr/bin/ld: velox/parse/libvelox_parse_utils.so: undefined reference to `facebook::velox::core::Expressions::resolverHook_'
collect2: error: ld returned 1 exit status
```

```
/usr/bin/ld: velox/exec/tests/utils/libvelox_exec_test_lib.so: undefined reference to `facebook::velox::parse::registerTypeResolver()'
/usr/bin/ld: velox/exec/tests/utils/libvelox_exec_test_lib.so: undefined reference to `facebook::velox::parse::resolveScalarFunctionType(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<std::shared_ptr<facebook::velox::Type const>, std::allocator<std::shared_ptr<facebook::velox::Type const> > > const&, bool)'
/usr/bin/ld: velox/exec/tests/utils/libvelox_exec_test_lib.so: undefined reference to `facebook::velox::VectorFuzzer::fuzzInputRow(std::shared_ptr<facebook::velox::RowType const> const&)'
collect2: error: ld returned 1 exit status
```

```
/usr/bin/ld: velox/external/duckdb/tpch/dbgen/libdbgen.a(dbgen.cpp.o): undefined reference to symbol '_ZN6duckdb17NotNullConstraintC1Em'
/usr/bin/ld: velox/external/duckdb/libduckdb.so: error adding symbols: DSO missing from command line
```

The additional changes reflect fixing the dependencies.

There is still an issue with the Google `typeinfo for google::protobuf::io::ZeroCopyOutputStream` where two issues have been raised for (and so maybe use a different PR to fix this). This also occurs when using shared libraries.

