### PR TITLE
Fix signatures of combinations Presto function

### DIFF
--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -49,7 +49,7 @@ inline void registerArrayCombinationsFunctions(const std::string& prefix) {
       ParameterBinder<CombinationsFunction, T>,
       Array<Array<T>>,
       Array<T>,
-      int64_t>({prefix + "combinations"});
+      int32_t>({prefix + "combinations"});
 }
 
 template <typename T>


### PR DESCRIPTION
In Presto, the type of the second argument is INTEGER, not BIGINT.