### PR TITLE
Add spill support to RowNumber operator

### DIFF
--- a/velox/common/config/SpillConfig.h
+++ b/velox/common/config/SpillConfig.h
@@ -65,7 +65,7 @@ struct SpillConfig {
   /// its data size exceeds this limit, otherwise it spills the partition with
   /// most data. If the limit is zero, then the spiller always spill a
   /// previously spilled partition if it has any data. This is to avoid spill
-  /// from a partition wigth a small amount of data which might result in
+  /// from a partition with a small amount of data which might result in
   /// generating too many small spilled files.
   uint64_t minSpillRunSize;
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2144,6 +2144,10 @@ class RowNumberNode : public PlanNode {
     return outputType_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return !partitionKeys_.empty() && queryConfig.rowNumberSpillEnabled();
+  }
+
   const std::vector<FieldAccessTypedExprPtr>& partitionKeys() const {
     return partitionKeys_;
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -191,6 +191,10 @@ class QueryConfig {
   /// OrderBy spilling flag, only applies if "spill_enabled" flag is set.
   static constexpr const char* kOrderBySpillEnabled = "order_by_spill_enabled";
 
+  /// RowNumber spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kRowNumberSpillEnabled =
+      "row_number_spill_enabled";
+
   /// The max memory that a final aggregation can use before spilling. If it 0,
   /// then there is no limit.
   static constexpr const char* kAggregationSpillMemoryThreshold =
@@ -463,6 +467,12 @@ class QueryConfig {
   /// spillEnabled()!
   bool orderBySpillEnabled() const {
     return get<bool>(kOrderBySpillEnabled, true);
+  }
+
+  /// Returns 'is row_number spilling enabled' flag. Must also check the
+  /// spillEnabled()!
+  bool rowNumberSpillEnabled() const {
+    return get<bool>(kRowNumberSpillEnabled, true);
   }
 
   // Returns a percentage of aggregation or join input batches that

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -187,19 +187,23 @@ Spilling
      - Spill memory to disk to avoid exceeding memory limits for the query.
    * - aggregation_spill_enabled
      - boolean
-     - false
-     - When `spill_enabled` is true, determines whether to spill memory to disk for aggregations to avoid exceeding
+     - true
+     - When `spill_enabled` is true, determines whether HashAggregation operator can spill to disk under memory pressure.
        memory limits for the query.
    * - join_spill_enabled
      - boolean
-     - false
-     - When `spill_enabled` is true, determines whether to spill memory to disk for hash joins to avoid exceeding memory
+     - true
+     - When `spill_enabled` is true, determines whether HashBuild and HashProbe operators can spill to disk under memory pressure.
        limits for the query.
    * - order_by_spill_enabled
      - boolean
-     - false
-     - When `spill_enabled` is true, determines whether to spill memory to disk for order by to avoid exceeding memory
+     - true
+     - When `spill_enabled` is true, determines whether OrderBy operator can spill to disk under memory pressure.
        limits for the query.
+   * - row_number_spill_enabled
+     - boolean
+     - true
+     - When `spill_enabled` is true, determines whether RowNumber operator can spill to disk under memory pressure.
    * - aggregation_spill_memory_threshold
      - integer
      - 0
@@ -270,7 +274,7 @@ Spilling
    * - join_spiller_partition_bits
      - integer
      - 2
-     - The number of bits (N) used to calculate the spilling partition number for hash join: 2 ^ N. At the moment the maximum
+     - The number of bits (N) used to calculate the spilling partition number for hash join and RowNumber: 2 ^ N. At the moment the maximum
        value is 3, meaning we only support up to 8-way spill partitioning.
    * - aggregation_spiller_partition_bits
      - integer

--- a/velox/exec/GroupingSet.h
+++ b/velox/exec/GroupingSet.h
@@ -305,7 +305,7 @@ class GroupingSet {
   // The row with the current merge state, allocated from 'mergeRow_'.
   char* mergeState_ = nullptr;
 
-  // The currently running spill partition in producing spilld output.
+  // The currently running spill partition in producing spilled output.
   int32_t outputPartition_{-1};
 
   // Intermediate vector for passing arguments to aggregate in merging spill.
@@ -334,7 +334,7 @@ class GroupingSet {
   std::unique_ptr<RowContainer> nonSpilledRowContainer_;
 
   // Counts input batches and triggers spilling if folly hash of this % 100 <=
-  // 'testSpillPct_';.
+  // 'spillConfig_->testSpillPct'.
   uint64_t spillTestCounter_{0};
 
   // True if partial aggregation has been given up as non-productive.

--- a/velox/exec/HashProbe.cpp
+++ b/velox/exec/HashProbe.cpp
@@ -411,8 +411,8 @@ void HashProbe::spillInput(RowVectorPtr& input) {
   }
 
   // Ensure vector are lazy loaded before spilling.
-  for (int32_t i = 0; i < input_->childrenSize(); ++i) {
-    input_->childAt(i)->loadedVector();
+  for (int32_t i = 0; i < input->childrenSize(); ++i) {
+    input->childAt(i)->loadedVector();
   }
 
   for (int32_t partition = 0; partition < numSpillInputs_.size(); ++partition) {

--- a/velox/exec/RowNumber.h
+++ b/velox/exec/RowNumber.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "velox/exec/HashPartitionFunction.h"
 #include "velox/exec/HashTable.h"
 #include "velox/exec/Operator.h"
 
@@ -29,6 +30,8 @@ class RowNumber : public Operator {
 
   void addInput(RowVectorPtr input) override;
 
+  void noMoreInput() override;
+
   RowVectorPtr getOutput() override;
 
   bool needsInput() const override {
@@ -40,10 +43,33 @@ class RowNumber : public Operator {
   }
 
   bool isFinished() override {
-    return (noMoreInput_ && input_ == nullptr) || finishedEarly_;
+    return (noMoreInput_ && input_ == nullptr &&
+            spillInputReader_ == nullptr) ||
+        finishedEarly_;
   }
 
+  void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
+      override;
+
  private:
+  bool spillEnabled() const {
+    return spillConfig_.has_value();
+  }
+
+  void setupHashTableSpiller();
+
+  void setupInputSpiller();
+
+  void ensureInputFits(const RowVectorPtr& input);
+
+  void spillInput(const RowVectorPtr& input, memory::MemoryPool* pool);
+
+  void spill();
+
+  void addSpillInput();
+
+  void restoreNextSpillPartition();
+
   int64_t numRows(char* partition);
 
   void setNumRows(char* partition, int64_t numRows);
@@ -55,19 +81,40 @@ class RowNumber : public Operator {
   const std::optional<int32_t> limit_;
   const bool generateRowNumber_;
 
-  /// Hash table to store number of rows seen so far per partition. Not used if
-  /// there are no partitioning keys.
+  // Hash table to store number of rows seen so far per partition. Not used if
+  // there are no partitioning keys.
   std::unique_ptr<BaseHashTable> table_;
   std::unique_ptr<HashLookup> lookup_;
   int32_t numRowsOffset_;
 
-  /// Total number of input rows. Used when there are no partitioning keys and
-  /// therefore no hash table.
+  // Total number of input rows. Used when there are no partitioning keys and
+  // therefore no hash table.
   int64_t numTotalInput_{0};
 
-  /// Boolean indicating that the operator finished processing before seeing all
-  /// the input. This happens when there are no partitioning keys and the
-  /// operator already received 'limit_' rows.
+  // Boolean indicating that the operator finished processing before seeing all
+  // the input. This happens when there are no partitioning keys and the
+  // operator already received 'limit_' rows.
   bool finishedEarly_{false};
+
+  RowTypePtr inputType_;
+
+  // Spiller for contents of the HashTable,
+  std::unique_ptr<Spiller> hashTableSpiller_;
+
+  // Used to restore previously spilled hash table.
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillHashTableReader_;
+
+  SpillPartitionSet spillHashTablePartitionSet_;
+
+  // Spiller for input received after spilling has been triggered.
+  std::unique_ptr<Spiller> inputSpiller_;
+
+  // Used to restore previously spilled input.
+  std::unique_ptr<UnorderedStreamReader<BatchStream>> spillInputReader_;
+
+  SpillPartitionSet spillInputPartitionSet_;
+
+  // Used to calculate the spill partition numbers of the inputs.
+  std::unique_ptr<HashPartitionFunction> spillHashFunction_;
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
RowNumber operator uses HashTable to accumulate the set of unique partition-by
keys along with the number of rows seen for each partition.

When asked to spill, RowNumber operator spills the whole HashTable, stops
producing output and spills all future input.

After receiving (and spilling) all input, RowNumber operator starts processing
spilled data one spill partition at a time (note spill partition is different
from partition defined by partitiong by keys of the input).

For each spilled partition, RowNumber operator first restores the HashTable,
then reads spilled input one vector at a time and produces output.

RowNumber operator uses 2 separate Spiller objects: one for spilling from the
HashTable, another for spilling input data.

Recursive spilling is not supported yet.

Spilling is enabled by default. It can be disabled by setting
row_number_spill_enabled configuration property to false.

Spilling configuration (number of hash bits) is shared with the hash join.