### PR TITLE
Fix checksum Presto aggregate function

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ChecksumAggregateTest.cpp
@@ -205,16 +205,45 @@ TEST_F(ChecksumAggregateTest, maps) {
 }
 
 TEST_F(ChecksumAggregateTest, rows) {
-  auto row = makeRowVector(
-      {makeFlatVector<int64_t>({1, 3}), makeFlatVector<int64_t>({2, 4})});
+  auto row = makeRowVector({
+      makeFlatVector<int64_t>({1, 3}),
+      makeFlatVector<int64_t>({2, 4}),
+  });
 
   assertChecksum(row, "jMIvLQ5YEVg=");
 
-  row = makeRowVector(
-      {makeNullableFlatVector<int64_t>({1, std::nullopt}),
-       makeNullableFlatVector<int64_t>({std::nullopt, 4})});
+  row->setNull(0, true);
+  assertChecksum(row, "nbYF0I9UTeU=");
+
+  row->setNull(1, true);
+  assertChecksum(row, "DpXXC2Pzbjw=");
+
+  row = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 4}),
+  });
 
   assertChecksum(row, "6jtxEIUj7Hg=");
+
+  row = makeRowVector({
+      makeRowVector({
+          makeNullableFlatVector<std::string>({"Hello", "world!"}),
+          makeNullableFlatVector<bool>({true, false}),
+      }),
+      makeNullableFlatVector<int64_t>({17, 4}),
+  });
+
+  assertChecksum(row, "21pwcVg31Kc=");
+
+  row = makeRowVector({
+      makeRowVector({
+          makeNullableFlatVector<std::string>({"Hello", std::nullopt}),
+          makeNullableFlatVector<bool>({std::nullopt, false}),
+      }),
+      makeNullableFlatVector<int64_t>({std::nullopt, 4}),
+  });
+
+  assertChecksum(row, "Aw9tzUPOiUc=");
 }
 
 TEST_F(ChecksumAggregateTest, globalAggregationNoData) {

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -310,16 +310,25 @@ TEST_F(PrestoHasherTest, maps) {
 }
 
 TEST_F(PrestoHasherTest, rows) {
-  auto row = makeRowVector(
-      {makeFlatVector<int64_t>({1, 3}), makeFlatVector<int64_t>({2, 4})});
+  auto row = makeRowVector({
+      makeFlatVector<int64_t>({1, 3}),
+      makeFlatVector<int64_t>({2, 4}),
+  });
 
   assertHash(row, {4329740752828761434, 655643799837772474});
 
-  row = makeRowVector(
-      {makeNullableFlatVector<int64_t>({1, std::nullopt}),
-       makeNullableFlatVector<int64_t>({std::nullopt, 4})});
+  row = makeRowVector({
+      makeNullableFlatVector<int64_t>({1, std::nullopt}),
+      makeNullableFlatVector<int64_t>({std::nullopt, 4}),
+  });
 
   assertHash(row, {7113531408683827503, -1169223928725763049});
+
+  row->setNull(0, true);
+  assertHash(row, {0, -1169223928725763049});
+
+  row->setNull(1, true);
+  assertHash(row, {0, 0});
 }
 
 TEST_F(PrestoHasherTest, wrongVectorType) {


### PR DESCRIPTION
PrestoHasher used to ignore null flags for structs producing incorrect hashes.

Fixes #6715 and #6449