### PR TITLE
Add Yield as a Driver/Operator blocking reason.

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -968,6 +968,8 @@ std::string blockingReasonToString(BlockingReason reason) {
       return "kWaitForConnector";
     case BlockingReason::kWaitForSpill:
       return "kWaitForSpill";
+    case BlockingReason::kYield:
+      return "kYield";
   }
   VELOX_UNREACHABLE();
   return "";

--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -162,6 +162,10 @@ enum class BlockingReason {
   /// Build operator is blocked waiting for all its peers to stop to run group
   /// spill on all of them.
   kWaitForSpill,
+  /// Some operators (like Table Scan) may run long loops and can 'voluntarily'
+  /// exit them because Task requested to yield or stop or after a certain time.
+  /// This is the blocking reason used in such cases.
+  kYield,
 };
 
 std::string blockingReasonToString(BlockingReason reason);

--- a/velox/exec/TableScan.cpp
+++ b/velox/exec/TableScan.cpp
@@ -61,13 +61,13 @@ RowVectorPtr TableScan::getOutput() {
   const auto startTimeMs = getCurrentTimeMs();
   for (;;) {
     if (needNewSplit_) {
-      // Check if our task needs us to yield or we've been running for too long
-      // w/o producing a result. In this case we setup a fake blocking reason
-      // and one already fulfilled future.
+      // Check if our Task needs us to yield or we've been running for too long
+      // w/o producing a result. In this case we return with the Yield blocking
+      // reason and an already fulfilled future.
       if (this->driverCtx_->task->shouldStop() != StopReason::kNone or
           (getOutputTimeLimitMs_ != 0 and
            (getCurrentTimeMs() - startTimeMs) >= getOutputTimeLimitMs_)) {
-        blockingReason_ = BlockingReason::kWaitForSplit;
+        blockingReason_ = BlockingReason::kYield;
         blockingFuture_ = ContinueFuture{folly::Unit{}};
         // A point for test code injection.
         TestValue::adjust(

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -381,7 +381,7 @@ TEST_F(TableScanTest, timestamp) {
       "SELECT c0 FROM tmp WHERE c1 < timestamp'1970-01-01 01:30:00'");
 }
 
-DEBUG_ONLY_TEST_F(TableScanTest, getOutputTimeLimit) {
+DEBUG_ONLY_TEST_F(TableScanTest, timeLimitInGetOutput) {
   // Create two different row vectors: with some nulls and with no nulls.
   vector_size_t numRows = 100;
   auto tsFunc = [](vector_size_t row) {


### PR DESCRIPTION
Summary:
Add Yield as a Driver/Operator blocking reason.
Use it when yielding from TableScan.

Differential Revision: D50380442


