### PR TITLE
Remove task remove from partition output buffer manager on task dtor

### DIFF
--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -266,17 +266,6 @@ Task::Task(
 Task::~Task() {
   TestValue::adjust("facebook::velox::exec::Task::~Task", this);
 
-  try {
-    if (hasPartitionedOutput()) {
-      if (auto bufferManager = bufferManager_.lock()) {
-        bufferManager->removeTask(taskId_);
-      }
-    }
-  } catch (const std::exception& e) {
-    LOG(WARNING) << "Caught exception in Task " << taskId()
-                 << " destructor: " << e.what();
-  }
-
   removeSpillDirectoryIfExists();
 }
 


### PR DESCRIPTION
Partition output buffer holds a shared reference to task so
task can never go destruction if its associated partition output
buffer still stays in partition output buffer manager.
This PR removes the code that remove a task's output buffer from
partition output buffer manager