### PR TITLE
Include spill stats in printPlanWithStats() output

### DIFF
--- a/velox/exec/PlanNodeStats.cpp
+++ b/velox/exec/PlanNodeStats.cpp
@@ -102,6 +102,12 @@ std::string PlanNodeStats::toString(bool includeInputStats) const {
   if (numSplits > 0) {
     out << ", Splits: " << numSplits;
   }
+
+  if (spilledRows > 0) {
+    out << ", Spilled: " << spilledRows << " rows ("
+        << succinctBytes(spilledBytes) << ", " << spilledFiles << " files)";
+  }
+
   return out.str();
 }
 


### PR DESCRIPTION
Include number of rows, bytes and files spilled: Spilled: 9 rows (459B, 5 files).

Sample output:

```
-- Aggregation[SINGLE [row_number] a0 := count(1)] -> row_number:BIGINT, a0:BIGINT
   Output: 3 rows (23.84KB, 1 batches), Cpu time: 8.38ms, Blocked wall time: 0ns, Peak memory: 88.12KB, Memory allocations: 10, Threads: 1, Spilled: 9 rows (459B, 5 files)
      ...
      spillDiskWrites              sum: 5, count: 1, min: 5, max: 5
      spillFileSize                sum: 459B, count: 5, min: 79B, max: 95B
      spillFillTime                sum: 1.48ms, count: 1, min: 1.48ms, max: 1.48ms
      spillFlushTime               sum: 29.00us, count: 1, min: 29.00us, max: 29.00us
      spillRuns                    sum: 5, count: 1, min: 5, max: 5
      spillSerializationTime       sum: 251.00us, count: 1, min: 251.00us, max: 251.00us
      spillSortTime                sum: 32.00us, count: 1, min: 32.00us, max: 32.00us
      spillWriteTime               sum: 53.00us, count: 1, min: 53.00us, max: 53.00us
```