### PR TITLE
Introducing TableFormatReader in HiveConnector

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -25,7 +25,8 @@ add_library(
   HiveDataSource.cpp
   HivePartitionUtil.cpp
   PartitionIdGenerator.cpp
-  TableHandle.cpp)
+  TableHandle.cpp
+  TableFormatReader.cpp)
 
 target_link_libraries(
   velox_hive_connector

--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <unordered_map>
 
-#include "velox/common/caching/AsyncDataCache.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/expression/ExprToSubfieldFilter.h"
@@ -31,36 +30,6 @@ class HiveTableHandle;
 class HiveColumnHandle;
 
 namespace {
-
-static const char* kPath = "$path";
-static const char* kBucket = "$bucket";
-
-bool applyPartitionFilter(
-    TypeKind kind,
-    const std::string& partitionValue,
-    common::Filter* filter) {
-  switch (kind) {
-    case TypeKind::BIGINT:
-    case TypeKind::INTEGER:
-    case TypeKind::SMALLINT:
-    case TypeKind::TINYINT: {
-      return applyFilter(*filter, folly::to<int64_t>(partitionValue));
-    }
-    case TypeKind::REAL:
-    case TypeKind::DOUBLE: {
-      return applyFilter(*filter, folly::to<double>(partitionValue));
-    }
-    case TypeKind::BOOLEAN: {
-      return applyFilter(*filter, folly::to<bool>(partitionValue));
-    }
-    case TypeKind::VARCHAR: {
-      return applyFilter(*filter, partitionValue);
-    }
-    default:
-      VELOX_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
-      break;
-  }
-}
 
 struct SubfieldSpec {
   const common::Subfield* subfield;
@@ -257,71 +226,6 @@ void addSubfields(
   }
 }
 
-bool testFilters(
-    common::ScanSpec* scanSpec,
-    dwio::common::Reader* reader,
-    const std::string& filePath,
-    const std::unordered_map<std::string, std::optional<std::string>>&
-        partitionKey,
-    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
-        partitionKeysHandle) {
-  auto totalRows = reader->numberOfRows();
-  const auto& fileTypeWithId = reader->typeWithId();
-  const auto& rowType = reader->rowType();
-  for (const auto& child : scanSpec->children()) {
-    if (child->filter()) {
-      const auto& name = child->fieldName();
-      if (!rowType->containsChild(name)) {
-        // If missing column is partition key.
-        auto iter = partitionKey.find(name);
-        if (iter != partitionKey.end() && iter->second.has_value()) {
-          return applyPartitionFilter(
-              partitionKeysHandle[name]->dataType()->kind(),
-              iter->second.value(),
-              child->filter());
-        }
-        // Column is missing. Most likely due to schema evolution.
-        if (child->filter()->isDeterministic() &&
-            !child->filter()->testNull()) {
-          return false;
-        }
-      } else {
-        const auto& typeWithId = fileTypeWithId->childByName(name);
-        auto columnStats = reader->columnStatistics(typeWithId->id());
-        if (columnStats != nullptr &&
-            !testFilter(
-                child->filter(),
-                columnStats.get(),
-                totalRows.value(),
-                typeWithId->type())) {
-          VLOG(1) << "Skipping " << filePath
-                  << " based on stats and filter for column "
-                  << child->fieldName();
-          return false;
-        }
-      }
-    }
-  }
-
-  return true;
-}
-
-template <TypeKind ToKind>
-velox::variant convertFromString(const std::optional<std::string>& value) {
-  if (value.has_value()) {
-    if constexpr (ToKind == TypeKind::VARCHAR) {
-      return velox::variant(value.value());
-    }
-    if constexpr (ToKind == TypeKind::VARBINARY) {
-      return velox::variant::binary((value.value()));
-    }
-    auto result = velox::util::Converter<ToKind>::cast(value.value());
-
-    return velox::variant(result);
-  }
-  return velox::variant(ToKind);
-}
-
 core::CallTypedExprPtr replaceInputs(
     const core::CallTypedExpr* call,
     std::vector<core::TypedExprPtr>&& inputs) {
@@ -497,51 +401,50 @@ HiveDataSource::HiveDataSource(
     }
   }
 
-  auto hiveTableHandle =
-      std::dynamic_pointer_cast<HiveTableHandle>(tableHandle);
+  hiveTableHandle_ = std::dynamic_pointer_cast<HiveTableHandle>(tableHandle);
   VELOX_CHECK(
-      hiveTableHandle != nullptr,
+      hiveTableHandle_ != nullptr,
       "TableHandle must be an instance of HiveTableHandle");
   if (readerOpts_.isFileColumnNamesReadAsLowerCase()) {
     checkColumnNameLowerCase(outputType_);
-    checkColumnNameLowerCase(hiveTableHandle->subfieldFilters());
-    checkColumnNameLowerCase(hiveTableHandle->remainingFilter());
+    checkColumnNameLowerCase(hiveTableHandle_->subfieldFilters());
+    checkColumnNameLowerCase(hiveTableHandle_->remainingFilter());
   }
 
   SubfieldFilters filters;
   core::TypedExprPtr remainingFilter;
-  if (hiveTableHandle->isFilterPushdownEnabled()) {
-    for (auto& [k, v] : hiveTableHandle->subfieldFilters()) {
+  if (hiveTableHandle_->isFilterPushdownEnabled()) {
+    for (auto& [k, v] : hiveTableHandle_->subfieldFilters()) {
       filters.emplace(k.clone(), v->clone());
     }
     remainingFilter = extractFiltersFromRemainingFilter(
-        hiveTableHandle->remainingFilter(),
+        hiveTableHandle_->remainingFilter(),
         expressionEvaluator_,
         false,
         filters);
   } else {
-    for (auto& [field, _] : hiveTableHandle->subfieldFilters()) {
+    for (auto& [field, _] : hiveTableHandle_->subfieldFilters()) {
       VELOX_USER_CHECK_EQ(
           field.path().size(),
           1,
           "Unexpected filter on table {}, field {}",
-          hiveTableHandle->tableName(),
+          hiveTableHandle_->tableName(),
           field.toString());
       auto* nestedField = dynamic_cast<const common::Subfield::NestedField*>(
           field.path()[0].get());
       VELOX_USER_CHECK_NOT_NULL(
           nestedField,
           "Unexpected filter on table {}, field {}",
-          hiveTableHandle->tableName(),
+          hiveTableHandle_->tableName(),
           field.toString());
       VELOX_USER_CHECK_GT(
           partitionKeys_.count(nestedField->name()),
           0,
           "Unexpected filter on table {}, field {}",
-          hiveTableHandle->tableName(),
+          hiveTableHandle_->tableName(),
           field.toString());
     }
-    remainingFilter = hiveTableHandle->remainingFilter();
+    remainingFilter = hiveTableHandle_->remainingFilter();
   }
 
   std::vector<common::Subfield> remainingFilterSubfields;
@@ -584,23 +487,14 @@ HiveDataSource::HiveDataSource(
       readerOutputType_,
       subfields,
       filters,
-      hiveTableHandle->dataColumns(),
+      hiveTableHandle_->dataColumns(),
       pool_);
   if (remainingFilter) {
     metadataFilter_ = std::make_shared<common::MetadataFilter>(
         *scanSpec_, *remainingFilter, expressionEvaluator_);
   }
 
-  readerOpts_.setFileSchema(hiveTableHandle->dataColumns());
-  rowReaderOpts_.setScanSpec(scanSpec_);
-  rowReaderOpts_.setMetadataFilter(metadataFilter_);
-
-  auto skipRowsIt = hiveTableHandle->tableParameters().find(
-      dwio::common::TableParameter::kSkipHeaderLineCount);
-  if (skipRowsIt != hiveTableHandle->tableParameters().end()) {
-    rowReaderOpts_.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
-  }
-
+  readerOpts_.setFileSchema(hiveTableHandle_->dataColumns());
   ioStats_ = std::make_shared<dwio::common::IoStatistics>();
 }
 
@@ -662,9 +556,6 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
 
   VLOG(1) << "Adding split " << split_->toString();
 
-  fileHandle_ = fileHandleFactory_->generate(split_->filePath).second;
-  auto input = createBufferedInput(*fileHandle_, readerOpts_);
-
   if (readerOpts_.getFileFormat() != dwio::common::FileFormat::UNKNOWN) {
     VELOX_CHECK(
         readerOpts_.getFileFormat() == split_->fileFormat,
@@ -676,85 +567,25 @@ void HiveDataSource::addSplit(std::shared_ptr<ConnectorSplit> split) {
     readerOpts_.setFileFormat(split_->fileFormat);
   }
 
-  reader_ = dwio::common::getReaderFactory(readerOpts_.getFileFormat())
-                ->createReader(std::move(input), readerOpts_);
+  fileHandle_ = fileHandleFactory_->generate(split_->filePath).second;
+  auto input = createBufferedInput(*fileHandle_, readerOpts_);
 
-  emptySplit_ = false;
-  if (reader_->numberOfRows() == 0) {
-    emptySplit_ = true;
-    return;
-  }
-
-  // Check filters and see if the whole split can be skipped.
-  if (!testFilters(
-          scanSpec_.get(),
-          reader_.get(),
-          split_->filePath,
-          split_->partitionKeys,
-          partitionKeys_)) {
-    emptySplit_ = true;
-    ++runtimeStats_.skippedSplits;
-    runtimeStats_.skippedSplitBytes += split_->length;
-    return;
-  }
-
-  auto& fileType = reader_->rowType();
-  // Keep track of schema types for columns in file, used by ColumnSelector.
-  std::vector<TypePtr> columnTypes = fileType->children();
-
-  auto& childrenSpecs = scanSpec_->children();
-  for (size_t i = 0; i < childrenSpecs.size(); ++i) {
-    auto* childSpec = childrenSpecs[i].get();
-    const std::string& fieldName = childSpec->fieldName();
-
-    auto iter = split_->partitionKeys.find(fieldName);
-    if (iter != split_->partitionKeys.end()) {
-      setPartitionValue(childSpec, fieldName, iter->second);
-    } else if (fieldName == kPath) {
-      setConstantValue(childSpec, VARCHAR(), velox::variant(split_->filePath));
-    } else if (fieldName == kBucket) {
-      if (split_->tableBucketNumber.has_value()) {
-        setConstantValue(
-            childSpec,
-            INTEGER(),
-            velox::variant(split_->tableBucketNumber.value()));
-      }
-    } else {
-      auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
-      if (!fileTypeIdx.has_value()) {
-        // Column is missing. Most likely due to schema evolution.
-        VELOX_CHECK(readerOpts_.getFileSchema());
-        setNullConstantValue(
-            childSpec, readerOpts_.getFileSchema()->findChild(fieldName));
-      } else {
-        // Column no longer missing, reset constant value set on the spec.
-        childSpec->setConstantValue(nullptr);
-        auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
-        if (outputTypeIdx.has_value()) {
-          // We know the fieldName exists in the file, make the type at that
-          // position match what we expect in the output.
-          columnTypes[fileTypeIdx.value()] =
-              readerOutputType_->childAt(*outputTypeIdx);
-        }
-      }
-    }
-  }
-
-  scanSpec_->resetCachedValues(false);
-  configureRowReaderOptions(
-      rowReaderOpts_,
-      ROW(std::vector<std::string>(fileType->names()), std::move(columnTypes)));
-  // NOTE: we firstly reset the finished 'rowReader_' of previous split before
-  // setting up for the next one to avoid doubling the peak memory usage.
-  rowReader_.reset();
-  rowReader_ = createRowReader(rowReaderOpts_);
+  tableReader_ = TableFormatReader::create(
+      split_, readerOutputType_, partitionKeys_, scanSpec_, pool_);
+  tableReader_->prepareSplit(
+      hiveTableHandle_,
+      readerOpts_,
+      std::move(input),
+      metadataFilter_,
+      runtimeStats_);
 }
 
 std::optional<RowVectorPtr> HiveDataSource::next(
     uint64_t size,
     velox::ContinueFuture& /*future*/) {
   VELOX_CHECK(split_ != nullptr, "No split to process. Call addSplit first.");
-  if (emptySplit_) {
+
+  if (tableReader_ && tableReader_->emptySplit()) {
     resetSplit();
     return nullptr;
   }
@@ -821,8 +652,7 @@ std::optional<RowVectorPtr> HiveDataSource::next(
         pool_, outputType_, BufferPtr(nullptr), rowsRemaining, outputColumns);
   }
 
-  rowReader_->updateRuntimeStats(runtimeStats_);
-
+  tableReader_->updateRuntimeStats(runtimeStats_);
   resetSplit();
   return nullptr;
 }
@@ -833,8 +663,8 @@ void HiveDataSource::addDynamicFilter(
   auto& fieldSpec = scanSpec_->getChildByChannel(outputChannel);
   fieldSpec.addFilter(*filter);
   scanSpec_->resetCachedValues(true);
-  if (rowReader_) {
-    rowReader_->resetFilterCaches();
+  if (tableReader_) {
+    tableReader_->resetFilterCaches();
   }
 }
 
@@ -874,15 +704,14 @@ void HiveDataSource::setFromDataSource(
     std::unique_ptr<DataSource> sourceUnique) {
   auto source = dynamic_cast<HiveDataSource*>(sourceUnique.get());
   VELOX_CHECK(source, "Bad DataSource type");
-  emptySplit_ = source->emptySplit_;
+
   split_ = std::move(source->split_);
-  if (emptySplit_) {
+  if (source->tableReader_ && source->tableReader_->emptySplit()) {
     return;
   }
   source->scanSpec_->moveAdaptationFrom(*scanSpec_);
   scanSpec_ = std::move(source->scanSpec_);
-  reader_ = std::move(source->reader_);
-  rowReader_ = std::move(source->rowReader_);
+  tableReader_ = std::move(source->tableReader_);
   // New io will be accounted on the stats of 'source'. Add the existing
   // balance to that.
   source->ioStats_->merge(*ioStats_);
@@ -890,14 +719,10 @@ void HiveDataSource::setFromDataSource(
 }
 
 int64_t HiveDataSource::estimatedRowSize() {
-  if (!rowReader_) {
+  if (!tableReader_) {
     return kUnknownRowSize;
   }
-  auto size = rowReader_->estimatedRowSize();
-  if (size.has_value()) {
-    return size.value();
-  }
-  return kUnknownRowSize;
+  return tableReader_->estimatedRowSize();
 }
 
 std::shared_ptr<common::ScanSpec> HiveDataSource::makeScanSpec(
@@ -1005,55 +830,10 @@ vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {
       filterResult_, filterRows_, filterEvalCtx_, pool_);
 }
 
-void HiveDataSource::setConstantValue(
-    common::ScanSpec* spec,
-    const TypePtr& type,
-    const velox::variant& value) const {
-  spec->setConstantValue(BaseVector::createConstant(type, value, 1, pool_));
-}
-
-void HiveDataSource::setNullConstantValue(
-    common::ScanSpec* spec,
-    const TypePtr& type) const {
-  spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
-}
-
-void HiveDataSource::setPartitionValue(
-    common::ScanSpec* spec,
-    const std::string& partitionKey,
-    const std::optional<std::string>& value) const {
-  auto it = partitionKeys_.find(partitionKey);
-  VELOX_CHECK(
-      it != partitionKeys_.end(),
-      "ColumnHandle is missing for partition key {}",
-      partitionKey);
-  auto constValue = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
-      convertFromString, it->second->dataType()->kind(), value);
-  setConstantValue(spec, it->second->dataType(), constValue);
-}
-
 void HiveDataSource::resetSplit() {
   split_.reset();
+  tableReader_->resetSplit();
   // Keep readers around to hold adaptation.
-}
-
-void HiveDataSource::configureRowReaderOptions(
-    dwio::common::RowReaderOptions& options,
-    const RowTypePtr& rowType) const {
-  std::vector<std::string> columnNames;
-  for (auto& spec : scanSpec_->children()) {
-    if (!spec->isConstant()) {
-      columnNames.push_back(spec->fieldName());
-    }
-  }
-  std::shared_ptr<dwio::common::ColumnSelector> cs;
-  if (columnNames.empty()) {
-    static const RowTypePtr kEmpty{ROW({}, {})};
-    cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
-  } else {
-    cs = std::make_shared<dwio::common::ColumnSelector>(rowType, columnNames);
-  }
-  options.select(cs).range(split_->start, split_->length);
 }
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -18,6 +18,7 @@
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/FileHandle.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/TableFormatReader.h"
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/dwio/common/BufferedInput.h"
 #include "velox/dwio/common/Reader.h"
@@ -62,7 +63,7 @@ class HiveDataSource : public DataSource {
   std::unordered_map<std::string, RuntimeCounter> runtimeStats() override;
 
   bool allPrefetchIssued() const override {
-    return rowReader_ && rowReader_->allPrefetchIssued();
+    return tableReader_ && tableReader_->allPrefetchIssued();
   }
 
   void setFromDataSource(std::unique_ptr<DataSource> sourceUnique) override;
@@ -90,30 +91,18 @@ class HiveDataSource : public DataSource {
 
  protected:
   virtual uint64_t readNext(uint64_t size) {
-    return rowReader_->next(size, output_);
+    return tableReader_->next(size, output_);
   }
 
   std::unique_ptr<dwio::common::BufferedInput> createBufferedInput(
       const FileHandle&,
       const dwio::common::ReaderOptions&);
 
-  virtual std::unique_ptr<dwio::common::RowReader> createRowReader(
-      dwio::common::RowReaderOptions& options) {
-    return reader_->createRowReader(options);
-  }
-
   std::shared_ptr<HiveConnectorSplit> split_;
   FileHandleFactory* fileHandleFactory_;
   dwio::common::ReaderOptions readerOpts_;
   memory::MemoryPool* pool_;
   VectorPtr output_;
-
-  // Output type from file reader.  This is different from outputType_ that it
-  // contains column names before assignment, and columns that only used in
-  // remaining filter.
-  RowTypePtr readerOutputType_;
-
-  std::unique_ptr<dwio::common::RowReader> rowReader_;
 
  private:
   // Evaluates remainingFilter_ on the specified vector. Returns number of rows
@@ -122,31 +111,19 @@ class HiveDataSource : public DataSource {
   // filterEvalCtx_.selectedIndices and selectedBits are not updated.
   vector_size_t evaluateRemainingFilter(RowVectorPtr& rowVector);
 
-  void setConstantValue(
-      common::ScanSpec* FOLLY_NONNULL spec,
-      const TypePtr& type,
-      const velox::variant& value) const;
-
-  void setNullConstantValue(
-      common::ScanSpec* FOLLY_NONNULL spec,
-      const TypePtr& type) const;
-
-  void setPartitionValue(
-      common::ScanSpec* FOLLY_NONNULL spec,
-      const std::string& partitionKey,
-      const std::optional<std::string>& value) const;
-
   // Clear split_ after split has been fully processed.  Keep readers around to
   // hold adaptation.
   void resetSplit();
 
-  void configureRowReaderOptions(
-      dwio::common::RowReaderOptions&,
-      const RowTypePtr& rowType) const;
-
   void parseSerdeParameters(
       const std::unordered_map<std::string, std::string>& serdeParameters);
 
+  std::shared_ptr<HiveTableHandle> hiveTableHandle_;
+  // Output type from file reader.  This is different from outputType_ that it
+  // contains column names before assignment, and columns that only used in
+  // remaining filter.
+  RowTypePtr readerOutputType_;
+  // The row type for the data source output, not including filter only columns
   const RowTypePtr outputType_;
   // Column handles for the partition key columns keyed on partition key column
   // name.
@@ -155,13 +132,9 @@ class HiveDataSource : public DataSource {
   std::shared_ptr<dwio::common::IoStatistics> ioStats_;
   std::shared_ptr<common::ScanSpec> scanSpec_;
   std::shared_ptr<common::MetadataFilter> metadataFilter_;
-  dwio::common::RowReaderOptions rowReaderOpts_;
-  std::unique_ptr<dwio::common::Reader> reader_;
+  std::unique_ptr<TableFormatReader> tableReader_;
   std::unique_ptr<exec::ExprSet> remainingFilterExprSet_;
-  bool emptySplit_;
-
   dwio::common::RuntimeStatistics runtimeStats_;
-
   std::shared_ptr<FileHandle> fileHandle_;
   core::ExpressionEvaluator* expressionEvaluator_;
   uint64_t completedRows_ = 0;

--- a/velox/connectors/hive/TableFormatReader.cpp
+++ b/velox/connectors/hive/TableFormatReader.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/connectors/hive/TableFormatReader.h"
+
+#include "velox/dwio/common/ReaderFactory.h"
+
+namespace facebook::velox::connector::hive {
+
+class HiveTableHandle;
+class HiveColumnHandle;
+
+namespace {
+
+bool applyPartitionFilter(
+    TypeKind kind,
+    const std::string& partitionValue,
+    common::Filter* filter) {
+  switch (kind) {
+    case TypeKind::BIGINT:
+    case TypeKind::INTEGER:
+    case TypeKind::SMALLINT:
+    case TypeKind::TINYINT: {
+      return applyFilter(*filter, folly::to<int64_t>(partitionValue));
+    }
+    case TypeKind::REAL:
+    case TypeKind::DOUBLE: {
+      return applyFilter(*filter, folly::to<double>(partitionValue));
+    }
+    case TypeKind::BOOLEAN: {
+      return applyFilter(*filter, folly::to<bool>(partitionValue));
+    }
+    case TypeKind::VARCHAR: {
+      return applyFilter(*filter, partitionValue);
+    }
+    default:
+      VELOX_FAIL("Bad type {} for partition value: {}", kind, partitionValue);
+      break;
+  }
+}
+
+bool testFilters(
+    common::ScanSpec* scanSpec,
+    dwio::common::Reader* reader,
+    const std::string& filePath,
+    const std::unordered_map<std::string, std::optional<std::string>>&
+        partitionKey,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+        partitionKeysHandle) {
+  auto totalRows = reader->numberOfRows();
+  const auto& fileTypeWithId = reader->typeWithId();
+  const auto& rowType = reader->rowType();
+  for (const auto& child : scanSpec->children()) {
+    if (child->filter()) {
+      const auto& name = child->fieldName();
+      if (!rowType->containsChild(name)) {
+        // If missing column is partition key.
+        auto iter = partitionKey.find(name);
+        if (iter != partitionKey.end() && iter->second.has_value()) {
+          return applyPartitionFilter(
+              partitionKeysHandle[name]->dataType()->kind(),
+              iter->second.value(),
+              child->filter());
+        }
+        // Column is missing. Most likely due to schema evolution.
+        if (child->filter()->isDeterministic() &&
+            !child->filter()->testNull()) {
+          return false;
+        }
+      } else {
+        const auto& typeWithId = fileTypeWithId->childByName(name);
+        auto columnStats = reader->columnStatistics(typeWithId->id());
+        if (columnStats != nullptr &&
+            !testFilter(
+                child->filter(),
+                columnStats.get(),
+                totalRows.value(),
+                typeWithId->type())) {
+          VLOG(1) << "Skipping " << filePath
+                  << " based on stats and filter for column "
+                  << child->fieldName();
+          return false;
+        }
+      }
+    }
+  }
+
+  return true;
+}
+
+template <TypeKind ToKind>
+velox::variant convertFromString(const std::optional<std::string>& value) {
+  if (value.has_value()) {
+    if constexpr (ToKind == TypeKind::VARCHAR) {
+      return velox::variant(value.value());
+    }
+    if constexpr (ToKind == TypeKind::VARBINARY) {
+      return velox::variant::binary((value.value()));
+    }
+    auto result = velox::util::Converter<ToKind>::cast(value.value());
+
+    return velox::variant(result);
+  }
+  return velox::variant(ToKind);
+}
+
+} // namespace
+
+std::unique_ptr<TableFormatReader> TableFormatReader::create(
+    std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
+    RowTypePtr readerOutputType,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+        partitionKeys,
+    std::shared_ptr<common::ScanSpec> scanSpec,
+    memory::MemoryPool*& pool) {
+  //  Create the TableFormatReader based on
+  //  hiveSplit->customSplitInfo["table_format"]
+  return std::make_unique<TableFormatReader>(
+      hiveSplit, readerOutputType, partitionKeys, scanSpec, pool);
+}
+
+TableFormatReader::TableFormatReader(
+    std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
+    RowTypePtr readerOutputType,
+    std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+        partitionKeys,
+    std::shared_ptr<common::ScanSpec> scanSpec,
+    memory::MemoryPool*& pool)
+    : hiveSplit_(hiveSplit),
+      readerOutputType_(readerOutputType),
+      partitionKeys_(partitionKeys),
+      scanSpec_(scanSpec),
+      pool_(pool) {}
+
+void TableFormatReader::prepareSplit(
+    const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+    const dwio::common::ReaderOptions& readerOptions,
+    std::unique_ptr<dwio::common::BufferedInput> baseFileInput,
+    std::shared_ptr<common::MetadataFilter> metadataFilter,
+    dwio::common::RuntimeStatistics& runtimeStats) {
+  baseReader_ = dwio::common::getReaderFactory(readerOptions.getFileFormat())
+                    ->createReader(std::move(baseFileInput), readerOptions);
+
+  // Note that this doesn't apply to Hudi tables.
+  emptySplit_ = false;
+  if (baseReader_->numberOfRows() == 0) {
+    emptySplit_ = true;
+    return;
+  }
+
+  // Check filters and see if the whole split can be skipped. Note that this
+  // doesn't apply to Hudi tables.
+  if (!testFilters(
+          scanSpec_.get(),
+          baseReader_.get(),
+          hiveSplit_->filePath,
+          hiveSplit_->partitionKeys,
+          partitionKeys_)) {
+    emptySplit_ = true;
+    ++runtimeStats.skippedSplits;
+    runtimeStats.skippedSplitBytes += hiveSplit_->length;
+    return;
+  }
+
+  auto& fileType = baseReader_->rowType();
+  auto columnTypes = adaptColumns(fileType, readerOptions.getFileSchema());
+
+  auto skipRowsIt = hiveTableHandle->tableParameters().find(
+      dwio::common::TableParameter::kSkipHeaderLineCount);
+  if (skipRowsIt != hiveTableHandle->tableParameters().end()) {
+    rowReaderOpts_.setSkipRows(folly::to<uint64_t>(skipRowsIt->second));
+  }
+
+  rowReaderOpts_.setScanSpec(scanSpec_);
+  rowReaderOpts_.setMetadataFilter(metadataFilter);
+  configureRowReaderOptions(
+      rowReaderOpts_,
+      ROW(std::vector<std::string>(fileType->names()), std::move(columnTypes)));
+  // NOTE: we firstly reset the finished 'baseRowReader_' of previous split
+  // before setting up for the next one to avoid doubling the peak memory usage.
+  baseRowReader_.reset();
+  baseRowReader_ = createRowReader(rowReaderOpts_);
+}
+
+std::vector<TypePtr> TableFormatReader::adaptColumns(
+    const RowTypePtr& fileType,
+    const std::shared_ptr<const velox::RowType>& tableSchema) {
+  // Keep track of schema types for columns in file, used by ColumnSelector.
+  std::vector<TypePtr> columnTypes = fileType->children();
+
+  auto& childrenSpecs = scanSpec_->children();
+  for (size_t i = 0; i < childrenSpecs.size(); ++i) {
+    auto* childSpec = childrenSpecs[i].get();
+    const std::string& fieldName = childSpec->fieldName();
+
+    auto iter = hiveSplit_->partitionKeys.find(fieldName);
+    if (iter != hiveSplit_->partitionKeys.end()) {
+      setPartitionValue(childSpec, fieldName, iter->second);
+    } else if (fieldName == kPath) {
+      setConstantValue(
+          childSpec, VARCHAR(), velox::variant(hiveSplit_->filePath));
+    } else if (fieldName == kBucket) {
+      if (hiveSplit_->tableBucketNumber.has_value()) {
+        setConstantValue(
+            childSpec,
+            INTEGER(),
+            velox::variant(hiveSplit_->tableBucketNumber.value()));
+      }
+    } else {
+      auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
+      if (!fileTypeIdx.has_value()) {
+        // Column is missing. Most likely due to schema evolution.
+        VELOX_CHECK(tableSchema);
+        setNullConstantValue(childSpec, tableSchema->findChild(fieldName));
+      } else {
+        // Column no longer missing, reset constant value set on the spec.
+        childSpec->setConstantValue(nullptr);
+        auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
+        if (outputTypeIdx.has_value()) {
+          // We know the fieldName exists in the file, make the type at that
+          // position match what we expect in the output.
+          columnTypes[fileTypeIdx.value()] =
+              readerOutputType_->childAt(*outputTypeIdx);
+        }
+      }
+    }
+  }
+
+  scanSpec_->resetCachedValues(false);
+
+  return columnTypes;
+}
+
+uint64_t TableFormatReader::next(int64_t size, VectorPtr& output) {
+  return baseRowReader_->next(size, output);
+}
+
+void TableFormatReader::resetFilterCaches() {
+  if (baseRowReader_) {
+    baseRowReader_->resetFilterCaches();
+  }
+}
+
+bool TableFormatReader::emptySplit() const {
+  return emptySplit_;
+}
+
+void TableFormatReader::resetSplit() {
+  hiveSplit_.reset();
+}
+
+int64_t TableFormatReader::estimatedRowSize() const {
+  if (!baseRowReader_) {
+    return DataSource::kUnknownRowSize;
+  }
+
+  auto size = baseRowReader_->estimatedRowSize();
+  if (size.has_value()) {
+    return size.value();
+  }
+  return DataSource::kUnknownRowSize;
+}
+
+void TableFormatReader::updateRuntimeStats(
+    dwio::common::RuntimeStatistics& stats) const {
+  if (baseRowReader_) {
+    baseRowReader_->updateRuntimeStats(stats);
+  }
+}
+
+bool TableFormatReader::allPrefetchIssued() const {
+  return baseRowReader_ && baseRowReader_->allPrefetchIssued();
+}
+
+void TableFormatReader::setConstantValue(
+    common::ScanSpec* spec,
+    const TypePtr& type,
+    const velox::variant& value) const {
+  spec->setConstantValue(BaseVector::createConstant(type, value, 1, pool_));
+}
+
+void TableFormatReader::setNullConstantValue(
+    common::ScanSpec* spec,
+    const TypePtr& type) const {
+  spec->setConstantValue(BaseVector::createNullConstant(type, 1, pool_));
+}
+
+void TableFormatReader::setPartitionValue(
+    common::ScanSpec* spec,
+    const std::string& partitionKey,
+    const std::optional<std::string>& value) const {
+  auto it = partitionKeys_.find(partitionKey);
+  VELOX_CHECK(
+      it != partitionKeys_.end(),
+      "ColumnHandle is missing for partition key {}",
+      partitionKey);
+  auto constValue = VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+      convertFromString, it->second->dataType()->kind(), value);
+  setConstantValue(spec, it->second->dataType(), constValue);
+}
+
+void TableFormatReader::configureRowReaderOptions(
+    dwio::common::RowReaderOptions& options,
+    const RowTypePtr& rowType) {
+  std::vector<std::string> columnNames;
+  for (auto& spec : scanSpec_->children()) {
+    if (!spec->isConstant()) {
+      columnNames.push_back(spec->fieldName());
+    }
+  }
+  std::shared_ptr<dwio::common::ColumnSelector> cs;
+  if (columnNames.empty()) {
+    static const RowTypePtr kEmpty{ROW({}, {})};
+    cs = std::make_shared<dwio::common::ColumnSelector>(kEmpty);
+  } else {
+    cs = std::make_shared<dwio::common::ColumnSelector>(rowType, columnNames);
+  }
+  options.select(cs).range(hiveSplit_->start, hiveSplit_->length);
+}
+
+std::string TableFormatReader::toString() const {
+  std::string partitionKeys;
+  std::for_each(
+      partitionKeys_.begin(),
+      partitionKeys_.end(),
+      [&](std::pair<
+          const std::string,
+          std::shared_ptr<facebook::velox::connector::hive::HiveColumnHandle>>
+              column) { partitionKeys += " " + column.second->toString(); });
+  return fmt::format(
+      "TableFormatReader: hiveSplit_{} scanSpec_{} readerOutputType_{} partitionKeys_{} reader{} rowReader{}",
+      hiveSplit_->toString(),
+      scanSpec_->toString(),
+      readerOutputType_->toString(),
+      partitionKeys,
+      static_cast<const void*>(baseReader_.get()),
+      static_cast<const void*>(baseRowReader_.get()));
+}
+
+} // namespace facebook::velox::connector::hive

--- a/velox/connectors/hive/TableFormatReader.h
+++ b/velox/connectors/hive/TableFormatReader.h
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/connectors/hive/HiveConnectorSplit.h"
+#include "velox/connectors/hive/TableHandle.h"
+#include "velox/dwio/common/BufferedInput.h"
+#include "velox/dwio/common/Reader.h"
+
+namespace facebook::velox::connector::hive {
+
+static const char* kPath = "$path";
+static const char* kBucket = "$bucket";
+
+class TableFormatReader {
+ public:
+  static std::unique_ptr<TableFormatReader> create(
+      std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
+      RowTypePtr readerOutputType,
+      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+          partitionKeys,
+      std::shared_ptr<common::ScanSpec> scanSpec,
+      memory::MemoryPool*& pool);
+
+  TableFormatReader(
+      std::shared_ptr<velox::connector::hive::HiveConnectorSplit> hiveSplit,
+      RowTypePtr readerOutputType,
+      std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+          partitionKeys,
+      std::shared_ptr<common::ScanSpec> scanSpec,
+      memory::MemoryPool*& pool);
+
+  virtual ~TableFormatReader() = default;
+
+  /**
+   * This function is used by different table formats like Iceberg and Hudi to
+   * do additional preparations before reading the split, e.g. Open delete files
+   * or log files, and add column adapatations for metadata columns
+   */
+  virtual void prepareSplit(
+      const std::shared_ptr<HiveTableHandle>& hiveTableHandle,
+      const dwio::common::ReaderOptions& readerOptions,
+      std::unique_ptr<dwio::common::BufferedInput> baseFileInput,
+      std::shared_ptr<common::MetadataFilter> metadataFilter,
+      dwio::common::RuntimeStatistics& runtimeStats);
+
+  virtual uint64_t next(int64_t size, VectorPtr& output);
+
+  std::unique_ptr<dwio::common::RowReader> createRowReader(
+      dwio::common::RowReaderOptions& options) {
+    return baseReader_->createRowReader(options);
+  };
+
+  std::shared_ptr<dwio::common::RowReader> baseRowReader() {
+    return baseRowReader_;
+  }
+
+  void resetFilterCaches();
+
+  bool emptySplit() const;
+
+  void resetSplit();
+
+  int64_t estimatedRowSize() const;
+
+  void updateRuntimeStats(dwio::common::RuntimeStatistics& stats) const;
+
+  bool allPrefetchIssued() const;
+
+  std::string toString() const;
+
+ protected:
+  /**
+   * Different table formats may have different meatadata columns. This function
+   * will be used to update the scanSpec for these columns.
+   */
+  virtual std::vector<TypePtr> adaptColumns(
+      const RowTypePtr& fileType,
+      const std::shared_ptr<const velox::RowType>& tableSchema);
+
+  void setConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const TypePtr& type,
+      const velox::variant& value) const;
+
+  void setNullConstantValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const TypePtr& type) const;
+
+  void setPartitionValue(
+      common::ScanSpec* FOLLY_NONNULL spec,
+      const std::string& partitionKey,
+      const std::optional<std::string>& value) const;
+
+  std::shared_ptr<HiveConnectorSplit> hiveSplit_;
+  RowTypePtr readerOutputType_;
+  std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+      partitionKeys_;
+  std::shared_ptr<common::ScanSpec> scanSpec_;
+  memory::MemoryPool* pool_;
+  dwio::common::RowReaderOptions rowReaderOpts_;
+  std::unique_ptr<dwio::common::Reader> baseReader_;
+  std::shared_ptr<dwio::common::RowReader> baseRowReader_;
+
+ private:
+  void configureRowReaderOptions(
+      dwio::common::RowReaderOptions& options,
+      const RowTypePtr& rowType);
+
+  bool emptySplit_;
+};
+
+} // namespace facebook::velox::connector::hive

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/TableScan.h"
+
 #include "velox/common/time/Timer.h"
 #include "velox/exec/Task.h"
 #include "velox/expression/Expr.h"

--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -340,8 +340,24 @@ velox::variant arrayVariantAt(
 std::vector<MaterializedRow> materialize(
     ::duckdb::DataChunk* dataChunk,
     const std::shared_ptr<const RowType>& rowType) {
+  std::string rowTypeStr = rowType ? rowType->toString() : "";
+  std::string dataChunkTypeName = "";
+  for (const auto& type : dataChunk->GetTypes()) {
+    dataChunkTypeName += type.ToString() + " ";
+  }
+  int rowTypeSize = rowType ? rowType->size() : 0;
+  int dataChunkTypeSize = dataChunk->GetTypes().size();
   VELOX_CHECK_EQ(
-      rowType->size(), dataChunk->GetTypes().size(), "Wrong number of columns");
+      rowTypeSize,
+      dataChunkTypeSize,
+      "Wrong number of columns. rowType has ",
+      rowTypeSize,
+      " columns, ",
+      rowTypeStr,
+      " dataChunk has ",
+      dataChunkTypeSize,
+      "columns. ",
+      dataChunkTypeName);
 
   auto size = dataChunk->size();
   std::vector<MaterializedRow> rows;

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -93,6 +93,8 @@ TEST_F(FunctionTest, getNameBeforeDelimiter) {
 TEST_F(FunctionTest, constructFunctionMap) {
   std::string planPath =
       getDataFilePath("velox/substrait/tests", "data/q1_first_stage.json");
+  std::cout << "planPath " << planPath << std::endl;
+
   ::substrait::Plan substraitPlan;
   JsonToProtoConverter::readFromFile(planPath, substraitPlan);
   planConverter_->constructFunctionMap(substraitPlan);

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -268,6 +268,7 @@ TEST_F(Substrait2VeloxPlanConversionTest, q6) {
   // Find and deserialize Substrait plan json file.
   std::string planPath =
       getDataFilePath("velox/substrait/tests", "data/q6_first_stage.json");
+  std::cout << "planPath " << planPath << std::endl;
 
   // Read q6_first_stage.json and resume the Substrait plan.
   ::substrait::Plan substraitPlan;


### PR DESCRIPTION
The lakehouse table formats like Iceberg and Hudi define their protocols to address data management issue like versioning, row level inserts and deletes. These protocols usually define their specific metadata formats, delete files or log files, and the way to apply these information on the underlying data. In order to handle such different protocols on top of the basic Hive data, we introduce TableReader, the base class for different table formats. The TableFormatReader owns the Reader and RowReader, and is used as a delegate of HiveDataSource to handle table readings.

Improve materialize error message