### PR TITLE
PeeledEncoding to accept DecodedVector as opposed to LocalDecodedVector

### DIFF
--- a/velox/expression/PeeledEncoding.h
+++ b/velox/expression/PeeledEncoding.h
@@ -113,6 +113,13 @@ class PeeledEncoding {
   static std::shared_ptr<PeeledEncoding> peel(
       const std::vector<VectorPtr>& vectorsToPeel,
       const SelectivityVector& rows,
+      DecodedVector& decodedVector,
+      bool canPeelsHaveNulls,
+      std::vector<VectorPtr>& peeledVectors);
+
+  static std::shared_ptr<PeeledEncoding> peel(
+      const std::vector<VectorPtr>& vectorsToPeel,
+      const SelectivityVector& rows,
       LocalDecodedVector& decodedVector,
       bool canPeelsHaveNulls,
       std::vector<VectorPtr>& peeledVectors);
@@ -174,7 +181,7 @@ class PeeledEncoding {
   bool peelInternal(
       const std::vector<VectorPtr>& vectorsToPeel,
       const SelectivityVector& rows,
-      LocalDecodedVector& decodedVector,
+      DecodedVector& decodedVector,
       bool canPeelsHaveNulls,
       std::vector<VectorPtr>& peeledVectors);
 


### PR DESCRIPTION
Summary:
LocalDecodedVector is only ever used as DecodedVector in PeeledEncoding methods, so the signature should really not restrict to LocalDecodedVectors. This also allows other use cases to use encoding peeling to help vector transforms.

Due to the requirement of calling get() for the conversion, I'm adding an additional api for smaller blast radius.

Differential Revision: D50376955


