### PR TITLE
 Fix null input handling in Reduce function

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -662,7 +662,7 @@ void CastExpr::apply(
   // If there are nulls in input, add nulls to the result at the same rows.
   VELOX_CHECK_NOT_NULL(result);
   if (rawNulls) {
-    Expr::addNulls(
+    EvalCtx::addNulls(
         rows, nonNullRows->asRange().bits(), context, toType, result);
   }
 }

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -273,6 +273,47 @@ VectorPtr EvalCtx::ensureFieldLoaded(
   return field;
 }
 
+// static
+void EvalCtx::addNulls(
+    const SelectivityVector& rows,
+    const uint64_t* rawNulls,
+    EvalCtx& context,
+    const TypePtr& type,
+    VectorPtr& result) {
+  // If there's no `result` yet, return a NULL ContantVector.
+  if (!result) {
+    result = BaseVector::createNullConstant(type, rows.end(), context.pool());
+    return;
+  }
+
+  // If result is already a NULL ConstantVector, resize the vector if necessary,
+  // or do nothing otherwise.
+  if (result->isConstantEncoding() && result->isNullAt(0)) {
+    if (result->size() < rows.end()) {
+      if (result.unique()) {
+        result->resize(rows.end());
+      } else {
+        result =
+            BaseVector::createNullConstant(type, rows.end(), context.pool());
+      }
+    }
+    return;
+  }
+
+  if (!result.unique() || !result->isNullsWritable()) {
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(), type, context.pool(), result);
+  }
+
+  if (result->size() < rows.end()) {
+    BaseVector::ensureWritable(
+        SelectivityVector::empty(), type, context.pool(), result);
+    result->resize(rows.end());
+  }
+
+  result->addNulls(rawNulls, rows);
+}
+
 ScopedFinalSelectionSetter::ScopedFinalSelectionSetter(
     EvalCtx& evalCtx,
     const SelectivityVector* finalSelection,

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -271,6 +271,17 @@ class EvalCtx {
     }
   }
 
+  /// Adds nulls from 'rawNulls' to positions of 'result' given by
+  /// 'rows'. Ensures that '*result' is writable, of sufficient size
+  /// and that it can take nulls. Makes a new '*result' when
+  /// appropriate.
+  static void addNulls(
+      const SelectivityVector& rows,
+      const uint64_t* FOLLY_NULLABLE rawNulls,
+      EvalCtx& context,
+      const TypePtr& type,
+      VectorPtr& result);
+
   VectorPool& vectorPool() const {
     return execCtx_->vectorPool();
   }

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1093,53 +1093,12 @@ bool Expr::removeSureNulls(
   return false;
 }
 
-// static
-void Expr::addNulls(
-    const SelectivityVector& rows,
-    const uint64_t* rawNulls,
-    EvalCtx& context,
-    const TypePtr& type,
-    VectorPtr& result) {
-  // If there's no `result` yet, return a NULL ContantVector.
-  if (!result) {
-    result = BaseVector::createNullConstant(type, rows.end(), context.pool());
-    return;
-  }
-
-  // If result is already a NULL ConstantVector, resize the vector if necessary,
-  // or do nothing otherwise.
-  if (result->isConstantEncoding() && result->isNullAt(0)) {
-    if (result->size() < rows.end()) {
-      if (result.unique()) {
-        result->resize(rows.end());
-      } else {
-        result =
-            BaseVector::createNullConstant(type, rows.end(), context.pool());
-      }
-    }
-    return;
-  }
-
-  if (!result.unique() || !result->isNullsWritable()) {
-    BaseVector::ensureWritable(
-        SelectivityVector::empty(), type, context.pool(), result);
-  }
-
-  if (result->size() < rows.end()) {
-    BaseVector::ensureWritable(
-        SelectivityVector::empty(), type, context.pool(), result);
-    result->resize(rows.end());
-  }
-
-  result->addNulls(rawNulls, rows);
-}
-
 void Expr::addNulls(
     const SelectivityVector& rows,
     const uint64_t* FOLLY_NULLABLE rawNulls,
     EvalCtx& context,
     VectorPtr& result) {
-  addNulls(rows, rawNulls, context, type(), result);
+  EvalCtx::addNulls(rows, rawNulls, context, type(), result);
 }
 
 void Expr::evalWithNulls(

--- a/velox/expression/Expr.h
+++ b/velox/expression/Expr.h
@@ -349,17 +349,6 @@ class Expr {
     return stats_;
   }
 
-  // Adds nulls from 'rawNulls' to positions of 'result' given by
-  // 'rows'. Ensures that '*result' is writable, of sufficient size
-  // and that it can take nulls. Makes a new '*result' when
-  // appropriate.
-  static void addNulls(
-      const SelectivityVector& rows,
-      const uint64_t* FOLLY_NULLABLE rawNulls,
-      EvalCtx& context,
-      const TypePtr& type,
-      VectorPtr& result);
-
   void addNulls(
       const SelectivityVector& rows,
       const uint64_t* FOLLY_NULLABLE rawNulls,

--- a/velox/expression/SwitchExpr.cpp
+++ b/velox/expression/SwitchExpr.cpp
@@ -77,7 +77,7 @@ void SwitchExpr::evalSpecialForm(
       const auto& vector = context.getField(field->index(context));
       if (vector->mayHaveNulls()) {
         LocalDecodedVector decoded(context, *vector, remaining);
-        addNulls(remaining, decoded->nulls(), context, type(), localResult);
+        addNulls(remaining, decoded->nulls(), context, localResult);
         remaining.deselectNulls(
             decoded->nulls(), remaining.begin(), remaining.end());
       }

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3199,7 +3199,7 @@ TEST_F(ExprTest, addNulls) {
   // Test vector that is nullptr.
   {
     VectorPtr vector;
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
     ASSERT_NE(vector, nullptr);
     checkConstantResult(vector);
   }
@@ -3208,7 +3208,7 @@ TEST_F(ExprTest, addNulls) {
   // referenced.
   {
     auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
     checkConstantResult(vector);
   }
 
@@ -3217,7 +3217,7 @@ TEST_F(ExprTest, addNulls) {
   {
     auto vector = makeNullConstant(TypeKind::BIGINT, kSize - 1);
     auto another = vector;
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
     ASSERT_EQ(another->size(), kSize - 1);
     checkConstantResult(vector);
   }
@@ -3225,7 +3225,7 @@ TEST_F(ExprTest, addNulls) {
   // Test vector that is a non-null constant vector.
   {
     auto vector = makeConstant<int64_t>(100, kSize - 1);
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
     ASSERT_TRUE(vector->isFlatEncoding());
     ASSERT_EQ(vector->size(), kSize);
     for (auto i = 0; i < kSize - 1; ++i) {
@@ -3249,7 +3249,7 @@ TEST_F(ExprTest, addNulls) {
     VectorPtr vector =
         makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
     auto another = vector;
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
 
     ASSERT_EQ(another->size(), kSize - 1);
     checkResult(vector);
@@ -3259,7 +3259,7 @@ TEST_F(ExprTest, addNulls) {
   {
     VectorPtr vector =
         makeFlatVector<int64_t>(kSize - 1, [](auto row) { return row; });
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), vector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
 
     checkResult(vector);
   }
@@ -3272,7 +3272,7 @@ TEST_F(ExprTest, addNulls) {
         makeFlatVector<int64_t>(kSize, [](auto row) { return row; });
     auto slicedVector = vector->slice(0, kSize - 1);
     ASSERT_FALSE(slicedVector->values()->isMutable());
-    exec::Expr::addNulls(rows, rawNulls, context, BIGINT(), slicedVector);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), slicedVector);
 
     checkResult(slicedVector);
   }
@@ -3293,7 +3293,7 @@ TEST_F(ExprTest, addNulls) {
         std::vector<VectorPtr>({a, b}));
     row->setNull(kSize - 1, true);
     VectorPtr result = row;
-    exec::Expr::addNulls(rows, rawNulls, context, row->type(), result);
+    exec::EvalCtx::addNulls(rows, rawNulls, context, row->type(), result);
     ASSERT_NE(result.get(), row.get());
     ASSERT_EQ(result->size(), kSize);
     for (int i = 0; i < kSize - 1; ++i) {
@@ -3315,7 +3315,7 @@ TEST_F(ExprTest, addNulls) {
     // Vector of size 2 using only the first two indices of sharedIndices.
     auto wrappedVectorSmaller = BaseVector::wrapInDictionary(
         nullptr, sharedIndices, 2, makeFlatVector<int64_t>({1, 2, 3}));
-    exec::Expr::addNulls(
+    exec::EvalCtx::addNulls(
         SelectivityVector(3),
         rawNulls,
         context,

--- a/velox/functions/prestosql/Reduce.cpp
+++ b/velox/functions/prestosql/Reduce.cpp
@@ -67,7 +67,7 @@ class ReduceFunction : public exec::VectorFunction {
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
-      const TypePtr& /* outputType */,
+      const TypePtr& outputType,
       exec::EvalCtx& context,
       VectorPtr& result) const override {
     VELOX_CHECK_EQ(args.size(), 4);
@@ -173,7 +173,8 @@ class ReduceFunction : public exec::VectorFunction {
           &localResult);
     }
     if (flatArray->rawNulls()) {
-      localResult->addNulls(flatArray->rawNulls(), rows);
+      exec::EvalCtx::addNulls(
+          rows, flatArray->rawNulls(), context, outputType, localResult);
     }
     context.moveOrCopyResult(localResult, rows, result);
   }


### PR DESCRIPTION
Reduce currently used the BaseVector's addNulls to add nulls at the end
to the localResult. This API is very basic and does not handle the variety
of cases that Expr::addNulls is designed to handle. For eg, if the target
vector is smaller than the input rows, or has a different encoding or is
empty. This change moves the Expr::addNulls() API to EvalCtx to make
it easily accessible to vector functions like Reduce without pulling in the
complete Expr header file and finally employing it to add nulls.

Test Plan:
Added unit tests