### PR TITLE
Add query memory per node session override

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -353,7 +353,7 @@ class SharedArbitrationTest : public exec::test::HiveConnectorTestBase {
                              : MemoryReclaimer::create());
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(),
-        std::unordered_map<std::string, std::string>{},
+        core::QueryConfig({}),
         configs,
         cache::AsyncDataCache::getInstance(),
         std::move(pool));

--- a/velox/core/QueryConfig.cpp
+++ b/velox/core/QueryConfig.cpp
@@ -13,9 +13,94 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include <re2/re2.h>
+
 #include "velox/core/QueryConfig.h"
 
 namespace facebook::velox::core {
+
+double toBytesPerCapacityUnit(CapacityUnit unit) {
+  switch (unit) {
+    case CapacityUnit::BYTE:
+      return 1;
+    case CapacityUnit::KILOBYTE:
+      return exp2(10);
+    case CapacityUnit::MEGABYTE:
+      return exp2(20);
+    case CapacityUnit::GIGABYTE:
+      return exp2(30);
+    case CapacityUnit::TERABYTE:
+      return exp2(40);
+    case CapacityUnit::PETABYTE:
+      return exp2(50);
+    default:
+      VELOX_USER_FAIL("Invalid capacity unit '{}'", (int)unit);
+  }
+}
+
+CapacityUnit valueOfCapacityUnit(const std::string& unitStr) {
+  if (unitStr == "B") {
+    return CapacityUnit::BYTE;
+  }
+  if (unitStr == "kB") {
+    return CapacityUnit::KILOBYTE;
+  }
+  if (unitStr == "MB") {
+    return CapacityUnit::MEGABYTE;
+  }
+  if (unitStr == "GB") {
+    return CapacityUnit::GIGABYTE;
+  }
+  if (unitStr == "TB") {
+    return CapacityUnit::TERABYTE;
+  }
+  if (unitStr == "PB") {
+    return CapacityUnit::PETABYTE;
+  }
+  VELOX_USER_FAIL("Invalid capacity unit '{}'", unitStr);
+}
+
+// Convert capacity string with unit to the capacity number in the specified
+// units
+uint64_t toCapacity(const std::string& from, CapacityUnit to) {
+  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*$)");
+  double value;
+  std::string unit;
+  if (!RE2::FullMatch(from, kPattern, &value, &unit)) {
+    VELOX_USER_FAIL("Invalid capacity string '{}'", from);
+  }
+
+  return value *
+      (toBytesPerCapacityUnit(valueOfCapacityUnit(unit)) /
+       toBytesPerCapacityUnit(to));
+}
+
+std::chrono::duration<double> toDuration(const std::string& str) {
+  static const RE2 kPattern(R"(^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]+)\s*)");
+
+  double value;
+  std::string unit;
+  if (!RE2::FullMatch(str, kPattern, &value, &unit)) {
+    VELOX_USER_FAIL("Invalid duration {}", str);
+  }
+  if (unit == "ns") {
+    return std::chrono::duration<double, std::nano>(value);
+  } else if (unit == "us") {
+    return std::chrono::duration<double, std::micro>(value);
+  } else if (unit == "ms") {
+    return std::chrono::duration<double, std::milli>(value);
+  } else if (unit == "s") {
+    return std::chrono::duration<double>(value);
+  } else if (unit == "m") {
+    return std::chrono::duration<double, std::ratio<60>>(value);
+  } else if (unit == "h") {
+    return std::chrono::duration<double, std::ratio<60 * 60>>(value);
+  } else if (unit == "d") {
+    return std::chrono::duration<double, std::ratio<60 * 60 * 24>>(value);
+  }
+  VELOX_USER_FAIL("Invalid duration {}", str);
+}
 
 QueryConfig::QueryConfig(
     const std::unordered_map<std::string, std::string>& values)

--- a/velox/core/QueryCtx.cpp
+++ b/velox/core/QueryCtx.cpp
@@ -36,6 +36,24 @@ QueryCtx::QueryCtx(
 }
 
 QueryCtx::QueryCtx(
+    folly::Executor* executor,
+    QueryConfig&& queryConfig,
+    std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,
+    cache::AsyncDataCache* cache,
+    std::shared_ptr<memory::MemoryPool> pool,
+    std::shared_ptr<folly::Executor> spillExecutor,
+    const std::string& queryId)
+    : queryId_(queryId),
+      connectorConfigs_(connectorConfigs),
+      cache_(cache),
+      pool_(std::move(pool)),
+      executor_(executor),
+      queryConfig_{std::move(queryConfig)},
+      spillExecutor_(std::move(spillExecutor)) {
+  initPool(queryId);
+}
+
+QueryCtx::QueryCtx(
     folly::Executor::KeepAlive<> executorKeepalive,
     std::unordered_map<std::string, std::string> queryConfigValues,
     std::unordered_map<std::string, std::shared_ptr<Config>> connectorConfigs,

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -34,9 +34,21 @@ class QueryCtx {
   /// mode, executor is not needed. Hence, we don't require executor to always
   /// be passed in here, but instead, ensure that executor exists when actually
   /// being used.
+  // TODO(jtan6): Deprecate this constructor after external dependencies are
+  //   migrated
+  QueryCtx(
+      folly::Executor* executor,
+      std::unordered_map<std::string, std::string> queryConfigValues,
+      std::unordered_map<std::string, std::shared_ptr<Config>>
+          connectorConfigs = {},
+      cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),
+      std::shared_ptr<memory::MemoryPool> pool = nullptr,
+      std::shared_ptr<folly::Executor> spillExecutor = nullptr,
+      const std::string& queryId = "");
+
   QueryCtx(
       folly::Executor* executor = nullptr,
-      std::unordered_map<std::string, std::string> queryConfigValues = {},
+      QueryConfig&& queryConfig = QueryConfig{{}},
       std::unordered_map<std::string, std::shared_ptr<Config>>
           connectorConfigs = {},
       cache::AsyncDataCache* cache = cache::AsyncDataCache::getInstance(),

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -246,7 +246,7 @@ class ExchangeBenchmark : public VectorTestBase {
       int64_t maxMemory = kMaxMemory) {
     auto configCopy = configSettings_;
     auto queryCtx = std::make_shared<core::QueryCtx>(
-        executor_.get(), std::move(configCopy));
+        executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
             queryCtx->queryId(), maxMemory));

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -553,8 +553,8 @@ TEST_F(DriverTest, pause) {
   // Make sure CPU usage tracking is enabled.
   std::unordered_map<std::string, std::string> queryConfig{
       {core::QueryConfig::kOperatorTrackCpuUsage, "true"}};
-  params.queryCtx =
-      std::make_shared<core::QueryCtx>(executor_.get(), std::move(queryConfig));
+  params.queryCtx = std::make_shared<core::QueryCtx>(
+      executor_.get(), core::QueryConfig(std::move(queryConfig)));
   int32_t numRead = 0;
   readResults(params, ResultOperation::kPause, 370'000'000, &numRead);
   // Each thread will fully read the 1M rows in values.

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -67,7 +67,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
       int64_t maxMemory = memory::kMaxMemory) {
     auto configCopy = configSettings_;
     auto queryCtx = std::make_shared<core::QueryCtx>(
-        executor_.get(), std::move(configCopy));
+        executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
             queryCtx->queryId(), maxMemory));

--- a/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
+++ b/velox/exec/tests/PartitionedOutputBufferManagerTest.cpp
@@ -68,7 +68,7 @@ class PartitionedOutputBufferManagerTest : public testing::Test {
           std::to_string(maxPartitionedOutputBufferSize);
     }
     auto queryCtx = std::make_shared<core::QueryCtx>(
-        executor_.get(), std::move(configSettings));
+        executor_.get(), core::QueryConfig(std::move(configSettings)));
 
     auto task =
         Task::create(taskId, std::move(planFragment), 0, std::move(queryCtx));

--- a/velox/exec/tests/utils/AssertQueryBuilder.cpp
+++ b/velox/exec/tests/utils/AssertQueryBuilder.cpp
@@ -222,7 +222,7 @@ AssertQueryBuilder::readCursor() {
       static std::atomic<uint64_t> cursorQueryId{0};
       params_.queryCtx = std::make_shared<core::QueryCtx>(
           executor_.get(),
-          std::unordered_map<std::string, std::string>{},
+          core::QueryConfig({}),
           std::unordered_map<std::string, std::shared_ptr<Config>>{},
           cache::AsyncDataCache::getInstance(),
           nullptr,

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -143,7 +143,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
     static std::atomic<uint64_t> cursorQueryId{0};
     queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(),
-        std::unordered_map<std::string, std::string>{},
+        core::QueryConfig({}),
         std::unordered_map<std::string, std::shared_ptr<Config>>{},
         cache::AsyncDataCache::getInstance(),
         nullptr,

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -414,8 +414,8 @@ class ParameterizedExprTest : public ExprTest,
     std::unordered_map<std::string, std::string> configData(
         {{core::QueryConfig::kEnableExpressionEvaluationCache,
           GetParam() ? "true" : "false"}});
-    queryCtx_ =
-        std::make_shared<core::QueryCtx>(nullptr, std::move(configData));
+    queryCtx_ = std::make_shared<core::QueryCtx>(
+        nullptr, core::QueryConfig(std::move(configData)));
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
   }
 };


### PR DESCRIPTION
Query memory per node is currently only configured through system config properties. Queries should be able to override the property by passing session properties. This PR allows this behavior.