### PR TITLE
Ensure AsciiInfo is updated during resize() & prepareForReuse().

### DIFF
--- a/velox/vector/CMakeLists.txt
+++ b/velox/vector/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   LazyVector.cpp
   SelectivityVector.cpp
   SequenceVector.cpp
+  SimpleVector.cpp
   VectorSaver.cpp
   VectorEncoding.cpp
   VectorPool.cpp

--- a/velox/vector/ConstantVector.h
+++ b/velox/vector/ConstantVector.h
@@ -255,8 +255,12 @@ class ConstantVector final : public SimpleVector<T> {
     return index_;
   }
 
-  void resize(vector_size_t size, bool setNotNull = true) override {
-    BaseVector::length_ = size;
+  void resize(vector_size_t newSize, bool /*setNotNull*/ = true) override {
+    BaseVector::length_ = newSize;
+    if constexpr (std::is_same_v<T, StringView>) {
+      SimpleVector<StringView>::resizeIsAsciiIfNotEmpty(
+          newSize, SimpleVector<StringView>::getAllIsAscii());
+    }
   }
 
   VectorPtr slice(vector_size_t /*offset*/, vector_size_t length)

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -414,8 +414,9 @@ void FlatVector<T>::resize(vector_size_t newSize, bool setNotNull) {
   if constexpr (std::is_same_v<T, StringView>) {
     resizeValues(newSize, StringView());
     if (newSize < previousSize) {
-      auto vector = this->template asUnchecked<SimpleVector<StringView>>();
-      vector->invalidateIsAscii();
+      // If we downsize, just invalidate ascii, because we might have become
+      // 'all ascii' from 'not all ascii'.
+      SimpleVector<StringView>::invalidateIsAscii();
     } else {
       // Properly init stringView objects. This is useful when vectors are
       // re-used where the size changes but not the capacity.
@@ -425,6 +426,7 @@ void FlatVector<T>::resize(vector_size_t newSize, bool setNotNull) {
       for (auto index = previousSize; index < newSize; ++index) {
         new (&stringViews[index]) StringView();
       }
+      SimpleVector<StringView>::resizeIsAsciiIfNotEmpty(newSize, false);
     }
     if (newSize == 0) {
       clearStringBuffers();

--- a/velox/vector/FlatVector.cpp
+++ b/velox/vector/FlatVector.cpp
@@ -296,7 +296,7 @@ void FlatVector<StringView>::copy(
       setIsAscii(ascii.value(), rows);
     } else {
       // ASCII-ness for the 'rows' is not known.
-      ensureIsAsciiCapacity(rows.end());
+      ensureIsAsciiCapacity();
       // If we arent All ascii, then invalidate
       // because the remaining selected rows might be ascii
       if (!asciiInfo.isAllAscii()) {

--- a/velox/vector/SimpleVector.cpp
+++ b/velox/vector/SimpleVector.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/vector/SimpleVector.h"
+
+namespace facebook::velox {
+
+template <>
+void SimpleVector<StringView>::validate(
+    const VectorValidateOptions& options) const {
+  BaseVector::validate(options);
+
+  // We only validate the right size of ascii info, if it has any selection.
+  if (asciiInfo.asciiSetRows().hasSelections()) {
+    VELOX_CHECK_GE(asciiInfo.asciiSetRows().size(), size());
+  }
+}
+
+} // namespace facebook::velox


### PR DESCRIPTION
Summary:
We are seeing rare crashes and not so rare ASAN crashes during
Vector copy() when trying to process SimpleVector's AsciiInfo.
It happens so during the Vector recycling we don't touch AsciiInfo at all
and the new vector might have AsciiInfo from the previous one.
When accessing AsciiInfo it might be smaller than the vector and we are
accessing memory outside of the buffer.

To fix this we do the following:
1. Call SimpleVector<StringView>::resizeIsAsciiIfNotEmpty() from FlatVector<T>::resize().
2. Call SimpleVector<StringView>::resizeIsAsciiIfNotEmpty() from ConstantVector::resize().
3. Check if AsciiInfo is at least size of the SimpleVector in SimpleVector::validate().
4. Ensure we use vector's length_ when allocating capacity for ascii bit vector, no matter what selectivity vector is passed.

Differential Revision: D50051589


