### PR TITLE
Extend AggregationFuzzer to test with empty input

### DIFF
--- a/velox/exec/fuzzer/AggregationFuzzer.cpp
+++ b/velox/exec/fuzzer/AggregationFuzzer.cpp
@@ -411,7 +411,21 @@ void AggregationFuzzer::go() {
           groupingKeys = generateKeys("g", argNames, argTypes);
         }
 
+        // 40% of times test aggregation fuzzer on empty input vectors.
+        bool testEmptyInput = vectorFuzzer_.coinToss(0.4);
+        auto opts = vectorFuzzer_.getOptions();
+        if (testEmptyInput) {
+          opts.vectorSize = 0;
+          vectorFuzzer_.setOptions(opts);
+        }
         auto input = generateInputData(argNames, argTypes, signature);
+
+        // Reset vectorSize to batch_size after empty input vector is generated.
+        if (testEmptyInput) {
+          opts.vectorSize = FLAGS_batch_size;
+          vectorFuzzer_.setOptions(opts);
+        }
+
         std::shared_ptr<ResultVerifier> customVerifier;
         if (customVerification) {
           customVerifier = customVerificationFunctions_.at(signature.name);

--- a/velox/vector/fuzzer/VectorFuzzer.cpp
+++ b/velox/vector/fuzzer/VectorFuzzer.cpp
@@ -431,7 +431,7 @@ VectorPtr VectorFuzzer::fuzzConstant(const TypePtr& type, vector_size_t size) {
   // generated inner vector.
 
   // Inner vector size can't be zero.
-  auto innerVectorSize = rand<uint32_t>(rng_) % opts_.vectorSize + 1;
+  auto innerVectorSize = rand<uint32_t>(rng_) % 100 + 1;
   auto constantIndex = rand<vector_size_t>(rng_) % innerVectorSize;
 
   ScopedOptions restorer(this);


### PR DESCRIPTION
When an `Aggregate` object is used without any calls to `addSingleGroupRawInput` or
`addInput`, such usages should not throw an error. While working on #6872, the aggregate
`approx_percentile` was found to throw an error for such usages:
```
 Error Source: RUNTIME
 Error Code: INVALID_STATE
 Retriable: False
 Expression: result
 Function: extract
 File: velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
 Line: 415
```
This was because the function `decodeArguments` updated the percentile class variables,
which determined the codepath taken in the `extract` function. This was resolved in #6661.

This PR extends AggregationFuzzer to test such usages for all aggregate functions.
Resolves #7029 .