### PR TITLE
Support ordered memory pool reclaim

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -187,20 +187,41 @@ uint64_t MemoryReclaimer::reclaim(MemoryPool* pool, uint64_t targetBytes) {
   if (pool->kind() == MemoryPool::Kind::kLeaf) {
     return 0;
   }
-  // TODO: add to sort the child memory pools based on the reclaimable bytes
-  // before memory reclamation.
+
+  // Sort the child pools based on their reserved memory and reclaim from the
+  // child pool with most reservation first.
+  struct Candidate {
+    std::shared_ptr<memory::MemoryPool> pool;
+    int64_t reservedBytes;
+  };
+  std::vector<Candidate> candidates;
+  candidates.reserve(pool->children_.size());
+  for (auto& entry : pool->children_) {
+    auto child = entry.second.lock();
+    if (child != nullptr) {
+      const int64_t reservedBytes = child->reservedBytes();
+      candidates.push_back(Candidate{std::move(child), reservedBytes});
+    }
+  }
+
+  std::sort(
+      candidates.begin(),
+      candidates.end(),
+      [](const auto& lhs, const auto& rhs) {
+        return lhs.reservedBytes > rhs.reservedBytes;
+      });
+
   uint64_t reclaimedBytes{0};
-  pool->visitChildren([&targetBytes, &reclaimedBytes](MemoryPool* child) {
-    const auto bytes = child->reclaim(targetBytes);
+  for (const auto& candidate : candidates) {
+    const auto bytes = candidate.pool->reclaim(targetBytes);
     reclaimedBytes += bytes;
     if (targetBytes != 0) {
       if (bytes >= targetBytes) {
-        return false;
+        break;
       }
       targetBytes -= bytes;
     }
-    return true;
-  });
+  }
   return reclaimedBytes;
 }
 

--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -537,6 +537,7 @@ class MemoryPool : public std::enable_shared_from_this<MemoryPool> {
   std::unordered_map<std::string, std::weak_ptr<MemoryPool>> children_;
 
   friend class TestMemoryReclaimer;
+  friend class MemoryReclaimer;
 };
 
 std::ostream& operator<<(std::ostream& out, MemoryPool::Kind kind);

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -329,7 +329,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.checkUsageLeak = true;
-    options.arbitrationStateCheckCb = driverArbitrationStateCheck;
+    options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
     memoryManager_ = std::make_unique<MemoryManager>(options);
     ASSERT_EQ(memoryManager_->arbitrator()->kind(), "SHARED");
     arbitrator_ = static_cast<SharedArbitrator*>(memoryManager_->arbitrator());

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/HashTable.h"
 #include "velox/exec/JoinBridge.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Spill.h"
 
 namespace facebook::velox::exec {
@@ -135,7 +136,7 @@ class HashJoinBridge : public JoinBridge {
 bool isLeftNullAwareJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode);
 
-class HashJoinMemoryReclaimer final : public memory::MemoryReclaimer {
+class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
   static std::unique_ptr<memory::MemoryReclaimer> create() {
     return std::unique_ptr<memory::MemoryReclaimer>(

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -22,17 +22,25 @@
 namespace facebook::velox::exec {
 /// Provides the default memory reclaimer implementation for velox task
 /// execution.
-class DefaultMemoryReclaimer : public memory::MemoryReclaimer {
+class MemoryReclaimer : public memory::MemoryReclaimer {
  public:
-  virtual ~DefaultMemoryReclaimer() = default;
+  virtual ~MemoryReclaimer() = default;
 
-  static std::unique_ptr<MemoryReclaimer> create();
+  static std::unique_ptr<memory::MemoryReclaimer> create();
 
   void enterArbitration() override;
 
   void leaveArbitration() noexcept override;
 
  protected:
-  DefaultMemoryReclaimer() = default;
+  MemoryReclaimer() = default;
 };
+
+/// Callback used by memory arbitration to check if a driver thread under memory
+/// arbitration has been put in suspension state. This is to prevent arbitration
+/// deadlock as the arbitrator might reclaim memory from the task of the driver
+/// thread which is under arbitration. The task reclaim needs to wait for the
+/// drivers to go off thread. A suspended driver thread is not counted as
+/// running.
+void memoryArbitrationStateCheck(memory::MemoryPool& pool);
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -346,7 +346,7 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createNodeReclaimer(
   // Sets memory reclaimer for the parent node memory pool on the first child
   // operator construction which has set memory reclaimer.
   return isHashJoinNode ? HashJoinMemoryReclaimer::create()
-                        : memory::MemoryReclaimer::create();
+                        : exec::MemoryReclaimer::create();
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createExchangeClientReclaimer()
@@ -354,7 +354,7 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createExchangeClientReclaimer()
   if (pool()->reclaimer() == nullptr) {
     return nullptr;
   }
-  return DefaultMemoryReclaimer::create();
+  return exec::MemoryReclaimer::create();
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createTaskReclaimer() {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -18,6 +18,7 @@
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/LocalPartition.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/MergeSource.h"
 #include "velox/exec/Split.h"
 #include "velox/exec/TaskStats.h"
@@ -645,7 +646,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// occurred. This should only be called inside mutex_ protection.
   std::string errorMessageLocked() const;
 
-  class MemoryReclaimer : public memory::MemoryReclaimer {
+  class MemoryReclaimer : public exec::MemoryReclaimer {
    public:
     static std::unique_ptr<memory::MemoryReclaimer> create(
         const std::shared_ptr<Task>& task);

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -61,7 +61,7 @@ TEST_F(MemoryReclaimerTest, enterArbitrationTest) {
   for (const auto& underDriverContext : {false, true}) {
     SCOPED_TRACE(fmt::format("underDriverContext: {}", underDriverContext));
 
-    auto reclaimer = DefaultMemoryReclaimer::create();
+    auto reclaimer = exec::MemoryReclaimer::create();
     auto driver = Driver::testingCreate(
         std::make_unique<DriverCtx>(fakeTask_, 0, 0, 0, 0));
     if (underDriverContext) {


### PR DESCRIPTION
In Meta internal arbitration and spilling shadowing test, we found that without
enforcing reclaim order from a plan node, then the arbitrator always reclaim
memory follow the memory pool hierarchy, that is, always first reclaim from the
first child, second and so on. This might generates small files as the first operator
has less amount of in-memory state than the other which is not efficient as for
aggregation, we want to reduce the number of files as each file is a sorted run.

This PR optimizes this by sort the memory pool based on its reserved memory
before the actual memory reclaimation.