### PR TITLE
Add substring_index Spark function

### DIFF
--- a/velox/docs/functions/spark/string.rst
+++ b/velox/docs/functions/spark/string.rst
@@ -179,6 +179,30 @@ Unless specified otherwise, all functions return NULL if at least one of the arg
         SELECT substring('Spark SQL', -10, 3); -- "Sp"
         SELECT substring('Spark SQL', -20, 3); -- ""
 
+.. spark:function:: substring_index(string, delim, count) -> [same as string]
+
+    Returns the substring from ``string`` before ``count`` occurrences of the delimiter ``delim``.
+    Here the ``string`` can be VARCHAR or VARBINARY and return type matches type of ``string``.
+    If ``count`` is positive, returns everything to the left of the final delimiter
+    (counting from the left). If ``count`` is negative, returns everything to the right
+    of the final delimiter (counting from the right). If ``count`` is 0, returns empty string.
+    If ``delim`` is not found or found fewer times than ``count``, returns the original input string.
+    ``delim`` is case-sensitive. It also takes into account overlapping strings. ::
+
+        SELECT substring_index('Spark.SQL', '.', 1); -- "Spark"
+        SELECT substring_index('Spark.SQL', '.', 0); -- ""
+        SELECT substring_index('Spark.SQL', '.', -1); -- "SQL"
+        SELECT substring_index('TEST.Spark.SQL', '.',2); -- "TEST.Spark"
+        SELECT substring_index('TEST.Spark.SQL', '', 0); -- ""
+        SELECT substring_index('TEST.Spark.SQL', '.', -2); -- "Spark.SQL"
+        SELECT substring_index('TEST.Spark.SQL', '.', 10); -- "TEST.Spark.SQL"
+        SELECT substring_index('TEST.Spark.SQL', '.', -12); -- "TEST.Spark.SQL"
+        SELECT substring_index('aaaaa', 'aa', 2); -- "a"
+        SELECT substring_index('aaaaa', 'aa', -4); -- "aaa"
+        SELECT substring_index('aaaaa', 'aa', 0); -- ""
+        SELECT substring_index('aaaaa', 'aa', 5); -- "aaaaa"
+        SELECT substring_index('aaaaa', 'aa', -5); -- "aaaaa"
+
 .. spark:function:: translate(string, match, replace) -> varchar
 
     Returns a new translated string. It translates the character in ``string`` by a

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -146,6 +146,8 @@ void registerFunctions(const std::string& prefix) {
       prefix + "instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(
       prefix + "length", lengthSignatures(), makeLength);
+  registerFunction<SubstringIndexFunction, Varchar, Varchar, Varchar, int32_t>(
+      {prefix + "substring_index"});
 
   registerFunction<Md5Function, Varchar, Varbinary>({prefix + "md5"});
   registerFunction<Sha1HexStringFunction, Varchar, Varbinary>(

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -20,6 +20,9 @@
 #include "folly/ssl/OpenSSLHash.h"
 #pragma GCC diagnostic pop
 
+#include <boost/locale.hpp>
+#include <codecvt>
+#include <string>
 #include "velox/expression/VectorFunction.h"
 #include "velox/functions/Macros.h"
 #include "velox/functions/UDFOutputString.h"
@@ -280,6 +283,60 @@ struct EndsWithFunction {
           str1.substr(str1.length() - str2.length(), str2.length()) == str2;
     }
     return true;
+  }
+};
+
+/// Returns the substring from str before count occurrences of the delimiter
+/// delim. If count is positive, everything to the left of the final delimiter
+/// (counting from the left) is returned. If count is negative, everything to
+/// the right of the final delimiter (counting from the right) is returned. The
+/// function substring_index performs a case-sensitive match when searching for
+/// delim.
+template <typename T>
+struct SubstringIndexFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& str,
+      const arg_type<Varchar>& delim,
+      const int32_t& count) {
+    if (count == 0) {
+      result.setEmpty();
+      return;
+    }
+
+    int64_t index;
+    if (count > 0) {
+      index = stringImpl::stringPosition<true, true>(str, delim, count);
+    } else {
+      index = stringImpl::stringPosition<true, false>(str, delim, -count);
+    }
+
+    // If 'delim' is not found or found fewer than 'count' times,
+    // return the input string directly.
+    if (index == 0) {
+      result.setNoCopy(str);
+      return;
+    }
+
+    auto start = 0;
+    auto length = str.size();
+    const auto delimLength = delim.size();
+    if (count > 0) {
+      length = index - 1;
+    } else {
+      start = index + delimLength - 1;
+      length -= start;
+    }
+
+    result.setNoCopy(StringView(str.data() + start, length));
   }
 };
 

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -140,6 +140,14 @@ class StringTest : public SparkFunctionBaseTest {
     return evaluateOnce<std::string>("left(c0, c1)", str, length);
   }
 
+  std::optional<std::string> substringIndex(
+      const std::string& str,
+      const std::string& delim,
+      int32_t count) {
+    return evaluateOnce<std::string, std::string, std::string, int32_t>(
+        "substring_index(c0, c1, c2)", str, delim, count);
+  }
+
   std::optional<std::string> overlay(
       std::optional<std::string> input,
       std::optional<std::string> replace,
@@ -368,6 +376,37 @@ TEST_F(StringTest, endsWith) {
   EXPECT_EQ(endsWith("-- hello there!", "hello there"), false);
   EXPECT_EQ(endsWith("-- hello there!", std::nullopt), std::nullopt);
   EXPECT_EQ(endsWith(std::nullopt, "abc"), std::nullopt);
+}
+
+TEST_F(StringTest, substringIndex) {
+  EXPECT_EQ(substringIndex("www.apache.org", ".", 3), "www.apache.org");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", 2), "www.apache");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", 1), "www");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", 0), "");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", -1), "org");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", -2), "apache.org");
+  EXPECT_EQ(substringIndex("www.apache.org", ".", -3), "www.apache.org");
+  // Str is empty string.
+  EXPECT_EQ(substringIndex("", ".", 1), "");
+  // Empty string delim.
+  EXPECT_EQ(substringIndex("www.apache.org", "", 1), "");
+  // Delim does not exist in str.
+  EXPECT_EQ(substringIndex("www.apache.org", "#", 2), "www.apache.org");
+  EXPECT_EQ(substringIndex("www.apache.org", "WW", 1), "www.apache.org");
+  // Delim is 2 chars.
+  EXPECT_EQ(substringIndex("www||apache||org", "||", 2), "www||apache");
+  EXPECT_EQ(substringIndex("www||apache||org", "||", -2), "apache||org");
+  // Non ascii chars.
+  EXPECT_EQ(substringIndex("大千世界大千世界", "千", 2), "大千世界大");
+
+  // Overlapped delim.
+  EXPECT_EQ(substringIndex("||||||", "|||", 3), "||");
+  EXPECT_EQ(substringIndex("||||||", "|||", -4), "|||");
+  EXPECT_EQ(substringIndex("aaaaa", "aa", 2), "a");
+  EXPECT_EQ(substringIndex("aaaaa", "aa", -4), "aaa");
+  EXPECT_EQ(substringIndex("aaaaa", "aa", 0), "");
+  EXPECT_EQ(substringIndex("aaaaa", "aa", 5), "aaaaa");
+  EXPECT_EQ(substringIndex("aaaaa", "aa", -5), "aaaaa");
 }
 
 TEST_F(StringTest, trim) {


### PR DESCRIPTION
substring_index(str, delim, count)

Returns the substring from 'str' before 'count' occurrences of the delimiter.
If 'count' is positive, returns everything to the left of the final delimiter
(counting from the left). If count is 'negative', return everything to the
right of the final delimiter (counting from the right). Performs case-sensitive
match and supports overlap. 

Spark's implementation:
https://github.com/apache/spark/blob/77aab6edb7c2b7be54cb19d40c0eeeb2c699f0f7/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/stringExpressions.scala#L1369.
Spark's unit test:
https://github.com/apache/spark/blob/deaa2f7200bb79b5340c722bc8707dd45d50a1c2/common/unsafe/src/test/java/org/apache/spark/unsafe/types/UTF8StringSuite.java#L281.