### PR TITLE
Fix lazy vector handling in ReduceAgg::toIntermediate()

### DIFF
--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -297,7 +297,10 @@ class ReduceAgg : public exec::Aggregate {
     // Do not evaluate on null input.
     SelectivityVector remainingRows = rows;
     if (input->mayHaveNulls()) {
-      remainingRows.deselectNulls(input->rawNulls(), 0, rows.size());
+      DecodedVector decoded(*input, rows);
+      if (auto* rawNulls = decoded.nulls()) {
+        remainingRows.deselectNulls(rawNulls, rows.begin(), rows.end());
+      }
     }
 
     const auto& lambda = initializeInputLambda();

--- a/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ReduceAggTest.cpp
@@ -62,15 +62,11 @@ TEST_F(ReduceAggTest, integersGlobal) {
   int64_t product = 1 * 2 * 3 * 4 * 5 * 1 * 1;
   auto expected = makeRowVector({makeConstant(product, 1)});
 
-  // Skip testing with TableScan until
-  // https://github.com/facebookincubator/velox/issues/6740 is fixed.
   testAggregations(
       {data},
       {},
       {"reduce_agg(c0, 1, (x, y) -> (x * y), (x, y) -> (x * y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // No nulls. With mask.
   product = 1 * 3 * 4 * 1;
@@ -80,9 +76,7 @@ TEST_F(ReduceAggTest, integersGlobal) {
       {data},
       {},
       {"reduce_agg(c0, 1, (x, y) -> (x * y), (x, y) -> (x * y)) FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // Some nulls.
   product = 1 * 2 * 0 * 1 * 3;
@@ -92,9 +86,7 @@ TEST_F(ReduceAggTest, integersGlobal) {
       {data},
       {},
       {"reduce_agg(c1, 1, (x, y) -> (x * y), (x, y) -> (x * y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // Same as above, but using a sum reduction.
   int64_t sum = 1 + 2 + 3 + 4 + 5 + 1 + 1;
@@ -104,9 +96,7 @@ TEST_F(ReduceAggTest, integersGlobal) {
       {data},
       {},
       {"reduce_agg(c0, 0, (x, y) -> (x + y), (x, y) -> (x + y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   sum = 1 + 2 + 0 + 1 + 3;
   expected = makeRowVector({makeConstant(sum, 1)});
@@ -115,9 +105,7 @@ TEST_F(ReduceAggTest, integersGlobal) {
       {data},
       {},
       {"reduce_agg(c1, 0, (x, y) -> (x + y), (x, y) -> (x + y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 }
 
 TEST_F(ReduceAggTest, integersGroupBy) {
@@ -138,9 +126,7 @@ TEST_F(ReduceAggTest, integersGroupBy) {
       {data},
       {"k"},
       {"reduce_agg(c0, 1, (x, y) -> (x * y), (x, y) -> (x * y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // With mask.
   expected = makeRowVector({
@@ -152,9 +138,7 @@ TEST_F(ReduceAggTest, integersGroupBy) {
       {data},
       {"k"},
       {"reduce_agg(c0, 1, (x, y) -> (x * y), (x, y) -> (x * y)) FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // Sum reduction.
   expected = makeRowVector({
@@ -166,9 +150,7 @@ TEST_F(ReduceAggTest, integersGroupBy) {
       {data},
       {"k"},
       {"reduce_agg(c0, 0, (x, y) -> (x + y), (x, y) -> (x + y))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   // With mask.
   expected = makeRowVector({
@@ -180,9 +162,7 @@ TEST_F(ReduceAggTest, integersGroupBy) {
       {data},
       {"k"},
       {"reduce_agg(c0, 0, (x, y) -> (x + y), (x, y) -> (x + y)) FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 }
 
 TEST_F(ReduceAggTest, arraysGlobal) {
@@ -208,9 +188,7 @@ TEST_F(ReduceAggTest, arraysGlobal) {
       {"reduce_agg(c0, c1, "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3), "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   expected = makeRowVector({makeArrayVector<int64_t>({{7, 3, 2}})});
 
@@ -221,9 +199,7 @@ TEST_F(ReduceAggTest, arraysGlobal) {
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3), "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3)) "
        "FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 }
 
 TEST_F(ReduceAggTest, arraysGroupBy) {
@@ -256,9 +232,7 @@ TEST_F(ReduceAggTest, arraysGroupBy) {
       {"reduce_agg(c0, c1, "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3), "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   expected = makeRowVector({
       makeFlatVector<int32_t>({1, 2}),
@@ -275,9 +249,7 @@ TEST_F(ReduceAggTest, arraysGroupBy) {
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3), "
        "(a, b) -> slice(reverse(array_sort(array_distinct(concat(a, b)))), 1, 3)) "
        "FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 }
 
 TEST_F(ReduceAggTest, differentInputAndCombine) {
@@ -303,9 +275,7 @@ TEST_F(ReduceAggTest, differentInputAndCombine) {
       {"reduce_agg(c0, c1, "
        "(s, x) -> array_sort(array_distinct(concat(s, array[x]))), "
        "(s, s2) -> array_sort(array_distinct(concat(s, s2))))"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 
   expected = makeRowVector({
       makeFlatVector<int32_t>({1, 2}),
@@ -319,9 +289,7 @@ TEST_F(ReduceAggTest, differentInputAndCombine) {
        "(s, x) -> array_sort(array_distinct(concat(s, array[x]))), "
        "(s, s2) -> array_sort(array_distinct(concat(s, s2)))) "
        "FILTER (WHERE m)"},
-      {expected},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {expected});
 }
 
 TEST_F(ReduceAggTest, fuzzGlobalSum) {
@@ -336,9 +304,7 @@ TEST_F(ReduceAggTest, fuzzGlobalSum) {
       {},
       {"reduce_agg(c0, 0, (x, y) -> (x + y), (x, y) -> (x + y))"},
       {},
-      {sumResults},
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      {sumResults});
 }
 
 TEST_F(ReduceAggTest, fuzzGroupBySum) {
@@ -358,9 +324,7 @@ TEST_F(ReduceAggTest, fuzzGroupBySum) {
       {"key"},
       {"reduce_agg(c0, 0, (x, y) -> (x + y), (x, y) -> (x + y))"},
       {},
-      [&](auto& builder) { return builder.assertResults(sumResults); },
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      [&](auto& builder) { return builder.assertResults(sumResults); });
 }
 
 TEST_F(ReduceAggTest, fuzzGlobalAvg) {
@@ -382,9 +346,7 @@ TEST_F(ReduceAggTest, fuzzGlobalAvg) {
        "(s, x) -> (row_constructor(s.sum + x, s.count + 1)), "
        "(s, s2) -> (row_constructor(s.sum + s2.sum, s.count + s2.count)))"},
       {"a0.sum / cast(a0.count as double)"},
-      [&](auto& builder) { return builder.assertResults(avgResults); },
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      [&](auto& builder) { return builder.assertResults(avgResults); });
 }
 
 TEST_F(ReduceAggTest, fuzzGroupByAvg) {
@@ -410,9 +372,7 @@ TEST_F(ReduceAggTest, fuzzGroupByAvg) {
        "(s, x) -> (row_constructor(s.sum + x, s.count + 1)), "
        "(s, s2) -> (row_constructor(s.sum + s2.sum, s.count + s2.count)))"},
       {"key", "a0.sum / cast(a0.count as double)"},
-      [&](auto& builder) { return builder.assertResults(avgResults); },
-      /*config*/ {},
-      /*testWithTableScan*/ false);
+      [&](auto& builder) { return builder.assertResults(avgResults); });
 }
 
 } // namespace


### PR DESCRIPTION
Summary:
ReduceAgg::toIntermediate() needs to remove nulls in the input
vector before evaluating the expression. The code used to not
handle lazy vector over constant vector correctly where
remainingRows.deselectNulls() causes heap-buffer-overflow error.
This diff fixes this bug by decode the input vector to handle lazy
vector together with others.

This diff fixes https://github.com/facebookincubator/velox/issues/6740.

Differential Revision: D50145451


