### PR TITLE
Fully decouple Accumulator from Aggregate

### DIFF
--- a/velox/exec/DistinctAggregations.cpp
+++ b/velox/exec/DistinctAggregations.cpp
@@ -43,6 +43,9 @@ class TypedDistinctAggregations : public DistinctAggregations {
         sizeof(AccumulatorType),
         false, // usesExternalMemory
         1, // alignment
+        [](folly::Range<char**> /*groups*/, VectorPtr& /*result*/) {
+          VELOX_UNREACHABLE();
+        },
         [this](folly::Range<char**> groups) {
           for (auto* group : groups) {
             auto* accumulator =

--- a/velox/exec/RowContainer.cpp
+++ b/velox/exec/RowContainer.cpp
@@ -53,11 +53,15 @@ Accumulator::Accumulator(Aggregate* aggregate)
       fixedSize_{aggregate->accumulatorFixedWidthSize()},
       usesExternalMemory_{aggregate->accumulatorUsesExternalMemory()},
       alignment_{aggregate->accumulatorAlignmentSize()},
+      extractFunction_{
+          [aggregate](folly::Range<char**> groups, VectorPtr& result) {
+            aggregate->extractAccumulators(
+                groups.data(), groups.size(), &result);
+          }},
       destroyFunction_{[aggregate](folly::Range<char**> groups) {
         aggregate->destroy(groups);
-      }},
-      aggregate_{aggregate} {
-  VELOX_CHECK_NOT_NULL(aggregate_);
+      }} {
+  VELOX_CHECK_NOT_NULL(aggregate);
 }
 
 Accumulator::Accumulator(
@@ -65,11 +69,14 @@ Accumulator::Accumulator(
     int32_t fixedSize,
     bool usesExternalMemory,
     int32_t alignment,
+    std::function<void(folly::Range<char**> groups, VectorPtr& result)>
+        extractFunction,
     std::function<void(folly::Range<char**> groups)> destroyFunction)
     : isFixedSize_{isFixedSize},
       fixedSize_{fixedSize},
       usesExternalMemory_{usesExternalMemory},
       alignment_{alignment},
+      extractFunction_{extractFunction},
       destroyFunction_{destroyFunction} {}
 
 bool Accumulator::isFixedSize() const {
@@ -90,6 +97,12 @@ int32_t Accumulator::alignment() const {
 
 void Accumulator::destroy(folly::Range<char**> groups) {
   destroyFunction_(groups);
+}
+
+void Accumulator::extractForSpill(
+    folly::Range<char**> groups,
+    VectorPtr& result) const {
+  extractFunction_(groups, result);
 }
 
 // static

--- a/velox/exec/RowContainer.h
+++ b/velox/exec/RowContainer.h
@@ -34,6 +34,8 @@ class Accumulator {
       int32_t fixedSize,
       bool usesExternalMemory,
       int32_t alignment,
+      std::function<void(folly::Range<char**> groups, VectorPtr& result)>
+          extractFunction,
       std::function<void(folly::Range<char**> groups)> destroyFunction);
 
   explicit Accumulator(Aggregate* aggregate);
@@ -48,19 +50,15 @@ class Accumulator {
 
   void destroy(folly::Range<char**> groups);
 
-  /// Used only for spilling. Do not introduce other usages.
-  Aggregate* aggregateForSpill() const {
-    VELOX_CHECK_NOT_NULL(aggregate_);
-    return aggregate_;
-  }
+  void extractForSpill(folly::Range<char**> groups, VectorPtr& result) const;
 
  private:
   const bool isFixedSize_;
   const int32_t fixedSize_;
   const bool usesExternalMemory_;
   const int32_t alignment_;
+  std::function<void(folly::Range<char**>, VectorPtr&)> extractFunction_;
   std::function<void(folly::Range<char**> groups)> destroyFunction_;
-  Aggregate* aggregate_{nullptr};
 };
 
 using normalized_key_t = uint64_t;

--- a/velox/exec/SortedAggregations.cpp
+++ b/velox/exec/SortedAggregations.cpp
@@ -110,6 +110,9 @@ Accumulator SortedAggregations::accumulator() const {
       sizeof(RowPointers),
       false,
       1,
+      [](folly::Range<char**> /*groups*/, VectorPtr& /*result*/) {
+        VELOX_UNREACHABLE();
+      },
       [this](folly::Range<char**> groups) {
         for (auto* group : groups) {
           auto* accumulator = reinterpret_cast<RowPointers*>(group + offset_);

--- a/velox/exec/Spiller.cpp
+++ b/velox/exec/Spiller.cpp
@@ -189,8 +189,7 @@ void Spiller::extractSpill(folly::Range<char**> rows, RowVectorPtr& resultPtr) {
 
   auto numKeys = types.size();
   for (auto i = 0; i < accumulators.size(); ++i) {
-    accumulators[i].aggregateForSpill()->extractAccumulators(
-        rows.data(), rows.size(), &result->childAt(i + numKeys));
+    accumulators[i].extractForSpill(rows, result->childAt(i + numKeys));
   }
 }
 

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -41,7 +41,8 @@ TopNRowNumber::TopNRowNumber(
   const auto numKeys = keys.size();
 
   if (numKeys > 0) {
-    Accumulator accumulator{true, sizeof(TopRows), false, 1, [](auto) {}};
+    Accumulator accumulator{
+        true, sizeof(TopRows), false, 1, [](auto, auto) {}, [](auto) {}};
 
     table_ = std::make_unique<HashTable<false>>(
         createVectorHashers(inputType_, keys),


### PR DESCRIPTION
Finish decoupling Accumulator structure from Aggregate function instance.

This would allow spilling accumulators that are not backed by aggregate
functions, e.g. use cases like TopNRowNumber.