### PR TITLE
Add a check for the RowVector cast in VectorSaver.

### DIFF
--- a/velox/vector/VectorSaver.cpp
+++ b/velox/vector/VectorSaver.cpp
@@ -416,7 +416,9 @@ void writeRowVector(const BaseVector& vector, std::ostream& out) {
   // Nulls buffer.
   writeOptionalBuffer(vector.nulls(), out);
 
-  auto rowVector = vector.as<RowVector>();
+  const auto* rowVector = vector.as<RowVector>();
+  VELOX_CHECK_NOT_NULL(
+      rowVector, "Expected a RowVector, got: {}", vector.toString());
 
   // Child vectors.
   auto numChildren = rowVector->childrenSize();


### PR DESCRIPTION
Summary:
We are observing weird crashes in VectorSaver while
trying to save RowVectors. The analysis of the code indicates
that dynamic cast to the RowVector might return null.
While we are investigating further, we are adding a check.

Reviewed By: mbasmanova

Differential Revision: D50429659

