### PR TITLE
[Not Ready for Review] Fail if inputs contain nested nulls in multimapp_agg Presto aggregates

### DIFF
--- a/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MultiMapAggTest.cpp
@@ -180,5 +180,34 @@ TEST_F(MultiMapAggTest, stringKeyGroupBy) {
       {expected});
 }
 
+TEST_F(MultiMapAggTest, arrayCheckNulls) {
+  auto data = makeRowVector({
+      makeFlatVector<int32_t>({2, 1}),
+      makeArrayVectorFromJson<int32_t>({
+          "[3,1,null]",
+          "[9,2,7,null]",
+      }),
+  });
+
+  testFailingAggregations(
+      {data},
+      {},
+      {"multimap_agg(c0, c1)"},
+      "ARRAY comparison not supported for values that contain nulls");
+
+  data = makeRowVector({
+      makeFlatVector<int32_t>({2, 1, 2, 1}),
+      makeFlatVector<int32_t>({4, 5, 5, 2}),
+      makeArrayVectorFromJson<int32_t>(
+          {"[3,1,null]", "[9,2,7,null]", "[9,2,7,null]", "[3,1,null]"}),
+  });
+
+  testFailingAggregations(
+      {data},
+      {"c0"},
+      {"multimap_agg(c1, c2)"},
+      "ARRAY comparison not supported for values that contain nulls");
+}
+
 } // namespace
 } // namespace facebook::velox::aggregate::prestosql


### PR DESCRIPTION
 multimap_agg checks nested nulls for keys of complex type and throws an exception in Velox.

```
presto:tpch> select multimap_agg(x,y) from (values (2, array[3,1,null]), (1, array[9,2,7,null])) AS tbl(x,y);
                  _col0                  
-----------------------------------------
 {1=[[9, 2, 7, null]], 2=[[3, 1, null]]} 
(1 row)

presto:tpch> select multimap_agg(x,y) from (values (2, array[3,1,null]), (1, array[9,2,7,null])) AS tbl(x,y);
Query 20231011_102917_00012_b7zgv failed: !decoded.base()->containsNullAt(indices[index]) ARRAY comparison not supported for values that contain nulls

presto:tpch> select multimap_agg(x,y) from (values (2, array[array[3,1,null
]]), (1, array[array[9,2,7,null]])) AS tbl(x,y);
Query 20231011_103432_00015_b7zgv failed: !decoded.base()->containsNullAt(indices[index]) ARRAY comparison not supported for values that contain nulls

```