### PR TITLE
Address missing snappy.h on Mac when VELOX_ENABLE_PARQUET is ON

### DIFF
--- a/velox/dwio/parquet/writer/arrow/util/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/util/CMakeLists.txt
@@ -15,4 +15,5 @@
 add_library(velox_dwio_arrow_parquet_writer_util_lib
             Compression.cpp CompressionSnappy.cpp Hashing.cpp Crc32.cpp)
 
-target_link_libraries(velox_dwio_arrow_parquet_writer_util_lib parquet arrow)
+target_link_libraries(velox_dwio_arrow_parquet_writer_util_lib parquet arrow
+                      Snappy::snappy)


### PR DESCRIPTION
On MacOS when VELOX_ENABLE_PARQUET is ON the build fails with

```
FAILED: velox/dwio/parquet/writer/arrow/util/CMakeFiles/velox_dwio_arrow_parquet_writer_util_lib.dir/CompressionSnappy.cpp.o 
ccache /Library/Developer/CommandLineTools/usr/bin/c++ -DFOLLY_HAVE_INT128_T=1 -DVELOX_ENABLE_PARQUET -I/Users/czentgr/gitspace/velox/_build/debug/_deps/protobuf-src/src -I/Users/czentgr/gitspace/velox/. -I/Users/czentgr/gitspace/velox/velox/external/xxhash -isystem /Users/czentgr/gitspace/velox/velox -isystem /Users/czentgr/gitspace/velox/velox/external -isystem /Users/czentgr/gitspace/velox/velox/external/duckdb -isystem /Users/czentgr/gitspace/velox/velox/external/duckdb/tpch/dbgen/include -isystem /Users/czentgr/gitspace/velox/_build/debug/third_party/arrow_ep/install/include -isystem /Users/czentgr/gitspace/velox/_build/debug/third_party/arrow_ep/src/arrow_ep-build/thrift_ep-install/include -mcpu=apple-m1+crc -std=c++17 -fvisibility=hidden -D USE_VELOX_COMMON_BASE -D HAS_UNCAUGHT_EXCEPTIONS -Wall -Wextra -Wno-unused        -Wno-unused-parameter        -Wno-sign-compare        -Wno-ignored-qualifiers        -Wno-range-loop-analysis          -Wno-mismatched-tags          -Wno-nullability-completeness -Werror -g -std=gnu++17 -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX14.0.sdk -mmacosx-version-min=13.5 -fPIC -MD -MT velox/dwio/parquet/writer/arrow/util/CMakeFiles/velox_dwio_arrow_parquet_writer_util_lib.dir/CompressionSnappy.cpp.o -MF velox/dwio/parquet/writer/arrow/util/CMakeFiles/velox_dwio_arrow_parquet_writer_util_lib.dir/CompressionSnappy.cpp.o.d -o velox/dwio/parquet/writer/arrow/util/CMakeFiles/velox_dwio_arrow_parquet_writer_util_lib.dir/CompressionSnappy.cpp.o -c /Users/czentgr/gitspace/velox/velox/dwio/parquet/writer/arrow/util/CompressionSnappy.cpp
/Users/czentgr/gitspace/velox/velox/dwio/parquet/writer/arrow/util/CompressionSnappy.cpp:25:10: fatal error: 'snappy.h' file not found
#include <snappy.h>
         ^~~~~~~~~~
1 error generated.
```

The issue is that Snappy is not recognized as dependency. Thus, the header include is missing when compiling.