### PR TITLE
Fix linux build 

### DIFF
--- a/velox/common/config/CMakeLists.txt
+++ b/velox/common/config/CMakeLists.txt
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 add_library(velox_spill_config SpillConfig.cpp)
-target_link_libraries(velox_spill_config Folly::folly velox_exception)
+target_link_libraries(velox_spill_config Folly::folly velox_exception
+                      velox_common_compression)


### PR DESCRIPTION
linux-build failing with error Error:`undefined reference to stringToCompressionKind`