### PR TITLE
use system patchelf in eden fs build

### DIFF
--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -1023,7 +1023,7 @@ jobs:
                 out.write("    - name: Disable autocrlf\n")
                 out.write("      run: git config --system core.autocrlf false\n")
 
-            out.write("    - uses: actions/checkout@v2\n")
+            out.write("    - uses: actions/checkout@v4\n")
 
             if build_opts.free_up_disk:
                 free_up_disk = "--free-up-disk "

--- a/build/fbcode_builder/getdeps.py
+++ b/build/fbcode_builder/getdeps.py
@@ -497,6 +497,12 @@ class ShowInstDirCmd(ProjectCmdBase):
             manifests = [manifest]
 
         for m in manifests:
+            fetcher = loader.create_fetcher(m)
+            if isinstance(fetcher, SystemPackageFetcher):
+                # We are guaranteed that if the fetcher is set to
+                # SystemPackageFetcher then this item is completely
+                # satisfied by the appropriate system packages
+                continue
             inst_dir = loader.get_project_install_dir_respecting_install_prefix(m)
             print(inst_dir)
 
@@ -1056,6 +1062,11 @@ jobs:
                 out.write(
                     f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive {manifest.name}\n"
                 )
+                if build_opts.is_linux() or build_opts.is_freebsd():
+                    out.write("    - name: Install packaging system deps\n")
+                    out.write(
+                        f"      run: {sudo_arg}python3 build/fbcode_builder/getdeps.py --allow-system-packages install-system-deps --recursive patchelf\n"
+                    )
 
             projects = loader.manifests_in_dependency_order()
 

--- a/build/fbcode_builder/getdeps/dyndeps.py
+++ b/build/fbcode_builder/getdeps/dyndeps.py
@@ -336,16 +336,21 @@ class ElfDeps(DepBase):
         super(ElfDeps, self).__init__(buildopts, install_dirs, strip)
 
         # We need patchelf to rewrite deps, so ensure that it is built...
-        subprocess.check_call([sys.executable, sys.argv[0], "build", "patchelf"])
+        args = [sys.executable, sys.argv[0]]
+        if buildopts.allow_system_packages:
+            args.append("--allow-system-packages")
+        subprocess.check_call(args + ["build", "patchelf"])
+
         # ... and that we know where it lives
-        self.patchelf = os.path.join(
-            os.fsdecode(
-                subprocess.check_output(
-                    [sys.executable, sys.argv[0], "show-inst-dir", "patchelf"]
-                ).strip()
-            ),
-            "bin/patchelf",
+        patchelf_install = os.fsdecode(
+            subprocess.check_output(args + ["show-inst-dir", "patchelf"]).strip()
         )
+        if not patchelf_install:
+            # its a system package, so we assume it is in the path
+            patchelf_install = "patchelf"
+        else:
+            patchelf_install = os.path.join(patchelf_install, "bin", "patchelf")
+        self.patchelf = patchelf_install
 
     def list_dynamic_deps(self, objfile):
         out = (


### PR DESCRIPTION
Summary:
use system patchelf in eden fs build

Saves us from doing a fetch and build of autoconf, libtool, automake and patchelf during the arfifacts part of CI

X-link: https://github.com/facebook/sapling/pull/750

Reviewed By: sggutier

Differential Revision: D50313417

Pulled By: genevievehelsel

