### PR TITLE
Add spill support to TopNRowNumber operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2267,6 +2267,10 @@ class TopNRowNumberNode : public PlanNode {
     return outputType_;
   }
 
+  bool canSpill(const QueryConfig& queryConfig) const override {
+    return !partitionKeys_.empty() && queryConfig.topNRowNumberSpillEnabled();
+  }
+
   const RowTypePtr& inputType() const {
     return sources_[0]->outputType();
   }

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -199,6 +199,10 @@ class QueryConfig {
   static constexpr const char* kRowNumberSpillEnabled =
       "row_number_spill_enabled";
 
+  /// TopNRowNumber spilling flag, only applies if "spill_enabled" flag is set.
+  static constexpr const char* kTopNRowNumberSpillEnabled =
+      "topn_row_number_spill_enabled";
+
   /// The max memory that a final aggregation can use before spilling. If it 0,
   /// then there is no limit.
   static constexpr const char* kAggregationSpillMemoryThreshold =
@@ -479,10 +483,16 @@ class QueryConfig {
     return get<bool>(kWriterSpillEnabled, true);
   }
 
-  /// Returns 'is row_number spilling enabled' flag. Must also check the
-  /// spillEnabled()!
+  /// Returns true if spilling is enabled for RowNumber operator. Must also
+  /// check the spillEnabled()!
   bool rowNumberSpillEnabled() const {
     return get<bool>(kRowNumberSpillEnabled, true);
+  }
+
+  /// Returns true if spilling is enabled for TopNRowNumber operator. Must also
+  /// check the spillEnabled()!
+  bool topNRowNumberSpillEnabled() const {
+    return get<bool>(kTopNRowNumberSpillEnabled, true);
   }
 
   /// Returns a percentage of aggregation or join input batches that will be

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -203,6 +203,10 @@ Spilling
      - boolean
      - true
      - When `spill_enabled` is true, determines whether RowNumber operator can spill to disk under memory pressure.
+   * - topn_row_number_spill_enabled
+     - boolean
+     - true
+     - When `spill_enabled` is true, determines whether TopNRowNumber operator can spill to disk under memory pressure.
    * - writer_spill_enabled
      - boolean
      - true

--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -176,7 +176,7 @@ void RowNumber::restoreNextSpillPartition() {
 }
 
 void RowNumber::ensureInputFits(const RowVectorPtr& input) {
-  if (!spillConfig_.has_value()) {
+  if (!spillEnabled()) {
     // Spilling is disabled.
     return;
   }

--- a/velox/exec/TopNRowNumber.cpp
+++ b/velox/exec/TopNRowNumber.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "velox/exec/TopNRowNumber.h"
+#include "velox/exec/OperatorUtils.h"
 
 namespace facebook::velox::exec {
 
@@ -69,6 +70,35 @@ RowTypePtr reorderInputType(
 
   return ROW(std::move(names), std::move(types));
 }
+
+std::vector<CompareFlags> makeSpillCompareFlags(
+    int32_t numPartitionKeys,
+    const std::vector<core::SortOrder>& sortingOrders) {
+  std::vector<CompareFlags> compareFlags;
+  compareFlags.reserve(numPartitionKeys + sortingOrders.size());
+
+  for (auto i = 0; i < numPartitionKeys; ++i) {
+    compareFlags.push_back({});
+  }
+
+  for (const auto& order : sortingOrders) {
+    compareFlags.push_back(
+        {order.isNullsFirst(), order.isAscending(), false /*equalsOnly*/});
+  }
+
+  return compareFlags;
+}
+
+// Returns a [start, end) slice of the 'types' vector.
+std::vector<TypePtr>
+slice(const std::vector<TypePtr>& types, int32_t start, int32_t end) {
+  std::vector<TypePtr> result;
+  result.reserve(end - start);
+  for (auto i = start; i < end; ++i) {
+    result.push_back(types[i]);
+  }
+  return result;
+}
 } // namespace
 
 TopNRowNumber::TopNRowNumber(
@@ -80,15 +110,27 @@ TopNRowNumber::TopNRowNumber(
           node->outputType(),
           operatorId,
           node->id(),
-          "TopNRowNumber"),
+          "TopNRowNumber",
+          node->canSpill(driverCtx->queryConfig())
+              ? driverCtx->makeSpillConfig(operatorId)
+              : std::nullopt),
       limit_{node->limit()},
       generateRowNumber_{node->generateRowNumber()},
+      numPartitionKeys_{node->partitionKeys().size()},
       inputChannels_{reorderInputChannels(
           node->inputType(),
           node->partitionKeys(),
           node->sortingKeys())},
       inputType_{reorderInputType(node->inputType(), inputChannels_)},
-      data_(std::make_unique<RowContainer>(inputType_->children(), pool())),
+      spillCompareFlags_{
+          makeSpillCompareFlags(numPartitionKeys_, node->sortingOrders())},
+      data_(std::make_unique<RowContainer>(
+          slice(inputType_->children(), 0, spillCompareFlags_.size()),
+          slice(
+              inputType_->children(),
+              spillCompareFlags_.size(),
+              inputType_->size()),
+          pool())),
       comparator_(
           inputType_,
           node->sortingKeys(),
@@ -100,7 +142,12 @@ TopNRowNumber::TopNRowNumber(
 
   if (numKeys > 0) {
     Accumulator accumulator{
-        true, sizeof(TopRows), false, 1, [](auto, auto) {}, [](auto) {}};
+        true,
+        sizeof(TopRows),
+        false,
+        1,
+        [](auto, auto) { VELOX_UNREACHABLE(); },
+        [](auto) {}};
 
     table_ = std::make_unique<HashTable<false>>(
         createVectorHashers(node->inputType(), keys),
@@ -131,6 +178,8 @@ void TopNRowNumber::addInput(RowVectorPtr input) {
   }
 
   if (table_) {
+    ensureInputFits(input);
+
     SelectivityVector rows(numInput);
     table_->prepareForProbe(*lookup_, input, rows, false);
     table_->groupProbe(*lookup_);
@@ -190,13 +239,41 @@ void TopNRowNumber::processInputRow(vector_size_t index, TopRows& partition) {
 void TopNRowNumber::noMoreInput() {
   Operator::noMoreInput();
 
-  auto rowSize = data_->estimateRowSize();
-  if (rowSize && generateRowNumber_) {
-    rowSize.value() += sizeof(int64_t);
+  updateEstimatedOutputRowSize();
+
+  outputBatchSize_ = outputBatchRows(estimatedOutputRowSize_);
+
+  if (spiller_ != nullptr) {
+    // Spill remaining data to avoid running out of memory while sort-merging
+    // spilled data.
+    spill();
+
+    spiller_->finishSpill();
+    recordSpillStats(spiller_->stats());
+
+    merge_ = spiller_->startMerge(0);
+  } else {
+    outputRows_.resize(outputBatchSize_);
+  }
+}
+
+void TopNRowNumber::updateEstimatedOutputRowSize() {
+  const auto optionalRowSize = data_->estimateRowSize();
+  if (!optionalRowSize.has_value()) {
+    return;
   }
 
-  outputBatchSize_ = outputBatchRows(rowSize);
-  outputRows_.resize(outputBatchSize_);
+  auto rowSize = optionalRowSize.value();
+
+  if (rowSize && generateRowNumber_) {
+    rowSize += sizeof(int64_t);
+  }
+
+  if (!estimatedOutputRowSize_.has_value()) {
+    estimatedOutputRowSize_ = rowSize;
+  } else if (rowSize > estimatedOutputRowSize_.value()) {
+    estimatedOutputRowSize_ = rowSize;
+  }
 }
 
 TopNRowNumber::TopRows* TopNRowNumber::nextPartition() {
@@ -264,13 +341,20 @@ RowVectorPtr TopNRowNumber::getOutput() {
     return nullptr;
   }
 
+  if (merge_ != nullptr) {
+    return getOutputFromSpill();
+  }
+
+  return getOutputFromMemory();
+}
+
+RowVectorPtr TopNRowNumber::getOutputFromMemory() {
   // Loop over partitions and emit sorted rows along with row numbers.
   auto output =
       BaseVector::create<RowVector>(outputType_, outputBatchSize_, pool());
   FlatVector<int64_t>* rowNumbers = nullptr;
   if (generateRowNumber_) {
     rowNumbers = output->children().back()->as<FlatVector<int64_t>>();
-    rowNumbers->resize(outputBatchSize_);
   }
 
   vector_size_t offset = 0;
@@ -325,11 +409,139 @@ RowVectorPtr TopNRowNumber::getOutput() {
   return output;
 }
 
+bool TopNRowNumber::isNewPartition(
+    const RowVectorPtr& output,
+    vector_size_t index,
+    SpillMergeStream* next) {
+  VELOX_CHECK_GT(index, 0);
+
+  for (auto i = 0; i < numPartitionKeys_; ++i) {
+    if (!output->childAt(inputChannels_[i])
+             ->equalValueAt(
+                 next->current().childAt(i).get(),
+                 index - 1,
+                 next->currentIndex())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void TopNRowNumber::setupNextOutput(
+    const RowVectorPtr& output,
+    int32_t rowNumber) {
+  nextRowNumber_ = rowNumber;
+
+  auto lookAhead = merge_->next();
+  if (lookAhead == nullptr) {
+    nextRowNumber_ = 0;
+    return;
+  }
+
+  if (isNewPartition(output, output->size(), lookAhead)) {
+    nextRowNumber_ = 0;
+    return;
+  }
+
+  if (nextRowNumber_ < limit_) {
+    return;
+  }
+
+  // Skip remaining rows for this partition.
+  lookAhead->pop();
+
+  while (auto next = merge_->next()) {
+    if (isNewPartition(output, output->size(), next)) {
+      nextRowNumber_ = 0;
+      return;
+    }
+    next->pop();
+  }
+}
+
+RowVectorPtr TopNRowNumber::getOutputFromSpill() {
+  VELOX_CHECK_NOT_NULL(merge_);
+
+  // merge_->next() produces data sorted by partition keys, then sorting keys.
+  // All rows from the same partition will appear together.
+  // We'll identify partition boundaries by comparing partition keys of the
+  // current row with the previous row. When new partition starts, we'll reset
+  // row number to zero. Once row number reaches the 'limit_', we'll start
+  // dropping rows until the next partition starts.
+  // We'll emit output every time we accumulate 'outputBatchSize_' rows.
+
+  auto output =
+      BaseVector::create<RowVector>(outputType_, outputBatchSize_, pool());
+  FlatVector<int64_t>* rowNumbers = nullptr;
+  if (generateRowNumber_) {
+    rowNumbers = output->children().back()->as<FlatVector<int64_t>>();
+  }
+
+  // Index of the next row to append to output.
+  vector_size_t index = 0;
+
+  // Row number of the next row in the current partition.
+  vector_size_t rowNumber = nextRowNumber_;
+  VELOX_CHECK_LT(rowNumber, limit_);
+  for (;;) {
+    auto next = merge_->next();
+    if (next == nullptr) {
+      break;
+    }
+
+    // Check if this row comes from a new partition.
+    if (index > 0 && isNewPartition(output, index, next)) {
+      rowNumber = 0;
+    }
+
+    if (rowNumber < limit_) {
+      for (auto i = 0; i < inputChannels_.size(); ++i) {
+        output->childAt(inputChannels_[i])
+            ->copy(
+                next->current().childAt(i).get(),
+                index,
+                next->currentIndex(),
+                1);
+      }
+      if (rowNumbers) {
+        // Row numbers start with 1.
+        rowNumbers->set(index, rowNumber + 1);
+      }
+      ++index;
+    } else {
+      // Drop the row.
+    }
+
+    ++rowNumber;
+    next->pop();
+
+    if (index == outputBatchSize_) {
+      // Check if next row is from a new partition. Reset 'nextRowNumber_' if
+      // so. Check if next row is from the current partition, but we have
+      // reached the 'limit_'. Skip to the start of the next partition if so.
+      setupNextOutput(output, rowNumber);
+
+      return output;
+    }
+  }
+
+  if (index > 0) {
+    output->resize(index);
+  } else {
+    output = nullptr;
+  }
+
+  finished_ = true;
+  return output;
+}
+
 bool TopNRowNumber::isFinished() {
   return finished_;
 }
 
 void TopNRowNumber::close() {
+  Operator::close();
+
   if (table_) {
     partitionIt_.reset();
     partitions_.resize(1000);
@@ -346,4 +558,119 @@ void TopNRowNumber::close() {
   }
 }
 
+void TopNRowNumber::reclaim(
+    uint64_t /*targetBytes*/,
+    memory::MemoryReclaimer::Stats& stats) {
+  if (data_->numRows() == 0) {
+    // Nothing to spill.
+    return;
+  }
+
+  if (nonReclaimableSection_) {
+    ++stats.numNonReclaimableAttempts;
+    return;
+  }
+
+  if (noMoreInput_) {
+    // TODO Add support for spilling after noMoreInput().
+    return;
+  }
+
+  spill();
+}
+
+void TopNRowNumber::ensureInputFits(const RowVectorPtr& input) {
+  if (!spillEnabled()) {
+    // Spilling is disabled.
+    return;
+  }
+
+  if (data_->numRows() == 0) {
+    // Nothing to spill.
+    return;
+  }
+
+  // Test-only spill path.
+  if (spillConfig_->testSpillPct > 0) {
+    spill();
+    return;
+  }
+
+  auto [freeRows, outOfLineFreeBytes] = data_->freeSpace();
+  const auto outOfLineBytes =
+      data_->stringAllocator().retainedSize() - outOfLineFreeBytes;
+  const auto outOfLineBytesPerRow = outOfLineBytes / data_->numRows();
+
+  const auto currentUsage = pool()->currentBytes();
+  const auto minReservationBytes =
+      currentUsage * spillConfig_->minSpillableReservationPct / 100;
+  const auto availableReservationBytes = pool()->availableReservation();
+  const auto tableIncrementBytes = table_->hashTableSizeIncrease(input->size());
+  const auto incrementBytes =
+      data_->sizeIncrement(
+          input->size(), outOfLineBytesPerRow * input->size()) +
+      tableIncrementBytes;
+
+  // First to check if we have sufficient minimal memory reservation.
+  if (availableReservationBytes >= minReservationBytes) {
+    if ((tableIncrementBytes == 0) && (freeRows > input->size()) &&
+        (outOfLineBytes == 0 ||
+         outOfLineFreeBytes >= outOfLineBytesPerRow * input->size())) {
+      // Enough free rows for input rows and enough variable length free space.
+      return;
+    }
+  }
+
+  // Check if we can increase reservation. The increment is the largest of twice
+  // the maximum increment from this input and 'spillableReservationGrowthPct_'
+  // of the current memory usage.
+  const auto targetIncrementBytes = std::max<int64_t>(
+      incrementBytes * 2,
+      currentUsage * spillConfig_->spillableReservationGrowthPct / 100);
+  {
+    ReclaimableSectionGuard guard(this);
+    if (pool()->maybeReserve(targetIncrementBytes)) {
+      return;
+    }
+  }
+
+  spill();
+}
+
+void TopNRowNumber::spill() {
+  if (spiller_ == nullptr) {
+    setupSpiller();
+  }
+
+  updateEstimatedOutputRowSize();
+
+  spiller_->spill(0, 0);
+  table_->clear();
+  data_->clear();
+  pool()->release();
+}
+
+void TopNRowNumber::setupSpiller() {
+  VELOX_CHECK_NULL(spiller_);
+
+  spiller_ = std::make_unique<Spiller>(
+      // TODO Replace Spiller::Type::kOrderBy.
+      Spiller::Type::kOrderBy,
+      data_.get(),
+      [&](folly::Range<char**> rows) {
+        // TODO Fix Spiller to allow spilling the whole container and not
+        // require erasing rows one at a time.
+        data_->eraseRows(rows);
+      },
+      inputType_,
+      spillCompareFlags_.size(),
+      spillCompareFlags_,
+      spillConfig_->filePath,
+      std::numeric_limits<uint64_t>::max(),
+      spillConfig_->writeBufferSize,
+      spillConfig_->minSpillRunSize,
+      spillConfig_->compressionKind,
+      memory::spillMemoryPool(),
+      spillConfig_->executor);
+}
 } // namespace facebook::velox::exec

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -59,6 +59,9 @@ class TopNRowNumber : public Operator {
 
   void close() override;
 
+  void reclaim(uint64_t targetBytes, memory::MemoryReclaimer::Stats& stats)
+      override;
+
  private:
   // A priority queue to keep track of top 'limit' rows for a given partition.
   struct TopRows {
@@ -102,14 +105,57 @@ class TopNRowNumber : public Operator {
       vector_size_t outputOffset,
       FlatVector<int64_t>* rowNumbers);
 
+  bool spillEnabled() const {
+    return spillConfig_.has_value();
+  }
+
+  void ensureInputFits(const RowVectorPtr& input);
+
+  // Sorts, spills and clears all of 'data_'. Clears 'table_'.
+  void spill();
+
+  void setupSpiller();
+
+  RowVectorPtr getOutputFromSpill();
+
+  RowVectorPtr getOutputFromMemory();
+
+  // Returns true if 'next' row belongs to a different partition then index-1
+  // row of output.
+  bool isNewPartition(
+      const RowVectorPtr& output,
+      vector_size_t index,
+      SpillMergeStream* next);
+
+  // Sets nextRowNumber_ to rowNumber. Checks if next row in 'merge_' belongs to
+  // a different partition than last row in 'output' and if so updates
+  // nextRowNumber_ to 0. Also, checks current partition reached the limit on
+  // number of rows and if so advances 'merge_' to the first row on the next
+  // partition and sets nextRowNumber_ to 0.
+  //
+  // @post 'merge_->next()' is either at end or points to a row that should be
+  // included in the next output batch using 'nextRowNumber_'.
+  void setupNextOutput(const RowVectorPtr& output, int32_t rowNumber);
+
+  // Called in noMoreInput() and spill().
+  void updateEstimatedOutputRowSize();
+
   const int32_t limit_;
   const bool generateRowNumber_;
+  const size_t numPartitionKeys_;
 
   // Input columns in the order of: partition keys, sorting keys, the rest.
   const std::vector<column_index_t> inputChannels_;
 
   // Input column types in 'inputChannels_' order.
   const RowTypePtr inputType_;
+
+  // Compare flags for partition and sorting keys. Compare flags for partition
+  // keys are set to default values. Compare flags for sorting keys match
+  // sorting order specified in the plan node.
+  //
+  // Used to sort 'data_' while spilling.
+  const std::vector<CompareFlags> spillCompareFlags_;
 
   // Hash table to keep track of partitions. Not used if there are no
   // partitioning keys. For each partition, stores an instance of TopRows
@@ -126,6 +172,10 @@ class TopNRowNumber : public Operator {
   // Stores input data. For each partition, only up to 'limit_' rows are stored.
   // Order of columns matches 'inputChannels_': partition keys, sorting keys,
   // the rest.
+  //
+  // Partition and sorting columns are specified as 'keys'. The rest of the
+  // columns are specified as 'dependents'. This enables sorting 'data_' using
+  // 'spillCompareFlags_' when spilling.
   std::unique_ptr<RowContainer> data_;
 
   RowComparator comparator_;
@@ -133,6 +183,11 @@ class TopNRowNumber : public Operator {
   std::vector<DecodedVector> decodedVectors_;
 
   bool finished_{false};
+
+  // Size of a single output row estimated using 'data_->estimateRowSize()'.
+  // If spilling, this value is set to max 'data_->estimateRowSize()' across all
+  // accumulated 'data_'.
+  std::optional<int64_t> estimatedOutputRowSize_;
 
   // Maximum number of rows in the output batch.
   vector_size_t outputBatchSize_;
@@ -147,5 +202,14 @@ class TopNRowNumber : public Operator {
   size_t numPartitions_{0};
   std::optional<int32_t> currentPartition_;
   vector_size_t remainingRowsInPartition_{0};
+
+  // Spiller for contents of the 'data_'.
+  std::unique_ptr<Spiller> spiller_;
+
+  // Used to sort-merge spilled data.
+  std::unique_ptr<TreeOfLosers<SpillMergeStream>> merge_;
+
+  // Row number for the first row in the next output batch.
+  int32_t nextRowNumber_{0};
 };
 } // namespace facebook::velox::exec


### PR DESCRIPTION
TopNRowNumber operator maintains a hash table of unique partition keys and a
RowContainer of input rows with up to N rows per partition.

When asked to spill, TopNRowNumber operator sorts accumulated input rows by
partition and sorting keys, spills all of them, clears both hash table and
RowContainer, and continues to accumulate future input into freed up hash table
and container.

After receiving (and spilling) all input, TopNRowNumber operator sort-merged
spilled data and generates output. Since at this point all data is sorted by 
partition and sorting keys, the operator produces data in streaming fashion.

Spilling is enabled by default. It can be disabled by setting
topn_row_number_spill_enabled configuration property to false.

Spilling after noMoreInput() is not supported yet.