### PR TITLE
Check input types when creating hash Spark functions

### DIFF
--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -5,22 +5,30 @@ Binary Functions
 .. spark:function:: hash(x, ...) -> integer
 
     Computes the hash of one or more input values using seed value of 42.
-    Not supports types like ARRAY, MAP, etc.
+    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
+    Not supports types like ARRAY, MAP, STRUCT, etc.
 
 .. spark:function:: hash_with_seed(seed, x, ...) -> integer
 
     Computes the hash of one or more input values using specified seed.
-    Not supports types like ARRAY, MAP, etc.
+    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
+    Not supports types like ARRAY, MAP, STRUCT, etc.
 
 .. spark:function:: xxhash64(x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using seed value of 42.
-    Not supports types like ARRAY, MAP, etc.
+    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
+    Not supports types like ARRAY, MAP, STRUCT, etc.
 
 .. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using specified seed.
-    Not supports types like ARRAY, MAP, etc.
+    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
+    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
+    Not supports types like ARRAY, MAP, STRUCT, etc.
 
 .. spark:function:: md5(x) -> varbinary
 

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -5,18 +5,22 @@ Binary Functions
 .. spark:function:: hash(x, ...) -> integer
 
     Computes the hash of one or more input values using seed value of 42.
+    Not supports types like ARRAY, MAP, etc.
 
 .. spark:function:: hash_with_seed(seed, x, ...) -> integer
 
     Computes the hash of one or more input values using specified seed.
+    Not supports types like ARRAY, MAP, etc.
 
 .. spark:function:: xxhash64(x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using seed value of 42.
+    Not supports types like ARRAY, MAP, etc.
 
 .. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using specified seed.
+    Not supports types like ARRAY, MAP, etc.
 
 .. spark:function:: md5(x) -> varbinary
 

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -4,30 +4,30 @@ Binary Functions
 
 .. spark:function:: hash(x, ...) -> integer
 
-    Computes the hash of one or more input values using seed value of 42. Each
-    input's type can be different from each other's.
+    Computes the hash of one or more input values using seed value of 42. For
+    multiple arguments, their types can be different.
     Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
     VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 
 .. spark:function:: hash_with_seed(seed, x, ...) -> integer
 
-    Computes the hash of one or more input values using specified seed. Each
-    input's type can be different from each other's.
+    Computes the hash of one or more input values using specified seed. For
+    multiple arguments, their types can be different.
     Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
     VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 .. spark:function:: xxhash64(x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using seed value of 42.
-    Each input's type can be different from each other's.
+    For multiple arguments, their types can be different.
     Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
     VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 .. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
 
-    Computes the xxhash64 of one or more input values using specified seed. Each
-    input's type can be different from each other's.
+    Computes the xxhash64 of one or more input values using specified seed. For
+    multiple arguments, their types can be different.
     Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
     VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 

--- a/velox/docs/functions/spark/binary.rst
+++ b/velox/docs/functions/spark/binary.rst
@@ -4,31 +4,32 @@ Binary Functions
 
 .. spark:function:: hash(x, ...) -> integer
 
-    Computes the hash of one or more input values using seed value of 42.
-    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
-    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
-    Not supports types like ARRAY, MAP, STRUCT, etc.
+    Computes the hash of one or more input values using seed value of 42. Each
+    input's type can be different from each other's.
+    Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
+    VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
+
 
 .. spark:function:: hash_with_seed(seed, x, ...) -> integer
 
-    Computes the hash of one or more input values using specified seed.
-    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
-    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
-    Not supports types like ARRAY, MAP, STRUCT, etc.
+    Computes the hash of one or more input values using specified seed. Each
+    input's type can be different from each other's.
+    Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
+    VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 .. spark:function:: xxhash64(x, ...) -> bigint
 
     Computes the xxhash64 of one or more input values using seed value of 42.
-    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
-    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
-    Not supports types like ARRAY, MAP, STRUCT, etc.
+    Each input's type can be different from each other's.
+    Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
+    VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 .. spark:function:: xxhash64_with_seed(seed, x, ...) -> bigint
 
-    Computes the xxhash64 of one or more input values using specified seed.
-    Supports types including: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT,
-    VARCHAR, VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
-    Not supports types like ARRAY, MAP, STRUCT, etc.
+    Computes the xxhash64 of one or more input values using specified seed. Each
+    input's type can be different from each other's.
+    Supported types are: BOOLEAN, TINYINT, SMALLINT, INTEGER, BIGINT, VARCHAR,
+    VARBINARY, REAL, DOUBLE, HUGEINT and TIMESTAMP.
 
 .. spark:function:: md5(x) -> varbinary
 

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -370,6 +370,8 @@ class XxHash64Function final : public exec::VectorFunction {
 
 } // namespace
 
+// Not all types are supported by now. Check types when making hash function.
+// See checkArgTypes.
 std::vector<std::shared_ptr<exec::FunctionSignature>> hashSignatures() {
   return {exec::FunctionSignatureBuilder()
               .returnType("integer")
@@ -378,9 +380,9 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> hashSignatures() {
               .build()};
 }
 
-void checkInputType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
-  for (int i = 0; i < inputArgs.size(); i++) {
-    switch (inputArgs[i].type->kind()) {
+void checkArgTypes(const std::vector<exec::VectorFunctionArg>& args) {
+  for (const auto& arg : args) {
+    switch (arg.type->kind()) {
       case TypeKind::BOOLEAN:
       case TypeKind::TINYINT:
       case TypeKind::SMALLINT:
@@ -394,8 +396,7 @@ void checkInputType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
       case TypeKind::TIMESTAMP:
         break;
       default:
-        VELOX_USER_FAIL(
-            "Unsupported type for hash: {}", inputArgs[i].type->toString())
+        VELOX_USER_FAIL("Unsupported type for hash: {}", arg.type->toString())
     }
   }
 }
@@ -404,7 +405,7 @@ std::shared_ptr<exec::VectorFunction> makeHash(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  checkInputType(inputArgs);
+  checkArgTypes(inputArgs);
   static const auto kHashFunction = std::make_shared<Murmur3HashFunction>();
   return kHashFunction;
 }
@@ -413,7 +414,7 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  checkInputType(inputArgs);
+  checkArgTypes(inputArgs);
   const auto& constantSeed = inputArgs[0].constantValue;
   if (!constantSeed || constantSeed->isNullAt(0)) {
     VELOX_USER_FAIL("{} requires a constant non-null seed argument.", name);
@@ -453,7 +454,7 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
-  checkInputType(inputArgs);
+  checkArgTypes(inputArgs);
   static const auto kXxHash64Function = std::make_shared<XxHash64Function>();
   return kXxHash64Function;
 }

--- a/velox/functions/sparksql/Hash.cpp
+++ b/velox/functions/sparksql/Hash.cpp
@@ -378,10 +378,33 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> hashSignatures() {
               .build()};
 }
 
+void checkInputType(const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  for (int i = 0; i < inputArgs.size(); i++) {
+    switch (inputArgs[i].type->kind()) {
+      case TypeKind::BOOLEAN:
+      case TypeKind::TINYINT:
+      case TypeKind::SMALLINT:
+      case TypeKind::INTEGER:
+      case TypeKind::BIGINT:
+      case TypeKind::VARCHAR:
+      case TypeKind::VARBINARY:
+      case TypeKind::REAL:
+      case TypeKind::DOUBLE:
+      case TypeKind::HUGEINT:
+      case TypeKind::TIMESTAMP:
+        break;
+      default:
+        VELOX_USER_FAIL(
+            "Unsupported type for hash: {}", inputArgs[i].type->toString())
+    }
+  }
+}
+
 std::shared_ptr<exec::VectorFunction> makeHash(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
+  checkInputType(inputArgs);
   static const auto kHashFunction = std::make_shared<Murmur3HashFunction>();
   return kHashFunction;
 }
@@ -390,6 +413,7 @@ std::shared_ptr<exec::VectorFunction> makeHashWithSeed(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
+  checkInputType(inputArgs);
   const auto& constantSeed = inputArgs[0].constantValue;
   if (!constantSeed || constantSeed->isNullAt(0)) {
     VELOX_USER_FAIL("{} requires a constant non-null seed argument.", name);
@@ -429,6 +453,7 @@ std::shared_ptr<exec::VectorFunction> makeXxHash64(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs,
     const core::QueryConfig& /*config*/) {
+  checkInputType(inputArgs);
   static const auto kXxHash64Function = std::make_shared<XxHash64Function>();
   return kXxHash64Function;
 }


### PR DESCRIPTION
The implemented spark hash functions allow any types according to their signatures, but not all types are supported actually. Here, I'm proposing a check during creating the function. Thus, we can make it fallback to other framework when check failure occurs.