### PR TITLE
Add spill support during aggregation output stage

### DIFF
--- a/velox/common/memory/MemoryArbitrator.cpp
+++ b/velox/common/memory/MemoryArbitrator.cpp
@@ -244,6 +244,10 @@ void MemoryReclaimer::abort(MemoryPool* pool, const std::exception_ptr& error) {
   });
 }
 
+void MemoryReclaimer::Stats::reset() {
+  numNonReclaimableAttempts = 0;
+}
+
 bool MemoryReclaimer::Stats::operator==(
     const MemoryReclaimer::Stats& other) const {
   return numNonReclaimableAttempts == other.numNonReclaimableAttempts;

--- a/velox/common/memory/MemoryArbitrator.h
+++ b/velox/common/memory/MemoryArbitrator.h
@@ -262,8 +262,9 @@ class MemoryReclaimer {
     /// due to reclaiming at non-reclaimable stage.
     uint64_t numNonReclaimableAttempts{0};
 
-    bool operator==(const Stats& other) const;
+    void reset();
 
+    bool operator==(const Stats& other) const;
     bool operator!=(const Stats& other) const;
   };
 

--- a/velox/common/memory/tests/MemoryArbitratorTest.cpp
+++ b/velox/common/memory/tests/MemoryArbitratorTest.cpp
@@ -741,4 +741,20 @@ TEST_F(MemoryReclaimerTest, concurrentRandomMockReclaims) {
   ASSERT_EQ(totalUsedBytes, 0);
   ASSERT_EQ(stats_, MemoryReclaimer::Stats{});
 }
+
+TEST_F(MemoryArbitrationTest, reclaimerStats) {
+  MemoryReclaimer::Stats stats1;
+  MemoryReclaimer::Stats stats2;
+  ASSERT_EQ(stats1.numNonReclaimableAttempts, 0);
+  ASSERT_EQ(stats1, stats2);
+  stats1.numNonReclaimableAttempts = 2;
+  ASSERT_NE(stats1, stats2);
+  stats2.numNonReclaimableAttempts = 3;
+  ASSERT_NE(stats1, stats2);
+  stats2.reset();
+  ASSERT_EQ(stats2.numNonReclaimableAttempts, 0);
+  ASSERT_NE(stats1, stats2);
+  stats1.reset();
+  ASSERT_EQ(stats1, stats2);
+}
 } // namespace facebook::velox::memory

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -499,6 +499,8 @@ StopReason Driver::runInternal(
                     op->stats().wlock()->getOutputTiming.add(deltaTiming);
                   });
               RuntimeStatWriterScopeGuard statsWriterGuard(op);
+              TestValue::adjust(
+                  "facebook::velox::exec::Driver::runInternal::getOutput", op);
               CALL_OPERATOR(
                   intermediateResult = op->getOutput(), op, "getOutput");
               if (intermediateResult) {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -100,6 +100,10 @@ class GroupingSet {
   /// of this will be in a paused state and off thread.
   void spill(int64_t targetRows, int64_t targetBytes);
 
+  /// Spills all the rows in container starting from the offset specified by
+  /// 'rowIterator'.
+  void spill(const RowContainerIterator& rowIterator);
+
   /// Returns the spiller stats including total bytes and rows spilled so far.
   std::optional<SpillStats> spilledStats() const {
     if (spiller_ == nullptr) {
@@ -162,10 +166,14 @@ class GroupingSet {
   // index for this aggregation), otherwise it returns reference to activeRows_.
   const SelectivityVector& getSelectivityVector(size_t aggregateIndex) const;
 
-  // Checks if input will fit in the existing memory and increases
-  // reservation if not. If reservation cannot be increased, spills
-  // enough to make 'input' fit.
+  // Checks if input will fit in the existing memory and increases reservation
+  // if not. If reservation cannot be increased, spills enough to make 'input'
+  // fit.
   void ensureInputFits(const RowVectorPtr& input);
+
+  // Reserves memory for output processing. If reservation cannot be increased,
+  // spills enough to make output fit.
+  void ensureOutputFits();
 
   // Copies the grouping keys and aggregates for 'groups' into 'result' If
   // partial output, extracts the intermediate type for aggregates, final result
@@ -235,6 +243,7 @@ class GroupingSet {
   const bool isGlobal_;
   const bool isPartial_;
   const bool isRawInput_;
+  const core::QueryConfig* const queryConfig_;
 
   std::vector<AggregateInfo> aggregates_;
   AggregationMasks masks_;
@@ -310,8 +319,8 @@ class GroupingSet {
   // one.
   bool nextKeyIsEqual_{false};
 
-  // The set of rows that are outside of the spillable hash number
-  // ranges. Used when producing output.
+  // The set of rows that are outside of the spillable hash number ranges. Used
+  // when producing output.
   std::optional<Spiller::SpillRows> nonSpilledRows_;
 
   // Index of first in 'nonSpilledRows_' that has not been added to output.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1086,7 +1086,7 @@ void HashBuild::reclaim(
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                  << stateName(state_) << "], nonReclaimableSection_["
-                 << nonReclaimableSection_ << "], " << toString();
+                 << nonReclaimableSection_ << "], " << pool()->name();
     return;
   }
 
@@ -1106,7 +1106,7 @@ void HashBuild::reclaim(
       LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                    << stateName(buildOp->state_) << "], nonReclaimableSection_["
                    << buildOp->nonReclaimableSection_ << "], "
-                   << buildOp->toString();
+                   << buildOp->pool()->name();
       return;
     }
   }

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -543,6 +543,12 @@ class Operator : public BaseRuntimeStatWriter {
     return operatorCtx_.get();
   }
 
+  /// Returns true if this operator has received no more input signal. This
+  /// method is only used for test.
+  bool testingNoMoreInput() const {
+    return noMoreInput_;
+  }
+
  protected:
   static std::vector<std::unique_ptr<PlanNodeTranslator>>& translators();
   friend class NonReclaimableSection;

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -89,7 +89,7 @@ void OrderBy::reclaim(
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from order by operator, noMoreInput_["
                  << noMoreInput_ << "], nonReclaimableSection_["
-                 << nonReclaimableSection_ << "], " << toString();
+                 << nonReclaimableSection_ << "], " << pool()->name();
     return;
   }
 

--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -359,7 +359,7 @@ std::unique_ptr<TreeOfLosers<SpillMergeStream>> SpillState::startMerge(
       result.push_back(FileSpillMergeStream::create(std::move(file)));
     }
   }
-  VELOX_DCHECK_EQ(!result.empty(), isPartitionSpilled(partition));
+  VELOX_CHECK_EQ(!result.empty(), isPartitionSpilled(partition));
   if (extra != nullptr) {
     result.push_back(std::move(extra));
   }

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -620,16 +620,15 @@ class SpillState {
     return spilledPartitionSet_.size() == maxPartitions_;
   }
 
-  // Appends data to 'partition'. The rows given by 'indices' must be
-  // sorted for a sorted spill and must hash to 'partition'. It is
-  // safe to call this on multiple threads if all threads specify a
-  // different partition.
-  // Returns the size to sppend to partition.
+  /// Appends data to 'partition'. The rows given by 'indices' must be sorted
+  /// for a sorted spill and must hash to 'partition'. It is safe to call this
+  /// on multiple threads if all threads specify a different partition. Returns
+  /// the size to sppend to partition.
   uint64_t appendToPartition(int32_t partition, const RowVectorPtr& rows);
 
-  // Finishes a sorted run for 'partition'. If write is called for 'partition'
-  // again, the data does not have to be sorted relative to the data
-  // written so far.
+  /// Finishes a sorted run for 'partition'. If write is called for 'partition'
+  /// again, the data does not have to be sorted relative to the data written so
+  /// far.
   void finishWrite(int32_t partition) {
     VELOX_DCHECK(isPartitionSpilled(partition));
     files_[partition]->finishFile();
@@ -640,9 +639,9 @@ class SpillState {
   /// no spilled data.
   SpillFiles files(int32_t partition);
 
-  // Starts reading values for 'partition'. If 'extra' is non-null, it can be
-  // a stream of rows from a RowContainer so as to merge unspilled data with
-  // spilled data.
+  /// Starts reading values for 'partition'. If 'extra' is non-null, it can be
+  /// a stream of rows from a RowContainer so as to merge unspilled data with
+  /// spilled data.
   std::unique_ptr<TreeOfLosers<SpillMergeStream>> startMerge(
       int32_t partition,
       std::unique_ptr<SpillMergeStream>&& extra);

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -25,6 +25,12 @@ using facebook::velox::common::testutil::TestValue;
 namespace facebook::velox::exec {
 namespace {
 constexpr int32_t kLogEveryN = 32;
+
+#define CHECK_NOT_FINALIZED() \
+  VELOX_CHECK(!finalized_, "Spiller has been finalized")
+
+#define CHECK_FINALIZED() \
+  VELOX_CHECK(finalized_, "Spiller hasn't been finalized yet");
 } // namespace
 
 Spiller::Spiller(
@@ -57,6 +63,36 @@ Spiller::Spiller(
           pool,
           executor) {
   VELOX_CHECK_EQ(type_, Type::kOrderBy);
+}
+
+Spiller::Spiller(
+    Type type,
+    RowContainer* container,
+    RowContainer::Eraser eraser,
+    RowTypePtr rowType,
+    const std::string& path,
+    uint64_t writeBufferSize,
+    common::CompressionKind compressionKind,
+    memory::MemoryPool* pool,
+    folly::Executor* executor)
+    : Spiller(
+          type,
+          container,
+          std::move(eraser),
+          std::move(rowType),
+          HashBitRange{},
+          0,
+          {},
+          path,
+          std::numeric_limits<uint64_t>::max(),
+          writeBufferSize,
+          0,
+          compressionKind,
+          pool,
+          executor) {
+  VELOX_CHECK_EQ(type, Type::kAggregateOutput);
+  VELOX_CHECK_EQ(state_.maxPartitions(), 1);
+  VELOX_CHECK_EQ(state_.targetFileSize(), std::numeric_limits<uint64_t>::max());
 }
 
 Spiller::Spiller(
@@ -126,7 +162,9 @@ Spiller::Spiller(
 
   VELOX_CHECK_EQ(container_ == nullptr, type_ == Type::kHashJoinProbe);
   // kOrderBy spiller type must only have one partition.
-  VELOX_CHECK((type_ != Type::kOrderBy) || (state_.maxPartitions() == 1));
+  VELOX_CHECK(
+      (type_ != Type::kOrderBy && type_ != Type::kAggregateOutput) ||
+      (state_.maxPartitions() == 1));
   spillRuns_.reserve(state_.maxPartitions());
   for (int i = 0; i < state_.maxPartitions(); ++i) {
     spillRuns_.emplace_back(*pool_);
@@ -240,10 +278,14 @@ class RowContainerSpillMergeStream : public SpillMergeStream {
 
 std::unique_ptr<SpillMergeStream> Spiller::spillMergeStreamOverRows(
     int32_t partition) {
-  VELOX_CHECK(finalized_);
+  CHECK_FINALIZED();
   VELOX_CHECK_LT(partition, state_.maxPartitions());
 
   if (!state_.isPartitionSpilled(partition)) {
+    return nullptr;
+  }
+  // Skip the merge stream from row container if it is empty.
+  if (spillRuns_[partition].rows.empty()) {
     return nullptr;
   }
   ensureSorted(spillRuns_[partition]);
@@ -349,9 +391,11 @@ void Spiller::advanceSpill() {
     }
     run.rows.erase(run.rows.begin(), run.rows.begin() + numWritten);
     if (run.rows.empty()) {
-      // Run ends, start with a new file next time.
       run.clear();
-      if (needSort()) {
+      // When a sorted run ends, we start with a new file next time. For
+      // aggregation output spiller, we expect only one spill call to spill all
+      // the rows starting from the specified row offset.
+      if (needSort() || (type_ == Spiller::Type::kAggregateOutput)) {
         state_.finishWrite(partition);
       }
       pendingSpillPartitions_.erase(partition);
@@ -370,11 +414,23 @@ void Spiller::updateSpillSortTime(uint64_t timeUs) {
 }
 
 bool Spiller::needSort() const {
-  return type_ != Type::kHashJoinProbe && type_ != Type::kHashJoinBuild;
+  return type_ != Type::kHashJoinProbe && type_ != Type::kHashJoinBuild &&
+      type_ != Type::kAggregateOutput;
 }
 
 void Spiller::spill(uint64_t targetRows, uint64_t targetBytes) {
-  VELOX_CHECK(!finalized_);
+  return spill(targetRows, targetBytes, nullptr);
+}
+
+void Spiller::spill(const RowContainerIterator& startRowIter) {
+  return spill(0, 0, &startRowIter);
+}
+
+void Spiller::spill(
+    uint64_t targetRows,
+    uint64_t targetBytes,
+    const RowContainerIterator* startRowIter) {
+  CHECK_NOT_FINALIZED();
 
   if (type_ == Type::kHashJoinBuild || type_ == Type::kHashJoinProbe) {
     VELOX_FAIL("Don't support incremental spill on type: {}", typeName(type_));
@@ -399,19 +455,23 @@ void Spiller::spill(uint64_t targetRows, uint64_t targetBytes) {
     // NOTE: there might be some leftover from previous spill run so that we
     // finish spilling them first.
     if (!hasFilledRuns) {
-      fillSpillRuns();
+      fillSpillRuns(startRowIter);
       hasFilledRuns = true;
     }
 
     while (rowsLeft > 0 && (rowsLeft > targetRows || spaceLeft > targetBytes)) {
       const int32_t partition = pickNextPartitionToSpill();
       if (partition == -1) {
-        VELOX_FAIL(
-            "No partition has spillable data but still doesn't reach the spill target, target rows {}, target bytes {}, rows left {}, bytes left {}",
-            targetRows,
-            targetBytes,
-            rowsLeft,
-            spaceLeft);
+        // If 'startRowIter' is set, we only spill rows starting from the offset
+        // as specified in 'startRowIter'.
+        if (startRowIter == nullptr) {
+          VELOX_FAIL(
+              "No partition has spillable data but still doesn't reach the spill target, target rows {}, target bytes {}, rows left {}, bytes left {}",
+              targetRows,
+              targetBytes,
+              rowsLeft,
+              spaceLeft);
+        }
         break;
       }
       if (!state_.isPartitionSpilled(partition)) {
@@ -438,7 +498,8 @@ void Spiller::spill(uint64_t targetRows, uint64_t targetBytes) {
 }
 
 void Spiller::spill(const SpillPartitionNumSet& partitions) {
-  VELOX_CHECK(!finalized_);
+  CHECK_NOT_FINALIZED();
+
   if (type_ == Type::kHashJoinProbe) {
     VELOX_FAIL("There is no row container for {}", typeName(type_));
   }
@@ -469,7 +530,7 @@ void Spiller::spill(const SpillPartitionNumSet& partitions) {
 }
 
 void Spiller::spill(uint32_t partition, const RowVectorPtr& spillVector) {
-  VELOX_CHECK(!finalized_);
+  CHECK_NOT_FINALIZED();
 
   if (FOLLY_UNLIKELY(needSort())) {
     VELOX_FAIL(
@@ -527,20 +588,18 @@ int32_t Spiller::pickNextPartitionToSpill() {
 }
 
 Spiller::SpillRows Spiller::finishSpill() {
-  VELOX_CHECK(!finalized_);
-  finalized_ = true;
+  finalizeSpill();
 
   SpillRows rowsFromNonSpillingPartitions(
       0, memory::StlAllocator<char*>(*pool_));
   if (type_ != Spiller::Type::kHashJoinProbe) {
-    fillSpillRuns(&rowsFromNonSpillingPartitions);
+    fillSpillRuns(nullptr, &rowsFromNonSpillingPartitions);
   }
   return rowsFromNonSpillingPartitions;
 }
 
 void Spiller::finishSpill(SpillPartitionSet& partitionSet) {
-  VELOX_CHECK(!finalized_);
-  finalized_ = true;
+  finalizeSpill();
 
   for (auto& partition : state_.spilledPartitionSet()) {
     const SpillPartitionId partitionId(bits_.begin(), partition);
@@ -555,19 +614,60 @@ void Spiller::finishSpill(SpillPartitionSet& partitionSet) {
   }
 }
 
+void Spiller::finalizeSpill() {
+  CHECK_NOT_FINALIZED();
+  finalized_ = true;
+
+  for (const auto partition : state_.spilledPartitionSet()) {
+    if (state_.hasFiles(partition)) {
+      state_.finishWrite(partition);
+    }
+  }
+}
+
+std::unique_ptr<TreeOfLosers<SpillMergeStream>> Spiller::startMerge(
+    int32_t partition) {
+  CHECK_FINALIZED();
+
+  // We expect the spilled data are sorted for sort merge read except
+  // 'kAggregateOutput' type which is used during the aggregation output
+  // processing. The latter only only has one merge stream with one row per each
+  // distinct aggregation group. Hence, we don't need to sort in that case.
+  if (type_ != Type::kAggregateOutput) {
+    VELOX_CHECK(
+        needSort(), "Can't sort merge the unsorted spill data: {}", toString());
+  }
+
+  auto merger =
+      state_.startMerge(partition, spillMergeStreamOverRows(partition));
+  if (merger != nullptr && type_ == Type::kAggregateOutput) {
+    VELOX_CHECK_EQ(
+        merger->numStreams(),
+        1,
+        "{} spiller can only have one merge stream",
+        typeName(type_));
+  }
+  return merger;
+}
+
 void Spiller::clearSpillRuns() {
   for (auto& run : spillRuns_) {
     run.clear();
   }
 }
 
-void Spiller::fillSpillRuns(SpillRows* rowsFromNonSpillingPartitions) {
+void Spiller::fillSpillRuns(
+    const RowContainerIterator* startRowIter,
+    SpillRows* rowsFromNonSpillingPartitions) {
   clearSpillRuns();
 
   uint64_t execTimeUs{0};
   {
     MicrosecondTimer timer(&execTimeUs);
     RowContainerIterator iterator;
+    if (startRowIter != nullptr) {
+      iterator = *startRowIter;
+    }
     // Number of rows to hash and divide into spill partitions at a time.
     constexpr int32_t kHashBatchSize = 4096;
     std::vector<uint64_t> hashes(kHashBatchSize);
@@ -640,8 +740,10 @@ std::string Spiller::typeName(Type type) {
       return "HASH_JOIN_BUILD";
     case Type::kHashJoinProbe:
       return "HASH_JOIN_PROBE";
-    case Type::kAggregate:
-      return "AGGREGATE";
+    case Type::kAggregateInput:
+      return "AGGREGATE_INPUT";
+    case Type::kAggregateOutput:
+      return "AGGREGATE_OUTPUT";
     default:
       VELOX_UNREACHABLE("Unknown type: {}", static_cast<int>(type));
   }
@@ -655,7 +757,7 @@ void Spiller::fillSpillRuns(std::vector<SpillableStats>& statsList) {
   if (isAllSpilled()) {
     return;
   }
-  fillSpillRuns(nullptr);
+  fillSpillRuns();
   for (int partitionNum = 0; partitionNum < state_.maxPartitions();
        ++partitionNum) {
     const auto& spillRun = spillRuns_[partitionNum];

--- a/velox/exec/tests/TreeOfLosersTest.cpp
+++ b/velox/exec/tests/TreeOfLosersTest.cpp
@@ -61,7 +61,9 @@ TEST_F(TreeOfLosersTest, nextWithEquals) {
     mergeStreams.push_back(std::make_unique<TestingStream>(std::move(stream)));
   }
   std::sort(allNumbers.begin(), allNumbers.end());
+  const int expectedNumMergeStreams = mergeStreams.size();
   TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+  ASSERT_EQ(merge.numStreams(), expectedNumMergeStreams);
   bool expectRepeat = false;
   for (auto i = 0; i < allNumbers.size(); ++i) {
     auto result = merge.nextWithEquals();
@@ -88,6 +90,7 @@ TEST_F(TreeOfLosersTest, singleWithEquals) {
   std::vector<std::unique_ptr<TestingStream>> mergeStreams;
   mergeStreams.push_back(std::make_unique<TestingStream>(std::move(stream)));
   TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+  ASSERT_EQ(merge.numStreams(), 1);
   for (auto i = 0; i < allNumbers.size(); ++i) {
     auto result = merge.nextWithEquals();
     if (result.first == nullptr) {
@@ -116,7 +119,9 @@ TEST_F(TreeOfLosersTest, allDuplicates) {
       mergeStreams.push_back(
           std::make_unique<TestingStream>(std::move(streamNumbers)));
     }
+    const int expectedNumMergeStreams = mergeStreams.size();
     TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+    ASSERT_EQ(merge.numStreams(), expectedNumMergeStreams);
     for (auto i = 0; i < kNumStreams * kNumsPerStream; ++i) {
       TestingStream* stream;
       if (testNextEqual) {
@@ -154,7 +159,9 @@ TEST_F(TreeOfLosersTest, allSorted) {
       mergeStreams.push_back(
           std::make_unique<TestingStream>(std::move(streamNumbers)));
     }
+    const int expectedNumMergeStreams = mergeStreams.size();
     TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+    ASSERT_EQ(merge.numStreams(), expectedNumMergeStreams);
     for (auto i = 0; i < kNumStreams * kNumsPerStream; ++i) {
       TestingStream* stream;
       if (testNextEqual) {
@@ -186,7 +193,9 @@ TEST_F(TreeOfLosersTest, allEmpty) {
             TreeOfLosers<TestingStream> merge(std::move(mergeStreams)));
         continue;
       }
+      const int expectedNumMergeStreams = mergeStreams.size();
       TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+      ASSERT_EQ(merge.numStreams(), expectedNumMergeStreams);
       if (testNextEqual) {
         ASSERT_TRUE(merge.nextWithEquals().first == nullptr);
       } else {
@@ -222,7 +231,9 @@ TEST_F(TreeOfLosersTest, randomWithDuplicates) {
         mergeStreams.push_back(
             std::make_unique<TestingStream>(std::move(streamNumVectors[i])));
       }
+      const int expectedNumMergeStreams = mergeStreams.size();
       TreeOfLosers<TestingStream> merge(std::move(mergeStreams));
+      ASSERT_EQ(merge.numStreams(), expectedNumMergeStreams);
       for (auto i = 3; i <= 3 * numCount; ++i) {
         TestingStream* stream;
         if (testNextEqual) {


### PR DESCRIPTION
Add spilling support during the aggregation output stage processing
which spill all the rows starting from the output row offset and switch
the output mode from non-spill to spill mode. Unit tests are added to
cover the new spilling path at different layers.