### PR TITLE
Move unit tests from Arrow Parquet writer

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -35,6 +35,7 @@ if(VELOX_ENABLE_ARROW)
       -DARROW_SIMD_LEVEL=NONE
       -DARROW_RUNTIME_SIMD_LEVEL=NONE
       -DARROW_WITH_UTF8PROC=OFF
+      -DARROW_TESTING=ON
       -DCMAKE_INSTALL_PREFIX=${ARROW_PREFIX}/install
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DARROW_BUILD_STATIC=ON
@@ -71,18 +72,23 @@ if(VELOX_ENABLE_ARROW)
     SOURCE_SUBDIR cpp
     CMAKE_ARGS ${ARROW_CMAKE_ARGS}
     BUILD_BYPRODUCTS ${ARROW_LIBDIR}/libarrow.a ${ARROW_LIBDIR}/libparquet.a
-                     ${THRIFT_LIB})
+                     ${ARROW_LIBDIR}/libarrow_testing.a ${THRIFT_LIB})
   add_library(arrow STATIC IMPORTED GLOBAL)
+  add_library(arrow_testing STATIC IMPORTED GLOBAL)
   add_library(parquet STATIC IMPORTED GLOBAL)
   add_dependencies(arrow arrow_ep)
+  add_dependencies(arrow_testing arrow)
   add_dependencies(parquet arrow)
   file(MAKE_DIRECTORY ${ARROW_PREFIX}/install/include)
   set_target_properties(
-    arrow parquet PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
-                             ${ARROW_PREFIX}/install/include)
+    arrow arrow_testing parquet PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                           ${ARROW_PREFIX}/install/include)
   set_target_properties(arrow PROPERTIES IMPORTED_LOCATION
                                          ${ARROW_LIBDIR}/libarrow.a)
   set_property(TARGET arrow PROPERTY INTERFACE_LINK_LIBRARIES ${RE2} thrift)
+  set_target_properties(
+    arrow_testing PROPERTIES IMPORTED_LOCATION
+                             ${ARROW_LIBDIR}/libarrow_testing.a)
   set_target_properties(parquet PROPERTIES IMPORTED_LOCATION
                                            ${ARROW_LIBDIR}/libparquet.a)
 

--- a/velox/dwio/parquet/writer/arrow/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/CMakeLists.txt
@@ -15,6 +15,10 @@
 add_subdirectory(util)
 add_subdirectory(generated)
 
+if(${VELOX_BUILD_TESTING})
+  add_subdirectory(tests)
+endif()
+
 add_library(
   velox_dwio_arrow_parquet_writer_lib
   ArrowSchema.cpp

--- a/velox/dwio/parquet/writer/arrow/ColumnWriter.h
+++ b/velox/dwio/parquet/writer/arrow/ColumnWriter.h
@@ -117,8 +117,9 @@ class PARQUET_EXPORT PageWriter {
       OffsetIndexBuilder* offset_index_builder = NULLPTR,
       const util::CodecOptions& codec_options = util::CodecOptions{});
 
-  ARROW_DEPRECATED(
-      "Deprecated in 13.0.0. Use CodecOptions-taking overload instead.")
+  // TODO: remove this and port to new signature.
+  // ARROW_DEPRECATED(
+  //    "Deprecated in 13.0.0. Use CodecOptions-taking overload instead.")
   static std::unique_ptr<PageWriter> Open(
       std::shared_ptr<ArrowOutputStream> sink,
       Compression::type codec,

--- a/velox/dwio/parquet/writer/arrow/Platform.h
+++ b/velox/dwio/parquet/writer/arrow/Platform.h
@@ -87,7 +87,6 @@
 namespace facebook::velox::parquet::arrow {
 
 using Buffer = ::arrow::Buffer;
-using Codec = ::arrow::util::Codec;
 using MemoryPool = ::arrow::MemoryPool;
 using MutableBuffer = ::arrow::MutableBuffer;
 using ResizableBuffer = ::arrow::ResizableBuffer;

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilter.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilter.cpp
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+
+#include "arrow/result.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/macros.h"
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/generated/parquet_types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilter.h"
+#include "velox/dwio/parquet/writer/arrow/tests/XxHasher.h"
+
+namespace facebook::velox::parquet::arrow {
+
+constexpr uint32_t BlockSplitBloomFilter::SALT[kBitsSetPerBlock];
+
+BlockSplitBloomFilter::BlockSplitBloomFilter(::arrow::MemoryPool* pool)
+    : pool_(pool),
+      hash_strategy_(HashStrategy::XXHASH),
+      algorithm_(Algorithm::BLOCK),
+      compression_strategy_(CompressionStrategy::UNCOMPRESSED) {}
+
+void BlockSplitBloomFilter::Init(uint32_t num_bytes) {
+  if (num_bytes < kMinimumBloomFilterBytes) {
+    num_bytes = kMinimumBloomFilterBytes;
+  }
+
+  // Get next power of 2 if it is not power of 2.
+  if ((num_bytes & (num_bytes - 1)) != 0) {
+    num_bytes = static_cast<uint32_t>(::arrow::bit_util::NextPower2(num_bytes));
+  }
+
+  if (num_bytes > kMaximumBloomFilterBytes) {
+    num_bytes = kMaximumBloomFilterBytes;
+  }
+
+  num_bytes_ = num_bytes;
+  PARQUET_ASSIGN_OR_THROW(data_, ::arrow::AllocateBuffer(num_bytes_, pool_));
+  memset(data_->mutable_data(), 0, num_bytes_);
+
+  this->hasher_ = std::make_unique<XxHasher>();
+}
+
+void BlockSplitBloomFilter::Init(const uint8_t* bitset, uint32_t num_bytes) {
+  DCHECK(bitset != nullptr);
+
+  if (num_bytes < kMinimumBloomFilterBytes ||
+      num_bytes > kMaximumBloomFilterBytes ||
+      (num_bytes & (num_bytes - 1)) != 0) {
+    throw ParquetException("Given length of bitset is illegal");
+  }
+
+  num_bytes_ = num_bytes;
+  PARQUET_ASSIGN_OR_THROW(data_, ::arrow::AllocateBuffer(num_bytes_, pool_));
+  memcpy(data_->mutable_data(), bitset, num_bytes_);
+
+  this->hasher_ = std::make_unique<XxHasher>();
+}
+
+static constexpr uint32_t kBloomFilterHeaderSizeGuess = 256;
+
+static ::arrow::Status ValidateBloomFilterHeader(
+    const format::BloomFilterHeader& header) {
+  if (!header.algorithm.__isset.BLOCK) {
+    return ::arrow::Status::Invalid(
+        "Unsupported Bloom filter algorithm: ", header.algorithm, ".");
+  }
+
+  if (!header.hash.__isset.XXHASH) {
+    return ::arrow::Status::Invalid(
+        "Unsupported Bloom filter hash: ", header.hash, ".");
+  }
+
+  if (!header.compression.__isset.UNCOMPRESSED) {
+    return ::arrow::Status::Invalid(
+        "Unsupported Bloom filter compression: ", header.compression, ".");
+  }
+
+  if (header.numBytes <= 0 ||
+      static_cast<uint32_t>(header.numBytes) >
+          BloomFilter::kMaximumBloomFilterBytes) {
+    std::stringstream ss;
+    ss << "Bloom filter size is incorrect: " << header.numBytes
+       << ". Must be in range (" << 0 << ", "
+       << BloomFilter::kMaximumBloomFilterBytes << "].";
+    return ::arrow::Status::Invalid(ss.str());
+  }
+
+  return ::arrow::Status::OK();
+}
+
+BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
+    const ReaderProperties& properties,
+    ArrowInputStream* input) {
+  // NOTE: we don't know the bloom filter header size upfront, and we can't rely
+  // on InputStream::Peek() which isn't always implemented. Therefore, we must
+  // first Read() with an upper bound estimate of the header size, then once we
+  // know the bloom filter data size, we can Read() the exact number of
+  // remaining data bytes.
+  ThriftDeserializer deserializer(properties);
+  format::BloomFilterHeader header;
+
+  // Read and deserialize bloom filter header
+  PARQUET_ASSIGN_OR_THROW(
+      auto header_buf, input->Read(kBloomFilterHeaderSizeGuess));
+  // This gets used, then set by DeserializeThriftMsg
+  uint32_t header_size = static_cast<uint32_t>(header_buf->size());
+  try {
+    deserializer.DeserializeMessage(
+        reinterpret_cast<const uint8_t*>(header_buf->data()),
+        &header_size,
+        &header);
+    DCHECK_LE(header_size, header_buf->size());
+  } catch (std::exception& e) {
+    std::stringstream ss;
+    ss << "Deserializing bloom filter header failed.\n" << e.what();
+    throw ParquetException(ss.str());
+  }
+  PARQUET_THROW_NOT_OK(ValidateBloomFilterHeader(header));
+
+  const int32_t bloom_filter_size = header.numBytes;
+  if (bloom_filter_size + header_size <= header_buf->size()) {
+    // The bloom filter data is entirely contained in the buffer we just read
+    // => just return it.
+    BlockSplitBloomFilter bloom_filter(properties.memory_pool());
+    bloom_filter.Init(header_buf->data() + header_size, bloom_filter_size);
+    return bloom_filter;
+  }
+  // We have read a part of the bloom filter already, copy it to the target
+  // buffer and read the remaining part from the InputStream.
+  auto buffer = AllocateBuffer(properties.memory_pool(), bloom_filter_size);
+
+  const auto bloom_filter_bytes_in_header = header_buf->size() - header_size;
+  if (bloom_filter_bytes_in_header > 0) {
+    std::memcpy(
+        buffer->mutable_data(),
+        header_buf->data() + header_size,
+        bloom_filter_bytes_in_header);
+  }
+
+  const auto required_read_size =
+      bloom_filter_size - bloom_filter_bytes_in_header;
+  PARQUET_ASSIGN_OR_THROW(
+      auto read_size,
+      input->Read(
+          required_read_size,
+          buffer->mutable_data() + bloom_filter_bytes_in_header));
+  if (ARROW_PREDICT_FALSE(read_size < required_read_size)) {
+    throw ParquetException("Bloom Filter read failed: not enough data");
+  }
+  BlockSplitBloomFilter bloom_filter(properties.memory_pool());
+  bloom_filter.Init(buffer->data(), bloom_filter_size);
+  return bloom_filter;
+}
+
+void BlockSplitBloomFilter::WriteTo(ArrowOutputStream* sink) const {
+  DCHECK(sink != nullptr);
+
+  format::BloomFilterHeader header;
+  if (ARROW_PREDICT_FALSE(algorithm_ != BloomFilter::Algorithm::BLOCK)) {
+    throw ParquetException(
+        "BloomFilter does not support Algorithm other than BLOCK");
+  }
+  header.algorithm.__set_BLOCK(format::SplitBlockAlgorithm());
+  if (ARROW_PREDICT_FALSE(hash_strategy_ != HashStrategy::XXHASH)) {
+    throw ParquetException(
+        "BloomFilter does not support Hash other than XXHASH");
+  }
+  header.hash.__set_XXHASH(format::XxHash());
+  if (ARROW_PREDICT_FALSE(
+          compression_strategy_ != CompressionStrategy::UNCOMPRESSED)) {
+    throw ParquetException(
+        "BloomFilter does not support Compression other than UNCOMPRESSED");
+  }
+  header.compression.__set_UNCOMPRESSED(format::Uncompressed());
+  header.__set_numBytes(num_bytes_);
+
+  ThriftSerializer serializer;
+  serializer.Serialize(&header, sink);
+
+  PARQUET_THROW_NOT_OK(sink->Write(data_->data(), num_bytes_));
+}
+
+bool BlockSplitBloomFilter::FindHash(uint64_t hash) const {
+  const uint32_t bucket_index = static_cast<uint32_t>(
+      ((hash >> 32) * (num_bytes_ / kBytesPerFilterBlock)) >> 32);
+  const uint32_t key = static_cast<uint32_t>(hash);
+  const uint32_t* bitset32 = reinterpret_cast<const uint32_t*>(data_->data());
+
+  for (int i = 0; i < kBitsSetPerBlock; ++i) {
+    // Calculate mask for key in the given bitset.
+    const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
+    if (ARROW_PREDICT_FALSE(
+            0 == (bitset32[kBitsSetPerBlock * bucket_index + i] & mask))) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void BlockSplitBloomFilter::InsertHashImpl(uint64_t hash) {
+  const uint32_t bucket_index = static_cast<uint32_t>(
+      ((hash >> 32) * (num_bytes_ / kBytesPerFilterBlock)) >> 32);
+  const uint32_t key = static_cast<uint32_t>(hash);
+  uint32_t* bitset32 = reinterpret_cast<uint32_t*>(data_->mutable_data());
+
+  for (int i = 0; i < kBitsSetPerBlock; i++) {
+    // Calculate mask for key in the given bitset.
+    const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
+    bitset32[bucket_index * kBitsSetPerBlock + i] |= mask;
+  }
+}
+
+void BlockSplitBloomFilter::InsertHash(uint64_t hash) {
+  InsertHashImpl(hash);
+}
+
+void BlockSplitBloomFilter::InsertHashes(
+    const uint64_t* hashes,
+    int num_values) {
+  for (int i = 0; i < num_values; ++i) {
+    InsertHashImpl(hashes[i]);
+  }
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilter.h
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilter.h
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+#include <memory>
+
+#include "arrow/util/bit_util.h"
+#include "arrow/util/logging.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/Hasher.h"
+
+namespace facebook::velox::parquet::arrow {
+
+// A Bloom filter is a compact structure to indicate whether an item is not in a
+// set or probably in a set. The Bloom filter usually consists of a bit set that
+// represents a set of elements, a hash strategy and a Bloom filter algorithm.
+class PARQUET_EXPORT BloomFilter {
+ public:
+  // Maximum Bloom filter size, it sets to HDFS default block size 128MB
+  // This value will be reconsidered when implementing Bloom filter producer.
+  static constexpr uint32_t kMaximumBloomFilterBytes = 128 * 1024 * 1024;
+
+  /// Determine whether an element exist in set or not.
+  ///
+  /// @param hash the element to contain.
+  /// @return false if value is definitely not in set, and true means PROBABLY
+  /// in set.
+  virtual bool FindHash(uint64_t hash) const = 0;
+
+  /// Insert element to set represented by Bloom filter bitset.
+  /// @param hash the hash of value to insert into Bloom filter.
+  virtual void InsertHash(uint64_t hash) = 0;
+
+  /// Insert elements to set represented by Bloom filter bitset.
+  /// @param hashes the hash values to insert into Bloom filter.
+  /// @param num_values the number of hash values to insert.
+  virtual void InsertHashes(const uint64_t* hashes, int num_values) = 0;
+
+  /// Write this Bloom filter to an output stream. A Bloom filter structure
+  /// should include bitset length, hash strategy, algorithm, and bitset.
+  ///
+  /// @param sink the output stream to write
+  virtual void WriteTo(ArrowOutputStream* sink) const = 0;
+
+  /// Get the number of bytes of bitset
+  virtual uint32_t GetBitsetSize() const = 0;
+
+  /// Compute hash for 32 bits value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(int32_t value) const = 0;
+
+  /// Compute hash for 64 bits value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(int64_t value) const = 0;
+
+  /// Compute hash for float value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(float value) const = 0;
+
+  /// Compute hash for double value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(double value) const = 0;
+
+  /// Compute hash for Int96 value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(const Int96* value) const = 0;
+
+  /// Compute hash for ByteArray value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(const ByteArray* value) const = 0;
+
+  /// Compute hash for fixed byte array value by using its plain encoding
+  /// result.
+  ///
+  /// @param value the value address.
+  /// @param len the value length.
+  /// @return hash result.
+  virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
+
+  /// Batch compute hashes for 32 bits values by using its plain encoding
+  /// result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for 64 bits values by using its plain encoding
+  /// result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for float values by using its plain encoding result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const float* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for double values by using its plain encoding result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const double* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for Int96 values by using its plain encoding result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for ByteArray values by using its plain encoding
+  /// result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const ByteArray* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for fixed byte array values by using its plain
+  /// encoding result.
+  ///
+  /// @param values values a pointer to the values to hash.
+  /// @param type_len the value length.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(
+      const FLBA* values,
+      uint32_t type_len,
+      int num_values,
+      uint64_t* hashes) const = 0;
+
+  virtual ~BloomFilter() = default;
+
+ protected:
+  // Hash strategy available for Bloom filter.
+  enum class HashStrategy : uint32_t { XXHASH = 0 };
+
+  // Bloom filter algorithm.
+  enum class Algorithm : uint32_t { BLOCK = 0 };
+
+  enum class CompressionStrategy : uint32_t { UNCOMPRESSED = 0 };
+};
+
+/// The BlockSplitBloomFilter is implemented using block-based Bloom filters
+/// from Putze et al.'s "Cache-,Hash- and Space-Efficient Bloom filters". The
+/// basic idea is to hash the item to a tiny Bloom filter which size fit a
+/// single cache line or smaller.
+///
+/// This implementation sets 8 bits in each tiny Bloom filter. Each tiny Bloom
+/// filter is 32 bytes to take advantage of 32-byte SIMD instructions.
+class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
+ public:
+  /// The constructor of BlockSplitBloomFilter. It uses XXH64 as hash function.
+  ///
+  /// \param pool memory pool to use.
+  explicit BlockSplitBloomFilter(
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+  /// Initialize the BlockSplitBloomFilter. The range of num_bytes should be
+  /// within [kMinimumBloomFilterBytes, kMaximumBloomFilterBytes], it will be
+  /// rounded up/down to lower/upper bound if num_bytes is out of range and also
+  /// will be rounded up to a power of 2.
+  ///
+  /// @param num_bytes The number of bytes to store Bloom filter bitset.
+  void Init(uint32_t num_bytes);
+
+  /// Initialize the BlockSplitBloomFilter. It copies the bitset as underlying
+  /// bitset because the given bitset may not satisfy the 32-byte alignment
+  /// requirement which may lead to segfault when performing SIMD instructions.
+  /// It is the caller's responsibility to free the bitset passed in. This is
+  /// used when reconstructing a Bloom filter from a parquet file.
+  ///
+  /// @param bitset The given bitset to initialize the Bloom filter.
+  /// @param num_bytes  The number of bytes of given bitset.
+  void Init(const uint8_t* bitset, uint32_t num_bytes);
+
+  /// Minimum Bloom filter size, it sets to 32 bytes to fit a tiny Bloom filter.
+  static constexpr uint32_t kMinimumBloomFilterBytes = 32;
+
+  /// Calculate optimal size according to the number of distinct values and
+  /// false positive probability.
+  ///
+  /// @param ndv The number of distinct values.
+  /// @param fpp The false positive probability.
+  /// @return it always return a value between kMinimumBloomFilterBytes and
+  /// kMaximumBloomFilterBytes, and the return value is always a power of 2
+  static uint32_t OptimalNumOfBytes(uint32_t ndv, double fpp) {
+    uint32_t optimal_num_of_bits = OptimalNumOfBits(ndv, fpp);
+    DCHECK(::arrow::bit_util::IsMultipleOf8(optimal_num_of_bits));
+    return optimal_num_of_bits >> 3;
+  }
+
+  /// Calculate optimal size according to the number of distinct values and
+  /// false positive probability.
+  ///
+  /// @param ndv The number of distinct values.
+  /// @param fpp The false positive probability.
+  /// @return it always return a value between kMinimumBloomFilterBytes * 8 and
+  /// kMaximumBloomFilterBytes * 8, and the return value is always a power of 16
+  static uint32_t OptimalNumOfBits(uint32_t ndv, double fpp) {
+    DCHECK(fpp > 0.0 && fpp < 1.0);
+    const double m = -8.0 * ndv / log(1 - pow(fpp, 1.0 / 8));
+    uint32_t num_bits;
+
+    // Handle overflow.
+    if (m < 0 || m > kMaximumBloomFilterBytes << 3) {
+      num_bits = static_cast<uint32_t>(kMaximumBloomFilterBytes << 3);
+    } else {
+      num_bits = static_cast<uint32_t>(m);
+    }
+
+    // Round up to lower bound
+    if (num_bits < kMinimumBloomFilterBytes << 3) {
+      num_bits = kMinimumBloomFilterBytes << 3;
+    }
+
+    // Get next power of 2 if bits is not power of 2.
+    if ((num_bits & (num_bits - 1)) != 0) {
+      num_bits = static_cast<uint32_t>(::arrow::bit_util::NextPower2(num_bits));
+    }
+
+    // Round down to upper bound
+    if (num_bits > kMaximumBloomFilterBytes << 3) {
+      num_bits = kMaximumBloomFilterBytes << 3;
+    }
+
+    return num_bits;
+  }
+
+  bool FindHash(uint64_t hash) const override;
+  void InsertHash(uint64_t hash) override;
+  void InsertHashes(const uint64_t* hashes, int num_values) override;
+  void WriteTo(ArrowOutputStream* sink) const override;
+  uint32_t GetBitsetSize() const override {
+    return num_bytes_;
+  }
+
+  uint64_t Hash(int32_t value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(int64_t value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(float value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(double value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(const Int96* value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(const ByteArray* value) const override {
+    return hasher_->Hash(value);
+  }
+  uint64_t Hash(const FLBA* value, uint32_t len) const override {
+    return hasher_->Hash(value, len);
+  }
+
+  void Hashes(const int32_t* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(const int64_t* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(const float* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(const double* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(const Int96* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(const ByteArray* values, int num_values, uint64_t* hashes)
+      const override {
+    hasher_->Hashes(values, num_values, hashes);
+  }
+  void Hashes(
+      const FLBA* values,
+      uint32_t type_len,
+      int num_values,
+      uint64_t* hashes) const override {
+    hasher_->Hashes(values, type_len, num_values, hashes);
+  }
+
+  uint64_t Hash(const int32_t* value) const {
+    return hasher_->Hash(*value);
+  }
+  uint64_t Hash(const int64_t* value) const {
+    return hasher_->Hash(*value);
+  }
+  uint64_t Hash(const float* value) const {
+    return hasher_->Hash(*value);
+  }
+  uint64_t Hash(const double* value) const {
+    return hasher_->Hash(*value);
+  }
+
+  /// Deserialize the Bloom filter from an input stream. It is used when
+  /// reconstructing a Bloom filter from a parquet filter.
+  ///
+  /// @param properties The parquet reader properties.
+  /// @param input_stream The input stream from which to construct the Bloom
+  /// filter.
+  /// @return The BlockSplitBloomFilter.
+  static BlockSplitBloomFilter Deserialize(
+      const ReaderProperties& properties,
+      ArrowInputStream* input_stream);
+
+ private:
+  inline void InsertHashImpl(uint64_t hash);
+
+  // Bytes in a tiny Bloom filter block.
+  static constexpr int kBytesPerFilterBlock = 32;
+
+  // The number of bits to be set in each tiny Bloom filter
+  static constexpr int kBitsSetPerBlock = 8;
+
+  // A mask structure used to set bits in each tiny Bloom filter.
+  struct BlockMask {
+    uint32_t item[kBitsSetPerBlock];
+  };
+
+  // The block-based algorithm needs eight odd SALT values to calculate eight
+  // indexes of bit to set, one bit in each 32-bit word.
+  static constexpr uint32_t SALT[kBitsSetPerBlock] = {
+      0x47b6137bU,
+      0x44974d91U,
+      0x8824ad5bU,
+      0xa2b7289dU,
+      0x705495c7U,
+      0x2df1424bU,
+      0x9efc4947U,
+      0x5c6bfb31U};
+
+  // Memory pool to allocate aligned buffer for bitset
+  ::arrow::MemoryPool* pool_;
+
+  // The underlying buffer of bitset.
+  std::shared_ptr<Buffer> data_;
+
+  // The number of bytes of Bloom filter bitset.
+  uint32_t num_bytes_;
+
+  // Hash strategy used in this Bloom filter.
+  HashStrategy hash_strategy_;
+
+  // Algorithm used in this Bloom filter.
+  Algorithm algorithm_;
+
+  // Compression used in this Bloom filter.
+  CompressionStrategy compression_strategy_;
+
+  // The hash pointer points to actual hash class used.
+  std::unique_ptr<Hasher> hasher_;
+};
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.h"
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilter.h"
+
+namespace facebook::velox::parquet::arrow {
+
+class RowGroupBloomFilterReaderImpl final : public RowGroupBloomFilterReader {
+ public:
+  RowGroupBloomFilterReaderImpl(
+      std::shared_ptr<::arrow::io::RandomAccessFile> input,
+      std::shared_ptr<RowGroupMetaData> row_group_metadata,
+      const ReaderProperties& properties)
+      : input_(std::move(input)),
+        row_group_metadata_(std::move(row_group_metadata)),
+        properties_(properties) {}
+
+  std::unique_ptr<BloomFilter> GetColumnBloomFilter(int i) override;
+
+ private:
+  /// The input stream that can perform random access read.
+  std::shared_ptr<::arrow::io::RandomAccessFile> input_;
+
+  /// The row group metadata to get column chunk metadata.
+  std::shared_ptr<RowGroupMetaData> row_group_metadata_;
+
+  /// Reader properties used to deserialize thrift object.
+  const ReaderProperties& properties_;
+};
+
+std::unique_ptr<BloomFilter>
+RowGroupBloomFilterReaderImpl::GetColumnBloomFilter(int i) {
+  if (i < 0 || i >= row_group_metadata_->num_columns()) {
+    throw ParquetException("Invalid column index at column ordinal ", i);
+  }
+
+  auto col_chunk = row_group_metadata_->ColumnChunk(i);
+  std::unique_ptr<ColumnCryptoMetaData> crypto_metadata =
+      col_chunk->crypto_metadata();
+  if (crypto_metadata != nullptr) {
+    ParquetException::NYI("Cannot read encrypted bloom filter yet");
+  }
+
+  auto bloom_filter_offset = col_chunk->bloom_filter_offset();
+  if (!bloom_filter_offset.has_value()) {
+    return nullptr;
+  }
+  PARQUET_ASSIGN_OR_THROW(auto file_size, input_->GetSize());
+  if (file_size <= *bloom_filter_offset) {
+    throw ParquetException("file size less or equal than bloom offset");
+  }
+  auto stream = ::arrow::io::RandomAccessFile::GetStream(
+      input_, *bloom_filter_offset, file_size - *bloom_filter_offset);
+  auto bloom_filter =
+      BlockSplitBloomFilter::Deserialize(properties_, stream->get());
+  return std::make_unique<BlockSplitBloomFilter>(std::move(bloom_filter));
+}
+
+class BloomFilterReaderImpl final : public BloomFilterReader {
+ public:
+  BloomFilterReaderImpl(
+      std::shared_ptr<::arrow::io::RandomAccessFile> input,
+      std::shared_ptr<FileMetaData> file_metadata,
+      const ReaderProperties& properties,
+      std::shared_ptr<InternalFileDecryptor> file_decryptor)
+      : input_(std::move(input)),
+        file_metadata_(std::move(file_metadata)),
+        properties_(properties) {
+    if (file_decryptor != nullptr) {
+      ParquetException::NYI("BloomFilter decryption is not yet supported");
+    }
+  }
+
+  std::shared_ptr<RowGroupBloomFilterReader> RowGroup(int i) {
+    if (i < 0 || i >= file_metadata_->num_row_groups()) {
+      throw ParquetException("Invalid row group ordinal: ", i);
+    }
+
+    auto row_group_metadata = file_metadata_->RowGroup(i);
+    return std::make_shared<RowGroupBloomFilterReaderImpl>(
+        input_, std::move(row_group_metadata), properties_);
+  }
+
+ private:
+  /// The input stream that can perform random read.
+  std::shared_ptr<::arrow::io::RandomAccessFile> input_;
+
+  /// The file metadata to get row group metadata.
+  std::shared_ptr<FileMetaData> file_metadata_;
+
+  /// Reader properties used to deserialize thrift object.
+  const ReaderProperties& properties_;
+};
+
+std::unique_ptr<BloomFilterReader> BloomFilterReader::Make(
+    std::shared_ptr<::arrow::io::RandomAccessFile> input,
+    std::shared_ptr<FileMetaData> file_metadata,
+    const ReaderProperties& properties,
+    std::shared_ptr<InternalFileDecryptor> file_decryptor) {
+  return std::make_unique<BloomFilterReaderImpl>(
+      std::move(input), file_metadata, properties, std::move(file_decryptor));
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.h
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include "arrow/io/interfaces.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+
+namespace facebook::velox::parquet::arrow {
+
+class InternalFileDecryptor;
+class BloomFilter;
+class FileMetaData;
+
+class PARQUET_EXPORT RowGroupBloomFilterReader {
+ public:
+  virtual ~RowGroupBloomFilterReader() = default;
+
+  /// \brief Read bloom filter of a column chunk.
+  ///
+  /// \param[in] i column ordinal of the column chunk.
+  /// \returns bloom filter of the column or nullptr if it does not exist.
+  /// \throws ParquetException if the index is out of bound, or read bloom
+  /// filter failed.
+  virtual std::unique_ptr<BloomFilter> GetColumnBloomFilter(int i) = 0;
+};
+
+/// \brief Interface for reading the bloom filter for a Parquet file.
+class PARQUET_EXPORT BloomFilterReader {
+ public:
+  virtual ~BloomFilterReader() = default;
+
+  /// \brief Create a BloomFilterReader instance.
+  /// \returns a BloomFilterReader instance.
+  /// WARNING: The returned BloomFilterReader references to all the input
+  /// parameters, so it must not outlive all of the input parameters. Usually
+  /// these input parameters come from the same ParquetFileReader object, so it
+  /// must not outlive the reader that creates this BloomFilterReader.
+  static std::unique_ptr<BloomFilterReader> Make(
+      std::shared_ptr<::arrow::io::RandomAccessFile> input,
+      std::shared_ptr<FileMetaData> file_metadata,
+      const ReaderProperties& properties,
+      std::shared_ptr<InternalFileDecryptor> file_decryptor = NULLPTR);
+
+  /// \brief Get the bloom filter reader of a specific row group.
+  /// \param[in] i row group ordinal to get bloom filter reader.
+  /// \returns RowGroupBloomFilterReader of the specified row group. A nullptr
+  /// may or may
+  ///          not be returned if the bloom filter for the row group is
+  ///          unavailable. It is the caller's responsibility to check the
+  ///          return value of follow-up calls to the RowGroupBloomFilterReader.
+  /// \throws ParquetException if the index is out of bound.
+  virtual std::shared_ptr<RowGroupBloomFilterReader> RowGroup(int i) = 0;
+};
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/BloomFilterTest.cpp
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/buffer.h"
+#include "arrow/io/file.h"
+#include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilter.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+#include "velox/dwio/parquet/writer/arrow/tests/XxHasher.h"
+
+namespace facebook::velox::parquet::arrow {
+namespace test {
+
+TEST(ConstructorTest, TestBloomFilter) {
+  BlockSplitBloomFilter bloom_filter;
+  EXPECT_NO_THROW(bloom_filter.Init(1000));
+
+  // It throws because the length cannot be zero
+  std::unique_ptr<uint8_t[]> bitset1(new uint8_t[1024]());
+  EXPECT_THROW(bloom_filter.Init(bitset1.get(), 0), ParquetException);
+
+  // It throws because the number of bytes of Bloom filter bitset must be a
+  // power of 2.
+  std::unique_ptr<uint8_t[]> bitset2(new uint8_t[1024]());
+  EXPECT_THROW(bloom_filter.Init(bitset2.get(), 1023), ParquetException);
+}
+
+// The BasicTest is used to test basic operations including InsertHash, FindHash
+// and serializing and de-serializing.
+TEST(BasicTest, TestBloomFilter) {
+  const std::vector<uint32_t> kBloomFilterSizes = {
+      32, 64, 128, 256, 512, 1024, 2048};
+  const std::vector<int32_t> kIntInserts = {
+      1, 2, 3, 5, 6, 7, 8, 9, 10, 42, -1, 1 << 29, 1 << 30};
+  const std::vector<double> kFloatInserts = {
+      1.5, -1.5, 3.0, 6.0, 0.0, 123.456, 1e6, 1e7, 1e8};
+  const std::vector<int32_t> kNegativeIntLookups = {
+      0, 11, 12, 13, -2, -3, 43, 1 << 27, 1 << 28};
+
+  for (const auto bloom_filter_bytes : kBloomFilterSizes) {
+    BlockSplitBloomFilter bloom_filter;
+    bloom_filter.Init(bloom_filter_bytes);
+
+    // Empty bloom filter deterministically returns false
+    for (const auto v : kIntInserts) {
+      EXPECT_FALSE(bloom_filter.FindHash(bloom_filter.Hash(v)));
+    }
+    for (const auto v : kFloatInserts) {
+      EXPECT_FALSE(bloom_filter.FindHash(bloom_filter.Hash(v)));
+    }
+
+    // Insert all values
+    for (const auto v : kIntInserts) {
+      bloom_filter.InsertHash(bloom_filter.Hash(v));
+    }
+    for (const auto v : kFloatInserts) {
+      bloom_filter.InsertHash(bloom_filter.Hash(v));
+    }
+
+    // They should always lookup successfully
+    for (const auto v : kIntInserts) {
+      EXPECT_TRUE(bloom_filter.FindHash(bloom_filter.Hash(v)));
+    }
+    for (const auto v : kFloatInserts) {
+      EXPECT_TRUE(bloom_filter.FindHash(bloom_filter.Hash(v)));
+    }
+
+    // Values not inserted in the filter should only rarely lookup successfully
+    int false_positives = 0;
+    for (const auto v : kNegativeIntLookups) {
+      false_positives += bloom_filter.FindHash(bloom_filter.Hash(v));
+    }
+    // (this is a crude check, see FPPTest below for a more rigorous formula)
+    EXPECT_LE(false_positives, 2);
+
+    // Serialize Bloom filter to memory output stream
+    auto sink = CreateOutputStream();
+    bloom_filter.WriteTo(sink.get());
+
+    // Deserialize Bloom filter from memory
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+    ::arrow::io::BufferReader source(buffer);
+
+    ReaderProperties reader_properties;
+    BlockSplitBloomFilter de_bloom =
+        BlockSplitBloomFilter::Deserialize(reader_properties, &source);
+
+    // Lookup previously inserted values
+    for (const auto v : kIntInserts) {
+      EXPECT_TRUE(de_bloom.FindHash(de_bloom.Hash(v)));
+    }
+    for (const auto v : kFloatInserts) {
+      EXPECT_TRUE(de_bloom.FindHash(de_bloom.Hash(v)));
+    }
+    false_positives = 0;
+    for (const auto v : kNegativeIntLookups) {
+      false_positives += de_bloom.FindHash(de_bloom.Hash(v));
+    }
+    EXPECT_LE(false_positives, 2);
+  }
+}
+
+// Helper function to generate random string.
+std::string GetRandomString(uint32_t length) {
+  // Character set used to generate random string
+  const std::string charset =
+      "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+
+  std::default_random_engine gen(42);
+  std::uniform_int_distribution<uint32_t> dist(
+      0, static_cast<int>(charset.size() - 1));
+  std::string ret(length, 'x');
+
+  for (uint32_t i = 0; i < length; i++) {
+    ret[i] = charset[dist(gen)];
+  }
+  return ret;
+}
+
+TEST(FPPTest, TestBloomFilter) {
+  // It counts the number of times FindHash returns true.
+  int exist = 0;
+
+  // Total count of elements that will be used
+#ifdef PARQUET_VALGRIND
+  const int total_count = 5000;
+#else
+  const int total_count = 100000;
+#endif
+
+  // Bloom filter fpp parameter
+  const double fpp = 0.01;
+
+  std::vector<std::string> members;
+  BlockSplitBloomFilter bloom_filter;
+  bloom_filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(total_count, fpp));
+
+  // Insert elements into the Bloom filter
+  for (int i = 0; i < total_count; i++) {
+    // Insert random string which length is 8
+    std::string tmp = GetRandomString(8);
+    const ByteArray byte_array(
+        8, reinterpret_cast<const uint8_t*>(tmp.c_str()));
+    members.push_back(tmp);
+    bloom_filter.InsertHash(bloom_filter.Hash(&byte_array));
+  }
+
+  for (int i = 0; i < total_count; i++) {
+    const ByteArray byte_array1(
+        8, reinterpret_cast<const uint8_t*>(members[i].c_str()));
+    ASSERT_TRUE(bloom_filter.FindHash(bloom_filter.Hash(&byte_array1)));
+    std::string tmp = GetRandomString(7);
+    const ByteArray byte_array2(
+        7, reinterpret_cast<const uint8_t*>(tmp.c_str()));
+
+    if (bloom_filter.FindHash(bloom_filter.Hash(&byte_array2))) {
+      exist++;
+    }
+  }
+
+  // The exist should be probably less than 1000 according default FPP 0.01.
+  EXPECT_LT(exist, total_count * fpp);
+}
+
+// The CompatibilityTest is used to test cross compatibility with parquet-mr, it
+// reads the Bloom filter binary generated by the Bloom filter class in the
+// parquet-mr project and tests whether the values inserted before could be
+// filtered or not.
+
+// TODO: disabled as it requires Arrow parquet data dir.
+// The Bloom filter binary is generated by three steps in from Parquet-mr.
+// Step 1: Construct a Bloom filter with 1024 bytes bitset.
+// Step 2: Insert "hello", "parquet", "bloom", "filter" to Bloom filter.
+// Step 3: Call writeTo API to write to File.
+/*
+TEST(CompatibilityTest, TestBloomFilter) {
+  const std::string test_string[4] = {"hello", "parquet", "bloom", "filter"};
+  const std::string bloom_filter_test_binary =
+      std::string(test::get_data_dir()) + "/bloom_filter.xxhash.bin";
+
+  PARQUET_ASSIGN_OR_THROW(auto handle,
+                          ::arrow::io::ReadableFile::Open(bloom_filter_test_binary));
+  PARQUET_ASSIGN_OR_THROW(int64_t size, handle->GetSize());
+
+  // 16 bytes (thrift header) + 1024 bytes (bitset)
+  EXPECT_EQ(size, 1040);
+
+  std::unique_ptr<uint8_t[]> bitset(new uint8_t[size]());
+  PARQUET_ASSIGN_OR_THROW(auto buffer, handle->Read(size));
+
+  ::arrow::io::BufferReader source(buffer);
+  ReaderProperties reader_properties;
+  BlockSplitBloomFilter bloom_filter1 =
+      BlockSplitBloomFilter::Deserialize(reader_properties, &source);
+
+  for (int i = 0; i < 4; i++) {
+    const ByteArray tmp(static_cast<uint32_t>(test_string[i].length()),
+                        reinterpret_cast<const
+uint8_t*>(test_string[i].c_str()));
+    EXPECT_TRUE(bloom_filter1.FindHash(bloom_filter1.Hash(&tmp)));
+  }
+
+  // The following is used to check whether the new created Bloom filter in
+parquet-cpp is
+  // byte-for-byte identical to file at bloom_data_path which is created from
+parquet-mr
+  // with same inserted hashes.
+  BlockSplitBloomFilter bloom_filter2;
+  bloom_filter2.Init(bloom_filter1.GetBitsetSize());
+  for (int i = 0; i < 4; i++) {
+    const ByteArray byte_array(static_cast<uint32_t>(test_string[i].length()),
+                               reinterpret_cast<const
+uint8_t*>(test_string[i].c_str()));
+    bloom_filter2.InsertHash(bloom_filter2.Hash(&byte_array));
+  }
+
+  // Serialize Bloom filter to memory output stream
+  auto sink = CreateOutputStream();
+  bloom_filter2.WriteTo(sink.get());
+  PARQUET_ASSIGN_OR_THROW(auto buffer1, sink->Finish());
+
+  PARQUET_THROW_NOT_OK(handle->Seek(0));
+  PARQUET_ASSIGN_OR_THROW(size, handle->GetSize());
+  PARQUET_ASSIGN_OR_THROW(auto buffer2, handle->Read(size));
+
+  EXPECT_TRUE((*buffer1).Equals(*buffer2));
+}
+*/
+
+// OptimalValueTest is used to test whether OptimalNumOfBits returns expected
+// numbers according to formula:
+//     num_of_bits = -8.0 * ndv / log(1 - pow(fpp, 1.0 / 8.0))
+// where ndv is the number of distinct values and fpp is the false positive
+// probability. Also it is used to test whether OptimalNumOfBits returns value
+// between [MINIMUM_BLOOM_FILTER_SIZE, MAXIMUM_BLOOM_FILTER_SIZE].
+TEST(OptimalValueTest, TestBloomFilter) {
+  auto testOptimalNumEstimation = [](uint32_t ndv,
+                                     double fpp,
+                                     uint32_t num_bits) {
+    EXPECT_EQ(BlockSplitBloomFilter::OptimalNumOfBits(ndv, fpp), num_bits);
+    EXPECT_EQ(BlockSplitBloomFilter::OptimalNumOfBytes(ndv, fpp), num_bits / 8);
+  };
+
+  testOptimalNumEstimation(256, 0.01, UINT32_C(4096));
+  testOptimalNumEstimation(512, 0.01, UINT32_C(8192));
+  testOptimalNumEstimation(1024, 0.01, UINT32_C(16384));
+  testOptimalNumEstimation(2048, 0.01, UINT32_C(32768));
+
+  testOptimalNumEstimation(200, 0.01, UINT32_C(2048));
+  testOptimalNumEstimation(300, 0.01, UINT32_C(4096));
+  testOptimalNumEstimation(700, 0.01, UINT32_C(8192));
+  testOptimalNumEstimation(1500, 0.01, UINT32_C(16384));
+
+  testOptimalNumEstimation(200, 0.025, UINT32_C(2048));
+  testOptimalNumEstimation(300, 0.025, UINT32_C(4096));
+  testOptimalNumEstimation(700, 0.025, UINT32_C(8192));
+  testOptimalNumEstimation(1500, 0.025, UINT32_C(16384));
+
+  testOptimalNumEstimation(200, 0.05, UINT32_C(2048));
+  testOptimalNumEstimation(300, 0.05, UINT32_C(4096));
+  testOptimalNumEstimation(700, 0.05, UINT32_C(8192));
+  testOptimalNumEstimation(1500, 0.05, UINT32_C(16384));
+
+  // Boundary check
+  testOptimalNumEstimation(
+      4, 0.01, BlockSplitBloomFilter::kMinimumBloomFilterBytes * 8);
+  testOptimalNumEstimation(
+      4, 0.25, BlockSplitBloomFilter::kMinimumBloomFilterBytes * 8);
+
+  testOptimalNumEstimation(
+      std::numeric_limits<uint32_t>::max(),
+      0.01,
+      BlockSplitBloomFilter::kMaximumBloomFilterBytes * 8);
+  testOptimalNumEstimation(
+      std::numeric_limits<uint32_t>::max(),
+      0.25,
+      BlockSplitBloomFilter::kMaximumBloomFilterBytes * 8);
+}
+
+// The test below is plainly copied from parquet-mr and serves as a basic sanity
+// check of our XXH64 wrapper.
+const int64_t HASHES_OF_LOOPING_BYTES_WITH_SEED_0[32] = {
+    -1205034819632174695L, -1642502924627794072L, 5216751715308240086L,
+    -1889335612763511331L, -13835840860730338L,   -2521325055659080948L,
+    4867868962443297827L,  1498682999415010002L,  -8626056615231480947L,
+    7482827008138251355L,  -617731006306969209L,  7289733825183505098L,
+    4776896707697368229L,  1428059224718910376L,  6690813482653982021L,
+    -6248474067697161171L, 4951407828574235127L,  6198050452789369270L,
+    5776283192552877204L,  -626480755095427154L,  -6637184445929957204L,
+    8370873622748562952L,  -1705978583731280501L, -7898818752540221055L,
+    -2516210193198301541L, 8356900479849653862L,  -4413748141896466000L,
+    -6040072975510680789L, 1451490609699316991L,  -7948005844616396060L,
+    8567048088357095527L,  -4375578310507393311L};
+
+/**
+ * Test data is output of the following program with xxHash implementation
+ * from https://github.com/Cyan4973/xxHash with commit
+ * c8c4cc0f812719ce1f5b2c291159658980e7c255
+ *
+ * #define XXH_INLINE_ALL
+ * #include "xxhash.h"
+ * #include <stdlib.h>
+ * #include <stdio.h>
+ * int main()
+ * {
+ *     char* src = (char*) malloc(32);
+ *     const int N = 32;
+ *     for (int i = 0; i < N; i++) {
+ *         src[i] = (char) i;
+ *     }
+ *
+ *     printf("without seed\n");
+ *     for (int i = 0; i <= N; i++) {
+ *        printf("%lldL,\n", (long long) XXH64(src, i, 0));
+ *     }
+ * }
+ */
+TEST(XxHashTest, TestBloomFilter) {
+  constexpr int kNumValues = 32;
+  uint8_t bytes[kNumValues] = {};
+
+  for (int i = 0; i < kNumValues; i++) {
+    ByteArray byte_array(i, bytes);
+    bytes[i] = i;
+
+    auto hasher_seed_0 = std::make_unique<XxHasher>();
+    EXPECT_EQ(
+        HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i],
+        hasher_seed_0->Hash(&byte_array))
+        << "Hash with seed 0 Error: " << i;
+  }
+}
+
+// Same as TestBloomFilter but using Batch interface
+TEST(XxHashTest, TestBloomFilterHashes) {
+  constexpr int kNumValues = 32;
+  uint8_t bytes[kNumValues] = {};
+
+  std::vector<ByteArray> byte_array_vector;
+  for (int i = 0; i < kNumValues; i++) {
+    bytes[i] = i;
+    byte_array_vector.emplace_back(i, bytes);
+  }
+  auto hasher_seed_0 = std::make_unique<XxHasher>();
+  std::vector<uint64_t> hashes;
+  hashes.resize(kNumValues);
+  hasher_seed_0->Hashes(
+      byte_array_vector.data(),
+      static_cast<int>(byte_array_vector.size()),
+      hashes.data());
+  for (int i = 0; i < kNumValues; i++) {
+    EXPECT_EQ(HASHES_OF_LOOPING_BYTES_WITH_SEED_0[i], hashes[i])
+        << "Hash with seed 0 Error: " << i;
+  }
+}
+
+template <typename DType>
+class TestBatchBloomFilter : public testing::Test {
+ public:
+  constexpr static int kTestDataSize = 64;
+
+  // GenerateTestData with size 64.
+  std::vector<typename DType::c_type> GenerateTestData();
+
+  // The Lifetime owner for Test data
+  std::vector<uint8_t> members;
+};
+
+template <typename DType>
+std::vector<typename DType::c_type>
+TestBatchBloomFilter<DType>::GenerateTestData() {
+  std::vector<typename DType::c_type> values(kTestDataSize);
+  GenerateData(kTestDataSize, values.data(), &members);
+  return values;
+}
+
+// Note: BloomFilter doesn't support BooleanType.
+using BloomFilterTestTypes = ::testing::Types<
+    Int32Type,
+    Int64Type,
+    FloatType,
+    DoubleType,
+    Int96Type,
+    FLBAType,
+    ByteArrayType>;
+
+TYPED_TEST_SUITE(TestBatchBloomFilter, BloomFilterTestTypes);
+
+TYPED_TEST(TestBatchBloomFilter, Basic) {
+  using Type = typename TypeParam::c_type;
+  std::vector<Type> test_data = TestFixture::GenerateTestData();
+  BlockSplitBloomFilter batch_insert_filter;
+  BlockSplitBloomFilter filter;
+
+  // Bloom filter fpp parameter
+  const double fpp = 0.05;
+  filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(
+      TestFixture::kTestDataSize, fpp));
+  batch_insert_filter.Init(BlockSplitBloomFilter::OptimalNumOfBytes(
+      TestFixture::kTestDataSize, fpp));
+
+  std::vector<uint64_t> hashes;
+  for (const Type& value : test_data) {
+    uint64_t hash = 0;
+    if constexpr (std::is_same_v<Type, FLBA>) {
+      hash = filter.Hash(&value, kGenerateDataFLBALength);
+    } else {
+      hash = filter.Hash(&value);
+    }
+    hashes.push_back(hash);
+  }
+
+  std::vector<uint64_t> batch_hashes(test_data.size());
+  if constexpr (std::is_same_v<Type, FLBA>) {
+    batch_insert_filter.Hashes(
+        test_data.data(),
+        kGenerateDataFLBALength,
+        static_cast<int>(test_data.size()),
+        batch_hashes.data());
+  } else {
+    batch_insert_filter.Hashes(
+        test_data.data(),
+        static_cast<int>(test_data.size()),
+        batch_hashes.data());
+  }
+
+  EXPECT_EQ(hashes, batch_hashes);
+
+  std::shared_ptr<Buffer> buffer;
+  std::shared_ptr<Buffer> batch_insert_buffer;
+  {
+    auto sink = CreateOutputStream();
+    filter.WriteTo(sink.get());
+    ASSERT_OK_AND_ASSIGN(buffer, sink->Finish());
+  }
+  {
+    auto sink = CreateOutputStream();
+    batch_insert_filter.WriteTo(sink.get());
+    ASSERT_OK_AND_ASSIGN(batch_insert_buffer, sink->Finish());
+  }
+  AssertBufferEqual(*buffer, *batch_insert_buffer);
+}
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/writer/arrow/tests/CMakeLists.txt
@@ -1,0 +1,56 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(
+  velox_dwio_arrow_parquet_writer_test
+  BloomFilterTest.cpp
+  ColumnReaderTest.cpp
+  ColumnWriterTest.cpp
+  EncodingTest.cpp
+  FileDeserializeTest.cpp
+  FileSerializeTest.cpp
+  LevelConversionTest.cpp
+  MetadataTest.cpp
+  PageIndexTest.cpp
+  PropertiesTest.cpp
+  SchemaTest.cpp
+  StatisticsTest.cpp
+  TypesTest.cpp)
+
+add_test(velox_dwio_arrow_parquet_writer_test
+         velox_dwio_arrow_parquet_writer_test)
+
+target_link_libraries(
+  velox_dwio_arrow_parquet_writer_test
+  velox_dwio_arrow_parquet_writer_lib
+  velox_dwio_arrow_parquet_writer_test_lib
+  gmock
+  gtest
+  gtest_main
+  parquet
+  arrow
+  arrow_testing)
+
+add_library(
+  velox_dwio_arrow_parquet_writer_test_lib
+  BloomFilter.cpp
+  BloomFilterReader.cpp
+  ColumnReader.cpp
+  ColumnScanner.cpp
+  FileReader.cpp
+  TestUtil.cpp
+  XxHasher.cpp)
+
+target_link_libraries(velox_dwio_arrow_parquet_writer_test_lib
+                      velox_dwio_arrow_parquet_writer_lib parquet arrow gtest)

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReader.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReader.cpp
@@ -1,0 +1,2548 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_dict.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/chunked_array.h"
+#include "arrow/type.h"
+#include "arrow/util/bit_stream_utils.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/compression.h"
+#include "arrow/util/crc32.h"
+#include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/rle_encoding.h"
+#include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
+#include "velox/dwio/parquet/writer/arrow/Encoding.h"
+#include "velox/dwio/parquet/writer/arrow/EncryptionInternal.h"
+#include "velox/dwio/parquet/writer/arrow/FileDecryptorInternal.h"
+#include "velox/dwio/parquet/writer/arrow/LevelComparison.h"
+#include "velox/dwio/parquet/writer/arrow/LevelConversion.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+
+using arrow::MemoryPool;
+using arrow::internal::AddWithOverflow;
+using arrow::internal::checked_cast;
+using arrow::internal::MultiplyWithOverflow;
+
+namespace bit_util = arrow::bit_util;
+
+namespace facebook::velox::parquet::arrow {
+namespace {
+
+// The minimum number of repetition/definition levels to decode at a time, for
+// better vectorized performance when doing many smaller record reads
+constexpr int64_t kMinLevelBatchSize = 1024;
+
+// Batch size for reading and throwing away values during skip.
+// Both RecordReader and the ColumnReader use this for skipping.
+constexpr int64_t kSkipScratchBatchSize = 1024;
+
+inline bool HasSpacedValues(const ColumnDescriptor* descr) {
+  if (descr->max_repetition_level() > 0) {
+    // repeated+flat case
+    return !descr->schema_node()->is_required();
+  } else {
+    // non-repeated+nested case
+    // Find if a node forces nulls in the lowest level along the hierarchy
+    const schema::Node* node = descr->schema_node().get();
+    while (node) {
+      if (node->is_optional()) {
+        return true;
+      }
+      node = node->parent();
+    }
+    return false;
+  }
+}
+
+// Throws exception if number_decoded does not match expected.
+inline void CheckNumberDecoded(int64_t number_decoded, int64_t expected) {
+  if (ARROW_PREDICT_FALSE(number_decoded != expected)) {
+    ParquetException::EofException(
+        "Decoded values " + std::to_string(number_decoded) +
+        " does not match expected " + std::to_string(expected));
+  }
+}
+} // namespace
+
+LevelDecoder::LevelDecoder() : num_values_remaining_(0) {}
+
+LevelDecoder::~LevelDecoder() {}
+
+int LevelDecoder::SetData(
+    Encoding::type encoding,
+    int16_t max_level,
+    int num_buffered_values,
+    const uint8_t* data,
+    int32_t data_size) {
+  max_level_ = max_level;
+  int32_t num_bytes = 0;
+  encoding_ = encoding;
+  num_values_remaining_ = num_buffered_values;
+  bit_width_ = bit_util::Log2(max_level + 1);
+  switch (encoding) {
+    case Encoding::RLE: {
+      if (data_size < 4) {
+        throw ParquetException("Received invalid levels (corrupt data page?)");
+      }
+      num_bytes = ::arrow::util::SafeLoadAs<int32_t>(data);
+      if (num_bytes < 0 || num_bytes > data_size - 4) {
+        throw ParquetException(
+            "Received invalid number of bytes (corrupt data page?)");
+      }
+      const uint8_t* decoder_data = data + 4;
+      if (!rle_decoder_) {
+        rle_decoder_ = std::make_unique<::arrow::util::RleDecoder>(
+            decoder_data, num_bytes, bit_width_);
+      } else {
+        rle_decoder_->Reset(decoder_data, num_bytes, bit_width_);
+      }
+      return 4 + num_bytes;
+    }
+    case Encoding::BIT_PACKED: {
+      int num_bits = 0;
+      if (MultiplyWithOverflow(num_buffered_values, bit_width_, &num_bits)) {
+        throw ParquetException(
+            "Number of buffered values too large (corrupt data page?)");
+      }
+      num_bytes = static_cast<int32_t>(bit_util::BytesForBits(num_bits));
+      if (num_bytes < 0 || num_bytes > data_size - 4) {
+        throw ParquetException(
+            "Received invalid number of bytes (corrupt data page?)");
+      }
+      if (!bit_packed_decoder_) {
+        bit_packed_decoder_ =
+            std::make_unique<::arrow::bit_util::BitReader>(data, num_bytes);
+      } else {
+        bit_packed_decoder_->Reset(data, num_bytes);
+      }
+      return num_bytes;
+    }
+    default:
+      throw ParquetException("Unknown encoding type for levels.");
+  }
+  return -1;
+}
+
+void LevelDecoder::SetDataV2(
+    int32_t num_bytes,
+    int16_t max_level,
+    int num_buffered_values,
+    const uint8_t* data) {
+  max_level_ = max_level;
+  // Repetition and definition levels always uses RLE encoding
+  // in the DataPageV2 format.
+  if (num_bytes < 0) {
+    throw ParquetException("Invalid page header (corrupt data page?)");
+  }
+  encoding_ = Encoding::RLE;
+  num_values_remaining_ = num_buffered_values;
+  bit_width_ = bit_util::Log2(max_level + 1);
+
+  if (!rle_decoder_) {
+    rle_decoder_ = std::make_unique<::arrow::util::RleDecoder>(
+        data, num_bytes, bit_width_);
+  } else {
+    rle_decoder_->Reset(data, num_bytes, bit_width_);
+  }
+}
+
+int LevelDecoder::Decode(int batch_size, int16_t* levels) {
+  int num_decoded = 0;
+
+  int num_values = std::min(num_values_remaining_, batch_size);
+  if (encoding_ == Encoding::RLE) {
+    num_decoded = rle_decoder_->GetBatch(levels, num_values);
+  } else {
+    num_decoded = bit_packed_decoder_->GetBatch(bit_width_, levels, num_values);
+  }
+  if (num_decoded > 0) {
+    internal::MinMax min_max = internal::FindMinMax(levels, num_decoded);
+    if (ARROW_PREDICT_FALSE(min_max.min < 0 || min_max.max > max_level_)) {
+      std::stringstream ss;
+      ss << "Malformed levels. min: " << min_max.min << " max: " << min_max.max
+         << " out of range.  Max Level: " << max_level_;
+      throw ParquetException(ss.str());
+    }
+  }
+  num_values_remaining_ -= num_decoded;
+  return num_decoded;
+}
+
+namespace {
+
+// Extracts encoded statistics from V1 and V2 data page headers
+template <typename H>
+EncodedStatistics ExtractStatsFromHeader(const H& header) {
+  EncodedStatistics page_statistics;
+  if (!header.__isset.statistics) {
+    return page_statistics;
+  }
+  const format::Statistics& stats = header.statistics;
+  // Use the new V2 min-max statistics over the former one if it is filled
+  if (stats.__isset.max_value || stats.__isset.min_value) {
+    // TODO: check if the column_order is TYPE_DEFINED_ORDER.
+    if (stats.__isset.max_value) {
+      page_statistics.set_max(stats.max_value);
+    }
+    if (stats.__isset.min_value) {
+      page_statistics.set_min(stats.min_value);
+    }
+  } else if (stats.__isset.max || stats.__isset.min) {
+    // TODO: check created_by to see if it is corrupted for some types.
+    // TODO: check if the sort_order is SIGNED.
+    if (stats.__isset.max) {
+      page_statistics.set_max(stats.max);
+    }
+    if (stats.__isset.min) {
+      page_statistics.set_min(stats.min);
+    }
+  }
+  if (stats.__isset.null_count) {
+    page_statistics.set_null_count(stats.null_count);
+  }
+  if (stats.__isset.distinct_count) {
+    page_statistics.set_distinct_count(stats.distinct_count);
+  }
+  return page_statistics;
+}
+
+void CheckNumValuesInHeader(int num_values) {
+  if (num_values < 0) {
+    throw ParquetException("Invalid page header (negative number of values)");
+  }
+}
+
+// ----------------------------------------------------------------------
+// SerializedPageReader deserializes Thrift metadata and pages that have been
+// assembled in a serialized stream for storing in a Parquet files
+
+// This subclass delimits pages appearing in a serialized stream, each preceded
+// by a serialized Thrift format::PageHeader indicating the type of each page
+// and the page metadata.
+class SerializedPageReader : public PageReader {
+ public:
+  SerializedPageReader(
+      std::shared_ptr<ArrowInputStream> stream,
+      int64_t total_num_values,
+      Compression::type codec,
+      const ReaderProperties& properties,
+      const CryptoContext* crypto_ctx,
+      bool always_compressed)
+      : properties_(properties),
+        stream_(std::move(stream)),
+        decompression_buffer_(AllocateBuffer(properties_.memory_pool(), 0)),
+        page_ordinal_(0),
+        seen_num_values_(0),
+        total_num_values_(total_num_values),
+        decryption_buffer_(AllocateBuffer(properties_.memory_pool(), 0)) {
+    if (crypto_ctx != nullptr) {
+      crypto_ctx_ = *crypto_ctx;
+      InitDecryption();
+    }
+    max_page_header_size_ = kDefaultMaxPageHeaderSize;
+    decompressor_ = GetCodec(codec);
+    always_compressed_ = always_compressed;
+  }
+
+  // Implement the PageReader interface
+  //
+  // The returned Page contains references that aren't guaranteed to live
+  // beyond the next call to NextPage(). SerializedPageReader reuses the
+  // decryption and decompression buffers internally, so if NextPage() is
+  // called then the content of previous page might be invalidated.
+  std::shared_ptr<Page> NextPage() override;
+
+  void set_max_page_header_size(uint32_t size) override {
+    max_page_header_size_ = size;
+  }
+
+ private:
+  void UpdateDecryption(
+      const std::shared_ptr<Decryptor>& decryptor,
+      int8_t module_type,
+      std::string* page_aad);
+
+  void InitDecryption();
+
+  std::shared_ptr<Buffer> DecompressIfNeeded(
+      std::shared_ptr<Buffer> page_buffer,
+      int compressed_len,
+      int uncompressed_len,
+      int levels_byte_len = 0);
+
+  // Returns true for non-data pages, and if we should skip based on
+  // data_page_filter_. Performs basic checks on values in the page header.
+  // Fills in data_page_statistics.
+  bool ShouldSkipPage(EncodedStatistics* data_page_statistics);
+
+  const ReaderProperties properties_;
+  std::shared_ptr<ArrowInputStream> stream_;
+
+  format::PageHeader current_page_header_;
+  std::shared_ptr<Page> current_page_;
+
+  // Compression codec to use.
+  std::unique_ptr<util::Codec> decompressor_;
+  std::shared_ptr<ResizableBuffer> decompression_buffer_;
+
+  bool always_compressed_;
+
+  // The fields below are used for calculation of AAD (additional authenticated
+  // data) suffix which is part of the Parquet Modular Encryption. The AAD
+  // suffix for a parquet module is built internally by concatenating different
+  // parts some of which include the row group ordinal, column ordinal and page
+  // ordinal. Please refer to the encryption specification for more details:
+  // https://github.com/apache/parquet-format/blob/encryption/Encryption.md#44-additional-authenticated-data
+
+  // The ordinal fields in the context below are used for AAD suffix
+  // calculation.
+  CryptoContext crypto_ctx_;
+  int32_t page_ordinal_; // page ordinal does not count the dictionary page
+
+  // Maximum allowed page size
+  uint32_t max_page_header_size_;
+
+  // Number of values read in data pages so far
+  int64_t seen_num_values_;
+
+  // Number of values in all the data pages
+  int64_t total_num_values_;
+
+  // data_page_aad_ and data_page_header_aad_ contain the AAD for data page and
+  // data page header in a single column respectively. While calculating AAD for
+  // different pages in a single column the pages AAD is updated by only the
+  // page ordinal.
+  std::string data_page_aad_;
+  std::string data_page_header_aad_;
+  // Encryption
+  std::shared_ptr<ResizableBuffer> decryption_buffer_;
+};
+
+void SerializedPageReader::InitDecryption() {
+  // Prepare the AAD for quick update later.
+  if (crypto_ctx_.data_decryptor != nullptr) {
+    ARROW_DCHECK(!crypto_ctx_.data_decryptor->file_aad().empty());
+    data_page_aad_ = encryption::CreateModuleAad(
+        crypto_ctx_.data_decryptor->file_aad(),
+        encryption::kDataPage,
+        crypto_ctx_.row_group_ordinal,
+        crypto_ctx_.column_ordinal,
+        kNonPageOrdinal);
+  }
+  if (crypto_ctx_.meta_decryptor != nullptr) {
+    ARROW_DCHECK(!crypto_ctx_.meta_decryptor->file_aad().empty());
+    data_page_header_aad_ = encryption::CreateModuleAad(
+        crypto_ctx_.meta_decryptor->file_aad(),
+        encryption::kDataPageHeader,
+        crypto_ctx_.row_group_ordinal,
+        crypto_ctx_.column_ordinal,
+        kNonPageOrdinal);
+  }
+}
+
+void SerializedPageReader::UpdateDecryption(
+    const std::shared_ptr<Decryptor>& decryptor,
+    int8_t module_type,
+    std::string* page_aad) {
+  ARROW_DCHECK(decryptor != nullptr);
+  if (crypto_ctx_.start_decrypt_with_dictionary_page) {
+    std::string aad = encryption::CreateModuleAad(
+        decryptor->file_aad(),
+        module_type,
+        crypto_ctx_.row_group_ordinal,
+        crypto_ctx_.column_ordinal,
+        kNonPageOrdinal);
+    decryptor->UpdateAad(aad);
+  } else {
+    encryption::QuickUpdatePageAad(page_ordinal_, page_aad);
+    decryptor->UpdateAad(*page_aad);
+  }
+}
+
+bool SerializedPageReader::ShouldSkipPage(
+    EncodedStatistics* data_page_statistics) {
+  const PageType::type page_type = LoadEnumSafe(&current_page_header_.type);
+  if (page_type == PageType::DATA_PAGE) {
+    const format::DataPageHeader& header =
+        current_page_header_.data_page_header;
+    CheckNumValuesInHeader(header.num_values);
+    *data_page_statistics = ExtractStatsFromHeader(header);
+    seen_num_values_ += header.num_values;
+    if (data_page_filter_) {
+      const EncodedStatistics* filter_statistics =
+          data_page_statistics->is_set() ? data_page_statistics : nullptr;
+      DataPageStats data_page_stats(
+          filter_statistics,
+          header.num_values,
+          /*num_rows=*/std::nullopt);
+      if (data_page_filter_(data_page_stats)) {
+        return true;
+      }
+    }
+  } else if (page_type == PageType::DATA_PAGE_V2) {
+    const format::DataPageHeaderV2& header =
+        current_page_header_.data_page_header_v2;
+    CheckNumValuesInHeader(header.num_values);
+    if (header.num_rows < 0) {
+      throw ParquetException("Invalid page header (negative number of rows)");
+    }
+    if (header.definition_levels_byte_length < 0 ||
+        header.repetition_levels_byte_length < 0) {
+      throw ParquetException(
+          "Invalid page header (negative levels byte length)");
+    }
+    *data_page_statistics = ExtractStatsFromHeader(header);
+    seen_num_values_ += header.num_values;
+    if (data_page_filter_) {
+      const EncodedStatistics* filter_statistics =
+          data_page_statistics->is_set() ? data_page_statistics : nullptr;
+      DataPageStats data_page_stats(
+          filter_statistics, header.num_values, header.num_rows);
+      if (data_page_filter_(data_page_stats)) {
+        return true;
+      }
+    }
+  } else if (page_type == PageType::DICTIONARY_PAGE) {
+    const format::DictionaryPageHeader& dict_header =
+        current_page_header_.dictionary_page_header;
+    CheckNumValuesInHeader(dict_header.num_values);
+  } else {
+    // We don't know what this page type is. We're allowed to skip non-data
+    // pages.
+    return true;
+  }
+  return false;
+}
+
+std::shared_ptr<Page> SerializedPageReader::NextPage() {
+  ThriftDeserializer deserializer(properties_);
+
+  // Loop here because there may be unhandled page types that we skip until
+  // finding a page that we do know what to do with
+  while (seen_num_values_ < total_num_values_) {
+    uint32_t header_size = 0;
+    uint32_t allowed_page_size = kDefaultPageHeaderSize;
+
+    // Page headers can be very large because of page statistics
+    // We try to deserialize a larger buffer progressively
+    // until a maximum allowed header limit
+    while (true) {
+      PARQUET_ASSIGN_OR_THROW(auto view, stream_->Peek(allowed_page_size));
+      if (view.size() == 0) {
+        return std::shared_ptr<Page>(nullptr);
+      }
+
+      // This gets used, then set by DeserializeThriftMsg
+      header_size = static_cast<uint32_t>(view.size());
+      try {
+        if (crypto_ctx_.meta_decryptor != nullptr) {
+          UpdateDecryption(
+              crypto_ctx_.meta_decryptor,
+              encryption::kDictionaryPageHeader,
+              &data_page_header_aad_);
+        }
+        // Reset current page header to avoid unclearing the __isset flag.
+        current_page_header_ = format::PageHeader();
+        deserializer.DeserializeMessage(
+            reinterpret_cast<const uint8_t*>(view.data()),
+            &header_size,
+            &current_page_header_,
+            crypto_ctx_.meta_decryptor);
+        break;
+      } catch (std::exception& e) {
+        // Failed to deserialize. Double the allowed page header size and try
+        // again
+        std::stringstream ss;
+        ss << e.what();
+        allowed_page_size *= 2;
+        if (allowed_page_size > max_page_header_size_) {
+          ss << "Deserializing page header failed.\n";
+          throw ParquetException(ss.str());
+        }
+      }
+    }
+    // Advance the stream offset
+    PARQUET_THROW_NOT_OK(stream_->Advance(header_size));
+
+    int compressed_len = current_page_header_.compressed_page_size;
+    int uncompressed_len = current_page_header_.uncompressed_page_size;
+    if (compressed_len < 0 || uncompressed_len < 0) {
+      throw ParquetException("Invalid page header");
+    }
+
+    EncodedStatistics data_page_statistics;
+    if (ShouldSkipPage(&data_page_statistics)) {
+      PARQUET_THROW_NOT_OK(stream_->Advance(compressed_len));
+      continue;
+    }
+
+    if (crypto_ctx_.data_decryptor != nullptr) {
+      UpdateDecryption(
+          crypto_ctx_.data_decryptor,
+          encryption::kDictionaryPage,
+          &data_page_aad_);
+    }
+
+    // Read the compressed data page.
+    PARQUET_ASSIGN_OR_THROW(auto page_buffer, stream_->Read(compressed_len));
+    if (page_buffer->size() != compressed_len) {
+      std::stringstream ss;
+      ss << "Page was smaller (" << page_buffer->size() << ") than expected ("
+         << compressed_len << ")";
+      ParquetException::EofException(ss.str());
+    }
+
+    const PageType::type page_type = LoadEnumSafe(&current_page_header_.type);
+
+    if (properties_.page_checksum_verification() &&
+        current_page_header_.__isset.crc && PageCanUseChecksum(page_type)) {
+      // verify crc
+      uint32_t checksum = ::arrow::internal::crc32(
+          /* prev */ 0, page_buffer->data(), compressed_len);
+      if (static_cast<int32_t>(checksum) != current_page_header_.crc) {
+        throw ParquetException(
+            "could not verify page integrity, CRC checksum verification failed for "
+            "page_ordinal " +
+            std::to_string(page_ordinal_));
+      }
+    }
+
+    // Decrypt it if we need to
+    if (crypto_ctx_.data_decryptor != nullptr) {
+      PARQUET_THROW_NOT_OK(decryption_buffer_->Resize(
+          compressed_len - crypto_ctx_.data_decryptor->CiphertextSizeDelta(),
+          /*shrink_to_fit=*/false));
+      compressed_len = crypto_ctx_.data_decryptor->Decrypt(
+          page_buffer->data(),
+          compressed_len,
+          decryption_buffer_->mutable_data());
+
+      page_buffer = decryption_buffer_;
+    }
+
+    if (page_type == PageType::DICTIONARY_PAGE) {
+      crypto_ctx_.start_decrypt_with_dictionary_page = false;
+      const format::DictionaryPageHeader& dict_header =
+          current_page_header_.dictionary_page_header;
+      bool is_sorted =
+          dict_header.__isset.is_sorted ? dict_header.is_sorted : false;
+
+      page_buffer = DecompressIfNeeded(
+          std::move(page_buffer), compressed_len, uncompressed_len);
+
+      return std::make_shared<DictionaryPage>(
+          page_buffer,
+          dict_header.num_values,
+          LoadEnumSafe(&dict_header.encoding),
+          is_sorted);
+    } else if (page_type == PageType::DATA_PAGE) {
+      ++page_ordinal_;
+      const format::DataPageHeader& header =
+          current_page_header_.data_page_header;
+      page_buffer = DecompressIfNeeded(
+          std::move(page_buffer), compressed_len, uncompressed_len);
+
+      return std::make_shared<DataPageV1>(
+          page_buffer,
+          header.num_values,
+          LoadEnumSafe(&header.encoding),
+          LoadEnumSafe(&header.definition_level_encoding),
+          LoadEnumSafe(&header.repetition_level_encoding),
+          uncompressed_len,
+          data_page_statistics);
+    } else if (page_type == PageType::DATA_PAGE_V2) {
+      ++page_ordinal_;
+      const format::DataPageHeaderV2& header =
+          current_page_header_.data_page_header_v2;
+
+      // Arrow prior to 3.0.0 set is_compressed to false but still compressed.
+      bool is_compressed =
+          (header.__isset.is_compressed ? header.is_compressed : false) ||
+          always_compressed_;
+
+      // Uncompress if needed
+      int levels_byte_len;
+      if (AddWithOverflow(
+              header.definition_levels_byte_length,
+              header.repetition_levels_byte_length,
+              &levels_byte_len)) {
+        throw ParquetException("Levels size too large (corrupt file?)");
+      }
+      // DecompressIfNeeded doesn't take `is_compressed` into account as
+      // it's page type-agnostic.
+      if (is_compressed) {
+        page_buffer = DecompressIfNeeded(
+            std::move(page_buffer),
+            compressed_len,
+            uncompressed_len,
+            levels_byte_len);
+      }
+
+      return std::make_shared<DataPageV2>(
+          page_buffer,
+          header.num_values,
+          header.num_nulls,
+          header.num_rows,
+          LoadEnumSafe(&header.encoding),
+          header.definition_levels_byte_length,
+          header.repetition_levels_byte_length,
+          uncompressed_len,
+          is_compressed,
+          data_page_statistics);
+    } else {
+      throw ParquetException(
+          "Internal error, we have already skipped non-data pages in ShouldSkipPage()");
+    }
+  }
+  return std::shared_ptr<Page>(nullptr);
+}
+
+std::shared_ptr<Buffer> SerializedPageReader::DecompressIfNeeded(
+    std::shared_ptr<Buffer> page_buffer,
+    int compressed_len,
+    int uncompressed_len,
+    int levels_byte_len) {
+  if (decompressor_ == nullptr) {
+    return page_buffer;
+  }
+  if (compressed_len < levels_byte_len || uncompressed_len < levels_byte_len) {
+    throw ParquetException("Invalid page header");
+  }
+
+  // Grow the uncompressed buffer if we need to.
+  PARQUET_THROW_NOT_OK(
+      decompression_buffer_->Resize(uncompressed_len, /*shrink_to_fit=*/false));
+
+  if (levels_byte_len > 0) {
+    // First copy the levels as-is
+    uint8_t* decompressed = decompression_buffer_->mutable_data();
+    memcpy(decompressed, page_buffer->data(), levels_byte_len);
+  }
+
+  // Decompress the values
+  PARQUET_THROW_NOT_OK(decompressor_->Decompress(
+      compressed_len - levels_byte_len,
+      page_buffer->data() + levels_byte_len,
+      uncompressed_len - levels_byte_len,
+      decompression_buffer_->mutable_data() + levels_byte_len));
+
+  return decompression_buffer_;
+}
+
+} // namespace
+
+std::unique_ptr<PageReader> PageReader::Open(
+    std::shared_ptr<ArrowInputStream> stream,
+    int64_t total_num_values,
+    Compression::type codec,
+    const ReaderProperties& properties,
+    bool always_compressed,
+    const CryptoContext* ctx) {
+  return std::unique_ptr<PageReader>(new SerializedPageReader(
+      std::move(stream),
+      total_num_values,
+      codec,
+      properties,
+      ctx,
+      always_compressed));
+}
+
+std::unique_ptr<PageReader> PageReader::Open(
+    std::shared_ptr<ArrowInputStream> stream,
+    int64_t total_num_values,
+    Compression::type codec,
+    bool always_compressed,
+    ::arrow::MemoryPool* pool,
+    const CryptoContext* ctx) {
+  return std::unique_ptr<PageReader>(new SerializedPageReader(
+      std::move(stream),
+      total_num_values,
+      codec,
+      ReaderProperties(pool),
+      ctx,
+      always_compressed));
+}
+
+namespace {
+
+// ----------------------------------------------------------------------
+// Impl base class for TypedColumnReader and RecordReader
+
+// PLAIN_DICTIONARY is deprecated but used to be used as a dictionary index
+// encoding.
+static bool IsDictionaryIndexEncoding(const Encoding::type& e) {
+  return e == Encoding::RLE_DICTIONARY || e == Encoding::PLAIN_DICTIONARY;
+}
+
+template <typename DType>
+class ColumnReaderImplBase {
+ public:
+  using T = typename DType::c_type;
+
+  ColumnReaderImplBase(const ColumnDescriptor* descr, ::arrow::MemoryPool* pool)
+      : descr_(descr),
+        max_def_level_(descr->max_definition_level()),
+        max_rep_level_(descr->max_repetition_level()),
+        num_buffered_values_(0),
+        num_decoded_values_(0),
+        pool_(pool),
+        current_decoder_(nullptr),
+        current_encoding_(Encoding::UNKNOWN) {}
+
+  virtual ~ColumnReaderImplBase() = default;
+
+ protected:
+  // Read up to batch_size values from the current data page into the
+  // pre-allocated memory T*
+  //
+  // @returns: the number of values read into the out buffer
+  int64_t ReadValues(int64_t batch_size, T* out) {
+    int64_t num_decoded =
+        current_decoder_->Decode(out, static_cast<int>(batch_size));
+    return num_decoded;
+  }
+
+  // Read up to batch_size values from the current data page into the
+  // pre-allocated memory T*, leaving spaces for null entries according
+  // to the def_levels.
+  //
+  // @returns: the number of values read into the out buffer
+  int64_t ReadValuesSpaced(
+      int64_t batch_size,
+      T* out,
+      int64_t null_count,
+      uint8_t* valid_bits,
+      int64_t valid_bits_offset) {
+    return current_decoder_->DecodeSpaced(
+        out,
+        static_cast<int>(batch_size),
+        static_cast<int>(null_count),
+        valid_bits,
+        valid_bits_offset);
+  }
+
+  // Read multiple definition levels into preallocated memory
+  //
+  // Returns the number of decoded definition levels
+  int64_t ReadDefinitionLevels(int64_t batch_size, int16_t* levels) {
+    if (max_def_level_ == 0) {
+      return 0;
+    }
+    return definition_level_decoder_.Decode(
+        static_cast<int>(batch_size), levels);
+  }
+
+  bool HasNextInternal() {
+    // Either there is no data page available yet, or the data page has been
+    // exhausted
+    if (num_buffered_values_ == 0 ||
+        num_decoded_values_ == num_buffered_values_) {
+      if (!ReadNewPage() || num_buffered_values_ == 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Read multiple repetition levels into preallocated memory
+  // Returns the number of decoded repetition levels
+  int64_t ReadRepetitionLevels(int64_t batch_size, int16_t* levels) {
+    if (max_rep_level_ == 0) {
+      return 0;
+    }
+    return repetition_level_decoder_.Decode(
+        static_cast<int>(batch_size), levels);
+  }
+
+  // Advance to the next data page
+  bool ReadNewPage() {
+    // Loop until we find the next data page.
+    while (true) {
+      current_page_ = pager_->NextPage();
+      if (!current_page_) {
+        // EOS
+        return false;
+      }
+
+      if (current_page_->type() == PageType::DICTIONARY_PAGE) {
+        ConfigureDictionary(
+            static_cast<const DictionaryPage*>(current_page_.get()));
+        continue;
+      } else if (current_page_->type() == PageType::DATA_PAGE) {
+        const auto page = std::static_pointer_cast<DataPageV1>(current_page_);
+        const int64_t levels_byte_size = InitializeLevelDecoders(
+            *page,
+            page->repetition_level_encoding(),
+            page->definition_level_encoding());
+        InitializeDataDecoder(*page, levels_byte_size);
+        return true;
+      } else if (current_page_->type() == PageType::DATA_PAGE_V2) {
+        const auto page = std::static_pointer_cast<DataPageV2>(current_page_);
+        int64_t levels_byte_size = InitializeLevelDecodersV2(*page);
+        InitializeDataDecoder(*page, levels_byte_size);
+        return true;
+      } else {
+        // We don't know what this page type is. We're allowed to skip non-data
+        // pages.
+        continue;
+      }
+    }
+    return true;
+  }
+
+  void ConfigureDictionary(const DictionaryPage* page) {
+    int encoding = static_cast<int>(page->encoding());
+    if (page->encoding() == Encoding::PLAIN_DICTIONARY ||
+        page->encoding() == Encoding::PLAIN) {
+      encoding = static_cast<int>(Encoding::RLE_DICTIONARY);
+    }
+
+    auto it = decoders_.find(encoding);
+    if (it != decoders_.end()) {
+      throw ParquetException("Column cannot have more than one dictionary.");
+    }
+
+    if (page->encoding() == Encoding::PLAIN_DICTIONARY ||
+        page->encoding() == Encoding::PLAIN) {
+      auto dictionary = MakeTypedDecoder<DType>(Encoding::PLAIN, descr_);
+      dictionary->SetData(page->num_values(), page->data(), page->size());
+
+      // The dictionary is fully decoded during DictionaryDecoder::Init, so the
+      // DictionaryPage buffer is no longer required after this step
+      //
+      // TODO(wesm): investigate whether this all-or-nothing decoding of the
+      // dictionary makes sense and whether performance can be improved
+
+      std::unique_ptr<DictDecoder<DType>> decoder =
+          MakeDictDecoder<DType>(descr_, pool_);
+      decoder->SetDict(dictionary.get());
+      decoders_[encoding] = std::unique_ptr<DecoderType>(
+          dynamic_cast<DecoderType*>(decoder.release()));
+    } else {
+      ParquetException::NYI(
+          "only plain dictionary encoding has been implemented");
+    }
+
+    new_dictionary_ = true;
+    current_decoder_ = decoders_[encoding].get();
+    ARROW_DCHECK(current_decoder_);
+  }
+
+  // Initialize repetition and definition level decoders on the next data page.
+
+  // If the data page includes repetition and definition levels, we
+  // initialize the level decoders and return the number of encoded level bytes.
+  // The return value helps determine the number of bytes in the encoded data.
+  int64_t InitializeLevelDecoders(
+      const DataPage& page,
+      Encoding::type repetition_level_encoding,
+      Encoding::type definition_level_encoding) {
+    // Read a data page.
+    num_buffered_values_ = page.num_values();
+
+    // Have not decoded any values from the data page yet
+    num_decoded_values_ = 0;
+
+    const uint8_t* buffer = page.data();
+    int32_t levels_byte_size = 0;
+    int32_t max_size = page.size();
+
+    // Data page Layout: Repetition Levels - Definition Levels - encoded values.
+    // Levels are encoded as rle or bit-packed.
+    // Init repetition levels
+    if (max_rep_level_ > 0) {
+      int32_t rep_levels_bytes = repetition_level_decoder_.SetData(
+          repetition_level_encoding,
+          max_rep_level_,
+          static_cast<int>(num_buffered_values_),
+          buffer,
+          max_size);
+      buffer += rep_levels_bytes;
+      levels_byte_size += rep_levels_bytes;
+      max_size -= rep_levels_bytes;
+    }
+    // TODO figure a way to set max_def_level_ to 0
+    // if the initial value is invalid
+
+    // Init definition levels
+    if (max_def_level_ > 0) {
+      int32_t def_levels_bytes = definition_level_decoder_.SetData(
+          definition_level_encoding,
+          max_def_level_,
+          static_cast<int>(num_buffered_values_),
+          buffer,
+          max_size);
+      levels_byte_size += def_levels_bytes;
+      max_size -= def_levels_bytes;
+    }
+
+    return levels_byte_size;
+  }
+
+  int64_t InitializeLevelDecodersV2(const DataPageV2& page) {
+    // Read a data page.
+    num_buffered_values_ = page.num_values();
+
+    // Have not decoded any values from the data page yet
+    num_decoded_values_ = 0;
+    const uint8_t* buffer = page.data();
+
+    const int64_t total_levels_length =
+        static_cast<int64_t>(page.repetition_levels_byte_length()) +
+        page.definition_levels_byte_length();
+
+    if (total_levels_length > page.size()) {
+      throw ParquetException(
+          "Data page too small for levels (corrupt header?)");
+    }
+
+    if (max_rep_level_ > 0) {
+      repetition_level_decoder_.SetDataV2(
+          page.repetition_levels_byte_length(),
+          max_rep_level_,
+          static_cast<int>(num_buffered_values_),
+          buffer);
+    }
+    // ARROW-17453: Even if max_rep_level_ is 0, there may still be
+    // repetition level bytes written and/or reported in the header by
+    // some writers (e.g. Athena)
+    buffer += page.repetition_levels_byte_length();
+
+    if (max_def_level_ > 0) {
+      definition_level_decoder_.SetDataV2(
+          page.definition_levels_byte_length(),
+          max_def_level_,
+          static_cast<int>(num_buffered_values_),
+          buffer);
+    }
+
+    return total_levels_length;
+  }
+
+  // Get a decoder object for this page or create a new decoder if this is the
+  // first page with this encoding.
+  void InitializeDataDecoder(const DataPage& page, int64_t levels_byte_size) {
+    const uint8_t* buffer = page.data() + levels_byte_size;
+    const int64_t data_size = page.size() - levels_byte_size;
+
+    if (data_size < 0) {
+      throw ParquetException("Page smaller than size of encoded levels");
+    }
+
+    Encoding::type encoding = page.encoding();
+
+    if (IsDictionaryIndexEncoding(encoding)) {
+      encoding = Encoding::RLE_DICTIONARY;
+    }
+
+    auto it = decoders_.find(static_cast<int>(encoding));
+    if (it != decoders_.end()) {
+      ARROW_DCHECK(it->second.get() != nullptr);
+      current_decoder_ = it->second.get();
+    } else {
+      switch (encoding) {
+        case Encoding::PLAIN: {
+          auto decoder = MakeTypedDecoder<DType>(Encoding::PLAIN, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+        case Encoding::BYTE_STREAM_SPLIT: {
+          auto decoder =
+              MakeTypedDecoder<DType>(Encoding::BYTE_STREAM_SPLIT, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+        case Encoding::RLE: {
+          auto decoder = MakeTypedDecoder<DType>(Encoding::RLE, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+        case Encoding::RLE_DICTIONARY:
+          throw ParquetException("Dictionary page must be before data page.");
+
+        case Encoding::DELTA_BINARY_PACKED: {
+          auto decoder =
+              MakeTypedDecoder<DType>(Encoding::DELTA_BINARY_PACKED, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+        case Encoding::DELTA_BYTE_ARRAY: {
+          auto decoder =
+              MakeTypedDecoder<DType>(Encoding::DELTA_BYTE_ARRAY, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+        case Encoding::DELTA_LENGTH_BYTE_ARRAY: {
+          auto decoder = MakeTypedDecoder<DType>(
+              Encoding::DELTA_LENGTH_BYTE_ARRAY, descr_);
+          current_decoder_ = decoder.get();
+          decoders_[static_cast<int>(encoding)] = std::move(decoder);
+          break;
+        }
+
+        default:
+          throw ParquetException("Unknown encoding type.");
+      }
+    }
+    current_encoding_ = encoding;
+    current_decoder_->SetData(
+        static_cast<int>(num_buffered_values_),
+        buffer,
+        static_cast<int>(data_size));
+  }
+
+  int64_t available_values_current_page() const {
+    return num_buffered_values_ - num_decoded_values_;
+  }
+
+  const ColumnDescriptor* descr_;
+  const int16_t max_def_level_;
+  const int16_t max_rep_level_;
+
+  std::unique_ptr<PageReader> pager_;
+  std::shared_ptr<Page> current_page_;
+
+  // Not set if full schema for this field has no optional or repeated elements
+  LevelDecoder definition_level_decoder_;
+
+  // Not set for flat schemas.
+  LevelDecoder repetition_level_decoder_;
+
+  // The total number of values stored in the data page. This is the maximum of
+  // the number of encoded definition levels or encoded values. For
+  // non-repeated, required columns, this is equal to the number of encoded
+  // values. For repeated or optional values, there may be fewer data values
+  // than levels, and this tells you how many encoded levels there are in that
+  // case.
+  int64_t num_buffered_values_;
+
+  // The number of values from the current data page that have been decoded
+  // into memory
+  int64_t num_decoded_values_;
+
+  ::arrow::MemoryPool* pool_;
+
+  using DecoderType = TypedDecoder<DType>;
+  DecoderType* current_decoder_;
+  Encoding::type current_encoding_;
+
+  /// Flag to signal when a new dictionary has been set, for the benefit of
+  /// DictionaryRecordReader
+  bool new_dictionary_;
+
+  // The exposed encoding
+  ExposedEncoding exposed_encoding_ = ExposedEncoding::NO_ENCODING;
+
+  // Map of encoding type to the respective decoder object. For example, a
+  // column chunk's data pages may include both dictionary-encoded and
+  // plain-encoded data.
+  std::unordered_map<int, std::unique_ptr<DecoderType>> decoders_;
+
+  void ConsumeBufferedValues(int64_t num_values) {
+    num_decoded_values_ += num_values;
+  }
+};
+
+// ----------------------------------------------------------------------
+// TypedColumnReader implementations
+
+template <typename DType>
+class TypedColumnReaderImpl : public TypedColumnReader<DType>,
+                              public ColumnReaderImplBase<DType> {
+ public:
+  using T = typename DType::c_type;
+
+  TypedColumnReaderImpl(
+      const ColumnDescriptor* descr,
+      std::unique_ptr<PageReader> pager,
+      ::arrow::MemoryPool* pool)
+      : ColumnReaderImplBase<DType>(descr, pool) {
+    this->pager_ = std::move(pager);
+  }
+
+  bool HasNext() override {
+    return this->HasNextInternal();
+  }
+
+  int64_t ReadBatch(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      T* values,
+      int64_t* values_read) override;
+
+  int64_t ReadBatchSpaced(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      T* values,
+      uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      int64_t* levels_read,
+      int64_t* values_read,
+      int64_t* null_count) override;
+
+  int64_t Skip(int64_t num_values_to_skip) override;
+
+  Type::type type() const override {
+    return this->descr_->physical_type();
+  }
+
+  const ColumnDescriptor* descr() const override {
+    return this->descr_;
+  }
+
+  ExposedEncoding GetExposedEncoding() override {
+    return this->exposed_encoding_;
+  };
+
+  int64_t ReadBatchWithDictionary(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      int32_t* indices,
+      int64_t* indices_read,
+      const T** dict,
+      int32_t* dict_len) override;
+
+ protected:
+  void SetExposedEncoding(ExposedEncoding encoding) override {
+    this->exposed_encoding_ = encoding;
+  }
+
+  // Allocate enough scratch space to accommodate skipping 16-bit levels or any
+  // value type.
+  void InitScratchForSkip();
+
+  // Scratch space for reading and throwing away rep/def levels and values when
+  // skipping.
+  std::shared_ptr<ResizableBuffer> scratch_for_skip_;
+
+ private:
+  // Read dictionary indices. Similar to ReadValues but decode data to
+  // dictionary indices. This function is called only by
+  // ReadBatchWithDictionary().
+  int64_t ReadDictionaryIndices(int64_t indices_to_read, int32_t* indices) {
+    auto decoder = dynamic_cast<DictDecoder<DType>*>(this->current_decoder_);
+    return decoder->DecodeIndices(static_cast<int>(indices_to_read), indices);
+  }
+
+  // Get dictionary. The dictionary should have been set by SetDict(). The
+  // dictionary is owned by the internal decoder and is destroyed when the
+  // reader is destroyed. This function is called only by
+  // ReadBatchWithDictionary() after dictionary is configured.
+  void GetDictionary(const T** dictionary, int32_t* dictionary_length) {
+    auto decoder = dynamic_cast<DictDecoder<DType>*>(this->current_decoder_);
+    decoder->GetDictionary(dictionary, dictionary_length);
+  }
+
+  // Read definition and repetition levels. Also return the number of definition
+  // levels and number of values to read. This function is called before reading
+  // values.
+  void ReadLevels(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      int64_t* num_def_levels,
+      int64_t* values_to_read) {
+    batch_size = std::min(
+        batch_size, this->num_buffered_values_ - this->num_decoded_values_);
+
+    // If the field is required and non-repeated, there are no definition levels
+    if (this->max_def_level_ > 0 && def_levels != nullptr) {
+      *num_def_levels = this->ReadDefinitionLevels(batch_size, def_levels);
+      // TODO(wesm): this tallying of values-to-decode can be performed with
+      // better cache-efficiency if fused with the level decoding.
+      for (int64_t i = 0; i < *num_def_levels; ++i) {
+        if (def_levels[i] == this->max_def_level_) {
+          ++(*values_to_read);
+        }
+      }
+    } else {
+      // Required field, read all values
+      *values_to_read = batch_size;
+    }
+
+    // Not present for non-repeated fields
+    if (this->max_rep_level_ > 0 && rep_levels != nullptr) {
+      int64_t num_rep_levels =
+          this->ReadRepetitionLevels(batch_size, rep_levels);
+      if (def_levels != nullptr && *num_def_levels != num_rep_levels) {
+        throw ParquetException(
+            "Number of decoded rep / def levels did not match");
+      }
+    }
+  }
+};
+
+template <typename DType>
+int64_t TypedColumnReaderImpl<DType>::ReadBatchWithDictionary(
+    int64_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    int32_t* indices,
+    int64_t* indices_read,
+    const T** dict,
+    int32_t* dict_len) {
+  bool has_dict_output = dict != nullptr && dict_len != nullptr;
+  // Similar logic as ReadValues to get pages.
+  if (!HasNext()) {
+    *indices_read = 0;
+    if (has_dict_output) {
+      *dict = nullptr;
+      *dict_len = 0;
+    }
+    return 0;
+  }
+
+  // Verify the current data page is dictionary encoded.
+  if (this->current_encoding_ != Encoding::RLE_DICTIONARY) {
+    std::stringstream ss;
+    ss << "Data page is not dictionary encoded. Encoding: "
+       << EncodingToString(this->current_encoding_);
+    throw ParquetException(ss.str());
+  }
+
+  // Get dictionary pointer and length.
+  if (has_dict_output) {
+    GetDictionary(dict, dict_len);
+  }
+
+  // Similar logic as ReadValues to get def levels and rep levels.
+  int64_t num_def_levels = 0;
+  int64_t indices_to_read = 0;
+  ReadLevels(
+      batch_size, def_levels, rep_levels, &num_def_levels, &indices_to_read);
+
+  // Read dictionary indices.
+  *indices_read = ReadDictionaryIndices(indices_to_read, indices);
+  int64_t total_indices = std::max<int64_t>(num_def_levels, *indices_read);
+  // Some callers use a batch size of 0 just to get the dictionary.
+  int64_t expected_values = std::min(
+      batch_size, this->num_buffered_values_ - this->num_decoded_values_);
+  if (total_indices == 0 && expected_values > 0) {
+    std::stringstream ss;
+    ss << "Read 0 values, expected " << expected_values;
+    ParquetException::EofException(ss.str());
+  }
+  this->ConsumeBufferedValues(total_indices);
+
+  return total_indices;
+}
+
+template <typename DType>
+int64_t TypedColumnReaderImpl<DType>::ReadBatch(
+    int64_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    T* values,
+    int64_t* values_read) {
+  // HasNext invokes ReadNewPage
+  if (!HasNext()) {
+    *values_read = 0;
+    return 0;
+  }
+
+  // TODO(wesm): keep reading data pages until batch_size is reached, or the
+  // row group is finished
+  int64_t num_def_levels = 0;
+  int64_t values_to_read = 0;
+  ReadLevels(
+      batch_size, def_levels, rep_levels, &num_def_levels, &values_to_read);
+
+  *values_read = this->ReadValues(values_to_read, values);
+  int64_t total_values = std::max<int64_t>(num_def_levels, *values_read);
+  int64_t expected_values = std::min(
+      batch_size, this->num_buffered_values_ - this->num_decoded_values_);
+  if (total_values == 0 && expected_values > 0) {
+    std::stringstream ss;
+    ss << "Read 0 values, expected " << expected_values;
+    ParquetException::EofException(ss.str());
+  }
+  this->ConsumeBufferedValues(total_values);
+
+  return total_values;
+}
+
+template <typename DType>
+int64_t TypedColumnReaderImpl<DType>::ReadBatchSpaced(
+    int64_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    T* values,
+    uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    int64_t* levels_read,
+    int64_t* values_read,
+    int64_t* null_count_out) {
+  // HasNext invokes ReadNewPage
+  if (!HasNext()) {
+    *levels_read = 0;
+    *values_read = 0;
+    *null_count_out = 0;
+    return 0;
+  }
+
+  int64_t total_values;
+  // TODO(wesm): keep reading data pages until batch_size is reached, or the
+  // row group is finished
+  batch_size = std::min(
+      batch_size, this->num_buffered_values_ - this->num_decoded_values_);
+
+  // If the field is required and non-repeated, there are no definition levels
+  if (this->max_def_level_ > 0) {
+    int64_t num_def_levels = this->ReadDefinitionLevels(batch_size, def_levels);
+
+    // Not present for non-repeated fields
+    if (this->max_rep_level_ > 0) {
+      int64_t num_rep_levels =
+          this->ReadRepetitionLevels(batch_size, rep_levels);
+      if (num_def_levels != num_rep_levels) {
+        throw ParquetException(
+            "Number of decoded rep / def levels did not match");
+      }
+    }
+
+    const bool has_spaced_values = HasSpacedValues(this->descr_);
+    int64_t null_count = 0;
+    if (!has_spaced_values) {
+      int values_to_read = 0;
+      for (int64_t i = 0; i < num_def_levels; ++i) {
+        if (def_levels[i] == this->max_def_level_) {
+          ++values_to_read;
+        }
+      }
+      total_values = this->ReadValues(values_to_read, values);
+      ::arrow::bit_util::SetBitsTo(
+          valid_bits,
+          valid_bits_offset,
+          /*length=*/total_values,
+          /*bits_are_set=*/true);
+      *values_read = total_values;
+    } else {
+      LevelInfo info;
+      info.repeated_ancestor_def_level = this->max_def_level_ - 1;
+      info.def_level = this->max_def_level_;
+      info.rep_level = this->max_rep_level_;
+      ValidityBitmapInputOutput validity_io;
+      validity_io.values_read_upper_bound = num_def_levels;
+      validity_io.valid_bits = valid_bits;
+      validity_io.valid_bits_offset = valid_bits_offset;
+      validity_io.null_count = null_count;
+      validity_io.values_read = *values_read;
+
+      DefLevelsToBitmap(def_levels, num_def_levels, info, &validity_io);
+      null_count = validity_io.null_count;
+      *values_read = validity_io.values_read;
+
+      total_values = this->ReadValuesSpaced(
+          *values_read,
+          values,
+          static_cast<int>(null_count),
+          valid_bits,
+          valid_bits_offset);
+    }
+    *levels_read = num_def_levels;
+    *null_count_out = null_count;
+
+  } else {
+    // Required field, read all values
+    total_values = this->ReadValues(batch_size, values);
+    ::arrow::bit_util::SetBitsTo(
+        valid_bits,
+        valid_bits_offset,
+        /*length=*/total_values,
+        /*bits_are_set=*/true);
+    *null_count_out = 0;
+    *values_read = total_values;
+    *levels_read = total_values;
+  }
+
+  this->ConsumeBufferedValues(*levels_read);
+  return total_values;
+}
+
+template <typename DType>
+void TypedColumnReaderImpl<DType>::InitScratchForSkip() {
+  if (this->scratch_for_skip_ == nullptr) {
+    int value_size = type_traits<DType::type_num>::value_byte_size;
+    this->scratch_for_skip_ = AllocateBuffer(
+        this->pool_,
+        kSkipScratchBatchSize * std::max<int>(sizeof(int16_t), value_size));
+  }
+}
+
+template <typename DType>
+int64_t TypedColumnReaderImpl<DType>::Skip(int64_t num_values_to_skip) {
+  int64_t values_to_skip = num_values_to_skip;
+  // Optimization: Do not call HasNext() when values_to_skip == 0.
+  while (values_to_skip > 0 && HasNext()) {
+    // If the number of values to skip is more than the number of undecoded
+    // values, skip the Page.
+    const int64_t available_values = this->available_values_current_page();
+    if (values_to_skip >= available_values) {
+      values_to_skip -= available_values;
+      this->ConsumeBufferedValues(available_values);
+    } else {
+      // We need to read this Page
+      // Jump to the right offset in the Page
+      int64_t values_read = 0;
+      InitScratchForSkip();
+      ARROW_DCHECK_NE(this->scratch_for_skip_, nullptr);
+      do {
+        int64_t batch_size = std::min(kSkipScratchBatchSize, values_to_skip);
+        values_read = ReadBatch(
+            static_cast<int>(batch_size),
+            reinterpret_cast<int16_t*>(this->scratch_for_skip_->mutable_data()),
+            reinterpret_cast<int16_t*>(this->scratch_for_skip_->mutable_data()),
+            reinterpret_cast<T*>(this->scratch_for_skip_->mutable_data()),
+            &values_read);
+        values_to_skip -= values_read;
+      } while (values_read > 0 && values_to_skip > 0);
+    }
+  }
+  return num_values_to_skip - values_to_skip;
+}
+
+} // namespace
+
+// ----------------------------------------------------------------------
+// Dynamic column reader constructor
+
+std::shared_ptr<ColumnReader> ColumnReader::Make(
+    const ColumnDescriptor* descr,
+    std::unique_ptr<PageReader> pager,
+    MemoryPool* pool) {
+  switch (descr->physical_type()) {
+    case Type::BOOLEAN:
+      return std::make_shared<TypedColumnReaderImpl<BooleanType>>(
+          descr, std::move(pager), pool);
+    case Type::INT32:
+      return std::make_shared<TypedColumnReaderImpl<Int32Type>>(
+          descr, std::move(pager), pool);
+    case Type::INT64:
+      return std::make_shared<TypedColumnReaderImpl<Int64Type>>(
+          descr, std::move(pager), pool);
+    case Type::INT96:
+      return std::make_shared<TypedColumnReaderImpl<Int96Type>>(
+          descr, std::move(pager), pool);
+    case Type::FLOAT:
+      return std::make_shared<TypedColumnReaderImpl<FloatType>>(
+          descr, std::move(pager), pool);
+    case Type::DOUBLE:
+      return std::make_shared<TypedColumnReaderImpl<DoubleType>>(
+          descr, std::move(pager), pool);
+    case Type::BYTE_ARRAY:
+      return std::make_shared<TypedColumnReaderImpl<ByteArrayType>>(
+          descr, std::move(pager), pool);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_shared<TypedColumnReaderImpl<FLBAType>>(
+          descr, std::move(pager), pool);
+    default:
+      ParquetException::NYI("type reader not implemented");
+  }
+  // Unreachable code, but suppress compiler warning
+  return std::shared_ptr<ColumnReader>(nullptr);
+}
+
+// ----------------------------------------------------------------------
+// RecordReader
+
+namespace internal {
+
+namespace {
+
+template <typename DType>
+class TypedRecordReader : public TypedColumnReaderImpl<DType>,
+                          virtual public RecordReader {
+ public:
+  using T = typename DType::c_type;
+  using BASE = TypedColumnReaderImpl<DType>;
+  TypedRecordReader(
+      const ColumnDescriptor* descr,
+      LevelInfo leaf_info,
+      MemoryPool* pool,
+      bool read_dense_for_nullable)
+      // Pager must be set using SetPageReader.
+      : BASE(descr, /* pager = */ nullptr, pool) {
+    leaf_info_ = leaf_info;
+    nullable_values_ = leaf_info_.HasNullableValues();
+    at_record_start_ = true;
+    values_written_ = 0;
+    null_count_ = 0;
+    values_capacity_ = 0;
+    levels_written_ = 0;
+    levels_position_ = 0;
+    levels_capacity_ = 0;
+    read_dense_for_nullable_ = read_dense_for_nullable;
+    uses_values_ = !(descr->physical_type() == Type::BYTE_ARRAY);
+
+    if (uses_values_) {
+      values_ = AllocateBuffer(pool);
+    }
+    valid_bits_ = AllocateBuffer(pool);
+    def_levels_ = AllocateBuffer(pool);
+    rep_levels_ = AllocateBuffer(pool);
+    TypedRecordReader::Reset();
+  }
+
+  // Compute the values capacity in bytes for the given number of elements
+  int64_t bytes_for_values(int64_t nitems) const {
+    int64_t type_size = GetTypeByteSize(this->descr_->physical_type());
+    int64_t bytes_for_values = -1;
+    if (MultiplyWithOverflow(nitems, type_size, &bytes_for_values)) {
+      throw ParquetException("Total size of items too large");
+    }
+    return bytes_for_values;
+  }
+
+  int64_t ReadRecords(int64_t num_records) override {
+    if (num_records == 0)
+      return 0;
+    // Delimit records, then read values at the end
+    int64_t records_read = 0;
+
+    if (has_values_to_process()) {
+      records_read += ReadRecordData(num_records);
+    }
+
+    int64_t level_batch_size =
+        std::max<int64_t>(kMinLevelBatchSize, num_records);
+
+    // If we are in the middle of a record, we continue until reaching the
+    // desired number of records or the end of the current record if we've found
+    // enough records
+    while (!at_record_start_ || records_read < num_records) {
+      // Is there more data to read in this row group?
+      if (!this->HasNextInternal()) {
+        if (!at_record_start_) {
+          // We ended the row group while inside a record that we haven't seen
+          // the end of yet. So increment the record count for the last record
+          // in the row group
+          ++records_read;
+          at_record_start_ = true;
+        }
+        break;
+      }
+
+      /// We perform multiple batch reads until we either exhaust the row group
+      /// or observe the desired number of records
+      int64_t batch_size =
+          std::min(level_batch_size, this->available_values_current_page());
+
+      // No more data in column
+      if (batch_size == 0) {
+        break;
+      }
+
+      if (this->max_def_level_ > 0) {
+        ReserveLevels(batch_size);
+
+        int16_t* def_levels = this->def_levels() + levels_written_;
+        int16_t* rep_levels = this->rep_levels() + levels_written_;
+
+        // Not present for non-repeated fields
+        int64_t levels_read = 0;
+        if (this->max_rep_level_ > 0) {
+          levels_read = this->ReadDefinitionLevels(batch_size, def_levels);
+          if (this->ReadRepetitionLevels(batch_size, rep_levels) !=
+              levels_read) {
+            throw ParquetException(
+                "Number of decoded rep / def levels did not match");
+          }
+        } else if (this->max_def_level_ > 0) {
+          levels_read = this->ReadDefinitionLevels(batch_size, def_levels);
+        }
+
+        // Exhausted column chunk
+        if (levels_read == 0) {
+          break;
+        }
+
+        levels_written_ += levels_read;
+        records_read += ReadRecordData(num_records - records_read);
+      } else {
+        // No repetition or definition levels
+        batch_size = std::min(num_records - records_read, batch_size);
+        records_read += ReadRecordData(batch_size);
+      }
+    }
+
+    return records_read;
+  }
+
+  // Throw away levels from start_levels_position to levels_position_.
+  // Will update levels_position_, levels_written_, and levels_capacity_
+  // accordingly and move the levels to left to fill in the gap.
+  // It will resize the buffer without releasing the memory allocation.
+  void ThrowAwayLevels(int64_t start_levels_position) {
+    ARROW_DCHECK_LE(levels_position_, levels_written_);
+    ARROW_DCHECK_LE(start_levels_position, levels_position_);
+    ARROW_DCHECK_GT(this->max_def_level_, 0);
+    ARROW_DCHECK_NE(def_levels_, nullptr);
+
+    int64_t gap = levels_position_ - start_levels_position;
+    if (gap == 0)
+      return;
+
+    int64_t levels_remaining = levels_written_ - gap;
+
+    auto left_shift = [&](::arrow::ResizableBuffer* buffer) {
+      int16_t* data = reinterpret_cast<int16_t*>(buffer->mutable_data());
+      std::copy(
+          data + levels_position_,
+          data + levels_written_,
+          data + start_levels_position);
+      PARQUET_THROW_NOT_OK(buffer->Resize(
+          levels_remaining * sizeof(int16_t),
+          /*shrink_to_fit=*/false));
+    };
+
+    left_shift(def_levels_.get());
+
+    if (this->max_rep_level_ > 0) {
+      ARROW_DCHECK_NE(rep_levels_, nullptr);
+      left_shift(rep_levels_.get());
+    }
+
+    levels_written_ -= gap;
+    levels_position_ -= gap;
+    levels_capacity_ -= gap;
+  }
+
+  // Skip records that we have in our buffer. This function is only for
+  // non-repeated fields.
+  int64_t SkipRecordsInBufferNonRepeated(int64_t num_records) {
+    ARROW_DCHECK_EQ(this->max_rep_level_, 0);
+    if (!this->has_values_to_process() || num_records == 0)
+      return 0;
+
+    int64_t remaining_records = levels_written_ - levels_position_;
+    int64_t skipped_records = std::min(num_records, remaining_records);
+    int64_t start_levels_position = levels_position_;
+    // Since there is no repetition, number of levels equals number of records.
+    levels_position_ += skipped_records;
+
+    // We skipped the levels by incrementing 'levels_position_'. For values
+    // we do not have a buffer, so we need to read them and throw them away.
+    // First we need to figure out how many present/not-null values there are.
+    std::shared_ptr<::arrow::ResizableBuffer> valid_bits;
+    valid_bits = AllocateBuffer(this->pool_);
+    PARQUET_THROW_NOT_OK(valid_bits->Resize(
+        bit_util::BytesForBits(skipped_records),
+        /*shrink_to_fit=*/true));
+    ValidityBitmapInputOutput validity_io;
+    validity_io.values_read_upper_bound = skipped_records;
+    validity_io.valid_bits = valid_bits->mutable_data();
+    validity_io.valid_bits_offset = 0;
+    DefLevelsToBitmap(
+        def_levels() + start_levels_position,
+        skipped_records,
+        this->leaf_info_,
+        &validity_io);
+    int64_t values_to_read = validity_io.values_read - validity_io.null_count;
+
+    // Now that we have figured out number of values to read, we do not need
+    // these levels anymore. We will remove these values from the buffer.
+    // This requires shifting the levels in the buffer to left. So this will
+    // update levels_position_ and levels_written_.
+    ThrowAwayLevels(start_levels_position);
+    // For values, we do not have them in buffer, so we will read them and
+    // throw them away.
+    ReadAndThrowAwayValues(values_to_read);
+
+    // Mark the levels as read in the underlying column reader.
+    this->ConsumeBufferedValues(skipped_records);
+
+    return skipped_records;
+  }
+
+  // Attempts to skip num_records from the buffer. Will throw away levels
+  // and corresponding values for the records it skipped and consumes them from
+  // the underlying decoder. Will advance levels_position_ and update
+  // at_record_start_.
+  // Returns how many records were skipped.
+  int64_t DelimitAndSkipRecordsInBuffer(int64_t num_records) {
+    if (num_records == 0)
+      return 0;
+    // Look at the buffered levels, delimit them based on
+    // (rep_level == 0), report back how many records are in there, and
+    // fill in how many not-null values (def_level == max_def_level_).
+    // DelimitRecords updates levels_position_.
+    int64_t start_levels_position = levels_position_;
+    int64_t values_seen = 0;
+    int64_t skipped_records = DelimitRecords(num_records, &values_seen);
+    ReadAndThrowAwayValues(values_seen);
+    // Mark those levels and values as consumed in the underlying page.
+    // This must be done before we throw away levels since it updates
+    // levels_position_ and levels_written_.
+    this->ConsumeBufferedValues(levels_position_ - start_levels_position);
+    // Updated levels_position_ and levels_written_.
+    ThrowAwayLevels(start_levels_position);
+    return skipped_records;
+  }
+
+  // Skip records for repeated fields. For repeated fields, we are technically
+  // reading and throwing away the levels and values since we do not know the
+  // record boundaries in advance. Keep filling the buffer and skipping until we
+  // reach the desired number of records or we run out of values in the column
+  // chunk. Returns number of skipped records.
+  int64_t SkipRecordsRepeated(int64_t num_records) {
+    ARROW_DCHECK_GT(this->max_rep_level_, 0);
+    int64_t skipped_records = 0;
+
+    // First consume what is in the buffer.
+    if (levels_position_ < levels_written_) {
+      // This updates at_record_start_.
+      skipped_records = DelimitAndSkipRecordsInBuffer(num_records);
+    }
+
+    int64_t level_batch_size =
+        std::max<int64_t>(kMinLevelBatchSize, num_records - skipped_records);
+
+    // If 'at_record_start_' is false, but (skipped_records == num_records), it
+    // means that for the last record that was counted, we have not seen all
+    // of its values yet.
+    while (!at_record_start_ || skipped_records < num_records) {
+      // Is there more data to read in this row group?
+      // HasNextInternal() will advance to the next page if necessary.
+      if (!this->HasNextInternal()) {
+        if (!at_record_start_) {
+          // We ended the row group while inside a record that we haven't seen
+          // the end of yet. So increment the record count for the last record
+          // in the row group
+          ++skipped_records;
+          at_record_start_ = true;
+        }
+        break;
+      }
+
+      // Read some more levels.
+      int64_t batch_size =
+          std::min(level_batch_size, this->available_values_current_page());
+      // No more data in column. This must be an empty page.
+      // If we had exhausted the last page, HasNextInternal() must have advanced
+      // to the next page. So there must be available values to process.
+      if (batch_size == 0) {
+        break;
+      }
+
+      // For skipping we will read the levels and append them to the end
+      // of the def_levels and rep_levels just like for read.
+      ReserveLevels(batch_size);
+
+      int16_t* def_levels = this->def_levels() + levels_written_;
+      int16_t* rep_levels = this->rep_levels() + levels_written_;
+
+      int64_t levels_read = 0;
+      levels_read = this->ReadDefinitionLevels(batch_size, def_levels);
+      if (this->ReadRepetitionLevels(batch_size, rep_levels) != levels_read) {
+        throw ParquetException(
+            "Number of decoded rep / def levels did not match");
+      }
+
+      levels_written_ += levels_read;
+      int64_t remaining_records = num_records - skipped_records;
+      // This updates at_record_start_.
+      skipped_records += DelimitAndSkipRecordsInBuffer(remaining_records);
+    }
+
+    return skipped_records;
+  }
+
+  // Read 'num_values' values and throw them away.
+  // Throws an error if it could not read 'num_values'.
+  void ReadAndThrowAwayValues(int64_t num_values) {
+    int64_t values_left = num_values;
+    int64_t values_read = 0;
+
+    // Allocate enough scratch space to accommodate 16-bit levels or any
+    // value type
+    this->InitScratchForSkip();
+    ARROW_DCHECK_NE(this->scratch_for_skip_, nullptr);
+    do {
+      int64_t batch_size =
+          std::min<int64_t>(kSkipScratchBatchSize, values_left);
+      values_read = this->ReadValues(
+          batch_size,
+          reinterpret_cast<T*>(this->scratch_for_skip_->mutable_data()));
+      values_left -= values_read;
+    } while (values_read > 0 && values_left > 0);
+    if (values_left > 0) {
+      std::stringstream ss;
+      ss << "Could not read and throw away " << num_values << " values";
+      throw ParquetException(ss.str());
+    }
+  }
+
+  int64_t SkipRecords(int64_t num_records) override {
+    if (num_records == 0)
+      return 0;
+
+    // Top level required field. Number of records equals to number of levels,
+    // and there is not read-ahead for levels.
+    if (this->max_rep_level_ == 0 && this->max_def_level_ == 0) {
+      return this->Skip(num_records);
+    }
+    int64_t skipped_records = 0;
+    if (this->max_rep_level_ == 0) {
+      // Non-repeated optional field.
+      // First consume whatever is in the buffer.
+      skipped_records = SkipRecordsInBufferNonRepeated(num_records);
+
+      ARROW_DCHECK_LE(skipped_records, num_records);
+
+      // For records that we have not buffered, we will use the column
+      // reader's Skip to do the remaining Skip. Since the field is not
+      // repeated number of levels to skip is the same as number of records
+      // to skip.
+      skipped_records += this->Skip(num_records - skipped_records);
+    } else {
+      skipped_records += this->SkipRecordsRepeated(num_records);
+    }
+    return skipped_records;
+  }
+
+  // We may outwardly have the appearance of having exhausted a column chunk
+  // when in fact we are in the middle of processing the last batch
+  bool has_values_to_process() const {
+    return levels_position_ < levels_written_;
+  }
+
+  std::shared_ptr<ResizableBuffer> ReleaseValues() override {
+    if (uses_values_) {
+      auto result = values_;
+      PARQUET_THROW_NOT_OK(result->Resize(
+          bytes_for_values(values_written_), /*shrink_to_fit=*/true));
+      values_ = AllocateBuffer(this->pool_);
+      values_capacity_ = 0;
+      return result;
+    } else {
+      return nullptr;
+    }
+  }
+
+  std::shared_ptr<ResizableBuffer> ReleaseIsValid() override {
+    if (nullable_values()) {
+      auto result = valid_bits_;
+      PARQUET_THROW_NOT_OK(result->Resize(
+          bit_util::BytesForBits(values_written_),
+          /*shrink_to_fit=*/true));
+      valid_bits_ = AllocateBuffer(this->pool_);
+      return result;
+    } else {
+      return nullptr;
+    }
+  }
+
+  // Process written repetition/definition levels to reach the end of
+  // records. Only used for repeated fields.
+  // Process no more levels than necessary to delimit the indicated
+  // number of logical records. Updates internal state of RecordReader
+  //
+  // \return Number of records delimited
+  int64_t DelimitRecords(int64_t num_records, int64_t* values_seen) {
+    int64_t values_to_read = 0;
+    int64_t records_read = 0;
+
+    const int16_t* def_levels = this->def_levels() + levels_position_;
+    const int16_t* rep_levels = this->rep_levels() + levels_position_;
+
+    ARROW_DCHECK_GT(this->max_rep_level_, 0);
+
+    // Count logical records and number of values to read
+    while (levels_position_ < levels_written_) {
+      const int16_t rep_level = *rep_levels++;
+      if (rep_level == 0) {
+        // If at_record_start_ is true, we are seeing the start of a record
+        // for the second time, such as after repeated calls to
+        // DelimitRecords. In this case we must continue until we find
+        // another record start or exhausting the ColumnChunk
+        if (!at_record_start_) {
+          // We've reached the end of a record; increment the record count.
+          ++records_read;
+          if (records_read == num_records) {
+            // We've found the number of records we were looking for. Set
+            // at_record_start_ to true and break
+            at_record_start_ = true;
+            break;
+          }
+        }
+      }
+      // We have decided to consume the level at this position; therefore we
+      // must advance until we find another record boundary
+      at_record_start_ = false;
+
+      const int16_t def_level = *def_levels++;
+      if (def_level == this->max_def_level_) {
+        ++values_to_read;
+      }
+      ++levels_position_;
+    }
+    *values_seen = values_to_read;
+    return records_read;
+  }
+
+  void Reserve(int64_t capacity) override {
+    ReserveLevels(capacity);
+    ReserveValues(capacity);
+  }
+
+  int64_t UpdateCapacity(int64_t capacity, int64_t size, int64_t extra_size) {
+    if (extra_size < 0) {
+      throw ParquetException("Negative size (corrupt file?)");
+    }
+    int64_t target_size = -1;
+    if (AddWithOverflow(size, extra_size, &target_size)) {
+      throw ParquetException("Allocation size too large (corrupt file?)");
+    }
+    if (target_size >= (1LL << 62)) {
+      throw ParquetException("Allocation size too large (corrupt file?)");
+    }
+    if (capacity >= target_size) {
+      return capacity;
+    }
+    return bit_util::NextPower2(target_size);
+  }
+
+  void ReserveLevels(int64_t extra_levels) {
+    if (this->max_def_level_ > 0) {
+      const int64_t new_levels_capacity =
+          UpdateCapacity(levels_capacity_, levels_written_, extra_levels);
+      if (new_levels_capacity > levels_capacity_) {
+        constexpr auto kItemSize = static_cast<int64_t>(sizeof(int16_t));
+        int64_t capacity_in_bytes = -1;
+        if (MultiplyWithOverflow(
+                new_levels_capacity, kItemSize, &capacity_in_bytes)) {
+          throw ParquetException("Allocation size too large (corrupt file?)");
+        }
+        PARQUET_THROW_NOT_OK(
+            def_levels_->Resize(capacity_in_bytes, /*shrink_to_fit=*/false));
+        if (this->max_rep_level_ > 0) {
+          PARQUET_THROW_NOT_OK(
+              rep_levels_->Resize(capacity_in_bytes, /*shrink_to_fit=*/false));
+        }
+        levels_capacity_ = new_levels_capacity;
+      }
+    }
+  }
+
+  void ReserveValues(int64_t extra_values) {
+    const int64_t new_values_capacity =
+        UpdateCapacity(values_capacity_, values_written_, extra_values);
+    if (new_values_capacity > values_capacity_) {
+      // XXX(wesm): A hack to avoid memory allocation when reading directly
+      // into builder classes
+      if (uses_values_) {
+        PARQUET_THROW_NOT_OK(values_->Resize(
+            bytes_for_values(new_values_capacity),
+            /*shrink_to_fit=*/false));
+      }
+      values_capacity_ = new_values_capacity;
+    }
+    if (nullable_values() && !read_dense_for_nullable_) {
+      int64_t valid_bytes_new = bit_util::BytesForBits(values_capacity_);
+      if (valid_bits_->size() < valid_bytes_new) {
+        int64_t valid_bytes_old = bit_util::BytesForBits(values_written_);
+        PARQUET_THROW_NOT_OK(
+            valid_bits_->Resize(valid_bytes_new, /*shrink_to_fit=*/false));
+
+        // Avoid valgrind warnings
+        memset(
+            valid_bits_->mutable_data() + valid_bytes_old,
+            0,
+            valid_bytes_new - valid_bytes_old);
+      }
+    }
+  }
+
+  void Reset() override {
+    ResetValues();
+
+    if (levels_written_ > 0) {
+      // Throw away levels from 0 to levels_position_.
+      ThrowAwayLevels(0);
+    }
+
+    // Call Finish on the binary builders to reset them
+  }
+
+  void SetPageReader(std::unique_ptr<PageReader> reader) override {
+    at_record_start_ = true;
+    this->pager_ = std::move(reader);
+    ResetDecoders();
+  }
+
+  bool HasMoreData() const override {
+    return this->pager_ != nullptr;
+  }
+
+  const ColumnDescriptor* descr() const override {
+    return this->descr_;
+  }
+
+  // Dictionary decoders must be reset when advancing row groups
+  void ResetDecoders() {
+    this->decoders_.clear();
+  }
+
+  virtual void ReadValuesSpaced(int64_t values_with_nulls, int64_t null_count) {
+    uint8_t* valid_bits = valid_bits_->mutable_data();
+    const int64_t valid_bits_offset = values_written_;
+
+    int64_t num_decoded = this->current_decoder_->DecodeSpaced(
+        ValuesHead<T>(),
+        static_cast<int>(values_with_nulls),
+        static_cast<int>(null_count),
+        valid_bits,
+        valid_bits_offset);
+    CheckNumberDecoded(num_decoded, values_with_nulls);
+  }
+
+  virtual void ReadValuesDense(int64_t values_to_read) {
+    int64_t num_decoded = this->current_decoder_->Decode(
+        ValuesHead<T>(), static_cast<int>(values_to_read));
+    CheckNumberDecoded(num_decoded, values_to_read);
+  }
+
+  // Reads repeated records and returns number of records read. Fills in
+  // values_to_read and null_count.
+  int64_t ReadRepeatedRecords(
+      int64_t num_records,
+      int64_t* values_to_read,
+      int64_t* null_count) {
+    const int64_t start_levels_position = levels_position_;
+    // Note that repeated records may be required or nullable. If they have
+    // an optional parent in the path, they will be nullable, otherwise,
+    // they are required. We use leaf_info_->HasNullableValues() that looks
+    // at repeated_ancestor_def_level to determine if it is required or
+    // nullable. Even if they are required, we may have to read ahead and
+    // delimit the records to get the right number of values and they will
+    // have associated levels.
+    int64_t records_read = DelimitRecords(num_records, values_to_read);
+    if (!nullable_values() || read_dense_for_nullable_) {
+      ReadValuesDense(*values_to_read);
+      // null_count is always 0 for required.
+      ARROW_DCHECK_EQ(*null_count, 0);
+    } else {
+      ReadSpacedForOptionalOrRepeated(
+          start_levels_position, values_to_read, null_count);
+    }
+    return records_read;
+  }
+
+  // Reads optional records and returns number of records read. Fills in
+  // values_to_read and null_count.
+  int64_t ReadOptionalRecords(
+      int64_t num_records,
+      int64_t* values_to_read,
+      int64_t* null_count) {
+    const int64_t start_levels_position = levels_position_;
+    // No repetition levels, skip delimiting logic. Each level represents a
+    // null or not null entry
+    int64_t records_read =
+        std::min<int64_t>(levels_written_ - levels_position_, num_records);
+    // This is advanced by DelimitRecords for the repeated field case above.
+    levels_position_ += records_read;
+
+    // Optional fields are always nullable.
+    if (read_dense_for_nullable_) {
+      ReadDenseForOptional(start_levels_position, values_to_read);
+      // We don't need to update null_count when reading dense. It should be
+      // already set to 0.
+      ARROW_DCHECK_EQ(*null_count, 0);
+    } else {
+      ReadSpacedForOptionalOrRepeated(
+          start_levels_position, values_to_read, null_count);
+    }
+    return records_read;
+  }
+
+  // Reads required records and returns number of records read. Fills in
+  // values_to_read.
+  int64_t ReadRequiredRecords(int64_t num_records, int64_t* values_to_read) {
+    *values_to_read = num_records;
+    ReadValuesDense(*values_to_read);
+    return num_records;
+  }
+
+  // Reads dense for optional records. First it figures out how many values to
+  // read.
+  void ReadDenseForOptional(
+      int64_t start_levels_position,
+      int64_t* values_to_read) {
+    // levels_position_ must already be incremented based on number of records
+    // read.
+    ARROW_DCHECK_GE(levels_position_, start_levels_position);
+
+    // When reading dense we need to figure out number of values to read.
+    const int16_t* def_levels = this->def_levels();
+    for (int64_t i = start_levels_position; i < levels_position_; ++i) {
+      if (def_levels[i] == this->max_def_level_) {
+        ++(*values_to_read);
+      }
+    }
+    ReadValuesDense(*values_to_read);
+  }
+
+  // Reads spaced for optional or repeated fields.
+  void ReadSpacedForOptionalOrRepeated(
+      int64_t start_levels_position,
+      int64_t* values_to_read,
+      int64_t* null_count) {
+    // levels_position_ must already be incremented based on number of records
+    // read.
+    ARROW_DCHECK_GE(levels_position_, start_levels_position);
+    ValidityBitmapInputOutput validity_io;
+    validity_io.values_read_upper_bound =
+        levels_position_ - start_levels_position;
+    validity_io.valid_bits = valid_bits_->mutable_data();
+    validity_io.valid_bits_offset = values_written_;
+
+    DefLevelsToBitmap(
+        def_levels() + start_levels_position,
+        levels_position_ - start_levels_position,
+        leaf_info_,
+        &validity_io);
+    *values_to_read = validity_io.values_read - validity_io.null_count;
+    *null_count = validity_io.null_count;
+    ARROW_DCHECK_GE(*values_to_read, 0);
+    ARROW_DCHECK_GE(*null_count, 0);
+    ReadValuesSpaced(validity_io.values_read, *null_count);
+  }
+
+  // Return number of logical records read.
+  // Updates levels_position_, values_written_, and null_count_.
+  int64_t ReadRecordData(int64_t num_records) {
+    // Conservative upper bound
+    const int64_t possible_num_values =
+        std::max<int64_t>(num_records, levels_written_ - levels_position_);
+    ReserveValues(possible_num_values);
+
+    const int64_t start_levels_position = levels_position_;
+
+    // To be updated by the function calls below for each of the repetition
+    // types.
+    int64_t records_read = 0;
+    int64_t values_to_read = 0;
+    int64_t null_count = 0;
+    if (this->max_rep_level_ > 0) {
+      // Repeated fields may be nullable or not.
+      // This call updates levels_position_.
+      records_read =
+          ReadRepeatedRecords(num_records, &values_to_read, &null_count);
+    } else if (this->max_def_level_ > 0) {
+      // Non-repeated optional values are always nullable.
+      // This call updates levels_position_.
+      ARROW_DCHECK(nullable_values());
+      records_read =
+          ReadOptionalRecords(num_records, &values_to_read, &null_count);
+    } else {
+      ARROW_DCHECK(!nullable_values());
+      records_read = ReadRequiredRecords(num_records, &values_to_read);
+      // We don't need to update null_count, since it is 0.
+    }
+
+    ARROW_DCHECK_GE(records_read, 0);
+    ARROW_DCHECK_GE(values_to_read, 0);
+    ARROW_DCHECK_GE(null_count, 0);
+
+    if (read_dense_for_nullable_) {
+      values_written_ += values_to_read;
+      ARROW_DCHECK_EQ(null_count, 0);
+    } else {
+      values_written_ += values_to_read + null_count;
+      null_count_ += null_count;
+    }
+    // Total values, including null spaces, if any
+    if (this->max_def_level_ > 0) {
+      // Optional, repeated, or some mix thereof
+      this->ConsumeBufferedValues(levels_position_ - start_levels_position);
+    } else {
+      // Flat, non-repeated
+      this->ConsumeBufferedValues(values_to_read);
+    }
+
+    return records_read;
+  }
+
+  void DebugPrintState() override {
+    const int16_t* def_levels = this->def_levels();
+    const int16_t* rep_levels = this->rep_levels();
+    const int64_t total_levels_read = levels_position_;
+
+    const T* vals = reinterpret_cast<const T*>(this->values());
+
+    if (leaf_info_.def_level > 0) {
+      std::cout << "def levels: ";
+      for (int64_t i = 0; i < total_levels_read; ++i) {
+        std::cout << def_levels[i] << " ";
+      }
+      std::cout << std::endl;
+    }
+
+    if (leaf_info_.rep_level > 0) {
+      std::cout << "rep levels: ";
+      for (int64_t i = 0; i < total_levels_read; ++i) {
+        std::cout << rep_levels[i] << " ";
+      }
+      std::cout << std::endl;
+    }
+
+    std::cout << "values: ";
+    for (int64_t i = 0; i < this->values_written(); ++i) {
+      std::cout << vals[i] << " ";
+    }
+    std::cout << std::endl;
+  }
+
+  void ResetValues() {
+    if (values_written_ > 0) {
+      // Resize to 0, but do not shrink to fit
+      if (uses_values_) {
+        PARQUET_THROW_NOT_OK(values_->Resize(0, /*shrink_to_fit=*/false));
+      }
+      PARQUET_THROW_NOT_OK(valid_bits_->Resize(0, /*shrink_to_fit=*/false));
+      values_written_ = 0;
+      values_capacity_ = 0;
+      null_count_ = 0;
+    }
+  }
+
+ protected:
+  template <typename T>
+  T* ValuesHead() {
+    return reinterpret_cast<T*>(values_->mutable_data()) + values_written_;
+  }
+  LevelInfo leaf_info_;
+};
+
+class FLBARecordReader : public TypedRecordReader<FLBAType>,
+                         virtual public BinaryRecordReader {
+ public:
+  FLBARecordReader(
+      const ColumnDescriptor* descr,
+      LevelInfo leaf_info,
+      ::arrow::MemoryPool* pool,
+      bool read_dense_for_nullable)
+      : TypedRecordReader<FLBAType>(
+            descr,
+            leaf_info,
+            pool,
+            read_dense_for_nullable),
+        builder_(nullptr) {
+    ARROW_DCHECK_EQ(descr_->physical_type(), Type::FIXED_LEN_BYTE_ARRAY);
+    int byte_width = descr_->type_length();
+    std::shared_ptr<::arrow::DataType> type =
+        ::arrow::fixed_size_binary(byte_width);
+    builder_ =
+        std::make_unique<::arrow::FixedSizeBinaryBuilder>(type, this->pool_);
+  }
+
+  ::arrow::ArrayVector GetBuilderChunks() override {
+    std::shared_ptr<::arrow::Array> chunk;
+    PARQUET_THROW_NOT_OK(builder_->Finish(&chunk));
+    return ::arrow::ArrayVector({chunk});
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    auto values = ValuesHead<FLBA>();
+    int64_t num_decoded = this->current_decoder_->Decode(
+        values, static_cast<int>(values_to_read));
+    CheckNumberDecoded(num_decoded, values_to_read);
+
+    for (int64_t i = 0; i < num_decoded; i++) {
+      PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
+    }
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    uint8_t* valid_bits = valid_bits_->mutable_data();
+    const int64_t valid_bits_offset = values_written_;
+    auto values = ValuesHead<FLBA>();
+
+    int64_t num_decoded = this->current_decoder_->DecodeSpaced(
+        values,
+        static_cast<int>(values_to_read),
+        static_cast<int>(null_count),
+        valid_bits,
+        valid_bits_offset);
+    ARROW_DCHECK_EQ(num_decoded, values_to_read);
+
+    for (int64_t i = 0; i < num_decoded; i++) {
+      if (::arrow::bit_util::GetBit(valid_bits, valid_bits_offset + i)) {
+        PARQUET_THROW_NOT_OK(builder_->Append(values[i].ptr));
+      } else {
+        PARQUET_THROW_NOT_OK(builder_->AppendNull());
+      }
+    }
+    ResetValues();
+  }
+
+ private:
+  std::unique_ptr<::arrow::FixedSizeBinaryBuilder> builder_;
+};
+
+class ByteArrayChunkedRecordReader : public TypedRecordReader<ByteArrayType>,
+                                     virtual public BinaryRecordReader {
+ public:
+  ByteArrayChunkedRecordReader(
+      const ColumnDescriptor* descr,
+      LevelInfo leaf_info,
+      ::arrow::MemoryPool* pool,
+      bool read_dense_for_nullable)
+      : TypedRecordReader<ByteArrayType>(
+            descr,
+            leaf_info,
+            pool,
+            read_dense_for_nullable) {
+    ARROW_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
+    accumulator_.builder = std::make_unique<::arrow::BinaryBuilder>(pool);
+  }
+
+  ::arrow::ArrayVector GetBuilderChunks() override {
+    ::arrow::ArrayVector result = accumulator_.chunks;
+    if (result.size() == 0 || accumulator_.builder->length() > 0) {
+      std::shared_ptr<::arrow::Array> last_chunk;
+      PARQUET_THROW_NOT_OK(accumulator_.builder->Finish(&last_chunk));
+      result.push_back(std::move(last_chunk));
+    }
+    accumulator_.chunks = {};
+    return result;
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    int64_t num_decoded = this->current_decoder_->DecodeArrowNonNull(
+        static_cast<int>(values_to_read), &accumulator_);
+    CheckNumberDecoded(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    int64_t num_decoded = this->current_decoder_->DecodeArrow(
+        static_cast<int>(values_to_read),
+        static_cast<int>(null_count),
+        valid_bits_->mutable_data(),
+        values_written_,
+        &accumulator_);
+    CheckNumberDecoded(num_decoded, values_to_read - null_count);
+    ResetValues();
+  }
+
+ private:
+  // Helper data structure for accumulating builder chunks
+  typename EncodingTraits<ByteArrayType>::Accumulator accumulator_;
+};
+
+class ByteArrayDictionaryRecordReader : public TypedRecordReader<ByteArrayType>,
+                                        virtual public DictionaryRecordReader {
+ public:
+  ByteArrayDictionaryRecordReader(
+      const ColumnDescriptor* descr,
+      LevelInfo leaf_info,
+      ::arrow::MemoryPool* pool,
+      bool read_dense_for_nullable)
+      : TypedRecordReader<ByteArrayType>(
+            descr,
+            leaf_info,
+            pool,
+            read_dense_for_nullable),
+        builder_(pool) {
+    this->read_dictionary_ = true;
+  }
+
+  std::shared_ptr<::arrow::ChunkedArray> GetResult() override {
+    FlushBuilder();
+    std::vector<std::shared_ptr<::arrow::Array>> result;
+    std::swap(result, result_chunks_);
+    return std::make_shared<::arrow::ChunkedArray>(
+        std::move(result), builder_.type());
+  }
+
+  void FlushBuilder() {
+    if (builder_.length() > 0) {
+      std::shared_ptr<::arrow::Array> chunk;
+      PARQUET_THROW_NOT_OK(builder_.Finish(&chunk));
+      result_chunks_.emplace_back(std::move(chunk));
+
+      // Also clears the dictionary memo table
+      builder_.Reset();
+    }
+  }
+
+  void MaybeWriteNewDictionary() {
+    if (this->new_dictionary_) {
+      /// If there is a new dictionary, we may need to flush the builder, then
+      /// insert the new dictionary values
+      FlushBuilder();
+      builder_.ResetFull();
+      auto decoder = dynamic_cast<BinaryDictDecoder*>(this->current_decoder_);
+      decoder->InsertDictionary(&builder_);
+      this->new_dictionary_ = false;
+    }
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    int64_t num_decoded = 0;
+    if (current_encoding_ == Encoding::RLE_DICTIONARY) {
+      MaybeWriteNewDictionary();
+      auto decoder = dynamic_cast<BinaryDictDecoder*>(this->current_decoder_);
+      num_decoded =
+          decoder->DecodeIndices(static_cast<int>(values_to_read), &builder_);
+    } else {
+      num_decoded = this->current_decoder_->DecodeArrowNonNull(
+          static_cast<int>(values_to_read), &builder_);
+
+      /// Flush values since they have been copied into the builder
+      ResetValues();
+    }
+    CheckNumberDecoded(num_decoded, values_to_read);
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    int64_t num_decoded = 0;
+    if (current_encoding_ == Encoding::RLE_DICTIONARY) {
+      MaybeWriteNewDictionary();
+      auto decoder = dynamic_cast<BinaryDictDecoder*>(this->current_decoder_);
+      num_decoded = decoder->DecodeIndicesSpaced(
+          static_cast<int>(values_to_read),
+          static_cast<int>(null_count),
+          valid_bits_->mutable_data(),
+          values_written_,
+          &builder_);
+    } else {
+      num_decoded = this->current_decoder_->DecodeArrow(
+          static_cast<int>(values_to_read),
+          static_cast<int>(null_count),
+          valid_bits_->mutable_data(),
+          values_written_,
+          &builder_);
+
+      /// Flush values since they have been copied into the builder
+      ResetValues();
+    }
+    ARROW_DCHECK_EQ(num_decoded, values_to_read - null_count);
+  }
+
+ private:
+  using BinaryDictDecoder = DictDecoder<ByteArrayType>;
+
+  ::arrow::BinaryDictionary32Builder builder_;
+  std::vector<std::shared_ptr<::arrow::Array>> result_chunks_;
+};
+
+// TODO(wesm): Implement these to some satisfaction
+template <>
+void TypedRecordReader<Int96Type>::DebugPrintState() {}
+
+template <>
+void TypedRecordReader<ByteArrayType>::DebugPrintState() {}
+
+template <>
+void TypedRecordReader<FLBAType>::DebugPrintState() {}
+
+std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
+    const ColumnDescriptor* descr,
+    LevelInfo leaf_info,
+    ::arrow::MemoryPool* pool,
+    bool read_dictionary,
+    bool read_dense_for_nullable) {
+  if (read_dictionary) {
+    return std::make_shared<ByteArrayDictionaryRecordReader>(
+        descr, leaf_info, pool, read_dense_for_nullable);
+  } else {
+    return std::make_shared<ByteArrayChunkedRecordReader>(
+        descr, leaf_info, pool, read_dense_for_nullable);
+  }
+}
+
+} // namespace
+
+std::shared_ptr<RecordReader> RecordReader::Make(
+    const ColumnDescriptor* descr,
+    LevelInfo leaf_info,
+    MemoryPool* pool,
+    bool read_dictionary,
+    bool read_dense_for_nullable) {
+  switch (descr->physical_type()) {
+    case Type::BOOLEAN:
+      return std::make_shared<TypedRecordReader<BooleanType>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::INT32:
+      return std::make_shared<TypedRecordReader<Int32Type>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::INT64:
+      return std::make_shared<TypedRecordReader<Int64Type>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::INT96:
+      return std::make_shared<TypedRecordReader<Int96Type>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::FLOAT:
+      return std::make_shared<TypedRecordReader<FloatType>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::DOUBLE:
+      return std::make_shared<TypedRecordReader<DoubleType>>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    case Type::BYTE_ARRAY: {
+      return MakeByteArrayRecordReader(
+          descr, leaf_info, pool, read_dictionary, read_dense_for_nullable);
+    }
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_shared<FLBARecordReader>(
+          descr, leaf_info, pool, read_dense_for_nullable);
+    default: {
+      // PARQUET-1481: This can occur if the file is corrupt
+      std::stringstream ss;
+      ss << "Invalid physical column type: "
+         << static_cast<int>(descr->physical_type());
+      throw ParquetException(ss.str());
+    }
+  }
+  // Unreachable code, but suppress compiler warning
+  return nullptr;
+}
+
+} // namespace internal
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReader.h
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReader.h
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/LevelConversion.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+
+namespace arrow {
+
+class Array;
+class ChunkedArray;
+
+namespace bit_util {
+class BitReader;
+} // namespace bit_util
+
+namespace util {
+class RleDecoder;
+} // namespace util
+
+} // namespace arrow
+
+namespace facebook::velox::parquet::arrow {
+
+class Decryptor;
+class Page;
+
+// 16 MB is the default maximum page header size
+static constexpr uint32_t kDefaultMaxPageHeaderSize = 16 * 1024 * 1024;
+
+// 16 KB is the default expected page header size
+static constexpr uint32_t kDefaultPageHeaderSize = 16 * 1024;
+
+// \brief DataPageStats stores encoded statistics and number of values/rows for
+// a page.
+struct PARQUET_EXPORT DataPageStats {
+  DataPageStats(
+      const EncodedStatistics* encoded_statistics,
+      int32_t num_values,
+      std::optional<int32_t> num_rows)
+      : encoded_statistics(encoded_statistics),
+        num_values(num_values),
+        num_rows(num_rows) {}
+
+  // Encoded statistics extracted from the page header.
+  // Nullptr if there are no statistics in the page header.
+  const EncodedStatistics* encoded_statistics;
+  // Number of values stored in the page. Filled for both V1 and V2 data pages.
+  // For repeated fields, this can be greater than number of rows. For
+  // non-repeated fields, this will be the same as the number of rows.
+  int32_t num_values;
+  // Number of rows stored in the page. std::nullopt if not available.
+  std::optional<int32_t> num_rows;
+};
+
+class PARQUET_EXPORT LevelDecoder {
+ public:
+  LevelDecoder();
+  ~LevelDecoder();
+
+  // Initialize the LevelDecoder state with new data
+  // and return the number of bytes consumed
+  int SetData(
+      Encoding::type encoding,
+      int16_t max_level,
+      int num_buffered_values,
+      const uint8_t* data,
+      int32_t data_size);
+
+  void SetDataV2(
+      int32_t num_bytes,
+      int16_t max_level,
+      int num_buffered_values,
+      const uint8_t* data);
+
+  // Decodes a batch of levels into an array and returns the number of levels
+  // decoded
+  int Decode(int batch_size, int16_t* levels);
+
+ private:
+  int bit_width_;
+  int num_values_remaining_;
+  Encoding::type encoding_;
+  std::unique_ptr<::arrow::util::RleDecoder> rle_decoder_;
+  std::unique_ptr<::arrow::bit_util::BitReader> bit_packed_decoder_;
+  int16_t max_level_;
+};
+
+struct CryptoContext {
+  CryptoContext(
+      bool start_with_dictionary_page,
+      int16_t rg_ordinal,
+      int16_t col_ordinal,
+      std::shared_ptr<Decryptor> meta,
+      std::shared_ptr<Decryptor> data)
+      : start_decrypt_with_dictionary_page(start_with_dictionary_page),
+        row_group_ordinal(rg_ordinal),
+        column_ordinal(col_ordinal),
+        meta_decryptor(std::move(meta)),
+        data_decryptor(std::move(data)) {}
+  CryptoContext() {}
+
+  bool start_decrypt_with_dictionary_page = false;
+  int16_t row_group_ordinal = -1;
+  int16_t column_ordinal = -1;
+  std::shared_ptr<Decryptor> meta_decryptor;
+  std::shared_ptr<Decryptor> data_decryptor;
+};
+
+// Abstract page iterator interface. This way, we can feed column pages to the
+// ColumnReader through whatever mechanism we choose
+class PARQUET_EXPORT PageReader {
+  using DataPageFilter = std::function<bool(const DataPageStats&)>;
+
+ public:
+  virtual ~PageReader() = default;
+
+  static std::unique_ptr<PageReader> Open(
+      std::shared_ptr<ArrowInputStream> stream,
+      int64_t total_num_values,
+      Compression::type codec,
+      bool always_compressed = false,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
+      const CryptoContext* ctx = NULLPTR);
+  static std::unique_ptr<PageReader> Open(
+      std::shared_ptr<ArrowInputStream> stream,
+      int64_t total_num_values,
+      Compression::type codec,
+      const ReaderProperties& properties,
+      bool always_compressed = false,
+      const CryptoContext* ctx = NULLPTR);
+
+  // If data_page_filter is present (not null), NextPage() will call the
+  // callback function exactly once per page in the order the pages appear in
+  // the column. If the callback function returns true the page will be
+  // skipped. The callback will be called only if the page type is DATA_PAGE or
+  // DATA_PAGE_V2. Dictionary pages will not be skipped.
+  // Caller is responsible for checking that statistics are correct using
+  // ApplicationVersion::HasCorrectStatistics().
+  // \note API EXPERIMENTAL
+  void set_data_page_filter(DataPageFilter data_page_filter) {
+    data_page_filter_ = std::move(data_page_filter);
+  }
+
+  // @returns: shared_ptr<Page>(nullptr) on EOS, std::shared_ptr<Page>
+  // containing new Page otherwise
+  //
+  // The returned Page may contain references that aren't guaranteed to live
+  // beyond the next call to NextPage().
+  virtual std::shared_ptr<Page> NextPage() = 0;
+
+  virtual void set_max_page_header_size(uint32_t size) = 0;
+
+ protected:
+  // Callback that decides if we should skip a page or not.
+  DataPageFilter data_page_filter_;
+};
+
+class PARQUET_EXPORT ColumnReader {
+ public:
+  virtual ~ColumnReader() = default;
+
+  static std::shared_ptr<ColumnReader> Make(
+      const ColumnDescriptor* descr,
+      std::unique_ptr<PageReader> pager,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+  // Returns true if there are still values in this column.
+  virtual bool HasNext() = 0;
+
+  virtual Type::type type() const = 0;
+
+  virtual const ColumnDescriptor* descr() const = 0;
+
+  // Get the encoding that can be exposed by this reader. If it returns
+  // dictionary encoding, then ReadBatchWithDictionary can be used to read data.
+  //
+  // \note API EXPERIMENTAL
+  virtual ExposedEncoding GetExposedEncoding() = 0;
+
+ protected:
+  friend class RowGroupReader;
+  // Set the encoding that can be exposed by this reader.
+  //
+  // \note API EXPERIMENTAL
+  virtual void SetExposedEncoding(ExposedEncoding encoding) = 0;
+};
+
+// API to read values from a single column. This is a main client facing API.
+template <typename DType>
+class TypedColumnReader : public ColumnReader {
+ public:
+  typedef typename DType::c_type T;
+
+  // Read a batch of repetition levels, definition levels, and values from the
+  // column.
+  //
+  // Since null values are not stored in the values, the number of values read
+  // may be less than the number of repetition and definition levels. With
+  // nested data this is almost certainly true.
+  //
+  // Set def_levels or rep_levels to nullptr if you want to skip reading them.
+  // This is only safe if you know through some other source that there are no
+  // undefined values.
+  //
+  // To fully exhaust a row group, you must read batches until the number of
+  // values read reaches the number of stored values according to the metadata.
+  //
+  // This API is the same for both V1 and V2 of the DataPage
+  //
+  // @returns: actual number of levels read (see values_read for number of
+  // values read)
+  virtual int64_t ReadBatch(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      T* values,
+      int64_t* values_read) = 0;
+
+  /// Read a batch of repetition levels, definition levels, and values from the
+  /// column and leave spaces for null entries on the lowest level in the values
+  /// buffer.
+  ///
+  /// In comparison to ReadBatch the length of repetition and definition levels
+  /// is the same as of the number of values read for max_definition_level == 1.
+  /// In the case of max_definition_level > 1, the repetition and definition
+  /// levels are larger than the values but the values include the null entries
+  /// with definition_level == (max_definition_level - 1).
+  ///
+  /// To fully exhaust a row group, you must read batches until the number of
+  /// values read reaches the number of stored values according to the metadata.
+  ///
+  /// @param batch_size the number of levels to read
+  /// @param[out] def_levels The Parquet definition levels, output has
+  ///   the length levels_read.
+  /// @param[out] rep_levels The Parquet repetition levels, output has
+  ///   the length levels_read.
+  /// @param[out] values The values in the lowest nested level including
+  ///   spacing for nulls on the lowest levels; output has the length
+  ///   values_read.
+  /// @param[out] valid_bits Memory allocated for a bitmap that indicates if
+  ///   the row is null or on the maximum definition level. For performance
+  ///   reasons the underlying buffer should be able to store 1 bit more than
+  ///   required. If this requires an additional byte, this byte is only read
+  ///   but never written to.
+  /// @param valid_bits_offset The offset in bits of the valid_bits where the
+  ///   first relevant bit resides.
+  /// @param[out] levels_read The number of repetition/definition levels that
+  /// were read.
+  /// @param[out] values_read The number of values read, this includes all
+  ///   non-null entries as well as all null-entries on the lowest level
+  ///   (i.e. definition_level == max_definition_level - 1)
+  /// @param[out] null_count The number of nulls on the lowest levels.
+  ///   (i.e. (values_read - null_count) is total number of non-null entries)
+  ///
+  /// \deprecated Since 4.0.0
+  ARROW_DEPRECATED(
+      "Doesn't handle nesting correctly and unused outside of unit tests.")
+  virtual int64_t ReadBatchSpaced(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      T* values,
+      uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      int64_t* levels_read,
+      int64_t* values_read,
+      int64_t* null_count) = 0;
+
+  // Skip reading values. This method will work for both repeated and
+  // non-repeated fields. Note that this method is skipping values and not
+  // records. This distinction is important for repeated fields, meaning that
+  // we are not skipping over the values to the next record. For example,
+  // consider the following two consecutive records containing one repeated
+  // field:
+  // {[1, 2, 3]}, {[4, 5]}. If we Skip(2), our next read value will be 3, which
+  // is inside the first record.
+  // Returns the number of values skipped.
+  virtual int64_t Skip(int64_t num_values_to_skip) = 0;
+
+  // Read a batch of repetition levels, definition levels, and indices from the
+  // column. And read the dictionary if a dictionary page is encountered during
+  // reading pages. This API is similar to ReadBatch(), with ability to read
+  // dictionary and indices. It is only valid to call this method  when the
+  // reader can expose dictionary encoding. (i.e., the reader's
+  // GetExposedEncoding() returns DICTIONARY).
+  //
+  // The dictionary is read along with the data page. When there's no data page,
+  // the dictionary won't be returned.
+  //
+  // @param batch_size The batch size to read
+  // @param[out] def_levels The Parquet definition levels.
+  // @param[out] rep_levels The Parquet repetition levels.
+  // @param[out] indices The dictionary indices.
+  // @param[out] indices_read The number of indices read.
+  // @param[out] dict The pointer to dictionary values. It will return nullptr
+  // if there's no data page. Each column chunk only has one dictionary page.
+  // The dictionary is owned by the reader, so the caller is responsible for
+  // copying the dictionary values before the reader gets destroyed.
+  // @param[out] dict_len The dictionary length. It will return 0 if there's no
+  // data page.
+  // @returns: actual number of levels read (see indices_read for number of
+  // indices read
+  //
+  // \note API EXPERIMENTAL
+  virtual int64_t ReadBatchWithDictionary(
+      int64_t batch_size,
+      int16_t* def_levels,
+      int16_t* rep_levels,
+      int32_t* indices,
+      int64_t* indices_read,
+      const T** dict,
+      int32_t* dict_len) = 0;
+};
+
+namespace internal {
+
+/// \brief Stateful column reader that delimits semantic records for both flat
+/// and nested columns
+///
+/// \note API EXPERIMENTAL
+/// \since 1.3.0
+class PARQUET_EXPORT RecordReader {
+ public:
+  /// \brief Creates a record reader.
+  /// @param descr Column descriptor
+  /// @param leaf_info Level info, used to determine if a column is nullable or
+  /// not
+  /// @param pool Memory pool to use for buffering values and rep/def levels
+  /// @param read_dictionary True if reading directly as Arrow
+  /// dictionary-encoded
+  /// @param read_dense_for_nullable True if reading dense and not leaving space
+  /// for null values
+  static std::shared_ptr<RecordReader> Make(
+      const ColumnDescriptor* descr,
+      LevelInfo leaf_info,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
+      bool read_dictionary = false,
+      bool read_dense_for_nullable = false);
+
+  virtual ~RecordReader() = default;
+
+  /// \brief Attempt to read indicated number of records from column chunk
+  /// Note that for repeated fields, a record may have more than one value
+  /// and all of them are read. If read_dense_for_nullable() it will
+  /// not leave any space for null values. Otherwise, it will read spaced.
+  /// \return number of records read
+  virtual int64_t ReadRecords(int64_t num_records) = 0;
+
+  /// \brief Attempt to skip indicated number of records from column chunk.
+  /// Note that for repeated fields, a record may have more than one value
+  /// and all of them are skipped.
+  /// \return number of records skipped
+  virtual int64_t SkipRecords(int64_t num_records) = 0;
+
+  /// \brief Pre-allocate space for data. Results in better flat read
+  /// performance
+  virtual void Reserve(int64_t num_values) = 0;
+
+  /// \brief Clear consumed values and repetition/definition levels as the
+  /// result of calling ReadRecords
+  /// For FLBA and ByteArray types, call GetBuilderChunks() to reset them.
+  virtual void Reset() = 0;
+
+  /// \brief Transfer filled values buffer to caller. A new one will be
+  /// allocated in subsequent ReadRecords calls
+  virtual std::shared_ptr<ResizableBuffer> ReleaseValues() = 0;
+
+  /// \brief Transfer filled validity bitmap buffer to caller. A new one will
+  /// be allocated in subsequent ReadRecords calls
+  virtual std::shared_ptr<ResizableBuffer> ReleaseIsValid() = 0;
+
+  /// \brief Return true if the record reader has more internal data yet to
+  /// process
+  virtual bool HasMoreData() const = 0;
+
+  /// \brief Advance record reader to the next row group. Must be set before
+  /// any records could be read/skipped.
+  /// \param[in] reader obtained from RowGroupReader::GetColumnPageReader
+  virtual void SetPageReader(std::unique_ptr<PageReader> reader) = 0;
+
+  /// \brief Returns the underlying column reader's descriptor.
+  virtual const ColumnDescriptor* descr() const = 0;
+
+  virtual void DebugPrintState() = 0;
+
+  /// \brief Decoded definition levels
+  int16_t* def_levels() const {
+    return reinterpret_cast<int16_t*>(def_levels_->mutable_data());
+  }
+
+  /// \brief Decoded repetition levels
+  int16_t* rep_levels() const {
+    return reinterpret_cast<int16_t*>(rep_levels_->mutable_data());
+  }
+
+  /// \brief Decoded values, including nulls, if any
+  /// FLBA and ByteArray types do not use this array and read into their own
+  /// builders.
+  uint8_t* values() const {
+    return values_->mutable_data();
+  }
+
+  /// \brief Number of values written, including space left for nulls if any.
+  /// If this Reader was constructed with read_dense_for_nullable(), there is no
+  /// space for nulls and null_count() will be 0. There is no
+  /// read-ahead/buffering for values. For FLBA and ByteArray types this value
+  /// reflects the values written with the last ReadRecords call since those
+  /// readers will reset the values after each call.
+  int64_t values_written() const {
+    return values_written_;
+  }
+
+  /// \brief Number of definition / repetition levels (from those that have
+  /// been decoded) that have been consumed inside the reader.
+  int64_t levels_position() const {
+    return levels_position_;
+  }
+
+  /// \brief Number of definition / repetition levels that have been written
+  /// internally in the reader. This may be larger than values_written() because
+  /// for repeated fields we need to look at the levels in advance to figure out
+  /// the record boundaries.
+  int64_t levels_written() const {
+    return levels_written_;
+  }
+
+  /// \brief Number of nulls in the leaf that we have read so far into the
+  /// values vector. This is only valid when !read_dense_for_nullable(). When
+  /// read_dense_for_nullable() it will always be 0.
+  int64_t null_count() const {
+    return null_count_;
+  }
+
+  /// \brief True if the leaf values are nullable
+  bool nullable_values() const {
+    return nullable_values_;
+  }
+
+  /// \brief True if reading directly as Arrow dictionary-encoded
+  bool read_dictionary() const {
+    return read_dictionary_;
+  }
+
+  /// \brief True if reading dense for nullable columns.
+  bool read_dense_for_nullable() const {
+    return read_dense_for_nullable_;
+  }
+
+ protected:
+  /// \brief Indicates if we can have nullable values. Note that repeated fields
+  /// may or may not be nullable.
+  bool nullable_values_;
+
+  bool at_record_start_;
+  int64_t records_read_;
+
+  /// \brief Stores values. These values are populated based on each ReadRecords
+  /// call. No extra values are buffered for the next call. SkipRecords will not
+  /// add any value to this buffer.
+  std::shared_ptr<::arrow::ResizableBuffer> values_;
+  /// \brief False for BYTE_ARRAY, in which case we don't allocate the values
+  /// buffer and we directly read into builder classes.
+  bool uses_values_;
+
+  /// \brief Values that we have read into 'values_' + 'null_count_'.
+  int64_t values_written_;
+  int64_t values_capacity_;
+  int64_t null_count_;
+
+  /// \brief Each bit corresponds to one element in 'values_' and specifies if
+  /// it is null or not null. Not set if read_dense_for_nullable_ is true.
+  std::shared_ptr<::arrow::ResizableBuffer> valid_bits_;
+
+  /// \brief Buffer for definition levels. May contain more levels than
+  /// is actually read. This is because we read levels ahead to
+  /// figure out record boundaries for repeated fields.
+  /// For flat required fields, 'def_levels_' and 'rep_levels_' are not
+  ///  populated. For non-repeated fields 'rep_levels_' is not populated.
+  /// 'def_levels_' and 'rep_levels_' must be of the same size if present.
+  std::shared_ptr<::arrow::ResizableBuffer> def_levels_;
+  /// \brief Buffer for repetition levels. Only populated for repeated
+  /// fields.
+  std::shared_ptr<::arrow::ResizableBuffer> rep_levels_;
+
+  /// \brief Number of definition / repetition levels that have been written
+  /// internally in the reader. This may be larger than values_written() since
+  /// for repeated fields we need to look at the levels in advance to figure out
+  /// the record boundaries.
+  int64_t levels_written_;
+  /// \brief Position of the next level that should be consumed.
+  int64_t levels_position_;
+  int64_t levels_capacity_;
+
+  bool read_dictionary_ = false;
+  // If true, we will not leave any space for the null values in the values_
+  // vector.
+  bool read_dense_for_nullable_ = false;
+};
+
+class BinaryRecordReader : virtual public RecordReader {
+ public:
+  virtual std::vector<std::shared_ptr<::arrow::Array>> GetBuilderChunks() = 0;
+};
+
+/// \brief Read records directly to dictionary-encoded Arrow form (int32
+/// indices). Only valid for BYTE_ARRAY columns
+class DictionaryRecordReader : virtual public RecordReader {
+ public:
+  virtual std::shared_ptr<::arrow::ChunkedArray> GetResult() = 0;
+};
+
+} // namespace internal
+
+using BoolReader = TypedColumnReader<BooleanType>;
+using Int32Reader = TypedColumnReader<Int32Type>;
+using Int64Reader = TypedColumnReader<Int64Type>;
+using Int96Reader = TypedColumnReader<Int96Type>;
+using FloatReader = TypedColumnReader<FloatType>;
+using DoubleReader = TypedColumnReader<DoubleType>;
+using ByteArrayReader = TypedColumnReader<ByteArrayType>;
+using FixedLenByteArrayReader = TypedColumnReader<FLBAType>;
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnReaderTest.cpp
@@ -1,0 +1,2323 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/util/macros.h"
+
+#include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+namespace facebook::velox::parquet::arrow {
+
+using ParquetType = parquet::Type;
+
+using internal::BinaryRecordReader;
+using schema::GroupNode;
+using schema::NodePtr;
+using schema::PrimitiveNode;
+using testing::ElementsAre;
+
+namespace test {
+
+template <typename T>
+static inline bool vector_equal_with_def_levels(
+    const std::vector<T>& left,
+    const std::vector<int16_t>& def_levels,
+    int16_t max_def_levels,
+    int16_t max_rep_levels,
+    const std::vector<T>& right) {
+  size_t i_left = 0;
+  size_t i_right = 0;
+  for (size_t i = 0; i < def_levels.size(); i++) {
+    if (def_levels[i] == max_def_levels) {
+      // Compare
+      if (left[i_left] != right[i_right]) {
+        std::cerr << "index " << i << " left was " << left[i_left]
+                  << " right was " << right[i] << std::endl;
+        return false;
+      }
+      i_left++;
+      i_right++;
+    } else if (def_levels[i] == (max_def_levels - 1)) {
+      // Null entry on the lowest nested level
+      i_right++;
+    } else if (def_levels[i] < (max_def_levels - 1)) {
+      // Null entry on a higher nesting level, only supported for non-repeating
+      // data
+      if (max_rep_levels == 0) {
+        i_right++;
+      }
+    }
+  }
+
+  return true;
+}
+
+class TestPrimitiveReader : public ::testing::Test {
+ public:
+  void InitReader(const ColumnDescriptor* d) {
+    auto pager = std::make_unique<MockPageReader>(pages_);
+    reader_ = ColumnReader::Make(d, std::move(pager));
+  }
+
+  void CheckResults() {
+    std::vector<int32_t> vresult(num_values_, -1);
+    std::vector<int16_t> dresult(num_levels_, -1);
+    std::vector<int16_t> rresult(num_levels_, -1);
+    int64_t values_read = 0;
+    int total_values_read = 0;
+    int batch_actual = 0;
+
+    Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
+    int32_t batch_size = 8;
+    int batch = 0;
+    // This will cover both the cases
+    // 1) batch_size < page_size (multiple ReadBatch from a single page)
+    // 2) batch_size > page_size (BatchRead limits to a single page)
+    do {
+      batch = static_cast<int>(reader->ReadBatch(
+          batch_size,
+          &dresult[0] + batch_actual,
+          &rresult[0] + batch_actual,
+          &vresult[0] + total_values_read,
+          &values_read));
+      total_values_read += static_cast<int>(values_read);
+      batch_actual += batch;
+      batch_size = std::min(1 << 24, std::max(batch_size * 2, 4096));
+    } while (batch > 0);
+
+    ASSERT_EQ(num_levels_, batch_actual);
+    ASSERT_EQ(num_values_, total_values_read);
+    ASSERT_TRUE(vector_equal(values_, vresult));
+    if (max_def_level_ > 0) {
+      ASSERT_TRUE(vector_equal(def_levels_, dresult));
+    }
+    if (max_rep_level_ > 0) {
+      ASSERT_TRUE(vector_equal(rep_levels_, rresult));
+    }
+    // catch improper writes at EOS
+    batch_actual = static_cast<int>(
+        reader->ReadBatch(5, nullptr, nullptr, nullptr, &values_read));
+    ASSERT_EQ(0, batch_actual);
+    ASSERT_EQ(0, values_read);
+  }
+  void CheckResultsSpaced() {
+    std::vector<int32_t> vresult(num_levels_, -1);
+    std::vector<int16_t> dresult(num_levels_, -1);
+    std::vector<int16_t> rresult(num_levels_, -1);
+    std::vector<uint8_t> valid_bits(num_levels_, 255);
+    int total_values_read = 0;
+    int batch_actual = 0;
+    int levels_actual = 0;
+    int64_t null_count = -1;
+    int64_t levels_read = 0;
+    int64_t values_read;
+
+    Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
+    int32_t batch_size = 8;
+    int batch = 0;
+    // This will cover both the cases
+    // 1) batch_size < page_size (multiple ReadBatch from a single page)
+    // 2) batch_size > page_size (BatchRead limits to a single page)
+    do {
+      ARROW_SUPPRESS_DEPRECATION_WARNING
+      batch = static_cast<int>(reader->ReadBatchSpaced(
+          batch_size,
+          dresult.data() + levels_actual,
+          rresult.data() + levels_actual,
+          vresult.data() + batch_actual,
+          valid_bits.data() + batch_actual,
+          0,
+          &levels_read,
+          &values_read,
+          &null_count));
+      ARROW_UNSUPPRESS_DEPRECATION_WARNING
+      total_values_read += batch - static_cast<int>(null_count);
+      batch_actual += batch;
+      levels_actual += static_cast<int>(levels_read);
+      batch_size = std::min(1 << 24, std::max(batch_size * 2, 4096));
+    } while ((batch > 0) || (levels_read > 0));
+
+    ASSERT_EQ(num_levels_, levels_actual);
+    ASSERT_EQ(num_values_, total_values_read);
+    if (max_def_level_ > 0) {
+      ASSERT_TRUE(vector_equal(def_levels_, dresult));
+      ASSERT_TRUE(vector_equal_with_def_levels(
+          values_, dresult, max_def_level_, max_rep_level_, vresult));
+    } else {
+      ASSERT_TRUE(vector_equal(values_, vresult));
+    }
+    if (max_rep_level_ > 0) {
+      ASSERT_TRUE(vector_equal(rep_levels_, rresult));
+    }
+    // catch improper writes at EOS
+    ARROW_SUPPRESS_DEPRECATION_WARNING
+    batch_actual = static_cast<int>(reader->ReadBatchSpaced(
+        5,
+        nullptr,
+        nullptr,
+        nullptr,
+        valid_bits.data(),
+        0,
+        &levels_read,
+        &values_read,
+        &null_count));
+    ARROW_UNSUPPRESS_DEPRECATION_WARNING
+    ASSERT_EQ(0, batch_actual);
+    ASSERT_EQ(0, null_count);
+  }
+
+  void Clear() {
+    values_.clear();
+    def_levels_.clear();
+    rep_levels_.clear();
+    pages_.clear();
+    reader_.reset();
+  }
+
+  void
+  ExecutePlain(int num_pages, int levels_per_page, const ColumnDescriptor* d) {
+    num_values_ = MakePages<Int32Type>(
+        d,
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        data_buffer_,
+        pages_,
+        Encoding::PLAIN);
+    num_levels_ = num_pages * levels_per_page;
+    InitReader(d);
+    CheckResults();
+    Clear();
+
+    num_values_ = MakePages<Int32Type>(
+        d,
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        data_buffer_,
+        pages_,
+        Encoding::PLAIN);
+    num_levels_ = num_pages * levels_per_page;
+    InitReader(d);
+    CheckResultsSpaced();
+    Clear();
+  }
+
+  void
+  ExecuteDict(int num_pages, int levels_per_page, const ColumnDescriptor* d) {
+    num_values_ = MakePages<Int32Type>(
+        d,
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        data_buffer_,
+        pages_,
+        Encoding::RLE_DICTIONARY);
+    num_levels_ = num_pages * levels_per_page;
+    InitReader(d);
+    CheckResults();
+    Clear();
+
+    num_values_ = MakePages<Int32Type>(
+        d,
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        data_buffer_,
+        pages_,
+        Encoding::RLE_DICTIONARY);
+    num_levels_ = num_pages * levels_per_page;
+    InitReader(d);
+    CheckResultsSpaced();
+    Clear();
+  }
+
+ protected:
+  int num_levels_;
+  int num_values_;
+  int16_t max_def_level_;
+  int16_t max_rep_level_;
+  std::vector<std::shared_ptr<Page>> pages_;
+  std::shared_ptr<ColumnReader> reader_;
+  std::vector<int32_t> values_;
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  std::vector<uint8_t> data_buffer_; // For BA and FLBA
+};
+
+TEST_F(TestPrimitiveReader, TestInt32FlatRequired) {
+  int levels_per_page = 100;
+  int num_pages = 50;
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("a", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  ASSERT_NO_FATAL_FAILURE(ExecutePlain(num_pages, levels_per_page, &descr));
+  ASSERT_NO_FATAL_FAILURE(ExecuteDict(num_pages, levels_per_page, &descr));
+}
+
+TEST_F(TestPrimitiveReader, TestInt32FlatOptional) {
+  int levels_per_page = 100;
+  int num_pages = 50;
+  max_def_level_ = 4;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("b", Repetition::OPTIONAL);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  ASSERT_NO_FATAL_FAILURE(ExecutePlain(num_pages, levels_per_page, &descr));
+  ASSERT_NO_FATAL_FAILURE(ExecuteDict(num_pages, levels_per_page, &descr));
+}
+
+TEST_F(TestPrimitiveReader, TestInt32FlatRepeated) {
+  int levels_per_page = 100;
+  int num_pages = 50;
+  max_def_level_ = 4;
+  max_rep_level_ = 2;
+  NodePtr type = schema::Int32("c", Repetition::REPEATED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  ASSERT_NO_FATAL_FAILURE(ExecutePlain(num_pages, levels_per_page, &descr));
+  ASSERT_NO_FATAL_FAILURE(ExecuteDict(num_pages, levels_per_page, &descr));
+}
+
+// Tests skipping around page boundaries.
+TEST_F(TestPrimitiveReader, TestSkipAroundPageBoundries) {
+  int levels_per_page = 100;
+  int num_pages = 7;
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("b", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  MakePages<Int32Type>(
+      &descr,
+      num_pages,
+      levels_per_page,
+      def_levels_,
+      rep_levels_,
+      values_,
+      data_buffer_,
+      pages_,
+      Encoding::PLAIN);
+  InitReader(&descr);
+  std::vector<int32_t> vresult(levels_per_page / 2, -1);
+  std::vector<int16_t> dresult(levels_per_page / 2, -1);
+  std::vector<int16_t> rresult(levels_per_page / 2, -1);
+
+  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
+  int64_t values_read = 0;
+
+  // 1) skip_size > page_size (multiple pages skipped)
+  // Skip first 2 pages
+  int64_t levels_skipped = reader->Skip(2 * levels_per_page);
+  ASSERT_EQ(2 * levels_per_page, levels_skipped);
+  // Read half a page
+  reader->ReadBatch(
+      levels_per_page / 2,
+      dresult.data(),
+      rresult.data(),
+      vresult.data(),
+      &values_read);
+  std::vector<int32_t> sub_values(
+      values_.begin() + 2 * levels_per_page,
+      values_.begin() + static_cast<int>(2.5 * levels_per_page));
+  ASSERT_TRUE(vector_equal(sub_values, vresult));
+
+  // 2) skip_size == page_size (skip across two pages from page 2.5 to 3.5)
+  levels_skipped = reader->Skip(levels_per_page);
+  ASSERT_EQ(levels_per_page, levels_skipped);
+  // Read half a page (page 3.5 to 4)
+  reader->ReadBatch(
+      levels_per_page / 2,
+      dresult.data(),
+      rresult.data(),
+      vresult.data(),
+      &values_read);
+  sub_values.clear();
+  sub_values.insert(
+      sub_values.end(),
+      values_.begin() + static_cast<int>(3.5 * levels_per_page),
+      values_.begin() + 4 * levels_per_page);
+  ASSERT_TRUE(vector_equal(sub_values, vresult));
+
+  // 3) skip_size == page_size (skip page 4 from start of the page to the end)
+  levels_skipped = reader->Skip(levels_per_page);
+  ASSERT_EQ(levels_per_page, levels_skipped);
+  // Read half a page (page 5 to 5.5)
+  reader->ReadBatch(
+      levels_per_page / 2,
+      dresult.data(),
+      rresult.data(),
+      vresult.data(),
+      &values_read);
+  sub_values.clear();
+  sub_values.insert(
+      sub_values.end(),
+      values_.begin() + static_cast<int>(5.0 * levels_per_page),
+      values_.begin() + static_cast<int>(5.5 * levels_per_page));
+  ASSERT_TRUE(vector_equal(sub_values, vresult));
+
+  // 4) skip_size < page_size (skip limited to a single page)
+  // Skip half a page (page 5.5 to 6)
+  levels_skipped = reader->Skip(levels_per_page / 2);
+  ASSERT_EQ(0.5 * levels_per_page, levels_skipped);
+  // Read half a page (6 to 6.5)
+  reader->ReadBatch(
+      levels_per_page / 2,
+      dresult.data(),
+      rresult.data(),
+      vresult.data(),
+      &values_read);
+  sub_values.clear();
+  sub_values.insert(
+      sub_values.end(),
+      values_.begin() + static_cast<int>(6.0 * levels_per_page),
+      values_.begin() + static_cast<int>(6.5 * levels_per_page));
+  ASSERT_TRUE(vector_equal(sub_values, vresult));
+
+  // 5) skip_size = 0
+  levels_skipped = reader->Skip(0);
+  ASSERT_EQ(0, levels_skipped);
+
+  // 6) Skip past the end page.
+  levels_skipped = reader->Skip(levels_per_page / 2 + 10);
+  ASSERT_EQ(levels_per_page / 2, levels_skipped);
+
+  values_.clear();
+  def_levels_.clear();
+  rep_levels_.clear();
+  pages_.clear();
+  reader_.reset();
+}
+
+// Skip with repeated field. This test makes it clear that we are skipping
+// values and not records.
+TEST_F(TestPrimitiveReader, TestSkipRepeatedField) {
+  // Example schema: message M { repeated int32 b = 1 }
+  max_def_level_ = 1;
+  max_rep_level_ = 1;
+  NodePtr type = schema::Int32("b", Repetition::REPEATED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  // Example rows: {}, {[10, 10]}, {[20, 20, 20]}
+  std::vector<int32_t> values = {10, 10, 20, 20, 20};
+  std::vector<int16_t> def_levels = {0, 1, 1, 1, 1, 1};
+  std::vector<int16_t> rep_levels = {0, 0, 1, 0, 1, 1};
+  num_values_ = static_cast<int>(def_levels.size());
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      &descr,
+      values,
+      num_values_,
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      max_def_level_,
+      rep_levels,
+      max_rep_level_);
+
+  pages_.push_back(std::move(page));
+
+  InitReader(&descr);
+  Int32Reader* reader = static_cast<Int32Reader*>(reader_.get());
+
+  // Vecotrs to hold read values, definition levels, and repetition levels.
+  std::vector<int32_t> read_vals(4, -1);
+  std::vector<int16_t> read_defs(4, -1);
+  std::vector<int16_t> read_reps(4, -1);
+
+  // Skip two levels.
+  int64_t levels_skipped = reader->Skip(2);
+  ASSERT_EQ(2, levels_skipped);
+
+  int64_t num_read_values = 0;
+  // Read the next set of values
+  reader->ReadBatch(
+      10,
+      read_defs.data(),
+      read_reps.data(),
+      read_vals.data(),
+      &num_read_values);
+  ASSERT_EQ(num_read_values, 4);
+  // Note that we end up in the record with {[10, 10]}
+  ASSERT_TRUE(vector_equal({10, 20, 20, 20}, read_vals));
+  ASSERT_TRUE(vector_equal({1, 1, 1, 1}, read_defs));
+  ASSERT_TRUE(vector_equal({1, 0, 1, 1}, read_reps));
+
+  // No values remain in data page
+  levels_skipped = reader->Skip(2);
+  ASSERT_EQ(0, levels_skipped);
+  reader->ReadBatch(
+      10,
+      read_defs.data(),
+      read_reps.data(),
+      read_vals.data(),
+      &num_read_values);
+  ASSERT_EQ(num_read_values, 0);
+}
+
+// Page claims to have two values but only 1 is present.
+TEST_F(TestPrimitiveReader, TestReadValuesMissing) {
+  max_def_level_ = 1;
+  max_rep_level_ = 0;
+  constexpr int batch_size = 1;
+  std::vector<bool> values(1, false);
+  std::vector<int16_t> input_def_levels(1, 1);
+  NodePtr type = schema::Boolean("a", Repetition::OPTIONAL);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+
+  // The data page falls back to plain encoding
+  std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<BooleanType>(
+      &descr,
+      values,
+      /*num_values=*/2,
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      /*def_levels=*/input_def_levels,
+      max_def_level_,
+      /*rep_levels=*/{},
+      /*max_rep_level=*/0);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  auto reader = static_cast<BoolReader*>(reader_.get());
+  ASSERT_TRUE(reader->HasNext());
+  std::vector<int16_t> def_levels(batch_size, 0);
+  std::vector<int16_t> rep_levels(batch_size, 0);
+  bool values_out[batch_size];
+  int64_t values_read;
+  EXPECT_EQ(
+      1,
+      reader->ReadBatch(
+          batch_size,
+          def_levels.data(),
+          rep_levels.data(),
+          values_out,
+          &values_read));
+  ASSERT_THROW(
+      reader->ReadBatch(
+          batch_size,
+          def_levels.data(),
+          rep_levels.data(),
+          values_out,
+          &values_read),
+      ParquetException);
+}
+
+// Repetition level byte length reported in Page but Max Repetition level
+// is zero for the column.
+TEST_F(TestPrimitiveReader, TestRepetitionLvlBytesWithMaxRepetitionZero) {
+  constexpr int batch_size = 4;
+  max_def_level_ = 1;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("a", Repetition::OPTIONAL);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  // Bytes here came from the example parquet file in ARROW-17453's int32
+  // column which was delta bit-packed. The key part is the first three
+  // bytes: the page header reports 1 byte for repetition levels even
+  // though the max rep level is 0. If that byte isn't skipped then
+  // we get def levels of [1, 1, 0, 0] instead of the correct [1, 1, 1, 0].
+  const std::vector<uint8_t> page_data{0x3,  0x3, 0x7, 0x80, 0x1, 0x4, 0x3,
+                                       0x18, 0x1, 0x2, 0x0,  0x0, 0x0, 0xc,
+                                       0x0,  0x0, 0x0, 0x0,  0x0, 0x0, 0x0};
+
+  std::shared_ptr<DataPageV2> data_page = std::make_shared<DataPageV2>(
+      Buffer::Wrap(page_data.data(), page_data.size()),
+      4,
+      1,
+      4,
+      Encoding::DELTA_BINARY_PACKED,
+      2,
+      1,
+      21);
+
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  auto reader = static_cast<Int32Reader*>(reader_.get());
+  int16_t def_levels_out[batch_size];
+  int32_t values[batch_size];
+  int64_t values_read;
+  ASSERT_TRUE(reader->HasNext());
+  EXPECT_EQ(
+      4,
+      reader->ReadBatch(
+          batch_size,
+          def_levels_out,
+          /*replevels=*/nullptr,
+          values,
+          &values_read));
+  EXPECT_EQ(3, values_read);
+}
+
+// Page claims to have two values but only 1 is present.
+TEST_F(TestPrimitiveReader, TestReadValuesMissingWithDictionary) {
+  constexpr int batch_size = 1;
+  max_def_level_ = 1;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("a", Repetition::OPTIONAL);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
+
+  std::shared_ptr<DictionaryPage> dict_page =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
+  std::vector<int16_t> input_def_levels(1, 0);
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+      &descr,
+      {},
+      /*num_values=*/2,
+      Encoding::RLE_DICTIONARY,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      /*def_levels=*/input_def_levels,
+      max_def_level_,
+      /*rep_levels=*/{},
+      /*max_rep_level=*/0);
+  pages_.push_back(dict_page);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  auto reader = static_cast<ByteArrayReader*>(reader_.get());
+  const ByteArray* dict = nullptr;
+  int32_t dict_len = 0;
+  int64_t indices_read = 0;
+  int32_t indices[batch_size];
+  int16_t def_levels_out[batch_size];
+  ASSERT_TRUE(reader->HasNext());
+  EXPECT_EQ(
+      1,
+      reader->ReadBatchWithDictionary(
+          batch_size,
+          def_levels_out,
+          /*rep_levels=*/nullptr,
+          indices,
+          &indices_read,
+          &dict,
+          &dict_len));
+  ASSERT_THROW(
+      reader->ReadBatchWithDictionary(
+          batch_size,
+          def_levels_out,
+          /*rep_levels=*/nullptr,
+          indices,
+          &indices_read,
+          &dict,
+          &dict_len),
+      ParquetException);
+}
+
+TEST_F(TestPrimitiveReader, TestDictionaryEncodedPages) {
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  NodePtr type = schema::Int32("a", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+  std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
+
+  std::shared_ptr<DictionaryPage> dict_page =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+      &descr, {}, 0, Encoding::RLE_DICTIONARY, {}, 0, {}, 0, {}, 0);
+  pages_.push_back(dict_page);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  // Tests Dict : PLAIN, Data : RLE_DICTIONARY
+  ASSERT_NO_THROW(reader_->HasNext());
+  pages_.clear();
+
+  dict_page =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN_DICTIONARY);
+  data_page = MakeDataPage<Int32Type>(
+      &descr, {}, 0, Encoding::PLAIN_DICTIONARY, {}, 0, {}, 0, {}, 0);
+  pages_.push_back(dict_page);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  // Tests Dict : PLAIN_DICTIONARY, Data : PLAIN_DICTIONARY
+  ASSERT_NO_THROW(reader_->HasNext());
+  pages_.clear();
+
+  data_page = MakeDataPage<Int32Type>(
+      &descr, {}, 0, Encoding::RLE_DICTIONARY, {}, 0, {}, 0, {}, 0);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  // Tests dictionary page must occur before data page
+  ASSERT_THROW(reader_->HasNext(), ParquetException);
+  pages_.clear();
+
+  dict_page =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::DELTA_BYTE_ARRAY);
+  pages_.push_back(dict_page);
+  InitReader(&descr);
+  // Tests only RLE_DICTIONARY is supported
+  ASSERT_THROW(reader_->HasNext(), ParquetException);
+  pages_.clear();
+
+  std::shared_ptr<DictionaryPage> dict_page1 =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN_DICTIONARY);
+  std::shared_ptr<DictionaryPage> dict_page2 =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
+  pages_.push_back(dict_page1);
+  pages_.push_back(dict_page2);
+  InitReader(&descr);
+  // Column cannot have more than one dictionary
+  ASSERT_THROW(reader_->HasNext(), ParquetException);
+  pages_.clear();
+
+  data_page = MakeDataPage<Int32Type>(
+      &descr, {}, 0, Encoding::DELTA_BYTE_ARRAY, {}, 0, {}, 0, {}, 0);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+  // unsupported encoding
+  ASSERT_THROW(reader_->HasNext(), ParquetException);
+  pages_.clear();
+}
+
+TEST_F(TestPrimitiveReader, TestDictionaryEncodedPagesWithExposeEncoding) {
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  int levels_per_page = 100;
+  int num_pages = 5;
+  std::vector<int16_t> def_levels;
+  std::vector<int16_t> rep_levels;
+  std::vector<ByteArray> values;
+  std::vector<uint8_t> buffer;
+  NodePtr type = schema::ByteArray("a", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+
+  // Fully dictionary encoded
+  MakePages<ByteArrayType>(
+      &descr,
+      num_pages,
+      levels_per_page,
+      def_levels,
+      rep_levels,
+      values,
+      buffer,
+      pages_,
+      Encoding::RLE_DICTIONARY);
+  InitReader(&descr);
+
+  auto reader = static_cast<ByteArrayReader*>(reader_.get());
+  const ByteArray* dict = nullptr;
+  int32_t dict_len = 0;
+  int64_t total_indices = 0;
+  int64_t indices_read = 0;
+  int64_t value_size = values.size();
+  auto indices = std::make_unique<int32_t[]>(value_size);
+  while (total_indices < value_size && reader->HasNext()) {
+    const ByteArray* tmp_dict = nullptr;
+    int32_t tmp_dict_len = 0;
+    EXPECT_NO_THROW(reader->ReadBatchWithDictionary(
+        value_size,
+        /*def_levels=*/nullptr,
+        /*rep_levels=*/nullptr,
+        indices.get() + total_indices,
+        &indices_read,
+        &tmp_dict,
+        &tmp_dict_len));
+    if (tmp_dict != nullptr) {
+      // Dictionary is read along with data
+      EXPECT_GT(indices_read, 0);
+      dict = tmp_dict;
+      dict_len = tmp_dict_len;
+    } else {
+      // Dictionary is not read when there's no data
+      EXPECT_EQ(indices_read, 0);
+    }
+    total_indices += indices_read;
+  }
+
+  EXPECT_EQ(total_indices, value_size);
+  for (int64_t i = 0; i < total_indices; ++i) {
+    EXPECT_LT(indices[i], dict_len);
+    EXPECT_EQ(dict[indices[i]].len, values[i].len);
+    EXPECT_EQ(memcmp(dict[indices[i]].ptr, values[i].ptr, values[i].len), 0);
+  }
+  pages_.clear();
+}
+
+TEST_F(TestPrimitiveReader, TestNonDictionaryEncodedPagesWithExposeEncoding) {
+  max_def_level_ = 0;
+  max_rep_level_ = 0;
+  int64_t value_size = 100;
+  std::vector<int32_t> values(value_size, 0);
+  NodePtr type = schema::Int32("a", Repetition::REQUIRED);
+  const ColumnDescriptor descr(type, max_def_level_, max_rep_level_);
+
+  // The data page falls back to plain encoding
+  std::shared_ptr<ResizableBuffer> dummy = AllocateBuffer();
+  std::shared_ptr<DictionaryPage> dict_page =
+      std::make_shared<DictionaryPage>(dummy, 0, Encoding::PLAIN);
+  std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+      &descr,
+      values,
+      static_cast<int>(value_size),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      /*def_levels=*/{},
+      /*max_def_level=*/0,
+      /*rep_levels=*/{},
+      /*max_rep_level=*/0);
+  pages_.push_back(dict_page);
+  pages_.push_back(data_page);
+  InitReader(&descr);
+
+  auto reader = static_cast<ByteArrayReader*>(reader_.get());
+  const ByteArray* dict = nullptr;
+  int32_t dict_len = 0;
+  int64_t indices_read = 0;
+  auto indices = std::make_unique<int32_t[]>(value_size);
+  // Dictionary cannot be exposed when it's not fully dictionary encoded
+  EXPECT_THROW(
+      reader->ReadBatchWithDictionary(
+          value_size,
+          /*def_levels=*/nullptr,
+          /*rep_levels=*/nullptr,
+          indices.get(),
+          &indices_read,
+          &dict,
+          &dict_len),
+      ParquetException);
+  pages_.clear();
+}
+
+namespace {
+
+LevelInfo ComputeLevelInfo(const ColumnDescriptor* descr) {
+  LevelInfo level_info;
+  level_info.def_level = descr->max_definition_level();
+  level_info.rep_level = descr->max_repetition_level();
+
+  int16_t min_spaced_def_level = descr->max_definition_level();
+  const schema::Node* node = descr->schema_node().get();
+  while (node != nullptr && !node->is_repeated()) {
+    if (node->is_optional()) {
+      min_spaced_def_level--;
+    }
+    node = node->parent();
+  }
+  level_info.repeated_ancestor_def_level = min_spaced_def_level;
+  return level_info;
+}
+
+} // namespace
+
+using ReadDenseForNullable = bool;
+class RecordReaderPrimitiveTypeTest
+    : public ::testing::TestWithParam<ReadDenseForNullable> {
+ public:
+  const int32_t kNullValue = -1;
+
+  void Init(NodePtr column) {
+    NodePtr root = GroupNode::Make("root", Repetition::REQUIRED, {column});
+    schema_descriptor_.Init(root);
+    descr_ = schema_descriptor_.Column(0);
+    record_reader_ = internal::RecordReader::Make(
+        descr_,
+        ComputeLevelInfo(descr_),
+        ::arrow::default_memory_pool(),
+        /*read_dictionary=*/false,
+        GetParam());
+  }
+
+  void CheckReadValues(
+      std::vector<int32_t> expected_values,
+      std::vector<int16_t> expected_defs,
+      std::vector<int16_t> expected_reps) {
+    const auto read_values =
+        reinterpret_cast<const int32_t*>(record_reader_->values());
+    std::vector<int32_t> read_vals(
+        read_values, read_values + record_reader_->values_written());
+    ASSERT_EQ(read_vals.size(), expected_values.size());
+    for (size_t i = 0; i < expected_values.size(); ++i) {
+      if (expected_values[i] != kNullValue) {
+        ASSERT_EQ(expected_values[i], read_values[i]);
+      }
+    }
+
+    if (!descr_->schema_node()->is_required()) {
+      std::vector<int16_t> read_defs(
+          record_reader_->def_levels(),
+          record_reader_->def_levels() + record_reader_->levels_position());
+      ASSERT_TRUE(vector_equal(expected_defs, read_defs));
+    }
+
+    if (descr_->schema_node()->is_repeated()) {
+      std::vector<int16_t> read_reps(
+          record_reader_->rep_levels(),
+          record_reader_->rep_levels() + record_reader_->levels_position());
+      ASSERT_TRUE(vector_equal(expected_reps, read_reps));
+    }
+  }
+
+  void CheckState(
+      int64_t values_written,
+      int64_t null_count,
+      int64_t levels_written,
+      int64_t levels_position) {
+    ASSERT_EQ(record_reader_->values_written(), values_written);
+    ASSERT_EQ(record_reader_->null_count(), null_count);
+    ASSERT_EQ(record_reader_->levels_written(), levels_written);
+    ASSERT_EQ(record_reader_->levels_position(), levels_position);
+  }
+
+ protected:
+  SchemaDescriptor schema_descriptor_;
+  std::shared_ptr<internal::RecordReader> record_reader_;
+  const ColumnDescriptor* descr_;
+};
+
+// Tests reading a required field. The expected results are the same for
+// reading dense and spaced.
+TEST_P(RecordReaderPrimitiveTypeTest, ReadRequired) {
+  Init(schema::Int32("b", Repetition::REQUIRED));
+
+  // Records look like: {10, 20, 20, 30, 30, 30}
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 20, 30, 30, 30};
+  std::vector<int16_t> def_levels = {};
+  std::vector<int16_t> rep_levels = {};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(def_levels.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      rep_levels,
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  // Read [10]
+  int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+  ASSERT_EQ(records_read, 1);
+  CheckState(
+      /*values_written=*/1,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+  CheckReadValues(
+      /*expected_values=*/{10},
+      /*expected_defs=*/{},
+      /*expected_reps=*/{});
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+
+  // Read 20, 20, 30, 30, 30
+  records_read = record_reader_->ReadRecords(/*num_records=*/10);
+  ASSERT_EQ(records_read, 5);
+  CheckState(
+      /*values_written=*/5,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+  CheckReadValues(
+      /*expected_values=*/{20, 20, 30, 30, 30},
+      /*expected_defs=*/{},
+      /*expected_reps=*/{});
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+}
+
+// Tests reading an optional field.
+// Use a max definition field > 1 to test both cases where parent is present or
+// parent is missing.
+TEST_P(RecordReaderPrimitiveTypeTest, ReadOptional) {
+  NodePtr column = GroupNode::Make(
+      "a",
+      Repetition::OPTIONAL,
+      {PrimitiveNode::Make(
+          "element", Repetition::OPTIONAL, ParquetType::INT32)});
+  Init(column);
+
+  // Records look like: {10, null, 20, 20, null, 30, 30, 30, null}
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 20, 30, 30, 30};
+  std::vector<int16_t> def_levels = {2, 0, 2, 2, 1, 2, 2, 2, 0};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(def_levels.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      /*rep_levels=*/{},
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  // Read 10, null
+  int64_t records_read = record_reader_->ReadRecords(/*num_records=*/2);
+  ASSERT_EQ(records_read, 2);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/9,
+        /*levels_position=*/2);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{2, 0},
+        /*expected_reps=*/{});
+  } else {
+    CheckState(
+        /*values_written=*/2,
+        /*null_count=*/1,
+        /*levels_written=*/9,
+        /*levels_position=*/2);
+    CheckReadValues(
+        /*expected_values=*/{10, kNullValue},
+        /*expected_defs=*/{2, 0},
+        /*expected_reps=*/{});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/7,
+      /*levels_position=*/0);
+
+  // Read 20, 20, null (parent present), 30, 30, 30
+  records_read = record_reader_->ReadRecords(/*num_records=*/6);
+  ASSERT_EQ(records_read, 6);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/5,
+        /*null_count=*/0,
+        /*levels_written=*/7,
+        /*levels_position=*/6);
+    CheckReadValues(
+        /*expected_values=*/{20, 20, 30, 30, 30},
+        /*expected_defs=*/{2, 2, 1, 2, 2, 2},
+        /*expected_reps=*/{});
+  } else {
+    CheckState(
+        /*values_written=*/6,
+        /*null_count=*/1,
+        /*levels_written=*/7,
+        /*levels_position=*/6);
+    CheckReadValues(
+        /*expected_values=*/{20, 20, kNullValue, 30, 30, 30},
+        /*expected_defs=*/{2, 2, 1, 2, 2, 2},
+        /*expected_reps=*/{});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/1,
+      /*levels_position=*/0);
+
+  // Read the last null value and read past the end.
+  records_read = record_reader_->ReadRecords(/*num_records=*/3);
+  ASSERT_EQ(records_read, 1);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/1,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{},
+        /*expected_defs=*/{0},
+        /*expected_reps=*/{});
+  } else {
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/1,
+        /*levels_written=*/1,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{kNullValue},
+        /*expected_defs=*/{0},
+        /*expected_reps=*/{});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+}
+
+// Tests reading a required repeated field. The results are the same for reading
+// dense or spaced.
+TEST_P(RecordReaderPrimitiveTypeTest, ReadRequiredRepeated) {
+  NodePtr column = GroupNode::Make(
+      "p",
+      Repetition::REQUIRED,
+      {GroupNode::Make(
+          "list",
+          Repetition::REPEATED,
+          {PrimitiveNode::Make(
+              "element", Repetition::REQUIRED, ParquetType::INT32)})});
+  Init(column);
+
+  // Records look like: {[10], [20, 20], [30, 30, 30]}
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 20, 30, 30, 30};
+  std::vector<int16_t> def_levels = {1, 1, 1, 1, 1, 1};
+  std::vector<int16_t> rep_levels = {0, 0, 1, 0, 1, 1};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(def_levels.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      rep_levels,
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  // Read [10]
+  int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+  ASSERT_EQ(records_read, 1);
+  CheckState(
+      /*values_written=*/1,
+      /*null_count=*/0,
+      /*levels_written=*/6,
+      /*levels_position=*/1);
+  CheckReadValues(
+      /*expected_values=*/{10},
+      /*expected_defs=*/{1},
+      /*expected_reps=*/{0});
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/5,
+      /*levels_position=*/0);
+
+  // Read [20, 20], [30, 30, 30]
+  records_read = record_reader_->ReadRecords(/*num_records=*/3);
+  ASSERT_EQ(records_read, 2);
+  CheckState(
+      /*values_written=*/5,
+      /*null_count=*/0,
+      /*levels_written=*/5,
+      /*levels_position=*/5);
+  CheckReadValues(
+      /*expected_values=*/{20, 20, 30, 30, 30},
+      /*expected_defs=*/{1, 1, 1, 1, 1},
+      /*expected_reps=*/{0, 1, 0, 1, 1});
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+}
+
+// Tests reading a nullable repeated field. Tests reading null values at
+// differnet levels and reading an empty list.
+TEST_P(RecordReaderPrimitiveTypeTest, ReadNullableRepeated) {
+  NodePtr column = GroupNode::Make(
+      "p",
+      Repetition::OPTIONAL,
+      {GroupNode::Make(
+          "list",
+          Repetition::REPEATED,
+          {PrimitiveNode::Make(
+              "element", Repetition::OPTIONAL, ParquetType::INT32)})});
+  Init(column);
+
+  // Records look like: {[10], null, [20, 20], [], [30, 30, null, 30]}
+  // Some explanation regarding the behavior. When reading spaced, for an empty
+  // list or for a top-level null, we do not leave a space and we do not count
+  // it towards null_count.  For a leaf-level null, we leave a space for it and
+  // we count it towards null_count. When reading dense, null_count is always 0,
+  // and we do not leave any space for values.
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 20, 30, 30, 30};
+  std::vector<int16_t> def_levels = {3, 0, 3, 3, 1, 3, 3, 2, 3};
+  std::vector<int16_t> rep_levels = {0, 0, 0, 1, 0, 0, 1, 1, 1};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(def_levels.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      rep_levels,
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  // Test reading 0 records.
+  int64_t records_read = record_reader_->ReadRecords(/*num_records=*/0);
+  ASSERT_EQ(records_read, 0);
+
+  // Test the descr() accessor.
+  ASSERT_EQ(record_reader_->descr()->max_definition_level(), 3);
+
+  // Read [10], null
+  // We do not read this null for both reading dense and spaced.
+  records_read = record_reader_->ReadRecords(/*num_records=*/2);
+  ASSERT_EQ(records_read, 2);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/9,
+        /*levels_position=*/2);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{3, 0},
+        /*expected_reps=*/{0, 0});
+  } else {
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/9,
+        /*levels_position=*/2);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{3, 0},
+        /*expected_reps=*/{0, 0});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/7,
+      /*levels_position=*/0);
+
+  // Read [20, 20], []
+  // We do not read any value for this, it will be counted towards null count
+  // when reading spaced.
+  records_read = record_reader_->ReadRecords(/*num_records=*/2);
+  ASSERT_EQ(records_read, 2);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/2,
+        /*null_count=*/0,
+        /*levels_written=*/7,
+        /*levels_position=*/3);
+    CheckReadValues(
+        /*expected_values=*/{20, 20},
+        /*expected_defs=*/{3, 3, 1},
+        /*expected_reps=*/{0, 1, 0});
+  } else {
+    CheckState(
+        /*values_written=*/2,
+        /*null_count=*/0,
+        /*levels_written=*/7,
+        /*levels_position=*/3);
+    CheckReadValues(
+        /*expected_values=*/{20, 20},
+        /*expected_defs=*/{3, 3, 1},
+        /*expected_reps=*/{0, 1, 0});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/4,
+      /*levels_position=*/0);
+
+  // Test reading 0 records.
+  records_read = record_reader_->ReadRecords(/*num_records=*/0);
+  ASSERT_EQ(records_read, 0);
+
+  // Read the last record.
+  records_read = record_reader_->ReadRecords(/*num_records=*/1);
+  ASSERT_EQ(records_read, 1);
+  if (GetParam() == /*read_dense_for_nullable=*/true) {
+    CheckState(
+        /*values_written=*/3,
+        /*null_count=*/0,
+        /*levels_written=*/4,
+        /*levels_position=*/4);
+    CheckReadValues(
+        /*expected_values=*/{30, 30, 30},
+        /*expected_defs=*/{3, 3, 2, 3},
+        /*expected_reps=*/{0, 1, 1, 1});
+  } else {
+    CheckState(
+        /*values_written=*/4,
+        /*null_count=*/1,
+        /*levels_written=*/4,
+        /*levels_position=*/4);
+    CheckReadValues(
+        /*expected_values=*/{30, 30, kNullValue, 30},
+        /*expected_defs=*/{3, 3, 2, 3},
+        /*expected_reps=*/{0, 1, 1, 1});
+  }
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+}
+
+// Test that we can skip required top level field.
+TEST_P(RecordReaderPrimitiveTypeTest, SkipRequiredTopLevel) {
+  Init(schema::Int32("b", Repetition::REQUIRED));
+
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 20, 30, 30, 30};
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(values.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      /*def_levels=*/{},
+      descr_->max_definition_level(),
+      /*rep_levels=*/{},
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/3);
+  ASSERT_EQ(records_skipped, 3);
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+
+  int64_t records_read = record_reader_->ReadRecords(/*num_records=*/2);
+  ASSERT_EQ(records_read, 2);
+  CheckState(
+      /*values_written=*/2,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+  CheckReadValues(
+      /*expected_values=*/{30, 30},
+      /*expected_defs=*/{},
+      /*expected_reps=*/{});
+  record_reader_->Reset();
+  CheckState(
+      /*values_written=*/0,
+      /*null_count=*/0,
+      /*levels_written=*/0,
+      /*levels_position=*/0);
+}
+
+// Skip an optional field. Intentionally included some null values.
+TEST_P(RecordReaderPrimitiveTypeTest, SkipOptional) {
+  Init(schema::Int32("b", Repetition::OPTIONAL));
+
+  // Records look like {null, 10, 20, 30, null, 40, 50, 60}
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {10, 20, 30, 40, 50, 60};
+  std::vector<int16_t> def_levels = {0, 1, 1, 0, 1, 1, 1, 1};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(values.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      /*rep_levels=*/{},
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  {
+    // Skip {null, 10}
+    // This also tests when we start with a Skip.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/2);
+    ASSERT_EQ(records_skipped, 2);
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/0,
+        /*levels_position=*/0);
+  }
+
+  {
+    // Read 3 records: {20, null, 30}
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/3);
+
+    ASSERT_EQ(records_read, 3);
+    if (GetParam() == /*read_dense_for_nullable=*/true) {
+      // We had skipped 2 of the levels above. So there is only 6 left in total
+      // to read, and we read 3 of them here.
+      CheckState(
+          /*values_written=*/2,
+          /*null_count=*/0,
+          /*levels_written=*/6,
+          /*levels_position=*/3);
+      CheckReadValues(
+          /*expected_values=*/{20, 30},
+          /*expected_defs=*/{1, 0, 1},
+          /*expected_reps=*/{});
+    } else {
+      CheckState(
+          /*values_written=*/3,
+          /*null_count=*/1,
+          /*levels_written=*/6,
+          /*levels_position=*/3);
+      CheckReadValues(
+          /*expected_values=*/{20, kNullValue, 30},
+          /*expected_defs=*/{1, 0, 1},
+          /*expected_reps=*/{});
+    }
+
+    record_reader_->Reset();
+  }
+
+  {
+    // Skip {40, 50}.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/2);
+    ASSERT_EQ(records_skipped, 2);
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/1,
+        /*levels_position=*/0);
+    CheckReadValues(
+        /*expected_values=*/{},
+        /*expected_defs=*/{},
+        /*expected_reps=*/{});
+    // Try reset after a Skip.
+    record_reader_->Reset();
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/1,
+        /*levels_position=*/0);
+  }
+
+  {
+    // Read to the end of the column. Read {60}
+    // This test checks that ReadAndThrowAwayValues works, since if it
+    // does not we would read the wrong values.
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/1,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{60},
+        /*expected_defs=*/{1},
+        /*expected_reps=*/{});
+  }
+
+  // We have exhausted all the records.
+  ASSERT_EQ(record_reader_->ReadRecords(/*num_records=*/3), 0);
+  ASSERT_EQ(record_reader_->SkipRecords(/*num_records=*/3), 0);
+}
+
+// Test skipping for repeated fields.
+TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeated) {
+  Init(schema::Int32("b", Repetition::REPEATED));
+
+  // Records look like {null, [20, 20, 20], null, [30, 30], [40]}
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values = {20, 20, 20, 30, 30, 40};
+  std::vector<int16_t> def_levels = {0, 1, 1, 1, 0, 1, 1, 1};
+  std::vector<int16_t> rep_levels = {0, 0, 1, 1, 0, 0, 1, 0};
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(values.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      rep_levels,
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  {
+    // Skip 0 records.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/0);
+    ASSERT_EQ(records_skipped, 0);
+  }
+
+  {
+    // This should skip the first null record.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/1);
+    ASSERT_EQ(records_skipped, 1);
+    ASSERT_EQ(record_reader_->values_written(), 0);
+    ASSERT_EQ(record_reader_->null_count(), 0);
+    // For repeated fields, we need to read the levels to find the record
+    // boundaries and skip. So some levels are read, however, the skipped
+    // level should not be there after the skip. That's why levels_position()
+    // is 0.
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/7,
+        /*levels_position=*/0);
+    CheckReadValues(
+        /*expected_values=*/{},
+        /*expected_defs=*/{},
+        /*expected_reps=*/{});
+  }
+
+  {
+    // Read [20, 20, 20]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/3,
+        /*null_count=*/0,
+        /*levels_written=*/7,
+        /*levels_position=*/3);
+    CheckReadValues(
+        /*expected_values=*/{20, 20, 20},
+        /*expected_defs=*/{1, 1, 1},
+        /*expected_reps=*/{0, 1, 1});
+  }
+
+  {
+    // Skip 0 records.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/0);
+    ASSERT_EQ(records_skipped, 0);
+  }
+
+  {
+    // Skip the null record and also skip [30, 30]
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/2);
+    ASSERT_EQ(records_skipped, 2);
+    // We remove the skipped levels from the buffer.
+    CheckState(
+        /*values_written=*/3,
+        /*null_count=*/0,
+        /*levels_written=*/4,
+        /*levels_position=*/3);
+    CheckReadValues(
+        /*expected_values=*/{20, 20, 20},
+        /*expected_defs=*/{1, 1, 1},
+        /*expected_reps=*/{0, 1, 1});
+  }
+
+  {
+    // Read [40]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/4,
+        /*null_count=*/0,
+        /*levels_written=*/4,
+        /*levels_position=*/4);
+    CheckReadValues(
+        /*expected_values=*/{20, 20, 20, 40},
+        /*expected_defs=*/{1, 1, 1, 1},
+        /*expected_reps=*/{0, 1, 1, 0});
+  }
+}
+
+// Tests that for repeated fields, we first consume what is in the buffer
+// before reading more levels.
+TEST_P(RecordReaderPrimitiveTypeTest, SkipRepeatedConsumeBufferFirst) {
+  Init(schema::Int32("b", Repetition::REPEATED));
+
+  std::vector<std::shared_ptr<Page>> pages;
+  std::vector<int32_t> values(2048, 10);
+  std::vector<int16_t> def_levels(2048, 1);
+  std::vector<int16_t> rep_levels(2048, 0);
+
+  std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+      descr_,
+      values,
+      /*num_values=*/static_cast<int>(values.size()),
+      Encoding::PLAIN,
+      /*indices=*/{},
+      /*indices_size=*/0,
+      def_levels,
+      descr_->max_definition_level(),
+      rep_levels,
+      descr_->max_repetition_level());
+  pages.push_back(std::move(page));
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+  {
+    // Read 1000 records. We will read 1024 levels because that is the minimum
+    // number of levels to read.
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1000);
+    ASSERT_EQ(records_read, 1000);
+    CheckState(
+        /*values_written=*/1000,
+        /*null_count=*/0,
+        /*levels_written=*/1024,
+        /*levels_position=*/1000);
+    std::vector<int32_t> expected_values(1000, 10);
+    std::vector<int16_t> expected_def_levels(1000, 1);
+    std::vector<int16_t> expected_rep_levels(1000, 0);
+    CheckReadValues(expected_values, expected_def_levels, expected_rep_levels);
+    // Reset removes the already consumed values and levels.
+    record_reader_->Reset();
+  }
+
+  { // Skip 12 records. Since we already have 24 in the buffer, we should not be
+    // reading any more levels into the buffer, we will just consume 12 of it.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/12);
+    ASSERT_EQ(records_skipped, 12);
+    CheckState(
+        /*values_written=*/0,
+        /*null_count=*/0,
+        /*levels_written=*/12,
+        /*levels_position=*/0);
+    // Everthing is empty because we reset the reader before this skip.
+    CheckReadValues(
+        /*expected_values=*/{},
+        /*expected_def_levels=*/{},
+        /*expected_rep_levels=*/{});
+  }
+}
+
+// Test reading when one record spans multiple pages for a repeated field.
+TEST_P(RecordReaderPrimitiveTypeTest, ReadPartialRecord) {
+  Init(schema::Int32("b", Repetition::REPEATED));
+
+  std::vector<std::shared_ptr<Page>> pages;
+
+  // Page 1: {[10], [20, 20, 20 ... } continues to next page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{10, 20, 20, 20},
+        /*num_values=*/4,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1, 1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{0, 0, 1, 1},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  // Page 2: {... 20, 20, ...} continues from previous page and to next page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{20, 20},
+        /*num_values=*/2,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{1, 1},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  // Page 3: { ... 20], [30]} continues from previous page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{20, 30},
+        /*num_values=*/2,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{1, 0},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  {
+    // Read [10]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/4,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{1},
+        /*expected_reps=*/{0});
+  }
+
+  {
+    // Read [20, 20, 20, 20, 20, 20] that spans multiple pages.
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/7,
+        /*null_count=*/0,
+        /*levels_written=*/8,
+        /*levels_position=*/7);
+    CheckReadValues(
+        /*expected_values=*/{10, 20, 20, 20, 20, 20, 20},
+        /*expected_defs=*/{1, 1, 1, 1, 1, 1, 1},
+        /*expected_reps=*/{0, 0, 1, 1, 1, 1, 1});
+  }
+
+  {
+    // Read [30]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/8,
+        /*null_count=*/0,
+        /*levels_written=*/8,
+        /*levels_position=*/8);
+    CheckReadValues(
+        /*expected_values=*/{10, 20, 20, 20, 20, 20, 20, 30},
+        /*expected_defs=*/{1, 1, 1, 1, 1, 1, 1, 1},
+        /*expected_reps=*/{0, 0, 1, 1, 1, 1, 1, 0});
+  }
+}
+
+// Test skipping for repeated fields for the case when one record spans multiple
+// pages.
+TEST_P(RecordReaderPrimitiveTypeTest, SkipPartialRecord) {
+  Init(schema::Int32("b", Repetition::REPEATED));
+
+  std::vector<std::shared_ptr<Page>> pages;
+
+  // Page 1: {[10], [20, 20, 20 ... } continues to next page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{10, 20, 20, 20},
+        /*num_values=*/4,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1, 1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{0, 0, 1, 1},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  // Page 2: {... 20, 20, ...} continues from previous page and to next page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{20, 20},
+        /*num_values=*/2,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{1, 1},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  // Page 3: { ... 20, [30]} continues from previous page.
+  {
+    std::shared_ptr<DataPageV1> page = MakeDataPage<Int32Type>(
+        descr_,
+        /*values=*/{20, 30},
+        /*num_values=*/2,
+        Encoding::PLAIN,
+        /*indices=*/{},
+        /*indices_size=*/0,
+        /*def_levels=*/{1, 1},
+        descr_->max_definition_level(),
+        /*rep_levels=*/{1, 0},
+        descr_->max_repetition_level());
+    pages.push_back(std::move(page));
+  }
+
+  auto pager = std::make_unique<MockPageReader>(pages);
+  record_reader_->SetPageReader(std::move(pager));
+
+  {
+    // Read [10]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+    ASSERT_EQ(records_read, 1);
+    // There are 4 levels in the first page.
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/4,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{1},
+        /*expected_reps=*/{0});
+  }
+
+  {
+    // Skip the record that goes across pages.
+    int64_t records_skipped = record_reader_->SkipRecords(/*num_records=*/1);
+    ASSERT_EQ(records_skipped, 1);
+    CheckState(
+        /*values_written=*/1,
+        /*null_count=*/0,
+        /*levels_written=*/2,
+        /*levels_position=*/1);
+    CheckReadValues(
+        /*expected_values=*/{10},
+        /*expected_defs=*/{1},
+        /*expected_reps=*/{0});
+  }
+
+  {
+    // Read [30]
+    int64_t records_read = record_reader_->ReadRecords(/*num_records=*/1);
+
+    ASSERT_EQ(records_read, 1);
+    CheckState(
+        /*values_written=*/2,
+        /*null_count=*/0,
+        /*levels_written=*/2,
+        /*levels_position=*/2);
+    CheckReadValues(
+        /*expected_values=*/{10, 30},
+        /*expected_defs=*/{1, 1},
+        /*expected_reps=*/{0, 0});
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    RecordReaderPrimitveTypeTests,
+    RecordReaderPrimitiveTypeTest,
+    ::testing::Values(/*read_dense_for_nullable=*/true, false),
+    testing::PrintToStringParamName());
+
+// Parameterized test for FLBA record reader.
+class FLBARecordReaderTest : public ::testing::TestWithParam<bool> {
+ public:
+  bool read_dense_for_nullable() {
+    return GetParam();
+  }
+
+  void
+  MakeRecordReader(int levels_per_page, int num_pages, int FLBA_type_length) {
+    levels_per_page_ = levels_per_page;
+    FLBA_type_length_ = FLBA_type_length;
+    LevelInfo level_info;
+    level_info.def_level = 1;
+    level_info.rep_level = 0;
+    NodePtr type = schema::PrimitiveNode::Make(
+        "b",
+        Repetition::OPTIONAL,
+        Type::FIXED_LEN_BYTE_ARRAY,
+        ConvertedType::NONE,
+        FLBA_type_length_);
+    descr_ = std::make_unique<ColumnDescriptor>(
+        type, level_info.def_level, level_info.rep_level);
+    MakePages<FLBAType>(
+        descr_.get(),
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        buffer_,
+        pages_,
+        Encoding::PLAIN);
+    auto pager = std::make_unique<MockPageReader>(pages_);
+    record_reader_ = internal::RecordReader::Make(
+        descr_.get(),
+        level_info,
+        ::arrow::default_memory_pool(),
+        /*read_dictionary=*/false,
+        read_dense_for_nullable());
+    record_reader_->SetPageReader(std::move(pager));
+  }
+
+  // Returns expected values in row range.
+  // We need this since some values are null.
+  std::vector<std::string_view> expected_values(int start, int end) {
+    std::vector<std::string_view> result;
+    // Find out where in the values_ vector we start from.
+    size_t values_index = 0;
+    for (int i = 0; i < start; ++i) {
+      if (def_levels_[i] != 0) {
+        ++values_index;
+      }
+    }
+
+    for (int i = start; i < end; ++i) {
+      if (def_levels_[i] == 0) {
+        if (!read_dense_for_nullable()) {
+          result.emplace_back();
+        }
+        continue;
+      }
+      result.emplace_back(
+          reinterpret_cast<const char*>(values_[values_index].ptr),
+          FLBA_type_length_);
+      ++values_index;
+    }
+    return result;
+  }
+
+  void CheckReadValues(int start, int end) {
+    auto binary_reader =
+        dynamic_cast<BinaryRecordReader*>(record_reader_.get());
+    ASSERT_NE(binary_reader, nullptr);
+    // Chunks are reset after this call.
+    ::arrow::ArrayVector array_vector = binary_reader->GetBuilderChunks();
+    ASSERT_EQ(array_vector.size(), 1);
+    auto binary_array =
+        dynamic_cast<::arrow::FixedSizeBinaryArray*>(array_vector[0].get());
+
+    ASSERT_NE(binary_array, nullptr);
+    ASSERT_EQ(binary_array->length(), record_reader_->values_written());
+    if (read_dense_for_nullable()) {
+      ASSERT_EQ(binary_array->null_count(), 0);
+      ASSERT_EQ(record_reader_->null_count(), 0);
+    } else {
+      ASSERT_EQ(binary_array->null_count(), record_reader_->null_count());
+    }
+
+    std::vector<std::string_view> expected = expected_values(start, end);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      if (def_levels_[i + start] == 0) {
+        ASSERT_EQ(!read_dense_for_nullable(), binary_array->IsNull(i));
+      } else {
+        ASSERT_EQ(expected[i].compare(binary_array->GetView(i)), 0);
+        ASSERT_FALSE(binary_array->IsNull(i));
+      }
+    }
+  }
+
+ protected:
+  std::shared_ptr<internal::RecordReader> record_reader_;
+
+ private:
+  int levels_per_page_;
+  int FLBA_type_length_;
+  std::vector<std::shared_ptr<Page>> pages_;
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  std::vector<FixedLenByteArray> values_;
+  std::vector<uint8_t> buffer_;
+  std::unique_ptr<ColumnDescriptor> descr_;
+};
+
+// Similar to above, except for Byte arrays. FLBA and Byte arrays are
+// sufficiently different to warrant a separate class for readability.
+class ByteArrayRecordReaderTest : public ::testing::TestWithParam<bool> {
+ public:
+  bool read_dense_for_nullable() {
+    return GetParam();
+  }
+
+  void MakeRecordReader(int levels_per_page, int num_pages) {
+    levels_per_page_ = levels_per_page;
+    LevelInfo level_info;
+    level_info.def_level = 1;
+    level_info.rep_level = 0;
+    NodePtr type = schema::ByteArray("b", Repetition::OPTIONAL);
+    descr_ = std::make_unique<ColumnDescriptor>(
+        type, level_info.def_level, level_info.rep_level);
+    MakePages<ByteArrayType>(
+        descr_.get(),
+        num_pages,
+        levels_per_page,
+        def_levels_,
+        rep_levels_,
+        values_,
+        buffer_,
+        pages_,
+        Encoding::PLAIN);
+
+    auto pager = std::make_unique<MockPageReader>(pages_);
+
+    record_reader_ = internal::RecordReader::Make(
+        descr_.get(),
+        level_info,
+        ::arrow::default_memory_pool(),
+        /*read_dictionary=*/false,
+        read_dense_for_nullable());
+    record_reader_->SetPageReader(std::move(pager));
+  }
+
+  // Returns expected values in row range.
+  // We need this since some values are null.
+  std::vector<std::string_view> expected_values(int start, int end) {
+    std::vector<std::string_view> result;
+    // Find out where in the values_ vector we start from.
+    size_t values_index = 0;
+    for (int i = 0; i < start; ++i) {
+      if (def_levels_[i] != 0) {
+        ++values_index;
+      }
+    }
+
+    for (int i = start; i < end; ++i) {
+      if (def_levels_[i] == 0) {
+        if (!read_dense_for_nullable()) {
+          result.emplace_back();
+        }
+        continue;
+      }
+      result.emplace_back(
+          reinterpret_cast<const char*>(values_[values_index].ptr),
+          values_[values_index].len);
+      ++values_index;
+    }
+    return result;
+  }
+
+  void CheckReadValues(int start, int end) {
+    auto binary_reader =
+        dynamic_cast<BinaryRecordReader*>(record_reader_.get());
+    ASSERT_NE(binary_reader, nullptr);
+    // Chunks are reset after this call.
+    ::arrow::ArrayVector array_vector = binary_reader->GetBuilderChunks();
+    ASSERT_EQ(array_vector.size(), 1);
+    ::arrow::BinaryArray* binary_array =
+        dynamic_cast<::arrow::BinaryArray*>(array_vector[0].get());
+
+    ASSERT_NE(binary_array, nullptr);
+    ASSERT_EQ(binary_array->length(), record_reader_->values_written());
+    if (read_dense_for_nullable()) {
+      ASSERT_EQ(binary_array->null_count(), 0);
+      ASSERT_EQ(record_reader_->null_count(), 0);
+    } else {
+      ASSERT_EQ(binary_array->null_count(), record_reader_->null_count());
+    }
+
+    std::vector<std::string_view> expected = expected_values(start, end);
+    for (size_t i = 0; i < expected.size(); ++i) {
+      if (def_levels_[i + start] == 0) {
+        ASSERT_EQ(!read_dense_for_nullable(), binary_array->IsNull(i));
+      } else {
+        ASSERT_EQ(expected[i].compare(binary_array->GetView(i)), 0);
+        ASSERT_FALSE(binary_array->IsNull(i));
+      }
+    }
+  }
+
+ protected:
+  std::shared_ptr<internal::RecordReader> record_reader_;
+
+ private:
+  int levels_per_page_;
+  std::vector<std::shared_ptr<Page>> pages_;
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  std::vector<ByteArray> values_;
+  std::vector<uint8_t> buffer_;
+  std::unique_ptr<ColumnDescriptor> descr_;
+};
+
+// Tests reading and skipping a ByteArray field.
+// The binary readers only differ in DeocdeDense and DecodeSpaced functions, so
+// testing optional is sufficient in excercising those code paths.
+TEST_P(ByteArrayRecordReaderTest, ReadAndSkipOptional) {
+  MakeRecordReader(/*levels_per_page=*/90, /*num_pages=*/1);
+
+  // Read one-third of the page.
+  ASSERT_EQ(record_reader_->ReadRecords(/*num_records=*/30), 30);
+  CheckReadValues(0, 30);
+  record_reader_->Reset();
+
+  // Skip 30 records.
+  ASSERT_EQ(record_reader_->SkipRecords(/*num_records=*/30), 30);
+
+  // Read 60 more records. Only 30 will be read, since we read 30 and skipped
+  // 30, so only 30 is left.
+  ASSERT_EQ(record_reader_->ReadRecords(/*num_records=*/60), 30);
+  CheckReadValues(60, 90);
+  record_reader_->Reset();
+}
+
+// Tests reading and skipping an optional FLBA field.
+// The binary readers only differ in DeocdeDense and DecodeSpaced functions, so
+// testing optional is sufficient in excercising those code paths.
+TEST_P(FLBARecordReaderTest, ReadAndSkipOptional) {
+  MakeRecordReader(
+      /*levels_per_page=*/90, /*num_pages=*/1, /*FLBA_type_length=*/4);
+
+  // Read one-third of the page.
+  ASSERT_EQ(record_reader_->ReadRecords(/*num_records=*/30), 30);
+  CheckReadValues(0, 30);
+  record_reader_->Reset();
+
+  // Skip 30 records.
+  ASSERT_EQ(record_reader_->SkipRecords(/*num_records=*/30), 30);
+
+  // Read 60 more records. Only 30 will be read, since we read 30 and skipped
+  // 30, so only 30 is left.
+  ASSERT_EQ(record_reader_->ReadRecords(/*num_records=*/60), 30);
+  CheckReadValues(60, 90);
+  record_reader_->Reset();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ByteArrayRecordReaderTests,
+    ByteArrayRecordReaderTest,
+    testing::Bool());
+
+INSTANTIATE_TEST_SUITE_P(
+    FLBARecordReaderTests,
+    FLBARecordReaderTest,
+    testing::Bool());
+
+// Test random combination of ReadRecords and SkipRecords.
+class RecordReaderStressTest
+    : public ::testing::TestWithParam<Repetition::type> {};
+
+TEST_P(RecordReaderStressTest, StressTest) {
+  LevelInfo level_info;
+  // Define these boolean variables for improving readability below.
+  bool repeated = false, required = false;
+  if (GetParam() == Repetition::REQUIRED) {
+    level_info.def_level = 0;
+    level_info.rep_level = 0;
+    required = true;
+  } else if (GetParam() == Repetition::OPTIONAL) {
+    level_info.def_level = 1;
+    level_info.rep_level = 0;
+  } else {
+    level_info.def_level = 1;
+    level_info.rep_level = 1;
+    repeated = true;
+  }
+
+  NodePtr type = schema::Int32("b", GetParam());
+  const ColumnDescriptor descr(
+      type, level_info.def_level, level_info.rep_level);
+
+  auto seed1 = static_cast<uint32_t>(time(0));
+  std::default_random_engine gen(seed1);
+  // Generate random number of pages with random number of values per page.
+  std::uniform_int_distribution<int> d(0, 2000);
+  const int num_pages = d(gen);
+  const int levels_per_page = d(gen);
+  std::vector<int32_t> values;
+  std::vector<int16_t> def_levels;
+  std::vector<int16_t> rep_levels;
+  std::vector<uint8_t> data_buffer;
+  std::vector<std::shared_ptr<Page>> pages;
+  auto seed2 = static_cast<uint32_t>(time(0));
+  // Uses time(0) as seed so it would run a different test every time it is
+  // run.
+  MakePages<Int32Type>(
+      &descr,
+      num_pages,
+      levels_per_page,
+      def_levels,
+      rep_levels,
+      values,
+      data_buffer,
+      pages,
+      Encoding::PLAIN,
+      seed2);
+  std::unique_ptr<PageReader> pager;
+  pager.reset(new test::MockPageReader(pages));
+
+  // Set up the RecordReader.
+  std::shared_ptr<internal::RecordReader> record_reader =
+      internal::RecordReader::Make(&descr, level_info);
+  record_reader->SetPageReader(std::move(pager));
+
+  // Figure out how many total records.
+  int total_records = 0;
+  if (repeated) {
+    for (int16_t rep : rep_levels) {
+      if (rep == 0) {
+        ++total_records;
+      }
+    }
+  } else {
+    total_records = static_cast<int>(def_levels.size());
+  }
+
+  // Generate a sequence of reads and skips.
+  int records_left = total_records;
+  // The first element of the pair is 1 if SkipRecords and 0 if ReadRecords.
+  // The second element indicates the number of records for reading or
+  // skipping.
+  std::vector<std::pair<bool, int>> sequence;
+  while (records_left > 0) {
+    std::uniform_int_distribution<int> d(0, records_left);
+    // Generate a number to decide if this is a skip or read.
+    bool is_skip = d(gen) < records_left / 2;
+    int num_records = d(gen);
+
+    sequence.emplace_back(is_skip, num_records);
+    records_left -= num_records;
+  }
+
+  // The levels_index and values_index are over the original vectors that have
+  // all the rep/def values for all the records. In the following loop, we will
+  // read/skip a numebr of records and Reset the reader after each iteration.
+  // This is on-par with how the record reader is used.
+  size_t levels_index = 0;
+  size_t values_index = 0;
+  for (const auto& [is_skip, num_records] : sequence) {
+    // Reset the reader before the next round of read/skip.
+    record_reader->Reset();
+
+    // Prepare the expected result and do the SkipRecords and ReadRecords.
+    std::vector<int32_t> expected_values;
+    std::vector<int16_t> expected_def_levels;
+    std::vector<int16_t> expected_rep_levels;
+    bool inside_repeated_field = false;
+
+    int read_records = 0;
+    while (read_records < num_records || inside_repeated_field) {
+      if (!repeated || (repeated && rep_levels[levels_index] == 0)) {
+        ++read_records;
+      }
+
+      bool has_value = required ||
+          (!required && def_levels[levels_index] == level_info.def_level);
+
+      // If we are not skipping, we need to update the expected values and
+      // rep/defs. If we are skipping, we just keep going.
+      if (!is_skip) {
+        if (!required) {
+          expected_def_levels.push_back(def_levels[levels_index]);
+          if (!has_value) {
+            expected_values.push_back(-1);
+          }
+        }
+        if (repeated) {
+          expected_rep_levels.push_back(rep_levels[levels_index]);
+        }
+        if (has_value) {
+          expected_values.push_back(values[values_index]);
+        }
+      }
+
+      if (has_value) {
+        ++values_index;
+      }
+
+      // If we are in the middle of a repeated field, we should keep going
+      // until we consume it all.
+      if (repeated && levels_index + 1 < rep_levels.size() &&
+          rep_levels[levels_index + 1] == 1) {
+        inside_repeated_field = true;
+      } else {
+        inside_repeated_field = false;
+      }
+
+      ++levels_index;
+    }
+
+    // Print out the seeds with each failing ASSERT to easily reproduce the bug.
+    std::string seeds =
+        "seeds: " + std::to_string(seed1) + " " + std::to_string(seed2);
+
+    // Perform the actual read/skip.
+    if (is_skip) {
+      int64_t skipped_records = record_reader->SkipRecords(num_records);
+      ASSERT_EQ(skipped_records, num_records) << seeds;
+    } else {
+      int64_t read_records = record_reader->ReadRecords(num_records);
+      ASSERT_EQ(read_records, num_records) << seeds;
+    }
+
+    const auto read_values =
+        reinterpret_cast<const int32_t*>(record_reader->values());
+    if (required) {
+      ASSERT_EQ(record_reader->null_count(), 0) << seeds;
+    }
+    std::vector<int32_t> read_vals(
+        read_values, read_values + record_reader->values_written());
+    for (size_t i = 0; i < expected_values.size(); ++i) {
+      if (expected_values[i] != -1) {
+        ASSERT_EQ(read_vals[i], expected_values[i]) << seeds;
+      }
+    }
+
+    if (!required) {
+      std::vector<int16_t> read_def_levels(
+          record_reader->def_levels(),
+          record_reader->def_levels() + record_reader->levels_position());
+      ASSERT_TRUE(vector_equal(read_def_levels, expected_def_levels)) << seeds;
+    }
+
+    if (repeated) {
+      std::vector<int16_t> read_rep_levels(
+          record_reader->rep_levels(),
+          record_reader->rep_levels() + record_reader->levels_position());
+      ASSERT_TRUE(vector_equal(read_rep_levels, expected_rep_levels)) << seeds;
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Repetition_type,
+    RecordReaderStressTest,
+    ::testing::Values(
+        Repetition::REQUIRED,
+        Repetition::OPTIONAL,
+        Repetition::REPEATED));
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnScanner.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnScanner.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnScanner.h"
+
+#include <cstdint>
+#include <memory>
+
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+
+using arrow::MemoryPool;
+
+namespace facebook::velox::parquet::arrow {
+
+std::shared_ptr<Scanner> Scanner::Make(
+    std::shared_ptr<ColumnReader> col_reader,
+    int64_t batch_size,
+    MemoryPool* pool) {
+  switch (col_reader->type()) {
+    case Type::BOOLEAN:
+      return std::make_shared<BoolScanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::INT32:
+      return std::make_shared<Int32Scanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::INT64:
+      return std::make_shared<Int64Scanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::INT96:
+      return std::make_shared<Int96Scanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::FLOAT:
+      return std::make_shared<FloatScanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::DOUBLE:
+      return std::make_shared<DoubleScanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::BYTE_ARRAY:
+      return std::make_shared<ByteArrayScanner>(
+          std::move(col_reader), batch_size, pool);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_shared<FixedLenByteArrayScanner>(
+          std::move(col_reader), batch_size, pool);
+    default:
+      ParquetException::NYI("type reader not implemented");
+  }
+  // Unreachable code, but suppress compiler warning
+  return std::shared_ptr<Scanner>(nullptr);
+}
+
+int64_t ScanAllValues(
+    int32_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    uint8_t* values,
+    int64_t* values_buffered,
+    ColumnReader* reader) {
+  switch (reader->type()) {
+    case parquet::Type::BOOLEAN:
+      return ScanAll<BoolReader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::INT32:
+      return ScanAll<Int32Reader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::INT64:
+      return ScanAll<Int64Reader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::INT96:
+      return ScanAll<Int96Reader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::FLOAT:
+      return ScanAll<FloatReader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::DOUBLE:
+      return ScanAll<DoubleReader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::BYTE_ARRAY:
+      return ScanAll<ByteArrayReader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    case parquet::Type::FIXED_LEN_BYTE_ARRAY:
+      return ScanAll<FixedLenByteArrayReader>(
+          batch_size, def_levels, rep_levels, values, values_buffered, reader);
+    default:
+      ParquetException::NYI("type reader not implemented");
+  }
+  // Unreachable code, but suppress compiler warning
+  return 0;
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnScanner.h
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnScanner.h
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <stdio.h>
+
+#include <cstdint>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+
+namespace facebook::velox::parquet::arrow {
+
+static constexpr int64_t DEFAULT_SCANNER_BATCH_SIZE = 128;
+
+class PARQUET_EXPORT Scanner {
+ public:
+  explicit Scanner(
+      std::shared_ptr<ColumnReader> reader,
+      int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+      : batch_size_(batch_size),
+        level_offset_(0),
+        levels_buffered_(0),
+        value_buffer_(AllocateBuffer(pool)),
+        value_offset_(0),
+        values_buffered_(0),
+        reader_(std::move(reader)) {
+    def_levels_.resize(descr()->max_definition_level() > 0 ? batch_size_ : 0);
+    rep_levels_.resize(descr()->max_repetition_level() > 0 ? batch_size_ : 0);
+  }
+
+  virtual ~Scanner() {}
+
+  static std::shared_ptr<Scanner> Make(
+      std::shared_ptr<ColumnReader> col_reader,
+      int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+  virtual void
+  PrintNext(std::ostream& out, int width, bool with_levels = false) = 0;
+
+  bool HasNext() {
+    return level_offset_ < levels_buffered_ || reader_->HasNext();
+  }
+
+  const ColumnDescriptor* descr() const {
+    return reader_->descr();
+  }
+
+  int64_t batch_size() const {
+    return batch_size_;
+  }
+
+  void SetBatchSize(int64_t batch_size) {
+    batch_size_ = batch_size;
+  }
+
+ protected:
+  int64_t batch_size_;
+
+  std::vector<int16_t> def_levels_;
+  std::vector<int16_t> rep_levels_;
+  int level_offset_;
+  int levels_buffered_;
+
+  std::shared_ptr<ResizableBuffer> value_buffer_;
+  int value_offset_;
+  int64_t values_buffered_;
+  std::shared_ptr<ColumnReader> reader_;
+};
+
+template <typename DType>
+class PARQUET_TEMPLATE_CLASS_EXPORT TypedScanner : public Scanner {
+ public:
+  typedef typename DType::c_type T;
+
+  explicit TypedScanner(
+      std::shared_ptr<ColumnReader> reader,
+      int64_t batch_size = DEFAULT_SCANNER_BATCH_SIZE,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool())
+      : Scanner(std::move(reader), batch_size, pool) {
+    typed_reader_ = static_cast<TypedColumnReader<DType>*>(reader_.get());
+    int value_byte_size = type_traits<DType::type_num>::value_byte_size;
+    PARQUET_THROW_NOT_OK(value_buffer_->Resize(batch_size_ * value_byte_size));
+    values_ = reinterpret_cast<T*>(value_buffer_->mutable_data());
+  }
+
+  virtual ~TypedScanner() {}
+
+  bool NextLevels(int16_t* def_level, int16_t* rep_level) {
+    if (level_offset_ == levels_buffered_) {
+      levels_buffered_ = static_cast<int>(typed_reader_->ReadBatch(
+          static_cast<int>(batch_size_),
+          def_levels_.data(),
+          rep_levels_.data(),
+          values_,
+          &values_buffered_));
+
+      value_offset_ = 0;
+      level_offset_ = 0;
+      if (!levels_buffered_) {
+        return false;
+      }
+    }
+    *def_level =
+        descr()->max_definition_level() > 0 ? def_levels_[level_offset_] : 0;
+    *rep_level =
+        descr()->max_repetition_level() > 0 ? rep_levels_[level_offset_] : 0;
+    level_offset_++;
+    return true;
+  }
+
+  bool Next(T* val, int16_t* def_level, int16_t* rep_level, bool* is_null) {
+    if (level_offset_ == levels_buffered_) {
+      if (!HasNext()) {
+        // Out of data pages
+        return false;
+      }
+    }
+
+    NextLevels(def_level, rep_level);
+    *is_null = *def_level < descr()->max_definition_level();
+
+    if (*is_null) {
+      return true;
+    }
+
+    if (value_offset_ == values_buffered_) {
+      throw ParquetException("Value was non-null, but has not been buffered");
+    }
+    *val = values_[value_offset_++];
+    return true;
+  }
+
+  // Returns true if there is a next value
+  bool NextValue(T* val, bool* is_null) {
+    if (level_offset_ == levels_buffered_) {
+      if (!HasNext()) {
+        // Out of data pages
+        return false;
+      }
+    }
+
+    // Out of values
+    int16_t def_level = -1;
+    int16_t rep_level = -1;
+    NextLevels(&def_level, &rep_level);
+    *is_null = def_level < descr()->max_definition_level();
+
+    if (*is_null) {
+      return true;
+    }
+
+    if (value_offset_ == values_buffered_) {
+      throw ParquetException("Value was non-null, but has not been buffered");
+    }
+    *val = values_[value_offset_++];
+    return true;
+  }
+
+  virtual void
+  PrintNext(std::ostream& out, int width, bool with_levels = false) {
+    T val{};
+    int16_t def_level = -1;
+    int16_t rep_level = -1;
+    bool is_null = false;
+    char buffer[80];
+
+    if (!Next(&val, &def_level, &rep_level, &is_null)) {
+      throw ParquetException("No more values buffered");
+    }
+
+    if (with_levels) {
+      out << "  D:" << def_level << " R:" << rep_level << " ";
+      if (!is_null) {
+        out << "V:";
+      }
+    }
+
+    if (is_null) {
+      std::string null_fmt = format_fwf<ByteArrayType>(width);
+      snprintf(buffer, sizeof(buffer), null_fmt.c_str(), "NULL");
+    } else {
+      FormatValue(&val, buffer, sizeof(buffer), width);
+    }
+    out << buffer;
+  }
+
+ private:
+  // The ownership of this object is expressed through the reader_ variable in
+  // the base
+  TypedColumnReader<DType>* typed_reader_;
+
+  inline void FormatValue(void* val, char* buffer, int bufsize, int width);
+
+  T* values_;
+};
+
+template <typename DType>
+inline void TypedScanner<DType>::FormatValue(
+    void* val,
+    char* buffer,
+    int bufsize,
+    int width) {
+  std::string fmt = format_fwf<DType>(width);
+  snprintf(buffer, bufsize, fmt.c_str(), *reinterpret_cast<T*>(val));
+}
+
+template <>
+inline void TypedScanner<Int96Type>::FormatValue(
+    void* val,
+    char* buffer,
+    int bufsize,
+    int width) {
+  std::string fmt = format_fwf<Int96Type>(width);
+  std::string result = Int96ToString(*reinterpret_cast<Int96*>(val));
+  snprintf(buffer, bufsize, fmt.c_str(), result.c_str());
+}
+
+template <>
+inline void TypedScanner<ByteArrayType>::FormatValue(
+    void* val,
+    char* buffer,
+    int bufsize,
+    int width) {
+  std::string fmt = format_fwf<ByteArrayType>(width);
+  std::string result = ByteArrayToString(*reinterpret_cast<ByteArray*>(val));
+  snprintf(buffer, bufsize, fmt.c_str(), result.c_str());
+}
+
+template <>
+inline void TypedScanner<FLBAType>::FormatValue(
+    void* val,
+    char* buffer,
+    int bufsize,
+    int width) {
+  std::string fmt = format_fwf<FLBAType>(width);
+  std::string result = FixedLenByteArrayToString(
+      *reinterpret_cast<FixedLenByteArray*>(val), descr()->type_length());
+  snprintf(buffer, bufsize, fmt.c_str(), result.c_str());
+}
+
+typedef TypedScanner<BooleanType> BoolScanner;
+typedef TypedScanner<Int32Type> Int32Scanner;
+typedef TypedScanner<Int64Type> Int64Scanner;
+typedef TypedScanner<Int96Type> Int96Scanner;
+typedef TypedScanner<FloatType> FloatScanner;
+typedef TypedScanner<DoubleType> DoubleScanner;
+typedef TypedScanner<ByteArrayType> ByteArrayScanner;
+typedef TypedScanner<FLBAType> FixedLenByteArrayScanner;
+
+template <typename RType>
+int64_t ScanAll(
+    int32_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    uint8_t* values,
+    int64_t* values_buffered,
+    ColumnReader* reader) {
+  typedef typename RType::T Type;
+  auto typed_reader = static_cast<RType*>(reader);
+  auto vals = reinterpret_cast<Type*>(&values[0]);
+  return typed_reader->ReadBatch(
+      batch_size, def_levels, rep_levels, vals, values_buffered);
+}
+
+int64_t PARQUET_EXPORT ScanAllValues(
+    int32_t batch_size,
+    int16_t* def_levels,
+    int16_t* rep_levels,
+    uint8_t* values,
+    int64_t* values_buffered,
+    ColumnReader* reader);
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/ColumnWriterTest.cpp
@@ -1,0 +1,1772 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/io/buffered.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_builders.h"
+
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+namespace bit_util = arrow::bit_util;
+
+namespace facebook::velox::parquet::arrow {
+
+using schema::GroupNode;
+using schema::NodePtr;
+using schema::PrimitiveNode;
+using util::Codec;
+
+namespace test {
+
+// The default size used in most tests.
+const int SMALL_SIZE = 100;
+#ifdef PARQUET_VALGRIND
+// Larger size to test some corner cases, only used in some specific cases.
+const int LARGE_SIZE = 10000;
+// Very large size to test dictionary fallback.
+const int VERY_LARGE_SIZE = 40000;
+// Reduced dictionary page size to use for testing dictionary fallback with
+// valgrind
+const int64_t DICTIONARY_PAGE_SIZE = 1024;
+#else
+// Larger size to test some corner cases, only used in some specific cases.
+const int LARGE_SIZE = 100000;
+// Very large size to test dictionary fallback.
+const int VERY_LARGE_SIZE = 400000;
+// Dictionary page size to use for testing dictionary fallback
+const int64_t DICTIONARY_PAGE_SIZE = 1024 * 1024;
+#endif
+
+template <typename TestType>
+class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
+ public:
+  void SetUp() {
+    this->SetupValuesOut(SMALL_SIZE);
+    writer_properties_ = default_writer_properties();
+    definition_levels_out_.resize(SMALL_SIZE);
+    repetition_levels_out_.resize(SMALL_SIZE);
+
+    this->SetUpSchema(Repetition::REQUIRED);
+
+    descr_ = this->schema_.Column(0);
+  }
+
+  Type::type type_num() {
+    return TestType::type_num;
+  }
+
+  void BuildReader(
+      int64_t num_rows,
+      Compression::type compression = Compression::UNCOMPRESSED,
+      bool page_checksum_verify = false) {
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink_->Finish());
+    auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+    ReaderProperties readerProperties;
+    readerProperties.set_page_checksum_verification(page_checksum_verify);
+    std::unique_ptr<PageReader> page_reader = PageReader::Open(
+        std::move(source), num_rows, compression, readerProperties);
+    reader_ = std::static_pointer_cast<TypedColumnReader<TestType>>(
+        ColumnReader::Make(this->descr_, std::move(page_reader)));
+  }
+
+  std::shared_ptr<TypedColumnWriter<TestType>> BuildWriter(
+      int64_t output_size = SMALL_SIZE,
+      const ColumnProperties& column_properties = ColumnProperties(),
+      const ParquetVersion::type version = ParquetVersion::PARQUET_1_0,
+      bool enable_checksum = false) {
+    sink_ = CreateOutputStream();
+    WriterProperties::Builder wp_builder;
+    wp_builder.version(version);
+    if (column_properties.encoding() == Encoding::PLAIN_DICTIONARY ||
+        column_properties.encoding() == Encoding::RLE_DICTIONARY) {
+      wp_builder.enable_dictionary();
+      wp_builder.dictionary_pagesize_limit(DICTIONARY_PAGE_SIZE);
+    } else {
+      wp_builder.disable_dictionary();
+      wp_builder.encoding(column_properties.encoding());
+    }
+    if (enable_checksum) {
+      wp_builder.enable_page_checksum();
+    }
+    wp_builder.max_statistics_size(column_properties.max_statistics_size());
+    writer_properties_ = wp_builder.build();
+
+    metadata_ =
+        ColumnChunkMetaDataBuilder::Make(writer_properties_, this->descr_);
+    std::unique_ptr<PageWriter> pager = PageWriter::Open(
+        sink_,
+        column_properties.compression(),
+        Codec::UseDefaultCompressionLevel(),
+        metadata_.get(),
+        /* row_group_ordinal */ -1,
+        /* column_chunk_ordinal*/ -1,
+        ::arrow::default_memory_pool(),
+        /* buffered_row_group */ false,
+        /* header_encryptor */ NULLPTR,
+        /* data_encryptor */ NULLPTR,
+        enable_checksum);
+    std::shared_ptr<ColumnWriter> writer = ColumnWriter::Make(
+        metadata_.get(), std::move(pager), writer_properties_.get());
+    return std::static_pointer_cast<TypedColumnWriter<TestType>>(writer);
+  }
+
+  void ReadColumn(
+      Compression::type compression = Compression::UNCOMPRESSED,
+      bool page_checksum_verify = false) {
+    BuildReader(
+        static_cast<int64_t>(this->values_out_.size()),
+        compression,
+        page_checksum_verify);
+    reader_->ReadBatch(
+        static_cast<int>(this->values_out_.size()),
+        definition_levels_out_.data(),
+        repetition_levels_out_.data(),
+        this->values_out_ptr_,
+        &values_read_);
+    this->SyncValuesOut();
+  }
+
+  void ReadColumnFully(
+      Compression::type compression = Compression::UNCOMPRESSED,
+      bool page_checksum_verify = false);
+
+  void TestRequiredWithEncoding(Encoding::type encoding) {
+    return TestRequiredWithSettings(
+        encoding, Compression::UNCOMPRESSED, false, false);
+  }
+
+  void TestRequiredWithSettings(
+      Encoding::type encoding,
+      Compression::type compression,
+      bool enable_dictionary,
+      bool enable_statistics,
+      int64_t num_rows = SMALL_SIZE,
+      int compression_level = Codec::UseDefaultCompressionLevel(),
+      bool enable_checksum = false) {
+    this->GenerateData(num_rows);
+
+    this->WriteRequiredWithSettings(
+        encoding,
+        compression,
+        enable_dictionary,
+        enable_statistics,
+        compression_level,
+        num_rows,
+        enable_checksum);
+    ASSERT_NO_FATAL_FAILURE(
+        this->ReadAndCompare(compression, num_rows, enable_checksum));
+
+    this->WriteRequiredWithSettingsSpaced(
+        encoding,
+        compression,
+        enable_dictionary,
+        enable_statistics,
+        num_rows,
+        compression_level,
+        enable_checksum);
+    ASSERT_NO_FATAL_FAILURE(
+        this->ReadAndCompare(compression, num_rows, enable_checksum));
+  }
+
+  void TestDictionaryFallbackEncoding(ParquetVersion::type version) {
+    this->GenerateData(VERY_LARGE_SIZE);
+    ColumnProperties column_properties;
+    column_properties.set_dictionary_enabled(true);
+
+    if (version == ParquetVersion::PARQUET_1_0) {
+      column_properties.set_encoding(Encoding::PLAIN_DICTIONARY);
+    } else {
+      column_properties.set_encoding(Encoding::RLE_DICTIONARY);
+    }
+
+    auto writer =
+        this->BuildWriter(VERY_LARGE_SIZE, column_properties, version);
+
+    writer->WriteBatch(
+        this->values_.size(), nullptr, nullptr, this->values_ptr_);
+    writer->Close();
+
+    // Read all rows so we are sure that also the non-dictionary pages are read
+    // correctly
+    this->SetupValuesOut(VERY_LARGE_SIZE);
+    this->ReadColumnFully();
+    ASSERT_EQ(VERY_LARGE_SIZE, this->values_read_);
+    this->values_.resize(VERY_LARGE_SIZE);
+    ASSERT_EQ(this->values_, this->values_out_);
+    std::vector<Encoding::type> encodings_vector = this->metadata_encodings();
+    std::set<Encoding::type> encodings(
+        encodings_vector.begin(), encodings_vector.end());
+
+    if (this->type_num() == Type::BOOLEAN) {
+      // Dictionary encoding is not allowed for boolean type
+      // There are 2 encodings (PLAIN, RLE) in a non dictionary encoding case
+      std::set<Encoding::type> expected({Encoding::PLAIN, Encoding::RLE});
+      ASSERT_EQ(encodings, expected);
+    } else if (version == ParquetVersion::PARQUET_1_0) {
+      // There are 3 encodings (PLAIN_DICTIONARY, PLAIN, RLE) in a fallback case
+      // for version 1.0
+      std::set<Encoding::type> expected(
+          {Encoding::PLAIN_DICTIONARY, Encoding::PLAIN, Encoding::RLE});
+      ASSERT_EQ(encodings, expected);
+    } else {
+      // There are 3 encodings (RLE_DICTIONARY, PLAIN, RLE) in a fallback case
+      // for version 2.0
+      std::set<Encoding::type> expected(
+          {Encoding::RLE_DICTIONARY, Encoding::PLAIN, Encoding::RLE});
+      ASSERT_EQ(encodings, expected);
+    }
+
+    std::vector<PageEncodingStats> encoding_stats =
+        this->metadata_encoding_stats();
+    if (this->type_num() == Type::BOOLEAN) {
+      ASSERT_EQ(encoding_stats[0].encoding, Encoding::PLAIN);
+      ASSERT_EQ(encoding_stats[0].page_type, PageType::DATA_PAGE);
+    } else if (version == ParquetVersion::PARQUET_1_0) {
+      std::vector<Encoding::type> expected(
+          {Encoding::PLAIN_DICTIONARY,
+           Encoding::PLAIN,
+           Encoding::PLAIN_DICTIONARY});
+      ASSERT_EQ(encoding_stats[0].encoding, expected[0]);
+      ASSERT_EQ(encoding_stats[0].page_type, PageType::DICTIONARY_PAGE);
+      for (size_t i = 1; i < encoding_stats.size(); i++) {
+        ASSERT_EQ(encoding_stats[i].encoding, expected[i]);
+        ASSERT_EQ(encoding_stats[i].page_type, PageType::DATA_PAGE);
+      }
+    } else {
+      std::vector<Encoding::type> expected(
+          {Encoding::PLAIN, Encoding::PLAIN, Encoding::RLE_DICTIONARY});
+      ASSERT_EQ(encoding_stats[0].encoding, expected[0]);
+      ASSERT_EQ(encoding_stats[0].page_type, PageType::DICTIONARY_PAGE);
+      for (size_t i = 1; i < encoding_stats.size(); i++) {
+        ASSERT_EQ(encoding_stats[i].encoding, expected[i]);
+        ASSERT_EQ(encoding_stats[i].page_type, PageType::DATA_PAGE);
+      }
+    }
+  }
+
+  void WriteRequiredWithSettings(
+      Encoding::type encoding,
+      Compression::type compression,
+      bool enable_dictionary,
+      bool enable_statistics,
+      int compression_level,
+      int64_t num_rows,
+      bool enable_checksum) {
+    ColumnProperties column_properties(
+        encoding, compression, enable_dictionary, enable_statistics);
+    column_properties.set_compression_level(compression_level);
+    std::shared_ptr<TypedColumnWriter<TestType>> writer = this->BuildWriter(
+        num_rows,
+        column_properties,
+        ParquetVersion::PARQUET_1_0,
+        enable_checksum);
+    writer->WriteBatch(
+        this->values_.size(), nullptr, nullptr, this->values_ptr_);
+    // The behaviour should be independent from the number of Close() calls
+    writer->Close();
+    writer->Close();
+  }
+
+  void WriteRequiredWithSettingsSpaced(
+      Encoding::type encoding,
+      Compression::type compression,
+      bool enable_dictionary,
+      bool enable_statistics,
+      int64_t num_rows,
+      int compression_level,
+      bool enable_checksum) {
+    std::vector<uint8_t> valid_bits(
+        bit_util::BytesForBits(static_cast<uint32_t>(this->values_.size())) + 1,
+        255);
+    ColumnProperties column_properties(
+        encoding, compression, enable_dictionary, enable_statistics);
+    column_properties.set_compression_level(compression_level);
+    std::shared_ptr<TypedColumnWriter<TestType>> writer = this->BuildWriter(
+        num_rows,
+        column_properties,
+        ParquetVersion::PARQUET_1_0,
+        enable_checksum);
+    writer->WriteBatchSpaced(
+        this->values_.size(),
+        nullptr,
+        nullptr,
+        valid_bits.data(),
+        0,
+        this->values_ptr_);
+    // The behaviour should be independent from the number of Close() calls
+    writer->Close();
+    writer->Close();
+  }
+
+  void ReadAndCompare(
+      Compression::type compression,
+      int64_t num_rows,
+      bool page_checksum_verify) {
+    this->SetupValuesOut(num_rows);
+    this->ReadColumnFully(compression, page_checksum_verify);
+    auto comparator = MakeComparator<TestType>(this->descr_);
+    for (size_t i = 0; i < this->values_.size(); i++) {
+      if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
+          comparator->Compare(this->values_out_[i], this->values_[i])) {
+        ARROW_SCOPED_TRACE("i = ", i);
+      }
+      ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
+      ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));
+    }
+    ASSERT_EQ(this->values_, this->values_out_);
+  }
+
+  int64_t metadata_num_values() {
+    // Metadata accessor must be created lazily.
+    // This is because the ColumnChunkMetaData semantics dictate the metadata
+    // object is complete (no changes to the metadata buffer can be made after
+    // instantiation)
+    auto metadata_accessor =
+        ColumnChunkMetaData::Make(metadata_->contents(), this->descr_);
+    return metadata_accessor->num_values();
+  }
+
+  bool metadata_is_stats_set() {
+    // Metadata accessor must be created lazily.
+    // This is because the ColumnChunkMetaData semantics dictate the metadata
+    // object is complete (no changes to the metadata buffer can be made after
+    // instantiation)
+    ApplicationVersion app_version(this->writer_properties_->created_by());
+    auto metadata_accessor = ColumnChunkMetaData::Make(
+        metadata_->contents(),
+        this->descr_,
+        default_reader_properties(),
+        &app_version);
+    return metadata_accessor->is_stats_set();
+  }
+
+  std::pair<bool, bool> metadata_stats_has_min_max() {
+    // Metadata accessor must be created lazily.
+    // This is because the ColumnChunkMetaData semantics dictate the metadata
+    // object is complete (no changes to the metadata buffer can be made after
+    // instantiation)
+    ApplicationVersion app_version(this->writer_properties_->created_by());
+    auto metadata_accessor = ColumnChunkMetaData::Make(
+        metadata_->contents(),
+        this->descr_,
+        default_reader_properties(),
+        &app_version);
+    auto encoded_stats = metadata_accessor->statistics()->Encode();
+    return {encoded_stats.has_min, encoded_stats.has_max};
+  }
+
+  std::vector<Encoding::type> metadata_encodings() {
+    // Metadata accessor must be created lazily.
+    // This is because the ColumnChunkMetaData semantics dictate the metadata
+    // object is complete (no changes to the metadata buffer can be made after
+    // instantiation)
+    auto metadata_accessor =
+        ColumnChunkMetaData::Make(metadata_->contents(), this->descr_);
+    return metadata_accessor->encodings();
+  }
+
+  std::vector<PageEncodingStats> metadata_encoding_stats() {
+    // Metadata accessor must be created lazily.
+    // This is because the ColumnChunkMetaData semantics dictate the metadata
+    // object is complete (no changes to the metadata buffer can be made after
+    // instantiation)
+    auto metadata_accessor =
+        ColumnChunkMetaData::Make(metadata_->contents(), this->descr_);
+    return metadata_accessor->encoding_stats();
+  }
+
+ protected:
+  int64_t values_read_;
+  // Keep the reader alive as for ByteArray the lifetime of the ByteArray
+  // content is bound to the reader.
+  std::shared_ptr<TypedColumnReader<TestType>> reader_;
+
+  std::vector<int16_t> definition_levels_out_;
+  std::vector<int16_t> repetition_levels_out_;
+
+  const ColumnDescriptor* descr_;
+
+ private:
+  std::unique_ptr<ColumnChunkMetaDataBuilder> metadata_;
+  std::shared_ptr<::arrow::io::BufferOutputStream> sink_;
+  std::shared_ptr<WriterProperties> writer_properties_;
+  std::vector<std::vector<uint8_t>> data_buffer_;
+};
+
+template <typename TestType>
+void TestPrimitiveWriter<TestType>::ReadColumnFully(
+    Compression::type compression,
+    bool page_checksum_verify) {
+  int64_t total_values = static_cast<int64_t>(this->values_out_.size());
+  BuildReader(total_values, compression, page_checksum_verify);
+  values_read_ = 0;
+  while (values_read_ < total_values) {
+    int64_t values_read_recently = 0;
+    reader_->ReadBatch(
+        static_cast<int>(this->values_out_.size()) -
+            static_cast<int>(values_read_),
+        definition_levels_out_.data() + values_read_,
+        repetition_levels_out_.data() + values_read_,
+        this->values_out_ptr_ + values_read_,
+        &values_read_recently);
+    values_read_ += values_read_recently;
+  }
+  this->SyncValuesOut();
+}
+
+template <>
+void TestPrimitiveWriter<Int96Type>::ReadAndCompare(
+    Compression::type compression,
+    int64_t num_rows,
+    bool page_checksum_verify) {
+  this->SetupValuesOut(num_rows);
+  this->ReadColumnFully(compression, page_checksum_verify);
+
+  auto comparator = MakeComparator<Int96Type>(Type::INT96, SortOrder::SIGNED);
+  for (size_t i = 0; i < this->values_.size(); i++) {
+    if (comparator->Compare(this->values_[i], this->values_out_[i]) ||
+        comparator->Compare(this->values_out_[i], this->values_[i])) {
+      ARROW_SCOPED_TRACE("i = ", i);
+    }
+    ASSERT_FALSE(comparator->Compare(this->values_[i], this->values_out_[i]));
+    ASSERT_FALSE(comparator->Compare(this->values_out_[i], this->values_[i]));
+  }
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+template <>
+void TestPrimitiveWriter<FLBAType>::ReadColumnFully(
+    Compression::type compression,
+    bool page_checksum_verify) {
+  int64_t total_values = static_cast<int64_t>(this->values_out_.size());
+  BuildReader(total_values, compression, page_checksum_verify);
+  this->data_buffer_.clear();
+
+  values_read_ = 0;
+  while (values_read_ < total_values) {
+    int64_t values_read_recently = 0;
+    reader_->ReadBatch(
+        static_cast<int>(this->values_out_.size()) -
+            static_cast<int>(values_read_),
+        definition_levels_out_.data() + values_read_,
+        repetition_levels_out_.data() + values_read_,
+        this->values_out_ptr_ + values_read_,
+        &values_read_recently);
+
+    // Copy contents of the pointers
+    std::vector<uint8_t> data(
+        values_read_recently * this->descr_->type_length());
+    uint8_t* data_ptr = data.data();
+    for (int64_t i = 0; i < values_read_recently; i++) {
+      memcpy(
+          data_ptr + this->descr_->type_length() * i,
+          this->values_out_[i + values_read_].ptr,
+          this->descr_->type_length());
+      this->values_out_[i + values_read_].ptr =
+          data_ptr + this->descr_->type_length() * i;
+    }
+    data_buffer_.emplace_back(std::move(data));
+
+    values_read_ += values_read_recently;
+  }
+  this->SyncValuesOut();
+}
+
+typedef ::testing::Types<
+    Int32Type,
+    Int64Type,
+    Int96Type,
+    FloatType,
+    DoubleType,
+    BooleanType,
+    ByteArrayType,
+    FLBAType>
+    TestTypes;
+
+TYPED_TEST_SUITE(TestPrimitiveWriter, TestTypes);
+
+using TestValuesWriterInt32Type = TestPrimitiveWriter<Int32Type>;
+using TestValuesWriterInt64Type = TestPrimitiveWriter<Int64Type>;
+using TestByteArrayValuesWriter = TestPrimitiveWriter<ByteArrayType>;
+using TestFixedLengthByteArrayValuesWriter = TestPrimitiveWriter<FLBAType>;
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlain) {
+  this->TestRequiredWithEncoding(Encoding::PLAIN);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredDictionary) {
+  this->TestRequiredWithEncoding(Encoding::PLAIN_DICTIONARY);
+}
+
+/*
+TYPED_TEST(TestPrimitiveWriter, RequiredRLE) {
+  this->TestRequiredWithEncoding(Encoding::RLE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredBitPacked) {
+  this->TestRequiredWithEncoding(Encoding::BIT_PACKED);
+}
+*/
+
+TEST_F(TestValuesWriterInt32Type, RequiredDeltaBinaryPacked) {
+  this->TestRequiredWithEncoding(Encoding::DELTA_BINARY_PACKED);
+}
+
+TEST_F(TestValuesWriterInt64Type, RequiredDeltaBinaryPacked) {
+  this->TestRequiredWithEncoding(Encoding::DELTA_BINARY_PACKED);
+}
+
+TEST_F(TestByteArrayValuesWriter, RequiredDeltaLengthByteArray) {
+  this->TestRequiredWithEncoding(Encoding::DELTA_LENGTH_BYTE_ARRAY);
+}
+
+/*
+TYPED_TEST(TestByteArrayValuesWriter, RequiredDeltaByteArray) {
+  this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
+}
+
+TEST_F(TestFixedLengthByteArrayValuesWriter, RequiredDeltaByteArray) {
+  this->TestRequiredWithEncoding(Encoding::DELTA_BYTE_ARRAY);
+}
+*/
+
+TYPED_TEST(TestPrimitiveWriter, RequiredRLEDictionary) {
+  this->TestRequiredWithEncoding(Encoding::RLE_DICTIONARY);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStats) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::UNCOMPRESSED, false, true, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithSnappyCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::SNAPPY, false, false, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndSnappyCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::SNAPPY, false, true, LARGE_SIZE);
+}
+
+#ifdef ARROW_WITH_BROTLI
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::BROTLI, false, false, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithBrotliCompressionAndLevel) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::BROTLI, false, false, LARGE_SIZE, 10);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndBrotliCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::BROTLI, false, true, LARGE_SIZE);
+}
+
+#endif
+
+#ifdef ARROW_WITH_GZIP
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::GZIP, false, false, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithGzipCompressionAndLevel) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::GZIP, false, false, LARGE_SIZE, 10);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndGzipCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::GZIP, false, true, LARGE_SIZE);
+}
+#endif
+
+#ifdef ARROW_WITH_LZ4
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithLz4Compression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::LZ4, false, false, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndLz4Compression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::LZ4, false, true, LARGE_SIZE);
+}
+#endif
+
+#ifdef ARROW_WITH_ZSTD
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::ZSTD, false, false, LARGE_SIZE);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCompressionAndLevel) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::ZSTD, false, false, LARGE_SIZE, 6);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndZstdCompression) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN, Compression::ZSTD, false, true, LARGE_SIZE);
+}
+#endif
+
+TYPED_TEST(TestPrimitiveWriter, Optional) {
+  // Optional and non-repeated, with definition levels
+  // but no repetition levels
+  this->SetUpSchema(Repetition::OPTIONAL);
+
+  this->GenerateData(SMALL_SIZE);
+  std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
+  definition_levels[1] = 0;
+
+  auto writer = this->BuildWriter();
+  writer->WriteBatch(
+      this->values_.size(),
+      definition_levels.data(),
+      nullptr,
+      this->values_ptr_);
+  writer->Close();
+
+  // PARQUET-703
+  ASSERT_EQ(100, this->metadata_num_values());
+
+  this->ReadColumn();
+  ASSERT_EQ(99, this->values_read_);
+  this->values_out_.resize(99);
+  this->values_.resize(99);
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+TYPED_TEST(TestPrimitiveWriter, OptionalSpaced) {
+  // Optional and non-repeated, with definition levels
+  // but no repetition levels
+  this->SetUpSchema(Repetition::OPTIONAL);
+
+  this->GenerateData(SMALL_SIZE);
+  std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
+  std::vector<uint8_t> valid_bits(
+      ::arrow::bit_util::BytesForBits(SMALL_SIZE), 255);
+
+  definition_levels[SMALL_SIZE - 1] = 0;
+  ::arrow::bit_util::ClearBit(valid_bits.data(), SMALL_SIZE - 1);
+  definition_levels[1] = 0;
+  ::arrow::bit_util::ClearBit(valid_bits.data(), 1);
+
+  auto writer = this->BuildWriter();
+  writer->WriteBatchSpaced(
+      this->values_.size(),
+      definition_levels.data(),
+      nullptr,
+      valid_bits.data(),
+      0,
+      this->values_ptr_);
+  writer->Close();
+
+  // PARQUET-703
+  ASSERT_EQ(100, this->metadata_num_values());
+
+  this->ReadColumn();
+  ASSERT_EQ(98, this->values_read_);
+  this->values_out_.resize(98);
+  this->values_.resize(99);
+  this->values_.erase(this->values_.begin() + 1);
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+TYPED_TEST(TestPrimitiveWriter, Repeated) {
+  // Optional and repeated, so definition and repetition levels
+  this->SetUpSchema(Repetition::REPEATED);
+
+  this->GenerateData(SMALL_SIZE);
+  std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
+  definition_levels[1] = 0;
+  std::vector<int16_t> repetition_levels(SMALL_SIZE, 0);
+
+  auto writer = this->BuildWriter();
+  writer->WriteBatch(
+      this->values_.size(),
+      definition_levels.data(),
+      repetition_levels.data(),
+      this->values_ptr_);
+  writer->Close();
+
+  this->ReadColumn();
+  ASSERT_EQ(SMALL_SIZE - 1, this->values_read_);
+  this->values_out_.resize(SMALL_SIZE - 1);
+  this->values_.resize(SMALL_SIZE - 1);
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredLargeChunk) {
+  this->GenerateData(LARGE_SIZE);
+
+  // Test case 1: required and non-repeated, so no definition or repetition
+  // levels
+  auto writer = this->BuildWriter(LARGE_SIZE);
+  writer->WriteBatch(this->values_.size(), nullptr, nullptr, this->values_ptr_);
+  writer->Close();
+
+  // Just read the first SMALL_SIZE rows to ensure we could read it back in
+  this->ReadColumn();
+  ASSERT_EQ(SMALL_SIZE, this->values_read_);
+  this->values_.resize(SMALL_SIZE);
+  ASSERT_EQ(this->values_, this->values_out_);
+}
+
+// Test cases for dictionary fallback encoding
+TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion1_0) {
+  this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_1_0);
+}
+
+TYPED_TEST(TestPrimitiveWriter, DictionaryFallbackVersion2_0) {
+  this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_4);
+  this->TestDictionaryFallbackEncoding(ParquetVersion::PARQUET_2_6);
+}
+
+TEST(TestWriter, NullValuesBuffer) {
+  std::shared_ptr<::arrow::io::BufferOutputStream> sink = CreateOutputStream();
+
+  const auto item_node = schema::PrimitiveNode::Make(
+      "item", Repetition::REQUIRED, LogicalType::Int(32, true), Type::INT32);
+  const auto list_node =
+      schema::GroupNode::Make("list", Repetition::REPEATED, {item_node});
+  const auto column_node = schema::GroupNode::Make(
+      "array_of_ints_column",
+      Repetition::OPTIONAL,
+      {list_node},
+      LogicalType::List());
+  const auto schema_node =
+      schema::GroupNode::Make("schema", Repetition::REQUIRED, {column_node});
+
+  auto file_writer = ParquetFileWriter::Open(
+      sink, std::dynamic_pointer_cast<schema::GroupNode>(schema_node));
+  auto group_writer = file_writer->AppendRowGroup();
+  auto column_writer = group_writer->NextColumn();
+  auto typed_writer = dynamic_cast<Int32Writer*>(column_writer);
+
+  const int64_t num_values = 1;
+  const int16_t def_levels[] = {0};
+  const int16_t rep_levels[] = {0};
+  const uint8_t valid_bits[] = {0};
+  const int64_t valid_bits_offset = 0;
+  const int32_t* values = nullptr;
+
+  typed_writer->WriteBatchSpaced(
+      num_values,
+      def_levels,
+      rep_levels,
+      valid_bits,
+      valid_bits_offset,
+      values);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainChecksum) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN,
+      Compression::UNCOMPRESSED,
+      /* enable_dictionary */ false,
+      false,
+      SMALL_SIZE,
+      Codec::UseDefaultCompressionLevel(),
+      /* enable_checksum */ true);
+}
+
+TYPED_TEST(TestPrimitiveWriter, RequiredDictChecksum) {
+  this->TestRequiredWithSettings(
+      Encoding::PLAIN,
+      Compression::UNCOMPRESSED,
+      /* enable_dictionary */ true,
+      false,
+      SMALL_SIZE,
+      Codec::UseDefaultCompressionLevel(),
+      /* enable_checksum */ true);
+}
+
+// PARQUET-719
+// Test case for NULL values
+TEST_F(TestValuesWriterInt32Type, OptionalNullValueChunk) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+
+  this->GenerateData(LARGE_SIZE);
+
+  std::vector<int16_t> definition_levels(LARGE_SIZE, 0);
+  std::vector<int16_t> repetition_levels(LARGE_SIZE, 0);
+
+  auto writer = this->BuildWriter(LARGE_SIZE);
+  // All values being written are NULL
+  writer->WriteBatch(
+      this->values_.size(),
+      definition_levels.data(),
+      repetition_levels.data(),
+      nullptr);
+  writer->Close();
+
+  // Just read the first SMALL_SIZE rows to ensure we could read it back in
+  this->ReadColumn();
+  ASSERT_EQ(0, this->values_read_);
+}
+
+// PARQUET-764
+// Correct bitpacking for boolean write at non-byte boundaries
+using TestBooleanValuesWriter = TestPrimitiveWriter<BooleanType>;
+TEST_F(TestBooleanValuesWriter, AlternateBooleanValues) {
+  this->SetUpSchema(Repetition::REQUIRED);
+  auto writer = this->BuildWriter();
+  for (int i = 0; i < SMALL_SIZE; i++) {
+    bool value = (i % 2 == 0) ? true : false;
+    writer->WriteBatch(1, nullptr, nullptr, &value);
+  }
+  writer->Close();
+  this->ReadColumn();
+  for (int i = 0; i < SMALL_SIZE; i++) {
+    ASSERT_EQ((i % 2 == 0) ? true : false, this->values_out_[i]) << i;
+  }
+}
+
+// PARQUET-979
+// Prevent writing large MIN, MAX stats
+TEST_F(TestByteArrayValuesWriter, OmitStats) {
+  int min_len = 1024 * 4;
+  int max_len = 1024 * 8;
+  this->SetUpSchema(Repetition::REQUIRED);
+  auto writer = this->BuildWriter();
+
+  values_.resize(SMALL_SIZE);
+  InitWideByteArrayValues(
+      SMALL_SIZE, this->values_, this->buffer_, min_len, max_len);
+  writer->WriteBatch(SMALL_SIZE, nullptr, nullptr, this->values_.data());
+  writer->Close();
+
+  auto has_min_max = this->metadata_stats_has_min_max();
+  ASSERT_FALSE(has_min_max.first);
+  ASSERT_FALSE(has_min_max.second);
+}
+
+// PARQUET-1405
+// Prevent writing large stats in the DataPageHeader
+TEST_F(TestByteArrayValuesWriter, OmitDataPageStats) {
+  int min_len = static_cast<int>(std::pow(10, 7));
+  int max_len = static_cast<int>(std::pow(10, 7));
+  this->SetUpSchema(Repetition::REQUIRED);
+  ColumnProperties column_properties;
+  column_properties.set_statistics_enabled(false);
+  auto writer = this->BuildWriter(SMALL_SIZE, column_properties);
+
+  values_.resize(1);
+  InitWideByteArrayValues(1, this->values_, this->buffer_, min_len, max_len);
+  writer->WriteBatch(1, nullptr, nullptr, this->values_.data());
+  writer->Close();
+
+  ASSERT_NO_THROW(this->ReadColumn());
+}
+
+TEST_F(TestByteArrayValuesWriter, LimitStats) {
+  int min_len = 1024 * 4;
+  int max_len = 1024 * 8;
+  this->SetUpSchema(Repetition::REQUIRED);
+  ColumnProperties column_properties;
+  column_properties.set_max_statistics_size(static_cast<size_t>(max_len));
+  auto writer = this->BuildWriter(SMALL_SIZE, column_properties);
+
+  values_.resize(SMALL_SIZE);
+  InitWideByteArrayValues(
+      SMALL_SIZE, this->values_, this->buffer_, min_len, max_len);
+  writer->WriteBatch(SMALL_SIZE, nullptr, nullptr, this->values_.data());
+  writer->Close();
+
+  ASSERT_TRUE(this->metadata_is_stats_set());
+}
+
+TEST_F(TestByteArrayValuesWriter, CheckDefaultStats) {
+  this->SetUpSchema(Repetition::REQUIRED);
+  auto writer = this->BuildWriter();
+  this->GenerateData(SMALL_SIZE);
+
+  writer->WriteBatch(SMALL_SIZE, nullptr, nullptr, this->values_ptr_);
+  writer->Close();
+
+  ASSERT_TRUE(this->metadata_is_stats_set());
+}
+
+TEST(TestColumnWriter, RepeatedListsUpdateSpacedBug) {
+  // In ARROW-3930 we discovered a bug when writing from Arrow when we had data
+  // that looks like this:
+  //
+  // [null, [0, 1, null, 2, 3, 4, null]]
+
+  // Create schema
+  NodePtr item = schema::Int32("item"); // optional item
+  NodePtr list(
+      GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST));
+  NodePtr bag(
+      GroupNode::Make("bag", Repetition::OPTIONAL, {list})); // optional list
+  std::vector<NodePtr> fields = {bag};
+  NodePtr root = GroupNode::Make("schema", Repetition::REPEATED, fields);
+
+  SchemaDescriptor schema;
+  schema.Init(root);
+
+  auto sink = CreateOutputStream();
+  auto props = WriterProperties::Builder().build();
+
+  auto metadata = ColumnChunkMetaDataBuilder::Make(props, schema.Column(0));
+  std::unique_ptr<PageWriter> pager = PageWriter::Open(
+      sink,
+      Compression::UNCOMPRESSED,
+      Codec::UseDefaultCompressionLevel(),
+      metadata.get());
+  std::shared_ptr<ColumnWriter> writer =
+      ColumnWriter::Make(metadata.get(), std::move(pager), props.get());
+  auto typed_writer =
+      std::static_pointer_cast<TypedColumnWriter<Int32Type>>(writer);
+
+  std::vector<int16_t> def_levels = {1, 3, 3, 2, 3, 3, 3, 2, 3, 3, 3, 2, 3, 3};
+  std::vector<int16_t> rep_levels = {0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
+  std::vector<int32_t> values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+
+  // Write the values into uninitialized memory
+  ASSERT_OK_AND_ASSIGN(auto values_buffer, ::arrow::AllocateBuffer(64));
+  memcpy(values_buffer->mutable_data(), values.data(), 13 * sizeof(int32_t));
+  auto values_data = reinterpret_cast<const int32_t*>(values_buffer->data());
+
+  std::shared_ptr<Buffer> valid_bits;
+  ASSERT_OK_AND_ASSIGN(
+      valid_bits,
+      ::arrow::internal::BytesToBits({1, 1, 0, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1}));
+
+  // valgrind will warn about out of bounds access into def_levels_data
+  typed_writer->WriteBatchSpaced(
+      14,
+      def_levels.data(),
+      rep_levels.data(),
+      valid_bits->data(),
+      0,
+      values_data);
+  writer->Close();
+}
+
+void GenerateLevels(
+    int min_repeat_factor,
+    int max_repeat_factor,
+    int max_level,
+    std::vector<int16_t>& input_levels) {
+  // for each repetition count up to max_repeat_factor
+  for (int repeat = min_repeat_factor; repeat <= max_repeat_factor; repeat++) {
+    // repeat count increases by a factor of 2 for every iteration
+    int repeat_count = (1 << repeat);
+    // generate levels for repetition count up to the maximum level
+    int16_t value = 0;
+    int bwidth = 0;
+    while (value <= max_level) {
+      for (int i = 0; i < repeat_count; i++) {
+        input_levels.push_back(value);
+      }
+      value = static_cast<int16_t>((2 << bwidth) - 1);
+      bwidth++;
+    }
+  }
+}
+
+void EncodeLevels(
+    Encoding::type encoding,
+    int16_t max_level,
+    int num_levels,
+    const int16_t* input_levels,
+    std::vector<uint8_t>& bytes) {
+  LevelEncoder encoder;
+  int levels_count = 0;
+  bytes.resize(2 * num_levels);
+  ASSERT_EQ(2 * num_levels, static_cast<int>(bytes.size()));
+  // encode levels
+  if (encoding == Encoding::RLE) {
+    // leave space to write the rle length value
+    encoder.Init(
+        encoding,
+        max_level,
+        num_levels,
+        bytes.data() + sizeof(int32_t),
+        static_cast<int>(bytes.size()));
+
+    levels_count = encoder.Encode(num_levels, input_levels);
+    (reinterpret_cast<int32_t*>(bytes.data()))[0] = encoder.len();
+  } else {
+    encoder.Init(
+        encoding,
+        max_level,
+        num_levels,
+        bytes.data(),
+        static_cast<int>(bytes.size()));
+    levels_count = encoder.Encode(num_levels, input_levels);
+  }
+  ASSERT_EQ(num_levels, levels_count);
+}
+
+void VerifyDecodingLevels(
+    Encoding::type encoding,
+    int16_t max_level,
+    std::vector<int16_t>& input_levels,
+    std::vector<uint8_t>& bytes) {
+  LevelDecoder decoder;
+  int levels_count = 0;
+  std::vector<int16_t> output_levels;
+  int num_levels = static_cast<int>(input_levels.size());
+
+  output_levels.resize(num_levels);
+  ASSERT_EQ(num_levels, static_cast<int>(output_levels.size()));
+
+  // Decode levels and test with multiple decode calls
+  decoder.SetData(
+      encoding,
+      max_level,
+      num_levels,
+      bytes.data(),
+      static_cast<int32_t>(bytes.size()));
+  int decode_count = 4;
+  int num_inner_levels = num_levels / decode_count;
+  // Try multiple decoding on a single SetData call
+  for (int ct = 0; ct < decode_count; ct++) {
+    int offset = ct * num_inner_levels;
+    levels_count = decoder.Decode(num_inner_levels, output_levels.data());
+    ASSERT_EQ(num_inner_levels, levels_count);
+    for (int i = 0; i < num_inner_levels; i++) {
+      EXPECT_EQ(input_levels[i + offset], output_levels[i]);
+    }
+  }
+  // check the remaining levels
+  int num_levels_completed = decode_count * (num_levels / decode_count);
+  int num_remaining_levels = num_levels - num_levels_completed;
+  if (num_remaining_levels > 0) {
+    levels_count = decoder.Decode(num_remaining_levels, output_levels.data());
+    ASSERT_EQ(num_remaining_levels, levels_count);
+    for (int i = 0; i < num_remaining_levels; i++) {
+      EXPECT_EQ(input_levels[i + num_levels_completed], output_levels[i]);
+    }
+  }
+  // Test zero Decode values
+  ASSERT_EQ(0, decoder.Decode(1, output_levels.data()));
+}
+
+void VerifyDecodingMultipleSetData(
+    Encoding::type encoding,
+    int16_t max_level,
+    std::vector<int16_t>& input_levels,
+    std::vector<std::vector<uint8_t>>& bytes) {
+  LevelDecoder decoder;
+  int levels_count = 0;
+  std::vector<int16_t> output_levels;
+
+  // Decode levels and test with multiple SetData calls
+  int setdata_count = static_cast<int>(bytes.size());
+  int num_levels = static_cast<int>(input_levels.size()) / setdata_count;
+  output_levels.resize(num_levels);
+  // Try multiple SetData
+  for (int ct = 0; ct < setdata_count; ct++) {
+    int offset = ct * num_levels;
+    ASSERT_EQ(num_levels, static_cast<int>(output_levels.size()));
+    decoder.SetData(
+        encoding,
+        max_level,
+        num_levels,
+        bytes[ct].data(),
+        static_cast<int32_t>(bytes[ct].size()));
+    levels_count = decoder.Decode(num_levels, output_levels.data());
+    ASSERT_EQ(num_levels, levels_count);
+    for (int i = 0; i < num_levels; i++) {
+      EXPECT_EQ(input_levels[i + offset], output_levels[i]);
+    }
+  }
+}
+
+// Test levels with maximum bit-width from 1 to 8
+// increase the repetition count for each iteration by a factor of 2
+TEST(TestLevels, TestLevelsDecodeMultipleBitWidth) {
+  int min_repeat_factor = 0;
+  int max_repeat_factor = 7; // 128
+  int max_bit_width = 8;
+  std::vector<int16_t> input_levels;
+  std::vector<uint8_t> bytes;
+  Encoding::type encodings[2] = {Encoding::RLE, Encoding::BIT_PACKED};
+
+  // for each encoding
+  for (int encode = 0; encode < 2; encode++) {
+    Encoding::type encoding = encodings[encode];
+    // BIT_PACKED requires a sequence of at least 8
+    if (encoding == Encoding::BIT_PACKED)
+      min_repeat_factor = 3;
+    // for each maximum bit-width
+    for (int bit_width = 1; bit_width <= max_bit_width; bit_width++) {
+      // find the maximum level for the current bit_width
+      int16_t max_level = static_cast<int16_t>((1 << bit_width) - 1);
+      // Generate levels
+      GenerateLevels(
+          min_repeat_factor, max_repeat_factor, max_level, input_levels);
+      ASSERT_NO_FATAL_FAILURE(EncodeLevels(
+          encoding,
+          max_level,
+          static_cast<int>(input_levels.size()),
+          input_levels.data(),
+          bytes));
+      ASSERT_NO_FATAL_FAILURE(
+          VerifyDecodingLevels(encoding, max_level, input_levels, bytes));
+      input_levels.clear();
+    }
+  }
+}
+
+// Test multiple decoder SetData calls
+TEST(TestLevels, TestLevelsDecodeMultipleSetData) {
+  int min_repeat_factor = 3;
+  int max_repeat_factor = 7; // 128
+  int bit_width = 8;
+  int16_t max_level = static_cast<int16_t>((1 << bit_width) - 1);
+  std::vector<int16_t> input_levels;
+  std::vector<std::vector<uint8_t>> bytes;
+  Encoding::type encodings[2] = {Encoding::RLE, Encoding::BIT_PACKED};
+  GenerateLevels(min_repeat_factor, max_repeat_factor, max_level, input_levels);
+  int num_levels = static_cast<int>(input_levels.size());
+  int setdata_factor = 8;
+  int split_level_size = num_levels / setdata_factor;
+  bytes.resize(setdata_factor);
+
+  // for each encoding
+  for (int encode = 0; encode < 2; encode++) {
+    Encoding::type encoding = encodings[encode];
+    for (int rf = 0; rf < setdata_factor; rf++) {
+      int offset = rf * split_level_size;
+      ASSERT_NO_FATAL_FAILURE(EncodeLevels(
+          encoding,
+          max_level,
+          split_level_size,
+          reinterpret_cast<int16_t*>(input_levels.data()) + offset,
+          bytes[rf]));
+    }
+    ASSERT_NO_FATAL_FAILURE(VerifyDecodingMultipleSetData(
+        encoding, max_level, input_levels, bytes));
+  }
+}
+
+TEST(TestLevelEncoder, MinimumBufferSize) {
+  // PARQUET-676, PARQUET-698
+  const int kNumToEncode = 1024;
+
+  std::vector<int16_t> levels;
+  for (int i = 0; i < kNumToEncode; ++i) {
+    if (i % 9 == 0) {
+      levels.push_back(0);
+    } else {
+      levels.push_back(1);
+    }
+  }
+
+  std::vector<uint8_t> output(
+      LevelEncoder::MaxBufferSize(Encoding::RLE, 1, kNumToEncode));
+
+  LevelEncoder encoder;
+  encoder.Init(
+      Encoding::RLE,
+      1,
+      kNumToEncode,
+      output.data(),
+      static_cast<int>(output.size()));
+  int encode_count = encoder.Encode(kNumToEncode, levels.data());
+
+  ASSERT_EQ(kNumToEncode, encode_count);
+}
+
+TEST(TestLevelEncoder, MinimumBufferSize2) {
+  // PARQUET-708
+  // Test the worst case for bit_width=2 consisting of
+  // LiteralRun(size=8)
+  // RepeatedRun(size=8)
+  // LiteralRun(size=8)
+  // ...
+  const int kNumToEncode = 1024;
+
+  std::vector<int16_t> levels;
+  for (int i = 0; i < kNumToEncode; ++i) {
+    // This forces a literal run of 00000001
+    // followed by eight 1s
+    if ((i % 16) < 7) {
+      levels.push_back(0);
+    } else {
+      levels.push_back(1);
+    }
+  }
+
+  for (int16_t bit_width = 1; bit_width <= 8; bit_width++) {
+    std::vector<uint8_t> output(
+        LevelEncoder::MaxBufferSize(Encoding::RLE, bit_width, kNumToEncode));
+
+    LevelEncoder encoder;
+    encoder.Init(
+        Encoding::RLE,
+        bit_width,
+        kNumToEncode,
+        output.data(),
+        static_cast<int>(output.size()));
+    int encode_count = encoder.Encode(kNumToEncode, levels.data());
+
+    ASSERT_EQ(kNumToEncode, encode_count);
+  }
+}
+
+TEST(TestColumnWriter, WriteDataPageV2Header) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {
+          schema::Int32("required", Repetition::REQUIRED),
+          schema::Int32("optional", Repetition::OPTIONAL),
+          schema::Int32("repeated", Repetition::REPEATED),
+      }));
+  auto properties = WriterProperties::Builder()
+                        .disable_dictionary()
+                        ->data_page_version(ParquetDataPageVersion::V2)
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_rows = 100;
+
+  auto required_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  for (int32_t i = 0; i < num_rows; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+
+  // Write a null value at every other row.
+  auto optional_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  for (int32_t i = 0; i < num_rows; i++) {
+    int16_t definition_level = i % 2 == 0 ? 1 : 0;
+    optional_writer->WriteBatch(1, &definition_level, nullptr, &i);
+  }
+
+  // Each row has repeated twice.
+  auto repeated_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  for (int i = 0; i < 2 * num_rows; i++) {
+    int32_t value = i * 1000;
+    int16_t definition_level = 1;
+    int16_t repetition_level = i % 2 == 0 ? 1 : 0;
+    repeated_writer->WriteBatch(
+        1, &definition_level, &repetition_level, &value);
+  }
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  // Verify required column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(0);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows, data_page->num_values());
+    EXPECT_EQ(0, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
+  }
+
+  // Verify optional column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(1);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows, data_page->num_values());
+    EXPECT_EQ(num_rows / 2, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
+  }
+
+  // Verify repeated column.
+  {
+    auto page_reader = row_group_reader->GetColumnPageReader(2);
+    auto page = page_reader->NextPage();
+    ASSERT_NE(page, nullptr);
+    auto data_page = std::static_pointer_cast<DataPageV2>(page);
+    EXPECT_EQ(num_rows, data_page->num_rows());
+    EXPECT_EQ(num_rows * 2, data_page->num_values());
+    EXPECT_EQ(0, data_page->num_nulls());
+    EXPECT_EQ(page_reader->NextPage(), nullptr);
+  }
+}
+
+// The test below checks that data page v2 changes on record boundaries for
+// all repetition types (i.e. required, optional, and repeated)
+TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundaries) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {schema::Int32("required", Repetition::REQUIRED),
+       schema::Int32("optional", Repetition::OPTIONAL),
+       schema::Int32("repeated", Repetition::REPEATED)}));
+  // Write at most 11 levels per batch.
+  constexpr int64_t batch_size = 11;
+  auto properties =
+      WriterProperties::Builder()
+          .disable_dictionary()
+          ->data_page_version(ParquetDataPageVersion::V2)
+          ->write_batch_size(batch_size)
+          ->data_pagesize(1) /* every page size check creates a new page */
+          ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_levels = 100;
+  const std::vector<int32_t> values(num_levels, 1024);
+  std::array<int16_t, num_levels> def_levels;
+  std::array<int16_t, num_levels> rep_levels;
+  for (int32_t i = 0; i < num_levels; i++) {
+    def_levels[i] = i % 2 == 0 ? 1 : 0;
+    rep_levels[i] = i % 2 == 0 ? 0 : 1;
+  }
+
+  auto required_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  required_writer->WriteBatch(num_levels, nullptr, nullptr, values.data());
+
+  // Write a null value at every other row.
+  auto optional_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  optional_writer->WriteBatch(
+      num_levels, def_levels.data(), nullptr, values.data());
+
+  // Each row has repeated twice.
+  auto repeated_writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+  repeated_writer->WriteBatch(
+      num_levels, def_levels.data(), rep_levels.data(), values.data());
+  repeated_writer->WriteBatch(
+      num_levels, def_levels.data(), rep_levels.data(), values.data());
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  // Check if pages are changed on record boundaries.
+  constexpr int num_columns = 3;
+  const std::array<int64_t, num_columns> expected_num_pages = {10, 10, 19};
+  for (int i = 0; i < num_columns; ++i) {
+    auto page_reader = row_group_reader->GetColumnPageReader(i);
+    int64_t num_rows = 0;
+    int64_t num_pages = 0;
+    std::shared_ptr<Page> page;
+    while ((page = page_reader->NextPage()) != nullptr) {
+      auto data_page = std::static_pointer_cast<DataPageV2>(page);
+      if (i < 2) {
+        EXPECT_EQ(data_page->num_values(), data_page->num_rows());
+      } else {
+        // Make sure repeated column has 2 values per row and not span multiple
+        // pages.
+        EXPECT_EQ(data_page->num_values(), 2 * data_page->num_rows());
+      }
+      num_rows += data_page->num_rows();
+      num_pages++;
+    }
+    EXPECT_EQ(num_levels, num_rows);
+    EXPECT_EQ(expected_num_pages[i], num_pages);
+  }
+}
+
+// The test below checks that data page v2 changes on record boundaries for
+// repeated columns with small batches.
+TEST(TestColumnWriter, WriteDataPagesChangeOnRecordBoundariesWithSmallBatches) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {schema::Int32("tiny_repeat", Repetition::REPEATED),
+       schema::Int32("small_repeat", Repetition::REPEATED),
+       schema::Int32("medium_repeat", Repetition::REPEATED),
+       schema::Int32("large_repeat", Repetition::REPEATED)}));
+
+  // The batch_size is large enough so each WriteBatch call checks page size at
+  // most once.
+  constexpr int64_t batch_size = std::numeric_limits<int64_t>::max();
+  auto properties =
+      WriterProperties::Builder()
+          .disable_dictionary()
+          ->data_page_version(ParquetDataPageVersion::V2)
+          ->write_batch_size(batch_size)
+          ->data_pagesize(1) /* every page size check creates a new page */
+          ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_cols = 4;
+  constexpr int64_t num_rows = 400;
+  constexpr int64_t num_levels = 100;
+  constexpr std::array<int64_t, num_cols> num_levels_per_row_by_col = {
+      1, 50, 99, 150};
+
+  // All values are not null and fixed to 1024 for simplicity.
+  const std::vector<int32_t> values(num_levels, 1024);
+  const std::vector<int16_t> def_levels(num_levels, 1);
+  std::vector<int16_t> rep_levels(num_levels, 0);
+
+  for (int32_t i = 0; i < num_cols; ++i) {
+    auto writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+    const auto num_levels_per_row = num_levels_per_row_by_col[i];
+    int64_t num_rows_written = 0;
+    int64_t num_levels_written_curr_row = 0;
+    while (num_rows_written < num_rows) {
+      int32_t num_levels_to_write = 0;
+      while (num_levels_to_write < num_levels) {
+        if (num_levels_written_curr_row == 0) {
+          // A new record.
+          rep_levels[num_levels_to_write++] = 0;
+        } else {
+          rep_levels[num_levels_to_write++] = 1;
+        }
+
+        if (++num_levels_written_curr_row == num_levels_per_row) {
+          // Current row has enough levels.
+          num_levels_written_curr_row = 0;
+          if (++num_rows_written == num_rows) {
+            // Enough rows have been written.
+            break;
+          }
+        }
+      }
+
+      writer->WriteBatch(
+          num_levels_to_write,
+          def_levels.data(),
+          rep_levels.data(),
+          values.data());
+    }
+  }
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  // Check if pages are changed on record boundaries.
+  const std::array<int64_t, num_cols> expect_num_pages_by_col = {
+      5, 201, 397, 201};
+  const std::array<int64_t, num_cols> expect_num_rows_1st_page_by_col = {
+      99, 1, 1, 1};
+  const std::array<int64_t, num_cols> expect_num_vals_1st_page_by_col = {
+      99, 50, 99, 150};
+  for (int32_t i = 0; i < num_cols; ++i) {
+    auto page_reader = row_group_reader->GetColumnPageReader(i);
+    int64_t num_rows_read = 0;
+    int64_t num_pages_read = 0;
+    int64_t num_values_read = 0;
+    std::shared_ptr<Page> page;
+    while ((page = page_reader->NextPage()) != nullptr) {
+      auto data_page = std::static_pointer_cast<DataPageV2>(page);
+      num_values_read += data_page->num_values();
+      num_rows_read += data_page->num_rows();
+      if (num_pages_read++ == 0) {
+        EXPECT_EQ(expect_num_rows_1st_page_by_col[i], data_page->num_rows());
+        EXPECT_EQ(expect_num_vals_1st_page_by_col[i], data_page->num_values());
+      }
+    }
+    EXPECT_EQ(num_rows, num_rows_read);
+    EXPECT_EQ(expect_num_pages_by_col[i], num_pages_read);
+    EXPECT_EQ(num_levels_per_row_by_col[i] * num_rows, num_values_read);
+  }
+}
+
+class ColumnWriterTestSizeEstimated : public ::testing::Test {
+ public:
+  void SetUp() {
+    sink_ = CreateOutputStream();
+    node_ = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+        "schema",
+        Repetition::REQUIRED,
+        {
+            schema::Int32("required", Repetition::REQUIRED),
+        }));
+    std::vector<schema::NodePtr> fields;
+    schema_descriptor_ = std::make_unique<SchemaDescriptor>();
+    schema_descriptor_->Init(node_);
+  }
+
+  std::shared_ptr<Int32Writer> BuildWriter(
+      Compression::type compression,
+      bool buffered,
+      bool enable_dictionary = false) {
+    auto builder = WriterProperties::Builder();
+    builder.disable_dictionary()
+        ->compression(compression)
+        ->data_pagesize(100 * sizeof(int));
+    if (enable_dictionary) {
+      builder.enable_dictionary();
+    } else {
+      builder.disable_dictionary();
+    }
+    writer_properties_ = builder.build();
+    metadata_ = ColumnChunkMetaDataBuilder::Make(
+        writer_properties_, schema_descriptor_->Column(0));
+
+    std::unique_ptr<PageWriter> pager = PageWriter::Open(
+        sink_,
+        compression,
+        Codec::UseDefaultCompressionLevel(),
+        metadata_.get(),
+        /* row_group_ordinal */ -1,
+        /* column_chunk_ordinal*/ -1,
+        ::arrow::default_memory_pool(),
+        /* buffered_row_group */ buffered,
+        /* header_encryptor */ NULLPTR,
+        /* data_encryptor */ NULLPTR,
+        /* enable_checksum */ false);
+    return std::static_pointer_cast<Int32Writer>(ColumnWriter::Make(
+        metadata_.get(), std::move(pager), writer_properties_.get()));
+  }
+
+  std::shared_ptr<::arrow::io::BufferOutputStream> sink_;
+  std::shared_ptr<GroupNode> node_;
+  std::unique_ptr<SchemaDescriptor> schema_descriptor_;
+
+  std::shared_ptr<WriterProperties> writer_properties_;
+  std::unique_ptr<ColumnChunkMetaDataBuilder> metadata_;
+};
+
+TEST_F(ColumnWriterTestSizeEstimated, NonBuffered) {
+  auto required_writer =
+      this->BuildWriter(Compression::UNCOMPRESSED, /* buffered*/ false);
+  // Write half page, page will not be flushed after loop
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page not flushed, check size
+  EXPECT_EQ(0, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes()); // unbuffered
+  EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
+  // Write half page, page be flushed after loop
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page flushed, check size
+  EXPECT_LT(400, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_LT(400, required_writer->total_compressed_bytes_written());
+
+  // Test after closed
+  int64_t written_size = required_writer->Close();
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_EQ(written_size, required_writer->total_bytes_written());
+  // uncompressed writer should be equal
+  EXPECT_EQ(written_size, required_writer->total_compressed_bytes_written());
+}
+
+TEST_F(ColumnWriterTestSizeEstimated, Buffered) {
+  auto required_writer =
+      this->BuildWriter(Compression::UNCOMPRESSED, /* buffered*/ true);
+  // Write half page, page will not be flushed after loop
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page not flushed, check size
+  EXPECT_EQ(0, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes()); // buffered
+  EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
+  // Write half page, page be flushed after loop
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page flushed, check size
+  EXPECT_LT(400, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_LT(400, required_writer->total_compressed_bytes_written());
+
+  // Test after closed
+  int64_t written_size = required_writer->Close();
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_EQ(written_size, required_writer->total_bytes_written());
+  // uncompressed writer should be equal
+  EXPECT_EQ(written_size, required_writer->total_compressed_bytes_written());
+}
+
+TEST_F(ColumnWriterTestSizeEstimated, NonBufferedDictionary) {
+  auto required_writer =
+      this->BuildWriter(Compression::UNCOMPRESSED, /* buffered*/ false, true);
+  // for dict, keep all values equal
+  int32_t dict_value = 1;
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &dict_value);
+  }
+  // Page not flushed, check size
+  EXPECT_EQ(0, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
+  // write a huge batch to trigger page flush
+  for (int32_t i = 0; i < 50000; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &dict_value);
+  }
+  // Page flushed, check size
+  EXPECT_EQ(0, required_writer->total_bytes_written());
+  EXPECT_LT(400, required_writer->total_compressed_bytes());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
+
+  required_writer->Close();
+
+  // Test after closed
+  int64_t written_size = required_writer->Close();
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_EQ(written_size, required_writer->total_bytes_written());
+  // uncompressed writer should be equal
+  EXPECT_EQ(written_size, required_writer->total_compressed_bytes_written());
+}
+
+TEST_F(ColumnWriterTestSizeEstimated, BufferedCompression) {
+  auto required_writer = this->BuildWriter(Compression::SNAPPY, true);
+
+  // Write half page
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page not flushed, check size
+  EXPECT_EQ(0, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes()); // buffered
+  EXPECT_EQ(0, required_writer->total_compressed_bytes_written());
+  for (int32_t i = 0; i < 50; i++) {
+    required_writer->WriteBatch(1, nullptr, nullptr, &i);
+  }
+  // Page flushed, check size
+  EXPECT_LT(400, required_writer->total_bytes_written());
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_LT(
+      required_writer->total_compressed_bytes_written(),
+      required_writer->total_bytes_written());
+
+  // Test after closed
+  int64_t written_size = required_writer->Close();
+  EXPECT_EQ(0, required_writer->total_compressed_bytes());
+  EXPECT_EQ(written_size, required_writer->total_bytes_written());
+  EXPECT_GT(written_size, required_writer->total_compressed_bytes_written());
+}
+
+TEST(TestColumnWriter, WriteDataPageV2HeaderNullCount) {
+  auto sink = CreateOutputStream();
+  auto list_type = GroupNode::Make(
+      "list",
+      Repetition::REPEATED,
+      {schema::Int32("elem", Repetition::OPTIONAL)});
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema",
+      Repetition::REQUIRED,
+      {
+          schema::Int32("non_null", Repetition::OPTIONAL),
+          schema::Int32("half_null", Repetition::OPTIONAL),
+          schema::Int32("all_null", Repetition::OPTIONAL),
+          GroupNode::Make("half_null_list", Repetition::OPTIONAL, {list_type}),
+          GroupNode::Make("half_empty_list", Repetition::OPTIONAL, {list_type}),
+          GroupNode::Make(
+              "half_list_of_null", Repetition::OPTIONAL, {list_type}),
+          GroupNode::Make("all_single_list", Repetition::OPTIONAL, {list_type}),
+      }));
+  auto properties = WriterProperties::Builder()
+                        /* Use V2 data page to read null_count from header */
+                        .data_page_version(ParquetDataPageVersion::V2)
+                        /* Disable stats to test null_count is properly set */
+                        ->disable_statistics()
+                        ->disable_dictionary()
+                        ->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_rows = 10;
+  constexpr int32_t num_cols = 7;
+  const std::vector<std::vector<int16_t>> def_levels_by_col = {
+      {1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+      {1, 0, 1, 0, 1, 0, 1, 0, 1, 0},
+      {0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+      {0, 3, 0, 3, 0, 3, 0, 3, 0, 3},
+      {1, 3, 1, 3, 1, 3, 1, 3, 1, 3},
+      {2, 3, 2, 3, 2, 3, 2, 3, 2, 3},
+      {3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
+  };
+  const std::vector<int16_t> ref_levels(num_rows, 0);
+  const std::vector<int32_t> values(num_rows, 123);
+  const std::vector<int64_t> expect_null_count_by_col = {0, 5, 10, 5, 5, 5, 0};
+
+  for (int32_t i = 0; i < num_cols; ++i) {
+    auto writer = static_cast<Int32Writer*>(rg_writer->NextColumn());
+    writer->WriteBatch(
+        num_rows,
+        def_levels_by_col[i].data(),
+        i >= 3 ? ref_levels.data() : nullptr,
+        values.data());
+  }
+
+  ASSERT_NO_THROW(file_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer),
+      default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+
+  std::shared_ptr<Page> page;
+  for (int32_t i = 0; i < num_cols; ++i) {
+    auto page_reader = row_group_reader->GetColumnPageReader(i);
+    int64_t num_nulls_read = 0;
+    int64_t num_rows_read = 0;
+    int64_t num_values_read = 0;
+    while ((page = page_reader->NextPage()) != nullptr) {
+      auto data_page = std::static_pointer_cast<DataPageV2>(page);
+      num_nulls_read += data_page->num_nulls();
+      num_rows_read += data_page->num_rows();
+      num_values_read += data_page->num_values();
+    }
+    EXPECT_EQ(expect_null_count_by_col[i], num_nulls_read);
+    EXPECT_EQ(num_rows, num_rows_read);
+    EXPECT_EQ(num_rows, num_values_read);
+  }
+}
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/EncodingTest.cpp
@@ -1,0 +1,4013 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/Encoding.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/array/builder_dict.h"
+#include "arrow/stl_allocator.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bit_run_reader.h"
+#include "arrow/util/bit_stream_utils.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_ops.h"
+#include "arrow/util/bitmap_writer.h"
+#include "arrow/util/byte_stream_split.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/hashing.h"
+#include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/rle_encoding.h"
+#include "arrow/util/ubsan.h"
+#include "arrow/visit_data_inline.h"
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+
+namespace bit_util = arrow::bit_util;
+
+using arrow::Status;
+using arrow::VisitNullBitmapInline;
+using arrow::internal::AddWithOverflow;
+using arrow::internal::checked_cast;
+using arrow::util::SafeLoad;
+using arrow::util::SafeLoadAs;
+using ::parquet::ParquetException;
+using std::string_view;
+
+template <typename T>
+using ArrowPoolVector = std::vector<T, ::arrow::stl::allocator<T>>;
+
+namespace facebook::velox::parquet::arrow {
+namespace {
+
+constexpr int64_t kInMemoryDefaultCapacity = 1024;
+// The Parquet spec isn't very clear whether ByteArray lengths are signed or
+// unsigned, but the Java implementation uses signed ints.
+constexpr size_t kMaxByteArraySize = std::numeric_limits<int32_t>::max();
+
+class EncoderImpl : virtual public Encoder {
+ public:
+  EncoderImpl(
+      const ColumnDescriptor* descr,
+      Encoding::type encoding,
+      MemoryPool* pool)
+      : descr_(descr),
+        encoding_(encoding),
+        pool_(pool),
+        type_length_(descr ? descr->type_length() : -1) {}
+
+  Encoding::type encoding() const override {
+    return encoding_;
+  }
+
+  MemoryPool* memory_pool() const override {
+    return pool_;
+  }
+
+ protected:
+  // For accessing type-specific metadata, like FIXED_LEN_BYTE_ARRAY
+  const ColumnDescriptor* descr_;
+  const Encoding::type encoding_;
+  MemoryPool* pool_;
+
+  /// Type length from descr
+  int type_length_;
+};
+
+// ----------------------------------------------------------------------
+// Plain encoder implementation
+
+template <typename DType>
+class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
+ public:
+  using T = typename DType::c_type;
+
+  explicit PlainEncoder(const ColumnDescriptor* descr, MemoryPool* pool)
+      : EncoderImpl(descr, Encoding::PLAIN, pool), sink_(pool) {}
+
+  int64_t EstimatedDataEncodedSize() override {
+    return sink_.length();
+  }
+
+  std::shared_ptr<Buffer> FlushValues() override {
+    std::shared_ptr<Buffer> buffer;
+    PARQUET_THROW_NOT_OK(sink_.Finish(&buffer));
+    return buffer;
+  }
+
+  using TypedEncoder<DType>::Put;
+
+  void Put(const T* buffer, int num_values) override;
+
+  void Put(const ::arrow::Array& values) override;
+
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    if (valid_bits != NULLPTR) {
+      PARQUET_ASSIGN_OR_THROW(
+          auto buffer,
+          ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+      T* data = reinterpret_cast<T*>(buffer->mutable_data());
+      int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+          src, num_values, valid_bits, valid_bits_offset, data);
+      Put(data, num_valid_values);
+    } else {
+      Put(src, num_values);
+    }
+  }
+
+  void UnsafePutByteArray(const void* data, uint32_t length) {
+    DCHECK(length == 0 || data != nullptr) << "Value ptr cannot be NULL";
+    sink_.UnsafeAppend(&length, sizeof(uint32_t));
+    sink_.UnsafeAppend(data, static_cast<int64_t>(length));
+  }
+
+  void Put(const ByteArray& val) {
+    // Write the result to the output stream
+    const int64_t increment = static_cast<int64_t>(val.len + sizeof(uint32_t));
+    if (ARROW_PREDICT_FALSE(sink_.length() + increment > sink_.capacity())) {
+      PARQUET_THROW_NOT_OK(sink_.Reserve(increment));
+    }
+    UnsafePutByteArray(val.ptr, val.len);
+  }
+
+ protected:
+  template <typename ArrayType>
+  void PutBinaryArray(const ArrayType& array) {
+    const int64_t total_bytes =
+        array.value_offset(array.length()) - array.value_offset(0);
+    PARQUET_THROW_NOT_OK(
+        sink_.Reserve(total_bytes + array.length() * sizeof(uint32_t)));
+
+    PARQUET_THROW_NOT_OK(
+        ::arrow::VisitArraySpanInline<typename ArrayType::TypeClass>(
+            *array.data(),
+            [&](::std::string_view view) {
+              if (ARROW_PREDICT_FALSE(view.size() > kMaxByteArraySize)) {
+                return Status::Invalid(
+                    "Parquet cannot store strings with size 2GB or more");
+              }
+              UnsafePutByteArray(
+                  view.data(), static_cast<uint32_t>(view.size()));
+              return Status::OK();
+            },
+            []() { return Status::OK(); }));
+  }
+
+  ::arrow::BufferBuilder sink_;
+};
+
+template <typename DType>
+void PlainEncoder<DType>::Put(const T* buffer, int num_values) {
+  if (num_values > 0) {
+    PARQUET_THROW_NOT_OK(sink_.Append(buffer, num_values * sizeof(T)));
+  }
+}
+
+template <>
+inline void PlainEncoder<ByteArrayType>::Put(
+    const ByteArray* src,
+    int num_values) {
+  for (int i = 0; i < num_values; ++i) {
+    Put(src[i]);
+  }
+}
+
+template <typename ArrayType>
+void DirectPutImpl(const ::arrow::Array& values, ::arrow::BufferBuilder* sink) {
+  if (values.type_id() != ArrayType::TypeClass::type_id) {
+    std::string type_name = ArrayType::TypeClass::type_name();
+    throw ParquetException(
+        "direct put to " + type_name + " from " + values.type()->ToString() +
+        " not supported");
+  }
+
+  using value_type = typename ArrayType::value_type;
+  constexpr auto value_size = sizeof(value_type);
+  auto raw_values = checked_cast<const ArrayType&>(values).raw_values();
+
+  if (values.null_count() == 0) {
+    // no nulls, just dump the data
+    PARQUET_THROW_NOT_OK(
+        sink->Append(raw_values, values.length() * value_size));
+  } else {
+    PARQUET_THROW_NOT_OK(
+        sink->Reserve((values.length() - values.null_count()) * value_size));
+
+    for (int64_t i = 0; i < values.length(); i++) {
+      if (values.IsValid(i)) {
+        sink->UnsafeAppend(&raw_values[i], value_size);
+      }
+    }
+  }
+}
+
+template <>
+void PlainEncoder<Int32Type>::Put(const ::arrow::Array& values) {
+  DirectPutImpl<::arrow::Int32Array>(values, &sink_);
+}
+
+template <>
+void PlainEncoder<Int64Type>::Put(const ::arrow::Array& values) {
+  DirectPutImpl<::arrow::Int64Array>(values, &sink_);
+}
+
+template <>
+void PlainEncoder<Int96Type>::Put(const ::arrow::Array& values) {
+  ParquetException::NYI("direct put to Int96");
+}
+
+template <>
+void PlainEncoder<FloatType>::Put(const ::arrow::Array& values) {
+  DirectPutImpl<::arrow::FloatArray>(values, &sink_);
+}
+
+template <>
+void PlainEncoder<DoubleType>::Put(const ::arrow::Array& values) {
+  DirectPutImpl<::arrow::DoubleArray>(values, &sink_);
+}
+
+template <typename DType>
+void PlainEncoder<DType>::Put(const ::arrow::Array& values) {
+  ParquetException::NYI("direct put of " + values.type()->ToString());
+}
+
+void AssertBaseBinary(const ::arrow::Array& values) {
+  if (!::arrow::is_base_binary_like(values.type_id())) {
+    throw ParquetException("Only BaseBinaryArray and subclasses supported");
+  }
+}
+
+template <>
+inline void PlainEncoder<ByteArrayType>::Put(const ::arrow::Array& values) {
+  AssertBaseBinary(values);
+
+  if (::arrow::is_binary_like(values.type_id())) {
+    PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  }
+}
+
+void AssertFixedSizeBinary(const ::arrow::Array& values, int type_length) {
+  if (values.type_id() != ::arrow::Type::FIXED_SIZE_BINARY &&
+      values.type_id() != ::arrow::Type::DECIMAL) {
+    throw ParquetException(
+        "Only FixedSizeBinaryArray and subclasses supported");
+  }
+  if (checked_cast<const ::arrow::FixedSizeBinaryType&>(*values.type())
+          .byte_width() != type_length) {
+    throw ParquetException(
+        "Size mismatch: " + values.type()->ToString() + " should have been " +
+        std::to_string(type_length) + " wide");
+  }
+}
+
+template <>
+inline void PlainEncoder<FLBAType>::Put(const ::arrow::Array& values) {
+  AssertFixedSizeBinary(values, descr_->type_length());
+  const auto& data = checked_cast<const ::arrow::FixedSizeBinaryArray&>(values);
+
+  if (data.null_count() == 0) {
+    // no nulls, just dump the data
+    PARQUET_THROW_NOT_OK(
+        sink_.Append(data.raw_values(), data.length() * data.byte_width()));
+  } else {
+    const int64_t total_bytes = data.length() * data.byte_width() -
+        data.null_count() * data.byte_width();
+    PARQUET_THROW_NOT_OK(sink_.Reserve(total_bytes));
+    for (int64_t i = 0; i < data.length(); i++) {
+      if (data.IsValid(i)) {
+        sink_.UnsafeAppend(data.Value(i), data.byte_width());
+      }
+    }
+  }
+}
+
+template <>
+inline void PlainEncoder<FLBAType>::Put(
+    const FixedLenByteArray* src,
+    int num_values) {
+  if (descr_->type_length() == 0) {
+    return;
+  }
+  for (int i = 0; i < num_values; ++i) {
+    // Write the result to the output stream
+    DCHECK(src[i].ptr != nullptr) << "Value ptr cannot be NULL";
+    PARQUET_THROW_NOT_OK(sink_.Append(src[i].ptr, descr_->type_length()));
+  }
+}
+
+template <>
+class PlainEncoder<BooleanType> : public EncoderImpl,
+                                  virtual public BooleanEncoder {
+ public:
+  explicit PlainEncoder(const ColumnDescriptor* descr, MemoryPool* pool)
+      : EncoderImpl(descr, Encoding::PLAIN, pool),
+        bits_available_(kInMemoryDefaultCapacity * 8),
+        bits_buffer_(AllocateBuffer(pool, kInMemoryDefaultCapacity)),
+        sink_(pool),
+        bit_writer_(
+            bits_buffer_->mutable_data(),
+            static_cast<int>(bits_buffer_->size())) {}
+
+  int64_t EstimatedDataEncodedSize() override;
+  std::shared_ptr<Buffer> FlushValues() override;
+
+  void Put(const bool* src, int num_values) override;
+
+  void Put(const std::vector<bool>& src, int num_values) override;
+
+  void PutSpaced(
+      const bool* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    if (valid_bits != NULLPTR) {
+      PARQUET_ASSIGN_OR_THROW(
+          auto buffer,
+          ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+      T* data = reinterpret_cast<T*>(buffer->mutable_data());
+      int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+          src, num_values, valid_bits, valid_bits_offset, data);
+      Put(data, num_valid_values);
+    } else {
+      Put(src, num_values);
+    }
+  }
+
+  void Put(const ::arrow::Array& values) override {
+    if (values.type_id() != ::arrow::Type::BOOL) {
+      throw ParquetException(
+          "direct put to boolean from " + values.type()->ToString() +
+          " not supported");
+    }
+
+    const auto& data = checked_cast<const ::arrow::BooleanArray&>(values);
+    if (data.null_count() == 0) {
+      PARQUET_THROW_NOT_OK(
+          sink_.Reserve(bit_util::BytesForBits(data.length())));
+      // no nulls, just dump the data
+      ::arrow::internal::CopyBitmap(
+          data.data()->GetValues<uint8_t>(1),
+          data.offset(),
+          data.length(),
+          sink_.mutable_data(),
+          sink_.length());
+    } else {
+      auto n_valid = bit_util::BytesForBits(data.length() - data.null_count());
+      PARQUET_THROW_NOT_OK(sink_.Reserve(n_valid));
+      ::arrow::internal::FirstTimeBitmapWriter writer(
+          sink_.mutable_data(), sink_.length(), n_valid);
+
+      for (int64_t i = 0; i < data.length(); i++) {
+        if (data.IsValid(i)) {
+          if (data.Value(i)) {
+            writer.Set();
+          } else {
+            writer.Clear();
+          }
+          writer.Next();
+        }
+      }
+      writer.Finish();
+    }
+    sink_.UnsafeAdvance(data.length());
+  }
+
+ private:
+  int bits_available_;
+  std::shared_ptr<ResizableBuffer> bits_buffer_;
+  ::arrow::BufferBuilder sink_;
+  ::arrow::bit_util::BitWriter bit_writer_;
+
+  template <typename SequenceType>
+  void PutImpl(const SequenceType& src, int num_values);
+};
+
+template <typename SequenceType>
+void PlainEncoder<BooleanType>::PutImpl(
+    const SequenceType& src,
+    int num_values) {
+  int bit_offset = 0;
+  if (bits_available_ > 0) {
+    int bits_to_write = std::min(bits_available_, num_values);
+    for (int i = 0; i < bits_to_write; i++) {
+      bit_writer_.PutValue(src[i], 1);
+    }
+    bits_available_ -= bits_to_write;
+    bit_offset = bits_to_write;
+
+    if (bits_available_ == 0) {
+      bit_writer_.Flush();
+      PARQUET_THROW_NOT_OK(
+          sink_.Append(bit_writer_.buffer(), bit_writer_.bytes_written()));
+      bit_writer_.Clear();
+    }
+  }
+
+  int bits_remaining = num_values - bit_offset;
+  while (bit_offset < num_values) {
+    bits_available_ = static_cast<int>(bits_buffer_->size()) * 8;
+
+    int bits_to_write = std::min(bits_available_, bits_remaining);
+    for (int i = bit_offset; i < bit_offset + bits_to_write; i++) {
+      bit_writer_.PutValue(src[i], 1);
+    }
+    bit_offset += bits_to_write;
+    bits_available_ -= bits_to_write;
+    bits_remaining -= bits_to_write;
+
+    if (bits_available_ == 0) {
+      bit_writer_.Flush();
+      PARQUET_THROW_NOT_OK(
+          sink_.Append(bit_writer_.buffer(), bit_writer_.bytes_written()));
+      bit_writer_.Clear();
+    }
+  }
+}
+
+int64_t PlainEncoder<BooleanType>::EstimatedDataEncodedSize() {
+  int64_t position = sink_.length();
+  return position + bit_writer_.bytes_written();
+}
+
+std::shared_ptr<Buffer> PlainEncoder<BooleanType>::FlushValues() {
+  if (bits_available_ > 0) {
+    bit_writer_.Flush();
+    PARQUET_THROW_NOT_OK(
+        sink_.Append(bit_writer_.buffer(), bit_writer_.bytes_written()));
+    bit_writer_.Clear();
+    bits_available_ = static_cast<int>(bits_buffer_->size()) * 8;
+  }
+
+  std::shared_ptr<Buffer> buffer;
+  PARQUET_THROW_NOT_OK(sink_.Finish(&buffer));
+  return buffer;
+}
+
+void PlainEncoder<BooleanType>::Put(const bool* src, int num_values) {
+  PutImpl(src, num_values);
+}
+
+void PlainEncoder<BooleanType>::Put(
+    const std::vector<bool>& src,
+    int num_values) {
+  PutImpl(src, num_values);
+}
+
+// ----------------------------------------------------------------------
+// DictEncoder<T> implementations
+
+template <typename DType>
+struct DictEncoderTraits {
+  using c_type = typename DType::c_type;
+  using MemoTableType = ::arrow::internal::ScalarMemoTable<c_type>;
+};
+
+template <>
+struct DictEncoderTraits<ByteArrayType> {
+  using MemoTableType =
+      ::arrow::internal::BinaryMemoTable<::arrow::BinaryBuilder>;
+};
+
+template <>
+struct DictEncoderTraits<FLBAType> {
+  using MemoTableType =
+      ::arrow::internal::BinaryMemoTable<::arrow::BinaryBuilder>;
+};
+
+// Initially 1024 elements
+static constexpr int32_t kInitialHashTableSize = 1 << 10;
+
+int RlePreserveBufferSize(int num_values, int bit_width) {
+  // Note: because of the way RleEncoder::CheckBufferFull()
+  // is called, we have to reserve an extra "RleEncoder::MinBufferSize"
+  // bytes. These extra bytes won't be used but not reserving them
+  // would cause the encoder to fail.
+  return ::arrow::util::RleEncoder::MaxBufferSize(bit_width, num_values) +
+      ::arrow::util::RleEncoder::MinBufferSize(bit_width);
+}
+
+/// See the dictionary encoding section of
+/// https://github.com/Parquet/parquet-format.  The encoding supports
+/// streaming encoding. Values are encoded as they are added while the
+/// dictionary is being constructed. At any time, the buffered values
+/// can be written out with the current dictionary size. More values
+/// can then be added to the encoder, including new dictionary
+/// entries.
+template <typename DType>
+class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
+  using MemoTableType = typename DictEncoderTraits<DType>::MemoTableType;
+
+ public:
+  typedef typename DType::c_type T;
+
+  /// In data page, the bit width used to encode the entry
+  /// ids stored as 1 byte (max bit width = 32).
+  constexpr static int32_t kDataPageBitWidthBytes = 1;
+
+  explicit DictEncoderImpl(const ColumnDescriptor* desc, MemoryPool* pool)
+      : EncoderImpl(desc, Encoding::PLAIN_DICTIONARY, pool),
+        buffered_indices_(::arrow::stl::allocator<int32_t>(pool)),
+        dict_encoded_size_(0),
+        memo_table_(pool, kInitialHashTableSize) {}
+
+  ~DictEncoderImpl() override {
+    DCHECK(buffered_indices_.empty());
+  }
+
+  int dict_encoded_size() const override {
+    return dict_encoded_size_;
+  }
+
+  int WriteIndices(uint8_t* buffer, int buffer_len) override {
+    // Write bit width in first byte
+    *buffer = static_cast<uint8_t>(bit_width());
+    ++buffer;
+    --buffer_len;
+
+    ::arrow::util::RleEncoder encoder(buffer, buffer_len, bit_width());
+
+    for (int32_t index : buffered_indices_) {
+      if (ARROW_PREDICT_FALSE(!encoder.Put(index)))
+        return -1;
+    }
+    encoder.Flush();
+
+    ClearIndices();
+    return kDataPageBitWidthBytes + encoder.len();
+  }
+
+  void set_type_length(int type_length) {
+    this->type_length_ = type_length;
+  }
+
+  /// Returns a conservative estimate of the number of bytes needed to encode
+  /// the buffered indices. Used to size the buffer passed to WriteIndices().
+  int64_t EstimatedDataEncodedSize() override {
+    return kDataPageBitWidthBytes +
+        RlePreserveBufferSize(
+               static_cast<int>(buffered_indices_.size()), bit_width());
+  }
+
+  /// The minimum bit width required to encode the currently buffered indices.
+  int bit_width() const override {
+    if (ARROW_PREDICT_FALSE(num_entries() == 0))
+      return 0;
+    if (ARROW_PREDICT_FALSE(num_entries() == 1))
+      return 1;
+    return bit_util::Log2(num_entries());
+  }
+
+  /// Encode value. Note that this does not actually write any data, just
+  /// buffers the value's index to be written later.
+  inline void Put(const T& value);
+
+  // Not implemented for other data types
+  inline void PutByteArray(const void* ptr, int32_t length);
+
+  void Put(const T* src, int num_values) override {
+    for (int32_t i = 0; i < num_values; i++) {
+      Put(SafeLoad(src + i));
+    }
+  }
+
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    ::arrow::internal::VisitSetBitRunsVoid(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        [&](int64_t position, int64_t length) {
+          for (int64_t i = 0; i < length; i++) {
+            Put(SafeLoad(src + i + position));
+          }
+        });
+  }
+
+  using TypedEncoder<DType>::Put;
+
+  void Put(const ::arrow::Array& values) override;
+  void PutDictionary(const ::arrow::Array& values) override;
+
+  template <typename ArrowType, typename T = typename ArrowType::c_type>
+  void PutIndicesTyped(const ::arrow::Array& data) {
+    auto values = data.data()->GetValues<T>(1);
+    size_t buffer_position = buffered_indices_.size();
+    buffered_indices_.resize(
+        buffer_position +
+        static_cast<size_t>(data.length() - data.null_count()));
+    ::arrow::internal::VisitSetBitRunsVoid(
+        data.null_bitmap_data(),
+        data.offset(),
+        data.length(),
+        [&](int64_t position, int64_t length) {
+          for (int64_t i = 0; i < length; ++i) {
+            buffered_indices_[buffer_position++] =
+                static_cast<int32_t>(values[i + position]);
+          }
+        });
+  }
+
+  void PutIndices(const ::arrow::Array& data) override {
+    switch (data.type()->id()) {
+      case ::arrow::Type::UINT8:
+      case ::arrow::Type::INT8:
+        return PutIndicesTyped<::arrow::UInt8Type>(data);
+      case ::arrow::Type::UINT16:
+      case ::arrow::Type::INT16:
+        return PutIndicesTyped<::arrow::UInt16Type>(data);
+      case ::arrow::Type::UINT32:
+      case ::arrow::Type::INT32:
+        return PutIndicesTyped<::arrow::UInt32Type>(data);
+      case ::arrow::Type::UINT64:
+      case ::arrow::Type::INT64:
+        return PutIndicesTyped<::arrow::UInt64Type>(data);
+      default:
+        throw ParquetException("Passed non-integer array to PutIndices");
+    }
+  }
+
+  std::shared_ptr<Buffer> FlushValues() override {
+    std::shared_ptr<ResizableBuffer> buffer =
+        AllocateBuffer(this->pool_, EstimatedDataEncodedSize());
+    int result_size = WriteIndices(
+        buffer->mutable_data(), static_cast<int>(EstimatedDataEncodedSize()));
+    PARQUET_THROW_NOT_OK(buffer->Resize(result_size, false));
+    return std::move(buffer);
+  }
+
+  /// Writes out the encoded dictionary to buffer. buffer must be preallocated
+  /// to dict_encoded_size() bytes.
+  void WriteDict(uint8_t* buffer) const override;
+
+  /// The number of entries in the dictionary.
+  int num_entries() const override {
+    return memo_table_.size();
+  }
+
+ private:
+  /// Clears all the indices (but leaves the dictionary).
+  void ClearIndices() {
+    buffered_indices_.clear();
+  }
+
+  /// Indices that have not yet be written out by WriteIndices().
+  ArrowPoolVector<int32_t> buffered_indices_;
+
+  template <typename ArrayType>
+  void PutBinaryArray(const ArrayType& array) {
+    PARQUET_THROW_NOT_OK(
+        ::arrow::VisitArraySpanInline<typename ArrayType::TypeClass>(
+            *array.data(),
+            [&](::std::string_view view) {
+              if (ARROW_PREDICT_FALSE(view.size() > kMaxByteArraySize)) {
+                return Status::Invalid(
+                    "Parquet cannot store strings with size 2GB or more");
+              }
+              PutByteArray(view.data(), static_cast<uint32_t>(view.size()));
+              return Status::OK();
+            },
+            []() { return Status::OK(); }));
+  }
+
+  template <typename ArrayType>
+  void PutBinaryDictionaryArray(const ArrayType& array) {
+    DCHECK_EQ(array.null_count(), 0);
+    for (int64_t i = 0; i < array.length(); i++) {
+      auto v = array.GetView(i);
+      if (ARROW_PREDICT_FALSE(v.size() > kMaxByteArraySize)) {
+        throw ParquetException(
+            "Parquet cannot store strings with size 2GB or more");
+      }
+      dict_encoded_size_ += static_cast<int>(v.size() + sizeof(uint32_t));
+      int32_t unused_memo_index;
+      PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
+          v.data(), static_cast<int32_t>(v.size()), &unused_memo_index));
+    }
+  }
+
+  /// The number of bytes needed to encode the dictionary.
+  int dict_encoded_size_;
+
+  MemoTableType memo_table_;
+};
+
+template <typename DType>
+void DictEncoderImpl<DType>::WriteDict(uint8_t* buffer) const {
+  // For primitive types, only a memcpy
+  DCHECK_EQ(
+      static_cast<size_t>(dict_encoded_size_), sizeof(T) * memo_table_.size());
+  memo_table_.CopyValues(0 /* start_pos */, reinterpret_cast<T*>(buffer));
+}
+
+// ByteArray and FLBA already have the dictionary encoded in their data heaps
+template <>
+void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) const {
+  memo_table_.VisitValues(0, [&buffer](::std::string_view v) {
+    uint32_t len = static_cast<uint32_t>(v.length());
+    memcpy(buffer, &len, sizeof(len));
+    buffer += sizeof(len);
+    memcpy(buffer, v.data(), len);
+    buffer += len;
+  });
+}
+
+template <>
+void DictEncoderImpl<FLBAType>::WriteDict(uint8_t* buffer) const {
+  memo_table_.VisitValues(0, [&](::std::string_view v) {
+    DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
+    memcpy(buffer, v.data(), type_length_);
+    buffer += type_length_;
+  });
+}
+
+template <typename DType>
+inline void DictEncoderImpl<DType>::Put(const T& v) {
+  // Put() implementation for primitive types
+  auto on_found = [](int32_t memo_index) {};
+  auto on_not_found = [this](int32_t memo_index) {
+    dict_encoded_size_ += static_cast<int>(sizeof(T));
+  };
+
+  int32_t memo_index;
+  PARQUET_THROW_NOT_OK(
+      memo_table_.GetOrInsert(v, on_found, on_not_found, &memo_index));
+  buffered_indices_.push_back(memo_index);
+}
+
+template <typename DType>
+inline void DictEncoderImpl<DType>::PutByteArray(
+    const void* ptr,
+    int32_t length) {
+  DCHECK(false);
+}
+
+template <>
+inline void DictEncoderImpl<ByteArrayType>::PutByteArray(
+    const void* ptr,
+    int32_t length) {
+  static const uint8_t empty[] = {0};
+
+  auto on_found = [](int32_t memo_index) {};
+  auto on_not_found = [&](int32_t memo_index) {
+    dict_encoded_size_ += static_cast<int>(length + sizeof(uint32_t));
+  };
+
+  DCHECK(ptr != nullptr || length == 0);
+  ptr = (ptr != nullptr) ? ptr : empty;
+  int32_t memo_index;
+  PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
+      ptr, length, on_found, on_not_found, &memo_index));
+  buffered_indices_.push_back(memo_index);
+}
+
+template <>
+inline void DictEncoderImpl<ByteArrayType>::Put(const ByteArray& val) {
+  return PutByteArray(val.ptr, static_cast<int32_t>(val.len));
+}
+
+template <>
+inline void DictEncoderImpl<FLBAType>::Put(const FixedLenByteArray& v) {
+  static const uint8_t empty[] = {0};
+
+  auto on_found = [](int32_t memo_index) {};
+  auto on_not_found = [this](int32_t memo_index) {
+    dict_encoded_size_ += type_length_;
+  };
+
+  DCHECK(v.ptr != nullptr || type_length_ == 0);
+  const void* ptr = (v.ptr != nullptr) ? v.ptr : empty;
+  int32_t memo_index;
+  PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
+      ptr, type_length_, on_found, on_not_found, &memo_index));
+  buffered_indices_.push_back(memo_index);
+}
+
+template <>
+void DictEncoderImpl<Int96Type>::Put(const ::arrow::Array& values) {
+  ParquetException::NYI("Direct put to Int96");
+}
+
+template <>
+void DictEncoderImpl<Int96Type>::PutDictionary(const ::arrow::Array& values) {
+  ParquetException::NYI("Direct put to Int96");
+}
+
+template <typename DType>
+void DictEncoderImpl<DType>::Put(const ::arrow::Array& values) {
+  using ArrayType =
+      typename ::arrow::CTypeTraits<typename DType::c_type>::ArrayType;
+  const auto& data = checked_cast<const ArrayType&>(values);
+  if (data.null_count() == 0) {
+    // no nulls, just dump the data
+    for (int64_t i = 0; i < data.length(); i++) {
+      Put(data.Value(i));
+    }
+  } else {
+    for (int64_t i = 0; i < data.length(); i++) {
+      if (data.IsValid(i)) {
+        Put(data.Value(i));
+      }
+    }
+  }
+}
+
+template <>
+void DictEncoderImpl<FLBAType>::Put(const ::arrow::Array& values) {
+  AssertFixedSizeBinary(values, type_length_);
+  const auto& data = checked_cast<const ::arrow::FixedSizeBinaryArray&>(values);
+  if (data.null_count() == 0) {
+    // no nulls, just dump the data
+    for (int64_t i = 0; i < data.length(); i++) {
+      Put(FixedLenByteArray(data.Value(i)));
+    }
+  } else {
+    std::vector<uint8_t> empty(type_length_, 0);
+    for (int64_t i = 0; i < data.length(); i++) {
+      if (data.IsValid(i)) {
+        Put(FixedLenByteArray(data.Value(i)));
+      }
+    }
+  }
+}
+
+template <>
+void DictEncoderImpl<ByteArrayType>::Put(const ::arrow::Array& values) {
+  AssertBaseBinary(values);
+  if (::arrow::is_binary_like(values.type_id())) {
+    PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  }
+}
+
+template <typename DType>
+void AssertCanPutDictionary(
+    DictEncoderImpl<DType>* encoder,
+    const ::arrow::Array& dict) {
+  if (dict.null_count() > 0) {
+    throw ParquetException("Inserted dictionary cannot cannot contain nulls");
+  }
+
+  if (encoder->num_entries() > 0) {
+    throw ParquetException(
+        "Can only call PutDictionary on an empty DictEncoder");
+  }
+}
+
+template <typename DType>
+void DictEncoderImpl<DType>::PutDictionary(const ::arrow::Array& values) {
+  AssertCanPutDictionary(this, values);
+
+  using ArrayType =
+      typename ::arrow::CTypeTraits<typename DType::c_type>::ArrayType;
+  const auto& data = checked_cast<const ArrayType&>(values);
+
+  dict_encoded_size_ +=
+      static_cast<int>(sizeof(typename DType::c_type) * data.length());
+  for (int64_t i = 0; i < data.length(); i++) {
+    int32_t unused_memo_index;
+    PARQUET_THROW_NOT_OK(
+        memo_table_.GetOrInsert(data.Value(i), &unused_memo_index));
+  }
+}
+
+template <>
+void DictEncoderImpl<FLBAType>::PutDictionary(const ::arrow::Array& values) {
+  AssertFixedSizeBinary(values, type_length_);
+  AssertCanPutDictionary(this, values);
+
+  const auto& data = checked_cast<const ::arrow::FixedSizeBinaryArray&>(values);
+
+  dict_encoded_size_ += static_cast<int>(type_length_ * data.length());
+  for (int64_t i = 0; i < data.length(); i++) {
+    int32_t unused_memo_index;
+    PARQUET_THROW_NOT_OK(memo_table_.GetOrInsert(
+        data.Value(i), type_length_, &unused_memo_index));
+  }
+}
+
+template <>
+void DictEncoderImpl<ByteArrayType>::PutDictionary(
+    const ::arrow::Array& values) {
+  AssertBaseBinary(values);
+  AssertCanPutDictionary(this, values);
+
+  if (::arrow::is_binary_like(values.type_id())) {
+    PutBinaryDictionaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+    PutBinaryDictionaryArray(
+        checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  }
+}
+
+// ----------------------------------------------------------------------
+// ByteStreamSplitEncoder<T> implementations
+
+template <typename DType>
+class ByteStreamSplitEncoder : public EncoderImpl,
+                               virtual public TypedEncoder<DType> {
+ public:
+  using T = typename DType::c_type;
+  using TypedEncoder<DType>::Put;
+
+  explicit ByteStreamSplitEncoder(
+      const ColumnDescriptor* descr,
+      ::arrow::MemoryPool* pool = ::arrow::default_memory_pool());
+
+  int64_t EstimatedDataEncodedSize() override;
+  std::shared_ptr<Buffer> FlushValues() override;
+
+  void Put(const T* buffer, int num_values) override;
+  void Put(const ::arrow::Array& values) override;
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override;
+
+ protected:
+  template <typename ArrowType>
+  void PutImpl(const ::arrow::Array& values) {
+    if (values.type_id() != ArrowType::type_id) {
+      throw ParquetException(
+          std::string() + "direct put to " + ArrowType::type_name() + " from " +
+          values.type()->ToString() + " not supported");
+    }
+    const auto& data = *values.data();
+    PutSpaced(
+        data.GetValues<typename ArrowType::c_type>(1),
+        static_cast<int>(data.length),
+        data.GetValues<uint8_t>(0, 0),
+        data.offset);
+  }
+
+  ::arrow::BufferBuilder sink_;
+  int64_t num_values_in_buffer_;
+};
+
+template <typename DType>
+ByteStreamSplitEncoder<DType>::ByteStreamSplitEncoder(
+    const ColumnDescriptor* descr,
+    ::arrow::MemoryPool* pool)
+    : EncoderImpl(descr, Encoding::BYTE_STREAM_SPLIT, pool),
+      sink_{pool},
+      num_values_in_buffer_{0} {}
+
+template <typename DType>
+int64_t ByteStreamSplitEncoder<DType>::EstimatedDataEncodedSize() {
+  return sink_.length();
+}
+
+template <typename DType>
+std::shared_ptr<Buffer> ByteStreamSplitEncoder<DType>::FlushValues() {
+  std::shared_ptr<ResizableBuffer> output_buffer =
+      AllocateBuffer(this->memory_pool(), EstimatedDataEncodedSize());
+  uint8_t* output_buffer_raw = output_buffer->mutable_data();
+  const uint8_t* raw_values = sink_.data();
+  ::arrow::util::internal::ByteStreamSplitEncode<T>(
+      raw_values, num_values_in_buffer_, output_buffer_raw);
+  sink_.Reset();
+  num_values_in_buffer_ = 0;
+  return std::move(output_buffer);
+}
+
+template <typename DType>
+void ByteStreamSplitEncoder<DType>::Put(const T* buffer, int num_values) {
+  if (num_values > 0) {
+    PARQUET_THROW_NOT_OK(sink_.Append(buffer, num_values * sizeof(T)));
+    num_values_in_buffer_ += num_values;
+  }
+}
+
+template <>
+void ByteStreamSplitEncoder<FloatType>::Put(const ::arrow::Array& values) {
+  PutImpl<::arrow::FloatType>(values);
+}
+
+template <>
+void ByteStreamSplitEncoder<DoubleType>::Put(const ::arrow::Array& values) {
+  PutImpl<::arrow::DoubleType>(values);
+}
+
+template <typename DType>
+void ByteStreamSplitEncoder<DType>::PutSpaced(
+    const T* src,
+    int num_values,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset) {
+  if (valid_bits != NULLPTR) {
+    PARQUET_ASSIGN_OR_THROW(
+        auto buffer,
+        ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+    T* data = reinterpret_cast<T*>(buffer->mutable_data());
+    int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+        src, num_values, valid_bits, valid_bits_offset, data);
+    Put(data, num_valid_values);
+  } else {
+    Put(src, num_values);
+  }
+}
+
+class DecoderImpl : virtual public Decoder {
+ public:
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    num_values_ = num_values;
+    data_ = data;
+    len_ = len;
+  }
+
+  int values_left() const override {
+    return num_values_;
+  }
+  Encoding::type encoding() const override {
+    return encoding_;
+  }
+
+ protected:
+  explicit DecoderImpl(const ColumnDescriptor* descr, Encoding::type encoding)
+      : descr_(descr),
+        encoding_(encoding),
+        num_values_(0),
+        data_(NULLPTR),
+        len_(0) {}
+
+  // For accessing type-specific metadata, like FIXED_LEN_BYTE_ARRAY
+  const ColumnDescriptor* descr_;
+
+  const Encoding::type encoding_;
+  int num_values_;
+  const uint8_t* data_;
+  int len_;
+  int type_length_;
+};
+
+template <typename DType>
+class PlainDecoder : public DecoderImpl, virtual public TypedDecoder<DType> {
+ public:
+  using T = typename DType::c_type;
+  explicit PlainDecoder(const ColumnDescriptor* descr);
+
+  int Decode(T* buffer, int max_values) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::Accumulator* builder) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::DictAccumulator* builder) override;
+};
+
+template <>
+inline int PlainDecoder<Int96Type>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<Int96Type>::Accumulator* builder) {
+  ParquetException::NYI("DecodeArrow not supported for Int96");
+}
+
+template <>
+inline int PlainDecoder<Int96Type>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<Int96Type>::DictAccumulator* builder) {
+  ParquetException::NYI("DecodeArrow not supported for Int96");
+}
+
+template <>
+inline int PlainDecoder<BooleanType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<BooleanType>::DictAccumulator* builder) {
+  ParquetException::NYI("dictionaries of BooleanType");
+}
+
+template <typename DType>
+int PlainDecoder<DType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<DType>::Accumulator* builder) {
+  using value_type = typename DType::c_type;
+
+  constexpr int value_size = static_cast<int>(sizeof(value_type));
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(len_ < value_size * values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        builder->UnsafeAppend(SafeLoadAs<value_type>(data_));
+        data_ += sizeof(value_type);
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+  num_values_ -= values_decoded;
+  len_ -= sizeof(value_type) * values_decoded;
+  return values_decoded;
+}
+
+template <typename DType>
+int PlainDecoder<DType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<DType>::DictAccumulator* builder) {
+  using value_type = typename DType::c_type;
+
+  constexpr int value_size = static_cast<int>(sizeof(value_type));
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(len_ < value_size * values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        PARQUET_THROW_NOT_OK(builder->Append(SafeLoadAs<value_type>(data_)));
+        data_ += sizeof(value_type);
+      },
+      [&]() { PARQUET_THROW_NOT_OK(builder->AppendNull()); });
+
+  num_values_ -= values_decoded;
+  len_ -= sizeof(value_type) * values_decoded;
+  return values_decoded;
+}
+
+// Decode routine templated on C++ type rather than type enum
+template <typename T>
+inline int DecodePlain(
+    const uint8_t* data,
+    int64_t data_size,
+    int num_values,
+    int type_length,
+    T* out) {
+  int64_t bytes_to_decode = num_values * static_cast<int64_t>(sizeof(T));
+  if (bytes_to_decode > data_size || bytes_to_decode > INT_MAX) {
+    ParquetException::EofException();
+  }
+  // If bytes_to_decode == 0, data could be null
+  if (bytes_to_decode > 0) {
+    memcpy(out, data, bytes_to_decode);
+  }
+  return static_cast<int>(bytes_to_decode);
+}
+
+template <typename DType>
+PlainDecoder<DType>::PlainDecoder(const ColumnDescriptor* descr)
+    : DecoderImpl(descr, Encoding::PLAIN) {
+  if (descr_ && descr_->physical_type() == Type::FIXED_LEN_BYTE_ARRAY) {
+    type_length_ = descr_->type_length();
+  } else {
+    type_length_ = -1;
+  }
+}
+
+// Template specialization for BYTE_ARRAY. The written values do not own their
+// own data.
+
+static inline int64_t
+ReadByteArray(const uint8_t* data, int64_t data_size, ByteArray* out) {
+  if (ARROW_PREDICT_FALSE(data_size < 4)) {
+    ParquetException::EofException();
+  }
+  const int32_t len = SafeLoadAs<int32_t>(data);
+  if (len < 0) {
+    throw ParquetException("Invalid BYTE_ARRAY value");
+  }
+  const int64_t consumed_length = static_cast<int64_t>(len) + 4;
+  if (ARROW_PREDICT_FALSE(data_size < consumed_length)) {
+    ParquetException::EofException();
+  }
+  *out = ByteArray{static_cast<uint32_t>(len), data + 4};
+  return consumed_length;
+}
+
+template <>
+inline int DecodePlain<ByteArray>(
+    const uint8_t* data,
+    int64_t data_size,
+    int num_values,
+    int type_length,
+    ByteArray* out) {
+  int bytes_decoded = 0;
+  for (int i = 0; i < num_values; ++i) {
+    const auto increment = ReadByteArray(data, data_size, out + i);
+    if (ARROW_PREDICT_FALSE(increment > INT_MAX - bytes_decoded)) {
+      throw ParquetException("BYTE_ARRAY chunk too large");
+    }
+    data += increment;
+    data_size -= increment;
+    bytes_decoded += static_cast<int>(increment);
+  }
+  return bytes_decoded;
+}
+
+// Template specialization for FIXED_LEN_BYTE_ARRAY. The written values do not
+// own their own data.
+template <>
+inline int DecodePlain<FixedLenByteArray>(
+    const uint8_t* data,
+    int64_t data_size,
+    int num_values,
+    int type_length,
+    FixedLenByteArray* out) {
+  int64_t bytes_to_decode = static_cast<int64_t>(type_length) * num_values;
+  if (bytes_to_decode > data_size || bytes_to_decode > INT_MAX) {
+    ParquetException::EofException();
+  }
+  for (int i = 0; i < num_values; ++i) {
+    out[i].ptr = data;
+    data += type_length;
+    data_size -= type_length;
+  }
+  return static_cast<int>(bytes_to_decode);
+}
+
+template <typename DType>
+int PlainDecoder<DType>::Decode(T* buffer, int max_values) {
+  max_values = std::min(max_values, num_values_);
+  int bytes_consumed =
+      DecodePlain<T>(data_, len_, max_values, type_length_, buffer);
+  data_ += bytes_consumed;
+  len_ -= bytes_consumed;
+  num_values_ -= max_values;
+  return max_values;
+}
+
+class PlainBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
+ public:
+  explicit PlainBooleanDecoder(const ColumnDescriptor* descr);
+  void SetData(int num_values, const uint8_t* data, int len) override;
+
+  // Two flavors of bool decoding
+  int Decode(uint8_t* buffer, int max_values) override;
+  int Decode(bool* buffer, int max_values) override;
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<BooleanType>::Accumulator* out) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<BooleanType>::DictAccumulator* out) override;
+
+ private:
+  std::unique_ptr<::arrow::bit_util::BitReader> bit_reader_;
+};
+
+PlainBooleanDecoder::PlainBooleanDecoder(const ColumnDescriptor* descr)
+    : DecoderImpl(descr, Encoding::PLAIN) {}
+
+void PlainBooleanDecoder::SetData(
+    int num_values,
+    const uint8_t* data,
+    int len) {
+  num_values_ = num_values;
+  bit_reader_ = std::make_unique<bit_util::BitReader>(data, len);
+}
+
+int PlainBooleanDecoder::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<BooleanType>::Accumulator* builder) {
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(num_values_ < values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        bool value;
+        ARROW_IGNORE_EXPR(bit_reader_->GetValue(1, &value));
+        builder->UnsafeAppend(value);
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+  num_values_ -= values_decoded;
+  return values_decoded;
+}
+
+inline int PlainBooleanDecoder::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<BooleanType>::DictAccumulator* builder) {
+  ParquetException::NYI("dictionaries of BooleanType");
+}
+
+int PlainBooleanDecoder::Decode(uint8_t* buffer, int max_values) {
+  max_values = std::min(max_values, num_values_);
+  bool val;
+  ::arrow::internal::BitmapWriter bit_writer(buffer, 0, max_values);
+  for (int i = 0; i < max_values; ++i) {
+    if (!bit_reader_->GetValue(1, &val)) {
+      ParquetException::EofException();
+    }
+    if (val) {
+      bit_writer.Set();
+    }
+    bit_writer.Next();
+  }
+  bit_writer.Finish();
+  num_values_ -= max_values;
+  return max_values;
+}
+
+int PlainBooleanDecoder::Decode(bool* buffer, int max_values) {
+  max_values = std::min(max_values, num_values_);
+  if (bit_reader_->GetBatch(1, buffer, max_values) != max_values) {
+    ParquetException::EofException();
+  }
+  num_values_ -= max_values;
+  return max_values;
+}
+
+struct ArrowBinaryHelper {
+  explicit ArrowBinaryHelper(
+      typename EncodingTraits<ByteArrayType>::Accumulator* out) {
+    this->out = out;
+    this->builder = out->builder.get();
+    this->chunk_space_remaining =
+        ::arrow::kBinaryMemoryLimit - this->builder->value_data_length();
+  }
+
+  Status PushChunk() {
+    std::shared_ptr<::arrow::Array> result;
+    RETURN_NOT_OK(builder->Finish(&result));
+    out->chunks.push_back(result);
+    chunk_space_remaining = ::arrow::kBinaryMemoryLimit;
+    return Status::OK();
+  }
+
+  bool CanFit(int64_t length) const {
+    return length <= chunk_space_remaining;
+  }
+
+  void UnsafeAppend(const uint8_t* data, int32_t length) {
+    chunk_space_remaining -= length;
+    builder->UnsafeAppend(data, length);
+  }
+
+  void UnsafeAppendNull() {
+    builder->UnsafeAppendNull();
+  }
+
+  Status Append(const uint8_t* data, int32_t length) {
+    chunk_space_remaining -= length;
+    return builder->Append(data, length);
+  }
+
+  Status AppendNull() {
+    return builder->AppendNull();
+  }
+
+  typename EncodingTraits<ByteArrayType>::Accumulator* out;
+  ::arrow::BinaryBuilder* builder;
+  int64_t chunk_space_remaining;
+};
+
+template <>
+inline int PlainDecoder<ByteArrayType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<ByteArrayType>::Accumulator* builder) {
+  ParquetException::NYI();
+}
+
+template <>
+inline int PlainDecoder<ByteArrayType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<ByteArrayType>::DictAccumulator* builder) {
+  ParquetException::NYI();
+}
+
+template <>
+inline int PlainDecoder<FLBAType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<FLBAType>::Accumulator* builder) {
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(len_ < descr_->type_length() * values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        builder->UnsafeAppend(data_);
+        data_ += descr_->type_length();
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+  num_values_ -= values_decoded;
+  len_ -= descr_->type_length() * values_decoded;
+  return values_decoded;
+}
+
+template <>
+inline int PlainDecoder<FLBAType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<FLBAType>::DictAccumulator* builder) {
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(len_ < descr_->type_length() * values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        PARQUET_THROW_NOT_OK(builder->Append(data_));
+        data_ += descr_->type_length();
+      },
+      [&]() { PARQUET_THROW_NOT_OK(builder->AppendNull()); });
+
+  num_values_ -= values_decoded;
+  len_ -= descr_->type_length() * values_decoded;
+  return values_decoded;
+}
+
+class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
+                              virtual public ByteArrayDecoder {
+ public:
+  using Base = PlainDecoder<ByteArrayType>;
+  using Base::DecodeSpaced;
+  using Base::PlainDecoder;
+
+  // ----------------------------------------------------------------------
+  // Dictionary read paths
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      ::arrow::BinaryDictionary32Builder* builder) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrow(
+        num_values,
+        null_count,
+        valid_bits,
+        valid_bits_offset,
+        builder,
+        &result));
+    return result;
+  }
+
+  // ----------------------------------------------------------------------
+  // Optimized dense binary read paths
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowDense(
+        num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    return result;
+  }
+
+ private:
+  Status DecodeArrowDense(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_values_decoded) {
+    ArrowBinaryHelper helper(out);
+    int values_decoded = 0;
+
+    RETURN_NOT_OK(helper.builder->Reserve(num_values));
+    RETURN_NOT_OK(helper.builder->ReserveData(
+        std::min<int64_t>(len_, helper.chunk_space_remaining)));
+
+    int i = 0;
+    RETURN_NOT_OK(VisitNullBitmapInline(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        null_count,
+        [&]() {
+          if (ARROW_PREDICT_FALSE(len_ < 4)) {
+            ParquetException::EofException();
+          }
+          auto value_len = SafeLoadAs<int32_t>(data_);
+          if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > INT32_MAX - 4)) {
+            return Status::Invalid(
+                "Invalid or corrupted value_len '", value_len, "'");
+          }
+          auto increment = value_len + 4;
+          if (ARROW_PREDICT_FALSE(len_ < increment)) {
+            ParquetException::EofException();
+          }
+          if (ARROW_PREDICT_FALSE(!helper.CanFit(value_len))) {
+            // This element would exceed the capacity of a chunk
+            RETURN_NOT_OK(helper.PushChunk());
+            RETURN_NOT_OK(helper.builder->Reserve(num_values - i));
+            RETURN_NOT_OK(helper.builder->ReserveData(
+                std::min<int64_t>(len_, helper.chunk_space_remaining)));
+          }
+          helper.UnsafeAppend(data_ + 4, value_len);
+          data_ += increment;
+          len_ -= increment;
+          ++values_decoded;
+          ++i;
+          return Status::OK();
+        },
+        [&]() {
+          helper.UnsafeAppendNull();
+          ++i;
+          return Status::OK();
+        }));
+
+    num_values_ -= values_decoded;
+    *out_values_decoded = values_decoded;
+    return Status::OK();
+  }
+
+  template <typename BuilderType>
+  Status DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      BuilderType* builder,
+      int* out_values_decoded) {
+    RETURN_NOT_OK(builder->Reserve(num_values));
+    int values_decoded = 0;
+
+    RETURN_NOT_OK(VisitNullBitmapInline(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        null_count,
+        [&]() {
+          if (ARROW_PREDICT_FALSE(len_ < 4)) {
+            ParquetException::EofException();
+          }
+          auto value_len = SafeLoadAs<int32_t>(data_);
+          if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > INT32_MAX - 4)) {
+            return Status::Invalid(
+                "Invalid or corrupted value_len '", value_len, "'");
+          }
+          auto increment = value_len + 4;
+          if (ARROW_PREDICT_FALSE(len_ < increment)) {
+            ParquetException::EofException();
+          }
+          RETURN_NOT_OK(builder->Append(data_ + 4, value_len));
+          data_ += increment;
+          len_ -= increment;
+          ++values_decoded;
+          return Status::OK();
+        },
+        [&]() { return builder->AppendNull(); }));
+
+    num_values_ -= values_decoded;
+    *out_values_decoded = values_decoded;
+    return Status::OK();
+  }
+};
+
+class PlainFLBADecoder : public PlainDecoder<FLBAType>,
+                         virtual public FLBADecoder {
+ public:
+  using Base = PlainDecoder<FLBAType>;
+  using Base::PlainDecoder;
+};
+
+// ----------------------------------------------------------------------
+// Dictionary encoding and decoding
+
+template <typename Type>
+class DictDecoderImpl : public DecoderImpl, virtual public DictDecoder<Type> {
+ public:
+  typedef typename Type::c_type T;
+
+  // Initializes the dictionary with values from 'dictionary'. The data in
+  // dictionary is not guaranteed to persist in memory after this call so the
+  // dictionary decoder needs to copy the data out if necessary.
+  explicit DictDecoderImpl(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool = ::arrow::default_memory_pool())
+      : DecoderImpl(descr, Encoding::RLE_DICTIONARY),
+        dictionary_(AllocateBuffer(pool, 0)),
+        dictionary_length_(0),
+        byte_array_data_(AllocateBuffer(pool, 0)),
+        byte_array_offsets_(AllocateBuffer(pool, 0)),
+        indices_scratch_space_(AllocateBuffer(pool, 0)) {}
+
+  // Perform type-specific initiatialization
+  void SetDict(TypedDecoder<Type>* dictionary) override;
+
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    num_values_ = num_values;
+    if (len == 0) {
+      // Initialize dummy decoder to avoid crashes later on
+      idx_decoder_ = ::arrow::util::RleDecoder(data, len, /*bit_width=*/1);
+      return;
+    }
+    uint8_t bit_width = *data;
+    if (ARROW_PREDICT_FALSE(bit_width > 32)) {
+      throw ParquetException(
+          "Invalid or corrupted bit_width " + std::to_string(bit_width) +
+          ". Maximum allowed is 32.");
+    }
+    idx_decoder_ = ::arrow::util::RleDecoder(++data, --len, bit_width);
+  }
+
+  int Decode(T* buffer, int num_values) override {
+    num_values = std::min(num_values, num_values_);
+    int decoded_values = idx_decoder_.GetBatchWithDict(
+        reinterpret_cast<const T*>(dictionary_->data()),
+        dictionary_length_,
+        buffer,
+        num_values);
+    if (decoded_values != num_values) {
+      ParquetException::EofException();
+    }
+    num_values_ -= num_values;
+    return num_values;
+  }
+
+  int DecodeSpaced(
+      T* buffer,
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    num_values = std::min(num_values, num_values_);
+    if (num_values !=
+        idx_decoder_.GetBatchWithDictSpaced(
+            reinterpret_cast<const T*>(dictionary_->data()),
+            dictionary_length_,
+            buffer,
+            num_values,
+            null_count,
+            valid_bits,
+            valid_bits_offset)) {
+      ParquetException::EofException();
+    }
+    num_values_ -= num_values;
+    return num_values;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<Type>::Accumulator* out) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<Type>::DictAccumulator* out) override;
+
+  void InsertDictionary(::arrow::ArrayBuilder* builder) override;
+
+  int DecodeIndicesSpaced(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      ::arrow::ArrayBuilder* builder) override {
+    if (num_values > 0) {
+      // TODO(wesm): Refactor to batch reads for improved memory use. It is not
+      // trivial because the null_count is relative to the entire bitmap
+      PARQUET_THROW_NOT_OK(indices_scratch_space_->TypedResize<int32_t>(
+          num_values, /*shrink_to_fit=*/false));
+    }
+
+    auto indices_buffer =
+        reinterpret_cast<int32_t*>(indices_scratch_space_->mutable_data());
+
+    if (num_values !=
+        idx_decoder_.GetBatchSpaced(
+            num_values,
+            null_count,
+            valid_bits,
+            valid_bits_offset,
+            indices_buffer)) {
+      ParquetException::EofException();
+    }
+
+    // XXX(wesm): Cannot append "valid bits" directly to the builder
+    std::vector<uint8_t> valid_bytes(num_values, 0);
+    int64_t i = 0;
+    VisitNullBitmapInline(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        null_count,
+        [&]() { valid_bytes[i++] = 1; },
+        [&]() { ++i; });
+
+    auto binary_builder =
+        checked_cast<::arrow::BinaryDictionary32Builder*>(builder);
+    PARQUET_THROW_NOT_OK(binary_builder->AppendIndices(
+        indices_buffer, num_values, valid_bytes.data()));
+    num_values_ -= num_values - null_count;
+    return num_values - null_count;
+  }
+
+  int DecodeIndices(int num_values, ::arrow::ArrayBuilder* builder) override {
+    num_values = std::min(num_values, num_values_);
+    if (num_values > 0) {
+      // TODO(wesm): Refactor to batch reads for improved memory use. This is
+      // relatively simple here because we don't have to do any bookkeeping of
+      // nulls
+      PARQUET_THROW_NOT_OK(indices_scratch_space_->TypedResize<int32_t>(
+          num_values, /*shrink_to_fit=*/false));
+    }
+    auto indices_buffer =
+        reinterpret_cast<int32_t*>(indices_scratch_space_->mutable_data());
+    if (num_values != idx_decoder_.GetBatch(indices_buffer, num_values)) {
+      ParquetException::EofException();
+    }
+    auto binary_builder =
+        checked_cast<::arrow::BinaryDictionary32Builder*>(builder);
+    PARQUET_THROW_NOT_OK(
+        binary_builder->AppendIndices(indices_buffer, num_values));
+    num_values_ -= num_values;
+    return num_values;
+  }
+
+  int DecodeIndices(int num_values, int32_t* indices) override {
+    if (num_values != idx_decoder_.GetBatch(indices, num_values)) {
+      ParquetException::EofException();
+    }
+    num_values_ -= num_values;
+    return num_values;
+  }
+
+  void GetDictionary(const T** dictionary, int32_t* dictionary_length)
+      override {
+    *dictionary_length = dictionary_length_;
+    *dictionary = reinterpret_cast<T*>(dictionary_->mutable_data());
+  }
+
+ protected:
+  Status IndexInBounds(int32_t index) {
+    if (ARROW_PREDICT_TRUE(0 <= index && index < dictionary_length_)) {
+      return Status::OK();
+    }
+    return Status::Invalid("Index not in dictionary bounds");
+  }
+
+  inline void DecodeDict(TypedDecoder<Type>* dictionary) {
+    dictionary_length_ = static_cast<int32_t>(dictionary->values_left());
+    PARQUET_THROW_NOT_OK(dictionary_->Resize(
+        dictionary_length_ * sizeof(T),
+        /*shrink_to_fit=*/false));
+    dictionary->Decode(
+        reinterpret_cast<T*>(dictionary_->mutable_data()), dictionary_length_);
+  }
+
+  // Only one is set.
+  std::shared_ptr<ResizableBuffer> dictionary_;
+
+  int32_t dictionary_length_;
+
+  // Data that contains the byte array data (byte_array_dictionary_ just has the
+  // pointers).
+  std::shared_ptr<ResizableBuffer> byte_array_data_;
+
+  // Arrow-style byte offsets for each dictionary value. We maintain two
+  // representations of the dictionary, one as ByteArray* for non-Arrow
+  // consumers and this one for Arrow consumers. Since dictionaries are
+  // generally pretty small to begin with this doesn't mean too much extra
+  // memory use in most cases
+  std::shared_ptr<ResizableBuffer> byte_array_offsets_;
+
+  // Reusable buffer for decoding dictionary indices to be appended to a
+  // BinaryDictionary32Builder
+  std::shared_ptr<ResizableBuffer> indices_scratch_space_;
+
+  ::arrow::util::RleDecoder idx_decoder_;
+};
+
+template <typename Type>
+void DictDecoderImpl<Type>::SetDict(TypedDecoder<Type>* dictionary) {
+  DecodeDict(dictionary);
+}
+
+template <>
+void DictDecoderImpl<BooleanType>::SetDict(
+    TypedDecoder<BooleanType>* dictionary) {
+  ParquetException::NYI(
+      "Dictionary encoding is not implemented for boolean values");
+}
+
+template <>
+void DictDecoderImpl<ByteArrayType>::SetDict(
+    TypedDecoder<ByteArrayType>* dictionary) {
+  DecodeDict(dictionary);
+
+  auto dict_values = reinterpret_cast<ByteArray*>(dictionary_->mutable_data());
+
+  int total_size = 0;
+  for (int i = 0; i < dictionary_length_; ++i) {
+    total_size += dict_values[i].len;
+  }
+  PARQUET_THROW_NOT_OK(byte_array_data_->Resize(
+      total_size,
+      /*shrink_to_fit=*/false));
+  PARQUET_THROW_NOT_OK(byte_array_offsets_->Resize(
+      (dictionary_length_ + 1) * sizeof(int32_t),
+      /*shrink_to_fit=*/false));
+
+  int32_t offset = 0;
+  uint8_t* bytes_data = byte_array_data_->mutable_data();
+  int32_t* bytes_offsets =
+      reinterpret_cast<int32_t*>(byte_array_offsets_->mutable_data());
+  for (int i = 0; i < dictionary_length_; ++i) {
+    memcpy(bytes_data + offset, dict_values[i].ptr, dict_values[i].len);
+    bytes_offsets[i] = offset;
+    dict_values[i].ptr = bytes_data + offset;
+    offset += dict_values[i].len;
+  }
+  bytes_offsets[dictionary_length_] = offset;
+}
+
+template <>
+inline void DictDecoderImpl<FLBAType>::SetDict(
+    TypedDecoder<FLBAType>* dictionary) {
+  DecodeDict(dictionary);
+
+  auto dict_values = reinterpret_cast<FLBA*>(dictionary_->mutable_data());
+
+  int fixed_len = descr_->type_length();
+  int total_size = dictionary_length_ * fixed_len;
+
+  PARQUET_THROW_NOT_OK(byte_array_data_->Resize(
+      total_size,
+      /*shrink_to_fit=*/false));
+  uint8_t* bytes_data = byte_array_data_->mutable_data();
+  for (int32_t i = 0, offset = 0; i < dictionary_length_;
+       ++i, offset += fixed_len) {
+    memcpy(bytes_data + offset, dict_values[i].ptr, fixed_len);
+    dict_values[i].ptr = bytes_data + offset;
+  }
+}
+
+template <>
+inline int DictDecoderImpl<Int96Type>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<Int96Type>::Accumulator* builder) {
+  ParquetException::NYI("DecodeArrow to Int96Type");
+}
+
+template <>
+inline int DictDecoderImpl<Int96Type>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<Int96Type>::DictAccumulator* builder) {
+  ParquetException::NYI("DecodeArrow to Int96Type");
+}
+
+template <>
+inline int DictDecoderImpl<ByteArrayType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<ByteArrayType>::Accumulator* builder) {
+  ParquetException::NYI("DecodeArrow implemented elsewhere");
+}
+
+template <>
+inline int DictDecoderImpl<ByteArrayType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<ByteArrayType>::DictAccumulator* builder) {
+  ParquetException::NYI("DecodeArrow implemented elsewhere");
+}
+
+template <typename DType>
+int DictDecoderImpl<DType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<DType>::DictAccumulator* builder) {
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  auto dict_values =
+      reinterpret_cast<const typename DType::c_type*>(dictionary_->data());
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        PARQUET_THROW_NOT_OK(IndexInBounds(index));
+        PARQUET_THROW_NOT_OK(builder->Append(dict_values[index]));
+      },
+      [&]() { PARQUET_THROW_NOT_OK(builder->AppendNull()); });
+
+  return num_values - null_count;
+}
+
+template <>
+int DictDecoderImpl<BooleanType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<BooleanType>::DictAccumulator* builder) {
+  ParquetException::NYI("No dictionary encoding for BooleanType");
+}
+
+template <>
+inline int DictDecoderImpl<FLBAType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<FLBAType>::Accumulator* builder) {
+  if (builder->byte_width() != descr_->type_length()) {
+    throw ParquetException(
+        "Byte width mismatch: builder was " +
+        std::to_string(builder->byte_width()) + " but decoder was " +
+        std::to_string(descr_->type_length()));
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  auto dict_values = reinterpret_cast<const FLBA*>(dictionary_->data());
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        PARQUET_THROW_NOT_OK(IndexInBounds(index));
+        builder->UnsafeAppend(dict_values[index].ptr);
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+  return num_values - null_count;
+}
+
+template <>
+int DictDecoderImpl<FLBAType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<FLBAType>::DictAccumulator* builder) {
+  auto value_type =
+      checked_cast<const ::arrow::DictionaryType&>(*builder->type())
+          .value_type();
+  auto byte_width =
+      checked_cast<const ::arrow::FixedSizeBinaryType&>(*value_type)
+          .byte_width();
+  if (byte_width != descr_->type_length()) {
+    throw ParquetException(
+        "Byte width mismatch: builder was " + std::to_string(byte_width) +
+        " but decoder was " + std::to_string(descr_->type_length()));
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  auto dict_values = reinterpret_cast<const FLBA*>(dictionary_->data());
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        PARQUET_THROW_NOT_OK(IndexInBounds(index));
+        PARQUET_THROW_NOT_OK(builder->Append(dict_values[index].ptr));
+      },
+      [&]() { PARQUET_THROW_NOT_OK(builder->AppendNull()); });
+
+  return num_values - null_count;
+}
+
+template <typename Type>
+int DictDecoderImpl<Type>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<Type>::Accumulator* builder) {
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  using value_type = typename Type::c_type;
+  auto dict_values = reinterpret_cast<const value_type*>(dictionary_->data());
+
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        int32_t index;
+        if (ARROW_PREDICT_FALSE(!idx_decoder_.Get(&index))) {
+          throw ParquetException("");
+        }
+        PARQUET_THROW_NOT_OK(IndexInBounds(index));
+        builder->UnsafeAppend(dict_values[index]);
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+  return num_values - null_count;
+}
+
+template <typename Type>
+void DictDecoderImpl<Type>::InsertDictionary(::arrow::ArrayBuilder* builder) {
+  ParquetException::NYI(
+      "InsertDictionary only implemented for BYTE_ARRAY types");
+}
+
+template <>
+void DictDecoderImpl<ByteArrayType>::InsertDictionary(
+    ::arrow::ArrayBuilder* builder) {
+  auto binary_builder =
+      checked_cast<::arrow::BinaryDictionary32Builder*>(builder);
+
+  // Make a BinaryArray referencing the internal dictionary data
+  auto arr = std::make_shared<::arrow::BinaryArray>(
+      dictionary_length_, byte_array_offsets_, byte_array_data_);
+  PARQUET_THROW_NOT_OK(binary_builder->InsertMemoValues(*arr));
+}
+
+class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
+                                 virtual public ByteArrayDecoder {
+ public:
+  using BASE = DictDecoderImpl<ByteArrayType>;
+  using BASE::DictDecoderImpl;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      ::arrow::BinaryDictionary32Builder* builder) override {
+    int result = 0;
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowNonNull(num_values, builder, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrow(
+          num_values,
+          null_count,
+          valid_bits,
+          valid_bits_offset,
+          builder,
+          &result));
+    }
+    return result;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
+    int result = 0;
+    if (null_count == 0) {
+      PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
+    } else {
+      PARQUET_THROW_NOT_OK(DecodeArrowDense(
+          num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    }
+    return result;
+  }
+
+ private:
+  Status DecodeArrowDense(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_num_values) {
+    constexpr int32_t kBufferSize = 1024;
+    int32_t indices[kBufferSize];
+
+    ArrowBinaryHelper helper(out);
+
+    auto dict_values = reinterpret_cast<const ByteArray*>(dictionary_->data());
+    int values_decoded = 0;
+    int num_indices = 0;
+    int pos_indices = 0;
+
+    auto visit_valid = [&](int64_t position) -> Status {
+      if (num_indices == pos_indices) {
+        // Refill indices buffer
+        const auto batch_size = std::min<int32_t>(
+            kBufferSize, num_values - null_count - values_decoded);
+        num_indices = idx_decoder_.GetBatch(indices, batch_size);
+        if (ARROW_PREDICT_FALSE(num_indices < 1)) {
+          return Status::Invalid("Invalid number of indices: ", num_indices);
+        }
+        pos_indices = 0;
+      }
+      const auto index = indices[pos_indices++];
+      RETURN_NOT_OK(IndexInBounds(index));
+      const auto& val = dict_values[index];
+      if (ARROW_PREDICT_FALSE(!helper.CanFit(val.len))) {
+        RETURN_NOT_OK(helper.PushChunk());
+      }
+      RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
+      ++values_decoded;
+      return Status::OK();
+    };
+
+    auto visit_null = [&]() -> Status {
+      RETURN_NOT_OK(helper.AppendNull());
+      return Status::OK();
+    };
+
+    ::arrow::internal::BitBlockCounter bit_blocks(
+        valid_bits, valid_bits_offset, num_values);
+    int64_t position = 0;
+    while (position < num_values) {
+      const auto block = bit_blocks.NextWord();
+      if (block.AllSet()) {
+        for (int64_t i = 0; i < block.length; ++i, ++position) {
+          ARROW_RETURN_NOT_OK(visit_valid(position));
+        }
+      } else if (block.NoneSet()) {
+        for (int64_t i = 0; i < block.length; ++i, ++position) {
+          ARROW_RETURN_NOT_OK(visit_null());
+        }
+      } else {
+        for (int64_t i = 0; i < block.length; ++i, ++position) {
+          if (bit_util::GetBit(valid_bits, valid_bits_offset + position)) {
+            ARROW_RETURN_NOT_OK(visit_valid(position));
+          } else {
+            ARROW_RETURN_NOT_OK(visit_null());
+          }
+        }
+      }
+    }
+
+    *out_num_values = values_decoded;
+    return Status::OK();
+  }
+
+  Status DecodeArrowDenseNonNull(
+      int num_values,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_num_values) {
+    constexpr int32_t kBufferSize = 2048;
+    int32_t indices[kBufferSize];
+    int values_decoded = 0;
+
+    ArrowBinaryHelper helper(out);
+    auto dict_values = reinterpret_cast<const ByteArray*>(dictionary_->data());
+
+    while (values_decoded < num_values) {
+      int32_t batch_size =
+          std::min<int32_t>(kBufferSize, num_values - values_decoded);
+      int num_indices = idx_decoder_.GetBatch(indices, batch_size);
+      if (num_indices == 0)
+        ParquetException::EofException();
+      for (int i = 0; i < num_indices; ++i) {
+        auto idx = indices[i];
+        RETURN_NOT_OK(IndexInBounds(idx));
+        const auto& val = dict_values[idx];
+        if (ARROW_PREDICT_FALSE(!helper.CanFit(val.len))) {
+          RETURN_NOT_OK(helper.PushChunk());
+        }
+        RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
+      }
+      values_decoded += num_indices;
+    }
+    *out_num_values = values_decoded;
+    return Status::OK();
+  }
+
+  template <typename BuilderType>
+  Status DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      BuilderType* builder,
+      int* out_num_values) {
+    constexpr int32_t kBufferSize = 1024;
+    int32_t indices[kBufferSize];
+
+    RETURN_NOT_OK(builder->Reserve(num_values));
+    ::arrow::internal::BitmapReader bit_reader(
+        valid_bits, valid_bits_offset, num_values);
+
+    auto dict_values = reinterpret_cast<const ByteArray*>(dictionary_->data());
+
+    int values_decoded = 0;
+    int num_appended = 0;
+    while (num_appended < num_values) {
+      bool is_valid = bit_reader.IsSet();
+      bit_reader.Next();
+
+      if (is_valid) {
+        int32_t batch_size = std::min<int32_t>(
+            kBufferSize, num_values - num_appended - null_count);
+        int num_indices = idx_decoder_.GetBatch(indices, batch_size);
+
+        int i = 0;
+        while (true) {
+          // Consume all indices
+          if (is_valid) {
+            auto idx = indices[i];
+            RETURN_NOT_OK(IndexInBounds(idx));
+            const auto& val = dict_values[idx];
+            RETURN_NOT_OK(builder->Append(val.ptr, val.len));
+            ++i;
+            ++values_decoded;
+          } else {
+            RETURN_NOT_OK(builder->AppendNull());
+            --null_count;
+          }
+          ++num_appended;
+          if (i == num_indices) {
+            // Do not advance the bit_reader if we have fulfilled the decode
+            // request
+            break;
+          }
+          is_valid = bit_reader.IsSet();
+          bit_reader.Next();
+        }
+      } else {
+        RETURN_NOT_OK(builder->AppendNull());
+        --null_count;
+        ++num_appended;
+      }
+    }
+    *out_num_values = values_decoded;
+    return Status::OK();
+  }
+
+  template <typename BuilderType>
+  Status DecodeArrowNonNull(
+      int num_values,
+      BuilderType* builder,
+      int* out_num_values) {
+    constexpr int32_t kBufferSize = 2048;
+    int32_t indices[kBufferSize];
+
+    RETURN_NOT_OK(builder->Reserve(num_values));
+
+    auto dict_values = reinterpret_cast<const ByteArray*>(dictionary_->data());
+
+    int values_decoded = 0;
+    while (values_decoded < num_values) {
+      int32_t batch_size =
+          std::min<int32_t>(kBufferSize, num_values - values_decoded);
+      int num_indices = idx_decoder_.GetBatch(indices, batch_size);
+      if (num_indices == 0)
+        ParquetException::EofException();
+      for (int i = 0; i < num_indices; ++i) {
+        auto idx = indices[i];
+        RETURN_NOT_OK(IndexInBounds(idx));
+        const auto& val = dict_values[idx];
+        RETURN_NOT_OK(builder->Append(val.ptr, val.len));
+      }
+      values_decoded += num_indices;
+    }
+    *out_num_values = values_decoded;
+    return Status::OK();
+  }
+};
+
+// ----------------------------------------------------------------------
+// DeltaBitPackEncoder
+
+/// DeltaBitPackEncoder is an encoder for the DeltaBinary Packing format
+/// as per the parquet spec. See:
+/// https://github.com/apache/parquet-format/blob/master/Encodings.md#delta-encoding-delta_binary_packed--5
+///
+/// Consists of a header followed by blocks of delta encoded values binary
+/// packed.
+///
+///  Format
+///    [header] [block 1] [block 2] ... [block N]
+///
+///  Header
+///    [block size] [number of mini blocks per block] [total value count] [first
+///    value]
+///
+///  Block
+///    [min delta] [list of bitwidths of the mini blocks] [miniblocks]
+///
+/// Sets aside bytes at the start of the internal buffer where the header will
+/// be written, and only writes the header when FlushValues is called before
+/// returning it.
+///
+/// To encode a block, we will:
+///
+/// 1. Compute the differences between consecutive elements. For the first
+/// element in the block, use the last element in the previous block or, in the
+/// case of the first block, use the first value of the whole sequence, stored
+/// in the header.
+///
+/// 2. Compute the frame of reference (the minimum of the deltas in the block).
+/// Subtract this min delta from all deltas in the block. This guarantees that
+/// all values are non-negative.
+///
+/// 3. Encode the frame of reference (min delta) as a zigzag ULEB128 int
+/// followed by the bit widths of the mini blocks and the delta values (minus
+/// the min delta) bit packed per mini block.
+///
+/// Supports only INT32 and INT64.
+
+template <typename DType>
+class DeltaBitPackEncoder : public EncoderImpl,
+                            virtual public TypedEncoder<DType> {
+  // Maximum possible header size
+  static constexpr uint32_t kMaxPageHeaderWriterSize = 32;
+  static constexpr uint32_t kValuesPerBlock =
+      std::is_same_v<int32_t, typename DType::c_type> ? 128 : 256;
+  static constexpr uint32_t kMiniBlocksPerBlock = 4;
+
+ public:
+  using T = typename DType::c_type;
+  using UT = std::make_unsigned_t<T>;
+  using TypedEncoder<DType>::Put;
+
+  explicit DeltaBitPackEncoder(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool,
+      const uint32_t values_per_block = kValuesPerBlock,
+      const uint32_t mini_blocks_per_block = kMiniBlocksPerBlock)
+      : EncoderImpl(descr, Encoding::DELTA_BINARY_PACKED, pool),
+        values_per_block_(values_per_block),
+        mini_blocks_per_block_(mini_blocks_per_block),
+        values_per_mini_block_(values_per_block / mini_blocks_per_block),
+        deltas_(values_per_block, ::arrow::stl::allocator<T>(pool)),
+        bits_buffer_(AllocateBuffer(
+            pool,
+            (kMiniBlocksPerBlock + values_per_block) * sizeof(T))),
+        sink_(pool),
+        bit_writer_(
+            bits_buffer_->mutable_data(),
+            static_cast<int>(bits_buffer_->size())) {
+    if (values_per_block_ % 128 != 0) {
+      throw ParquetException(
+          "the number of values in a block must be multiple of 128, but it's " +
+          std::to_string(values_per_block_));
+    }
+    if (values_per_mini_block_ % 32 != 0) {
+      throw ParquetException(
+          "the number of values in a miniblock must be multiple of 32, but it's " +
+          std::to_string(values_per_mini_block_));
+    }
+    if (values_per_block % mini_blocks_per_block != 0) {
+      throw ParquetException(
+          "the number of values per block % number of miniblocks per block must be 0, "
+          "but it's " +
+          std::to_string(values_per_block % mini_blocks_per_block));
+    }
+    // Reserve enough space at the beginning of the buffer for largest possible
+    // header.
+    PARQUET_THROW_NOT_OK(sink_.Advance(kMaxPageHeaderWriterSize));
+  }
+
+  std::shared_ptr<Buffer> FlushValues() override;
+
+  int64_t EstimatedDataEncodedSize() override {
+    return sink_.length();
+  }
+
+  void Put(const ::arrow::Array& values) override;
+
+  void Put(const T* buffer, int num_values) override;
+
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override;
+
+  void FlushBlock();
+
+ private:
+  const uint32_t values_per_block_;
+  const uint32_t mini_blocks_per_block_;
+  const uint32_t values_per_mini_block_;
+  uint32_t values_current_block_{0};
+  uint32_t total_value_count_{0};
+  UT first_value_{0};
+  UT current_value_{0};
+  ArrowPoolVector<UT> deltas_;
+  std::shared_ptr<ResizableBuffer> bits_buffer_;
+  ::arrow::BufferBuilder sink_;
+  ::arrow::bit_util::BitWriter bit_writer_;
+};
+
+template <typename DType>
+void DeltaBitPackEncoder<DType>::Put(const T* src, int num_values) {
+  if (num_values == 0) {
+    return;
+  }
+
+  int idx = 0;
+  if (total_value_count_ == 0) {
+    current_value_ = src[0];
+    first_value_ = current_value_;
+    idx = 1;
+  }
+  total_value_count_ += num_values;
+
+  while (idx < num_values) {
+    UT value = static_cast<UT>(src[idx]);
+    // Calculate deltas. The possible overflow is handled by use of unsigned
+    // integers making subtraction operations well-defined and correct even in
+    // case of overflow. Encoded integers will wrap back around on decoding. See
+    // http://en.wikipedia.org/wiki/Modular_arithmetic#Integers_modulo_n
+    deltas_[values_current_block_] = value - current_value_;
+    current_value_ = value;
+    idx++;
+    values_current_block_++;
+    if (values_current_block_ == values_per_block_) {
+      FlushBlock();
+    }
+  }
+}
+
+template <typename DType>
+void DeltaBitPackEncoder<DType>::FlushBlock() {
+  if (values_current_block_ == 0) {
+    return;
+  }
+
+  const UT min_delta = *std::min_element(
+      deltas_.begin(), deltas_.begin() + values_current_block_);
+  bit_writer_.PutZigZagVlqInt(static_cast<T>(min_delta));
+
+  // Call to GetNextBytePtr reserves mini_blocks_per_block_ bytes of space to
+  // write bit widths of miniblocks as they become known during the encoding.
+  uint8_t* bit_width_data = bit_writer_.GetNextBytePtr(mini_blocks_per_block_);
+  DCHECK(bit_width_data != nullptr);
+
+  const uint32_t num_miniblocks = static_cast<uint32_t>(std::ceil(
+      static_cast<double>(values_current_block_) /
+      static_cast<double>(values_per_mini_block_)));
+  for (uint32_t i = 0; i < num_miniblocks; i++) {
+    const uint32_t values_current_mini_block =
+        std::min(values_per_mini_block_, values_current_block_);
+
+    const uint32_t start = i * values_per_mini_block_;
+    const UT max_delta = *std::max_element(
+        deltas_.begin() + start,
+        deltas_.begin() + start + values_current_mini_block);
+
+    // The minimum number of bits required to write any of values in deltas_
+    // vector. See overflow comment above.
+    const auto bit_width = bit_width_data[i] =
+        bit_util::NumRequiredBits(max_delta - min_delta);
+
+    for (uint32_t j = start; j < start + values_current_mini_block; j++) {
+      // See overflow comment above.
+      const UT value = deltas_[j] - min_delta;
+      bit_writer_.PutValue(value, bit_width);
+    }
+    // If there are not enough values to fill the last mini block, we pad the
+    // mini block with zeroes so that its length is the number of values in a
+    // full mini block multiplied by the bit width.
+    for (uint32_t j = values_current_mini_block; j < values_per_mini_block_;
+         j++) {
+      bit_writer_.PutValue(0, bit_width);
+    }
+    values_current_block_ -= values_current_mini_block;
+  }
+
+  // If, in the last block, less than <number of miniblocks in a block>
+  // miniblocks are needed to store the values, the bytes storing the bit widths
+  // of the unneeded miniblocks are still present, their value should be zero,
+  // but readers must accept arbitrary values as well.
+  for (uint32_t i = num_miniblocks; i < mini_blocks_per_block_; i++) {
+    bit_width_data[i] = 0;
+  }
+  DCHECK_EQ(values_current_block_, 0);
+
+  bit_writer_.Flush();
+  PARQUET_THROW_NOT_OK(
+      sink_.Append(bit_writer_.buffer(), bit_writer_.bytes_written()));
+  bit_writer_.Clear();
+}
+
+template <typename DType>
+std::shared_ptr<Buffer> DeltaBitPackEncoder<DType>::FlushValues() {
+  if (values_current_block_ > 0) {
+    FlushBlock();
+  }
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink_.Finish(/*shrink_to_fit=*/true));
+
+  uint8_t header_buffer_[kMaxPageHeaderWriterSize] = {};
+  bit_util::BitWriter header_writer(header_buffer_, sizeof(header_buffer_));
+  if (!header_writer.PutVlqInt(values_per_block_) ||
+      !header_writer.PutVlqInt(mini_blocks_per_block_) ||
+      !header_writer.PutVlqInt(total_value_count_) ||
+      !header_writer.PutZigZagVlqInt(static_cast<T>(first_value_))) {
+    throw ParquetException("header writing error");
+  }
+  header_writer.Flush();
+
+  // We reserved enough space at the beginning of the buffer for largest
+  // possible header and data was written immediately after. We now write the
+  // header data immediately before the end of reserved space.
+  const size_t offset_bytes =
+      kMaxPageHeaderWriterSize - header_writer.bytes_written();
+  std::memcpy(
+      buffer->mutable_data() + offset_bytes,
+      header_buffer_,
+      header_writer.bytes_written());
+
+  // Reset counter of cached values
+  total_value_count_ = 0;
+  // Reserve enough space at the beginning of the buffer for largest possible
+  // header.
+  PARQUET_THROW_NOT_OK(sink_.Advance(kMaxPageHeaderWriterSize));
+
+  // Excess bytes at the beginning are sliced off and ignored.
+  return SliceBuffer(buffer, offset_bytes);
+}
+
+template <>
+void DeltaBitPackEncoder<Int32Type>::Put(const ::arrow::Array& values) {
+  const ::arrow::ArrayData& data = *values.data();
+  if (values.type_id() != ::arrow::Type::INT32) {
+    throw ParquetException(
+        "Expected Int32TArray, got ", values.type()->ToString());
+  }
+  if (data.length > std::numeric_limits<int32_t>::max()) {
+    throw ParquetException(
+        "Array cannot be longer than ", std::numeric_limits<int32_t>::max());
+  }
+
+  if (values.null_count() == 0) {
+    Put(data.GetValues<int32_t>(1), static_cast<int>(data.length));
+  } else {
+    PutSpaced(
+        data.GetValues<int32_t>(1),
+        static_cast<int>(data.length),
+        data.GetValues<uint8_t>(0, 0),
+        data.offset);
+  }
+}
+
+template <>
+void DeltaBitPackEncoder<Int64Type>::Put(const ::arrow::Array& values) {
+  const ::arrow::ArrayData& data = *values.data();
+  if (values.type_id() != ::arrow::Type::INT64) {
+    throw ParquetException(
+        "Expected Int64TArray, got ", values.type()->ToString());
+  }
+  if (data.length > std::numeric_limits<int32_t>::max()) {
+    throw ParquetException(
+        "Array cannot be longer than ", std::numeric_limits<int32_t>::max());
+  }
+  if (values.null_count() == 0) {
+    Put(data.GetValues<int64_t>(1), static_cast<int>(data.length));
+  } else {
+    PutSpaced(
+        data.GetValues<int64_t>(1),
+        static_cast<int>(data.length),
+        data.GetValues<uint8_t>(0, 0),
+        data.offset);
+  }
+}
+
+template <typename DType>
+void DeltaBitPackEncoder<DType>::PutSpaced(
+    const T* src,
+    int num_values,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset) {
+  if (valid_bits != NULLPTR) {
+    PARQUET_ASSIGN_OR_THROW(
+        auto buffer,
+        ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+    T* data = reinterpret_cast<T*>(buffer->mutable_data());
+    int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+        src, num_values, valid_bits, valid_bits_offset, data);
+    Put(data, num_valid_values);
+  } else {
+    Put(src, num_values);
+  }
+}
+
+// ----------------------------------------------------------------------
+// DeltaBitPackDecoder
+
+template <typename DType>
+class DeltaBitPackDecoder : public DecoderImpl,
+                            virtual public TypedDecoder<DType> {
+ public:
+  typedef typename DType::c_type T;
+  using UT = std::make_unsigned_t<T>;
+
+  explicit DeltaBitPackDecoder(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool = ::arrow::default_memory_pool())
+      : DecoderImpl(descr, Encoding::DELTA_BINARY_PACKED), pool_(pool) {
+    if (DType::type_num != Type::INT32 && DType::type_num != Type::INT64) {
+      throw ParquetException(
+          "Delta bit pack encoding should only be for integer data.");
+    }
+  }
+
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    // num_values is equal to page's num_values, including null values in this
+    // page
+    this->num_values_ = num_values;
+    decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
+    InitHeader();
+  }
+
+  // Set BitReader which is already initialized by DeltaLengthByteArrayDecoder
+  // or DeltaByteArrayDecoder
+  void SetDecoder(
+      int num_values,
+      std::shared_ptr<::arrow::bit_util::BitReader> decoder) {
+    this->num_values_ = num_values;
+    decoder_ = std::move(decoder);
+    InitHeader();
+  }
+
+  int ValidValuesCount() {
+    // total_values_remaining_ in header ignores of null values
+    return static_cast<int>(total_values_remaining_);
+  }
+
+  int Decode(T* buffer, int max_values) override {
+    return GetInternal(buffer, max_values);
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::Accumulator* out) override {
+    if (null_count != 0) {
+      // TODO(ARROW-34660): implement DecodeArrow with null slots.
+      ParquetException::NYI("Delta bit pack DecodeArrow with null slots");
+    }
+    std::vector<T> values(num_values);
+    int decoded_count = GetInternal(values.data(), num_values);
+    PARQUET_THROW_NOT_OK(out->AppendValues(values.data(), decoded_count));
+    return decoded_count;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::DictAccumulator* out) override {
+    if (null_count != 0) {
+      // TODO(ARROW-34660): implement DecodeArrow with null slots.
+      ParquetException::NYI("Delta bit pack DecodeArrow with null slots");
+    }
+    std::vector<T> values(num_values);
+    int decoded_count = GetInternal(values.data(), num_values);
+    PARQUET_THROW_NOT_OK(out->Reserve(decoded_count));
+    for (int i = 0; i < decoded_count; ++i) {
+      PARQUET_THROW_NOT_OK(out->Append(values[i]));
+    }
+    return decoded_count;
+  }
+
+ private:
+  static constexpr int kMaxDeltaBitWidth = static_cast<int>(sizeof(T) * 8);
+
+  void InitHeader() {
+    if (!decoder_->GetVlqInt(&values_per_block_) ||
+        !decoder_->GetVlqInt(&mini_blocks_per_block_) ||
+        !decoder_->GetVlqInt(&total_value_count_) ||
+        !decoder_->GetZigZagVlqInt(&last_value_)) {
+      ParquetException::EofException("InitHeader EOF");
+    }
+
+    if (values_per_block_ == 0) {
+      throw ParquetException("cannot have zero value per block");
+    }
+    if (values_per_block_ % 128 != 0) {
+      throw ParquetException(
+          "the number of values in a block must be multiple of 128, but it's " +
+          std::to_string(values_per_block_));
+    }
+    if (mini_blocks_per_block_ == 0) {
+      throw ParquetException("cannot have zero miniblock per block");
+    }
+    values_per_mini_block_ = values_per_block_ / mini_blocks_per_block_;
+    if (values_per_mini_block_ == 0) {
+      throw ParquetException("cannot have zero value per miniblock");
+    }
+    if (values_per_mini_block_ % 32 != 0) {
+      throw ParquetException(
+          "the number of values in a miniblock must be multiple of 32, but it's " +
+          std::to_string(values_per_mini_block_));
+    }
+
+    total_values_remaining_ = total_value_count_;
+    if (delta_bit_widths_ == nullptr) {
+      delta_bit_widths_ = AllocateBuffer(pool_, mini_blocks_per_block_);
+    } else {
+      PARQUET_THROW_NOT_OK(delta_bit_widths_->Resize(
+          mini_blocks_per_block_, /*shrink_to_fit*/ false));
+    }
+    first_block_initialized_ = false;
+    values_remaining_current_mini_block_ = 0;
+  }
+
+  void InitBlock() {
+    DCHECK_GT(total_values_remaining_, 0) << "InitBlock called at EOF";
+
+    if (!decoder_->GetZigZagVlqInt(&min_delta_))
+      ParquetException::EofException("InitBlock EOF");
+
+    // read the bitwidth of each miniblock
+    uint8_t* bit_width_data = delta_bit_widths_->mutable_data();
+    for (uint32_t i = 0; i < mini_blocks_per_block_; ++i) {
+      if (!decoder_->GetAligned<uint8_t>(1, bit_width_data + i)) {
+        ParquetException::EofException("Decode bit-width EOF");
+      }
+      // Note that non-conformant bitwidth entries are allowed by the Parquet
+      // spec for extraneous miniblocks in the last block (GH-14923), so we
+      // check the bitwidths when actually using them (see InitMiniBlock()).
+    }
+
+    mini_block_idx_ = 0;
+    first_block_initialized_ = true;
+    InitMiniBlock(bit_width_data[0]);
+  }
+
+  void InitMiniBlock(int bit_width) {
+    if (ARROW_PREDICT_FALSE(bit_width > kMaxDeltaBitWidth)) {
+      throw ParquetException("delta bit width larger than integer bit width");
+    }
+    delta_bit_width_ = bit_width;
+    values_remaining_current_mini_block_ = values_per_mini_block_;
+  }
+
+  int GetInternal(T* buffer, int max_values) {
+    max_values = static_cast<int>(
+        std::min<int64_t>(max_values, total_values_remaining_));
+    if (max_values == 0) {
+      return 0;
+    }
+
+    int i = 0;
+    while (i < max_values) {
+      if (ARROW_PREDICT_FALSE(values_remaining_current_mini_block_ == 0)) {
+        if (ARROW_PREDICT_FALSE(!first_block_initialized_)) {
+          buffer[i++] = last_value_;
+          DCHECK_EQ(i, 1); // we're at the beginning of the page
+          if (ARROW_PREDICT_FALSE(i == max_values)) {
+            // When block is uninitialized and i reaches max_values we have two
+            // different possibilities:
+            // 1. total_value_count_ == 1, which means that the page may have
+            // only one value (encoded in the header), and we should not
+            // initialize any block.
+            // 2. total_value_count_ != 1, which means we should initialize the
+            // incoming block for subsequent reads.
+            if (total_value_count_ != 1) {
+              InitBlock();
+            }
+            break;
+          }
+          InitBlock();
+        } else {
+          ++mini_block_idx_;
+          if (mini_block_idx_ < mini_blocks_per_block_) {
+            InitMiniBlock(delta_bit_widths_->data()[mini_block_idx_]);
+          } else {
+            InitBlock();
+          }
+        }
+      }
+
+      int values_decode = std::min(
+          values_remaining_current_mini_block_,
+          static_cast<uint32_t>(max_values - i));
+      if (decoder_->GetBatch(delta_bit_width_, buffer + i, values_decode) !=
+          values_decode) {
+        ParquetException::EofException();
+      }
+      for (int j = 0; j < values_decode; ++j) {
+        // Addition between min_delta, packed int and last_value should be
+        // treated as unsigned addition. Overflow is as expected.
+        buffer[i + j] = static_cast<UT>(min_delta_) +
+            static_cast<UT>(buffer[i + j]) + static_cast<UT>(last_value_);
+        last_value_ = buffer[i + j];
+      }
+      values_remaining_current_mini_block_ -= values_decode;
+      i += values_decode;
+    }
+    total_values_remaining_ -= max_values;
+    this->num_values_ -= max_values;
+
+    if (ARROW_PREDICT_FALSE(total_values_remaining_ == 0)) {
+      uint32_t padding_bits =
+          values_remaining_current_mini_block_ * delta_bit_width_;
+      // skip the padding bits
+      if (!decoder_->Advance(padding_bits)) {
+        ParquetException::EofException();
+      }
+      values_remaining_current_mini_block_ = 0;
+    }
+    return max_values;
+  }
+
+  MemoryPool* pool_;
+  std::shared_ptr<::arrow::bit_util::BitReader> decoder_;
+  uint32_t values_per_block_;
+  uint32_t mini_blocks_per_block_;
+  uint32_t values_per_mini_block_;
+  uint32_t total_value_count_;
+
+  uint32_t total_values_remaining_;
+  // Remaining values in current mini block. If the current block is the last
+  // mini block, values_remaining_current_mini_block_ may greater than
+  // total_values_remaining_.
+  uint32_t values_remaining_current_mini_block_;
+
+  // If the page doesn't contain any block, `first_block_initialized_` will
+  // always be false. Otherwise, it will be true when first block initialized.
+  bool first_block_initialized_;
+  T min_delta_;
+  uint32_t mini_block_idx_;
+  std::shared_ptr<ResizableBuffer> delta_bit_widths_;
+  int delta_bit_width_;
+
+  T last_value_;
+};
+
+// ----------------------------------------------------------------------
+// DELTA_LENGTH_BYTE_ARRAY
+
+// ----------------------------------------------------------------------
+// DeltaLengthByteArrayEncoder
+
+template <typename DType>
+class DeltaLengthByteArrayEncoder : public EncoderImpl,
+                                    virtual public TypedEncoder<ByteArrayType> {
+ public:
+  explicit DeltaLengthByteArrayEncoder(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool)
+      : EncoderImpl(
+            descr,
+            Encoding::DELTA_LENGTH_BYTE_ARRAY,
+            pool = ::arrow::default_memory_pool()),
+        sink_(pool),
+        length_encoder_(nullptr, pool),
+        encoded_size_{0} {}
+
+  std::shared_ptr<Buffer> FlushValues() override;
+
+  int64_t EstimatedDataEncodedSize() override {
+    return encoded_size_ + length_encoder_.EstimatedDataEncodedSize();
+  }
+
+  using TypedEncoder<ByteArrayType>::Put;
+
+  void Put(const ::arrow::Array& values) override;
+
+  void Put(const T* buffer, int num_values) override;
+
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override;
+
+ protected:
+  template <typename ArrayType>
+  void PutBinaryArray(const ArrayType& array) {
+    PARQUET_THROW_NOT_OK(
+        ::arrow::VisitArraySpanInline<typename ArrayType::TypeClass>(
+            *array.data(),
+            [&](::std::string_view view) {
+              if (ARROW_PREDICT_FALSE(view.size() > kMaxByteArraySize)) {
+                return Status::Invalid(
+                    "Parquet cannot store strings with size 2GB or more");
+              }
+              length_encoder_.Put({static_cast<int32_t>(view.length())}, 1);
+              PARQUET_THROW_NOT_OK(sink_.Append(view.data(), view.length()));
+              return Status::OK();
+            },
+            []() { return Status::OK(); }));
+  }
+
+  ::arrow::BufferBuilder sink_;
+  DeltaBitPackEncoder<Int32Type> length_encoder_;
+  uint32_t encoded_size_;
+};
+
+template <typename DType>
+void DeltaLengthByteArrayEncoder<DType>::Put(const ::arrow::Array& values) {
+  AssertBaseBinary(values);
+  if (::arrow::is_binary_like(values.type_id())) {
+    PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
+  } else {
+    PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  }
+}
+
+template <typename DType>
+void DeltaLengthByteArrayEncoder<DType>::Put(const T* src, int num_values) {
+  if (num_values == 0) {
+    return;
+  }
+
+  constexpr int kBatchSize = 256;
+  std::array<int32_t, kBatchSize> lengths;
+  uint32_t total_increment_size = 0;
+  for (int idx = 0; idx < num_values; idx += kBatchSize) {
+    const int batch_size = std::min(kBatchSize, num_values - idx);
+    for (int j = 0; j < batch_size; ++j) {
+      const int32_t len = src[idx + j].len;
+      if (AddWithOverflow(total_increment_size, len, &total_increment_size)) {
+        throw ParquetException("excess expansion in DELTA_LENGTH_BYTE_ARRAY");
+      }
+      lengths[j] = len;
+    }
+    length_encoder_.Put(lengths.data(), batch_size);
+  }
+
+  if (AddWithOverflow(encoded_size_, total_increment_size, &encoded_size_)) {
+    throw ParquetException("excess expansion in DELTA_LENGTH_BYTE_ARRAY");
+  }
+  PARQUET_THROW_NOT_OK(sink_.Reserve(total_increment_size));
+  for (int idx = 0; idx < num_values; idx++) {
+    sink_.UnsafeAppend(src[idx].ptr, src[idx].len);
+  }
+}
+
+template <typename DType>
+void DeltaLengthByteArrayEncoder<DType>::PutSpaced(
+    const T* src,
+    int num_values,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset) {
+  if (valid_bits != NULLPTR) {
+    PARQUET_ASSIGN_OR_THROW(
+        auto buffer,
+        ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+    T* data = reinterpret_cast<T*>(buffer->mutable_data());
+    int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+        src, num_values, valid_bits, valid_bits_offset, data);
+    Put(data, num_valid_values);
+  } else {
+    Put(src, num_values);
+  }
+}
+
+template <typename DType>
+std::shared_ptr<Buffer> DeltaLengthByteArrayEncoder<DType>::FlushValues() {
+  std::shared_ptr<Buffer> encoded_lengths = length_encoder_.FlushValues();
+
+  std::shared_ptr<Buffer> data;
+  PARQUET_THROW_NOT_OK(sink_.Finish(&data));
+  sink_.Reset();
+
+  PARQUET_THROW_NOT_OK(sink_.Resize(encoded_lengths->size() + data->size()));
+  PARQUET_THROW_NOT_OK(
+      sink_.Append(encoded_lengths->data(), encoded_lengths->size()));
+  PARQUET_THROW_NOT_OK(sink_.Append(data->data(), data->size()));
+
+  std::shared_ptr<Buffer> buffer;
+  PARQUET_THROW_NOT_OK(sink_.Finish(&buffer, true));
+  encoded_size_ = 0;
+  return buffer;
+}
+
+// ----------------------------------------------------------------------
+// DeltaLengthByteArrayDecoder
+
+class DeltaLengthByteArrayDecoder : public DecoderImpl,
+                                    virtual public TypedDecoder<ByteArrayType> {
+ public:
+  explicit DeltaLengthByteArrayDecoder(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool = ::arrow::default_memory_pool())
+      : DecoderImpl(descr, Encoding::DELTA_LENGTH_BYTE_ARRAY),
+        len_decoder_(nullptr, pool),
+        buffered_length_(AllocateBuffer(pool, 0)) {}
+
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    DecoderImpl::SetData(num_values, data, len);
+    decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
+    DecodeLengths();
+  }
+
+  int Decode(ByteArray* buffer, int max_values) override {
+    // Decode up to `max_values` strings into an internal buffer
+    // and reference them into `buffer`.
+    max_values = std::min(max_values, num_valid_values_);
+    DCHECK_GE(max_values, 0);
+    if (max_values == 0) {
+      return 0;
+    }
+
+    int32_t data_size = 0;
+    const int32_t* length_ptr =
+        reinterpret_cast<const int32_t*>(buffered_length_->data()) +
+        length_idx_;
+    int bytes_offset = len_ - decoder_->bytes_left();
+    for (int i = 0; i < max_values; ++i) {
+      int32_t len = length_ptr[i];
+      if (ARROW_PREDICT_FALSE(len < 0)) {
+        throw ParquetException("negative string delta length");
+      }
+      buffer[i].len = len;
+      if (AddWithOverflow(data_size, len, &data_size)) {
+        throw ParquetException("excess expansion in DELTA_(LENGTH_)BYTE_ARRAY");
+      }
+    }
+    length_idx_ += max_values;
+    if (ARROW_PREDICT_FALSE(
+            !decoder_->Advance(8 * static_cast<int64_t>(data_size)))) {
+      ParquetException::EofException();
+    }
+    const uint8_t* data_ptr = data_ + bytes_offset;
+    for (int i = 0; i < max_values; ++i) {
+      buffer[i].ptr = data_ptr;
+      data_ptr += buffer[i].len;
+    }
+    this->num_values_ -= max_values;
+    num_valid_values_ -= max_values;
+    return max_values;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowDense(
+        num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    return result;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::DictAccumulator* out) override {
+    ParquetException::NYI(
+        "DecodeArrow of DictAccumulator for DeltaLengthByteArrayDecoder");
+  }
+
+ private:
+  // Decode all the encoded lengths. The decoder_ will be at the start of the
+  // encoded data after that.
+  void DecodeLengths() {
+    len_decoder_.SetDecoder(num_values_, decoder_);
+
+    // get the number of encoded lengths
+    int num_length = len_decoder_.ValidValuesCount();
+    PARQUET_THROW_NOT_OK(
+        buffered_length_->Resize(num_length * sizeof(int32_t)));
+
+    // call len_decoder_.Decode to decode all the lengths.
+    // all the lengths are buffered in buffered_length_.
+    int ret = len_decoder_.Decode(
+        reinterpret_cast<int32_t*>(buffered_length_->mutable_data()),
+        num_length);
+    DCHECK_EQ(ret, num_length);
+    length_idx_ = 0;
+    num_valid_values_ = num_length;
+  }
+
+  Status DecodeArrowDense(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_num_values) {
+    ArrowBinaryHelper helper(out);
+
+    std::vector<ByteArray> values(num_values - null_count);
+    const int num_valid_values = Decode(values.data(), num_values - null_count);
+    if (ARROW_PREDICT_FALSE(num_values - null_count != num_valid_values)) {
+      throw ParquetException(
+          "Expected to decode ",
+          num_values - null_count,
+          " values, but decoded ",
+          num_valid_values,
+          " values.");
+    }
+
+    auto values_ptr = values.data();
+    int value_idx = 0;
+
+    RETURN_NOT_OK(VisitNullBitmapInline(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        null_count,
+        [&]() {
+          const auto& val = values_ptr[value_idx];
+          if (ARROW_PREDICT_FALSE(!helper.CanFit(val.len))) {
+            RETURN_NOT_OK(helper.PushChunk());
+          }
+          RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
+          ++value_idx;
+          return Status::OK();
+        },
+        [&]() {
+          RETURN_NOT_OK(helper.AppendNull());
+          --null_count;
+          return Status::OK();
+        }));
+
+    DCHECK_EQ(null_count, 0);
+    *out_num_values = num_valid_values;
+    return Status::OK();
+  }
+
+  std::shared_ptr<::arrow::bit_util::BitReader> decoder_;
+  DeltaBitPackDecoder<Int32Type> len_decoder_;
+  int num_valid_values_;
+  uint32_t length_idx_;
+  std::shared_ptr<ResizableBuffer> buffered_length_;
+};
+
+// ----------------------------------------------------------------------
+// RLE_BOOLEAN_ENCODER
+
+class RleBooleanEncoder final : public EncoderImpl,
+                                virtual public BooleanEncoder {
+ public:
+  explicit RleBooleanEncoder(
+      const ColumnDescriptor* descr,
+      ::arrow::MemoryPool* pool)
+      : EncoderImpl(descr, Encoding::RLE, pool),
+        buffered_append_values_(::arrow::stl::allocator<T>(pool)) {}
+
+  int64_t EstimatedDataEncodedSize() override {
+    return kRleLengthInBytes + MaxRleBufferSize();
+  }
+
+  std::shared_ptr<Buffer> FlushValues() override;
+
+  void Put(const T* buffer, int num_values) override;
+  void Put(const ::arrow::Array& values) override {
+    if (values.type_id() != ::arrow::Type::BOOL) {
+      throw ParquetException(
+          "RleBooleanEncoder expects BooleanArray, got ",
+          values.type()->ToString());
+    }
+    const auto& boolean_array =
+        checked_cast<const ::arrow::BooleanArray&>(values);
+    if (values.null_count() == 0) {
+      for (int i = 0; i < boolean_array.length(); ++i) {
+        // null_count == 0, so just call Value directly is ok.
+        buffered_append_values_.push_back(boolean_array.Value(i));
+      }
+    } else {
+      PARQUET_THROW_NOT_OK(::arrow::VisitArraySpanInline<::arrow::BooleanType>(
+          *boolean_array.data(),
+          [&](bool value) {
+            buffered_append_values_.push_back(value);
+            return Status::OK();
+          },
+          []() { return Status::OK(); }));
+    }
+  }
+
+  void PutSpaced(
+      const T* src,
+      int num_values,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset) override {
+    if (valid_bits != NULLPTR) {
+      PARQUET_ASSIGN_OR_THROW(
+          auto buffer,
+          ::arrow::AllocateBuffer(num_values * sizeof(T), this->memory_pool()));
+      T* data = reinterpret_cast<T*>(buffer->mutable_data());
+      int num_valid_values = ::arrow::util::internal::SpacedCompress<T>(
+          src, num_values, valid_bits, valid_bits_offset, data);
+      Put(data, num_valid_values);
+    } else {
+      Put(src, num_values);
+    }
+  }
+
+  void Put(const std::vector<bool>& src, int num_values) override;
+
+ protected:
+  template <typename SequenceType>
+  void PutImpl(const SequenceType& src, int num_values);
+
+  int MaxRleBufferSize() const noexcept {
+    return RlePreserveBufferSize(
+        static_cast<int>(buffered_append_values_.size()), kBitWidth);
+  }
+
+  constexpr static int32_t kBitWidth = 1;
+  /// 4 bytes in little-endian, which indicates the length.
+  constexpr static int32_t kRleLengthInBytes = 4;
+
+  // std::vector<bool> in C++ is tricky, because it's a bitmap.
+  // Here RleBooleanEncoder will only append values into it, and
+  // dump values into Buffer, so using it here is ok.
+  ArrowPoolVector<bool> buffered_append_values_;
+};
+
+void RleBooleanEncoder::Put(const bool* src, int num_values) {
+  PutImpl(src, num_values);
+}
+
+void RleBooleanEncoder::Put(const std::vector<bool>& src, int num_values) {
+  PutImpl(src, num_values);
+}
+
+template <typename SequenceType>
+void RleBooleanEncoder::PutImpl(const SequenceType& src, int num_values) {
+  for (int i = 0; i < num_values; ++i) {
+    buffered_append_values_.push_back(src[i]);
+  }
+}
+
+std::shared_ptr<Buffer> RleBooleanEncoder::FlushValues() {
+  int rle_buffer_size_max = MaxRleBufferSize();
+  std::shared_ptr<ResizableBuffer> buffer =
+      AllocateBuffer(this->pool_, rle_buffer_size_max + kRleLengthInBytes);
+  ::arrow::util::RleEncoder encoder(
+      buffer->mutable_data() + kRleLengthInBytes,
+      rle_buffer_size_max,
+      /*bit_width*/ kBitWidth);
+
+  for (bool value : buffered_append_values_) {
+    encoder.Put(value ? 1 : 0);
+  }
+  encoder.Flush();
+  ::arrow::util::SafeStore(
+      buffer->mutable_data(), ::arrow::bit_util::ToLittleEndian(encoder.len()));
+  PARQUET_THROW_NOT_OK(buffer->Resize(kRleLengthInBytes + encoder.len()));
+  buffered_append_values_.clear();
+  return buffer;
+}
+
+// ----------------------------------------------------------------------
+// RLE_BOOLEAN_DECODER
+
+class RleBooleanDecoder : public DecoderImpl, virtual public BooleanDecoder {
+ public:
+  explicit RleBooleanDecoder(const ColumnDescriptor* descr)
+      : DecoderImpl(descr, Encoding::RLE) {}
+
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    num_values_ = num_values;
+    uint32_t num_bytes = 0;
+
+    if (len < 4) {
+      throw ParquetException(
+          "Received invalid length : " + std::to_string(len) +
+          " (corrupt data page?)");
+    }
+    // Load the first 4 bytes in little-endian, which indicates the length
+    num_bytes = ::arrow::bit_util::FromLittleEndian(SafeLoadAs<uint32_t>(data));
+    if (num_bytes < 0 || num_bytes > static_cast<uint32_t>(len - 4)) {
+      throw ParquetException(
+          "Received invalid number of bytes : " + std::to_string(num_bytes) +
+          " (corrupt data page?)");
+    }
+
+    auto decoder_data = data + 4;
+    if (decoder_ == nullptr) {
+      decoder_ = std::make_shared<::arrow::util::RleDecoder>(
+          decoder_data,
+          num_bytes,
+          /*bit_width=*/1);
+    } else {
+      decoder_->Reset(decoder_data, num_bytes, /*bit_width=*/1);
+    }
+  }
+
+  int Decode(bool* buffer, int max_values) override {
+    max_values = std::min(max_values, num_values_);
+
+    if (decoder_->GetBatch(buffer, max_values) != max_values) {
+      ParquetException::EofException();
+    }
+    num_values_ -= max_values;
+    return max_values;
+  }
+
+  int Decode(uint8_t* buffer, int max_values) override {
+    ParquetException::NYI("Decode(uint8_t*, int) for RleBooleanDecoder");
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<BooleanType>::Accumulator* out) override {
+    if (null_count != 0) {
+      // TODO(ARROW-34660): implement DecodeArrow with null slots.
+      ParquetException::NYI("RleBoolean DecodeArrow with null slots");
+    }
+    constexpr int kBatchSize = 1024;
+    std::array<bool, kBatchSize> values;
+    int sum_decode_count = 0;
+    do {
+      int current_batch = std::min(kBatchSize, num_values);
+      int decoded_count = decoder_->GetBatch(values.data(), current_batch);
+      if (decoded_count == 0) {
+        break;
+      }
+      sum_decode_count += decoded_count;
+      PARQUET_THROW_NOT_OK(out->Reserve(sum_decode_count));
+      for (int i = 0; i < decoded_count; ++i) {
+        PARQUET_THROW_NOT_OK(out->Append(values[i]));
+      }
+      num_values -= decoded_count;
+    } while (num_values > 0);
+    return sum_decode_count;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<BooleanType>::DictAccumulator* builder) override {
+    ParquetException::NYI("DecodeArrow for RleBooleanDecoder");
+  }
+
+ private:
+  std::shared_ptr<::arrow::util::RleDecoder> decoder_;
+};
+
+// ----------------------------------------------------------------------
+// DELTA_BYTE_ARRAY
+
+class DeltaByteArrayDecoder : public DecoderImpl,
+                              virtual public TypedDecoder<ByteArrayType> {
+ public:
+  explicit DeltaByteArrayDecoder(
+      const ColumnDescriptor* descr,
+      MemoryPool* pool = ::arrow::default_memory_pool())
+      : DecoderImpl(descr, Encoding::DELTA_BYTE_ARRAY),
+        prefix_len_decoder_(nullptr, pool),
+        suffix_decoder_(nullptr, pool),
+        last_value_in_previous_page_(""),
+        buffered_prefix_length_(AllocateBuffer(pool, 0)),
+        buffered_data_(AllocateBuffer(pool, 0)) {}
+
+  void SetData(int num_values, const uint8_t* data, int len) override {
+    num_values_ = num_values;
+    decoder_ = std::make_shared<::arrow::bit_util::BitReader>(data, len);
+    prefix_len_decoder_.SetDecoder(num_values, decoder_);
+
+    // get the number of encoded prefix lengths
+    int num_prefix = prefix_len_decoder_.ValidValuesCount();
+    // call prefix_len_decoder_.Decode to decode all the prefix lengths.
+    // all the prefix lengths are buffered in buffered_prefix_length_.
+    PARQUET_THROW_NOT_OK(
+        buffered_prefix_length_->Resize(num_prefix * sizeof(int32_t)));
+    int ret = prefix_len_decoder_.Decode(
+        reinterpret_cast<int32_t*>(buffered_prefix_length_->mutable_data()),
+        num_prefix);
+    DCHECK_EQ(ret, num_prefix);
+    prefix_len_offset_ = 0;
+    num_valid_values_ = num_prefix;
+
+    int bytes_left = decoder_->bytes_left();
+    // If len < bytes_left, prefix_len_decoder.Decode will throw exception.
+    DCHECK_GE(len, bytes_left);
+    int suffix_begins = len - bytes_left;
+    // at this time, the decoder_ will be at the start of the encoded suffix
+    // data.
+    suffix_decoder_.SetData(num_values, data + suffix_begins, bytes_left);
+
+    // TODO: read corrupted files written with bug(PARQUET-246). last_value_
+    // should be set to last_value_in_previous_page_ when decoding a new
+    // page(except the first page)
+    last_value_ = "";
+  }
+
+  int Decode(ByteArray* buffer, int max_values) override {
+    return GetInternal(buffer, max_values);
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
+    int result = 0;
+    PARQUET_THROW_NOT_OK(DecodeArrowDense(
+        num_values, null_count, valid_bits, valid_bits_offset, out, &result));
+    return result;
+  }
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::DictAccumulator* builder)
+      override {
+    ParquetException::NYI(
+        "DecodeArrow of DictAccumulator for DeltaByteArrayDecoder");
+  }
+
+ private:
+  int GetInternal(ByteArray* buffer, int max_values) {
+    // Decode up to `max_values` strings into an internal buffer
+    // and reference them into `buffer`.
+    max_values = std::min(max_values, num_valid_values_);
+    if (max_values == 0) {
+      return max_values;
+    }
+
+    int suffix_read = suffix_decoder_.Decode(buffer, max_values);
+    if (ARROW_PREDICT_FALSE(suffix_read != max_values)) {
+      ParquetException::EofException(
+          "Read " + std::to_string(suffix_read) + ", expecting " +
+          std::to_string(max_values) + " from suffix decoder");
+    }
+
+    int64_t data_size = 0;
+    const int32_t* prefix_len_ptr =
+        reinterpret_cast<const int32_t*>(buffered_prefix_length_->data()) +
+        prefix_len_offset_;
+    for (int i = 0; i < max_values; ++i) {
+      if (ARROW_PREDICT_FALSE(prefix_len_ptr[i] < 0)) {
+        throw ParquetException("negative prefix length in DELTA_BYTE_ARRAY");
+      }
+      if (ARROW_PREDICT_FALSE(
+              AddWithOverflow(data_size, prefix_len_ptr[i], &data_size) ||
+              AddWithOverflow(data_size, buffer[i].len, &data_size))) {
+        throw ParquetException("excess expansion in DELTA_BYTE_ARRAY");
+      }
+    }
+    PARQUET_THROW_NOT_OK(buffered_data_->Resize(data_size));
+
+    string_view prefix{last_value_};
+    uint8_t* data_ptr = buffered_data_->mutable_data();
+    for (int i = 0; i < max_values; ++i) {
+      if (ARROW_PREDICT_FALSE(
+              static_cast<size_t>(prefix_len_ptr[i]) > prefix.length())) {
+        throw ParquetException("prefix length too large in DELTA_BYTE_ARRAY");
+      }
+      memcpy(data_ptr, prefix.data(), prefix_len_ptr[i]);
+      // buffer[i] currently points to the string suffix
+      memcpy(data_ptr + prefix_len_ptr[i], buffer[i].ptr, buffer[i].len);
+      buffer[i].ptr = data_ptr;
+      buffer[i].len += prefix_len_ptr[i];
+      data_ptr += buffer[i].len;
+      prefix = string_view{
+          reinterpret_cast<const char*>(buffer[i].ptr), buffer[i].len};
+    }
+    prefix_len_offset_ += max_values;
+    this->num_values_ -= max_values;
+    num_valid_values_ -= max_values;
+    last_value_ = std::string{prefix};
+
+    if (num_valid_values_ == 0) {
+      last_value_in_previous_page_ = last_value_;
+    }
+    return max_values;
+  }
+
+  Status DecodeArrowDense(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_num_values) {
+    ArrowBinaryHelper helper(out);
+
+    std::vector<ByteArray> values(num_values);
+    const int num_valid_values =
+        GetInternal(values.data(), num_values - null_count);
+    DCHECK_EQ(num_values - null_count, num_valid_values);
+
+    auto values_ptr = reinterpret_cast<const ByteArray*>(values.data());
+    int value_idx = 0;
+
+    RETURN_NOT_OK(VisitNullBitmapInline(
+        valid_bits,
+        valid_bits_offset,
+        num_values,
+        null_count,
+        [&]() {
+          const auto& val = values_ptr[value_idx];
+          if (ARROW_PREDICT_FALSE(!helper.CanFit(val.len))) {
+            RETURN_NOT_OK(helper.PushChunk());
+          }
+          RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
+          ++value_idx;
+          return Status::OK();
+        },
+        [&]() {
+          RETURN_NOT_OK(helper.AppendNull());
+          --null_count;
+          return Status::OK();
+        }));
+
+    DCHECK_EQ(null_count, 0);
+    *out_num_values = num_valid_values;
+    return Status::OK();
+  }
+
+  std::shared_ptr<::arrow::bit_util::BitReader> decoder_;
+  DeltaBitPackDecoder<Int32Type> prefix_len_decoder_;
+  DeltaLengthByteArrayDecoder suffix_decoder_;
+  std::string last_value_;
+  // string buffer for last value in previous page
+  std::string last_value_in_previous_page_;
+  int num_valid_values_;
+  uint32_t prefix_len_offset_;
+  std::shared_ptr<ResizableBuffer> buffered_prefix_length_;
+  std::shared_ptr<ResizableBuffer> buffered_data_;
+};
+
+// ----------------------------------------------------------------------
+// BYTE_STREAM_SPLIT
+
+template <typename DType>
+class ByteStreamSplitDecoder : public DecoderImpl,
+                               virtual public TypedDecoder<DType> {
+ public:
+  using T = typename DType::c_type;
+  explicit ByteStreamSplitDecoder(const ColumnDescriptor* descr);
+
+  int Decode(T* buffer, int max_values) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::Accumulator* builder) override;
+
+  int DecodeArrow(
+      int num_values,
+      int null_count,
+      const uint8_t* valid_bits,
+      int64_t valid_bits_offset,
+      typename EncodingTraits<DType>::DictAccumulator* builder) override;
+
+  void SetData(int num_values, const uint8_t* data, int len) override;
+
+  T* EnsureDecodeBuffer(int64_t min_values) {
+    const int64_t size = sizeof(T) * min_values;
+    if (!decode_buffer_ || decode_buffer_->size() < size) {
+      PARQUET_ASSIGN_OR_THROW(decode_buffer_, ::arrow::AllocateBuffer(size));
+    }
+    return reinterpret_cast<T*>(decode_buffer_->mutable_data());
+  }
+
+ private:
+  int num_values_in_buffer_{0};
+  std::shared_ptr<Buffer> decode_buffer_;
+
+  static constexpr size_t kNumStreams = sizeof(T);
+};
+
+template <typename DType>
+ByteStreamSplitDecoder<DType>::ByteStreamSplitDecoder(
+    const ColumnDescriptor* descr)
+    : DecoderImpl(descr, Encoding::BYTE_STREAM_SPLIT) {}
+
+template <typename DType>
+void ByteStreamSplitDecoder<DType>::SetData(
+    int num_values,
+    const uint8_t* data,
+    int len) {
+  if (num_values * static_cast<int64_t>(sizeof(T)) < len) {
+    throw ParquetException(
+        "Data size too large for number of values (padding in byte stream split data "
+        "page?)");
+  }
+  if (len % sizeof(T) != 0) {
+    throw ParquetException(
+        "ByteStreamSplit data size " + std::to_string(len) +
+        " not aligned with type " + TypeToString(DType::type_num));
+  }
+  num_values = len / sizeof(T);
+  DecoderImpl::SetData(num_values, data, len);
+  num_values_in_buffer_ = num_values_;
+}
+
+template <typename DType>
+int ByteStreamSplitDecoder<DType>::Decode(T* buffer, int max_values) {
+  const int values_to_decode = std::min(num_values_, max_values);
+  const int num_decoded_previously = num_values_in_buffer_ - num_values_;
+  const uint8_t* data = data_ + num_decoded_previously;
+
+  ::arrow::util::internal::ByteStreamSplitDecode<T>(
+      data, values_to_decode, num_values_in_buffer_, buffer);
+  num_values_ -= values_to_decode;
+  len_ -= sizeof(T) * values_to_decode;
+  return values_to_decode;
+}
+
+template <typename DType>
+int ByteStreamSplitDecoder<DType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<DType>::Accumulator* builder) {
+  constexpr int value_size = static_cast<int>(kNumStreams);
+  int values_decoded = num_values - null_count;
+  if (ARROW_PREDICT_FALSE(len_ < value_size * values_decoded)) {
+    ParquetException::EofException();
+  }
+
+  PARQUET_THROW_NOT_OK(builder->Reserve(num_values));
+
+  const int num_decoded_previously = num_values_in_buffer_ - num_values_;
+  const uint8_t* data = data_ + num_decoded_previously;
+  int offset = 0;
+
+#if defined(ARROW_HAVE_SIMD_SPLIT)
+  // Use fast decoding into intermediate buffer.  This will also decode
+  // some null values, but it's fast enough that we don't care.
+  T* decode_out = EnsureDecodeBuffer(values_decoded);
+  ::arrow::util::internal::ByteStreamSplitDecode<T>(
+      data, values_decoded, num_values_in_buffer_, decode_out);
+
+  // XXX If null_count is 0, we could even append in bulk or decode directly
+  // into builder
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        builder->UnsafeAppend(decode_out[offset]);
+        ++offset;
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+
+#else
+  VisitNullBitmapInline(
+      valid_bits,
+      valid_bits_offset,
+      num_values,
+      null_count,
+      [&]() {
+        uint8_t gathered_byte_data[kNumStreams];
+        for (size_t b = 0; b < kNumStreams; ++b) {
+          const size_t byte_index = b * num_values_in_buffer_ + offset;
+          gathered_byte_data[b] = data[byte_index];
+        }
+        builder->UnsafeAppend(SafeLoadAs<T>(&gathered_byte_data[0]));
+        ++offset;
+      },
+      [&]() { builder->UnsafeAppendNull(); });
+#endif
+
+  num_values_ -= values_decoded;
+  len_ -= sizeof(T) * values_decoded;
+  return values_decoded;
+}
+
+template <typename DType>
+int ByteStreamSplitDecoder<DType>::DecodeArrow(
+    int num_values,
+    int null_count,
+    const uint8_t* valid_bits,
+    int64_t valid_bits_offset,
+    typename EncodingTraits<DType>::DictAccumulator* builder) {
+  ParquetException::NYI("DecodeArrow for ByteStreamSplitDecoder");
+}
+
+} // namespace
+
+// ----------------------------------------------------------------------
+// Encoder and decoder factory functions
+
+std::unique_ptr<Encoder> MakeEncoder(
+    Type::type type_num,
+    Encoding::type encoding,
+    bool use_dictionary,
+    const ColumnDescriptor* descr,
+    MemoryPool* pool) {
+  if (use_dictionary) {
+    switch (type_num) {
+      case Type::INT32:
+        return std::make_unique<DictEncoderImpl<Int32Type>>(descr, pool);
+      case Type::INT64:
+        return std::make_unique<DictEncoderImpl<Int64Type>>(descr, pool);
+      case Type::INT96:
+        return std::make_unique<DictEncoderImpl<Int96Type>>(descr, pool);
+      case Type::FLOAT:
+        return std::make_unique<DictEncoderImpl<FloatType>>(descr, pool);
+      case Type::DOUBLE:
+        return std::make_unique<DictEncoderImpl<DoubleType>>(descr, pool);
+      case Type::BYTE_ARRAY:
+        return std::make_unique<DictEncoderImpl<ByteArrayType>>(descr, pool);
+      case Type::FIXED_LEN_BYTE_ARRAY:
+        return std::make_unique<DictEncoderImpl<FLBAType>>(descr, pool);
+      default:
+        DCHECK(false) << "Encoder not implemented";
+        break;
+    }
+  } else if (encoding == Encoding::PLAIN) {
+    switch (type_num) {
+      case Type::BOOLEAN:
+        return std::make_unique<PlainEncoder<BooleanType>>(descr, pool);
+      case Type::INT32:
+        return std::make_unique<PlainEncoder<Int32Type>>(descr, pool);
+      case Type::INT64:
+        return std::make_unique<PlainEncoder<Int64Type>>(descr, pool);
+      case Type::INT96:
+        return std::make_unique<PlainEncoder<Int96Type>>(descr, pool);
+      case Type::FLOAT:
+        return std::make_unique<PlainEncoder<FloatType>>(descr, pool);
+      case Type::DOUBLE:
+        return std::make_unique<PlainEncoder<DoubleType>>(descr, pool);
+      case Type::BYTE_ARRAY:
+        return std::make_unique<PlainEncoder<ByteArrayType>>(descr, pool);
+      case Type::FIXED_LEN_BYTE_ARRAY:
+        return std::make_unique<PlainEncoder<FLBAType>>(descr, pool);
+      default:
+        DCHECK(false) << "Encoder not implemented";
+        break;
+    }
+  } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
+    switch (type_num) {
+      case Type::FLOAT:
+        return std::make_unique<ByteStreamSplitEncoder<FloatType>>(descr, pool);
+      case Type::DOUBLE:
+        return std::make_unique<ByteStreamSplitEncoder<DoubleType>>(
+            descr, pool);
+      default:
+        throw ParquetException(
+            "BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE");
+    }
+  } else if (encoding == Encoding::DELTA_BINARY_PACKED) {
+    switch (type_num) {
+      case Type::INT32:
+        return std::make_unique<DeltaBitPackEncoder<Int32Type>>(descr, pool);
+      case Type::INT64:
+        return std::make_unique<DeltaBitPackEncoder<Int64Type>>(descr, pool);
+      default:
+        throw ParquetException(
+            "DELTA_BINARY_PACKED encoder only supports INT32 and INT64");
+    }
+  } else if (encoding == Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+    switch (type_num) {
+      case Type::BYTE_ARRAY:
+        return std::make_unique<DeltaLengthByteArrayEncoder<ByteArrayType>>(
+            descr, pool);
+      default:
+        throw ParquetException(
+            "DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
+    }
+  } else if (encoding == Encoding::RLE) {
+    switch (type_num) {
+      case Type::BOOLEAN:
+        return std::make_unique<RleBooleanEncoder>(descr, pool);
+      default:
+        throw ParquetException("RLE only supports BOOLEAN");
+    }
+  } else {
+    ParquetException::NYI("Selected encoding is not supported");
+  }
+  DCHECK(false) << "Should not be able to reach this code";
+  return nullptr;
+}
+
+std::unique_ptr<Decoder> MakeDecoder(
+    Type::type type_num,
+    Encoding::type encoding,
+    const ColumnDescriptor* descr,
+    ::arrow::MemoryPool* pool) {
+  if (encoding == Encoding::PLAIN) {
+    switch (type_num) {
+      case Type::BOOLEAN:
+        return std::make_unique<PlainBooleanDecoder>(descr);
+      case Type::INT32:
+        return std::make_unique<PlainDecoder<Int32Type>>(descr);
+      case Type::INT64:
+        return std::make_unique<PlainDecoder<Int64Type>>(descr);
+      case Type::INT96:
+        return std::make_unique<PlainDecoder<Int96Type>>(descr);
+      case Type::FLOAT:
+        return std::make_unique<PlainDecoder<FloatType>>(descr);
+      case Type::DOUBLE:
+        return std::make_unique<PlainDecoder<DoubleType>>(descr);
+      case Type::BYTE_ARRAY:
+        return std::make_unique<PlainByteArrayDecoder>(descr);
+      case Type::FIXED_LEN_BYTE_ARRAY:
+        return std::make_unique<PlainFLBADecoder>(descr);
+      default:
+        break;
+    }
+  } else if (encoding == Encoding::BYTE_STREAM_SPLIT) {
+    switch (type_num) {
+      case Type::FLOAT:
+        return std::make_unique<ByteStreamSplitDecoder<FloatType>>(descr);
+      case Type::DOUBLE:
+        return std::make_unique<ByteStreamSplitDecoder<DoubleType>>(descr);
+      default:
+        throw ParquetException(
+            "BYTE_STREAM_SPLIT only supports FLOAT and DOUBLE");
+    }
+  } else if (encoding == Encoding::DELTA_BINARY_PACKED) {
+    switch (type_num) {
+      case Type::INT32:
+        return std::make_unique<DeltaBitPackDecoder<Int32Type>>(descr, pool);
+      case Type::INT64:
+        return std::make_unique<DeltaBitPackDecoder<Int64Type>>(descr, pool);
+      default:
+        throw ParquetException(
+            "DELTA_BINARY_PACKED decoder only supports INT32 and INT64");
+    }
+  } else if (encoding == Encoding::DELTA_BYTE_ARRAY) {
+    if (type_num == Type::BYTE_ARRAY) {
+      return std::make_unique<DeltaByteArrayDecoder>(descr, pool);
+    }
+    throw ParquetException("DELTA_BYTE_ARRAY only supports BYTE_ARRAY");
+  } else if (encoding == Encoding::DELTA_LENGTH_BYTE_ARRAY) {
+    if (type_num == Type::BYTE_ARRAY) {
+      return std::make_unique<DeltaLengthByteArrayDecoder>(descr, pool);
+    }
+    throw ParquetException("DELTA_LENGTH_BYTE_ARRAY only supports BYTE_ARRAY");
+  } else if (encoding == Encoding::RLE) {
+    if (type_num == Type::BOOLEAN) {
+      return std::make_unique<RleBooleanDecoder>(descr);
+    }
+    throw ParquetException("RLE encoding only supports BOOLEAN");
+  } else {
+    ParquetException::NYI("Selected encoding is not supported");
+  }
+  DCHECK(false) << "Should not be able to reach this code";
+  return nullptr;
+}
+
+namespace detail {
+std::unique_ptr<Decoder> MakeDictDecoder(
+    Type::type type_num,
+    const ColumnDescriptor* descr,
+    MemoryPool* pool) {
+  switch (type_num) {
+    case Type::BOOLEAN:
+      ParquetException::NYI(
+          "Dictionary encoding not implemented for boolean type");
+    case Type::INT32:
+      return std::make_unique<DictDecoderImpl<Int32Type>>(descr, pool);
+    case Type::INT64:
+      return std::make_unique<DictDecoderImpl<Int64Type>>(descr, pool);
+    case Type::INT96:
+      return std::make_unique<DictDecoderImpl<Int96Type>>(descr, pool);
+    case Type::FLOAT:
+      return std::make_unique<DictDecoderImpl<FloatType>>(descr, pool);
+    case Type::DOUBLE:
+      return std::make_unique<DictDecoderImpl<DoubleType>>(descr, pool);
+    case Type::BYTE_ARRAY:
+      return std::make_unique<DictByteArrayDecoderImpl>(descr, pool);
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return std::make_unique<DictDecoderImpl<FLBAType>>(descr, pool);
+    default:
+      break;
+  }
+  DCHECK(false) << "Should not be able to reach this code";
+  return nullptr;
+}
+
+} // namespace detail
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileDeserializeTest.cpp
@@ -1,0 +1,1039 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+#include "arrow/io/memory.h"
+#include "arrow/status.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/compression.h"
+#include "arrow/util/crc32.h"
+
+namespace facebook::velox::parquet::arrow {
+
+using ::arrow::io::BufferReader;
+
+// Adds page statistics occupying a certain amount of bytes (for testing very
+// large page headers)
+template <typename H>
+static inline void
+AddDummyStats(int stat_size, H& header, bool fill_all_stats = false) {
+  std::vector<uint8_t> stat_bytes(stat_size);
+  // Some non-zero value
+  std::fill(stat_bytes.begin(), stat_bytes.end(), 1);
+  header.statistics.__set_max(
+      std::string(reinterpret_cast<const char*>(stat_bytes.data()), stat_size));
+
+  if (fill_all_stats) {
+    header.statistics.__set_min(std::string(
+        reinterpret_cast<const char*>(stat_bytes.data()), stat_size));
+    header.statistics.__set_null_count(42);
+    header.statistics.__set_distinct_count(1);
+  }
+
+  header.__isset.statistics = true;
+}
+
+template <typename H>
+static inline void CheckStatistics(
+    const H& expected,
+    const EncodedStatistics& actual) {
+  if (expected.statistics.__isset.max) {
+    ASSERT_EQ(expected.statistics.max, actual.max());
+  }
+  if (expected.statistics.__isset.min) {
+    ASSERT_EQ(expected.statistics.min, actual.min());
+  }
+  if (expected.statistics.__isset.null_count) {
+    ASSERT_EQ(expected.statistics.null_count, actual.null_count);
+  }
+  if (expected.statistics.__isset.distinct_count) {
+    ASSERT_EQ(expected.statistics.distinct_count, actual.distinct_count);
+  }
+}
+
+static std::vector<Compression::type> GetSupportedCodecTypes() {
+  std::vector<Compression::type> codec_types;
+
+  codec_types.push_back(Compression::SNAPPY);
+
+#ifdef ARROW_WITH_BROTLI
+  codec_types.push_back(Compression::BROTLI);
+#endif
+
+#ifdef ARROW_WITH_GZIP
+  codec_types.push_back(Compression::GZIP);
+#endif
+
+#ifdef ARROW_WITH_LZ4
+  codec_types.push_back(Compression::LZ4);
+  codec_types.push_back(Compression::LZ4_HADOOP);
+#endif
+
+#ifdef ARROW_WITH_ZSTD
+  codec_types.push_back(Compression::ZSTD);
+#endif
+  return codec_types;
+}
+
+class TestPageSerde : public ::testing::Test {
+ public:
+  void SetUp() {
+    data_page_header_.encoding = format::Encoding::PLAIN;
+    data_page_header_.definition_level_encoding = format::Encoding::RLE;
+    data_page_header_.repetition_level_encoding = format::Encoding::RLE;
+
+    ResetStream();
+  }
+
+  void InitSerializedPageReader(
+      int64_t num_rows,
+      Compression::type codec = Compression::UNCOMPRESSED,
+      const ReaderProperties& properties = ReaderProperties()) {
+    EndStream();
+
+    auto stream = std::make_shared<::arrow::io::BufferReader>(out_buffer_);
+    page_reader_ = PageReader::Open(stream, num_rows, codec, properties);
+  }
+
+  void WriteDataPageHeader(
+      int max_serialized_len = 1024,
+      int32_t uncompressed_size = 0,
+      int32_t compressed_size = 0,
+      std::optional<int32_t> checksum = std::nullopt) {
+    // Simplifying writing serialized data page headers which may or may not
+    // have meaningful data associated with them
+
+    // Serialize the Page header
+    page_header_.__set_data_page_header(data_page_header_);
+    page_header_.uncompressed_page_size = uncompressed_size;
+    page_header_.compressed_page_size = compressed_size;
+    page_header_.type = format::PageType::DATA_PAGE;
+    if (checksum.has_value()) {
+      page_header_.__set_crc(checksum.value());
+    }
+
+    ThriftSerializer serializer;
+    ASSERT_NO_THROW(serializer.Serialize(&page_header_, out_stream_.get()));
+  }
+
+  void WriteDataPageHeaderV2(
+      int max_serialized_len = 1024,
+      int32_t uncompressed_size = 0,
+      int32_t compressed_size = 0,
+      std::optional<int32_t> checksum = std::nullopt) {
+    // Simplifying writing serialized data page V2 headers which may or may not
+    // have meaningful data associated with them
+
+    // Serialize the Page header
+    page_header_.__set_data_page_header_v2(data_page_header_v2_);
+    page_header_.uncompressed_page_size = uncompressed_size;
+    page_header_.compressed_page_size = compressed_size;
+    page_header_.type = format::PageType::DATA_PAGE_V2;
+    if (checksum.has_value()) {
+      page_header_.__set_crc(checksum.value());
+    }
+
+    ThriftSerializer serializer;
+    ASSERT_NO_THROW(serializer.Serialize(&page_header_, out_stream_.get()));
+  }
+
+  void WriteDictionaryPageHeader(
+      int32_t uncompressed_size = 0,
+      int32_t compressed_size = 0,
+      std::optional<int32_t> checksum = std::nullopt) {
+    page_header_.__set_dictionary_page_header(dictionary_page_header_);
+    page_header_.uncompressed_page_size = uncompressed_size;
+    page_header_.compressed_page_size = compressed_size;
+    page_header_.type = format::PageType::DICTIONARY_PAGE;
+    if (checksum.has_value()) {
+      page_header_.__set_crc(checksum.value());
+    }
+
+    ThriftSerializer serializer;
+    ASSERT_NO_THROW(serializer.Serialize(&page_header_, out_stream_.get()));
+  }
+
+  void WriteIndexPageHeader(
+      int32_t uncompressed_size = 0,
+      int32_t compressed_size = 0) {
+    page_header_.__set_index_page_header(index_page_header_);
+    page_header_.uncompressed_page_size = uncompressed_size;
+    page_header_.compressed_page_size = compressed_size;
+    page_header_.type = format::PageType::INDEX_PAGE;
+
+    ThriftSerializer serializer;
+    ASSERT_NO_THROW(serializer.Serialize(&page_header_, out_stream_.get()));
+  }
+
+  void ResetStream() {
+    out_stream_ = CreateOutputStream();
+  }
+
+  void EndStream() {
+    PARQUET_ASSIGN_OR_THROW(out_buffer_, out_stream_->Finish());
+  }
+
+  void TestPageSerdeCrc(
+      bool write_checksum,
+      bool write_page_corrupt,
+      bool verification_checksum,
+      bool has_dictionary = false,
+      bool write_data_page_v2 = false);
+
+  void TestPageCompressionRoundTrip(const std::vector<int>& page_sizes);
+
+ protected:
+  std::shared_ptr<::arrow::io::BufferOutputStream> out_stream_;
+  std::shared_ptr<Buffer> out_buffer_;
+
+  std::unique_ptr<PageReader> page_reader_;
+  format::PageHeader page_header_;
+  format::DataPageHeader data_page_header_;
+  format::DataPageHeaderV2 data_page_header_v2_;
+  format::IndexPageHeader index_page_header_;
+  format::DictionaryPageHeader dictionary_page_header_;
+};
+
+void TestPageSerde::TestPageSerdeCrc(
+    bool write_checksum,
+    bool write_page_corrupt,
+    bool verification_checksum,
+    bool has_dictionary,
+    bool write_data_page_v2) {
+  auto codec_types = GetSupportedCodecTypes();
+  codec_types.push_back(Compression::UNCOMPRESSED);
+  const int32_t num_rows = 32; // dummy value
+  if (write_data_page_v2) {
+    data_page_header_v2_.num_values = num_rows;
+  } else {
+    data_page_header_.num_values = num_rows;
+  }
+  dictionary_page_header_.num_values = num_rows;
+
+  const int num_pages = 10;
+
+  std::vector<std::vector<uint8_t>> faux_data;
+  faux_data.resize(num_pages);
+  for (int i = 0; i < num_pages; ++i) {
+    // The pages keep getting larger
+    int page_size = (i + 1) * 64;
+    test::random_bytes(page_size, 0, &faux_data[i]);
+  }
+  for (auto codec_type : codec_types) {
+    auto codec = GetCodec(codec_type);
+
+    std::vector<uint8_t> buffer;
+    for (int i = 0; i < num_pages; ++i) {
+      const uint8_t* data = faux_data[i].data();
+      int data_size = static_cast<int>(faux_data[i].size());
+      int64_t actual_size;
+      if (codec == nullptr) {
+        buffer = faux_data[i];
+        actual_size = data_size;
+      } else {
+        int64_t max_compressed_size = codec->MaxCompressedLen(data_size, data);
+        buffer.resize(max_compressed_size);
+
+        ASSERT_OK_AND_ASSIGN(
+            actual_size,
+            codec->Compress(data_size, data, max_compressed_size, &buffer[0]));
+      }
+      std::optional<uint32_t> checksum_opt;
+      if (write_checksum) {
+        uint32_t checksum =
+            ::arrow::internal::crc32(/* prev */ 0, buffer.data(), actual_size);
+        if (write_page_corrupt) {
+          checksum += 1; // write a bad checksum
+        }
+        checksum_opt = checksum;
+      }
+      if (has_dictionary && i == 0) {
+        ASSERT_NO_FATAL_FAILURE(WriteDictionaryPageHeader(
+            data_size, static_cast<int32_t>(actual_size), checksum_opt));
+      } else {
+        if (write_data_page_v2) {
+          ASSERT_NO_FATAL_FAILURE(WriteDataPageHeaderV2(
+              1024,
+              data_size,
+              static_cast<int32_t>(actual_size),
+              checksum_opt));
+        } else {
+          ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader(
+              1024,
+              data_size,
+              static_cast<int32_t>(actual_size),
+              checksum_opt));
+        }
+      }
+      ASSERT_OK(out_stream_->Write(buffer.data(), actual_size));
+    }
+    ReaderProperties readerProperties;
+    readerProperties.set_page_checksum_verification(verification_checksum);
+    InitSerializedPageReader(
+        num_rows * num_pages, codec_type, readerProperties);
+
+    for (int i = 0; i < num_pages; ++i) {
+      if (write_checksum && write_page_corrupt && verification_checksum) {
+        EXPECT_THROW_THAT(
+            [&]() { page_reader_->NextPage(); },
+            ParquetException,
+            ::testing::Property(
+                &ParquetException::what,
+                ::testing::HasSubstr("CRC checksum verification failed")));
+      } else {
+        const auto page = page_reader_->NextPage();
+        const int data_size = static_cast<int>(faux_data[i].size());
+        if (has_dictionary && i == 0) {
+          ASSERT_EQ(PageType::DICTIONARY_PAGE, page->type());
+          const auto dict_page = static_cast<const DictionaryPage*>(page.get());
+          ASSERT_EQ(data_size, dict_page->size());
+          ASSERT_EQ(
+              0, memcmp(faux_data[i].data(), dict_page->data(), data_size));
+        } else if (write_data_page_v2) {
+          ASSERT_EQ(PageType::DATA_PAGE_V2, page->type());
+          const auto data_page = static_cast<const DataPageV2*>(page.get());
+          ASSERT_EQ(data_size, data_page->size());
+          ASSERT_EQ(
+              0, memcmp(faux_data[i].data(), data_page->data(), data_size));
+        } else {
+          ASSERT_EQ(PageType::DATA_PAGE, page->type());
+          const auto data_page = static_cast<const DataPageV1*>(page.get());
+          ASSERT_EQ(data_size, data_page->size());
+          ASSERT_EQ(
+              0, memcmp(faux_data[i].data(), data_page->data(), data_size));
+        }
+      }
+    }
+
+    ResetStream();
+  }
+}
+
+void CheckDataPageHeader(
+    const format::DataPageHeader& expected,
+    const Page* page) {
+  ASSERT_EQ(PageType::DATA_PAGE, page->type());
+
+  const DataPageV1* data_page = static_cast<const DataPageV1*>(page);
+  ASSERT_EQ(expected.num_values, data_page->num_values());
+  ASSERT_EQ(expected.encoding, data_page->encoding());
+  ASSERT_EQ(
+      expected.definition_level_encoding,
+      data_page->definition_level_encoding());
+  ASSERT_EQ(
+      expected.repetition_level_encoding,
+      data_page->repetition_level_encoding());
+  CheckStatistics(expected, data_page->statistics());
+}
+
+// Overload for DataPageV2 tests.
+void CheckDataPageHeader(
+    const format::DataPageHeaderV2& expected,
+    const Page* page) {
+  ASSERT_EQ(PageType::DATA_PAGE_V2, page->type());
+
+  const DataPageV2* data_page = static_cast<const DataPageV2*>(page);
+  ASSERT_EQ(expected.num_values, data_page->num_values());
+  ASSERT_EQ(expected.num_nulls, data_page->num_nulls());
+  ASSERT_EQ(expected.num_rows, data_page->num_rows());
+  ASSERT_EQ(expected.encoding, data_page->encoding());
+  ASSERT_EQ(
+      expected.definition_levels_byte_length,
+      data_page->definition_levels_byte_length());
+  ASSERT_EQ(
+      expected.repetition_levels_byte_length,
+      data_page->repetition_levels_byte_length());
+  ASSERT_EQ(expected.is_compressed, data_page->is_compressed());
+  CheckStatistics(expected, data_page->statistics());
+}
+
+TEST_F(TestPageSerde, DataPageV1) {
+  int stats_size = 512;
+  const int32_t num_rows = 4444;
+  AddDummyStats(stats_size, data_page_header_, /* fill_all_stats = */ true);
+  data_page_header_.num_values = num_rows;
+
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader());
+  InitSerializedPageReader(num_rows);
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_NO_FATAL_FAILURE(
+      CheckDataPageHeader(data_page_header_, current_page.get()));
+}
+
+// Templated test class to test page filtering for both format::DataPageHeader
+// and format::DataPageHeaderV2.
+template <typename T>
+class PageFilterTest : public TestPageSerde {
+ public:
+  const int kNumPages = 10;
+  void WriteStream();
+  void WritePageWithoutStats();
+  void CheckNumRows(std::optional<int32_t> num_rows, const T& header);
+
+ protected:
+  std::vector<T> data_page_headers_;
+  int total_rows_ = 0;
+};
+
+template <>
+void PageFilterTest<format::DataPageHeader>::WriteStream() {
+  for (int i = 0; i < kNumPages; ++i) {
+    // Vary the number of rows to produce different headers.
+    int32_t num_rows = i + 100;
+    total_rows_ += num_rows;
+    int data_size = i + 1024;
+    this->data_page_header_.__set_num_values(num_rows);
+    this->data_page_header_.statistics.__set_min_value("A" + std::to_string(i));
+    this->data_page_header_.statistics.__set_max_value("Z" + std::to_string(i));
+    this->data_page_header_.statistics.__set_null_count(0);
+    this->data_page_header_.statistics.__set_distinct_count(num_rows);
+    this->data_page_header_.__isset.statistics = true;
+    ASSERT_NO_FATAL_FAILURE(this->WriteDataPageHeader(
+        /*max_serialized_len=*/1024, data_size, data_size));
+    data_page_headers_.push_back(this->data_page_header_);
+    // Also write data, to make sure we skip the data correctly.
+    std::vector<uint8_t> faux_data(data_size);
+    ASSERT_OK(this->out_stream_->Write(faux_data.data(), data_size));
+  }
+  this->EndStream();
+}
+
+template <>
+void PageFilterTest<format::DataPageHeaderV2>::WriteStream() {
+  for (int i = 0; i < kNumPages; ++i) {
+    // Vary the number of rows to produce different headers.
+    int32_t num_rows = i + 100;
+    total_rows_ += num_rows;
+    int data_size = i + 1024;
+    this->data_page_header_v2_.__set_num_values(num_rows);
+    this->data_page_header_v2_.__set_num_rows(num_rows);
+    this->data_page_header_v2_.statistics.__set_min_value(
+        "A" + std::to_string(i));
+    this->data_page_header_v2_.statistics.__set_max_value(
+        "Z" + std::to_string(i));
+    this->data_page_header_v2_.statistics.__set_null_count(0);
+    this->data_page_header_v2_.statistics.__set_distinct_count(num_rows);
+    this->data_page_header_v2_.__isset.statistics = true;
+    ASSERT_NO_FATAL_FAILURE(this->WriteDataPageHeaderV2(
+        /*max_serialized_len=*/1024, data_size, data_size));
+    data_page_headers_.push_back(this->data_page_header_v2_);
+    // Also write data, to make sure we skip the data correctly.
+    std::vector<uint8_t> faux_data(data_size);
+    ASSERT_OK(this->out_stream_->Write(faux_data.data(), data_size));
+  }
+  this->EndStream();
+}
+
+template <>
+void PageFilterTest<format::DataPageHeader>::WritePageWithoutStats() {
+  int32_t num_rows = 100;
+  total_rows_ += num_rows;
+  int data_size = 1024;
+  this->data_page_header_.__set_num_values(num_rows);
+  ASSERT_NO_FATAL_FAILURE(this->WriteDataPageHeader(
+      /*max_serialized_len=*/1024, data_size, data_size));
+  data_page_headers_.push_back(this->data_page_header_);
+  std::vector<uint8_t> faux_data(data_size);
+  ASSERT_OK(this->out_stream_->Write(faux_data.data(), data_size));
+  this->EndStream();
+}
+
+template <>
+void PageFilterTest<format::DataPageHeaderV2>::WritePageWithoutStats() {
+  int32_t num_rows = 100;
+  total_rows_ += num_rows;
+  int data_size = 1024;
+  this->data_page_header_v2_.__set_num_values(num_rows);
+  this->data_page_header_v2_.__set_num_rows(num_rows);
+  ASSERT_NO_FATAL_FAILURE(this->WriteDataPageHeaderV2(
+      /*max_serialized_len=*/1024, data_size, data_size));
+  data_page_headers_.push_back(this->data_page_header_v2_);
+  std::vector<uint8_t> faux_data(data_size);
+  ASSERT_OK(this->out_stream_->Write(faux_data.data(), data_size));
+  this->EndStream();
+}
+
+template <>
+void PageFilterTest<format::DataPageHeader>::CheckNumRows(
+    std::optional<int32_t> num_rows,
+    const format::DataPageHeader& header) {
+  ASSERT_EQ(num_rows, std::nullopt);
+}
+
+template <>
+void PageFilterTest<format::DataPageHeaderV2>::CheckNumRows(
+    std::optional<int32_t> num_rows,
+    const format::DataPageHeaderV2& header) {
+  ASSERT_EQ(*num_rows, header.num_rows);
+}
+
+using DataPageHeaderTypes =
+    ::testing::Types<format::DataPageHeader, format::DataPageHeaderV2>;
+TYPED_TEST_SUITE(PageFilterTest, DataPageHeaderTypes);
+
+// Test that the returned encoded_statistics is nullptr when there are no
+// statistics in the page header.
+TYPED_TEST(PageFilterTest, TestPageWithoutStatistics) {
+  this->WritePageWithoutStats();
+
+  auto stream = std::make_shared<::arrow::io::BufferReader>(this->out_buffer_);
+  this->page_reader_ =
+      PageReader::Open(stream, this->total_rows_, Compression::UNCOMPRESSED);
+
+  int num_pages = 0;
+  bool is_stats_null = false;
+  auto read_all_pages = [&](const DataPageStats& stats) -> bool {
+    is_stats_null = stats.encoded_statistics == nullptr;
+    ++num_pages;
+    return false;
+  };
+
+  this->page_reader_->set_data_page_filter(read_all_pages);
+  std::shared_ptr<Page> current_page = this->page_reader_->NextPage();
+  ASSERT_EQ(num_pages, 1);
+  ASSERT_EQ(is_stats_null, true);
+  ASSERT_EQ(this->page_reader_->NextPage(), nullptr);
+}
+
+// Creates a number of pages and skips some of them with the page filter
+// callback.
+TYPED_TEST(PageFilterTest, TestPageFilterCallback) {
+  this->WriteStream();
+
+  { // Read all pages.
+    // Also check that the encoded statistics passed to the callback function
+    // are right.
+    auto stream =
+        std::make_shared<::arrow::io::BufferReader>(this->out_buffer_);
+    this->page_reader_ =
+        PageReader::Open(stream, this->total_rows_, Compression::UNCOMPRESSED);
+
+    std::vector<EncodedStatistics> read_stats;
+    std::vector<int64_t> read_num_values;
+    std::vector<std::optional<int32_t>> read_num_rows;
+    auto read_all_pages = [&](const DataPageStats& stats) -> bool {
+      DCHECK_NE(stats.encoded_statistics, nullptr);
+      read_stats.push_back(*stats.encoded_statistics);
+      read_num_values.push_back(stats.num_values);
+      read_num_rows.push_back(stats.num_rows);
+      return false;
+    };
+
+    this->page_reader_->set_data_page_filter(read_all_pages);
+    for (int i = 0; i < this->kNumPages; ++i) {
+      std::shared_ptr<Page> current_page = this->page_reader_->NextPage();
+      ASSERT_NE(current_page, nullptr);
+      ASSERT_NO_FATAL_FAILURE(
+          CheckDataPageHeader(this->data_page_headers_[i], current_page.get()));
+      auto data_page = static_cast<const DataPage*>(current_page.get());
+      const EncodedStatistics encoded_statistics = data_page->statistics();
+      ASSERT_EQ(read_stats[i].max(), encoded_statistics.max());
+      ASSERT_EQ(read_stats[i].min(), encoded_statistics.min());
+      ASSERT_EQ(read_stats[i].null_count, encoded_statistics.null_count);
+      ASSERT_EQ(
+          read_stats[i].distinct_count, encoded_statistics.distinct_count);
+      ASSERT_EQ(read_num_values[i], this->data_page_headers_[i].num_values);
+      this->CheckNumRows(read_num_rows[i], this->data_page_headers_[i]);
+    }
+    ASSERT_EQ(this->page_reader_->NextPage(), nullptr);
+  }
+
+  { // Skip all pages.
+    auto stream =
+        std::make_shared<::arrow::io::BufferReader>(this->out_buffer_);
+    this->page_reader_ =
+        PageReader::Open(stream, this->total_rows_, Compression::UNCOMPRESSED);
+
+    auto skip_all_pages = [](const DataPageStats& stats) -> bool {
+      return true;
+    };
+
+    this->page_reader_->set_data_page_filter(skip_all_pages);
+    std::shared_ptr<Page> current_page = this->page_reader_->NextPage();
+    ASSERT_EQ(this->page_reader_->NextPage(), nullptr);
+  }
+
+  { // Skip every other page.
+    auto stream =
+        std::make_shared<::arrow::io::BufferReader>(this->out_buffer_);
+    this->page_reader_ =
+        PageReader::Open(stream, this->total_rows_, Compression::UNCOMPRESSED);
+
+    // Skip pages with even number of values.
+    auto skip_even_pages = [](const DataPageStats& stats) -> bool {
+      if (stats.num_values % 2 == 0)
+        return true;
+      return false;
+    };
+
+    this->page_reader_->set_data_page_filter(skip_even_pages);
+
+    for (int i = 0; i < this->kNumPages; ++i) {
+      // Only pages with odd number of values are read.
+      if (i % 2 != 0) {
+        std::shared_ptr<Page> current_page = this->page_reader_->NextPage();
+        ASSERT_NE(current_page, nullptr);
+        ASSERT_NO_FATAL_FAILURE(CheckDataPageHeader(
+            this->data_page_headers_[i], current_page.get()));
+      }
+    }
+    // We should have exhausted reading the pages by reading the odd pages only.
+    ASSERT_EQ(this->page_reader_->NextPage(), nullptr);
+  }
+}
+
+// Set the page filter more than once. The new filter should be effective
+// on the next NextPage() call.
+TYPED_TEST(PageFilterTest, TestChangingPageFilter) {
+  this->WriteStream();
+
+  auto stream = std::make_shared<::arrow::io::BufferReader>(this->out_buffer_);
+  this->page_reader_ =
+      PageReader::Open(stream, this->total_rows_, Compression::UNCOMPRESSED);
+
+  // This callback will always return false.
+  auto read_all_pages = [](const DataPageStats& stats) -> bool {
+    return false;
+  };
+  this->page_reader_->set_data_page_filter(read_all_pages);
+  std::shared_ptr<Page> current_page = this->page_reader_->NextPage();
+  ASSERT_NE(current_page, nullptr);
+  ASSERT_NO_FATAL_FAILURE(
+      CheckDataPageHeader(this->data_page_headers_[0], current_page.get()));
+
+  // This callback will skip all pages.
+  auto skip_all_pages = [](const DataPageStats& stats) -> bool { return true; };
+  this->page_reader_->set_data_page_filter(skip_all_pages);
+  ASSERT_EQ(this->page_reader_->NextPage(), nullptr);
+}
+
+// Test that we do not skip dictionary pages.
+TEST_F(TestPageSerde, DoesNotFilterDictionaryPages) {
+  int data_size = 1024;
+  std::vector<uint8_t> faux_data(data_size);
+
+  ASSERT_NO_FATAL_FAILURE(
+      WriteDataPageHeader(/*max_serialized_len=*/1024, data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+
+  ASSERT_NO_FATAL_FAILURE(WriteDictionaryPageHeader(data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+
+  ASSERT_NO_FATAL_FAILURE(
+      WriteDataPageHeader(/*max_serialized_len=*/1024, data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+  EndStream();
+
+  // Try to read it back while asking for all data pages to be skipped.
+  auto stream = std::make_shared<::arrow::io::BufferReader>(out_buffer_);
+  page_reader_ =
+      PageReader::Open(stream, /*num_rows=*/100, Compression::UNCOMPRESSED);
+
+  auto skip_all_pages = [](const DataPageStats& stats) -> bool { return true; };
+
+  page_reader_->set_data_page_filter(skip_all_pages);
+  // The first data page is skipped, so we are now at the dictionary page.
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_NE(current_page, nullptr);
+  ASSERT_EQ(current_page->type(), PageType::DICTIONARY_PAGE);
+  // The data page after dictionary page is skipped.
+  ASSERT_EQ(page_reader_->NextPage(), nullptr);
+}
+
+// Tests that we successfully skip non-data pages.
+TEST_F(TestPageSerde, SkipsNonDataPages) {
+  int data_size = 1024;
+  std::vector<uint8_t> faux_data(data_size);
+  ASSERT_NO_FATAL_FAILURE(WriteIndexPageHeader(data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+
+  ASSERT_NO_FATAL_FAILURE(
+      WriteDataPageHeader(/*max_serialized_len=*/1024, data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+
+  ASSERT_NO_FATAL_FAILURE(WriteIndexPageHeader(data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+  ASSERT_NO_FATAL_FAILURE(WriteIndexPageHeader(data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+
+  ASSERT_NO_FATAL_FAILURE(
+      WriteDataPageHeader(/*max_serialized_len=*/1024, data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+  ASSERT_NO_FATAL_FAILURE(WriteIndexPageHeader(data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+  EndStream();
+
+  auto stream = std::make_shared<::arrow::io::BufferReader>(out_buffer_);
+  page_reader_ =
+      PageReader::Open(stream, /*num_rows=*/100, Compression::UNCOMPRESSED);
+
+  // Only the two data pages are returned.
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_EQ(current_page->type(), PageType::DATA_PAGE);
+  current_page = page_reader_->NextPage();
+  ASSERT_EQ(current_page->type(), PageType::DATA_PAGE);
+  ASSERT_EQ(page_reader_->NextPage(), nullptr);
+}
+
+TEST_F(TestPageSerde, DataPageV2) {
+  int stats_size = 512;
+  const int32_t num_rows = 4444;
+  AddDummyStats(stats_size, data_page_header_v2_, /* fill_all_stats = */ true);
+  data_page_header_v2_.num_values = num_rows;
+
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeaderV2());
+  InitSerializedPageReader(num_rows);
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_NO_FATAL_FAILURE(
+      CheckDataPageHeader(data_page_header_v2_, current_page.get()));
+}
+
+TEST_F(TestPageSerde, TestLargePageHeaders) {
+  int stats_size = 256 * 1024; // 256 KB
+  AddDummyStats(stats_size, data_page_header_);
+
+  // Any number to verify metadata roundtrip
+  const int32_t num_rows = 4141;
+  data_page_header_.num_values = num_rows;
+
+  int max_header_size = 512 * 1024; // 512 KB
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader(max_header_size));
+
+  ASSERT_OK_AND_ASSIGN(int64_t position, out_stream_->Tell());
+  ASSERT_GE(max_header_size, position);
+
+  // check header size is between 256 KB to 16 MB
+  ASSERT_LE(stats_size, position);
+  ASSERT_GE(kDefaultMaxPageHeaderSize, position);
+
+  InitSerializedPageReader(num_rows);
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_NO_FATAL_FAILURE(
+      CheckDataPageHeader(data_page_header_, current_page.get()));
+}
+
+TEST_F(TestPageSerde, TestFailLargePageHeaders) {
+  const int32_t num_rows = 1337; // dummy value
+
+  int stats_size = 256 * 1024; // 256 KB
+  AddDummyStats(stats_size, data_page_header_);
+
+  // Serialize the Page header
+  int max_header_size = 512 * 1024; // 512 KB
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader(max_header_size));
+  ASSERT_OK_AND_ASSIGN(int64_t position, out_stream_->Tell());
+  ASSERT_GE(max_header_size, position);
+
+  int smaller_max_size = 128 * 1024;
+  ASSERT_LE(smaller_max_size, position);
+  InitSerializedPageReader(num_rows);
+
+  // Set the max page header size to 128 KB, which is less than the current
+  // header size
+  page_reader_->set_max_page_header_size(smaller_max_size);
+  ASSERT_THROW(page_reader_->NextPage(), ParquetException);
+}
+
+void TestPageSerde::TestPageCompressionRoundTrip(
+    const std::vector<int>& page_sizes) {
+  auto codec_types = GetSupportedCodecTypes();
+
+  const int32_t num_rows = 32; // dummy value
+  data_page_header_.num_values = num_rows;
+
+  std::vector<std::vector<uint8_t>> faux_data;
+  int num_pages = static_cast<int>(page_sizes.size());
+  faux_data.resize(num_pages);
+  for (int i = 0; i < num_pages; ++i) {
+    test::random_bytes(page_sizes[i], 0, &faux_data[i]);
+  }
+  for (auto codec_type : codec_types) {
+    auto codec = GetCodec(codec_type);
+
+    std::vector<uint8_t> buffer;
+    for (int i = 0; i < num_pages; ++i) {
+      const uint8_t* data = faux_data[i].data();
+      int data_size = static_cast<int>(faux_data[i].size());
+
+      int64_t max_compressed_size = codec->MaxCompressedLen(data_size, data);
+      buffer.resize(max_compressed_size);
+
+      int64_t actual_size;
+      ASSERT_OK_AND_ASSIGN(
+          actual_size,
+          codec->Compress(data_size, data, max_compressed_size, &buffer[0]));
+
+      ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader(
+          1024, data_size, static_cast<int32_t>(actual_size)));
+      ASSERT_OK(out_stream_->Write(buffer.data(), actual_size));
+    }
+
+    InitSerializedPageReader(num_rows * num_pages, codec_type);
+
+    std::shared_ptr<Page> page;
+    const DataPageV1* data_page;
+    for (int i = 0; i < num_pages; ++i) {
+      int data_size = static_cast<int>(faux_data[i].size());
+      page = page_reader_->NextPage();
+      data_page = static_cast<const DataPageV1*>(page.get());
+      ASSERT_EQ(data_size, data_page->size());
+      ASSERT_EQ(0, memcmp(faux_data[i].data(), data_page->data(), data_size));
+    }
+
+    ResetStream();
+  }
+}
+
+TEST_F(TestPageSerde, Compression) {
+  std::vector<int> page_sizes;
+  page_sizes.reserve(10);
+  for (int i = 0; i < 10; ++i) {
+    // The pages keep getting larger
+    page_sizes.push_back((i + 1) * 64);
+  }
+  this->TestPageCompressionRoundTrip(page_sizes);
+}
+
+TEST_F(TestPageSerde, PageSizeResetWhenRead) {
+  // GH-35423: Parquet SerializedPageReader need to
+  // reset the size after getting a smaller page.
+  std::vector<int> page_sizes;
+  page_sizes.reserve(10);
+  for (int i = 0; i < 10; ++i) {
+    // The pages keep getting smaller
+    page_sizes.push_back((10 - i) * 64);
+  }
+  this->TestPageCompressionRoundTrip(page_sizes);
+}
+
+TEST_F(TestPageSerde, LZONotSupported) {
+  // Must await PARQUET-530
+  int data_size = 1024;
+  std::vector<uint8_t> faux_data(data_size);
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader(1024, data_size, data_size));
+  ASSERT_OK(out_stream_->Write(faux_data.data(), data_size));
+  ASSERT_THROW(
+      InitSerializedPageReader(data_size, Compression::LZO), ParquetException);
+}
+
+TEST_F(TestPageSerde, NoCrc) {
+  int stats_size = 512;
+  const int32_t num_rows = 4444;
+  AddDummyStats(stats_size, data_page_header_, /*fill_all_stats=*/true);
+  data_page_header_.num_values = num_rows;
+
+  ASSERT_NO_FATAL_FAILURE(WriteDataPageHeader());
+  ReaderProperties readerProperties;
+  readerProperties.set_page_checksum_verification(true);
+  InitSerializedPageReader(
+      num_rows, Compression::UNCOMPRESSED, readerProperties);
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+  ASSERT_NO_FATAL_FAILURE(
+      CheckDataPageHeader(data_page_header_, current_page.get()));
+}
+
+TEST_F(TestPageSerde, NoCrcDict) {
+  const int32_t num_rows = 4444;
+  dictionary_page_header_.num_values = num_rows;
+
+  ASSERT_NO_FATAL_FAILURE(WriteDictionaryPageHeader());
+  ReaderProperties readerProperties;
+  readerProperties.set_page_checksum_verification(true);
+  InitSerializedPageReader(
+      num_rows, Compression::UNCOMPRESSED, readerProperties);
+  std::shared_ptr<Page> current_page = page_reader_->NextPage();
+
+  ASSERT_EQ(PageType::DICTIONARY_PAGE, current_page->type());
+
+  const auto* dict_page =
+      static_cast<const DictionaryPage*>(current_page.get());
+  EXPECT_EQ(num_rows, dict_page->num_values());
+}
+
+TEST_F(TestPageSerde, CrcCheckSuccessful) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true);
+}
+
+TEST_F(TestPageSerde, CrcCheckFail) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ true);
+}
+
+TEST_F(TestPageSerde, CrcCorruptNotChecked) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ false);
+}
+
+TEST_F(TestPageSerde, CrcCheckNonExistent) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ false,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true);
+}
+
+TEST_F(TestPageSerde, DictCrcCheckSuccessful) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true,
+      /* has_dictionary */ true);
+}
+
+TEST_F(TestPageSerde, DictCrcCheckFail) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ true,
+      /* has_dictionary */ true);
+}
+
+TEST_F(TestPageSerde, DictCrcCorruptNotChecked) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ false,
+      /* has_dictionary */ true);
+}
+
+TEST_F(TestPageSerde, DictCrcCheckNonExistent) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ false,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true,
+      /* has_dictionary */ true);
+}
+
+TEST_F(TestPageSerde, DataPageV2CrcCheckSuccessful) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true,
+      /* has_dictionary */ false,
+      /* write_data_page_v2 */ true);
+}
+
+TEST_F(TestPageSerde, DataPageV2CrcCheckFail) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ true,
+      /* has_dictionary */ false,
+      /* write_data_page_v2 */ true);
+}
+
+TEST_F(TestPageSerde, DataPageV2CrcCorruptNotChecked) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ true,
+      /* write_page_corrupt */ true,
+      /* verification_checksum */ false,
+      /* has_dictionary */ false,
+      /* write_data_page_v2 */ true);
+}
+
+TEST_F(TestPageSerde, DataPageV2CrcCheckNonExistent) {
+  this->TestPageSerdeCrc(
+      /* write_checksum */ false,
+      /* write_page_corrupt */ false,
+      /* verification_checksum */ true,
+      /* has_dictionary */ false,
+      /* write_data_page_v2 */ true);
+}
+
+// ----------------------------------------------------------------------
+// File structure tests
+
+class TestParquetFileReader : public ::testing::Test {
+ public:
+  void AssertInvalidFileThrows(const std::shared_ptr<Buffer>& buffer) {
+    reader_.reset(new ParquetFileReader());
+
+    auto reader = std::make_shared<BufferReader>(buffer);
+
+    ASSERT_THROW(
+        reader_->Open(ParquetFileReader::Contents::Open(reader)),
+        ParquetException);
+  }
+
+ protected:
+  std::unique_ptr<ParquetFileReader> reader_;
+};
+
+TEST_F(TestParquetFileReader, InvalidHeader) {
+  const char* bad_header = "PAR2";
+
+  auto buffer = Buffer::Wrap(bad_header, strlen(bad_header));
+  ASSERT_NO_FATAL_FAILURE(AssertInvalidFileThrows(buffer));
+}
+
+TEST_F(TestParquetFileReader, InvalidFooter) {
+  // File is smaller than FOOTER_SIZE
+  const char* bad_file = "PAR1PAR";
+  auto buffer = Buffer::Wrap(bad_file, strlen(bad_file));
+  ASSERT_NO_FATAL_FAILURE(AssertInvalidFileThrows(buffer));
+
+  // Magic number incorrect
+  const char* bad_file2 = "PAR1PAR2";
+  buffer = Buffer::Wrap(bad_file2, strlen(bad_file2));
+  ASSERT_NO_FATAL_FAILURE(AssertInvalidFileThrows(buffer));
+}
+
+TEST_F(TestParquetFileReader, IncompleteMetadata) {
+  auto stream = CreateOutputStream();
+
+  const char* magic = "PAR1";
+
+  ASSERT_OK(
+      stream->Write(reinterpret_cast<const uint8_t*>(magic), strlen(magic)));
+  std::vector<uint8_t> bytes(10);
+  ASSERT_OK(stream->Write(bytes.data(), bytes.size()));
+  uint32_t metadata_len = 24;
+  ASSERT_OK(stream->Write(
+      reinterpret_cast<const uint8_t*>(&metadata_len), sizeof(uint32_t)));
+  ASSERT_OK(
+      stream->Write(reinterpret_cast<const uint8_t*>(magic), strlen(magic)));
+
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Finish());
+  ASSERT_NO_FATAL_FAILURE(AssertInvalidFileThrows(buffer));
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/FileReader.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileReader.cpp
@@ -1,0 +1,1117 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+#include "arrow/io/caching.h"
+#include "arrow/io/file.h"
+#include "arrow/io/memory.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/future.h"
+#include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/ubsan.h"
+#include "parquet/exception.h"
+
+#include "velox/dwio/parquet/writer/arrow/EncryptionInternal.h"
+#include "velox/dwio/parquet/writer/arrow/FileDecryptorInternal.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/PageIndex.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilter.h"
+#include "velox/dwio/parquet/writer/arrow/tests/BloomFilterReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnScanner.h"
+
+using arrow::internal::AddWithOverflow;
+
+namespace facebook::velox::parquet::arrow {
+
+// PARQUET-978: Minimize footer reads by reading 64 KB from the end of the file
+static constexpr int64_t kDefaultFooterReadSize = 64 * 1024;
+static constexpr uint32_t kFooterSize = 8;
+
+// For PARQUET-816
+static constexpr int64_t kMaxDictHeaderSize = 100;
+
+// ----------------------------------------------------------------------
+// RowGroupReader public API
+
+RowGroupReader::RowGroupReader(std::unique_ptr<Contents> contents)
+    : contents_(std::move(contents)) {}
+
+std::shared_ptr<ColumnReader> RowGroupReader::Column(int i) {
+  if (i >= metadata()->num_columns()) {
+    std::stringstream ss;
+    ss << "Trying to read column index " << i
+       << " but row group metadata has only " << metadata()->num_columns()
+       << " columns";
+    throw ParquetException(ss.str());
+  }
+  const ColumnDescriptor* descr = metadata()->schema()->Column(i);
+
+  std::unique_ptr<PageReader> page_reader = contents_->GetColumnPageReader(i);
+  return ColumnReader::Make(
+      descr,
+      std::move(page_reader),
+      const_cast<ReaderProperties*>(contents_->properties())->memory_pool());
+}
+
+std::shared_ptr<ColumnReader> RowGroupReader::ColumnWithExposeEncoding(
+    int i,
+    ExposedEncoding encoding_to_expose) {
+  std::shared_ptr<ColumnReader> reader = Column(i);
+
+  if (encoding_to_expose == ExposedEncoding::DICTIONARY) {
+    // Check the encoding_stats to see if all data pages are dictionary encoded.
+    std::unique_ptr<ColumnChunkMetaData> col = metadata()->ColumnChunk(i);
+    const std::vector<PageEncodingStats>& encoding_stats =
+        col->encoding_stats();
+    if (encoding_stats.empty()) {
+      // Some parquet files may have empty encoding_stats. In this case we are
+      // not sure whether all data pages are dictionary encoded. So we do not
+      // enable exposing dictionary.
+      return reader;
+    }
+    // The 1st page should be the dictionary page.
+    if (encoding_stats[0].page_type != PageType::DICTIONARY_PAGE ||
+        (encoding_stats[0].encoding != Encoding::PLAIN &&
+         encoding_stats[0].encoding != Encoding::PLAIN_DICTIONARY)) {
+      return reader;
+    }
+    // The following pages should be dictionary encoded data pages.
+    for (size_t idx = 1; idx < encoding_stats.size(); ++idx) {
+      if ((encoding_stats[idx].encoding != Encoding::RLE_DICTIONARY &&
+           encoding_stats[idx].encoding != Encoding::PLAIN_DICTIONARY) ||
+          (encoding_stats[idx].page_type != PageType::DATA_PAGE &&
+           encoding_stats[idx].page_type != PageType::DATA_PAGE_V2)) {
+        return reader;
+      }
+    }
+  } else {
+    // Exposing other encodings are not supported for now.
+    return reader;
+  }
+
+  // Set exposed encoding.
+  reader->SetExposedEncoding(encoding_to_expose);
+  return reader;
+}
+
+std::unique_ptr<PageReader> RowGroupReader::GetColumnPageReader(int i) {
+  if (i >= metadata()->num_columns()) {
+    std::stringstream ss;
+    ss << "Trying to read column index " << i
+       << " but row group metadata has only " << metadata()->num_columns()
+       << " columns";
+    throw ParquetException(ss.str());
+  }
+  return contents_->GetColumnPageReader(i);
+}
+
+// Returns the rowgroup metadata
+const RowGroupMetaData* RowGroupReader::metadata() const {
+  return contents_->metadata();
+}
+
+/// Compute the section of the file that should be read for the given
+/// row group and column chunk.
+::arrow::io::ReadRange ComputeColumnChunkRange(
+    FileMetaData* file_metadata,
+    int64_t source_size,
+    int row_group_index,
+    int column_index) {
+  auto row_group_metadata = file_metadata->RowGroup(row_group_index);
+  auto column_metadata = row_group_metadata->ColumnChunk(column_index);
+
+  int64_t col_start = column_metadata->data_page_offset();
+  if (column_metadata->has_dictionary_page() &&
+      column_metadata->dictionary_page_offset() > 0 &&
+      col_start > column_metadata->dictionary_page_offset()) {
+    col_start = column_metadata->dictionary_page_offset();
+  }
+
+  int64_t col_length = column_metadata->total_compressed_size();
+  int64_t col_end;
+  if (col_start < 0 || col_length < 0) {
+    throw ParquetException("Invalid column metadata (corrupt file?)");
+  }
+
+  if (AddWithOverflow(col_start, col_length, &col_end) ||
+      col_end > source_size) {
+    throw ParquetException("Invalid column metadata (corrupt file?)");
+  }
+
+  // PARQUET-816 workaround for old files created by older parquet-mr
+  const ApplicationVersion& version = file_metadata->writer_version();
+  if (version.VersionLt(ApplicationVersion::PARQUET_816_FIXED_VERSION())) {
+    // The Parquet MR writer had a bug in 1.2.8 and below where it didn't
+    // include the dictionary page header size in total_compressed_size and
+    // total_uncompressed_size (see IMPALA-694). We add padding to compensate.
+    int64_t bytes_remaining = source_size - col_end;
+    int64_t padding = std::min<int64_t>(kMaxDictHeaderSize, bytes_remaining);
+    col_length += padding;
+  }
+
+  return {col_start, col_length};
+}
+
+// RowGroupReader::Contents implementation for the Parquet file specification
+class SerializedRowGroup : public RowGroupReader::Contents {
+ public:
+  SerializedRowGroup(
+      std::shared_ptr<ArrowInputFile> source,
+      std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source,
+      int64_t source_size,
+      FileMetaData* file_metadata,
+      int row_group_number,
+      const ReaderProperties& props,
+      std::shared_ptr<Buffer> prebuffered_column_chunks_bitmap,
+      std::shared_ptr<InternalFileDecryptor> file_decryptor = nullptr)
+      : source_(std::move(source)),
+        cached_source_(std::move(cached_source)),
+        source_size_(source_size),
+        file_metadata_(file_metadata),
+        properties_(props),
+        row_group_ordinal_(row_group_number),
+        prebuffered_column_chunks_bitmap_(
+            std::move(prebuffered_column_chunks_bitmap)),
+        file_decryptor_(file_decryptor) {
+    row_group_metadata_ = file_metadata->RowGroup(row_group_number);
+  }
+
+  const RowGroupMetaData* metadata() const override {
+    return row_group_metadata_.get();
+  }
+
+  const ReaderProperties* properties() const override {
+    return &properties_;
+  }
+
+  std::unique_ptr<PageReader> GetColumnPageReader(int i) override {
+    // Read column chunk from the file
+    auto col = row_group_metadata_->ColumnChunk(i);
+
+    ::arrow::io::ReadRange col_range = ComputeColumnChunkRange(
+        file_metadata_, source_size_, row_group_ordinal_, i);
+    std::shared_ptr<ArrowInputStream> stream;
+    if (cached_source_ && prebuffered_column_chunks_bitmap_ != nullptr &&
+        ::arrow::bit_util::GetBit(
+            prebuffered_column_chunks_bitmap_->data(), i)) {
+      // PARQUET-1698: if read coalescing is enabled, read from pre-buffered
+      // segments.
+      PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->Read(col_range));
+      stream = std::make_shared<::arrow::io::BufferReader>(buffer);
+    } else {
+      stream =
+          properties_.GetStream(source_, col_range.offset, col_range.length);
+    }
+
+    std::unique_ptr<ColumnCryptoMetaData> crypto_metadata =
+        col->crypto_metadata();
+
+    // Prior to Arrow 3.0.0, is_compressed was always set to false in column
+    // headers, even if compression was used. See ARROW-17100.
+    bool always_compressed = file_metadata_->writer_version().VersionLt(
+        ApplicationVersion::PARQUET_CPP_10353_FIXED_VERSION());
+
+    // Column is encrypted only if crypto_metadata exists.
+    if (!crypto_metadata) {
+      return PageReader::Open(
+          stream,
+          col->num_values(),
+          col->compression(),
+          properties_,
+          always_compressed);
+    }
+
+    if (file_decryptor_ == nullptr) {
+      throw ParquetException(
+          "RowGroup is noted as encrypted but no file decryptor");
+    }
+
+    constexpr auto kEncryptedRowGroupsLimit = 32767;
+    if (i > kEncryptedRowGroupsLimit) {
+      throw ParquetException(
+          "Encrypted files cannot contain more than 32767 row groups");
+    }
+
+    // The column is encrypted
+    std::shared_ptr<Decryptor> meta_decryptor;
+    std::shared_ptr<Decryptor> data_decryptor;
+    // The column is encrypted with footer key
+    if (crypto_metadata->encrypted_with_footer_key()) {
+      meta_decryptor = file_decryptor_->GetFooterDecryptorForColumnMeta();
+      data_decryptor = file_decryptor_->GetFooterDecryptorForColumnData();
+      CryptoContext ctx(
+          col->has_dictionary_page(),
+          row_group_ordinal_,
+          static_cast<int16_t>(i),
+          meta_decryptor,
+          data_decryptor);
+      return PageReader::Open(
+          stream,
+          col->num_values(),
+          col->compression(),
+          properties_,
+          always_compressed,
+          &ctx);
+    }
+
+    // The column is encrypted with its own key
+    std::string column_key_metadata = crypto_metadata->key_metadata();
+    const std::string column_path =
+        crypto_metadata->path_in_schema()->ToDotString();
+
+    meta_decryptor = file_decryptor_->GetColumnMetaDecryptor(
+        column_path, column_key_metadata);
+    data_decryptor = file_decryptor_->GetColumnDataDecryptor(
+        column_path, column_key_metadata);
+
+    CryptoContext ctx(
+        col->has_dictionary_page(),
+        row_group_ordinal_,
+        static_cast<int16_t>(i),
+        meta_decryptor,
+        data_decryptor);
+    return PageReader::Open(
+        stream,
+        col->num_values(),
+        col->compression(),
+        properties_,
+        always_compressed,
+        &ctx);
+  }
+
+ private:
+  std::shared_ptr<ArrowInputFile> source_;
+  // Will be nullptr if PreBuffer() is not called.
+  std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source_;
+  int64_t source_size_;
+  FileMetaData* file_metadata_;
+  std::unique_ptr<RowGroupMetaData> row_group_metadata_;
+  ReaderProperties properties_;
+  int row_group_ordinal_;
+  const std::shared_ptr<Buffer> prebuffered_column_chunks_bitmap_;
+  std::shared_ptr<InternalFileDecryptor> file_decryptor_;
+};
+
+// ----------------------------------------------------------------------
+// SerializedFile: An implementation of ParquetFileReader::Contents that deals
+// with the Parquet file structure, Thrift deserialization, and other internal
+// matters
+
+// This class takes ownership of the provided data source
+class SerializedFile : public ParquetFileReader::Contents {
+ public:
+  SerializedFile(
+      std::shared_ptr<ArrowInputFile> source,
+      const ReaderProperties& props = default_reader_properties())
+      : source_(std::move(source)), properties_(props) {
+    PARQUET_ASSIGN_OR_THROW(source_size_, source_->GetSize());
+  }
+
+  ~SerializedFile() override {
+    try {
+      Close();
+    } catch (...) {
+    }
+  }
+
+  void Close() override {
+    if (file_decryptor_)
+      file_decryptor_->WipeOutDecryptionKeys();
+  }
+
+  std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
+    std::shared_ptr<Buffer> prebuffered_column_chunks_bitmap;
+    // Avoid updating the bitmap as this function can be called concurrently.
+    // The bitmap can only be updated within Prebuffer().
+    auto prebuffered_column_chunks_iter = prebuffered_column_chunks_.find(i);
+    if (prebuffered_column_chunks_iter != prebuffered_column_chunks_.end()) {
+      prebuffered_column_chunks_bitmap = prebuffered_column_chunks_iter->second;
+    }
+
+    std::unique_ptr<SerializedRowGroup> contents =
+        std::make_unique<SerializedRowGroup>(
+            source_,
+            cached_source_,
+            source_size_,
+            file_metadata_.get(),
+            i,
+            properties_,
+            std::move(prebuffered_column_chunks_bitmap),
+            file_decryptor_);
+    return std::make_shared<RowGroupReader>(std::move(contents));
+  }
+
+  std::shared_ptr<FileMetaData> metadata() const override {
+    return file_metadata_;
+  }
+
+  std::shared_ptr<PageIndexReader> GetPageIndexReader() override {
+    if (!file_metadata_) {
+      // Usually this won't happen if user calls one of the static Open()
+      // functions to create a ParquetFileReader instance. But if user calls the
+      // constructor directly and calls GetPageIndexReader() before Open() then
+      // this could happen.
+      throw ParquetException(
+          "Cannot call GetPageIndexReader() due to missing file metadata. Did you "
+          "forget to call ParquetFileReader::Open() first?");
+    }
+    if (!page_index_reader_) {
+      page_index_reader_ = PageIndexReader::Make(
+          source_.get(), file_metadata_, properties_, file_decryptor_);
+    }
+    return page_index_reader_;
+  }
+
+  BloomFilterReader& GetBloomFilterReader() override {
+    if (!file_metadata_) {
+      // Usually this won't happen if user calls one of the static Open()
+      // functions to create a ParquetFileReader instance. But if user calls the
+      // constructor directly and calls GetBloomFilterReader() before Open()
+      // then this could happen.
+      throw ParquetException(
+          "Cannot call GetBloomFilterReader() due to missing file metadata. Did you "
+          "forget to call ParquetFileReader::Open() first?");
+    }
+    if (!bloom_filter_reader_) {
+      bloom_filter_reader_ = BloomFilterReader::Make(
+          source_, file_metadata_, properties_, file_decryptor_);
+      if (bloom_filter_reader_ == nullptr) {
+        throw ParquetException("Cannot create BloomFilterReader");
+      }
+    }
+    return *bloom_filter_reader_;
+  }
+
+  void set_metadata(std::shared_ptr<FileMetaData> metadata) {
+    file_metadata_ = std::move(metadata);
+  }
+
+  void PreBuffer(
+      const std::vector<int>& row_groups,
+      const std::vector<int>& column_indices,
+      const ::arrow::io::IOContext& ctx,
+      const ::arrow::io::CacheOptions& options) {
+    cached_source_ = std::make_shared<::arrow::io::internal::ReadRangeCache>(
+        source_, ctx, options);
+    std::vector<::arrow::io::ReadRange> ranges;
+    prebuffered_column_chunks_.clear();
+    for (int row : row_groups) {
+      std::shared_ptr<Buffer>& col_bitmap = prebuffered_column_chunks_[row];
+      int num_cols = file_metadata_->num_columns();
+      PARQUET_THROW_NOT_OK(
+          AllocateEmptyBitmap(num_cols, properties_.memory_pool())
+              .Value(&col_bitmap));
+      for (int col : column_indices) {
+        ::arrow::bit_util::SetBit(col_bitmap->mutable_data(), col);
+        ranges.push_back(ComputeColumnChunkRange(
+            file_metadata_.get(), source_size_, row, col));
+      }
+    }
+    PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
+  }
+
+  ::arrow::Future<> WhenBuffered(
+      const std::vector<int>& row_groups,
+      const std::vector<int>& column_indices) const {
+    if (!cached_source_) {
+      return ::arrow::Status::Invalid(
+          "Must call PreBuffer before WhenBuffered");
+    }
+    std::vector<::arrow::io::ReadRange> ranges;
+    for (int row : row_groups) {
+      for (int col : column_indices) {
+        ranges.push_back(ComputeColumnChunkRange(
+            file_metadata_.get(), source_size_, row, col));
+      }
+    }
+    return cached_source_->WaitFor(ranges);
+  }
+
+  // Metadata/footer parsing. Divided up to separate sync/async paths, and to
+  // use exceptions for error handling (with the async path converting to
+  // Future/Status).
+
+  void ParseMetaData() {
+    int64_t footer_read_size = GetFooterReadSize();
+    PARQUET_ASSIGN_OR_THROW(
+        auto footer_buffer,
+        source_->ReadAt(source_size_ - footer_read_size, footer_read_size));
+    uint32_t metadata_len = ParseFooterLength(footer_buffer, footer_read_size);
+    int64_t metadata_start = source_size_ - kFooterSize - metadata_len;
+
+    std::shared_ptr<::arrow::Buffer> metadata_buffer;
+    if (footer_read_size >= (metadata_len + kFooterSize)) {
+      metadata_buffer = SliceBuffer(
+          footer_buffer,
+          footer_read_size - metadata_len - kFooterSize,
+          metadata_len);
+    } else {
+      PARQUET_ASSIGN_OR_THROW(
+          metadata_buffer, source_->ReadAt(metadata_start, metadata_len));
+    }
+
+    // Parse the footer depending on encryption type
+    const bool is_encrypted_footer =
+        memcmp(
+            footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) ==
+        0;
+    if (is_encrypted_footer) {
+      // Encrypted file with Encrypted footer.
+      const std::pair<int64_t, uint32_t> read_size =
+          ParseMetaDataOfEncryptedFileWithEncryptedFooter(
+              metadata_buffer, metadata_len);
+      // Read the actual footer
+      metadata_start = read_size.first;
+      metadata_len = read_size.second;
+      PARQUET_ASSIGN_OR_THROW(
+          metadata_buffer, source_->ReadAt(metadata_start, metadata_len));
+      // Fall through
+    }
+
+    const uint32_t read_metadata_len =
+        ParseUnencryptedFileMetadata(metadata_buffer, metadata_len);
+    auto file_decryption_properties =
+        properties_.file_decryption_properties().get();
+    if (is_encrypted_footer) {
+      // Nothing else to do here.
+      return;
+    } else if (!file_metadata_
+                    ->is_encryption_algorithm_set()) { // Non encrypted file.
+      if (file_decryption_properties != nullptr) {
+        if (!file_decryption_properties->plaintext_files_allowed()) {
+          throw ParquetException(
+              "Applying decryption properties on plaintext file");
+        }
+      }
+    } else {
+      // Encrypted file with plaintext footer mode.
+      ParseMetaDataOfEncryptedFileWithPlaintextFooter(
+          file_decryption_properties,
+          metadata_buffer,
+          metadata_len,
+          read_metadata_len);
+    }
+  }
+
+  // Validate the source size and get the initial read size.
+  int64_t GetFooterReadSize() {
+    if (source_size_ == 0) {
+      throw ParquetInvalidOrCorruptedFileException(
+          "Parquet file size is 0 bytes");
+    } else if (source_size_ < kFooterSize) {
+      throw ParquetInvalidOrCorruptedFileException(
+          "Parquet file size is ",
+          source_size_,
+          " bytes, smaller than the minimum file footer (",
+          kFooterSize,
+          " bytes)");
+    }
+    return std::min(source_size_, kDefaultFooterReadSize);
+  }
+
+  // Validate the magic bytes and get the length of the full footer.
+  uint32_t ParseFooterLength(
+      const std::shared_ptr<::arrow::Buffer>& footer_buffer,
+      const int64_t footer_read_size) {
+    // Check if all bytes are read. Check if last 4 bytes read have the magic
+    // bits
+    if (footer_buffer->size() != footer_read_size ||
+        (memcmp(
+             footer_buffer->data() + footer_read_size - 4, kParquetMagic, 4) !=
+             0 &&
+         memcmp(
+             footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) !=
+             0)) {
+      throw ParquetInvalidOrCorruptedFileException(
+          "Parquet magic bytes not found in footer. Either the file is corrupted or this "
+          "is not a parquet file.");
+    }
+    // Both encrypted/unencrypted footers have the same footer length check.
+    uint32_t metadata_len = ::arrow::util::SafeLoadAs<uint32_t>(
+        reinterpret_cast<const uint8_t*>(footer_buffer->data()) +
+        footer_read_size - kFooterSize);
+    if (metadata_len > source_size_ - kFooterSize) {
+      throw ParquetInvalidOrCorruptedFileException(
+          "Parquet file size is ",
+          source_size_,
+          " bytes, smaller than the size reported by footer's (",
+          metadata_len,
+          "bytes)");
+    }
+    return metadata_len;
+  }
+
+  // Does not throw.
+  ::arrow::Future<> ParseMetaDataAsync() {
+    int64_t footer_read_size;
+    BEGIN_PARQUET_CATCH_EXCEPTIONS
+    footer_read_size = GetFooterReadSize();
+    END_PARQUET_CATCH_EXCEPTIONS
+    // Assumes this is kept alive externally
+    return source_->ReadAsync(source_size_ - footer_read_size, footer_read_size)
+        .Then(
+            [this, footer_read_size](
+                const std::shared_ptr<::arrow::Buffer>& footer_buffer)
+                -> ::arrow::Future<> {
+              uint32_t metadata_len;
+              BEGIN_PARQUET_CATCH_EXCEPTIONS
+              metadata_len = ParseFooterLength(footer_buffer, footer_read_size);
+              END_PARQUET_CATCH_EXCEPTIONS
+              int64_t metadata_start =
+                  source_size_ - kFooterSize - metadata_len;
+
+              std::shared_ptr<::arrow::Buffer> metadata_buffer;
+              if (footer_read_size >= (metadata_len + kFooterSize)) {
+                metadata_buffer = SliceBuffer(
+                    footer_buffer,
+                    footer_read_size - metadata_len - kFooterSize,
+                    metadata_len);
+                return ParseMaybeEncryptedMetaDataAsync(
+                    footer_buffer,
+                    std::move(metadata_buffer),
+                    footer_read_size,
+                    metadata_len);
+              }
+              return source_->ReadAsync(metadata_start, metadata_len)
+                  .Then([this, footer_buffer, footer_read_size, metadata_len](
+                            const std::shared_ptr<::arrow::Buffer>&
+                                metadata_buffer) {
+                    return ParseMaybeEncryptedMetaDataAsync(
+                        footer_buffer,
+                        metadata_buffer,
+                        footer_read_size,
+                        metadata_len);
+                  });
+            });
+  }
+
+  // Continuation
+  ::arrow::Future<> ParseMaybeEncryptedMetaDataAsync(
+      std::shared_ptr<::arrow::Buffer> footer_buffer,
+      std::shared_ptr<::arrow::Buffer> metadata_buffer,
+      int64_t footer_read_size,
+      uint32_t metadata_len) {
+    // Parse the footer depending on encryption type
+    const bool is_encrypted_footer =
+        memcmp(
+            footer_buffer->data() + footer_read_size - 4, kParquetEMagic, 4) ==
+        0;
+    if (is_encrypted_footer) {
+      // Encrypted file with Encrypted footer.
+      std::pair<int64_t, uint32_t> read_size;
+      BEGIN_PARQUET_CATCH_EXCEPTIONS
+      read_size = ParseMetaDataOfEncryptedFileWithEncryptedFooter(
+          metadata_buffer, metadata_len);
+      END_PARQUET_CATCH_EXCEPTIONS
+      // Read the actual footer
+      int64_t metadata_start = read_size.first;
+      metadata_len = read_size.second;
+      return source_->ReadAsync(metadata_start, metadata_len)
+          .Then([this, metadata_len, is_encrypted_footer](
+                    const std::shared_ptr<::arrow::Buffer>& metadata_buffer) {
+            // Continue and read the file footer
+            return ParseMetaDataFinal(
+                metadata_buffer, metadata_len, is_encrypted_footer);
+          });
+    }
+    return ParseMetaDataFinal(
+        std::move(metadata_buffer), metadata_len, is_encrypted_footer);
+  }
+
+  // Continuation
+  ::arrow::Status ParseMetaDataFinal(
+      std::shared_ptr<::arrow::Buffer> metadata_buffer,
+      uint32_t metadata_len,
+      const bool is_encrypted_footer) {
+    BEGIN_PARQUET_CATCH_EXCEPTIONS
+    const uint32_t read_metadata_len =
+        ParseUnencryptedFileMetadata(metadata_buffer, metadata_len);
+    auto file_decryption_properties =
+        properties_.file_decryption_properties().get();
+    if (is_encrypted_footer) {
+      // Nothing else to do here.
+      return ::arrow::Status::OK();
+    } else if (!file_metadata_
+                    ->is_encryption_algorithm_set()) { // Non encrypted file.
+      if (file_decryption_properties != nullptr) {
+        if (!file_decryption_properties->plaintext_files_allowed()) {
+          throw ParquetException(
+              "Applying decryption properties on plaintext file");
+        }
+      }
+    } else {
+      // Encrypted file with plaintext footer mode.
+      ParseMetaDataOfEncryptedFileWithPlaintextFooter(
+          file_decryption_properties,
+          metadata_buffer,
+          metadata_len,
+          read_metadata_len);
+    }
+    END_PARQUET_CATCH_EXCEPTIONS
+    return ::arrow::Status::OK();
+  }
+
+ private:
+  std::shared_ptr<ArrowInputFile> source_;
+  std::shared_ptr<::arrow::io::internal::ReadRangeCache> cached_source_;
+  int64_t source_size_;
+  std::shared_ptr<FileMetaData> file_metadata_;
+  ReaderProperties properties_;
+  std::shared_ptr<PageIndexReader> page_index_reader_;
+  std::unique_ptr<BloomFilterReader> bloom_filter_reader_;
+  // Maps row group ordinal and prebuffer status of its column chunks in the
+  // form of a bitmap buffer.
+  std::unordered_map<int, std::shared_ptr<Buffer>> prebuffered_column_chunks_;
+  std::shared_ptr<InternalFileDecryptor> file_decryptor_;
+
+  // \return The true length of the metadata in bytes
+  uint32_t ParseUnencryptedFileMetadata(
+      const std::shared_ptr<Buffer>& footer_buffer,
+      const uint32_t metadata_len);
+
+  std::string HandleAadPrefix(
+      FileDecryptionProperties* file_decryption_properties,
+      EncryptionAlgorithm& algo);
+
+  void ParseMetaDataOfEncryptedFileWithPlaintextFooter(
+      FileDecryptionProperties* file_decryption_properties,
+      const std::shared_ptr<Buffer>& metadata_buffer,
+      uint32_t metadata_len,
+      uint32_t read_metadata_len);
+
+  // \return The position and size of the actual footer
+  std::pair<int64_t, uint32_t> ParseMetaDataOfEncryptedFileWithEncryptedFooter(
+      const std::shared_ptr<Buffer>& crypto_metadata_buffer,
+      uint32_t footer_len);
+};
+
+uint32_t SerializedFile::ParseUnencryptedFileMetadata(
+    const std::shared_ptr<Buffer>& metadata_buffer,
+    const uint32_t metadata_len) {
+  if (metadata_buffer->size() != metadata_len) {
+    throw ParquetException(
+        "Failed reading metadata buffer (requested " +
+        std::to_string(metadata_len) + " bytes but got " +
+        std::to_string(metadata_buffer->size()) + " bytes)");
+  }
+  uint32_t read_metadata_len = metadata_len;
+  // The encrypted read path falls through to here, so pass in the decryptor
+  file_metadata_ = FileMetaData::Make(
+      metadata_buffer->data(),
+      &read_metadata_len,
+      properties_,
+      file_decryptor_);
+  return read_metadata_len;
+}
+
+std::pair<int64_t, uint32_t>
+SerializedFile::ParseMetaDataOfEncryptedFileWithEncryptedFooter(
+    const std::shared_ptr<::arrow::Buffer>& crypto_metadata_buffer,
+    // both metadata & crypto metadata length
+    const uint32_t footer_len) {
+  // encryption with encrypted footer
+  // Check if the footer_buffer contains the entire metadata
+  if (crypto_metadata_buffer->size() != footer_len) {
+    throw ParquetException(
+        "Failed reading encrypted metadata buffer (requested " +
+        std::to_string(footer_len) + " bytes but got " +
+        std::to_string(crypto_metadata_buffer->size()) + " bytes)");
+  }
+  auto file_decryption_properties =
+      properties_.file_decryption_properties().get();
+  if (file_decryption_properties == nullptr) {
+    throw ParquetException(
+        "Could not read encrypted metadata, no decryption found in reader's properties");
+  }
+  uint32_t crypto_metadata_len = footer_len;
+  std::shared_ptr<FileCryptoMetaData> file_crypto_metadata =
+      FileCryptoMetaData::Make(
+          crypto_metadata_buffer->data(), &crypto_metadata_len);
+  // Handle AAD prefix
+  EncryptionAlgorithm algo = file_crypto_metadata->encryption_algorithm();
+  std::string file_aad = HandleAadPrefix(file_decryption_properties, algo);
+  file_decryptor_ = std::make_shared<InternalFileDecryptor>(
+      file_decryption_properties,
+      file_aad,
+      algo.algorithm,
+      file_crypto_metadata->key_metadata(),
+      properties_.memory_pool());
+
+  int64_t metadata_offset =
+      source_size_ - kFooterSize - footer_len + crypto_metadata_len;
+  uint32_t metadata_len = footer_len - crypto_metadata_len;
+  return std::make_pair(metadata_offset, metadata_len);
+}
+
+void SerializedFile::ParseMetaDataOfEncryptedFileWithPlaintextFooter(
+    FileDecryptionProperties* file_decryption_properties,
+    const std::shared_ptr<Buffer>& metadata_buffer,
+    uint32_t metadata_len,
+    uint32_t read_metadata_len) {
+  // Providing decryption properties in plaintext footer mode is not mandatory,
+  // for example when reading by legacy reader.
+  if (file_decryption_properties != nullptr) {
+    EncryptionAlgorithm algo = file_metadata_->encryption_algorithm();
+    // Handle AAD prefix
+    std::string file_aad = HandleAadPrefix(file_decryption_properties, algo);
+    file_decryptor_ = std::make_shared<InternalFileDecryptor>(
+        file_decryption_properties,
+        file_aad,
+        algo.algorithm,
+        file_metadata_->footer_signing_key_metadata(),
+        properties_.memory_pool());
+    // set the InternalFileDecryptor in the metadata as well, as it's used
+    // for signature verification and for ColumnChunkMetaData creation.
+    file_metadata_->set_file_decryptor(file_decryptor_);
+
+    if (file_decryption_properties->check_plaintext_footer_integrity()) {
+      if (metadata_len - read_metadata_len !=
+          (encryption::kGcmTagLength + encryption::kNonceLength)) {
+        throw ParquetInvalidOrCorruptedFileException(
+            "Failed reading metadata for encryption signature (requested ",
+            encryption::kGcmTagLength + encryption::kNonceLength,
+            " bytes but have ",
+            metadata_len - read_metadata_len,
+            " bytes)");
+      }
+
+      if (!file_metadata_->VerifySignature(
+              metadata_buffer->data() + read_metadata_len)) {
+        throw ParquetInvalidOrCorruptedFileException(
+            "Parquet crypto signature verification failed");
+      }
+    }
+  }
+}
+
+std::string SerializedFile::HandleAadPrefix(
+    FileDecryptionProperties* file_decryption_properties,
+    EncryptionAlgorithm& algo) {
+  std::string aad_prefix_in_properties =
+      file_decryption_properties->aad_prefix();
+  std::string aad_prefix = aad_prefix_in_properties;
+  bool file_has_aad_prefix = algo.aad.aad_prefix.empty() ? false : true;
+  std::string aad_prefix_in_file = algo.aad.aad_prefix;
+
+  if (algo.aad.supply_aad_prefix && aad_prefix_in_properties.empty()) {
+    throw ParquetException(
+        "AAD prefix used for file encryption, "
+        "but not stored in file and not supplied "
+        "in decryption properties");
+  }
+
+  if (file_has_aad_prefix) {
+    if (!aad_prefix_in_properties.empty()) {
+      if (aad_prefix_in_properties.compare(aad_prefix_in_file) != 0) {
+        throw ParquetException(
+            "AAD Prefix in file and in properties "
+            "is not the same");
+      }
+    }
+    aad_prefix = aad_prefix_in_file;
+    std::shared_ptr<AADPrefixVerifier> aad_prefix_verifier =
+        file_decryption_properties->aad_prefix_verifier();
+    if (aad_prefix_verifier != nullptr)
+      aad_prefix_verifier->Verify(aad_prefix);
+  } else {
+    if (!algo.aad.supply_aad_prefix && !aad_prefix_in_properties.empty()) {
+      throw ParquetException(
+          "AAD Prefix set in decryption properties, but was not used "
+          "for file encryption");
+    }
+    std::shared_ptr<AADPrefixVerifier> aad_prefix_verifier =
+        file_decryption_properties->aad_prefix_verifier();
+    if (aad_prefix_verifier != nullptr) {
+      throw ParquetException(
+          "AAD Prefix Verifier is set, but AAD Prefix not found in file");
+    }
+  }
+  return aad_prefix + algo.aad.aad_file_unique;
+}
+
+// ----------------------------------------------------------------------
+// ParquetFileReader public API
+
+ParquetFileReader::ParquetFileReader() {}
+
+ParquetFileReader::~ParquetFileReader() {
+  try {
+    Close();
+  } catch (...) {
+  }
+}
+
+// Open the file. If no metadata is passed, it is parsed from the footer of
+// the file
+std::unique_ptr<ParquetFileReader::Contents> ParquetFileReader::Contents::Open(
+    std::shared_ptr<ArrowInputFile> source,
+    const ReaderProperties& props,
+    std::shared_ptr<FileMetaData> metadata) {
+  std::unique_ptr<ParquetFileReader::Contents> result(
+      new SerializedFile(std::move(source), props));
+
+  // Access private methods here, but otherwise unavailable
+  SerializedFile* file = static_cast<SerializedFile*>(result.get());
+
+  if (metadata == nullptr) {
+    // Validates magic bytes, parses metadata, and initializes the
+    // SchemaDescriptor
+    file->ParseMetaData();
+  } else {
+    file->set_metadata(std::move(metadata));
+  }
+
+  return result;
+}
+
+::arrow::Future<std::unique_ptr<ParquetFileReader::Contents>>
+ParquetFileReader::Contents::OpenAsync(
+    std::shared_ptr<ArrowInputFile> source,
+    const ReaderProperties& props,
+    std::shared_ptr<FileMetaData> metadata) {
+  BEGIN_PARQUET_CATCH_EXCEPTIONS
+  std::unique_ptr<ParquetFileReader::Contents> result(
+      new SerializedFile(std::move(source), props));
+  SerializedFile* file = static_cast<SerializedFile*>(result.get());
+  if (metadata == nullptr) {
+    // TODO(ARROW-12259): workaround since we have Future<(move-only type)>
+    struct {
+      ::arrow::Result<std::unique_ptr<ParquetFileReader::Contents>>
+      operator()() {
+        return std::move(result);
+      }
+
+      std::unique_ptr<ParquetFileReader::Contents> result;
+    } Continuation;
+    Continuation.result = std::move(result);
+    return file->ParseMetaDataAsync().Then(std::move(Continuation));
+  } else {
+    file->set_metadata(std::move(metadata));
+    return ::arrow::Future<std::unique_ptr<ParquetFileReader::Contents>>::
+        MakeFinished(std::move(result));
+  }
+  END_PARQUET_CATCH_EXCEPTIONS
+}
+
+std::unique_ptr<ParquetFileReader> ParquetFileReader::Open(
+    std::shared_ptr<::arrow::io::RandomAccessFile> source,
+    const ReaderProperties& props,
+    std::shared_ptr<FileMetaData> metadata) {
+  auto contents =
+      SerializedFile::Open(std::move(source), props, std::move(metadata));
+  std::unique_ptr<ParquetFileReader> result =
+      std::make_unique<ParquetFileReader>();
+  result->Open(std::move(contents));
+  return result;
+}
+
+std::unique_ptr<ParquetFileReader> ParquetFileReader::OpenFile(
+    const std::string& path,
+    bool memory_map,
+    const ReaderProperties& props,
+    std::shared_ptr<FileMetaData> metadata) {
+  std::shared_ptr<::arrow::io::RandomAccessFile> source;
+  if (memory_map) {
+    PARQUET_ASSIGN_OR_THROW(
+        source,
+        ::arrow::io::MemoryMappedFile::Open(path, ::arrow::io::FileMode::READ));
+  } else {
+    PARQUET_ASSIGN_OR_THROW(
+        source, ::arrow::io::ReadableFile::Open(path, props.memory_pool()));
+  }
+
+  return Open(std::move(source), props, std::move(metadata));
+}
+
+::arrow::Future<std::unique_ptr<ParquetFileReader>>
+ParquetFileReader::OpenAsync(
+    std::shared_ptr<::arrow::io::RandomAccessFile> source,
+    const ReaderProperties& props,
+    std::shared_ptr<FileMetaData> metadata) {
+  BEGIN_PARQUET_CATCH_EXCEPTIONS
+  auto fut =
+      SerializedFile::OpenAsync(std::move(source), props, std::move(metadata));
+  // TODO(ARROW-12259): workaround since we have Future<(move-only type)>
+  auto completed = ::arrow::Future<std::unique_ptr<ParquetFileReader>>::Make();
+  fut.AddCallback(
+      [fut, completed](
+          const ::arrow::Result<std::unique_ptr<ParquetFileReader::Contents>>&
+              contents) mutable {
+        if (!contents.ok()) {
+          completed.MarkFinished(contents.status());
+          return;
+        }
+        std::unique_ptr<ParquetFileReader> result =
+            std::make_unique<ParquetFileReader>();
+        result->Open(fut.MoveResult().MoveValueUnsafe());
+        completed.MarkFinished(std::move(result));
+      });
+  return completed;
+  END_PARQUET_CATCH_EXCEPTIONS
+}
+
+void ParquetFileReader::Open(
+    std::unique_ptr<ParquetFileReader::Contents> contents) {
+  contents_ = std::move(contents);
+}
+
+void ParquetFileReader::Close() {
+  if (contents_) {
+    contents_->Close();
+  }
+}
+
+std::shared_ptr<FileMetaData> ParquetFileReader::metadata() const {
+  return contents_->metadata();
+}
+
+std::shared_ptr<PageIndexReader> ParquetFileReader::GetPageIndexReader() {
+  return contents_->GetPageIndexReader();
+}
+
+BloomFilterReader& ParquetFileReader::GetBloomFilterReader() {
+  return contents_->GetBloomFilterReader();
+}
+
+std::shared_ptr<RowGroupReader> ParquetFileReader::RowGroup(int i) {
+  if (i >= metadata()->num_row_groups()) {
+    std::stringstream ss;
+    ss << "Trying to read row group " << i << " but file only has "
+       << metadata()->num_row_groups() << " row groups";
+    throw ParquetException(ss.str());
+  }
+  return contents_->GetRowGroup(i);
+}
+
+void ParquetFileReader::PreBuffer(
+    const std::vector<int>& row_groups,
+    const std::vector<int>& column_indices,
+    const ::arrow::io::IOContext& ctx,
+    const ::arrow::io::CacheOptions& options) {
+  // Access private methods here
+  SerializedFile* file =
+      ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
+  file->PreBuffer(row_groups, column_indices, ctx, options);
+}
+
+::arrow::Future<> ParquetFileReader::WhenBuffered(
+    const std::vector<int>& row_groups,
+    const std::vector<int>& column_indices) const {
+  // Access private methods here
+  SerializedFile* file =
+      ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
+  return file->WhenBuffered(row_groups, column_indices);
+}
+
+// ----------------------------------------------------------------------
+// File metadata helpers
+
+std::shared_ptr<FileMetaData> ReadMetaData(
+    const std::shared_ptr<::arrow::io::RandomAccessFile>& source) {
+  return ParquetFileReader::Open(source)->metadata();
+}
+
+// ----------------------------------------------------------------------
+// File scanner for performance testing
+
+int64_t ScanFileContents(
+    std::vector<int> columns,
+    const int32_t column_batch_size,
+    ParquetFileReader* reader) {
+  std::vector<int16_t> rep_levels(column_batch_size);
+  std::vector<int16_t> def_levels(column_batch_size);
+
+  int num_columns = static_cast<int>(columns.size());
+
+  // columns are not specified explicitly. Add all columns
+  if (columns.size() == 0) {
+    num_columns = reader->metadata()->num_columns();
+    columns.resize(num_columns);
+    for (int i = 0; i < num_columns; i++) {
+      columns[i] = i;
+    }
+  }
+  if (num_columns == 0) {
+    // If we still have no columns(none in file), return early. The remainder of
+    // function expects there to be at least one column.
+    return 0;
+  }
+
+  std::vector<int64_t> total_rows(num_columns, 0);
+
+  for (int r = 0; r < reader->metadata()->num_row_groups(); ++r) {
+    auto group_reader = reader->RowGroup(r);
+    int col = 0;
+    for (auto i : columns) {
+      std::shared_ptr<ColumnReader> col_reader = group_reader->Column(i);
+      size_t value_byte_size =
+          GetTypeByteSize(col_reader->descr()->physical_type());
+      std::vector<uint8_t> values(column_batch_size * value_byte_size);
+
+      int64_t values_read = 0;
+      while (col_reader->HasNext()) {
+        int64_t levels_read = ScanAllValues(
+            column_batch_size,
+            def_levels.data(),
+            rep_levels.data(),
+            values.data(),
+            &values_read,
+            col_reader.get());
+        if (col_reader->descr()->max_repetition_level() > 0) {
+          for (int64_t i = 0; i < levels_read; i++) {
+            if (rep_levels[i] == 0) {
+              total_rows[col]++;
+            }
+          }
+        } else {
+          total_rows[col] += levels_read;
+        }
+      }
+      col++;
+    }
+  }
+
+  for (int i = 1; i < num_columns; ++i) {
+    if (total_rows[0] != total_rows[i]) {
+      throw ParquetException(
+          "Parquet error: Total rows among columns do not match");
+    }
+  }
+
+  return total_rows[0];
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/FileReader.h
+++ b/velox/dwio/parquet/writer/arrow/tests/FileReader.h
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/io/caching.h"
+#include "arrow/util/type_fwd.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+
+namespace facebook::velox::parquet::arrow {
+
+class ColumnReader;
+class FileMetaData;
+class PageIndexReader;
+class BloomFilterReader;
+class PageReader;
+class RowGroupMetaData;
+
+class PARQUET_EXPORT RowGroupReader {
+ public:
+  // Forward declare a virtual class 'Contents' to aid dependency injection and
+  // more easily create test fixtures An implementation of the Contents class is
+  // defined in the .cc file
+  struct Contents {
+    virtual ~Contents() {}
+    virtual std::unique_ptr<PageReader> GetColumnPageReader(int i) = 0;
+    virtual const RowGroupMetaData* metadata() const = 0;
+    virtual const ReaderProperties* properties() const = 0;
+  };
+
+  explicit RowGroupReader(std::unique_ptr<Contents> contents);
+
+  // Returns the rowgroup metadata
+  const RowGroupMetaData* metadata() const;
+
+  // Construct a ColumnReader for the indicated row group-relative
+  // column. Ownership is shared with the RowGroupReader.
+  std::shared_ptr<ColumnReader> Column(int i);
+
+  // Construct a ColumnReader, trying to enable exposed encoding.
+  //
+  // For dictionary encoding, currently we only support column chunks that are
+  // fully dictionary encoded, i.e., all data pages in the column chunk are
+  // dictionary encoded. If a column chunk uses dictionary encoding but then
+  // falls back to plain encoding, the encoding will not be exposed.
+  //
+  // The returned column reader provides an API GetExposedEncoding() for the
+  // users to check the exposed encoding and determine how to read the batches.
+  //
+  // \note API EXPERIMENTAL
+  std::shared_ptr<ColumnReader> ColumnWithExposeEncoding(
+      int i,
+      ExposedEncoding encoding_to_expose);
+
+  std::unique_ptr<PageReader> GetColumnPageReader(int i);
+
+ private:
+  // Holds a pointer to an instance of Contents implementation
+  std::unique_ptr<Contents> contents_;
+};
+
+class PARQUET_EXPORT ParquetFileReader {
+ public:
+  // Declare a virtual class 'Contents' to aid dependency injection and more
+  // easily create test fixtures
+  // An implementation of the Contents class is defined in the .cc file
+  struct PARQUET_EXPORT Contents {
+    static std::unique_ptr<Contents> Open(
+        std::shared_ptr<::arrow::io::RandomAccessFile> source,
+        const ReaderProperties& props = default_reader_properties(),
+        std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+    static ::arrow::Future<std::unique_ptr<Contents>> OpenAsync(
+        std::shared_ptr<::arrow::io::RandomAccessFile> source,
+        const ReaderProperties& props = default_reader_properties(),
+        std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+    virtual ~Contents() = default;
+    // Perform any cleanup associated with the file contents
+    virtual void Close() = 0;
+    virtual std::shared_ptr<RowGroupReader> GetRowGroup(int i) = 0;
+    virtual std::shared_ptr<FileMetaData> metadata() const = 0;
+    virtual std::shared_ptr<PageIndexReader> GetPageIndexReader() = 0;
+    virtual BloomFilterReader& GetBloomFilterReader() = 0;
+  };
+
+  ParquetFileReader();
+  ~ParquetFileReader();
+
+  // Create a file reader instance from an Arrow file object. Thread-safety is
+  // the responsibility of the file implementation
+  static std::unique_ptr<ParquetFileReader> Open(
+      std::shared_ptr<::arrow::io::RandomAccessFile> source,
+      const ReaderProperties& props = default_reader_properties(),
+      std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+  // API Convenience to open a serialized Parquet file on disk, using Arrow IO
+  // interfaces.
+  static std::unique_ptr<ParquetFileReader> OpenFile(
+      const std::string& path,
+      bool memory_map = false,
+      const ReaderProperties& props = default_reader_properties(),
+      std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+  // Asynchronously open a file reader from an Arrow file object.
+  // Does not throw - all errors are reported through the Future.
+  static ::arrow::Future<std::unique_ptr<ParquetFileReader>> OpenAsync(
+      std::shared_ptr<::arrow::io::RandomAccessFile> source,
+      const ReaderProperties& props = default_reader_properties(),
+      std::shared_ptr<FileMetaData> metadata = NULLPTR);
+
+  void Open(std::unique_ptr<Contents> contents);
+  void Close();
+
+  // The RowGroupReader is owned by the FileReader
+  std::shared_ptr<RowGroupReader> RowGroup(int i);
+
+  // Returns the file metadata. Only one instance is ever created
+  std::shared_ptr<FileMetaData> metadata() const;
+
+  /// Returns the PageIndexReader. Only one instance is ever created.
+  ///
+  /// If the file does not have the page index, nullptr may be returned.
+  /// Because it pays to check existence of page index in the file, it
+  /// is possible to return a non null value even if page index does
+  /// not exist. It is the caller's responsibility to check the return
+  /// value and follow-up calls to PageIndexReader.
+  ///
+  /// WARNING: The returned PageIndexReader must not outlive the
+  /// ParquetFileReader. Initialize GetPageIndexReader() is not thread-safety.
+  std::shared_ptr<PageIndexReader> GetPageIndexReader();
+
+  /// Returns the BloomFilterReader. Only one instance is ever created.
+  ///
+  /// WARNING: The returned BloomFilterReader must not outlive the
+  /// ParquetFileReader. Initialize GetBloomFilterReader() is not thread-safety.
+  BloomFilterReader& GetBloomFilterReader();
+
+  /// Pre-buffer the specified column indices in all row groups.
+  ///
+  /// Readers can optionally call this to cache the necessary slices
+  /// of the file in-memory before deserialization. Arrow readers can
+  /// automatically do this via an option. This is intended to
+  /// increase performance when reading from high-latency filesystems
+  /// (e.g. Amazon S3).
+  ///
+  /// After calling this, creating readers for row groups/column
+  /// indices that were not buffered may fail. Creating multiple
+  /// readers for the a subset of the buffered regions is
+  /// acceptable. This may be called again to buffer a different set
+  /// of row groups/columns.
+  ///
+  /// If memory usage is a concern, note that data will remain
+  /// buffered in memory until either \a PreBuffer() is called again,
+  /// or the reader itself is destructed. Reading - and buffering -
+  /// only one row group at a time may be useful.
+  ///
+  /// This method may throw.
+  void PreBuffer(
+      const std::vector<int>& row_groups,
+      const std::vector<int>& column_indices,
+      const ::arrow::io::IOContext& ctx,
+      const ::arrow::io::CacheOptions& options);
+
+  /// Wait for the specified row groups and column indices to be pre-buffered.
+  ///
+  /// After the returned Future completes, reading the specified row
+  /// groups/columns will not block.
+  ///
+  /// PreBuffer must be called first. This method does not throw.
+  ::arrow::Future<> WhenBuffered(
+      const std::vector<int>& row_groups,
+      const std::vector<int>& column_indices) const;
+
+ private:
+  // Holds a pointer to an instance of Contents implementation
+  std::unique_ptr<Contents> contents_;
+};
+
+// Read only Parquet file metadata
+std::shared_ptr<FileMetaData> PARQUET_EXPORT
+ReadMetaData(const std::shared_ptr<::arrow::io::RandomAccessFile>& source);
+
+/// \brief Scan all values in file. Useful for performance testing
+/// \param[in] columns the column numbers to scan. If empty scans all
+/// \param[in] column_batch_size number of values to read at a time when
+/// scanning column \param[in] reader a ParquetFileReader instance \return
+/// number of semantic rows in file
+PARQUET_EXPORT
+int64_t ScanFileContents(
+    std::vector<int> columns,
+    const int32_t column_batch_size,
+    ParquetFileReader* reader);
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/FileSerializeTest.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_compat.h"
+
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+namespace facebook::velox::parquet::arrow {
+
+using schema::GroupNode;
+using schema::NodePtr;
+using schema::PrimitiveNode;
+using ::testing::ElementsAre;
+
+namespace test {
+
+template <typename TestType>
+class TestSerialize : public PrimitiveTypedTest<TestType> {
+ public:
+  void SetUp() {
+    num_columns_ = 4;
+    num_rowgroups_ = 4;
+    rows_per_rowgroup_ = 50;
+    rows_per_batch_ = 10;
+    this->SetUpSchema(Repetition::OPTIONAL, num_columns_);
+  }
+
+ protected:
+  int num_columns_;
+  int num_rowgroups_;
+  int rows_per_rowgroup_;
+  int rows_per_batch_;
+
+  void FileSerializeTest(Compression::type codec_type) {
+    FileSerializeTest(codec_type, codec_type);
+  }
+
+  void FileSerializeTest(
+      Compression::type codec_type,
+      Compression::type expected_codec_type) {
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+
+    WriterProperties::Builder prop_builder;
+
+    for (int i = 0; i < num_columns_; ++i) {
+      prop_builder.compression(this->schema_.Column(i)->name(), codec_type);
+    }
+    std::shared_ptr<WriterProperties> writer_properties = prop_builder.build();
+
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
+    this->GenerateData(rows_per_rowgroup_);
+    for (int rg = 0; rg < num_rowgroups_ / 2; ++rg) {
+      RowGroupWriter* row_group_writer;
+      row_group_writer = file_writer->AppendRowGroup();
+      for (int col = 0; col < num_columns_; ++col) {
+        auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+            row_group_writer->NextColumn());
+        column_writer->WriteBatch(
+            rows_per_rowgroup_,
+            this->def_levels_.data(),
+            nullptr,
+            this->values_ptr_);
+        column_writer->Close();
+        // Ensure column() API which is specific to BufferedRowGroup cannot be
+        // called
+        ASSERT_THROW(row_group_writer->column(col), ParquetException);
+      }
+      EXPECT_EQ(0, row_group_writer->total_compressed_bytes());
+      EXPECT_NE(0, row_group_writer->total_bytes_written());
+      EXPECT_NE(0, row_group_writer->total_compressed_bytes_written());
+      row_group_writer->Close();
+      EXPECT_EQ(0, row_group_writer->total_compressed_bytes());
+      EXPECT_NE(0, row_group_writer->total_bytes_written());
+      EXPECT_NE(0, row_group_writer->total_compressed_bytes_written());
+    }
+    // Write half BufferedRowGroups
+    for (int rg = 0; rg < num_rowgroups_ / 2; ++rg) {
+      RowGroupWriter* row_group_writer;
+      row_group_writer = file_writer->AppendBufferedRowGroup();
+      for (int batch = 0; batch < (rows_per_rowgroup_ / rows_per_batch_);
+           ++batch) {
+        for (int col = 0; col < num_columns_; ++col) {
+          auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+              row_group_writer->column(col));
+          column_writer->WriteBatch(
+              rows_per_batch_,
+              this->def_levels_.data() + (batch * rows_per_batch_),
+              nullptr,
+              this->values_ptr_ + (batch * rows_per_batch_));
+          // Ensure NextColumn() API which is specific to RowGroup cannot be
+          // called
+          ASSERT_THROW(row_group_writer->NextColumn(), ParquetException);
+        }
+      }
+      // total_compressed_bytes() may equal to 0 if no dictionary enabled and no
+      // buffered values.
+      EXPECT_EQ(0, row_group_writer->total_bytes_written());
+      EXPECT_EQ(0, row_group_writer->total_compressed_bytes_written());
+      for (int col = 0; col < num_columns_; ++col) {
+        auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+            row_group_writer->column(col));
+        column_writer->Close();
+      }
+      row_group_writer->Close();
+      EXPECT_EQ(0, row_group_writer->total_compressed_bytes());
+      EXPECT_NE(0, row_group_writer->total_bytes_written());
+      EXPECT_NE(0, row_group_writer->total_compressed_bytes_written());
+    }
+    file_writer->Close();
+
+    PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+
+    int num_rows_ = num_rowgroups_ * rows_per_rowgroup_;
+
+    auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+    auto file_reader = ParquetFileReader::Open(source);
+    ASSERT_EQ(num_columns_, file_reader->metadata()->num_columns());
+    ASSERT_EQ(num_rowgroups_, file_reader->metadata()->num_row_groups());
+    ASSERT_EQ(num_rows_, file_reader->metadata()->num_rows());
+
+    for (int rg = 0; rg < num_rowgroups_; ++rg) {
+      auto rg_reader = file_reader->RowGroup(rg);
+      auto rg_metadata = rg_reader->metadata();
+      ASSERT_EQ(num_columns_, rg_metadata->num_columns());
+      ASSERT_EQ(rows_per_rowgroup_, rg_metadata->num_rows());
+      // Check that the specified compression was actually used.
+      ASSERT_EQ(
+          expected_codec_type, rg_metadata->ColumnChunk(0)->compression());
+
+      const int64_t total_byte_size = rg_metadata->total_byte_size();
+      const int64_t total_compressed_size =
+          rg_metadata->total_compressed_size();
+      if (expected_codec_type == Compression::UNCOMPRESSED) {
+        ASSERT_EQ(total_byte_size, total_compressed_size);
+      } else {
+        ASSERT_NE(total_byte_size, total_compressed_size);
+      }
+
+      int64_t total_column_byte_size = 0;
+      int64_t total_column_compressed_size = 0;
+
+      for (int i = 0; i < num_columns_; ++i) {
+        int64_t values_read;
+        ASSERT_FALSE(rg_metadata->ColumnChunk(i)->has_index_page());
+        total_column_byte_size +=
+            rg_metadata->ColumnChunk(i)->total_uncompressed_size();
+        total_column_compressed_size +=
+            rg_metadata->ColumnChunk(i)->total_compressed_size();
+
+        std::vector<int16_t> def_levels_out(rows_per_rowgroup_);
+        std::vector<int16_t> rep_levels_out(rows_per_rowgroup_);
+        auto col_reader = std::static_pointer_cast<TypedColumnReader<TestType>>(
+            rg_reader->Column(i));
+        this->SetupValuesOut(rows_per_rowgroup_);
+        col_reader->ReadBatch(
+            rows_per_rowgroup_,
+            def_levels_out.data(),
+            rep_levels_out.data(),
+            this->values_out_ptr_,
+            &values_read);
+        this->SyncValuesOut();
+        ASSERT_EQ(rows_per_rowgroup_, values_read);
+        ASSERT_EQ(this->values_, this->values_out_);
+        ASSERT_EQ(this->def_levels_, def_levels_out);
+      }
+
+      ASSERT_EQ(total_byte_size, total_column_byte_size);
+      ASSERT_EQ(total_compressed_size, total_column_compressed_size);
+    }
+  }
+
+  void UnequalNumRows(
+      int64_t max_rows,
+      const std::vector<int64_t> rows_per_column) {
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+
+    std::shared_ptr<WriterProperties> props =
+        WriterProperties::Builder().build();
+
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, props);
+
+    RowGroupWriter* row_group_writer;
+    row_group_writer = file_writer->AppendRowGroup();
+
+    this->GenerateData(max_rows);
+    for (int col = 0; col < num_columns_; ++col) {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->NextColumn());
+      column_writer->WriteBatch(
+          rows_per_column[col],
+          this->def_levels_.data(),
+          nullptr,
+          this->values_ptr_);
+      column_writer->Close();
+    }
+    row_group_writer->Close();
+    file_writer->Close();
+  }
+
+  void UnequalNumRowsBuffered(
+      int64_t max_rows,
+      const std::vector<int64_t> rows_per_column) {
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+
+    std::shared_ptr<WriterProperties> props =
+        WriterProperties::Builder().build();
+
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, props);
+
+    RowGroupWriter* row_group_writer;
+    row_group_writer = file_writer->AppendBufferedRowGroup();
+
+    this->GenerateData(max_rows);
+    for (int col = 0; col < num_columns_; ++col) {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->column(col));
+      column_writer->WriteBatch(
+          rows_per_column[col],
+          this->def_levels_.data(),
+          nullptr,
+          this->values_ptr_);
+      column_writer->Close();
+    }
+    row_group_writer->Close();
+    file_writer->Close();
+  }
+
+  void RepeatedUnequalRows() {
+    // Optional and repeated, so definition and repetition levels
+    this->SetUpSchema(Repetition::REPEATED);
+
+    const int kNumRows = 100;
+    this->GenerateData(kNumRows);
+
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+    std::shared_ptr<WriterProperties> props =
+        WriterProperties::Builder().build();
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, props);
+
+    RowGroupWriter* row_group_writer;
+    row_group_writer = file_writer->AppendRowGroup();
+
+    this->GenerateData(kNumRows);
+
+    std::vector<int16_t> definition_levels(kNumRows, 1);
+    std::vector<int16_t> repetition_levels(kNumRows, 0);
+
+    {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->NextColumn());
+      column_writer->WriteBatch(
+          kNumRows,
+          definition_levels.data(),
+          repetition_levels.data(),
+          this->values_ptr_);
+      column_writer->Close();
+    }
+
+    definition_levels[1] = 0;
+    repetition_levels[3] = 1;
+
+    {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->NextColumn());
+      column_writer->WriteBatch(
+          kNumRows,
+          definition_levels.data(),
+          repetition_levels.data(),
+          this->values_ptr_);
+      column_writer->Close();
+    }
+  }
+
+  void ZeroRowsRowGroup() {
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+
+    std::shared_ptr<WriterProperties> props =
+        WriterProperties::Builder().build();
+
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, props);
+
+    RowGroupWriter* row_group_writer;
+
+    row_group_writer = file_writer->AppendRowGroup();
+    for (int col = 0; col < num_columns_; ++col) {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->NextColumn());
+      column_writer->Close();
+    }
+    row_group_writer->Close();
+
+    row_group_writer = file_writer->AppendBufferedRowGroup();
+    for (int col = 0; col < num_columns_; ++col) {
+      auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+          row_group_writer->column(col));
+      column_writer->Close();
+    }
+    row_group_writer->Close();
+
+    file_writer->Close();
+  }
+};
+
+typedef ::testing::Types<
+    Int32Type,
+    Int64Type,
+    Int96Type,
+    FloatType,
+    DoubleType,
+    BooleanType,
+    ByteArrayType,
+    FLBAType>
+    TestTypes;
+
+TYPED_TEST_SUITE(TestSerialize, TestTypes);
+
+TYPED_TEST(TestSerialize, SmallFileUncompressed) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::UNCOMPRESSED));
+}
+
+TYPED_TEST(TestSerialize, TooFewRows) {
+  std::vector<int64_t> num_rows = {100, 100, 100, 99};
+  ASSERT_THROW(this->UnequalNumRows(100, num_rows), ParquetException);
+  ASSERT_THROW(this->UnequalNumRowsBuffered(100, num_rows), ParquetException);
+}
+
+TYPED_TEST(TestSerialize, TooManyRows) {
+  std::vector<int64_t> num_rows = {100, 100, 100, 101};
+  ASSERT_THROW(this->UnequalNumRows(101, num_rows), ParquetException);
+  ASSERT_THROW(this->UnequalNumRowsBuffered(101, num_rows), ParquetException);
+}
+
+TYPED_TEST(TestSerialize, ZeroRows) {
+  ASSERT_NO_THROW(this->ZeroRowsRowGroup());
+}
+
+TYPED_TEST(TestSerialize, RepeatedTooFewRows) {
+  ASSERT_THROW(this->RepeatedUnequalRows(), ParquetException);
+}
+
+TYPED_TEST(TestSerialize, SmallFileSnappy) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::SNAPPY));
+}
+
+#ifdef ARROW_WITH_BROTLI
+TYPED_TEST(TestSerialize, SmallFileBrotli) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::BROTLI));
+}
+#endif
+
+#ifdef ARROW_WITH_GZIP
+TYPED_TEST(TestSerialize, SmallFileGzip) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::GZIP));
+}
+#endif
+
+#ifdef ARROW_WITH_LZ4
+TYPED_TEST(TestSerialize, SmallFileLz4) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4));
+}
+
+TYPED_TEST(TestSerialize, SmallFileLz4Hadoop) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::LZ4_HADOOP));
+}
+#endif
+
+#ifdef ARROW_WITH_ZSTD
+TYPED_TEST(TestSerialize, SmallFileZstd) {
+  ASSERT_NO_FATAL_FAILURE(this->FileSerializeTest(Compression::ZSTD));
+}
+#endif
+
+TEST(TestBufferedRowGroupWriter, DisabledDictionary) {
+  // PARQUET-1706:
+  // Wrong dictionary_page_offset when writing only data pages via
+  // BufferedPageWriter
+  auto sink = CreateOutputStream();
+  auto writer_props = WriterProperties::Builder().disable_dictionary()->build();
+  schema::NodeVector fields;
+  fields.push_back(
+      PrimitiveNode::Make("col", Repetition::REQUIRED, Type::INT32));
+  auto schema = std::static_pointer_cast<GroupNode>(
+      GroupNode::Make("schema", Repetition::REQUIRED, fields));
+  auto file_writer = ParquetFileWriter::Open(sink, schema, writer_props);
+  auto rg_writer = file_writer->AppendBufferedRowGroup();
+  auto col_writer = static_cast<Int32Writer*>(rg_writer->column(0));
+  int value = 0;
+  col_writer->WriteBatch(1, nullptr, nullptr, &value);
+  rg_writer->Close();
+  file_writer->Close();
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+
+  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto file_reader = ParquetFileReader::Open(source);
+  ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
+  auto rg_reader = file_reader->RowGroup(0);
+  ASSERT_EQ(1, rg_reader->metadata()->num_columns());
+  ASSERT_EQ(1, rg_reader->metadata()->num_rows());
+  ASSERT_FALSE(rg_reader->metadata()->ColumnChunk(0)->has_dictionary_page());
+}
+
+TEST(TestBufferedRowGroupWriter, MultiPageDisabledDictionary) {
+  constexpr int kValueCount = 10000;
+  constexpr int kPageSize = 16384;
+  auto sink = CreateOutputStream();
+  auto writer_props = WriterProperties::Builder()
+                          .disable_dictionary()
+                          ->data_pagesize(kPageSize)
+                          ->build();
+  schema::NodeVector fields;
+  fields.push_back(
+      PrimitiveNode::Make("col", Repetition::REQUIRED, Type::INT32));
+  auto schema = std::static_pointer_cast<GroupNode>(
+      GroupNode::Make("schema", Repetition::REQUIRED, fields));
+  auto file_writer = ParquetFileWriter::Open(sink, schema, writer_props);
+  auto rg_writer = file_writer->AppendBufferedRowGroup();
+  auto col_writer = static_cast<Int32Writer*>(rg_writer->column(0));
+  std::vector<int32_t> values_in;
+  for (int i = 0; i < kValueCount; ++i) {
+    values_in.push_back((i % 100) + 1);
+  }
+  col_writer->WriteBatch(kValueCount, nullptr, nullptr, values_in.data());
+  rg_writer->Close();
+  file_writer->Close();
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+
+  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto file_reader = ParquetFileReader::Open(source);
+  auto file_metadata = file_reader->metadata();
+  ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
+  std::vector<int32_t> values_out(kValueCount);
+  for (int r = 0; r < file_metadata->num_row_groups(); ++r) {
+    auto rg_reader = file_reader->RowGroup(r);
+    ASSERT_EQ(1, rg_reader->metadata()->num_columns());
+    ASSERT_EQ(kValueCount, rg_reader->metadata()->num_rows());
+    int64_t total_values_read = 0;
+    std::shared_ptr<ColumnReader> col_reader;
+    ASSERT_NO_THROW(col_reader = rg_reader->Column(0));
+    Int32Reader* int32_reader = static_cast<Int32Reader*>(col_reader.get());
+    int64_t vn = kValueCount;
+    int32_t* vx = values_out.data();
+    while (int32_reader->HasNext()) {
+      int64_t values_read;
+      int32_reader->ReadBatch(vn, nullptr, nullptr, vx, &values_read);
+      vn -= values_read;
+      vx += values_read;
+      total_values_read += values_read;
+    }
+    ASSERT_EQ(kValueCount, total_values_read);
+    ASSERT_EQ(values_in, values_out);
+  }
+}
+
+TEST(ParquetRoundtrip, AllNulls) {
+  auto primitive_node =
+      PrimitiveNode::Make("nulls", Repetition::OPTIONAL, nullptr, Type::INT32);
+  schema::NodeVector columns({primitive_node});
+
+  auto root_node =
+      GroupNode::Make("root", Repetition::REQUIRED, columns, nullptr);
+
+  auto sink = CreateOutputStream();
+
+  auto file_writer = ParquetFileWriter::Open(
+      sink, std::static_pointer_cast<GroupNode>(root_node));
+  auto row_group_writer = file_writer->AppendRowGroup();
+  auto column_writer =
+      static_cast<Int32Writer*>(row_group_writer->NextColumn());
+
+  int32_t values[3];
+  int16_t def_levels[] = {0, 0, 0};
+
+  column_writer->WriteBatch(3, def_levels, nullptr, values);
+
+  column_writer->Close();
+  row_group_writer->Close();
+  file_writer->Close();
+
+  ReaderProperties props = default_reader_properties();
+  props.enable_buffered_stream();
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+
+  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto file_reader = ParquetFileReader::Open(source, props);
+  auto row_group_reader = file_reader->RowGroup(0);
+  auto column_reader =
+      std::static_pointer_cast<Int32Reader>(row_group_reader->Column(0));
+
+  int64_t values_read;
+  def_levels[0] = -1;
+  def_levels[1] = -1;
+  def_levels[2] = -1;
+  column_reader->ReadBatch(3, def_levels, nullptr, values, &values_read);
+  EXPECT_THAT(def_levels, ElementsAre(0, 0, 0));
+}
+
+} // namespace test
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/Hasher.h
+++ b/velox/dwio/parquet/writer/arrow/tests/Hasher.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <cstdint>
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+
+namespace facebook::velox::parquet::arrow {
+
+// Abstract class for hash
+class Hasher {
+ public:
+  /// Compute hash for 32 bits value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(int32_t value) const = 0;
+
+  /// Compute hash for 64 bits value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(int64_t value) const = 0;
+
+  /// Compute hash for float value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(float value) const = 0;
+
+  /// Compute hash for double value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(double value) const = 0;
+
+  /// Compute hash for Int96 value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(const Int96* value) const = 0;
+
+  /// Compute hash for ByteArray value by using its plain encoding result.
+  ///
+  /// @param value the value to hash.
+  /// @return hash result.
+  virtual uint64_t Hash(const ByteArray* value) const = 0;
+
+  /// Compute hash for fixed byte array value by using its plain encoding
+  /// result.
+  ///
+  /// @param value the value address.
+  /// @param len the value length.
+  virtual uint64_t Hash(const FLBA* value, uint32_t len) const = 0;
+
+  /// Batch compute hashes for 32 bits values by using its plain encoding
+  /// result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const int32_t* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for 64 bits values by using its plain encoding
+  /// result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const int64_t* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for float values by using its plain encoding result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const float* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for double values by using its plain encoding result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const double* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for Int96 values by using its plain encoding result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const Int96* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for ByteArray values by using its plain encoding
+  /// result.
+  ///
+  /// @param values a pointer to the values to hash.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(const ByteArray* values, int num_values, uint64_t* hashes)
+      const = 0;
+
+  /// Batch compute hashes for fixed byte array values by using its plain
+  /// encoding result.
+  ///
+  /// @param values the value address.
+  /// @param type_len the value length.
+  /// @param num_values the number of values to hash.
+  /// @param hashes a pointer to the output hash values, its length should be
+  /// equal to num_values.
+  virtual void Hashes(
+      const FLBA* values,
+      uint32_t type_len,
+      int num_values,
+      uint64_t* hashes) const = 0;
+
+  virtual ~Hasher() = default;
+};
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/LevelConversionTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/LevelConversionTest.cpp
@@ -1,0 +1,413 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/LevelConversion.h"
+
+#include "velox/dwio/parquet/writer/arrow/LevelComparison.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "arrow/testing/gtest_compat.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap.h"
+#include "arrow/util/ubsan.h"
+
+namespace facebook::velox::parquet::arrow {
+namespace internal {
+
+using ::arrow::internal::Bitmap;
+using ::testing::ElementsAreArray;
+
+std::string BitmapToString(const uint8_t* bitmap, int64_t bit_count) {
+  return ::arrow::internal::Bitmap(bitmap, /*offset*/ 0, /*length=*/bit_count)
+      .ToString();
+}
+
+std::string BitmapToString(
+    const std::vector<uint8_t>& bitmap,
+    int64_t bit_count) {
+  return BitmapToString(bitmap.data(), bit_count);
+}
+
+TEST(TestColumnReader, DefLevelsToBitmap) {
+  // Bugs in this function were exposed in ARROW-3930
+  std::vector<int16_t> def_levels = {3, 3, 3, 2, 3, 3, 3, 3, 3};
+
+  std::vector<uint8_t> valid_bits(2, 0);
+
+  LevelInfo level_info;
+  level_info.def_level = 3;
+  level_info.rep_level = 1;
+
+  ValidityBitmapInputOutput io;
+  io.values_read_upper_bound = def_levels.size();
+  io.values_read = -1;
+  io.valid_bits = valid_bits.data();
+
+  DefLevelsToBitmap(def_levels.data(), 9, level_info, &io);
+  ASSERT_EQ(9, io.values_read);
+  ASSERT_EQ(1, io.null_count);
+
+  // Call again with 0 definition levels, make sure that valid_bits is
+  // unmodified
+  const uint8_t current_byte = valid_bits[1];
+  io.null_count = 0;
+  DefLevelsToBitmap(def_levels.data(), 0, level_info, &io);
+
+  ASSERT_EQ(0, io.values_read);
+  ASSERT_EQ(0, io.null_count);
+  ASSERT_EQ(current_byte, valid_bits[1]);
+}
+
+TEST(TestColumnReader, DefLevelsToBitmapPowerOfTwo) {
+  // PARQUET-1623: Invalid memory access when decoding a valid bits vector that
+  // has a length equal to a power of two and also using a non-zero
+  // valid_bits_offset.  This should not fail when run with ASAN or valgrind.
+  std::vector<int16_t> def_levels = {3, 3, 3, 2, 3, 3, 3, 3};
+  std::vector<uint8_t> valid_bits(1, 0);
+
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 3;
+
+  ValidityBitmapInputOutput io;
+  io.values_read_upper_bound = def_levels.size();
+  io.values_read = -1;
+  io.valid_bits = valid_bits.data();
+
+  // Read the latter half of the validity bitmap
+  DefLevelsToBitmap(def_levels.data() + 4, 4, level_info, &io);
+  ASSERT_EQ(4, io.values_read);
+  ASSERT_EQ(0, io.null_count);
+}
+
+#if defined(ARROW_LITTLE_ENDIAN)
+TEST(GreaterThanBitmap, GeneratesExpectedBitmasks) {
+  std::vector<int16_t> levels = {
+      0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5,
+      6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3,
+      4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7};
+  EXPECT_EQ(GreaterThanBitmap(levels.data(), /*num_levels=*/0, /*rhs*/ 0), 0);
+  EXPECT_EQ(GreaterThanBitmap(levels.data(), /*num_levels=*/64, /*rhs*/ 8), 0);
+  EXPECT_EQ(
+      GreaterThanBitmap(levels.data(), /*num_levels=*/64, /*rhs*/ -1),
+      0xFFFFFFFFFFFFFFFF);
+  // Should be zero padded.
+  EXPECT_EQ(
+      GreaterThanBitmap(levels.data(), /*num_levels=*/47, /*rhs*/ -1),
+      0x7FFFFFFFFFFF);
+  EXPECT_EQ(
+      GreaterThanBitmap(levels.data(), /*num_levels=*/64, /*rhs*/ 6),
+      0x8080808080808080);
+}
+#endif
+
+TEST(DefLevelsToBitmap, WithRepetitionLevelFiltersOutEmptyListValues) {
+  std::vector<uint8_t> validity_bitmap(/*count*/ 8, 0);
+
+  ValidityBitmapInputOutput io;
+  io.values_read_upper_bound = 64;
+  io.values_read = 1;
+  io.null_count = 5;
+  io.valid_bits = validity_bitmap.data();
+  io.valid_bits_offset = 1;
+
+  LevelInfo level_info;
+  level_info.repeated_ancestor_def_level = 1;
+  level_info.def_level = 2;
+  level_info.rep_level = 1;
+  // All zeros should be ignored, ones should be unset in the bitmp and 2 should
+  // be set.
+  std::vector<int16_t> def_levels = {0, 0, 0, 2, 2, 1, 0, 2};
+  DefLevelsToBitmap(def_levels.data(), def_levels.size(), level_info, &io);
+
+  EXPECT_EQ(BitmapToString(validity_bitmap, /*bit_count=*/8), "01101000");
+  for (size_t x = 1; x < validity_bitmap.size(); x++) {
+    EXPECT_EQ(validity_bitmap[x], 0) << "index: " << x;
+  }
+  EXPECT_EQ(io.null_count, /*5 + 1 =*/6);
+  EXPECT_EQ(io.values_read, 4); // value should get overwritten.
+}
+
+struct MultiLevelTestData {
+ public:
+  std::vector<int16_t> def_levels;
+  std::vector<int16_t> rep_levels;
+};
+
+MultiLevelTestData TriplyNestedList() {
+  // Triply nested list values borrow from write_path
+  // [null, [[1 , null, 3], []], []],
+  // [[[]], [[], [1, 2]], null, [[3]]],
+  // null,
+  // []
+  return MultiLevelTestData{
+      /*def_levels=*/std::vector<int16_t>{
+          2,
+          7,
+          6,
+          7,
+          5,
+          3, // first row
+          5,
+          5,
+          7,
+          7,
+          2,
+          7, // second row
+          0, // third row
+          1},
+      /*rep_levels=*/
+      std::vector<int16_t>{
+          0,
+          1,
+          3,
+          3,
+          2,
+          1, // first row
+          0,
+          1,
+          2,
+          3,
+          1,
+          1, // second row
+          0,
+          0}};
+}
+
+template <typename ConverterType>
+class NestedListTest : public testing::Test {
+ public:
+  void InitForLength(int length) {
+    this->validity_bits_.clear();
+    this->validity_bits_.insert(this->validity_bits_.end(), length, 0);
+    validity_io_.valid_bits = validity_bits_.data();
+    validity_io_.values_read_upper_bound = length;
+    offsets_.clear();
+    offsets_.insert(offsets_.end(), length + 1, 0);
+  }
+
+  typename ConverterType::OffsetsType* Run(
+      const MultiLevelTestData& test_data,
+      LevelInfo level_info) {
+    return this->converter_.ComputeListInfo(
+        test_data, level_info, &validity_io_, offsets_.data());
+  }
+
+  ConverterType converter_;
+  ValidityBitmapInputOutput validity_io_;
+  std::vector<uint8_t> validity_bits_;
+  std::vector<typename ConverterType::OffsetsType> offsets_;
+};
+
+template <typename IndexType>
+struct RepDefLevelConverter {
+  using OffsetsType = IndexType;
+  OffsetsType* ComputeListInfo(
+      const MultiLevelTestData& test_data,
+      LevelInfo level_info,
+      ValidityBitmapInputOutput* output,
+      IndexType* offsets) {
+    DefRepLevelsToList(
+        test_data.def_levels.data(),
+        test_data.rep_levels.data(),
+        test_data.def_levels.size(),
+        level_info,
+        output,
+        offsets);
+    return offsets + output->values_read;
+  }
+};
+
+using ConverterTypes = ::testing::Types<
+    RepDefLevelConverter</*list_length_type=*/int32_t>,
+    RepDefLevelConverter</*list_length_type=*/int64_t>>;
+TYPED_TEST_SUITE(NestedListTest, ConverterTypes);
+
+TYPED_TEST(NestedListTest, OuterMostTest) {
+  // [null, [[1 , null, 3], []], []],
+  // [[[]], [[], [1, 2]], null, [[3]]],
+  // null,
+  // []
+  // -> 4 outer most lists (len(3), len(4), null, len(0))
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 2;
+
+  this->InitForLength(4);
+  typename TypeParam::OffsetsType* next_position =
+      this->Run(TriplyNestedList(), level_info);
+
+  EXPECT_EQ(next_position, this->offsets_.data() + 4);
+  EXPECT_THAT(this->offsets_, testing::ElementsAre(0, 3, 7, 7, 7));
+
+  EXPECT_EQ(this->validity_io_.values_read, 4);
+  EXPECT_EQ(this->validity_io_.null_count, 1);
+  EXPECT_EQ(
+      BitmapToString(this->validity_io_.valid_bits, /*length=*/4), "1101");
+}
+
+TYPED_TEST(NestedListTest, MiddleListTest) {
+  // [null, [[1 , null, 3], []], []],
+  // [[[]], [[], [1, 2]], null, [[3]]],
+  // null,
+  // []
+  // -> middle lists (null, len(2), len(0),
+  //                  len(1), len(2), null, len(1),
+  //                  N/A,
+  //                  N/A
+  LevelInfo level_info;
+  level_info.rep_level = 2;
+  level_info.def_level = 4;
+  level_info.repeated_ancestor_def_level = 2;
+
+  this->InitForLength(7);
+  typename TypeParam::OffsetsType* next_position =
+      this->Run(TriplyNestedList(), level_info);
+
+  EXPECT_EQ(next_position, this->offsets_.data() + 7);
+  EXPECT_THAT(this->offsets_, testing::ElementsAre(0, 0, 2, 2, 3, 5, 5, 6));
+
+  EXPECT_EQ(this->validity_io_.values_read, 7);
+  EXPECT_EQ(this->validity_io_.null_count, 2);
+  EXPECT_EQ(
+      BitmapToString(this->validity_io_.valid_bits, /*length=*/7), "0111101");
+}
+
+TYPED_TEST(NestedListTest, InnerMostListTest) {
+  // [null, [[1, null, 3], []], []],
+  // [[[]], [[], [1, 2]], null, [[3]]],
+  // null,
+  // []
+  // -> 6 inner lists (N/A, [len(3), len(0)], N/A
+  //                        len(0), [len(0), len(2)], N/A, len(1),
+  //                        N/A,
+  //                        N/A
+  LevelInfo level_info;
+  level_info.rep_level = 3;
+  level_info.def_level = 6;
+  level_info.repeated_ancestor_def_level = 4;
+
+  this->InitForLength(6);
+  typename TypeParam::OffsetsType* next_position =
+      this->Run(TriplyNestedList(), level_info);
+
+  EXPECT_EQ(next_position, this->offsets_.data() + 6);
+  EXPECT_THAT(this->offsets_, testing::ElementsAre(0, 3, 3, 3, 3, 5, 6));
+
+  EXPECT_EQ(this->validity_io_.values_read, 6);
+  EXPECT_EQ(this->validity_io_.null_count, 0);
+  EXPECT_EQ(
+      BitmapToString(this->validity_io_.valid_bits, /*length=*/6), "111111");
+}
+
+TYPED_TEST(NestedListTest, SimpleLongList) {
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 2;
+  level_info.repeated_ancestor_def_level = 0;
+
+  MultiLevelTestData test_data;
+  // No empty lists.
+  test_data.def_levels = std::vector<int16_t>(65 * 9, 2);
+  for (int x = 0; x < 65; x++) {
+    test_data.rep_levels.push_back(0);
+    test_data.rep_levels.insert(
+        test_data.rep_levels.end(),
+        8,
+        /*rep_level=*/1);
+  }
+
+  std::vector<typename TypeParam::OffsetsType> expected_offsets(66, 0);
+  for (size_t x = 1; x < expected_offsets.size(); x++) {
+    expected_offsets[x] = static_cast<typename TypeParam::OffsetsType>(x) * 9;
+  }
+  this->InitForLength(65);
+  typename TypeParam::OffsetsType* next_position =
+      this->Run(test_data, level_info);
+
+  EXPECT_EQ(next_position, this->offsets_.data() + 65);
+  EXPECT_THAT(this->offsets_, testing::ElementsAreArray(expected_offsets));
+
+  EXPECT_EQ(this->validity_io_.values_read, 65);
+  EXPECT_EQ(this->validity_io_.null_count, 0);
+  EXPECT_EQ(
+      BitmapToString(this->validity_io_.valid_bits, /*length=*/65),
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "11111111 "
+      "1");
+}
+
+TYPED_TEST(NestedListTest, TestOverflow) {
+  LevelInfo level_info;
+  level_info.rep_level = 1;
+  level_info.def_level = 2;
+  level_info.repeated_ancestor_def_level = 0;
+
+  MultiLevelTestData test_data;
+  test_data.def_levels = std::vector<int16_t>{2};
+  test_data.rep_levels = std::vector<int16_t>{0};
+
+  this->InitForLength(2);
+  // Offsets is populated as the cumulative sum of all elements,
+  // so populating the offsets[0] with max-value impacts the
+  // other values populated.
+  this->offsets_[0] =
+      std::numeric_limits<typename TypeParam::OffsetsType>::max();
+  this->offsets_[1] =
+      std::numeric_limits<typename TypeParam::OffsetsType>::max();
+  ASSERT_THROW(this->Run(test_data, level_info), ParquetException);
+
+  ASSERT_THROW(this->Run(test_data, level_info), ParquetException);
+
+  // Same thing should happen if the list already existed.
+  test_data.rep_levels = std::vector<int16_t>{1};
+  ASSERT_THROW(this->Run(test_data, level_info), ParquetException);
+
+  // Should be OK because it shouldn't increment.
+  test_data.def_levels = std::vector<int16_t>{0};
+  test_data.rep_levels = std::vector<int16_t>{0};
+  this->Run(test_data, level_info);
+}
+
+TEST(TestOnlyExtractBitsSoftware, BasicTest) {
+  auto check =
+      [](uint64_t bitmap, uint64_t selection, uint64_t expected) -> void {
+    EXPECT_EQ(TestOnlyExtractBitsSoftware(bitmap, selection), expected);
+  };
+  check(0xFF, 0, 0);
+  check(0xFF, ~uint64_t{0}, 0xFF);
+  check(0xFF00FF, 0xAAAA, 0x000F);
+  check(0xFF0AFF, 0xAFAA, 0x00AF);
+  check(0xFFAAFF, 0xAFAA, 0x03AF);
+  check(0xFECBDA9876543210ULL, 0xF00FF00FF00FF00FULL, 0xFBD87430ULL);
+}
+
+} // namespace internal
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/MetadataTest.cpp
@@ -1,0 +1,790 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+
+#include <gtest/gtest.h>
+
+#include "arrow/util/key_value_metadata.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+namespace facebook::velox::parquet::arrow {
+namespace metadata {
+
+// Helper function for generating table metadata
+std::unique_ptr<FileMetaData> GenerateTableMetaData(
+    const SchemaDescriptor& schema,
+    const std::shared_ptr<WriterProperties>& props,
+    const int64_t& nrows,
+    EncodedStatistics stats_int,
+    EncodedStatistics stats_float) {
+  auto f_builder = FileMetaDataBuilder::Make(&schema, props);
+  auto rg1_builder = f_builder->AppendRowGroup();
+  // Write the metadata
+  // rowgroup1 metadata
+  auto col1_builder = rg1_builder->NextColumnChunk();
+  auto col2_builder = rg1_builder->NextColumnChunk();
+  // column metadata
+  std::map<Encoding::type, int32_t> dict_encoding_stats(
+      {{Encoding::RLE_DICTIONARY, 1}});
+  std::map<Encoding::type, int32_t> data_encoding_stats(
+      {{Encoding::PLAIN, 1}, {Encoding::RLE, 1}});
+  stats_int.set_is_signed(true);
+  col1_builder->SetStatistics(stats_int);
+  stats_float.set_is_signed(true);
+  col2_builder->SetStatistics(stats_float);
+  col1_builder->Finish(
+      nrows / 2,
+      4,
+      0,
+      10,
+      512,
+      600,
+      true,
+      false,
+      dict_encoding_stats,
+      data_encoding_stats);
+  col2_builder->Finish(
+      nrows / 2,
+      24,
+      0,
+      30,
+      512,
+      600,
+      true,
+      false,
+      dict_encoding_stats,
+      data_encoding_stats);
+
+  rg1_builder->set_num_rows(nrows / 2);
+  rg1_builder->Finish(1024);
+
+  // rowgroup2 metadata
+  auto rg2_builder = f_builder->AppendRowGroup();
+  col1_builder = rg2_builder->NextColumnChunk();
+  col2_builder = rg2_builder->NextColumnChunk();
+  // column metadata
+  col1_builder->SetStatistics(stats_int);
+  col2_builder->SetStatistics(stats_float);
+  col1_builder->Finish(
+      nrows / 2,
+      /*dictionary_page_offset=*/0,
+      0,
+      10,
+      512,
+      600,
+      /*has_dictionary=*/false,
+      false,
+      dict_encoding_stats,
+      data_encoding_stats);
+  col2_builder->Finish(
+      nrows / 2,
+      16,
+      0,
+      26,
+      512,
+      600,
+      true,
+      false,
+      dict_encoding_stats,
+      data_encoding_stats);
+
+  rg2_builder->set_num_rows(nrows / 2);
+  rg2_builder->Finish(1024);
+
+  // Return the metadata accessor
+  return f_builder->Finish();
+}
+
+void AssertEncodings(
+    const ColumnChunkMetaData& data,
+    const std::set<Encoding::type>& expected) {
+  std::set<Encoding::type> encodings(
+      data.encodings().begin(), data.encodings().end());
+  ASSERT_EQ(encodings, expected);
+}
+
+TEST(Metadata, TestBuildAccess) {
+  schema::NodeVector fields;
+  schema::NodePtr root;
+  SchemaDescriptor schema;
+
+  WriterProperties::Builder prop_builder;
+
+  std::shared_ptr<WriterProperties> props =
+      prop_builder.version(ParquetVersion::PARQUET_2_6)->build();
+
+  fields.push_back(schema::Int32("int_col", Repetition::REQUIRED));
+  fields.push_back(schema::Float("float_col", Repetition::REQUIRED));
+  root = schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  schema.Init(root);
+
+  int64_t nrows = 1000;
+  int32_t int_min = 100, int_max = 200;
+  EncodedStatistics stats_int;
+  stats_int.set_null_count(0)
+      .set_distinct_count(nrows)
+      .set_min(std::string(reinterpret_cast<const char*>(&int_min), 4))
+      .set_max(std::string(reinterpret_cast<const char*>(&int_max), 4));
+  EncodedStatistics stats_float;
+  float float_min = 100.100f, float_max = 200.200f;
+  stats_float.set_null_count(0)
+      .set_distinct_count(nrows)
+      .set_min(std::string(reinterpret_cast<const char*>(&float_min), 4))
+      .set_max(std::string(reinterpret_cast<const char*>(&float_max), 4));
+
+  // Generate the metadata
+  auto f_accessor =
+      GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
+
+  std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
+  uint32_t expected_len =
+      static_cast<uint32_t>(f_accessor_serialized_metadata.length());
+
+  // decoded_len is an in-out parameter
+  uint32_t decoded_len = expected_len;
+  auto f_accessor_copy =
+      FileMetaData::Make(f_accessor_serialized_metadata.data(), &decoded_len);
+
+  // Check that all of the serialized data is consumed
+  ASSERT_EQ(expected_len, decoded_len);
+
+  // Run this block twice, one for f_accessor, one for f_accessor_copy.
+  // To make sure SerializedMetadata was deserialized correctly.
+  std::vector<FileMetaData*> f_accessors = {
+      f_accessor.get(), f_accessor_copy.get()};
+  for (int loop_index = 0; loop_index < 2; loop_index++) {
+    // file metadata
+    ASSERT_EQ(nrows, f_accessors[loop_index]->num_rows());
+    ASSERT_LE(0, static_cast<int>(f_accessors[loop_index]->size()));
+    ASSERT_EQ(2, f_accessors[loop_index]->num_row_groups());
+    ASSERT_EQ(ParquetVersion::PARQUET_2_6, f_accessors[loop_index]->version());
+    ASSERT_EQ(DEFAULT_CREATED_BY, f_accessors[loop_index]->created_by());
+    ASSERT_EQ(3, f_accessors[loop_index]->num_schema_elements());
+
+    // row group1 metadata
+    auto rg1_accessor = f_accessors[loop_index]->RowGroup(0);
+    ASSERT_EQ(2, rg1_accessor->num_columns());
+    ASSERT_EQ(nrows / 2, rg1_accessor->num_rows());
+    ASSERT_EQ(1024, rg1_accessor->total_byte_size());
+    ASSERT_EQ(1024, rg1_accessor->total_compressed_size());
+    EXPECT_EQ(
+        rg1_accessor->file_offset(),
+        rg1_accessor->ColumnChunk(0)->dictionary_page_offset());
+
+    auto rg1_column1 = rg1_accessor->ColumnChunk(0);
+    auto rg1_column2 = rg1_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg1_column1->is_stats_set());
+    ASSERT_EQ(true, rg1_column2->is_stats_set());
+    ASSERT_EQ(stats_float.min(), rg1_column2->statistics()->EncodeMin());
+    ASSERT_EQ(stats_float.max(), rg1_column2->statistics()->EncodeMax());
+    ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
+    ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
+    ASSERT_EQ(0, rg1_column1->statistics()->null_count());
+    ASSERT_EQ(0, rg1_column2->statistics()->null_count());
+    ASSERT_EQ(nrows, rg1_column1->statistics()->distinct_count());
+    ASSERT_EQ(nrows, rg1_column2->statistics()->distinct_count());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column1->compression());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg1_column2->compression());
+    ASSERT_EQ(nrows / 2, rg1_column1->num_values());
+    ASSERT_EQ(nrows / 2, rg1_column2->num_values());
+    {
+      std::set<Encoding::type> encodings{
+          Encoding::RLE, Encoding::RLE_DICTIONARY, Encoding::PLAIN};
+      AssertEncodings(*rg1_column1, encodings);
+    }
+    {
+      std::set<Encoding::type> encodings{
+          Encoding::RLE, Encoding::RLE_DICTIONARY, Encoding::PLAIN};
+      AssertEncodings(*rg1_column2, encodings);
+    }
+    ASSERT_EQ(512, rg1_column1->total_compressed_size());
+    ASSERT_EQ(512, rg1_column2->total_compressed_size());
+    ASSERT_EQ(600, rg1_column1->total_uncompressed_size());
+    ASSERT_EQ(600, rg1_column2->total_uncompressed_size());
+    ASSERT_EQ(4, rg1_column1->dictionary_page_offset());
+    ASSERT_EQ(24, rg1_column2->dictionary_page_offset());
+    ASSERT_EQ(10, rg1_column1->data_page_offset());
+    ASSERT_EQ(30, rg1_column2->data_page_offset());
+    ASSERT_EQ(3, rg1_column1->encoding_stats().size());
+    ASSERT_EQ(3, rg1_column2->encoding_stats().size());
+
+    auto rg2_accessor = f_accessors[loop_index]->RowGroup(1);
+    ASSERT_EQ(2, rg2_accessor->num_columns());
+    ASSERT_EQ(nrows / 2, rg2_accessor->num_rows());
+    ASSERT_EQ(1024, rg2_accessor->total_byte_size());
+    ASSERT_EQ(1024, rg2_accessor->total_compressed_size());
+    EXPECT_EQ(
+        rg2_accessor->file_offset(),
+        rg2_accessor->ColumnChunk(0)->data_page_offset());
+
+    auto rg2_column1 = rg2_accessor->ColumnChunk(0);
+    auto rg2_column2 = rg2_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg2_column1->is_stats_set());
+    ASSERT_EQ(true, rg2_column2->is_stats_set());
+    ASSERT_EQ(stats_float.min(), rg2_column2->statistics()->EncodeMin());
+    ASSERT_EQ(stats_float.max(), rg2_column2->statistics()->EncodeMax());
+    ASSERT_EQ(stats_int.min(), rg1_column1->statistics()->EncodeMin());
+    ASSERT_EQ(stats_int.max(), rg1_column1->statistics()->EncodeMax());
+    ASSERT_EQ(0, rg2_column1->statistics()->null_count());
+    ASSERT_EQ(0, rg2_column2->statistics()->null_count());
+    ASSERT_EQ(nrows, rg2_column1->statistics()->distinct_count());
+    ASSERT_EQ(nrows, rg2_column2->statistics()->distinct_count());
+    ASSERT_EQ(nrows / 2, rg2_column1->num_values());
+    ASSERT_EQ(nrows / 2, rg2_column2->num_values());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column1->compression());
+    ASSERT_EQ(DEFAULT_COMPRESSION_TYPE, rg2_column2->compression());
+    {
+      std::set<Encoding::type> encodings{Encoding::RLE, Encoding::PLAIN};
+      AssertEncodings(*rg2_column1, encodings);
+    }
+    {
+      std::set<Encoding::type> encodings{
+          Encoding::RLE, Encoding::RLE_DICTIONARY, Encoding::PLAIN};
+      AssertEncodings(*rg2_column2, encodings);
+    }
+    ASSERT_EQ(512, rg2_column1->total_compressed_size());
+    ASSERT_EQ(512, rg2_column2->total_compressed_size());
+    ASSERT_EQ(600, rg2_column1->total_uncompressed_size());
+    ASSERT_EQ(600, rg2_column2->total_uncompressed_size());
+    EXPECT_FALSE(rg2_column1->has_dictionary_page());
+    ASSERT_EQ(0, rg2_column1->dictionary_page_offset());
+    ASSERT_EQ(16, rg2_column2->dictionary_page_offset());
+    ASSERT_EQ(10, rg2_column1->data_page_offset());
+    ASSERT_EQ(26, rg2_column2->data_page_offset());
+    ASSERT_EQ(2, rg2_column1->encoding_stats().size());
+    ASSERT_EQ(3, rg2_column2->encoding_stats().size());
+
+    // Test FileMetaData::set_file_path
+    ASSERT_TRUE(rg2_column1->file_path().empty());
+    f_accessors[loop_index]->set_file_path("/foo/bar/bar.parquet");
+    ASSERT_EQ("/foo/bar/bar.parquet", rg2_column1->file_path());
+  }
+
+  // Test AppendRowGroups
+  auto f_accessor_2 =
+      GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
+  f_accessor->AppendRowGroups(*f_accessor_2);
+  ASSERT_EQ(4, f_accessor->num_row_groups());
+  ASSERT_EQ(nrows * 2, f_accessor->num_rows());
+  ASSERT_LE(0, static_cast<int>(f_accessor->size()));
+  ASSERT_EQ(ParquetVersion::PARQUET_2_6, f_accessor->version());
+  ASSERT_EQ(DEFAULT_CREATED_BY, f_accessor->created_by());
+  ASSERT_EQ(3, f_accessor->num_schema_elements());
+
+  // Test AppendRowGroups from self (ARROW-13654)
+  f_accessor->AppendRowGroups(*f_accessor);
+  ASSERT_EQ(8, f_accessor->num_row_groups());
+  ASSERT_EQ(nrows * 4, f_accessor->num_rows());
+  ASSERT_EQ(3, f_accessor->num_schema_elements());
+
+  // Test Subset
+  auto f_accessor_1 = f_accessor->Subset({2, 3});
+  ASSERT_TRUE(f_accessor_1->Equals(*f_accessor_2));
+
+  f_accessor_1 = f_accessor_2->Subset({0});
+  f_accessor_1->AppendRowGroups(*f_accessor->Subset({0}));
+  ASSERT_TRUE(f_accessor_1->Equals(*f_accessor->Subset({2, 0})));
+}
+
+TEST(Metadata, TestV1Version) {
+  // PARQUET-839
+  schema::NodeVector fields;
+  schema::NodePtr root;
+  SchemaDescriptor schema;
+
+  WriterProperties::Builder prop_builder;
+
+  std::shared_ptr<WriterProperties> props =
+      prop_builder.version(ParquetVersion::PARQUET_1_0)->build();
+
+  fields.push_back(schema::Int32("int_col", Repetition::REQUIRED));
+  fields.push_back(schema::Float("float_col", Repetition::REQUIRED));
+  root = schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  schema.Init(root);
+
+  auto f_builder = FileMetaDataBuilder::Make(&schema, props);
+
+  // Read the metadata
+  auto f_accessor = f_builder->Finish();
+
+  // file metadata
+  ASSERT_EQ(ParquetVersion::PARQUET_1_0, f_accessor->version());
+}
+
+TEST(Metadata, TestKeyValueMetadata) {
+  schema::NodeVector fields;
+  schema::NodePtr root;
+  SchemaDescriptor schema;
+
+  WriterProperties::Builder prop_builder;
+
+  std::shared_ptr<WriterProperties> props =
+      prop_builder.version(ParquetVersion::PARQUET_1_0)->build();
+
+  fields.push_back(schema::Int32("int_col", Repetition::REQUIRED));
+  fields.push_back(schema::Float("float_col", Repetition::REQUIRED));
+  root = schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  schema.Init(root);
+
+  auto kvmeta = std::make_shared<KeyValueMetadata>();
+  kvmeta->Append("test_key", "test_value");
+
+  auto f_builder = FileMetaDataBuilder::Make(&schema, props);
+
+  // Read the metadata
+  auto f_accessor = f_builder->Finish(kvmeta);
+
+  // Key value metadata
+  ASSERT_TRUE(f_accessor->key_value_metadata());
+  EXPECT_TRUE(f_accessor->key_value_metadata()->Equals(*kvmeta));
+}
+
+TEST(Metadata, TestAddKeyValueMetadata) {
+  schema::NodeVector fields;
+  fields.push_back(schema::Int32("int_col", Repetition::REQUIRED));
+  auto schema = std::static_pointer_cast<schema::GroupNode>(
+      schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
+
+  auto kv_meta = std::make_shared<KeyValueMetadata>();
+  kv_meta->Append("test_key_1", "test_value_1");
+  kv_meta->Append("test_key_2", "test_value_2_");
+
+  auto sink = CreateOutputStream();
+  auto writer_props = WriterProperties::Builder().disable_dictionary()->build();
+  auto file_writer =
+      ParquetFileWriter::Open(sink, schema, writer_props, kv_meta);
+
+  // Key value metadata that will be added to the file.
+  auto kv_meta_added = std::make_shared<KeyValueMetadata>();
+  kv_meta_added->Append("test_key_2", "test_value_2");
+  kv_meta_added->Append("test_key_3", "test_value_3");
+
+  file_writer->AddKeyValueMetadata(kv_meta_added);
+  file_writer->Close();
+
+  // Throw if appending key value metadata to closed file.
+  auto kv_meta_ignored = std::make_shared<KeyValueMetadata>();
+  kv_meta_ignored->Append("test_key_4", "test_value_4");
+  EXPECT_THROW(
+      file_writer->AddKeyValueMetadata(kv_meta_ignored), ParquetException);
+
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto file_reader = ParquetFileReader::Open(source);
+
+  ASSERT_NE(nullptr, file_reader->metadata());
+  ASSERT_NE(nullptr, file_reader->metadata()->key_value_metadata());
+  auto read_kv_meta = file_reader->metadata()->key_value_metadata();
+
+  // Verify keys that were added before file writer was closed are present.
+  for (int i = 1; i <= 3; ++i) {
+    auto index = std::to_string(i);
+    PARQUET_ASSIGN_OR_THROW(auto value, read_kv_meta->Get("test_key_" + index));
+    EXPECT_EQ("test_value_" + index, value);
+  }
+  // Verify keys that were added after file writer was closed are not present.
+  EXPECT_FALSE(read_kv_meta->Contains("test_key_4"));
+}
+
+// TODO: disabled as they require Arrow parquet data dir.
+/*
+TEST(Metadata, TestHasBloomFilter) {
+  std::string dir_string(test::get_data_dir());
+  std::string path = dir_string + "/data_index_bloom_encoding_stats.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+  ASSERT_EQ(1, file_metadata->num_row_groups());
+  auto row_group_metadata = file_metadata->RowGroup(0);
+  ASSERT_EQ(1, row_group_metadata->num_columns());
+  auto col_chunk_metadata = row_group_metadata->ColumnChunk(0);
+  auto bloom_filter_offset = col_chunk_metadata->bloom_filter_offset();
+  ASSERT_TRUE(bloom_filter_offset.has_value());
+  ASSERT_EQ(192, bloom_filter_offset);
+}
+
+TEST(Metadata, TestReadPageIndex) {
+  std::string dir_string(test::get_data_dir());
+  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+  ASSERT_EQ(1, file_metadata->num_row_groups());
+  auto row_group_metadata = file_metadata->RowGroup(0);
+  ASSERT_EQ(13, row_group_metadata->num_columns());
+  std::vector<int64_t> ci_offsets = {323583, 327502, 328009, 331928, 335847,
+                                     339766, 350345, 354264, 364843, 384342,
+                                     -1,     386473, 390392};
+  std::vector<int32_t> ci_lengths = {3919,  507,   3919, 3919, 3919, 10579,
+3919, 10579, 19499, 2131, -1,   3919, 3919}; std::vector<int64_t> oi_offsets =
+{394311, 397814, 398637, 401888, 405139, 408390, 413670, 416921, 422201, 431936,
+                                     435457, 446002, 449253};
+  std::vector<int32_t> oi_lengths = {3503, 823,  3251, 3251,  3251, 5280, 3251,
+                                     5280, 9735, 3521, 10545, 3251, 3251};
+  for (int i = 0; i < row_group_metadata->num_columns(); ++i) {
+    auto col_chunk_metadata = row_group_metadata->ColumnChunk(i);
+    auto ci_location = col_chunk_metadata->GetColumnIndexLocation();
+    if (i == 10) {
+      // column_id 10 does not have column index
+      ASSERT_FALSE(ci_location.has_value());
+    } else {
+      ASSERT_TRUE(ci_location.has_value());
+    }
+    if (ci_location.has_value()) {
+      ASSERT_EQ(ci_offsets.at(i), ci_location->offset);
+      ASSERT_EQ(ci_lengths.at(i), ci_location->length);
+    }
+    auto oi_location = col_chunk_metadata->GetOffsetIndexLocation();
+    ASSERT_TRUE(oi_location.has_value());
+    ASSERT_EQ(oi_offsets.at(i), oi_location->offset);
+    ASSERT_EQ(oi_lengths.at(i), oi_location->length);
+    ASSERT_FALSE(col_chunk_metadata->bloom_filter_offset().has_value());
+  }
+}
+*/
+
+TEST(Metadata, TestSortingColumns) {
+  schema::NodeVector fields;
+  fields.push_back(schema::Int32("sort_col", Repetition::REQUIRED));
+  fields.push_back(schema::Int32("int_col", Repetition::REQUIRED));
+
+  auto schema = std::static_pointer_cast<schema::GroupNode>(
+      schema::GroupNode::Make("schema", Repetition::REQUIRED, fields));
+
+  std::vector<SortingColumn> sorting_columns;
+  {
+    SortingColumn sorting_column;
+    sorting_column.column_idx = 0;
+    sorting_column.descending = false;
+    sorting_column.nulls_first = false;
+    sorting_columns.push_back(sorting_column);
+  }
+
+  auto sink = CreateOutputStream();
+  auto writer_props = WriterProperties::Builder()
+                          .disable_dictionary()
+                          ->set_sorting_columns(sorting_columns)
+                          ->build();
+
+  EXPECT_EQ(sorting_columns, writer_props->sorting_columns());
+
+  auto file_writer = ParquetFileWriter::Open(sink, schema, writer_props);
+
+  auto row_group_writer = file_writer->AppendBufferedRowGroup();
+  row_group_writer->Close();
+  file_writer->Close();
+
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+  auto file_reader = ParquetFileReader::Open(source);
+
+  ASSERT_NE(nullptr, file_reader->metadata());
+  ASSERT_EQ(1, file_reader->metadata()->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+  auto* row_group_read_metadata = row_group_reader->metadata();
+  ASSERT_NE(nullptr, row_group_read_metadata);
+  EXPECT_EQ(sorting_columns, row_group_read_metadata->sorting_columns());
+}
+
+TEST(ApplicationVersion, Basics) {
+  ApplicationVersion version("parquet-mr version 1.7.9");
+  ApplicationVersion version1("parquet-mr version 1.8.0");
+  ApplicationVersion version2("parquet-cpp version 1.0.0");
+  ApplicationVersion version3("");
+  ApplicationVersion version4(
+      "parquet-mr version 1.5.0ab-cdh5.5.0+cd (build abcd)");
+  ApplicationVersion version5("parquet-mr");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(9, version.version.patch);
+
+  ASSERT_EQ("parquet-cpp", version2.application_);
+  ASSERT_EQ(1, version2.version.major);
+  ASSERT_EQ(0, version2.version.minor);
+  ASSERT_EQ(0, version2.version.patch);
+
+  ASSERT_EQ("parquet-mr", version4.application_);
+  ASSERT_EQ("abcd", version4.build_);
+  ASSERT_EQ(1, version4.version.major);
+  ASSERT_EQ(5, version4.version.minor);
+  ASSERT_EQ(0, version4.version.patch);
+  ASSERT_EQ("ab", version4.version.unknown);
+  ASSERT_EQ("cdh5.5.0", version4.version.pre_release);
+  ASSERT_EQ("cd", version4.version.build_info);
+
+  ASSERT_EQ("parquet-mr", version5.application_);
+  ASSERT_EQ(0, version5.version.major);
+  ASSERT_EQ(0, version5.version.minor);
+  ASSERT_EQ(0, version5.version.patch);
+
+  ASSERT_EQ(true, version.VersionLt(version1));
+
+  EncodedStatistics stats;
+  ASSERT_FALSE(
+      version1.HasCorrectStatistics(Type::INT96, stats, SortOrder::UNKNOWN));
+  ASSERT_TRUE(
+      version.HasCorrectStatistics(Type::INT32, stats, SortOrder::SIGNED));
+  ASSERT_FALSE(
+      version.HasCorrectStatistics(Type::BYTE_ARRAY, stats, SortOrder::SIGNED));
+  ASSERT_TRUE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats, SortOrder::SIGNED));
+  ASSERT_FALSE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats, SortOrder::UNSIGNED));
+  ASSERT_TRUE(version3.HasCorrectStatistics(
+      Type::FIXED_LEN_BYTE_ARRAY, stats, SortOrder::SIGNED));
+
+  // Check that the old stats are correct if min and max are the same
+  // regardless of sort order
+  EncodedStatistics stats_str;
+  stats_str.set_min("a").set_max("b");
+  ASSERT_FALSE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats_str, SortOrder::UNSIGNED));
+  stats_str.set_max("a");
+  ASSERT_TRUE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats_str, SortOrder::UNSIGNED));
+
+  // Check that the same holds true for ints
+  int32_t int_min = 100, int_max = 200;
+  EncodedStatistics stats_int;
+  stats_int.set_min(std::string(reinterpret_cast<const char*>(&int_min), 4))
+      .set_max(std::string(reinterpret_cast<const char*>(&int_max), 4));
+  ASSERT_FALSE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats_int, SortOrder::UNSIGNED));
+  stats_int.set_max(std::string(reinterpret_cast<const char*>(&int_min), 4));
+  ASSERT_TRUE(version1.HasCorrectStatistics(
+      Type::BYTE_ARRAY, stats_int, SortOrder::UNSIGNED));
+}
+
+TEST(ApplicationVersion, Empty) {
+  ApplicationVersion version("");
+
+  ASSERT_EQ("", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(0, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, NoVersion) {
+  ApplicationVersion version("parquet-mr (build abcd)");
+
+  ASSERT_EQ("parquet-mr (build abcd)", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(0, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionEmpty) {
+  ApplicationVersion version("parquet-mr version ");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(0, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoMajor) {
+  ApplicationVersion version("parquet-mr version .");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(0, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionInvalidMajor) {
+  ApplicationVersion version("parquet-mr version x1");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(0, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionMajorOnly) {
+  ApplicationVersion version("parquet-mr version 1");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoMinor) {
+  ApplicationVersion version("parquet-mr version 1.");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionMajorMinorOnly) {
+  ApplicationVersion version("parquet-mr version 1.7");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionInvalidMinor) {
+  ApplicationVersion version("parquet-mr version 1.x7");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(0, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoPatch) {
+  ApplicationVersion version("parquet-mr version 1.7.");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionInvalidPatch) {
+  ApplicationVersion version("parquet-mr version 1.7.x9");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(0, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoUnknown) {
+  ApplicationVersion version("parquet-mr version 1.7.9-cdh5.5.0+cd");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(9, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("cdh5.5.0", version.version.pre_release);
+  ASSERT_EQ("cd", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoPreRelease) {
+  ApplicationVersion version("parquet-mr version 1.7.9ab+cd");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(9, version.version.patch);
+  ASSERT_EQ("ab", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("cd", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoUnknownNoPreRelease) {
+  ApplicationVersion version("parquet-mr version 1.7.9+cd");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(9, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("cd", version.version.build_info);
+}
+
+TEST(ApplicationVersion, VersionNoUnknownBuildInfoPreRelease) {
+  ApplicationVersion version("parquet-mr version 1.7.9+cd-cdh5.5.0");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(7, version.version.minor);
+  ASSERT_EQ(9, version.version.patch);
+  ASSERT_EQ("", version.version.unknown);
+  ASSERT_EQ("", version.version.pre_release);
+  ASSERT_EQ("cd-cdh5.5.0", version.version.build_info);
+}
+
+TEST(ApplicationVersion, FullWithSpaces) {
+  ApplicationVersion version(
+      " parquet-mr \t version \v 1.5.3ab-cdh5.5.0+cd \r (build \n abcd \f) ");
+
+  ASSERT_EQ("parquet-mr", version.application_);
+  ASSERT_EQ("abcd", version.build_);
+  ASSERT_EQ(1, version.version.major);
+  ASSERT_EQ(5, version.version.minor);
+  ASSERT_EQ(3, version.version.patch);
+  ASSERT_EQ("ab", version.version.unknown);
+  ASSERT_EQ("cdh5.5.0", version.version.pre_release);
+  ASSERT_EQ("cd", version.version.build_info);
+}
+
+} // namespace metadata
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/PageIndexTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/PageIndexTest.cpp
@@ -1,0 +1,1022 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/PageIndex.h"
+
+#include <gtest/gtest.h>
+#include <memory>
+
+#include "arrow/io/file.h"
+#include "velox/dwio/parquet/writer/arrow/Metadata.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+namespace facebook::velox::parquet::arrow {
+
+// TODO: disabled as it requires Arrow parquet data dir.
+/*
+TEST(PageIndex, ReadOffsetIndex) {
+  std::string dir_string(test::get_data_dir());
+  std::string path = dir_string + "/alltypes_tiny_pages.parquet";
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+
+  // Get offset index location to column 0 of row group 0.
+  const int row_group_id = 0;
+  const int column_id = 0;
+  ASSERT_LT(row_group_id, file_metadata->num_row_groups());
+  ASSERT_LT(column_id, file_metadata->num_columns());
+  auto index_location = file_metadata->RowGroup(row_group_id)
+                            ->ColumnChunk(column_id)
+                            ->GetOffsetIndexLocation();
+  ASSERT_TRUE(index_location.has_value());
+
+  // Read serialized offset index from the file.
+  std::shared_ptr<::arrow::io::RandomAccessFile> source;
+  PARQUET_ASSIGN_OR_THROW(source, ::arrow::io::ReadableFile::Open(path));
+  PARQUET_ASSIGN_OR_THROW(auto buffer,
+                          source->ReadAt(index_location->offset,
+index_location->length)); PARQUET_THROW_NOT_OK(source->Close());
+
+  // Deserialize offset index.
+  auto properties = default_reader_properties();
+  std::unique_ptr<OffsetIndex> offset_index = OffsetIndex::Make(
+      buffer->data(), static_cast<uint32_t>(buffer->size()), properties);
+
+  // Verify only partial data as it contains 325 pages in total.
+  const size_t num_pages = 325;
+  const std::vector<size_t> page_indices = {0, 100, 200, 300};
+  const std::vector<PageLocation> page_locations = {
+      PageLocation{4, 109, 0}, PageLocation{11480, 133, 2244},
+      PageLocation{22980, 133, 4494}, PageLocation{34480, 133, 6744}};
+
+  ASSERT_EQ(num_pages, offset_index->page_locations().size());
+  for (size_t i = 0; i < page_indices.size(); ++i) {
+    size_t page_id = page_indices.at(i);
+    const auto& read_page_location = offset_index->page_locations().at(page_id);
+    const auto& expected_page_location = page_locations.at(i);
+    ASSERT_EQ(expected_page_location.offset, read_page_location.offset);
+    ASSERT_EQ(expected_page_location.compressed_page_size,
+              read_page_location.compressed_page_size);
+    ASSERT_EQ(expected_page_location.first_row_index,
+read_page_location.first_row_index);
+  }
+}
+*/
+
+template <typename DType, typename T = typename DType::c_type>
+void TestReadTypedColumnIndex(
+    const std::string& file_name,
+    int column_id,
+    size_t num_pages,
+    BoundaryOrder::type boundary_order,
+    const std::vector<size_t>& page_indices,
+    const std::vector<bool>& null_pages,
+    const std::vector<T>& min_values,
+    const std::vector<T>& max_values,
+    bool has_null_counts = false,
+    const std::vector<int64_t>& null_counts = {}) {
+  std::string dir_string(test::get_data_dir());
+  std::string path = dir_string + "/" + file_name;
+  auto reader = ParquetFileReader::OpenFile(path, false);
+  auto file_metadata = reader->metadata();
+
+  // Get column index location to a specific column chunk.
+  const int row_group_id = 0;
+  ASSERT_LT(row_group_id, file_metadata->num_row_groups());
+  ASSERT_LT(column_id, file_metadata->num_columns());
+  auto index_location = file_metadata->RowGroup(row_group_id)
+                            ->ColumnChunk(column_id)
+                            ->GetColumnIndexLocation();
+  ASSERT_TRUE(index_location.has_value());
+
+  // Read serialized column index from the file.
+  std::shared_ptr<::arrow::io::RandomAccessFile> source;
+  PARQUET_ASSIGN_OR_THROW(source, ::arrow::io::ReadableFile::Open(path));
+  PARQUET_ASSIGN_OR_THROW(
+      auto buffer,
+      source->ReadAt(index_location->offset, index_location->length));
+  PARQUET_THROW_NOT_OK(source->Close());
+
+  // Deserialize column index.
+  auto properties = default_reader_properties();
+  auto descr = file_metadata->schema()->Column(column_id);
+  std::unique_ptr<ColumnIndex> column_index = ColumnIndex::Make(
+      *descr,
+      buffer->data(),
+      static_cast<uint32_t>(buffer->size()),
+      properties);
+  auto typed_column_index =
+      dynamic_cast<TypedColumnIndex<DType>*>(column_index.get());
+  ASSERT_TRUE(typed_column_index != nullptr);
+
+  // Verify only partial data as there are too many pages.
+  ASSERT_EQ(num_pages, column_index->null_pages().size());
+  ASSERT_EQ(has_null_counts, column_index->has_null_counts());
+  ASSERT_EQ(boundary_order, column_index->boundary_order());
+  for (size_t i = 0; i < page_indices.size(); ++i) {
+    size_t page_id = page_indices.at(i);
+    ASSERT_EQ(null_pages.at(i), column_index->null_pages().at(page_id));
+    if (has_null_counts) {
+      ASSERT_EQ(null_counts.at(i), column_index->null_counts().at(page_id));
+    }
+    // min/max values are only meaningful for non-null pages.
+    if (!null_pages.at(i)) {
+      if constexpr (std::is_same_v<T, double>) {
+        ASSERT_DOUBLE_EQ(
+            min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_DOUBLE_EQ(
+            max_values.at(i), typed_column_index->max_values().at(page_id));
+      } else if constexpr (std::is_same_v<T, float>) {
+        ASSERT_FLOAT_EQ(
+            min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_FLOAT_EQ(
+            max_values.at(i), typed_column_index->max_values().at(page_id));
+      } else if constexpr (std::is_same_v<T, FLBA>) {
+        auto len = descr->type_length();
+        ASSERT_EQ(
+            0,
+            ::memcmp(
+                min_values.at(i).ptr,
+                typed_column_index->min_values().at(page_id).ptr,
+                len));
+        ASSERT_EQ(
+            0,
+            ::memcmp(
+                max_values.at(i).ptr,
+                typed_column_index->max_values().at(page_id).ptr,
+                len));
+      } else {
+        ASSERT_EQ(
+            min_values.at(i), typed_column_index->min_values().at(page_id));
+        ASSERT_EQ(
+            max_values.at(i), typed_column_index->max_values().at(page_id));
+      }
+    }
+  }
+}
+
+// TODO: disabled as it requires Arrow parquet data dir.
+/*
+TEST(PageIndex, ReadInt64ColumnIndex) {
+  const int column_id = 5;
+  const size_t num_pages = 528;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {0, 99, 426, 520};
+  const std::vector<bool> null_pages = {false, false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0, 0};
+  const std::vector<int64_t> min_values = {0, 10, 0, 0};
+  const std::vector<int64_t> max_values = {90, 90, 80, 70};
+
+  TestReadTypedColumnIndex<Int64Type>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order,
+page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ReadDoubleColumnIndex) {
+  const int column_id = 7;
+  const size_t num_pages = 528;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {0, 51, 212, 527};
+  const std::vector<bool> null_pages = {false, false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0, 0};
+  const std::vector<double> min_values = {-0, 30.3, 10.1, 40.4};
+  const std::vector<double> max_values = {90.9, 90.9, 90.9, 60.6};
+
+  TestReadTypedColumnIndex<DoubleType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order,
+page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ReadByteArrayColumnIndex) {
+  const int column_id = 9;
+  const size_t num_pages = 352;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
+  const std::vector<size_t> page_indices = {0, 128, 256};
+  const std::vector<bool> null_pages = {false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0};
+
+  // All min values are "0" and max values are "9".
+  const std::string_view min_value = "0";
+  const std::string_view max_value = "9";
+  const std::vector<ByteArray> min_values = {ByteArray{min_value},
+ByteArray{min_value}, ByteArray{min_value}}; const std::vector<ByteArray>
+max_values = {ByteArray{max_value}, ByteArray{max_value}, ByteArray{max_value}};
+
+  TestReadTypedColumnIndex<ByteArrayType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order,
+page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ReadBoolColumnIndex) {
+  const int column_id = 1;
+  const size_t num_pages = 82;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Ascending;
+  const std::vector<size_t> page_indices = {0, 16, 64};
+  const std::vector<bool> null_pages = {false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {0, 0, 0};
+  const std::vector<bool> min_values = {false, false, false};
+  const std::vector<bool> max_values = {true, true, true};
+
+  TestReadTypedColumnIndex<BooleanType>(
+      "alltypes_tiny_pages.parquet", column_id, num_pages, boundary_order,
+page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+
+TEST(PageIndex, ReadFixedLengthByteArrayColumnIndex) {
+  auto to_flba = [](const char* ptr) {
+    return FLBA{reinterpret_cast<const uint8_t*>(ptr)};
+  };
+
+  const int column_id = 0;
+  const size_t num_pages = 10;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Descending;
+  const std::vector<size_t> page_indices = {0, 4, 8};
+  const std::vector<bool> null_pages = {false, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {9, 13, 9};
+  const std::vector<const char*> min_literals = {"\x00\x00\x03\x85",
+"\x00\x00\x01\xF5",
+                                                 "\x00\x00\x00\x65"};
+  const std::vector<const char*> max_literals = {"\x00\x00\x03\xE8",
+"\x00\x00\x02\x58",
+                                                 "\x00\x00\x00\xC8"};
+  const std::vector<FLBA> min_values = {
+      to_flba(min_literals[0]), to_flba(min_literals[1]),
+to_flba(min_literals[2])}; const std::vector<FLBA> max_values = {
+      to_flba(max_literals[0]), to_flba(max_literals[1]),
+to_flba(max_literals[2])};
+
+  TestReadTypedColumnIndex<FLBAType>(
+      "fixed_length_byte_array.parquet", column_id, num_pages, boundary_order,
+      page_indices, null_pages, min_values, max_values, has_null_counts,
+null_counts);
+}
+
+TEST(PageIndex, ReadColumnIndexWithNullPage) {
+  const int column_id = 0;
+  const size_t num_pages = 10;
+  const BoundaryOrder::type boundary_order = BoundaryOrder::Unordered;
+  const std::vector<size_t> page_indices = {2, 4, 8};
+  const std::vector<bool> null_pages = {true, false, false};
+  const bool has_null_counts = true;
+  const std::vector<int64_t> null_counts = {100, 16, 8};
+  const std::vector<int32_t> min_values = {0, -2048691758, -2046900272};
+  const std::vector<int32_t> max_values = {0, 2143189382, 2087168549};
+
+  TestReadTypedColumnIndex<Int32Type>(
+      "int32_with_null_pages.parquet", column_id, num_pages, boundary_order,
+page_indices, null_pages, min_values, max_values, has_null_counts, null_counts);
+}
+*/
+
+struct PageIndexRanges {
+  int64_t column_index_offset;
+  int64_t column_index_length;
+  int64_t offset_index_offset;
+  int64_t offset_index_length;
+};
+
+using RowGroupRanges = std::vector<PageIndexRanges>;
+
+/// Creates an FileMetaData object w/ single row group based on data in
+/// 'row_group_ranges'. It sets the offsets and sizes of the column index and
+/// offset index members of the row group. It doesn't set the member if the
+/// input value is -1.
+std::shared_ptr<FileMetaData> ConstructFakeMetaData(
+    const RowGroupRanges& row_group_ranges) {
+  format::RowGroup row_group;
+  for (auto& page_index_ranges : row_group_ranges) {
+    format::ColumnChunk col_chunk;
+    if (page_index_ranges.column_index_offset != -1) {
+      col_chunk.__set_column_index_offset(
+          page_index_ranges.column_index_offset);
+    }
+    if (page_index_ranges.column_index_length != -1) {
+      col_chunk.__set_column_index_length(
+          static_cast<int32_t>(page_index_ranges.column_index_length));
+    }
+    if (page_index_ranges.offset_index_offset != -1) {
+      col_chunk.__set_offset_index_offset(
+          page_index_ranges.offset_index_offset);
+    }
+    if (page_index_ranges.offset_index_length != -1) {
+      col_chunk.__set_offset_index_length(
+          static_cast<int32_t>(page_index_ranges.offset_index_length));
+    }
+    row_group.columns.push_back(col_chunk);
+  }
+
+  format::FileMetaData metadata;
+  metadata.row_groups.push_back(row_group);
+
+  metadata.schema.emplace_back();
+  schema::NodeVector fields;
+  for (size_t i = 0; i < row_group_ranges.size(); ++i) {
+    fields.push_back(schema::Int64(std::to_string(i)));
+    metadata.schema.emplace_back();
+    fields.back()->ToParquet(&metadata.schema.back());
+  }
+  schema::GroupNode::Make("schema", Repetition::REPEATED, fields)
+      ->ToParquet(&metadata.schema.front());
+
+  auto sink = CreateOutputStream();
+  ThriftSerializer{}.Serialize(&metadata, sink.get());
+  auto buffer = sink->Finish().MoveValueUnsafe();
+  uint32_t len = static_cast<uint32_t>(buffer->size());
+  return FileMetaData::Make(buffer->data(), &len);
+}
+
+/// Validates that 'DeterminePageIndexRangesInRowGroup()' selects the expected
+/// file offsets and sizes or returns false when the row group doesn't have a
+/// page index.
+void ValidatePageIndexRange(
+    const RowGroupRanges& row_group_ranges,
+    const std::vector<int32_t>& column_indices,
+    bool expected_has_column_index,
+    bool expected_has_offset_index,
+    int expected_ci_start,
+    int expected_ci_size,
+    int expected_oi_start,
+    int expected_oi_size) {
+  auto file_metadata = ConstructFakeMetaData(row_group_ranges);
+  auto read_range = PageIndexReader::DeterminePageIndexRangesInRowGroup(
+      *file_metadata->RowGroup(0), column_indices);
+  ASSERT_EQ(expected_has_column_index, read_range.column_index.has_value());
+  ASSERT_EQ(expected_has_offset_index, read_range.offset_index.has_value());
+  if (expected_has_column_index) {
+    EXPECT_EQ(expected_ci_start, read_range.column_index->offset);
+    EXPECT_EQ(expected_ci_size, read_range.column_index->length);
+  }
+  if (expected_has_offset_index) {
+    EXPECT_EQ(expected_oi_start, read_range.offset_index->offset);
+    EXPECT_EQ(expected_oi_size, read_range.offset_index->length);
+  }
+}
+
+/// This test constructs a couple of artificial row groups with page index
+/// offsets in them. Then it validates if
+/// PageIndexReader::DeterminePageIndexRangesInRowGroup() properly computes the
+/// file range that contains the whole page index.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroup) {
+  // No Column chunks
+  ValidatePageIndexRange({}, {}, false, false, -1, -1, -1, -1);
+  // No page index at all.
+  ValidatePageIndexRange({{-1, -1, -1, -1}}, {}, false, false, -1, -1, -1, -1);
+  // Page index for single column chunk.
+  ValidatePageIndexRange({{10, 5, 15, 5}}, {}, true, true, 10, 5, 15, 5);
+  // Page index for two column chunks.
+  ValidatePageIndexRange(
+      {{10, 5, 30, 25}, {15, 15, 50, 20}}, {}, true, true, 10, 20, 30, 40);
+  // Page index for second column chunk.
+  ValidatePageIndexRange(
+      {{-1, -1, -1, -1}, {20, 10, 30, 25}}, {}, true, true, 20, 10, 30, 25);
+  // Page index for first column chunk.
+  ValidatePageIndexRange(
+      {{10, 5, 15, 5}, {-1, -1, -1, -1}}, {}, true, true, 10, 5, 15, 5);
+  // Missing offset index for first column chunk. Gap in column index.
+  ValidatePageIndexRange(
+      {{10, 5, -1, -1}, {20, 10, 30, 25}}, {}, true, true, 10, 20, 30, 25);
+  // Missing offset index for second column chunk.
+  ValidatePageIndexRange(
+      {{10, 5, 25, 5}, {20, 10, -1, -1}}, {}, true, true, 10, 20, 25, 5);
+  // Four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30},
+       {110, 25, 250, 10},
+       {140, 30, 260, 40},
+       {200, 10, 300, 100}},
+      {},
+      true,
+      true,
+      100,
+      110,
+      220,
+      180);
+}
+
+/// This test constructs a couple of artificial row groups with page index
+/// offsets in them. Then it validates if
+/// PageIndexReader::DeterminePageIndexRangesInRowGroup() properly computes the
+/// file range that contains the page index of selected columns.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithPartialColumnsSelected) {
+  // No page index at all.
+  ValidatePageIndexRange({{-1, -1, -1, -1}}, {0}, false, false, -1, -1, -1, -1);
+  // Page index for single column chunk.
+  ValidatePageIndexRange({{10, 5, 15, 5}}, {0}, true, true, 10, 5, 15, 5);
+  // Page index for the 1st column chunk.
+  ValidatePageIndexRange(
+      {{10, 5, 30, 25}, {15, 15, 50, 20}}, {0}, true, true, 10, 5, 30, 25);
+  // Page index for the 2nd column chunk.
+  ValidatePageIndexRange(
+      {{10, 5, 30, 25}, {15, 15, 50, 20}}, {1}, true, true, 15, 15, 50, 20);
+  // Only 2nd column is selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30},
+       {110, 25, 250, 10},
+       {140, 30, 260, 40},
+       {200, 10, 300, 100}},
+      {1},
+      true,
+      true,
+      110,
+      25,
+      250,
+      10);
+  // Only 2nd and 3rd columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30},
+       {110, 25, 250, 10},
+       {140, 30, 260, 40},
+       {200, 10, 300, 100}},
+      {1, 2},
+      true,
+      true,
+      110,
+      60,
+      250,
+      50);
+  // Only 2nd and 4th columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30},
+       {110, 25, 250, 10},
+       {140, 30, 260, 40},
+       {200, 10, 300, 100}},
+      {1, 3},
+      true,
+      true,
+      110,
+      100,
+      250,
+      150);
+  // Only 1st, 2nd and 4th columns are selected among four column chunks.
+  ValidatePageIndexRange(
+      {{100, 10, 220, 30},
+       {110, 25, 250, 10},
+       {140, 30, 260, 40},
+       {200, 10, 300, 100}},
+      {0, 1, 3},
+      true,
+      true,
+      100,
+      110,
+      220,
+      180);
+  // 3rd column is selected but not present in the row group.
+  EXPECT_THROW(
+      ValidatePageIndexRange(
+          {{10, 5, 30, 25}, {15, 15, 50, 20}},
+          {2},
+          false,
+          false,
+          -1,
+          -1,
+          -1,
+          -1),
+      ParquetException);
+}
+
+/// This test constructs a couple of artificial row groups with page index
+/// offsets in them. Then it validates if
+/// PageIndexReader::DeterminePageIndexRangesInRowGroup() properly detects if
+/// column index or offset index is missing.
+TEST(PageIndex, DeterminePageIndexRangesInRowGroupWithMissingPageIndex) {
+  // No column index at all.
+  ValidatePageIndexRange({{-1, -1, 15, 5}}, {}, false, true, -1, -1, 15, 5);
+  // No offset index at all.
+  ValidatePageIndexRange({{10, 5, -1, -1}}, {}, true, false, 10, 5, -1, -1);
+  // No column index at all among two column chunks.
+  ValidatePageIndexRange(
+      {{-1, -1, 30, 25}, {-1, -1, 50, 20}}, {}, false, true, -1, -1, 30, 40);
+  // No offset index at all among two column chunks.
+  ValidatePageIndexRange(
+      {{10, 5, -1, -1}, {15, 15, -1, -1}}, {}, true, false, 10, 20, -1, -1);
+}
+
+TEST(PageIndex, WriteOffsetIndex) {
+  /// Create offset index via the OffsetIndexBuilder interface.
+  auto builder = OffsetIndexBuilder::Make();
+  const size_t num_pages = 5;
+  const std::vector<int64_t> offsets = {100, 200, 300, 400, 500};
+  const std::vector<int32_t> page_sizes = {1024, 2048, 3072, 4096, 8192};
+  const std::vector<int64_t> first_row_indices = {
+      0, 10000, 20000, 30000, 40000};
+  for (size_t i = 0; i < num_pages; ++i) {
+    builder->AddPage(offsets[i], page_sizes[i], first_row_indices[i]);
+  }
+  const int64_t final_position = 4096;
+  builder->Finish(final_position);
+
+  std::vector<std::unique_ptr<OffsetIndex>> offset_indexes;
+  /// 1st element is the offset index just built.
+  offset_indexes.emplace_back(builder->Build());
+  /// 2nd element is the offset index restored by serialize-then-deserialize
+  /// round trip.
+  auto sink = CreateOutputStream();
+  builder->WriteTo(sink.get());
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  offset_indexes.emplace_back(OffsetIndex::Make(
+      buffer->data(),
+      static_cast<uint32_t>(buffer->size()),
+      default_reader_properties()));
+
+  /// Verify the data of the offset index.
+  for (const auto& offset_index : offset_indexes) {
+    ASSERT_EQ(num_pages, offset_index->page_locations().size());
+    for (size_t i = 0; i < num_pages; ++i) {
+      const auto& page_location = offset_index->page_locations().at(i);
+      ASSERT_EQ(offsets[i] + final_position, page_location.offset);
+      ASSERT_EQ(page_sizes[i], page_location.compressed_page_size);
+      ASSERT_EQ(first_row_indices[i], page_location.first_row_index);
+    }
+  }
+}
+
+void TestWriteTypedColumnIndex(
+    schema::NodePtr node,
+    const std::vector<EncodedStatistics>& page_stats,
+    BoundaryOrder::type boundary_order,
+    bool has_null_counts) {
+  auto descr =
+      std::make_unique<ColumnDescriptor>(node, /*max_definition_level=*/1, 0);
+
+  auto builder = ColumnIndexBuilder::Make(descr.get());
+  for (const auto& stats : page_stats) {
+    builder->AddPage(stats);
+  }
+  ASSERT_NO_THROW(builder->Finish());
+
+  std::vector<std::unique_ptr<ColumnIndex>> column_indexes;
+  /// 1st element is the column index just built.
+  column_indexes.emplace_back(builder->Build());
+  /// 2nd element is the column index restored by serialize-then-deserialize
+  /// round trip.
+  auto sink = CreateOutputStream();
+  builder->WriteTo(sink.get());
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  column_indexes.emplace_back(ColumnIndex::Make(
+      *descr,
+      buffer->data(),
+      static_cast<uint32_t>(buffer->size()),
+      default_reader_properties()));
+
+  /// Verify the data of the column index.
+  for (const auto& column_index : column_indexes) {
+    ASSERT_EQ(boundary_order, column_index->boundary_order());
+    ASSERT_EQ(has_null_counts, column_index->has_null_counts());
+    const size_t num_pages = column_index->null_pages().size();
+    for (size_t i = 0; i < num_pages; ++i) {
+      ASSERT_EQ(page_stats[i].all_null_value, column_index->null_pages()[i]);
+      ASSERT_EQ(page_stats[i].min(), column_index->encoded_min_values()[i]);
+      ASSERT_EQ(page_stats[i].max(), column_index->encoded_max_values()[i]);
+      if (has_null_counts) {
+        ASSERT_EQ(page_stats[i].null_count, column_index->null_counts()[i]);
+      }
+    }
+  }
+}
+
+TEST(PageIndex, WriteInt32ColumnIndex) {
+  auto encode = [=](int32_t value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
+  };
+
+  // Integer values in the ascending order.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_null_count(1).set_min(encode(1)).set_max(encode(2));
+  page_stats.at(1).set_null_count(2).set_min(encode(2)).set_max(encode(3));
+  page_stats.at(2).set_null_count(3).set_min(encode(3)).set_max(encode(4));
+
+  TestWriteTypedColumnIndex(
+      schema::Int32("c1"),
+      page_stats,
+      BoundaryOrder::Ascending,
+      /*has_null_counts=*/true);
+}
+
+TEST(PageIndex, WriteInt64ColumnIndex) {
+  auto encode = [=](int64_t value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(int64_t));
+  };
+
+  // Integer values in the descending order.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_null_count(4).set_min(encode(-1)).set_max(encode(-2));
+  page_stats.at(1).set_null_count(0).set_min(encode(-2)).set_max(encode(-3));
+  page_stats.at(2).set_null_count(4).set_min(encode(-3)).set_max(encode(-4));
+
+  TestWriteTypedColumnIndex(
+      schema::Int64("c1"),
+      page_stats,
+      BoundaryOrder::Descending,
+      /*has_null_counts=*/true);
+}
+
+TEST(PageIndex, WriteFloatColumnIndex) {
+  auto encode = [=](float value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(float));
+  };
+
+  // Float values with no specific order.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0)
+      .set_null_count(0)
+      .set_min(encode(2.2F))
+      .set_max(encode(4.4F));
+  page_stats.at(1)
+      .set_null_count(0)
+      .set_min(encode(1.1F))
+      .set_max(encode(5.5F));
+  page_stats.at(2)
+      .set_null_count(0)
+      .set_min(encode(3.3F))
+      .set_max(encode(6.6F));
+
+  TestWriteTypedColumnIndex(
+      schema::Float("c1"),
+      page_stats,
+      BoundaryOrder::Unordered,
+      /*has_null_counts=*/true);
+}
+
+TEST(PageIndex, WriteDoubleColumnIndex) {
+  auto encode = [=](double value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(double));
+  };
+
+  // Double values with no specific order and without null count.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_min(encode(1.2)).set_max(encode(4.4));
+  page_stats.at(1).set_min(encode(2.2)).set_max(encode(5.5));
+  page_stats.at(2).set_min(encode(3.3)).set_max(encode(-6.6));
+
+  TestWriteTypedColumnIndex(
+      schema::Double("c1"),
+      page_stats,
+      BoundaryOrder::Unordered,
+      /*has_null_counts=*/false);
+}
+
+TEST(PageIndex, WriteByteArrayColumnIndex) {
+  // Byte array values with identical min/max.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_min("bar").set_max("foo");
+  page_stats.at(1).set_min("bar").set_max("foo");
+  page_stats.at(2).set_min("bar").set_max("foo");
+
+  TestWriteTypedColumnIndex(
+      schema::ByteArray("c1"),
+      page_stats,
+      BoundaryOrder::Ascending,
+      /*has_null_counts=*/false);
+}
+
+TEST(PageIndex, WriteFLBAColumnIndex) {
+  // FLBA values in the ascending order with some null pages
+  std::vector<EncodedStatistics> page_stats(5);
+  page_stats.at(0).set_min("abc").set_max("ABC");
+  page_stats.at(1).all_null_value = true;
+  page_stats.at(2).set_min("foo").set_max("FOO");
+  page_stats.at(3).all_null_value = true;
+  page_stats.at(4).set_min("xyz").set_max("XYZ");
+
+  auto node = schema::PrimitiveNode::Make(
+      "c1",
+      Repetition::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::NONE,
+      /*length=*/3);
+  TestWriteTypedColumnIndex(
+      std::move(node),
+      page_stats,
+      BoundaryOrder::Ascending,
+      /*has_null_counts=*/false);
+}
+
+TEST(PageIndex, WriteColumnIndexWithAllNullPages) {
+  // All values are null.
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_null_count(100).all_null_value = true;
+  page_stats.at(1).set_null_count(100).all_null_value = true;
+  page_stats.at(2).set_null_count(100).all_null_value = true;
+
+  TestWriteTypedColumnIndex(
+      schema::Int32("c1"),
+      page_stats,
+      BoundaryOrder::Unordered,
+      /*has_null_counts=*/true);
+}
+
+TEST(PageIndex, WriteColumnIndexWithInvalidNullCounts) {
+  auto encode = [=](int32_t value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
+  };
+
+  // Some pages do not provide null_count
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_min(encode(1)).set_max(encode(2)).set_null_count(0);
+  page_stats.at(1).set_min(encode(1)).set_max(encode(3));
+  page_stats.at(2).set_min(encode(2)).set_max(encode(3)).set_null_count(0);
+
+  TestWriteTypedColumnIndex(
+      schema::Int32("c1"),
+      page_stats,
+      BoundaryOrder::Ascending,
+      /*has_null_counts=*/false);
+}
+
+TEST(PageIndex, WriteColumnIndexWithCorruptedStats) {
+  auto encode = [=](int32_t value) {
+    return std::string(reinterpret_cast<const char*>(&value), sizeof(int32_t));
+  };
+
+  // 2nd page does not set anything
+  std::vector<EncodedStatistics> page_stats(3);
+  page_stats.at(0).set_min(encode(1)).set_max(encode(2));
+  page_stats.at(2).set_min(encode(3)).set_max(encode(4));
+
+  ColumnDescriptor descr(schema::Int32("c1"), /*max_definition_level=*/1, 0);
+  auto builder = ColumnIndexBuilder::Make(&descr);
+  for (const auto& stats : page_stats) {
+    builder->AddPage(stats);
+  }
+  ASSERT_NO_THROW(builder->Finish());
+  ASSERT_EQ(nullptr, builder->Build());
+
+  auto sink = CreateOutputStream();
+  builder->WriteTo(sink.get());
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  EXPECT_EQ(0, buffer->size());
+}
+
+TEST(PageIndex, TestPageIndexBuilderWithZeroRowGroup) {
+  schema::NodeVector fields = {schema::Int32("c1"), schema::ByteArray("c2")};
+  schema::NodePtr root =
+      schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  SchemaDescriptor schema;
+  schema.Init(root);
+
+  auto builder = PageIndexBuilder::Make(&schema);
+
+  // AppendRowGroup() is not called and expect throw.
+  ASSERT_THROW(builder->GetColumnIndexBuilder(0), ParquetException);
+  ASSERT_THROW(builder->GetOffsetIndexBuilder(0), ParquetException);
+
+  // Finish the builder without calling AppendRowGroup().
+  ASSERT_NO_THROW(builder->Finish());
+
+  // Verify WriteTo does not write anything.
+  auto sink = CreateOutputStream();
+  PageIndexLocation location;
+  builder->WriteTo(sink.get(), &location);
+  PARQUET_ASSIGN_OR_THROW(auto buffer, sink->Finish());
+  ASSERT_EQ(0, buffer->size());
+  ASSERT_TRUE(location.column_index_location.empty());
+  ASSERT_TRUE(location.offset_index_location.empty());
+}
+
+class PageIndexBuilderTest : public ::testing::Test {
+ public:
+  void WritePageIndexes(
+      int num_row_groups,
+      int num_columns,
+      const std::vector<std::vector<EncodedStatistics>>& page_stats,
+      const std::vector<std::vector<PageLocation>>& page_locations,
+      int final_position) {
+    auto builder = PageIndexBuilder::Make(&schema_);
+    for (int row_group = 0; row_group < num_row_groups; ++row_group) {
+      ASSERT_NO_THROW(builder->AppendRowGroup());
+
+      for (int column = 0; column < num_columns; ++column) {
+        if (static_cast<size_t>(column) < page_stats[row_group].size()) {
+          auto column_index_builder = builder->GetColumnIndexBuilder(column);
+          ASSERT_NO_THROW(
+              column_index_builder->AddPage(page_stats[row_group][column]));
+          ASSERT_NO_THROW(column_index_builder->Finish());
+        }
+
+        if (static_cast<size_t>(column) < page_locations[row_group].size()) {
+          auto offset_index_builder = builder->GetOffsetIndexBuilder(column);
+          ASSERT_NO_THROW(
+              offset_index_builder->AddPage(page_locations[row_group][column]));
+          ASSERT_NO_THROW(offset_index_builder->Finish(final_position));
+        }
+      }
+    }
+    ASSERT_NO_THROW(builder->Finish());
+
+    auto sink = CreateOutputStream();
+    builder->WriteTo(sink.get(), &page_index_location_);
+    PARQUET_ASSIGN_OR_THROW(buffer_, sink->Finish());
+
+    ASSERT_EQ(
+        static_cast<size_t>(num_row_groups),
+        page_index_location_.column_index_location.size());
+    ASSERT_EQ(
+        static_cast<size_t>(num_row_groups),
+        page_index_location_.offset_index_location.size());
+    for (int row_group = 0; row_group < num_row_groups; ++row_group) {
+      ASSERT_EQ(
+          static_cast<size_t>(num_columns),
+          page_index_location_.column_index_location[row_group].size());
+      ASSERT_EQ(
+          static_cast<size_t>(num_columns),
+          page_index_location_.offset_index_location[row_group].size());
+    }
+  }
+
+  void
+  CheckColumnIndex(int row_group, int column, const EncodedStatistics& stats) {
+    auto column_index = ReadColumnIndex(row_group, column);
+    ASSERT_NE(nullptr, column_index);
+    ASSERT_EQ(size_t{1}, column_index->null_pages().size());
+    ASSERT_EQ(stats.all_null_value, column_index->null_pages()[0]);
+    ASSERT_EQ(stats.min(), column_index->encoded_min_values()[0]);
+    ASSERT_EQ(stats.max(), column_index->encoded_max_values()[0]);
+    ASSERT_EQ(stats.has_null_count, column_index->has_null_counts());
+    if (stats.has_null_count) {
+      ASSERT_EQ(stats.null_count, column_index->null_counts()[0]);
+    }
+  }
+
+  void CheckOffsetIndex(
+      int row_group,
+      int column,
+      const PageLocation& expected_location,
+      int64_t final_location) {
+    auto offset_index = ReadOffsetIndex(row_group, column);
+    ASSERT_NE(nullptr, offset_index);
+    ASSERT_EQ(size_t{1}, offset_index->page_locations().size());
+    const auto& location = offset_index->page_locations()[0];
+    ASSERT_EQ(expected_location.offset + final_location, location.offset);
+    ASSERT_EQ(
+        expected_location.compressed_page_size, location.compressed_page_size);
+    ASSERT_EQ(expected_location.first_row_index, location.first_row_index);
+  }
+
+ protected:
+  std::unique_ptr<ColumnIndex> ReadColumnIndex(int row_group, int column) {
+    auto location =
+        page_index_location_.column_index_location[row_group][column];
+    if (!location.has_value()) {
+      return nullptr;
+    }
+    auto properties = default_reader_properties();
+    return ColumnIndex::Make(
+        *schema_.Column(column),
+        buffer_->data() + location->offset,
+        static_cast<uint32_t>(location->length),
+        properties);
+  }
+
+  std::unique_ptr<OffsetIndex> ReadOffsetIndex(int row_group, int column) {
+    auto location =
+        page_index_location_.offset_index_location[row_group][column];
+    if (!location.has_value()) {
+      return nullptr;
+    }
+    auto properties = default_reader_properties();
+    return OffsetIndex::Make(
+        buffer_->data() + location->offset,
+        static_cast<uint32_t>(location->length),
+        properties);
+  }
+
+  SchemaDescriptor schema_;
+  std::shared_ptr<Buffer> buffer_;
+  PageIndexLocation page_index_location_;
+};
+
+TEST_F(PageIndexBuilderTest, SingleRowGroup) {
+  schema::NodePtr root = schema::GroupNode::Make(
+      "schema",
+      Repetition::REPEATED,
+      {schema::ByteArray("c1"),
+       schema::ByteArray("c2"),
+       schema::ByteArray("c3")});
+  schema_.Init(root);
+
+  // Prepare page stats and page locations for single row group.
+  // Note that the 3rd column does not have any stats and its page index is
+  // disabled.
+  const int num_row_groups = 1;
+  const int num_columns = 3;
+  const std::vector<std::vector<EncodedStatistics>> page_stats = {
+      /*row_group_id=0*/
+      {/*column_id=0*/ EncodedStatistics()
+           .set_null_count(0)
+           .set_min("a")
+           .set_max("b"),
+       /*column_id=1*/
+       EncodedStatistics().set_null_count(0).set_min("A").set_max("B")}};
+  const std::vector<std::vector<PageLocation>> page_locations = {
+      /*row_group_id=0*/
+      {/*column_id=0*/ {
+           /*offset=*/128,
+           /*compressed_page_size=*/512,
+           /*first_row_index=*/0},
+       /*column_id=1*/
+       {/*offset=*/1024,
+        /*compressed_page_size=*/512,
+        /*first_row_index=*/0}}};
+  const int64_t final_position = 200;
+
+  WritePageIndexes(
+      num_row_groups, num_columns, page_stats, page_locations, final_position);
+
+  // Verify that first two columns have good page indexes.
+  for (int column = 0; column < 2; ++column) {
+    CheckColumnIndex(/*row_group=*/0, column, page_stats[0][column]);
+    CheckOffsetIndex(
+        /*row_group=*/0, column, page_locations[0][column], final_position);
+  }
+
+  // Verify the 3rd column does not have page indexes.
+  ASSERT_EQ(nullptr, ReadColumnIndex(/*row_group=*/0, /*column=*/2));
+  ASSERT_EQ(nullptr, ReadOffsetIndex(/*row_group=*/0, /*column=*/2));
+}
+
+TEST_F(PageIndexBuilderTest, TwoRowGroups) {
+  schema::NodePtr root = schema::GroupNode::Make(
+      "schema",
+      Repetition::REPEATED,
+      {schema::ByteArray("c1"), schema::ByteArray("c2")});
+  schema_.Init(root);
+
+  // Prepare page stats and page locations for two row groups.
+  // Note that the 2nd column in the 2nd row group has corrupted stats.
+  const int num_row_groups = 2;
+  const int num_columns = 2;
+  const std::vector<std::vector<EncodedStatistics>> page_stats = {
+      /*row_group_id=0*/
+      {/*column_id=0*/ EncodedStatistics().set_min("a").set_max("b"),
+       /*column_id=1*/
+       EncodedStatistics().set_null_count(0).set_min("A").set_max("B")},
+      /*row_group_id=1*/
+      {/*column_id=0*/ EncodedStatistics() /* corrupted stats */,
+       /*column_id=1*/
+       EncodedStatistics().set_null_count(0).set_min("bar").set_max("foo")}};
+  const std::vector<std::vector<PageLocation>> page_locations = {
+      /*row_group_id=0*/
+      {/*column_id=0*/ {
+           /*offset=*/128,
+           /*compressed_page_size=*/512,
+           /*first_row_index=*/0},
+       /*column_id=1*/
+       {/*offset=*/1024,
+        /*compressed_page_size=*/512,
+        /*first_row_index=*/0}},
+      /*row_group_id=0*/
+      {/*column_id=0*/ {
+           /*offset=*/128,
+           /*compressed_page_size=*/512,
+           /*first_row_index=*/0},
+       /*column_id=1*/
+       {/*offset=*/1024,
+        /*compressed_page_size=*/512,
+        /*first_row_index=*/0}}};
+  const int64_t final_position = 200;
+
+  WritePageIndexes(
+      num_row_groups, num_columns, page_stats, page_locations, final_position);
+
+  // Verify that all columns have good column indexes except the 2nd column in
+  // the 2nd row group.
+  CheckColumnIndex(/*row_group=*/0, /*column=*/0, page_stats[0][0]);
+  CheckColumnIndex(/*row_group=*/0, /*column=*/1, page_stats[0][1]);
+  CheckColumnIndex(/*row_group=*/1, /*column=*/1, page_stats[1][1]);
+  ASSERT_EQ(nullptr, ReadColumnIndex(/*row_group=*/1, /*column=*/0));
+
+  // Verify that two columns have good offset indexes.
+  CheckOffsetIndex(
+      /*row_group=*/0, /*column=*/0, page_locations[0][0], final_position);
+  CheckOffsetIndex(
+      /*row_group=*/0, /*column=*/1, page_locations[0][1], final_position);
+  CheckOffsetIndex(
+      /*row_group=*/1, /*column=*/0, page_locations[1][0], final_position);
+  CheckOffsetIndex(
+      /*row_group=*/1, /*column=*/1, page_locations[1][1], final_position);
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/PropertiesTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/PropertiesTest.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "arrow/buffer.h"
+#include "arrow/io/memory.h"
+
+#include "velox/dwio/parquet/writer/arrow/Properties.h"
+
+namespace facebook::velox::parquet::arrow {
+
+using schema::ColumnPath;
+
+namespace test {
+
+TEST(TestReaderProperties, Basics) {
+  ReaderProperties props;
+
+  ASSERT_EQ(props.buffer_size(), kDefaultBufferSize);
+  ASSERT_FALSE(props.is_buffered_stream_enabled());
+  ASSERT_FALSE(props.page_checksum_verification());
+}
+
+TEST(TestWriterProperties, Basics) {
+  std::shared_ptr<WriterProperties> props = WriterProperties::Builder().build();
+
+  ASSERT_EQ(kDefaultDataPageSize, props->data_pagesize());
+  ASSERT_EQ(
+      DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT, props->dictionary_pagesize_limit());
+  ASSERT_EQ(ParquetVersion::PARQUET_2_6, props->version());
+  ASSERT_EQ(ParquetDataPageVersion::V1, props->data_page_version());
+  ASSERT_FALSE(props->page_checksum_enabled());
+}
+
+TEST(TestWriterProperties, AdvancedHandling) {
+  WriterProperties::Builder builder;
+  builder.compression("gzip", Compression::GZIP);
+  builder.compression("zstd", Compression::ZSTD);
+  builder.compression(Compression::SNAPPY);
+  builder.encoding(Encoding::DELTA_BINARY_PACKED);
+  builder.encoding("delta-length", Encoding::DELTA_LENGTH_BYTE_ARRAY);
+  builder.data_page_version(ParquetDataPageVersion::V2);
+  std::shared_ptr<WriterProperties> props = builder.build();
+
+  ASSERT_EQ(
+      Compression::GZIP, props->compression(ColumnPath::FromDotString("gzip")));
+  ASSERT_EQ(
+      Compression::ZSTD, props->compression(ColumnPath::FromDotString("zstd")));
+  ASSERT_EQ(
+      Compression::SNAPPY,
+      props->compression(ColumnPath::FromDotString("delta-length")));
+  ASSERT_EQ(
+      Encoding::DELTA_BINARY_PACKED,
+      props->encoding(ColumnPath::FromDotString("gzip")));
+  ASSERT_EQ(
+      Encoding::DELTA_LENGTH_BYTE_ARRAY,
+      props->encoding(ColumnPath::FromDotString("delta-length")));
+  ASSERT_EQ(ParquetDataPageVersion::V2, props->data_page_version());
+}
+
+TEST(TestReaderProperties, GetStreamInsufficientData) {
+  // ARROW-6058
+  std::string data = "shorter than expected";
+  auto buf = std::make_shared<Buffer>(data);
+  auto reader = std::make_shared<::arrow::io::BufferReader>(buf);
+
+  ReaderProperties props;
+  try {
+    ARROW_UNUSED(props.GetStream(reader, 12, 15));
+    FAIL() << "No exception raised";
+  } catch (const ParquetException& e) {
+    std::string ex_what =
+        ("Tried reading 15 bytes starting at position 12"
+         " from file but only got 9");
+    ASSERT_EQ(ex_what, e.what());
+  }
+}
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/SchemaTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/SchemaTest.cpp
@@ -1,0 +1,2982 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/util/checked_cast.h"
+#include "parquet/exception.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/SchemaInternal.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+
+using ::arrow::internal::checked_cast;
+
+namespace facebook::velox::parquet::arrow {
+
+using format::FieldRepetitionType;
+using format::SchemaElement;
+
+namespace schema {
+
+static inline SchemaElement NewPrimitive(
+    const std::string& name,
+    FieldRepetitionType::type repetition,
+    Type::type type,
+    int field_id = -1) {
+  SchemaElement result;
+  result.__set_name(name);
+  result.__set_repetition_type(repetition);
+  result.__set_type(static_cast<format::Type::type>(type));
+  if (field_id >= 0) {
+    result.__set_field_id(field_id);
+  }
+  return result;
+}
+
+static inline SchemaElement NewGroup(
+    const std::string& name,
+    FieldRepetitionType::type repetition,
+    int num_children,
+    int field_id = -1) {
+  SchemaElement result;
+  result.__set_name(name);
+  result.__set_repetition_type(repetition);
+  result.__set_num_children(num_children);
+
+  if (field_id >= 0) {
+    result.__set_field_id(field_id);
+  }
+
+  return result;
+}
+
+template <typename NodeType>
+static void CheckNodeRoundtrip(const Node& node) {
+  format::SchemaElement serialized;
+  node.ToParquet(&serialized);
+  std::unique_ptr<Node> recovered = NodeType::FromParquet(&serialized);
+  ASSERT_TRUE(node.Equals(recovered.get()))
+      << "Recovered node not equivalent to original node constructed "
+      << "with logical type " << node.logical_type()->ToString() << " got "
+      << recovered->logical_type()->ToString();
+}
+
+static void ConfirmPrimitiveNodeRoundtrip(
+    const std::shared_ptr<const LogicalType>& logical_type,
+    Type::type physical_type,
+    int physical_length,
+    int field_id = -1) {
+  auto node = PrimitiveNode::Make(
+      "something",
+      Repetition::REQUIRED,
+      logical_type,
+      physical_type,
+      physical_length,
+      field_id);
+  CheckNodeRoundtrip<PrimitiveNode>(*node);
+}
+
+static void ConfirmGroupNodeRoundtrip(
+    std::string name,
+    const std::shared_ptr<const LogicalType>& logical_type,
+    int field_id = -1) {
+  auto node =
+      GroupNode::Make(name, Repetition::REQUIRED, {}, logical_type, field_id);
+  CheckNodeRoundtrip<GroupNode>(*node);
+}
+
+// ----------------------------------------------------------------------
+// ColumnPath
+
+TEST(TestColumnPath, TestAttrs) {
+  ColumnPath path(std::vector<std::string>({"toplevel", "leaf"}));
+
+  ASSERT_EQ(path.ToDotString(), "toplevel.leaf");
+
+  std::shared_ptr<ColumnPath> path_ptr =
+      ColumnPath::FromDotString("toplevel.leaf");
+  ASSERT_EQ(path_ptr->ToDotString(), "toplevel.leaf");
+
+  std::shared_ptr<ColumnPath> extended = path_ptr->extend("anotherlevel");
+  ASSERT_EQ(extended->ToDotString(), "toplevel.leaf.anotherlevel");
+}
+
+// ----------------------------------------------------------------------
+// Primitive node
+
+class TestPrimitiveNode : public ::testing::Test {
+ public:
+  void SetUp() {
+    name_ = "name";
+    field_id_ = 5;
+  }
+
+  void Convert(const format::SchemaElement* element) {
+    node_ = PrimitiveNode::FromParquet(element);
+    ASSERT_TRUE(node_->is_primitive());
+    prim_node_ = static_cast<const PrimitiveNode*>(node_.get());
+  }
+
+ protected:
+  std::string name_;
+  const PrimitiveNode* prim_node_;
+
+  int field_id_;
+  std::unique_ptr<Node> node_;
+};
+
+TEST_F(TestPrimitiveNode, Attrs) {
+  PrimitiveNode node1("foo", Repetition::REPEATED, Type::INT32);
+
+  PrimitiveNode node2(
+      "bar", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::UTF8);
+
+  ASSERT_EQ("foo", node1.name());
+
+  ASSERT_TRUE(node1.is_primitive());
+  ASSERT_FALSE(node1.is_group());
+
+  ASSERT_EQ(Repetition::REPEATED, node1.repetition());
+  ASSERT_EQ(Repetition::OPTIONAL, node2.repetition());
+
+  ASSERT_EQ(Node::PRIMITIVE, node1.node_type());
+
+  ASSERT_EQ(Type::INT32, node1.physical_type());
+  ASSERT_EQ(Type::BYTE_ARRAY, node2.physical_type());
+
+  // logical types
+  ASSERT_EQ(ConvertedType::NONE, node1.converted_type());
+  ASSERT_EQ(ConvertedType::UTF8, node2.converted_type());
+
+  // repetition
+  PrimitiveNode node3("foo", Repetition::REPEATED, Type::INT32);
+  PrimitiveNode node4("foo", Repetition::REQUIRED, Type::INT32);
+  PrimitiveNode node5("foo", Repetition::OPTIONAL, Type::INT32);
+
+  ASSERT_TRUE(node3.is_repeated());
+  ASSERT_FALSE(node3.is_optional());
+
+  ASSERT_TRUE(node4.is_required());
+
+  ASSERT_TRUE(node5.is_optional());
+  ASSERT_FALSE(node5.is_required());
+}
+
+TEST_F(TestPrimitiveNode, FromParquet) {
+  SchemaElement elt = NewPrimitive(
+      name_, FieldRepetitionType::OPTIONAL, Type::INT32, field_id_);
+  ASSERT_NO_FATAL_FAILURE(Convert(&elt));
+  ASSERT_EQ(name_, prim_node_->name());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
+  ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
+  ASSERT_EQ(Type::INT32, prim_node_->physical_type());
+  ASSERT_EQ(ConvertedType::NONE, prim_node_->converted_type());
+
+  // Test a logical type
+  elt = NewPrimitive(
+      name_, FieldRepetitionType::REQUIRED, Type::BYTE_ARRAY, field_id_);
+  elt.__set_converted_type(format::ConvertedType::UTF8);
+
+  ASSERT_NO_FATAL_FAILURE(Convert(&elt));
+  ASSERT_EQ(Repetition::REQUIRED, prim_node_->repetition());
+  ASSERT_EQ(Type::BYTE_ARRAY, prim_node_->physical_type());
+  ASSERT_EQ(ConvertedType::UTF8, prim_node_->converted_type());
+
+  // FIXED_LEN_BYTE_ARRAY
+  elt = NewPrimitive(
+      name_,
+      FieldRepetitionType::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      field_id_);
+  elt.__set_type_length(16);
+
+  ASSERT_NO_FATAL_FAILURE(Convert(&elt));
+  ASSERT_EQ(name_, prim_node_->name());
+  ASSERT_EQ(field_id_, prim_node_->field_id());
+  ASSERT_EQ(Repetition::OPTIONAL, prim_node_->repetition());
+  ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, prim_node_->physical_type());
+  ASSERT_EQ(16, prim_node_->type_length());
+
+  // format::ConvertedType::Decimal
+  elt = NewPrimitive(
+      name_,
+      FieldRepetitionType::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      field_id_);
+  elt.__set_converted_type(format::ConvertedType::DECIMAL);
+  elt.__set_type_length(6);
+  elt.__set_scale(2);
+  elt.__set_precision(12);
+
+  ASSERT_NO_FATAL_FAILURE(Convert(&elt));
+  ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, prim_node_->physical_type());
+  ASSERT_EQ(ConvertedType::DECIMAL, prim_node_->converted_type());
+  ASSERT_EQ(6, prim_node_->type_length());
+  ASSERT_EQ(2, prim_node_->decimal_metadata().scale);
+  ASSERT_EQ(12, prim_node_->decimal_metadata().precision);
+}
+
+TEST_F(TestPrimitiveNode, Equals) {
+  PrimitiveNode node1("foo", Repetition::REQUIRED, Type::INT32);
+  PrimitiveNode node2("foo", Repetition::REQUIRED, Type::INT64);
+  PrimitiveNode node3("bar", Repetition::REQUIRED, Type::INT32);
+  PrimitiveNode node4("foo", Repetition::OPTIONAL, Type::INT32);
+  PrimitiveNode node5("foo", Repetition::REQUIRED, Type::INT32);
+
+  ASSERT_TRUE(node1.Equals(&node1));
+  ASSERT_FALSE(node1.Equals(&node2));
+  ASSERT_FALSE(node1.Equals(&node3));
+  ASSERT_FALSE(node1.Equals(&node4));
+  ASSERT_TRUE(node1.Equals(&node5));
+
+  PrimitiveNode flba1(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      12,
+      4,
+      2);
+
+  PrimitiveNode flba2(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      1,
+      4,
+      2);
+  flba2.SetTypeLength(12);
+
+  PrimitiveNode flba3(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      1,
+      4,
+      2);
+  flba3.SetTypeLength(16);
+
+  PrimitiveNode flba4(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      12,
+      4,
+      0);
+
+  PrimitiveNode flba5(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::NONE,
+      12,
+      4,
+      0);
+
+  ASSERT_TRUE(flba1.Equals(&flba2));
+  ASSERT_FALSE(flba1.Equals(&flba3));
+  ASSERT_FALSE(flba1.Equals(&flba4));
+  ASSERT_FALSE(flba1.Equals(&flba5));
+}
+
+TEST_F(TestPrimitiveNode, PhysicalLogicalMapping) {
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo", Repetition::REQUIRED, Type::INT32, ConvertedType::INT_32));
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, ConvertedType::JSON));
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo", Repetition::REQUIRED, Type::INT32, ConvertedType::JSON),
+      ParquetException);
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo",
+      Repetition::REQUIRED,
+      Type::INT64,
+      ConvertedType::TIMESTAMP_MILLIS));
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo", Repetition::REQUIRED, Type::INT32, ConvertedType::INT_64),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, ConvertedType::INT_8),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::BYTE_ARRAY,
+          ConvertedType::INTERVAL),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::ENUM),
+      ParquetException);
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo", Repetition::REQUIRED, Type::BYTE_ARRAY, ConvertedType::ENUM));
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::DECIMAL,
+          0,
+          2,
+          4),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FLOAT,
+          ConvertedType::DECIMAL,
+          0,
+          2,
+          4),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::DECIMAL,
+          0,
+          4,
+          0),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::DECIMAL,
+          10,
+          0,
+          4),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::DECIMAL,
+          10,
+          4,
+          -1),
+      ParquetException);
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::DECIMAL,
+          10,
+          2,
+          4),
+      ParquetException);
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      10,
+      6,
+      4));
+  ASSERT_NO_THROW(PrimitiveNode::Make(
+      "foo",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::INTERVAL,
+      12));
+  ASSERT_THROW(
+      PrimitiveNode::Make(
+          "foo",
+          Repetition::REQUIRED,
+          Type::FIXED_LEN_BYTE_ARRAY,
+          ConvertedType::INTERVAL,
+          10),
+      ParquetException);
+}
+
+// ----------------------------------------------------------------------
+// Group node
+
+class TestGroupNode : public ::testing::Test {
+ public:
+  NodeVector Fields1() {
+    NodeVector fields;
+
+    fields.push_back(Int32("one", Repetition::REQUIRED));
+    fields.push_back(Int64("two"));
+    fields.push_back(Double("three"));
+
+    return fields;
+  }
+
+  NodeVector Fields2() {
+    // Fields with a duplicate name
+    NodeVector fields;
+
+    fields.push_back(Int32("duplicate", Repetition::REQUIRED));
+    fields.push_back(Int64("unique"));
+    fields.push_back(Double("duplicate"));
+
+    return fields;
+  }
+};
+
+TEST_F(TestGroupNode, Attrs) {
+  NodeVector fields = Fields1();
+
+  GroupNode node1("foo", Repetition::REPEATED, fields);
+  GroupNode node2("bar", Repetition::OPTIONAL, fields, ConvertedType::LIST);
+
+  ASSERT_EQ("foo", node1.name());
+
+  ASSERT_TRUE(node1.is_group());
+  ASSERT_FALSE(node1.is_primitive());
+
+  ASSERT_EQ(fields.size(), node1.field_count());
+
+  ASSERT_TRUE(node1.is_repeated());
+  ASSERT_TRUE(node2.is_optional());
+
+  ASSERT_EQ(Repetition::REPEATED, node1.repetition());
+  ASSERT_EQ(Repetition::OPTIONAL, node2.repetition());
+
+  ASSERT_EQ(Node::GROUP, node1.node_type());
+
+  // logical types
+  ASSERT_EQ(ConvertedType::NONE, node1.converted_type());
+  ASSERT_EQ(ConvertedType::LIST, node2.converted_type());
+}
+
+TEST_F(TestGroupNode, Equals) {
+  NodeVector f1 = Fields1();
+  NodeVector f2 = Fields1();
+
+  GroupNode group1("group", Repetition::REPEATED, f1);
+  GroupNode group2("group", Repetition::REPEATED, f2);
+  GroupNode group3("group2", Repetition::REPEATED, f2);
+
+  // This is copied in the GroupNode ctor, so this is okay
+  f2.push_back(Float("four", Repetition::OPTIONAL));
+  GroupNode group4("group", Repetition::REPEATED, f2);
+  GroupNode group5("group", Repetition::REPEATED, Fields1());
+
+  ASSERT_TRUE(group1.Equals(&group1));
+  ASSERT_TRUE(group1.Equals(&group2));
+  ASSERT_FALSE(group1.Equals(&group3));
+
+  ASSERT_FALSE(group1.Equals(&group4));
+  ASSERT_FALSE(group5.Equals(&group4));
+}
+
+TEST_F(TestGroupNode, FieldIndex) {
+  NodeVector fields = Fields1();
+  GroupNode group("group", Repetition::REQUIRED, fields);
+  for (size_t i = 0; i < fields.size(); i++) {
+    auto field = group.field(static_cast<int>(i));
+    ASSERT_EQ(i, group.FieldIndex(*field));
+  }
+
+  // Test a non field node
+  auto non_field_alien = Int32("alien", Repetition::REQUIRED); // other name
+  auto non_field_familiar = Int32("one", Repetition::REPEATED); // other node
+  ASSERT_LT(group.FieldIndex(*non_field_alien), 0);
+  ASSERT_LT(group.FieldIndex(*non_field_familiar), 0);
+}
+
+TEST_F(TestGroupNode, FieldIndexDuplicateName) {
+  NodeVector fields = Fields2();
+  GroupNode group("group", Repetition::REQUIRED, fields);
+  for (size_t i = 0; i < fields.size(); i++) {
+    auto field = group.field(static_cast<int>(i));
+    ASSERT_EQ(i, group.FieldIndex(*field));
+  }
+}
+
+// ----------------------------------------------------------------------
+// Test convert group
+
+class TestSchemaConverter : public ::testing::Test {
+ public:
+  void setUp() {
+    name_ = "parquet_schema";
+  }
+
+  void Convert(const format::SchemaElement* elements, int length) {
+    node_ = Unflatten(elements, length);
+    ASSERT_TRUE(node_->is_group());
+    group_ = static_cast<const GroupNode*>(node_.get());
+  }
+
+ protected:
+  std::string name_;
+  const GroupNode* group_;
+  std::unique_ptr<Node> node_;
+};
+
+bool check_for_parent_consistency(const GroupNode* node) {
+  // Each node should have the group as parent
+  for (int i = 0; i < node->field_count(); i++) {
+    const NodePtr& field = node->field(i);
+    if (field->parent() != node) {
+      return false;
+    }
+    if (field->is_group()) {
+      const GroupNode* group = static_cast<GroupNode*>(field.get());
+      if (!check_for_parent_consistency(group)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+TEST_F(TestSchemaConverter, NestedExample) {
+  SchemaElement elt;
+  std::vector<SchemaElement> elements;
+  elements.push_back(NewGroup(
+      name_,
+      FieldRepetitionType::REPEATED,
+      /*num_children=*/2,
+      /*field_id=*/0));
+
+  // A primitive one
+  elements.push_back(
+      NewPrimitive("a", FieldRepetitionType::REQUIRED, Type::INT32, 1));
+
+  // A group
+  elements.push_back(NewGroup("bag", FieldRepetitionType::OPTIONAL, 1, 2));
+
+  // 3-level list encoding, by hand
+  elt = NewGroup("b", FieldRepetitionType::REPEATED, 1, 3);
+  elt.__set_converted_type(format::ConvertedType::LIST);
+  elements.push_back(elt);
+  elements.push_back(
+      NewPrimitive("item", FieldRepetitionType::OPTIONAL, Type::INT64, 4));
+
+  ASSERT_NO_FATAL_FAILURE(
+      Convert(&elements[0], static_cast<int>(elements.size())));
+
+  // Construct the expected schema
+  NodeVector fields;
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
+
+  // 3-level list encoding
+  NodePtr item = Int64("item", Repetition::OPTIONAL, 4);
+  NodePtr list(GroupNode::Make(
+      "b", Repetition::REPEATED, {item}, ConvertedType::LIST, 3));
+  NodePtr bag(GroupNode::Make(
+      "bag", Repetition::OPTIONAL, {list}, /*logical_type=*/nullptr, 2));
+  fields.push_back(bag);
+
+  NodePtr schema = GroupNode::Make(
+      name_,
+      Repetition::REPEATED,
+      fields,
+      /*logical_type=*/nullptr,
+      0);
+
+  ASSERT_TRUE(schema->Equals(group_));
+
+  // Check that the parent relationship in each node is consistent
+  ASSERT_EQ(group_->parent(), nullptr);
+  ASSERT_TRUE(check_for_parent_consistency(group_));
+}
+
+TEST_F(TestSchemaConverter, ZeroColumns) {
+  // ARROW-3843
+  SchemaElement elements[1];
+  elements[0] = NewGroup("schema", FieldRepetitionType::REPEATED, 0, 0);
+  ASSERT_NO_THROW(Convert(elements, 1));
+}
+
+TEST_F(TestSchemaConverter, InvalidRoot) {
+  // According to the Parquet specification, the first element in the
+  // list<SchemaElement> is a group whose children (and their descendants)
+  // contain all of the rest of the flattened schema elements. If the first
+  // element is not a group, it is a malformed Parquet file.
+
+  SchemaElement elements[2];
+  elements[0] = NewPrimitive(
+      "not-a-group", FieldRepetitionType::REQUIRED, Type::INT32, 0);
+  ASSERT_THROW(Convert(elements, 2), ParquetException);
+
+  // While the Parquet spec indicates that the root group should have REPEATED
+  // repetition type, some implementations may return REQUIRED or OPTIONAL
+  // groups as the first element. These tests check that this is okay as a
+  // practicality matter.
+  elements[0] = NewGroup("not-repeated", FieldRepetitionType::REQUIRED, 1, 0);
+  elements[1] =
+      NewPrimitive("a", FieldRepetitionType::REQUIRED, Type::INT32, 1);
+  ASSERT_NO_FATAL_FAILURE(Convert(elements, 2));
+
+  elements[0] = NewGroup("not-repeated", FieldRepetitionType::OPTIONAL, 1, 0);
+  ASSERT_NO_FATAL_FAILURE(Convert(elements, 2));
+}
+
+TEST_F(TestSchemaConverter, NotEnoughChildren) {
+  // Throw a ParquetException, but don't core dump or anything
+  SchemaElement elt;
+  std::vector<SchemaElement> elements;
+  elements.push_back(NewGroup(name_, FieldRepetitionType::REPEATED, 2, 0));
+  ASSERT_THROW(Convert(&elements[0], 1), ParquetException);
+}
+
+// ----------------------------------------------------------------------
+// Schema tree flatten / unflatten
+
+class TestSchemaFlatten : public ::testing::Test {
+ public:
+  void setUp() {
+    name_ = "parquet_schema";
+  }
+
+  void Flatten(const GroupNode* schema) {
+    ToParquet(schema, &elements_);
+  }
+
+ protected:
+  std::string name_;
+  std::vector<format::SchemaElement> elements_;
+};
+
+TEST_F(TestSchemaFlatten, DecimalMetadata) {
+  // Checks that DecimalMetadata is only set for DecimalTypes
+  NodePtr node = PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      Type::INT64,
+      ConvertedType::DECIMAL,
+      -1,
+      8,
+      4);
+  NodePtr group = GroupNode::Make(
+      "group", Repetition::REPEATED, {node}, ConvertedType::LIST);
+  Flatten(reinterpret_cast<GroupNode*>(group.get()));
+  ASSERT_EQ("decimal", elements_[1].name);
+  ASSERT_TRUE(elements_[1].__isset.precision);
+  ASSERT_TRUE(elements_[1].__isset.scale);
+
+  elements_.clear();
+  // ... including those created with new logical types
+  node = PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(10, 5),
+      Type::INT64,
+      -1);
+  group = GroupNode::Make(
+      "group", Repetition::REPEATED, {node}, ListLogicalType::Make());
+  Flatten(reinterpret_cast<GroupNode*>(group.get()));
+  ASSERT_EQ("decimal", elements_[1].name);
+  ASSERT_TRUE(elements_[1].__isset.precision);
+  ASSERT_TRUE(elements_[1].__isset.scale);
+
+  elements_.clear();
+  // Not for integers with no logical type
+  group = GroupNode::Make(
+      "group", Repetition::REPEATED, {Int64("int64")}, ConvertedType::LIST);
+  Flatten(reinterpret_cast<GroupNode*>(group.get()));
+  ASSERT_EQ("int64", elements_[1].name);
+  ASSERT_FALSE(elements_[0].__isset.precision);
+  ASSERT_FALSE(elements_[0].__isset.scale);
+}
+
+TEST_F(TestSchemaFlatten, NestedExample) {
+  SchemaElement elt;
+  std::vector<SchemaElement> elements;
+  elements.push_back(NewGroup(name_, FieldRepetitionType::REPEATED, 2, 0));
+
+  // A primitive one
+  elements.push_back(
+      NewPrimitive("a", FieldRepetitionType::REQUIRED, Type::INT32, 1));
+
+  // A group
+  elements.push_back(NewGroup("bag", FieldRepetitionType::OPTIONAL, 1, 2));
+
+  // 3-level list encoding, by hand
+  elt = NewGroup("b", FieldRepetitionType::REPEATED, 1, 3);
+  elt.__set_converted_type(format::ConvertedType::LIST);
+  format::ListType ls;
+  format::LogicalType lt;
+  lt.__set_LIST(ls);
+  elt.__set_logicalType(lt);
+  elements.push_back(elt);
+  elements.push_back(
+      NewPrimitive("item", FieldRepetitionType::OPTIONAL, Type::INT64, 4));
+
+  // Construct the schema
+  NodeVector fields;
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
+
+  // 3-level list encoding
+  NodePtr item = Int64("item", Repetition::OPTIONAL, 4);
+  NodePtr list(GroupNode::Make(
+      "b", Repetition::REPEATED, {item}, ConvertedType::LIST, 3));
+  NodePtr bag(GroupNode::Make(
+      "bag",
+      Repetition::OPTIONAL,
+      {list},
+      /*logical_type=*/nullptr,
+      2));
+  fields.push_back(bag);
+
+  NodePtr schema = GroupNode::Make(
+      name_,
+      Repetition::REPEATED,
+      fields,
+      /*logical_type=*/nullptr,
+      0);
+
+  Flatten(static_cast<GroupNode*>(schema.get()));
+  ASSERT_EQ(elements_.size(), elements.size());
+  for (size_t i = 0; i < elements_.size(); i++) {
+    ASSERT_EQ(elements_[i], elements[i]);
+  }
+}
+
+TEST(TestColumnDescriptor, TestAttrs) {
+  NodePtr node = PrimitiveNode::Make(
+      "name", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 4, 1);
+
+  ASSERT_EQ("name", descr.name());
+  ASSERT_EQ(4, descr.max_definition_level());
+  ASSERT_EQ(1, descr.max_repetition_level());
+
+  ASSERT_EQ(Type::BYTE_ARRAY, descr.physical_type());
+
+  ASSERT_EQ(-1, descr.type_length());
+  const char* expected_descr = R"(column descriptor = {
+  name: name,
+  path: ,
+  physical_type: BYTE_ARRAY,
+  converted_type: UTF8,
+  logical_type: String,
+  max_definition_level: 4,
+  max_repetition_level: 1,
+})";
+  ASSERT_EQ(expected_descr, descr.ToString());
+
+  // Test FIXED_LEN_BYTE_ARRAY
+  node = PrimitiveNode::Make(
+      "name",
+      Repetition::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::DECIMAL,
+      12,
+      10,
+      4);
+  ColumnDescriptor descr2(node, 4, 1);
+
+  ASSERT_EQ(Type::FIXED_LEN_BYTE_ARRAY, descr2.physical_type());
+  ASSERT_EQ(12, descr2.type_length());
+
+  expected_descr = R"(column descriptor = {
+  name: name,
+  path: ,
+  physical_type: FIXED_LEN_BYTE_ARRAY,
+  converted_type: DECIMAL,
+  logical_type: Decimal(precision=10, scale=4),
+  max_definition_level: 4,
+  max_repetition_level: 1,
+  length: 12,
+  precision: 10,
+  scale: 4,
+})";
+  ASSERT_EQ(expected_descr, descr2.ToString());
+}
+
+class TestSchemaDescriptor : public ::testing::Test {
+ public:
+  void setUp() {}
+
+ protected:
+  SchemaDescriptor descr_;
+};
+
+TEST_F(TestSchemaDescriptor, InitNonGroup) {
+  NodePtr node =
+      PrimitiveNode::Make("field", Repetition::OPTIONAL, Type::INT32);
+
+  ASSERT_THROW(descr_.Init(node), ParquetException);
+}
+
+TEST_F(TestSchemaDescriptor, Equals) {
+  NodePtr schema;
+
+  NodePtr inta = Int32("a", Repetition::REQUIRED);
+  NodePtr intb = Int64("b", Repetition::OPTIONAL);
+  NodePtr intb2 = Int64("b2", Repetition::OPTIONAL);
+  NodePtr intc = ByteArray("c", Repetition::REPEATED);
+
+  NodePtr item1 = Int64("item1", Repetition::REQUIRED);
+  NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
+  NodePtr item3 = Int32("item3", Repetition::REPEATED);
+  NodePtr list(GroupNode::Make(
+      "records",
+      Repetition::REPEATED,
+      {item1, item2, item3},
+      ConvertedType::LIST));
+
+  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  NodePtr bag2(GroupNode::Make("bag", Repetition::REQUIRED, {list}));
+
+  SchemaDescriptor descr1;
+  descr1.Init(
+      GroupNode::Make("schema", Repetition::REPEATED, {inta, intb, intc, bag}));
+
+  ASSERT_TRUE(descr1.Equals(descr1));
+
+  SchemaDescriptor descr2;
+  descr2.Init(GroupNode::Make(
+      "schema", Repetition::REPEATED, {inta, intb, intc, bag2}));
+  ASSERT_FALSE(descr1.Equals(descr2));
+
+  SchemaDescriptor descr3;
+  descr3.Init(GroupNode::Make(
+      "schema", Repetition::REPEATED, {inta, intb2, intc, bag}));
+  ASSERT_FALSE(descr1.Equals(descr3));
+
+  // Robust to name of parent node
+  SchemaDescriptor descr4;
+  descr4.Init(
+      GroupNode::Make("SCHEMA", Repetition::REPEATED, {inta, intb, intc, bag}));
+  ASSERT_TRUE(descr1.Equals(descr4));
+
+  SchemaDescriptor descr5;
+  descr5.Init(GroupNode::Make(
+      "schema", Repetition::REPEATED, {inta, intb, intc, bag, intb2}));
+  ASSERT_FALSE(descr1.Equals(descr5));
+
+  // Different max repetition / definition levels
+  ColumnDescriptor col1(inta, 5, 1);
+  ColumnDescriptor col2(inta, 6, 1);
+  ColumnDescriptor col3(inta, 5, 2);
+
+  ASSERT_TRUE(col1.Equals(col1));
+  ASSERT_FALSE(col1.Equals(col2));
+  ASSERT_FALSE(col1.Equals(col3));
+}
+
+TEST_F(TestSchemaDescriptor, BuildTree) {
+  NodeVector fields;
+  NodePtr schema;
+
+  NodePtr inta = Int32("a", Repetition::REQUIRED);
+  fields.push_back(inta);
+  fields.push_back(Int64("b", Repetition::OPTIONAL));
+  fields.push_back(ByteArray("c", Repetition::REPEATED));
+
+  // 3-level list encoding
+  NodePtr item1 = Int64("item1", Repetition::REQUIRED);
+  NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
+  NodePtr item3 = Int32("item3", Repetition::REPEATED);
+  NodePtr list(GroupNode::Make(
+      "records",
+      Repetition::REPEATED,
+      {item1, item2, item3},
+      ConvertedType::LIST));
+  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  fields.push_back(bag);
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+
+  descr_.Init(schema);
+
+  int nleaves = 6;
+
+  // 6 leaves
+  ASSERT_EQ(nleaves, descr_.num_columns());
+
+  //                             mdef mrep
+  // required int32 a            0    0
+  // optional int64 b            1    0
+  // repeated byte_array c       1    1
+  // optional group bag          1    0
+  //   repeated group records    2    1
+  //     required int64 item1    2    1
+  //     optional boolean item2  3    1
+  //     repeated int32 item3    3    2
+  int16_t ex_max_def_levels[6] = {0, 1, 1, 2, 3, 3};
+  int16_t ex_max_rep_levels[6] = {0, 0, 1, 1, 1, 2};
+
+  for (int i = 0; i < nleaves; ++i) {
+    const ColumnDescriptor* col = descr_.Column(i);
+    EXPECT_EQ(ex_max_def_levels[i], col->max_definition_level()) << i;
+    EXPECT_EQ(ex_max_rep_levels[i], col->max_repetition_level()) << i;
+  }
+
+  ASSERT_EQ(descr_.Column(0)->path()->ToDotString(), "a");
+  ASSERT_EQ(descr_.Column(1)->path()->ToDotString(), "b");
+  ASSERT_EQ(descr_.Column(2)->path()->ToDotString(), "c");
+  ASSERT_EQ(descr_.Column(3)->path()->ToDotString(), "bag.records.item1");
+  ASSERT_EQ(descr_.Column(4)->path()->ToDotString(), "bag.records.item2");
+  ASSERT_EQ(descr_.Column(5)->path()->ToDotString(), "bag.records.item3");
+
+  for (int i = 0; i < nleaves; ++i) {
+    auto col = descr_.Column(i);
+    ASSERT_EQ(i, descr_.ColumnIndex(*col->schema_node()));
+  }
+
+  // Test non-column nodes find
+  NodePtr non_column_alien = Int32("alien", Repetition::REQUIRED); // other path
+  NodePtr non_column_familiar = Int32("a", Repetition::REPEATED); // other node
+  ASSERT_LT(descr_.ColumnIndex(*non_column_alien), 0);
+  ASSERT_LT(descr_.ColumnIndex(*non_column_familiar), 0);
+
+  ASSERT_EQ(inta.get(), descr_.GetColumnRoot(0));
+  ASSERT_EQ(bag.get(), descr_.GetColumnRoot(3));
+  ASSERT_EQ(bag.get(), descr_.GetColumnRoot(4));
+  ASSERT_EQ(bag.get(), descr_.GetColumnRoot(5));
+
+  ASSERT_EQ(schema.get(), descr_.group_node());
+
+  // Init clears the leaves
+  descr_.Init(schema);
+  ASSERT_EQ(nleaves, descr_.num_columns());
+}
+
+TEST_F(TestSchemaDescriptor, HasRepeatedFields) {
+  NodeVector fields;
+  NodePtr schema;
+
+  NodePtr inta = Int32("a", Repetition::REQUIRED);
+  fields.push_back(inta);
+  fields.push_back(Int64("b", Repetition::OPTIONAL));
+  fields.push_back(ByteArray("c", Repetition::REPEATED));
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+
+  // 3-level list encoding
+  NodePtr item1 = Int64("item1", Repetition::REQUIRED);
+  NodePtr item2 = Boolean("item2", Repetition::OPTIONAL);
+  NodePtr item3 = Int32("item3", Repetition::REPEATED);
+  NodePtr list(GroupNode::Make(
+      "records",
+      Repetition::REPEATED,
+      {item1, item2, item3},
+      ConvertedType::LIST));
+  NodePtr bag(GroupNode::Make("bag", Repetition::OPTIONAL, {list}));
+  fields.push_back(bag);
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+
+  // 3-level list encoding
+  NodePtr item_key = Int64("key", Repetition::REQUIRED);
+  NodePtr item_value = Boolean("value", Repetition::OPTIONAL);
+  NodePtr map(GroupNode::Make(
+      "map", Repetition::REPEATED, {item_key, item_value}, ConvertedType::MAP));
+  NodePtr my_map(GroupNode::Make("my_map", Repetition::OPTIONAL, {map}));
+  fields.push_back(my_map);
+
+  schema = GroupNode::Make("schema", Repetition::REPEATED, fields);
+  descr_.Init(schema);
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+  ASSERT_EQ(true, descr_.HasRepeatedFields());
+}
+
+static std::string Print(const NodePtr& node) {
+  std::stringstream ss;
+  PrintSchema(node.get(), ss);
+  return ss.str();
+}
+
+TEST(TestSchemaPrinter, Examples) {
+  // Test schema 1
+  NodeVector fields;
+  fields.push_back(Int32("a", Repetition::REQUIRED, 1));
+
+  // 3-level list encoding
+  NodePtr item1 = Int64("item1", Repetition::OPTIONAL, 4);
+  NodePtr item2 = Boolean("item2", Repetition::REQUIRED, 5);
+  NodePtr list(GroupNode::Make(
+      "b", Repetition::REPEATED, {item1, item2}, ConvertedType::LIST, 3));
+  NodePtr bag(GroupNode::Make(
+      "bag", Repetition::OPTIONAL, {list}, /*logical_type=*/nullptr, 2));
+  fields.push_back(bag);
+
+  fields.push_back(PrimitiveNode::Make(
+      "c",
+      Repetition::REQUIRED,
+      Type::INT32,
+      ConvertedType::DECIMAL,
+      -1,
+      3,
+      2,
+      6));
+
+  fields.push_back(PrimitiveNode::Make(
+      "d",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(10, 5),
+      Type::INT64,
+      /*length=*/-1,
+      7));
+
+  NodePtr schema = GroupNode::Make(
+      "schema",
+      Repetition::REPEATED,
+      fields,
+      /*logical_type=*/nullptr,
+      0);
+
+  std::string result = Print(schema);
+
+  std::string expected = R"(repeated group field_id=0 schema {
+  required int32 field_id=1 a;
+  optional group field_id=2 bag {
+    repeated group field_id=3 b (List) {
+      optional int64 field_id=4 item1;
+      required boolean field_id=5 item2;
+    }
+  }
+  required int32 field_id=6 c (Decimal(precision=3, scale=2));
+  required int64 field_id=7 d (Decimal(precision=10, scale=5));
+}
+)";
+  ASSERT_EQ(expected, result);
+}
+
+static void ConfirmFactoryEquivalence(
+    ConvertedType::type converted_type,
+    const std::shared_ptr<const LogicalType>& from_make,
+    std::function<bool(const std::shared_ptr<const LogicalType>&)>
+        check_is_type) {
+  std::shared_ptr<const LogicalType> from_converted_type =
+      LogicalType::FromConvertedType(converted_type);
+  ASSERT_EQ(from_converted_type->type(), from_make->type())
+      << from_make->ToString()
+      << " logical types unexpectedly do not match on type";
+  ASSERT_TRUE(from_converted_type->Equals(*from_make))
+      << from_make->ToString() << " logical types unexpectedly not equivalent";
+  ASSERT_TRUE(check_is_type(from_converted_type))
+      << from_converted_type->ToString()
+      << " logical type (from converted type) does not have expected type property";
+  ASSERT_TRUE(check_is_type(from_make))
+      << from_make->ToString()
+      << " logical type (from Make()) does not have expected type property";
+  return;
+}
+
+TEST(TestLogicalTypeConstruction, FactoryEquivalence) {
+  // For each legacy converted type, ensure that the equivalent logical type
+  // object can be obtained from either the base class's FromConvertedType()
+  // factory method or the logical type type class's Make() method (accessed via
+  // convenience methods on the base class) and that these logical type objects
+  // are equivalent
+
+  struct ConfirmFactoryEquivalenceArguments {
+    ConvertedType::type converted_type;
+    std::shared_ptr<const LogicalType> logical_type;
+    std::function<bool(const std::shared_ptr<const LogicalType>&)>
+        check_is_type;
+  };
+
+  auto check_is_string =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_string();
+      };
+  auto check_is_map =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_map();
+      };
+  auto check_is_list =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_list();
+      };
+  auto check_is_enum =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_enum();
+      };
+  auto check_is_date =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_date();
+      };
+  auto check_is_time =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_time();
+      };
+  auto check_is_timestamp =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_timestamp();
+      };
+  auto check_is_int =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_int();
+      };
+  auto check_is_JSON =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_JSON();
+      };
+  auto check_is_BSON =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_BSON();
+      };
+  auto check_is_interval =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_interval();
+      };
+  auto check_is_none =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_none();
+      };
+
+  std::vector<ConfirmFactoryEquivalenceArguments> cases = {
+      {ConvertedType::UTF8, LogicalType::String(), check_is_string},
+      {ConvertedType::MAP, LogicalType::Map(), check_is_map},
+      {ConvertedType::MAP_KEY_VALUE, LogicalType::Map(), check_is_map},
+      {ConvertedType::LIST, LogicalType::List(), check_is_list},
+      {ConvertedType::ENUM, LogicalType::Enum(), check_is_enum},
+      {ConvertedType::DATE, LogicalType::Date(), check_is_date},
+      {ConvertedType::TIME_MILLIS,
+       LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       check_is_time},
+      {ConvertedType::TIME_MICROS,
+       LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       check_is_time},
+      {ConvertedType::TIMESTAMP_MILLIS,
+       LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       check_is_timestamp},
+      {ConvertedType::TIMESTAMP_MICROS,
+       LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       check_is_timestamp},
+      {ConvertedType::UINT_8, LogicalType::Int(8, false), check_is_int},
+      {ConvertedType::UINT_16, LogicalType::Int(16, false), check_is_int},
+      {ConvertedType::UINT_32, LogicalType::Int(32, false), check_is_int},
+      {ConvertedType::UINT_64, LogicalType::Int(64, false), check_is_int},
+      {ConvertedType::INT_8, LogicalType::Int(8, true), check_is_int},
+      {ConvertedType::INT_16, LogicalType::Int(16, true), check_is_int},
+      {ConvertedType::INT_32, LogicalType::Int(32, true), check_is_int},
+      {ConvertedType::INT_64, LogicalType::Int(64, true), check_is_int},
+      {ConvertedType::JSON, LogicalType::JSON(), check_is_JSON},
+      {ConvertedType::BSON, LogicalType::BSON(), check_is_BSON},
+      {ConvertedType::INTERVAL, LogicalType::Interval(), check_is_interval},
+      {ConvertedType::NONE, LogicalType::None(), check_is_none}};
+
+  for (const ConfirmFactoryEquivalenceArguments& c : cases) {
+    ConfirmFactoryEquivalence(
+        c.converted_type, c.logical_type, c.check_is_type);
+  }
+
+  // ConvertedType::DECIMAL, LogicalType::Decimal, is_decimal
+  schema::DecimalMetadata converted_decimal_metadata;
+  converted_decimal_metadata.isset = true;
+  converted_decimal_metadata.precision = 10;
+  converted_decimal_metadata.scale = 4;
+  std::shared_ptr<const LogicalType> from_converted_type =
+      LogicalType::FromConvertedType(
+          ConvertedType::DECIMAL, converted_decimal_metadata);
+  std::shared_ptr<const LogicalType> from_make = LogicalType::Decimal(10, 4);
+  ASSERT_EQ(from_converted_type->type(), from_make->type());
+  ASSERT_TRUE(from_converted_type->Equals(*from_make));
+  ASSERT_TRUE(from_converted_type->is_decimal());
+  ASSERT_TRUE(from_make->is_decimal());
+  ASSERT_TRUE(LogicalType::Decimal(16)->Equals(*LogicalType::Decimal(16, 0)));
+}
+
+static void ConfirmConvertedTypeCompatibility(
+    const std::shared_ptr<const LogicalType>& original,
+    ConvertedType::type expected_converted_type) {
+  ASSERT_TRUE(original->is_valid())
+      << original->ToString() << " logical type unexpectedly is not valid";
+  schema::DecimalMetadata converted_decimal_metadata;
+  ConvertedType::type converted_type =
+      original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, expected_converted_type)
+      << original->ToString()
+      << " logical type unexpectedly returns incorrect converted type";
+  ASSERT_FALSE(converted_decimal_metadata.isset)
+      << original->ToString()
+      << " logical type unexpectedly returns converted decimal metadata that is set";
+  ASSERT_TRUE(
+      original->is_compatible(converted_type, converted_decimal_metadata))
+      << original->ToString()
+      << " logical type unexpectedly is incompatible with converted type and decimal "
+         "metadata it returned";
+  ASSERT_FALSE(original->is_compatible(converted_type, {true, 1, 1}))
+      << original->ToString()
+      << " logical type unexpectedly is compatible with converted decimal metadata that "
+         "is "
+         "set";
+  ASSERT_TRUE(original->is_compatible(converted_type))
+      << original->ToString()
+      << " logical type unexpectedly is incompatible with converted type it returned";
+  std::shared_ptr<const LogicalType> reconstructed =
+      LogicalType::FromConvertedType(
+          converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_valid())
+      << "Reconstructed " << reconstructed->ToString()
+      << " logical type unexpectedly is not valid";
+  ASSERT_TRUE(reconstructed->Equals(*original))
+      << "Reconstructed logical type (" << reconstructed->ToString()
+      << ") unexpectedly not equivalent to original logical type ("
+      << original->ToString() << ")";
+  return;
+}
+
+TEST(TestLogicalTypeConstruction, ConvertedTypeCompatibility) {
+  // For each legacy converted type, ensure that the equivalent logical type
+  // emits correct, compatible converted type information and that the emitted
+  // information can be used to reconstruct another equivalent logical type.
+
+  struct ExpectedConvertedType {
+    std::shared_ptr<const LogicalType> logical_type;
+    ConvertedType::type converted_type;
+  };
+
+  std::vector<ExpectedConvertedType> cases = {
+      {LogicalType::String(), ConvertedType::UTF8},
+      {LogicalType::Map(), ConvertedType::MAP},
+      {LogicalType::List(), ConvertedType::LIST},
+      {LogicalType::Enum(), ConvertedType::ENUM},
+      {LogicalType::Date(), ConvertedType::DATE},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       ConvertedType::TIME_MILLIS},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       ConvertedType::TIME_MICROS},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       ConvertedType::TIMESTAMP_MILLIS},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       ConvertedType::TIMESTAMP_MICROS},
+      {LogicalType::Int(8, false), ConvertedType::UINT_8},
+      {LogicalType::Int(16, false), ConvertedType::UINT_16},
+      {LogicalType::Int(32, false), ConvertedType::UINT_32},
+      {LogicalType::Int(64, false), ConvertedType::UINT_64},
+      {LogicalType::Int(8, true), ConvertedType::INT_8},
+      {LogicalType::Int(16, true), ConvertedType::INT_16},
+      {LogicalType::Int(32, true), ConvertedType::INT_32},
+      {LogicalType::Int(64, true), ConvertedType::INT_64},
+      {LogicalType::JSON(), ConvertedType::JSON},
+      {LogicalType::BSON(), ConvertedType::BSON},
+      {LogicalType::Interval(), ConvertedType::INTERVAL},
+      {LogicalType::None(), ConvertedType::NONE}};
+
+  for (const ExpectedConvertedType& c : cases) {
+    ConfirmConvertedTypeCompatibility(c.logical_type, c.converted_type);
+  }
+
+  // Special cases ...
+
+  std::shared_ptr<const LogicalType> original;
+  ConvertedType::type converted_type;
+  schema::DecimalMetadata converted_decimal_metadata;
+  std::shared_ptr<const LogicalType> reconstructed;
+
+  // DECIMAL
+  std::memset(
+      &converted_decimal_metadata, 0x00, sizeof(converted_decimal_metadata));
+  original = LogicalType::Decimal(6, 2);
+  ASSERT_TRUE(original->is_valid());
+  converted_type = original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, ConvertedType::DECIMAL);
+  ASSERT_TRUE(converted_decimal_metadata.isset);
+  ASSERT_EQ(converted_decimal_metadata.precision, 6);
+  ASSERT_EQ(converted_decimal_metadata.scale, 2);
+  ASSERT_TRUE(
+      original->is_compatible(converted_type, converted_decimal_metadata));
+  reconstructed = LogicalType::FromConvertedType(
+      converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_valid());
+  ASSERT_TRUE(reconstructed->Equals(*original));
+
+  // Undefined
+  original = UndefinedLogicalType::Make();
+  ASSERT_TRUE(original->is_invalid());
+  ASSERT_FALSE(original->is_valid());
+  converted_type = original->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, ConvertedType::UNDEFINED);
+  ASSERT_FALSE(converted_decimal_metadata.isset);
+  ASSERT_TRUE(
+      original->is_compatible(converted_type, converted_decimal_metadata));
+  ASSERT_TRUE(original->is_compatible(converted_type));
+  reconstructed = LogicalType::FromConvertedType(
+      converted_type, converted_decimal_metadata);
+  ASSERT_TRUE(reconstructed->is_invalid());
+  ASSERT_TRUE(reconstructed->Equals(*original));
+}
+
+static void ConfirmNewTypeIncompatibility(
+    const std::shared_ptr<const LogicalType>& logical_type,
+    std::function<bool(const std::shared_ptr<const LogicalType>&)>
+        check_is_type) {
+  ASSERT_TRUE(logical_type->is_valid())
+      << logical_type->ToString() << " logical type unexpectedly is not valid";
+  ASSERT_TRUE(check_is_type(logical_type))
+      << logical_type->ToString()
+      << " logical type is not expected logical type";
+  schema::DecimalMetadata converted_decimal_metadata;
+  ConvertedType::type converted_type =
+      logical_type->ToConvertedType(&converted_decimal_metadata);
+  ASSERT_EQ(converted_type, ConvertedType::NONE)
+      << logical_type->ToString()
+      << " logical type converted type unexpectedly is not NONE";
+  ASSERT_FALSE(converted_decimal_metadata.isset)
+      << logical_type->ToString()
+      << " logical type converted decimal metadata unexpectedly is set";
+  return;
+}
+
+TEST(TestLogicalTypeConstruction, NewTypeIncompatibility) {
+  // For each new logical type, ensure that the type
+  // correctly reports that it has no legacy equivalent
+
+  struct ConfirmNewTypeIncompatibilityArguments {
+    std::shared_ptr<const LogicalType> logical_type;
+    std::function<bool(const std::shared_ptr<const LogicalType>&)>
+        check_is_type;
+  };
+
+  auto check_is_UUID =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_UUID();
+      };
+  auto check_is_null =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_null();
+      };
+  auto check_is_time =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_time();
+      };
+  auto check_is_timestamp =
+      [](const std::shared_ptr<const LogicalType>& logical_type) {
+        return logical_type->is_timestamp();
+      };
+
+  std::vector<ConfirmNewTypeIncompatibilityArguments> cases = {
+      {LogicalType::UUID(), check_is_UUID},
+      {LogicalType::Null(), check_is_null},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MILLIS), check_is_time},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MICROS), check_is_time},
+      {LogicalType::Time(false, LogicalType::TimeUnit::NANOS), check_is_time},
+      {LogicalType::Time(true, LogicalType::TimeUnit::NANOS), check_is_time},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::NANOS),
+       check_is_timestamp},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS),
+       check_is_timestamp},
+  };
+
+  for (const ConfirmNewTypeIncompatibilityArguments& c : cases) {
+    ConfirmNewTypeIncompatibility(c.logical_type, c.check_is_type);
+  }
+}
+
+TEST(TestLogicalTypeConstruction, FactoryExceptions) {
+  // Ensure that logical type construction catches invalid arguments
+
+  std::vector<std::function<void()>> cases = {
+      []() {
+        TimeLogicalType::Make(true, LogicalType::TimeUnit::UNKNOWN);
+      }, // Invalid TimeUnit
+      []() {
+        TimestampLogicalType::Make(true, LogicalType::TimeUnit::UNKNOWN);
+      }, // Invalid TimeUnit
+      []() { IntLogicalType::Make(-1, false); }, // Invalid bit width
+      []() { IntLogicalType::Make(0, false); }, // Invalid bit width
+      []() { IntLogicalType::Make(1, false); }, // Invalid bit width
+      []() { IntLogicalType::Make(65, false); }, // Invalid bit width
+      []() { DecimalLogicalType::Make(-1); }, // Invalid precision
+      []() { DecimalLogicalType::Make(0); }, // Invalid precision
+      []() { DecimalLogicalType::Make(0, 0); }, // Invalid precision
+      []() { DecimalLogicalType::Make(10, -1); }, // Invalid scale
+      []() { DecimalLogicalType::Make(10, 11); } // Invalid scale
+  };
+
+  for (auto f : cases) {
+    ASSERT_ANY_THROW(f());
+  }
+}
+
+static void ConfirmLogicalTypeProperties(
+    const std::shared_ptr<const LogicalType>& logical_type,
+    bool nested,
+    bool serialized,
+    bool valid) {
+  ASSERT_TRUE(logical_type->is_nested() == nested)
+      << logical_type->ToString()
+      << " logical type has incorrect nested() property";
+  ASSERT_TRUE(logical_type->is_serialized() == serialized)
+      << logical_type->ToString()
+      << " logical type has incorrect serialized() property";
+  ASSERT_TRUE(logical_type->is_valid() == valid)
+      << logical_type->ToString()
+      << " logical type has incorrect valid() property";
+  ASSERT_TRUE(logical_type->is_nonnested() != nested)
+      << logical_type->ToString()
+      << " logical type has incorrect nonnested() property";
+  ASSERT_TRUE(logical_type->is_invalid() != valid)
+      << logical_type->ToString()
+      << " logical type has incorrect invalid() property";
+  return;
+}
+
+TEST(TestLogicalTypeOperation, LogicalTypeProperties) {
+  // For each logical type, ensure that the correct general properties are
+  // reported
+
+  struct ExpectedProperties {
+    std::shared_ptr<const LogicalType> logical_type;
+    bool nested;
+    bool serialized;
+    bool valid;
+  };
+
+  std::vector<ExpectedProperties> cases = {
+      {StringLogicalType::Make(), false, true, true},
+      {MapLogicalType::Make(), true, true, true},
+      {ListLogicalType::Make(), true, true, true},
+      {EnumLogicalType::Make(), false, true, true},
+      {DecimalLogicalType::Make(16, 6), false, true, true},
+      {DateLogicalType::Make(), false, true, true},
+      {TimeLogicalType::Make(true, LogicalType::TimeUnit::MICROS),
+       false,
+       true,
+       true},
+      {TimestampLogicalType::Make(true, LogicalType::TimeUnit::MICROS),
+       false,
+       true,
+       true},
+      {IntervalLogicalType::Make(), false, true, true},
+      {IntLogicalType::Make(8, false), false, true, true},
+      {IntLogicalType::Make(64, true), false, true, true},
+      {NullLogicalType::Make(), false, true, true},
+      {JSONLogicalType::Make(), false, true, true},
+      {BSONLogicalType::Make(), false, true, true},
+      {UUIDLogicalType::Make(), false, true, true},
+      {NoLogicalType::Make(), false, false, true},
+  };
+
+  for (const ExpectedProperties& c : cases) {
+    ConfirmLogicalTypeProperties(
+        c.logical_type, c.nested, c.serialized, c.valid);
+  }
+}
+
+static constexpr int PHYSICAL_TYPE_COUNT = 8;
+
+static Type::type physical_type[PHYSICAL_TYPE_COUNT] = {
+    Type::BOOLEAN,
+    Type::INT32,
+    Type::INT64,
+    Type::INT96,
+    Type::FLOAT,
+    Type::DOUBLE,
+    Type::BYTE_ARRAY,
+    Type::FIXED_LEN_BYTE_ARRAY};
+
+static void ConfirmSinglePrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalType>& logical_type,
+    Type::type applicable_type) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    if (physical_type[i] == applicable_type) {
+      ASSERT_TRUE(logical_type->is_applicable(physical_type[i]))
+          << logical_type->ToString()
+          << " logical type unexpectedly inapplicable to physical type "
+          << TypeToString(physical_type[i]);
+    } else {
+      ASSERT_FALSE(logical_type->is_applicable(physical_type[i]))
+          << logical_type->ToString()
+          << " logical type unexpectedly applicable to physical type "
+          << TypeToString(physical_type[i]);
+    }
+  }
+  return;
+}
+
+static void ConfirmAnyPrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalType>& logical_type) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    ASSERT_TRUE(logical_type->is_applicable(physical_type[i]))
+        << logical_type->ToString()
+        << " logical type unexpectedly inapplicable to physical type "
+        << TypeToString(physical_type[i]);
+  }
+  return;
+}
+
+static void ConfirmNoPrimitiveTypeApplicability(
+    const std::shared_ptr<const LogicalType>& logical_type) {
+  for (int i = 0; i < PHYSICAL_TYPE_COUNT; ++i) {
+    ASSERT_FALSE(logical_type->is_applicable(physical_type[i]))
+        << logical_type->ToString()
+        << " logical type unexpectedly applicable to physical type "
+        << TypeToString(physical_type[i]);
+  }
+  return;
+}
+
+TEST(TestLogicalTypeOperation, LogicalTypeApplicability) {
+  // Check that each logical type correctly reports which
+  // underlying primitive type(s) it can be applied to
+
+  struct ExpectedApplicability {
+    std::shared_ptr<const LogicalType> logical_type;
+    Type::type applicable_type;
+  };
+
+  std::vector<ExpectedApplicability> single_type_cases = {
+      {LogicalType::String(), Type::BYTE_ARRAY},
+      {LogicalType::Enum(), Type::BYTE_ARRAY},
+      {LogicalType::Date(), Type::INT32},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS), Type::INT32},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS), Type::INT64},
+      {LogicalType::Time(true, LogicalType::TimeUnit::NANOS), Type::INT64},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       Type::INT64},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       Type::INT64},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS), Type::INT64},
+      {LogicalType::Int(8, false), Type::INT32},
+      {LogicalType::Int(16, false), Type::INT32},
+      {LogicalType::Int(32, false), Type::INT32},
+      {LogicalType::Int(64, false), Type::INT64},
+      {LogicalType::Int(8, true), Type::INT32},
+      {LogicalType::Int(16, true), Type::INT32},
+      {LogicalType::Int(32, true), Type::INT32},
+      {LogicalType::Int(64, true), Type::INT64},
+      {LogicalType::JSON(), Type::BYTE_ARRAY},
+      {LogicalType::BSON(), Type::BYTE_ARRAY}};
+
+  for (const ExpectedApplicability& c : single_type_cases) {
+    ConfirmSinglePrimitiveTypeApplicability(c.logical_type, c.applicable_type);
+  }
+
+  std::vector<std::shared_ptr<const LogicalType>> no_type_cases = {
+      LogicalType::Map(), LogicalType::List()};
+
+  for (auto c : no_type_cases) {
+    ConfirmNoPrimitiveTypeApplicability(c);
+  }
+
+  std::vector<std::shared_ptr<const LogicalType>> any_type_cases = {
+      LogicalType::Null(), LogicalType::None(), UndefinedLogicalType::Make()};
+
+  for (auto c : any_type_cases) {
+    ConfirmAnyPrimitiveTypeApplicability(c);
+  }
+
+  // Fixed binary, exact length cases ...
+
+  struct InapplicableType {
+    Type::type physical_type;
+    int physical_length;
+  };
+
+  std::vector<InapplicableType> inapplicable_types = {
+      {Type::FIXED_LEN_BYTE_ARRAY, 8},
+      {Type::FIXED_LEN_BYTE_ARRAY, 20},
+      {Type::BOOLEAN, -1},
+      {Type::INT32, -1},
+      {Type::INT64, -1},
+      {Type::INT96, -1},
+      {Type::FLOAT, -1},
+      {Type::DOUBLE, -1},
+      {Type::BYTE_ARRAY, -1}};
+
+  std::shared_ptr<const LogicalType> logical_type;
+
+  logical_type = LogicalType::Interval();
+  ASSERT_TRUE(logical_type->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, 12));
+  for (const InapplicableType& t : inapplicable_types) {
+    ASSERT_FALSE(
+        logical_type->is_applicable(t.physical_type, t.physical_length));
+  }
+
+  logical_type = LogicalType::UUID();
+  ASSERT_TRUE(logical_type->is_applicable(Type::FIXED_LEN_BYTE_ARRAY, 16));
+  for (const InapplicableType& t : inapplicable_types) {
+    ASSERT_FALSE(
+        logical_type->is_applicable(t.physical_type, t.physical_length));
+  }
+}
+
+TEST(TestLogicalTypeOperation, DecimalLogicalTypeApplicability) {
+  // Check that the decimal logical type correctly reports which
+  // underlying primitive type(s) it can be applied to
+
+  std::shared_ptr<const LogicalType> logical_type;
+
+  for (int32_t precision = 1; precision <= 9; ++precision) {
+    logical_type = DecimalLogicalType::Make(precision, 0);
+    ASSERT_TRUE(logical_type->is_applicable(Type::INT32))
+        << logical_type->ToString()
+        << " unexpectedly inapplicable to physical type INT32";
+  }
+  logical_type = DecimalLogicalType::Make(10, 0);
+  ASSERT_FALSE(logical_type->is_applicable(Type::INT32))
+      << logical_type->ToString()
+      << " unexpectedly applicable to physical type INT32";
+
+  for (int32_t precision = 1; precision <= 18; ++precision) {
+    logical_type = DecimalLogicalType::Make(precision, 0);
+    ASSERT_TRUE(logical_type->is_applicable(Type::INT64))
+        << logical_type->ToString()
+        << " unexpectedly inapplicable to physical type INT64";
+  }
+  logical_type = DecimalLogicalType::Make(19, 0);
+  ASSERT_FALSE(logical_type->is_applicable(Type::INT64))
+      << logical_type->ToString()
+      << " unexpectedly applicable to physical type INT64";
+
+  for (int32_t precision = 1; precision <= 36; ++precision) {
+    logical_type = DecimalLogicalType::Make(precision, 0);
+    ASSERT_TRUE(logical_type->is_applicable(Type::BYTE_ARRAY))
+        << logical_type->ToString()
+        << " unexpectedly inapplicable to physical type BYTE_ARRAY";
+  }
+
+  struct PrecisionLimits {
+    int32_t physical_length;
+    int32_t precision_limit;
+  };
+
+  std::vector<PrecisionLimits> cases = {
+      {1, 2},
+      {2, 4},
+      {3, 6},
+      {4, 9},
+      {8, 18},
+      {10, 23},
+      {16, 38},
+      {20, 47},
+      {32, 76}};
+
+  for (const PrecisionLimits& c : cases) {
+    int32_t precision;
+    for (precision = 1; precision <= c.precision_limit; ++precision) {
+      logical_type = DecimalLogicalType::Make(precision, 0);
+      ASSERT_TRUE(logical_type->is_applicable(
+          Type::FIXED_LEN_BYTE_ARRAY, c.physical_length))
+          << logical_type->ToString()
+          << " unexpectedly inapplicable to physical type FIXED_LEN_BYTE_ARRAY with "
+             "length "
+          << c.physical_length;
+    }
+    logical_type = DecimalLogicalType::Make(precision, 0);
+    ASSERT_FALSE(logical_type->is_applicable(
+        Type::FIXED_LEN_BYTE_ARRAY, c.physical_length))
+        << logical_type->ToString()
+        << " unexpectedly applicable to physical type FIXED_LEN_BYTE_ARRAY with length "
+        << c.physical_length;
+  }
+
+  ASSERT_FALSE((DecimalLogicalType::Make(16, 6))->is_applicable(Type::BOOLEAN));
+  ASSERT_FALSE((DecimalLogicalType::Make(16, 6))->is_applicable(Type::FLOAT));
+  ASSERT_FALSE((DecimalLogicalType::Make(16, 6))->is_applicable(Type::DOUBLE));
+}
+
+TEST(TestLogicalTypeOperation, LogicalTypeRepresentation) {
+  // Ensure that each logical type prints a correct string and
+  // JSON representation
+
+  struct ExpectedRepresentation {
+    std::shared_ptr<const LogicalType> logical_type;
+    const char* string_representation;
+    const char* JSON_representation;
+  };
+
+  std::vector<ExpectedRepresentation> cases = {
+      {UndefinedLogicalType::Make(), "Undefined", R"({"Type": "Undefined"})"},
+      {LogicalType::String(), "String", R"({"Type": "String"})"},
+      {LogicalType::Map(), "Map", R"({"Type": "Map"})"},
+      {LogicalType::List(), "List", R"({"Type": "List"})"},
+      {LogicalType::Enum(), "Enum", R"({"Type": "Enum"})"},
+      {LogicalType::Decimal(10, 4),
+       "Decimal(precision=10, scale=4)",
+       R"({"Type": "Decimal", "precision": 10, "scale": 4})"},
+      {LogicalType::Decimal(10),
+       "Decimal(precision=10, scale=0)",
+       R"({"Type": "Decimal", "precision": 10, "scale": 0})"},
+      {LogicalType::Date(), "Date", R"({"Type": "Date"})"},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       "Time(isAdjustedToUTC=true, timeUnit=milliseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "milliseconds"})"},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       "Time(isAdjustedToUTC=true, timeUnit=microseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "microseconds"})"},
+      {LogicalType::Time(true, LogicalType::TimeUnit::NANOS),
+       "Time(isAdjustedToUTC=true, timeUnit=nanoseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": true, "timeUnit": "nanoseconds"})"},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MILLIS),
+       "Time(isAdjustedToUTC=false, timeUnit=milliseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "milliseconds"})"},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MICROS),
+       "Time(isAdjustedToUTC=false, timeUnit=microseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "microseconds"})"},
+      {LogicalType::Time(false, LogicalType::TimeUnit::NANOS),
+       "Time(isAdjustedToUTC=false, timeUnit=nanoseconds)",
+       R"({"Type": "Time", "isAdjustedToUTC": false, "timeUnit": "nanoseconds"})"},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=milliseconds, "
+       "is_from_converted_type=false, force_set_converted_type=false)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "milliseconds", )"
+       R"("is_from_converted_type": false, "force_set_converted_type": false})"},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=microseconds, "
+       "is_from_converted_type=false, force_set_converted_type=false)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "microseconds", )"
+       R"("is_from_converted_type": false, "force_set_converted_type": false})"},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS),
+       "Timestamp(isAdjustedToUTC=true, timeUnit=nanoseconds, "
+       "is_from_converted_type=false, force_set_converted_type=false)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": true, "timeUnit": "nanoseconds", )"
+       R"("is_from_converted_type": false, "force_set_converted_type": false})"},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MILLIS, true, true),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=milliseconds, "
+       "is_from_converted_type=true, force_set_converted_type=true)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "milliseconds", )"
+       R"("is_from_converted_type": true, "force_set_converted_type": true})"},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MICROS),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=microseconds, "
+       "is_from_converted_type=false, force_set_converted_type=false)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "microseconds", )"
+       R"("is_from_converted_type": false, "force_set_converted_type": false})"},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::NANOS),
+       "Timestamp(isAdjustedToUTC=false, timeUnit=nanoseconds, "
+       "is_from_converted_type=false, force_set_converted_type=false)",
+       R"({"Type": "Timestamp", "isAdjustedToUTC": false, "timeUnit": "nanoseconds", )"
+       R"("is_from_converted_type": false, "force_set_converted_type": false})"},
+      {LogicalType::Interval(), "Interval", R"({"Type": "Interval"})"},
+      {LogicalType::Int(8, false),
+       "Int(bitWidth=8, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 8, "isSigned": false})"},
+      {LogicalType::Int(16, false),
+       "Int(bitWidth=16, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 16, "isSigned": false})"},
+      {LogicalType::Int(32, false),
+       "Int(bitWidth=32, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 32, "isSigned": false})"},
+      {LogicalType::Int(64, false),
+       "Int(bitWidth=64, isSigned=false)",
+       R"({"Type": "Int", "bitWidth": 64, "isSigned": false})"},
+      {LogicalType::Int(8, true),
+       "Int(bitWidth=8, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 8, "isSigned": true})"},
+      {LogicalType::Int(16, true),
+       "Int(bitWidth=16, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 16, "isSigned": true})"},
+      {LogicalType::Int(32, true),
+       "Int(bitWidth=32, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 32, "isSigned": true})"},
+      {LogicalType::Int(64, true),
+       "Int(bitWidth=64, isSigned=true)",
+       R"({"Type": "Int", "bitWidth": 64, "isSigned": true})"},
+      {LogicalType::Null(), "Null", R"({"Type": "Null"})"},
+      {LogicalType::JSON(), "JSON", R"({"Type": "JSON"})"},
+      {LogicalType::BSON(), "BSON", R"({"Type": "BSON"})"},
+      {LogicalType::UUID(), "UUID", R"({"Type": "UUID"})"},
+      {LogicalType::None(), "None", R"({"Type": "None"})"},
+  };
+
+  for (const ExpectedRepresentation& c : cases) {
+    ASSERT_STREQ(c.logical_type->ToString().c_str(), c.string_representation);
+    ASSERT_STREQ(c.logical_type->ToJSON().c_str(), c.JSON_representation);
+  }
+}
+
+TEST(TestLogicalTypeOperation, LogicalTypeSortOrder) {
+  // Ensure that each logical type reports the correct sort order
+
+  struct ExpectedSortOrder {
+    std::shared_ptr<const LogicalType> logical_type;
+    SortOrder::type sort_order;
+  };
+
+  std::vector<ExpectedSortOrder> cases = {
+      {LogicalType::String(), SortOrder::UNSIGNED},
+      {LogicalType::Map(), SortOrder::UNKNOWN},
+      {LogicalType::List(), SortOrder::UNKNOWN},
+      {LogicalType::Enum(), SortOrder::UNSIGNED},
+      {LogicalType::Decimal(8, 2), SortOrder::SIGNED},
+      {LogicalType::Date(), SortOrder::SIGNED},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalType::Time(true, LogicalType::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalType::Time(false, LogicalType::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MILLIS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MICROS),
+       SortOrder::SIGNED},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::NANOS),
+       SortOrder::SIGNED},
+      {LogicalType::Interval(), SortOrder::UNKNOWN},
+      {LogicalType::Int(8, false), SortOrder::UNSIGNED},
+      {LogicalType::Int(16, false), SortOrder::UNSIGNED},
+      {LogicalType::Int(32, false), SortOrder::UNSIGNED},
+      {LogicalType::Int(64, false), SortOrder::UNSIGNED},
+      {LogicalType::Int(8, true), SortOrder::SIGNED},
+      {LogicalType::Int(16, true), SortOrder::SIGNED},
+      {LogicalType::Int(32, true), SortOrder::SIGNED},
+      {LogicalType::Int(64, true), SortOrder::SIGNED},
+      {LogicalType::Null(), SortOrder::UNKNOWN},
+      {LogicalType::JSON(), SortOrder::UNSIGNED},
+      {LogicalType::BSON(), SortOrder::UNSIGNED},
+      {LogicalType::UUID(), SortOrder::UNSIGNED},
+      {LogicalType::None(), SortOrder::UNKNOWN}};
+
+  for (const ExpectedSortOrder& c : cases) {
+    ASSERT_EQ(c.logical_type->sort_order(), c.sort_order)
+        << c.logical_type->ToString()
+        << " logical type has incorrect sort order";
+  }
+}
+
+static void ConfirmPrimitiveNodeFactoryEquivalence(
+    const std::shared_ptr<const LogicalType>& logical_type,
+    ConvertedType::type converted_type,
+    Type::type physical_type,
+    int physical_length,
+    int precision,
+    int scale) {
+  std::string name = "something";
+  Repetition::type repetition = Repetition::REQUIRED;
+  NodePtr from_converted_type = PrimitiveNode::Make(
+      name,
+      repetition,
+      physical_type,
+      converted_type,
+      physical_length,
+      precision,
+      scale);
+  NodePtr from_logical_type = PrimitiveNode::Make(
+      name, repetition, logical_type, physical_type, physical_length);
+  ASSERT_TRUE(from_converted_type->Equals(from_logical_type.get()))
+      << "Primitive node constructed with converted type "
+      << ConvertedTypeToString(converted_type)
+      << " unexpectedly not equivalent to primitive node constructed with logical "
+         "type "
+      << logical_type->ToString();
+  return;
+}
+
+static void ConfirmGroupNodeFactoryEquivalence(
+    std::string name,
+    const std::shared_ptr<const LogicalType>& logical_type,
+    ConvertedType::type converted_type) {
+  Repetition::type repetition = Repetition::OPTIONAL;
+  NodePtr from_converted_type =
+      GroupNode::Make(name, repetition, {}, converted_type);
+  NodePtr from_logical_type =
+      GroupNode::Make(name, repetition, {}, logical_type);
+  ASSERT_TRUE(from_converted_type->Equals(from_logical_type.get()))
+      << "Group node constructed with converted type "
+      << ConvertedTypeToString(converted_type)
+      << " unexpectedly not equivalent to group node constructed with logical type "
+      << logical_type->ToString();
+  return;
+}
+
+TEST(TestSchemaNodeCreation, FactoryEquivalence) {
+  // Ensure that the Node factory methods produce equivalent results regardless
+  // of whether they are given a converted type or a logical type.
+
+  // Primitive nodes ...
+
+  struct PrimitiveNodeFactoryArguments {
+    std::shared_ptr<const LogicalType> logical_type;
+    ConvertedType::type converted_type;
+    Type::type physical_type;
+    int physical_length;
+    int precision;
+    int scale;
+  };
+
+  std::vector<PrimitiveNodeFactoryArguments> cases = {
+      {LogicalType::String(),
+       ConvertedType::UTF8,
+       Type::BYTE_ARRAY,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Enum(), ConvertedType::ENUM, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalType::Decimal(16, 6),
+       ConvertedType::DECIMAL,
+       Type::INT64,
+       -1,
+       16,
+       6},
+      {LogicalType::Date(), ConvertedType::DATE, Type::INT32, -1, -1, -1},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       ConvertedType::TIME_MILLIS,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       ConvertedType::TIME_MICROS,
+       Type::INT64,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       ConvertedType::TIMESTAMP_MILLIS,
+       Type::INT64,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       ConvertedType::TIMESTAMP_MICROS,
+       Type::INT64,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Interval(),
+       ConvertedType::INTERVAL,
+       Type::FIXED_LEN_BYTE_ARRAY,
+       12,
+       -1,
+       -1},
+      {LogicalType::Int(8, false),
+       ConvertedType::UINT_8,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(8, true),
+       ConvertedType::INT_8,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(16, false),
+       ConvertedType::UINT_16,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(16, true),
+       ConvertedType::INT_16,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(32, false),
+       ConvertedType::UINT_32,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(32, true),
+       ConvertedType::INT_32,
+       Type::INT32,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(64, false),
+       ConvertedType::UINT_64,
+       Type::INT64,
+       -1,
+       -1,
+       -1},
+      {LogicalType::Int(64, true),
+       ConvertedType::INT_64,
+       Type::INT64,
+       -1,
+       -1,
+       -1},
+      {LogicalType::JSON(), ConvertedType::JSON, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalType::BSON(), ConvertedType::BSON, Type::BYTE_ARRAY, -1, -1, -1},
+      {LogicalType::None(), ConvertedType::NONE, Type::INT64, -1, -1, -1}};
+
+  for (const PrimitiveNodeFactoryArguments& c : cases) {
+    ConfirmPrimitiveNodeFactoryEquivalence(
+        c.logical_type,
+        c.converted_type,
+        c.physical_type,
+        c.physical_length,
+        c.precision,
+        c.scale);
+  }
+
+  // Group nodes ...
+  ConfirmGroupNodeFactoryEquivalence(
+      "map", LogicalType::Map(), ConvertedType::MAP);
+  ConfirmGroupNodeFactoryEquivalence(
+      "list", LogicalType::List(), ConvertedType::LIST);
+}
+
+TEST(TestSchemaNodeCreation, FactoryExceptions) {
+  // Ensure that the Node factory method that accepts a logical type refuses to
+  // create an object if compatibility conditions are not met
+
+  // Nested logical type on non-group node ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "map", Repetition::REQUIRED, MapLogicalType::Make(), Type::INT64));
+  // Incompatible primitive type ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "string",
+      Repetition::REQUIRED,
+      StringLogicalType::Make(),
+      Type::BOOLEAN));
+  // Incompatible primitive length ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "interval",
+      Repetition::REQUIRED,
+      IntervalLogicalType::Make(),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      11));
+  // Scale is greater than precision.
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(10, 11),
+      Type::INT64));
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(17, 18),
+      Type::INT64));
+  // Primitive too small for given precision ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(16, 6),
+      Type::INT32));
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(10, 9),
+      Type::INT32));
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(19, 17),
+      Type::INT64));
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(308, 6),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      128));
+  // Length is too long
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(10, 6),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      891723283));
+
+  // Incompatible primitive length ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "uuid",
+      Repetition::REQUIRED,
+      UUIDLogicalType::Make(),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      64));
+  // Non-positive length argument for fixed length binary ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "negative_length",
+      Repetition::REQUIRED,
+      NoLogicalType::Make(),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      -16));
+  // Non-positive length argument for fixed length binary ...
+  ASSERT_ANY_THROW(PrimitiveNode::Make(
+      "zero_length",
+      Repetition::REQUIRED,
+      NoLogicalType::Make(),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      0));
+  // Non-nested logical type on group node ...
+  ASSERT_ANY_THROW(GroupNode::Make(
+      "list", Repetition::REPEATED, {}, JSONLogicalType::Make()));
+
+  // nullptr logical type arguments convert to NoLogicalType/ConvertedType::NONE
+  std::shared_ptr<const LogicalType> empty;
+  NodePtr node;
+  ASSERT_NO_THROW(
+      node = PrimitiveNode::Make(
+          "value", Repetition::REQUIRED, empty, Type::DOUBLE));
+  ASSERT_TRUE(node->logical_type()->is_none());
+  ASSERT_EQ(node->converted_type(), ConvertedType::NONE);
+  ASSERT_NO_THROW(
+      node = GroupNode::Make("items", Repetition::REPEATED, {}, empty));
+  ASSERT_TRUE(node->logical_type()->is_none());
+  ASSERT_EQ(node->converted_type(), ConvertedType::NONE);
+
+  // Invalid ConvertedType in deserialized element ...
+  node = PrimitiveNode::Make(
+      "string",
+      Repetition::REQUIRED,
+      StringLogicalType::Make(),
+      Type::BYTE_ARRAY);
+  ASSERT_EQ(node->logical_type()->type(), LogicalType::Type::STRING);
+  ASSERT_TRUE(node->logical_type()->is_valid());
+  ASSERT_TRUE(node->logical_type()->is_serialized());
+  format::SchemaElement string_intermediary;
+  node->ToParquet(&string_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  string_intermediary.logicalType.__isset.STRING = false;
+  ASSERT_ANY_THROW(node = PrimitiveNode::FromParquet(&string_intermediary));
+
+  // Invalid TimeUnit in deserialized TimeLogicalType ...
+  node = PrimitiveNode::Make(
+      "time",
+      Repetition::REQUIRED,
+      TimeLogicalType::Make(true, LogicalType::TimeUnit::NANOS),
+      Type::INT64);
+  format::SchemaElement time_intermediary;
+  node->ToParquet(&time_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  time_intermediary.logicalType.TIME.unit.__isset.NANOS = false;
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&time_intermediary));
+
+  // Invalid TimeUnit in deserialized TimestampLogicalType ...
+  node = PrimitiveNode::Make(
+      "timestamp",
+      Repetition::REQUIRED,
+      TimestampLogicalType::Make(true, LogicalType::TimeUnit::NANOS),
+      Type::INT64);
+  format::SchemaElement timestamp_intermediary;
+  node->ToParquet(&timestamp_intermediary);
+  // ... corrupt the Thrift intermediary ....
+  timestamp_intermediary.logicalType.TIMESTAMP.unit.__isset.NANOS = false;
+  ASSERT_ANY_THROW(PrimitiveNode::FromParquet(&timestamp_intermediary));
+}
+
+struct SchemaElementConstructionArguments {
+  std::string name;
+  std::shared_ptr<const LogicalType> logical_type;
+  Type::type physical_type;
+  int physical_length;
+  bool expect_converted_type;
+  ConvertedType::type converted_type;
+  bool expect_logicalType;
+  std::function<bool()> check_logicalType;
+};
+
+struct LegacySchemaElementConstructionArguments {
+  std::string name;
+  Type::type physical_type;
+  int physical_length;
+  bool expect_converted_type;
+  ConvertedType::type converted_type;
+  bool expect_logicalType;
+  std::function<bool()> check_logicalType;
+};
+
+class TestSchemaElementConstruction : public ::testing::Test {
+ public:
+  TestSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    // Make node, create serializable Thrift object from it ...
+    node_ = PrimitiveNode::Make(
+        c.name,
+        Repetition::REQUIRED,
+        c.logical_type,
+        c.physical_type,
+        c.physical_length);
+    element_.reset(new format::SchemaElement);
+    node_->ToParquet(element_.get());
+
+    // ... then set aside some values for later inspection.
+    name_ = c.name;
+    expect_converted_type_ = c.expect_converted_type;
+    converted_type_ = c.converted_type;
+    expect_logicalType_ = c.expect_logicalType;
+    check_logicalType_ = c.check_logicalType;
+    return this;
+  }
+
+  TestSchemaElementConstruction* LegacyReconstruct(
+      const LegacySchemaElementConstructionArguments& c) {
+    // Make node, create serializable Thrift object from it ...
+    node_ = PrimitiveNode::Make(
+        c.name,
+        Repetition::REQUIRED,
+        c.physical_type,
+        c.converted_type,
+        c.physical_length);
+    element_.reset(new format::SchemaElement);
+    node_->ToParquet(element_.get());
+
+    // ... then set aside some values for later inspection.
+    name_ = c.name;
+    expect_converted_type_ = c.expect_converted_type;
+    converted_type_ = c.converted_type;
+    expect_logicalType_ = c.expect_logicalType;
+    check_logicalType_ = c.check_logicalType;
+    return this;
+  }
+
+  void Inspect() {
+    ASSERT_EQ(element_->name, name_);
+    if (expect_converted_type_) {
+      ASSERT_TRUE(element_->__isset.converted_type)
+          << node_->logical_type()->ToString()
+          << " logical type unexpectedly failed to generate a converted type in the "
+             "Thrift "
+             "intermediate object";
+      ASSERT_EQ(element_->converted_type, ToThrift(converted_type_))
+          << node_->logical_type()->ToString()
+          << " logical type unexpectedly failed to generate correct converted type in "
+             "the "
+             "Thrift intermediate object";
+    } else {
+      ASSERT_FALSE(element_->__isset.converted_type)
+          << node_->logical_type()->ToString()
+          << " logical type unexpectedly generated a converted type in the Thrift "
+             "intermediate object";
+    }
+    if (expect_logicalType_) {
+      ASSERT_TRUE(element_->__isset.logicalType)
+          << node_->logical_type()->ToString()
+          << " logical type unexpectedly failed to genverate a logicalType in the Thrift "
+             "intermediate object";
+      ASSERT_TRUE(check_logicalType_())
+          << node_->logical_type()->ToString()
+          << " logical type generated incorrect logicalType "
+             "settings in the Thrift intermediate object";
+    } else {
+      ASSERT_FALSE(element_->__isset.logicalType)
+          << node_->logical_type()->ToString()
+          << " logical type unexpectedly generated a logicalType in the Thrift "
+             "intermediate object";
+    }
+    return;
+  }
+
+ protected:
+  NodePtr node_;
+  std::unique_ptr<format::SchemaElement> element_;
+  std::string name_;
+  bool expect_converted_type_;
+  ConvertedType::type
+      converted_type_; // expected converted type in Thrift object
+  bool expect_logicalType_;
+  std::function<bool()>
+      check_logicalType_; // specialized (by logical type)
+                          // logicalType check for Thrift object
+};
+
+/*
+ * The Test*SchemaElementConstruction suites confirm that the logical type
+ * and converted type members of the Thrift intermediate message object
+ * (format::SchemaElement) that is created upon serialization of an annotated
+ * schema node are correctly populated.
+ */
+
+TEST_F(TestSchemaElementConstruction, SimpleCases) {
+  auto check_nothing = []() {
+    return true;
+  }; // used for logical types that don't expect a logicalType to be set
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"string",
+       LogicalType::String(),
+       Type::BYTE_ARRAY,
+       -1,
+       true,
+       ConvertedType::UTF8,
+       true,
+       [this]() { return element_->logicalType.__isset.STRING; }},
+      {"enum",
+       LogicalType::Enum(),
+       Type::BYTE_ARRAY,
+       -1,
+       true,
+       ConvertedType::ENUM,
+       true,
+       [this]() { return element_->logicalType.__isset.ENUM; }},
+      {"date",
+       LogicalType::Date(),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::DATE,
+       true,
+       [this]() { return element_->logicalType.__isset.DATE; }},
+      {"interval",
+       LogicalType::Interval(),
+       Type::FIXED_LEN_BYTE_ARRAY,
+       12,
+       true,
+       ConvertedType::INTERVAL,
+       false,
+       check_nothing},
+      {"null",
+       LogicalType::Null(),
+       Type::DOUBLE,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       [this]() { return element_->logicalType.__isset.UNKNOWN; }},
+      {"json",
+       LogicalType::JSON(),
+       Type::BYTE_ARRAY,
+       -1,
+       true,
+       ConvertedType::JSON,
+       true,
+       [this]() { return element_->logicalType.__isset.JSON; }},
+      {"bson",
+       LogicalType::BSON(),
+       Type::BYTE_ARRAY,
+       -1,
+       true,
+       ConvertedType::BSON,
+       true,
+       [this]() { return element_->logicalType.__isset.BSON; }},
+      {"uuid",
+       LogicalType::UUID(),
+       Type::FIXED_LEN_BYTE_ARRAY,
+       16,
+       false,
+       ConvertedType::NA,
+       true,
+       [this]() { return element_->logicalType.__isset.UUID; }},
+      {"none",
+       LogicalType::None(),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       false,
+       check_nothing}};
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+
+  std::vector<LegacySchemaElementConstructionArguments> legacy_cases = {
+      {"timestamp_ms",
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MILLIS,
+       false,
+       check_nothing},
+      {"timestamp_us",
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MICROS,
+       false,
+       check_nothing},
+  };
+
+  for (const LegacySchemaElementConstructionArguments& c : legacy_cases) {
+    this->LegacyReconstruct(c)->Inspect();
+  }
+}
+
+class TestDecimalSchemaElementConstruction
+    : public TestSchemaElementConstruction {
+ public:
+  TestDecimalSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& decimal_logical_type =
+        checked_cast<const DecimalLogicalType&>(*c.logical_type);
+    precision_ = decimal_logical_type.precision();
+    scale_ = decimal_logical_type.scale();
+    return this;
+  }
+
+  void Inspect() {
+    TestSchemaElementConstruction::Inspect();
+    ASSERT_EQ(element_->precision, precision_);
+    ASSERT_EQ(element_->scale, scale_);
+    ASSERT_EQ(element_->logicalType.DECIMAL.precision, precision_);
+    ASSERT_EQ(element_->logicalType.DECIMAL.scale, scale_);
+    return;
+  }
+
+ protected:
+  int32_t precision_;
+  int32_t scale_;
+};
+
+TEST_F(TestDecimalSchemaElementConstruction, DecimalCases) {
+  auto check_DECIMAL = [this]() {
+    return element_->logicalType.__isset.DECIMAL;
+  };
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"decimal",
+       LogicalType::Decimal(16, 6),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(1, 0),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(10),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(11, 11),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(9, 9),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(18, 18),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(307, 7),
+       Type::FIXED_LEN_BYTE_ARRAY,
+       128,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(310, 32),
+       Type::FIXED_LEN_BYTE_ARRAY,
+       129,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+      {"decimal",
+       LogicalType::Decimal(2147483645, 2147483645),
+       Type::FIXED_LEN_BYTE_ARRAY,
+       891723282,
+       true,
+       ConvertedType::DECIMAL,
+       true,
+       check_DECIMAL},
+  };
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+}
+
+class TestTemporalSchemaElementConstruction
+    : public TestSchemaElementConstruction {
+ public:
+  template <typename T>
+  TestTemporalSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& t = checked_cast<const T&>(*c.logical_type);
+    adjusted_ = t.is_adjusted_to_utc();
+    unit_ = t.time_unit();
+    return this;
+  }
+
+  template <typename T>
+  void Inspect() {
+    FAIL() << "Invalid typename specified in test suite";
+    return;
+  }
+
+ protected:
+  bool adjusted_;
+  LogicalType::TimeUnit::unit unit_;
+};
+
+template <>
+void TestTemporalSchemaElementConstruction::Inspect<format::TimeType>() {
+  TestSchemaElementConstruction::Inspect();
+  ASSERT_EQ(element_->logicalType.TIME.isAdjustedToUTC, adjusted_);
+  switch (unit_) {
+    case LogicalType::TimeUnit::MILLIS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.MILLIS);
+      break;
+    case LogicalType::TimeUnit::MICROS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.MICROS);
+      break;
+    case LogicalType::TimeUnit::NANOS:
+      ASSERT_TRUE(element_->logicalType.TIME.unit.__isset.NANOS);
+      break;
+    case LogicalType::TimeUnit::UNKNOWN:
+    default:
+      FAIL() << "Invalid time unit in test case";
+  }
+  return;
+}
+
+template <>
+void TestTemporalSchemaElementConstruction::Inspect<format::TimestampType>() {
+  TestSchemaElementConstruction::Inspect();
+  ASSERT_EQ(element_->logicalType.TIMESTAMP.isAdjustedToUTC, adjusted_);
+  switch (unit_) {
+    case LogicalType::TimeUnit::MILLIS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.MILLIS);
+      break;
+    case LogicalType::TimeUnit::MICROS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.MICROS);
+      break;
+    case LogicalType::TimeUnit::NANOS:
+      ASSERT_TRUE(element_->logicalType.TIMESTAMP.unit.__isset.NANOS);
+      break;
+    case LogicalType::TimeUnit::UNKNOWN:
+    default:
+      FAIL() << "Invalid time unit in test case";
+  }
+  return;
+}
+
+TEST_F(TestTemporalSchemaElementConstruction, TemporalCases) {
+  auto check_TIME = [this]() { return element_->logicalType.__isset.TIME; };
+
+  std::vector<SchemaElementConstructionArguments> time_cases = {
+      {"time_T_ms",
+       LogicalType::Time(true, LogicalType::TimeUnit::MILLIS),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::TIME_MILLIS,
+       true,
+       check_TIME},
+      {"time_F_ms",
+       LogicalType::Time(false, LogicalType::TimeUnit::MILLIS),
+       Type::INT32,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIME},
+      {"time_T_us",
+       LogicalType::Time(true, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIME_MICROS,
+       true,
+       check_TIME},
+      {"time_F_us",
+       LogicalType::Time(false, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIME},
+      {"time_T_ns",
+       LogicalType::Time(true, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIME},
+      {"time_F_ns",
+       LogicalType::Time(false, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIME},
+  };
+
+  for (const SchemaElementConstructionArguments& c : time_cases) {
+    this->Reconstruct<TimeLogicalType>(c)->Inspect<format::TimeType>();
+  }
+
+  auto check_TIMESTAMP = [this]() {
+    return element_->logicalType.__isset.TIMESTAMP;
+  };
+
+  std::vector<SchemaElementConstructionArguments> timestamp_cases = {
+      {"timestamp_T_ms",
+       LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MILLIS,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_F_ms",
+       LogicalType::Timestamp(false, LogicalType::TimeUnit::MILLIS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_F_ms_force",
+       LogicalType::Timestamp(
+           false,
+           LogicalType::TimeUnit::MILLIS,
+           /*is_from_converted_type=*/false,
+           /*force_set_converted_type=*/true),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MILLIS,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_T_us",
+       LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MICROS,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_F_us",
+       LogicalType::Timestamp(false, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_F_us_force",
+       LogicalType::Timestamp(
+           false,
+           LogicalType::TimeUnit::MILLIS,
+           /*is_from_converted_type=*/false,
+           /*force_set_converted_type=*/true),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::TIMESTAMP_MILLIS,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_T_ns",
+       LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIMESTAMP},
+      {"timestamp_F_ns",
+       LogicalType::Timestamp(false, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1,
+       false,
+       ConvertedType::NA,
+       true,
+       check_TIMESTAMP},
+  };
+
+  for (const SchemaElementConstructionArguments& c : timestamp_cases) {
+    this->Reconstruct<TimestampLogicalType>(c)
+        ->Inspect<format::TimestampType>();
+  }
+}
+
+class TestIntegerSchemaElementConstruction
+    : public TestSchemaElementConstruction {
+ public:
+  TestIntegerSchemaElementConstruction* Reconstruct(
+      const SchemaElementConstructionArguments& c) {
+    TestSchemaElementConstruction::Reconstruct(c);
+    const auto& int_logical_type =
+        checked_cast<const IntLogicalType&>(*c.logical_type);
+    width_ = int_logical_type.bit_width();
+    signed_ = int_logical_type.is_signed();
+    return this;
+  }
+
+  void Inspect() {
+    TestSchemaElementConstruction::Inspect();
+    ASSERT_EQ(element_->logicalType.INTEGER.bitWidth, width_);
+    ASSERT_EQ(element_->logicalType.INTEGER.isSigned, signed_);
+    return;
+  }
+
+ protected:
+  int width_;
+  bool signed_;
+};
+
+TEST_F(TestIntegerSchemaElementConstruction, IntegerCases) {
+  auto check_INTEGER = [this]() {
+    return element_->logicalType.__isset.INTEGER;
+  };
+
+  std::vector<SchemaElementConstructionArguments> cases = {
+      {"uint8",
+       LogicalType::Int(8, false),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::UINT_8,
+       true,
+       check_INTEGER},
+      {"uint16",
+       LogicalType::Int(16, false),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::UINT_16,
+       true,
+       check_INTEGER},
+      {"uint32",
+       LogicalType::Int(32, false),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::UINT_32,
+       true,
+       check_INTEGER},
+      {"uint64",
+       LogicalType::Int(64, false),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::UINT_64,
+       true,
+       check_INTEGER},
+      {"int8",
+       LogicalType::Int(8, true),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::INT_8,
+       true,
+       check_INTEGER},
+      {"int16",
+       LogicalType::Int(16, true),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::INT_16,
+       true,
+       check_INTEGER},
+      {"int32",
+       LogicalType::Int(32, true),
+       Type::INT32,
+       -1,
+       true,
+       ConvertedType::INT_32,
+       true,
+       check_INTEGER},
+      {"int64",
+       LogicalType::Int(64, true),
+       Type::INT64,
+       -1,
+       true,
+       ConvertedType::INT_64,
+       true,
+       check_INTEGER},
+  };
+
+  for (const SchemaElementConstructionArguments& c : cases) {
+    this->Reconstruct(c)->Inspect();
+  }
+}
+
+TEST(TestLogicalTypeSerialization, SchemaElementNestedCases) {
+  // Confirm that the intermediate Thrift objects created during node
+  // serialization contain correct ConvertedType and ConvertedType information
+
+  NodePtr string_node = PrimitiveNode::Make(
+      "string",
+      Repetition::REQUIRED,
+      StringLogicalType::Make(),
+      Type::BYTE_ARRAY);
+  NodePtr date_node = PrimitiveNode::Make(
+      "date", Repetition::REQUIRED, DateLogicalType::Make(), Type::INT32);
+  NodePtr json_node = PrimitiveNode::Make(
+      "json", Repetition::REQUIRED, JSONLogicalType::Make(), Type::BYTE_ARRAY);
+  NodePtr uuid_node = PrimitiveNode::Make(
+      "uuid",
+      Repetition::REQUIRED,
+      UUIDLogicalType::Make(),
+      Type::FIXED_LEN_BYTE_ARRAY,
+      16);
+  NodePtr timestamp_node = PrimitiveNode::Make(
+      "timestamp",
+      Repetition::REQUIRED,
+      TimestampLogicalType::Make(false, LogicalType::TimeUnit::NANOS),
+      Type::INT64);
+  NodePtr int_node = PrimitiveNode::Make(
+      "int",
+      Repetition::REQUIRED,
+      IntLogicalType::Make(64, false),
+      Type::INT64);
+  NodePtr decimal_node = PrimitiveNode::Make(
+      "decimal",
+      Repetition::REQUIRED,
+      DecimalLogicalType::Make(16, 6),
+      Type::INT64);
+
+  NodePtr list_node = GroupNode::Make(
+      "list",
+      Repetition::REPEATED,
+      {string_node,
+       date_node,
+       json_node,
+       uuid_node,
+       timestamp_node,
+       int_node,
+       decimal_node},
+      ListLogicalType::Make());
+  std::vector<format::SchemaElement> list_elements;
+  ToParquet(reinterpret_cast<GroupNode*>(list_node.get()), &list_elements);
+  ASSERT_EQ(list_elements[0].name, "list");
+  ASSERT_TRUE(list_elements[0].__isset.converted_type);
+  ASSERT_TRUE(list_elements[0].__isset.logicalType);
+  ASSERT_EQ(list_elements[0].converted_type, ToThrift(ConvertedType::LIST));
+  ASSERT_TRUE(list_elements[0].logicalType.__isset.LIST);
+  ASSERT_TRUE(list_elements[1].logicalType.__isset.STRING);
+  ASSERT_TRUE(list_elements[2].logicalType.__isset.DATE);
+  ASSERT_TRUE(list_elements[3].logicalType.__isset.JSON);
+  ASSERT_TRUE(list_elements[4].logicalType.__isset.UUID);
+  ASSERT_TRUE(list_elements[5].logicalType.__isset.TIMESTAMP);
+  ASSERT_TRUE(list_elements[6].logicalType.__isset.INTEGER);
+  ASSERT_TRUE(list_elements[7].logicalType.__isset.DECIMAL);
+
+  NodePtr map_node =
+      GroupNode::Make("map", Repetition::REQUIRED, {}, MapLogicalType::Make());
+  std::vector<format::SchemaElement> map_elements;
+  ToParquet(reinterpret_cast<GroupNode*>(map_node.get()), &map_elements);
+  ASSERT_EQ(map_elements[0].name, "map");
+  ASSERT_TRUE(map_elements[0].__isset.converted_type);
+  ASSERT_TRUE(map_elements[0].__isset.logicalType);
+  ASSERT_EQ(map_elements[0].converted_type, ToThrift(ConvertedType::MAP));
+  ASSERT_TRUE(map_elements[0].logicalType.__isset.MAP);
+}
+
+TEST(TestLogicalTypeSerialization, Roundtrips) {
+  // Confirm that Thrift serialization-deserialization of nodes with logical
+  // types produces equivalent reconstituted nodes
+
+  // Primitive nodes ...
+  struct AnnotatedPrimitiveNodeFactoryArguments {
+    std::shared_ptr<const LogicalType> logical_type;
+    Type::type physical_type;
+    int physical_length;
+  };
+
+  std::vector<AnnotatedPrimitiveNodeFactoryArguments> cases = {
+      {LogicalType::String(), Type::BYTE_ARRAY, -1},
+      {LogicalType::Enum(), Type::BYTE_ARRAY, -1},
+      {LogicalType::Decimal(16, 6), Type::INT64, -1},
+      {LogicalType::Date(), Type::INT32, -1},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MILLIS), Type::INT32, -1},
+      {LogicalType::Time(true, LogicalType::TimeUnit::MICROS), Type::INT64, -1},
+      {LogicalType::Time(true, LogicalType::TimeUnit::NANOS), Type::INT64, -1},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MILLIS),
+       Type::INT32,
+       -1},
+      {LogicalType::Time(false, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1},
+      {LogicalType::Time(false, LogicalType::TimeUnit::NANOS), Type::INT64, -1},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MILLIS),
+       Type::INT64,
+       -1},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1},
+      {LogicalType::Timestamp(true, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MILLIS),
+       Type::INT64,
+       -1},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::MICROS),
+       Type::INT64,
+       -1},
+      {LogicalType::Timestamp(false, LogicalType::TimeUnit::NANOS),
+       Type::INT64,
+       -1},
+      {LogicalType::Interval(), Type::FIXED_LEN_BYTE_ARRAY, 12},
+      {LogicalType::Int(8, false), Type::INT32, -1},
+      {LogicalType::Int(16, false), Type::INT32, -1},
+      {LogicalType::Int(32, false), Type::INT32, -1},
+      {LogicalType::Int(64, false), Type::INT64, -1},
+      {LogicalType::Int(8, true), Type::INT32, -1},
+      {LogicalType::Int(16, true), Type::INT32, -1},
+      {LogicalType::Int(32, true), Type::INT32, -1},
+      {LogicalType::Int(64, true), Type::INT64, -1},
+      {LogicalType::Null(), Type::BOOLEAN, -1},
+      {LogicalType::JSON(), Type::BYTE_ARRAY, -1},
+      {LogicalType::BSON(), Type::BYTE_ARRAY, -1},
+      {LogicalType::UUID(), Type::FIXED_LEN_BYTE_ARRAY, 16},
+      {LogicalType::None(), Type::BOOLEAN, -1}};
+
+  for (const AnnotatedPrimitiveNodeFactoryArguments& c : cases) {
+    ConfirmPrimitiveNodeRoundtrip(
+        c.logical_type, c.physical_type, c.physical_length);
+  }
+
+  // Group nodes ...
+  ConfirmGroupNodeRoundtrip("map", LogicalType::Map());
+  ConfirmGroupNodeRoundtrip("list", LogicalType::List());
+}
+
+} // namespace schema
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/StatisticsTest.cpp
@@ -1,0 +1,1633 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/buffer.h"
+#include "arrow/memory_pool.h"
+#include "arrow/testing/builder.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/bit_util.h"
+#include "arrow/util/bitmap_ops.h"
+#include "arrow/util/ubsan.h"
+
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
+#include "velox/dwio/parquet/writer/arrow/FileWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Schema.h"
+#include "velox/dwio/parquet/writer/arrow/Statistics.h"
+#include "velox/dwio/parquet/writer/arrow/ThriftInternal.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/FileReader.h"
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+using arrow::default_memory_pool;
+using arrow::MemoryPool;
+using arrow::util::SafeCopy;
+
+namespace bit_util = arrow::bit_util;
+
+namespace facebook::velox::parquet::arrow {
+
+using schema::GroupNode;
+using schema::NodePtr;
+using schema::PrimitiveNode;
+
+namespace test {
+
+// ----------------------------------------------------------------------
+// Test comparators
+
+static ByteArray ByteArrayFromString(const std::string& s) {
+  auto ptr = reinterpret_cast<const uint8_t*>(s.data());
+  return ByteArray(static_cast<uint32_t>(s.size()), ptr);
+}
+
+static FLBA FLBAFromString(const std::string& s) {
+  auto ptr = reinterpret_cast<const uint8_t*>(s.data());
+  return FLBA(ptr);
+}
+
+TEST(Comparison, SignedByteArray) {
+  // Signed byte array comparison is only used for Decimal comparison. When
+  // decimals are encoded as byte arrays they use twos complement big-endian
+  // encoded values. Comparisons of byte arrays of unequal types need to handle
+  // sign extension.
+  auto comparator =
+      MakeComparator<ByteArrayType>(Type::BYTE_ARRAY, SortOrder::SIGNED);
+  struct Case {
+    std::vector<uint8_t> bytes;
+    int order;
+    ByteArray ToByteArray() const {
+      return ByteArray(static_cast<int>(bytes.size()), bytes.data());
+    }
+  };
+
+  // Test a mix of big-endian comparison values that are both equal and
+  // unequal after sign extension.
+  std::vector<Case> cases = {
+      {{0x80, 0x80, 0, 0}, 0},
+      {{/*0xFF,*/ 0x80, 0, 0}, 1},
+      {{0xFF, 0x80, 0, 0}, 1},
+      {{/*0xFF,*/ 0xFF, 0x01, 0}, 2},
+      {{/*0xFF,  0xFF,*/ 0x80, 0}, 3},
+      {{/*0xFF,*/ 0xFF, 0x80, 0}, 3},
+      {{0xFF, 0xFF, 0x80, 0}, 3},
+      {{/*0xFF,0xFF,0xFF,*/ 0x80}, 4},
+      {{/*0xFF, 0xFF, 0xFF,*/ 0xFF}, 5},
+      {{/*0, 0,*/ 0x01, 0x01}, 6},
+      {{/*0,*/ 0, 0x01, 0x01}, 6},
+      {{0, 0, 0x01, 0x01}, 6},
+      {{/*0,*/ 0x01, 0x01, 0}, 7},
+      {{0x01, 0x01, 0, 0}, 8}};
+
+  for (size_t x = 0; x < cases.size(); x++) {
+    const auto& case1 = cases[x];
+    // Empty array is always the smallest values
+    EXPECT_TRUE(comparator->Compare(ByteArray(), case1.ToByteArray())) << x;
+    EXPECT_FALSE(comparator->Compare(case1.ToByteArray(), ByteArray())) << x;
+    // Equals is always false.
+    EXPECT_FALSE(comparator->Compare(case1.ToByteArray(), case1.ToByteArray()))
+        << x;
+
+    for (size_t y = 0; y < cases.size(); y++) {
+      const auto& case2 = cases[y];
+      if (case1.order < case2.order) {
+        EXPECT_TRUE(
+            comparator->Compare(case1.ToByteArray(), case2.ToByteArray()))
+            << x << " (order: " << case1.order << ") " << y
+            << " (order: " << case2.order << ")";
+      } else {
+        EXPECT_FALSE(
+            comparator->Compare(case1.ToByteArray(), case2.ToByteArray()))
+            << x << " (order: " << case1.order << ") " << y
+            << " (order: " << case2.order << ")";
+      }
+    }
+  }
+}
+
+TEST(Comparison, UnsignedByteArray) {
+  // Check if UTF-8 is compared using unsigned correctly
+  auto comparator =
+      MakeComparator<ByteArrayType>(Type::BYTE_ARRAY, SortOrder::UNSIGNED);
+
+  std::string s1 = "arrange";
+  std::string s2 = "arrangement";
+  ByteArray s1ba = ByteArrayFromString(s1);
+  ByteArray s2ba = ByteArrayFromString(s2);
+  ASSERT_TRUE(comparator->Compare(s1ba, s2ba));
+
+  // Multi-byte UTF-8 characters
+  s1 = "braten";
+  s2 = "bügeln";
+  s1ba = ByteArrayFromString(s1);
+  s2ba = ByteArrayFromString(s2);
+  ASSERT_TRUE(comparator->Compare(s1ba, s2ba));
+
+  s1 = "ünk123456"; // ü = 252
+  s2 = "ănk123456"; // ă = 259
+  s1ba = ByteArrayFromString(s1);
+  s2ba = ByteArrayFromString(s2);
+  ASSERT_TRUE(comparator->Compare(s1ba, s2ba));
+}
+
+TEST(Comparison, SignedFLBA) {
+  int size = 4;
+  auto comparator = MakeComparator<FLBAType>(
+      Type::FIXED_LEN_BYTE_ARRAY, SortOrder::SIGNED, size);
+
+  std::vector<uint8_t> byte_values[] = {
+      {0x80, 0, 0, 0},
+      {0xFF, 0xFF, 0x01, 0},
+      {0xFF, 0xFF, 0x80, 0},
+      {0xFF, 0xFF, 0xFF, 0x80},
+      {0xFF, 0xFF, 0xFF, 0xFF},
+      {0, 0, 0x01, 0x01},
+      {0, 0x01, 0x01, 0},
+      {0x01, 0x01, 0, 0}};
+  std::vector<FLBA> values_to_compare;
+  for (auto& bytes : byte_values) {
+    values_to_compare.emplace_back(FLBA(bytes.data()));
+  }
+
+  for (size_t x = 0; x < values_to_compare.size(); x++) {
+    EXPECT_FALSE(
+        comparator->Compare(values_to_compare[x], values_to_compare[x]))
+        << x;
+    for (size_t y = x + 1; y < values_to_compare.size(); y++) {
+      EXPECT_TRUE(
+          comparator->Compare(values_to_compare[x], values_to_compare[y]))
+          << x << " " << y;
+      EXPECT_FALSE(
+          comparator->Compare(values_to_compare[y], values_to_compare[x]))
+          << y << " " << x;
+    }
+  }
+}
+
+TEST(Comparison, UnsignedFLBA) {
+  int size = 10;
+  auto comparator = MakeComparator<FLBAType>(
+      Type::FIXED_LEN_BYTE_ARRAY, SortOrder::UNSIGNED, size);
+
+  std::string s1 = "Anti123456";
+  std::string s2 = "Bunkd123456";
+  FLBA s1flba = FLBAFromString(s1);
+  FLBA s2flba = FLBAFromString(s2);
+  ASSERT_TRUE(comparator->Compare(s1flba, s2flba));
+
+  s1 = "Bunk123456";
+  s2 = "Bünk123456";
+  s1flba = FLBAFromString(s1);
+  s2flba = FLBAFromString(s2);
+  ASSERT_TRUE(comparator->Compare(s1flba, s2flba));
+}
+
+TEST(Comparison, SignedInt96) {
+  Int96 a{{1, 41, 14}}, b{{1, 41, 42}};
+  Int96 aa{{1, 41, 14}}, bb{{1, 41, 14}};
+  Int96 aaa{{1, 41, static_cast<uint32_t>(-14)}}, bbb{{1, 41, 42}};
+
+  auto comparator = MakeComparator<Int96Type>(Type::INT96, SortOrder::SIGNED);
+
+  ASSERT_TRUE(comparator->Compare(a, b));
+  ASSERT_TRUE(!comparator->Compare(aa, bb) && !comparator->Compare(bb, aa));
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+}
+
+TEST(Comparison, UnsignedInt96) {
+  Int96 a{{1, 41, 14}}, b{{1, static_cast<uint32_t>(-41), 42}};
+  Int96 aa{{1, 41, 14}}, bb{{1, 41, static_cast<uint32_t>(-14)}};
+  Int96 aaa, bbb;
+
+  auto comparator = MakeComparator<Int96Type>(Type::INT96, SortOrder::UNSIGNED);
+
+  ASSERT_TRUE(comparator->Compare(a, b));
+  ASSERT_TRUE(comparator->Compare(aa, bb));
+
+  // INT96 Timestamp
+  aaa.value[2] = 2451545; // 2000-01-01
+  bbb.value[2] = 2451546; // 2000-01-02
+  // 12 hours + 34 minutes + 56 seconds.
+  Int96SetNanoSeconds(aaa, 45296000000000);
+  // 12 hours + 34 minutes + 50 seconds.
+  Int96SetNanoSeconds(bbb, 45290000000000);
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+
+  aaa.value[2] = 2451545; // 2000-01-01
+  bbb.value[2] = 2451545; // 2000-01-01
+  // 11 hours + 34 minutes + 56 seconds.
+  Int96SetNanoSeconds(aaa, 41696000000000);
+  // 12 hours + 34 minutes + 50 seconds.
+  Int96SetNanoSeconds(bbb, 45290000000000);
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+
+  aaa.value[2] = 2451545; // 2000-01-01
+  bbb.value[2] = 2451545; // 2000-01-01
+  // 12 hours + 34 minutes + 55 seconds.
+  Int96SetNanoSeconds(aaa, 45295000000000);
+  // 12 hours + 34 minutes + 56 seconds.
+  Int96SetNanoSeconds(bbb, 45296000000000);
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+}
+
+TEST(Comparison, SignedInt64) {
+  int64_t a = 1, b = 4;
+  int64_t aa = 1, bb = 1;
+  int64_t aaa = -1, bbb = 1;
+
+  NodePtr node =
+      PrimitiveNode::Make("SignedInt64", Repetition::REQUIRED, Type::INT64);
+  ColumnDescriptor descr(node, 0, 0);
+
+  auto comparator = MakeComparator<Int64Type>(&descr);
+
+  ASSERT_TRUE(comparator->Compare(a, b));
+  ASSERT_TRUE(!comparator->Compare(aa, bb) && !comparator->Compare(bb, aa));
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+}
+
+TEST(Comparison, UnsignedInt64) {
+  uint64_t a = 1, b = 4;
+  uint64_t aa = 1, bb = 1;
+  uint64_t aaa = 1, bbb = -1;
+
+  NodePtr node = PrimitiveNode::Make(
+      "UnsignedInt64",
+      Repetition::REQUIRED,
+      Type::INT64,
+      ConvertedType::UINT_64);
+  ColumnDescriptor descr(node, 0, 0);
+
+  ASSERT_EQ(SortOrder::UNSIGNED, descr.sort_order());
+  auto comparator = MakeComparator<Int64Type>(&descr);
+
+  ASSERT_TRUE(comparator->Compare(a, b));
+  ASSERT_TRUE(!comparator->Compare(aa, bb) && !comparator->Compare(bb, aa));
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+}
+
+TEST(Comparison, UnsignedInt32) {
+  uint32_t a = 1, b = 4;
+  uint32_t aa = 1, bb = 1;
+  uint32_t aaa = 1, bbb = -1;
+
+  NodePtr node = PrimitiveNode::Make(
+      "UnsignedInt32",
+      Repetition::REQUIRED,
+      Type::INT32,
+      ConvertedType::UINT_32);
+  ColumnDescriptor descr(node, 0, 0);
+
+  ASSERT_EQ(SortOrder::UNSIGNED, descr.sort_order());
+  auto comparator = MakeComparator<Int32Type>(&descr);
+
+  ASSERT_TRUE(comparator->Compare(a, b));
+  ASSERT_TRUE(!comparator->Compare(aa, bb) && !comparator->Compare(bb, aa));
+  ASSERT_TRUE(comparator->Compare(aaa, bbb));
+}
+
+TEST(Comparison, UnknownSortOrder) {
+  NodePtr node = PrimitiveNode::Make(
+      "Unknown",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::INTERVAL,
+      12);
+  ColumnDescriptor descr(node, 0, 0);
+
+  ASSERT_THROW(Comparator::Make(&descr), ParquetException);
+}
+
+// ----------------------------------------------------------------------
+
+template <typename TestType>
+class TestStatistics : public PrimitiveTypedTest<TestType> {
+ public:
+  using c_type = typename TestType::c_type;
+
+  std::vector<c_type> GetDeepCopy(
+      const std::vector<c_type>&); // allocates new memory for FLBA/ByteArray
+
+  c_type* GetValuesPointer(std::vector<c_type>&);
+  void DeepFree(std::vector<c_type>&);
+
+  void TestMinMaxEncode() {
+    this->GenerateData(1000);
+
+    auto statistics1 = MakeStatistics<TestType>(this->schema_.Column(0));
+    statistics1->Update(this->values_ptr_, this->values_.size(), 0);
+    std::string encoded_min = statistics1->EncodeMin();
+    std::string encoded_max = statistics1->EncodeMax();
+
+    auto statistics2 = MakeStatistics<TestType>(
+        this->schema_.Column(0),
+        encoded_min,
+        encoded_max,
+        this->values_.size(),
+        0,
+        0,
+        true,
+        true,
+        true);
+
+    auto statistics3 = MakeStatistics<TestType>(this->schema_.Column(0));
+    std::vector<uint8_t> valid_bits(
+        bit_util::BytesForBits(static_cast<uint32_t>(this->values_.size())) + 1,
+        255);
+    statistics3->UpdateSpaced(
+        this->values_ptr_,
+        valid_bits.data(),
+        0,
+        this->values_.size(),
+        this->values_.size(),
+        0);
+    std::string encoded_min_spaced = statistics3->EncodeMin();
+    std::string encoded_max_spaced = statistics3->EncodeMax();
+
+    ASSERT_EQ(encoded_min, statistics2->EncodeMin());
+    ASSERT_EQ(encoded_max, statistics2->EncodeMax());
+    ASSERT_EQ(statistics1->min(), statistics2->min());
+    ASSERT_EQ(statistics1->max(), statistics2->max());
+    ASSERT_EQ(encoded_min_spaced, statistics2->EncodeMin());
+    ASSERT_EQ(encoded_max_spaced, statistics2->EncodeMax());
+    ASSERT_EQ(statistics3->min(), statistics2->min());
+    ASSERT_EQ(statistics3->max(), statistics2->max());
+  }
+
+  void TestReset() {
+    this->GenerateData(1000);
+
+    auto statistics = MakeStatistics<TestType>(this->schema_.Column(0));
+    statistics->Update(this->values_ptr_, this->values_.size(), 0);
+    ASSERT_EQ(this->values_.size(), statistics->num_values());
+
+    statistics->Reset();
+    ASSERT_TRUE(statistics->HasNullCount());
+    ASSERT_FALSE(statistics->HasMinMax());
+    ASSERT_FALSE(statistics->HasDistinctCount());
+    ASSERT_EQ(0, statistics->null_count());
+    ASSERT_EQ(0, statistics->num_values());
+    ASSERT_EQ(0, statistics->distinct_count());
+    ASSERT_EQ("", statistics->EncodeMin());
+    ASSERT_EQ("", statistics->EncodeMax());
+  }
+
+  void TestMerge() {
+    int num_null[2];
+    random_numbers(2, 42, 0, 100, num_null);
+
+    auto statistics1 = MakeStatistics<TestType>(this->schema_.Column(0));
+    this->GenerateData(1000);
+    statistics1->Update(
+        this->values_ptr_, this->values_.size() - num_null[0], num_null[0]);
+
+    auto statistics2 = MakeStatistics<TestType>(this->schema_.Column(0));
+    this->GenerateData(1000);
+    statistics2->Update(
+        this->values_ptr_, this->values_.size() - num_null[1], num_null[1]);
+
+    auto total = MakeStatistics<TestType>(this->schema_.Column(0));
+    total->Merge(*statistics1);
+    total->Merge(*statistics2);
+
+    ASSERT_EQ(num_null[0] + num_null[1], total->null_count());
+    ASSERT_EQ(
+        this->values_.size() * 2 - num_null[0] - num_null[1],
+        total->num_values());
+    ASSERT_EQ(total->min(), std::min(statistics1->min(), statistics2->min()));
+    ASSERT_EQ(total->max(), std::max(statistics1->max(), statistics2->max()));
+  }
+
+  void TestEquals() {
+    const auto n_values = 1;
+    auto statistics_have_minmax1 =
+        MakeStatistics<TestType>(this->schema_.Column(0));
+    const auto seed1 = 1;
+    this->GenerateData(n_values, seed1);
+    statistics_have_minmax1->Update(this->values_ptr_, this->values_.size(), 0);
+    auto statistics_have_minmax2 =
+        MakeStatistics<TestType>(this->schema_.Column(0));
+    const auto seed2 = 9999;
+    this->GenerateData(n_values, seed2);
+    statistics_have_minmax2->Update(this->values_ptr_, this->values_.size(), 0);
+    auto statistics_no_minmax =
+        MakeStatistics<TestType>(this->schema_.Column(0));
+
+    ASSERT_EQ(true, statistics_have_minmax1->Equals(*statistics_have_minmax1));
+    ASSERT_EQ(true, statistics_no_minmax->Equals(*statistics_no_minmax));
+    ASSERT_EQ(false, statistics_have_minmax1->Equals(*statistics_have_minmax2));
+    ASSERT_EQ(false, statistics_have_minmax1->Equals(*statistics_no_minmax));
+  }
+
+  void TestFullRoundtrip(int64_t num_values, int64_t null_count) {
+    this->GenerateData(num_values);
+
+    // compute statistics for the whole batch
+    auto expected_stats = MakeStatistics<TestType>(this->schema_.Column(0));
+    expected_stats->Update(
+        this->values_ptr_, num_values - null_count, null_count);
+
+    auto sink = CreateOutputStream();
+    auto gnode = std::static_pointer_cast<GroupNode>(this->node_);
+    std::shared_ptr<WriterProperties> writer_properties =
+        WriterProperties::Builder().enable_statistics("column")->build();
+    auto file_writer = ParquetFileWriter::Open(sink, gnode, writer_properties);
+    auto row_group_writer = file_writer->AppendRowGroup();
+    auto column_writer = static_cast<TypedColumnWriter<TestType>*>(
+        row_group_writer->NextColumn());
+
+    // simulate the case when data comes from multiple buffers,
+    // in which case special care is necessary for FLBA/ByteArray types
+    for (int i = 0; i < 2; i++) {
+      int64_t batch_num_values =
+          i ? num_values - num_values / 2 : num_values / 2;
+      int64_t batch_null_count = i ? null_count : 0;
+      DCHECK(null_count <= num_values); // avoid too much headache
+      std::vector<int16_t> definition_levels(batch_null_count, 0);
+      definition_levels.insert(
+          definition_levels.end(), batch_num_values - batch_null_count, 1);
+      auto beg = this->values_.begin() + i * num_values / 2;
+      auto end = beg + batch_num_values;
+      std::vector<c_type> batch = GetDeepCopy(std::vector<c_type>(beg, end));
+      c_type* batch_values_ptr = GetValuesPointer(batch);
+      column_writer->WriteBatch(
+          batch_num_values,
+          definition_levels.data(),
+          nullptr,
+          batch_values_ptr);
+      DeepFree(batch);
+    }
+    column_writer->Close();
+    row_group_writer->Close();
+    file_writer->Close();
+
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+    auto source = std::make_shared<::arrow::io::BufferReader>(buffer);
+    auto file_reader = ParquetFileReader::Open(source);
+    auto rg_reader = file_reader->RowGroup(0);
+    auto column_chunk = rg_reader->metadata()->ColumnChunk(0);
+    if (!column_chunk->is_stats_set())
+      return;
+    std::shared_ptr<Statistics> stats = column_chunk->statistics();
+    // check values after serialization + deserialization
+    EXPECT_EQ(null_count, stats->null_count());
+    EXPECT_EQ(num_values - null_count, stats->num_values());
+    EXPECT_TRUE(expected_stats->HasMinMax());
+    EXPECT_EQ(expected_stats->EncodeMin(), stats->EncodeMin());
+    EXPECT_EQ(expected_stats->EncodeMax(), stats->EncodeMax());
+  }
+};
+
+template <typename TestType>
+typename TestType::c_type* TestStatistics<TestType>::GetValuesPointer(
+    std::vector<typename TestType::c_type>& values) {
+  return values.data();
+}
+
+template <>
+bool* TestStatistics<BooleanType>::GetValuesPointer(std::vector<bool>& values) {
+  static std::vector<uint8_t> bool_buffer;
+  bool_buffer.clear();
+  bool_buffer.resize(values.size());
+  std::copy(values.begin(), values.end(), bool_buffer.begin());
+  return reinterpret_cast<bool*>(bool_buffer.data());
+}
+
+template <typename TestType>
+typename std::vector<typename TestType::c_type>
+TestStatistics<TestType>::GetDeepCopy(
+    const std::vector<typename TestType::c_type>& values) {
+  return values;
+}
+
+template <>
+std::vector<FLBA> TestStatistics<FLBAType>::GetDeepCopy(
+    const std::vector<FLBA>& values) {
+  std::vector<FLBA> copy;
+  MemoryPool* pool = ::arrow::default_memory_pool();
+  for (const FLBA& flba : values) {
+    uint8_t* ptr;
+    PARQUET_THROW_NOT_OK(pool->Allocate(FLBA_LENGTH, &ptr));
+    memcpy(ptr, flba.ptr, FLBA_LENGTH);
+    copy.emplace_back(ptr);
+  }
+  return copy;
+}
+
+template <>
+std::vector<ByteArray> TestStatistics<ByteArrayType>::GetDeepCopy(
+    const std::vector<ByteArray>& values) {
+  std::vector<ByteArray> copy;
+  MemoryPool* pool = default_memory_pool();
+  for (const ByteArray& ba : values) {
+    uint8_t* ptr;
+    PARQUET_THROW_NOT_OK(pool->Allocate(ba.len, &ptr));
+    memcpy(ptr, ba.ptr, ba.len);
+    copy.emplace_back(ba.len, ptr);
+  }
+  return copy;
+}
+
+template <typename TestType>
+void TestStatistics<TestType>::DeepFree(
+    std::vector<typename TestType::c_type>& values) {}
+
+template <>
+void TestStatistics<FLBAType>::DeepFree(std::vector<FLBA>& values) {
+  MemoryPool* pool = default_memory_pool();
+  for (FLBA& flba : values) {
+    auto ptr = const_cast<uint8_t*>(flba.ptr);
+    memset(ptr, 0, FLBA_LENGTH);
+    pool->Free(ptr, FLBA_LENGTH);
+  }
+}
+
+template <>
+void TestStatistics<ByteArrayType>::DeepFree(std::vector<ByteArray>& values) {
+  MemoryPool* pool = default_memory_pool();
+  for (ByteArray& ba : values) {
+    auto ptr = const_cast<uint8_t*>(ba.ptr);
+    memset(ptr, 0, ba.len);
+    pool->Free(ptr, ba.len);
+  }
+}
+
+template <>
+void TestStatistics<ByteArrayType>::TestMinMaxEncode() {
+  this->GenerateData(1000);
+  // Test that we encode min max strings correctly
+  auto statistics1 = MakeStatistics<ByteArrayType>(this->schema_.Column(0));
+  statistics1->Update(this->values_ptr_, this->values_.size(), 0);
+  std::string encoded_min = statistics1->EncodeMin();
+  std::string encoded_max = statistics1->EncodeMax();
+
+  // encoded is same as unencoded
+  ASSERT_EQ(
+      encoded_min,
+      std::string(
+          reinterpret_cast<const char*>(statistics1->min().ptr),
+          statistics1->min().len));
+  ASSERT_EQ(
+      encoded_max,
+      std::string(
+          reinterpret_cast<const char*>(statistics1->max().ptr),
+          statistics1->max().len));
+
+  auto statistics2 = MakeStatistics<ByteArrayType>(
+      this->schema_.Column(0),
+      encoded_min,
+      encoded_max,
+      this->values_.size(),
+      0,
+      0,
+      true,
+      true,
+      true);
+
+  ASSERT_EQ(encoded_min, statistics2->EncodeMin());
+  ASSERT_EQ(encoded_max, statistics2->EncodeMax());
+  ASSERT_EQ(statistics1->min(), statistics2->min());
+  ASSERT_EQ(statistics1->max(), statistics2->max());
+}
+
+using Types = ::testing::Types<
+    Int32Type,
+    Int64Type,
+    FloatType,
+    DoubleType,
+    ByteArrayType,
+    FLBAType,
+    BooleanType>;
+
+TYPED_TEST_SUITE(TestStatistics, Types);
+
+TYPED_TEST(TestStatistics, MinMaxEncode) {
+  this->SetUpSchema(Repetition::REQUIRED);
+  ASSERT_NO_FATAL_FAILURE(this->TestMinMaxEncode());
+}
+
+TYPED_TEST(TestStatistics, Reset) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestReset());
+}
+
+TYPED_TEST(TestStatistics, Equals) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestEquals());
+}
+
+TYPED_TEST(TestStatistics, FullRoundtrip) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestFullRoundtrip(100, 31));
+  ASSERT_NO_FATAL_FAILURE(this->TestFullRoundtrip(1000, 415));
+  ASSERT_NO_FATAL_FAILURE(this->TestFullRoundtrip(10000, 926));
+}
+
+template <typename TestType>
+class TestNumericStatistics : public TestStatistics<TestType> {};
+
+using NumericTypes =
+    ::testing::Types<Int32Type, Int64Type, FloatType, DoubleType>;
+
+TYPED_TEST_SUITE(TestNumericStatistics, NumericTypes);
+
+TYPED_TEST(TestNumericStatistics, Merge) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestMerge());
+}
+
+TYPED_TEST(TestNumericStatistics, Equals) {
+  this->SetUpSchema(Repetition::OPTIONAL);
+  ASSERT_NO_FATAL_FAILURE(this->TestEquals());
+}
+
+template <typename TestType>
+class TestStatisticsHasFlag : public TestStatistics<TestType> {
+ public:
+  void SetUp() override {
+    TestStatistics<TestType>::SetUp();
+    this->SetUpSchema(Repetition::OPTIONAL);
+  }
+
+  std::shared_ptr<TypedStatistics<TestType>> MergedStatistics(
+      const TypedStatistics<TestType>& stats1,
+      const TypedStatistics<TestType>& stats2) {
+    auto chunk_statistics = MakeStatistics<TestType>(this->schema_.Column(0));
+    chunk_statistics->Merge(stats1);
+    chunk_statistics->Merge(stats2);
+    return chunk_statistics;
+  }
+
+  void VerifyMergedStatistics(
+      const TypedStatistics<TestType>& stats1,
+      const TypedStatistics<TestType>& stats2,
+      const std::function<void(TypedStatistics<TestType>*)>& test_fn) {
+    ASSERT_NO_FATAL_FAILURE(test_fn(MergedStatistics(stats1, stats2).get()));
+    ASSERT_NO_FATAL_FAILURE(test_fn(MergedStatistics(stats2, stats1).get()));
+  }
+
+  // Distinct count should set to false when Merge is called.
+  void TestMergeDistinctCount() {
+    // Create a statistics object with distinct count.
+    std::shared_ptr<TypedStatistics<TestType>> statistics1;
+    {
+      EncodedStatistics encoded_statistics1;
+      statistics1 =
+          std::dynamic_pointer_cast<TypedStatistics<TestType>>(Statistics::Make(
+              this->schema_.Column(0),
+              &encoded_statistics1,
+              /*num_values=*/1000));
+      EXPECT_FALSE(statistics1->HasDistinctCount());
+    }
+
+    // Create a statistics object with distinct count.
+    std::shared_ptr<TypedStatistics<TestType>> statistics2;
+    {
+      EncodedStatistics encoded_statistics2;
+      encoded_statistics2.has_distinct_count = true;
+      encoded_statistics2.distinct_count = 500;
+      statistics2 =
+          std::dynamic_pointer_cast<TypedStatistics<TestType>>(Statistics::Make(
+              this->schema_.Column(0),
+              &encoded_statistics2,
+              /*num_values=*/1000));
+      EXPECT_TRUE(statistics2->HasDistinctCount());
+    }
+
+    VerifyMergedStatistics(
+        *statistics1,
+        *statistics2,
+        [](TypedStatistics<TestType>* merged_statistics) {
+          EXPECT_FALSE(merged_statistics->HasDistinctCount());
+          EXPECT_FALSE(merged_statistics->Encode().has_distinct_count);
+        });
+  }
+
+  // If all values in a page are null or nan, its stats should not set min-max.
+  // Merging its stats with another page having good min-max stats should not
+  // drop the valid min-max from the latter page.
+  void TestMergeMinMax() {
+    this->GenerateData(1000);
+    // Create a statistics object without min-max.
+    std::shared_ptr<TypedStatistics<TestType>> statistics1;
+    {
+      statistics1 = MakeStatistics<TestType>(this->schema_.Column(0));
+      statistics1->Update(
+          this->values_ptr_,
+          /*num_values=*/0,
+          /*null_count=*/this->values_.size());
+      auto encoded_stats1 = statistics1->Encode();
+      EXPECT_FALSE(statistics1->HasMinMax());
+      EXPECT_FALSE(encoded_stats1.has_min);
+      EXPECT_FALSE(encoded_stats1.has_max);
+    }
+    // Create a statistics object with min-max.
+    std::shared_ptr<TypedStatistics<TestType>> statistics2;
+    {
+      statistics2 = MakeStatistics<TestType>(this->schema_.Column(0));
+      statistics2->Update(this->values_ptr_, this->values_.size(), 0);
+      auto encoded_stats2 = statistics2->Encode();
+      EXPECT_TRUE(statistics2->HasMinMax());
+      EXPECT_TRUE(encoded_stats2.has_min);
+      EXPECT_TRUE(encoded_stats2.has_max);
+    }
+    VerifyMergedStatistics(
+        *statistics1,
+        *statistics2,
+        [](TypedStatistics<TestType>* merged_statistics) {
+          EXPECT_TRUE(merged_statistics->HasMinMax());
+          EXPECT_TRUE(merged_statistics->Encode().has_min);
+          EXPECT_TRUE(merged_statistics->Encode().has_max);
+        });
+  }
+
+  // Default statistics should have null_count even if no nulls is written.
+  // However, if statistics is created from thrift message, it might not
+  // have null_count. Merging statistics from such page will result in an
+  // invalid null_count as well.
+  void TestMergeNullCount() {
+    this->GenerateData(/*num_values=*/1000);
+
+    // Page should have null-count even if no nulls
+    std::shared_ptr<TypedStatistics<TestType>> statistics1;
+    {
+      statistics1 = MakeStatistics<TestType>(this->schema_.Column(0));
+      statistics1->Update(
+          this->values_ptr_,
+          /*num_values=*/this->values_.size(),
+          /*null_count=*/0);
+      auto encoded_stats1 = statistics1->Encode();
+      EXPECT_TRUE(statistics1->HasNullCount());
+      EXPECT_EQ(0, statistics1->null_count());
+      EXPECT_TRUE(statistics1->Encode().has_null_count);
+    }
+    // Merge with null-count should also have null count
+    VerifyMergedStatistics(
+        *statistics1,
+        *statistics1,
+        [](TypedStatistics<TestType>* merged_statistics) {
+          EXPECT_TRUE(merged_statistics->HasNullCount());
+          EXPECT_EQ(0, merged_statistics->null_count());
+          auto encoded = merged_statistics->Encode();
+          EXPECT_TRUE(encoded.has_null_count);
+          EXPECT_EQ(0, encoded.null_count);
+        });
+
+    // When loaded from thrift, might not have null count.
+    std::shared_ptr<TypedStatistics<TestType>> statistics2;
+    {
+      EncodedStatistics encoded_statistics2;
+      encoded_statistics2.has_null_count = false;
+      statistics2 =
+          std::dynamic_pointer_cast<TypedStatistics<TestType>>(Statistics::Make(
+              this->schema_.Column(0),
+              &encoded_statistics2,
+              /*num_values=*/1000));
+      EXPECT_FALSE(statistics2->Encode().has_null_count);
+      EXPECT_FALSE(statistics2->HasNullCount());
+    }
+
+    // Merge without null-count should not have null count
+    VerifyMergedStatistics(
+        *statistics1,
+        *statistics2,
+        [](TypedStatistics<TestType>* merged_statistics) {
+          EXPECT_FALSE(merged_statistics->HasNullCount());
+          EXPECT_FALSE(merged_statistics->Encode().has_null_count);
+        });
+  }
+
+  // statistics.all_null_value is used to build the page index.
+  // If statistics doesn't have null count, all_null_value should be false.
+  void TestMissingNullCount() {
+    EncodedStatistics encoded_statistics;
+    encoded_statistics.has_null_count = false;
+    auto statistics = Statistics::Make(
+        this->schema_.Column(0),
+        &encoded_statistics,
+        /*num_values=*/1000);
+    auto typed_stats =
+        std::dynamic_pointer_cast<TypedStatistics<TestType>>(statistics);
+    EXPECT_FALSE(typed_stats->HasNullCount());
+    auto encoded = typed_stats->Encode();
+    EXPECT_FALSE(encoded.all_null_value);
+    EXPECT_FALSE(encoded.has_null_count);
+    EXPECT_FALSE(encoded.has_distinct_count);
+    EXPECT_FALSE(encoded.has_min);
+    EXPECT_FALSE(encoded.has_max);
+  }
+};
+
+TYPED_TEST_SUITE(TestStatisticsHasFlag, Types);
+
+TYPED_TEST(TestStatisticsHasFlag, MergeDistinctCount) {
+  ASSERT_NO_FATAL_FAILURE(this->TestMergeDistinctCount());
+}
+
+TYPED_TEST(TestStatisticsHasFlag, MergeNullCount) {
+  ASSERT_NO_FATAL_FAILURE(this->TestMergeNullCount());
+}
+
+TYPED_TEST(TestStatisticsHasFlag, MergeMinMax) {
+  ASSERT_NO_FATAL_FAILURE(this->TestMergeMinMax());
+}
+
+TYPED_TEST(TestStatisticsHasFlag, MissingNullCount) {
+  ASSERT_NO_FATAL_FAILURE(this->TestMissingNullCount());
+}
+
+// Helper for basic statistics tests below
+void AssertStatsSet(
+    const ApplicationVersion& version,
+    std::shared_ptr<WriterProperties> props,
+    const ColumnDescriptor* column,
+    bool expected_is_set) {
+  auto metadata_builder = ColumnChunkMetaDataBuilder::Make(props, column);
+  auto column_chunk = ColumnChunkMetaData::Make(
+      metadata_builder->contents(),
+      column,
+      default_reader_properties(),
+      &version);
+  EncodedStatistics stats;
+  stats.set_is_signed(false);
+  metadata_builder->SetStatistics(stats);
+  ASSERT_EQ(column_chunk->is_stats_set(), expected_is_set);
+}
+
+// Statistics are restricted for few types in older parquet version
+TEST(CorruptStatistics, Basics) {
+  std::string created_by = "parquet-mr version 1.8.0";
+  ApplicationVersion version(created_by);
+  SchemaDescriptor schema;
+  schema::NodePtr node;
+  std::vector<schema::NodePtr> fields;
+  // Test Physical Types
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col1", Repetition::OPTIONAL, Type::INT32, ConvertedType::NONE));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col2", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::NONE));
+  // Test Logical Types
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col3", Repetition::OPTIONAL, Type::INT32, ConvertedType::DATE));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col4", Repetition::OPTIONAL, Type::INT32, ConvertedType::UINT_32));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col5",
+      Repetition::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::INTERVAL,
+      12));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col6", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::UTF8));
+  node = schema::GroupNode::Make("schema", Repetition::REQUIRED, fields);
+  schema.Init(node);
+
+  WriterProperties::Builder builder;
+  builder.created_by(created_by);
+  std::shared_ptr<WriterProperties> props = builder.build();
+
+  AssertStatsSet(version, props, schema.Column(0), true);
+  AssertStatsSet(version, props, schema.Column(1), false);
+  AssertStatsSet(version, props, schema.Column(2), true);
+  AssertStatsSet(version, props, schema.Column(3), false);
+  AssertStatsSet(version, props, schema.Column(4), false);
+  AssertStatsSet(version, props, schema.Column(5), false);
+}
+
+// Statistics for all types have no restrictions in newer parquet version
+TEST(CorrectStatistics, Basics) {
+  std::string created_by = "parquet-cpp version 1.3.0";
+  ApplicationVersion version(created_by);
+  SchemaDescriptor schema;
+  schema::NodePtr node;
+  std::vector<schema::NodePtr> fields;
+  // Test Physical Types
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col1", Repetition::OPTIONAL, Type::INT32, ConvertedType::NONE));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col2", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::NONE));
+  // Test Logical Types
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col3", Repetition::OPTIONAL, Type::INT32, ConvertedType::DATE));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col4", Repetition::OPTIONAL, Type::INT32, ConvertedType::UINT_32));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col5",
+      Repetition::OPTIONAL,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::INTERVAL,
+      12));
+  fields.push_back(schema::PrimitiveNode::Make(
+      "col6", Repetition::OPTIONAL, Type::BYTE_ARRAY, ConvertedType::UTF8));
+  node = schema::GroupNode::Make("schema", Repetition::REQUIRED, fields);
+  schema.Init(node);
+
+  WriterProperties::Builder builder;
+  builder.created_by(created_by);
+  std::shared_ptr<WriterProperties> props = builder.build();
+
+  AssertStatsSet(version, props, schema.Column(0), true);
+  AssertStatsSet(version, props, schema.Column(1), true);
+  AssertStatsSet(version, props, schema.Column(2), true);
+  AssertStatsSet(version, props, schema.Column(3), true);
+  AssertStatsSet(version, props, schema.Column(4), false);
+  AssertStatsSet(version, props, schema.Column(5), true);
+}
+
+// Test SortOrder class
+static const int NUM_VALUES = 10;
+
+template <typename TestType>
+class TestStatisticsSortOrder : public ::testing::Test {
+ public:
+  using c_type = typename TestType::c_type;
+
+  void AddNodes(std::string name) {
+    fields_.push_back(schema::PrimitiveNode::Make(
+        name, Repetition::REQUIRED, TestType::type_num, ConvertedType::NONE));
+  }
+
+  void SetUpSchema() {
+    stats_.resize(fields_.size());
+    values_.resize(NUM_VALUES);
+    schema_ = std::static_pointer_cast<GroupNode>(
+        GroupNode::Make("Schema", Repetition::REQUIRED, fields_));
+
+    parquet_sink_ = CreateOutputStream();
+  }
+
+  void SetValues();
+
+  void WriteParquet() {
+    // Add writer properties
+    WriterProperties::Builder builder;
+    builder.compression(Compression::SNAPPY);
+    builder.created_by("parquet-cpp version 1.3.0");
+    std::shared_ptr<WriterProperties> props = builder.build();
+
+    // Create a ParquetFileWriter instance
+    auto file_writer = ParquetFileWriter::Open(parquet_sink_, schema_, props);
+
+    // Append a RowGroup with a specific number of rows.
+    auto rg_writer = file_writer->AppendRowGroup();
+
+    this->SetValues();
+
+    // Insert Values
+    for (int i = 0; i < static_cast<int>(fields_.size()); i++) {
+      auto column_writer =
+          static_cast<TypedColumnWriter<TestType>*>(rg_writer->NextColumn());
+      column_writer->WriteBatch(NUM_VALUES, nullptr, nullptr, values_.data());
+    }
+  }
+
+  void VerifyParquetStats() {
+    ASSERT_OK_AND_ASSIGN(auto pbuffer, parquet_sink_->Finish());
+
+    // Create a ParquetReader instance
+    std::unique_ptr<ParquetFileReader> parquet_reader = ParquetFileReader::Open(
+        std::make_shared<::arrow::io::BufferReader>(pbuffer));
+
+    // Get the File MetaData
+    std::shared_ptr<FileMetaData> file_metadata = parquet_reader->metadata();
+    std::shared_ptr<RowGroupMetaData> rg_metadata = file_metadata->RowGroup(0);
+    for (int i = 0; i < static_cast<int>(fields_.size()); i++) {
+      ARROW_SCOPED_TRACE("Statistics for field #", i);
+      std::shared_ptr<ColumnChunkMetaData> cc_metadata =
+          rg_metadata->ColumnChunk(i);
+      EXPECT_EQ(stats_[i].min(), cc_metadata->statistics()->EncodeMin());
+      EXPECT_EQ(stats_[i].max(), cc_metadata->statistics()->EncodeMax());
+    }
+  }
+
+ protected:
+  std::vector<c_type> values_;
+  std::vector<uint8_t> values_buf_;
+  std::vector<schema::NodePtr> fields_;
+  std::shared_ptr<schema::GroupNode> schema_;
+  std::shared_ptr<::arrow::io::BufferOutputStream> parquet_sink_;
+  std::vector<EncodedStatistics> stats_;
+};
+
+using CompareTestTypes = ::testing::
+    Types<Int32Type, Int64Type, FloatType, DoubleType, ByteArrayType, FLBAType>;
+
+// TYPE::INT32
+template <>
+void TestStatisticsSortOrder<Int32Type>::AddNodes(std::string name) {
+  // UINT_32 logical type to set Unsigned Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name, Repetition::REQUIRED, Type::INT32, ConvertedType::UINT_32));
+  // INT_32 logical type to set Signed Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name, Repetition::REQUIRED, Type::INT32, ConvertedType::INT_32));
+}
+
+template <>
+void TestStatisticsSortOrder<Int32Type>::SetValues() {
+  for (int i = 0; i < NUM_VALUES; i++) {
+    values_[i] = i - 5; // {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
+  }
+
+  // Write UINT32 min/max values
+  stats_[0]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[5]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[4]), sizeof(c_type)));
+
+  // Write INT32 min/max values
+  stats_[1]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[0]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[9]), sizeof(c_type)));
+}
+
+// TYPE::INT64
+template <>
+void TestStatisticsSortOrder<Int64Type>::AddNodes(std::string name) {
+  // UINT_64 logical type to set Unsigned Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name, Repetition::REQUIRED, Type::INT64, ConvertedType::UINT_64));
+  // INT_64 logical type to set Signed Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name, Repetition::REQUIRED, Type::INT64, ConvertedType::INT_64));
+}
+
+template <>
+void TestStatisticsSortOrder<Int64Type>::SetValues() {
+  for (int i = 0; i < NUM_VALUES; i++) {
+    values_[i] = i - 5; // {-5, -4, -3, -2, -1, 0, 1, 2, 3, 4};
+  }
+
+  // Write UINT64 min/max values
+  stats_[0]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[5]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[4]), sizeof(c_type)));
+
+  // Write INT64 min/max values
+  stats_[1]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[0]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[9]), sizeof(c_type)));
+}
+
+// TYPE::FLOAT
+template <>
+void TestStatisticsSortOrder<FloatType>::SetValues() {
+  for (int i = 0; i < NUM_VALUES; i++) {
+    values_[i] = static_cast<float>(i) -
+        5; // {-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
+  }
+
+  // Write Float min/max values
+  stats_[0]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[0]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[9]), sizeof(c_type)));
+}
+
+// TYPE::DOUBLE
+template <>
+void TestStatisticsSortOrder<DoubleType>::SetValues() {
+  for (int i = 0; i < NUM_VALUES; i++) {
+    values_[i] = static_cast<float>(i) -
+        5; // {-5.0, -4.0, -3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0};
+  }
+
+  // Write Double min/max values
+  stats_[0]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(&values_[0]), sizeof(c_type)))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(&values_[9]), sizeof(c_type)));
+}
+
+// TYPE::ByteArray
+template <>
+void TestStatisticsSortOrder<ByteArrayType>::AddNodes(std::string name) {
+  // UTF8 logical type to set Unsigned Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name, Repetition::REQUIRED, Type::BYTE_ARRAY, ConvertedType::UTF8));
+}
+
+template <>
+void TestStatisticsSortOrder<ByteArrayType>::SetValues() {
+  int max_byte_array_len = 10;
+  size_t nbytes = NUM_VALUES * max_byte_array_len;
+  values_buf_.resize(nbytes);
+  std::vector<std::string> vals = {
+      "c123",
+      "b123",
+      "a123",
+      "d123",
+      "e123",
+      "f123",
+      "g123",
+      "h123",
+      "i123",
+      "ü123"};
+
+  uint8_t* base = &values_buf_.data()[0];
+  for (int i = 0; i < NUM_VALUES; i++) {
+    memcpy(base, vals[i].c_str(), vals[i].length());
+    values_[i].ptr = base;
+    values_[i].len = static_cast<uint32_t>(vals[i].length());
+    base += vals[i].length();
+  }
+
+  // Write String min/max values
+  stats_[0]
+      .set_min(std::string(
+          reinterpret_cast<const char*>(vals[2].c_str()), vals[2].length()))
+      .set_max(std::string(
+          reinterpret_cast<const char*>(vals[9].c_str()), vals[9].length()));
+}
+
+// TYPE::FLBAArray
+template <>
+void TestStatisticsSortOrder<FLBAType>::AddNodes(std::string name) {
+  // FLBA has only Unsigned Statistics
+  fields_.push_back(schema::PrimitiveNode::Make(
+      name,
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::NONE,
+      FLBA_LENGTH));
+}
+
+template <>
+void TestStatisticsSortOrder<FLBAType>::SetValues() {
+  size_t nbytes = NUM_VALUES * FLBA_LENGTH;
+  values_buf_.resize(nbytes);
+  char vals[NUM_VALUES][FLBA_LENGTH] = {
+      "b12345",
+      "a12345",
+      "c12345",
+      "d12345",
+      "e12345",
+      "f12345",
+      "g12345",
+      "h12345",
+      "z12345",
+      "a12345"};
+
+  uint8_t* base = &values_buf_.data()[0];
+  for (int i = 0; i < NUM_VALUES; i++) {
+    memcpy(base, &vals[i][0], FLBA_LENGTH);
+    values_[i].ptr = base;
+    base += FLBA_LENGTH;
+  }
+
+  // Write FLBA min,max values
+  stats_[0]
+      .set_min(
+          std::string(reinterpret_cast<const char*>(&vals[1][0]), FLBA_LENGTH))
+      .set_max(
+          std::string(reinterpret_cast<const char*>(&vals[8][0]), FLBA_LENGTH));
+}
+
+TYPED_TEST_SUITE(TestStatisticsSortOrder, CompareTestTypes);
+
+TYPED_TEST(TestStatisticsSortOrder, MinMax) {
+  this->AddNodes("Column ");
+  this->SetUpSchema();
+  this->WriteParquet();
+  ASSERT_NO_FATAL_FAILURE(this->VerifyParquetStats());
+}
+
+template <typename ArrowType>
+void TestByteArrayStatisticsFromArrow() {
+  using TypeTraits = ::arrow::TypeTraits<ArrowType>;
+  using ArrayType = typename TypeTraits::ArrayType;
+
+  auto values = ArrayFromJSON(
+      TypeTraits::type_singleton(),
+      "[\"c123\", \"b123\", \"a123\", null, "
+      "null, \"f123\", \"g123\", \"h123\", \"i123\", \"ü123\"]");
+
+  const auto& typed_values = static_cast<const ArrayType&>(*values);
+
+  NodePtr node = PrimitiveNode::Make(
+      "field", Repetition::REQUIRED, Type::BYTE_ARRAY, ConvertedType::UTF8);
+  ColumnDescriptor descr(node, 0, 0);
+  auto stats = MakeStatistics<ByteArrayType>(&descr);
+  ASSERT_NO_FATAL_FAILURE(stats->Update(*values));
+
+  ASSERT_EQ(ByteArray(typed_values.GetView(2)), stats->min());
+  ASSERT_EQ(ByteArray(typed_values.GetView(9)), stats->max());
+  ASSERT_EQ(2, stats->null_count());
+}
+
+TEST(TestByteArrayStatisticsFromArrow, StringType) {
+  // Part of ARROW-3246. Replicating TestStatisticsSortOrder test but via Arrow
+  TestByteArrayStatisticsFromArrow<::arrow::StringType>();
+}
+
+TEST(TestByteArrayStatisticsFromArrow, LargeStringType) {
+  TestByteArrayStatisticsFromArrow<::arrow::LargeStringType>();
+}
+
+// Ensure UNKNOWN sort order is handled properly
+using TestStatisticsSortOrderFLBA = TestStatisticsSortOrder<FLBAType>;
+
+TEST_F(TestStatisticsSortOrderFLBA, UnknownSortOrder) {
+  this->fields_.push_back(schema::PrimitiveNode::Make(
+      "Column 0",
+      Repetition::REQUIRED,
+      Type::FIXED_LEN_BYTE_ARRAY,
+      ConvertedType::INTERVAL,
+      FLBA_LENGTH));
+  this->SetUpSchema();
+  this->WriteParquet();
+
+  ASSERT_OK_AND_ASSIGN(auto pbuffer, parquet_sink_->Finish());
+
+  // Create a ParquetReader instance
+  std::unique_ptr<ParquetFileReader> parquet_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(pbuffer));
+  // Get the File MetaData
+  std::shared_ptr<FileMetaData> file_metadata = parquet_reader->metadata();
+  std::shared_ptr<RowGroupMetaData> rg_metadata = file_metadata->RowGroup(0);
+  std::shared_ptr<ColumnChunkMetaData> cc_metadata =
+      rg_metadata->ColumnChunk(0);
+
+  // stats should not be set for UNKNOWN sort order
+  ASSERT_FALSE(cc_metadata->is_stats_set());
+}
+
+template <
+    typename Stats,
+    typename Array,
+    typename T = typename Array::value_type>
+void AssertMinMaxAre(
+    Stats stats,
+    const Array& values,
+    T expected_min,
+    T expected_max) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_TRUE(stats->HasMinMax());
+  EXPECT_EQ(stats->min(), expected_min);
+  EXPECT_EQ(stats->max(), expected_max);
+}
+
+template <typename Stats, typename Array, typename T = typename Stats::T>
+void AssertMinMaxAre(
+    Stats stats,
+    const Array& values,
+    const uint8_t* valid_bitmap,
+    T expected_min,
+    T expected_max) {
+  auto n_values = values.size();
+  auto null_count = ::arrow::internal::CountSetBits(valid_bitmap, n_values, 0);
+  auto non_null_count = n_values - null_count;
+  stats->UpdateSpaced(
+      values.data(),
+      valid_bitmap,
+      0,
+      non_null_count + null_count,
+      non_null_count,
+      null_count);
+  ASSERT_TRUE(stats->HasMinMax());
+  EXPECT_EQ(stats->min(), expected_min);
+  EXPECT_EQ(stats->max(), expected_max);
+}
+
+template <typename Stats, typename Array>
+void AssertUnsetMinMax(Stats stats, const Array& values) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_FALSE(stats->HasMinMax());
+}
+
+template <typename Stats, typename Array>
+void AssertUnsetMinMax(
+    Stats stats,
+    const Array& values,
+    const uint8_t* valid_bitmap) {
+  auto n_values = values.size();
+  auto null_count = ::arrow::internal::CountSetBits(valid_bitmap, n_values, 0);
+  auto non_null_count = n_values - null_count;
+  stats->UpdateSpaced(
+      values.data(),
+      valid_bitmap,
+      0,
+      non_null_count + null_count,
+      non_null_count,
+      null_count);
+  ASSERT_FALSE(stats->HasMinMax());
+}
+
+template <typename ParquetType, typename T = typename ParquetType::c_type>
+void CheckExtrema() {
+  using UT = typename std::make_unsigned<T>::type;
+
+  const T smin = std::numeric_limits<T>::min();
+  const T smax = std::numeric_limits<T>::max();
+  const T umin = SafeCopy<T>(std::numeric_limits<UT>::min());
+  const T umax = SafeCopy<T>(std::numeric_limits<UT>::max());
+
+  constexpr int kNumValues = 8;
+  std::array<T, kNumValues> values{
+      0, smin, smax, umin, umax, smin + 1, smax - 1, umax - 1};
+
+  NodePtr unsigned_node = PrimitiveNode::Make(
+      "uint",
+      Repetition::OPTIONAL,
+      LogicalType::Int(sizeof(T) * CHAR_BIT, false /*signed*/),
+      ParquetType::type_num);
+  ColumnDescriptor unsigned_descr(unsigned_node, 1, 1);
+  NodePtr signed_node = PrimitiveNode::Make(
+      "int",
+      Repetition::OPTIONAL,
+      LogicalType::Int(sizeof(T) * CHAR_BIT, true /*signed*/),
+      ParquetType::type_num);
+  ColumnDescriptor signed_descr(signed_node, 1, 1);
+
+  {
+    ARROW_SCOPED_TRACE(
+        "unsigned statistics: umin = ",
+        umin,
+        ", umax = ",
+        umax,
+        ", node type = ",
+        unsigned_node->logical_type()->ToString(),
+        ", physical type = ",
+        unsigned_descr.physical_type(),
+        ", sort order = ",
+        unsigned_descr.sort_order());
+    auto unsigned_stats = MakeStatistics<ParquetType>(&unsigned_descr);
+    AssertMinMaxAre(unsigned_stats, values, umin, umax);
+  }
+  {
+    ARROW_SCOPED_TRACE(
+        "signed statistics: smin = ",
+        smin,
+        ", smax = ",
+        smax,
+        ", node type = ",
+        signed_node->logical_type()->ToString(),
+        ", physical type = ",
+        signed_descr.physical_type(),
+        ", sort order = ",
+        signed_descr.sort_order());
+    auto signed_stats = MakeStatistics<ParquetType>(&signed_descr);
+    AssertMinMaxAre(signed_stats, values, smin, smax);
+  }
+
+  // With validity bitmap
+  std::vector<bool> is_valid = {
+      true, false, false, false, false, true, true, true};
+  std::shared_ptr<Buffer> valid_bitmap;
+  ::arrow::BitmapFromVector(is_valid, &valid_bitmap);
+  {
+    ARROW_SCOPED_TRACE(
+        "spaced unsigned statistics: umin = ",
+        umin,
+        ", umax = ",
+        umax,
+        ", node type = ",
+        unsigned_node->logical_type()->ToString(),
+        ", physical type = ",
+        unsigned_descr.physical_type(),
+        ", sort order = ",
+        unsigned_descr.sort_order());
+    auto unsigned_stats = MakeStatistics<ParquetType>(&unsigned_descr);
+    AssertMinMaxAre(
+        unsigned_stats, values, valid_bitmap->data(), T{0}, umax - 1);
+  }
+  {
+    ARROW_SCOPED_TRACE(
+        "spaced signed statistics: smin = ",
+        smin,
+        ", smax = ",
+        smax,
+        ", node type = ",
+        signed_node->logical_type()->ToString(),
+        ", physical type = ",
+        signed_descr.physical_type(),
+        ", sort order = ",
+        signed_descr.sort_order());
+    auto signed_stats = MakeStatistics<ParquetType>(&signed_descr);
+    AssertMinMaxAre(
+        signed_stats, values, valid_bitmap->data(), smin + 1, smax - 1);
+  }
+}
+
+TEST(TestStatistic, Int32Extrema) {
+  CheckExtrema<Int32Type>();
+}
+TEST(TestStatistic, Int64Extrema) {
+  CheckExtrema<Int64Type>();
+}
+
+// PARQUET-1225: Float NaN values may lead to incorrect min-max
+template <typename ParquetType>
+void CheckNaNs() {
+  using T = typename ParquetType::c_type;
+
+  constexpr int kNumValues = 8;
+  NodePtr node =
+      PrimitiveNode::Make("f", Repetition::OPTIONAL, ParquetType::type_num);
+  ColumnDescriptor descr(node, 1, 1);
+
+  constexpr T nan = std::numeric_limits<T>::quiet_NaN();
+  constexpr T min = -4.0f;
+  constexpr T max = 3.0f;
+
+  std::array<T, kNumValues> all_nans{nan, nan, nan, nan, nan, nan, nan, nan};
+  std::array<T, kNumValues> some_nans{
+      nan, max, -3.0f, -1.0f, nan, 2.0f, min, nan};
+  uint8_t valid_bitmap = 0x7F; // 0b01111111
+  // NaNs excluded
+  uint8_t valid_bitmap_no_nans = 0x6E; // 0b01101110
+
+  // Test values
+  auto some_nan_stats = MakeStatistics<ParquetType>(&descr);
+  // Ingesting only nans should not yield valid min max
+  AssertUnsetMinMax(some_nan_stats, all_nans);
+  // Ingesting a mix of NaNs and non-NaNs should not yield valid min max.
+  AssertMinMaxAre(some_nan_stats, some_nans, min, max);
+  // Ingesting only nans after a valid min/max, should have not effect
+  AssertMinMaxAre(some_nan_stats, all_nans, min, max);
+
+  some_nan_stats = MakeStatistics<ParquetType>(&descr);
+  AssertUnsetMinMax(some_nan_stats, all_nans, &valid_bitmap);
+  // NaNs should not pollute min max when excluded via null bitmap.
+  AssertMinMaxAre(some_nan_stats, some_nans, &valid_bitmap_no_nans, min, max);
+  // Ingesting NaNs with a null bitmap should not change the result.
+  AssertMinMaxAre(some_nan_stats, some_nans, &valid_bitmap, min, max);
+
+  // An array that doesn't start with NaN
+  std::array<T, kNumValues> other_nans{
+      1.5f, max, -3.0f, -1.0f, nan, 2.0f, min, nan};
+  auto other_stats = MakeStatistics<ParquetType>(&descr);
+  AssertMinMaxAre(other_stats, other_nans, min, max);
+}
+
+TEST(TestStatistic, NaNFloatValues) {
+  CheckNaNs<FloatType>();
+}
+
+TEST(TestStatistic, NaNDoubleValues) {
+  CheckNaNs<DoubleType>();
+}
+
+// ARROW-7376
+TEST(TestStatisticsSortOrderFloatNaN, NaNAndNullsInfiniteLoop) {
+  constexpr int kNumValues = 8;
+  NodePtr node =
+      PrimitiveNode::Make("nan_float", Repetition::OPTIONAL, Type::FLOAT);
+  ColumnDescriptor descr(node, 1, 1);
+
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  std::array<float, kNumValues> nans_but_last{
+      nan, nan, nan, nan, nan, nan, nan, 0.0f};
+
+  uint8_t all_but_last_valid = 0x7F; // 0b01111111
+  auto stats = MakeStatistics<FloatType>(&descr);
+  AssertUnsetMinMax(stats, nans_but_last, &all_but_last_valid);
+}
+
+template <
+    typename Stats,
+    typename Array,
+    typename T = typename Array::value_type>
+void AssertMinMaxZeroesSign(Stats stats, const Array& values) {
+  stats->Update(values.data(), values.size(), 0);
+  ASSERT_TRUE(stats->HasMinMax());
+
+  T zero{};
+  ASSERT_EQ(stats->min(), zero);
+  ASSERT_TRUE(std::signbit(stats->min()));
+
+  ASSERT_EQ(stats->max(), zero);
+  ASSERT_FALSE(std::signbit(stats->max()));
+}
+
+// ARROW-5562: Ensure that -0.0f and 0.0f values are properly handled like in
+// parquet-mr
+template <typename ParquetType>
+void CheckNegativeZeroStats() {
+  using T = typename ParquetType::c_type;
+
+  NodePtr node =
+      PrimitiveNode::Make("f", Repetition::OPTIONAL, ParquetType::type_num);
+  ColumnDescriptor descr(node, 1, 1);
+  T zero{};
+
+  {
+    std::array<T, 2> values{-zero, zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
+  }
+
+  {
+    std::array<T, 2> values{zero, -zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
+  }
+
+  {
+    std::array<T, 2> values{-zero, -zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
+  }
+
+  {
+    std::array<T, 2> values{zero, zero};
+    auto stats = MakeStatistics<ParquetType>(&descr);
+    AssertMinMaxZeroesSign(stats, values);
+  }
+}
+
+TEST(TestStatistics, FloatNegativeZero) {
+  CheckNegativeZeroStats<FloatType>();
+}
+
+TEST(TestStatistics, DoubleNegativeZero) {
+  CheckNegativeZeroStats<DoubleType>();
+}
+
+// TODO: disabled as it requires Arrow parquet data dir.
+// Test statistics for binary column with UNSIGNED sort order
+/*
+TEST(TestStatisticsSortOrderMinMax, Unsigned) {
+  std::string dir_string(test::get_data_dir());
+  std::stringstream ss;
+  ss << dir_string << "/binary.parquet";
+  auto path = ss.str();
+
+  // The file is generated by parquet-mr 1.10.0, the first version that
+  // supports correct statistics for binary data (see PARQUET-1025). It
+  // contains a single column of binary type. Data is just single byte values
+  // from 0x00 to 0x0B.
+  auto file_reader = ParquetFileReader::OpenFile(path);
+  auto rg_reader = file_reader->RowGroup(0);
+  auto metadata = rg_reader->metadata();
+  auto column_schema = metadata->schema()->Column(0);
+  ASSERT_EQ(SortOrder::UNSIGNED, column_schema->sort_order());
+
+  auto column_chunk = metadata->ColumnChunk(0);
+  ASSERT_TRUE(column_chunk->is_stats_set());
+
+  std::shared_ptr<Statistics> stats = column_chunk->statistics();
+  ASSERT_TRUE(stats != NULL);
+  ASSERT_EQ(0, stats->null_count());
+  ASSERT_EQ(12, stats->num_values());
+  ASSERT_EQ(0x00, stats->EncodeMin()[0]);
+  ASSERT_EQ(0x0b, stats->EncodeMax()[0]);
+}
+
+TEST(TestEncodedStatistics, CopySafe) {
+  EncodedStatistics encoded_statistics;
+  encoded_statistics.set_max("abc");
+  encoded_statistics.has_max = true;
+
+  encoded_statistics.set_min("abc");
+  encoded_statistics.has_min = true;
+
+  EncodedStatistics copy_statistics = encoded_statistics;
+  copy_statistics.set_max("abcd");
+  copy_statistics.set_min("a");
+
+  EXPECT_EQ("abc", encoded_statistics.min());
+  EXPECT_EQ("abc", encoded_statistics.max());
+}
+*/
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/TestUtil.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/TestUtil.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/TestUtil.h"
+
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Encoding.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+
+namespace facebook::velox::parquet::arrow {
+namespace test {
+
+const char* get_data_dir() {
+  const auto result = std::getenv("PARQUET_TEST_DATA");
+  if (!result || !result[0]) {
+    throw ParquetTestException(
+        "Please point the PARQUET_TEST_DATA environment "
+        "variable to the test data directory");
+  }
+  return result;
+}
+
+std::string get_bad_data_dir() {
+  // PARQUET_TEST_DATA should point to
+  // ARROW_HOME/cpp/submodules/parquet-testing/data so need to reach one folder
+  // up to access the "bad_data" folder.
+  std::string data_dir(get_data_dir());
+  std::stringstream ss;
+  ss << data_dir << "/../bad_data";
+  return ss.str();
+}
+
+std::string get_data_file(const std::string& filename, bool is_good) {
+  std::stringstream ss;
+
+  if (is_good) {
+    ss << get_data_dir();
+  } else {
+    ss << get_bad_data_dir();
+  }
+
+  ss << "/" << filename;
+  return ss.str();
+}
+
+void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<int> d(0, 255);
+
+  out->resize(n);
+  for (int i = 0; i < n; ++i) {
+    (*out)[i] = static_cast<uint8_t>(d(gen));
+  }
+}
+
+void random_bools(int n, double p, uint32_t seed, bool* out) {
+  std::default_random_engine gen(seed);
+  std::bernoulli_distribution d(p);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
+void random_Int96_numbers(
+    int n,
+    uint32_t seed,
+    int32_t min_value,
+    int32_t max_value,
+    Int96* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<int32_t> d(min_value, max_value);
+  for (int i = 0; i < n; ++i) {
+    out[i].value[0] = d(gen);
+    out[i].value[1] = d(gen);
+    out[i].value[2] = d(gen);
+  }
+}
+
+void random_fixed_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    int len,
+    FLBA* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<int> d(0, 255);
+  for (int i = 0; i < n; ++i) {
+    out[i].ptr = buf;
+    for (int j = 0; j < len; ++j) {
+      buf[j] = static_cast<uint8_t>(d(gen));
+    }
+    buf += len;
+  }
+}
+
+void random_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    ByteArray* out,
+    int min_size,
+    int max_size) {
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<int> d1(min_size, max_size);
+  std::uniform_int_distribution<int> d2(0, 255);
+  for (int i = 0; i < n; ++i) {
+    int len = d1(gen);
+    out[i].len = len;
+    out[i].ptr = buf;
+    for (int j = 0; j < len; ++j) {
+      buf[j] = static_cast<uint8_t>(d2(gen));
+    }
+    buf += len;
+  }
+}
+
+void random_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    ByteArray* out,
+    int max_size) {
+  random_byte_array(n, seed, buf, out, 0, max_size);
+}
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/TestUtil.h
+++ b/velox/dwio/parquet/writer/arrow/tests/TestUtil.h
@@ -1,0 +1,974 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/io/memory.h"
+#include "arrow/testing/util.h"
+
+#include "velox/dwio/parquet/writer/arrow/ColumnPage.h"
+#include "velox/dwio/parquet/writer/arrow/ColumnWriter.h"
+#include "velox/dwio/parquet/writer/arrow/Encoding.h"
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/tests/ColumnReader.h"
+
+// https://github.com/google/googletest/pull/2904 might not be available
+// in our version of gtest/gmock
+#define EXPECT_THROW_THAT(callable, ex_type, property)   \
+  EXPECT_THROW(                                          \
+      try { (callable)(); } catch (const ex_type& err) { \
+        EXPECT_THAT(err, (property));                    \
+        throw;                                           \
+      },                                                 \
+      ex_type)
+
+namespace facebook::velox::parquet::arrow {
+
+static constexpr int FLBA_LENGTH = 12;
+
+inline bool operator==(const FixedLenByteArray& a, const FixedLenByteArray& b) {
+  return 0 == memcmp(a.ptr, b.ptr, FLBA_LENGTH);
+}
+
+namespace test {
+
+typedef ::testing::Types<
+    BooleanType,
+    Int32Type,
+    Int64Type,
+    Int96Type,
+    FloatType,
+    DoubleType,
+    ByteArrayType,
+    FLBAType>
+    ParquetTypes;
+
+class ParquetTestException : public ParquetException {
+  using ParquetException::ParquetException;
+};
+
+const char* get_data_dir();
+std::string get_bad_data_dir();
+
+std::string get_data_file(const std::string& filename, bool is_good = true);
+
+template <typename T>
+static inline void assert_vector_equal(
+    const std::vector<T>& left,
+    const std::vector<T>& right) {
+  ASSERT_EQ(left.size(), right.size());
+
+  for (size_t i = 0; i < left.size(); ++i) {
+    ASSERT_EQ(left[i], right[i]) << i;
+  }
+}
+
+template <typename T>
+static inline bool vector_equal(
+    const std::vector<T>& left,
+    const std::vector<T>& right) {
+  if (left.size() != right.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (left[i] != right[i]) {
+      std::cerr << "index " << i << " left was " << left[i] << " right was "
+                << right[i] << std::endl;
+      return false;
+    }
+  }
+
+  return true;
+}
+
+template <typename T>
+static std::vector<T> slice(const std::vector<T>& values, int start, int end) {
+  if (end < start) {
+    return std::vector<T>(0);
+  }
+
+  std::vector<T> out(end - start);
+  for (int i = start; i < end; ++i) {
+    out[i - start] = values[i];
+  }
+  return out;
+}
+
+void random_bytes(int n, uint32_t seed, std::vector<uint8_t>* out);
+void random_bools(int n, double p, uint32_t seed, bool* out);
+
+template <typename T>
+inline void
+random_numbers(int n, uint32_t seed, T min_value, T max_value, T* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_int_distribution<T> d(min_value, max_value);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
+template <>
+inline void random_numbers(
+    int n,
+    uint32_t seed,
+    float min_value,
+    float max_value,
+    float* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_real_distribution<float> d(min_value, max_value);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
+template <>
+inline void random_numbers(
+    int n,
+    uint32_t seed,
+    double min_value,
+    double max_value,
+    double* out) {
+  std::default_random_engine gen(seed);
+  std::uniform_real_distribution<double> d(min_value, max_value);
+  for (int i = 0; i < n; ++i) {
+    out[i] = d(gen);
+  }
+}
+
+void random_Int96_numbers(
+    int n,
+    uint32_t seed,
+    int32_t min_value,
+    int32_t max_value,
+    Int96* out);
+
+void random_fixed_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    int len,
+    FLBA* out);
+
+void random_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    ByteArray* out,
+    int min_size,
+    int max_size);
+
+void random_byte_array(
+    int n,
+    uint32_t seed,
+    uint8_t* buf,
+    ByteArray* out,
+    int max_size);
+
+template <typename Type, typename Sequence>
+std::shared_ptr<Buffer> EncodeValues(
+    Encoding::type encoding,
+    bool use_dictionary,
+    const Sequence& values,
+    int length,
+    const ColumnDescriptor* descr) {
+  auto encoder = MakeTypedEncoder<Type>(encoding, use_dictionary, descr);
+  encoder->Put(values, length);
+  return encoder->FlushValues();
+}
+
+template <typename T>
+static void InitValues(
+    int num_values,
+    uint32_t seed,
+    std::vector<T>& values,
+    std::vector<uint8_t>& buffer) {
+  random_numbers(
+      num_values,
+      seed,
+      std::numeric_limits<T>::min(),
+      std::numeric_limits<T>::max(),
+      values.data());
+}
+
+template <typename T>
+static void InitValues(
+    int num_values,
+    std::vector<T>& values,
+    std::vector<uint8_t>& buffer) {
+  InitValues(num_values, 0, values, buffer);
+}
+
+template <typename T>
+static void InitDictValues(
+    int num_values,
+    int num_dicts,
+    std::vector<T>& values,
+    std::vector<uint8_t>& buffer) {
+  int repeat_factor = num_values / num_dicts;
+  InitValues<T>(num_dicts, values, buffer);
+  // add some repeated values
+  for (int j = 1; j < repeat_factor; ++j) {
+    for (int i = 0; i < num_dicts; ++i) {
+      std::memcpy(&values[num_dicts * j + i], &values[i], sizeof(T));
+    }
+  }
+  // computed only dict_per_page * repeat_factor - 1 values < num_values
+  // compute remaining
+  for (int i = num_dicts * repeat_factor; i < num_values; ++i) {
+    std::memcpy(&values[i], &values[i - num_dicts * repeat_factor], sizeof(T));
+  }
+}
+
+template <>
+inline void InitDictValues<bool>(
+    int num_values,
+    int num_dicts,
+    std::vector<bool>& values,
+    std::vector<uint8_t>& buffer) {
+  // No op for bool
+}
+
+class MockPageReader : public PageReader {
+ public:
+  explicit MockPageReader(const std::vector<std::shared_ptr<Page>>& pages)
+      : pages_(pages), page_index_(0) {}
+
+  std::shared_ptr<Page> NextPage() override {
+    if (page_index_ == static_cast<int>(pages_.size())) {
+      // EOS to consumer
+      return std::shared_ptr<Page>(nullptr);
+    }
+    return pages_[page_index_++];
+  }
+
+  // No-op
+  void set_max_page_header_size(uint32_t size) override {}
+
+ private:
+  std::vector<std::shared_ptr<Page>> pages_;
+  int page_index_;
+};
+
+// TODO(wesm): this is only used for testing for now. Refactor to form part of
+// primary file write path
+template <typename Type>
+class DataPageBuilder {
+ public:
+  using c_type = typename Type::c_type;
+
+  // This class writes data and metadata to the passed inputs
+  explicit DataPageBuilder(ArrowOutputStream* sink)
+      : sink_(sink),
+        num_values_(0),
+        encoding_(Encoding::PLAIN),
+        definition_level_encoding_(Encoding::RLE),
+        repetition_level_encoding_(Encoding::RLE),
+        have_def_levels_(false),
+        have_rep_levels_(false),
+        have_values_(false) {}
+
+  void AppendDefLevels(
+      const std::vector<int16_t>& levels,
+      int16_t max_level,
+      Encoding::type encoding = Encoding::RLE) {
+    AppendLevels(levels, max_level, encoding);
+
+    num_values_ = std::max(static_cast<int32_t>(levels.size()), num_values_);
+    definition_level_encoding_ = encoding;
+    have_def_levels_ = true;
+  }
+
+  void AppendRepLevels(
+      const std::vector<int16_t>& levels,
+      int16_t max_level,
+      Encoding::type encoding = Encoding::RLE) {
+    AppendLevels(levels, max_level, encoding);
+
+    num_values_ = std::max(static_cast<int32_t>(levels.size()), num_values_);
+    repetition_level_encoding_ = encoding;
+    have_rep_levels_ = true;
+  }
+
+  void AppendValues(
+      const ColumnDescriptor* d,
+      const std::vector<c_type>& values,
+      Encoding::type encoding = Encoding::PLAIN) {
+    std::shared_ptr<Buffer> values_sink = EncodeValues<Type>(
+        encoding, false, values.data(), static_cast<int>(values.size()), d);
+    PARQUET_THROW_NOT_OK(
+        sink_->Write(values_sink->data(), values_sink->size()));
+
+    num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
+    encoding_ = encoding;
+    have_values_ = true;
+  }
+
+  int32_t num_values() const {
+    return num_values_;
+  }
+
+  Encoding::type encoding() const {
+    return encoding_;
+  }
+
+  Encoding::type rep_level_encoding() const {
+    return repetition_level_encoding_;
+  }
+
+  Encoding::type def_level_encoding() const {
+    return definition_level_encoding_;
+  }
+
+ private:
+  ArrowOutputStream* sink_;
+
+  int32_t num_values_;
+  Encoding::type encoding_;
+  Encoding::type definition_level_encoding_;
+  Encoding::type repetition_level_encoding_;
+
+  bool have_def_levels_;
+  bool have_rep_levels_;
+  bool have_values_;
+
+  // Used internally for both repetition and definition levels
+  void AppendLevels(
+      const std::vector<int16_t>& levels,
+      int16_t max_level,
+      Encoding::type encoding) {
+    if (encoding != Encoding::RLE) {
+      ParquetException::NYI("only rle encoding currently implemented");
+    }
+
+    std::vector<uint8_t> encode_buffer(LevelEncoder::MaxBufferSize(
+        Encoding::RLE, max_level, static_cast<int>(levels.size())));
+
+    // We encode into separate memory from the output stream because the
+    // RLE-encoded bytes have to be preceded in the stream by their absolute
+    // size.
+    LevelEncoder encoder;
+    encoder.Init(
+        encoding,
+        max_level,
+        static_cast<int>(levels.size()),
+        encode_buffer.data(),
+        static_cast<int>(encode_buffer.size()));
+
+    encoder.Encode(static_cast<int>(levels.size()), levels.data());
+
+    int32_t rle_bytes = encoder.len();
+    PARQUET_THROW_NOT_OK(sink_->Write(
+        reinterpret_cast<const uint8_t*>(&rle_bytes), sizeof(int32_t)));
+    PARQUET_THROW_NOT_OK(sink_->Write(encode_buffer.data(), rle_bytes));
+  }
+};
+
+template <>
+inline void DataPageBuilder<BooleanType>::AppendValues(
+    const ColumnDescriptor* d,
+    const std::vector<bool>& values,
+    Encoding::type encoding) {
+  if (encoding != Encoding::PLAIN) {
+    ParquetException::NYI("only plain encoding currently implemented");
+  }
+
+  auto encoder = MakeTypedEncoder<BooleanType>(Encoding::PLAIN, false, d);
+  dynamic_cast<BooleanEncoder*>(encoder.get())
+      ->Put(values, static_cast<int>(values.size()));
+  std::shared_ptr<Buffer> buffer = encoder->FlushValues();
+  PARQUET_THROW_NOT_OK(sink_->Write(buffer->data(), buffer->size()));
+
+  num_values_ = std::max(static_cast<int32_t>(values.size()), num_values_);
+  encoding_ = encoding;
+  have_values_ = true;
+}
+
+template <typename Type>
+static std::shared_ptr<DataPageV1> MakeDataPage(
+    const ColumnDescriptor* d,
+    const std::vector<typename Type::c_type>& values,
+    int num_vals,
+    Encoding::type encoding,
+    const uint8_t* indices,
+    int indices_size,
+    const std::vector<int16_t>& def_levels,
+    int16_t max_def_level,
+    const std::vector<int16_t>& rep_levels,
+    int16_t max_rep_level) {
+  int num_values = 0;
+
+  auto page_stream = CreateOutputStream();
+  test::DataPageBuilder<Type> page_builder(page_stream.get());
+
+  if (!rep_levels.empty()) {
+    page_builder.AppendRepLevels(rep_levels, max_rep_level);
+  }
+  if (!def_levels.empty()) {
+    page_builder.AppendDefLevels(def_levels, max_def_level);
+  }
+
+  if (encoding == Encoding::PLAIN) {
+    page_builder.AppendValues(d, values, encoding);
+    num_values = std::max(page_builder.num_values(), num_vals);
+  } else { // DICTIONARY PAGES
+    PARQUET_THROW_NOT_OK(page_stream->Write(indices, indices_size));
+    num_values = std::max(page_builder.num_values(), num_vals);
+  }
+
+  PARQUET_ASSIGN_OR_THROW(auto buffer, page_stream->Finish());
+
+  return std::make_shared<DataPageV1>(
+      buffer,
+      num_values,
+      encoding,
+      page_builder.def_level_encoding(),
+      page_builder.rep_level_encoding(),
+      buffer->size());
+}
+
+template <typename TYPE>
+class DictionaryPageBuilder {
+ public:
+  typedef typename TYPE::c_type TC;
+  static constexpr int TN = TYPE::type_num;
+  using SpecializedEncoder = typename EncodingTraits<TYPE>::Encoder;
+
+  // This class writes data and metadata to the passed inputs
+  explicit DictionaryPageBuilder(const ColumnDescriptor* d)
+      : num_dict_values_(0), have_values_(false) {
+    auto encoder = MakeTypedEncoder<TYPE>(Encoding::PLAIN, true, d);
+    dict_traits_ = dynamic_cast<DictEncoder<TYPE>*>(encoder.get());
+    encoder_.reset(dynamic_cast<SpecializedEncoder*>(encoder.release()));
+  }
+
+  ~DictionaryPageBuilder() {}
+
+  std::shared_ptr<Buffer> AppendValues(const std::vector<TC>& values) {
+    int num_values = static_cast<int>(values.size());
+    // Dictionary encoding
+    encoder_->Put(values.data(), num_values);
+    num_dict_values_ = dict_traits_->num_entries();
+    have_values_ = true;
+    return encoder_->FlushValues();
+  }
+
+  std::shared_ptr<Buffer> WriteDict() {
+    std::shared_ptr<Buffer> dict_buffer = AllocateBuffer(
+        ::arrow::default_memory_pool(), dict_traits_->dict_encoded_size());
+    dict_traits_->WriteDict(dict_buffer->mutable_data());
+    return dict_buffer;
+  }
+
+  int32_t num_values() const {
+    return num_dict_values_;
+  }
+
+ private:
+  DictEncoder<TYPE>* dict_traits_;
+  std::unique_ptr<SpecializedEncoder> encoder_;
+  int32_t num_dict_values_;
+  bool have_values_;
+};
+
+template <>
+inline DictionaryPageBuilder<BooleanType>::DictionaryPageBuilder(
+    const ColumnDescriptor* d) {
+  ParquetException::NYI(
+      "only plain encoding currently implemented for boolean");
+}
+
+template <>
+inline std::shared_ptr<Buffer> DictionaryPageBuilder<BooleanType>::WriteDict() {
+  ParquetException::NYI(
+      "only plain encoding currently implemented for boolean");
+  return nullptr;
+}
+
+template <>
+inline std::shared_ptr<Buffer> DictionaryPageBuilder<BooleanType>::AppendValues(
+    const std::vector<TC>& values) {
+  ParquetException::NYI(
+      "only plain encoding currently implemented for boolean");
+  return nullptr;
+}
+
+template <typename Type>
+inline static std::shared_ptr<DictionaryPage> MakeDictPage(
+    const ColumnDescriptor* d,
+    const std::vector<typename Type::c_type>& values,
+    const std::vector<int>& values_per_page,
+    Encoding::type encoding,
+    std::vector<std::shared_ptr<Buffer>>& rle_indices) {
+  test::DictionaryPageBuilder<Type> page_builder(d);
+  int num_pages = static_cast<int>(values_per_page.size());
+  int value_start = 0;
+
+  for (int i = 0; i < num_pages; i++) {
+    rle_indices.push_back(page_builder.AppendValues(
+        slice(values, value_start, value_start + values_per_page[i])));
+    value_start += values_per_page[i];
+  }
+
+  auto buffer = page_builder.WriteDict();
+
+  return std::make_shared<DictionaryPage>(
+      buffer, page_builder.num_values(), Encoding::PLAIN);
+}
+
+// Given def/rep levels and values create multiple dict pages
+template <typename Type>
+inline static void PaginateDict(
+    const ColumnDescriptor* d,
+    const std::vector<typename Type::c_type>& values,
+    const std::vector<int16_t>& def_levels,
+    int16_t max_def_level,
+    const std::vector<int16_t>& rep_levels,
+    int16_t max_rep_level,
+    int num_levels_per_page,
+    const std::vector<int>& values_per_page,
+    std::vector<std::shared_ptr<Page>>& pages,
+    Encoding::type encoding = Encoding::RLE_DICTIONARY) {
+  int num_pages = static_cast<int>(values_per_page.size());
+  std::vector<std::shared_ptr<Buffer>> rle_indices;
+  std::shared_ptr<DictionaryPage> dict_page =
+      MakeDictPage<Type>(d, values, values_per_page, encoding, rle_indices);
+  pages.push_back(dict_page);
+  int def_level_start = 0;
+  int def_level_end = 0;
+  int rep_level_start = 0;
+  int rep_level_end = 0;
+  for (int i = 0; i < num_pages; i++) {
+    if (max_def_level > 0) {
+      def_level_start = i * num_levels_per_page;
+      def_level_end = (i + 1) * num_levels_per_page;
+    }
+    if (max_rep_level > 0) {
+      rep_level_start = i * num_levels_per_page;
+      rep_level_end = (i + 1) * num_levels_per_page;
+    }
+    std::shared_ptr<DataPageV1> data_page = MakeDataPage<Int32Type>(
+        d,
+        {},
+        values_per_page[i],
+        encoding,
+        rle_indices[i]->data(),
+        static_cast<int>(rle_indices[i]->size()),
+        slice(def_levels, def_level_start, def_level_end),
+        max_def_level,
+        slice(rep_levels, rep_level_start, rep_level_end),
+        max_rep_level);
+    pages.push_back(data_page);
+  }
+}
+
+// Given def/rep levels and values create multiple plain pages
+template <typename Type>
+static inline void PaginatePlain(
+    const ColumnDescriptor* d,
+    const std::vector<typename Type::c_type>& values,
+    const std::vector<int16_t>& def_levels,
+    int16_t max_def_level,
+    const std::vector<int16_t>& rep_levels,
+    int16_t max_rep_level,
+    int num_levels_per_page,
+    const std::vector<int>& values_per_page,
+    std::vector<std::shared_ptr<Page>>& pages,
+    Encoding::type encoding = Encoding::PLAIN) {
+  int num_pages = static_cast<int>(values_per_page.size());
+  int def_level_start = 0;
+  int def_level_end = 0;
+  int rep_level_start = 0;
+  int rep_level_end = 0;
+  int value_start = 0;
+  for (int i = 0; i < num_pages; i++) {
+    if (max_def_level > 0) {
+      def_level_start = i * num_levels_per_page;
+      def_level_end = (i + 1) * num_levels_per_page;
+    }
+    if (max_rep_level > 0) {
+      rep_level_start = i * num_levels_per_page;
+      rep_level_end = (i + 1) * num_levels_per_page;
+    }
+    std::shared_ptr<DataPage> page = MakeDataPage<Type>(
+        d,
+        slice(values, value_start, value_start + values_per_page[i]),
+        values_per_page[i],
+        encoding,
+        nullptr,
+        0,
+        slice(def_levels, def_level_start, def_level_end),
+        max_def_level,
+        slice(rep_levels, rep_level_start, rep_level_end),
+        max_rep_level);
+    pages.push_back(page);
+    value_start += values_per_page[i];
+  }
+}
+
+// Generates pages from randomly generated data
+template <typename Type>
+static inline int MakePages(
+    const ColumnDescriptor* d,
+    int num_pages,
+    int levels_per_page,
+    std::vector<int16_t>& def_levels,
+    std::vector<int16_t>& rep_levels,
+    std::vector<typename Type::c_type>& values,
+    std::vector<uint8_t>& buffer,
+    std::vector<std::shared_ptr<Page>>& pages,
+    Encoding::type encoding = Encoding::PLAIN,
+    uint32_t seed = 0) {
+  int num_levels = levels_per_page * num_pages;
+  int num_values = 0;
+  int16_t zero = 0;
+  int16_t max_def_level = d->max_definition_level();
+  int16_t max_rep_level = d->max_repetition_level();
+  std::vector<int> values_per_page(num_pages, levels_per_page);
+  // Create definition levels
+  if (max_def_level > 0 && num_levels != 0) {
+    def_levels.resize(num_levels);
+    random_numbers(num_levels, seed, zero, max_def_level, def_levels.data());
+    for (int p = 0; p < num_pages; p++) {
+      int num_values_per_page = 0;
+      for (int i = 0; i < levels_per_page; i++) {
+        if (def_levels[i + p * levels_per_page] == max_def_level) {
+          num_values_per_page++;
+          num_values++;
+        }
+      }
+      values_per_page[p] = num_values_per_page;
+    }
+  } else {
+    num_values = num_levels;
+  }
+  // Create repitition levels
+  if (max_rep_level > 0 && num_levels != 0) {
+    rep_levels.resize(num_levels);
+    // Using a different seed so that def_levels and rep_levels are different.
+    random_numbers(
+        num_levels, seed + 789, zero, max_rep_level, rep_levels.data());
+    // The generated levels are random. Force the very first page to start with
+    // a new record.
+    rep_levels[0] = 0;
+    // For a null value, rep_levels and def_levels are both 0.
+    // If we have a repeated value right after this, it needs to start with
+    // rep_level = 0 to indicate a new record.
+    for (int i = 0; i < num_levels - 1; ++i) {
+      if (rep_levels[i] == 0 && def_levels[i] == 0) {
+        rep_levels[i + 1] = 0;
+      }
+    }
+  }
+  // Create values
+  values.resize(num_values);
+  if (encoding == Encoding::PLAIN) {
+    InitValues<typename Type::c_type>(num_values, values, buffer);
+    PaginatePlain<Type>(
+        d,
+        values,
+        def_levels,
+        max_def_level,
+        rep_levels,
+        max_rep_level,
+        levels_per_page,
+        values_per_page,
+        pages);
+  } else if (
+      encoding == Encoding::RLE_DICTIONARY ||
+      encoding == Encoding::PLAIN_DICTIONARY) {
+    // Calls InitValues and repeats the data
+    InitDictValues<typename Type::c_type>(
+        num_values, levels_per_page, values, buffer);
+    PaginateDict<Type>(
+        d,
+        values,
+        def_levels,
+        max_def_level,
+        rep_levels,
+        max_rep_level,
+        levels_per_page,
+        values_per_page,
+        pages);
+  }
+
+  return num_values;
+}
+
+// ----------------------------------------------------------------------
+// Test data generation
+
+template <>
+void inline InitValues<bool>(
+    int num_values,
+    uint32_t seed,
+    std::vector<bool>& values,
+    std::vector<uint8_t>& buffer) {
+  values = {};
+  if (seed == 0) {
+    seed = static_cast<uint32_t>(::arrow::random_seed());
+  }
+  ::arrow::random_is_valid(num_values, 0.5, &values, static_cast<int>(seed));
+}
+
+template <>
+inline void InitValues<ByteArray>(
+    int num_values,
+    uint32_t seed,
+    std::vector<ByteArray>& values,
+    std::vector<uint8_t>& buffer) {
+  int max_byte_array_len = 12;
+  int num_bytes = static_cast<int>(max_byte_array_len + sizeof(uint32_t));
+  size_t nbytes = num_values * num_bytes;
+  buffer.resize(nbytes);
+  random_byte_array(
+      num_values, seed, buffer.data(), values.data(), max_byte_array_len);
+}
+
+inline void InitWideByteArrayValues(
+    int num_values,
+    std::vector<ByteArray>& values,
+    std::vector<uint8_t>& buffer,
+    int min_len,
+    int max_len) {
+  int num_bytes = static_cast<int>(max_len + sizeof(uint32_t));
+  size_t nbytes = num_values * num_bytes;
+  buffer.resize(nbytes);
+  random_byte_array(
+      num_values, 0, buffer.data(), values.data(), min_len, max_len);
+}
+
+template <>
+inline void InitValues<FLBA>(
+    int num_values,
+    uint32_t seed,
+    std::vector<FLBA>& values,
+    std::vector<uint8_t>& buffer) {
+  size_t nbytes = num_values * FLBA_LENGTH;
+  buffer.resize(nbytes);
+  random_fixed_byte_array(
+      num_values, seed, buffer.data(), FLBA_LENGTH, values.data());
+}
+
+template <>
+inline void InitValues<Int96>(
+    int num_values,
+    uint32_t seed,
+    std::vector<Int96>& values,
+    std::vector<uint8_t>& buffer) {
+  random_Int96_numbers(
+      num_values,
+      seed,
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+      values.data());
+}
+
+inline std::string TestColumnName(int i) {
+  std::stringstream col_name;
+  col_name << "column_" << i;
+  return col_name.str();
+}
+
+// This class lives here because of its dependency on the InitValues
+// specializations.
+template <typename TestType>
+class PrimitiveTypedTest : public ::testing::Test {
+ public:
+  using c_type = typename TestType::c_type;
+
+  void SetUpSchema(Repetition::type repetition, int num_columns = 1) {
+    std::vector<schema::NodePtr> fields;
+
+    for (int i = 0; i < num_columns; ++i) {
+      std::string name = TestColumnName(i);
+      fields.push_back(schema::PrimitiveNode::Make(
+          name,
+          repetition,
+          TestType::type_num,
+          ConvertedType::NONE,
+          FLBA_LENGTH));
+    }
+    node_ = schema::GroupNode::Make("schema", Repetition::REQUIRED, fields);
+    schema_.Init(node_);
+  }
+
+  void GenerateData(int64_t num_values, uint32_t seed = 0);
+  void SetupValuesOut(int64_t num_values);
+  void SyncValuesOut();
+
+ protected:
+  schema::NodePtr node_;
+  SchemaDescriptor schema_;
+
+  // Input buffers
+  std::vector<c_type> values_;
+
+  std::vector<int16_t> def_levels_;
+
+  std::vector<uint8_t> buffer_;
+  // Pointer to the values, needed as we cannot use std::vector<bool>::data()
+  c_type* values_ptr_;
+  std::vector<uint8_t> bool_buffer_;
+
+  // Output buffers
+  std::vector<c_type> values_out_;
+  std::vector<uint8_t> bool_buffer_out_;
+  c_type* values_out_ptr_;
+};
+
+template <typename TestType>
+inline void PrimitiveTypedTest<TestType>::SyncValuesOut() {}
+
+template <>
+inline void PrimitiveTypedTest<BooleanType>::SyncValuesOut() {
+  std::vector<uint8_t>::const_iterator source_iterator =
+      bool_buffer_out_.begin();
+  std::vector<c_type>::iterator destination_iterator = values_out_.begin();
+  while (source_iterator != bool_buffer_out_.end()) {
+    *destination_iterator++ = *source_iterator++ != 0;
+  }
+}
+
+template <typename TestType>
+inline void PrimitiveTypedTest<TestType>::SetupValuesOut(int64_t num_values) {
+  values_out_.clear();
+  values_out_.resize(num_values);
+  values_out_ptr_ = values_out_.data();
+}
+
+template <>
+inline void PrimitiveTypedTest<BooleanType>::SetupValuesOut(
+    int64_t num_values) {
+  values_out_.clear();
+  values_out_.resize(num_values);
+
+  bool_buffer_out_.clear();
+  bool_buffer_out_.resize(num_values);
+  // Write once to all values so we can copy it without getting Valgrind errors
+  // about uninitialised values.
+  std::fill(bool_buffer_out_.begin(), bool_buffer_out_.end(), true);
+  values_out_ptr_ = reinterpret_cast<bool*>(bool_buffer_out_.data());
+}
+
+template <typename TestType>
+inline void PrimitiveTypedTest<TestType>::GenerateData(
+    int64_t num_values,
+    uint32_t seed) {
+  def_levels_.resize(num_values);
+  values_.resize(num_values);
+
+  InitValues<c_type>(static_cast<int>(num_values), seed, values_, buffer_);
+  values_ptr_ = values_.data();
+
+  std::fill(def_levels_.begin(), def_levels_.end(), 1);
+}
+
+template <>
+inline void PrimitiveTypedTest<BooleanType>::GenerateData(
+    int64_t num_values,
+    uint32_t seed) {
+  def_levels_.resize(num_values);
+  values_.resize(num_values);
+
+  InitValues<c_type>(static_cast<int>(num_values), seed, values_, buffer_);
+  bool_buffer_.resize(num_values);
+  std::copy(values_.begin(), values_.end(), bool_buffer_.begin());
+  values_ptr_ = reinterpret_cast<bool*>(bool_buffer_.data());
+
+  std::fill(def_levels_.begin(), def_levels_.end(), 1);
+}
+
+// ----------------------------------------------------------------------
+// test data generation
+
+template <typename T>
+inline void GenerateData(int num_values, T* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_numbers(
+      num_values,
+      0,
+      std::numeric_limits<T>::min(),
+      std::numeric_limits<T>::max(),
+      out);
+}
+
+template <typename T>
+inline void GenerateBoundData(
+    int num_values,
+    T* out,
+    T min,
+    T max,
+    std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_numbers(num_values, 0, min, max, out);
+}
+
+template <>
+inline void
+GenerateData<bool>(int num_values, bool* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_bools(num_values, 0.5, 0, out);
+}
+
+template <>
+inline void
+GenerateData<Int96>(int num_values, Int96* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  random_Int96_numbers(
+      num_values,
+      0,
+      std::numeric_limits<int32_t>::min(),
+      std::numeric_limits<int32_t>::max(),
+      out);
+}
+
+template <>
+inline void GenerateData<ByteArray>(
+    int num_values,
+    ByteArray* out,
+    std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  int max_byte_array_len = 12;
+  heap->resize(num_values * max_byte_array_len);
+  random_byte_array(num_values, 0, heap->data(), out, 2, max_byte_array_len);
+}
+
+static constexpr int kGenerateDataFLBALength = 8;
+
+template <>
+inline void
+GenerateData<FLBA>(int num_values, FLBA* out, std::vector<uint8_t>* heap) {
+  // seed the prng so failure is deterministic
+  heap->resize(num_values * kGenerateDataFLBALength);
+  random_fixed_byte_array(
+      num_values, 0, heap->data(), kGenerateDataFLBALength, out);
+}
+
+} // namespace test
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/TypesTest.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "arrow/util/endian.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+
+namespace facebook::velox::parquet::arrow {
+
+TEST(TestTypeToString, PhysicalTypes) {
+  ASSERT_STREQ("BOOLEAN", TypeToString(Type::BOOLEAN).c_str());
+  ASSERT_STREQ("INT32", TypeToString(Type::INT32).c_str());
+  ASSERT_STREQ("INT64", TypeToString(Type::INT64).c_str());
+  ASSERT_STREQ("INT96", TypeToString(Type::INT96).c_str());
+  ASSERT_STREQ("FLOAT", TypeToString(Type::FLOAT).c_str());
+  ASSERT_STREQ("DOUBLE", TypeToString(Type::DOUBLE).c_str());
+  ASSERT_STREQ("BYTE_ARRAY", TypeToString(Type::BYTE_ARRAY).c_str());
+  ASSERT_STREQ(
+      "FIXED_LEN_BYTE_ARRAY", TypeToString(Type::FIXED_LEN_BYTE_ARRAY).c_str());
+}
+
+TEST(TestConvertedTypeToString, ConvertedTypes) {
+  ASSERT_STREQ("NONE", ConvertedTypeToString(ConvertedType::NONE).c_str());
+  ASSERT_STREQ("UTF8", ConvertedTypeToString(ConvertedType::UTF8).c_str());
+  ASSERT_STREQ("MAP", ConvertedTypeToString(ConvertedType::MAP).c_str());
+  ASSERT_STREQ(
+      "MAP_KEY_VALUE",
+      ConvertedTypeToString(ConvertedType::MAP_KEY_VALUE).c_str());
+  ASSERT_STREQ("LIST", ConvertedTypeToString(ConvertedType::LIST).c_str());
+  ASSERT_STREQ("ENUM", ConvertedTypeToString(ConvertedType::ENUM).c_str());
+  ASSERT_STREQ(
+      "DECIMAL", ConvertedTypeToString(ConvertedType::DECIMAL).c_str());
+  ASSERT_STREQ("DATE", ConvertedTypeToString(ConvertedType::DATE).c_str());
+  ASSERT_STREQ(
+      "TIME_MILLIS", ConvertedTypeToString(ConvertedType::TIME_MILLIS).c_str());
+  ASSERT_STREQ(
+      "TIME_MICROS", ConvertedTypeToString(ConvertedType::TIME_MICROS).c_str());
+  ASSERT_STREQ(
+      "TIMESTAMP_MILLIS",
+      ConvertedTypeToString(ConvertedType::TIMESTAMP_MILLIS).c_str());
+  ASSERT_STREQ(
+      "TIMESTAMP_MICROS",
+      ConvertedTypeToString(ConvertedType::TIMESTAMP_MICROS).c_str());
+  ASSERT_STREQ("UINT_8", ConvertedTypeToString(ConvertedType::UINT_8).c_str());
+  ASSERT_STREQ(
+      "UINT_16", ConvertedTypeToString(ConvertedType::UINT_16).c_str());
+  ASSERT_STREQ(
+      "UINT_32", ConvertedTypeToString(ConvertedType::UINT_32).c_str());
+  ASSERT_STREQ(
+      "UINT_64", ConvertedTypeToString(ConvertedType::UINT_64).c_str());
+  ASSERT_STREQ("INT_8", ConvertedTypeToString(ConvertedType::INT_8).c_str());
+  ASSERT_STREQ("INT_16", ConvertedTypeToString(ConvertedType::INT_16).c_str());
+  ASSERT_STREQ("INT_32", ConvertedTypeToString(ConvertedType::INT_32).c_str());
+  ASSERT_STREQ("INT_64", ConvertedTypeToString(ConvertedType::INT_64).c_str());
+  ASSERT_STREQ("JSON", ConvertedTypeToString(ConvertedType::JSON).c_str());
+  ASSERT_STREQ("BSON", ConvertedTypeToString(ConvertedType::BSON).c_str());
+  ASSERT_STREQ(
+      "INTERVAL", ConvertedTypeToString(ConvertedType::INTERVAL).c_str());
+}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
+TEST(TypePrinter, StatisticsTypes) {
+  std::string smin;
+  std::string smax;
+  int32_t int_min = 1024;
+  int32_t int_max = 2048;
+  smin = std::string(reinterpret_cast<char*>(&int_min), sizeof(int32_t));
+  smax = std::string(reinterpret_cast<char*>(&int_max), sizeof(int32_t));
+  ASSERT_STREQ("1024", FormatStatValue(Type::INT32, smin).c_str());
+  ASSERT_STREQ("2048", FormatStatValue(Type::INT32, smax).c_str());
+
+  int64_t int64_min = 10240000000000;
+  int64_t int64_max = 20480000000000;
+  smin = std::string(reinterpret_cast<char*>(&int64_min), sizeof(int64_t));
+  smax = std::string(reinterpret_cast<char*>(&int64_max), sizeof(int64_t));
+  ASSERT_STREQ("10240000000000", FormatStatValue(Type::INT64, smin).c_str());
+  ASSERT_STREQ("20480000000000", FormatStatValue(Type::INT64, smax).c_str());
+
+  float float_min = 1.024f;
+  float float_max = 2.048f;
+  smin = std::string(reinterpret_cast<char*>(&float_min), sizeof(float));
+  smax = std::string(reinterpret_cast<char*>(&float_max), sizeof(float));
+  ASSERT_STREQ("1.024", FormatStatValue(Type::FLOAT, smin).c_str());
+  ASSERT_STREQ("2.048", FormatStatValue(Type::FLOAT, smax).c_str());
+
+  double double_min = 1.0245;
+  double double_max = 2.0489;
+  smin = std::string(reinterpret_cast<char*>(&double_min), sizeof(double));
+  smax = std::string(reinterpret_cast<char*>(&double_max), sizeof(double));
+  ASSERT_STREQ("1.0245", FormatStatValue(Type::DOUBLE, smin).c_str());
+  ASSERT_STREQ("2.0489", FormatStatValue(Type::DOUBLE, smax).c_str());
+
+#if ARROW_LITTLE_ENDIAN
+  Int96 Int96_min = {{1024, 2048, 4096}};
+  Int96 Int96_max = {{2048, 4096, 8192}};
+#else
+  Int96 Int96_min = {{2048, 1024, 4096}};
+  Int96 Int96_max = {{4096, 2048, 8192}};
+#endif
+  smin = std::string(reinterpret_cast<char*>(&Int96_min), sizeof(Int96));
+  smax = std::string(reinterpret_cast<char*>(&Int96_max), sizeof(Int96));
+  ASSERT_STREQ("1024 2048 4096", FormatStatValue(Type::INT96, smin).c_str());
+  ASSERT_STREQ("2048 4096 8192", FormatStatValue(Type::INT96, smax).c_str());
+
+  smin = std::string("abcdef");
+  smax = std::string("ijklmnop");
+  ASSERT_STREQ("abcdef", FormatStatValue(Type::BYTE_ARRAY, smin).c_str());
+  ASSERT_STREQ("ijklmnop", FormatStatValue(Type::BYTE_ARRAY, smax).c_str());
+
+  // PARQUET-1357: FormatStatValue truncates binary statistics on zero character
+  smax.push_back('\0');
+  ASSERT_EQ(smax, FormatStatValue(Type::BYTE_ARRAY, smax));
+
+  smin = std::string("abcdefgh");
+  smax = std::string("ijklmnop");
+  ASSERT_STREQ(
+      "abcdefgh", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin).c_str());
+  ASSERT_STREQ(
+      "ijklmnop", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax).c_str());
+}
+
+TEST(TestInt96Timestamp, Decoding) {
+  auto check = [](int32_t julian_day, uint64_t nanoseconds) {
+#if ARROW_LITTLE_ENDIAN
+    Int96 i96{
+        static_cast<uint32_t>(nanoseconds),
+        static_cast<uint32_t>(nanoseconds >> 32),
+        static_cast<uint32_t>(julian_day)};
+#else
+    Int96 i96{
+        static_cast<uint32_t>(nanoseconds >> 32),
+        static_cast<uint32_t>(nanoseconds),
+        static_cast<uint32_t>(julian_day)};
+#endif
+    // Official formula according to
+    // https://github.com/apache/parquet-format/pull/49
+    int64_t expected =
+        (julian_day - 2440588) * (86400LL * 1000 * 1000 * 1000) + nanoseconds;
+    int64_t actual = Int96GetNanoSeconds(i96);
+    ASSERT_EQ(expected, actual);
+  };
+
+  // [2333837, 2547339] is the range of Julian days that can be converted to
+  // 64-bit Unix timestamps.
+  check(2333837, 0);
+  check(2333855, 0);
+  check(2547330, 0);
+  check(2547338, 0);
+  check(2547339, 0);
+
+  check(2547330, 13);
+  check(2547330, 32769);
+  check(2547330, 87654);
+  check(2547330, 0x123456789abcdefULL);
+  check(2547330, 0xfedcba9876543210ULL);
+  check(2547339, 0xffffffffffffffffULL);
+}
+
+#if !(defined(_WIN32) || defined(__CYGWIN__))
+#pragma GCC diagnostic pop
+#elif _MSC_VER
+#pragma warning(pop)
+#endif
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/XxHasher.cpp
+++ b/velox/dwio/parquet/writer/arrow/tests/XxHasher.cpp
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#include "velox/dwio/parquet/writer/arrow/tests/XxHasher.h"
+
+#define XXH_INLINE_ALL
+#include <xxhash.h>
+
+namespace facebook::velox::parquet::arrow {
+
+namespace {
+template <typename T>
+uint64_t XxHashHelper(T value, uint32_t seed) {
+  return XXH64(reinterpret_cast<const void*>(&value), sizeof(T), seed);
+}
+
+template <typename T>
+void XxHashesHelper(
+    const T* values,
+    uint32_t seed,
+    int num_values,
+    uint64_t* results) {
+  for (int i = 0; i < num_values; ++i) {
+    results[i] = XxHashHelper(values[i], seed);
+  }
+}
+
+} // namespace
+
+uint64_t XxHasher::Hash(int32_t value) const {
+  return XxHashHelper(value, kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(int64_t value) const {
+  return XxHashHelper(value, kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(float value) const {
+  return XxHashHelper(value, kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(double value) const {
+  return XxHashHelper(value, kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(const FLBA* value, uint32_t len) const {
+  return XXH64(
+      reinterpret_cast<const void*>(value->ptr), len, kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(const Int96* value) const {
+  return XXH64(
+      reinterpret_cast<const void*>(value->value),
+      sizeof(value->value),
+      kParquetBloomXxHashSeed);
+}
+
+uint64_t XxHasher::Hash(const ByteArray* value) const {
+  return XXH64(
+      reinterpret_cast<const void*>(value->ptr),
+      value->len,
+      kParquetBloomXxHashSeed);
+}
+
+void XxHasher::Hashes(const int32_t* values, int num_values, uint64_t* hashes)
+    const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+
+void XxHasher::Hashes(const int64_t* values, int num_values, uint64_t* hashes)
+    const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+
+void XxHasher::Hashes(const float* values, int num_values, uint64_t* hashes)
+    const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+
+void XxHasher::Hashes(const double* values, int num_values, uint64_t* hashes)
+    const {
+  XxHashesHelper(values, kParquetBloomXxHashSeed, num_values, hashes);
+}
+
+void XxHasher::Hashes(const Int96* values, int num_values, uint64_t* hashes)
+    const {
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(
+        reinterpret_cast<const void*>(values[i].value),
+        sizeof(values[i].value),
+        kParquetBloomXxHashSeed);
+  }
+}
+
+void XxHasher::Hashes(const ByteArray* values, int num_values, uint64_t* hashes)
+    const {
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(
+        reinterpret_cast<const void*>(values[i].ptr),
+        values[i].len,
+        kParquetBloomXxHashSeed);
+  }
+}
+
+void XxHasher::Hashes(
+    const FLBA* values,
+    uint32_t type_len,
+    int num_values,
+    uint64_t* hashes) const {
+  for (int i = 0; i < num_values; ++i) {
+    hashes[i] = XXH64(
+        reinterpret_cast<const void*>(values[i].ptr),
+        type_len,
+        kParquetBloomXxHashSeed);
+  }
+}
+
+} // namespace facebook::velox::parquet::arrow

--- a/velox/dwio/parquet/writer/arrow/tests/XxHasher.h
+++ b/velox/dwio/parquet/writer/arrow/tests/XxHasher.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Arrow.
+
+#pragma once
+
+#include <cstdint>
+
+#include "velox/dwio/parquet/writer/arrow/Platform.h"
+#include "velox/dwio/parquet/writer/arrow/Types.h"
+#include "velox/dwio/parquet/writer/arrow/tests/Hasher.h"
+
+namespace facebook::velox::parquet::arrow {
+
+class PARQUET_EXPORT XxHasher : public Hasher {
+ public:
+  uint64_t Hash(int32_t value) const override;
+  uint64_t Hash(int64_t value) const override;
+  uint64_t Hash(float value) const override;
+  uint64_t Hash(double value) const override;
+  uint64_t Hash(const Int96* value) const override;
+  uint64_t Hash(const ByteArray* value) const override;
+  uint64_t Hash(const FLBA* val, uint32_t len) const override;
+
+  void Hashes(const int32_t* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(const int64_t* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(const float* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(const double* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(const Int96* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(const ByteArray* values, int num_values, uint64_t* hashes)
+      const override;
+  void Hashes(
+      const FLBA* values,
+      uint32_t type_len,
+      int num_values,
+      uint64_t* hashes) const override;
+
+  static constexpr int kParquetBloomXxHashSeed = 0;
+};
+
+} // namespace facebook::velox::parquet::arrow


### PR DESCRIPTION
Summary:
Moving unit tests from Arrow Parquet to our recently vendored code.
Also moving Parquet reader codebase into the test directory, since most unit
tests need both a writer and a reader. We will refactor them to use our native
reader in the next PRs.

Differential Revision: D49780809


