### PR TITLE
Fix and optimize EvalCtx::addNulls

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3228,11 +3228,12 @@ TEST_F(ExprTest, addNulls) {
   {
     auto vector = makeConstant<int64_t>(100, kSize - 1);
     exec::EvalCtx::addNulls(rows, rawNulls, context, BIGINT(), vector);
-    ASSERT_TRUE(vector->isFlatEncoding());
+    ASSERT_EQ(vector->encoding(), VectorEncoding::Simple::DICTIONARY);
     ASSERT_EQ(vector->size(), kSize);
+    DecodedVector decoded(*vector, vector->size());
     for (auto i = 0; i < kSize - 1; ++i) {
       ASSERT_FALSE(vector->isNullAt(i));
-      ASSERT_EQ(vector->asFlatVector<int64_t>()->valueAt(i), 100);
+      ASSERT_EQ(decoded.valueAt<int64_t>(i), 100);
     }
     ASSERT_TRUE(vector->isNullAt(kSize - 1));
   }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -130,10 +130,12 @@ VectorPtr BaseVector::wrapInDictionary(
     BufferPtr nulls,
     BufferPtr indices,
     vector_size_t size,
-    VectorPtr vector) {
+    VectorPtr vector,
+    bool requireDictionaryOutput) {
   // Dictionary that doesn't add nulls over constant is same as constant. Just
   // make sure to adjust the size.
-  if (vector->encoding() == VectorEncoding::Simple::CONSTANT && !nulls) {
+  if (!requireDictionaryOutput &&
+      vector->encoding() == VectorEncoding::Simple::CONSTANT && !nulls) {
     if (size == vector->size()) {
       return vector;
     }

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -497,7 +497,8 @@ class BaseVector {
       BufferPtr nulls,
       BufferPtr indices,
       vector_size_t size,
-      VectorPtr vector);
+      VectorPtr vector,
+      bool requireDictionaryOutput = false);
 
   static VectorPtr
   wrapInSequence(BufferPtr lengths, vector_size_t size, VectorPtr vector);


### PR DESCRIPTION
Summary:
Optimize addNulls by avoiding copying complex types data and wrap vectors in
dictionary instead.

This also fix an issue with rowVector->resize() by avoid calling it which used to be
called when the input is of type ROW but complex encoding.

Best effort unit test is added.
fix https://github.com/facebookincubator/velox/issues/6935

Differential Revision: D50019636


