### PR TITLE
Allow restricting arguments as orderable or comparable in the function signature

### DIFF
--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -43,7 +43,9 @@ class SignatureVariable {
       std::string name,
       std::optional<std::string> constraint,
       ParameterType type,
-      bool knownTypesOnly = false);
+      bool knownTypesOnly = false,
+      bool orderableTypesOnly = false,
+      bool comparableTypesOnly = false);
 
   const std::string& name() const {
     return name_;
@@ -58,6 +60,16 @@ class SignatureVariable {
     return knownTypesOnly_;
   }
 
+  bool orderableTypesOnly() const {
+    VELOX_USER_CHECK(isTypeParameter());
+    return orderableTypesOnly_;
+  }
+
+  bool comparableTypesOnly() const {
+    VELOX_USER_CHECK(isTypeParameter());
+    return comparableTypesOnly_;
+  }
+
   bool isTypeParameter() const {
     return type_ == ParameterType::kTypeParameter;
   }
@@ -69,7 +81,9 @@ class SignatureVariable {
   bool operator==(const SignatureVariable& rhs) const {
     return type_ == rhs.type_ && name_ == rhs.name_ &&
         constraint_ == rhs.constraint_ &&
-        knownTypesOnly_ == rhs.knownTypesOnly_;
+        knownTypesOnly_ == rhs.knownTypesOnly_ &&
+        orderableTypesOnly_ == rhs.orderableTypesOnly_ &&
+        comparableTypesOnly_ == rhs.comparableTypesOnly_;
   }
 
  private:
@@ -79,6 +93,8 @@ class SignatureVariable {
   // This property only applies to type variables and indicates if the type
   // can bind to unknown or not.
   bool knownTypesOnly_ = false;
+  bool orderableTypesOnly_ = false;
+  bool comparableTypesOnly_ = false;
 };
 
 // Base type (e.g. map) and optional parameters (e.g. K, V).
@@ -258,12 +274,13 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
-  FunctionSignatureBuilder& knownTypeVariable(const std::string& name) {
-    addVariable(
-        variables_,
-        SignatureVariable(name, "", ParameterType::kTypeParameter, true));
-    return *this;
-  }
+  FunctionSignatureBuilder& knownTypeVariable(const std::string& name);
+
+  /// Orderable implies comparable, this method would enable
+  /// comaprableTypesOnly_ too.
+  FunctionSignatureBuilder& orderableTypeVariable(const std::string& name);
+
+  FunctionSignatureBuilder& comparableTypeVariable(const std::string& name);
 
   FunctionSignatureBuilder& integerVariable(
       const std::string& name,
@@ -326,13 +343,15 @@ class AggregateFunctionSignatureBuilder {
     return *this;
   }
 
-  AggregateFunctionSignatureBuilder& knownTypeVariable(
-      const std::string& name) {
-    addVariable(
-        variables_,
-        SignatureVariable(name, "", ParameterType::kTypeParameter, true));
-    return *this;
-  }
+  AggregateFunctionSignatureBuilder& knownTypeVariable(const std::string& name);
+
+  /// Orderable implies comparable, this method would enable
+  /// comaprableTypesOnly_ too.
+  AggregateFunctionSignatureBuilder& orderableTypeVariable(
+      const std::string& name);
+
+  AggregateFunctionSignatureBuilder& comparableTypeVariable(
+      const std::string& name);
 
   AggregateFunctionSignatureBuilder& integerVariable(
       const std::string& name,

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -90,8 +90,8 @@ class SignatureVariable {
   const std::string name_;
   const std::string constraint_;
   const ParameterType type_;
-  // This property only applies to type variables and indicates if the type
-  // can bind to unknown or not.
+  // The following properties apply only to type variables and indicate whether
+  // the type can bind only to known, orderable or comparable types.
   bool knownTypesOnly_ = false;
   bool orderableTypesOnly_ = false;
   bool comparableTypesOnly_ = false;
@@ -277,7 +277,7 @@ class FunctionSignatureBuilder {
   FunctionSignatureBuilder& knownTypeVariable(const std::string& name);
 
   /// Orderable implies comparable, this method would enable
-  /// comaprableTypesOnly_ too.
+  /// comparableTypesOnly_ too.
   FunctionSignatureBuilder& orderableTypeVariable(const std::string& name);
 
   FunctionSignatureBuilder& comparableTypeVariable(const std::string& name);
@@ -346,7 +346,7 @@ class AggregateFunctionSignatureBuilder {
   AggregateFunctionSignatureBuilder& knownTypeVariable(const std::string& name);
 
   /// Orderable implies comparable, this method would enable
-  /// comaprableTypesOnly_ too.
+  /// comparableTypesOnly_ too.
   AggregateFunctionSignatureBuilder& orderableTypeVariable(
       const std::string& name);
 

--- a/velox/expression/SignatureBinder.cpp
+++ b/velox/expression/SignatureBinder.cpp
@@ -165,6 +165,14 @@ bool SignatureBinderBase::tryBind(
       return false;
     }
 
+    if (variable.orderableTypesOnly() && !actualType->isOrderable()) {
+      return false;
+    }
+
+    if (variable.comparableTypesOnly() && !actualType->isComparable()) {
+      return false;
+    }
+
     typeVariablesBindings_[baseName] = actualType;
     return true;
   }


### PR DESCRIPTION
In Presto, input to min/max is restricted to orderable types. 
For example, MAP type is not orderable. Velox currently allows MAP inputs.

This PR adds two APIs in `FunctionSignatureBuilder`: `orderableTypeVariable`
and `comparableTypeVariable`. Use type's `orderable` and `comparable` flag
added in https://github.com/facebookincubator/velox/pull/6770 to do the check 
during type binding in `SignatureBinder.tryBind`.

Part of https://github.com/facebookincubator/velox/issues/6718