### PR TITLE
Fail if inputs contain nested nulls in map_agg Presto aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -39,4 +39,23 @@ int32_t compare(
   return result.value();
 }
 
+bool checkNestedNulls(
+    const DecodedVector& decoded,
+    const vector_size_t* indices,
+    vector_size_t index,
+    bool throwOnNestedNulls) {
+  if (decoded.isNullAt(index)) {
+    return true;
+  }
+
+  if (throwOnNestedNulls) {
+    VELOX_USER_CHECK(
+        !decoded.base()->containsNullAt(indices[index]),
+        "{} comparison not supported for values that contain nulls",
+        mapTypeKindToName(decoded.base()->typeKind()));
+  }
+
+  return false;
+}
+
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/Compare.h
+++ b/velox/functions/prestosql/aggregates/Compare.h
@@ -34,4 +34,13 @@ int32_t compare(
     const DecodedVector& decoded,
     vector_size_t index);
 
+/// Check nested nulls in a complex type vector. Returns true if value at
+/// specified index is null. Throw an exception if the base vector contains
+/// nulls if throwOnNestedNulls is true.
+bool checkNestedNulls(
+    const DecodedVector& decoded,
+    const vector_size_t* indices,
+    vector_size_t index,
+    bool throwOnNestedNulls);
+
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/Compare.h
+++ b/velox/functions/prestosql/aggregates/Compare.h
@@ -34,9 +34,9 @@ int32_t compare(
     const DecodedVector& decoded,
     vector_size_t index);
 
-/// Check nested nulls in a complex type vector. Returns true if value at
-/// specified index is null. Throw an exception if the base vector contains
-/// nulls if throwOnNestedNulls is true.
+/// Checks nested nulls in a complex type vector. Returns true if value at
+/// specified index is null. Throws an exception if the base vector contains
+/// nulls if 'throwOnNestedNulls' is true.
 bool checkNestedNulls(
     const DecodedVector& decoded,
     const vector_size_t* indices,

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -23,8 +23,11 @@ namespace {
 template <typename K>
 class MapAggAggregate : public MapAggregateBase<K> {
  public:
-  explicit MapAggAggregate(TypePtr resultType)
-      : MapAggregateBase<K>(std::move(resultType)) {}
+  explicit MapAggAggregate(
+      TypePtr resultType,
+      const bool throwOnNestedNulls = false)
+      : MapAggregateBase<K>(std::move(resultType)),
+        throwOnNestedNulls_(throwOnNestedNulls) {}
 
   using Base = MapAggregateBase<K>;
 
@@ -38,8 +41,14 @@ class MapAggAggregate : public MapAggregateBase<K> {
       VectorPtr& result) const override {
     const auto& keys = args[0];
     const auto& values = args[1];
-
     const auto numRows = rows.size();
+
+    if (throwOnNestedNulls_) {
+      DecodedVector decodedKeys(*keys, rows);
+      auto indices = decodedKeys.indices();
+      rows.applyToSelected(
+          [&](vector_size_t i) { checkNulls(decodedKeys, indices, i); });
+    }
 
     // Convert input to a single-entry map. Convert entries with null keys to
     // null maps.
@@ -90,16 +99,18 @@ class MapAggAggregate : public MapAggregateBase<K> {
       bool /*mayPushdown*/) override {
     Base::decodedKeys_.decode(*args[0], rows);
     Base::decodedValues_.decode(*args[1], rows);
+    auto indices = Base::decodedKeys_.indices();
 
     rows.applyToSelected([&](vector_size_t row) {
-      // Skip null keys
-      if (!Base::decodedKeys_.isNullAt(row)) {
-        auto group = groups[row];
-        Base::clearNull(group);
-        auto tracker = Base::trackRowSize(group);
-        Base::accumulator(group)->insert(
-            Base::decodedKeys_, Base::decodedValues_, row, *Base::allocator_);
+      if (checkNulls(Base::decodedKeys_, indices, row)) {
+        return;
       }
+
+      auto group = groups[row];
+      Base::clearNull(group);
+      auto tracker = Base::trackRowSize(group);
+      Base::accumulator(group)->insert(
+          Base::decodedKeys_, Base::decodedValues_, row, *Base::allocator_);
     });
   }
 
@@ -112,16 +123,40 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
     Base::decodedKeys_.decode(*args[0], rows);
     Base::decodedValues_.decode(*args[1], rows);
+    auto indices = Base::decodedKeys_.indices();
+
     auto tracker = Base::trackRowSize(group);
     rows.applyToSelected([&](vector_size_t row) {
-      // Skip null keys
-      if (!Base::decodedKeys_.isNullAt(row)) {
-        Base::clearNull(group);
-        singleAccumulator->insert(
-            Base::decodedKeys_, Base::decodedValues_, row, *Base::allocator_);
+      if (checkNulls(Base::decodedKeys_, indices, row)) {
+        return;
       }
+
+      Base::clearNull(group);
+      singleAccumulator->insert(
+          Base::decodedKeys_, Base::decodedValues_, row, *Base::allocator_);
     });
   }
+
+ private:
+  bool checkNulls(
+      const DecodedVector& decoded,
+      const vector_size_t* indices,
+      vector_size_t index) const {
+    if (decoded.isNullAt(index)) {
+      return true;
+    }
+
+    if (throwOnNestedNulls_) {
+      VELOX_USER_CHECK(
+          !decoded.base()->containsNullAt(indices[index]),
+          "{} comparison not supported for values that contain nulls",
+          mapTypeKindToName(decoded.base()->typeKind()));
+    }
+
+    return false;
+  }
+
+  const bool throwOnNestedNulls_;
 };
 
 exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
@@ -150,8 +185,40 @@ exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
             rawInput ? 2 : 1,
             "{} ({}): unexpected number of arguments",
             name);
-
-        return createMapAggregate<MapAggAggregate>(resultType);
+        const bool throwOnNestedNulls = rawInput;
+        auto typeKind = resultType->childAt(0)->kind();
+        switch (typeKind) {
+          case TypeKind::BOOLEAN:
+            return std::make_unique<MapAggAggregate<bool>>(resultType);
+          case TypeKind::TINYINT:
+            return std::make_unique<MapAggAggregate<int8_t>>(resultType);
+          case TypeKind::SMALLINT:
+            return std::make_unique<MapAggAggregate<int16_t>>(resultType);
+          case TypeKind::INTEGER:
+            return std::make_unique<MapAggAggregate<int32_t>>(resultType);
+          case TypeKind::BIGINT:
+            return std::make_unique<MapAggAggregate<int64_t>>(resultType);
+          case TypeKind::REAL:
+            return std::make_unique<MapAggAggregate<float>>(resultType);
+          case TypeKind::DOUBLE:
+            return std::make_unique<MapAggAggregate<double>>(resultType);
+          case TypeKind::TIMESTAMP:
+            return std::make_unique<MapAggAggregate<Timestamp>>(resultType);
+          case TypeKind::VARBINARY:
+            [[fallthrough]];
+          case TypeKind::VARCHAR:
+            return std::make_unique<MapAggAggregate<StringView>>(resultType);
+          case TypeKind::ARRAY:
+          case TypeKind::MAP:
+          case TypeKind::ROW:
+            return std::make_unique<MapAggAggregate<ComplexType>>(
+                resultType, throwOnNestedNulls);
+          case TypeKind::UNKNOWN:
+            return std::make_unique<MapAggAggregate<int32_t>>(resultType);
+          default:
+            VELOX_UNREACHABLE(
+                "Unexpected type {}", mapTypeKindToName(typeKind));
+        }
       });
 }
 

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -25,9 +25,7 @@ namespace {
 template <typename K>
 class MapAggAggregate : public MapAggregateBase<K> {
  public:
-  explicit MapAggAggregate(
-      TypePtr resultType,
-      const bool throwOnNestedNulls = false)
+  explicit MapAggAggregate(TypePtr resultType, bool throwOnNestedNulls = false)
       : MapAggregateBase<K>(std::move(resultType)),
         throwOnNestedNulls_(throwOnNestedNulls) {}
 
@@ -47,7 +45,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
     if (throwOnNestedNulls_) {
       DecodedVector decodedKeys(*keys, rows);
-      auto indices = decodedKeys.indices();
+      const auto* indices = decodedKeys.indices();
       rows.applyToSelected([&](vector_size_t i) {
         checkNestedNulls(decodedKeys, indices, i, throwOnNestedNulls_);
       });
@@ -102,7 +100,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
       bool /*mayPushdown*/) override {
     Base::decodedKeys_.decode(*args[0], rows);
     Base::decodedValues_.decode(*args[1], rows);
-    auto indices = Base::decodedKeys_.indices();
+    const auto* indices = Base::decodedKeys_.indices();
 
     rows.applyToSelected([&](vector_size_t row) {
       if (checkNestedNulls(
@@ -173,7 +171,7 @@ exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
             "{} ({}): unexpected number of arguments",
             name);
         const bool throwOnNestedNulls = rawInput;
-        auto typeKind = resultType->childAt(0)->kind();
+        const auto typeKind = resultType->childAt(0)->kind();
         switch (typeKind) {
           case TypeKind::BOOLEAN:
             return std::make_unique<MapAggAggregate<bool>>(resultType);

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(
   ValueListTest.cpp
   VarianceAggregationTest.cpp
   MaxSizeForStatsTest.cpp
+  CompareTest.cpp
   SumDataSizeForStatsTest.cpp)
 
 add_test(

--- a/velox/functions/prestosql/aggregates/tests/CompareTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/CompareTest.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "velox/common/base/tests/GTestUtils.h"
+
+#include "velox/functions/prestosql/aggregates/Compare.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace facebook::velox::aggregate::prestosql::test {
+
+class CompareTest : public testing::Test,
+                    public facebook::velox::test::VectorTestBase {};
+
+TEST_F(CompareTest, array) {
+  auto baseVector = makeArrayVectorFromJson<int32_t>({
+      "null",
+      "[6, 7]",
+      "[2, null]",
+  });
+  DecodedVector decodedVector(*baseVector);
+  const auto* indices = decodedVector.indices();
+
+  for (bool throwOnNestedNulls : {true, false}) {
+    ASSERT_TRUE(
+        checkNestedNulls(decodedVector, indices, 0, throwOnNestedNulls));
+    ASSERT_FALSE(
+        checkNestedNulls(decodedVector, indices, 1, throwOnNestedNulls));
+  }
+
+  VELOX_ASSERT_THROW(
+      checkNestedNulls(decodedVector, indices, 2, true),
+      "ARRAY comparison not supported for values that contain nulls");
+  ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
+}
+
+TEST_F(CompareTest, map) {
+  auto baseVector = makeMapVectorFromJson<int32_t, int32_t>({
+      "null",
+      "{4: 7, 1: 2}",
+      "{6: 8, 8: null}",
+  });
+  DecodedVector decodedVector(*baseVector);
+  const auto* indices = decodedVector.indices();
+
+  for (bool throwOnNestedNulls : {true, false}) {
+    ASSERT_TRUE(
+        checkNestedNulls(decodedVector, indices, 0, throwOnNestedNulls));
+    ASSERT_FALSE(
+        checkNestedNulls(decodedVector, indices, 1, throwOnNestedNulls));
+  }
+
+  VELOX_ASSERT_THROW(
+      checkNestedNulls(decodedVector, indices, 2, true),
+      "MAP comparison not supported for values that contain nulls");
+  ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
+}
+
+TEST_F(CompareTest, row) {
+  auto baseVector = makeRowVector(
+      {
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              "bb"_sv,
+              std::nullopt,
+          }),
+      },
+      [](vector_size_t row) { return row == 0; });
+  DecodedVector decodedVector(*baseVector);
+  const auto* indices = decodedVector.indices();
+
+  for (bool throwOnNestedNulls : {true, false}) {
+    ASSERT_TRUE(
+        checkNestedNulls(decodedVector, indices, 0, throwOnNestedNulls));
+    ASSERT_FALSE(
+        checkNestedNulls(decodedVector, indices, 1, throwOnNestedNulls));
+  }
+
+  VELOX_ASSERT_THROW(
+      checkNestedNulls(decodedVector, indices, 2, true),
+      "ROW comparison not supported for values that contain nulls");
+  ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
+}
+} // namespace facebook::velox::aggregate::prestosql::test


### PR DESCRIPTION
In Presto, map_agg checks nested nulls for keys of complex type
and throws, but in Velox, they don't. For example,
the following SQL should throw an exception.

```SQL
presto> select map_agg(x,y) from (values (array[1, null], 2), 
(array[1, null], 3) ) as tbl(x,y);
...
Query 20231008_050907_00082_xv6np failed: ARRAY comparison
not supported for arrays with null elements

presto> select map_agg(x,y) from (values (row(1, null), 2),
 (row(1, null), 3) ) as tbl(x,y);
...
Query 20231008_050933_00083_xv6np failed: ROW comparison
not supported for fields with null elements
```

This PR do the following things,
- Add a check that all raw inputs (in the `Partial/Single` step)
- Move the `checkNestedNulls` method into `aggregates/Compare.h`
    since lots of aggregate functions would use this method.

Part of https://github.com/facebookincubator/velox/issues/6314