### PR TITLE
Add overwrite parameter for all agg functions registration

### DIFF
--- a/velox/exec/Aggregate.h
+++ b/velox/exec/Aggregate.h
@@ -426,8 +426,8 @@ AggregateRegistrationResult registerAggregateFunction(
     const std::string& name,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
-    bool registerCompanionFunctions = false,
-    bool overwrite = false);
+    bool registerCompanionFunctions,
+    bool overwrite);
 
 // Register an aggregation function with multiple names. Returns a vector of
 // AggregateRegistrationResult, one for each name at the corresponding index.
@@ -435,8 +435,8 @@ std::vector<AggregateRegistrationResult> registerAggregateFunction(
     const std::vector<std::string>& names,
     const std::vector<std::shared_ptr<AggregateFunctionSignature>>& signatures,
     const AggregateFunctionFactory& factory,
-    bool registerCompanionFunctions = false,
-    bool overwrite = false);
+    bool registerCompanionFunctions,
+    bool overwrite);
 
 /// Returns signatures of the aggregate function with the specified name.
 /// Returns empty std::optional if function with that name is not found.

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -444,7 +444,9 @@ TEST_F(AggregationTest, missingFunctionOrSignature) {
           const std::vector<TypePtr>& argTypes,
           const TypePtr& resultType,
           const core::QueryConfig& /*config*/)
-          -> std::unique_ptr<exec::Aggregate> { VELOX_UNREACHABLE(); });
+          -> std::unique_ptr<exec::Aggregate> { VELOX_UNREACHABLE(); },
+      false /*registerCompanionFunctions*/,
+      true /*overwrite*/);
 
   std::vector<core::TypedExprPtr> inputs = {
       std::make_shared<core::FieldAccessTypedExpr>(BIGINT(), "c0"),

--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -432,7 +432,9 @@ exec::AggregateRegistrationResult registerSimpleCountNullsAggregate(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<SimpleAggregateAdapter<CountNullsAggregate>>(
             resultType);
-      });
+      },
+      false /*registerCompanionFunctions*/,
+      true /*overwrite*/);
 }
 
 void registerSimpleCountNullsAggregate() {

--- a/velox/exec/tests/SimpleArrayAggAggregate.cpp
+++ b/velox/exec/tests/SimpleArrayAggAggregate.cpp
@@ -157,7 +157,8 @@ exec::AggregateRegistrationResult registerSimpleArrayAggAggregate(
         return std::make_unique<SimpleAggregateAdapter<ArrayAggAggregate>>(
             resultType);
       },
-      /*registerCompanionFunctions*/ true);
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
 }
 
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/SimpleAverageAggregate.cpp
+++ b/velox/exec/tests/SimpleAverageAggregate.cpp
@@ -167,7 +167,8 @@ exec::AggregateRegistrationResult registerSimpleAverageAggregate(
           }
         }
       },
-      true);
+      true /*registerCompanionFunctions*/,
+      true /*overwrite*/);
 }
 
 } // namespace facebook::velox::aggregate

--- a/velox/exec/tests/utils/SumNonPODAggregate.cpp
+++ b/velox/exec/tests/utils/SumNonPODAggregate.cpp
@@ -162,7 +162,9 @@ exec::AggregateRegistrationResult registerSumNonPODAggregate(
           const core::QueryConfig& /*config*/)
           -> std::unique_ptr<velox::exec::Aggregate> {
         return std::make_unique<SumNonPODAggregate>(velox::BIGINT(), alignment);
-      });
+      },
+      false /*registerCompanionFunctions*/,
+      true /*overwrite*/);
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/functions/lib/aggregates/BitwiseAggregateBase.h
+++ b/velox/functions/lib/aggregates/BitwiseAggregateBase.h
@@ -73,7 +73,8 @@ template <template <typename U> class T>
 exec::AggregateRegistrationResult registerBitwise(
     const std::string& name,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures) {
+    bool onlyPrestoSignatures,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> typeList{"tinyint", "smallint", "integer", "bigint"};
   if (onlyPrestoSignatures) {
@@ -114,7 +115,8 @@ exec::AggregateRegistrationResult registerBitwise(
                 inputType->kindName());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate

--- a/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxDistinctAggregate.cpp
@@ -426,7 +426,8 @@ exec::AggregateRegistrationResult registerApproxDistinct(
     const std::string& name,
     bool hllAsFinalResult,
     bool hllAsRawInput,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   auto returnType = hllAsFinalResult ? "hyperloglog" : "bigint";
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -496,23 +497,29 @@ exec::AggregateRegistrationResult registerApproxDistinct(
             hllAsFinalResult,
             hllAsRawInput);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerApproxDistinctAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCustomType(
       prefix + "hyperloglog",
       std::make_unique<const HyperLogLogTypeFactories>());
   registerApproxDistinct(
-      prefix + kApproxDistinct, false, false, withCompanionFunctions);
+      prefix + kApproxDistinct,
+      false,
+      false,
+      withCompanionFunctions,
+      overwrite);
   // approx_set and merge are already companion functions themselves. Don't
   // register companion functions for them.
-  registerApproxDistinct(prefix + kApproxSet, true, false, false);
-  registerApproxDistinct(prefix + kMerge, true, true, false);
+  registerApproxDistinct(prefix + kApproxSet, true, false, false, overwrite);
+  registerApproxDistinct(prefix + kMerge, true, true, false, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -353,7 +353,8 @@ std::unique_ptr<exec::Aggregate> makeApproxMostFrequentAggregate(
 
 void registerApproxMostFrequentAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& valueType :
        {"tinyint", "smallint", "integer", "bigint", "varchar"}) {
@@ -387,7 +388,8 @@ void registerApproxMostFrequentAggregate(
             name,
             valueType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -830,7 +830,8 @@ void addSignatures(
 
 void registerApproxPercentileAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& inputType :
        {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
@@ -930,7 +931,8 @@ void registerApproxPercentileAggregate(
                 type->toString());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -264,7 +264,8 @@ class NonNumericArbitrary : public exec::Aggregate {
 
 void registerArbitraryAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -321,7 +322,8 @@ void registerArbitraryAggregate(
                 inputType->kindName());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -239,7 +239,8 @@ class ArrayAggAggregate : public exec::Aggregate {
 
 void registerArrayAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
@@ -262,7 +263,8 @@ void registerArrayAggAggregate(
         return std::make_unique<ArrayAggAggregate>(
             resultType, config.prestoArrayAggIgnoreNulls());
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -31,7 +31,8 @@ namespace facebook::velox::aggregate::prestosql {
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
 void registerAverageAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"smallint", "integer", "bigint", "double"}) {
@@ -141,7 +142,8 @@ void registerAverageAggregate(
           }
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseAggregates.cpp
@@ -104,11 +104,18 @@ class BitwiseAndAggregate : public BitwiseAggregateBase<T> {
 void registerBitwiseAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures) {
+    bool onlyPrestoSignatures,
+    bool overwrite) {
   registerBitwise<BitwiseOrAggregate>(
-      prefix + kBitwiseOr, withCompanionFunctions, onlyPrestoSignatures);
+      prefix + kBitwiseOr,
+      withCompanionFunctions,
+      onlyPrestoSignatures,
+      overwrite);
   registerBitwise<BitwiseAndAggregate>(
-      prefix + kBitwiseAnd, withCompanionFunctions, onlyPrestoSignatures);
+      prefix + kBitwiseAnd,
+      withCompanionFunctions,
+      onlyPrestoSignatures,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -69,7 +69,8 @@ class BitwiseXorAggregate {
 void registerBitwiseXorAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures) {
+    bool onlyPrestoSignatures,
+    bool overwrite) {
   const std::string name = prefix + kBitwiseXor;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -120,7 +121,8 @@ void registerBitwiseXorAggregate(
                 inputType->toString());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BoolAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/BoolAggregates.cpp
@@ -180,7 +180,8 @@ class BoolOrAggregate final : public BoolAndOrAggregate {
 template <class T>
 exec::AggregateRegistrationResult registerBool(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   // TODO Fix signature to match Presto.
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
@@ -208,17 +209,22 @@ exec::AggregateRegistrationResult registerBool(
             inputType->kindName());
         return std::make_unique<T>();
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerBoolAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
-  registerBool<BoolAndAggregate>(prefix + kBoolAnd, withCompanionFunctions);
-  registerBool<BoolAndAggregate>(prefix + kEvery, withCompanionFunctions);
-  registerBool<BoolOrAggregate>(prefix + kBoolOr, withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerBool<BoolAndAggregate>(
+      prefix + kBoolAnd, withCompanionFunctions, overwrite);
+  registerBool<BoolAndAggregate>(
+      prefix + kEvery, withCompanionFunctions, overwrite);
+  registerBool<BoolOrAggregate>(
+      prefix + kBoolOr, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CentralMomentsAggregates.cpp
@@ -493,7 +493,8 @@ void checkAccumulatorRowType(
 template <typename TResultAccessor>
 exec::AggregateRegistrationResult registerCentralMoments(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {
       "smallint", "integer", "bigint", "real", "double"};
@@ -554,18 +555,20 @@ exec::AggregateRegistrationResult registerCentralMoments(
               CentralMomentsAggregate<int64_t, TResultAccessor>>(resultType);
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerCentralMomentsAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCentralMoments<KurtosisResultAccessor>(
-      prefix + kKurtosis, withCompanionFunctions);
+      prefix + kKurtosis, withCompanionFunctions, overwrite);
   registerCentralMoments<SkewnessResultAccessor>(
-      prefix + kSkewness, withCompanionFunctions);
+      prefix + kSkewness, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -232,7 +232,8 @@ class ChecksumAggregate : public exec::Aggregate {
 
 void registerChecksumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -260,7 +261,8 @@ void registerChecksumAggregate(
 
         return std::make_unique<ChecksumAggregate>(VARBINARY());
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -152,7 +152,8 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
 
 void registerCountAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -180,7 +181,8 @@ void registerCountAggregate(
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<CountAggregate>();
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -172,7 +172,8 @@ class CountIfAggregate : public exec::Aggregate {
 
 void registerCountIfAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -204,7 +205,8 @@ void registerCountIfAggregate(
 
         return std::make_unique<CountIfAggregate>();
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/CovarianceAggregates.cpp
@@ -573,7 +573,8 @@ template <
     typename TResultAccessor>
 exec::AggregateRegistrationResult registerCovariance(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       // (double, double) -> double
       exec::AggregateFunctionSignatureBuilder()
@@ -623,40 +624,45 @@ exec::AggregateRegistrationResult registerCovariance(
                 rawInputType->toString())
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerCovarianceAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarPopResultAccessor>(prefix + kCovarPop, withCompanionFunctions);
+      CovarPopResultAccessor>(
+      prefix + kCovarPop, withCompanionFunctions, overwrite);
   registerCovariance<
       CovarAccumulator,
       CovarIntermediateInput,
       CovarIntermediateResult,
-      CovarSampResultAccessor>(prefix + kCovarSamp, withCompanionFunctions);
+      CovarSampResultAccessor>(
+      prefix + kCovarSamp, withCompanionFunctions, overwrite);
   registerCovariance<
       CorrAccumulator,
       CorrIntermediateInput,
       CorrIntermediateResult,
-      CorrResultAccessor>(prefix + kCorr, withCompanionFunctions);
+      CorrResultAccessor>(prefix + kCorr, withCompanionFunctions, overwrite);
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
       RegrInterceptResultAccessor>(
-      prefix + kRegrIntercept, withCompanionFunctions);
+      prefix + kRegrIntercept, withCompanionFunctions, overwrite);
   registerCovariance<
       RegrAccumulator,
       RegrIntermediateInput,
       RegrIntermediateResult,
-      RegrSlopeResultAccessor>(prefix + kRegrSlop, withCompanionFunctions);
+      RegrSlopeResultAccessor>(
+      prefix + kRegrSlop, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -338,7 +338,8 @@ void checkRowType(const TypePtr& type, const std::string& errorMessage) {
 
 void registerEntropyAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {"smallint", "integer", "bigint"};
   for (const auto& inputType : inputTypes) {
@@ -385,7 +386,8 @@ void registerEntropyAggregate(
           return std::make_unique<EntropyAggregate<int64_t>>(resultType);
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -84,7 +84,8 @@ class GeometricMeanAggregate {
 
 void registerGeometricMeanAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   const std::string name = prefix + kGeometricMean;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -135,7 +136,8 @@ void registerGeometricMeanAggregate(
                 inputType->toString());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -342,7 +342,8 @@ class HistogramAggregate : public exec::Aggregate {
 
 void registerHistogramAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto inputType :
        {"boolean",
@@ -408,7 +409,8 @@ void registerHistogramAggregate(
                 inputType->kindName());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -149,7 +149,8 @@ class MapAggAggregate : public MapAggregateBase<K> {
 
 void registerMapAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -211,7 +212,8 @@ void registerMapAggAggregate(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -77,7 +77,8 @@ class MapUnionAggregate : public MapAggregateBase<K> {
 
 void registerMapUnionAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -105,7 +106,8 @@ void registerMapUnionAggregate(
 
         return createMapAggregate<MapUnionAggregate>(resultType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -349,7 +349,8 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
 
 void registerMapUnionSumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   const std::vector<std::string> keyTypes = {
       "tinyint",
       "smallint",
@@ -420,7 +421,8 @@ void registerMapUnionSumAggregate(
             VELOX_UNREACHABLE();
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -206,7 +206,8 @@ class MaxSizeForStatsAggregate
 
 void registerMaxDataSizeForStatsAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -231,7 +232,8 @@ void registerMaxDataSizeForStatsAggregate(
 
         return std::make_unique<MaxSizeForStatsAggregate>(resultType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -908,7 +908,8 @@ template <
     class TNumericN>
 exec::AggregateRegistrationResult registerMinMax(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
                            .orderableTypeVariable("T")
@@ -1013,18 +1014,20 @@ exec::AggregateRegistrationResult registerMinMax(
           }
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerMinMaxAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerMinMax<MinAggregate, NonNumericMinAggregate, MinNAggregate>(
-      prefix + kMin, withCompanionFunctions);
+      prefix + kMin, withCompanionFunctions, overwrite);
   registerMinMax<MaxAggregate, NonNumericMaxAggregate, MaxNAggregate>(
-      prefix + kMax, withCompanionFunctions);
+      prefix + kMax, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxByAggregates.cpp
@@ -1124,7 +1124,8 @@ template <
     class NAggregate>
 exec::AggregateRegistrationResult registerMinMaxBy(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -1187,18 +1188,20 @@ exec::AggregateRegistrationResult registerMinMaxBy(
               resultType, argTypes[0], argTypes[1], errorMessage, true);
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerMinMaxByAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerMinMaxBy<MinMaxByAggregateBase, true, MaxByNAggregate>(
-      prefix + kMaxBy, withCompanionFunctions);
+      prefix + kMaxBy, withCompanionFunctions, overwrite);
   registerMinMaxBy<MinMaxByAggregateBase, false, MinByNAggregate>(
-      prefix + kMinBy, withCompanionFunctions);
+      prefix + kMinBy, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -479,7 +479,8 @@ class MultiMapAggAggregate : public exec::Aggregate {
 
 void registerMultiMapAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -538,7 +539,8 @@ void registerMultiMapAggAggregate(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -786,7 +786,10 @@ class ReduceAgg : public exec::Aggregate {
 
 } // namespace
 
-void registerReduceAgg(const std::string& prefix, bool withCompanionFunctions) {
+void registerReduceAgg(
+    const std::string& prefix,
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -811,7 +814,8 @@ void registerReduceAgg(const std::string& prefix, bool withCompanionFunctions) {
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<ReduceAgg>(resultType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -20,134 +20,168 @@ namespace facebook::velox::aggregate::prestosql {
 
 extern void registerApproxMostFrequentAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerApproxPercentileAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerArbitraryAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerArrayAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerAverageAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerBitwiseXorAggregate(
     const std::string& prefix,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures);
+    bool onlyPrestoSignatures,
+    bool overwrite);
 extern void registerChecksumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerCountAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerCountIfAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerEntropyAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerGeometricMeanAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerHistogramAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMapAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMapUnionAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMapUnionSumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMaxDataSizeForStatsAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMultiMapAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerSumDataSizeForStatsAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerReduceAgg(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerSetAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerSetUnionAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 extern void registerApproxDistinctAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerBitwiseAggregates(
     const std::string& prefix,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures);
+    bool onlyPrestoSignatures,
+    bool overwrite);
 extern void registerBoolAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerCentralMomentsAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerCovarianceAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMinMaxAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMinMaxByAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerSumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerVarianceAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 void registerAllAggregateFunctions(
     const std::string& prefix,
     bool withCompanionFunctions,
-    bool onlyPrestoSignatures) {
-  registerApproxDistinctAggregates(prefix, withCompanionFunctions);
-  registerApproxMostFrequentAggregate(prefix, withCompanionFunctions);
-  registerApproxPercentileAggregate(prefix, withCompanionFunctions);
-  registerArbitraryAggregate(prefix, withCompanionFunctions);
-  registerArrayAggAggregate(prefix, withCompanionFunctions);
-  registerAverageAggregate(prefix, withCompanionFunctions);
+    bool onlyPrestoSignatures,
+    bool overwrite) {
+  registerApproxDistinctAggregates(prefix, withCompanionFunctions, overwrite);
+  registerApproxMostFrequentAggregate(
+      prefix, withCompanionFunctions, overwrite);
+  registerApproxPercentileAggregate(prefix, withCompanionFunctions, overwrite);
+  registerArbitraryAggregate(prefix, withCompanionFunctions, overwrite);
+  registerArrayAggAggregate(prefix, withCompanionFunctions, overwrite);
+  registerAverageAggregate(prefix, withCompanionFunctions, overwrite);
   registerBitwiseAggregates(
-      prefix, withCompanionFunctions, onlyPrestoSignatures);
+      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
   registerBitwiseXorAggregate(
-      prefix, withCompanionFunctions, onlyPrestoSignatures);
-  registerBoolAggregates(prefix, withCompanionFunctions);
-  registerCentralMomentsAggregates(prefix, withCompanionFunctions);
-  registerChecksumAggregate(prefix, withCompanionFunctions);
-  registerCountAggregate(prefix, withCompanionFunctions);
-  registerCountIfAggregate(prefix, withCompanionFunctions);
-  registerCovarianceAggregates(prefix, withCompanionFunctions);
-  registerEntropyAggregate(prefix, withCompanionFunctions);
-  registerGeometricMeanAggregate(prefix, withCompanionFunctions);
-  registerHistogramAggregate(prefix, withCompanionFunctions);
-  registerMapAggAggregate(prefix, withCompanionFunctions);
-  registerMapUnionAggregate(prefix, withCompanionFunctions);
-  registerMapUnionSumAggregate(prefix, withCompanionFunctions);
-  registerMaxDataSizeForStatsAggregate(prefix, withCompanionFunctions);
-  registerMultiMapAggAggregate(prefix, withCompanionFunctions);
-  registerSumDataSizeForStatsAggregate(prefix, withCompanionFunctions);
-  registerMinMaxAggregates(prefix, withCompanionFunctions);
-  registerMinMaxByAggregates(prefix, withCompanionFunctions);
-  registerReduceAgg(prefix, withCompanionFunctions);
-  registerSetAggAggregate(prefix, withCompanionFunctions);
-  registerSetUnionAggregate(prefix, withCompanionFunctions);
-  registerSumAggregate(prefix, withCompanionFunctions);
-  registerVarianceAggregates(prefix, withCompanionFunctions);
+      prefix, withCompanionFunctions, onlyPrestoSignatures, overwrite);
+  registerBoolAggregates(prefix, withCompanionFunctions, overwrite);
+  registerCentralMomentsAggregates(prefix, withCompanionFunctions, overwrite);
+  registerChecksumAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCountAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCountIfAggregate(prefix, withCompanionFunctions, overwrite);
+  registerCovarianceAggregates(prefix, withCompanionFunctions, overwrite);
+  registerEntropyAggregate(prefix, withCompanionFunctions, overwrite);
+  registerGeometricMeanAggregate(prefix, withCompanionFunctions, overwrite);
+  registerHistogramAggregate(prefix, withCompanionFunctions, overwrite);
+  registerMapAggAggregate(prefix, withCompanionFunctions, overwrite);
+  registerMapUnionAggregate(prefix, withCompanionFunctions, overwrite);
+  registerMapUnionSumAggregate(prefix, withCompanionFunctions, overwrite);
+  registerMaxDataSizeForStatsAggregate(
+      prefix, withCompanionFunctions, overwrite);
+  registerMultiMapAggAggregate(prefix, withCompanionFunctions, overwrite);
+  registerSumDataSizeForStatsAggregate(
+      prefix, withCompanionFunctions, overwrite);
+  registerMinMaxAggregates(prefix, withCompanionFunctions, overwrite);
+  registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerReduceAgg(prefix, withCompanionFunctions, overwrite);
+  registerSetAggAggregate(prefix, withCompanionFunctions, overwrite);
+  registerSetUnionAggregate(prefix, withCompanionFunctions, overwrite);
+  registerSumAggregate(prefix, withCompanionFunctions, overwrite);
+  registerVarianceAggregates(prefix, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h
@@ -27,6 +27,7 @@ namespace facebook::velox::aggregate::prestosql {
 void registerAllAggregateFunctions(
     const std::string& prefix = "",
     bool withCompanionFunctions = true,
-    bool onlyPrestoSignatures = false);
+    bool onlyPrestoSignatures = false,
+    bool overwrite = true);
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -429,7 +429,8 @@ std::unique_ptr<exec::Aggregate> create(
 
 void registerSetAggAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -494,12 +495,14 @@ void registerSetAggAggregate(
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 void registerSetUnionAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -522,7 +525,8 @@ void registerSetUnionAggregate(
 
         return create<SetUnionAggregate>(argTypes[0]->childAt(0), resultType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumAggregate.cpp
@@ -26,7 +26,8 @@ using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, false>;
 template <template <typename U, typename V, typename W> class T>
 exec::AggregateRegistrationResult registerSum(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")
@@ -110,14 +111,16 @@ exec::AggregateRegistrationResult registerSum(
                 inputType->kindName());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 } // namespace
 
 void registerSumAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
-  registerSum<SumAggregate>(prefix + kSum, withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerSum<SumAggregate>(prefix + kSum, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -186,7 +186,8 @@ class SumDataSizeForStatsAggregate
 
 void registerSumDataSizeForStatsAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -211,7 +212,8 @@ void registerSumDataSizeForStatsAggregate(
 
         return std::make_unique<SumDataSizeForStatsAggregate>(resultType);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/VarianceAggregates.cpp
@@ -467,7 +467,8 @@ void checkSumCountRowType(
 template <template <typename TInput> class TClass>
 exec::AggregateRegistrationResult registerVariance(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {
       "smallint", "integer", "bigint", "real", "double"};
@@ -517,24 +518,28 @@ exec::AggregateRegistrationResult registerVariance(
           return std::make_unique<TClass<int64_t>>(resultType);
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerVarianceAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerVariance<StdDevSampAggregate>(
-      prefix + kStdDev, withCompanionFunctions);
+      prefix + kStdDev, withCompanionFunctions, overwrite);
   registerVariance<StdDevPopAggregate>(
-      prefix + kStdDevPop, withCompanionFunctions);
+      prefix + kStdDevPop, withCompanionFunctions, overwrite);
   registerVariance<StdDevSampAggregate>(
-      prefix + kStdDevSamp, withCompanionFunctions);
+      prefix + kStdDevSamp, withCompanionFunctions, overwrite);
   registerVariance<VarSampAggregate>(
-      prefix + kVariance, withCompanionFunctions);
-  registerVariance<VarPopAggregate>(prefix + kVarPop, withCompanionFunctions);
-  registerVariance<VarSampAggregate>(prefix + kVarSamp, withCompanionFunctions);
+      prefix + kVariance, withCompanionFunctions, overwrite);
+  registerVariance<VarPopAggregate>(
+      prefix + kVarPop, withCompanionFunctions, overwrite);
+  registerVariance<VarSampAggregate>(
+      prefix + kVarSamp, withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -86,7 +86,8 @@ class AverageAggregate
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
 exec::AggregateRegistrationResult registerAverage(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType :
@@ -189,7 +190,8 @@ exec::AggregateRegistrationResult registerAverage(
           }
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/AverageAggregate.h
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.h
@@ -24,6 +24,7 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerAverage(
     const std::string& name,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.cpp
@@ -67,9 +67,10 @@ class BitwiseXorAggregate : public BitwiseAggregateBase<T> {
 
 exec::AggregateRegistrationResult registerBitwiseXorAggregate(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   return functions::aggregate::registerBitwise<BitwiseXorAggregate>(
-      prefix + "bit_xor", withCompanionFunctions, false);
+      prefix + "bit_xor", withCompanionFunctions, false, overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
+++ b/velox/functions/sparksql/aggregates/BitwiseXorAggregate.h
@@ -24,6 +24,7 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerBitwiseXorAggregate(
     const std::string& name,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -289,7 +289,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
 
 exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .argumentType("bigint")
@@ -320,6 +321,7 @@ exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
           const core::QueryConfig& config) -> std::unique_ptr<exec::Aggregate> {
         return std::make_unique<BloomFilterAggAggregate>(resultType, config);
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h
@@ -24,6 +24,7 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerBloomFilterAggAggregate(
     const std::string& name,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/FirstLastAggregate.cpp
@@ -431,7 +431,8 @@ class LastAggregate : public FirstLastAggregateBase<numeric, TData> {
 template <template <bool B1, typename T, bool B2> class TClass, bool ignoreNull>
 AggregateRegistrationResult registerFirstLast(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<AggregateFunctionSignature>> signatures = {
       AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -502,20 +503,22 @@ AggregateRegistrationResult registerFirstLast(
                 inputType->toString());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 void registerFirstLastAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerFirstLast<FirstAggregate, false>(
-      prefix + "first", withCompanionFunctions);
+      prefix + "first", withCompanionFunctions, overwrite);
   registerFirstLast<FirstAggregate, true>(
-      prefix + "first_ignore_null", withCompanionFunctions);
+      prefix + "first_ignore_null", withCompanionFunctions, overwrite);
   registerFirstLast<LastAggregate, false>(
-      prefix + "last", withCompanionFunctions);
+      prefix + "last", withCompanionFunctions, overwrite);
   registerFirstLast<LastAggregate, true>(
-      prefix + "last_ignore_null", withCompanionFunctions);
+      prefix + "last_ignore_null", withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/MinMaxByAggregate.cpp
@@ -88,7 +88,8 @@ template <
     bool isMaxFunc>
 exec::AggregateRegistrationResult registerMinMaxBy(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   // V, C -> row(V, C) -> V.
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -140,18 +141,20 @@ exec::AggregateRegistrationResult registerMinMaxBy(
               resultType, valueType, compareType, errorMessage);
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace
 
 void registerMinMaxByAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   registerMinMaxBy<MinMaxByAggregateBase, true>(
-      prefix + "max_by", withCompanionFunctions);
+      prefix + "max_by", withCompanionFunctions, overwrite);
   registerMinMaxBy<MinMaxByAggregateBase, false>(
-      prefix + "min_by", withCompanionFunctions);
+      prefix + "min_by", withCompanionFunctions, overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -25,20 +25,23 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 extern void registerFirstLastAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 extern void registerMinMaxByAggregates(
     const std::string& prefix,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 void registerAggregateFunctions(
     const std::string& prefix,
-    bool withCompanionFunctions) {
-  registerFirstLastAggregates(prefix, withCompanionFunctions);
-  registerMinMaxByAggregates(prefix, withCompanionFunctions);
-  registerBitwiseXorAggregate(prefix, withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite) {
+  registerFirstLastAggregates(prefix, withCompanionFunctions, overwrite);
+  registerMinMaxByAggregates(prefix, withCompanionFunctions, overwrite);
+  registerBitwiseXorAggregate(prefix, withCompanionFunctions, overwrite);
   registerBloomFilterAggAggregate(
-      prefix + "bloom_filter_agg", withCompanionFunctions);
-  registerAverage(prefix + "avg", withCompanionFunctions);
-  registerSum(prefix + "sum", withCompanionFunctions);
+      prefix + "bloom_filter_agg", withCompanionFunctions, overwrite);
+  registerAverage(prefix + "avg", withCompanionFunctions, overwrite);
+  registerSum(prefix + "sum", withCompanionFunctions, overwrite);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.h
+++ b/velox/functions/sparksql/aggregates/Register.h
@@ -20,5 +20,6 @@
 namespace facebook::velox::functions::aggregate::sparksql {
 void registerAggregateFunctions(
     const std::string& prefix,
-    bool withCompanionFunctions = true);
+    bool withCompanionFunctions = true,
+    bool overwrite = true);
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -45,7 +45,8 @@ void checkAccumulatorRowType(const TypePtr& type) {
 
 exec::AggregateRegistrationResult registerSum(
     const std::string& name,
-    bool withCompanionFunctions) {
+    bool withCompanionFunctions,
+    bool overwrite) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")
@@ -154,7 +155,8 @@ exec::AggregateRegistrationResult registerSum(
                 inputType->kindName());
         }
       },
-      withCompanionFunctions);
+      withCompanionFunctions,
+      overwrite);
 }
 
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/SumAggregate.h
+++ b/velox/functions/sparksql/aggregates/SumAggregate.h
@@ -24,6 +24,7 @@ namespace facebook::velox::functions::aggregate::sparksql {
 
 exec::AggregateRegistrationResult registerSum(
     const std::string& name,
-    bool withCompanionFunctions);
+    bool withCompanionFunctions,
+    bool overwrite);
 
 } // namespace facebook::velox::functions::aggregate::sparksql


### PR DESCRIPTION
Method [registerAggregateFunction](https://github.com/facebookincubator/velox/blob/main/velox/exec/Aggregate.h#L420-L439) provides default arguments
`withCompanionFunctions` and `overwrite`. This PR adds `overwrite` parameter for 
the registration of all aggregate functions, and changes them as required arguments.