### PR TITLE
Fix bundled build linking failure with Parquet ON

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -72,4 +72,5 @@ target_link_libraries(
   velox_exec
   Boost::regex
   Folly::folly
-  glog::glog)
+  glog::glog
+  ${Protobuf_LIBRARIES})

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -37,5 +37,4 @@ target_link_libraries(
   arrow
   Snappy::snappy
   thrift
-  zstd::zstd
-  ${Protobuf_LIBRARIES})
+  zstd::zstd)


### PR DESCRIPTION
Fixes https://github.com/facebookincubator/velox/issues/6744