### PR TITLE
Ignore abort request at leaf reclaimer instead of failing

### DIFF
--- a/velox/common/memory/MmapAllocator.cpp
+++ b/velox/common/memory/MmapAllocator.cpp
@@ -292,7 +292,8 @@ bool MmapAllocator::allocateContiguousImpl(
     } catch (const std::exception& e) {
       VELOX_MEM_LOG_EVERY_MS(WARNING, 1000)
           << "Exceeded memory reservation limit when reserve " << newPages
-          << " new pages when allocate " << numPages << " pages";
+          << " new pages when allocate " << numPages
+          << " pages, error: " << e.what();
       numAllocated_ -= totalCollateralPages;
       numMapped_ -= numCollateralUnmap;
       numExternalMapped_ -= numCollateralUnmap;

--- a/velox/common/memory/SharedArbitrator.cpp
+++ b/velox/common/memory/SharedArbitrator.cpp
@@ -439,8 +439,8 @@ void SharedArbitrator::abort(
   try {
     pool->abort(error);
   } catch (const std::exception& e) {
-    VELOX_MEM_LOG(WARNING) << "Failed to abort memory pool "
-                           << pool->toString();
+    VELOX_MEM_LOG(WARNING) << "Failed to abort memory pool " << pool->toString()
+                           << ", error: " << e.what();
   }
   // NOTE: no matter memory pool abort throws or not, it should have been marked
   // as aborted to prevent any new memory arbitration triggered from the aborted

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -229,7 +229,7 @@ void HashBuild::setupSpiller(SpillPartition* spillPartition) {
       spillConfig.writeBufferSize,
       spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
-      Spiller::pool(),
+      memory::spillMemoryPool(),
       spillConfig.executor);
 
   const int32_t numPartitions = spiller_->hashBits().numPartitions();
@@ -1075,6 +1075,7 @@ void HashBuild::reclaim(
     memory::MemoryReclaimer::Stats& stats) {
   VELOX_CHECK(canReclaim());
   auto* driver = operatorCtx_->driver();
+  VELOX_CHECK_NOT_NULL(driver);
 
   TestValue::adjust("facebook::velox::exec::HashBuild::reclaim", this);
 

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -259,7 +259,7 @@ void HashProbe::maybeSetupSpillInput(
       spillConfig.writeBufferSize,
       spillConfig.minSpillRunSize,
       spillConfig.compressionKind,
-      Spiller::pool(),
+      memory::spillMemoryPool(),
       spillConfig.executor);
   // Set the spill partitions to the corresponding ones at the build side. The
   // hash probe operator itself won't trigger any spilling.

--- a/velox/exec/MemoryReclaimer.h
+++ b/velox/exec/MemoryReclaimer.h
@@ -32,6 +32,9 @@ class MemoryReclaimer : public memory::MemoryReclaimer {
 
   void leaveArbitration() noexcept override;
 
+  void abort(memory::MemoryPool* pool, const std::exception_ptr& error)
+      override;
+
  protected:
   MemoryReclaimer() = default;
 };

--- a/velox/exec/SortBuffer.cpp
+++ b/velox/exec/SortBuffer.cpp
@@ -192,7 +192,7 @@ void SortBuffer::spill(int64_t targetRows, int64_t targetBytes) {
         spillConfig_->writeBufferSize,
         spillConfig_->minSpillRunSize,
         spillConfig_->compressionKind,
-        Spiller::pool(),
+        memory::spillMemoryPool(),
         spillConfig_->executor);
     VELOX_CHECK_EQ(spiller_->state().maxPartitions(), 1);
   }

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -173,7 +173,8 @@ Spiller::Spiller(
 
 void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
   if (!resultPtr) {
-    resultPtr = BaseVector::create<RowVector>(rowType_, rows.size(), pool());
+    resultPtr = BaseVector::create<RowVector>(
+        rowType_, rows.size(), memory::spillMemoryPool());
   } else {
     resultPtr->prepareForReuse();
     resultPtr->resize(rows.size());
@@ -768,10 +769,5 @@ void Spiller::fillSpillRuns(std::vector<SpillableStats>& statsList) {
 
 SpillStats Spiller::stats() const {
   return stats_.copy();
-}
-
-// static
-memory::MemoryPool* Spiller::pool() {
-  return memory::spillMemoryPool();
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -212,10 +212,6 @@ class Spiller {
 
   SpillStats stats() const;
 
-  /// Global memory pool for spill intermediates. ~1MB per spill executor thread
-  /// is the expected peak utilization.
-  static memory::MemoryPool* pool();
-
   std::string toString() const;
 
  private:

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -297,7 +297,6 @@ void TableWriter::MemoryReclaimer::abort(
     memory::MemoryPool* pool,
     const std::exception_ptr& /* error */) {
   VELOX_CHECK(!pool->isLeaf());
-  return;
 }
 
 // static

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -622,8 +622,9 @@ class HashJoinBuilder {
     SCOPED_TRACE(
         injectSpill ? fmt::format("With Max Spill Level: {}", maxSpillLevel)
                     : "Without Spill");
-    ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-    const uint64_t peakSpillMemoryUsage = Spiller::pool()->stats().peakBytes;
+    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    const uint64_t peakSpillMemoryUsage =
+        memory::spillMemoryPool()->stats().peakBytes;
     auto task = builder.assertResults(referenceQuery_);
     const auto statsPair = taskSpilledStats(*task);
     if (injectSpill) {
@@ -643,10 +644,12 @@ class HashJoinBuilder {
         }
         verifyTaskSpilledRuntimeStats(*task, true);
       }
-      ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-      if (statsPair.first.spilledBytes > 0 && Spiller::pool()->trackUsage()) {
-        ASSERT_GT(Spiller::pool()->stats().peakBytes, 0);
-        ASSERT_GE(Spiller::pool()->stats().peakBytes, peakSpillMemoryUsage);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      if (statsPair.first.spilledBytes > 0 &&
+          memory::spillMemoryPool()->trackUsage()) {
+        ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
+        ASSERT_GE(
+            memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);
       }
       // NOTE: if 'spillDirectory_' is not empty and spill threshold is not
       // set, the test might trigger spilling by its own.
@@ -663,7 +666,7 @@ class HashJoinBuilder {
       ASSERT_EQ(statsPair.second.spilledFiles, 0);
       verifyTaskSpilledRuntimeStats(*task, false);
     }
-    ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
+    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
     // Customized test verification.
     if (testVerifier_ != nullptr) {
       testVerifier_(task, injectSpill);

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -193,8 +193,9 @@ class OrderByTest : public OperatorTestBase {
       params.spillDirectory = spillDirectory->path;
       auto task = assertQueryOrdered(params, duckDbSql, sortingKeys);
       auto inputRows = toPlanStats(task->taskStats()).at(orderById).inputRows;
-      const uint64_t peakSpillMemoryUsage = Spiller::pool()->stats().peakBytes;
-      ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
+      const uint64_t peakSpillMemoryUsage =
+          memory::spillMemoryPool()->stats().peakBytes;
+      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
       if (inputRows > 0) {
         EXPECT_LT(0, spilledStats(*task).spilledInputBytes);
         EXPECT_LT(0, spilledStats(*task).spilledBytes);
@@ -202,10 +203,12 @@ class OrderByTest : public OperatorTestBase {
         EXPECT_LT(0, spilledStats(*task).spilledFiles);
         // NOTE: the last input batch won't go spilling.
         EXPECT_GT(inputRows, spilledStats(*task).spilledRows);
-        ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-        if (Spiller::pool()->trackUsage()) {
-          ASSERT_GT(Spiller::pool()->stats().peakBytes, 0);
-          ASSERT_GE(Spiller::pool()->stats().peakBytes, peakSpillMemoryUsage);
+        ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+        if (memory::spillMemoryPool()->trackUsage()) {
+          ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
+          ASSERT_GE(
+              memory::spillMemoryPool()->stats().peakBytes,
+              peakSpillMemoryUsage);
         }
       } else {
         EXPECT_EQ(0, spilledStats(*task).spilledInputBytes);

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -417,8 +417,9 @@ TEST_F(SortBufferTest, spill) {
     VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
     uint64_t totalNumInput = 0;
 
-    ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-    const auto peakSpillMemoryUsage = Spiller::pool()->stats().peakBytes;
+    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    const auto peakSpillMemoryUsage =
+        memory::spillMemoryPool()->stats().peakBytes;
 
     for (int i = 0; i < 3; ++i) {
       sortBuffer->addInput(fuzzer.fuzzRow(inputType_));
@@ -443,10 +444,11 @@ TEST_F(SortBufferTest, spill) {
       // spill.
       ASSERT_EQ(spillStats->spilledFiles, 2);
       sortBuffer.reset();
-      ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-      if (Spiller::pool()->trackUsage()) {
-        ASSERT_GT(Spiller::pool()->stats().peakBytes, 0);
-        ASSERT_GE(Spiller::pool()->stats().peakBytes, peakSpillMemoryUsage);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      if (memory::spillMemoryPool()->trackUsage()) {
+        ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
+        ASSERT_GE(
+            memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);
       }
     }
   }

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -102,7 +102,7 @@ void JoinSpillInputTest::setUp() {
       FLAGS_spiller_benchmark_write_buffer_size,
       FLAGS_spiller_benchmark_min_spill_run_size,
       stringToCompressionKind(FLAGS_spiller_benchmark_compression_kind),
-      Spiller::pool(),
+      memory::spillMemoryPool(),
       executor_.get());
   spiller_->setPartitionsSpilled({0});
 }

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -160,9 +160,10 @@ class SpillerTest : public exec::test::RowContainerTestBase {
     spillIndicesBuffers_.resize(numPartitions_);
     numPartitionInputs_.resize(numPartitions_, 0);
     // Check spiller memory pool properties.
-    ASSERT_EQ(Spiller::pool()->name(), "_sys.spilling");
-    ASSERT_EQ(Spiller::pool()->kind(), memory::MemoryPool::Kind::kLeaf);
-    ASSERT_TRUE(Spiller::pool()->threadSafe());
+    ASSERT_EQ(memory::spillMemoryPool()->name(), "_sys.spilling");
+    ASSERT_EQ(
+        memory::spillMemoryPool()->kind(), memory::MemoryPool::Kind::kLeaf);
+    ASSERT_TRUE(memory::spillMemoryPool()->threadSafe());
   }
 
  protected:

--- a/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
+++ b/velox/functions/lib/aggregates/tests/AggregationTestBase.cpp
@@ -731,8 +731,9 @@ void AggregationTestBase::testAggregationsImpl(
 
     auto spillDirectory = exec::test::TempDirectoryPath::create();
 
-    ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-    const auto peakSpillMemoryUsage = Spiller::pool()->stats().peakBytes;
+    ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+    const auto peakSpillMemoryUsage =
+        memory::spillMemoryPool()->stats().peakBytes;
     AssertQueryBuilder queryBuilder(builder.planNode(), duckDbQueryRunner_);
     queryBuilder.configs(config)
         .config(core::QueryConfig::kTestingSpillPct, "100")
@@ -747,9 +748,10 @@ void AggregationTestBase::testAggregationsImpl(
     auto inputRows = toPlanStats(task->taskStats()).at(partialNodeId).inputRows;
     if (inputRows > 1) {
       EXPECT_LT(0, spilledBytes(*task));
-      ASSERT_EQ(Spiller::pool()->stats().currentBytes, 0);
-      ASSERT_GT(Spiller::pool()->stats().peakBytes, 0);
-      ASSERT_GE(Spiller::pool()->stats().peakBytes, peakSpillMemoryUsage);
+      ASSERT_EQ(memory::spillMemoryPool()->stats().currentBytes, 0);
+      ASSERT_GT(memory::spillMemoryPool()->stats().peakBytes, 0);
+      ASSERT_GE(
+          memory::spillMemoryPool()->stats().peakBytes, peakSpillMemoryUsage);
     } else {
       EXPECT_EQ(0, spilledBytes(*task));
     }


### PR DESCRIPTION
Meta internal test run into abort failure when arbitrator tries to
abort a non-operator leaf memory reclaimer such as exchange client.
This PR make changes to exec::MemoryReclaimer to ignore abort
request at leaf level instead of failing request.
Some memory code cleanup