### PR TITLE
Fix TEXTFILE reading when filter on partition key but not project out

### DIFF
--- a/velox/connectors/hive/HiveDataSource.h
+++ b/velox/connectors/hive/HiveDataSource.h
@@ -80,6 +80,8 @@ class HiveDataSource : public DataSource {
           std::vector<const common::Subfield*>>& outputSubfields,
       const SubfieldFilters& filters,
       const RowTypePtr& dataColumns,
+      const std::unordered_map<std::string, std::shared_ptr<HiveColumnHandle>>&
+          partitionKeys,
       memory::MemoryPool* pool);
 
   // Internal API, made public to be accessible in unit tests.  Do not use in


### PR DESCRIPTION
Summary: TEXTFILE table is pushing down partition key filters (not project out) down to the worker (DWRF table is not doing that in contrary).  These columns are not in data columns so it will give us an error when we try to get their type and constructing subfields pruning for them.  To handle this, we need to exclude them from subfields pruning construction.

Differential Revision: D50284303


