### PR TITLE
Fix crash in CAST(ARRAY/MAP(ROW)) to JSON

### DIFF
--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -383,6 +383,29 @@ TEST_F(JsonCastTest, fromArray) {
   testCast(ARRAY(BIGINT()), JSON(), allNullArray, allNullExpected);
 }
 
+TEST_F(JsonCastTest, fromAllNullOrEmptyArrayOfRows) {
+  // ARRAY(CONSTANT(ROW)) with all null or empty elements.
+  auto elements =
+      BaseVector::createNullConstant(ROW({"c0"}, {VARCHAR()}), 0, pool());
+  auto data = makeArrayVector({0, 0, 0, 0}, elements, {0, 2});
+
+  auto expected = makeNullableFlatVector<JsonNativeType>(
+      {std::nullopt, "[]", std::nullopt, "[]"}, JSON());
+  testCast(data->type(), JSON(), data, expected);
+}
+
+TEST_F(JsonCastTest, fromAllNullOrEmptyMapOfRows) {
+  // MAP(..., CONSTANT(ROW)) with all null or empty elements.
+  auto keys = makeNullConstant(TypeKind::INTEGER, 0);
+  auto values =
+      BaseVector::createNullConstant(ROW({"c0"}, {VARCHAR()}), 0, pool());
+  auto data = makeMapVector({0, 0, 0, 0}, keys, values, {0, 2});
+
+  auto expected = makeNullableFlatVector<JsonNativeType>(
+      {std::nullopt, "{}", std::nullopt, "{}"}, JSON());
+  testCast(data->type(), JSON(), data, expected);
+}
+
 TEST_F(JsonCastTest, fromMap) {
   // Tests map with string keys.
   std::vector<std::vector<Pair<StringView, int64_t>>> mapStringKey{


### PR DESCRIPTION
AsJson helper class used to skip peeling when there were no rows selected and
passing non-flat vectors to  castToJsonFromRow causing a crash.

A fix is to avoid calling AsJson helper class if there are no selected rows.