### PR TITLE
Fix set_union Presto aggregate

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -198,6 +198,8 @@ General Aggregate Functions
 
     Returns an array of all the distinct values contained in each array of the input.
 
+    Returns an empty array if all input arrays are NULL.
+
     Example::
 
         SELECT set_union(elements)

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -66,6 +66,7 @@ TEST_F(SetAggTest, global) {
   });
 
   expected = makeRowVector({
+      // An Array with a single NULL element: [null].
       makeNullableArrayVector(
           std::vector<std::vector<std::optional<int32_t>>>{{std::nullopt}}),
   });


### PR DESCRIPTION
set_union semantics in Presto are non-intuitive. When all inputs are null,
set_union returns an empty array, not a null.

Fixes #6720