### PR TITLE
Normalize connector session properties with config properties.

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -343,7 +343,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
   std::shared_ptr<core::QueryCtx> newQueryCtx(
       int64_t memoryCapacity = kMaxMemory,
       std::unique_ptr<MemoryReclaimer>&& reclaimer = nullptr) {
-    std::unordered_map<std::string, std::shared_ptr<Config>> configs;
+    std::unordered_map<std::string, std::shared_ptr<const Config>> configs;
     std::shared_ptr<MemoryPool> pool = memoryManager_->addRootPool(
         "",
         memoryCapacity,

--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -228,7 +228,7 @@ class ConnectorQueryCtx {
       memory::MemoryPool* operatorPool,
       memory::MemoryPool* connectorPool,
       memory::SetMemoryReclaimer setMemoryReclaimer,
-      const Config* connectorConfig,
+      std::shared_ptr<const Config> connectorConfig,
       const common::SpillConfig* spillConfig,
       std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator,
       cache::AsyncDataCache* cache,
@@ -239,7 +239,7 @@ class ConnectorQueryCtx {
       : operatorPool_(operatorPool),
         connectorPool_(connectorPool),
         setMemoryReclaimer_(std::move(setMemoryReclaimer)),
-        config_(connectorConfig),
+        connectorConfig_(std::move(connectorConfig)),
         spillConfig_(spillConfig),
         expressionEvaluator_(std::move(expressionEvaluator)),
         cache_(cache),
@@ -248,7 +248,7 @@ class ConnectorQueryCtx {
         taskId_(taskId),
         driverId_(driverId),
         planNodeId_(planNodeId) {
-    VELOX_CHECK_NOT_NULL(connectorConfig);
+    VELOX_CHECK_NOT_NULL(connectorConfig_);
   }
 
   /// Returns the associated operator's memory pool which is a leaf kind of
@@ -271,8 +271,12 @@ class ConnectorQueryCtx {
     return setMemoryReclaimer_;
   }
 
-  const Config* config() const {
-    return config_;
+  void setConnectorConfig(std::shared_ptr<const Config> config) {
+    connectorConfig_ = std::move(config);
+  }
+
+  std::shared_ptr<const Config> getConnectorConfig() const {
+    return connectorConfig_;
   }
 
   const common::SpillConfig* getSpillConfig() const {
@@ -315,7 +319,7 @@ class ConnectorQueryCtx {
   memory::MemoryPool* const operatorPool_;
   memory::MemoryPool* const connectorPool_;
   const memory::SetMemoryReclaimer setMemoryReclaimer_;
-  const Config* config_;
+  std::shared_ptr<const Config> connectorConfig_;
   const common::SpillConfig* const spillConfig_;
   std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;
   cache::AsyncDataCache* cache_;

--- a/velox/connectors/hive/HiveConnector.cpp
+++ b/velox/connectors/hive/HiveConnector.cpp
@@ -75,16 +75,14 @@ std::unique_ptr<DataSource> HiveConnector::createDataSource(
         std::string,
         std::shared_ptr<connector::ColumnHandle>>& columnHandles,
     ConnectorQueryCtx* connectorQueryCtx) {
+  const auto config = connectorQueryCtx->getConnectorConfig().get();
   dwio::common::ReaderOptions options(connectorQueryCtx->memoryPool());
-  options.setMaxCoalesceBytes(
-      HiveConfig::maxCoalescedBytes(connectorQueryCtx->config()));
-  options.setMaxCoalesceDistance(
-      HiveConfig::maxCoalescedDistanceBytes(connectorQueryCtx->config()));
+  options.setMaxCoalesceBytes(HiveConfig::maxCoalescedBytes(config));
+  options.setMaxCoalesceDistance(HiveConfig::maxCoalescedDistanceBytes(config));
   options.setFileColumnNamesReadAsLowerCase(
-      HiveConfig::isFileColumnNamesReadAsLowerCase(
-          connectorQueryCtx->config()));
+      HiveConfig::isFileColumnNamesReadAsLowerCase(config));
   options.setUseColumnNamesForColumnMapping(
-      HiveConfig::isOrcUseColumnNames(connectorQueryCtx->config()));
+      HiveConfig::isOrcUseColumnNames(config));
 
   return std::make_unique<HiveDataSource>(
       outputType,
@@ -107,12 +105,9 @@ std::unique_ptr<DataSink> HiveConnector::createDataSink(
       connectorInsertTableHandle);
   VELOX_CHECK_NOT_NULL(
       hiveInsertHandle, "Hive connector expecting hive write handle!");
+
   return std::make_unique<HiveDataSink>(
-      inputType,
-      hiveInsertHandle,
-      connectorQueryCtx,
-      commitStrategy,
-      connectorProperties());
+      inputType, hiveInsertHandle, connectorQueryCtx, commitStrategy);
 }
 
 std::unique_ptr<core::PartitionFunction> HivePartitionFunctionSpec::create(

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -390,8 +390,7 @@ class HiveDataSink : public DataSink {
       RowTypePtr inputType,
       std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx* connectorQueryCtx,
-      CommitStrategy commitStrategy,
-      const std::shared_ptr<const Config>& connectorProperties);
+      CommitStrategy commitStrategy);
 
   static uint32_t maxBucketCount() {
     static const uint32_t kMaxBucketCount = 100'000;
@@ -475,7 +474,6 @@ class HiveDataSink : public DataSink {
   const std::shared_ptr<const HiveInsertTableHandle> insertTableHandle_;
   const ConnectorQueryCtx* const connectorQueryCtx_;
   const CommitStrategy commitStrategy_;
-  const std::shared_ptr<const Config> connectorProperties_;
   const uint32_t maxOpenWriters_;
   const std::vector<column_index_t> partitionChannels_;
   const std::unique_ptr<PartitionIdGenerator> partitionIdGenerator_;

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -48,7 +48,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
         opPool_.get(),
         connectorPool_.get(),
         nullptr,
-        connectorConfig_.get(),
+        connectorConfig_,
         nullptr,
         nullptr,
         nullptr,
@@ -88,8 +88,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
         rowType,
         createHiveInsertTableHandle(rowType, outputDirectoryPath),
         connectorQueryCtx_.get(),
-        CommitStrategy::kNoCommit,
-        connectorConfig_);
+        CommitStrategy::kNoCommit);
   }
 
   std::vector<std::string> listFiles(const std::string& dirPath) {

--- a/velox/core/Config.h
+++ b/velox/core/Config.h
@@ -63,6 +63,10 @@ class Config {
   virtual std::unordered_map<std::string, std::string> valuesCopy() const {
     VELOX_UNSUPPORTED("method valuesCopy() is not supported by this config");
   }
+
+  virtual bool empty() const {
+    return values().empty();
+  }
 };
 
 namespace core {

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -20,7 +20,8 @@ namespace facebook::velox::core {
 QueryCtx::QueryCtx(
     folly::Executor* executor,
     std::unordered_map<std::string, std::string> queryConfigValues,
-    std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
+    std::unordered_map<std::string, std::shared_ptr<const Config>>
+        connectorConfigs,
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     std::shared_ptr<folly::Executor> spillExecutor,
@@ -38,7 +39,8 @@ QueryCtx::QueryCtx(
 QueryCtx::QueryCtx(
     folly::Executor::KeepAlive<> executorKeepalive,
     std::unordered_map<std::string, std::string> queryConfigValues,
-    std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
+    std::unordered_map<std::string, std::shared_ptr<const Config>>
+        connectorConfigs,
     cache::AsyncDataCache* cache,
     std::shared_ptr<memory::MemoryPool> pool,
     const std::string& queryId)

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -52,11 +52,18 @@ OperatorCtx::createConnectorQueryCtx(
     memory::MemoryPool* connectorPool,
     memory::SetMemoryReclaimer setMemoryReclaimer,
     const common::SpillConfig* spillConfig) const {
+  auto connectorConfig =
+      driverCtx_->task->queryCtx()->getConnectorConfig(connectorId);
+  VELOX_CHECK(connectorConfig);
+  if (connectorConfig->empty()) {
+    connectorConfig =
+        connector::getConnector(connectorId)->connectorProperties();
+  }
   return std::make_shared<connector::ConnectorQueryCtx>(
       pool_,
       connectorPool,
       std::move(setMemoryReclaimer),
-      driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
+      connectorConfig,
       spillConfig,
       std::make_unique<SimpleExpressionEvaluator>(
           execCtx()->queryCtx(), execCtx()->pool()),

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -223,7 +223,7 @@ AssertQueryBuilder::readCursor() {
       params_.queryCtx = std::make_shared<core::QueryCtx>(
           executor_.get(),
           std::unordered_map<std::string, std::string>{},
-          std::unordered_map<std::string, std::shared_ptr<Config>>{},
+          std::unordered_map<std::string, std::shared_ptr<const Config>>{},
           cache::AsyncDataCache::getInstance(),
           nullptr,
           nullptr,

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -124,7 +124,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
     queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(),
         std::unordered_map<std::string, std::string>{},
-        std::unordered_map<std::string, std::shared_ptr<Config>>{},
+        std::unordered_map<std::string, std::shared_ptr<const Config>>{},
         cache::AsyncDataCache::getInstance(),
         nullptr,
         nullptr,


### PR DESCRIPTION
If `task->queryCtx()` does not have the connector properties, get it from the connectors map.