### PR TITLE
Add spill memory pool check for memory reservation under arbitration

### DIFF
--- a/velox/common/memory/Memory.cpp
+++ b/velox/common/memory/Memory.cpp
@@ -241,4 +241,13 @@ std::shared_ptr<MemoryPool> addDefaultLeafMemoryPool(
 MemoryPool& deprecatedSharedLeafPool() {
   return defaultMemoryManager().deprecatedSharedLeafPool();
 }
+
+memory::MemoryPool* spillMemoryPool() {
+  static auto pool = memory::addDefaultLeafMemoryPool("_sys.spilling");
+  return pool.get();
+}
+
+bool isSpillMemoryPool(memory::MemoryPool* pool) {
+  return pool == spillMemoryPool();
+}
 } // namespace facebook::velox::memory

--- a/velox/common/memory/Memory.h
+++ b/velox/common/memory/Memory.h
@@ -251,6 +251,12 @@ std::shared_ptr<MemoryPool> addDefaultLeafMemoryPool(
 /// lifecycle of the allocated memory pools properly.
 MemoryPool& deprecatedSharedLeafPool();
 
+/// Returns the system-wide memory pool for spilling memory usage.
+memory::MemoryPool* spillMemoryPool();
+
+/// Returns true if the provided 'pool' is the spilling memory pool.
+bool isSpillMemoryPool(memory::MemoryPool* pool);
+
 FOLLY_ALWAYS_INLINE int32_t alignmentPadding(void* address, int32_t alignment) {
   auto extra = reinterpret_cast<uintptr_t>(address) % alignment;
   return extra == 0 ? 0 : alignment - extra;

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -300,4 +300,32 @@ class MemoryReclaimer {
  protected:
   MemoryReclaimer() = default;
 };
+
+/// The memory arbitration context which is set on per-thread local variable by
+/// memory arbitrator. It is used to indicate a running thread is under memory
+/// arbitration processing or not. This helps to enable sanity check such as all
+/// the memory reservations during memory arbitration should come from the
+/// spilling memory pool.
+struct MemoryArbitrationContext {
+  const MemoryPool& requestor;
+};
+
+/// Object used to set/restore the memory arbitration context when a thread is
+/// under memory arbitration processing.
+class ScopedMemoryArbitrationContext {
+ public:
+  explicit ScopedMemoryArbitrationContext(const MemoryPool& requestor);
+  ~ScopedMemoryArbitrationContext();
+
+ private:
+  MemoryArbitrationContext* const savedArbitrationCtx_{nullptr};
+  MemoryArbitrationContext currentArbitrationCtx_;
+};
+
+/// Returns the memory arbitration context set by a per-thread local variable if
+/// the running thread is under memory arbitration processing.
+MemoryArbitrationContext* memoryArbitrationContext();
+
+/// Returns true if the running thread is under memory arbitration or not.
+bool underMemoryArbitration();
 } // namespace facebook::velox::memory

--- a/velox/common/memory/MemoryPool.cpp
+++ b/velox/common/memory/MemoryPool.cpp
@@ -654,6 +654,13 @@ bool MemoryPoolImpl::maybeReserve(uint64_t increment) {
 }
 
 void MemoryPoolImpl::reserve(uint64_t size, bool reserveOnly) {
+  if (FOLLY_UNLIKELY(underMemoryArbitration() && !isSpillMemoryPool(this))) {
+    VELOX_FAIL(
+        "Unexpected non-spilling memory reservation from memory pool: {}, arbitration request pool: {}",
+        name(),
+        memoryArbitrationContext()->requestor.name());
+  }
+
   if (FOLLY_LIKELY(trackUsage_)) {
     if (FOLLY_LIKELY(threadSafe_)) {
       reserveThreadSafe(size, reserveOnly);

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -513,8 +513,8 @@ SharedArbitrator::ScopedArbitration::ScopedArbitration(
     SharedArbitrator* arbitrator)
     : requestor_(requestor),
       arbitrator_(arbitrator),
-      startTime_(std::chrono::steady_clock::now()) {
-  VELOX_CHECK_NOT_NULL(requestor_);
+      startTime_(std::chrono::steady_clock::now()),
+      arbitrationCtx_(*requestor_) {
   VELOX_CHECK_NOT_NULL(arbitrator_);
   arbitrator_->startArbitration(requestor);
   if (arbitrator_->arbitrationStateCheckCb_ != nullptr) {

--- a/velox/common/memory/SharedArbitrator.h
+++ b/velox/common/memory/SharedArbitrator.h
@@ -86,6 +86,7 @@ class SharedArbitrator : public MemoryArbitrator {
     MemoryPool* const requestor_;
     SharedArbitrator* const arbitrator_;
     const std::chrono::steady_clock::time_point startTime_;
+    const ScopedMemoryArbitrationContext arbitrationCtx_;
   };
 
   // Invoked to check if the memory growth will exceed the memory pool's max

--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -2386,6 +2386,67 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, asyncArbitratonFromNonDriverContext) {
   waitForAllTasksToBeDeleted();
 }
 
+DEBUG_ONLY_TEST_F(
+    SharedArbitrationTest,
+    allocationMemoryFromNonSpillMemoryPoolUnderArbitration) {
+  setupMemory(kMemoryCapacity, 0);
+  const int numVectors = 10;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+  std::shared_ptr<core::QueryCtx> queryCtx = newQueryCtx(kMemoryCapacity);
+  ASSERT_EQ(queryCtx->pool()->capacity(), 0);
+
+  std::atomic<bool> aggregationMaybeReserveInjectionOnce{true};
+  std::atomic<MemoryPool*> injectPool{nullptr};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::common::memory::MemoryPoolImpl::maybeReserve",
+      std::function<void(MemoryPool*)>(([&](MemoryPool* pool) {
+        if (!aggregationMaybeReserveInjectionOnce.exchange(false)) {
+          return;
+        }
+        if (pool->currentBytes() == 0) {
+          return;
+        }
+        injectPool = pool;
+        VELOX_ASSERT_THROW(
+            pool->allocate(kMemoryCapacity - pool->reservedBytes() / 2),
+            "Exceeded memory pool cap");
+      })));
+
+  std::atomic<bool> nonSpillMemoryPoolChecked{false};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Task::requestPauseLocked",
+      std::function<void(Task*)>(([&](Task* /*unused*/) {
+        VELOX_ASSERT_THROW(
+            injectPool.load()->allocate(20L << 20),
+            "Unexpected non-spilling memory reservation");
+        nonSpillMemoryPoolChecked = true;
+      })));
+
+  const auto spillDirectory = exec::test::TempDirectoryPath::create();
+  AssertQueryBuilder(duckDbQueryRunner_)
+      .queryCtx(queryCtx)
+      .spillDirectory(spillDirectory->path)
+      .config(core::QueryConfig::kSpillEnabled, "true")
+      .config(core::QueryConfig::kJoinSpillEnabled, "true")
+      .config(core::QueryConfig::kJoinSpillPartitionBits, "2")
+      .plan(PlanBuilder()
+                .values(vectors)
+                .localPartition({"c0", "c1"})
+                .singleAggregation({"c0", "c1"}, {"array_agg(c2)"})
+                .localPartition(std::vector<std::string>{})
+                .planNode())
+      .assertResults("SELECT c0, c1, array_agg(c2) FROM tmp GROUP BY c0, c1");
+
+  waitForAllTasksToBeDeleted();
+
+  ASSERT_TRUE(injectPool != nullptr);
+  ASSERT_TRUE(nonSpillMemoryPoolChecked);
+}
+
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrationFromTableWriter) {
   setupMemory(kMemoryCapacity, 0);
 

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -670,7 +670,6 @@ SpillStats Spiller::stats() const {
 
 // static
 memory::MemoryPool* Spiller::pool() {
-  static auto pool = memory::addDefaultLeafMemoryPool("_sys.spilling");
-  return pool.get();
+  return memory::spillMemoryPool();
 }
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Add check in memory reservation if the request memory pool is the spilling
memory pool or not under memory arbitration. We shall only allow memory
reservation from a spilling memory pool during memory arbitration. We add
MemoryArbitrationContext for this which is set o a per-thread local object, and
check this on memory pool reservation request.