### PR TITLE
Delete the flag declaration of 'velox_use_malloc'

### DIFF
--- a/velox/common/memory/MemoryAllocator.h
+++ b/velox/common/memory/MemoryAllocator.h
@@ -29,7 +29,6 @@
 #include "velox/common/memory/Allocation.h"
 #include "velox/common/time/Timer.h"
 
-DECLARE_bool(velox_use_malloc);
 DECLARE_int32(velox_memory_pool_mb);
 DECLARE_bool(velox_time_allocations);
 


### PR DESCRIPTION
The `velox_use_malloc` flag has already been removed in #3799.