### PR TITLE
Account for off-thread times for async parts of operators

### DIFF
--- a/velox/common/base/tests/AsyncSourceTest.cpp
+++ b/velox/common/base/tests/AsyncSourceTest.cpp
@@ -39,6 +39,7 @@ TEST(AsyncSourceTest, basic) {
   auto value = gizmo.move();
   EXPECT_FALSE(gizmo.hasValue());
   EXPECT_EQ(11, value->id);
+  EXPECT_EQ(1, gizmo.prepareTiming().count);
 
   AsyncSource<Gizmo> error(
       []() -> std::unique_ptr<Gizmo> { VELOX_USER_FAIL("Testing error"); });

--- a/velox/common/base/tests/CMakeLists.txt
+++ b/velox/common/base/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test(velox_base_test velox_base_test)
 target_link_libraries(
   velox_base_test
   PRIVATE velox_common_base
+          velox_time
           velox_exception
           velox_temp_path
           Boost::filesystem

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -958,6 +958,7 @@ void HashBuild::addRuntimeStats() {
   uint64_t asDistinct;
   auto lockedStats = stats_.wlock();
 
+  lockedStats->addInputTiming.add(table_->offThreadBuildTiming());
   for (auto i = 0; i < hashers.size(); i++) {
     hashers[i]->cardinality(0, asRange, asDistinct);
     if (asRange != VectorHasher::kRangeTooLarge) {

--- a/velox/exec/HashTable.h
+++ b/velox/exec/HashTable.h
@@ -290,6 +290,10 @@ class BaseHashTable {
 #endif
   }
 
+  const CpuWallTiming& offThreadBuildTiming() const {
+    return offThreadBuildTiming_;
+  }
+
  protected:
   static FOLLY_ALWAYS_INLINE size_t tableSlotSize() {
     // Each slot is 8 bytes.
@@ -300,6 +304,9 @@ class BaseHashTable {
 
   std::vector<std::unique_ptr<VectorHasher>> hashers_;
   std::unique_ptr<RowContainer> rows_;
+
+  // Time spent in build outside of the calling thread.
+  CpuWallTiming offThreadBuildTiming_;
 };
 
 FOLLY_ALWAYS_INLINE std::ostream& operator<<(

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -152,6 +152,8 @@ RowVectorPtr TableScan::getOutput() {
         // unique_ptr will be nullptr if there was a cancellation.
         numReadyPreloadedSplits_ += connectorSplit->dataSource->hasValue();
         auto preparedDataSource = connectorSplit->dataSource->move();
+        stats_.wlock()->getOutputTiming.add(
+            connectorSplit->dataSource->prepareTiming());
         if (!preparedDataSource) {
           // There must be a cancellation.
           VELOX_CHECK(operatorCtx_->task()->isCancelled());


### PR DESCRIPTION
AsyncSource records its prepare() time. This is normally on spent on a thread different from the initiating thread. if AsyncSource move() is called before prepare() starts, the compute is on the calling thread. Thus AsyncSource timing is to be added to the consumer's timing if the work was done in prepare()  but not if it was done in move().

Uses this to account for async off-thread parts of table scan and hash join build.