### PR TITLE
Add support for rows in HivePartitionFunction

### DIFF
--- a/velox/connectors/hive/HivePartitionFunction.h
+++ b/velox/connectors/hive/HivePartitionFunction.h
@@ -48,14 +48,39 @@ class HivePartitionFunction : public core::PartitionFunction {
   // Precompute single value hive hash for a constant partition key.
   void precompute(const BaseVector& value, size_t column_index_t);
 
+  void hash(
+      const DecodedVector& values,
+      TypeKind typeKind,
+      const SelectivityVector& rows,
+      bool mix,
+      std::vector<uint32_t>& hashes,
+      size_t poolIndex);
+
+  template <TypeKind kind>
+  void hashTyped(
+      const DecodedVector& /* values */,
+      const SelectivityVector& /* rows */,
+      bool /* mix */,
+      std::vector<uint32_t>& /* hashes */,
+      size_t /* poolIndex */) {
+    VELOX_UNSUPPORTED(
+        "Hive partitioning function doesn't support {} type",
+        TypeTraits<kind>::name);
+  }
+
+  // Helper functions to retrieve reusable memory from pools.
+  DecodedVector& getDecodedVector(size_t poolIndex = 0);
+  SelectivityVector& getRows(size_t poolIndex = 0);
+  std::vector<uint32_t>& getHashes(size_t poolIndex = 0);
+
   const int numBuckets_;
   const std::vector<int> bucketToPartition_;
   const std::vector<column_index_t> keyChannels_;
 
-  // Reusable memory.
-  std::vector<uint32_t> hashes_;
-  SelectivityVector rows_;
-  std::vector<DecodedVector> decodedVectors_;
+  // Pools of reusable memory.
+  std::vector<std::unique_ptr<std::vector<uint32_t>>> hashesPool_;
+  std::vector<std::unique_ptr<SelectivityVector>> rowsPool_;
+  std::vector<std::unique_ptr<DecodedVector>> decodedVectorsPool_;
   // Precomputed hashes for constant partition keys (one per key).
   std::vector<uint32_t> precomputedHashes_;
 };

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -30,7 +30,7 @@ using connector::hive::HivePartitionFunction;
 
 namespace {
 
-constexpr std::array<TypeKind, 10> kSupportedTypes{
+constexpr std::array<TypeKind, 10> kSupportedScalarTypes{
     TypeKind::BOOLEAN,
     TypeKind::TINYINT,
     TypeKind::SMALLINT,
@@ -52,9 +52,13 @@ class HivePartitionFunctionBenchmark
     opts.stringLength = 20;
     VectorFuzzer fuzzer(opts, pool(), FLAGS_fuzzer_seed);
     VectorMaker vm{pool_.get()};
-    for (auto typeKind : kSupportedTypes) {
-      auto flatVector = fuzzer.fuzzFlat(createScalarType(typeKind));
-      rowVectors_[typeKind] = vm.rowVector({flatVector});
+    auto addRowVector = [&](const TypePtr& type) {
+      auto flatVector = fuzzer.fuzzFlat(type);
+      rowVectors_[type->kind()] = vm.rowVector({flatVector});
+    };
+
+    for (auto typeKind : kSupportedScalarTypes) {
+      addRowVector(createScalarType(typeKind));
     }
 
     // Prepare HivePartitionFunction

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -62,6 +62,7 @@ class HivePartitionFunctionBenchmark
     }
 
     addRowVector(ARRAY(REAL()));
+    addRowVector(MAP(BIGINT(), BOOLEAN()));
 
     // Prepare HivePartitionFunction
     fewBucketsFunction_ = createHivePartitionFunction(20);
@@ -285,6 +286,24 @@ BENCHMARK(arrayManyRowsFewBuckets) {
 
 BENCHMARK_RELATIVE(arrayManyRowsManyBuckets) {
   benchmarkMany->runMany<TypeKind::ARRAY>();
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(mapFewRowsFewBuckets) {
+  benchmarkFew->runFew<TypeKind::MAP>();
+}
+
+BENCHMARK_RELATIVE(mapFewRowsManyBuckets) {
+  benchmarkFew->runMany<TypeKind::MAP>();
+}
+
+BENCHMARK(mapManyRowsFewBuckets) {
+  benchmarkMany->runFew<TypeKind::MAP>();
+}
+
+BENCHMARK_RELATIVE(mapManyRowsManyBuckets) {
+  benchmarkMany->runMany<TypeKind::MAP>();
 }
 
 BENCHMARK_DRAW_LINE();

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -63,6 +63,7 @@ class HivePartitionFunctionBenchmark
 
     addRowVector(ARRAY(REAL()));
     addRowVector(MAP(BIGINT(), BOOLEAN()));
+    addRowVector(ROW({"a", "b"}, {INTEGER(), DOUBLE()}));
 
     // Prepare HivePartitionFunction
     fewBucketsFunction_ = createHivePartitionFunction(20);
@@ -304,6 +305,24 @@ BENCHMARK(mapManyRowsFewBuckets) {
 
 BENCHMARK_RELATIVE(mapManyRowsManyBuckets) {
   benchmarkMany->runMany<TypeKind::MAP>();
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(rowFewRowsFewBuckets) {
+  benchmarkFew->runFew<TypeKind::ROW>();
+}
+
+BENCHMARK_RELATIVE(rowFewRowsManyBuckets) {
+  benchmarkFew->runMany<TypeKind::ROW>();
+}
+
+BENCHMARK(rowManyRowsFewBuckets) {
+  benchmarkMany->runFew<TypeKind::ROW>();
+}
+
+BENCHMARK_RELATIVE(rowManyRowsManyBuckets) {
+  benchmarkMany->runMany<TypeKind::ROW>();
 }
 
 BENCHMARK_DRAW_LINE();

--- a/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
+++ b/velox/connectors/hive/benchmarks/HivePartitionFunctionBenchmark.cpp
@@ -61,6 +61,8 @@ class HivePartitionFunctionBenchmark
       addRowVector(createScalarType(typeKind));
     }
 
+    addRowVector(ARRAY(REAL()));
+
     // Prepare HivePartitionFunction
     fewBucketsFunction_ = createHivePartitionFunction(20);
     manyBucketsFunction_ = createHivePartitionFunction(100);
@@ -265,6 +267,24 @@ BENCHMARK(timestampManyRowsFewBuckets) {
 
 BENCHMARK_RELATIVE(timestampManyRowsManyBuckets) {
   benchmarkMany->runMany<TypeKind::TIMESTAMP>();
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK(arrayFewRowsFewBuckets) {
+  benchmarkFew->runFew<TypeKind::ARRAY>();
+}
+
+BENCHMARK_RELATIVE(arrayFewRowsManyBuckets) {
+  benchmarkFew->runMany<TypeKind::ARRAY>();
+}
+
+BENCHMARK(arrayManyRowsFewBuckets) {
+  benchmarkMany->runFew<TypeKind::ARRAY>();
+}
+
+BENCHMARK_RELATIVE(arrayManyRowsManyBuckets) {
+  benchmarkMany->runMany<TypeKind::ARRAY>();
 }
 
 BENCHMARK_DRAW_LINE();


### PR DESCRIPTION
Summary:
As the title suggests, this adds support for computing the hash of rows, beyond the top level row in HivePartitionFunction.
This depends on the refactoring done here https://github.com/facebookincubator/velox/pull/6876
the addition of support for arrays here https://github.com/facebookincubator/velox/pull/6877
and the addition of support for maps here https://github.com/facebookincubator/velox/pull/6878

It's fairly straightforward, the flow is:
* create a SelectivityVector selecting only values in the child Vectors referred to by non-null rows in the parent Vector
* decode and hash each child, merging the hashes the same way as is done for the top level row
* combine the row hashes into the hashes per parent row

Added a benchmark:
```
============================================================================
[...]ks/HivePartitionFunctionBenchmark.cpp     relative  time/iter   iters/s
============================================================================
rowFewRowsFewBuckets                                        5.37us   186.11K
rowFewRowsManyBuckets                           93.833%     5.73us   174.63K
rowManyRowsFewBuckets                                      55.70us    17.95K
rowManyRowsManyBuckets                          106.25%    52.42us    19.08K
```

Validated all values in the tests with those produced by Presto Java.

Differential Revision: D49886517

