### PR TITLE
Fix potential segfault in HashTable's parallelJoinBuilder

### DIFF
--- a/velox/common/base/AsyncSource.h
+++ b/velox/common/base/AsyncSource.h
@@ -25,6 +25,7 @@
 #include "velox/common/base/Exceptions.h"
 #include "velox/common/base/Portability.h"
 #include "velox/common/future/VeloxPromise.h"
+#include "velox/common/testutil/TestValue.h"
 
 namespace facebook::velox {
 
@@ -43,6 +44,8 @@ class AsyncSource {
   // Makes an item if it is not already made. To be called on a background
   // executor.
   void prepare() {
+    common::testutil::TestValue::adjust(
+        "facebook::velox::AsyncSource::prepare", this);
     std::function<std::unique_ptr<Item>()> make = nullptr;
     {
       std::lock_guard<std::mutex> l(mutex_);
@@ -78,6 +81,8 @@ class AsyncSource {
   // the item is preparing on the executor, waits for the item and otherwise
   // makes it on the caller thread.
   std::unique_ptr<Item> move() {
+    common::testutil::TestValue::adjust(
+        "facebook::velox::AsyncSource::move", this);
     std::function<std::unique_ptr<Item>()> make = nullptr;
     ContinueFuture wait;
     {

--- a/velox/common/base/CMakeLists.txt
+++ b/velox/common/base/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(
 target_link_libraries(
   velox_common_base
   PUBLIC velox_exception Folly::folly fmt::fmt xsimd
-  PRIVATE velox_process glog::glog)
+  PRIVATE velox_process velox_test_util glog::glog)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -798,7 +798,7 @@ void syncWorkItems(
     bool log = false) {
   // All items must be synced also in case of error because the items
   // hold references to the table and rows which could be destructed
-  // if unwinding the stack did ont pause to sync.
+  // if unwinding the stack did not pause to sync.
   for (auto& item : items) {
     try {
       item->move();
@@ -860,6 +860,9 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
   buildPartitionBounds_.back() = sizeMask_ + 1;
   std::vector<std::shared_ptr<AsyncSource<bool>>> partitionSteps;
   std::vector<std::shared_ptr<AsyncSource<bool>>> buildSteps;
+  // rowPartitions are used in the async threads, so declare them before the
+  // sync guard.
+  std::vector<std::unique_ptr<RowPartitions>> rowPartitions;
   auto sync = folly::makeGuard([&]() {
     // This is executed on returning path, possibly in unwinding, so must not
     // throw.
@@ -868,14 +871,24 @@ void HashTable<ignoreNullKeys>::parallelJoinBuild() {
     syncWorkItems(buildSteps, error, true);
   });
 
-  // The parallel table partitioning step.
-  std::vector<std::unique_ptr<RowPartitions>> rowPartitions;
+  const auto getTable = [this](size_t i) INLINE_LAMBDA {
+    return i == 0 ? this : otherTables_[i - 1].get();
+  };
+
+  // This step can involve large memory allocations, so there is a chance of
+  // OOMs here. Do it before any async work is started to reduce the chances of
+  // concurrency issues.
   rowPartitions.reserve(numPartitions);
   for (auto i = 0; i < numPartitions; ++i) {
-    auto* table = i == 0 ? this : otherTables_[i - 1].get();
+    auto* table = getTable(i);
     rowPartitions.push_back(table->rows()->createRowPartitions(*rows_->pool()));
+  }
+
+  // The parallel table partitioning step.
+  for (auto i = 0; i < numPartitions; ++i) {
+    auto* table = getTable(i);
     partitionSteps.push_back(std::make_shared<AsyncSource<bool>>(
-        [this, table, rawRowPartitions = rowPartitions.back().get()]() {
+        [this, table, rawRowPartitions = rowPartitions[i].get()]() {
           partitionRows(*table, *rawRowPartitions);
           return std::make_unique<bool>(true);
         }));


### PR DESCRIPTION
Summary:
We have seen segfaults in HashTable's parallelJoinBuilder in the threads doing the parallel table partitioning.

The root cause seems to be:
* We 1 by 1 allocate a RowPartitions object and then spin up a thread asynchronously that uses that object to do table partitioning.
* Constructing a RowPartitions involves what can be a significant memory allocation.
* If constructing one of the RowPartitions triggers the MemoryPool to OOM, the resulting exception causes
the stack to unwind, notably destructing any RowPartitions objects we've constructed up to this point.
* Since the table partitioning threads we've already spawned may be actively using those RowPartitions
objects, we may see segfaults.

The fix is to declare the vector of RowPartitions before the sync guard that waits for the async threads to
finish, this way they are only destructed once the threads are finished with them.  This also protects us
against any other exceptions in this code that might cause it to exit while the table partitioning or table
building threads (which are also vulnerable) are still running.

I also split the loops for constructing the RowPartitions objects and spawning the table partitioning threads,
as this would protect us from any other potential concurrency issues caused by OOMs while creating
RowPartitions objects.

Differential Revision: D50035529


