### PR TITLE
Track the current Operator call in the Driver

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -251,7 +251,7 @@ void Driver::init(
   ctx_ = std::move(ctx);
   VELOX_CHECK(operators_.empty());
   operators_ = std::move(operators);
-  curOpIndex_ = operators_.size() - 1;
+  curOperatorId_ = operators_.size() - 1;
   trackOperatorCpuUsage_ = ctx_->queryConfig().operatorTrackCpuUsage();
 }
 
@@ -340,21 +340,43 @@ void Driver::enqueueInternal() {
 
 // Call an Oprator method. record silenced throws, but not a query
 // terminating throw. Annotate exceptions with Operator info.
-#define CALL_OPERATOR(call, operator, methodName)                       \
+#define CALL_OPERATOR(call, operatorPtr, operatorId, operatorMethod)    \
   try {                                                                 \
     threadNumVeloxThrow() = 0;                                          \
+    opCallStatus_.start(operatorId, operatorMethod);                    \
+    auto stopGuard = folly::makeGuard([&]() { opCallStatus_.stop(); }); \
     call;                                                               \
-    recordSilentThrows(*operator);                                      \
+    recordSilentThrows(*operatorPtr);                                   \
   } catch (const VeloxException& e) {                                   \
     throw;                                                              \
   } catch (const std::exception& e) {                                   \
     VELOX_FAIL(                                                         \
         "Operator::{} failed for [operator: {}, plan node ID: {}]: {}", \
-        methodName,                                                     \
-        operator->operatorType(),                                       \
-        operator->planNodeId(),                                         \
+        operatorMethod,                                                 \
+        operatorPtr->operatorType(),                                    \
+        operatorPtr->planNodeId(),                                      \
         e.what());                                                      \
   }
+
+void OpCallStatus::start(int32_t operatorId, const char* operatorMethod) {
+  timeStartMs = getCurrentTimeMs();
+  opId = operatorId;
+  method = operatorMethod;
+}
+
+void OpCallStatus::stop() {
+  timeStartMs = 0;
+}
+
+size_t OpCallStatusRaw::callDuration() const {
+  return empty() ? 0 : (getCurrentTimeMs() - timeStartMs);
+}
+
+/*static*/ std::string OpCallStatusRaw::formatCall(
+    Operator* op,
+    const char* operatorMethod) {
+  return fmt::format("{}::{}", op ? op->operatorType() : "N/A", operatorMethod);
+}
 
 CpuWallTiming Driver::processLazyTiming(
     Operator& op,
@@ -431,8 +453,8 @@ StopReason Driver::runInternal(
 
   // Update the queued time after entering the Task to ensure the stats have not
   // been deleted.
-  if (curOpIndex_ < operators_.size()) {
-    operators_[curOpIndex_]->addRuntimeStat(
+  if (curOperatorId_ < operators_.size()) {
+    operators_[curOperatorId_]->addRuntimeStat(
         "queuedWallNanos",
         RuntimeCounter(queuedTime, RuntimeCounter::Unit::kNanos));
   }
@@ -473,11 +495,14 @@ StopReason Driver::runInternal(
 
         // In case we are blocked, this index will point to the operator, whose
         // queuedTime we should update.
-        curOpIndex_ = i;
+        curOperatorId_ = i;
         RuntimeStatWriterScopeGuard statsWriterGuard(op);
 
         CALL_OPERATOR(
-            blockingReason_ = op->isBlocked(&future), op, "isBlocked");
+            blockingReason_ = op->isBlocked(&future),
+            op,
+            curOperatorId_,
+            kOpMethodIsBlocked);
         if (blockingReason_ != BlockingReason::kNotBlocked) {
           blockingState = std::make_shared<BlockingState>(
               self, std::move(future), op, blockingReason_);
@@ -491,7 +516,8 @@ StopReason Driver::runInternal(
           CALL_OPERATOR(
               blockingReason_ = nextOp->isBlocked(&future),
               nextOp,
-              "isBlocked");
+              curOperatorId_ + 1,
+              kOpMethodIsBlocked);
           if (blockingReason_ != BlockingReason::kNotBlocked) {
             blockingState = std::make_shared<BlockingState>(
                 self, std::move(future), nextOp, blockingReason_);
@@ -501,7 +527,10 @@ StopReason Driver::runInternal(
 
           bool needsInput;
           CALL_OPERATOR(
-              needsInput = nextOp->needsInput(), nextOp, "needsInput");
+              needsInput = nextOp->needsInput(),
+              nextOp,
+              curOperatorId_ + 1,
+              kOpMethodNeedsInput);
           if (needsInput) {
             uint64_t resultBytes = 0;
             RowVectorPtr intermediateResult;
@@ -515,7 +544,10 @@ StopReason Driver::runInternal(
               TestValue::adjust(
                   "facebook::velox::exec::Driver::runInternal::getOutput", op);
               CALL_OPERATOR(
-                  intermediateResult = op->getOutput(), op, "getOutput");
+                  intermediateResult = op->getOutput(),
+                  op,
+                  curOperatorId_,
+                  kOpMethodGetOutput);
               if (intermediateResult) {
                 VELOX_CHECK(
                     intermediateResult->size() > 0,
@@ -551,7 +583,10 @@ StopReason Driver::runInternal(
                   nextOp);
 
               CALL_OPERATOR(
-                  nextOp->addInput(intermediateResult), nextOp, "addInput");
+                  nextOp->addInput(intermediateResult),
+                  nextOp,
+                  curOperatorId_ + 1,
+                  kOpMethodAddInput);
 
               // The next iteration will see if operators_[i + 1] has
               // output now that it got input.
@@ -570,7 +605,10 @@ StopReason Driver::runInternal(
               // not the source, just try to get output from the one
               // before.
               CALL_OPERATOR(
-                  blockingReason_ = op->isBlocked(&future), op, "isBlocked");
+                  blockingReason_ = op->isBlocked(&future),
+                  op,
+                  curOperatorId_,
+                  kOpMethodIsBlocked);
               if (blockingReason_ != BlockingReason::kNotBlocked) {
                 blockingState = std::make_shared<BlockingState>(
                     self, std::move(future), op, blockingReason_);
@@ -588,7 +626,11 @@ StopReason Driver::runInternal(
                 TestValue::adjust(
                     "facebook::velox::exec::Driver::runInternal::noMoreInput",
                     nextOp);
-                CALL_OPERATOR(nextOp->noMoreInput(), nextOp, "noMoreInput");
+                CALL_OPERATOR(
+                    nextOp->noMoreInput(),
+                    nextOp,
+                    curOperatorId_ + 1,
+                    kOpMethodNoMoreInput);
                 break;
               }
             }
@@ -604,7 +646,11 @@ StopReason Driver::runInternal(
                   auto selfDelta = processLazyTiming(*op, timing);
                   op->stats().wlock()->getOutputTiming.add(selfDelta);
                 });
-            CALL_OPERATOR(result = op->getOutput(), op, "getOutput");
+            CALL_OPERATOR(
+                result = op->getOutput(),
+                op,
+                curOperatorId_,
+                kOpMethodGetOutput);
             if (result) {
               VELOX_CHECK(
                   result->size() > 0,
@@ -825,6 +871,11 @@ Operator* Driver::findOperator(int32_t operatorId) const {
   return operators_[operatorId].get();
 }
 
+Operator* Driver::findOperatorNoThrow(int32_t operatorId) const {
+  return (operatorId < operators_.size()) ? operators_[operatorId].get()
+                                          : nullptr;
+}
+
 std::vector<Operator*> Driver::operators() const {
   std::vector<Operator*> operators;
   operators.reserve(operators_.size());
@@ -840,10 +891,16 @@ std::string Driver::toString() const {
   if (state_.isOnThread()) {
     out << "running ";
   } else {
-    out << "blocked " << static_cast<int>(blockingReason_) << " ";
+    out << "blocked " << blockingReasonToString(blockingReason_) << " ";
   }
   for (auto& op : operators_) {
     out << op->toString() << " ";
+  }
+  const auto ocs = opCallStatus();
+  if (!ocs.empty()) {
+    out << "{OpCallStatus: executing "
+        << ocs.formatCall(findOperatorNoThrow(ocs.opId), ocs.method) << " for "
+        << ocs.callDuration() << "ms}";
   }
   out << "}";
   return out.str();
@@ -855,7 +912,12 @@ std::string Driver::toJsonString() const {
   obj["state"] = state_.toJsonString();
   obj["closed"] = closed_.load();
   obj["queueTimeStartMicros"] = queueTimeStartMicros_;
-  obj["curOpIndex"] = curOpIndex_;
+  const auto ocs = opCallStatus();
+  if (!ocs.empty()) {
+    obj["curOpCall"] =
+        ocs.formatCall(findOperatorNoThrow(ocs.opId), ocs.method);
+    obj["curOpCallDuration"] = ocs.callDuration();
+  }
 
   folly::dynamic operatorsObj = folly::dynamic::object;
   int index = 0;

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -1864,6 +1864,22 @@ TaskStats Task::taskStats() const {
     } else {
       ++taskStats.numBlockedDrivers[driver->blockingReason()];
     }
+    // Find the longest running operator.
+    auto ocs = driver->opCallStatus();
+    if (!ocs.empty()) {
+      const auto callDuration = ocs.callDuration();
+      if (callDuration > taskStats.longestRunningOpCallMs) {
+        taskStats.longestRunningOpCall =
+            ocs.formatCall(driver->findOperatorNoThrow(ocs.opId), ocs.method);
+        taskStats.longestRunningOpCallMs = callDuration;
+      }
+    }
+  }
+
+  // Don't bother with operator calls running under 30 seconds.
+  if (taskStats.longestRunningOpCallMs < 30000) {
+    taskStats.longestRunningOpCall.clear();
+    taskStats.longestRunningOpCallMs = 0;
   }
 
   auto bufferManager = bufferManager_.lock();

--- a/velox/exec/TaskStats.h
+++ b/velox/exec/TaskStats.h
@@ -91,6 +91,11 @@ struct TaskStats {
   double outputBufferUtilization{0};
   /// Indicates if output buffer is over-utilized and thus blocks the producers.
   bool outputBufferOverutilized{false};
+
+  /// The longest still running operator call in "op::call" format.
+  std::string longestRunningOpCall;
+  /// The longest still running operator call's duration in ms.
+  size_t longestRunningOpCallMs{0};
 };
 
 } // namespace facebook::velox::exec


### PR DESCRIPTION
Summary:
Track the current Operator call in the Driver using
OpCallStatus structure.
Expose the longest call in the TaskStats.
It can be used to detect deadlocks and otherwise blocked calls.

Differential Revision: D50150592


