### PR TITLE
Avoid calling resize on row vector in makeEncodingPreservedCopy

### DIFF
--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -947,9 +947,15 @@ VectorPtr VectorLoaderWrap::makeEncodingPreservedCopy(
 
   if (decoded.isConstantMapping() || decoded.isIdentityMapping()) {
     VectorPtr result;
-
     BaseVector::ensureWritable(rows, vector_->type(), vector_->pool(), result);
-    result->resize(vectorSize);
+    if (result->typeKind() == TypeKind::ROW) {
+      // Avoid calling resize on all children by adding top level nulls only.
+      // We know from the check above that result is unique and isNullsWritable.
+      result->asUnchecked<RowVector>()->appendNulls(
+          vectorSize - result->size());
+    } else {
+      result->resize(vectorSize);
+    }
     result->copy(vector_.get(), rows, nullptr);
     return result;
   }


### PR DESCRIPTION
Summary: This cause several fuzzer issues.

Differential Revision: D50205657

