### PR TITLE
Improve allocation success when evicting from cache

### DIFF
--- a/velox/common/memory/Allocation.cpp
+++ b/velox/common/memory/Allocation.cpp
@@ -37,6 +37,14 @@ void Allocation::append(uint8_t* address, int32_t numPages) {
       "Appending a duplicate address into a PageRun");
   runs_.emplace_back(address, numPages);
 }
+void Allocation::appendMove(Allocation& other) {
+  for (auto& run : other.runs_) {
+    numPages_ += run.numPages();
+    runs_.push_back(std::move(run));
+  }
+  other.runs_.clear();
+  other.numPages_ = 0;
+}
 
 void Allocation::findRun(uint64_t offset, int32_t* index, int32_t* offsetInRun)
     const {

--- a/velox/common/memory/Allocation.h
+++ b/velox/common/memory/Allocation.h
@@ -160,6 +160,9 @@ class Allocation {
     return numPages_ == 0;
   }
 
+  /// Moves the runs in 'from' to 'this'. 'from' is empty on return.
+  void appendMove(Allocation& from);
+
   std::string toString() const;
 
  private:
@@ -189,6 +192,7 @@ class Allocation {
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass1);
   VELOX_FRIEND_TEST(MemoryAllocatorTest, allocationClass2);
   VELOX_FRIEND_TEST(AllocationTest, append);
+  VELOX_FRIEND_TEST(AllocationTest, appendMove);
 };
 
 /// Represents a run of contiguous pages that do not belong to any size class.

--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -160,6 +160,14 @@ MachinePageCount MemoryAllocator::roundUpToSizeClassSize(
   return *std::lower_bound(sizes.begin(), sizes.end(), pages);
 }
 
+namespace {
+MachinePageCount pagesToAcquire(
+    MachinePageCount numPages,
+    MachinePageCount collateralPages) {
+  return numPages <= collateralPages ? 0 : numPages - collateralPages;
+}
+} // namespace
+
 bool MemoryAllocator::allocateNonContiguous(
     MachinePageCount numPages,
     Allocation& out,
@@ -169,10 +177,24 @@ bool MemoryAllocator::allocateNonContiguous(
     return allocateNonContiguousWithoutRetry(
         numPages, out, reservationCB, minSizeClass);
   }
-  return cache()->makeSpace(numPages, [&]() {
-    return allocateNonContiguousWithoutRetry(
-        numPages, out, reservationCB, minSizeClass);
-  });
+  bool success = cache()->makeSpace(
+      pagesToAcquire(numPages, out.numPages()), [&](Allocation& acquired) {
+        freeNonContiguous(acquired);
+        return allocateNonContiguousWithoutRetry(
+            numPages, out, reservationCB, minSizeClass);
+      });
+  if (!success) {
+    // There can be a failure where allocation was never called because there
+    // never was a chance based on numAllocated() and capacity(). Make sure old
+    // data is still freed.
+    if (!out.empty()) {
+      if (reservationCB) {
+        reservationCB(AllocationTraits::pageBytes(out.numPages()), false);
+      }
+      freeNonContiguous(out);
+    }
+  }
+  return success;
 }
 
 bool MemoryAllocator::allocateContiguous(
@@ -185,10 +207,36 @@ bool MemoryAllocator::allocateContiguous(
     return allocateContiguousWithoutRetry(
         numPages, collateral, allocation, reservationCB, maxPages);
   }
-  return cache()->makeSpace(numPages, [&]() {
-    return allocateContiguousWithoutRetry(
-        numPages, collateral, allocation, reservationCB, maxPages);
-  });
+  auto numCollateralPages =
+      allocation.numPages() + (collateral ? collateral->numPages() : 0);
+  bool success = cache()->makeSpace(
+      pagesToAcquire(numPages, numCollateralPages), [&](Allocation& acquired) {
+        freeNonContiguous(acquired);
+        return allocateContiguousWithoutRetry(
+            numPages, collateral, allocation, reservationCB, maxPages);
+      });
+  if (!success) {
+    // never was a chance based on numAllocated() and capacity(). Make sure old
+    // data is still freed.
+    int64_t bytes = 0;
+    ;
+    if (collateral && !collateral->empty()) {
+      if (reservationCB) {
+        bytes += AllocationTraits::pageBytes(collateral->numPages());
+      }
+      freeNonContiguous(*collateral);
+    }
+    if (!allocation.empty()) {
+      if (reservationCB) {
+        bytes += allocation.size();
+      }
+      freeContiguous(allocation);
+    }
+    if (bytes) {
+      reservationCB(bytes, false);
+    }
+  }
+  return success;
 }
 
 bool MemoryAllocator::growContiguous(
@@ -198,7 +246,8 @@ bool MemoryAllocator::growContiguous(
   if (cache() == nullptr) {
     return growContiguousWithoutRetry(increment, allocation, reservationCB);
   }
-  return cache()->makeSpace(increment, [&]() {
+  return cache()->makeSpace(increment, [&](Allocation& acquired) {
+    freeNonContiguous(acquired);
     return growContiguousWithoutRetry(increment, allocation, reservationCB);
   });
 }
@@ -208,10 +257,12 @@ void* MemoryAllocator::allocateBytes(uint64_t bytes, uint16_t alignment) {
     return allocateBytesWithoutRetry(bytes, alignment);
   }
   void* result = nullptr;
-  cache()->makeSpace(AllocationTraits::numPages(bytes), [&]() {
-    result = allocateBytesWithoutRetry(bytes, alignment);
-    return result != nullptr;
-  });
+  cache()->makeSpace(
+      AllocationTraits::numPages(bytes), [&](Allocation& acquired) {
+        freeNonContiguous(acquired);
+        result = allocateBytesWithoutRetry(bytes, alignment);
+        return result != nullptr;
+      });
   return result;
 }
 
@@ -220,10 +271,12 @@ void* MemoryAllocator::allocateZeroFilled(uint64_t bytes) {
     return allocateZeroFilledWithoutRetry(bytes);
   }
   void* result = nullptr;
-  cache()->makeSpace(AllocationTraits::numPages(bytes), [&]() {
-    result = allocateZeroFilledWithoutRetry(bytes);
-    return result != nullptr;
-  });
+  cache()->makeSpace(
+      AllocationTraits::numPages(bytes), [&](Allocation& acquired) {
+        freeNonContiguous(acquired);
+        result = allocateZeroFilledWithoutRetry(bytes);
+        return result != nullptr;
+      });
   return result;
 }
 

--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -146,13 +146,17 @@ class MemoryAllocator;
 class Cache {
  public:
   virtual ~Cache() = default;
-  /// This method should be implemented so that it tries to accommodate the
-  /// passed in 'allocate' by freeing up space from 'this' if needed. 'numPages'
-  /// is the number of pages 'allocate' tries to allocate.It should return true
-  /// if 'allocate' succeeds, and false otherwise.
+  /// This method should be implemented so that it tries to
+  /// accommodate the passed in 'allocate' by freeing up space from
+  /// 'this' if needed. 'numPages' is the number of pages 'allocate
+  /// needs to be free for allocate to succeed. This should return
+  /// true if 'allocate' succeeds, and false otherwise. 'numPages' can
+  /// be less than the planned allocation, even 0 but not
+  /// negative. This is possible if 'allocate' brings its own memory
+  /// that is exchanged for the new allocation.
   virtual bool makeSpace(
       memory::MachinePageCount numPages,
-      std::function<bool()> allocate) = 0;
+      std::function<bool(Allocation&)> allocate) = 0;
 
   virtual MemoryAllocator* allocator() const = 0;
 };


### PR DESCRIPTION
An allocation will evict cache to make space for data. If the the evicted data is freed and then an allocation is attempted, it can be that another thread has snatched the freed data. With high transient memory allocation rate and many threads, it can happen that a large allocation runs out of retries even if it could be satisfied.

Therefore, when evicting in order to make space for an allocation, we keep hold of the non-contiguous Allocations we remove from cache. Many allocations can in this way be concatenated into an allocation that covers the needed number of pages. This can then atomically be converted into a new non-contiguous or contiguous allocation. The allocate*WithoutRetry methods accept a non-contiguous allocation to be freed to provide pages for the new allocation. Memory mapping magic can convert non-contiguous freed pages to contiguous ones.

Note that the allocate*WithoutRetry methods mishandle the atomicity of the exchange: The allocated count is decremented by the size of the freed collateral and then incremented by the size of the new allocation. This should be a single atomic increment of allocatedSize
- collateralSize. This always succeeds if the collateral is >= the allocated amount. Even so, the window of vulnerability to another thread snatching the freed capacity before it is reacquired is probably negligible, only a few instructions.

The AsyncDataCache::makeSpace loop first tries to allocate. If it fails, it evicts and keeps up to the required amount in a a grab bag allocation. It loops until this allocation is large enough to convert into the desired allocation. If nothing is evicted and the allocation repeatedly fails, it gives up.