### PR TITLE
Add Spark atan2 function

### DIFF
--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -18,6 +18,10 @@ Mathematical Functions
 
     Returns inverse hyperbolic sine of ``x``.
 
+.. spark:function:: atan2(x, y) -> double
+
+    Returns the angle in radians between the positive x-axis of a plane and the point given by the coordinates(x, y).
+
 .. spark:function:: atanh(x) -> double
 
     Returns inverse hyperbolic tangent of ``x``.

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -20,7 +20,11 @@ Mathematical Functions
 
 .. spark:function:: atan2(y, x) -> double
 
-    Returns the arc tangent of ``y / x``.
+    Returns the arc tangent of ``y / x``. For compatibility with Spark, returns 0 for the following corner cases:
+    * if y and x are both 0.
+    * if y is -0 and x is 0.
+    * if y is 0 and x is -0.
+    * if y is -0 and x is -0.
 
 .. spark:function:: atanh(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -18,9 +18,9 @@ Mathematical Functions
 
     Returns inverse hyperbolic sine of ``x``.
 
-.. spark:function:: atan2(x, y) -> double
+.. spark:function:: atan2(y, x) -> double
 
-    Returns the angle in radians between the positive x-axis of a plane and the point given by the coordinates(x, y).
+    Returns the arc tangent of ``y / x``.
 
 .. spark:function:: atanh(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -21,10 +21,10 @@ Mathematical Functions
 .. spark:function:: atan2(y, x) -> double
 
     Returns the arc tangent of ``y / x``. For compatibility with Spark, returns 0 for the following corner cases:
-    * if y and x are both 0.
-    * if y and x are both -0.
-    * if y is -0 and x is 0.
-    * if y is 0 and x is -0.
+    * atan2(0.0, 0.0)
+    * atan2(-0.0, -0.0)
+    * atan2(-0.0, 0.0)
+    * atan2(0.0, -0.0)
 
 .. spark:function:: atanh(x) -> double
 

--- a/velox/docs/functions/spark/math.rst
+++ b/velox/docs/functions/spark/math.rst
@@ -22,9 +22,9 @@ Mathematical Functions
 
     Returns the arc tangent of ``y / x``. For compatibility with Spark, returns 0 for the following corner cases:
     * if y and x are both 0.
+    * if y and x are both -0.
     * if y is -0 and x is 0.
     * if y is 0 and x is -0.
-    * if y is -0 and x is -0.
 
 .. spark:function:: atanh(x) -> double
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -272,7 +272,8 @@ struct CotFunction {
 
 template <typename T>
 struct Atan2Function {
-  FOLLY_ALWAYS_INLINE void call(double& result, double y, double x) {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput y, TInput x) {
     result = std::atan2(y + 0.0, x + 0.0);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -272,8 +272,9 @@ struct CotFunction {
 
 template <typename T>
 struct Atan2Function {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput y, TInput x) {
+  FOLLY_ALWAYS_INLINE void call(double& result, double y, double x) {
+    // Spark (as of Spark 3.5)'s atan2 SQL function is internally calculated by
+    // Math.atan2(y + 0.0, x + 0.0). We do the same here for compatibility.
     result = std::atan2(y + 0.0, x + 0.0);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -275,6 +275,18 @@ struct Atan2Function {
   FOLLY_ALWAYS_INLINE void call(double& result, double y, double x) {
     // Spark (as of Spark 3.5)'s atan2 SQL function is internally calculated by
     // Math.atan2(y + 0.0, x + 0.0). We do the same here for compatibility.
+    //
+    // The sign (+/-) for 0.0 matters because it could make atan2 output
+    // different results. For example:
+
+    // * std::atan2(0.0, -0.0) = 0
+    // * std::atan2(0.0, -0.0) = 3.1415926535897931
+    // * std::atan2(-0.0, -0.0) = -3.1415926535897931
+    // * std::atan2(0.0, -0.0) = 0
+
+    // By doing x + 0.0 or y + 0.0, we make sure all the -0s have been
+    // replaced by 0s before sending to atan2 function. So the function
+    // will always return atan2(0.0, 0.0) = 0 for atan2(+0.0/-0.0, +0.0/-0.0).
     result = std::atan2(y + 0.0, x + 0.0);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -279,7 +279,7 @@ struct Atan2Function {
     // The sign (+/-) for 0.0 matters because it could make atan2 output
     // different results. For example:
 
-    // * std::atan2(0.0, -0.0) = 0
+    // * std::atan2(0.0, 0.0) = 0
     // * std::atan2(0.0, -0.0) = 3.1415926535897931
     // * std::atan2(-0.0, -0.0) = -3.1415926535897931
     // * std::atan2(0.0, -0.0) = 0

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -282,7 +282,7 @@ struct Atan2Function {
     // * std::atan2(0.0, 0.0) = 0
     // * std::atan2(0.0, -0.0) = 3.1415926535897931
     // * std::atan2(-0.0, -0.0) = -3.1415926535897931
-    // * std::atan2(0.0, -0.0) = 0
+    // * std::atan2(-0.0, 0.0) = 0
 
     // By doing x + 0.0 or y + 0.0, we make sure all the -0s have been
     // replaced by 0s before sending to atan2 function. So the function

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -270,9 +270,9 @@ struct CotFunction {
   }
 };
 
+template <typename T>
 struct Atan2Function {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput y, TInput x) {
+  FOLLY_ALWAYS_INLINE void call(double& result, double y, double x) {
     result = std::atan2(y + 0.0, x + 0.0);
   }
 };

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -270,6 +270,13 @@ struct CotFunction {
   }
 };
 
+struct Atan2Function {
+  template <typename TInput>
+  FOLLY_ALWAYS_INLINE void call(TInput& result, TInput y, TInput x) {
+    result = std::atan2(y + 0.0, x + 0.0);
+  }
+};
+
 template <typename T>
 struct Log10Function {
   FOLLY_ALWAYS_INLINE bool call(double& result, double a) {

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -63,6 +63,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   registerFunction<SinhFunction, double, double>({prefix + "sinh"});
   registerFunction<CoshFunction, double, double>({prefix + "cosh"});
   registerFunction<CotFunction, double, double>({prefix + "cot"});
+  registerFunction<Atan2Function, double, double, double>({prefix + "atan2"});
   registerFunction<Log1pFunction, double, double>({prefix + "log1p"});
   registerFunction<ToBinaryStringFunction, Varchar, int64_t>({prefix + "bin"});
   registerFunction<ExpFunction, double, double>({prefix + "exp"});

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -384,7 +384,10 @@ TEST_F(ArithmeticTest, atan2) {
     return evaluateOnce<double>("atan2(c0, c1)", y, x);
   };
 
-  EXPECT_EQ(atan2(0, 0), 0.0);
+  EXPECT_EQ(atan2(0.0, 0.0), 0.0);
+  EXPECT_EQ(atan2(-0.0, -0.0), 0.0);
+  EXPECT_EQ(atan2(0.0, -0.0), 0.0);
+  EXPECT_EQ(atan2(-0.0, 0.0), 0.0);
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -388,6 +388,13 @@ TEST_F(ArithmeticTest, atan2) {
   EXPECT_EQ(atan2(-0.0, -0.0), 0.0);
   EXPECT_EQ(atan2(0.0, -0.0), 0.0);
   EXPECT_EQ(atan2(-0.0, 0.0), 0.0);
+  EXPECT_EQ(atan2(-1.0, 1.0), std::atan2(-1.0, 1.0));
+  EXPECT_EQ(atan2(1.0, 1.0), std::atan2(1.0, 1.0));
+  EXPECT_EQ(atan2(1.0, -1.0), std::atan2(1.0, -1.0));
+  EXPECT_EQ(atan2(-1.0, -1.0), std::atan2(-1.0, -1.0));
+  EXPECT_EQ(atan2(std::nullopt, std::nullopt), std::nullopt);
+  EXPECT_EQ(atan2(1.0E0, std::nullopt), std::nullopt);
+  EXPECT_EQ(atan2(std::nullopt, 1.0E0), std::nullopt);
 }
 
 class LogNTest : public SparkFunctionBaseTest {

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -379,6 +379,14 @@ TEST_F(ArithmeticTest, cot) {
   EXPECT_EQ(cot(0), 1 / std::tan(0));
 }
 
+TEST_F(ArithmeticTest, atan2) {
+  const auto atan2 = [&](std::optional<double> y, std::optional<double> x) {
+    return evaluateOnce<double>("atan2(c0, c1)", y, x);
+  };
+
+  EXPECT_EQ(atan2(0, 0), 0.0);
+}
+
 class LogNTest : public SparkFunctionBaseTest {
  protected:
   static constexpr float kInf = std::numeric_limits<double>::infinity();

--- a/velox/functions/sparksql/tests/ArithmeticTest.cpp
+++ b/velox/functions/sparksql/tests/ArithmeticTest.cpp
@@ -392,9 +392,6 @@ TEST_F(ArithmeticTest, atan2) {
   EXPECT_EQ(atan2(1.0, 1.0), std::atan2(1.0, 1.0));
   EXPECT_EQ(atan2(1.0, -1.0), std::atan2(1.0, -1.0));
   EXPECT_EQ(atan2(-1.0, -1.0), std::atan2(-1.0, -1.0));
-  EXPECT_EQ(atan2(std::nullopt, std::nullopt), std::nullopt);
-  EXPECT_EQ(atan2(1.0E0, std::nullopt), std::nullopt);
-  EXPECT_EQ(atan2(std::nullopt, 1.0E0), std::nullopt);
 }
 
 class LogNTest : public SparkFunctionBaseTest {


### PR DESCRIPTION
The patch is to implement Spark's version of function `atan2`.

Expression:
```
atan2(0.0, 0.0)
atan2(0.0, -0.0)
atan2(-0.0, 0.0)
atan2(-0.0, -0.0)
```

Velox (Presto)'s output:
```
0.0
3.1415926535897931
0.0
-3.1415926535897931
```

Spark's output:
```
0.0
0.0
0.0
0.0
```

Spark's `atan2` source code:
https://github.com/apache/spark/blob/5cbad6aef2fd1214014d64ef602f9a726a019d99/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/mathExpressions.scala#L1225-L1239

Presto's `atan2` source code:
https://github.com/prestodb/presto/blob/038ff56f969d5169f9a2510dcd47e3728946f573/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java#L220-L226