### PR TITLE
Fail if inputs contain nested nulls in compare values of min_by/max_by Presto aggregates

### DIFF
--- a/velox/functions/lib/CMakeLists.txt
+++ b/velox/functions/lib/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(
   MapConcat.cpp
   Re2Functions.cpp
   StringEncodingUtils.cpp
-  SubscriptUtil.cpp)
+  SubscriptUtil.cpp
+  CheckNestedNulls.cpp)
 
 target_link_libraries(velox_functions_lib velox_functions_util velox_vector
                       re2::re2 Folly::folly)

--- a/velox/functions/lib/CheckNestedNulls.cpp
+++ b/velox/functions/lib/CheckNestedNulls.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/functions/lib/CheckNestedNulls.h"
+
+namespace facebook::velox::functions {
+
+/// Checks nested nulls in a complex type vector. Returns true if value at
+/// specified index is null. Throws an exception if the base vector contains
+/// nulls if 'throwOnNestedNulls' is true.
+bool checkNestedNulls(
+    const DecodedVector& decoded,
+    const vector_size_t* indices,
+    vector_size_t index,
+    bool throwOnNestedNulls) {
+  if (decoded.isNullAt(index)) {
+    return true;
+  }
+
+  if (throwOnNestedNulls) {
+    VELOX_USER_CHECK(
+        !decoded.base()->containsNullAt(indices[index]),
+        "{} comparison not supported for values that contain nulls",
+        mapTypeKindToName(decoded.base()->typeKind()));
+  }
+
+  return false;
+}
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/CheckNestedNulls.h
+++ b/velox/functions/lib/CheckNestedNulls.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/vector/DecodedVector.h"
+
+namespace facebook::velox::functions {
+
+/// Checks nested nulls in a complex type vector. Returns true if value at
+/// specified index is null. Throws an exception if the base vector contains
+/// nulls if 'throwOnNestedNulls' is true.
+bool checkNestedNulls(
+    const DecodedVector& decoded,
+    const vector_size_t* indices,
+    vector_size_t index,
+    bool throwOnNestedNulls = false);
+} // namespace facebook::velox::functions

--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -539,10 +539,10 @@ class MinMaxByAggregateBase : public exec::Aggregate {
         sizeof(ComparisonAccumulatorType));
   }
 
+  const bool throwOnNestedNulls_;
   DecodedVector decodedValue_;
   DecodedVector decodedComparison_;
   DecodedVector decodedIntermediateResult_;
-  const bool throwOnNestedNulls_;
 };
 
 template <

--- a/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
+++ b/velox/functions/lib/aggregates/MinMaxByAggregatesBase.h
@@ -17,8 +17,8 @@
 
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/ContainerRowSerde.h"
+#include "velox/functions/lib/CheckNestedNulls.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
-#include "velox/functions/prestosql/aggregates/Compare.h"
 #include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::functions::aggregate {
@@ -331,7 +331,7 @@ class MinMaxByAggregateBase : public exec::Aggregate {
     const auto* indices = decodedComparison_.indices();
     if (decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
       rows.applyToSelected([&](vector_size_t i) {
-        if (velox::aggregate::prestosql::checkNestedNulls(
+        if (checkNestedNulls(
                 decodedComparison_, indices, i, throwOnNestedNulls_)) {
           return;
         }
@@ -346,8 +346,7 @@ class MinMaxByAggregateBase : public exec::Aggregate {
     } else {
       rows.applyToSelected([&](vector_size_t i) {
         if (throwOnNestedNulls_) {
-          velox::aggregate::prestosql::checkNestedNulls(
-              decodedComparison_, indices, i, throwOnNestedNulls_);
+          checkNestedNulls(decodedComparison_, indices, i, throwOnNestedNulls_);
         }
         updateValues(
             groups[i], decodedValue_, decodedComparison_, i, false, mayUpdate);
@@ -415,7 +414,7 @@ class MinMaxByAggregateBase : public exec::Aggregate {
 
     if (decodedValue_.isConstantMapping() &&
         decodedComparison_.isConstantMapping()) {
-      if (velox::aggregate::prestosql::checkNestedNulls(
+      if (checkNestedNulls(
               decodedComparison_, indices, 0, throwOnNestedNulls_)) {
         return;
       }
@@ -429,7 +428,7 @@ class MinMaxByAggregateBase : public exec::Aggregate {
     } else if (
         decodedValue_.mayHaveNulls() || decodedComparison_.mayHaveNulls()) {
       rows.applyToSelected([&](vector_size_t i) {
-        if (velox::aggregate::prestosql::checkNestedNulls(
+        if (checkNestedNulls(
                 decodedComparison_, indices, i, throwOnNestedNulls_)) {
           return;
         }
@@ -444,8 +443,7 @@ class MinMaxByAggregateBase : public exec::Aggregate {
     } else {
       rows.applyToSelected([&](vector_size_t i) {
         if (throwOnNestedNulls_) {
-          velox::aggregate::prestosql::checkNestedNulls(
-              decodedComparison_, indices, i, throwOnNestedNulls_);
+          checkNestedNulls(decodedComparison_, indices, i, throwOnNestedNulls_);
         }
         updateValues(
             group, decodedValue_, decodedComparison_, i, false, mayUpdate);

--- a/velox/functions/lib/tests/CMakeLists.txt
+++ b/velox/functions/lib/tests/CMakeLists.txt
@@ -20,7 +20,8 @@ add_executable(
   KllSketchTest.cpp
   MapConcatTest.cpp
   Re2FunctionsTest.cpp
-  ZetaDistributionTest.cpp)
+  ZetaDistributionTest.cpp
+  CheckNestedNullsTest.cpp)
 
 add_test(
   NAME velox_functions_lib_test

--- a/velox/functions/lib/tests/CheckNestedNullsTest.cpp
+++ b/velox/functions/lib/tests/CheckNestedNullsTest.cpp
@@ -1,31 +1,30 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* Copyright (c) Facebook, Inc. and its affiliates.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 
-#include "velox/functions/prestosql/aggregates/Compare.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
+#include "velox/functions/lib/CheckNestedNulls.h"
 
-namespace facebook::velox::aggregate::prestosql::test {
+namespace facebook::velox::functions::test {
+class CheckNestedNullsTest : public testing::Test,
+                             public facebook::velox::test::VectorTestBase {};
 
-class CompareTest : public testing::Test,
-                    public facebook::velox::test::VectorTestBase {};
-
-TEST_F(CompareTest, array) {
+TEST_F(CheckNestedNullsTest, array) {
   auto baseVector = makeArrayVectorFromJson<int32_t>({
       "null",
       "[6, 7]",
@@ -47,7 +46,7 @@ TEST_F(CompareTest, array) {
   ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
 }
 
-TEST_F(CompareTest, map) {
+TEST_F(CheckNestedNullsTest, map) {
   auto baseVector = makeMapVectorFromJson<int32_t, int32_t>({
       "null",
       "{4: 7, 1: 2}",
@@ -69,7 +68,7 @@ TEST_F(CompareTest, map) {
   ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
 }
 
-TEST_F(CompareTest, row) {
+TEST_F(CheckNestedNullsTest, row) {
   auto baseVector = makeRowVector(
       {
           makeFlatVector<StringView>({
@@ -99,4 +98,4 @@ TEST_F(CompareTest, row) {
       "ROW comparison not supported for values that contain nulls");
   ASSERT_FALSE(checkNestedNulls(decodedVector, indices, 2, false));
 }
-} // namespace facebook::velox::aggregate::prestosql::test
+} // namespace facebook::velox::functions::test

--- a/velox/functions/lib/tests/CheckNestedNullsTest.cpp
+++ b/velox/functions/lib/tests/CheckNestedNullsTest.cpp
@@ -1,18 +1,18 @@
 /*
-* Copyright (c) Facebook, Inc. and its affiliates.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"

--- a/velox/functions/prestosql/aggregates/Compare.cpp
+++ b/velox/functions/prestosql/aggregates/Compare.cpp
@@ -38,24 +38,4 @@ int32_t compare(
           mapTypeKindToName(decoded.base()->typeKind())));
   return result.value();
 }
-
-bool checkNestedNulls(
-    const DecodedVector& decoded,
-    const vector_size_t* indices,
-    vector_size_t index,
-    bool throwOnNestedNulls) {
-  if (decoded.isNullAt(index)) {
-    return true;
-  }
-
-  if (throwOnNestedNulls) {
-    VELOX_USER_CHECK(
-        !decoded.base()->containsNullAt(indices[index]),
-        "{} comparison not supported for values that contain nulls",
-        mapTypeKindToName(decoded.base()->typeKind()));
-  }
-
-  return false;
-}
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/Compare.h
+++ b/velox/functions/prestosql/aggregates/Compare.h
@@ -33,14 +33,4 @@ int32_t compare(
     const velox::functions::aggregate::SingleValueAccumulator* accumulator,
     const DecodedVector& decoded,
     vector_size_t index);
-
-/// Checks nested nulls in a complex type vector. Returns true if value at
-/// specified index is null. Throws an exception if the base vector contains
-/// nulls if 'throwOnNestedNulls' is true.
-bool checkNestedNulls(
-    const DecodedVector& decoded,
-    const vector_size_t* indices,
-    vector_size_t index,
-    bool throwOnNestedNulls);
-
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "velox/functions/prestosql/aggregates/Compare.h"
+#include "velox/functions/lib/CheckNestedNulls.h"
 #include "velox/functions/prestosql/aggregates/MapAggregateBase.h"
 
 namespace facebook::velox::aggregate::prestosql {
@@ -47,7 +47,8 @@ class MapAggAggregate : public MapAggregateBase<K> {
       DecodedVector decodedKeys(*keys, rows);
       const auto* indices = decodedKeys.indices();
       rows.applyToSelected([&](vector_size_t i) {
-        checkNestedNulls(decodedKeys, indices, i, throwOnNestedNulls_);
+        velox::functions::checkNestedNulls(
+            decodedKeys, indices, i, throwOnNestedNulls_);
       });
     }
 
@@ -103,7 +104,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
     const auto* indices = Base::decodedKeys_.indices();
 
     rows.applyToSelected([&](vector_size_t row) {
-      if (checkNestedNulls(
+      if (velox::functions::checkNestedNulls(
               Base::decodedKeys_, indices, row, throwOnNestedNulls_)) {
         return;
       }
@@ -129,7 +130,7 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
     auto tracker = Base::trackRowSize(group);
     rows.applyToSelected([&](vector_size_t row) {
-      if (checkNestedNulls(
+      if (velox::functions::checkNestedNulls(
               Base::decodedKeys_, indices, row, throwOnNestedNulls_)) {
         return;
       }

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -17,6 +17,7 @@
 #include <limits>
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/AggregationHook.h"
+#include "velox/functions/lib/CheckNestedNulls.h"
 #include "velox/functions/lib/aggregates/SimpleNumericAggregate.h"
 #include "velox/functions/lib/aggregates/SingleValueAccumulator.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
@@ -312,7 +313,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
       DecodedVector decoded(*input, rows, true);
       auto indices = decoded.indices();
       rows.applyToSelected([&](vector_size_t i) {
-        checkNestedNulls(decoded, indices, i, throwOnNestedNulls_);
+        velox::functions::checkNestedNulls(
+            decoded, indices, i, throwOnNestedNulls_);
       });
     }
 
@@ -388,7 +390,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     }
 
     rows.applyToSelected([&](vector_size_t i) {
-      if (checkNestedNulls(decoded, indices, i, throwOnNestedNulls_)) {
+      if (velox::functions::checkNestedNulls(
+              decoded, indices, i, throwOnNestedNulls_)) {
         return;
       }
 
@@ -411,7 +414,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
     auto baseVector = decoded.base();
 
     if (decoded.isConstantMapping()) {
-      if (checkNestedNulls(decoded, indices, 0, throwOnNestedNulls_)) {
+      if (velox::functions::checkNestedNulls(
+              decoded, indices, 0, throwOnNestedNulls_)) {
         return;
       }
 
@@ -425,7 +429,8 @@ class NonNumericMinMaxAggregateBase : public exec::Aggregate {
 
     auto accumulator = value<SingleValueAccumulator>(group);
     rows.applyToSelected([&](vector_size_t i) {
-      if (checkNestedNulls(decoded, indices, i, throwOnNestedNulls_)) {
+      if (velox::functions::checkNestedNulls(
+              decoded, indices, i, throwOnNestedNulls_)) {
         return;
       }
 

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1182,7 +1182,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
             const auto& valueType = rowType->childAt(0);
             const auto& compareType = rowType->childAt(1);
             return create<Aggregate, Comparator, isMaxFunc>(
-                resultType, valueType, compareType, errorMessage);
+                resultType, valueType, compareType, errorMessage, true);
           }
         }
       });

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1175,7 +1175,7 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
           if (isRawInput) {
             // Input is: V, C.
             return create<Aggregate, Comparator, isMaxFunc>(
-                resultType, argTypes[0], argTypes[1], errorMessage);
+                resultType, argTypes[0], argTypes[1], errorMessage, true);
           } else {
             // Input is: ROW(V, C).
             const auto& rowType = argTypes[0];

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1159,31 +1159,11 @@ exec::AggregateRegistrationResult registerMinMaxBy(const std::string& name) {
             (argTypes.size() == 1 && argTypes[0]->size() == 3);
 
         if (nAgg) {
-          if (isRawInput) {
-            // Input is: V, C, BIGINT.
-            return createNArg<NAggregate>(
-                resultType, argTypes[0], argTypes[1], errorMessage);
-          } else {
-            // Input is: ROW(BIGINT, ARRAY(C), ARRAY(V)).
-            const auto& rowType = argTypes[0];
-            const auto& compareType = rowType->childAt(1)->childAt(0);
-            const auto& valueType = rowType->childAt(2)->childAt(0);
-            return createNArg<NAggregate>(
-                resultType, valueType, compareType, errorMessage);
-          }
+          return createNArg<NAggregate>(
+              resultType, argTypes[0], argTypes[1], errorMessage);
         } else {
-          if (isRawInput) {
-            // Input is: V, C.
-            return create<Aggregate, Comparator, isMaxFunc>(
-                resultType, argTypes[0], argTypes[1], errorMessage, true);
-          } else {
-            // Input is: ROW(V, C).
-            const auto& rowType = argTypes[0];
-            const auto& valueType = rowType->childAt(0);
-            const auto& compareType = rowType->childAt(1);
-            return create<Aggregate, Comparator, isMaxFunc>(
-                resultType, valueType, compareType, errorMessage, true);
-          }
+          return create<Aggregate, Comparator, isMaxFunc>(
+              resultType, argTypes[0], argTypes[1], errorMessage, true);
         }
       });
 }

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -15,9 +15,8 @@
  */
 #include "velox/exec/Aggregate.h"
 #include "velox/exec/SetAccumulator.h"
+#include "velox/functions/lib/CheckNestedNulls.h"
 #include "velox/functions/prestosql/aggregates/AggregateNames.h"
-#include "velox/functions/prestosql/aggregates/Compare.h"
-#include "velox/vector/FlatVector.h"
 
 namespace facebook::velox::aggregate::prestosql {
 
@@ -222,7 +221,8 @@ class SetAggAggregate : public SetBaseAggregate<T> {
       DecodedVector decodedElements(*elements, rows);
       auto indices = decodedElements.indices();
       rows.applyToSelected([&](vector_size_t i) {
-        checkNestedNulls(decodedElements, indices, i, throwOnNestedNulls_);
+        velox::functions::checkNestedNulls(
+            decodedElements, indices, i, throwOnNestedNulls_);
       });
     }
 
@@ -270,7 +270,8 @@ class SetAggAggregate : public SetBaseAggregate<T> {
       Base::clearNull(group);
 
       if (throwOnNestedNulls_) {
-        checkNestedNulls(Base::decoded_, indices, i, throwOnNestedNulls_);
+        velox::functions::checkNestedNulls(
+            Base::decoded_, indices, i, throwOnNestedNulls_);
       }
 
       auto tracker = Base::trackRowSize(group);
@@ -292,7 +293,8 @@ class SetAggAggregate : public SetBaseAggregate<T> {
     auto indices = Base::decoded_.indices();
     rows.applyToSelected([&](vector_size_t i) {
       if (throwOnNestedNulls_) {
-        checkNestedNulls(Base::decoded_, indices, i, throwOnNestedNulls_);
+        velox::functions::checkNestedNulls(
+            Base::decoded_, indices, i, throwOnNestedNulls_);
       }
 
       accumulator->addValue(Base::decoded_, i, Base::allocator_);

--- a/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/tests/CMakeLists.txt
@@ -47,7 +47,6 @@ add_executable(
   ValueListTest.cpp
   VarianceAggregationTest.cpp
   MaxSizeForStatsTest.cpp
-  CompareTest.cpp
   SumDataSizeForStatsTest.cpp)
 
 add_test(

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1231,19 +1231,6 @@ TEST_F(MinMaxByComplexTypes, mapGroupBy) {
 }
 
 TEST_F(MinMaxByComplexTypes, arrayCompare) {
-  auto data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableArrayVector<int64_t>({
-          {1, 2, 3},
-          {std::nullopt, 2},
-          {6, 7, 8},
-      }),
-  });
-
   auto expected = makeRowVector({
       makeArrayVector<int64_t>({
           {1, 2, 3},
@@ -1252,12 +1239,7 @@ TEST_F(MinMaxByComplexTypes, arrayCompare) {
           {6, 7, 8},
       }),
   });
-
-  VELOX_ASSERT_THROW(
-      testAggregations(
-          {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected}),
-      "ARRAY comparison not supported for values that contain nulls");
-  data = makeRowVector({
+  auto data = makeRowVector({
       makeArrayVector<int64_t>({
           {1, 2, 3},
           {4, 5},
@@ -1265,7 +1247,7 @@ TEST_F(MinMaxByComplexTypes, arrayCompare) {
       }),
       makeNullableArrayVector<int64_t>({
           {1, 2, 3},
-          {3, std::nullopt, 4},
+          {3, 4, 5},
           {6, 7, 8},
       }),
   });
@@ -1282,7 +1264,7 @@ TEST_F(MinMaxByComplexTypes, mapCompare) {
       }),
       makeNullableMapVector<int64_t, int64_t>({
           {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, std::nullopt}}},
+          {{{1, 1}, {2, 3}}},
           {{{4, 50}}},
       }),
   });
@@ -1296,23 +1278,6 @@ TEST_F(MinMaxByComplexTypes, mapCompare) {
       }),
   });
 
-  VELOX_ASSERT_THROW(
-      testAggregations(
-          {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected}),
-      "MAP comparison not supported for values that contain nulls");
-
-  data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeNullableMapVector<int64_t, int64_t>({
-          {{{1, 1}, {2, 2}}},
-          {{{1, 1}, {2, 3}}},
-          {{{4, 50}}},
-      }),
-  });
   testAggregations(
       {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
 }
@@ -1326,7 +1291,7 @@ TEST_F(MinMaxByComplexTypes, rowCompare) {
       }),
       makeRowVector({makeNullableFlatVector<int32_t>({
           1,
-          std::nullopt,
+          2,
           3,
       })}),
   });
@@ -1340,25 +1305,108 @@ TEST_F(MinMaxByComplexTypes, rowCompare) {
       }),
   });
 
-  VELOX_ASSERT_THROW(
-      testAggregations(
-          {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected}),
-      "ROW comparison not supported for values that contain nulls");
+  testAggregations(
+      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+}
 
-  data = makeRowVector({
-      makeArrayVector<int64_t>({
-          {1, 2, 3},
-          {4, 5},
-          {6, 7, 8},
-      }),
-      makeRowVector({makeNullableFlatVector<int32_t>({
+TEST_F(MinMaxByComplexTypes, arrayCheckNulls) {
+  auto batch = makeRowVector({
+      makeFlatVector<int32_t>({
           1,
           2,
           3,
-      })}),
+      }),
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2]",
+          "[6, 7]",
+          "[2, 3]",
+      }),
+      makeFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      }),
   });
-  testAggregations(
-      {data}, {}, {"min_by(c0, c1)", "max_by(c0, c1)"}, {expected});
+
+  auto batchWithNull = makeRowVector({
+      makeFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      }),
+      makeArrayVectorFromJson<int32_t>({
+          "[1, 2]",
+          "[6, 7]",
+          "[3, null]",
+      }),
+      makeFlatVector<int32_t>({
+          1,
+          2,
+          3,
+      }),
+  });
+
+  for (const auto& expr : {"min_by(c0, c1)", "max_by(c0, c1)"}) {
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {},
+        {expr},
+        "ARRAY comparison not supported for values that contain nulls");
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {"c2"},
+        {expr},
+        "ARRAY comparison not supported for values that contain nulls");
+  }
+}
+
+TEST_F(MinMaxByComplexTypes, rowCheckNull) {
+  auto batch = makeRowVector({
+      makeFlatVector<int8_t>({1, 2, 3}),
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              "bb"_sv,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  auto batchWithNull = makeRowVector({
+      makeFlatVector<int8_t>({1, 2, 3}),
+      makeRowVector({
+          makeFlatVector<StringView>({
+              "a"_sv,
+              "b"_sv,
+              "c"_sv,
+          }),
+          makeNullableFlatVector<StringView>({
+              "aa"_sv,
+              std::nullopt,
+              "cc"_sv,
+          }),
+      }),
+      makeFlatVector<int8_t>({1, 2, 3}),
+  });
+
+  for (const auto& expr : {"min_by(c0, c1)", "max_by(c0, c1)"}) {
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {},
+        {expr},
+        "ROW comparison not supported for values that contain nulls");
+    testFailingAggregations(
+        {batch, batchWithNull},
+        {"c2"},
+        {expr},
+        "ROW comparison not supported for values that contain nulls");
+  }
 }
 
 class MinMaxByNTest : public AggregationTestBase {

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1289,11 +1289,7 @@ TEST_F(MinMaxByComplexTypes, rowCompare) {
           {4, 5},
           {6, 7, 8},
       }),
-      makeRowVector({makeNullableFlatVector<int32_t>({
-          1,
-          2,
-          3,
-      })}),
+      makeRowVector({makeNullableFlatVector<int32_t>({1, 2, 3})}),
   });
 
   auto expected = makeRowVector({
@@ -1311,39 +1307,23 @@ TEST_F(MinMaxByComplexTypes, rowCompare) {
 
 TEST_F(MinMaxByComplexTypes, arrayCheckNulls) {
   auto batch = makeRowVector({
-      makeFlatVector<int32_t>({
-          1,
-          2,
-          3,
-      }),
+      makeFlatVector<int32_t>({1, 2, 3}),
       makeArrayVectorFromJson<int32_t>({
           "[1, 2]",
           "[6, 7]",
           "[2, 3]",
       }),
-      makeFlatVector<int32_t>({
-          1,
-          2,
-          3,
-      }),
+      makeFlatVector<int32_t>({1, 2, 3}),
   });
 
   auto batchWithNull = makeRowVector({
-      makeFlatVector<int32_t>({
-          1,
-          2,
-          3,
-      }),
+      makeFlatVector<int32_t>({1, 2, 3}),
       makeArrayVectorFromJson<int32_t>({
           "[1, 2]",
           "[6, 7]",
           "[3, null]",
       }),
-      makeFlatVector<int32_t>({
-          1,
-          2,
-          3,
-      }),
+      makeFlatVector<int32_t>({1, 2, 3}),
   });
 
   for (const auto& expr : {"min_by(c0, c1)", "max_by(c0, c1)"}) {
@@ -1364,16 +1344,8 @@ TEST_F(MinMaxByComplexTypes, rowCheckNull) {
   auto batch = makeRowVector({
       makeFlatVector<int8_t>({1, 2, 3}),
       makeRowVector({
-          makeFlatVector<StringView>({
-              "a"_sv,
-              "b"_sv,
-              "c"_sv,
-          }),
-          makeNullableFlatVector<StringView>({
-              "aa"_sv,
-              "bb"_sv,
-              "cc"_sv,
-          }),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+          makeFlatVector<std::string>({"aa", "bb", "cc"})
       }),
       makeFlatVector<int8_t>({1, 2, 3}),
   });
@@ -1381,16 +1353,8 @@ TEST_F(MinMaxByComplexTypes, rowCheckNull) {
   auto batchWithNull = makeRowVector({
       makeFlatVector<int8_t>({1, 2, 3}),
       makeRowVector({
-          makeFlatVector<StringView>({
-              "a"_sv,
-              "b"_sv,
-              "c"_sv,
-          }),
-          makeNullableFlatVector<StringView>({
-              "aa"_sv,
-              std::nullopt,
-              "cc"_sv,
-          }),
+          makeFlatVector<std::string>({"a", "b", "c"}),
+          makeNullableFlatVector<std::string>({"aa", std::nullopt, "cc"}),
       }),
       makeFlatVector<int8_t>({1, 2, 3}),
   });

--- a/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxByAggregationTest.cpp
@@ -1343,10 +1343,9 @@ TEST_F(MinMaxByComplexTypes, arrayCheckNulls) {
 TEST_F(MinMaxByComplexTypes, rowCheckNull) {
   auto batch = makeRowVector({
       makeFlatVector<int8_t>({1, 2, 3}),
-      makeRowVector({
-          makeFlatVector<std::string>({"a", "b", "c"}),
-          makeFlatVector<std::string>({"aa", "bb", "cc"})
-      }),
+      makeRowVector(
+          {makeFlatVector<std::string>({"a", "b", "c"}),
+           makeFlatVector<std::string>({"aa", "bb", "cc"})}),
       makeFlatVector<int8_t>({1, 2, 3}),
   });
 


### PR DESCRIPTION
`min_by/max_by` suffers the same issue described in #6723. For example,
```SQL
presto> select min_by(col0, col1) from (values (1, array [1, 2]), 
(2, array [2, 3]), (3, array [3, null]), (4, array [3, 4])) as tbl(col0, col1);
 _col0
-------
     1
presto> select min_by(col0,col1) from (values (1, array [1, 2]),
(2, array [2, 3])) as tbl(col0,col1);
 _col0
-------
     1
presto> select min_by(col0,col1) from (values (1, array [3, null]),
(2, array [3, 4])) as tbl(col0,col1);
Query 20231010_190419_00057_2vkwe failed: ARRAY comparison
not supported for arrays with null elements
```
This PR checks nested nulls in compare values when the
compare type is a complex type. 

Similar to #6723, part of #6314
