### PR TITLE
Throw VeloxUserError for decimal division by zero

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -207,7 +207,7 @@ class DecimalUtil {
       bool noRoundUp,
       uint8_t aRescale,
       uint8_t /*bRescale*/) {
-    VELOX_CHECK_NE(b, 0, "Division by zero");
+    VELOX_USER_CHECK_NE(b, 0, "Division by zero");
     int resultSign = 1;
     A unsignedDividendRescaled(a);
     if (a < 0) {


### PR DESCRIPTION
`try` should return NULL for division by zero during expression evaluation. For decimal
inputs, this does not happen as `VeloxUserError` is not thrown for divide by zero. This
PR modifies the divide by zero check for decimals to throw `VeloxUserError`.
Encountered while working on https://github.com/prestodb/presto/issues/21178