### PR TITLE
Add support for arrays in HivePartitionFunction

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -48,14 +48,39 @@ class HivePartitionFunction : public core::PartitionFunction {
   // Precompute single value hive hash for a constant partition key.
   void precompute(const BaseVector& value, size_t column_index_t);
 
+  void hash(
+      const DecodedVector& values,
+      TypeKind typeKind,
+      const SelectivityVector& rows,
+      bool mix,
+      std::vector<uint32_t>& hashes,
+      size_t poolIndex);
+
+  template <TypeKind kind>
+  void hashTyped(
+      const DecodedVector& /* values */,
+      const SelectivityVector& /* rows */,
+      bool /* mix */,
+      std::vector<uint32_t>& /* hashes */,
+      size_t /* poolIndex */) {
+    VELOX_UNSUPPORTED(
+        "Hive partitioning function doesn't support {} type",
+        TypeTraits<kind>::name);
+  }
+
+  // Helper functions to retrieve reusable memory from pools.
+  DecodedVector& getDecodedVector(size_t poolIndex = 0);
+  SelectivityVector& getRows(size_t poolIndex = 0);
+  std::vector<uint32_t>& getHashes(size_t poolIndex = 0);
+
   const int numBuckets_;
   const std::vector<int> bucketToPartition_;
   const std::vector<column_index_t> keyChannels_;
 
-  // Reusable memory.
-  std::vector<uint32_t> hashes_;
-  SelectivityVector rows_;
-  std::vector<DecodedVector> decodedVectors_;
+  // Pools of reusable memory.
+  std::vector<std::unique_ptr<std::vector<uint32_t>>> hashesPool_;
+  std::vector<std::unique_ptr<SelectivityVector>> rowsPool_;
+  std::vector<std::unique_ptr<DecodedVector>> decodedVectorsPool_;
   // Precomputed hashes for constant partition keys (one per key).
   std::vector<uint32_t> precomputedHashes_;
 };

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -30,7 +30,7 @@ using connector::hive::HivePartitionFunction;
 
 namespace {
 
-constexpr std::array<TypeKind, 10> kSupportedTypes{
+constexpr std::array<TypeKind, 10> kSupportedScalarTypes{
     TypeKind::BOOLEAN,
     TypeKind::TINYINT,
     TypeKind::SMALLINT,
@@ -52,9 +52,13 @@ class HivePartitionFunctionBenchmark
     opts.stringLength = 20;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
     VectorMaker vm{pool_.get()};
-    for (auto typeKind : kSupportedTypes) {
-      auto flatVector = fuzzer.fuzzFlat(createScalarType(typeKind));
-      rowVectors_[typeKind] = vm.rowVector({flatVector});
+    auto addRowVector = [&](const TypePtr& type) {
+      auto flatVector = fuzzer.fuzzFlat(type);
+      rowVectors_[type->kind()] = vm.rowVector({flatVector});
+    };
+
+    for (auto typeKind : kSupportedScalarTypes) {
+      addRowVector(createScalarType(typeKind));
     }
 
     // Prepare HivePartitionFunction

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -61,6 +61,8 @@ class HivePartitionFunctionBenchmark
       addRowVector(createScalarType(typeKind));
     }
 
+    addRowVector(ARRAY(REAL()));
+
     // Prepare HivePartitionFunction
     fewBucketsFunction_ = createHivePartitionFunction(20);
     manyBucketsFunction_ = createHivePartitionFunction(100);
@@ -265,6 +267,24 @@ BENCHMARK(timestampManyRowsFewBuckets) {
 
 BENCHMARK_RELATIVE(timestampManyRowsManyBuckets) {
   benchmarkMany->runMany<TypeKind::TIMESTAMP>();
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(arrayFewRowsFewBuckets) {
+  benchmarkFew->runFew<TypeKind::ARRAY>();
+}
+
+BENCHMARK_RELATIVE(arrayFewRowsManyBuckets) {
+  benchmarkFew->runMany<TypeKind::ARRAY>();
+}
+
+BENCHMARK(arrayManyRowsFewBuckets) {
+  benchmarkMany->runFew<TypeKind::ARRAY>();
+}
+
+BENCHMARK_RELATIVE(arrayManyRowsManyBuckets) {
+  benchmarkMany->runMany<TypeKind::ARRAY>();
 }
 
 BENCHMARK_DRAW_LINE();


### PR DESCRIPTION
Summary:
As the title suggests, this adds support for computing the hash of arrays in HivePartitionFunction.
This depends on the refactoring done here https://github.com/facebookincubator/velox/pull/6876

It's fairly straightforward, the flow is:
* decode the elements Vector
* create a SelectivityVector selecting only values in the elements Vector referred to by arrays in the parent Vector
* hash the elements
* combine the hashes per array (handling gaps and overlaps in the values pointed to by arrays)
* combine the array hashes into the hashes per row

Added a benchmark:
```
============================================================================
[...]ks/HivePartitionFunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
arrayFewRowsFewBuckets                                     35.42us    28.23K
arrayFewRowsManyBuckets                         102.56%    34.54us    28.95K
arrayManyRowsFewBuckets                                   167.49us     5.97K
arrayManyRowsManyBuckets                        100.02%   167.47us     5.97K
```

Validated all values in the tests with those produced by Presto Java.

Differential Revision: D49885456

