### PR TITLE
compareMaterializedRows should compare unique row counts

### DIFF
--- a/velox/exec/tests/utils/QueryAssertions.cpp
+++ b/velox/exec/tests/utils/QueryAssertions.cpp
@@ -927,7 +927,7 @@ static bool compareMaterializedRows(
   }
 
   for (auto& it : left) {
-    if (right.count(it) == 0) {
+    if (right.count(it) != left.count(it)) {
       return false;
     }
   }
@@ -936,7 +936,7 @@ static bool compareMaterializedRows(
   // left, check the other way around. E.g., left = {1, 1, 2}, right = {1, 2,
   // 3}.
   for (auto& it : right) {
-    if (left.count(it) == 0) {
+    if (left.count(it) != right.count(it)) {
       return false;
     }
   }


### PR DESCRIPTION
Summary:
compareMaterializedRows in QueryAssertions currently checks that the number of rows in Velox and DuckDb
match, and that every row output by one appears in the other's results.

This is not strict enough, as query results may have duplicate rows.  compareMaterializedRows will miss the
case where the total number of rows is the same but the number of each distinct row is different.

The fix is to check that the counts match, not just that the row is present.

Differential Revision: D49895573


