### PR TITLE
remove --silent from edenfsctl prefetch call in copytree.py

### DIFF
--- a/build/fbcode_builder/getdeps/copytree.py
+++ b/build/fbcode_builder/getdeps/copytree.py
@@ -59,9 +59,7 @@ def prefetch_dir_if_eden(dirpath) -> None:
         return
     glob = f"{os.path.relpath(dirpath, root).replace(os.sep, '/')}/**"
     print(f"Prefetching {glob}")
-    subprocess.call(
-        ["edenfsctl", "prefetch", "--repo", root, "--silent", glob, "--background"]
-    )
+    subprocess.call(["edenfsctl", "prefetch", "--repo", root, glob, "--background"])
     PREFETCHED_DIRS.add(dirpath)
 
 


### PR DESCRIPTION
Summary: `--silent` is the default mode for `edenfsctl prefetch` and the flag is deprecated. Removing this flag is a no-op

Differential Revision: D50287572

