### PR TITLE
Fix dayofmonth Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -46,17 +46,17 @@ These functions support TIMESTAMP and DATE input types.
 
     num_days can be positive or negative.
 
-.. spark:function:: dayofyear(date) -> integer
-
-    Returns Returns the day of year of the date/timestamp. ::
-
-        SELECT dayofyear('2016-04-09'); -- 100
-
 .. spark:function:: dayofmonth(date) -> integer
 
-    Returns the day of month of the date/timestamp. ::
+    Returns the day of month of the date. ::
 
         SELECT dayofmonth('2009-07-30'); -- 30
+
+.. spark:function:: dayofyear(date) -> integer
+
+    Returns the day of year of the date/timestamp. ::
+
+        SELECT dayofyear('2016-04-09'); -- 100
 
 .. spark:function:: dayofweek(date/timestamp) -> integer
 

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -391,4 +391,12 @@ struct QuarterFunction {
   }
 };
 
+template <typename T>
+struct DayFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    result = getDateTime(date).tm_mday;
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -251,9 +251,7 @@ void registerFunctions(const std::string& prefix) {
   registerFunction<DateAddFunction, Date, Date, int32_t>({prefix + "date_add"});
   registerFunction<DateSubFunction, Date, Date, int32_t>({prefix + "date_sub"});
 
-  registerFunction<DayFunction, int64_t, Timestamp>(
-      {prefix + "day", prefix + "dayofmonth"});
-  registerFunction<DayFunction, int64_t, Date>(
+  registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "dayofmonth"});
   registerFunction<DayOfYearFunction, int64_t, Timestamp>(
       {prefix + "doy", prefix + "dayofyear"});

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -301,7 +301,7 @@ TEST_F(DateTimeFunctionsTest, dayOfYear) {
 
 TEST_F(DateTimeFunctionsTest, dayOfMonth) {
   const auto day = [&](std::optional<int32_t> date) {
-    return evaluateOnce<int64_t, int32_t>("dayofmonth(c0)", {date}, {DATE()});
+    return evaluateOnce<int32_t, int32_t>("dayofmonth(c0)", {date}, {DATE()});
   };
   EXPECT_EQ(std::nullopt, day(std::nullopt));
   EXPECT_EQ(30, day(parseDate("2009-07-30")));


### PR DESCRIPTION
Returns the month of the year for the input DATE as an INTEGER between 1 and 12.

Before this change, the return type was BIGINT (fixed to INTEGER) and input could 
be DATE or TIMESTAMP (only DATE is allowed now.)

[Spark's implementation](https://github.com/apache/spark/blob/b0791b513da3f0671417b9fbcd3a0caddbb45318/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L853)  and  [unit test](https://github.com/apache/spark/blob/b0791b513da3f0671417b9fbcd3a0caddbb45318/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala#L196).