### PR TITLE
Fix PrestoSerializerTest build on MacOS

### DIFF
--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -432,7 +432,10 @@ TEST_P(PrestoSerializerTest, scatterEncoded) {
       numNonNull, [](auto row) { return row; }, pool_.get());
 
   inner->children()[0] = BaseVector::createConstant(
-      BIGINT(), variant(11L), numNonNull, pool_.get());
+      BIGINT(),
+      variant::create<TypeKind::BIGINT>(11L),
+      numNonNull,
+      pool_.get());
   inner->children()[1] = BaseVector::wrapInDictionary(
       BufferPtr(nullptr), indices, numNonNull, inner->childAt(1));
   inner->children()[2] =


### PR DESCRIPTION
Summary:
The build is failing with

/Users/distiller/project/velox/serializers/tests/PrestoSerializerTest.cpp:435:17: error: ambiguous conversion for functional-style cast from 'long' to 'facebook::velox::variant'
      BIGINT(), variant(11L), numNonNull, pool_.get());

avoid the functional-style cast to prevent the issue

Differential Revision: D50181643


