### PR TITLE
Fix BaseVector::create() for RowVectors

### DIFF
--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -206,26 +206,26 @@ RowVectorPtr Operator::fillOutput(
     wrapResults = false;
   }
 
-  auto output{std::make_shared<RowVector>(
-      operatorCtx_->pool(),
-      outputType_,
-      nullptr,
-      size,
-      std::vector<VectorPtr>(outputType_->size(), nullptr))};
-  output->resize(size);
+  std::vector<VectorPtr> projectedChildren(outputType_->size());
   projectChildren(
-      output,
+      projectedChildren,
       input_,
       identityProjections_,
       size,
       wrapResults ? mapping : nullptr);
   projectChildren(
-      output,
+      projectedChildren,
       results_,
       resultProjections_,
       size,
       wrapResults ? mapping : nullptr);
-  return output;
+
+  return std::make_shared<RowVector>(
+      operatorCtx_->pool(),
+      outputType_,
+      nullptr,
+      size,
+      std::move(projectedChildren));
 }
 
 OperatorStats Operator::stats(bool clear) {

--- a/velox/exec/OperatorUtils.h
+++ b/velox/exec/OperatorUtils.h
@@ -136,11 +136,14 @@ folly::Range<vector_size_t*> initializeRowNumberMapping(
     vector_size_t size,
     memory::MemoryPool* pool);
 
-/// Projects children of 'src' row vector to 'dest' row vector according to
-/// 'projections' and 'mapping'. 'size' specifies number of projected rows in
-/// 'dest'.
+/// Projects children of 'src' row vector according to 'projections'. Optionally
+/// takes a 'mapping' and 'size' that represent the indices and size,
+/// respectively, of a dictionary wrapping that should be applied to the
+/// projections. The output param 'projectedChildren' will contain all the final
+/// projections at the expected channel index. Indices not specified in
+/// 'projections' will be left untouched in 'projectedChildren'.
 void projectChildren(
-    const RowVectorPtr& dest,
+    std::vector<VectorPtr>& projectedChildren,
     const RowVectorPtr& src,
     const std::vector<IdentityProjection>& projections,
     int32_t size,
@@ -149,7 +152,7 @@ void projectChildren(
 /// Overload of the above function that takes reference to const vector of
 /// VectorPtr as 'src' argument, instead of row vector.
 void projectChildren(
-    const RowVectorPtr& dest,
+    std::vector<VectorPtr>& projectedChildren,
     const std::vector<VectorPtr>& src,
     const std::vector<IdentityProjection>& projections,
     int32_t size,

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -311,12 +311,15 @@ TEST_F(OperatorUtilsTest, projectChildren) {
 
   {
     std::vector<IdentityProjection> emptyProjection;
-    auto destRowVector =
-        BaseVector::create<RowVector>(srcRowType, srcVectorSize, pool());
+    std::vector<VectorPtr> projectedChildren(srcRowType->size());
     projectChildren(
-        destRowVector, srcRowVector, emptyProjection, srcVectorSize, nullptr);
-    for (vector_size_t i = 0; i < destRowVector->childrenSize(); ++i) {
-      ASSERT_EQ(destRowVector->childAt(i)->size(), 0);
+        projectedChildren,
+        srcRowVector,
+        emptyProjection,
+        srcVectorSize,
+        nullptr);
+    for (vector_size_t i = 0; i < projectedChildren.size(); ++i) {
+      ASSERT_EQ(projectedChildren[i], nullptr);
     }
   }
 
@@ -325,17 +328,16 @@ TEST_F(OperatorUtilsTest, projectChildren) {
     for (auto i = 0; i < srcRowType->size(); ++i) {
       identicalProjections.emplace_back(i, i);
     }
-    auto destRowVector =
-        BaseVector::create<RowVector>(srcRowType, srcVectorSize, pool());
+    std::vector<VectorPtr> projectedChildren(srcRowType->size());
     projectChildren(
-        destRowVector,
+        projectedChildren,
         srcRowVector,
         identicalProjections,
         srcVectorSize,
         nullptr);
     for (const auto& projection : identicalProjections) {
       ASSERT_EQ(
-          destRowVector->childAt(projection.outputChannel).get(),
+          projectedChildren[projection.outputChannel].get(),
           srcRowVector->childAt(projection.inputChannel).get());
     }
   }
@@ -348,13 +350,12 @@ TEST_F(OperatorUtilsTest, projectChildren) {
     std::vector<IdentityProjection> projections{};
     projections.emplace_back(2, 0);
     projections.emplace_back(0, 1);
-    auto destRowVector =
-        BaseVector::create<RowVector>(destRowType, srcVectorSize, pool());
+    std::vector<VectorPtr> projectedChildren(srcRowType->size());
     projectChildren(
-        destRowVector, srcRowVector, projections, srcVectorSize, nullptr);
+        projectedChildren, srcRowVector, projections, srcVectorSize, nullptr);
     for (const auto& projection : projections) {
       ASSERT_EQ(
-          destRowVector->childAt(projection.outputChannel).get(),
+          projectedChildren[projection.outputChannel].get(),
           srcRowVector->childAt(projection.inputChannel).get());
     }
   }

--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -284,10 +284,9 @@ VectorPtr BaseVector::createInternal(
     case TypeKind::ROW: {
       std::vector<VectorPtr> children;
       auto rowType = type->as<TypeKind::ROW>();
-      // Children are reserved the parent size but are set to 0 elements.
+      // Children are reserved the parent size and accessible for those rows.
       for (int32_t i = 0; i < rowType.size(); ++i) {
         children.push_back(create(rowType.childAt(i), size, pool));
-        children.back()->resize(0);
       }
       return std::make_shared<RowVector>(
           pool, type, nullptr, size, std::move(children));

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -50,6 +50,11 @@ class VectorSaverTest : public testing::Test, public VectorTestBase {
     // are the same.
     switch (expected->encoding()) {
       case VectorEncoding::Simple::CONSTANT:
+        if (expected->isNullAt(0)) {
+          // No need to compare value vector as deserialized RowVector can have
+          // different values in its flat children of size 1.
+          break;
+        }
       case VectorEncoding::Simple::DICTIONARY:
         if (expected->valueVector()) {
           ASSERT_TRUE(actual->valueVector() != nullptr);

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -1055,6 +1055,10 @@ TEST_F(VectorTest, row) {
       BaseVector::createNullConstant(baseRow->type(), 50, pool_.get());
   testCopy(allNull, numIterations_);
   testSlices(allNull);
+  // created from BaseVector::Create()
+  baseRow = BaseVector::create(baseRow->type(), vectorSize_, pool());
+  testCopy(baseRow, numIterations_);
+  testSlices(baseRow);
 }
 
 TEST_F(VectorTest, array) {


### PR DESCRIPTION
Fix bug in BaseVector::create() that ends up creating a malformed
RowVector with no nulls but children of size 0. When copy is
called on this vector, it tries to access the valid rows at those
indices but since they are not marked as null, copy() tries to
access them in the children. The fix here is that when create() is
called and the children of target size are allocated, we should not
resize them to zero.

Additionally, as a part of fixing this bug, I had to refactor
how projections are passed to output in Operator and
NestedLoopJoinProbe. Currently, it created a RowVector of the
required size that would allocate all children of that size
and then replace each with projections. This is redundant work,
so instead I changed it to gather all projections/children and
then create a RowVector with them.

Finally, a test needed to be fixed in VectorSaver.constantRow where it
was comparing the value vector of a null constant row vector. Since the
value vector of a null constant is not serialized, there is no need to
compare its equality in the test.

Found by #6600
