### PR TITLE
Optimize string direct column reader for inlined strings

### DIFF
--- a/velox/dwio/dwrf/reader/CMakeLists.txt
+++ b/velox/dwio/dwrf/reader/CMakeLists.txt
@@ -36,5 +36,10 @@ add_library(
   StripeStream.cpp)
 
 target_link_libraries(
-  velox_dwio_dwrf_reader velox_dwio_common velox_dwio_dwrf_common velox_caching
-  velox_dwio_dwrf_utils fmt::fmt)
+  velox_dwio_dwrf_reader
+  velox_dwio_common
+  velox_dwio_dwrf_common
+  velox_caching
+  velox_dwio_dwrf_utils
+  velox_test_util
+  fmt::fmt)

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h"
+
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/BufferUtil.h"
 #include "velox/dwio/dwrf/common/DecoderUtil.h"
 
@@ -134,18 +136,115 @@ void SelectiveStringDirectColumnReader::extractNSparse(
   lengthIndex_ = rows[row + numValues - 1] + 1;
 }
 
+namespace {
+
+#ifdef XSIMD_WITH_AVX2
+xsimd::make_sized_batch_t<uint16_t, 8> toUint16x8(xsimd::batch<uint32_t> x) {
+  auto y = _mm256_castsi128_si256(_mm256_extracti128_si256(x, 1));
+  return _mm256_castsi256_si128(_mm256_packus_epi32(x, y));
+}
+#endif
+
+bool allSmallEnough(const uint32_t* lengths, uint16_t* offsets, bool& gt4) {
+#ifdef XSIMD_WITH_AVX2
+  auto vlength = xsimd::load_unaligned(lengths);
+  static_assert(vlength.size == 8);
+  if (simd::toBitMask(vlength > xsimd::broadcast<uint32_t>(12))) {
+    return false;
+  }
+  gt4 = simd::toBitMask(vlength > xsimd::broadcast<uint32_t>(4));
+  // Convert to 128 bit vector to calculate prefix sums, because
+  // _mm256_slli_si256 is not shifting all 8 lanes together.
+  auto vlength16 = toUint16x8(vlength);
+  vlength16 += _mm_slli_si128(vlength16, 2);
+  vlength16 += _mm_slli_si128(vlength16, 4);
+  vlength16 += _mm_slli_si128(vlength16, 8);
+  offsets[0] = 0;
+  vlength16.store_unaligned(offsets + 1);
+#else
+  for (int i = 0; i < 8; ++i) {
+    if (lengths[i] > 12) {
+      return false;
+    }
+  }
+  gt4 = false;
+  for (int i = 0; i < 8; ++i) {
+    gt4 = gt4 || lengths[i] > 4;
+  }
+  offsets[0] = 0;
+  for (int i = 0; i < 8; ++i) {
+    offsets[i + 1] = offsets[i] + lengths[i];
+  }
+#endif
+  return true;
+}
+
+} // namespace
+
+template <bool kScatter, bool kGreaterThan4>
+bool SelectiveStringDirectColumnReader::try8ConsecutiveSmall(
+    const char* data,
+    const uint16_t* offsets,
+    int startRow) {
+#ifndef NDEBUG
+  bool testCoverage[] = {kScatter, kGreaterThan4};
+  common::testutil::TestValue::adjust(
+      "facebook::velox::dwrf::SelectiveStringDirectColumnReader::try8ConsecutiveSmall",
+      testCoverage);
+#endif
+  auto* result = reinterpret_cast<uint64_t*>(rawValues_);
+  // Make sure the iterations are independent with each other.
+  for (int i = 0; i < 8; ++i) {
+    unsigned j = kScatter ? outerNonNullRows_[startRow + i] : numValues_ + i;
+    uint64_t word;
+    memcpy(&word, data + offsets[i], 4);
+    uint64_t length = offsets[i + 1] - offsets[i];
+    if (kGreaterThan4 && length > 4) {
+      uint64_t word2;
+      memcpy(&word2, data + offsets[i] + 4, 8);
+      uint64_t mask = length == 12 ? -1ull : (1ull << (8 * (length - 4))) - 1;
+      result[2 * j] = length | (word << 32);
+      result[2 * j + 1] = word2 & mask;
+    } else {
+      uint64_t mask = (1ull << (8 * length)) - 1;
+      result[2 * j] = length | ((word & mask) << 32);
+      result[2 * j + 1] = 0;
+    }
+  }
+  bufferStart_ = data + offsets[8];
+  bytesToSkip_ = 0;
+  if constexpr (!kScatter) {
+    numValues_ += 8;
+  } else {
+    numValues_ = outerNonNullRows_[startRow + 7] + 1;
+  }
+  lengthIndex_ += 8;
+  return true;
+}
+
 template <bool scatter, bool sparse>
 inline bool SelectiveStringDirectColumnReader::try8Consecutive(
     int32_t start,
     const int32_t* rows,
     int32_t row) {
-  // If we haven't read in a buffer yet.
-  if (!bufferStart_) {
+  // If we haven't read in a buffer yet, or there is not enough data left.  This
+  // check is important to make sure the subsequent fast path will have enough
+  // data to read.
+  if (!bufferStart_ || bufferEnd_ - bufferStart_ - bytesToSkip_ < 8 * 12) {
     return false;
   }
   const char* data = bufferStart_ + start + bytesToSkip_;
-  if (!data || bufferEnd_ - data < start + 8 * 12) {
-    return false;
+  if constexpr (!sparse) {
+    auto* lengths = rawLengths_ + rows[row];
+    uint16_t offsets[9];
+    bool gt4;
+    if (allSmallEnough(lengths, offsets, gt4)) {
+      if (gt4) {
+        return try8ConsecutiveSmall<scatter, true>(data, offsets, row);
+      } else {
+        return try8ConsecutiveSmall<scatter, false>(data, offsets, row);
+      }
+    }
   }
   int32_t* result = reinterpret_cast<int32_t*>(rawValues_);
   int32_t resultIndex = numValues_ * 4 - 4;

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -94,6 +94,10 @@ class SelectiveStringDirectColumnReader
   template <bool scatter, bool skip>
   bool try8Consecutive(int32_t start, const int32_t* rows, int32_t row);
 
+  template <bool kScatter, bool kGreaterThan4>
+  bool
+  try8ConsecutiveSmall(const char* data, const uint16_t* offsets, int startRow);
+
   std::unique_ptr<dwio::common::IntDecoder</*isSigned*/ false>> lengthDecoder_;
   std::unique_ptr<dwio::common::SeekableInputStream> blobStream_;
   const char* bufferStart_ = nullptr;

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -348,6 +348,7 @@ target_link_libraries(
   velox_dwrf_e2e_filter_test
   velox_e2e_filter_test_base
   velox_link_libs
+  velox_test_util
   Folly::folly
   fmt::fmt
   lz4::lz4

--- a/velox/dwio/dwrf/test/E2EFilterTest.cpp
+++ b/velox/dwio/dwrf/test/E2EFilterTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "velox/common/base/Portability.h"
+#include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/tests/E2EFilterTestBase.h"
 #include "velox/dwio/dwrf/reader/DwrfReader.h"
 #include "velox/dwio/dwrf/writer/FlushPolicy.h"
@@ -244,6 +245,14 @@ TEST_F(E2EFilterTest, floatAndDouble) {
 }
 
 TEST_F(E2EFilterTest, stringDirect) {
+  testutil::TestValue::enable();
+  bool coverage[2][2]{};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::dwrf::SelectiveStringDirectColumnReader::try8ConsecutiveSmall",
+      std::function<void(bool*)>([&](bool* params) {
+        coverage[0][params[0]] = true;
+        coverage[1][params[1]] = true;
+      }));
   flushEveryNBatches_ = 1;
   testWithTypes(
       "string_val:string,"
@@ -252,11 +261,16 @@ TEST_F(E2EFilterTest, stringDirect) {
         makeStringUnique("string_val");
         makeStringUnique("string_val_2");
       },
-
       true,
       {"string_val", "string_val_2"},
       20,
       true);
+#ifndef NDEBUG
+  ASSERT_TRUE(coverage[0][0]);
+  ASSERT_TRUE(coverage[0][1]);
+  ASSERT_TRUE(coverage[1][0]);
+  ASSERT_TRUE(coverage[1][1]);
+#endif
 }
 
 TEST_F(E2EFilterTest, stringDictionary) {


### PR DESCRIPTION
Summary:
In direct string reader we need to read the length and data separately
and mix them into one `StringView`.  Presto Java does not need to do this due to
the different in-memory string representation.  This performance difference is
especially large for small strings.

We resolve this by adding a fast path
`SelectiveStringDirectColumnReader::try8ConsecutiveSmall` for small strings in
non-sparse case.  This fast path will process 8 strings in parallel, and use
efficient fixed size copy combined with bit manipulation to make it faster.

Also add in the optimization for efficiently iterating nested rows in
`SelectiveRepeatedColumnReader::makeOffsetsAndSizes`.

On a typical query these 2 optimizations together reduce CPU time by 30% and
make us 18% faster than Presto Java.

Differential Revision: D50243666


