### PR TITLE
Fix Timestamp::toTimezone for negative timestamps

### DIFF
--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -688,6 +688,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(0, hour(Timestamp(0, 0)));
   EXPECT_EQ(23, hour(Timestamp(-1, 9000)));
+  EXPECT_EQ(23, hour(Timestamp(-1, Timestamp::kMaxNanos)));
   EXPECT_EQ(7, hour(Timestamp(4000000000, 0)));
   EXPECT_EQ(7, hour(Timestamp(4000000000, 123000000)));
   EXPECT_EQ(10, hour(Timestamp(998474645, 321000000)));
@@ -697,7 +698,7 @@ TEST_F(DateTimeFunctionsTest, hour) {
 
   EXPECT_EQ(std::nullopt, hour(std::nullopt));
   EXPECT_EQ(13, hour(Timestamp(0, 0)));
-  EXPECT_EQ(13, hour(Timestamp(-1, Timestamp::kMaxNanos)));
+  EXPECT_EQ(12, hour(Timestamp(-1, Timestamp::kMaxNanos)));
   // Disabled for now because the TZ for Pacific/Apia in 2096 varies between
   // systems.
   // EXPECT_EQ(21, hour(Timestamp(4000000000, 0)));
@@ -3061,7 +3062,7 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
           fromTimestampString("2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));
   EXPECT_EQ(
-      "-2000-02-29 05:53:29.987000",
+      "-2000-02-29 05:53:28.987000",
       dateFormat(
           fromTimestampString("-2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));
@@ -3082,7 +3083,7 @@ TEST_F(DateTimeFunctionsTest, dateFormat) {
           fromTimestampString("2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));
   EXPECT_EQ(
-      "-2000-02-28 16:07:03.987000",
+      "-2000-02-28 16:07:02.987000",
       dateFormat(
           fromTimestampString("-2000-02-29 00:00:00.987"),
           "%Y-%m-%d %H:%i:%s.%f"));

--- a/velox/type/Timestamp.cpp
+++ b/velox/type/Timestamp.cpp
@@ -94,9 +94,8 @@ void validateTimePoint(const std::chrono::time_point<
 
 std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds>
 Timestamp::toTimePoint() const {
-  auto tp = std::chrono::
-      time_point<std::chrono::system_clock, std::chrono::milliseconds>(
-          std::chrono::milliseconds(toMillis()));
+  using namespace std::chrono;
+  auto tp = time_point<system_clock, milliseconds>(milliseconds(toMillis()));
   validateTimePoint(tp);
   return tp;
 }
@@ -104,7 +103,8 @@ Timestamp::toTimePoint() const {
 void Timestamp::toTimezone(const date::time_zone& zone) {
   auto tp = toTimePoint();
   auto epoch = zone.to_local(tp).time_since_epoch();
-  seconds_ = std::chrono::duration_cast<std::chrono::seconds>(epoch).count();
+  // NOTE: Round down to get the seconds of the current time point.
+  seconds_ = std::chrono::floor<std::chrono::seconds>(epoch).count();
 }
 
 void Timestamp::toTimezone(int16_t tzID) {


### PR DESCRIPTION
The value of `seconds_` in `Timepstamp` is the starting point of one 
second, so when converting a `time_point` from milliseconds to seconds, 
it should always be rounded down.

However, `std::chrono::duration_cast` will always round to 0, so for 
negative numbers (times before 1970-01-01 00:00:00), the result will 
be wrong(will differ from the correct result 1 second).

Correcting the rounding behavior also affects the unit test of 
`date_format`, which is also fixed in this PR.

Fixes #6489 and #6787. 