### PR TITLE
Consider load quantum in BufferedInput

### DIFF
--- a/velox/connectors/hive/HiveDataSource.cpp
+++ b/velox/connectors/hive/HiveDataSource.cpp
@@ -799,7 +799,11 @@ HiveDataSource::createBufferedInput(
       fileHandle.file,
       readerOpts.getMemoryPool(),
       dwio::common::MetricsLog::voidLog(),
-      ioStats_.get());
+      ioStats_.get(),
+      readerOpts.maxCoalesceDistance(),
+      std::nullopt,
+      &readerOpts);
+}
 }
 
 vector_size_t HiveDataSource::evaluateRemainingFilter(RowVectorPtr& rowVector) {


### PR DESCRIPTION
Takes a load quantum from an optional If ReaderOptions parameter for construction of BufferedInput.  If a non-zero load quantum is given and a single enqueud stream is is over 1.5 x load quantum, then this stream is loaded independently with a buffer size of load quantum.  In this case it is not coalesced or read together with the shorter stream in BufferedInput::load(). This is close to what Presto Java does.

Non-Velox users are not affected.