### PR TITLE
Fix: Explicit handle null pattern and escape in like function.

### DIFF
--- a/velox/expression/VectorFunction.h
+++ b/velox/expression/VectorFunction.h
@@ -152,6 +152,20 @@ class AlwaysFailingVectorFunction final : public VectorFunction {
   std::exception_ptr exceptionPtr_;
 };
 
+// This functions is used when we know a function will never be called because
+// it is default null with a literal null input value. For example like(c0,
+// null).
+class ApplyNeverCalled final : public VectorFunction {
+  void apply(
+      const SelectivityVector&,
+      std::vector<VectorPtr>&,
+      const TypePtr&,
+      EvalCtx&,
+      VectorPtr&) const final {
+    VELOX_UNREACHABLE("Not expected to be called.")
+  }
+};
+
 // Factory for functions which are template generated from simple functions.
 class SimpleFunctionAdapterFactory {
  public:

--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -947,6 +947,9 @@ std::shared_ptr<exec::VectorFunction> makeLike(
         inputArgs[2].type->toString());
 
     auto constantEscape = escape->as<ConstantVector<StringView>>();
+    if (constantEscape->isNullAt(0)) {
+      return std::make_shared<exec::ApplyNeverCalled>();
+    }
 
     try {
       VELOX_USER_CHECK_EQ(
@@ -966,6 +969,10 @@ std::shared_ptr<exec::VectorFunction> makeLike(
       "{} requires second argument to be a constant of type VARCHAR",
       name,
       inputArgs[1].type->toString());
+  if (constantPattern->isNullAt(0)) {
+    return std::make_shared<exec::ApplyNeverCalled>();
+  }
+
   auto pattern = constantPattern->as<ConstantVector<StringView>>()->valueAt(0);
   if (!escapeChar) {
     PatternKind patternKind;

--- a/velox/functions/lib/tests/Re2FunctionsTest.cpp
+++ b/velox/functions/lib/tests/Re2FunctionsTest.cpp
@@ -593,6 +593,16 @@ TEST_F(Re2FunctionsTest, likePatternSuffix) {
   EXPECT_TRUE(like(input, generateString(kAnyWildcardCharacter) + input));
 }
 
+TEST_F(Re2FunctionsTest, nullConstantPatternOrEscape) {
+  // Test null pattern.
+  ASSERT_TRUE(
+      !evaluateOnce<bool>("like('a', cast (null as varchar))").has_value());
+
+  // Test null escape.
+  ASSERT_TRUE(
+      !evaluateOnce<bool>("like('a', 'a', cast(null as varchar))").has_value());
+}
+
 TEST_F(Re2FunctionsTest, likePatternAndEscape) {
   auto like = ([&](std::optional<std::string> str,
                    std::optional<std::string> pattern,


### PR DESCRIPTION
Summary:
When value at constant vector is null we shall not call valueAt().
When i added a check in ConstantVector valueAt that value is not null i got other faluires
I will address them in seperate PR then add the check.

Differential Revision: D49917874


