### PR TITLE
Fix map subscript doucmentation.

### DIFF
--- a/velox/docs/functions/presto/map.rst
+++ b/velox/docs/functions/presto/map.rst
@@ -108,7 +108,7 @@ Map Functions
 .. function:: subscript(map(K, V), key) -> V
    :noindex:
 
-    Returns value for given ``key``. Throws if the key is not contained in the map.
+    Returns value for given ``key``. Return null if the key is not contained in the map.
     Corresponds to SQL subscript operator [].
 
     SELECT name_to_age_map['Bob'] AS bob_age;


### PR DESCRIPTION
Summary: Presto and Velox return null for invalid key in map susbcript, and does not throw.

Differential Revision: D50345503

