### PR TITLE
Add check for Skip and BackUp in PagedInputStream

### DIFF
--- a/velox/dwio/common/compression/PagedInputStream.cpp
+++ b/velox/dwio/common/compression/PagedInputStream.cpp
@@ -213,6 +213,7 @@ bool PagedInputStream::readOrSkip(const void** data, int32_t* size) {
 }
 
 void PagedInputStream::BackUp(int32_t count) {
+  VELOX_CHECK_GE(count, 0);
   if (pendingSkip_ > 0) {
     auto len = std::min<int64_t>(count, pendingSkip_);
     pendingSkip_ -= len;
@@ -258,6 +259,7 @@ bool PagedInputStream::skipAllPending() {
 }
 
 bool PagedInputStream::Skip(int32_t count) {
+  VELOX_CHECK_GE(count, 0);
   pendingSkip_ += count;
   // We never use the return value of this function so this is OK.
   return true;


### PR DESCRIPTION
Summary: `PagedInputStream::Skip` and `PagedInputStream::BackUp` should not accept negative values.  However some application might already be abusing this behavior (or some undiscovered bug) and this violates some extra check added recently down the line.  Adding this check to catch the offender.

Differential Revision: D50281344


