### PR TITLE
Support cast (from boolen to decimal)

### DIFF
--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -110,7 +110,7 @@ supported conversions to/from JSON are listed in :doc:`json`.
      -
      -
      -
-     -
+     - Y
    * - real
      - Y
      - Y
@@ -652,10 +652,23 @@ Valid examples
 Cast to Decimal
 ---------------
 
+From boolean type
+^^^^^^^^^^^^^^^^^
+
+Casting a boolean number to decimal of given precision and scale is allowed.
+True value is converted to 1 and false to 0.
+
+Valid examples
+
+::
+
+  SELECT cast(true as decimal(4, 2)); -- decimal '1.00'
+  SELECT cast(false as decimal(8, 2)); -- decimal '0'
+
 From integral types
 ^^^^^^^^^^^^^^^^^^^
 
-Casting an integral numberto a decimal of given precision and scale is allowed
+Casting an integral number to a decimal of given precision and scale is allowed
 if the input value can be represented by the precision and scale. Casting from
 invalid input values throws.
 

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -451,6 +451,10 @@ VectorPtr CastExpr::applyDecimal(
 
   // toType is a decimal
   switch (fromType->kind()) {
+    case TypeKind::BOOLEAN:
+      applyIntToDecimalCastKernel<bool, toDecimalType>(
+          rows, input, context, toType, castResult);
+      break;
     case TypeKind::TINYINT:
       applyIntToDecimalCastKernel<int8_t, toDecimalType>(
           rows, input, context, toType, castResult);

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -1700,6 +1700,30 @@ TEST_F(CastExprTest, integerToDecimal) {
   testIntToDecimalCasts<int64_t>();
 }
 
+TEST_F(CastExprTest, boolToDecimal) {
+  // Bool to short decimal.
+  auto input =
+      makeFlatVector<bool>({true, false, false, true, true, true, false});
+  testComplexCast(
+      "c0",
+      input,
+      makeFlatVector<int64_t>({100, 0, 0, 100, 100, 100, 0}, DECIMAL(6, 2)));
+
+  // Bool to long decimal.
+  testComplexCast(
+      "c0",
+      input,
+      makeFlatVector<int128_t>(
+          {10'000'000'000,
+           0,
+           0,
+           10'000'000'000,
+           10'000'000'000,
+           10'000'000'000,
+           0},
+          DECIMAL(20, 10)));
+}
+
 TEST_F(CastExprTest, castInTry) {
   // Test try(cast(array(varchar) as array(bigint))) whose input vector is
   // wrapped in dictinary encoding. The row of ["2a"] should trigger an error


### PR DESCRIPTION
Reuses `applyIntToDecimalCastKernel` to support cast (from boolean to decimal).