### PR TITLE
Enhance unit test of ExprSetListener::onError

### DIFF
--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -417,6 +417,14 @@ TEST_F(ExprStatsTest, errorLog) {
   evaluate(*exprSet, data);
   ASSERT_EQ(4, listener->exceptionCount());
   ASSERT_EQ(4, exceptions.size());
+  ASSERT_TRUE(
+      exceptions[0].find("Error Code: INVALID_ARGUMENT") != std::string::npos);
+  ASSERT_TRUE(
+      exceptions[1].find("Error Code: INVALID_ARGUMENT") != std::string::npos);
+  ASSERT_TRUE(
+      exceptions[2].find("Error Code: ARITHMETIC_ERROR") != std::string::npos);
+  ASSERT_TRUE(
+      exceptions[3].find("Error Code: ARITHMETIC_ERROR") != std::string::npos);
 
   // Test with no error.
   listener->reset();


### PR DESCRIPTION
Summary: This diff makes the unit test for ExprSetListener::onError to check not only the count of exceptions, but also the types of exceptions match the expectation.

Differential Revision: D50109972


