### PR TITLE
Add raw input types to AggregationNode.Aggregate

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -296,6 +296,7 @@ std::vector<SortOrder> deserializeSortingOrders(const folly::dynamic& array) {
 folly::dynamic AggregationNode::Aggregate::serialize() const {
   folly::dynamic obj = folly::dynamic::object();
   obj["call"] = call->serialize();
+  obj["rawInputTypes"] = ISerializable::serialize(rawInputTypes);
   if (mask) {
     obj["mask"] = mask->serialize();
   }
@@ -310,6 +311,8 @@ AggregationNode::Aggregate AggregationNode::Aggregate::deserialize(
     const folly::dynamic& obj,
     void* context) {
   auto call = ISerializable::deserialize<CallTypedExpr>(obj["call"]);
+  auto rawInputTypes =
+      ISerializable::deserialize<std::vector<Type>>(obj["rawInputTypes"]);
   FieldAccessTypedExprPtr mask;
   if (obj.count("mask")) {
     mask = ISerializable::deserialize<FieldAccessTypedExpr>(obj["mask"]);
@@ -318,7 +321,12 @@ AggregationNode::Aggregate AggregationNode::Aggregate::deserialize(
   auto sortingOrders = deserializeSortingOrders(obj["sortingOrders"]);
   bool distinct = obj["distinct"].asBool();
   return {
-      call, mask, std::move(sortingKeys), std::move(sortingOrders), distinct};
+      call,
+      rawInputTypes,
+      mask,
+      std::move(sortingKeys),
+      std::move(sortingOrders),
+      distinct};
 }
 
 // static

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -497,6 +497,13 @@ class AggregationNode : public PlanNode {
     /// Function name and input column names.
     CallTypedExprPtr call;
 
+    /// Raw input types used to properly identify aggregate function. These
+    /// might be different from the input types specified in 'call' when
+    /// aggregation step is kIntermediate or kFinal.
+    ///
+    /// Note: not used yet.
+    std::vector<TypePtr> rawInputTypes;
+
     /// Optional name of input column to use as a mask. Column type must be
     /// BOOLEAN.
     FieldAccessTypedExprPtr mask;

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -127,6 +127,7 @@ TEST_F(PlanFragmentTest, aggregationCanSpill) {
       std::make_shared<InputTypedExpr>(BIGINT())};
   const std::vector<AggregationNode::Aggregate> aggregates{
       {std::make_shared<core::CallTypedExpr>(BIGINT(), aggregateInputs, "sum"),
+       {},
        nullptr,
        {},
        {}}};

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -179,6 +179,8 @@ Properties of individual measures.
      - Description
    * - call
      - An expression for computing the measure, e.g. count(1), sum(a), avg(b). Expressions must be in the form of aggregate function calls over input columns directly, e.g. sum(c) is ok, but sum(c + d) is not.
+   * - rawInputTypes
+     - A list of raw input types for the aggregation function. There are used to correctly identify aggregation function, e.g. to decide between min(x) and min(x, n) in case of intermediate aggregation. These can be different from the input types specified in 'call' when aggregation step is intermediate or final.
    * - mask
      - An optional boolean input column that's used to mask out rows for this particular measure. Multiple measures may specify same input column as a mask.
    * - sortingKeys

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -411,7 +411,7 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
         .values({data})
         .addNode([&](auto nodeId, auto source) -> core::PlanNodePtr {
           std::vector<core::AggregationNode::Aggregate> aggregates{
-              {aggExpr, nullptr, {}, {}}};
+              {aggExpr, {}, nullptr, {}, {}}};
 
           return std::make_shared<core::AggregationNode>(
               nodeId,
@@ -471,6 +471,7 @@ TEST_F(AggregationTest, missingLambdaFunction) {
                     std::vector<core::AggregationNode::Aggregate> aggregates{
                         {std::make_shared<core::CallTypedExpr>(
                              BIGINT(), inputs, "missing-lambda"),
+                         {},
                          nullptr,
                          {},
                          {}}};

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -70,7 +70,7 @@ static std::shared_ptr<core::AggregationNode> generateAggregationNode(
       BIGINT(), std::vector<core::TypedExprPtr>{inputField}, "min");
   std::vector<std::string> aggregateNames = {"min"};
   std::vector<core::AggregationNode::Aggregate> aggregates = {
-      core::AggregationNode::Aggregate{callExpr, nullptr, {}, {}}};
+      core::AggregationNode::Aggregate{callExpr, {}, nullptr, {}, {}}};
   return std::make_shared<core::AggregationNode>(
       core::PlanNodeId(),
       step,
@@ -2404,19 +2404,23 @@ TEST_P(AllTableWriterTest, columnStatsDataTypes) {
       "count",
       "sum_data_size_for_stats",
   };
+
+  auto makeAggregate = [](const auto& callExpr) {
+    return core::AggregationNode::Aggregate{callExpr, {}, nullptr, {}, {}};
+  };
+
   std::vector<core::AggregationNode::Aggregate> aggregates = {
-      core::AggregationNode::Aggregate{minCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{maxCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{distinctCountCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{maxDataSizeCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{sumDataSizeCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{countCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{countIfCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{countMapCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{sumDataSizeMapCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{countArrayCallExpr, nullptr, {}, {}},
-      core::AggregationNode::Aggregate{
-          sumDataSizeArrayCallExpr, nullptr, {}, {}},
+      makeAggregate(minCallExpr),
+      makeAggregate(maxCallExpr),
+      makeAggregate(distinctCountCallExpr),
+      makeAggregate(maxDataSizeCallExpr),
+      makeAggregate(sumDataSizeCallExpr),
+      makeAggregate(countCallExpr),
+      makeAggregate(countIfCallExpr),
+      makeAggregate(countMapCallExpr),
+      makeAggregate(sumDataSizeMapCallExpr),
+      makeAggregate(countArrayCallExpr),
+      makeAggregate(sumDataSizeArrayCallExpr),
   };
   const auto aggregationNode = std::make_shared<core::AggregationNode>(
       core::PlanNodeId(),

--- a/velox/parse/QueryPlanner.cpp
+++ b/velox/parse/QueryPlanner.cpp
@@ -320,6 +320,7 @@ PlanNodePtr toVeloxPlan(
     aggregates.push_back(
         {std::make_shared<CallTypedExpr>(
              call->type(), fieldInputs, call->name()),
+         {},
          nullptr,
          {},
          {}});

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -155,7 +155,7 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     auto aggExpr = std::make_shared<const core::CallTypedExpr>(
         aggVeloxType, std::move(aggParams), funcName);
     aggregates.emplace_back(
-        core::AggregationNode::Aggregate{aggExpr, mask, {}, {}});
+        core::AggregationNode::Aggregate{aggExpr, {}, mask, {}, {}});
   }
 
   bool ignoreNullKeys = false;


### PR DESCRIPTION
Currently, it is not possible to correctly identify aggregate function for some intermediate aggregations.

For example, min(x) and min(x, n) may have the same intermediate type.

Intermediate type for min(x row(bigint, array(integer)) is row(bigint, array(integer)). In this case, intermediate aggregation needs to produce a minimum struct.

Intermediate type for min(x integer, n bigint) is also row(bigint, array(integer)). In this case, intermediate aggregation needs to combine the arrays and return n smallest values.

To disambiguate these calls, we add rawInputTypes property to AggregationNode.Aggregate. This will be the same regardless of the aggregation step and allow to correctly identify aggregate function. 

For min(x) in the example above, rawInputTypes will contain a single type row(bigint, array(integer). For min(x, n) it will be two types: integer, bigint.

This change introduces the new property, but doesn't use it yet.

A follow-up will modify HashAggregation operator to start using this property to identify aggregate function. For backwards compatibility, the existing logic will be used if rawInputTypes are not specified.

Part of #6506