### PR TITLE
Remove Presto-specific logic from AggregationFuzzerRunner.h

### DIFF
--- a/velox/exec/tests/AggregationRunnerTest.cpp
+++ b/velox/exec/tests/AggregationRunnerTest.cpp
@@ -77,6 +77,6 @@ int main(int argc, char** argv) {
 
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();
-  return exec::test::AggregationFuzzerRunner::run(
+  return exec::test::AggregationFuzzerRunner::runRepro(
       FLAGS_plan_nodes_path, std::move(duckQueryRunner));
 }

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -75,10 +75,9 @@ int main(int argc, char** argv) {
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();
-  return facebook::velox::exec::test::AggregationFuzzerRunner::runFuzzer(
+  return facebook::velox::exec::test::AggregationFuzzerRunner::run(
       FLAGS_only,
       initialSeed,
-      std::nullopt,
       std::move(duckQueryRunner),
       skipFunctions,
       customVerificationFunctions);


### PR DESCRIPTION
Move skip and custom-verification Presto-specific function lists from
AggregationFuzzerRunner.h into AggregationFuzzerTest.cpp. 

Would be nice to rename AggregationFuzzerTest.cpp to
PrestoAggregationFuzzerTest.cpp in a follow-up.