### PR TITLE
Add a new BaseVector::equalValueAt API with nullHandlingMode parameter

### DIFF
--- a/velox/vector/BaseVector.cpp
+++ b/velox/vector/BaseVector.cpp
@@ -249,6 +249,25 @@ VectorPtr BaseVector::wrapInConstant(
       addConstant, kind, length, index, std::move(vector), copyBase);
 }
 
+std::optional<bool> BaseVector::equalValueAt(
+    const BaseVector* other,
+    vector_size_t index,
+    vector_size_t otherIndex,
+    CompareFlags::NullHandlingMode nullHandlingMode) const {
+  const CompareFlags compareFlags = {
+      .nullsFirst = false,
+      .ascending = false,
+      .equalsOnly = true,
+      .nullHandlingMode = nullHandlingMode};
+  std::optional<int32_t> result =
+      compare(other, index, otherIndex, compareFlags);
+  if (result.has_value()) {
+    return result.value() == 0;
+  }
+
+  return std::nullopt;
+}
+
 template <TypeKind kind>
 static VectorPtr createEmpty(
     vector_size_t size,

--- a/velox/vector/BaseVector.h
+++ b/velox/vector/BaseVector.h
@@ -267,6 +267,16 @@ class BaseVector {
     return compare(other, index, otherIndex, kEqualValueAtFlags).value() == 0;
   }
 
+  /// Returns true if this vector has the same value at the given index as the
+  /// other vector at the other vector's index (including if both are null when
+  /// nullHandlingMode is NoStop), false otherwise. If nullHandlingMode is
+  /// StopAtNull, returns std::nullopt if null encountered.
+  virtual std::optional<bool> equalValueAt(
+      const BaseVector* other,
+      vector_size_t index,
+      vector_size_t otherIndex,
+      CompareFlags::NullHandlingMode nullHandlingMode) const;
+
   int32_t compare(
       const BaseVector* other,
       vector_size_t index,


### PR DESCRIPTION
Add a new BaseVector::equalValueAt API nullHandlingMode,
make it support stopAtNull compare mode, and return
std::nullopt if null is encountered.