### PR TITLE
Respect orderable constraint in ArgumentTypeFuzzer

### DIFF
--- a/velox/expression/tests/ArgumentTypeFuzzer.cpp
+++ b/velox/expression/tests/ArgumentTypeFuzzer.cpp
@@ -48,12 +48,20 @@ void ArgumentTypeFuzzer::determineUnboundedTypeVariables() {
     // Random randomType() never generates unknown here.
     // TODO: we should extend randomType types and exclude unknown based
     // on variableInfo.
-    bindings_[variableName] = randType();
+    if (variableInfo.orderableTypesOnly()) {
+      bindings_[variableName] = randOrderableType();
+    } else {
+      bindings_[variableName] = randType();
+    }
   }
 }
 
 TypePtr ArgumentTypeFuzzer::randType() {
   return velox::randType(rng_, 2);
+}
+
+TypePtr ArgumentTypeFuzzer::randOrderableType() {
+  return velox::randOrderableType(rng_, 2);
 }
 
 bool ArgumentTypeFuzzer::fuzzArgumentTypes(uint32_t maxVariadicArgs) {

--- a/velox/expression/tests/ArgumentTypeFuzzer.h
+++ b/velox/expression/tests/ArgumentTypeFuzzer.h
@@ -71,6 +71,9 @@ class ArgumentTypeFuzzer {
 
   TypePtr randType();
 
+  /// Generates an orderable random type, including structs, and arrays.
+  TypePtr randOrderableType();
+
   const exec::FunctionSignature& signature_;
 
   TypePtr returnType_;


### PR DESCRIPTION
PR #6906 added support to restricting arguments as orderable.

This PR changes ArgumentTypeFuzzer to respect this constraint.

Part of #6718 