### PR TITLE
Rename methods and variables related to enable_expression_evaluation_cache query config

### DIFF
--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -152,14 +152,12 @@ TEST(TestQueryConfig, enableExpressionEvaluationCacheConfig) {
         enableExpressionEvaluationCache);
 
     auto execCtx = std::make_shared<core::ExecCtx>(pool_.get(), queryCtx.get());
-    ASSERT_EQ(
-        execCtx->isExpressionEvaluationCacheEnabled(),
-        enableExpressionEvaluationCache);
+    ASSERT_EQ(execCtx->exprEvalCacheEnabled(), enableExpressionEvaluationCache);
     ASSERT_EQ(
         execCtx->vectorPool() != nullptr, enableExpressionEvaluationCache);
 
     auto evalCtx = std::make_shared<exec::EvalCtx>(execCtx.get());
-    ASSERT_EQ(evalCtx->isCacheEnabled(), enableExpressionEvaluationCache);
+    ASSERT_EQ(evalCtx->cacheEnabled(), enableExpressionEvaluationCache);
 
     // Test ExecCtx::selectivityVectorPool_.
     auto rows = execCtx->getSelectivityVector(100);

--- a/velox/expression/EvalCtx.cpp
+++ b/velox/expression/EvalCtx.cpp
@@ -32,7 +32,7 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx, ExprSet* exprSet, const RowVector* row)
     : execCtx_(execCtx),
       exprSet_(exprSet),
       row_(row),
-      isCacheEnabled_(execCtx->isExpressionEvaluationCacheEnabled()) {
+      cacheEnabled_(execCtx->exprEvalCacheEnabled()) {
   // TODO Change the API to replace raw pointers with non-const references.
   // Sanity check inputs to prevent crashes.
   VELOX_CHECK_NOT_NULL(execCtx);
@@ -53,7 +53,7 @@ EvalCtx::EvalCtx(core::ExecCtx* execCtx)
     : execCtx_(execCtx),
       exprSet_(nullptr),
       row_(nullptr),
-      isCacheEnabled_(execCtx->isExpressionEvaluationCacheEnabled()) {
+      cacheEnabled_(execCtx->exprEvalCacheEnabled()) {
   VELOX_CHECK_NOT_NULL(execCtx);
 }
 

--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -319,17 +319,17 @@ class EvalCtx {
     return peeledEncoding_.get();
   }
 
-  /// Return true if caching in expression evaluation is enabled, such as
+  /// Returns true if caching in expression evaluation is enabled, such as
   /// Expr::evalWithMemo.
-  bool isCacheEnabled() const {
-    return isCacheEnabled_;
+  bool cacheEnabled() const {
+    return cacheEnabled_;
   }
 
  private:
   core::ExecCtx* const FOLLY_NONNULL execCtx_;
   ExprSet* FOLLY_NULLABLE const exprSet_;
   const RowVector* FOLLY_NULLABLE row_;
-  const bool isCacheEnabled_;
+  const bool cacheEnabled_;
   bool inputFlatNoNulls_;
 
   // Corresponds 1:1 to children of 'row_'. Set to an inner vector

--- a/velox/expression/Expr.cpp
+++ b/velox/expression/Expr.cpp
@@ -1000,7 +1000,7 @@ Expr::PeelEncodingsResult Expr::peelEncodings(
 
   // If the expression depends on one dictionary, results are cacheable.
   bool mayCache = false;
-  if (context.isCacheEnabled()) {
+  if (context.cacheEnabled()) {
     mayCache = distinctFields_.size() == 1 &&
         VectorEncoding::isDictionary(context.wrapEncoding()) &&
         !peeledVectors[0]->memoDisabled();


### PR DESCRIPTION
Summary: Replace names of methods and variables related to the  enable_expression_evaluation_cache query config with shorter names.

Differential Revision: D50100883


