### PR TITLE
Rename PartitionedOutputBuffer and PartitionedOutputBufferManager

### DIFF
--- a/velox/docs/develop/joins.rst
+++ b/velox/docs/develop/joins.rst
@@ -197,7 +197,7 @@ the join is executed using broadcast or partitioned strategy has no effect on
 the join execution itself. The only difference is that broadcast execution
 allows for dynamic filter pushdown while partitioned execution does not.
 
-PartitionedOutput operator and PartitionedOutputBufferManager support
+PartitionedOutput operator and OutputBufferManager support
 broadcasting the results of the plan evaluation. This functionality is enabled
 by setting boolean flag "broadcast" in the PartitionedOutputNode to true.
 

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -53,8 +53,8 @@ add_library(
   OperatorUtils.cpp
   OrderBy.cpp
   PartitionedOutput.cpp
-  PartitionedOutputBuffer.cpp
-  PartitionedOutputBufferManager.cpp
+  OutputBuffer.cpp
+  OutputBufferManager.cpp
   PlanNodeStats.cpp
   ProbeOperatorState.cpp
   RowContainer.cpp

--- a/velox/exec/OutputBuffer.cpp
+++ b/velox/exec/OutputBuffer.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/exec/PartitionedOutputBuffer.h"
+#include "velox/exec/OutputBuffer.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -219,7 +219,7 @@ void releaseAfterAcknowledge(
 }
 } // namespace
 
-PartitionedOutputBuffer::PartitionedOutputBuffer(
+OutputBuffer::OutputBuffer(
     std::shared_ptr<Task> task,
     PartitionedOutputNode::Kind kind,
     int numDestinations,
@@ -238,9 +238,7 @@ PartitionedOutputBuffer::PartitionedOutputBuffer(
   }
 }
 
-void PartitionedOutputBuffer::updateOutputBuffers(
-    int numBuffers,
-    bool noMoreBuffers) {
+void OutputBuffer::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
   if (isPartitioned()) {
     VELOX_CHECK_EQ(buffers_.size(), numBuffers);
     VELOX_CHECK(noMoreBuffers);
@@ -272,7 +270,7 @@ void PartitionedOutputBuffer::updateOutputBuffers(
   }
 }
 
-void PartitionedOutputBuffer::updateNumDrivers(uint32_t newNumDrivers) {
+void OutputBuffer::updateNumDrivers(uint32_t newNumDrivers) {
   bool isNoMoreDrivers{false};
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -287,7 +285,7 @@ void PartitionedOutputBuffer::updateNumDrivers(uint32_t newNumDrivers) {
   }
 }
 
-void PartitionedOutputBuffer::addOutputBuffersLocked(int numBuffers) {
+void OutputBuffer::addOutputBuffersLocked(int numBuffers) {
   VELOX_CHECK(!noMoreBuffers_);
   VELOX_CHECK(!isPartitioned());
   buffers_.reserve(numBuffers);
@@ -305,7 +303,7 @@ void PartitionedOutputBuffer::addOutputBuffersLocked(int numBuffers) {
   }
 }
 
-bool PartitionedOutputBuffer::enqueue(
+bool OutputBuffer::enqueue(
     int destination,
     std::unique_ptr<SerializedPage> data,
     ContinueFuture* future) {
@@ -337,7 +335,7 @@ bool PartitionedOutputBuffer::enqueue(
     }
 
     if (totalSize_ > maxSize_ && future) {
-      promises_.emplace_back("PartitionedOutputBuffer::enqueue");
+      promises_.emplace_back("OutputBuffer::enqueue");
       *future = promises_.back().getSemiFuture();
       blocked = true;
     }
@@ -351,7 +349,7 @@ bool PartitionedOutputBuffer::enqueue(
   return blocked;
 }
 
-void PartitionedOutputBuffer::enqueueBroadcastOutputLocked(
+void OutputBuffer::enqueueBroadcastOutputLocked(
     std::unique_ptr<SerializedPage> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(isBroadcast());
@@ -373,7 +371,7 @@ void PartitionedOutputBuffer::enqueueBroadcastOutputLocked(
   }
 }
 
-void PartitionedOutputBuffer::enqueueArbitraryOutputLocked(
+void OutputBuffer::enqueueArbitraryOutputLocked(
     std::unique_ptr<SerializedPage> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
   VELOX_DCHECK(isArbitrary());
@@ -399,7 +397,7 @@ void PartitionedOutputBuffer::enqueueArbitraryOutputLocked(
   }
 }
 
-void PartitionedOutputBuffer::enqueuePartitionedOutputLocked(
+void OutputBuffer::enqueuePartitionedOutputLocked(
     int destination,
     std::unique_ptr<SerializedPage> data,
     std::vector<DataAvailable>& dataAvailableCbs) {
@@ -420,17 +418,17 @@ void PartitionedOutputBuffer::enqueuePartitionedOutputLocked(
   }
 }
 
-void PartitionedOutputBuffer::noMoreData() {
+void OutputBuffer::noMoreData() {
   // Increment number of finished drivers.
   checkIfDone(true);
 }
 
-void PartitionedOutputBuffer::noMoreDrivers() {
+void OutputBuffer::noMoreDrivers() {
   // Do not increment number of finished drivers.
   checkIfDone(false);
 }
 
-void PartitionedOutputBuffer::checkIfDone(bool oneDriverFinished) {
+void OutputBuffer::checkIfDone(bool oneDriverFinished) {
   std::vector<DataAvailable> finished;
   {
     std::lock_guard<std::mutex> l(mutex_);
@@ -469,12 +467,12 @@ void PartitionedOutputBuffer::checkIfDone(bool oneDriverFinished) {
   }
 }
 
-bool PartitionedOutputBuffer::isFinished() {
+bool OutputBuffer::isFinished() {
   std::lock_guard<std::mutex> l(mutex_);
   return isFinishedLocked();
 }
 
-bool PartitionedOutputBuffer::isFinishedLocked() {
+bool OutputBuffer::isFinishedLocked() {
   // NOTE: for broadcast output buffer, we can only mark it as finished after
   // receiving the no more (destination) buffers signal.
   if (isBroadcast() && !noMoreBuffers_) {
@@ -488,7 +486,7 @@ bool PartitionedOutputBuffer::isFinishedLocked() {
   return true;
 }
 
-void PartitionedOutputBuffer::acknowledge(int destination, int64_t sequence) {
+void OutputBuffer::acknowledge(int destination, int64_t sequence) {
   std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<ContinuePromise> promises;
   {
@@ -506,7 +504,7 @@ void PartitionedOutputBuffer::acknowledge(int destination, int64_t sequence) {
   releaseAfterAcknowledge(freed, promises);
 }
 
-void PartitionedOutputBuffer::updateAfterAcknowledgeLocked(
+void OutputBuffer::updateAfterAcknowledgeLocked(
     const std::vector<std::shared_ptr<SerializedPage>>& freed,
     std::vector<ContinuePromise>& promises) {
   uint64_t totalFreed = 0;
@@ -532,7 +530,7 @@ void PartitionedOutputBuffer::updateAfterAcknowledgeLocked(
   }
 }
 
-bool PartitionedOutputBuffer::deleteResults(int destination) {
+bool OutputBuffer::deleteResults(int destination) {
   std::vector<std::shared_ptr<SerializedPage>> freed;
   std::vector<ContinuePromise> promises;
   bool isFinished;
@@ -567,7 +565,7 @@ bool PartitionedOutputBuffer::deleteResults(int destination) {
   return isFinished;
 }
 
-void PartitionedOutputBuffer::getData(
+void OutputBuffer::getData(
     int destination,
     uint64_t maxBytes,
     int64_t sequence,
@@ -599,7 +597,7 @@ void PartitionedOutputBuffer::getData(
   }
 }
 
-void PartitionedOutputBuffer::terminate() {
+void OutputBuffer::terminate() {
   VELOX_CHECK(!task_->isRunning());
 
   std::vector<ContinuePromise> outstandingPromises;
@@ -612,14 +610,14 @@ void PartitionedOutputBuffer::terminate() {
   }
 }
 
-std::string PartitionedOutputBuffer::toString() {
+std::string OutputBuffer::toString() {
   std::lock_guard<std::mutex> l(mutex_);
   return toStringLocked();
 }
 
-std::string PartitionedOutputBuffer::toStringLocked() const {
+std::string OutputBuffer::toStringLocked() const {
   std::stringstream out;
-  out << "[PartitionedOutputBuffer[" << kind_ << "] totalSize_=" << totalSize_
+  out << "[OutputBuffer[" << kind_ << "] totalSize_=" << totalSize_
       << "b, num producers blocked=" << promises_.size()
       << ", completed=" << numFinished_ << "/" << numDrivers_ << ", "
       << (atEnd_ ? "at end, " : "") << "destinations: " << std::endl;
@@ -634,11 +632,11 @@ std::string PartitionedOutputBuffer::toStringLocked() const {
   return out.str();
 }
 
-double PartitionedOutputBuffer::getUtilization() const {
+double OutputBuffer::getUtilization() const {
   return totalSize_ / (double)maxSize_;
 }
 
-bool PartitionedOutputBuffer::isOverutilized() const {
+bool OutputBuffer::isOverutilized() const {
   return (totalSize_ > maxSize_) && !atEnd_;
 }
 

--- a/velox/exec/OutputBuffer.h
+++ b/velox/exec/OutputBuffer.h
@@ -128,9 +128,9 @@ class DestinationBuffer {
 
 class Task;
 
-class PartitionedOutputBuffer {
+class OutputBuffer {
  public:
-  PartitionedOutputBuffer(
+  OutputBuffer(
       std::shared_ptr<Task> task,
       core::PartitionedOutputNode::Kind kind,
       int numDestinations,

--- a/velox/exec/OutputBufferManager.h
+++ b/velox/exec/OutputBufferManager.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/OutputBuffer.h"
+
+namespace facebook::velox::exec {
+
+class OutputBufferManager {
+ public:
+  void initializeTask(
+      std::shared_ptr<Task> task,
+      core::PartitionedOutputNode::Kind kind,
+      int numDestinations,
+      int numDrivers);
+
+  /// Updates the number of buffers. Return true if the buffer exists for a
+  /// given taskId, else returns false.
+  bool updateOutputBuffers(
+      const std::string& taskId,
+      int numBuffers,
+      bool noMoreBuffers);
+
+  /// When we understand the final number of split groups (for grouped
+  /// execution only), we need to update the number of producing drivers here.
+  void updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers);
+
+  // Adds data to the outgoing queue for 'destination'. 'data' must not be
+  // nullptr. 'data' is always added but if the buffers are full the future is
+  // set to a ContinueFuture that will be realized when there is space.
+  bool enqueue(
+      const std::string& taskId,
+      int destination,
+      std::unique_ptr<SerializedPage> data,
+      ContinueFuture* future);
+
+  void noMoreData(const std::string& taskId);
+
+  // Returns true if noMoreData has been called and all the accumulated data
+  // have been fetched and acknowledged.
+  bool isFinished(const std::string& taskId);
+
+  // Removes data with sequence number < 'sequence' from the queue for
+  // 'destination_'.
+  void
+  acknowledge(const std::string& taskId, int destination, int64_t sequence);
+
+  void deleteResults(const std::string& taskId, int destination);
+
+  // Adds up to 'maxBytes' bytes worth of data for 'destination' from
+  // 'taskId'. The sequence number of the data must be >= 'sequence'.
+  // If there is no buffer associated with the given taskId, returns false.
+  // If there is no data, 'notify' will be registered and
+  // called when there is data or the source is at end, the function returns
+  // true.
+  // Existing data with a sequence number < sequence is deleted. The caller is
+  // expected to increment the sequence number between calls by the
+  // number of items received. In this way the next call implicitly
+  // acknowledges receipt of the results from the previous. The
+  // acknowledge method is offered for an early ack, so that the
+  // producer can continue before the consumer is done processing the
+  // received data.
+  bool getData(
+      const std::string& taskId,
+      int destination,
+      uint64_t maxBytes,
+      int64_t sequence,
+      DataAvailableCallback notify);
+
+  void removeTask(const std::string& taskId);
+
+  static std::weak_ptr<OutputBufferManager> getInstance();
+
+  uint64_t numBuffers() const;
+
+  // Returns a new stream listener if a listener factory has been set.
+  std::unique_ptr<OutputStreamListener> newListener() const {
+    return listenerFactory_ ? listenerFactory_() : nullptr;
+  }
+
+  // Sets the stream listener factory. This allows custom processing of data
+  // for repartitioning, e.g. computing checksums.
+  void setListenerFactory(
+      std::function<std::unique_ptr<OutputStreamListener>()> factory) {
+    listenerFactory_ = factory;
+  }
+
+  std::string toString();
+
+  // Gets the memory utilization ratio for the output buffer from a task of
+  // taskId, if the task of this taskId is not found, return 0.
+  double getUtilization(const std::string& taskId);
+
+  // If the output buffer from a task of taskId is over-utilized and blocks its
+  // producers. When the task of this taskId is not found, return false.
+  bool isOverutilized(const std::string& taskId);
+
+  // Retrieves the set of buffers for a query if exists.
+  // Returns NULL if task not found.
+  std::shared_ptr<OutputBuffer> getBufferIfExists(const std::string& taskId);
+
+ private:
+  // Retrieves the set of buffers for a query.
+  // Throws an exception if buffer doesn't exist.
+  std::shared_ptr<OutputBuffer> getBuffer(const std::string& taskId);
+
+  folly::Synchronized<
+      std::unordered_map<std::string, std::shared_ptr<OutputBuffer>>,
+      std::mutex>
+      buffers_;
+
+  std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory_{
+      nullptr};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/PartitionedOutput.cpp
+++ b/velox/exec/PartitionedOutput.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "velox/exec/PartitionedOutput.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 
 namespace facebook::velox::exec {
@@ -25,7 +25,7 @@ BlockingReason Destination::advance(
     uint64_t maxBytes,
     const std::vector<vector_size_t>& sizes,
     const RowVectorPtr& output,
-    PartitionedOutputBufferManager& bufferManager,
+    OutputBufferManager& bufferManager,
     const std::function<void()>& bufferReleaseFn,
     bool* atEnd,
     ContinueFuture* future) {
@@ -79,7 +79,7 @@ BlockingReason Destination::advance(
 }
 
 BlockingReason Destination::flush(
-    PartitionedOutputBufferManager& bufferManager,
+    OutputBufferManager& bufferManager,
     const std::function<void()>& bufferReleaseFn,
     ContinueFuture* future) {
   if (!current_) {
@@ -130,7 +130,7 @@ PartitionedOutput::PartitionedOutput(
           planNode->inputType(),
           planNode->outputType(),
           planNode->outputType())),
-      bufferManager_(PartitionedOutputBufferManager::getInstance()),
+      bufferManager_(OutputBufferManager::getInstance()),
       // NOTE: 'bufferReleaseFn_' holds a reference on the associated task to
       // prevent it from deleting while there are output buffers being accessed
       // out of the partitioned output buffer manager such as in Prestissimo,
@@ -307,7 +307,7 @@ RowVectorPtr PartitionedOutput::getOutput() {
   detail::Destination* blockedDestination = nullptr;
   auto bufferManager = bufferManager_.lock();
   VELOX_CHECK_NOT_NULL(
-      bufferManager, "PartitionedOutputBufferManager was already destructed");
+      bufferManager, "OutputBufferManager was already destructed");
 
   // Limit serialized pages to 1MB.
   static const uint64_t kMaxPageSize = 1 << 20;

--- a/velox/exec/PartitionedOutput.h
+++ b/velox/exec/PartitionedOutput.h
@@ -17,7 +17,7 @@
 
 #include <folly/Random.h>
 #include "velox/exec/Operator.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/vector/VectorStream.h"
 
 namespace facebook::velox::exec {
@@ -54,13 +54,13 @@ class Destination {
       uint64_t maxBytes,
       const std::vector<vector_size_t>& sizes,
       const RowVectorPtr& output,
-      PartitionedOutputBufferManager& bufferManager,
+      OutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
       bool* atEnd,
       ContinueFuture* future);
 
   BlockingReason flush(
-      PartitionedOutputBufferManager& bufferManager,
+      OutputBufferManager& bufferManager,
       const std::function<void()>& bufferReleaseFn,
       ContinueFuture* future);
 
@@ -193,7 +193,7 @@ class PartitionedOutput : public Operator {
   std::unique_ptr<core::PartitionFunction> partitionFunction_;
   // Empty if column order in the output is exactly the same as in input.
   const std::vector<column_index_t> outputChannels_;
-  const std::weak_ptr<exec::PartitionedOutputBufferManager> bufferManager_;
+  const std::weak_ptr<exec::OutputBufferManager> bufferManager_;
   const std::function<void()> bufferReleaseFn_;
   const int64_t maxBufferedBytes_;
 

--- a/velox/exec/PartitionedOutputBufferManager.h
+++ b/velox/exec/PartitionedOutputBufferManager.h
@@ -15,115 +15,12 @@
  */
 #pragma once
 
-#include "velox/exec/PartitionedOutputBuffer.h"
+#include "velox/exec/OutputBufferManager.h"
 
 namespace facebook::velox::exec {
 
-class PartitionedOutputBufferManager {
- public:
-  void initializeTask(
-      std::shared_ptr<Task> task,
-      core::PartitionedOutputNode::Kind kind,
-      int numDestinations,
-      int numDrivers);
+#ifdef VELOX_ENABLE_BACKWARD_COMPATIBILITY
+using PartitionedOutputBufferManager = OutputBufferManager;
+#endif
 
-  /// Updates the number of buffers. Return true if the buffer exists for a
-  /// given taskId, else returns false.
-  bool updateOutputBuffers(
-      const std::string& taskId,
-      int numBuffers,
-      bool noMoreBuffers);
-
-  /// When we understand the final number of split groups (for grouped
-  /// execution only), we need to update the number of producing drivers here.
-  void updateNumDrivers(const std::string& taskId, uint32_t newNumDrivers);
-
-  // Adds data to the outgoing queue for 'destination'. 'data' must not be
-  // nullptr. 'data' is always added but if the buffers are full the future is
-  // set to a ContinueFuture that will be realized when there is space.
-  bool enqueue(
-      const std::string& taskId,
-      int destination,
-      std::unique_ptr<SerializedPage> data,
-      ContinueFuture* future);
-
-  void noMoreData(const std::string& taskId);
-
-  // Returns true if noMoreData has been called and all the accumulated data
-  // have been fetched and acknowledged.
-  bool isFinished(const std::string& taskId);
-
-  // Removes data with sequence number < 'sequence' from the queue for
-  // 'destination_'.
-  void
-  acknowledge(const std::string& taskId, int destination, int64_t sequence);
-
-  void deleteResults(const std::string& taskId, int destination);
-
-  // Adds up to 'maxBytes' bytes worth of data for 'destination' from
-  // 'taskId'. The sequence number of the data must be >= 'sequence'.
-  // If there is no buffer associated with the given taskId, returns false.
-  // If there is no data, 'notify' will be registered and
-  // called when there is data or the source is at end, the function returns
-  // true.
-  // Existing data with a sequence number < sequence is deleted. The caller is
-  // expected to increment the sequence number between calls by the
-  // number of items received. In this way the next call implicitly
-  // acknowledges receipt of the results from the previous. The
-  // acknowledge method is offered for an early ack, so that the
-  // producer can continue before the consumer is done processing the
-  // received data.
-  bool getData(
-      const std::string& taskId,
-      int destination,
-      uint64_t maxBytes,
-      int64_t sequence,
-      DataAvailableCallback notify);
-
-  void removeTask(const std::string& taskId);
-
-  static std::weak_ptr<PartitionedOutputBufferManager> getInstance();
-
-  uint64_t numBuffers() const;
-
-  // Returns a new stream listener if a listener factory has been set.
-  std::unique_ptr<OutputStreamListener> newListener() const {
-    return listenerFactory_ ? listenerFactory_() : nullptr;
-  }
-
-  // Sets the stream listener factory. This allows custom processing of data
-  // for repartitioning, e.g. computing checksums.
-  void setListenerFactory(
-      std::function<std::unique_ptr<OutputStreamListener>()> factory) {
-    listenerFactory_ = factory;
-  }
-
-  std::string toString();
-
-  // Gets the memory utilization ratio for the output buffer from a task of
-  // taskId, if the task of this taskId is not found, return 0.
-  double getUtilization(const std::string& taskId);
-
-  // If the output buffer from a task of taskId is over-utilized and blocks its
-  // producers. When the task of this taskId is not found, return false.
-  bool isOverutilized(const std::string& taskId);
-
-  // Retrieves the set of buffers for a query if exists.
-  // Returns NULL if task not found.
-  std::shared_ptr<PartitionedOutputBuffer> getBufferIfExists(
-      const std::string& taskId);
-
- private:
-  // Retrieves the set of buffers for a query.
-  // Throws an exception if buffer doesn't exist.
-  std::shared_ptr<PartitionedOutputBuffer> getBuffer(const std::string& taskId);
-
-  folly::Synchronized<
-      std::unordered_map<std::string, std::shared_ptr<PartitionedOutputBuffer>>,
-      std::mutex>
-      buffers_;
-
-  std::function<std::unique_ptr<OutputStreamListener>()> listenerFactory_{
-      nullptr};
-};
 } // namespace facebook::velox::exec

--- a/velox/exec/Task.cpp
+++ b/velox/exec/Task.cpp
@@ -28,7 +28,7 @@
 #include "velox/exec/Merge.h"
 #include "velox/exec/NestedLoopJoinBuild.h"
 #include "velox/exec/OperatorUtils.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 #if CODEGEN_ENABLED == 1
 #include "velox/experimental/codegen/CodegenLogger.h"
@@ -261,7 +261,7 @@ Task::Task(
       consumerSupplier_(std::move(consumerSupplier)),
       onError_(onError),
       splitsStates_(buildSplitStates(planFragment_.planNode)),
-      bufferManager_(PartitionedOutputBufferManager::getInstance()) {}
+      bufferManager_(OutputBufferManager::getInstance()) {}
 
 Task::~Task() {
   TestValue::adjust("facebook::velox::exec::Task::~Task", this);
@@ -625,7 +625,7 @@ void Task::start(
     VELOX_CHECK_NOT_NULL(
         bufferManager,
         "Unable to initialize task. "
-        "PartitionedOutputBufferManager was already destructed");
+        "OutputBufferManager was already destructed");
 
     // In this loop we prepare the global state of pipelines: partitioned output
     // buffer and exchange client(s).
@@ -1376,7 +1376,7 @@ bool Task::updateOutputBuffers(int numBuffers, bool noMoreBuffers) {
   VELOX_CHECK_NOT_NULL(
       bufferManager,
       "Unable to initialize task. "
-      "PartitionedOutputBufferManager was already destructed");
+      "OutputBufferManager was already destructed");
   {
     std::lock_guard<std::mutex> l(mutex_);
     if (noMoreOutputBuffers_) {

--- a/velox/exec/Task.h
+++ b/velox/exec/Task.h
@@ -27,7 +27,7 @@
 
 namespace facebook::velox::exec {
 
-class PartitionedOutputBufferManager;
+class OutputBufferManager;
 
 class HashJoinBridge;
 class NestedLoopJoinBridge;
@@ -574,7 +574,7 @@ class Task : public std::enable_shared_from_this<Task> {
     return spillDirectory_;
   }
 
-  /// True if produces output via PartitionedOutputBufferManager.
+  /// True if produces output via OutputBufferManager.
   bool hasPartitionedOutput() const {
     return numDriversInPartitionedOutput_ > 0;
   }
@@ -883,7 +883,7 @@ class Task : public std::enable_shared_from_this<Task> {
   // NOTE: 'childPools_' holds the ownerships of node memory pools.
   std::unordered_map<core::PlanNodeId, memory::MemoryPool*> nodePools_;
 
-  // Set to true by PartitionedOutputBufferManager when all output is
+  // Set to true by OutputBufferManager when all output is
   // acknowledged. If this happens before Drivers are at end, the last
   // Driver to finish will set state_ to kFinished. If Drivers have
   // finished then setting this to true will also set state_ to
@@ -991,7 +991,7 @@ class Task : public std::enable_shared_from_this<Task> {
   /// During ungrouped execution we use the [0] entry in this vector.
   std::unordered_map<uint32_t, SplitGroupState> splitGroupStates_;
 
-  std::weak_ptr<PartitionedOutputBufferManager> bufferManager_;
+  std::weak_ptr<OutputBufferManager> bufferManager_;
 
   /// Boolean indicating that we have already received no-more-output-buffers
   /// message. Subsequent messages will be ignored.

--- a/velox/exec/TaskDriverOperatorLifecycle.md
+++ b/velox/exec/TaskDriverOperatorLifecycle.md
@@ -5,21 +5,21 @@ Tasks and Drivers which are cleared when Task drops references to Drivers.
 Task::terminate contains catch-all logic to clear things up in case of abnormal
 or early termination.
 
-## PartitionedOutputBufferManager
+## OutputBufferManager
 
-PartitionedOutputBuffer holds a reference to the task. This reference is used to
+OutputBuffer holds a reference to the task. This reference is used to
 notify the task that all output has been consumed by calling
-task->setAllOutputConsumed() from PartitionedOutputBuffer::deleteResults.
+task->setAllOutputConsumed() from OutputBuffer::deleteResults.
 
-This reference is dropped when PartitionedOutputBuffer is destroyed which
-happens in (1) PartitionedOutputBufferManager::deleteResults (happy path) and
-(2) PartitionedOutputBufferManager::removeTask (error path).
+This reference is dropped when OutputBuffer is destroyed which
+happens in (1) OutputBufferManager::deleteResults (happy path) and
+(2) OutputBufferManager::removeTask (error path).
 
-In Prestissimo application, PartitionedOutputBufferManager::deleteResults is called by
+In Prestissimo application, OutputBufferManager::deleteResults is called by
 TaskManager::abortResults which is called by TaskResource::abortResults
 attached to HTTP DELETE /v1/task/(.+)/results/(.+)
 
-PartitionedOutputBufferManager::removeTask is called by Task::terminate.
+OutputBufferManager::removeTask is called by Task::terminate.
 
 ## Operator
 

--- a/velox/exec/tests/CMakeLists.txt
+++ b/velox/exec/tests/CMakeLists.txt
@@ -54,7 +54,7 @@ add_executable(
   MultiFragmentTest.cpp
   NestedLoopJoinTest.cpp
   OrderByTest.cpp
-  PartitionedOutputBufferManagerTest.cpp
+  OutputBufferManagerTest.cpp
   PlanNodeSerdeTest.cpp
   PlanNodeToStringTest.cpp
   PrintPlanWithStatsTest.cpp

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/Task.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/exec/tests/utils/PlanBuilder.h"
@@ -37,7 +37,7 @@ class ExchangeClientTest : public testing::Test,
       velox::serializer::presto::PrestoVectorSerde::registerVectorSerde();
     }
 
-    bufferManager_ = PartitionedOutputBufferManager::getInstance().lock();
+    bufferManager_ = OutputBufferManager::getInstance().lock();
   }
 
   std::unique_ptr<SerializedPage> toSerializedPage(const RowVectorPtr& vector) {
@@ -86,7 +86,7 @@ class ExchangeClientTest : public testing::Test,
     }
   }
 
-  std::shared_ptr<PartitionedOutputBufferManager> bufferManager_;
+  std::shared_ptr<OutputBufferManager> bufferManager_;
 };
 
 TEST_F(ExchangeClientTest, nonVeloxCreateExchangeSourceException) {

--- a/velox/exec/tests/GroupedExecutionTest.cpp
+++ b/velox/exec/tests/GroupedExecutionTest.cpp
@@ -16,7 +16,7 @@
 #include <velox/type/Timestamp.h>
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/tests/utils/Cursor.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
@@ -256,8 +256,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithOutputBuffer) {
 
   // 'Delete results' from output buffer triggers 'set all output consumed',
   // which should finish the task.
-  auto outputBufferManager =
-      exec::PartitionedOutputBufferManager::getInstance().lock();
+  auto outputBufferManager = exec::OutputBufferManager::getInstance().lock();
   outputBufferManager->deleteResults(task->taskId(), 0);
 
   // Task must be finished at this stage.
@@ -410,8 +409,7 @@ TEST_F(GroupedExecutionTest, groupedExecutionWithHashAndNestedLoopJoin) {
 
     // 'Delete results' from output buffer triggers 'set all output consumed',
     // which should finish the task.
-    auto outputBufferManager =
-        exec::PartitionedOutputBufferManager::getInstance().lock();
+    auto outputBufferManager = exec::OutputBufferManager::getInstance().lock();
     outputBufferManager->deleteResults(task->taskId(), 0);
 
     // Task must be finished at this stage.

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -21,7 +21,7 @@
 #include "velox/dwio/common/FileSink.h"
 #include "velox/dwio/common/tests/utils/BatchMaker.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/RoundRobinPartitionFunction.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
@@ -523,7 +523,7 @@ TEST_F(MultiFragmentTest, partitionedOutput) {
                         .planNode();
     auto leafTask = makeTask(leafTaskId, leafPlan, 0);
     Task::start(leafTask, 4);
-    auto bufferMgr = PartitionedOutputBufferManager::getInstance().lock();
+    auto bufferMgr = OutputBufferManager::getInstance().lock();
     // Delete the results asynchronously to simulate abort from downstream.
     bufferMgr->deleteResults(leafTaskId, 0);
 
@@ -1422,7 +1422,7 @@ TEST_F(MultiFragmentTest, taskTerminateWithPendingOutputBuffers) {
   Task::start(task, 1);
   addHiveSplits(task, filePaths_);
 
-  auto bufferManager = PartitionedOutputBufferManager::getInstance().lock();
+  auto bufferManager = OutputBufferManager::getInstance().lock();
   const uint64_t maxBytes = std::numeric_limits<uint64_t>::max();
   const int destination = 0;
   std::vector<std::unique_ptr<folly::IOBuf>> receivedIobufs;
@@ -1619,8 +1619,8 @@ class DataFetcher {
  private:
   static constexpr int64_t kInitialSequence = 0;
 
-  std::shared_ptr<PartitionedOutputBufferManager> bufferManager() {
-    return PartitionedOutputBufferManager::getInstance().lock();
+  std::shared_ptr<OutputBufferManager> bufferManager() {
+    return OutputBufferManager::getInstance().lock();
   }
 
   void doFetch(int64_t sequence) {

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -20,7 +20,7 @@
 #include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/exec/tests/utils/Cursor.h"

--- a/velox/exec/tests/TaskTest.cpp
+++ b/velox/exec/tests/TaskTest.cpp
@@ -21,7 +21,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/connectors/hive/HiveConnector.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/PlanNodeStats.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/tests/utils/Cursor.h"
@@ -924,7 +924,7 @@ TEST_F(TaskTest, updateBroadCastOutputBuffers) {
                   .project({"c0 % 10"})
                   .partitionedOutputBroadcast({})
                   .planFragment();
-  auto bufferManager = PartitionedOutputBufferManager::getInstance().lock();
+  auto bufferManager = OutputBufferManager::getInstance().lock();
   {
     auto task = Task::create(
         "t0", plan, 0, std::make_shared<core::QueryCtx>(driverExecutor_.get()));

--- a/velox/exec/tests/utils/LocalExchangeSource.cpp
+++ b/velox/exec/tests/utils/LocalExchangeSource.cpp
@@ -15,7 +15,7 @@
  */
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
 #include "velox/common/testutil/TestValue.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 
 namespace facebook::velox::exec::test {
 namespace {
@@ -60,8 +60,8 @@ class LocalExchangeSource : public exec::ExchangeSource {
 
     promise_ = std::move(promise);
 
-    auto buffers = PartitionedOutputBufferManager::getInstance().lock();
-    VELOX_CHECK_NOT_NULL(buffers, "invalid PartitionedOutputBufferManager");
+    auto buffers = OutputBufferManager::getInstance().lock();
+    VELOX_CHECK_NOT_NULL(buffers, "invalid OutputBufferManager");
     VELOX_CHECK(requestPending_);
     auto requestedSequence = sequence_;
     auto self = shared_from_this();
@@ -150,7 +150,7 @@ class LocalExchangeSource : public exec::ExchangeSource {
   void close() override {
     checkSetRequestPromise();
 
-    auto buffers = PartitionedOutputBufferManager::getInstance().lock();
+    auto buffers = OutputBufferManager::getInstance().lock();
     buffers->deleteResults(taskId_, destination_);
   }
 

--- a/velox/exec/tests/utils/LocalExchangeSource.h
+++ b/velox/exec/tests/utils/LocalExchangeSource.h
@@ -19,7 +19,7 @@
 namespace facebook::velox::exec::test {
 
 /// Given taskId that starts with local:// returns an instance of ExchangeSource
-/// that fetches data from local PartitionedoutputBufferManager.
+/// that fetches data from local OutputBufferManager.
 std::unique_ptr<exec::ExchangeSource> createLocalExchangeSource(
     const std::string& taskId,
     int destination,

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -21,7 +21,7 @@
 #include "velox/common/testutil/TestValue.h"
 #include "velox/dwio/common/FileSink.h"
 #include "velox/exec/Exchange.h"
-#include "velox/exec/PartitionedOutputBufferManager.h"
+#include "velox/exec/OutputBufferManager.h"
 #include "velox/exec/tests/utils/AssertQueryBuilder.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"


### PR DESCRIPTION
Rename PartitionedOutputBuffer and PartitionedOutputBufferManager to
OutputBuffer and OutputBufferManager.

Because PartitionedOutputBuffer is not "partitioned" but a general output buffer 
which has three types: partitioned, broadcast and arbitrary. Similarly for 
PartitionedOutputBufferManager.