### PR TITLE
Fail if inputs contain nested nulls in set_agg Presto aggregates

### DIFF
--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -107,7 +107,7 @@ General Aggregate Functions
 .. function:: max(x) -> [same as input]
 
     Returns the maximum value of all input values.
-    ``x`` must not contains nulls when it is complex type.
+    ``x`` must not contain nulls when it is complex type.
 
 .. function:: max(x, n) -> array<[same as x]>
 
@@ -117,7 +117,7 @@ General Aggregate Functions
 .. function:: min(x) -> [same as input]
 
     Returns the minimum value of all input values.
-    ``x`` must not contains nulls when it is complex type.
+    ``x`` must not contain nulls when it is complex type.
 
 .. function:: min(x, n) -> array<[same as x]>
 
@@ -193,7 +193,7 @@ General Aggregate Functions
 .. function:: set_agg(x) -> array<[same as input]>
 
     Returns an array created from the distinct input ``x`` elements.
-    ``x`` must not contains nulls when it is complex type.
+    ``x`` must not contain nulls when it is complex type.
 
 .. function:: set_union(array(T)) -> array(T)
 

--- a/velox/docs/functions/presto/aggregate.rst
+++ b/velox/docs/functions/presto/aggregate.rst
@@ -193,6 +193,7 @@ General Aggregate Functions
 .. function:: set_agg(x) -> array<[same as input]>
 
     Returns an array created from the distinct input ``x`` elements.
+    ``x`` must not contains nulls when it is complex type.
 
 .. function:: set_union(array(T)) -> array(T)
 

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -310,7 +310,9 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
     if (throwOnNestedNulls_) {
       DecodedVector decoded(*input, rows, true);
-      rows.applyToSelected([&](vector_size_t i) { checkNulls(decoded, i); });
+      auto indices = decoded.indices();
+      rows.applyToSelected(
+          [&](vector_size_t i) { checkNulls(decoded, indices, i); });
     }
 
     if (rows.isAllSelected()) {
@@ -385,7 +387,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     }
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (checkNulls(decoded, i)) {
+      if (checkNulls(decoded, indices, i)) {
         return;
       }
 
@@ -408,7 +410,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     auto baseVector = decoded.base();
 
     if (decoded.isConstantMapping()) {
-      if (checkNulls(decoded, 0)) {
+      if (checkNulls(decoded, indices, 0)) {
         return;
       }
 
@@ -422,7 +424,7 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
     auto accumulator = value<SingleValueAccumulator>(group);
     rows.applyToSelected([&](vector_size_t i) {
-      if (checkNulls(decoded, i)) {
+      if (checkNulls(decoded, indices, i)) {
         return;
       }
 
@@ -433,14 +435,17 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     });
   }
 
-  bool checkNulls(const DecodedVector& decoded, vector_size_t index) const {
+  bool checkNulls(
+      const DecodedVector& decoded,
+      const vector_size_t* indices,
+      vector_size_t index) const {
     if (decoded.isNullAt(index)) {
       return true;
     }
 
     if (throwOnNestedNulls_) {
       VELOX_USER_CHECK(
-          !decoded.base()->containsNullAt(index),
+          !decoded.base()->containsNullAt(indices[index]),
           fmt::format(
               "{} comparison not supported for values that contain nulls",
               mapTypeKindToName(decoded.base()->typeKind())));

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -446,9 +446,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     if (throwOnNestedNulls_) {
       VELOX_USER_CHECK(
           !decoded.base()->containsNullAt(indices[index]),
-          fmt::format(
-              "{} comparison not supported for values that contain nulls",
-              mapTypeKindToName(decoded.base()->typeKind())));
+          "{} comparison not supported for values that contain nulls",
+          mapTypeKindToName(decoded.base()->typeKind()));
     }
 
     return false;

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -309,9 +309,8 @@ class SetAggAggregate : public SetBaseAggregate<T> {
     if (throwOnNestedNulls_) {
       VELOX_USER_CHECK(
           !decoded.base()->containsNullAt(indices[index]),
-          fmt::format(
-              "{} comparison not supported for values that contain nulls",
-              mapTypeKindToName(decoded.base()->typeKind())));
+          "{} comparison not supported for values that contain nulls",
+          mapTypeKindToName(decoded.base()->typeKind()));
     }
   }
 

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -199,8 +199,11 @@ class SetBaseAggregate : public exec::Aggregate {
 template <typename T>
 class SetAggAggregate : public SetBaseAggregate<T> {
  public:
+  SetAggAggregate(const TypePtr& resultType, const bool throwOnNestedNulls)
+      : SetBaseAggregate<T>(resultType),
+        throwOnNestedNulls_(throwOnNestedNulls) {}
   explicit SetAggAggregate(const TypePtr& resultType)
-      : SetBaseAggregate<T>(resultType) {}
+      : SetBaseAggregate<T>(resultType), throwOnNestedNulls_(false) {}
 
   using Base = SetBaseAggregate<T>;
 
@@ -213,6 +216,12 @@ class SetAggAggregate : public SetBaseAggregate<T> {
       std::vector<VectorPtr>& args,
       VectorPtr& result) const override {
     const auto& elements = args[0];
+
+    if (throwOnNestedNulls_) {
+      DecodedVector decodedElements(*elements, rows);
+      rows.applyToSelected(
+          [&](vector_size_t i) { checkNulls(decodedElements, i); });
+    }
 
     const auto numRows = rows.size();
 
@@ -257,6 +266,10 @@ class SetAggAggregate : public SetBaseAggregate<T> {
       auto* group = groups[i];
       Base::clearNull(group);
 
+      if (throwOnNestedNulls_) {
+        checkNulls(Base::decoded_, i);
+      }
+
       auto tracker = Base::trackRowSize(group);
       Base::value(group)->addValue(Base::decoded_, i, Base::allocator_);
     });
@@ -274,9 +287,32 @@ class SetAggAggregate : public SetBaseAggregate<T> {
 
     auto tracker = Base::trackRowSize(group);
     rows.applyToSelected([&](vector_size_t i) {
+      if (throwOnNestedNulls_) {
+        checkNulls(Base::decoded_, i);
+      }
+
       accumulator->addValue(Base::decoded_, i, Base::allocator_);
     });
   }
+
+ private:
+  bool checkNulls(const DecodedVector& decoded, vector_size_t index) const {
+    if (decoded.isNullAt(index)) {
+      return true;
+    }
+
+    if (throwOnNestedNulls_) {
+      VELOX_USER_CHECK(
+          !decoded.base()->containsNullAt(index),
+          fmt::format(
+              "{} comparison not supported for values that contain nulls",
+              mapTypeKindToName(decoded.base()->typeKind())));
+    }
+
+    return false;
+  }
+
+  const bool throwOnNestedNulls_;
 };
 
 template <typename T>
@@ -413,11 +449,43 @@ exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_EQ(argTypes.size(), 1);
 
-        const TypeKind typeKind = exec::isRawInput(step)
-            ? argTypes[0]->kind()
-            : argTypes[0]->childAt(0)->kind();
+        const bool isRawInput = exec::isRawInput(step);
+        const TypeKind typeKind =
+            isRawInput ? argTypes[0]->kind() : argTypes[0]->childAt(0)->kind();
+        const bool throwOnNestedNulls = isRawInput;
 
-        return create<SetAggAggregate>(typeKind, resultType);
+        switch (typeKind) {
+          case TypeKind::BOOLEAN:
+            return std::make_unique<SetAggAggregate<bool>>(resultType);
+          case TypeKind::TINYINT:
+            return std::make_unique<SetAggAggregate<int8_t>>(resultType);
+          case TypeKind::SMALLINT:
+            return std::make_unique<SetAggAggregate<int16_t>>(resultType);
+          case TypeKind::INTEGER:
+            return std::make_unique<SetAggAggregate<int32_t>>(resultType);
+          case TypeKind::BIGINT:
+            return std::make_unique<SetAggAggregate<int64_t>>(resultType);
+          case TypeKind::REAL:
+            return std::make_unique<SetAggAggregate<float>>(resultType);
+          case TypeKind::DOUBLE:
+            return std::make_unique<SetAggAggregate<double>>(resultType);
+          case TypeKind::TIMESTAMP:
+            return std::make_unique<SetAggAggregate<Timestamp>>(resultType);
+          case TypeKind::VARBINARY:
+            [[fallthrough]];
+          case TypeKind::VARCHAR:
+            return std::make_unique<SetAggAggregate<StringView>>(resultType);
+          case TypeKind::ARRAY:
+            [[fallthrough]];
+          case TypeKind::MAP:
+            [[fallthrough]];
+          case TypeKind::ROW:
+            return std::make_unique<SetAggAggregate<ComplexType>>(
+                resultType, throwOnNestedNulls);
+          default:
+            VELOX_UNREACHABLE(
+                "Unexpected type {}", mapTypeKindToName(typeKind));
+        }
       });
 }
 

--- a/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/SetAggTest.cpp
@@ -20,6 +20,7 @@
 
 using namespace facebook::velox::exec;
 using namespace facebook::velox::functions::aggregate::test;
+using namespace facebook::velox::exec::test;
 
 namespace facebook::velox::aggregate::test {
 
@@ -327,5 +328,90 @@ TEST_F(SetAggTest, groupByArray) {
       {"c0", "array_sort(a0)"},
       {expected});
 }
+
+TEST_F(SetAggTest, arrayCheckNulls) {
+  auto batch = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2]",
+          "[6, 7]",
+          "[2, 3]",
+      }),
+      makeFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      }),
+  });
+
+  auto batchWithNull = makeRowVector({
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2]",
+          "[6, 7]",
+          "[3, null]",
+      }),
+      makeFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      }),
+  });
+
+  testFailingAggregations(
+      {batch, batchWithNull},
+      {},
+      {"set_agg(c0)"},
+      "ARRAY comparison not supported for values that contain nulls");
+  testFailingAggregations(
+      {batch, batchWithNull},
+      {"c1"},
+      {"set_agg(c0)"},
+      "ARRAY comparison not supported for values that contain nulls");
+}
+
+TEST_F(SetAggTest, rowCheckNull) {
+  auto batch = makeRowVector({
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              "bb"_sv,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  auto batchWithNull = makeRowVector({
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              std::nullopt,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  testFailingAggregations(
+      {batch, batchWithNull},
+      {},
+      {"set_agg(c0)"},
+      "ROW comparison not supported for values that contain nulls");
+  testFailingAggregations(
+      {batch, batchWithNull},
+      {"c1"},
+      {"set_agg(c0)"},
+      "ROW comparison not supported for values that contain nulls");
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::test


### PR DESCRIPTION
In Presto, set_agg checks for null array elements, map values,
and struct fields and throws, but in Velox, they don't. For example,
the following SQL should throw an exception, "ARRAY comparison
not supported for arrays with null elements".

```SQL
presto> SELECT set_agg(col1) FROM (VALUES (1, array [1, 2, 3]), 
(2, array [null, 3, 1]), (2, array [null, 3, 1])) AS tbl(col0, col1);
Query 20230918_072245_00001_fggjk failed: ARRAY 
comparison not supported for arrays with null elements
```
This PR do the following things,
- Add a check that all raw inputs (in the `Partial/Single` step) 
of set_agg do not contain nested nulls before serializing them to the accumulator.
- **Fix a bug** of checkNulls in min/max that uses the wrong index. It must use
the base index, not the top-level index.

Part of https://github.com/facebookincubator/velox/issues/6314