### PR TITLE
Do not split files for sorted spill

### DIFF
--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -910,7 +910,7 @@ void GroupingSet::spill(int64_t targetRows, int64_t targetBytes) {
         rows->keyTypes().size(),
         std::vector<CompareFlags>(),
         spillConfig_->filePath,
-        spillConfig_->maxFileSize,
+        std::numeric_limits<uint64_t>::max(),
         spillConfig_->writeBufferSize,
         spillConfig_->minSpillRunSize,
         spillConfig_->compressionKind,

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -188,7 +188,7 @@ void SortBuffer::spill(int64_t targetRows, int64_t targetBytes) {
         data_->keyTypes().size(),
         sortCompareFlags_,
         spillConfig_->filePath,
-        spillConfig_->maxFileSize,
+        std::numeric_limits<uint64_t>::max(),
         spillConfig_->writeBufferSize,
         spillConfig_->minSpillRunSize,
         spillConfig_->compressionKind,

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1080,7 +1080,7 @@ TEST_F(AggregationTest, spillWithMemoryLimit) {
       ASSERT_GT(stats.spilledInputBytes, 0);
       ASSERT_GT(stats.spilledBytes, 0);
       ASSERT_GT(stats.spilledPartitions, 0);
-      ASSERT_GT(stats.spilledFiles, 0);
+      ASSERT_EQ(stats.spilledFiles, batches.size());
       ASSERT_GT(stats.runtimeStats["spillRuns"].sum, 0);
       ASSERT_GT(stats.runtimeStats["spillFillTime"].sum, 0);
       ASSERT_GT(stats.runtimeStats["spillSortTime"].sum, 0);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -438,7 +438,10 @@ TEST_F(SortBufferTest, spill) {
       ASSERT_LE(spillStats->spilledRows, totalNumInput);
       ASSERT_GT(spillStats->spilledBytes, 0);
       ASSERT_EQ(spillStats->spilledPartitions, 1);
-      ASSERT_GT(spillStats->spilledFiles, 0);
+      // SortBuffer shall not respect maxFileSize. Total files should be num
+      // addInput() calls minus one which is the first one that has nothing to
+      // spill.
+      ASSERT_EQ(spillStats->spilledFiles, 2);
       sortBuffer.reset();
       ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
       if (Spiller::pool()->trackUsage()) {


### PR DESCRIPTION
When spilling data needs sort (specifically OrderBy and HashAggregation), we do not need to respect the max target file size for better efficiency. This is because above sorted spilling is always serial when unspilled.