### PR TITLE
Fix hash build spiller been finalized error on reclaim

### DIFF
--- a/velox/common/memory/tests/SharedArbitratorTest.cpp
+++ b/velox/common/memory/tests/SharedArbitratorTest.cpp
@@ -2658,6 +2658,137 @@ DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrationFromTableWriter) {
   ASSERT_EQ(arbitrator_->stats().numFailures, 1);
 }
 
+// This test is to reproduce a race condition that memory arbitrator tries to
+// reclaim from a set of hash build operators in which the last hash build
+// operator has finished.
+DEBUG_ONLY_TEST_F(SharedArbitrationTest, raceBetweenRaclaimAndJoinFinish) {
+  const int kMemoryCapacity = 512 << 20;
+  setupMemory(kMemoryCapacity, 0);
+
+  const int numVectors = 5;
+  std::vector<RowVectorPtr> vectors;
+  for (int i = 0; i < numVectors; ++i) {
+    vectors.push_back(newVector());
+  }
+  createDuckDbTable(vectors);
+
+  std::shared_ptr<core::QueryCtx> joinQueryCtx = newQueryCtx(kMemoryCapacity);
+
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  core::PlanNodeId planNodeId;
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                  .values(vectors, false)
+                  .project({"c0 AS t0", "c1 AS t1", "c2 AS t2"})
+                  .hashJoin(
+                      {"t0"},
+                      {"u0"},
+                      PlanBuilder(planNodeIdGenerator)
+                          .values(vectors, true)
+                          .project({"c0 AS u0", "c1 AS u1", "c2 AS u2"})
+                          .planNode(),
+                      "",
+                      {"t1"},
+                      core::JoinType::kAnti)
+                  .capturePlanNodeId(planNodeId)
+                  .planNode();
+
+  std::atomic<bool> waitForBuildFinishFlag{true};
+  folly::EventCount waitForBuildFinishEvent;
+  std::atomic<Driver*> lastBuildDriver{nullptr};
+  std::atomic<Task*> task{nullptr};
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::HashBuild::finishHashBuild",
+      std::function<void(exec::HashBuild*)>([&](exec::HashBuild* buildOp) {
+        lastBuildDriver = buildOp->testingOperatorCtx()->driver();
+        task = lastBuildDriver.load()->task().get();
+        waitForBuildFinishFlag = false;
+        waitForBuildFinishEvent.notifyAll();
+      }));
+
+  std::atomic<bool> waitForReclaimFlag{true};
+  folly::EventCount waitForReclaimEvent;
+  SCOPED_TESTVALUE_SET(
+      "facebook::velox::exec::Driver::runInternal",
+      std::function<void(Driver*)>([&](Driver* driver) {
+        auto* op = driver->findOperator(planNodeId);
+        if (op->operatorType() != "HashBuild" &&
+            op->operatorType() != "HashProbe") {
+          return;
+        }
+
+        // Suspend hash probe driver to wait for the test triggered reclaim to
+        // finish.
+        if (op->operatorType() == "HashProbe") {
+          op->pool()->reclaimer()->enterArbitration();
+          waitForReclaimEvent.await(
+              [&]() { return !waitForReclaimFlag.load(); });
+          op->pool()->reclaimer()->leaveArbitration();
+        }
+
+        // Check if we have reached to the last hash build operator or not. The
+        // testvalue callback will set the last build driver.
+        if (lastBuildDriver == nullptr) {
+          return;
+        }
+
+        // Suspend all the remaining hash build drivers until the test triggered
+        // reclaim finish.
+        op->pool()->reclaimer()->enterArbitration();
+        waitForReclaimEvent.await([&]() { return !waitForReclaimFlag.load(); });
+        op->pool()->reclaimer()->leaveArbitration();
+      }));
+
+  const int numDrivers = 4;
+  std::thread queryThread([&]() {
+    const auto spillDirectory = exec::test::TempDirectoryPath::create();
+    AssertQueryBuilder(plan, duckDbQueryRunner_)
+        .maxDrivers(numDrivers)
+        .queryCtx(joinQueryCtx)
+        .spillDirectory(spillDirectory->path)
+        .config(core::QueryConfig::kSpillEnabled, "true")
+        .config(core::QueryConfig::kJoinSpillEnabled, "true")
+        .assertResults(
+            "SELECT c1 FROM tmp WHERE c0 NOT IN (SELECT c0 FROM tmp)");
+  });
+
+  // Wait for the last hash build operator to start building the hash table.
+  waitForBuildFinishEvent.await([&] { return !waitForBuildFinishFlag.load(); });
+  ASSERT_TRUE(lastBuildDriver != nullptr);
+  ASSERT_TRUE(task != nullptr);
+
+  // Wait until the last build driver gets removed from the task after finishes.
+  while (task.load()->numFinishedDrivers() != 1) {
+    bool foundLastBuildDriver{false};
+    task.load()->testingVisitDrivers([&](Driver* driver) {
+      if (driver == lastBuildDriver) {
+        foundLastBuildDriver = true;
+      }
+    });
+    if (!foundLastBuildDriver) {
+      break;
+    }
+  }
+
+  // Reclaim from the task, and we can't reclaim anything as we don't support
+  // spill after hash table built.
+  memory::MemoryReclaimer::Stats stats;
+  const uint64_t oldCapacity = joinQueryCtx->pool()->capacity();
+  task.load()->pool()->reclaim(1'000, stats);
+  ASSERT_EQ(stats.numNonReclaimableAttempts, 1);
+  // Make sure we don't leak memory capacity since we reclaim from task pool
+  // directly.
+  static_cast<MemoryPoolImpl*>(task.load()->pool())
+      ->testingSetCapacity(oldCapacity);
+  waitForReclaimFlag = false;
+  waitForReclaimEvent.notifyAll();
+
+  queryThread.join();
+
+  waitForAllTasksToBeDeleted();
+  ASSERT_EQ(arbitrator_->stats().numFailures, 0);
+  ASSERT_EQ(arbitrator_->stats().numReclaimedBytes, 0);
+}
+
 DEBUG_ONLY_TEST_F(SharedArbitrationTest, arbitrateMemoryFromOtherOperator) {
   setupMemory(kMemoryCapacity, 0);
   const int numVectors = 10;

--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -428,7 +428,6 @@ StopReason Driver::runInternal(
     std::shared_ptr<Driver>& self,
     std::shared_ptr<BlockingState>& blockingState,
     RowVectorPtr& result) {
-  TestValue::adjust("facebook::velox::exec::Driver::runInternal", self.get());
   const auto now = getCurrentTimeMicro();
   const auto queuedTime = (now - queueTimeStartMicros_) * 1'000;
   // Update the next operator's queueTime.
@@ -450,6 +449,8 @@ StopReason Driver::runInternal(
     }
     return stop;
   }
+
+  TestValue::adjust("facebook::velox::exec::Driver::runInternal", self.get());
 
   // Update the queued time after entering the Task to ensure the stats have not
   // been deleted.

--- a/velox/exec/HashBuild.cpp
+++ b/velox/exec/HashBuild.cpp
@@ -28,7 +28,7 @@ namespace {
 BlockingReason fromStateToBlockingReason(HashBuild::State state) {
   switch (state) {
     case HashBuild::State::kRunning:
-      [[fallthrough]];
+      FOLLY_FALLTHROUGH;
     case HashBuild::State::kFinish:
       return BlockingReason::kNotBlocked;
     case HashBuild::State::kWaitForSpill:
@@ -1057,11 +1057,11 @@ void HashBuild::checkStateTransition(State state) {
       }
       break;
     case State::kWaitForBuild:
-      [[fallthrough]];
+      FOLLY_FALLTHROUGH;
     case State::kWaitForSpill:
-      [[fallthrough]];
+      FOLLY_FALLTHROUGH;
     case State::kWaitForProbe:
-      [[fallthrough]];
+      FOLLY_FALLTHROUGH;
     case State::kFinish:
       VELOX_CHECK_EQ(state_, State::kRunning);
       break;
@@ -1097,6 +1097,10 @@ bool HashBuild::testingTriggerSpill() {
       spillConfig()->testSpillPct;
 }
 
+bool HashBuild::canReclaim() const {
+  return Operator::canReclaim() && (spiller_ != nullptr);
+}
+
 void HashBuild::reclaim(
     uint64_t /*unused*/,
     memory::MemoryReclaimer::Stats& stats) {
@@ -1107,13 +1111,14 @@ void HashBuild::reclaim(
 
   // NOTE: a hash build operator is reclaimable if it is in the middle of table
   // build processing and is not under non-reclaimable execution section.
-  if ((state_ != State::kRunning && state_ != State::kWaitForBuild) ||
-      nonReclaimableSection_) {
+  if (nonReclaimableState()) {
     // TODO: reduce the log frequency if it is too verbose.
     ++stats.numNonReclaimableAttempts;
     LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                  << stateName(state_) << "], nonReclaimableSection_["
-                 << nonReclaimableSection_ << "], " << pool()->name();
+                 << nonReclaimableSection_ << "], spiller_["
+                 << (spiller_->finalized() ? "finalized" : "non-finalized")
+                 << "] " << pool()->name();
     return;
   }
 
@@ -1125,15 +1130,14 @@ void HashBuild::reclaim(
     HashBuild* buildOp = dynamic_cast<HashBuild*>(op);
     VELOX_CHECK_NOT_NULL(buildOp);
     VELOX_CHECK(buildOp->canReclaim());
-    if ((buildOp->state_ != State::kRunning &&
-         buildOp->state_ != State::kWaitForBuild) ||
-        buildOp->nonReclaimableSection_) {
+    if (buildOp->nonReclaimableState()) {
       // TODO: reduce the log frequency if it is too verbose.
       ++stats.numNonReclaimableAttempts;
       LOG(WARNING) << "Can't reclaim from hash build operator, state_["
                    << stateName(buildOp->state_) << "], nonReclaimableSection_["
-                   << buildOp->nonReclaimableSection_ << "], "
-                   << buildOp->pool()->name();
+                   << nonReclaimableSection_ << "], spiller_["
+                   << (spiller_->finalized() ? "finalized" : "non-finalized")
+                   << "], " << buildOp->pool()->name();
       return;
     }
   }
@@ -1153,6 +1157,11 @@ void HashBuild::reclaim(
     // Release the minimum reserved memory.
     op->pool()->release();
   }
+}
+
+bool HashBuild::nonReclaimableState() const {
+  return ((state_ != State::kRunning) && (state_ != State::kWaitForBuild)) ||
+      nonReclaimableSection_ || spiller_->finalized();
 }
 
 void HashBuild::abort() {

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -80,6 +80,8 @@ class HashBuild final : public Operator {
   void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
       override;
 
+  bool canReclaim() const override;
+
   void abort() override;
 
  private:
@@ -236,6 +238,10 @@ class HashBuild final : public Operator {
 
   // Invoked to check if it needs to trigger spilling for test purpose only.
   bool testingTriggerSpill();
+
+  // Indicates if this hash build operator is under non-reclaimable state or
+  // not.
+  bool nonReclaimableState() const;
 
   const std::shared_ptr<const core::HashJoinNode> joinNode_;
 

--- a/velox/exec/Spiller.h
+++ b/velox/exec/Spiller.h
@@ -210,6 +210,11 @@ class Spiller {
     }
   }
 
+  /// Indicates if this spiller has finalized or not.
+  bool finalized() const {
+    return finalized_;
+  }
+
   SpillStats stats() const;
 
   /// Global memory pool for spill intermediates. ~1MB per spill executor thread

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -219,7 +219,9 @@ class SpillerTest : public exec::test::RowContainerTestBase {
       ASSERT_TRUE(spiller_->isAllSpilled());
     }
 
+    ASSERT_FALSE(spiller_->finalized());
     Spiller::SpillRows unspilledPartitionRows = spiller_->finishSpill();
+    ASSERT_TRUE(spiller_->finalized());
     SpillPartitionNumSet expectedSpillPartitions;
     if (spillPct == 100 || type_ == Spiller::Type::kAggregateOutput) {
       ASSERT_TRUE(unspilledPartitionRows.empty());
@@ -1205,7 +1207,9 @@ TEST_P(AggregationInputOnly, spillWithEmptyPartitions) {
     ASSERT_GT(stats.spillSerializationTimeUs, 0);
     ASSERT_GT(stats.spillDiskWrites, 0);
     // Expect no non-spilling partitions.
+    ASSERT_FALSE(spiller_->finalized());
     ASSERT_TRUE(spiller_->finishSpill().empty());
+    ASSERT_TRUE(spiller_->finalized());
     const auto finalStats = spiller_->stats();
     ASSERT_GT(finalStats, stats);
     ASSERT_GT(finalStats.spillFillTimeUs, stats.spillFillTimeUs);
@@ -1293,7 +1297,9 @@ TEST_P(NoHashJoin, spillPartition) {
         SpillPartitionNumSet{std::min<uint32_t>(1, numPartitions_ - 1)});
     spiller_->spill(
         SpillPartitionNumSet{std::min<uint32_t>(1, numPartitions_ - 1)});
+    ASSERT_FALSE(spiller_->finalized());
     spiller_->finishSpill();
+    ASSERT_TRUE(spiller_->finalized());
     verifySortedSpillData();
     VELOX_ASSERT_THROW(
         spiller_->spill(SpillPartitionNumSet{0}), "Spiller has been finalized");
@@ -1314,7 +1320,9 @@ TEST_P(NoHashJoin, spillPartition) {
     spiller_->spill(SpillPartitionNumSet(
         spillPartitionNums.begin(), spillPartitionNums.end()));
     ASSERT_TRUE(spiller_->isAllSpilled());
+    ASSERT_FALSE(spiller_->finalized());
     spiller_->finishSpill();
+    ASSERT_TRUE(spiller_->finalized());
     ASSERT_TRUE(spiller_->isAllSpilled());
     verifySortedSpillData();
     VELOX_ASSERT_THROW(
@@ -1336,7 +1344,9 @@ TEST_P(NoHashJoin, spillPartition) {
     ASSERT_TRUE(spiller_->isAllSpilled());
     spiller_->spill();
     ASSERT_TRUE(spiller_->isAllSpilled());
+    ASSERT_FALSE(spiller_->finalized());
     spiller_->finishSpill();
+    ASSERT_TRUE(spiller_->finalized());
     ASSERT_TRUE(spiller_->isAllSpilled());
     verifySortedSpillData();
     VELOX_ASSERT_THROW(
@@ -1363,7 +1373,9 @@ TEST_P(AllTypes, nonSortedSpillFunctions) {
     std::iota(spillPartitionNums.begin(), spillPartitionNums.end(), 0);
     spiller_->spill(SpillPartitionNumSet(
         spillPartitionNums.begin(), spillPartitionNums.end()));
+    ASSERT_FALSE(spiller_->finalized());
     spiller_->finishSpill();
+    ASSERT_TRUE(spiller_->finalized());
     verifySortedSpillData();
     return;
   }


### PR DESCRIPTION
There is a corner case that can lead to spiller is finalized error on memory reclaim:
T1: the last hash build operator finish hash table build and driver is closed
T2: the arbitrator reclaim memory from the hash build operator and its peers
T3: one of the peer hash build operator has been selected to spill and couldn't
      find the last hash build operator as it has already gone. All the other hash build
      operators are left in wait for build state and haven't got a chance to finish
T4: when arbitrator do reclaim and run into spiller finalized error.

This PR adds to check if any spiller has been finalized or not. Also overload canReclaim
method for hash build to consider the case that max spill level exceeded.