### PR TITLE
Refactor HivePartitionFunction in preparation for supporting complex types

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -48,14 +48,39 @@ class HivePartitionFunction : public core::PartitionFunction {
   // Precompute single value hive hash for a constant partition key.
   void precompute(const BaseVector& value, size_t column_index_t);
 
+  void hash(
+      const DecodedVector& values,
+      TypeKind typeKind,
+      const SelectivityVector& rows,
+      bool mix,
+      std::vector<uint32_t>& hashes,
+      size_t poolIndex);
+
+  template <TypeKind kind>
+  void hashTyped(
+      const DecodedVector& /* values */,
+      const SelectivityVector& /* rows */,
+      bool /* mix */,
+      std::vector<uint32_t>& /* hashes */,
+      size_t /* poolIndex */) {
+    VELOX_UNSUPPORTED(
+        "Hive partitioning function doesn't support {} type",
+        TypeTraits<kind>::name);
+  }
+
+  // Helper functions to retrieve reusable memory from pools.
+  DecodedVector& getDecodedVector(size_t poolIndex = 0);
+  SelectivityVector& getRows(size_t poolIndex = 0);
+  std::vector<uint32_t>& getHashes(size_t poolIndex = 0);
+
   const int numBuckets_;
   const std::vector<int> bucketToPartition_;
   const std::vector<column_index_t> keyChannels_;
 
-  // Reusable memory.
-  std::vector<uint32_t> hashes_;
-  SelectivityVector rows_;
-  std::vector<DecodedVector> decodedVectors_;
+  // Pools of reusable memory.
+  std::vector<std::unique_ptr<std::vector<uint32_t>>> hashesPool_;
+  std::vector<std::unique_ptr<SelectivityVector>> rowsPool_;
+  std::vector<std::unique_ptr<DecodedVector>> decodedVectorsPool_;
   // Precomputed hashes for constant partition keys (one per key).
   std::vector<uint32_t> precomputedHashes_;
 };

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -30,7 +30,7 @@ using connector::hive::HivePartitionFunction;
 
 namespace {
 
-constexpr std::array<TypeKind, 10> kSupportedTypes{
+constexpr std::array<TypeKind, 10> kSupportedScalarTypes{
     TypeKind::BOOLEAN,
     TypeKind::TINYINT,
     TypeKind::SMALLINT,
@@ -52,9 +52,13 @@ class HivePartitionFunctionBenchmark
     opts.stringLength = 20;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
     VectorMaker vm{pool_.get()};
-    for (auto typeKind : kSupportedTypes) {
-      auto flatVector = fuzzer.fuzzFlat(createScalarType(typeKind));
-      rowVectors_[typeKind] = vm.rowVector({flatVector});
+    auto addRowVector = [&](const TypePtr& type) {
+      auto flatVector = fuzzer.fuzzFlat(type);
+      rowVectors_[type->kind()] = vm.rowVector({flatVector});
+    };
+
+    for (auto typeKind : kSupportedScalarTypes) {
+      addRowVector(createScalarType(typeKind));
     }
 
     // Prepare HivePartitionFunction


### PR DESCRIPTION
Summary:
This change does some refactoring of the HivePartitionFunction code in order to help support complex
types.  I'll describe the changes below:

* When the only types being hashed are primitive, we could assume that we'd need only one DecodedVector
per input, one SelectivityVector, and one vector of hashes.  With Complex types, we will need these at each
level of the type tree.  To help reduce memory allocations and maintaining performance I've added pools for
each of these to HivePartitionFunction.  The first time the function is called, the pools will be filled as much
as necessary to support all of the types, and from then after the values in the pools will be reused.  Since
only one field from the top level row is hashed at a time, we can reuse the values in the pool across fields.
Since the pools are members of HivePartitionFunction, I made hash and hashTyped member functions so
they can access them.
* I had some trouble maintaining the same performance in abstractHashTyped (now hashPrimitive) because
before, we were only hashing primitives so we could take for granted that all values were selected and
process them in a for loop.  The compiler seemed to be very good at inlining and possibly other optimizations
when this is the case.  As soon as I hashed values based on a SelectivityVector (because in Complex types
not all values in the child Vectors may be relevant), the performance for primitives became 50% worse in the
benchmarks.  In order to maintain the same performance, I moved the single value hashing logic to an inlined
function hashOne (which seemed to be easier to inline that the previous lambda) and handled the case
where allSelected is true explicitly rather than leaving it to SelectivityVector which would be ideal.  With
these changes in place I'm seeing the same performance for primitives.  I had also considered always
processing all values, but thought the cost for nested complex types would be too high.
* Lastly, I also refactored the benchmark a little to make it easier to add cases for complex types in later
changes.

benchmark before:
```
============================================================================
[...]ks/HivePartitionFunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
booleanFewRowsFewBuckets                                    2.64us   379.27K
booleanFewRowsManyBuckets                       102.91%     2.56us   390.30K
booleanManyRowsFewBuckets                                  25.72us    38.88K
booleanManyRowsManyBuckets                      100.02%    25.72us    38.88K
tinyintFewRowsFewBuckets                                    2.12us   472.30K
tinyintFewRowsManyBuckets                       97.166%     2.18us   458.91K
tinyintManyRowsFewBuckets                                  21.46us    46.60K
tinyintManyRowsManyBuckets                      100.08%    21.44us    46.64K
smallintFewRowsFewBuckets                                   2.19us   457.61K
smallintFewRowsManyBuckets                      99.974%     2.19us   457.50K
smallintManyRowsFewBuckets                                 21.54us    46.43K
smallintManyRowsManyBuckets                     100.11%    21.52us    46.48K
integerFewRowsFewBuckets                                    2.19us   457.64K
integerFewRowsManyBuckets                       100.04%     2.18us   457.83K
integerManyRowsFewBuckets                                  21.56us    46.39K
integerManyRowsManyBuckets                      100.01%    21.55us    46.40K
bigintFewRowsFewBuckets                                     2.26us   443.21K
bigintFewRowsManyBuckets                        100.03%     2.26us   443.33K
bigintManyRowsFewBuckets                                   22.16us    45.12K
bigintManyRowsManyBuckets                       100.12%    22.14us    45.18K
realFewRowsFewBuckets                                       2.32us   431.06K
realFewRowsManyBuckets                          106.15%     2.19us   457.55K
realManyRowsFewBuckets                                     21.57us    46.37K
realManyRowsManyBuckets                         100.02%    21.56us    46.37K
doubleFewRowsFewBuckets                                     2.26us   442.86K
doubleFewRowsManyBuckets                        100.03%     2.26us   442.98K
doubleManyRowsFewBuckets                                   22.13us    45.19K
doubleManyRowsManyBuckets                       99.946%    22.14us    45.16K
varcharFewRowsFewBuckets                                   15.35us    65.13K
varcharFewRowsManyBuckets                       105.92%    14.50us    68.99K
varcharManyRowsFewBuckets                                 144.06us     6.94K
varcharManyRowsManyBuckets                      100.66%   143.12us     6.99K
timestampFewRowsFewBuckets                                  2.52us   396.36K
timestampFewRowsManyBuckets                     100.20%     2.52us   397.13K
timestampManyRowsFewBuckets                                24.49us    40.84K
timestampManyRowsManyBuckets                    99.930%    24.51us    40.81K
```

benchmark after:
```
============================================================================
[...]ks/HivePartitionFunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
booleanFewRowsFewBuckets                                    3.22us   310.78K
booleanFewRowsManyBuckets                       99.983%     3.22us   310.73K
booleanManyRowsFewBuckets                                  31.49us    31.76K
booleanManyRowsManyBuckets                      94.134%    33.45us    29.89K
tinyintFewRowsFewBuckets                                    2.20us   453.70K
tinyintFewRowsManyBuckets                       100.02%     2.20us   453.77K
tinyintManyRowsFewBuckets                                  21.49us    46.54K
tinyintManyRowsManyBuckets                      100.04%    21.48us    46.56K
smallintFewRowsFewBuckets                                   2.21us   452.47K
smallintFewRowsManyBuckets                      100.04%     2.21us   452.65K
smallintManyRowsFewBuckets                                 21.58us    46.34K
smallintManyRowsManyBuckets                     100.07%    21.56us    46.37K
integerFewRowsFewBuckets                                    2.20us   454.12K
integerFewRowsManyBuckets                       85.357%     2.58us   387.63K
integerManyRowsFewBuckets                                  22.95us    43.58K
integerManyRowsManyBuckets                      109.42%    20.97us    47.69K
bigintFewRowsFewBuckets                                     2.24us   447.15K
bigintFewRowsManyBuckets                        97.155%     2.30us   434.42K
bigintManyRowsFewBuckets                                   22.58us    44.28K
bigintManyRowsManyBuckets                       94.123%    23.99us    41.68K
realFewRowsFewBuckets                                       2.34us   427.46K
realFewRowsManyBuckets                          106.23%     2.20us   454.08K
realManyRowsFewBuckets                                     21.61us    46.27K
realManyRowsManyBuckets                         100.06%    21.60us    46.30K
doubleFewRowsFewBuckets                                     2.30us   434.41K
doubleFewRowsManyBuckets                        102.89%     2.24us   446.95K
doubleManyRowsFewBuckets                                   22.58us    44.28K
doubleManyRowsManyBuckets                       100.33%    22.51us    44.43K
varcharFewRowsFewBuckets                                   14.68us    68.11K
varcharFewRowsManyBuckets                       100.10%    14.67us    68.18K
varcharManyRowsFewBuckets                                 149.42us     6.69K
varcharManyRowsManyBuckets                      100.12%   149.24us     6.70K
timestampFewRowsFewBuckets                                  2.54us   393.69K
timestampFewRowsManyBuckets                     100.31%     2.53us   394.92K
timestampManyRowsFewBuckets                                25.26us    39.59K
timestampManyRowsManyBuckets                    100.72%    25.08us    39.87K
```

We see a bit of a regression for booleans, but everything else is roughly the same.

Differential Revision: D49881409


