### PR TITLE
Add VectorFuzzer::fuzzInputFlatRow API 

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -683,6 +683,18 @@ RowVectorPtr VectorFuzzer::fuzzInputRow(const RowTypePtr& rowType) {
   return fuzzRow(rowType, opts_.vectorSize, false);
 }
 
+RowVectorPtr VectorFuzzer::fuzzInputFlatRow(const RowTypePtr& rowType) {
+  std::vector<VectorPtr> children;
+  auto size = static_cast<vector_size_t>(opts_.vectorSize);
+  children.reserve(rowType->size());
+  for (auto i = 0; i < rowType->size(); ++i) {
+    children.emplace_back(fuzzFlat(rowType->childAt(i), size));
+  }
+
+  return std::make_shared<RowVector>(
+      pool_, rowType, nullptr, size, std::move(children));
+}
+
 RowVectorPtr VectorFuzzer::fuzzRow(
     std::vector<VectorPtr>&& children,
     std::vector<std::string> childrenNames,

--- a/velox/vector/fuzzer/VectorFuzzer.h
+++ b/velox/vector/fuzzer/VectorFuzzer.h
@@ -238,6 +238,10 @@ class VectorFuzzer {
   // elements.
   RowVectorPtr fuzzInputRow(const RowTypePtr& rowType);
 
+  /// Same as the function above, but all generated vectors are flat, i.e. no
+  /// constant or dictionary-encoded vectors at any level.
+  RowVectorPtr fuzzInputFlatRow(const RowTypePtr& rowType);
+
   // Generates a random type, including maps, vectors, and arrays. maxDepth
   // limits the maximum level of nesting for complex types. maxDepth <= 1 means
   // no complex types are allowed.


### PR DESCRIPTION
It is a good practice to use the fuzzer to generate row vectors as test data
while writing UT codes (e.g. fuzzer.fuzzRow(rowType_). But in some scenarios,
we need to control the generation encoding, say the parquet writer uses arrow
parquet writer, which could not support constant and dictionary encoding
vectors. See discussion here 
https://github.com/facebookincubator/velox/pull/6608#discussion_r1337578838.
With this new API, we could use fuzzer like the following,

```C++
VectorFuzzer fuzzer({.vectorSize = vectorSize}, leafPool_.get());
fuzzer.fuzzInputFlatRow(rowType));
```