### PR TITLE
Allow specifying timestamp precision and query configs in AggregationFuzzer

### DIFF
--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -114,10 +114,13 @@ int main(int argc, char** argv) {
           {"sum_data_size_for_stats", ""},
       };
 
-  return facebook::velox::exec::test::AggregationFuzzerRunner::run(
-      FLAGS_only,
-      initialSeed,
-      std::move(duckQueryRunner),
-      skipFunctions,
-      customVerificationFunctions);
+  using Runner = facebook::velox::exec::test::AggregationFuzzerRunner;
+
+  Runner::Options options;
+  options.onlyFunctions = FLAGS_only;
+  options.skipFunctions = skipFunctions;
+  options.customVerificationFunctions = customVerificationFunctions;
+  options.timestampPrecision =
+      facebook::velox::VectorFuzzer::Options::TimestampPrecision::kMilliSeconds;
+  return Runner::run(initialSeed, std::move(duckQueryRunner), options);
 }

--- a/velox/exec/tests/SparkAggregationFuzzerTest.cpp
+++ b/velox/exec/tests/SparkAggregationFuzzerTest.cpp
@@ -75,10 +75,12 @@ int main(int argc, char** argv) {
   size_t initialSeed = FLAGS_seed == 0 ? std::time(nullptr) : FLAGS_seed;
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();
-  return facebook::velox::exec::test::AggregationFuzzerRunner::run(
-      FLAGS_only,
-      initialSeed,
-      std::move(duckQueryRunner),
-      skipFunctions,
-      customVerificationFunctions);
+
+  using Runner = facebook::velox::exec::test::AggregationFuzzerRunner;
+
+  Runner::Options options;
+  options.onlyFunctions = FLAGS_only;
+  options.skipFunctions = skipFunctions;
+  options.customVerificationFunctions = customVerificationFunctions;
+  return Runner::run(initialSeed, std::move(duckQueryRunner), options);
 }

--- a/velox/exec/tests/utils/AggregationFuzzer.h
+++ b/velox/exec/tests/utils/AggregationFuzzer.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/tests/utils/ReferenceQueryRunner.h"
+#include "velox/vector/fuzzer/VectorFuzzer.h"
 
 namespace facebook::velox::exec::test {
 
@@ -35,6 +36,8 @@ void aggregateFuzzer(
     AggregateFunctionSignatureMap signatureMap,
     size_t seed,
     const std::unordered_map<std::string, std::string>& orderDependentFunctions,
+    VectorFuzzer::Options::TimestampPrecision timestampPrecision,
+    const std::unordered_map<std::string, std::string>& queryConfigs,
     const std::optional<std::string>& planPath,
     std::unique_ptr<ReferenceQueryRunner> referenceQueryRunner);
 } // namespace facebook::velox::exec::test


### PR DESCRIPTION
AggregationFuzzer is used for both Presto and Spark function packages. These
support different precision for timestamp values and have different query
configs that affect function semantics. Allow to specify these when
instantiating the fuzzer.