### PR TITLE
Fix data race in LocalExchangeSource

### DIFF
--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -178,8 +178,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
   }
 
   // Records the total number of pages fetched from sources.
-  int64_t numPages_{0};
-  uint64_t totalBytes_{0};
+  std::atomic<int64_t> numPages_{0};
+  std::atomic<uint64_t> totalBytes_{0};
   VeloxPromise<Response> promise_{VeloxPromise<Response>::makeEmpty()};
   int32_t numRequests_{0};
 };


### PR DESCRIPTION
Summary:
TSAN detected a data race where numPages_ and totalBytes_ were accessed from
multiple threads without lock protection. Fix by using std::atomic.

Differential Revision: D49966355


