### PR TITLE
Fix MultiFragmentTest.maxBytes unit test

### DIFF
--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1680,9 +1680,12 @@ class DataFetcher {
 /// sizes to no more than 1MB give and take 30%.
 TEST_F(MultiFragmentTest, maxBytes) {
   std::string s(25, 'x');
+  // Keep the row count under 7000 to avoid hitting the row limit in the
+  // operator instead.
   auto data = makeRowVector({
-      makeFlatVector<int64_t>(10'000, [](auto row) { return row; }),
-      makeConstant(StringView(s), 10'000),
+      makeFlatVector<int64_t>(5'000, [](auto row) { return row; }),
+      makeFlatVector<int64_t>(5'000, [](auto row) { return row; }),
+      makeConstant(StringView(s), 5'000),
   });
 
   auto plan = PlanBuilder()


### PR DESCRIPTION
Summary:
Currently the test relies on PartitionedOuput operator to enforce a
1MB limit on the output batches however the operator also has a
limit on the number of rows which varies randomly between 70% to
120% of 10000. This limit was not correctly enforced and was fixed
in #7059 so after it was merged this randomness resulted in this unit
test being flaky as it utilized a vector of size 10000 and expected
the output to be predictable.
The fix here is to reduce the row count of the input vector while
ensuring its memory usage stays the same in order to hit the memory
limit that the test is checking for.

Differential Revision: D50388151


