### PR TITLE
Fix zombie task caused by early task failure

### DIFF
--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -127,10 +127,16 @@ class Task : public std::enable_shared_from_this<Task> {
   /// nodes require splits and there are not enough of these.
   /// @param concurrentSplitGroups In grouped execution, maximum number of
   /// splits groups processed concurrently.
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
   static void start(
       std::shared_ptr<Task> self,
       uint32_t maxDrivers,
-      uint32_t concurrentSplitGroups = 1);
+      uint32_t concurrentSplitGroups = 1) {
+    self->start(maxDrivers, concurrentSplitGroups);
+  }
+#endif
+
+  void start(uint32_t maxDrivers, uint32_t concurrentSplitGroups = 1);
 
   /// If this returns true, this Task supports the single-threaded execution API
   /// next().
@@ -657,8 +663,12 @@ class Task : public std::enable_shared_from_this<Task> {
       const core::PlanNodeId& planNodeId,
       uint32_t pipelineId);
 
-  /// Returns task execution error message or empty string if not error
-  /// occurred. This should only be called inside mutex_ protection.
+  // Invoked to remove this task from the output buffer manager if it has set
+  // output buffer.
+  void maybeRemoveFromOutputBufferManager();
+
+  // Returns task execution error message or empty string if not error
+  // occurred. This should only be called inside mutex_ protection.
   std::string errorMessageLocked() const;
 
   class MemoryReclaimer : public exec::MemoryReclaimer {

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -99,7 +99,7 @@ class ExchangeBenchmark : public VectorTestBase {
       leafTaskIds.push_back(leafTaskId);
       auto leafTask = makeTask(leafTaskId, leafPlan, counter);
       tasks.push_back(leafTask);
-      Task::start(leafTask, taskWidth);
+      leafTask->start(taskWidth);
     }
 
     core::PlanNodePtr finalAggPlan;
@@ -117,7 +117,7 @@ class ExchangeBenchmark : public VectorTestBase {
           exec::Split(std::make_shared<exec::RemoteConnectorSplit>(taskId)));
       auto task = makeTask(taskId, finalAggPlan, i);
       tasks.push_back(task);
-      Task::start(task, taskWidth);
+      task->start(taskWidth);
       addRemoteSplits(task, leafTaskIds);
     }
 

--- a/velox/exec/tests/DriverTest.cpp
+++ b/velox/exec/tests/DriverTest.cpp
@@ -265,7 +265,7 @@ class DriverTest : public OperatorTestBase {
         [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/) {
           return exec::BlockingReason::kNotBlocked;
         });
-    task->start(task, numDrivers, 1);
+    task->start(numDrivers, 1);
     return task;
   }
 

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -120,7 +120,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
-      task->start(task, 3, 1),
+      task->start(3, 1),
       "groupedExecutionLeafNodeIds must be empty in ungrouped execution mode");
 
   // Check grouped execution without supplied leaf node ids.
@@ -129,7 +129,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
-      task->start(task, 3, 1),
+      task->start(3, 1),
       "groupedExecutionLeafNodeIds must not be empty in "
       "grouped execution mode");
 
@@ -140,7 +140,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
-      task->start(task, 3, 1),
+      task->start(3, 1),
       fmt::format(
           "Grouped execution leaf node {} is not a leaf node in any pipeline",
           projectNodeId));
@@ -153,7 +153,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
-      task->start(task, 3, 1),
+      task->start(3, 1),
       fmt::format(
           "Grouped execution leaf node {} is not a leaf node in any pipeline",
           projectNodeId));
@@ -166,7 +166,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionErrors) {
   queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   task = exec::Task::create("0", planFragment, 0, std::move(queryCtx));
   VELOX_ASSERT_THROW(
-      task->start(task, 3, 1),
+      task->start(3, 1),
       fmt::format(
           "Grouped execution leaf node {} not found or it is not a leaf node",
           localPartitionNodeId));
@@ -203,7 +203,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
   auto task =
       exec::Task::create("0", std::move(planFragment), 0, std::move(queryCtx));
   // 3 drivers max and 1 concurrent split group.
-  task->start(task, 3, 1);
+  task->start(3, 1);
 
   // All pipelines run grouped execution, so no drivers should be running.
   EXPECT_EQ(0, task->numRunningDrivers());
@@ -340,7 +340,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
     auto task = exec::Task::create(
         "0", std::move(planFragment), 0, std::move(queryCtx));
     // 3 drivers max and 1 concurrent split group.
-    task->start(task, 3, 1);
+    task->start(3, 1);
 
     // Build pipeline runs ungrouped execution, so it should have drivers
     // running.

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -70,7 +70,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
         memory::defaultMemoryManager().addRootPool(
-            queryCtx->queryId(), maxMemory));
+            queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(
         taskId,
@@ -189,7 +189,7 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
 
     auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     addHiveSplits(leafTask, filePaths_);
   }
 
@@ -205,7 +205,7 @@ TEST_F(MultiFragmentTest, aggregationSingleKey) {
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
     auto task = makeTask(finalAggTaskIds.back(), finalAggPlan, i);
     tasks.push_back(task);
-    Task::start(task, 1);
+    task->start(1);
     addRemoteSplits(task, {leafTaskId});
   }
 
@@ -276,7 +276,7 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
 
     auto leafTask = makeTask(leafTaskId, partialAggPlan, 0);
     tasks.push_back(leafTask);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     addHiveSplits(leafTask, filePaths_);
   }
 
@@ -293,7 +293,7 @@ TEST_F(MultiFragmentTest, aggregationMultiKey) {
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
     auto task = makeTask(finalAggTaskIds.back(), finalAggPlan, i);
     tasks.push_back(task);
-    Task::start(task, 1);
+    task->start(1);
     addRemoteSplits(task, {leafTaskId});
   }
 
@@ -322,7 +322,7 @@ TEST_F(MultiFragmentTest, distributedTableScan) {
                         .planNode();
 
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     addHiveSplits(leafTask, filePaths_);
 
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
@@ -368,7 +368,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
 
     auto sortTask = makeTask(sortTaskId, partialSortPlan, tasks.size());
     tasks.push_back(sortTask);
-    Task::start(sortTask, 4);
+    sortTask->start(4);
     addHiveSplits(sortTask, filePathsList[i]);
     outputType = partialSortPlan->outputType();
   }
@@ -381,7 +381,7 @@ TEST_F(MultiFragmentTest, mergeExchange) {
 
   auto task = makeTask(finalSortTaskId, finalSortPlan, 0);
   tasks.push_back(task);
-  Task::start(task, 1);
+  task->start(1);
   addRemoteSplits(task, partialSortTaskIds);
 
   auto op = PlanBuilder().exchange(outputType).planNode();
@@ -405,7 +405,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .partitionedOutput({}, 1, {"c0", "c1"})
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
 
     assertQuery(op, {leafTaskId}, "SELECT c0, c1 FROM tmp");
@@ -421,7 +421,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .partitionedOutput({}, 1, {"c3", "c0", "c2"})
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
 
     assertQuery(op, {leafTaskId}, "SELECT c3, c0, c2 FROM tmp");
@@ -439,7 +439,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                 {}, 1, {"c0", "c1", "c2", "c3", "c4", "c3", "c2", "c1", "c0"})
             .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
 
     assertQuery(
@@ -457,7 +457,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .partitionedOutput({"c5"}, kFanout, {"c2", "c0", "c3"})
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
 
     auto intermediatePlan = PlanBuilder()
                                 .exchange(leafPlan->outputType())
@@ -468,7 +468,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
       intermediateTaskIds.push_back(makeTaskId("intermediate", i));
       auto intermediateTask =
           makeTask(intermediateTaskIds.back(), intermediatePlan, i);
-      Task::start(intermediateTask, 1);
+      intermediateTask->start(1);
       addRemoteSplits(intermediateTask, {leafTaskId});
     }
 
@@ -495,7 +495,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                             })
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     leafTask->updateOutputBuffers(1, true);
 
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
@@ -522,7 +522,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .partitionedOutput({}, 1, {"c0", "c1"})
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 4);
+    leafTask->start(4);
     auto bufferMgr = OutputBufferManager::getInstance().lock();
     // Delete the results asynchronously to simulate abort from downstream.
     bufferMgr->deleteResults(leafTaskId, 0);
@@ -550,7 +550,7 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
             .planNode();
     auto leafTask =
         makeTask(leafTaskId, leafPlan, 0, nullptr, kRootMemoryLimit);
-    Task::start(leafTask, 1);
+    leafTask->start(1);
     auto op = PlanBuilder().exchange(leafPlan->outputType()).planNode();
 
     auto task =
@@ -576,7 +576,7 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
                 {"c0", "c1", "c2", "c3", "c4"})
             .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-    Task::start(leafTask, 1);
+    leafTask->start(1);
 
     auto intermediatePlan =
         PlanBuilder()
@@ -588,7 +588,7 @@ TEST_F(MultiFragmentTest, partitionedOutputWithLargeInput) {
       intermediateTaskIds.push_back(makeTaskId("intermediate", i));
       auto intermediateTask =
           makeTask(intermediateTaskIds.back(), intermediatePlan, i);
-      Task::start(intermediateTask, 1);
+      intermediateTask->start(1);
       addRemoteSplits(intermediateTask, {leafTaskId});
     }
 
@@ -614,7 +614,7 @@ TEST_F(MultiFragmentTest, broadcast) {
       PlanBuilder().values({data}).partitionedOutputBroadcast().planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
   tasks.emplace_back(leafTask);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
 
   // Make next stage tasks.
   core::PlanNodePtr finalAggPlan;
@@ -629,7 +629,7 @@ TEST_F(MultiFragmentTest, broadcast) {
     finalAggTaskIds.push_back(makeTaskId("final-agg", i));
     auto task = makeTask(finalAggTaskIds.back(), finalAggPlan, i);
     tasks.emplace_back(task);
-    Task::start(task, 1);
+    task->start(1);
     leafTask->updateOutputBuffers(i + 1, false);
     addRemoteSplits(task, {leafTaskId});
   }
@@ -681,7 +681,7 @@ TEST_F(MultiFragmentTest, roundRobinPartition) {
   auto addTask = [&](std::shared_ptr<Task> task,
                      const std::vector<std::string>& remoteTaskIds) {
     tasks.emplace_back(task);
-    Task::start(task, 1);
+    task->start(1);
     if (!remoteTaskIds.empty()) {
       addRemoteSplits(task, remoteTaskIds);
     }
@@ -721,7 +721,7 @@ TEST_F(MultiFragmentTest, replicateNullsAndAny) {
   auto addTask = [&](std::shared_ptr<Task> task,
                      const std::vector<std::string>& remoteTaskIds) {
     tasks.emplace_back(task);
-    Task::start(task, 1);
+    task->start(1);
     if (!remoteTaskIds.empty()) {
       addRemoteSplits(task, remoteTaskIds);
     }
@@ -788,7 +788,7 @@ TEST_F(MultiFragmentTest, limit) {
           .partitionedOutput({}, 1)
           .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
 
   leafTask.get()->addSplit(
       "0", exec::Split(makeHiveConnectorSplit(file->path)));
@@ -832,7 +832,7 @@ TEST_F(MultiFragmentTest, mergeExchangeOverEmptySources) {
 
     auto task = makeTask(taskId, plan, tasks.size());
     tasks.push_back(task);
-    Task::start(task, 4);
+    task->start(4);
   }
 
   auto exchangeTaskId = makeTaskId("exchange-", 0);
@@ -899,7 +899,7 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
 
   auto task = makeTask(leafTaskId, plan, tasks.size());
   tasks.push_back(task);
-  Task::start(task, 1);
+  task->start(1);
 
   // Create intermediate tasks.
   std::vector<std::string> joinTaskIds;
@@ -923,7 +923,7 @@ TEST_F(MultiFragmentTest, earlyCompletion) {
 
     auto task = makeTask(taskId, joinPlan, i);
     tasks.push_back(task);
-    Task::start(task, 4);
+    task->start(4);
 
     addRemoteSplits(task, {leafTaskId});
   }
@@ -962,7 +962,7 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
 
   auto leafTask = makeTask(leafTaskId, plan, tasks.size());
   tasks.push_back(leafTask);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
 
   // Create intermediate tasks.
   std::vector<std::string> joinTaskIds;
@@ -986,7 +986,7 @@ TEST_F(MultiFragmentTest, earlyCompletionBroadcast) {
 
     auto task = makeTask(taskId, joinPlan, i);
     tasks.push_back(task);
-    Task::start(task, 4);
+    task->start(4);
 
     leafTask->updateOutputBuffers(i + 1, false);
 
@@ -1026,7 +1026,7 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
 
   auto task = makeTask(leafTaskId, plan, tasks.size());
   tasks.push_back(task);
-  Task::start(task, 1);
+  task->start(1);
 
   // Create intermediate tasks.
   std::vector<std::string> joinTaskIds;
@@ -1060,7 +1060,7 @@ TEST_F(MultiFragmentTest, earlyCompletionMerge) {
 
     auto task = makeTask(taskId, joinPlan, i);
     tasks.push_back(task);
-    Task::start(task, 4);
+    task->start(4);
 
     addRemoteSplits(task, {leafTaskId});
   }
@@ -1176,7 +1176,7 @@ TEST_F(MultiFragmentTest, exchangeDestruction) {
                  .planNode();
 
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
   addHiveSplits(leafTask, filePaths_);
 
   auto rootPlan =
@@ -1189,7 +1189,7 @@ TEST_F(MultiFragmentTest, exchangeDestruction) {
           .planNode();
 
   auto rootTask = makeTask("root-task", rootPlan, 0);
-  Task::start(rootTask, 1);
+  rootTask->start(1);
   addRemoteSplits(rootTask, {leafTaskId});
 
   ASSERT_FALSE(waitForTaskCompletion(rootTask.get(), 1'000'000));
@@ -1220,7 +1220,7 @@ TEST_F(MultiFragmentTest, cancelledExchange) {
   auto exchangeTask =
       makeTask("output.0.0.1", planFragmentWithExchange.planNode, 0);
   // Start the task and abort it straight away.
-  Task::start(exchangeTask, 2);
+  exchangeTask->start(2);
   exchangeTask->requestAbort();
 
   /* sleep override */
@@ -1308,7 +1308,7 @@ TEST_F(MultiFragmentTest, customPlanNodeWithExchangeClient) {
   auto leafPlan =
       PlanBuilder().values(vectors_).partitionedOutput({}, 1).planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
 
   CursorParameters params;
   core::PlanNodeId testNodeId;
@@ -1359,7 +1359,7 @@ DEBUG_ONLY_TEST_F(
                                    .partitionedOutput({}, 1)
                                    .planNode();
   auto leafTask = makeTask(leafTaskId, leafPlan, 0);
-  Task::start(leafTask, 1);
+  leafTask->start(1);
   addHiveSplits(leafTask, filePaths_);
 
   const std::string kRootTaskId("root-task");
@@ -1401,7 +1401,7 @@ DEBUG_ONLY_TEST_F(
       [](RowVectorPtr /*unused*/, ContinueFuture* /*unused*/)
           -> BlockingReason { return BlockingReason::kNotBlocked; },
       kRootMemoryLimit);
-  Task::start(rootTask, 1);
+  rootTask->start(1);
   rootTask->addSplit("0", remoteSplit(leafTaskId));
   blockNoMoreSplits.await([&]() { return noMoreSplits.load(); });
   rootTask->noMoreSplits("0");
@@ -1419,7 +1419,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
       PlanBuilder().tableScan(rowType_).partitionedOutput({}, 1).planNode();
 
   auto task = makeTask(taskId, leafPlan, 0);
-  Task::start(task, 1);
+  task->start(1);
   addHiveSplits(task, filePaths_);
 
   auto bufferManager = OutputBufferManager::getInstance().lock();
@@ -1498,7 +1498,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithProblematicRemainingRemoteSplits) {
                   .planNode();
   auto taskId = makeTaskId("final", 0);
   auto task = makeTask(taskId, plan, 0);
-  Task::start(task, 2);
+  task->start(2);
 
   // Wait for all drivers to be blocked, so that the promises will be made.
   bool allDriversBlocked = false;
@@ -1547,7 +1547,7 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {
                              .planNode();
 
   auto partialSortTask = makeTask(sortTaskId, partialSortPlan, 1);
-  Task::start(partialSortTask, 1);
+  partialSortTask->start(1);
   addHiveSplits(partialSortTask, filePaths);
 
   std::atomic<bool> blockMergeOnce{true};
@@ -1573,7 +1573,7 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, mergeWithEarlyTermination) {
                            .partitionedOutput({}, 1)
                            .planNode();
   auto finalSortTask = makeTask(finalSortTaskId, finalSortPlan, 0);
-  Task::start(finalSortTask, 1);
+  finalSortTask->start(1);
   addRemoteSplits(finalSortTask, partialSortTaskIds);
 
   mergeIsBlockedReady.store(true);
@@ -1680,12 +1680,9 @@ class DataFetcher {
 /// sizes to no more than 1MB give and take 30%.
 TEST_F(MultiFragmentTest, maxBytes) {
   std::string s(25, 'x');
-  // Keep the row count under 7000 to avoid hitting the row limit in the
-  // operator instead.
   auto data = makeRowVector({
-      makeFlatVector<int64_t>(5'000, [](auto row) { return row; }),
-      makeFlatVector<int64_t>(5'000, [](auto row) { return row; }),
-      makeConstant(StringView(s), 5'000),
+      makeFlatVector<int64_t>(10'000, [](auto row) { return row; }),
+      makeConstant(StringView(s), 10'000),
   });
 
   auto plan = PlanBuilder()
@@ -1701,7 +1698,7 @@ TEST_F(MultiFragmentTest, maxBytes) {
 
     SCOPED_TRACE(taskId);
     auto task = makeTask(taskId, plan, 0);
-    Task::start(task, 1);
+    task->start(1);
     task->updateOutputBuffers(1, true);
 
     // Allow for data to accumulate.
@@ -1762,13 +1759,13 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, exchangeStatsOnFailure) {
 
   auto producerTaskId = makeTaskId("producer", 0);
   auto producerTask = makeTask(producerTaskId, producerPlan, 0);
-  Task::start(producerTask, 1);
+  producerTask->start(1);
   producerTask->updateOutputBuffers(1, true);
 
   auto plan = PlanBuilder().exchange(producerPlan->outputType()).planNode();
 
   auto task = makeTask("t", plan, 0, noopConsumer());
-  Task::start(task, 4);
+  task->start(4);
   task->addSplit("0", remoteSplit(producerTaskId));
   task->noMoreSplits("0");
 
@@ -1783,5 +1780,59 @@ DEBUG_ONLY_TEST_F(MultiFragmentTest, exchangeStatsOnFailure) {
   ASSERT_TRUE(waitForTaskCompletion(producerTask.get(), 3'000'000));
 }
 
+TEST_F(MultiFragmentTest, earlyTaskFailure) {
+  setupSources(1, 10);
+
+  const auto partialSortTaskId = makeTaskId("partialSortBy", 0);
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto partialSortPlan = PlanBuilder(planNodeIdGenerator)
+                             .localMerge(
+                                 {"c0"},
+                                 {PlanBuilder(planNodeIdGenerator)
+                                      .tableScan(rowType_)
+                                      .orderBy({"c0"}, true)
+                                      .planNode()})
+                             .partitionedOutput({}, 1)
+                             .planNode();
+  for (bool internalFailure : {false, true}) {
+    SCOPED_TRACE(fmt::format("internalFailure: {}", internalFailure));
+
+    auto partialSortTask = makeTask(partialSortTaskId, partialSortPlan, 1);
+    partialSortTask->start(1);
+    addHiveSplits(partialSortTask, filePaths_);
+    auto outputType = partialSortPlan->outputType();
+
+    auto finalSortTaskId = makeTaskId("finalSortBy", 0);
+    auto finalSortPlan = PlanBuilder()
+                             .mergeExchange(outputType, {"c0"})
+                             .partitionedOutput({}, 1)
+                             .planNode();
+
+    auto finalSortTask = makeTask(finalSortTaskId, finalSortPlan, 0);
+    if (internalFailure) {
+      try {
+        VELOX_FAIL("memoryAbortTest");
+      } catch (const VeloxRuntimeError& e) {
+        finalSortTask->pool()->abort(std::current_exception());
+      }
+    } else {
+      finalSortTask->requestAbort().wait();
+    }
+
+    finalSortTask->start(1);
+    addRemoteSplits(finalSortTask, std::vector<std::string>{partialSortTaskId});
+    partialSortTask->requestAbort().wait();
+
+    if (internalFailure) {
+      ASSERT_TRUE(waitForTaskFailure(finalSortTask.get()))
+          << finalSortTask->taskId();
+    } else {
+      ASSERT_TRUE(waitForTaskAborted(finalSortTask.get()))
+          << finalSortTask->taskId();
+    }
+    ASSERT_TRUE(waitForTaskAborted(partialSortTask.get()))
+        << partialSortTask->taskId();
+  }
+}
 } // namespace
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -929,7 +929,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
     auto task = Task::create(
         "t0", plan, 0, std::make_shared<core::QueryCtx>(driverExecutor_.get()));
 
-    task->start(task, 1, 1);
+    task->start(1, 1);
 
     ASSERT_TRUE(task->updateOutputBuffers(10, true /*noMoreBuffers*/));
 
@@ -943,7 +943,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
     auto task = Task::create(
         "t1", plan, 0, std::make_shared<core::QueryCtx>(driverExecutor_.get()));
 
-    task->start(task, 1, 1);
+    task->start(1, 1);
 
     ASSERT_TRUE(task->updateOutputBuffers(5, false));
     ASSERT_TRUE(task->updateOutputBuffers(10, false));
@@ -1308,7 +1308,7 @@ TEST_F(TaskTest, driverCreationMemoryAllocationCheck) {
         std::make_shared<core::QueryCtx>());
     if (singleThreadExecution) {
       VELOX_ASSERT_THROW(
-          Task::start(badTask, 1), "Unexpected memory pool allocations");
+          badTask->start(1), "Unexpected memory pool allocations");
     } else {
       VELOX_ASSERT_THROW(badTask->next(), "Unexpected memory pool allocations");
     }

--- a/velox/exec/tests/utils/Cursor.cpp
+++ b/velox/exec/tests/utils/Cursor.cpp
@@ -206,7 +206,7 @@ TaskCursor::TaskCursor(const CursorParameters& params)
 void TaskCursor::start() {
   if (!started_) {
     started_ = true;
-    exec::Task::start(task_, maxDrivers_, numConcurrentSplitGroups_);
+    task_->start(maxDrivers_, numConcurrentSplitGroups_);
     queue_->setNumProducers(numSplitGroups_ * task_->numOutputDrivers());
   }
 }


### PR DESCRIPTION
In Prestissimo, a velox task can be terminated by coordinator even before
it starts execution. This could lead to zombie task as the output buffer manager
will hold a reference on the task, and only the task terminate will remove the
task from the output buffer manager.
This PR checks the early task termination during the task start and verified with
unit test.