### PR TITLE
Fix setNullField in DWRF struct reader to handle missing subfield in file and newly created result

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -284,12 +284,16 @@ void setConstantField(
   }
 }
 
-void setNullField(vector_size_t size, VectorPtr& field) {
+void setNullField(
+    vector_size_t size,
+    VectorPtr& field,
+    const TypePtr& type,
+    memory::MemoryPool* pool) {
   if (field && field->isConstantEncoding() && field.unique() &&
       field->size() > 0 && field->isNullAt(0)) {
     field->resize(size);
   } else {
-    field = BaseVector::createNullConstant(field->type(), size, field->pool());
+    field = BaseVector::createNullConstant(type, size, pool);
   }
 }
 
@@ -349,7 +353,8 @@ void SelectiveStructColumnReaderBase::getValues(
     // Set missing fields to be null constant, if we're in the top level struct
     // missing columns should already be a null constant from the check above.
     if (index == kConstantChildSpecSubscript) {
-      setNullField(rows.size(), childResult);
+      auto& childType = rowType.childAt(channel);
+      setNullField(rows.size(), childResult, childType, resultRow->pool());
       continue;
     }
     if (childSpec->extractValues() || childSpec->hasFilter() ||

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -31,6 +31,7 @@
 #include "velox/vector/ComplexVector.h"
 #include "velox/vector/FlatVector.h"
 #include "velox/vector/tests/utils/VectorMaker.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 #include <fmt/core.h>
 #include <array>
@@ -2715,4 +2716,34 @@ TEST(TestReader, readStringDictionaryAsFlat) {
   stats = {};
   rowReader->updateRuntimeStats(stats);
   ASSERT_EQ(stats.columnReaderStatistics.flattenStringDictionaryValues, 1);
+}
+
+// A primitive subfield is missing in file, and result is not reused.
+TEST(TestReader, missingSubfieldsNoResultReusing) {
+  constexpr int kSize = 10;
+  auto* pool = getDefaultPool().get();
+  VectorMaker maker(pool);
+  auto batch = maker.rowVector({
+      maker.rowVector({
+          maker.flatVector<int64_t>(kSize, folly::identity),
+      }),
+  });
+  auto [writer, reader] = createWriterReader({batch}, *pool);
+  auto schema = ROW({{"c0", ROW({{"c0", BIGINT()}, {"c1", VARCHAR()}})}});
+  auto spec = std::make_shared<common::ScanSpec>("<root>");
+  spec->addAllChildFields(*schema);
+  RowReaderOptions rowReaderOpts;
+  rowReaderOpts.setScanSpec(spec);
+  auto rowReader = reader->createRowReader(rowReaderOpts);
+  auto actual = BaseVector::create(schema, 0, pool);
+  // Hold a second reference to result so it cannot be reused.
+  auto actual2 = actual;
+  ASSERT_EQ(rowReader->next(1024, actual), 10);
+  auto expected = maker.rowVector({
+      maker.rowVector({
+          maker.flatVector<int64_t>(kSize, folly::identity),
+          BaseVector::createNullConstant(VARCHAR(), kSize, pool),
+      }),
+  });
+  assertEqualVectors(expected, actual);
 }


### PR DESCRIPTION
Summary:
Currently if a leaf level nested subfield is missing in file, and we
cannot reuse the result, the `VectorPtr` is null at that child and we try to
access type and pool information out of it.  Fix this by getting the type and
pool from the parent vector instead.

Differential Revision: D50422967


