### PR TITLE
Optimize addNulls for row vector.

### DIFF
--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -1236,5 +1236,16 @@ void MapVector::copyRanges(
   copyRangesImpl(source, ranges, &values_, &keys_);
 }
 
+void RowVector::appendNulls(vector_size_t numberOfRows) {
+  VELOX_CHECK_GE(numberOfRows, 0);
+  if (numberOfRows == 0) {
+    return;
+  }
+  auto newSize = numberOfRows + BaseVector::length_;
+  auto oldSize = BaseVector::length_;
+  BaseVector::resize(newSize, false);
+  bits::fillBits(mutableRawNulls(), oldSize, newSize, bits::kNull);
+}
+
 } // namespace velox
 } // namespace facebook

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -109,6 +109,11 @@ class RowVector : public BaseVector {
     return childrenSize_;
   }
 
+  // Resize a row vector by adding trailing nulls to the top level row without
+  // resizing children.
+  // Caller should ensure that the vector is unique before calling this method.
+  void appendNulls(vector_size_t numberOfRows);
+
   /// Get the child vector at a given offset.
   VectorPtr& childAt(column_index_t index) {
     VELOX_USER_CHECK_LT(index, childrenSize_);


### PR DESCRIPTION
Summary:
Ones PR #6543 is re-landed, resizing row vectors will be expensive (children will be resized). #6543 was reverted due to other bugs that are exposed by it.
For the context of addNulls we can optimize that function by adding top level nulls in the row vector. instead of calling resize, this way we know #6543 will not add performance overhead for that path.
Moreover, this will mitigate the issues of resize for this location for row vectors. And will fix many fuzzer issues.

There are other optimizations that can be added to this function such as avoid calling ensnrewriable for complex types, by wrapping results in dictionary but those can be addressed in different diff.

Differential Revision: D49841643

