### PR TITLE
Support date-type partition column

### DIFF
--- a/velox/connectors/hive/HiveConnectorSplit.h
+++ b/velox/connectors/hive/HiveConnectorSplit.h
@@ -27,6 +27,11 @@ struct HiveConnectorSplit : public connector::ConnectorSplit {
   dwio::common::FileFormat fileFormat;
   const uint64_t start;
   const uint64_t length;
+
+  /// Mapping from partition keys to values. Values are specified as strings
+  /// formatted the same way as CAST(x as VARCHAR). Null values are specified as
+  /// std::nullopt. Date values must be formatted using ISO 8601 as YYYY-MM-DD.
+  /// All scalar types and date type are supported.
   const std::unordered_map<std::string, std::optional<std::string>>
       partitionKeys;
   std::optional<int32_t> tableBucketNumber;

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1499,6 +1499,15 @@ TEST_F(TableScanTest, partitionedTableDoubleKey) {
   testPartitionedTable(filePath->path, DOUBLE(), "3.5");
 }
 
+TEST_F(TableScanTest, partitionedTableDateKey) {
+  auto rowType = ROW({"c0", "c1"}, {BIGINT(), DOUBLE()});
+  auto vectors = makeVectors(10, 1'000, rowType);
+  auto filePath = TempFilePath::create();
+  writeToFile(filePath->path, vectors);
+  createDuckDbTable(vectors);
+  testPartitionedTable(filePath->path, DATE(), "2023-10-27");
+}
+
 std::vector<StringView> toStringViews(const std::vector<std::string>& values) {
   std::vector<StringView> views;
   views.reserve(values.size());


### PR DESCRIPTION
When the partition column is of date type, below error occurs when trying to 
convert date string as int. This PR fixes this exception by using 
`castFromDateString` with `isIso8601` set as true. With this fix, the date 
partition value formatted as string should be in the `[+-](YYYY-MM-DD)` format. 
The callers like Gluten need to generate compatible format of strings to be 
partition values.

```
Exceptions.h:69] Line: ../../velox/exec/Driver.cpp:545, Function:runInternal, Expression:  Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: Non-whitespace character found after end of conversion: "-10-27", Source: RUNTIME, ErrorCode: INVALID_STATE
unknown file: Failure
C++ exception with description "Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: INVALID_STATE
Reason: Operator::getOutput failed for [operator: TableScan, plan node ID: 0]: Non-whitespace character found after end of conversion: "-10-27"
```