### PR TITLE
Build hash table while adding input rows for left semi and anti join

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -535,7 +535,7 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, reclaimToJoinBuilder) {
     folly::EventCount taskPauseWait;
     auto taskPauseWaitKey = taskPauseWait.prepareWait();
 
-    const auto fakeAllocationSize = kMemoryCapacity - (32L << 20);
+    const auto fakeAllocationSize = kMemoryCapacity - (2L << 20);
 
     std::atomic<bool> injectAllocationOnce{true};
     fakeOperatorFactory_->setAllocationCallback([&](Operator* op) {

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -148,6 +148,12 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialTopNRowNumberMinPct =
       "abandon_partial_topn_row_number_min_pct";
 
+  static constexpr const char* kAbandonBuildNoDupHashMinRows =
+      "abandon_build_no_dup_hash_min_rows";
+
+  static constexpr const char* kAbandonBuildNoDupHashMinPct =
+      "abandon_build_no_dup_hash_min_pct";
+
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "max_page_partitioning_buffer_size";
 
@@ -383,6 +389,14 @@ class QueryConfig {
 
   int32_t abandonPartialTopNRowNumberMinPct() const {
     return get<int32_t>(kAbandonPartialTopNRowNumberMinPct, 80);
+  }
+
+  int32_t abandonBuildNoDupHashMinRows() const {
+    return get<int32_t>(kAbandonBuildNoDupHashMinRows, 100'000);
+  }
+
+  int32_t abandonBuildNoDupHashMinPct() const {
+    return get<int32_t>(kAbandonBuildNoDupHashMinPct, 80);
   }
 
   uint64_t maxSpillRunRows() const {

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -95,9 +95,11 @@ HashBuild::HashBuild(
     types.emplace_back(inputType->childAt(channel));
   }
 
+  dropDuplicates_ = canDropDuplicates(joinNode_);
+
   // Identify the non-key build side columns and make a decoder for each.
   const int32_t numDependents = inputType->size() - numKeys;
-  if (numDependents > 0) {
+  if (!dropDuplicates_ && numDependents > 0) {
     // Number of join keys (numKeys) may be less then number of input columns
     // (inputType->size()). In this case numDependents is negative and cannot be
     // used to call 'reserve'. This happens when we join different probe side
@@ -106,12 +108,16 @@ HashBuild::HashBuild(
     dependentChannels_.reserve(numDependents);
     decoders_.reserve(numDependents);
   }
-  for (auto i = 0; i < inputType->size(); ++i) {
-    if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
-      dependentChannels_.emplace_back(i);
-      decoders_.emplace_back(std::make_unique<DecodedVector>());
-      names.emplace_back(inputType->nameOf(i));
-      types.emplace_back(inputType->childAt(i));
+  if (!dropDuplicates_) {
+    // For left semi and anti join with no extra filter, hash table does not
+    // store dependent columns.
+    for (auto i = 0; i < inputType->size(); ++i) {
+      if (keyChannelMap_.find(i) == keyChannelMap_.end()) {
+        dependentChannels_.emplace_back(i);
+        decoders_.emplace_back(std::make_unique<DecodedVector>());
+        names.emplace_back(inputType->nameOf(i));
+        types.emplace_back(inputType->childAt(i));
+      }
     }
   }
 
@@ -159,11 +165,6 @@ void HashBuild::setupTable() {
             .minTableRowsForParallelJoinBuild(),
         pool());
   } else {
-    // (Left) semi and anti join with no extra filter only needs to know whether
-    // there is a match. Hence, no need to store entries with duplicate keys.
-    dropDuplicates_ = !joinNode_->filter() &&
-        (joinNode_->isLeftSemiFilterJoin() ||
-         joinNode_->isLeftSemiProjectJoin() || isAntiJoin(joinType_));
     // Right semi join needs to tag build rows that were probed.
     const bool needProbedFlag = joinNode_->isRightSemiFilterJoin();
     if (isLeftNullAwareJoinWithFilter(joinNode_)) {
@@ -407,8 +408,7 @@ void HashBuild::addInput(RowVectorPtr input) {
           input,
           activeRows_,
           false,
-          isInputFromSpill() ? spillConfig_->startPartitionBit
-                             : BaseHashTable::kNoSpillInputStartPartitionBit);
+          BaseHashTable::kNoSpillInputStartPartitionBit);
       if (lookup_->rows.empty()) {
         return;
       }

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -67,7 +67,11 @@ HashBuild::HashBuild(
       joinBridge_(operatorCtx_->task()->getHashJoinBridgeLocked(
           operatorCtx_->driverCtx()->splitGroupId,
           planNodeId())),
-      keyChannelMap_(joinNode_->rightKeys().size()) {
+      keyChannelMap_(joinNode_->rightKeys().size()),
+      abandonBuildNoDupHashMinRows_(
+          driverCtx->queryConfig().abandonBuildNoDupHashMinRows()),
+      abandonBuildNoDupHashMinPct_(
+          driverCtx->queryConfig().abandonBuildNoDupHashMinPct()) {
   VELOX_CHECK(pool()->trackUsage());
   VELOX_CHECK_NOT_NULL(joinBridge_);
 
@@ -145,6 +149,7 @@ void HashBuild::setupTable() {
   if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
       joinNode_->isRightSemiProjectJoin()) {
     // Do not ignore null keys.
+    ignoreNullKeys_ = false;
     table_ = HashTable<false>::createForJoin(
         std::move(keyHashers),
         dependentTypes,
@@ -157,7 +162,7 @@ void HashBuild::setupTable() {
   } else {
     // (Left) semi and anti join with no extra filter only needs to know whether
     // there is a match. Hence, no need to store entries with duplicate keys.
-    const bool dropDuplicates = !joinNode_->filter() &&
+    dropDuplicates_ = !joinNode_->filter() &&
         (joinNode_->isLeftSemiFilterJoin() ||
          joinNode_->isLeftSemiProjectJoin() || isAntiJoin(joinType_));
     // Right semi join needs to tag build rows that were probed.
@@ -165,10 +170,11 @@ void HashBuild::setupTable() {
     if (isLeftNullAwareJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // or left semi project join with filter set.
+      ignoreNullKeys_ = false;
       table_ = HashTable<false>::createForJoin(
           std::move(keyHashers),
           dependentTypes,
-          !dropDuplicates, // allowDuplicates
+          !dropDuplicates_, // allowDuplicates
           needProbedFlag, // hasProbedFlag
           operatorCtx_->driverCtx()
               ->queryConfig()
@@ -179,7 +185,7 @@ void HashBuild::setupTable() {
       table_ = HashTable<true>::createForJoin(
           std::move(keyHashers),
           dependentTypes,
-          !dropDuplicates, // allowDuplicates
+          !dropDuplicates_, // allowDuplicates
           needProbedFlag, // hasProbedFlag
           operatorCtx_->driverCtx()
               ->queryConfig()
@@ -187,6 +193,8 @@ void HashBuild::setupTable() {
           pool());
     }
   }
+  lookup_ = std::make_unique<HashLookup>(table_->hashers());
+  lookup_->reset(1);
   analyzeKeys_ = table_->hashMode() != BaseHashTable::HashMode::kHash;
 }
 
@@ -379,6 +387,29 @@ void HashBuild::addInput(RowVectorPtr input) {
   spillInput(input);
   if (!activeRows_.hasSelections()) {
     return;
+  }
+
+  numInputRows_ += input->size();
+
+  if (dropDuplicates_) {
+    const bool abandonEarly = abandonBuildNoDupHashEarly(table_->numDistinct());
+    if (abandonEarly) {
+      // The hash table is no longer directly constructed in addInput. The data
+      // that was previously inserted into the hash table is already in the
+      // RowContainer.
+      addRuntimeStat("abandonBuildNoDupHash", RuntimeCounter(1));
+      dropDuplicates_ = false;
+      table_->joinTableMayHaveDuplicates();
+    } else {
+      table_->prepareForGroupProbe(
+          *lookup_,
+          input,
+          activeRows_,
+          ignoreNullKeys_,
+          BaseHashTable::kNoSpillInputStartPartitionBit);
+      table_->groupProbe(*lookup_);
+      return;
+    }
   }
 
   if (analyzeKeys_ && hashes_.size() < activeRows_.end()) {
@@ -879,6 +910,7 @@ void HashBuild::setupSpillInput(HashJoinBridge::SpillInput spillInput) {
   setupTable();
   setupSpiller(spillInput.spillPartition.get());
   stateCleared_ = false;
+  numInputRows_ = 0;
 
   // Start to process spill input.
   processSpillInput();
@@ -1180,5 +1212,11 @@ void HashBuild::close() {
     spiller_.reset();
     table_.reset();
   }
+}
+
+bool HashBuild::abandonBuildNoDupHashEarly(int64_t numDistinct) const {
+  VELOX_CHECK(dropDuplicates_);
+  return numInputRows_ > abandonBuildNoDupHashMinRows_ &&
+      100 * numDistinct / numInputRows_ >= abandonBuildNoDupHashMinPct_;
 }
 } // namespace facebook::velox::exec

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -149,7 +149,6 @@ void HashBuild::setupTable() {
   if (joinNode_->isRightJoin() || joinNode_->isFullJoin() ||
       joinNode_->isRightSemiProjectJoin()) {
     // Do not ignore null keys.
-    ignoreNullKeys_ = false;
     table_ = HashTable<false>::createForJoin(
         std::move(keyHashers),
         dependentTypes,
@@ -170,7 +169,6 @@ void HashBuild::setupTable() {
     if (isLeftNullAwareJoinWithFilter(joinNode_)) {
       // We need to check null key rows in build side in case of null-aware anti
       // or left semi project join with filter set.
-      ignoreNullKeys_ = false;
       table_ = HashTable<false>::createForJoin(
           std::move(keyHashers),
           dependentTypes,
@@ -389,24 +387,31 @@ void HashBuild::addInput(RowVectorPtr input) {
     return;
   }
 
-  numInputRows_ += input->size();
+  numInputRows_ += activeRows_.countSelected();
 
-  if (dropDuplicates_) {
+  if (dropDuplicates_ && !abandonBuildNoDupHash_) {
     const bool abandonEarly = abandonBuildNoDupHashEarly(table_->numDistinct());
     if (abandonEarly) {
       // The hash table is no longer directly constructed in addInput. The data
       // that was previously inserted into the hash table is already in the
       // RowContainer.
       addRuntimeStat("abandonBuildNoDupHash", RuntimeCounter(1));
-      dropDuplicates_ = false;
+      abandonBuildNoDupHash_ = true;
       table_->joinTableMayHaveDuplicates();
     } else {
+      // Before this step, all rows containing null keys that need to be
+      // excluded have already been excluded. The ignoreNullKeys parameter is
+      // no longer effective.
       table_->prepareForGroupProbe(
           *lookup_,
           input,
           activeRows_,
-          ignoreNullKeys_,
-          BaseHashTable::kNoSpillInputStartPartitionBit);
+          false,
+          isInputFromSpill() ? spillConfig_->startPartitionBit
+                             : BaseHashTable::kNoSpillInputStartPartitionBit);
+      if (lookup_->rows.empty()) {
+        return;
+      }
       table_->groupProbe(*lookup_);
       return;
     }
@@ -775,6 +780,7 @@ bool HashBuild::finishHashBuild() {
         std::move(otherTables),
         allowParallelJoinBuild ? operatorCtx_->task()->queryCtx()->executor()
                                : nullptr,
+        dropDuplicates_,
         isInputFromSpill() ? spillConfig()->startPartitionBit
                            : BaseHashTable::kNoSpillInputStartPartitionBit);
   }

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -208,6 +208,11 @@ class HashBuild final : public Operator {
   // not.
   bool nonReclaimableState() const;
 
+  // True if we have enough rows and not enough duplicate join keys, i.e. more
+  // than 'abandonBuildNoDuplicatesHashMinRows_' rows and more than
+  // 'abandonBuildNoDuplicatesHashMinPct_' % of rows are unique.
+  bool abandonBuildNoDupHashEarly(int64_t numDistinct) const;
+
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 
   const core::JoinType joinType_;
@@ -245,6 +250,7 @@ class HashBuild final : public Operator {
 
   // Container for the rows being accumulated.
   std::unique_ptr<BaseHashTable> table_;
+  std::unique_ptr<HashLookup> lookup_;
 
   // Key channels in 'input_'
   std::vector<column_index_t> keyChannels_;
@@ -272,6 +278,13 @@ class HashBuild final : public Operator {
   // True if this is a build side of an anti or left semi project join and has
   // at least one entry with null join keys.
   bool joinHasNullKeys_{false};
+
+  // Indicates whether the hash table ignore null keys.
+  bool ignoreNullKeys_{false};
+
+  // Indicates whether drop duplicate rows. Rows containing duplicate keys
+  // can be removed for left semi and anti join.
+  bool dropDuplicates_{false};
 
   // The type used to spill hash table which might attach a boolean column to
   // record the probed flag if 'needProbedFlagSpill_' is true.
@@ -311,6 +324,18 @@ class HashBuild final : public Operator {
 
   // Maps key channel in 'input_' to channel in key.
   folly::F14FastMap<column_index_t, column_index_t> keyChannelMap_;
+
+  // Count the number of input rows. It is reset on partial aggregation output
+  // flush.
+  int64_t numInputRows_ = 0;
+
+  // Minimum number of rows to see before deciding to give up build no
+  // duplicates hash table.
+  const int32_t abandonBuildNoDupHashMinRows_;
+  // Min unique rows pct for give up build no duplicates hash table. If more
+  // than this many rows are unique, build hash table in addInput phase is not
+  // worthwhile.
+  const int32_t abandonBuildNoDupHashMinPct_;
 };
 
 inline std::ostream& operator<<(std::ostream& os, HashBuild::State state) {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -279,12 +279,10 @@ class HashBuild final : public Operator {
   // at least one entry with null join keys.
   bool joinHasNullKeys_{false};
 
-  // Indicates whether the hash table ignore null keys.
-  bool ignoreNullKeys_{false};
-
   // Indicates whether drop duplicate rows. Rows containing duplicate keys
   // can be removed for left semi and anti join.
   bool dropDuplicates_{false};
+  bool abandonBuildNoDupHash_{false};
 
   // The type used to spill hash table which might attach a boolean column to
   // record the probed flag if 'needProbedFlagSpill_' is true.

--- a/velox/exec/HashJoinBridge.cpp
+++ b/velox/exec/HashJoinBridge.cpp
@@ -192,6 +192,15 @@ bool isLeftNullAwareJoinWithFilter(
       joinNode->isNullAware() && (joinNode->filter() != nullptr);
 }
 
+bool canDropDuplicates(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode) {
+  // Left semi and anti join with no extra filter only needs to know whether
+  // there is a match. Hence, no need to store entries with duplicate keys.
+  return !joinNode->filter() &&
+      (joinNode->isLeftSemiFilterJoin() || joinNode->isLeftSemiProjectJoin() ||
+       joinNode->isAntiJoin());
+}
+
 uint64_t HashJoinMemoryReclaimer::reclaim(
     memory::MemoryPool* pool,
     uint64_t targetBytes,

--- a/velox/exec/HashJoinBridge.h
+++ b/velox/exec/HashJoinBridge.h
@@ -145,6 +145,11 @@ class HashJoinBridge : public JoinBridge {
 bool isLeftNullAwareJoinWithFilter(
     const std::shared_ptr<const core::HashJoinNode>& joinNode);
 
+// Indicates if 'joinNode' can drop duplicate rows with same join key. For left
+// semi and anti join, it is not necessary to store duplicate rows.
+bool canDropDuplicates(
+    const std::shared_ptr<const core::HashJoinNode>& joinNode);
+
 class HashJoinMemoryReclaimer final : public MemoryReclaimer {
  public:
   static std::unique_ptr<memory::MemoryReclaimer> create() {

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -1854,13 +1854,18 @@ void HashProbe::prepareTableSpill(
     names.emplace_back(tableInputType->nameOf(channel));
     types.emplace_back(tableInputType->childAt(channel));
   }
-  const auto numDependents = tableInputType->size() - numKeys;
-  for (auto i = 0; i < tableInputType->size(); ++i) {
-    if (keyChannelMap.find(i) == keyChannelMap.end()) {
-      names.emplace_back(tableInputType->nameOf(i));
-      types.emplace_back(tableInputType->childAt(i));
+  if (!canDropDuplicates(joinNode_)) {
+    // For left semi and anti join with no extra filter, hash table does not
+    // store dependent columns.
+    const auto numDependents = tableInputType->size() - numKeys;
+    for (auto i = 0; i < tableInputType->size(); ++i) {
+      if (keyChannelMap.find(i) == keyChannelMap.end()) {
+        names.emplace_back(tableInputType->nameOf(i));
+        types.emplace_back(tableInputType->childAt(i));
+      }
     }
   }
+
   tableSpillType_ = hashJoinTableSpillType(
       ROW(std::move(names), std::move(types)), joinType_);
 }

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1644,8 +1644,21 @@ template <bool ignoreNullKeys>
 void HashTable<ignoreNullKeys>::prepareJoinTable(
     std::vector<std::unique_ptr<BaseHashTable>> tables,
     folly::Executor* executor,
+    bool dropDuplicates,
     int8_t spillInputStartPartitionBit) {
   buildExecutor_ = executor;
+  if (dropDuplicates) {
+    if (table_ != nullptr) {
+      // Set table_ to nullptr to trigger rehash.
+      rows_->pool()->freeContiguous(tableAllocation_);
+      table_ = nullptr;
+    }
+    // Call analyze to insert all unique values in row container to the
+    // table hashers' uniqueValues_;
+    if (!analyze()) {
+      setHashMode(HashMode::kHash, 0);
+    }
+  }
   otherTables_.reserve(tables.size());
   for (auto& table : tables) {
     otherTables_.emplace_back(std::unique_ptr<HashTable<ignoreNullKeys>>(
@@ -1661,6 +1674,15 @@ void HashTable<ignoreNullKeys>::prepareJoinTable(
     }
     if (useValueIds) {
       for (auto& other : otherTables_) {
+        if (dropDuplicates) {
+          // Before merging with the current hashers, all values in the row
+          // containers of other table need to be inserted into uniqueValues_.
+          if (!other->analyze()) {
+            other->setHashMode(HashMode::kHash, 0);
+            useValueIds = false;
+            break;
+          }
+        }
         for (auto i = 0; i < hashers_.size(); ++i) {
           hashers_[i]->merge(*other->hashers_[i]);
           if (!hashers_[i]->mayUseValueIds()) {

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -56,7 +56,8 @@ HashTable<ignoreNullKeys>::HashTable(
     const std::shared_ptr<velox::HashStringAllocator>& stringArena)
     : BaseHashTable(std::move(hashers)),
       minTableSizeForParallelJoinBuild_(minTableSizeForParallelJoinBuild),
-      isJoinBuild_(isJoinBuild) {
+      isJoinBuild_(isJoinBuild),
+      joinBuildNoDuplicates_(!allowDuplicates) {
   std::vector<TypePtr> keys;
   for (auto& hasher : hashers_) {
     keys.push_back(hasher->type());
@@ -1431,7 +1432,9 @@ void HashTable<ignoreNullKeys>::decideHashMode(
     return;
   }
   disableRangeArrayHash_ |= disableRangeArrayHash;
-  if (numDistinct_ && !isJoinBuild_) {
+  if (numDistinct_ && (!isJoinBuild_ || joinBuildNoDuplicates_)) {
+    // If the join type is left semi and anti, allowDuplicates_ will be false,
+    // and join build is building hash table while adding input rows.
     if (!analyze()) {
       setHashMode(HashMode::kHash, numNew);
       return;

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -267,6 +267,17 @@ class BaseHashTable {
       folly::Executor* executor = nullptr,
       int8_t spillInputStartPartitionBit = kNoSpillInputStartPartitionBit) = 0;
 
+  /// The hash table used for join build in left semi and anti join does not
+  /// retain duplicate join keys by default. This is achieved by constructing
+  /// the hash table in the addInput phase to eliminate duplicate join keys.
+  /// When the percentage of duplicate data is small, it will adaptively adjust
+  /// to not build the hash table in the addInput phase. Instead, it operates
+  /// like other join types by reading all the data before building the hash
+  /// table. This function is used to indicate that the join hash table will not
+  /// be built during the addInput phase, and the input data will also not be
+  /// deduplicated.
+  virtual void joinTableMayHaveDuplicates() = 0;
+
   /// Returns the memory footprint in bytes for any data structures
   /// owned by 'this'.
   virtual int64_t allocatedBytes() const = 0;
@@ -551,6 +562,10 @@ class HashTable : public BaseHashTable {
 
   bool hasDuplicateKeys() const override {
     return hasDuplicates_;
+  }
+
+  void joinTableMayHaveDuplicates() override {
+    joinBuildNoDuplicates_ = false;
   }
 
   HashMode hashMode() const override {
@@ -875,7 +890,7 @@ class HashTable : public BaseHashTable {
   // or distinct mode VectorHashers in a group by hash table. 0 for
   // join build sides.
   int32_t reservePct() const {
-    return isJoinBuild_ ? 0 : 50;
+    return (isJoinBuild_ && !joinBuildNoDuplicates_) ? 0 : 50;
   }
 
   // Returns the byte offset of the bucket for 'hash' starting from 'table_'.
@@ -940,6 +955,7 @@ class HashTable : public BaseHashTable {
 
   int8_t sizeBits_;
   bool isJoinBuild_ = false;
+  bool joinBuildNoDuplicates_ = false;
 
   // Set at join build time if the table has duplicates, meaning that
   // the join can be cardinality increasing. Atomic for tsan because

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -265,6 +265,7 @@ class BaseHashTable {
   virtual void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
       folly::Executor* executor = nullptr,
+      bool dropDuplicates = false,
       int8_t spillInputStartPartitionBit = kNoSpillInputStartPartitionBit) = 0;
 
   /// The hash table used for join build in left semi and anti join does not
@@ -590,6 +591,7 @@ class HashTable : public BaseHashTable {
   void prepareJoinTable(
       std::vector<std::unique_ptr<BaseHashTable>> tables,
       folly::Executor* executor = nullptr,
+      bool dropDuplicates = false,
       int8_t spillInputStartPartitionBit =
           kNoSpillInputStartPartitionBit) override;
 

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -6509,6 +6509,81 @@ TEST_F(HashJoinTest, reclaimFromJoinBuilderWithMultiDrivers) {
   ASSERT_GT(arbitrator->stats().numReclaimedBytes, 0);
 }
 
+TEST_F(HashJoinTest, semiJoinAbandonBuildNoDupHashEarly) {
+  auto probeVectors = makeBatches(3, [&](int32_t /*unused*/) {
+    return makeRowVector({
+        makeFlatVector<int64_t>({1, 2, 2, 3, 3, 3, 4, 5, 5, 6, 7}),
+        makeFlatVector<int64_t>({10, 20, 21, 30, 31, 32, 40, 50, 51, 60, 70}),
+    });
+  });
+
+  auto buildVectors = makeBatches(3, [&](int32_t /*unused*/) {
+    return makeRowVector({
+        makeFlatVector<int64_t>({1, 1, 3, 4, 5, 5, 7, 8}),
+        makeFlatVector<int64_t>({100, 101, 300, 400, 500, 501, 700, 800}),
+    });
+  });
+
+  createDuckDbTable("t", probeVectors);
+  createDuckDbTable("u", buildVectors);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(probeVectors)
+                  .project({"c0 AS t0", "c1 AS t1"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(buildVectors)
+                          .project({"c0 AS u0", "c1 AS u1"})
+                          .planNode(),
+                      "",
+                      {"t0", "t1", "match"},
+                      core::JoinType::kLeftSemiProject)
+                  .planNode();
+
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .config(core::QueryConfig::kAbandonBuildNoDupHashMinRows, "1")
+      .config(core::QueryConfig::kAbandonBuildNoDupHashMinPct, "10")
+      .planNode(plan)
+      .referenceQuery(
+          "SELECT t.c0, t.c1, EXISTS (SELECT * FROM u WHERE t.c0 = u.c0) FROM t")
+      .run();
+}
+
+TEST_F(HashJoinTest, antiJoinAbandomBuildNoDupHashEarly) {
+  auto probeVectors = makeBatches(64, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"t0", "t1"},
+        {
+            makeNullableFlatVector<int32_t>({std::nullopt, 1, 2, 3, 4, 5, 6}),
+            makeFlatVector<int32_t>({0, 1, 2, 3, 4, 5, 6}),
+        });
+  });
+  auto buildVectors = makeBatches(64, [&](int32_t /*unused*/) {
+    return makeRowVector(
+        {"u0", "u1"},
+        {
+            makeNullableFlatVector<int32_t>({std::nullopt, 2, 3, 4, 6, 7, 8}),
+            makeFlatVector<int32_t>({0, 2, 3, 4, 6, 7, 8}),
+        });
+  });
+  HashJoinBuilder(*pool_, duckDbQueryRunner_, driverExecutor_.get())
+      .config(core::QueryConfig::kAbandonBuildNoDupHashMinRows, "1")
+      .config(core::QueryConfig::kAbandonBuildNoDupHashMinPct, "10")
+      .numDrivers(numDrivers_)
+      .probeKeys({"t0"})
+      .probeVectors(std::vector<RowVectorPtr>(probeVectors))
+      .buildKeys({"u0"})
+      .buildVectors(std::vector<RowVectorPtr>(buildVectors))
+      .joinType(core::JoinType::kAnti)
+      .joinOutputLayout({"t0", "t1"})
+      .referenceQuery(
+          "SELECT t.* FROM t WHERE NOT EXISTS (SELECT * FROM u WHERE u.u0 = t.t0)")
+      .run();
+}
+
 DEBUG_ONLY_TEST_F(
     HashJoinTest,
     failedToReclaimFromHashJoinBuildersInNonReclaimableSection) {


### PR DESCRIPTION
As discussed in the [issue](https://github.com/facebookincubator/velox/issues/6577), during the hash build process, left semi join and anti join can deduplicate the input rows based on the join key. However, Velox's hash build addInput process adds all inputs to the RowContainer, which can result in significant memory wastage in certain scenarios, such as TPCDS Q14 and Q95. To address this, we can construct the hash table directly during data input and utilize the existing allowDuplicates parameter of the hashTable to remove duplicate data without storing it in the RowContainer. This process is similar to constructing a hash table in the hash aggregation process.

Due to Velox's hash build potentially having multiple drivers executing, in this scenario, duplicate data can only be removed for individual driver inputs. However, in the case of single-driver execution mode, it is possible to remove all duplicate data.