### PR TITLE
Fix reserve bytes in ValueList

### DIFF
--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1237,7 +1237,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, spillWithEmptyPartition) {
 
 TEST_F(AggregationTest, spillWithNonSpillingPartition) {
   constexpr int32_t kNumDistinct = 100'000;
-  constexpr int64_t kMaxBytes = 20LL << 20; // 20 MB
+  constexpr int64_t kMaxBytes = 32 << 20; // 32 MB
   rowType_ = ROW({"c0", "a"}, {INTEGER(), VARCHAR()});
   // Used to calculate the aggregation spilling partition number.
   const int kPartitionsBits = 2;
@@ -1337,7 +1337,7 @@ TEST_F(AggregationTest, spillWithNonSpillingPartition) {
               std::to_string(kPartitionsBits))
           // Set to increase the hash table a little bit to only trigger spill
           // on the partition with most spillable data.
-          .config(QueryConfig::kSpillableReservationGrowthPct, "25")
+          .config(QueryConfig::kSpillableReservationGrowthPct, "5")
           .config(QueryConfig::kPreferredOutputBatchBytes, "1024")
           .assertResults(results);
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -237,7 +237,8 @@ add_library(velox_simple_aggregate SimpleAverageAggregate.cpp
 target_link_libraries(velox_simple_aggregate velox_exec velox_expression
                       velox_expression_functions velox_aggregates)
 
-add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp)
+add_executable(velox_simple_aggregate_test SimpleAggregateAdapterTest.cpp
+                                           Main.cpp)
 
 target_link_libraries(
   velox_simple_aggregate_test velox_simple_aggregate velox_exec

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -331,9 +331,9 @@ TEST_F(SimpleArrayAggAggregationTest, trackRowSize) {
       }
     }
 
-    VELOX_CHECK_GT(groups[0][rowSizeOffset], 0);
+    VELOX_CHECK_GT(*reinterpret_cast<int32_t*>(groups[0] + rowSizeOffset), 0);
     if (!testGlobal) {
-      VELOX_CHECK_GT(groups[1][rowSizeOffset], 0);
+      VELOX_CHECK_GT(*reinterpret_cast<int32_t*>(groups[1] + rowSizeOffset), 0);
     }
   };
 

--- a/velox/functions/prestosql/aggregates/ValueList.cpp
+++ b/velox/functions/prestosql/aggregates/ValueList.cpp
@@ -65,8 +65,12 @@ void ValueList::appendNonNull(
   allocator->extendWrite(dataCurrent_, stream);
   exec::ContainerRowSerde::serialize(values, index, stream);
   ++size_;
+  bytes_ += stream.size();
 
-  dataCurrent_ = allocator->finishWrite(stream, 1024).second;
+  // Leave space up to the size appended so far, at least 24 but no more
+  // than 1024.
+  dataCurrent_ =
+      allocator->finishWrite(stream, std::clamp(bytes_, 24, 1024)).second;
 }
 
 void ValueList::appendValue(

--- a/velox/functions/prestosql/aggregates/ValueList.h
+++ b/velox/functions/prestosql/aggregates/ValueList.h
@@ -108,6 +108,9 @@ class ValueList {
   // Number of values added, including nulls.
   uint32_t size_{0};
 
+  // Bytes added. Used to control allocation of reserve for future appends.
+  int32_t bytes_{0};
+
   // Last nulls word. 'size_ % 64' is the null bit for the next element.
   uint64_t lastNulls_{0};
 };

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -112,13 +112,20 @@ TEST_F(ValueListTest, integers) {
 
 TEST_F(ValueListTest, arrays) {
   // No nulls.
+  int32_t kSizeCaps[] = {500, 4000, 6000, 50000};
+  int32_t counter = 0;
   for (auto size : kTestSizes) {
     auto data = makeArrayVector<int32_t>(
         size,
         [](auto row) { return row % 7; },
         [](auto row) { return row % 11; });
 
+    auto previousBytes = allocator()->cumulativeBytes();
     testRoundTrip(data);
+    if (counter < sizeof(kSizeCaps) / sizeof(kSizeCaps[0])) {
+      auto cap = kSizeCaps[counter++];
+      EXPECT_GT(cap, allocator()->cumulativeBytes() - previousBytes);
+    }
   }
 
   // Different percentage of nulls.


### PR DESCRIPTION
ValueList is used in array_agg and map_agg and related. It is an append only container for non-contiguous aggregation state. It previously left up to 1K of space after the last inserted value, which is excessive if values are short and containers are many. Now, this leaves up to the amount appended of trailing space, clamped between 16 and 1024.

Decreases worth case space consumption of array and related aggs by over 10x when arrays are short and groups numerous.