### PR TITLE
Move non-reclaimable section set in driver framework

### DIFF
--- a/velox/exec/Driver.h
+++ b/velox/exec/Driver.h
@@ -231,7 +231,7 @@ struct DriverCtx {
   Driver* driver;
   facebook::velox::process::ThreadDebugInfo threadDebugInfo;
 
-  explicit DriverCtx(
+  DriverCtx(
       std::shared_ptr<Task> _task,
       int _driverId,
       int _pipelineId,
@@ -254,6 +254,7 @@ constexpr const char* kOpMethodNeedsInput = "needsInput";
 constexpr const char* kOpMethodGetOutput = "getOutput";
 constexpr const char* kOpMethodAddInput = "addInput";
 constexpr const char* kOpMethodNoMoreInput = "noMoreInput";
+constexpr const char* kOpMethodIsFinished = "isFinished";
 
 /// Same as the structure below, but does not have atomic members.
 /// Used to return the status from the struct with atomics.


### PR DESCRIPTION
Move non-reclaimable section set in driver framework to mark an operator
non-reclaimable during any one of its method call. The spillable operator can
clear non-reclaimable section to allow memory arbitration to reclaim memory
at specific execution point while it is waiting for memory arbitration and it is
safe to do so.

This PR also moves the per-op env setting in one place CALL_OPERATOR macro.
Unit test added.
