### PR TITLE
Fix window aggregate result for empty frames

### DIFF
--- a/velox/exec/WindowFunction.h
+++ b/velox/exec/WindowFunction.h
@@ -111,10 +111,14 @@ class WindowFunction {
       const core::QueryConfig& config);
 
  protected:
-  // Set result NULL for rows with invalid frames in the input.
-  void setNullEmptyFramesResults(
+  // defaultResult is a vector of size 1 containing the default value to be
+  // returned for rows with empty frames. For aggregate window functions,
+  // defaultResult contains the value returned by the aggregate when there are
+  // no input rows.
+  void setEmptyFramesResult(
       const SelectivityVector& validRows,
       vector_size_t resultOffset,
+      const VectorPtr& defaultResult,
       const VectorPtr& result);
 
   const TypePtr resultType_;

--- a/velox/functions/lib/window/tests/WindowTestBase.cpp
+++ b/velox/functions/lib/window/tests/WindowTestBase.cpp
@@ -177,6 +177,17 @@ void WindowTestBase::testWindowFunction(
   }
 }
 
+void WindowTestBase::testWindowFunction(
+    const std::vector<RowVectorPtr>& input,
+    const std::string& function,
+    const std::string& overClause,
+    const std::string& frameClause,
+    const RowVectorPtr& expectedResult) {
+  auto queryInfo = buildWindowQuery(input, function, overClause, frameClause);
+  SCOPED_TRACE(queryInfo.functionSql);
+  assertQuery(queryInfo.planNode, expectedResult);
+}
+
 void WindowTestBase::assertWindowFunctionError(
     const std::vector<RowVectorPtr>& input,
     const std::string& function,

--- a/velox/functions/lib/window/tests/WindowTestBase.h
+++ b/velox/functions/lib/window/tests/WindowTestBase.h
@@ -157,6 +157,15 @@ class WindowTestBase : public exec::test::OperatorTestBase {
       bool createTable = true,
       WindowStyle windowStyle = WindowStyle::kRandom);
 
+  /// Tests the window function with the {overClause, frameClause} pair and
+  /// asserts that the result is equal to expectedResult.
+  void testWindowFunction(
+      const std::vector<RowVectorPtr>& input,
+      const std::string& function,
+      const std::string& overClause,
+      const std::string& frameClause,
+      const RowVectorPtr& expectedResult);
+
   /// This function tests the SQL query for the window function and overClause
   /// combination with the input RowVectors. It is expected that query execution
   /// will throw an exception with the errorMessage specified.


### PR DESCRIPTION
Presto returns the default value of the aggregate for rows with empty frames. Velox like DuckDB always returned nulls. Fix Velox behavior to be consistent with Presto.

The default value of aggregates is usually null, but there are aggregates like count which return 0.

Resolves #6416 