### PR TITLE
Relink new targets in velox/common

### DIFF
--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -45,10 +45,5 @@ endif()
 add_library(velox_id_map BigintIdMap.cpp)
 target_link_libraries(
   velox_id_map
-  velox_memory
-  velox_flag_definitions
-  velox_process
-  glog::glog
-  Folly::folly
-  fmt::fmt
-  gflags::gflags)
+  PUBLIC velox_common_base velox_flag_definitions velox_memory Folly::folly
+  PRIVATE velox_exception)

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ target_link_libraries(
           velox_time
           velox_exception
           velox_temp_path
+          velox_type
           Boost::filesystem
           Boost::headers
           Folly::folly
@@ -49,17 +50,8 @@ add_executable(velox_id_map_test IdMapTest.cpp)
 
 add_test(velox_id_map_test velox_id_map_test)
 
-target_link_libraries(
-  velox_id_map_test
-  velox_id_map
-  velox_common_base
-  velox_memory
-  Boost::headers
-  gflags::gflags
-  glog::glog
-  gtest
-  gtest_main
-  pthread)
+target_link_libraries(velox_id_map_test PRIVATE velox_id_map Folly::folly gtest
+                                                gtest_main)
 
 add_executable(velox_memcpy_meter Memcpy.cpp)
 target_link_libraries(

--- a/velox/common/compression/CMakeLists.txt
+++ b/velox/common/compression/CMakeLists.txt
@@ -20,4 +20,4 @@ add_library(velox_common_compression Compression.cpp LzoDecompressor.cpp)
 target_link_libraries(
   velox_common_compression
   PUBLIC Folly::folly
-  PRIVATE velox_exception)
+  PRIVATE velox_dwio_common_exception velox_exception)

--- a/velox/common/config/CMakeLists.txt
+++ b/velox/common/config/CMakeLists.txt
@@ -13,5 +13,7 @@
 # limitations under the License.
 
 add_library(velox_spill_config SpillConfig.cpp)
-target_link_libraries(velox_spill_config Folly::folly velox_exception
-                      velox_common_compression)
+target_link_libraries(
+  velox_spill_config
+  PUBLIC velox_common_compression Folly::folly
+  PRIVATE velox_exception)

--- a/velox/common/file/CMakeLists.txt
+++ b/velox/common/file/CMakeLists.txt
@@ -17,7 +17,7 @@ include_directories(.)
 add_library(velox_file File.cpp FileSystems.cpp Utils.cpp)
 target_link_libraries(
   velox_file
-  PUBLIC velox_exception Folly::folly
+  PUBLIC velox_exception velox_memory Folly::folly
   PRIVATE velox_common_base fmt::fmt glog::glog)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/common/memory/tests/CMakeLists.txt
+++ b/velox/common/memory/tests/CMakeLists.txt
@@ -31,9 +31,11 @@ target_link_libraries(
   velox_memory_test
   PRIVATE velox_caching
           velox_common_base
+          velox_core
           velox_exception
           velox_exec
           velox_exec_test_lib
+          velox_hive_connector
           velox_memory
           velox_temp_path
           velox_test_util

--- a/velox/common/testutil/tests/CMakeLists.txt
+++ b/velox/common/testutil/tests/CMakeLists.txt
@@ -16,11 +16,5 @@ add_executable(velox_test_util_test TestValueTest.cpp SpillConfigTest.cpp)
 gtest_add_tests(velox_test_util_test "" AUTO)
 
 target_link_libraries(
-  velox_test_util_test
-  PRIVATE
-  velox_test_util
-  velox_exception
-  velox_spill_config
-  velox_exec
-  gtest
-  gtest_main)
+  velox_test_util_test PRIVATE velox_core velox_spill_config velox_test_util
+                               gtest gtest_main)


### PR DESCRIPTION
There were some changes merged to velox/common during review of #6237 that need to be updated.