### PR TITLE
use setVeloxExceptionError instead of setError to avoid throwing

### DIFF
--- a/velox/expression/EvalCtx.h
+++ b/velox/expression/EvalCtx.h
@@ -81,6 +81,8 @@ class EvalCtx {
 
   void restore(ScopedContextSaver& saver);
 
+  // If exceptionPtr is known to be a VeloxException use setVeloxExceptionError
+  // instead.
   void setError(vector_size_t index, const std::exception_ptr& exceptionPtr);
 
   // Similar to setError but more performant, should be used when the user knows

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -222,7 +222,7 @@ class SubscriptImpl : public exec::Subscript {
         const auto adjustedIndex =
             adjustIndex(originalIndex, isZeroSubscriptError);
         if (isZeroSubscriptError) {
-          context.setError(row, zeroSubscriptError());
+          context.setVeloxExceptionError(row, zeroSubscriptError());
           return;
         }
         const auto elementIndex = getIndex(
@@ -286,7 +286,7 @@ class SubscriptImpl : public exec::Subscript {
           index += arraySize;
         }
       } else {
-        context.setError(row, negativeSubscriptError());
+        context.setVeloxExceptionError(row, negativeSubscriptError());
         return -1;
       }
     }
@@ -297,7 +297,7 @@ class SubscriptImpl : public exec::Subscript {
       if constexpr (allowOutOfBound) {
         return -1;
       } else {
-        context.setError(row, badSubscriptError());
+        context.setVeloxExceptionError(row, badSubscriptError());
         return -1;
       }
     }


### PR DESCRIPTION
Summary:
setError calls toVeloxException which throw .
```
std::exception_ptr toVeloxException(const std::exception_ptr& exceptionPtr) {
  try {
    std::rethrow_exception(exceptionPtr);
  } catch (const VeloxException& e) {
    return exceptionPtr;
  } catch (const std::exception& e) {
    return std::make_exception_ptr(
        VeloxUserError(std::current_exception(), e.what(), false));
  }
}
```
When we know the error is a velox exception we shall use toVeloxException instead.

Differential Revision: D50342083


