### PR TITLE
Fix dayofyear Spark function

### DIFF
--- a/velox/docs/functions/spark/datetime.rst
+++ b/velox/docs/functions/spark/datetime.rst
@@ -54,7 +54,7 @@ These functions support TIMESTAMP and DATE input types.
 
 .. spark:function:: dayofyear(date) -> integer
 
-    Returns the day of year of the date/timestamp. ::
+    Returns the day of year of the date. ::
 
         SELECT dayofyear('2016-04-09'); -- 100
 

--- a/velox/functions/lib/TimeUtils.h
+++ b/velox/functions/lib/TimeUtils.h
@@ -88,6 +88,10 @@ FOLLY_ALWAYS_INLINE int32_t getQuarter(const std::tm& time) {
   return time.tm_mon / 3 + 1;
 }
 
+FOLLY_ALWAYS_INLINE int32_t getDayOfYear(const std::tm& time) {
+  return time.tm_yday + 1;
+}
+
 template <typename T>
 struct InitSessionTimezone {
   VELOX_DEFINE_FUNCTION_TYPES(T);

--- a/velox/functions/sparksql/DateTimeFunctions.h
+++ b/velox/functions/sparksql/DateTimeFunctions.h
@@ -399,4 +399,13 @@ struct DayFunction {
     result = getDateTime(date).tm_mday;
   }
 };
+
+template <typename T>
+struct DayOfYearFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(int32_t& result, const arg_type<Date>& date) {
+    result = getDayOfYear(getDateTime(date));
+  }
+};
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -253,9 +253,7 @@ void registerFunctions(const std::string& prefix) {
 
   registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "dayofmonth"});
-  registerFunction<DayOfYearFunction, int64_t, Timestamp>(
-      {prefix + "doy", prefix + "dayofyear"});
-  registerFunction<DayOfYearFunction, int64_t, Date>(
+  registerFunction<DayOfYearFunction, int32_t, Date>(
       {prefix + "doy", prefix + "dayofyear"});
 
   registerFunction<DayOfWeekFunction, int32_t, Timestamp>(

--- a/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeFunctionsTest.cpp
@@ -291,7 +291,7 @@ TEST_F(DateTimeFunctionsTest, dateSub) {
 
 TEST_F(DateTimeFunctionsTest, dayOfYear) {
   const auto day = [&](std::optional<int32_t> date) {
-    return evaluateOnce<int64_t, int32_t>("dayofyear(c0)", {date}, {DATE()});
+    return evaluateOnce<int32_t, int32_t>("dayofyear(c0)", {date}, {DATE()});
   };
   EXPECT_EQ(std::nullopt, day(std::nullopt));
   EXPECT_EQ(100, day(parseDate("2016-04-09")));


### PR DESCRIPTION
Returns the day of the year for the input DATE as an INTEGER between 0 and 366.
Before this change, the return type was BIGINT (fixed to INTEGER) and input could 
be DATE or TIMESTAMP (only DATE is allowed now.)

[Spark's implementation](https://github.com/apache/spark/blob/b0791b513da3f0671417b9fbcd3a0caddbb45318/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/datetimeExpressions.scala#L502) and [unit test](https://github.com/apache/spark/blob/b0791b513da3f0671417b9fbcd3a0caddbb45318/sql/catalyst/src/test/scala/org/apache/spark/sql/catalyst/expressions/DateExpressionsSuite.scala#L108).