### PR TITLE
Add ability for TableScan::getOutput() to exit with no data.

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -162,6 +162,12 @@ class QueryConfig {
   /// output rows.
   static constexpr const char* kMaxOutputBatchRows = "max_output_batch_rows";
 
+  /// TableScan operator will exit getOutput() method after this many
+  /// milliseconds even if it has no data to return yet. Zero means 'no time
+  /// limit'.
+  static constexpr const char* kTableScanGetOutputTimeLimitMs =
+      "table_scan_getoutput_time_limit_ms";
+
   /// If false, the 'group by' code is forced to use generic hash mode
   /// hashtable.
   static constexpr const char* kHashAdaptivityEnabled =
@@ -376,6 +382,10 @@ class QueryConfig {
 
   uint32_t maxOutputBatchRows() const {
     return get<uint32_t>(kMaxOutputBatchRows, 10'000);
+  }
+
+  uint32_t tableScanGetOutputTimeLimitMs() const {
+    return get<uint64_t>(kTableScanGetOutputTimeLimitMs, 5'000);
   }
 
   bool hashAdaptivityEnabled() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -27,6 +27,11 @@ Generic Configuration
      - 10000
      - Max number of rows that could be return by operators from Operator::getOutput. It is used when an estimate of
        average row size is known and preferred_output_batch_bytes is used to compute the number of output rows.
+   * - table_scan_getoutput_time_limit_ms
+     - integer
+     - 5000
+     - TableScan operator will exit getOutput() method after this many milliseconds even if it has no data to return yet.
+     - Zero means 'no time limit'.
    * - abandon_partial_aggregation_min_rows
      - integer
      - 100,000

--- a/velox/exec/TableScan.h
+++ b/velox/exec/TableScan.h
@@ -107,6 +107,11 @@ class TableScan : public SourceOperator {
 
   int32_t readBatchSize_;
   int32_t maxReadBatchSize_;
+
+  // Exits getOutput() method after this many milliseconds.
+  // Zero means 'no limit'.
+  size_t getOutputTimeLimitMs_{0};
+
   double maxFilteringRatio_{0};
 
   // String shown in ExceptionContext inside DataSource and LazyVector loading.


### PR DESCRIPTION
Summary:
Add ability for TableScan::getOutput() to exit with no data.
For this we check two conditions before taking the next split to work on:
- Has our Task requested a stop for some reason. This is like the Driver does.
- Have we've been running for too long w/o results? New query config property used.

This is done to avoid long loops inside the operator for corner case queries, which
have highly filtering scan and return no rows for many splits.
This allows operator to help Driver exit the thread when the Task has requested it
and also would eliminate false positives when we collect 'stuck operator calls' stats.

Differential Revision: D50283576


