### PR TITLE
Add a counter for silent throws

### DIFF
--- a/velox/common/base/Exceptions.h
+++ b/velox/common/base/Exceptions.h
@@ -73,6 +73,7 @@ template <typename Exception, typename StringType>
                << ", ErrorCode: " << args.errorCode;
   }
 
+  ++threadNumVeloxThrow();
   throw Exception(
       args.file,
       args.line,

--- a/velox/common/base/VeloxException.cpp
+++ b/velox/common/base/VeloxException.cpp
@@ -33,6 +33,11 @@ std::exception_ptr toVeloxException(const std::exception_ptr& exceptionPtr) {
   }
 }
 
+int64_t& threadNumVeloxThrow() {
+  thread_local int64_t numThrow;
+  return numThrow;
+}
+
 ExceptionContext& getExceptionContext() {
   thread_local ExceptionContext context;
   return context;

--- a/velox/common/base/VeloxException.h
+++ b/velox/common/base/VeloxException.h
@@ -332,6 +332,9 @@ class VeloxRuntimeError final : public VeloxException {
             exceptionName) {}
 };
 
+/// Returns a reference to a thread level counter of Velox error throws.
+int64_t& threadNumVeloxThrow();
+
 /// Holds a pointer to a function that provides addition context to be
 /// added to the detailed error message in case of an exception.
 struct ExceptionContext {


### PR DESCRIPTION
Throwing an error inside a loop is a major performance killer. Adds a counter for Velox throws. This is useful for diagnosing performance loss from frequent throws inside try or similar.