### PR TITLE
Fail if inputs contain nested nulls in min/max::toIntermediate

### DIFF
--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 #include "velox/common/file/FileSystems.h"
 #include "velox/connectors/hive/HiveConnector.h"
@@ -43,7 +44,16 @@ namespace facebook::velox::functions::aggregate::test {
 
 namespace {
 constexpr const char* kHiveConnectorId = "test-hive";
+
+void enableAbandonPartialAggregation(AssertQueryBuilder& queryBuilder) {
+  queryBuilder.config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
+      .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
+      .config(core::QueryConfig::kMaxPartialAggregationMemory, "0")
+      .config(core::QueryConfig::kMaxExtendedPartialAggregationMemory, "0")
+      .maxDrivers(1);
 }
+
+} // namespace
 
 std::vector<RowVectorPtr> AggregationTestBase::makeVectors(
     const RowTypePtr& rowType,
@@ -741,12 +751,8 @@ void AggregationTestBase::testAggregations(
     }
 
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
-    queryBuilder.configs(config)
-        .config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
-        .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
-        .config(core::QueryConfig::kMaxPartialAggregationMemory, "0")
-        .config(core::QueryConfig::kMaxExtendedPartialAggregationMemory, "0")
-        .maxDrivers(1);
+    queryBuilder.configs(config);
+    enableAbandonPartialAggregation(queryBuilder);
 
     auto task = assertResults(queryBuilder);
 
@@ -999,24 +1005,91 @@ VectorPtr AggregationTestBase::testStreaming(
   return result;
 }
 
-void AggregationTestBase::testToIntermediate(
+void AggregationTestBase::testFailingAggregations(
     const std::vector<RowVectorPtr>& data,
     const std::vector<std::string>& groupingKeys,
     const std::vector<std::string>& aggregates,
+    const std::string& expectedMessage,
     const std::unordered_map<std::string, std::string>& config) {
-  auto builder = PlanBuilder().values(data);
-  builder.partialAggregation(groupingKeys, aggregates)
-      .intermediateAggregation()
-      .finalAggregation();
-  AssertQueryBuilder queryBuilder(builder.planNode());
-  queryBuilder.config(core::QueryConfig::kAbandonPartialAggregationMinRows, "1")
-      .config(core::QueryConfig::kAbandonPartialAggregationMinPct, "0")
-      .config(core::QueryConfig::kMaxPartialAggregationMemory, "0")
-      .config(core::QueryConfig::kMaxExtendedPartialAggregationMemory, "0")
-      .maxDrivers(1);
-  for (const auto& [key, value] : config) {
-    queryBuilder.config(key, value);
+  {
+    SCOPED_TRACE("Run single");
+    auto builder = PlanBuilder().values(data);
+    builder.singleAggregation(groupingKeys, aggregates);
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
   }
-  queryBuilder.copyResults(pool());
+
+  {
+    SCOPED_TRACE("Run partial + final");
+    auto builder = PlanBuilder().values(data);
+    builder.partialAggregation(groupingKeys, aggregates).finalAggregation();
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
+  }
+
+  {
+    SCOPED_TRACE("Run partial + final with abandon partial agg");
+    auto builder = PlanBuilder().values(data);
+    builder.partialAggregation(groupingKeys, aggregates)
+        .intermediateAggregation()
+        .finalAggregation();
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    enableAbandonPartialAggregation(queryBuilder);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
+  }
+
+  {
+    SCOPED_TRACE("Run partial + intermediate + final");
+    auto builder = PlanBuilder().values(data);
+    builder.partialAggregation(groupingKeys, aggregates)
+        .intermediateAggregation()
+        .finalAggregation();
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
+  }
+
+  if (!groupingKeys.empty()) {
+    SCOPED_TRACE("Run partial + local exchange + final");
+    auto builder = PlanBuilder().values(data);
+    builder.partialAggregation(groupingKeys, aggregates)
+        .localPartition(groupingKeys)
+        .finalAggregation();
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
+  }
+
+  {
+    SCOPED_TRACE(
+        "Run partial + local exchange + intermediate + local exchange + final");
+    auto builder = PlanBuilder().values(data);
+    builder.partialAggregation(groupingKeys, aggregates);
+
+    if (groupingKeys.empty()) {
+      builder.localPartitionRoundRobinRow();
+    } else {
+      builder.localPartition(groupingKeys);
+    }
+
+    builder.intermediateAggregation()
+        .localPartition(groupingKeys)
+        .finalAggregation();
+
+    AssertQueryBuilder queryBuilder(builder.planNode());
+    queryBuilder.configs(config);
+    VELOX_ASSERT_THROW(queryBuilder.copyResults(pool()), expectedMessage);
+  }
+
+  if (testStreaming_ && groupingKeys.empty()) {
+    SCOPED_TRACE("Streaming");
+    auto makeSource = [&](PlanBuilder& builder) { builder.values(data); };
+    VELOX_ASSERT_THROW(
+        validateStreamingInTestAggregations(makeSource, aggregates, config),
+        expectedMessage);
+  }
 }
 } // namespace facebook::velox::functions::aggregate::test

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -206,12 +206,15 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
         });
   }
 
-  /// Use abandon-partial-aggregation optimization to trigger the toIntermediate
-  /// code path.
-  void testToIntermediate(
+  /// Generates a variety of logically equivalent plans to compute aggregations
+  /// using combinations of partial, final, single, and intermediate
+  /// aggregations with and without local exchanges. Runs all these plans and
+  /// verifies they all fail with the specified error message.
+  void testFailingAggregations(
       const std::vector<RowVectorPtr>& data,
       const std::vector<std::string>& groupingKeys,
       const std::vector<std::string>& aggregates,
+      const std::string& expectedMessage,
       const std::unordered_map<std::string, std::string>& config = {});
 
   /// Specifies that aggregate functions used in this test are not sensitive

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.h
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.h
@@ -206,6 +206,14 @@ class AggregationTestBase : public exec::test::OperatorTestBase {
         });
   }
 
+  /// Use abandon-partial-aggregation optimization to trigger the toIntermediate
+  /// code path.
+  void testToIntermediate(
+      const std::vector<RowVectorPtr>& data,
+      const std::vector<std::string>& groupingKeys,
+      const std::vector<std::string>& aggregates,
+      const std::unordered_map<std::string, std::string>& config = {});
+
   /// Specifies that aggregate functions used in this test are not sensitive
   /// to the order of inputs.
   void allowInputShuffle() {

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -307,6 +307,12 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       std::vector<VectorPtr>& args,
       VectorPtr& result) const override {
     const auto& input = args[0];
+
+    if (throwOnNestedNulls_) {
+      DecodedVector decoded(*input, rows, true);
+      rows.applyToSelected([&](vector_size_t i) { checkNulls(decoded, i); });
+    }
+
     if (rows.isAllSelected()) {
       result = input;
       return;
@@ -427,7 +433,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     });
   }
 
-  bool checkNulls(const DecodedVector& decoded, vector_size_t index) {
+  bool checkNulls(const DecodedVector& decoded, vector_size_t index) const {
     if (decoded.isNullAt(index)) {
       return true;
     }

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -389,49 +389,6 @@ TEST_F(MinMaxTest, row) {
 }
 
 TEST_F(MinMaxTest, arrayCheckNulls) {
-  auto data = makeRowVector({
-      makeNullableArrayVector<int64_t>({
-          {1, 2},
-          {2, std::nullopt},
-          {6, 7},
-      }),
-  });
-
-  for (const auto& expr : {"min(c0)", "max(c0)"}) {
-    auto plan =
-        PlanBuilder().values({data}).singleAggregation({}, {expr}).planNode();
-    VELOX_ASSERT_THROW(
-        AssertQueryBuilder(plan).copyResults(pool()),
-        "ARRAY comparison not supported for values that contain nulls");
-  }
-}
-
-TEST_F(MinMaxTest, rowCheckNull) {
-  auto data = makeRowVector({
-      makeRowVector({
-          makeFlatVector<StringView>({
-              "a"_sv,
-              "b"_sv,
-              "c"_sv,
-          }),
-          makeNullableFlatVector<StringView>({
-              "aa"_sv,
-              std::nullopt,
-              "cc"_sv,
-          }),
-      }),
-  });
-
-  for (const auto& expr : {"min(c0)", "max(c0)"}) {
-    auto plan =
-        PlanBuilder().values({data}).singleAggregation({}, {expr}).planNode();
-    VELOX_ASSERT_THROW(
-        AssertQueryBuilder(plan).copyResults(pool()),
-        "ROW comparison not supported for values that contain nulls");
-  }
-}
-
-TEST_F(MinMaxTest, toIntermediateNullCheck) {
   auto batch = makeRowVector({
       makeArrayVectorFromJson<int32_t>({
           "[1, 2]",
@@ -459,9 +416,63 @@ TEST_F(MinMaxTest, toIntermediateNullCheck) {
   });
 
   for (const auto& expr : {"min(c0)", "max(c0)"}) {
-    VELOX_ASSERT_THROW(
-        testToIntermediate({batch, batchWithNull}, {"c1"}, {expr}),
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {},
+        {expr},
         "ARRAY comparison not supported for values that contain nulls");
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {"c1"},
+        {expr},
+        "ARRAY comparison not supported for values that contain nulls");
+  }
+}
+
+TEST_F(MinMaxTest, rowCheckNull) {
+  auto batch = makeRowVector({
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              "bb"_sv,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  auto batchWithNull = makeRowVector({
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              std::nullopt,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  for (const auto& expr : {"min(c0)", "max(c0)"}) {
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {},
+        {expr},
+        "ROW comparison not supported for values that contain nulls");
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {"c1"},
+        {expr},
+        "ROW comparison not supported for values that contain nulls");
   }
 }
 


### PR DESCRIPTION
`toIntermediate`  is an adaptive optimization to abandon partial
aggregation that has no meaningful cardinality reduction. For min/max
aggregates `toIntermediate` act as follows,

- Raw data in raw data out (sometimes with dictionary encoding)
- It happens in step ofStep::kPartial
- Its result is the input of another step Step::kIntermediate\Step::kFinal,
  which would not check nested nulls of the input, causing no null checks for
  the rest of the raw input.

This is a follow-up to #6723. `NonNumericMinMaxAggregateBase::toIntermediate`
also needs to check complex type inputs and throw if there are nested nulls. 
