### PR TITLE
Optimize result combination for and/or

### DIFF
--- a/velox/expression/ConjunctExpr.cpp
+++ b/velox/expression/ConjunctExpr.cpp
@@ -193,6 +193,59 @@ void ConjunctExpr::maybeReorderInputs() {
   }
 }
 
+namespace {
+// helper functions for conjuncts operating on values, nulls and active rows a
+// word at a time.
+inline void setFalseForOne(uint64_t active, uint64_t source, uint64_t& target) {
+  target &= ~active | ~source;
+}
+
+inline void setTrueForOne(uint64_t active, uint64_t source, uint64_t& target) {
+  target |= active & source;
+}
+
+inline void
+setPresentForOne(uint64_t active, uint64_t source, uint64_t& target) {
+  target |= active & source;
+}
+
+inline void
+setNonPresentForOne(uint64_t active, uint64_t source, uint64_t& target) {
+  target &= ~active | ~source;
+}
+
+inline void updateAnd(
+    uint64_t& resultValue,
+    uint64_t& resultPresent,
+    uint64_t& active,
+    uint64_t testValue,
+    uint64_t testPresent) {
+  auto testFalse = ~testValue & testPresent;
+  setFalseForOne(active, testFalse, resultValue);
+  setPresentForOne(active, testFalse, resultPresent);
+  auto resultTrue = resultValue & resultPresent;
+  setNonPresentForOne(
+      active, resultPresent & resultTrue & ~testPresent, resultPresent);
+  active &= ~testFalse;
+}
+
+inline void updateOr(
+    uint64_t& resultValue,
+    uint64_t& resultPresent,
+    uint64_t& active,
+    uint64_t testValue,
+    uint64_t testPresent) {
+  auto testTrue = testValue & testPresent;
+  setTrueForOne(active, testTrue, resultValue);
+  setPresentForOne(active, testTrue, resultPresent);
+  auto resultFalse = ~resultValue & resultPresent;
+  setNonPresentForOne(
+      active, resultPresent & resultFalse & ~testPresent, resultPresent);
+  active &= ~testTrue;
+}
+
+} // namespace
+
 void ConjunctExpr::updateResult(
     BaseVector* inputResult,
     EvalCtx& context,
@@ -246,24 +299,77 @@ void ConjunctExpr::updateResult(
       }
       return;
     default: {
-      bits::forEachSetBit(
-          activeRows->asRange().bits(),
-          activeRows->begin(),
-          activeRows->end(),
-          [&](int32_t row) {
-            if (nulls && bits::isBitNull(nulls, row)) {
-              result->setNull(row, true);
-            } else {
-              bool isTrue = bits::isBitSet(values, row);
-              if (isAnd_ && !isTrue) {
-                result->set(row, false);
-                activeRows->setValid(row, false);
-              } else if (!isAnd_ && isTrue) {
-                result->set(row, true);
-                activeRows->setValid(row, false);
+      uint64_t* resultValues = result->mutableRawValues<uint64_t>();
+      uint64_t* resultNulls = nullptr;
+      if (nulls || result->mayHaveNulls()) {
+        resultNulls = result->mutableRawNulls();
+      }
+      auto* activeBits = activeRows->asMutableRange().bits();
+      if (isAnd_) {
+        bits::forEachWord(
+            activeRows->begin(),
+            activeRows->end(),
+            [&](int32_t index, uint64_t mask) {
+              uint64_t nullWord =
+                  resultNulls ? resultNulls[index] : bits::kNotNull64;
+              uint64_t activeWord = activeBits[index] & mask;
+              updateAnd(
+                  resultValues[index],
+                  nullWord,
+                  activeWord,
+                  values[index],
+                  nulls ? nulls[index] : bits::kNotNull64);
+              if (resultNulls) {
+                resultNulls[index] = nullWord;
               }
-            }
-          });
+              activeBits[index] &= ~mask | activeWord;
+            },
+            [&](int32_t index) {
+              uint64_t nullWord =
+                  resultNulls ? resultNulls[index] : bits::kNotNull64;
+              updateAnd(
+                  resultValues[index],
+                  nullWord,
+                  activeBits[index],
+                  values[index],
+                  nulls ? nulls[index] : bits::kNotNull64);
+              if (resultNulls) {
+                resultNulls[index] = nullWord;
+              }
+            });
+      } else {
+        bits::forEachWord(
+            activeRows->begin(),
+            activeRows->end(),
+            [&](int32_t index, uint64_t mask) {
+              uint64_t nullWord =
+                  resultNulls ? resultNulls[index] : bits::kNotNull64;
+              uint64_t activeWord = activeBits[index] & mask;
+              updateOr(
+                  resultValues[index],
+                  nullWord,
+                  activeWord,
+                  values[index],
+                  nulls ? nulls[index] : bits::kNotNull64);
+              if (resultNulls) {
+                resultNulls[index] = nullWord;
+              }
+              activeBits[index] &= ~mask | activeWord;
+            },
+            [&](int32_t index) {
+              uint64_t nullWord =
+                  resultNulls ? resultNulls[index] : bits::kNotNull64;
+              updateOr(
+                  resultValues[index],
+                  nullWord,
+                  activeBits[index],
+                  values[index],
+                  nulls ? nulls[index] : bits::kNotNull64);
+              if (resultNulls) {
+                resultNulls[index] = nullWord;
+              }
+            });
+      }
       activeRows->updateBounds();
     }
   }

--- a/velox/expression/tests/CMakeLists.txt
+++ b/velox/expression/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ExprStatsTest.cpp
   CastExprTest.cpp
   CoalesceTest.cpp
+  ConjunctTest.cpp
   ConstantFlatVectorReaderTest.cpp
   MapWriterTest.cpp
   ArrayWriterTest.cpp

--- a/velox/expression/tests/ConjunctTest.cpp
+++ b/velox/expression/tests/ConjunctTest.cpp
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/init/Init.h>
+
+#include "velox/exec/PlanNodeStats.h"
+#include "velox/exec/tests/utils/AssertQueryBuilder.h"
+#include "velox/exec/tests/utils/OperatorTestBase.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/parse/Expressions.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::exec::test;
+
+class ConjunctTest : public OperatorTestBase {};
+
+TEST_F(ConjunctTest, mixed) {
+  auto mixed = makeRowVector(
+      {makeFlatVector<int32_t>(18, [](auto row) { return row; }),
+       makeFlatVector<bool>(
+           18,
+           [](auto row) { return row % 3 == 0; },
+           [](auto row) { return row % 3 == 2; }),
+       makeFlatVector<bool>(
+           18,
+           [](auto row) { return (row / 3) % 3 == 0; },
+           [](auto row) { return (row / 3) % 3 == 2; })});
+  auto plan =
+      PlanBuilder()
+          .values({mixed})
+          .project({"c0", "c1", "c2", "if (c0 <9, c1 and c2, c1 or c2)"})
+          .planNode();
+  createDuckDbTable({mixed});
+
+  assertQuery(
+      plan, "select c0, c1, c2, if (c0 < 9, c1 and c2, c1 or c2) from tmp");
+
+  // Non-null and nullable
+  auto mixedOneNull = makeRowVector(
+      {makeFlatVector<int32_t>(18, [](auto row) { return row; }),
+       makeFlatVector<bool>(18, [](auto row) { return row % 3 == 0; }),
+       makeFlatVector<bool>(
+           18,
+           [](auto row) { return (row / 3) % 3 == 0; },
+           [](auto row) { return (row / 3) % 3 == 2; })});
+  plan = PlanBuilder()
+             .values({mixedOneNull})
+             .project({"c0", "c1", "c2", "if (c0 <9, c1 and c2, c1 or c2)"})
+             .planNode();
+  createDuckDbTable({mixedOneNull});
+
+  assertQuery(
+      plan, "select c0, c1, c2, if (c0 < 9, c1 and c2, c1 or c2) from tmp");
+
+  // Both are non-null
+  auto mixedNonNull = makeRowVector(
+      {makeFlatVector<int32_t>(18, [](auto row) { return row; }),
+       makeFlatVector<bool>(18, [](auto row) { return row % 3 == 0; }),
+       makeFlatVector<bool>(18, [](auto row) { return (row / 3) % 3 == 0; })});
+  plan = PlanBuilder()
+             .values({mixedNonNull})
+             .project({"c0", "c1", "c2", "if (c0 <9, c1 and c2, c1 or c2)"})
+             .planNode();
+  createDuckDbTable({mixedNonNull});
+
+  assertQuery(
+      plan, "select c0, c1, c2, if (c0 < 9, c1 and c2, c1 or c2) from tmp");
+}
+
+TEST_F(ConjunctTest, constant) {
+  for (auto counter = 0; counter < 9; ++counter) {
+    auto allSame = makeRowVector(
+        {makeFlatVector<int32_t>(18, [&](auto row) { return row; }),
+         makeFlatVector<bool>(
+             18,
+             [&](auto row) { return counter % 3 == 0; },
+             [&](auto row) { return counter % 3 == 2; }),
+         makeFlatVector<bool>(
+             18,
+             [&](auto row) { return (counter / 3) % 3 == 0; },
+             [&](auto row) { return (counter / 3) % 3 == 2; })});
+    auto plan =
+        PlanBuilder()
+            .values({allSame})
+            .project({"c0", "c1", "c2", "if (c0 <9, c1 and c2, c1 or c2)"})
+            .planNode();
+    createDuckDbTable({allSame});
+
+    assertQuery(
+        plan, "select c0, c1, c2, if (c0 < 9, c1 and c2, c1 or c2) from tmp");
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  // Calls common init functions in the necessary order, initializing
+  // singletons, installing proper signal handlers for better debugging
+  // experience, and initialize glog and gflags.
+  folly::init(&argc, &argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
When different rows have different results for and/or, ConjunctExpr::updateResult processes the result bit by bit. This can be up to 20% of Changes this to work 64 bits at a time using &,| and ~ to calculate truth value, nullness and active rows.