### PR TITLE
Fix heap buffer overflow in PrestoHasher when hashing dictionary encoded rows

### DIFF
--- a/velox/functions/prestosql/aggregates/PrestoHasher.cpp
+++ b/velox/functions/prestosql/aggregates/PrestoHasher.cpp
@@ -267,7 +267,7 @@ void PrestoHasher::hash<TypeKind::ROW>(
   BufferPtr combinedChildHashes =
       AlignedBuffer::allocate<int64_t>(elementRows.end(), baseRow->pool());
   auto* rawCombinedChildHashes = combinedChildHashes->asMutable<int64_t>();
-  std::fill_n(rawCombinedChildHashes, rows.end(), 1);
+  std::fill_n(rawCombinedChildHashes, elementRows.end(), 1);
 
   std::fill_n(rawHashes, rows.end(), 1);
 


### PR DESCRIPTION
Summary:
When PrestoHasher hashes a ROW type, if the vector is encoded and doesn't have nulls it hashes the
children at unique indices and then combines them after.

To do this it allocates a combinedChildHashes a Buffer to store the hashes of the children at unique indexes,
and elementRows a SelectivityVector for the unique indices.

combinedChildHashes is allocated to hold all the selected indices in elementRows. It's possible that
elementRows is smaller than rows (the original SelectivityVector passed in), e.g. if a DictionaryVector has a
smaller values Vector.

It looks like there's a typo that fills combinedChildHashes with rows.end() 1's, when it should be filling it with
elementRows.end() 1's.  Since elementRows.end() can be smaller than rows.end(), we can write off the end of
the memory allocated for combinedChildHashes leading to a heap buffer overflow.

Differential Revision: D50281970


