### PR TITLE
Optimize DateType::toString(int32_t) and functions::getDateTime

### DIFF
--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -51,8 +51,8 @@ FOLLY_ALWAYS_INLINE
 std::tm getDateTime(Timestamp timestamp, const date::time_zone* timeZone) {
   int64_t seconds = getSeconds(timestamp, timeZone);
   std::tm dateTime;
-  VELOX_USER_CHECK_NOT_NULL(
-      gmtime_r((const time_t*)&seconds, &dateTime),
+  VELOX_USER_CHECK(
+      epochToUtc(seconds, dateTime),
       "Timestamp is too large: {} seconds since epoch",
       seconds);
   return dateTime;
@@ -63,10 +63,8 @@ FOLLY_ALWAYS_INLINE
 std::tm getDateTime(int32_t days) {
   int64_t seconds = days * kSecondsInDay;
   std::tm dateTime;
-  VELOX_USER_CHECK_NOT_NULL(
-      gmtime_r((const time_t*)&seconds, &dateTime),
-      "Date is too large: {} days",
-      days);
+  VELOX_USER_CHECK(
+      epochToUtc(seconds, dateTime), "Date is too large: {} days", days);
   return dateTime;
 }
 


### PR DESCRIPTION
Summary: Optimize `DateType::toString(int32_t)` and `functions::getDateTime` by reusing the same optimization we did for `Timestamp::toString`.

Differential Revision: D49940219

Fix https://github.com/facebookincubator/velox/issues/6918


