### PR TITLE
Add backgroud profile collection

### DIFF
--- a/velox/common/process/CMakeLists.txt
+++ b/velox/common/process/CMakeLists.txt
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 add_library(velox_process ProcessBase.cpp StackTrace.cpp ThreadDebugInfo.cpp
-                          TraceContext.cpp)
+                          Profiler.cpp TraceContext.cpp)
 
 target_link_libraries(
   velox_process
-  PUBLIC velox_flag_definitions Folly::folly
+  PUBLIC velox_file velox_flag_definitions Folly::folly
   PRIVATE fmt::fmt gflags::gflags glog::glog)
 
 if(${VELOX_BUILD_TESTING})

--- a/velox/common/process/Profiler.cpp
+++ b/velox/common/process/Profiler.cpp
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/Profiler.h"
+#include "velox/common/file/File.h"
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#include <fcntl.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+namespace facebook::velox::process {
+
+bool Profiler::profileStarted_;
+std::thread Profiler::profileThread_;
+std::mutex Profiler::profileMutex_;
+std::shared_ptr<velox::filesystems::FileSystem> Profiler::fileSystem_;
+bool Profiler::isSleeping_;
+bool Profiler::shouldStop_;
+folly::Promise<bool> Profiler::sleepPromise_;
+
+void Profiler::copyToResult(int32_t counter, const std::string& path) {
+  int32_t fd = open("/tmp/perf", O_RDONLY);
+  if (fd < 0) {
+    return;
+  }
+  auto bufferSize = 400000;
+  char* buffer = reinterpret_cast<char*>(malloc(bufferSize));
+  auto readSize = ::read(fd, buffer, bufferSize);
+  close(fd);
+  auto target = fmt::format("{}/prof-{}", path, counter);
+  try {
+    try {
+      fileSystem_->remove(target);
+    } catch (const std::exception& e) {
+      // ignore
+    }
+    auto out = fileSystem_->openFileForWrite(target);
+    out->append(std::string_view(buffer, readSize));
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Error opening/writing " << target << ":" << e.what();
+  }
+  ::free(buffer);
+}
+
+void Profiler::makeProfileDir(std::string path) {
+  try {
+    fileSystem_->mkdir(path);
+  } catch (const std::exception& e) {
+    LOG(ERROR) << "Failed to create directory " << path << ":" << e.what();
+  }
+}
+
+void Profiler::threadFunction(std::string path) {
+  const int32_t pid = getpid();
+  makeProfileDir(path);
+  for (int32_t counter = 0;; ++counter) {
+    std::thread systemThread([&]() {
+      system(
+          fmt::format(
+              "cd /tmp; perf record --pid {};"
+              "perf report --sort symbol > /tmp/perf;"
+              "sed --in-place 's/      / /' /tmp/perf; sed --in-place 's/      / /' /tmp/perf; ",
+              pid)
+              .c_str());
+      copyToResult(counter, path);
+    });
+    folly::SemiFuture<bool> sleepFuture(false);
+    {
+      std::lock_guard<std::mutex> l(profileMutex_);
+      isSleeping_ = true;
+      sleepPromise_ = folly::Promise<bool>();
+      sleepFuture = sleepPromise_.getSemiFuture();
+    }
+    if (!shouldStop_) {
+      try {
+        auto& executor = folly::QueuedImmediateExecutor::instance();
+        std::move(sleepFuture)
+            .via(&executor)
+            .wait((std::chrono::seconds(counter < 2 ? 60 : 300)));
+      } catch (std::exception& e) {
+      }
+    }
+    {
+      std::lock_guard<std::mutex> l(profileMutex_);
+      isSleeping_ = false;
+    }
+    system("killall -2 perf");
+    systemThread.join();
+    if (shouldStop_) {
+      return;
+    }
+  }
+}
+
+bool Profiler::isRunning() {
+  std::lock_guard<std::mutex> l(profileMutex_);
+  return profileStarted_;
+}
+
+void Profiler::start(const std::string& path) {
+  {
+#if !defined(linux)
+    VELOX_FAIL("Profiler is only available for Linux");
+#endif
+    std::lock_guard<std::mutex> l(profileMutex_);
+    if (profileStarted_) {
+      return;
+    }
+    profileStarted_ = true;
+  }
+  fileSystem_ = velox::filesystems::getFileSystem(path, nullptr);
+  if (!fileSystem_) {
+    LOG(ERROR) << "Failed to find file system for " << path
+               << ". Profiler not started.";
+    return;
+  }
+  makeProfileDir(path);
+  atexit(Profiler::stop);
+  profileThread_ = std::thread([path]() { threadFunction(path); });
+}
+
+void Profiler::stop() {
+  {
+    std::lock_guard<std::mutex> l(profileMutex_);
+    shouldStop_ = true;
+    if (isSleeping_) {
+      sleepPromise_.setValue(true);
+    }
+  }
+  profileThread_.join();
+  {
+    std::lock_guard<std::mutex> l(profileMutex_);
+    profileStarted_ = false;
+  }
+  LOG(INFO) << "Stopped profiling";
+}
+
+} // namespace facebook::velox::process

--- a/velox/common/process/Profiler.h
+++ b/velox/common/process/Profiler.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
+#include <string>
+#include "velox/common/file/FileSystems.h"
+
+namespace facebook::velox::process {
+
+class Profiler {
+ public:
+  /// Starts periodic production of perf reports.
+  static void start(const std::string& path);
+
+  // Stops profiling background associated threads. Threads are stopped on
+  // return.
+  static void stop();
+
+  static bool isRunning();
+
+ private:
+  static void copyToResult(int32_t counter, const std::string& path);
+  static void makeProfileDir(std::string path);
+  static void threadFunction(std::string path);
+
+  static bool profileStarted_;
+  static std::thread profileThread_;
+  static std::mutex profileMutex_;
+  static std::shared_ptr<velox::filesystems::FileSystem> fileSystem_;
+  static bool isSleeping_;
+  static bool shouldStop_;
+  static folly::Promise<bool> sleepPromise_;
+};
+
+} // namespace facebook::velox::process

--- a/velox/common/process/tests/CMakeLists.txt
+++ b/velox/common/process/tests/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(velox_process_test TraceContextTest.cpp)
+add_executable(velox_process_test ProfilerTest.cpp TraceContextTest.cpp)
 
 add_test(velox_process_test velox_process_test)
 

--- a/velox/common/process/tests/ProfilerTest.cpp
+++ b/velox/common/process/tests/ProfilerTest.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/process/Profiler.h"
+#include <fmt/format.h>
+#include <gtest/gtest.h>
+#include <thread>
+#include "velox/common/process/TraceContext.h"
+
+using namespace facebook::velox::process;
+using namespace facebook::velox;
+
+namespace {
+int32_t fi(int32_t x) {
+  return x < 2 ? x : fi(x - 1) + fi(x - 2);
+}
+} // namespace
+
+TEST(ProfilerTest, basic) {
+  constexpr int32_t kNumThreads = 10;
+#if !defined(linux)
+  return;
+#endif
+  filesystems::registerLocalFileSystem();
+  Profiler::start("profilertest");
+  std::vector<std::thread> threads;
+  threads.reserve(kNumThreads);
+  std::atomic<int32_t> sum = 0;
+  for (int32_t i = 0; i < kNumThreads; ++i) {
+    threads.push_back(std::thread([&]() {
+      sum += fi(40);
+      std::this_thread::sleep_for(std::chrono::milliseconds(3));
+    }));
+  }
+  std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  LOG(INFO) << "Sum " << sum;
+  // The test exits during the measurement interval. We expect no
+  // crash on exit if the threads are properly joined.
+}

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -849,6 +849,12 @@ class Task : public std::enable_shared_from_this<Task> {
       Task::taskDeleted();
     }
   };
+
+  // Starts process::Profiler if profiling enabled. The profile path is named
+  // after the first Task. In Presto on Spark, this identifies the profile with
+  // the query.
+  void startProfilingLocked();
+
   friend class Task::TaskCounter;
 
   // NOTE: keep 'taskCount_' the first member so that it will be the first
@@ -1018,6 +1024,9 @@ class Task : public std::enable_shared_from_this<Task> {
 
   // Base spill directory for this task.
   std::string spillDirectory_;
+  // If constant profiling is on, directory to put results in. Derived from
+  // 'spillDirectory_'
+  std::string profileDirectory_;
 };
 
 /// Listener invoked on task completion.


### PR DESCRIPTION
Adds a backgound thread that gathers linux perf profiles of a running Velox process. The first two profiles are for one minutte and subsequent ones are for 5 minute timespanss. The profiles are collected in a directory specified when starting profiling.