### PR TITLE
Introduce simpler VectorMaker::arrayOfRowVector API

### DIFF
--- a/velox/functions/prestosql/tests/ArrayContainsTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayContainsTest.cpp
@@ -190,28 +190,16 @@ TEST_F(ArrayContainsTest, booleanWithNulls) {
 }
 
 TEST_F(ArrayContainsTest, row) {
-  std::vector<std::vector<variant>> data = {
-      {
-          variant::row({1, "red"}),
-          variant::row({2, "blue"}),
-          variant::row({3, "green"}),
-      },
-      {
-          variant::row({2, "blue"}),
-          variant(TypeKind::ROW), // null
-          variant::row({5, "green"}),
-      },
-      {},
-      {
-          variant::row({1, "yellow"}),
-          variant::row({2, "blue"}),
-          variant::row({4, "green"}),
-          variant::row({5, "purple"}),
-      },
-  };
+  std::vector<std::vector<std::optional<std::tuple<int32_t, std::string>>>>
+      data = {
+          {{{1, "red"}}, {{2, "blue"}}, {{3, "green"}}},
+          {{{2, "blue"}}, std::nullopt, {{5, "green"}}},
+          {},
+          {{{1, "yellow"}}, {{2, "blue"}}, {{4, "green"}}, {{5, "purple"}}},
+      };
 
   auto rowType = ROW({INTEGER(), VARCHAR()});
-  auto arrayVector = makeArrayOfRowVector(rowType, data);
+  auto arrayVector = makeArrayOfRowVector(data, rowType);
 
   auto testContains = [&](int32_t n,
                           const char* color,

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -237,6 +237,13 @@ class VectorTestBase {
     return vectorMaker_.arrayOfRowVector(rowType, data);
   }
 
+  template <typename TupleT>
+  ArrayVectorPtr makeArrayOfRowVector(
+      const std::vector<std::vector<std::optional<TupleT>>>& data,
+      const RowTypePtr& rowType) {
+    return vectorMaker_.arrayOfRowVector(data, rowType);
+  }
+
   // Create an ArrayVector<ArrayVector<T>> from nested std::vectors of values.
   // Example:
   //   using innerArrayType = std::vector<std::optional<int64_t>>;


### PR DESCRIPTION
The new API takes a list of list of optional std::tuples.

```
  std::vector<std::vector<std::optional<std::tuple<int32_t, std::string>>>>
      data = {
          {{{1, "red"}}, {{2, "blue"}}, {{3, "green"}}},
          {{{2, "blue"}}, std::nullopt, {{5, "green"}}},
          {},
          {{{1, "yellow"}}, {{2, "blue"}}, {{4, "green"}}, {{5, "purple"}}},
      };

  auto rowType = ROW({INTEGER(), VARCHAR()});
  auto arrayVector = makeArrayOfRowVector(data, rowType);
```