### PR TITLE
Uniform return type of UDAF registration functions

### DIFF
--- a/velox/exec/tests/SimpleAggregateAdapterTest.cpp
+++ b/velox/exec/tests/SimpleAggregateAdapterTest.cpp
@@ -410,7 +410,8 @@ class CountNullsAggregate {
   using AccumulatorType = Accumulator;
 };
 
-bool registerSimpleCountNullsAggregate(const std::string& name) {
+exec::AggregateRegistrationResult registerSimpleCountNullsAggregate(
+    const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -418,7 +419,7 @@ bool registerSimpleCountNullsAggregate(const std::string& name) {
           .argumentType("double")
           .build()};
 
-  exec::registerAggregateFunction(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](
@@ -432,7 +433,6 @@ bool registerSimpleCountNullsAggregate(const std::string& name) {
         return std::make_unique<SimpleAggregateAdapter<CountNullsAggregate>>(
             resultType);
       });
-  return true;
 }
 
 void registerSimpleCountNullsAggregate() {

--- a/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxMostFrequentAggregate.cpp
@@ -349,8 +349,10 @@ std::unique_ptr<exec::Aggregate> makeApproxMostFrequentAggregate(
   }
 }
 
-exec::AggregateRegistrationResult registerApproxMostFrequent(
-    const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& valueType :
        {"tinyint", "smallint", "integer", "bigint", "varchar"}) {
@@ -364,6 +366,7 @@ exec::AggregateRegistrationResult registerApproxMostFrequent(
             .argumentType("bigint")
             .build());
   }
+  auto name = prefix + kApproxMostFrequent;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -383,12 +386,6 @@ exec::AggregateRegistrationResult registerApproxMostFrequent(
             name,
             valueType);
       });
-}
-
-} // namespace
-
-void registerApproxMostFrequentAggregate(const std::string& prefix) {
-  registerApproxMostFrequent(prefix + kApproxMostFrequent);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ApproxPercentileAggregate.cpp
@@ -802,8 +802,10 @@ void addSignatures(
                            .build());
 }
 
-exec::AggregateRegistrationResult registerApproxPercentile(
-    const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerApproxPercentileAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto& inputType :
        {"tinyint", "smallint", "integer", "bigint", "real", "double"}) {
@@ -814,6 +816,7 @@ exec::AggregateRegistrationResult registerApproxPercentile(
         fmt::format("array({})", inputType),
         signatures);
   }
+  auto name = prefix + kApproxPercentile;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -903,12 +906,6 @@ exec::AggregateRegistrationResult registerApproxPercentile(
         }
       },
       /*registerCompanionFunctions*/ true);
-}
-
-} // namespace
-
-void registerApproxPercentileAggregate(const std::string& prefix) {
-  registerApproxPercentile(prefix + kApproxPercentile);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArbitraryAggregate.cpp
@@ -254,7 +254,10 @@ class NonNumericArbitrary : public exec::Aggregate {
   }
 };
 
-exec::AggregateRegistrationResult registerArbitrary(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerArbitraryAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -263,6 +266,7 @@ exec::AggregateRegistrationResult registerArbitrary(const std::string& name) {
           .argumentType("T")
           .build()};
 
+  auto name = prefix + kArbitrary;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -310,12 +314,6 @@ exec::AggregateRegistrationResult registerArbitrary(const std::string& name) {
                 inputType->kindName());
         }
       });
-}
-
-} // namespace
-
-void registerArbitraryAggregate(const std::string& prefix) {
-  registerArbitrary(prefix + kArbitrary);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ArrayAggAggregate.cpp
@@ -235,7 +235,10 @@ class ArrayAggAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-exec::AggregateRegistrationResult registerArray(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerArrayAggAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("E")
@@ -244,6 +247,7 @@ exec::AggregateRegistrationResult registerArray(const std::string& name) {
           .argumentType("E")
           .build()};
 
+  auto name = prefix + kArrayAgg;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -258,12 +262,6 @@ exec::AggregateRegistrationResult registerArray(const std::string& name) {
             resultType, config.prestoArrayAggIgnoreNulls());
       },
       /*registerCompanionFunctions*/ true);
-}
-
-} // namespace
-
-void registerArrayAggregate(const std::string& prefix) {
-  registerArray(prefix + kArrayAgg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/AverageAggregate.cpp
@@ -20,7 +20,6 @@
 using namespace facebook::velox::functions::aggregate;
 
 namespace facebook::velox::aggregate::prestosql {
-namespace {
 
 /// Count is BIGINT() while sum and the final aggregates type depends on
 /// the input types:
@@ -30,7 +29,8 @@ namespace {
 ///     REAL            |     DOUBLE          |    REAL
 ///     ALL INTs        |     DOUBLE          |    DOUBLE
 ///     DECIMAL         |     DECIMAL         |    DECIMAL
-exec::AggregateRegistrationResult registerAverage(const std::string& name) {
+exec::AggregateRegistrationResult registerAverageAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   for (const auto& inputType : {"smallint", "integer", "bigint", "double"}) {
@@ -55,6 +55,7 @@ exec::AggregateRegistrationResult registerAverage(const std::string& name) {
                            .returnType("DECIMAL(a_precision, a_scale)")
                            .build());
 
+  auto name = prefix + kAvg;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -139,11 +140,6 @@ exec::AggregateRegistrationResult registerAverage(const std::string& name) {
         }
       },
       /*registerCompanionFunctions*/ true);
-}
-} // namespace
-
-void registerAverageAggregate(const std::string& prefix) {
-  registerAverage(prefix + kAvg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/BitwiseXorAggregate.cpp
@@ -66,7 +66,8 @@ class BitwiseXorAggregate {
 
 } // namespace
 
-void registerBitwiseXorAggregate(const std::string& prefix) {
+exec::AggregateRegistrationResult registerBitwiseXorAggregate(
+    const std::string& prefix) {
   const std::string name = prefix + kBitwiseXor;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -79,7 +80,7 @@ void registerBitwiseXorAggregate(const std::string& prefix) {
                              .build());
   }
 
-  exec::registerAggregateFunction(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/ChecksumAggregate.cpp
@@ -207,7 +207,10 @@ class ChecksumAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-exec::AggregateRegistrationResult registerChecksum(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerChecksumAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -217,6 +220,7 @@ exec::AggregateRegistrationResult registerChecksum(const std::string& name) {
           .build(),
   };
 
+  auto name = prefix + kChecksum;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -234,12 +238,6 @@ exec::AggregateRegistrationResult registerChecksum(const std::string& name) {
 
         return std::make_unique<ChecksumAggregate>(VARBINARY());
       });
-}
-
-} // namespace
-
-void registerChecksumAggregate(const std::string& prefix) {
-  registerChecksum(prefix + kChecksum);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountAggregate.cpp
@@ -148,7 +148,10 @@ class CountAggregate : public SimpleNumericAggregate<bool, int64_t, int64_t> {
   DecodedVector decodedIntermediate_;
 };
 
-exec::AggregateRegistrationResult registerCount(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerCountAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -162,6 +165,7 @@ exec::AggregateRegistrationResult registerCount(const std::string& name) {
           .build(),
   };
 
+  auto name = prefix + kCount;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -175,12 +179,6 @@ exec::AggregateRegistrationResult registerCount(const std::string& name) {
             argTypes.size(), 1, "{} takes at most one argument", name);
         return std::make_unique<CountAggregate>();
       });
-}
-
-} // namespace
-
-void registerCountAggregate(const std::string& prefix) {
-  registerCount(prefix + kCount);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/CountIfAggregate.cpp
@@ -168,7 +168,10 @@ class CountIfAggregate : public exec::Aggregate {
   }
 };
 
-exec::AggregateRegistrationResult registerCountIf(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerCountIfAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("bigint")
@@ -177,6 +180,7 @@ exec::AggregateRegistrationResult registerCountIf(const std::string& name) {
           .build(),
   };
 
+  auto name = prefix + kCountIf;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -199,12 +203,6 @@ exec::AggregateRegistrationResult registerCountIf(const std::string& name) {
 
         return std::make_unique<CountIfAggregate>();
       });
-}
-
-} // namespace
-
-void registerCountIfAggregate(const std::string& prefix) {
-  registerCountIf(prefix + kCountIf);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/EntropyAggregates.cpp
@@ -334,7 +334,10 @@ void checkRowType(const TypePtr& type, const std::string& errorMessage) {
       errorMessage);
 }
 
-exec::AggregateRegistrationResult registerEntropy(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerEntropyAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   std::vector<std::string> inputTypes = {"smallint", "integer", "bigint"};
   for (const auto& inputType : inputTypes) {
@@ -345,6 +348,7 @@ exec::AggregateRegistrationResult registerEntropy(const std::string& name) {
                              .build());
   }
 
+  auto name = prefix + kEntropy;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -380,12 +384,6 @@ exec::AggregateRegistrationResult registerEntropy(const std::string& name) {
           return std::make_unique<EntropyAggregate<int64_t>>(resultType);
         }
       });
-}
-
-} // namespace
-
-void registerEntropyAggregates(const std::string& prefix) {
-  registerEntropy(prefix + kEntropy);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/GeometricMeanAggregate.cpp
@@ -82,7 +82,8 @@ class GeometricMeanAggregate {
 
 } // namespace
 
-void registerGeometricMeanAggregate(const std::string& prefix) {
+exec::AggregateRegistrationResult registerGeometricMeanAggregate(
+    const std::string& prefix) {
   const std::string name = prefix + kGeometricMean;
 
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
@@ -102,7 +103,7 @@ void registerGeometricMeanAggregate(const std::string& prefix) {
                            .argumentType("real")
                            .build());
 
-  exec::registerAggregateFunction(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/HistogramAggregate.cpp
@@ -338,7 +338,10 @@ class HistogramAggregate : public exec::Aggregate {
   DecodedVector decodedIntermediate_;
 };
 
-exec::AggregateRegistrationResult registerHistogram(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerHistogramAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
   for (const auto inputType :
        {"boolean",
@@ -360,6 +363,7 @@ exec::AggregateRegistrationResult registerHistogram(const std::string& name) {
                              .build());
   }
 
+  auto name = prefix + kHistogram;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -403,12 +407,6 @@ exec::AggregateRegistrationResult registerHistogram(const std::string& name) {
                 inputType->kindName());
         }
       });
-}
-
-} // namespace
-
-void registerHistogramAggregate(const std::string& prefix) {
-  registerHistogram(prefix + kHistogram);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapAggAggregate.cpp
@@ -145,7 +145,10 @@ class MapAggAggregate : public MapAggregateBase<K> {
   const bool throwOnNestedNulls_;
 };
 
-exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerMapAggAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .knownTypeVariable("K")
@@ -156,6 +159,7 @@ exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
           .argumentType("V")
           .build()};
 
+  auto name = prefix + kMapAgg;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -206,12 +210,6 @@ exec::AggregateRegistrationResult registerMapAgg(const std::string& name) {
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
       });
-}
-
-} // namespace
-
-void registerMapAggAggregate(const std::string& prefix) {
-  registerMapAgg(prefix + kMapAgg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionAggregate.cpp
@@ -73,7 +73,10 @@ class MapUnionAggregate : public MapAggregateBase<K> {
   }
 };
 
-exec::AggregateRegistrationResult registerMapUnion(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerMapUnionAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("K")
@@ -83,6 +86,7 @@ exec::AggregateRegistrationResult registerMapUnion(const std::string& name) {
           .argumentType("map(K,V)")
           .build()};
 
+  auto name = prefix + kMapUnion;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -100,12 +104,6 @@ exec::AggregateRegistrationResult registerMapUnion(const std::string& name) {
 
         return createMapAggregate<MapUnionAggregate>(resultType);
       });
-}
-
-} // namespace
-
-void registerMapUnionAggregate(const std::string& prefix) {
-  registerMapUnion(prefix + kMapUnion);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MapUnionSumAggregate.cpp
@@ -345,7 +345,10 @@ std::unique_ptr<exec::Aggregate> createMapUnionSumAggregate(
   }
 }
 
-exec::AggregateRegistrationResult registerMapUnionSum(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerMapUnionSumAggregate(
+    const std::string& prefix) {
   const std::vector<std::string> keyTypes = {
       "tinyint",
       "smallint",
@@ -376,6 +379,7 @@ exec::AggregateRegistrationResult registerMapUnionSum(const std::string& name) {
     }
   }
 
+  auto name = prefix + kMapUnionSum;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -415,12 +419,6 @@ exec::AggregateRegistrationResult registerMapUnionSum(const std::string& name) {
             VELOX_UNREACHABLE();
         }
       });
-}
-
-} // namespace
-
-void registerMapUnionSumAggregate(const std::string& prefix) {
-  registerMapUnionSum(prefix + kMapUnionSum);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MaxSizeForStatsAggregate.cpp
@@ -202,8 +202,10 @@ class MaxSizeForStatsAggregate
   }
 };
 
-exec::AggregateRegistrationResult registerMaxSizeForStats(
-    const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerMaxDataSizeForStatsAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -213,6 +215,7 @@ exec::AggregateRegistrationResult registerMaxSizeForStats(
                            .argumentType("T")
                            .build());
 
+  auto name = prefix + kMaxSizeForStats;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -227,12 +230,6 @@ exec::AggregateRegistrationResult registerMaxSizeForStats(
 
         return std::make_unique<MaxSizeForStatsAggregate>(resultType);
       });
-}
-
-} // namespace
-
-void registerMaxDataSizeForStatsAggregate(const std::string& prefix) {
-  registerMaxSizeForStats(prefix + kMaxSizeForStats);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/MultiMapAggAggregate.cpp
@@ -361,7 +361,10 @@ class MultiMapAggAggregate : public exec::Aggregate {
   DecodedVector decodedValueArrays_;
 };
 
-exec::AggregateRegistrationResult registerMultiMapAgg(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerMultiMapAggAggregate(
+    const std::string& prefix) {
   static const std::vector<std::string> kSupportedKeyTypes = {
       "boolean",
       "tinyint",
@@ -389,6 +392,7 @@ exec::AggregateRegistrationResult registerMultiMapAgg(const std::string& name) {
             .build());
   }
 
+  auto name = prefix + kMultiMapAgg;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -429,12 +433,6 @@ exec::AggregateRegistrationResult registerMultiMapAgg(const std::string& name) {
                 "Unexpected type {}", mapTypeKindToName(typeKind));
         }
       });
-}
-
-} // namespace
-
-void registerMultiMapAggAggregate(const std::string& prefix) {
-  registerMultiMapAgg(prefix + kMultiMapAgg);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/ReduceAgg.cpp
+++ b/velox/functions/prestosql/aggregates/ReduceAgg.cpp
@@ -786,7 +786,7 @@ class ReduceAgg : public exec::Aggregate {
 
 } // namespace
 
-void registerReduceAgg(const std::string& prefix) {
+exec::AggregateRegistrationResult registerReduceAgg(const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -801,7 +801,7 @@ void registerReduceAgg(const std::string& prefix) {
 
   const std::string name = prefix + kReduceAgg;
 
-  exec::registerAggregateFunction(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
+++ b/velox/functions/prestosql/aggregates/RegisterAggregateFunctions.cpp
@@ -14,37 +14,60 @@
  * limitations under the License.
  */
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
+#include "velox/exec/Aggregate.h"
 
 namespace facebook::velox::aggregate::prestosql {
 
+extern exec::AggregateRegistrationResult registerApproxMostFrequentAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerApproxPercentileAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerArbitraryAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerArrayAggAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerAverageAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerBitwiseXorAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerChecksumAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerCountAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerCountIfAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerEntropyAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerGeometricMeanAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerHistogramAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerMapAggAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerMapUnionAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerMapUnionSumAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerMaxDataSizeForStatsAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerMultiMapAggAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerSumDataSizeForStatsAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerReduceAgg(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerSetAggAggregate(
+    const std::string& prefix);
+extern exec::AggregateRegistrationResult registerSetUnionAggregate(
+    const std::string& prefix);
+
 extern void registerApproxDistinctAggregates(const std::string& prefix);
-extern void registerApproxMostFrequentAggregate(const std::string& prefix);
-extern void registerApproxPercentileAggregate(const std::string& prefix);
-extern void registerArbitraryAggregate(const std::string& prefix);
-extern void registerArrayAggregate(const std::string& prefix);
-extern void registerAverageAggregate(const std::string& prefix);
 extern void registerBitwiseAggregates(const std::string& prefix);
-extern void registerBitwiseXorAggregate(const std::string& prefix);
 extern void registerBoolAggregates(const std::string& prefix);
 extern void registerCentralMomentsAggregates(const std::string& prefix);
-extern void registerChecksumAggregate(const std::string& prefix);
-extern void registerCountAggregate(const std::string& prefix);
-extern void registerCountIfAggregate(const std::string& prefix);
 extern void registerCovarianceAggregates(const std::string& prefix);
-extern void registerEntropyAggregates(const std::string& prefix);
-extern void registerGeometricMeanAggregate(const std::string& prefix);
-extern void registerHistogramAggregate(const std::string& prefix);
-extern void registerMapAggAggregate(const std::string& prefix);
-extern void registerMapUnionAggregate(const std::string& prefix);
-extern void registerMapUnionSumAggregate(const std::string& prefix);
-extern void registerMaxDataSizeForStatsAggregate(const std::string& prefix);
-extern void registerMultiMapAggAggregate(const std::string& prefix);
-extern void registerSumDataSizeForStatsAggregate(const std::string& prefix);
 extern void registerMinMaxAggregates(const std::string& prefix);
 extern void registerMinMaxByAggregates(const std::string& prefix);
-extern void registerReduceAgg(const std::string& prefix);
-extern void registerSetAggAggregate(const std::string& prefix);
-extern void registerSetUnionAggregate(const std::string& prefix);
 extern void registerSumAggregate(const std::string& prefix);
 extern void registerVarianceAggregates(const std::string& prefix);
 
@@ -53,7 +76,7 @@ void registerAllAggregateFunctions(const std::string& prefix) {
   registerApproxMostFrequentAggregate(prefix);
   registerApproxPercentileAggregate(prefix);
   registerArbitraryAggregate(prefix);
-  registerArrayAggregate(prefix);
+  registerArrayAggAggregate(prefix);
   registerAverageAggregate(prefix);
   registerBitwiseAggregates(prefix);
   registerBitwiseXorAggregate(prefix);
@@ -63,7 +86,7 @@ void registerAllAggregateFunctions(const std::string& prefix) {
   registerCountAggregate(prefix);
   registerCountIfAggregate(prefix);
   registerCovarianceAggregates(prefix);
-  registerEntropyAggregates(prefix);
+  registerEntropyAggregate(prefix);
   registerGeometricMeanAggregate(prefix);
   registerHistogramAggregate(prefix);
   registerMapAggAggregate(prefix);

--- a/velox/functions/prestosql/aggregates/SetAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/SetAggregates.cpp
@@ -419,7 +419,10 @@ std::unique_ptr<exec::Aggregate> create(
   }
 }
 
-exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerSetAggAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -428,6 +431,7 @@ exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
           .argumentType("T")
           .build()};
 
+  auto name = prefix + kSetAgg;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -479,7 +483,8 @@ exec::AggregateRegistrationResult registerSetAgg(const std::string& name) {
       });
 }
 
-exec::AggregateRegistrationResult registerSetUnion(const std::string& name) {
+exec::AggregateRegistrationResult registerSetUnionAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
       exec::AggregateFunctionSignatureBuilder()
           .typeVariable("T")
@@ -488,6 +493,7 @@ exec::AggregateRegistrationResult registerSetUnion(const std::string& name) {
           .argumentType("array(T)")
           .build()};
 
+  auto name = prefix + kSetUnion;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -503,16 +509,6 @@ exec::AggregateRegistrationResult registerSetUnion(const std::string& name) {
 
         return create<SetUnionAggregate>(typeKind, resultType);
       });
-}
-
-} // namespace
-
-void registerSetAggAggregate(const std::string& prefix) {
-  registerSetAgg(prefix + kSetAgg);
-}
-
-void registerSetUnionAggregate(const std::string& prefix) {
-  registerSetUnion(prefix + kSetUnion);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
+++ b/velox/functions/prestosql/aggregates/SumDataSizeForStatsAggregate.cpp
@@ -182,8 +182,10 @@ class SumDataSizeForStatsAggregate
   std::vector<IndexRange> rowIndices_;
 };
 
-exec::AggregateRegistrationResult registerSumDataSizeForStats(
-    const std::string& name) {
+} // namespace
+
+exec::AggregateRegistrationResult registerSumDataSizeForStatsAggregate(
+    const std::string& prefix) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures;
 
   signatures.push_back(exec::AggregateFunctionSignatureBuilder()
@@ -193,6 +195,7 @@ exec::AggregateRegistrationResult registerSumDataSizeForStats(
                            .argumentType("T")
                            .build());
 
+  auto name = prefix + kSumDataSizeForStats;
   return exec::registerAggregateFunction(
       name,
       std::move(signatures),
@@ -207,12 +210,6 @@ exec::AggregateRegistrationResult registerSumDataSizeForStats(
 
         return std::make_unique<SumDataSizeForStatsAggregate>(resultType);
       });
-}
-
-} // namespace
-
-void registerSumDataSizeForStatsAggregate(const std::string& prefix) {
-  registerSumDataSizeForStats(prefix + kSumDataSizeForStats);
 }
 
 } // namespace facebook::velox::aggregate::prestosql

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "velox/functions/sparksql/aggregates/SumAggregate.h"
+
 #include "velox/functions/lib/aggregates/SumAggregateBase.h"
 
 using namespace facebook::velox::functions::aggregate;
@@ -24,7 +26,7 @@ template <typename TInput, typename TAccumulator, typename ResultType>
 using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, true>;
 }
 
-void registerSum(const std::string& name) {
+exec::AggregateRegistrationResult registerSum(const std::string& name) {
   std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures{
       exec::AggregateFunctionSignatureBuilder()
           .returnType("real")
@@ -46,7 +48,7 @@ void registerSum(const std::string& name) {
                              .build());
   }
 
-  exec::registerAggregateFunction(
+  return exec::registerAggregateFunction(
       name,
       std::move(signatures),
       [name](

--- a/velox/functions/sparksql/aggregates/SumAggregate.h
+++ b/velox/functions/sparksql/aggregates/SumAggregate.h
@@ -18,8 +18,10 @@
 
 #include <string>
 
+#include "velox/exec/Aggregate.h"
+
 namespace facebook::velox::functions::aggregate::sparksql {
 
-void registerSum(const std::string& name);
+exec::AggregateRegistrationResult registerSum(const std::string& name);
 
 } // namespace facebook::velox::functions::aggregate::sparksql


### PR DESCRIPTION
Summary: Make individual UDAF registration functions all return exec::AggregateRegistrationResult.

Differential Revision: D50436492


