### PR TITLE
Fix TimeStamp kMaxSeconds and kMinSeconds

### DIFF
--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -250,8 +250,8 @@ TEST_F(HivePartitionFunctionTest, timestamp) {
 
   assertPartitions(values, 1, {0, 0, 0, 0});
   assertPartitions(values, 2, {0, 0, 0, 0});
-  assertPartitions(values, 500, {0, 284, 122, 450});
-  assertPartitions(values, 997, {0, 514, 404, 733});
+  assertPartitions(values, 500, {0, 284, 446, 274});
+  assertPartitions(values, 997, {0, 514, 147, 476});
 
   assertPartitionsWithConstChannel(values, 1);
   assertPartitionsWithConstChannel(values, 2);

--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -408,7 +408,7 @@ struct TimestampMinusIntervalDayTime {
       out_type<IntervalDayTime>& result,
       const arg_type<Timestamp>& a,
       const arg_type<Timestamp>& b) {
-    result = a.toMillis() - b.toMillis();
+    result = checkedMinus(a.toMillis(), b.toMillis());
   }
 };
 

--- a/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/DateTimeFunctionsTest.cpp
@@ -407,12 +407,12 @@ TEST_F(DateTimeFunctionsTest, fromUnixtime) {
   EXPECT_EQ(Timestamp(-1, 9000), fromUnixtime(-0.999991));
   EXPECT_EQ(Timestamp(4000000000, 0), fromUnixtime(4000000000));
   EXPECT_EQ(
-      Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(3.87111e+37));
+      Timestamp(9'223'372'036'854'774, 807'000'000), fromUnixtime(3.87111e+37));
   // double(123000000) to uint64_t conversion returns 123000144.
   EXPECT_EQ(Timestamp(4000000000, 123000144), fromUnixtime(4000000000.123));
-  EXPECT_EQ(Timestamp(9'223'372'036'854'775, 807'000'000), fromUnixtime(kInf));
+  EXPECT_EQ(Timestamp(9'223'372'036'854'774, 807'000'000), fromUnixtime(kInf));
   EXPECT_EQ(
-      Timestamp(-9'223'372'036'854'776, 192'000'000), fromUnixtime(-kInf));
+      Timestamp(-9'223'372'036'854'775, 192'000'000), fromUnixtime(-kInf));
   EXPECT_EQ(Timestamp(0, 0), fromUnixtime(kNan));
 }
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "velox/common/base/CheckedArithmetic.h"
 #include "velox/functions/lib/DateTimeFormatter.h"
 #include "velox/functions/lib/TimeUtils.h"
 #include "velox/functions/prestosql/DateTimeImpl.h"

--- a/velox/type/Timestamp.h
+++ b/velox/type/Timestamp.h
@@ -48,14 +48,14 @@ struct Timestamp {
   static constexpr int64_t kNanosecondsInMillisecond = 1'000'000;
 
   // Limit the range of seconds to avoid some problems. Seconds should be
-  // in the range [INT64_MIN/1000 - 1, INT64_MAX/1000].
+  // in the range [INT64_MIN/1000, INT64_MAX/1000 -1].
   // Presto's Timestamp is stored in one 64-bit signed integer for
   // milliseconds, this range ensures that Timestamp's range in Velox will not
   // be smaller than Presto, and can make Timestamp::toString work correctly.
   static constexpr int64_t kMaxSeconds =
-      std::numeric_limits<int64_t>::max() / kMillisecondsInSecond;
+      std::numeric_limits<int64_t>::max() / kMillisecondsInSecond - 1;
   static constexpr int64_t kMinSeconds =
-      std::numeric_limits<int64_t>::min() / kMillisecondsInSecond - 1;
+      std::numeric_limits<int64_t>::min() / kMillisecondsInSecond;
 
   // Nanoseconds should be less than 1 second.
   static constexpr uint64_t kMaxNanos = 999'999'999;

--- a/velox/type/tests/TimestampTest.cpp
+++ b/velox/type/tests/TimestampTest.cpp
@@ -79,12 +79,6 @@ TEST(TimestampTest, arithmeticOverflow) {
 
   Timestamp ts1(positiveSecond, nano);
   VELOX_ASSERT_THROW(
-      ts1.toMillis(),
-      fmt::format(
-          "Could not convert Timestamp({}, {}) to milliseconds",
-          positiveSecond,
-          nano));
-  VELOX_ASSERT_THROW(
       ts1.toMicros(),
       fmt::format(
           "Could not convert Timestamp({}, {}) to microseconds",
@@ -98,12 +92,6 @@ TEST(TimestampTest, arithmeticOverflow) {
           nano));
 
   Timestamp ts2(negativeSecond, 0);
-  VELOX_ASSERT_THROW(
-      ts2.toMillis(),
-      fmt::format(
-          "Could not convert Timestamp({}, {}) to milliseconds",
-          negativeSecond,
-          0));
   VELOX_ASSERT_THROW(
       ts2.toMicros(),
       fmt::format(
@@ -187,8 +175,8 @@ DEBUG_ONLY_TEST(TimestampTest, invalidInput) {
 TEST(TimestampTest, toString) {
   auto kMin = Timestamp(Timestamp::kMinSeconds, 0);
   auto kMax = Timestamp(Timestamp::kMaxSeconds, Timestamp::kMaxNanos);
-  EXPECT_EQ("-292275055-05-16T16:47:04.000000000", kMin.toString());
-  EXPECT_EQ("292278994-08-17T07:12:55.999999999", kMax.toString());
+  EXPECT_EQ("-292275055-05-16T16:47:05.000000000", kMin.toString());
+  EXPECT_EQ("292278994-08-17T07:12:54.999999999", kMax.toString());
   EXPECT_EQ(
       "1-01-01T05:17:32.000000000", Timestamp(-62135577748, 0).toString());
   EXPECT_EQ(
@@ -206,8 +194,8 @@ TEST(TimestampTest, toStringPrestoCastBehavior) {
       .zeroPaddingYear = true,
       .dateTimeSeparator = ' ',
   };
-  EXPECT_EQ("-292275055-05-16 16:47:04.000", kMin.toString(options));
-  EXPECT_EQ("292278994-08-17 07:12:55.999", kMax.toString(options));
+  EXPECT_EQ("-292275055-05-16 16:47:05.000", kMin.toString(options));
+  EXPECT_EQ("292278994-08-17 07:12:54.999", kMax.toString(options));
   EXPECT_EQ(
       "0001-01-01 05:17:32.000", Timestamp(-62135577748, 0).toString(options));
   EXPECT_EQ(
@@ -297,6 +285,13 @@ TEST(TimestampTest, outOfRange) {
       t.toTimePoint(), "Timestamp is outside of supported range");
   VELOX_ASSERT_THROW(
       t.toTimezone(*timezone), "Timestamp is outside of supported range");
+}
+
+TEST(TimestampTest, limts) {
+  // Make sure that Timestamp fits as milliseconds in int64_t.
+  EXPECT_NO_THROW(Timestamp(Timestamp::kMinSeconds, 0).toMillis());
+  EXPECT_NO_THROW(
+      Timestamp(Timestamp::kMaxSeconds, Timestamp::kMaxNanos).toMillis());
 }
 } // namespace
 } // namespace facebook::velox


### PR DESCRIPTION
Summary:
The comment in timestamp says that

" Presto's Timestamp is stored in one 64-bit signed integer for
  milliseconds, this range ensures that Timestamp's range in Velox will not
  be smaller than Presto"
the -1 should be for kMaxSeconds not for kMinSeconds, tests updated.

Differential Revision: D49794381


