### PR TITLE
Prefetch units should only contain relevant stripes

### DIFF
--- a/velox/dwio/dwrf/reader/DwrfReader.cpp
+++ b/velox/dwio/dwrf/reader/DwrfReader.cpp
@@ -408,14 +408,17 @@ void DwrfRowReader::resetFilterCaches() {
 std::optional<std::vector<velox::dwio::common::RowReader::PrefetchUnit>>
 DwrfRowReader::prefetchUnits() {
   auto rowsInStripe = getReader().getRowsPerStripe();
-  DWIO_ENSURE(rowsInStripe.size() == lastStripe);
-  std::vector<PrefetchUnit> res;
-  res.reserve(lastStripe);
+  DWIO_ENSURE(firstStripe <= rowsInStripe.size());
+  DWIO_ENSURE(lastStripe <= rowsInStripe.size());
+  DWIO_ENSURE(firstStripe <= lastStripe);
 
-  for (int i = 0; i < rowsInStripe.size(); i++) {
+  std::vector<PrefetchUnit> res;
+  res.reserve(lastStripe - firstStripe);
+
+  for (auto stripe = firstStripe; stripe < lastStripe; ++stripe) {
     res.push_back(
-        {.rowCount = rowsInStripe[i],
-         .prefetch = std::bind(&DwrfRowReader::prefetch, this, i)});
+        {.rowCount = rowsInStripe[stripe],
+         .prefetch = std::bind(&DwrfRowReader::prefetch, this, stripe)});
   }
   return res;
 }


### PR DESCRIPTION
Summary:
We don't want to return prefetch units for stripes that are out of range of the current reader.

A row reader can be given a byte range to read from, and the reader will only ever read from the stripes that are included in that byte range.

The reader will keep the `firstStripe` and (past) `lastStripe` variables showing its relevant stripes range.

We only want to return prefetch units in that range. So that the first prefetch unit points to `firstStripe` and the last is the stripe before `lastStripe`.

Differential Revision: D49889856


