### PR TITLE
Support Spark array_union function

### DIFF
--- a/velox/docs/functions/spark/array.rst
+++ b/velox/docs/functions/spark/array.rst
@@ -74,6 +74,15 @@ Array Functions
         SELECT array_sort(ARRAY [NULL, 1, NULL]); -- [1, NULL, NULL]
         SELECT array_sort(ARRAY [NULL, 2, 1]); -- [1, 2, NULL]
 
+.. spark:function:: array_union(array(E), array(E1)) -> array(E2)
+
+    Returns an array of the elements in the union of array1 and array2, without duplicates. ::
+
+        SELECT array_union(array(1, 2, 3), array(1, 3, 5)); -- [1, 2, 3, 5]
+        SELECT array_union(array(1, 3, 5), array(1, 2, 3)); -- [1, 3, 5, 2]
+        SELECT array_union(array(1, 2, 3), array(1, 3, 5, null)); -- [1, 2, 3, 5, null]
+        SELECT array_union(array(1, 2, NaN), array(1, 3, NaN)); -- [1, 2, NaN, 3]
+
 .. spark:function:: concat(array(E), array(E1), ..., array(En)) -> array(E, E1, ..., En)
 
     Returns the concatenation of array(E), array(E1), ..., array(En). ::

--- a/velox/functions/lib/ArrayUnionFunction.h
+++ b/velox/functions/lib/ArrayUnionFunction.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/functions/Udf.h"
+
+namespace facebook::velox::functions {
+namespace {
+/// This class implements the array union function.
+///
+/// DEFINITION:
+/// array_union(x, y) → array
+/// Returns an array of the elements in the union of x and y, without
+/// duplicates.
+/// @tparam equalNaN: If true, NaNs are considered equal.
+template <typename T, bool equalNaN>
+struct ArrayUnionFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T)
+
+  // Fast path for primitives.
+  template <typename Out, typename In>
+  void call(Out& out, const In& inputArray1, const In& inputArray2) {
+    folly::F14FastSet<typename In::element_t> elementSet;
+    bool nullAdded = false;
+    bool nanAdded = false;
+    constexpr bool isFloating = std::is_same_v<In, arg_type<Array<float>>> ||
+        std::is_same_v<In, arg_type<Array<double>>>;
+    auto addItems = [&](auto& inputArray) {
+      for (const auto& item : inputArray) {
+        if (item.has_value()) {
+          if constexpr (isFloating && equalNaN) {
+            bool isNaN = std::isnan(item.value());
+            if ((isNaN && !nanAdded) ||
+                (!isNaN && elementSet.insert(item.value()).second)) {
+              auto& newItem = out.add_item();
+              newItem = item.value();
+              nanAdded = isNaN;
+            }
+          } else if (elementSet.insert(item.value()).second) {
+            auto& newItem = out.add_item();
+            newItem = item.value();
+          }
+        } else if (!nullAdded) {
+          nullAdded = true;
+          out.add_null();
+        }
+      }
+    };
+    addItems(inputArray1);
+    addItems(inputArray2);
+  }
+
+  void call(
+      out_type<Array<Generic<T1>>>& out,
+      const arg_type<Array<Generic<T1>>>& inputArray1,
+      const arg_type<Array<Generic<T1>>>& inputArray2) {
+    folly::F14FastSet<exec::GenericView> elementSet;
+    bool nullAdded = false;
+    auto addItems = [&](auto& inputArray) {
+      for (const auto& item : inputArray) {
+        if (item.has_value()) {
+          if (elementSet.insert(item.value()).second) {
+            auto& newItem = out.add_item();
+            newItem.copy_from(item.value());
+          }
+        } else if (!nullAdded) {
+          nullAdded = true;
+          out.add_null();
+        }
+      }
+    };
+    addItems(inputArray1);
+    addItems(inputArray2);
+  }
+};
+} // namespace
+
+template <typename T>
+struct ArrayUnionFunctionNaNEqual : public ArrayUnionFunction<T, true> {};
+
+template <typename T>
+struct ArrayUnionFunctionGeneral : public ArrayUnionFunction<T, false> {};
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ArrayFunctions.h
+++ b/velox/functions/prestosql/ArrayFunctions.h
@@ -867,37 +867,6 @@ struct ArrayFlattenFunction {
   }
 };
 
-/// This class implements the array union function.
-///
-/// DEFINITION:
-/// array_union(x, y) → array
-/// Returns an array of the elements in the union of x and y, without
-/// duplicates.
-template <typename T>
-struct ArrayUnionFunction {
-  VELOX_DEFINE_FUNCTION_TYPES(T)
-
-  template <typename Out, typename In>
-  void call(Out& out, const In& inputArray1, const In& inputArray2) {
-    folly::F14FastSet<typename In::element_t> elementSet;
-    bool nullAdded = false;
-    auto addItems = [&](auto& inputArray) {
-      for (const auto& item : inputArray) {
-        if (item.has_value()) {
-          if (elementSet.insert(item.value()).second) {
-            out.push_back(item.value());
-          }
-        } else if (!nullAdded) {
-          nullAdded = true;
-          out.add_null();
-        }
-      }
-    };
-    addItems(inputArray1);
-    addItems(inputArray2);
-  }
-};
-
 /// This class implements the array_remove function.
 ///
 /// DEFINITION:

--- a/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/ArrayFunctionsRegistration.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "velox/functions/Registerer.h"
+#include "velox/functions/lib/ArrayUnionFunction.h"
 #include "velox/functions/lib/Repeat.h"
 #include "velox/functions/prestosql/ArrayConstructor.h"
 #include "velox/functions/prestosql/ArrayFunctions.h"
@@ -97,7 +98,7 @@ inline void registerArrayRemoveNullFunctions(const std::string& prefix) {
 
 template <typename T>
 inline void registerArrayUnionFunctions(const std::string& prefix) {
-  registerFunction<ArrayUnionFunction, Array<T>, Array<T>, Array<T>>(
+  registerFunction<ArrayUnionFunctionGeneral, Array<T>, Array<T>, Array<T>>(
       {prefix + "array_union"});
 }
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -18,6 +18,7 @@
 #include "velox/expression/RegisterSpecialForm.h"
 #include "velox/expression/RowConstructor.h"
 #include "velox/expression/SpecialFormRegistry.h"
+#include "velox/functions/lib/ArrayUnionFunction.h"
 #include "velox/functions/lib/IsNull.h"
 #include "velox/functions/lib/Re2Functions.h"
 #include "velox/functions/lib/RegistrationHelpers.h"
@@ -118,6 +119,12 @@ inline void registerArrayMinMaxFunctions(const std::string& prefix) {
   registerArrayMinMaxFunctions<Date>(prefix);
 }
 } // namespace
+
+template <typename T>
+inline void registerArrayUnionFunctions(const std::string& prefix) {
+  registerFunction<ArrayUnionFunctionNaNEqual, Array<T>, Array<T>, Array<T>>(
+      {prefix + "array_union"});
+}
 
 void registerFunctions(const std::string& prefix) {
   registerAllSpecialFormGeneralFunctions();
@@ -334,6 +341,20 @@ void registerFunctions(const std::string& prefix) {
       prefix + "unscaled_value",
       unscaledValueSignatures(),
       makeUnscaledValue());
+
+  registerArrayUnionFunctions<bool>(prefix);
+  registerArrayUnionFunctions<int8_t>(prefix);
+  registerArrayUnionFunctions<int16_t>(prefix);
+  registerArrayUnionFunctions<int32_t>(prefix);
+  registerArrayUnionFunctions<int64_t>(prefix);
+  registerArrayUnionFunctions<int128_t>(prefix);
+  registerArrayUnionFunctions<float>(prefix);
+  registerArrayUnionFunctions<double>(prefix);
+  registerArrayUnionFunctions<Varchar>(prefix);
+  registerArrayUnionFunctions<Varbinary>(prefix);
+  registerArrayUnionFunctions<Date>(prefix);
+  registerArrayUnionFunctions<Timestamp>(prefix);
+  registerArrayUnionFunctions<Generic<T1>>(prefix);
 }
 
 } // namespace sparksql

--- a/velox/functions/sparksql/tests/ArrayUnionTest.cpp
+++ b/velox/functions/sparksql/tests/ArrayUnionTest.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/functions/sparksql/tests/SparkFunctionBaseTest.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::test;
+
+namespace facebook::velox::functions::sparksql::test {
+namespace {
+
+class ArrayUnionTest : public SparkFunctionBaseTest {
+ protected:
+  void testExpression(
+      const std::string& expression,
+      const std::vector<VectorPtr>& input,
+      const VectorPtr& expected) {
+    auto result = evaluate(expression, makeRowVector(input));
+    assertEqualVectors(expected, result);
+  }
+
+  template <typename T>
+  void testFloatArray() {
+    const auto array1 = makeArrayVector<T>(
+        {{1.99, 2.78, 3.98, 4.01},
+         {3.89, 4.99, 5.13},
+         {7.13, 8.91, std::numeric_limits<T>::quiet_NaN()},
+         {10.02, 20.01, std::numeric_limits<T>::quiet_NaN()}});
+    const auto array2 = makeArrayVector<T>(
+        {{2.78, 4.01, 5.99},
+         {3.89, 4.99, 5.13},
+         {7.13, 8.91, std::numeric_limits<T>::quiet_NaN()},
+         {40.99, 50.12}});
+
+    VectorPtr expected;
+    expected = makeArrayVector<T>({
+        {1.99, 2.78, 3.98, 4.01, 5.99},
+        {3.89, 4.99, 5.13},
+        {7.13, 8.91, std::numeric_limits<T>::quiet_NaN()},
+        {10.02, 20.01, std::numeric_limits<T>::quiet_NaN(), 40.99, 50.12},
+    });
+    testExpression("array_union(c0, c1)", {array1, array2}, expected);
+
+    expected = makeArrayVector<T>({
+        {2.78, 4.01, 5.99, 1.99, 3.98},
+        {3.89, 4.99, 5.13},
+        {7.13, 8.91, std::numeric_limits<T>::quiet_NaN()},
+        {40.99, 50.12, 10.02, 20.01, std::numeric_limits<T>::quiet_NaN()},
+    });
+    testExpression("array_union(c0, c1)", {array2, array1}, expected);
+  }
+};
+
+// Union two float or double arrays.
+TEST_F(ArrayUnionTest, floatArray) {
+  testFloatArray<float>();
+  testFloatArray<double>();
+}
+} // namespace
+} // namespace facebook::velox::functions::sparksql::test

--- a/velox/functions/sparksql/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   ArrayMaxTest.cpp
   ArrayMinTest.cpp
   ArraySortTest.cpp
+  ArrayUnionTest.cpp
   BitwiseTest.cpp
   ComparisonsTest.cpp
   DateTimeFunctionsTest.cpp


### PR DESCRIPTION
Array_union returns an array of the elements in the union of array1 and array2, 
without duplicates. In Spark, NaNs are treated as equal. This PR moves 
array_union function to lib and adds `equalNaN` template parameter to control 
different behaviors between Presto and Spark.
Spark's implementation: [ArrayUnion](https://github.com/apache/spark/blob/master/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/collectionOperations.scala#L4072).