### PR TITLE
Memory arbitration code cleanup (#6824)

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -329,7 +329,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
     options.memoryPoolInitCapacity = memoryPoolInitCapacity;
     options.memoryPoolTransferCapacity = memoryPoolTransferCapacity;
     options.checkUsageLeak = true;
-    options.arbitrationStateCheckCb = driverArbitrationStateCheck;
+    options.arbitrationStateCheckCb = memoryArbitrationStateCheck;
     memoryManager_ = std::make_unique<MemoryManager>(options);
     ASSERT_EQ(memoryManager_->arbitrator()->kind(), "SHARED");
     arbitrator_ = static_cast<SharedArbitrator*>(memoryManager_->arbitrator());

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -17,6 +17,7 @@
 
 #include "velox/exec/HashTable.h"
 #include "velox/exec/JoinBridge.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Spill.h"
 
 namespace facebook::velox::exec {
@@ -135,7 +136,7 @@ class HashJoinBridge : public JoinBridge {
 bool isLeftNullAwareJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode);
 
-class HashJoinMemoryReclaimer final : public memory::MemoryReclaimer {
+class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
   static std::unique_ptr<memory::MemoryReclaimer> create() {
     return std::unique_ptr<memory::MemoryReclaimer>(

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -22,17 +22,25 @@
 namespace facebook::velox::exec {
 /// Provides the default memory reclaimer implementation for velox task
 /// execution.
-class DefaultMemoryReclaimer : public memory::MemoryReclaimer {
+class MemoryReclaimer : public memory::MemoryReclaimer {
  public:
-  virtual ~DefaultMemoryReclaimer() = default;
+  virtual ~MemoryReclaimer() = default;
 
-  static std::unique_ptr<MemoryReclaimer> create();
+  static std::unique_ptr<memory::MemoryReclaimer> create();
 
   void enterArbitration() override;
 
   void leaveArbitration() noexcept override;
 
  protected:
-  DefaultMemoryReclaimer() = default;
+  MemoryReclaimer() = default;
 };
+
+/// Callback used by memory arbitration to check if a driver thread under memory
+/// arbitration has been put in suspension state. This is to prevent arbitration
+/// deadlock as the arbitrator might reclaim memory from the task of the driver
+/// thread which is under arbitration. The task reclaim needs to wait for the
+/// drivers to go off thread. A suspended driver thread is not counted as
+/// running.
+void memoryArbitrationStateCheck(memory::MemoryPool& pool);
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -346,7 +346,7 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createNodeReclaimer(
   // Sets memory reclaimer for the parent node memory pool on the first child
   // operator construction which has set memory reclaimer.
   return isHashJoinNode ? HashJoinMemoryReclaimer::create()
-                        : memory::MemoryReclaimer::create();
+                        : exec::MemoryReclaimer::create();
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createExchangeClientReclaimer()
@@ -354,7 +354,7 @@ std::unique_ptr<memory::MemoryReclaimer> Task::createExchangeClientReclaimer()
   if (pool()->reclaimer() == nullptr) {
     return nullptr;
   }
-  return DefaultMemoryReclaimer::create();
+  return exec::MemoryReclaimer::create();
 }
 
 std::unique_ptr<memory::MemoryReclaimer> Task::createTaskReclaimer() {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -18,6 +18,7 @@
 #include "velox/core/QueryCtx.h"
 #include "velox/exec/Driver.h"
 #include "velox/exec/LocalPartition.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/MergeSource.h"
 #include "velox/exec/Split.h"
 #include "velox/exec/TaskStats.h"
@@ -645,7 +646,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// occurred. This should only be called inside mutex_ protection.
   std::string errorMessageLocked() const;
 
-  class MemoryReclaimer : public memory::MemoryReclaimer {
+  class MemoryReclaimer : public exec::MemoryReclaimer {
    public:
     static std::unique_ptr<memory::MemoryReclaimer> create(
         const std::shared_ptr<Task>& task);

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -61,7 +61,7 @@ TEST_F(MemoryReclaimerTest, enterArbitrationTest) {
   for (const auto& underDriverContext : {false, true}) {
     SCOPED_TRACE(fmt::format("underDriverContext: {}", underDriverContext));
 
-    auto reclaimer = DefaultMemoryReclaimer::create();
+    auto reclaimer = exec::MemoryReclaimer::create();
     auto driver = Driver::testingCreate(
         std::make_unique<DriverCtx>(fakeTask_, 0, 0, 0, 0));
     if (underDriverContext) {


### PR DESCRIPTION
Summary:
Rename DefaultMemoryReclaimer to MemoryReclaimer
Move driverArbitrationStateCheck to memoryArbitrationStateCheck
in MemoryReclaimer.h/cpp


Reviewed By: tanjialiang

Differential Revision: D49778545

Pulled By: xiaoxmeng


