### PR TITLE
Avoid using Operator::results_ in FilterProject

### DIFF
--- a/velox/exec/FilterProject.h
+++ b/velox/exec/FilterProject.h
@@ -86,9 +86,11 @@ class FilterProject : public Operator {
   // updated.
   vector_size_t filter(EvalCtx& evalCtx, const SelectivityVector& allRows);
 
-  // Evaluate projections on the specified rows and populate results_.
+  // Evaluate projections on the specified rows and return the results.
   // pre-condition: !isIdentityProjection_
-  void project(const SelectivityVector& rows, EvalCtx& evalCtx);
+  std::vector<VectorPtr> project(
+      const SelectivityVector& rows,
+      EvalCtx& evalCtx);
 
   // If true exprs_[0] is a filter and the other expressions are projections
   const bool hasFilter_{false};

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -196,7 +196,8 @@ static bool isSequence(
 
 RowVectorPtr Operator::fillOutput(
     vector_size_t size,
-    const BufferPtr& mapping) {
+    const BufferPtr& mapping,
+    const std::vector<VectorPtr>& results) {
   bool wrapResults = true;
   if (size == input_->size() &&
       (!mapping || isSequence(mapping->as<vector_size_t>(), 0, size))) {
@@ -215,7 +216,7 @@ RowVectorPtr Operator::fillOutput(
       wrapResults ? mapping : nullptr);
   projectChildren(
       projectedChildren,
-      results_,
+      results,
       resultProjections_,
       size,
       wrapResults ? mapping : nullptr);
@@ -226,6 +227,12 @@ RowVectorPtr Operator::fillOutput(
       nullptr,
       size,
       std::move(projectedChildren));
+}
+
+RowVectorPtr Operator::fillOutput(
+    vector_size_t size,
+    const BufferPtr& mapping) {
+  return fillOutput(size, mapping, results_);
 }
 
 OperatorStats Operator::stats(bool clear) {

--- a/velox/exec/Operator.h
+++ b/velox/exec/Operator.h
@@ -650,12 +650,19 @@ class Operator : public BaseRuntimeStatWriter {
     return spillConfig_.has_value();
   }
 
-  /// Creates output vector from 'input_' and 'results_' according to
+  /// Creates output vector from 'input_' and 'results' according to
   /// 'identityProjections_' and 'resultProjections_'. If 'mapping' is set to
   /// nullptr, the children of the output vector will be identical to their
-  /// respective sources from 'input_' or 'results_'. However, if 'mapping' is
+  /// respective sources from 'input_' or 'results'. However, if 'mapping' is
   /// provided, the children of the output vector will be generated as
   /// dictionary of the sources using the specified 'mapping'.
+  RowVectorPtr fillOutput(
+      vector_size_t size,
+      const BufferPtr& mapping,
+      const std::vector<VectorPtr>& results);
+
+  /// Creates output vector from 'input_' and 'results_' according to
+  /// 'identityProjections_' and 'resultProjections_'.
   RowVectorPtr fillOutput(vector_size_t size, const BufferPtr& mapping);
 
   /// Returns the number of rows for the output batch. This uses averageRowSize

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1423,11 +1423,9 @@ TEST_F(AggregationTest, memoryAllocations) {
 
   auto task = assertQuery(plan, "SELECT sum(c0 + c1) FROM tmp");
 
-  // Verify memory allocations. Project operator should allocate a single vector
-  // and re-use it. Aggregation should make 2 allocations: 1 for the
+  // Verify memory allocations. Aggregation should make 2 allocations: 1 for the
   // RowContainer holding single accumulator and 1 for the result.
   auto planStats = toPlanStats(task->taskStats());
-  ASSERT_EQ(1, planStats.at(projectNodeId).numMemoryAllocations);
   ASSERT_EQ(2, planStats.at(aggNodeId).numMemoryAllocations);
 
   plan = PlanBuilder()
@@ -1440,12 +1438,10 @@ TEST_F(AggregationTest, memoryAllocations) {
 
   task = assertQuery(plan, "SELECT c0, sum(c0 + c1) FROM tmp GROUP BY 1");
 
-  // Verify memory allocations. Project operator should allocate a single vector
-  // and re-use it. Aggregation should make 5 allocations: 1 for the hash table,
-  // 1 for the RowContainer holding accumulators, 3 for results (2 for values
-  // and nulls buffers of the grouping key column, 1 for sum column).
+  // Verify memory allocations. Aggregation should make 5 allocations: 1 for the
+  // hash table, 1 for the RowContainer holding accumulators, 3 for results (2
+  // for values and nulls buffers of the grouping key column, 1 for sum column).
   planStats = toPlanStats(task->taskStats());
-  ASSERT_EQ(1, planStats.at(projectNodeId).numMemoryAllocations);
   ASSERT_EQ(5, planStats.at(aggNodeId).numMemoryAllocations);
 }
 


### PR DESCRIPTION
Summary:
FilterProject used to reuse the Operator::results_ vectors across batches.
This makes Velox not release vectors and free up memory between batches.
Since expression evaluation in FilterProject already benefits from VectorPool,
this diff makes FilterProject not use Operator::results_ to avoid caching vectors
between batches.

Differential Revision: D50339442


