### PR TITLE
Sort json keys during serialization in CAST from JSON

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -937,6 +937,24 @@ TEST_F(JsonCastTest, toMap) {
       "Not a JSON input");
 }
 
+TEST_F(JsonCastTest, orderOfKeys) {
+  auto data = makeFlatVector<JsonNativeType>(
+      {
+          R"({"k1": {"a": 1, "b": 2}})"_sv,
+          R"({"k2": {"a": 10, "b": 20}})"_sv,
+      },
+      JSON());
+
+  auto map = makeMapVector<std::string, JsonNativeType>(
+      {
+          {{"k1", R"({"a":1,"b":2})"}},
+          {{"k2", R"({"a":10,"b":20})"}},
+      },
+      MAP(VARCHAR(), JSON()));
+
+  testCast(JSON(), MAP(VARCHAR(), JSON()), data, map);
+}
+
 TEST_F(JsonCastTest, toRow) {
   // Test casting to ROW from JSON arrays.
   auto array = makeNullableFlatVector<JsonNativeType>(

--- a/velox/functions/prestosql/types/JsonType.cpp
+++ b/velox/functions/prestosql/types/JsonType.cpp
@@ -499,7 +499,10 @@ FOLLY_ALWAYS_INLINE void castFromJsonTyped<TypeKind::VARCHAR>(
     const folly::dynamic& object,
     exec::GenericWriter& writer) {
   if (isJsonType(writer.type())) {
-    writer.castTo<Varchar>().append(toJson(object));
+    // Sort keys to match Presto's behavior.
+    folly::json::serialization_opts opts;
+    opts.sort_keys = true;
+    writer.castTo<Varchar>().append(folly::json::serialize(object, opts));
   } else if (object.isBool()) {
     writer.castTo<Varchar>().append(object.asBool() ? "true" : "false");
   } else {


### PR DESCRIPTION
When serializing JSON, Presto sorts the keys.

presto-main/src/main/java/com/facebook/presto/operator/scalar/JsonFunctions.java

```
private static final ObjectMapper SORTED_MAPPER = new JsonObjectMapperProvider().get().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
```

Match this behavior in CAST from JSON.