### PR TITLE
Fix deserialization of members of nullable structs

### DIFF
--- a/velox/serializers/PrestoSerializer.h
+++ b/velox/serializers/PrestoSerializer.h
@@ -69,9 +69,16 @@ class PrestoVectorSerde : public VectorSerde {
       RowTypePtr type,
       std::shared_ptr<RowVector>* result,
       const Options* options) override;
-
   static void registerVectorSerde();
 };
+
+// Testing function for nested encodings. See comments in scatterStructNulls().
+void testingScatterStructNulls(
+    vector_size_t size,
+    vector_size_t scatterSize,
+    const vector_size_t* scatter,
+    const uint64_t* incomingNulls,
+    RowVector& row);
 
 class PrestoOutputStreamListener : public OutputStreamListener {
  public:


### PR DESCRIPTION
The Presto wire format encodes struct member values only for the rows where the struct is not null. To make the member rows aligned with the struct rows, the members values have to be scattered to leave a gap for places where the enclosing struct is null.

This was done on the returning edge of deserialization in the least efficient way possible. For several levels of structs this would for example copy the leaf payload once for every enclosing elevel.

Now therefore, we do an extra pass after deserialization to scatter the children according to the nulls of all enclosing nullable strucst in one pass. This is analogous to the ORC reader where we pass a scatter map of enclosing nulls, where the current level must insert a gap. We add to this set of incoming nulls wen descending deeper into structs.

The traversal covers the whole tree and also reaches structs inside lists, maps and dictionaries. Enclosing nulls do not propagate through lists, maps or dictionaries.

The round trip test in PrestoSerializerTest.cpp provides extensive coverage.