### PR TITLE
Build writer memory reclaim mechaism and integrate with arbitration

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -232,7 +232,6 @@ class ConnectorQueryCtx {
   ConnectorQueryCtx(
       memory::MemoryPool* operatorPool,
       memory::MemoryPool* connectorPool,
-      memory::SetMemoryReclaimer setMemoryReclaimer,
       const Config* connectorConfig,
       const common::SpillConfig* spillConfig,
       std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator,
@@ -243,7 +242,6 @@ class ConnectorQueryCtx {
       int driverId)
       : operatorPool_(operatorPool),
         connectorPool_(connectorPool),
-        setMemoryReclaimer_(std::move(setMemoryReclaimer)),
         config_(connectorConfig),
         spillConfig_(spillConfig),
         expressionEvaluator_(std::move(expressionEvaluator)),
@@ -269,18 +267,11 @@ class ConnectorQueryCtx {
     return connectorPool_;
   }
 
-  /// Returns the callback to set memory pool reclaimer if set. This is used by
-  /// file writer to set memory reclaimer for its internal used memory pools to
-  /// integrate with memory arbitration.
-  const memory::SetMemoryReclaimer& setMemoryReclaimer() const {
-    return setMemoryReclaimer_;
-  }
-
   const Config* config() const {
     return config_;
   }
 
-  const common::SpillConfig* getSpillConfig() const {
+  const common::SpillConfig* spillConfig() const {
     return spillConfig_;
   }
 
@@ -319,7 +310,6 @@ class ConnectorQueryCtx {
  private:
   memory::MemoryPool* const operatorPool_;
   memory::MemoryPool* const connectorPool_;
-  const memory::SetMemoryReclaimer setMemoryReclaimer_;
   const Config* config_;
   const common::SpillConfig* const spillConfig_;
   std::unique_ptr<core::ExpressionEvaluator> expressionEvaluator_;

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -166,7 +166,11 @@ int32_t HiveConfig::numCacheFileHandles(const Config* config) {
   return config->get<int32_t>(kNumCacheFileHandles, 20'000);
 }
 
-uint64_t const HiveConfig::getKOrcWriterMaxStripeSize(
+uint64_t HiveConfig::fileWriterFlushThresholdBytes(const Config* config) {
+  return config->get<int32_t>(kFileWriterFlushThresholdBytes, 96L << 20);
+}
+
+uint64_t HiveConfig::getOrcWriterMaxStripeSize(
     const Config* connectorQueryCtxConfig,
     const Config* connectorPropertiesConfig) {
   if (connectorQueryCtxConfig != nullptr &&
@@ -187,7 +191,7 @@ uint64_t const HiveConfig::getKOrcWriterMaxStripeSize(
   return 64L * 1024L * 1024L;
 }
 
-uint64_t const HiveConfig::getKOrcWriterMaxDictionaryMemory(
+uint64_t HiveConfig::getOrcWriterMaxDictionaryMemory(
     const Config* connectorQueryCtxConfig,
     const Config* connectorPropertiesConfig) {
   if (connectorQueryCtxConfig != nullptr &&

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -81,31 +81,37 @@ class HiveConfig {
   static constexpr const char* kS3IamRoleSessionName =
       "hive.s3.iam-role-session-name";
 
-  // The GCS storage endpoint server.
+  /// The GCS storage endpoint server.
   static constexpr const char* kGCSEndpoint = "hive.gcs.endpoint";
 
-  // The GCS storage scheme, https for default credentials.
+  /// The GCS storage scheme, https for default credentials.
   static constexpr const char* kGCSScheme = "hive.gcs.scheme";
 
-  // The GCS service account configuration as json string
+  /// The GCS service account configuration as json string
   static constexpr const char* kGCSCredentials = "hive.gcs.credentials";
 
-  // Map table field names to file field names using names, not indices.
+  /// Maps table field names to file field names using names, not indices.
   static constexpr const char* kOrcUseColumnNames = "hive.orc.use-column-names";
 
-  // Read the source file column name as lower case.
+  /// Reads the source file column name as lower case.
   static constexpr const char* kFileColumnNamesReadAsLowerCase =
       "file_column_names_read_as_lower_case";
 
-  // Set the max coalesce bytes for a request.
+  /// Sets the max coalesce bytes for a request.
   static constexpr const char* kMaxCoalescedBytes = "max-coalesced-bytes";
 
-  // Set the max coalesce distance bytes for combining requests.
+  /// Sets the max coalesce distance bytes for combining requests.
   static constexpr const char* kMaxCoalescedDistanceBytes =
       "max-coalesced-distance-bytes";
 
   /// Maximum number of entries in the file handle cache.
   static constexpr const char* kNumCacheFileHandles = "num_cached_file_handles";
+
+  /// The memory arbitrator might flush a file write to reclaim used memory if
+  /// its buffered data size is no less than this minimum threshold. The
+  /// buffered data size is measured by a file writer's memory footprint.
+  static constexpr const char* kFileWriterFlushThresholdBytes =
+      "file_writer_flush_threshold_bytes";
 
   // TODO: Refactor and merge config and session property.
   static constexpr const char* kOrcWriterMaxStripeSize =
@@ -159,11 +165,13 @@ class HiveConfig {
 
   static int32_t numCacheFileHandles(const Config* config);
 
-  static uint64_t const getKOrcWriterMaxStripeSize(
+  static uint64_t fileWriterFlushThresholdBytes(const Config* config);
+
+  static uint64_t getOrcWriterMaxStripeSize(
       const Config* connectorQueryCtxConfig,
       const Config* connectorPropertiesConfig);
 
-  static uint64_t const getKOrcWriterMaxDictionaryMemory(
+  static uint64_t getOrcWriterMaxDictionaryMemory(
       const Config* connectorQueryCtxConfig,
       const Config* connectorPropertiesConfig);
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -697,6 +697,10 @@ class TableWriteNode : public PlanNode {
     return aggregationNode_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return queryConfig.writerSpillEnabled();
+  }
+
   std::string_view name() const override {
     return "TableWrite";
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -191,6 +191,10 @@ class QueryConfig {
   /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kOrderBySpillEnabled = "order_by_spill_enabled";
 
+  /// If true, the memory arbitrator will reclaim memory from table writer by
+  /// flushing its buffered data to disk.
+  static constexpr const char* kWriterSpillEnabled = "writer_spill_enabled";
+
   /// RowNumber spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kRowNumberSpillEnabled =
       "row_number_spill_enabled";
@@ -469,14 +473,20 @@ class QueryConfig {
     return get<bool>(kOrderBySpillEnabled, true);
   }
 
+  /// Returns 'is writer spilling enabled' flag. Must also check the
+  /// spillEnabled()!
+  bool writerSpillEnabled() const {
+    return get<bool>(kWriterSpillEnabled, true);
+  }
+
   /// Returns 'is row_number spilling enabled' flag. Must also check the
   /// spillEnabled()!
   bool rowNumberSpillEnabled() const {
     return get<bool>(kRowNumberSpillEnabled, true);
   }
 
-  // Returns a percentage of aggregation or join input batches that
-  // will be forced to spill for testing. 0 means no extra spilling.
+  /// Returns a percentage of aggregation or join input batches that will be
+  /// forced to spill for testing. 0 means no extra spilling.
   int32_t testingSpillPct() const {
     return get<int32_t>(kTestingSpillPct, 0);
   }

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -203,6 +203,10 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether RowNumber operator can spill to disk under memory pressure.
+   * - writer_spill_enabled
+     - boolean
+     - true
+     - When `writer_spill_enabled` is true, determines whether TableWriter operator can spill to disk under memory pressure.
    * - aggregation_spill_memory_threshold
      - integer
      - 0
@@ -364,7 +368,10 @@ Hive Connector
      - integer
      - 128MB
      - Maximum distance in bytes between chunks to be fetched that may be coalesced into a single request.
-
+   * - file_writer_flush_threshold_bytes
+     - integer
+     - 96MB
+     - Minimum memory footprint size required to reclaim memory from a file writer by flushing its buffered data to disk.
 
 ``Amazon S3 Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -31,10 +31,7 @@
 #include "velox/dwio/common/ScanSpec.h"
 #include "velox/dwio/common/encryption/Encryption.h"
 
-namespace facebook {
-namespace velox {
-namespace dwio {
-namespace common {
+namespace facebook::velox::dwio::common {
 
 enum class FileFormat {
   UNKNOWN = 0,
@@ -539,16 +536,20 @@ class ReaderOptions : public io::ReaderOptions {
   }
 };
 
+struct WriterMemoryReclaimConfig {
+  /// The pct of the minimum free available memory reserved in a file write.
+  int32_t minReservationPct;
+  /// The pct of the memory reservation growth in a file write.
+  int32_t reservationGrowthPct;
+};
+
 struct WriterOptions {
   TypePtr schema;
   velox::memory::MemoryPool* memoryPool;
-  velox::memory::SetMemoryReclaimer setMemoryReclaimer{nullptr};
+  std::optional<WriterMemoryReclaimConfig> memoryReclaimConfig;
   std::optional<velox::common::CompressionKind> compressionKind;
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};
 };
 
-} // namespace common
-} // namespace dwio
-} // namespace velox
-} // namespace facebook
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/SortingWriter.cpp
+++ b/velox/dwio/common/SortingWriter.cpp
@@ -27,7 +27,9 @@ void SortingWriter::write(const VectorPtr& data) {
   sortBuffer_->addInput(data);
 }
 
-void SortingWriter::flush() {}
+void SortingWriter::flush() {
+  // TODO: add to support flush by disk spilling.
+}
 
 void SortingWriter::close() {
   sortBuffer_->noMoreInput();

--- a/velox/dwio/common/SortingWriter.h
+++ b/velox/dwio/common/SortingWriter.h
@@ -28,15 +28,15 @@ class SortingWriter : public Writer {
       std::unique_ptr<Writer> writer,
       std::unique_ptr<exec::SortBuffer> sortBuffer);
 
-  virtual void write(const VectorPtr& data) override;
+  void write(const VectorPtr& data) override;
 
   /// No action because we need to accumulate all data and sort before data can
   /// be flushed
-  virtual void flush() override;
+  void flush() override;
 
-  virtual void close() override;
+  void close() override;
 
-  virtual void abort() override;
+  void abort() override;
 
   const std::unique_ptr<Writer> outputWriter_;
   std::unique_ptr<exec::SortBuffer> sortBuffer_;

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -180,12 +180,10 @@ class MockMemoryPool : public velox::memory::MemoryPool {
   }
 
   void setReclaimer(
-      std::unique_ptr<memory::MemoryReclaimer> reclaimer) override {
-    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
-  }
+      std::unique_ptr<memory::MemoryReclaimer> reclaimer) override {}
 
   memory::MemoryReclaimer* reclaimer() const override {
-    VELOX_UNSUPPORTED("{} unsupported", __FUNCTION__);
+    return nullptr;
   }
 
   void enterArbitration() override {

--- a/velox/dwio/dwrf/writer/CMakeLists.txt
+++ b/velox/dwio/dwrf/writer/CMakeLists.txt
@@ -31,6 +31,7 @@ target_link_libraries(
   velox_dwio_common
   velox_dwio_dwrf_common
   velox_dwio_dwrf_utils
+  velox_exec
   velox_process
   velox_time
   velox_vector

--- a/velox/dwio/dwrf/writer/Writer.h
+++ b/velox/dwio/dwrf/writer/Writer.h
@@ -26,6 +26,7 @@
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
 #include "velox/dwio/dwrf/writer/LayoutPlanner.h"
 #include "velox/dwio/dwrf/writer/WriterBase.h"
+#include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::velox::dwrf {
 
@@ -33,7 +34,7 @@ struct WriterOptions {
   std::shared_ptr<const Config> config = std::make_shared<Config>();
   std::shared_ptr<const Type> schema;
   velox::memory::MemoryPool* memoryPool;
-  velox::memory::SetMemoryReclaimer setMemoryReclaimer{nullptr};
+  std::optional<dwio::common::WriterMemoryReclaimConfig> memoryReclaimConfig;
   /// The default factory allows the writer to construct the default flush
   /// policy with the configs in its ctor.
   std::function<std::unique_ptr<DWRFFlushPolicy>()> flushPolicyFactory;
@@ -59,7 +60,8 @@ class Writer : public dwio::common::Writer {
             std::move(sink),
             options,
             parentPool.addAggregateChild(fmt::format(
-                "writer_node_{}",
+                "{}.dwrf_{}",
+                parentPool.name(),
                 folly::to<std::string>(folly::Random::rand64())))} {}
 
   Writer(
@@ -131,10 +133,56 @@ class Writer : public dwio::common::Writer {
     return writerBase_->getSink();
   }
 
+  /// True if we can reclaim memory from this writer by memory arbitration.
+  bool canReclaim() const;
+
+  tsan_atomic<bool>& testingNonReclaimableSection() {
+    return nonReclaimableSection_;
+  }
+
  protected:
   std::shared_ptr<WriterBase> writerBase_;
 
  private:
+  class MemoryReclaimer : public exec::MemoryReclaimer {
+   public:
+    static std::unique_ptr<memory::MemoryReclaimer> create(Writer* writer);
+
+    bool reclaimableBytes(
+        const memory::MemoryPool& pool,
+        uint64_t& reclaimableBytes) const override;
+
+    uint64_t reclaim(
+        memory::MemoryPool* pool,
+        uint64_t targetBytes,
+        memory::MemoryReclaimer::Stats& stats) override;
+
+   private:
+    explicit MemoryReclaimer(Writer* writer) : writer_(writer) {
+      VELOX_CHECK_NOT_NULL(writer_);
+    }
+
+    Writer* const writer_;
+  };
+
+  // Sets the memory reclaimer for root memory pool used by this writer.
+  void setMemoryReclaimer(const std::shared_ptr<memory::MemoryPool>& pool);
+
+  // Invoked to ensure sufficient memory to process the given size of input by
+  // reserving memory from each of the leaf memory pool. This only applies if we
+  // support memory reclaim on this writer. The memory reservation might trigger
+  // stripe flush by memory arbitration if the query root memory pool doesn't
+  // enough memory capacity.
+  void ensureWriteFits(size_t appendBytes, size_t appendRows);
+
+  // Grows a memory pool size by the specified ratio.
+  bool maybeReserveMemory(
+      MemoryUsageCategory memoryUsageCategory,
+      double estimatedMemoryGrowthRatio);
+
+  // Releases the unused memory reservations after we flush a stripe.
+  void releaseMemory();
+
   // Create a new stripe. No-op if there is no data written.
   void flushInternal(bool close = false);
 
@@ -146,6 +194,9 @@ class Writer : public dwio::common::Writer {
   }
 
   const std::shared_ptr<const dwio::common::TypeWithId> schema_;
+  const std::optional<dwio::common::WriterMemoryReclaimConfig>
+      memoryReclaimConfig_{std::nullopt};
+  tsan_atomic<bool> nonReclaimableSection_{false};
   std::unique_ptr<DWRFFlushPolicy> flushPolicy_;
   std::unique_ptr<LayoutPlanner> layoutPlanner_;
   std::unique_ptr<ColumnWriter> writer_;

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -72,14 +72,9 @@ class WriterBase {
   void initContext(
       const std::shared_ptr<const Config>& config,
       std::shared_ptr<velox::memory::MemoryPool> pool,
-      const velox::memory::SetMemoryReclaimer& setReclaimer = nullptr,
       std::unique_ptr<encryption::EncryptionHandler> handler = nullptr) {
     context_ = std::make_unique<WriterContext>(
-        config,
-        std::move(pool),
-        setReclaimer,
-        sink_->metricsLog(),
-        std::move(handler));
+        config, std::move(pool), sink_->metricsLog(), std::move(handler));
     writerSink_ = std::make_unique<WriterSink>(
         *sink_,
         context_->getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM),

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/dwio/dwrf/writer/WriterContext.h"
+#include "velox/exec/MemoryReclaimer.h"
 
 namespace facebook::velox::dwrf {
 namespace {
@@ -24,14 +25,16 @@ constexpr uint32_t MIN_INDEX_STRIDE = 1000;
 WriterContext::WriterContext(
     const std::shared_ptr<const Config>& config,
     std::shared_ptr<memory::MemoryPool> pool,
-    const memory::SetMemoryReclaimer& setReclaimer,
     const dwio::common::MetricsLogPtr& metricLogger,
     std::unique_ptr<encryption::EncryptionHandler> handler)
     : config_{config},
       pool_{std::move(pool)},
-      dictionaryPool_{pool_->addLeafChild(".dictionary")},
-      outputStreamPool_{pool_->addLeafChild(".compression")},
-      generalPool_{pool_->addLeafChild(".general")},
+      dictionaryPool_{
+          pool_->addLeafChild(fmt::format("{}.dictionary", pool_->name()))},
+      outputStreamPool_{
+          pool_->addLeafChild(fmt::format("{}.compression", pool_->name()))},
+      generalPool_{
+          pool_->addLeafChild(fmt::format("{}.general", pool_->name()))},
       indexEnabled_{getConfig(Config::CREATE_INDEX)},
       indexStride_{getConfig(Config::ROW_INDEX_STRIDE)},
       compression_{getConfig(Config::COMPRESSION)},
@@ -47,14 +50,10 @@ WriterContext::WriterContext(
       // pass down the metric log.
       metricLogger_{metricLogger},
       handler_{std::move(handler)} {
-  if (setReclaimer != nullptr) {
-    setReclaimer(dictionaryPool_.get());
-    setReclaimer(outputStreamPool_.get());
-    setReclaimer(generalPool_.get());
-  }
   const bool forceLowMemoryMode{getConfig(Config::FORCE_LOW_MEMORY_MODE)};
   const bool disableLowMemoryMode{getConfig(Config::DISABLE_LOW_MEMORY_MODE)};
   VELOX_CHECK(!(forceLowMemoryMode && disableLowMemoryMode));
+  setMemoryReclaimers();
   checkLowMemoryMode_ = !forceLowMemoryMode && !disableLowMemoryMode;
   if (forceLowMemoryMode) {
     setLowMemoryMode();
@@ -86,6 +85,15 @@ void WriterContext::validateConfigs() const {
   VELOX_CHECK_GE(
       getConfig(Config::COMPRESSION_BLOCK_SIZE_EXTEND_RATIO),
       dwio::common::MIN_PAGE_GROW_RATIO);
+}
+
+void WriterContext::setMemoryReclaimers() {
+  if (pool_->reclaimer() == nullptr) {
+    return;
+  }
+  generalPool_->setReclaimer(exec::MemoryReclaimer::create());
+  dictionaryPool_->setReclaimer(exec::MemoryReclaimer::create());
+  outputStreamPool_->setReclaimer(exec::MemoryReclaimer::create());
 }
 
 memory::MemoryPool& WriterContext::getMemoryPool(
@@ -120,5 +128,17 @@ int64_t WriterContext::getTotalMemoryUsage() const {
   return getMemoryUsage(MemoryUsageCategory::OUTPUT_STREAM) +
       getMemoryUsage(MemoryUsageCategory::DICTIONARY) +
       getMemoryUsage(MemoryUsageCategory::GENERAL);
+}
+
+int64_t WriterContext::availableMemoryReservation() const {
+  return dictionaryPool_->availableReservation() +
+      outputStreamPool_->availableReservation() +
+      generalPool_->availableReservation();
+}
+
+void WriterContext::releaseMemoryReservation() {
+  dictionaryPool_->release();
+  outputStreamPool_->release();
+  generalPool_->release();
 }
 } // namespace facebook::velox::dwrf

--- a/velox/exec/GroupingSet.cpp
+++ b/velox/exec/GroupingSet.cpp
@@ -66,7 +66,7 @@ GroupingSet::GroupingSet(
       isGlobal_(hashers_.empty()),
       isPartial_(isPartial),
       isRawInput_(isRawInput),
-      queryConfig_(&operatorCtx->task()->queryCtx()->queryConfig()),
+      queryConfig_(operatorCtx->task()->queryCtx()->queryConfig()),
       aggregates_(std::move(aggregates)),
       masks_(maskChannels(aggregates_)),
       ignoreNullKeys_(ignoreNullKeys),
@@ -78,7 +78,7 @@ GroupingSet::GroupingSet(
       nonReclaimableSection_(nonReclaimableSection),
       stringAllocator_(operatorCtx->pool()),
       rows_(operatorCtx->pool()),
-      isAdaptive_(queryConfig_->hashAdaptivityEnabled()),
+      isAdaptive_(queryConfig_.hashAdaptivityEnabled()),
       pool_(*operatorCtx->pool()) {
   VELOX_CHECK_NOT_NULL(nonReclaimableSection_);
   VELOX_CHECK(pool_.trackUsage());
@@ -866,7 +866,7 @@ void GroupingSet::ensureOutputFits() {
   }
 
   const uint64_t outputBufferSizeToReserve =
-      queryConfig_->preferredOutputBatchBytes() * 1.2;
+      queryConfig_.preferredOutputBatchBytes() * 1.2;
   {
     ReclaimableSectionGuard guard(nonReclaimableSection_);
     if (pool_.maybeReserve(outputBufferSizeToReserve)) {

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -243,7 +243,7 @@ class GroupingSet {
   const bool isGlobal_;
   const bool isPartial_;
   const bool isRawInput_;
-  const core::QueryConfig* const queryConfig_;
+  const core::QueryConfig& queryConfig_;
 
   std::vector<AggregateInfo> aggregates_;
   AggregationMasks masks_;

--- a/velox/exec/HashAggregation.cpp
+++ b/velox/exec/HashAggregation.cpp
@@ -486,16 +486,18 @@ void HashAggregation::reclaim(
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING)
-        << "Can't reclaim from aggregation operator which is under non-reclaimable section: "
-        << pool()->toString();
+        << "Can't reclaim from aggregation operator which is under non-reclaimable section, pool["
+        << pool()->toString()
+        << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
     return;
   }
 
   if (noMoreInput_) {
     if (groupingSet_->hasSpilled()) {
       LOG(WARNING)
-          << "Can't reclaim from aggregation operator which has spilled and is under output processing: "
-          << pool()->toString();
+          << "Can't reclaim from aggregation operator which has spilled and is under output processing, pool["
+          << pool()->toString()
+          << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
       return;
     }
     // Spill all the rows starting from the next output row pointed by

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -1121,7 +1121,8 @@ void HashBuild::reclaim(
                  << stateName(state_) << "], nonReclaimableSection_["
                  << nonReclaimableSection_ << "], spiller_["
                  << (spiller_->finalized() ? "finalized" : "non-finalized")
-                 << "] " << pool()->name();
+                 << "] " << pool()->name()
+                 << ", usage: " << succinctBytes(pool()->currentBytes());
     return;
   }
 
@@ -1140,7 +1141,8 @@ void HashBuild::reclaim(
                    << stateName(buildOp->state_) << "], nonReclaimableSection_["
                    << nonReclaimableSection_ << "], spiller_["
                    << (spiller_->finalized() ? "finalized" : "non-finalized")
-                   << "], " << buildOp->pool()->name();
+                   << "], " << buildOp->pool()->name() << ", usage: "
+                   << succinctBytes(buildOp->pool()->currentBytes());
       return;
     }
   }

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/common/base/Exceptions.h"
+#include "velox/common/base/Portability.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 
 namespace facebook::velox::exec {
@@ -46,4 +47,43 @@ class MemoryReclaimer : public memory::MemoryReclaimer {
 /// drivers to go off thread. A suspended driver thread is not counted as
 /// running.
 void memoryArbitrationStateCheck(memory::MemoryPool& pool);
+
+/// The object is used to set/clear non-reclaimable section of an operation in
+/// the middle of its execution. It allows the memory arbitrator to reclaim
+/// memory from a running operator which is waiting for memory arbitration.
+/// 'nonReclaimableSection' points to the corresponding flag of the associated
+/// operator.
+class ReclaimableSectionGuard {
+ public:
+  explicit ReclaimableSectionGuard(tsan_atomic<bool>* nonReclaimableSection)
+      : nonReclaimableSection_(nonReclaimableSection),
+        oldMonReclaimableSectionValue_(*nonReclaimableSection_) {
+    *nonReclaimableSection_ = false;
+  }
+
+  ~ReclaimableSectionGuard() {
+    *nonReclaimableSection_ = oldMonReclaimableSectionValue_;
+  }
+
+ private:
+  tsan_atomic<bool>* const nonReclaimableSection_;
+  const bool oldMonReclaimableSectionValue_;
+};
+
+class NonReclaimableSectionGuard {
+ public:
+  explicit NonReclaimableSectionGuard(tsan_atomic<bool>* nonReclaimableSection)
+      : nonReclaimableSection_(nonReclaimableSection),
+        oldMonReclaimableSectionValue_(*nonReclaimableSection_) {
+    *nonReclaimableSection_ = true;
+  }
+
+  ~NonReclaimableSectionGuard() {
+    *nonReclaimableSection_ = oldMonReclaimableSectionValue_;
+  }
+
+ private:
+  tsan_atomic<bool>* const nonReclaimableSection_;
+  const bool oldMonReclaimableSectionValue_;
+};
 } // namespace facebook::velox::exec

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -50,12 +50,10 @@ OperatorCtx::createConnectorQueryCtx(
     const std::string& connectorId,
     const std::string& planNodeId,
     memory::MemoryPool* connectorPool,
-    memory::SetMemoryReclaimer setMemoryReclaimer,
     const common::SpillConfig* spillConfig) const {
   return std::make_shared<connector::ConnectorQueryCtx>(
       pool_,
       connectorPool,
-      std::move(setMemoryReclaimer),
       driverCtx_->task->queryCtx()->getConnectorConfig(connectorId),
       spillConfig,
       std::make_unique<SimpleExpressionEvaluator>(

--- a/velox/exec/OrderBy.cpp
+++ b/velox/exec/OrderBy.cpp
@@ -89,7 +89,8 @@ void OrderBy::reclaim(
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from order by operator, noMoreInput_["
                  << noMoreInput_ << "], nonReclaimableSection_["
-                 << nonReclaimableSection_ << "], " << pool()->name();
+                 << nonReclaimableSection_ << "], pool[" << pool()->name()
+                 << ", usage: " << succinctBytes(pool()->currentBytes()) << "]";
     return;
   }
 

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "SortBuffer.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/vector/BaseVector.h"
 
 namespace facebook::velox::exec {
@@ -270,7 +271,7 @@ void SortBuffer::ensureInputFits(const VectorPtr& input) {
       estimatedIncrementalBytes * 2,
       currentMemoryUsage * spillConfig_->spillableReservationGrowthPct / 100);
   {
-    ReclaimableSectionGuard guard(nonReclaimableSection_);
+    exec::ReclaimableSectionGuard guard(nonReclaimableSection_);
     if (pool_->maybeReserve(targetIncrementBytes)) {
       return;
     }

--- a/velox/exec/Spill.h
+++ b/velox/exec/Spill.h
@@ -638,7 +638,7 @@ class SpillState {
   /// Appends data to 'partition'. The rows given by 'indices' must be sorted
   /// for a sorted spill and must hash to 'partition'. It is safe to call this
   /// on multiple threads if all threads specify a different partition. Returns
-  /// the size to sppend to partition.
+  /// the size to append to partition.
   uint64_t appendToPartition(int32_t partition, const RowVectorPtr& rows);
 
   /// Finishes a sorted run for 'partition'. If write is called for 'partition'

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "velox/core/PlanNode.h"
+#include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
 
 namespace facebook::velox::exec {
@@ -127,18 +128,27 @@ class TableWriter : public Operator {
     return finished_;
   }
 
+  /// NOTE: we don't reclaim memory from table write operator directly but from
+  /// its paired connector pool which reclaims memory from the file writers
+  /// created inside the connector.
+  bool canReclaim() const override {
+    return false;
+  }
+
+  void abort() override;
+
  private:
-  // The memory reclaimer customized for connector and file writer memory pools.
-  //
-  // NOTE: we shall always reclaim memory from table write operator's reclaimer
-  // instead of file or connector writer's reclaimer. So the customized memory
-  // reclaimer here only handle memory arbitration enter/leave but does nothing
-  // for the actual memory reclamation related operations.
-  class MemoryReclaimer : public Operator::MemoryReclaimer {
+  // The memory reclaimer customized for connector which interface with the
+  // memory arbitrator to reclaim memory from the file writers created within
+  // the connector.
+  class ConnectorReclaimer : public Operator::MemoryReclaimer {
    public:
-    static std::unique_ptr<memory::MemoryReclaimer> create(
-        DriverCtx* driverCtx,
-        Operator* op);
+    static std::unique_ptr<memory::MemoryReclaimer>
+    create(DriverCtx* driverCtx, Operator* op, bool canReclaim);
+
+    void enterArbitration() override {}
+
+    void leaveArbitration() noexcept override {}
 
     bool reclaimableBytes(
         const memory::MemoryPool& pool,
@@ -150,11 +160,16 @@ class TableWriter : public Operator {
         memory::MemoryReclaimer::Stats& stats) override;
 
     void abort(memory::MemoryPool* pool, const std::exception_ptr& /* error */)
-        override;
+        override {}
 
    private:
-    MemoryReclaimer(const std::shared_ptr<Driver>& driver, Operator* op)
-        : Operator::MemoryReclaimer(driver, op) {}
+    ConnectorReclaimer(
+        const std::shared_ptr<Driver>& driver,
+        Operator* op,
+        bool canReclaim)
+        : Operator::MemoryReclaimer(driver, op), canReclaim_(canReclaim) {}
+
+    const bool canReclaim_{false};
   };
 
   void createDataSink();
@@ -171,14 +186,14 @@ class TableWriter : public Operator {
 
   std::string createTableCommitContext(bool lastOutput);
 
-  // Invoked to set memory reclaimer for connector and file writer memory pool.
-  void setConnectorOrWriterMemoryReclaimer(memory::MemoryPool* pool);
+  void setConnectorMemoryReclaimer();
 
   const DriverCtx* const driverCtx_;
   memory::MemoryPool* const connectorPool_;
   const std::shared_ptr<connector::ConnectorInsertTableHandle>
       insertTableHandle_;
   const connector::CommitStrategy commitStrategy_;
+
   std::unique_ptr<Operator> aggregation_;
   std::shared_ptr<connector::Connector> connector_;
   std::shared_ptr<connector::ConnectorQueryCtx> connectorQueryCtx_;

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -441,30 +441,4 @@ TEST_F(OperatorUtilsTest, reclaimableSectionGuard) {
     ASSERT_TRUE(mockOp.testingNonReclaimable());
   }
   ASSERT_FALSE(mockOp.testingNonReclaimable());
-
-  {
-    tsan_atomic<bool> nonReclaimableSection{false};
-    {
-      ReclaimableSectionGuard guard(&nonReclaimableSection);
-      ASSERT_FALSE(nonReclaimableSection);
-      {
-        ReclaimableSectionGuard guard(&nonReclaimableSection);
-        ASSERT_FALSE(nonReclaimableSection);
-      }
-    }
-    ASSERT_FALSE(nonReclaimableSection);
-  }
-
-  {
-    tsan_atomic<bool> nonReclaimableSection{true};
-    {
-      ReclaimableSectionGuard guard(&nonReclaimableSection);
-      ASSERT_FALSE(nonReclaimableSection);
-      {
-        ReclaimableSectionGuard guard(&nonReclaimableSection);
-        ASSERT_FALSE(nonReclaimableSection);
-      }
-    }
-    ASSERT_TRUE(nonReclaimableSection);
-  }
 }


### PR DESCRIPTION
- Build memory reclaim mechanism into dwrf writer through memory arbitration
   1.    customize the memory reclaimer for the root memory pool (aggregate type)
          to respond memory reclaim request from memory arbitration by flush internal
          buffered stripe
   2.    add non-reclaimable protection mechanism inside the dwrf writer as the
          operator as the operator non-reclaimable section mechanism doesn't apply here.
          A table writer could have multiple file writers opened for write. The write
          processing is sequential executed inside a table writer so there is only one
          active file writer at a time.
   3.    add memory reservation mechanism inside the dwrf writer which reserve
           sufficient memory before each dwrf stripe stride write (a macro batch). This
           is similar to the other memory reservation mechanism built for the other spillable
           operators. In practice, this prevents the memory arbitration triggered during
           a writer processing data. A file writer is only reclaimable while reserving memory.
    4.    add WriterMemoryReclaimConfig in dwio common writer interface to configure
           if a writer can reclaim memory which contains the spilling configs used by file
           writer for internal memory reservation.
- Build memory reclaim mechanism into HiveDataSink and connector memory pool to
   responds to the memory reclaim request from the memory arbitrator. It sorts the
   file writer based on their memory footprint and leverage the memory pool hierarchy to
   reclaim memory. It respects a new hive config 'file_writer_flush_threshold_bytes' which
   only reclaim memory from a large file writer to avoid small stripe size. Eventually, we
   might pushdown this control logic inside the file writer and let latter decide to flush or
   on reclaim without sacrificing the encoding efficiency. So far, HiveDataSink only support
   reclaim on dwrf and non-sorted writer.
- Change memory reclaim mechanism in table writer and always reclaim from the paired
   connector memory pool.
- Fix a table writer abort issue by avoiding abort a table writer if it is under non-reclaimable
   section. This is caused by the current dwrf writer abort handling which shall be improved
   later to handle the abort gracefully.
- Add query config 'writer_spill_enabled' to turn on/off the writer spilling
- Add hive config 'file_writer_flush_threshold_bytes' to specify the minimum memory
   footprint of a file writer to trigger flush to reclaim memory
- Restructure the memory pool hierarchy used by file writer and naming to ease debug
   and memory usage report
- Remove the setMemoryReclaimer callback and create the memory reclaimer in hive
   connector and file writer directly
The followup will (1) add support sorted writer reclaim, (2) other file formats and (3) report
spilling stats to operator performance to help analyze the writer spilling stats; (4) aggregated
table writer memory usage at Prestissimo layer.