### PR TITLE
Fix createCompressor API in dwio/common

### DIFF
--- a/velox/dwio/common/compression/Compression.h
+++ b/velox/dwio/common/compression/Compression.h
@@ -17,9 +17,7 @@
 #pragma once
 
 #include "velox/common/compression/Compression.h"
-#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/common/SeekableInputStream.h"
-#include "velox/dwio/common/compression/CompressionBufferPool.h"
 #include "velox/dwio/common/encryption/Encryption.h"
 
 namespace facebook::velox::dwio::common::compression {
@@ -111,18 +109,10 @@ std::unique_ptr<dwio::common::SeekableInputStream> createDecompressor(
 /**
  * Create a compressor for the given compression kind.
  * @param kind The compression type to implement
- * @param bufferPool Pool for compression buffer
- * @param bufferHolder Buffer holder that handles buffer allocation and
- * collection
- * @param pageHeaderSize Header size of compressed block
  * @param options The compression options to use
  */
-std::unique_ptr<BufferedOutputStream> createCompressor(
+std::unique_ptr<Compressor> createCompressor(
     facebook::velox::common::CompressionKind kind,
-    CompressionBufferPool& bufferPool,
-    DataBufferHolder& bufferHolder,
-    uint8_t pageHeaderSize,
-    const CompressionOptions& options,
-    const dwio::common::encryption::Encrypter* encrypter = nullptr);
+    const CompressionOptions& options);
 
 } // namespace facebook::velox::dwio::common::compression

--- a/velox/dwio/common/compression/PagedOutputStream.h
+++ b/velox/dwio/common/compression/PagedOutputStream.h
@@ -16,7 +16,9 @@
 
 #pragma once
 
+#include "velox/dwio/common/OutputStream.h"
 #include "velox/dwio/common/compression/Compression.h"
+#include "velox/dwio/common/compression/CompressionBufferPool.h"
 
 namespace facebook::velox::dwio::common::compression {
 

--- a/velox/dwio/parquet/reader/CMakeLists.txt
+++ b/velox/dwio/parquet/reader/CMakeLists.txt
@@ -37,5 +37,4 @@ target_link_libraries(
   arrow
   Snappy::snappy
   thrift
-  zstd::zstd
-  ${Protobuf_LIBRARIES})
+  zstd::zstd)


### PR DESCRIPTION
Remove the Protobuf dependency for Parquet.
BufferedOutputStream API depends on Protobuf and is specific to Dwrf/ORC.
The Parquet writer will likely use a different OutputStream.
