### PR TITLE
Emphasize that ContainerRowSerde::compare does not allow top level nulls.

### DIFF
--- a/velox/exec/ContainerRowSerde.cpp
+++ b/velox/exec/ContainerRowSerde.cpp
@@ -797,6 +797,8 @@ int32_t ContainerRowSerde::compare(
     const DecodedVector& right,
     vector_size_t index,
     CompareFlags flags) {
+  VELOX_DCHECK(
+      !right.isNullAt(index), "Null top-level values are not supported");
   VELOX_DCHECK(!flags.mayStopAtNull(), "not supported null handling mode");
   return compareSwitch(left, *right.base(), right.index(index), flags).value();
 }
@@ -817,6 +819,8 @@ std::optional<int32_t> ContainerRowSerde::compareWithNulls(
     const DecodedVector& right,
     vector_size_t index,
     CompareFlags flags) {
+  VELOX_DCHECK(
+      !right.isNullAt(index), "Null top-level values are not supported");
   return compareSwitch(left, *right.base(), right.index(index), flags);
 }
 

--- a/velox/exec/ContainerRowSerde.h
+++ b/velox/exec/ContainerRowSerde.h
@@ -35,6 +35,7 @@ class ContainerRowSerde {
   /// Returns < 0 if 'left' is less than 'right' at 'index', 0 if
   /// equal and > 0 otherwise. flags.nullHandlingMode can be only NoStop and
   /// support null-safe equal.
+  /// Top level rows in right are not allowed to be null.
   static int32_t compare(
       ByteStream& left,
       const DecodedVector& right,
@@ -55,6 +56,7 @@ class ContainerRowSerde {
   /// returns std::nullopt if either 'left' or 'right' value is null or contains
   /// a null. If flags.nullHandlingMode is NoStop then NULL is considered equal
   /// to NULL.
+  /// Top level rows in right are not allowed to be null.
   static std::optional<int32_t> compareWithNulls(
       ByteStream& left,
       const DecodedVector& right,


### PR DESCRIPTION
Summary: ContainerRowSerde::compare does not allow top level nulls, made that explicit using a comment and a DCHECK.

Differential Revision: D49775400


