### PR TITLE
Back out "Fix ByteRleDecoder::skipBytes to avoid reading data and breaking contiguous skips"

### DIFF
--- a/velox/dwio/common/CacheInputStream.cpp
+++ b/velox/dwio/common/CacheInputStream.cpp
@@ -212,7 +212,7 @@ void CacheInputStream::loadSync(Region region) {
     } else {
       // Hit memory cache.
       if (!entry->getAndClearFirstUseFlag()) {
-        ioStats_->ramHit().increment(region.length);
+        ioStats_->ramHit().increment(entry->size());
       }
       return;
     }
@@ -269,7 +269,7 @@ bool CacheInputStream::loadFromSsd(
     throw;
   }
   pin_ = std::move(pins[0]);
-  ioStats_->ssdRead().increment(region.length);
+  ioStats_->ssdRead().increment(entry.size());
   ioStats_->queryThreadIoLatency().increment(usec);
   entry.setExclusiveToShared();
   return true;

--- a/velox/dwio/common/compression/Compression.h
+++ b/velox/dwio/common/compression/Compression.h
@@ -46,14 +46,14 @@ class Compressor {
 class Decompressor {
  public:
   explicit Decompressor(uint64_t blockSize, const std::string& streamDebugInfo)
-      : blockSize_{static_cast<int64_t>(blockSize)},
-        streamDebugInfo_{streamDebugInfo} {}
+      : blockSize_{blockSize}, streamDebugInfo_{streamDebugInfo} {}
 
   virtual ~Decompressor() = default;
 
-  virtual std::pair<int64_t, bool /* Is the size exact? */>
-  getDecompressedLength(const char* /* src */, uint64_t /* srcLength */) const {
-    return {blockSize_, false};
+  virtual uint64_t getUncompressedLength(
+      const char* /* unused */,
+      uint64_t /* unused */) const {
+    return blockSize_;
   }
 
   virtual uint64_t decompress(
@@ -63,7 +63,7 @@ class Decompressor {
       uint64_t destLength) = 0;
 
  protected:
-  int64_t blockSize_;
+  uint64_t blockSize_;
   const std::string streamDebugInfo_;
 };
 

--- a/velox/dwio/common/compression/PagedInputStream.h
+++ b/velox/dwio/common/compression/PagedInputStream.h
@@ -52,14 +52,10 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
 
   bool Next(const void** data, int32_t* size) override;
   void BackUp(int32_t count) override;
-
-  // NOTE: This always returns true.
   bool Skip(int32_t count) override;
-
   google::protobuf::int64 ByteCount() const override {
-    return bytesReturned_ + pendingSkip_;
+    return bytesReturned_;
   }
-
   void seekToPosition(dwio::common::PositionProvider& position) override;
   std::string getName() const override {
     return folly::to<std::string>(
@@ -119,8 +115,6 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // make sure input is contiguous for decompression/decryption
   const char* ensureInput(size_t availableInputBytes);
 
-  virtual bool readOrSkip(const void** data, int32_t* size);
-
   // input stream where to read compressed/encrypted data
   std::unique_ptr<SeekableInputStream> input_;
   memory::MemoryPool& pool_;
@@ -163,7 +157,7 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // The first byte after the last range returned by 'input_->Next()'.
   const char* inputBufferPtrEnd_{nullptr};
 
-  // Bytes returned or skipped by this stream, not including pendingSkip_.
+  // bytes returned by this stream
   uint64_t bytesReturned_{0};
 
   // Size returned by the previous call to Next().
@@ -175,11 +169,7 @@ class PagedInputStream : public dwio::common::SeekableInputStream {
   // decrypter
   const dwio::common::encryption::Decrypter* decrypter_;
 
-  int64_t pendingSkip_{0};
-
  private:
-  bool skipAllPending();
-
   // Stream Debug Info
   const std::string streamDebugInfo_;
 };

--- a/velox/dwio/dwrf/common/ByteRLE.cpp
+++ b/velox/dwio/dwrf/common/ByteRLE.cpp
@@ -365,15 +365,16 @@ void ByteRleDecoder::seekToRowGroup(
 }
 
 void ByteRleDecoder::skipBytes(size_t count) {
-  if (bufferStart < bufferEnd) {
+  size_t consumedBytes = count;
+  while (consumedBytes > 0) {
+    if (bufferStart == bufferEnd) {
+      nextBuffer();
+    }
     size_t skipSize = std::min(
-        static_cast<size_t>(count),
+        static_cast<size_t>(consumedBytes),
         static_cast<size_t>(bufferEnd - bufferStart));
     bufferStart += skipSize;
-    count -= skipSize;
-  }
-  if (count > 0) {
-    inputStream->Skip(count);
+    consumedBytes -= skipSize;
   }
 }
 

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -627,14 +627,10 @@ class CompressBuffer {
     return buf.data();
   }
 
-  static void writeHeader(size_t compressedSize, char* buf) {
+  void writeHeader(size_t compressedSize) {
     buf[0] = static_cast<char>(compressedSize << 1);
     buf[1] = static_cast<char>(compressedSize >> 7);
     buf[2] = static_cast<char>(compressedSize >> 15);
-  }
-
-  void writeHeader(size_t compressedSize) {
-    writeHeader(compressedSize, buf.data());
   }
 
   void writeUncompressedHeader(size_t compressedSize) {
@@ -774,58 +770,6 @@ TEST(TestDecompression, testSkipSnappy) {
   for (int32_t i = N / 2; i < N; ++i) {
     EXPECT_EQ(i % 8, (reinterpret_cast<const int32_t*>(data))[i - N / 2]);
   }
-}
-
-TEST(TestDecompression, testDelayedSkip) {
-  constexpr int32_t N = 1024;
-  std::vector<int> buf(N);
-  for (int32_t i = 0; i < N; ++i) {
-    buf[i] = i % 8;
-  }
-  const auto bufByteSize = buf.size() * sizeof(int);
-  std::vector<char> compressed(2 * bufByteSize);
-  int totalCompressed = 0;
-  // Create 2 compressed frames, the first one is corrupted in data blocks and
-  // should be skipped without decompression.
-  for (int i = 0; i < 2; ++i) {
-    auto ioBuf = folly::IOBuf::wrapBuffer(buf.data(), bufByteSize);
-    auto cbuf = getCodec(CodecType::ZSTD)->compress(ioBuf.get());
-    ASSERT_LE(
-        totalCompressed + HEADER_SIZE + cbuf->length(), compressed.size());
-    CompressBuffer::writeHeader(cbuf->length(), &compressed[totalCompressed]);
-    totalCompressed += HEADER_SIZE;
-    if (i == 0) {
-      constexpr int kDataBlockOffset = 18;
-      memcpy(&compressed[totalCompressed], cbuf->data(), kDataBlockOffset);
-      memset(
-          &compressed[totalCompressed + kDataBlockOffset],
-          0xAA,
-          cbuf->length() - kDataBlockOffset);
-    } else {
-      memcpy(&compressed[totalCompressed], cbuf->data(), cbuf->length());
-    }
-    totalCompressed += cbuf->length();
-  }
-  constexpr long kBlockSize = 97;
-  auto result = createTestDecompressor(
-      CompressionKind_ZSTD,
-      std::make_unique<SeekableArrayInputStream>(
-          compressed.data(), totalCompressed, kBlockSize),
-      bufByteSize);
-  const void* data;
-  int32_t length;
-  ASSERT_TRUE(result->Skip(bufByteSize / 2));
-  ASSERT_TRUE(result->Skip(bufByteSize / 2));
-  ASSERT_TRUE(result->Next(&data, &length));
-  ASSERT_EQ(length, bufByteSize);
-  auto* dataAsInt = reinterpret_cast<const int*>(data);
-  for (int i = 0; i < N; ++i) {
-    ASSERT_EQ(dataAsInt[i], buf[i]);
-  }
-  std::vector<uint64_t> posVector(2, 0);
-  PositionProvider pos(posVector);
-  result->seekToPosition(pos);
-  ASSERT_THROW(result->Next(&data, &length), VeloxException);
 }
 
 void fillInput(char* buf, size_t size) {


### PR DESCRIPTION
Summary:
Original commit changeset: dcd56bfaeba5

Original Phabricator Diff: D49614579

Differential Revision: D49872684

