### PR TITLE
Optimize Timestamp::toString

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -46,6 +46,10 @@ int main(int argc, char** argv) {
       },
       nullptr,
       DECIMAL(38, 16));
+  auto timestampInput =
+      vectorMaker.flatVector<Timestamp>(vectorSize, [&](auto j) {
+        return Timestamp(1695859694 + j / 1000, j % 1000 * 1'000'000);
+      });
 
   invalidInput->resize(vectorSize);
   validInput->resize(vectorSize);
@@ -66,13 +70,15 @@ int main(int argc, char** argv) {
                "nan",
                "decimal",
                "short_decimal",
-               "long_decimal"},
+               "long_decimal",
+               "timestamp"},
               {validInput,
                invalidInput,
                nanInput,
                decimalInput,
                shortDecimalInput,
-               longDecimalInput}))
+               longDecimalInput,
+               timestampInput}))
       .addExpression("try_cast_invalid_empty_input", "try_cast (empty as int) ")
       .addExpression(
           "tryexpr_cast_invalid_empty_input", "try (cast (empty as int))")
@@ -85,6 +91,7 @@ int main(int argc, char** argv) {
           "cast_decimal_to_inline_string", "cast (decimal as varchar)")
       .addExpression("cast_short_decimal", "cast (short_decimal as varchar)")
       .addExpression("cast_long_decimal", "cast (long_decimal as varchar)")
+      .addExpression("cast_timestamp", "cast (timestamp as varchar)")
       .withIterations(100)
       .disableTesting();
 

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -265,31 +265,7 @@ struct Timestamp {
   };
 
   std::string toString(
-      const Precision& precision = Precision::kNanoseconds) const {
-    // gmtime is not thread-safe. Make sure to use gmtime_r.
-    std::tm tmValue;
-    VELOX_USER_CHECK_NOT_NULL(
-        gmtime_r((const time_t*)&seconds_, &tmValue),
-        "Can't convert seconds to time: {}",
-        folly::to<std::string>(seconds_));
-
-    // return ISO 8601 time format.
-    // %F - equivalent to "%Y-%m-%d" (the ISO 8601 date format)
-    // T - literal T
-    // %T - equivalent to "%H:%M:%S" (the ISO 8601 time format)
-    // so this return time in the format
-    // %Y-%m-%dT%H:%M:%S.nnnnnnnnn for nanoseconds precision, or
-    // %Y-%m-%dT%H:%M:%S.nnn for milliseconds precision
-    // Note there is no Z suffix, which denotes UTC timestamp.
-    auto width = static_cast<int>(precision);
-    auto value =
-        precision == Precision::kMilliseconds ? nanos_ / 1'000'000 : nanos_;
-    std::ostringstream oss;
-    oss << std::put_time(&tmValue, "%FT%T");
-    oss << '.' << std::setfill('0') << std::setw(width) << value;
-
-    return oss.str();
-  }
+      const Precision& precision = Precision::kNanoseconds) const;
 
   operator std::string() const {
     return toString();


### PR DESCRIPTION
Summary:
Rewrite `Timestamp::toString` to optimize it 8 times faster.  Changes include:
1. Replace `gmtime_r` to avoid expensive lock in `__tz_convert` under high concurrency.
2. Replace `std::put_time` (`strftime` under the hood) with more efficient calculation.
3. Avoid inefficient `ostringstream` and directly operate on result string.

Differential Revision: D49733818


