### PR TITLE
Upgrade to boost 1.83

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1009,7 +1009,7 @@ jobs:
                 # https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
                 out.write("    - name: Export boost environment\n")
                 out.write(
-                    '      run: "echo BOOST_ROOT=%BOOST_ROOT_1_78_0% >> %GITHUB_ENV%"\n'
+                    '      run: "echo BOOST_ROOT=%BOOST_ROOT_1_83_0% >> %GITHUB_ENV%"\n'
                 )
                 out.write("      shell: cmd\n")
 

--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -2,17 +2,17 @@
 name = boost
 
 [download.not(os=windows)]
-url = https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz
-sha256 = 94ced8b72956591c4775ae2207a9763d3600b30d9d7446562c552f0a14a63be7
+url = https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.gz
+sha256 = c0685b68dd44cc46574cce86c4e17c0f611b15e195be9848dfd0769a0a207628
 
 [download.os=windows]
-url = https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.zip
-sha256 = f22143b5528e081123c3c5ed437e92f648fe69748e95fa6e2bd41484e2986cc3
+url = https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.zip
+sha256 = c86bd9d9eef795b4b0d3802279419fde5221922805b073b9bd822edecb1ca28e
 
 [preinstalled.env]
 # Here we list the acceptable versions that cmake needs a hint to find
 BOOST_ROOT_1_69_0
-BOOST_ROOT_1_78_0
+BOOST_ROOT_1_83_0
 
 [debs]
 libboost-all-dev


### PR DESCRIPTION
Summary:
Update to boost 1.83.  This addresses a folly build failure on Xcode 15, due to
boost 1.78 referring to the removed std::unary_function.

Reviewed By: jdelliot

Differential Revision: D49972186

