### PR TITLE
[dwio][1/n] Refactor dwio::ReaderOptions

### DIFF
--- a/velox/common/io/CMakeLists.txt
+++ b/velox/common/io/CMakeLists.txt
@@ -11,16 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_subdirectory(base)
-add_subdirectory(caching)
-add_subdirectory(compression)
-add_subdirectory(config)
-add_subdirectory(encode)
-add_subdirectory(file)
-add_subdirectory(hyperloglog)
-add_subdirectory(io)
-add_subdirectory(memory)
-add_subdirectory(process)
-add_subdirectory(serialization)
-add_subdirectory(time)
-add_subdirectory(testutil)
+add_library(velox_common_io INTERFACE)

--- a/velox/common/io/Options.h
+++ b/velox/common/io/Options.h
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::velox::io {
+
+constexpr uint64_t DEFAULT_AUTO_PRELOAD_SIZE =
+    (static_cast<const uint64_t>((1ul << 20) * 72));
+
+/**
+ * Mode for prefetching data.
+ *
+ * This mode may be ignored for a reader, such as DWRF, where it does not
+ * make sense.
+ *
+ * To enable single-buffered reading, using the default autoPreloadLength:
+ *         ReaderOptions readerOpts;
+ *         readerOpts.setPrefetchMode(PrefetchMode::PRELOAD);
+ * To enable double-buffered reading, using the default autoPreloadLength:
+ *         ReaderOptions readerOpts;
+ *         readerOpts.setPrefetchMode(PrefetchMode::PREFETCH);
+ * To select unbuffered reading:
+ *         ReaderOptions readerOpts;
+ *         readerOpts.setPrefetchMode(PrefetchMode::NOT_SET);
+ *
+ * Single-buffered reading (as in dwio::PreloadableInputStream)
+ * reads ahead into a buffer.   Double-buffered reading additionally reads
+ * asynchronously into a second buffer, swaps the buffers when the
+ * first is fully consumed and the second has been filled, and then starts
+ * a new parallel read.  For clients with a slow network connection to
+ * Warm Storage, enabling PREFETCH reduces elapsed time by 10% or more,
+ * at the cost of a second buffer.   The relative improvment would be greater
+ * for cases where the network throughput is higher.
+ */
+enum class PrefetchMode {
+  NOT_SET = 0,
+  PRELOAD = 1, // read a buffer of autoPreloadLength bytes on a read beyond the
+               // current buffer, if any.
+  PREFETCH = 2, // read a second buffer of autoPreloadLength bytes ahead of
+                // actual reads.
+};
+
+class ReaderOptions {
+ protected:
+  velox::memory::MemoryPool* memoryPool;
+  uint64_t autoPreloadLength;
+  PrefetchMode prefetchMode;
+  int32_t loadQuantum_{kDefaultLoadQuantum};
+  int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
+  int64_t maxCoalesceBytes_{kDefaultCoalesceBytes};
+
+ public:
+  static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
+  static constexpr int32_t kDefaultCoalesceDistance = 512 << 10; // 512K
+  static constexpr int32_t kDefaultCoalesceBytes = 128 << 20; // 128M
+
+  explicit ReaderOptions(velox::memory::MemoryPool* pool)
+      : memoryPool(pool),
+        autoPreloadLength(DEFAULT_AUTO_PRELOAD_SIZE),
+        prefetchMode(PrefetchMode::PREFETCH) {}
+
+  ReaderOptions& operator=(const ReaderOptions& other) {
+    memoryPool = other.memoryPool;
+    autoPreloadLength = other.autoPreloadLength;
+    prefetchMode = other.prefetchMode;
+    maxCoalesceDistance_ = other.maxCoalesceDistance_;
+    maxCoalesceBytes_ = other.maxCoalesceBytes_;
+    return *this;
+  }
+
+  ReaderOptions(const ReaderOptions& other) {
+    *this = other;
+  }
+
+  /**
+   * Set the memory allocator.
+   */
+  ReaderOptions& setMemoryPool(velox::memory::MemoryPool& pool) {
+    memoryPool = &pool;
+    return *this;
+  }
+
+  /**
+   * Modify the autoPreloadLength
+   */
+  ReaderOptions& setAutoPreloadLength(uint64_t len) {
+    autoPreloadLength = len;
+    return *this;
+  }
+
+  /**
+   * Modify the prefetch mode.
+   */
+  ReaderOptions& setPrefetchMode(PrefetchMode mode) {
+    prefetchMode = mode;
+    return *this;
+  }
+
+  /**
+   * Modify the load quantum.
+   */
+  ReaderOptions& setLoadQuantum(int32_t quantum) {
+    loadQuantum_ = quantum;
+    return *this;
+  }
+  /**
+   * Modify the maximum load coalesce distance.
+   */
+  ReaderOptions& setMaxCoalesceDistance(int32_t distance) {
+    maxCoalesceDistance_ = distance;
+    return *this;
+  }
+  /**
+   * Modify the maximum load coalesce bytes.
+   */
+  ReaderOptions& setMaxCoalesceBytes(int64_t bytes) {
+    maxCoalesceBytes_ = bytes;
+    return *this;
+  }
+
+  /**
+   * Get the memory allocator.
+   */
+  velox::memory::MemoryPool& getMemoryPool() const {
+    return *memoryPool;
+  }
+
+  uint64_t getAutoPreloadLength() const {
+    return autoPreloadLength;
+  }
+
+  PrefetchMode getPrefetchMode() const {
+    return prefetchMode;
+  }
+
+  int32_t loadQuantum() const {
+    return loadQuantum_;
+  }
+
+  int32_t maxCoalesceDistance() const {
+    return maxCoalesceDistance_;
+  }
+
+  int64_t maxCoalesceBytes() const {
+    return maxCoalesceBytes_;
+  }
+};
+} // namespace facebook::velox::io

--- a/velox/dwio/common/CachedBufferedInput.h
+++ b/velox/dwio/common/CachedBufferedInput.h
@@ -21,11 +21,11 @@
 #include "velox/common/caching/FileGroupStats.h"
 #include "velox/common/caching/ScanTracker.h"
 #include "velox/common/caching/SsdCache.h"
+#include "velox/common/io/Options.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/CacheInputStream.h"
 #include "velox/dwio/common/InputStream.h"
 #include "velox/dwio/common/IoStatistics.h"
-#include "velox/dwio/common/Options.h"
 
 DECLARE_int32(cache_load_quantum);
 
@@ -65,7 +65,7 @@ class CachedBufferedInput : public BufferedInput {
       uint64_t groupId,
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* FOLLY_NULLABLE executor,
-      const ReaderOptions& readerOptions)
+      const io::ReaderOptions& readerOptions)
       : BufferedInput(
             std::move(readFile),
             readerOptions.getMemoryPool(),
@@ -87,7 +87,7 @@ class CachedBufferedInput : public BufferedInput {
       uint64_t groupId,
       std::shared_ptr<IoStatistics> ioStats,
       folly::Executor* FOLLY_NULLABLE executor,
-      const ReaderOptions& readerOptions)
+      const io::ReaderOptions& readerOptions)
       : BufferedInput(std::move(input), readerOptions.getMemoryPool()),
         cache_(cache),
         fileNum_(fileNum),
@@ -196,7 +196,7 @@ class CachedBufferedInput : public BufferedInput {
 
   const uint64_t fileSize_;
   int64_t prefetchSize_{0};
-  ReaderOptions options_;
+  io::ReaderOptions options_;
 };
 
 } // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/InputStream.h
+++ b/velox/dwio/common/InputStream.h
@@ -37,9 +37,6 @@
 
 namespace facebook::velox::dwio::common {
 
-constexpr uint64_t DEFAULT_AUTO_PRELOAD_SIZE =
-    (static_cast<const uint64_t>((1ul << 20) * 72));
-
 /**
  * An abstract interface for providing readers a stream of bytes.
  */

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -21,6 +21,7 @@
 
 #include <folly/Executor.h>
 #include "velox/common/compression/Compression.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/ErrorTolerance.h"
@@ -353,52 +354,13 @@ class RowReaderOptions {
 };
 
 /**
- * Mode for prefetching data.
- *
- * This mode may be ignored for a reader, such as DWRF, where it does not
- * make sense.
- *
- * To enable single-buffered reading, using the default autoPreloadLength:
- *         ReaderOptions readerOpts;
- *         readerOpts.setPrefetchMode(PrefetchMode::PRELOAD);
- * To enable double-buffered reading, using the default autoPreloadLength:
- *         ReaderOptions readerOpts;
- *         readerOpts.setPrefetchMode(PrefetchMode::PREFETCH);
- * To select unbuffered reading:
- *         ReaderOptions readerOpts;
- *         readerOpts.setPrefetchMode(PrefetchMode::NOT_SET);
- *
- * Single-buffered reading (as in dwio::PreloadableInputStream)
- * reads ahead into a buffer.   Double-buffered reading additionally reads
- * asynchronously into a second buffer, swaps the buffers when the
- * first is fully consumed and the second has been filled, and then starts
- * a new parallel read.  For clients with a slow network connection to
- * Warm Storage, enabling PREFETCH reduces elapsed time by 10% or more,
- * at the cost of a second buffer.   The relative improvment would be greater
- * for cases where the network throughput is higher.
- */
-enum class PrefetchMode {
-  NOT_SET = 0,
-  PRELOAD = 1, // read a buffer of autoPreloadLength bytes on a read beyond the
-               // current buffer, if any.
-  PREFETCH = 2, // read a second buffer of autoPreloadLength bytes ahead of
-                // actual reads.
-};
-
-/**
  * Options for creating a Reader.
  */
-class ReaderOptions {
+class ReaderOptions : public io::ReaderOptions {
  private:
   uint64_t tailLocation;
-  velox::memory::MemoryPool* memoryPool;
   FileFormat fileFormat;
   RowTypePtr fileSchema;
-  uint64_t autoPreloadLength;
-  PrefetchMode prefetchMode;
-  int32_t loadQuantum_{kDefaultLoadQuantum};
-  int32_t maxCoalesceDistance_{kDefaultCoalesceDistance};
-  int64_t maxCoalesceBytes_{kDefaultCoalesceBytes};
   SerDeOptions serDeOptions;
   std::shared_ptr<encryption::DecrypterFactory> decrypterFactory_;
   uint64_t directorySizeGuess{kDefaultDirectorySizeGuess};
@@ -407,53 +369,45 @@ class ReaderOptions {
   bool useColumnNamesForColumnMapping_{false};
 
  public:
-  static constexpr int32_t kDefaultLoadQuantum = 8 << 20; // 8MB
-  static constexpr int32_t kDefaultCoalesceDistance = 512 << 10; // 512K
-  static constexpr int32_t kDefaultCoalesceBytes = 128 << 20; // 128M
   static constexpr uint64_t kDefaultDirectorySizeGuess = 1024 * 1024; // 1MB
   static constexpr uint64_t kDefaultFilePreloadThreshold =
       1024 * 1024 * 8; // 8MB
 
   explicit ReaderOptions(velox::memory::MemoryPool* pool)
-      : tailLocation(std::numeric_limits<uint64_t>::max()),
-        memoryPool(pool),
+      : io::ReaderOptions(pool),
+        tailLocation(std::numeric_limits<uint64_t>::max()),
         fileFormat(FileFormat::UNKNOWN),
-        fileSchema(nullptr),
-        autoPreloadLength(DEFAULT_AUTO_PRELOAD_SIZE),
-        prefetchMode(PrefetchMode::PREFETCH) {}
+        fileSchema(nullptr) {}
 
   ReaderOptions& operator=(const ReaderOptions& other) {
+    io::ReaderOptions::operator=(other);
     tailLocation = other.tailLocation;
-    memoryPool = other.memoryPool;
     fileFormat = other.fileFormat;
     if (other.fileSchema != nullptr) {
       fileSchema = other.getFileSchema();
     } else {
       fileSchema = nullptr;
     }
-    autoPreloadLength = other.autoPreloadLength;
-    prefetchMode = other.prefetchMode;
     serDeOptions = other.serDeOptions;
     decrypterFactory_ = other.decrypterFactory_;
     directorySizeGuess = other.directorySizeGuess;
     filePreloadThreshold = other.filePreloadThreshold;
     fileColumnNamesReadAsLowerCase = other.fileColumnNamesReadAsLowerCase;
     useColumnNamesForColumnMapping_ = other.useColumnNamesForColumnMapping_;
-    maxCoalesceDistance_ = other.maxCoalesceDistance_;
-    maxCoalesceBytes_ = other.maxCoalesceBytes_;
     return *this;
   }
 
-  ReaderOptions(const ReaderOptions& other) {
-    *this = other;
-  }
-
-  /**
-   * Set the memory allocator.
-   */
-  ReaderOptions& setMemoryPool(velox::memory::MemoryPool& pool) {
-    memoryPool = &pool;
-    return *this;
+  ReaderOptions(const ReaderOptions& other)
+      : io::ReaderOptions(other),
+        tailLocation(other.tailLocation),
+        fileFormat(other.fileFormat),
+        fileSchema(other.fileSchema),
+        serDeOptions(other.serDeOptions),
+        decrypterFactory_(other.decrypterFactory_),
+        directorySizeGuess(other.directorySizeGuess),
+        filePreloadThreshold(other.filePreloadThreshold),
+        fileColumnNamesReadAsLowerCase(other.fileColumnNamesReadAsLowerCase),
+        useColumnNamesForColumnMapping_(other.useColumnNamesForColumnMapping_) {
   }
 
   /**
@@ -481,44 +435,6 @@ class ReaderOptions {
    */
   ReaderOptions& setTailLocation(uint64_t offset) {
     tailLocation = offset;
-    return *this;
-  }
-
-  /**
-   * Modify the autoPreloadLength
-   */
-  ReaderOptions& setAutoPreloadLength(uint64_t len) {
-    autoPreloadLength = len;
-    return *this;
-  }
-
-  /**
-   * Modify the prefetch mode.
-   */
-  ReaderOptions& setPrefetchMode(PrefetchMode mode) {
-    prefetchMode = mode;
-    return *this;
-  }
-
-  /**
-   * Modify the load quantum.
-   */
-  ReaderOptions& setLoadQuantum(int32_t quantum) {
-    loadQuantum_ = quantum;
-    return *this;
-  }
-  /**
-   * Modify the maximum load coalesce distance.
-   */
-  ReaderOptions& setMaxCoalesceDistance(int32_t distance) {
-    maxCoalesceDistance_ = distance;
-    return *this;
-  }
-  /**
-   * Modify the maximum load coalesce bytes.
-   */
-  ReaderOptions& setMaxCoalesceBytes(int64_t bytes) {
-    maxCoalesceBytes_ = bytes;
     return *this;
   }
 
@@ -565,13 +481,6 @@ class ReaderOptions {
   }
 
   /**
-   * Get the memory allocator.
-   */
-  velox::memory::MemoryPool& getMemoryPool() const {
-    return *memoryPool;
-  }
-
-  /**
    * Get the file format.
    */
   FileFormat getFileFormat() const {
@@ -583,26 +492,6 @@ class ReaderOptions {
    */
   const std::shared_ptr<const velox::RowType>& getFileSchema() const {
     return fileSchema;
-  }
-
-  uint64_t getAutoPreloadLength() const {
-    return autoPreloadLength;
-  }
-
-  PrefetchMode getPrefetchMode() const {
-    return prefetchMode;
-  }
-
-  int32_t loadQuantum() const {
-    return loadQuantum_;
-  }
-
-  int32_t maxCoalesceDistance() const {
-    return maxCoalesceDistance_;
-  }
-
-  int64_t maxCoalesceBytes() const {
-    return maxCoalesceBytes_;
   }
 
   SerDeOptions& getSerDeOptions() {

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -19,6 +19,7 @@
 #include <folly/executors/IOThreadPoolExecutor.h>
 #include "velox/common/caching/FileIds.h"
 #include "velox/common/file/FileSystems.h"
+#include "velox/common/io/Options.h"
 #include "velox/common/memory/MmapAllocator.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/dwrf/common/Common.h"
@@ -237,7 +238,7 @@ class CacheTest : public testing::Test {
         groupId,
         ioStats,
         executor_.get(),
-        ReaderOptions(pool_.get()));
+        io::ReaderOptions(pool_.get()));
     data->file = readFile.get();
     for (auto i = 0; i < numColumns; ++i) {
       int32_t streamIndex = i * (kMaxStreams / numColumns);
@@ -348,7 +349,7 @@ class CacheTest : public testing::Test {
     auto tracker = std::make_shared<ScanTracker>(
         "testTracker",
         nullptr,
-        dwio::common::ReaderOptions::kDefaultLoadQuantum,
+        io::ReaderOptions::kDefaultLoadQuantum,
         groupStats_);
     std::vector<std::unique_ptr<StripeData>> stripes;
     uint64_t fileId;
@@ -452,7 +453,7 @@ TEST_F(CacheTest, window) {
   auto tracker = std::make_shared<ScanTracker>(
       "testTracker",
       nullptr,
-      dwio::common::ReaderOptions::kDefaultLoadQuantum,
+      io::ReaderOptions::kDefaultLoadQuantum,
       groupStats_);
   uint64_t fileId;
   uint64_t groupId;
@@ -466,7 +467,7 @@ TEST_F(CacheTest, window) {
       groupId,
       ioStats_,
       executor_.get(),
-      ReaderOptions(pool_.get()));
+      io::ReaderOptions(pool_.get()));
   auto begin = 4 * kMB;
   auto end = 17 * kMB;
   auto stream = input->read(begin, end - begin, LogType::TEST);
@@ -678,7 +679,7 @@ class FileWithReadAhead {
   std::unique_ptr<CachedBufferedInput> bufferedInput_;
   std::unique_ptr<SeekableInputStream> stream_;
   std::shared_ptr<TestReadFile> file_;
-  ReaderOptions options_;
+  io::ReaderOptions options_;
 };
 
 TEST_F(CacheTest, readAhead) {


### PR DESCRIPTION
dwio modules and common io modules are interwined. This is 1/n PR attempting to refactor common-io libararies out from dwio.

In this PR we refactor ReaderOptions, the file contains a number of properties some are specific to dwio while some are mostly generic. Move the generic parts to io::ReaderOptions and leave rest in dwio::ReaderOptions

Update CachedBufferInput to use io::ReaderOptions