### PR TITLE
Fix stop condition bug in GroupingSet::numNonSpilledGroupsToExtract

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -1034,7 +1034,7 @@ size_t GroupingSet::numNonSpilledGroupsToExtract(
   for (; numGroups < maxNumGroups; ++numGroups, ++nextRow) {
     const auto rowSize =
         nonSpilledRowContainer_->rowSize(nonSpilledRows_.value()[nextRow]);
-    if (numGroups > 0 && (totalBytes + rowSize) < maxOutputBytes) {
+    if (numGroups > 0 && (totalBytes + rowSize) >= maxOutputBytes) {
       break;
     }
     totalBytes += rowSize;


### PR DESCRIPTION
Original code stops early when extracting non spilled groups. Potentially it can go into an infinite loop if a single batch exceeds maxOutputBytes.