### PR TITLE
Adopt spill-friendly order of input columns in TopNRowNumber operator

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2260,6 +2260,10 @@ class TopNRowNumberNode : public PlanNode {
     return outputType_;
   }
 
+  const RowTypePtr& inputType() const {
+    return sources_[0]->outputType();
+  }
+
   const std::vector<FieldAccessTypedExprPtr>& partitionKeys() const {
     return partitionKeys_;
   }

--- a/velox/exec/TopNRowNumber.h
+++ b/velox/exec/TopNRowNumber.h
@@ -60,7 +60,7 @@ class TopNRowNumber : public Operator {
   void close() override;
 
  private:
-  /// A priority queue to keep track of top 'limit' rows for a given partition.
+  // A priority queue to keep track of top 'limit' rows for a given partition.
   struct TopRows {
     struct Compare {
       RowComparator& comparator;
@@ -83,21 +83,18 @@ class TopNRowNumber : public Operator {
     return *reinterpret_cast<TopRows*>(group + partitionOffset_);
   }
 
-  /// Adds input row to a partition or discards the row.
-  void processInputRow(
-      const RowVectorPtr& input,
-      vector_size_t index,
-      TopRows& partition);
+  // Adds input row to a partition or discards the row.
+  void processInputRow(vector_size_t index, TopRows& partition);
 
-  /// Returns next partition to add to output or nullptr if there are no
-  /// partitions left.
+  // Returns next partition to add to output or nullptr if there are no
+  // partitions left.
   TopRows* nextPartition();
 
-  /// Returns partition that was partially added to the previous output batch.
+  // Returns partition that was partially added to the previous output batch.
   TopRows& currentPartition();
 
-  /// Appends partition rows to outputRows_ and optionally populates row
-  /// numbers.
+  // Appends partition rows to outputRows_ and optionally populates row
+  // numbers.
   void appendPartitionRows(
       TopRows& partition,
       vector_size_t start,
@@ -107,21 +104,28 @@ class TopNRowNumber : public Operator {
 
   const int32_t limit_;
   const bool generateRowNumber_;
+
+  // Input columns in the order of: partition keys, sorting keys, the rest.
+  const std::vector<column_index_t> inputChannels_;
+
+  // Input column types in 'inputChannels_' order.
   const RowTypePtr inputType_;
 
-  /// Hash table to keep track of partitions. Not used if there are no
-  /// partitioning keys. For each partition, stores an instance of TopRows
-  /// struct.
+  // Hash table to keep track of partitions. Not used if there are no
+  // partitioning keys. For each partition, stores an instance of TopRows
+  // struct.
   std::unique_ptr<BaseHashTable> table_;
   std::unique_ptr<HashLookup> lookup_;
   int32_t partitionOffset_;
 
-  /// TopRows struct to keep track of top rows for a single partition, when
-  /// there are no partitioning keys.
+  // TopRows struct to keep track of top rows for a single partition, when
+  // there are no partitioning keys.
   std::unique_ptr<HashStringAllocator> allocator_;
   std::unique_ptr<TopRows> singlePartition_;
 
-  /// Stores row data. For each partition, only up to 'limit' rows are stored.
+  // Stores input data. For each partition, only up to 'limit_' rows are stored.
+  // Order of columns matches 'inputChannels_': partition keys, sorting keys,
+  // the rest.
   std::unique_ptr<RowContainer> data_;
 
   RowComparator comparator_;
@@ -130,12 +134,12 @@ class TopNRowNumber : public Operator {
 
   bool finished_{false};
 
-  /// Maximum number of rows in the output batch.
+  // Maximum number of rows in the output batch.
   vector_size_t outputBatchSize_;
   std::vector<char*> outputRows_;
 
-  /// Number of partitions to fetch from a HashTable in a single listAllRows
-  /// call.
+  // Number of partitions to fetch from a HashTable in a single listAllRows
+  // call.
   static const size_t kPartitionBatchSize = 100;
 
   BaseHashTable::RowsIterator partitionIt_;

--- a/velox/exec/tests/RowNumberTest.cpp
+++ b/velox/exec/tests/RowNumberTest.cpp
@@ -70,7 +70,7 @@ TEST_F(RowNumberTest, spill) {
   test(1);
   test(100);
   test(1'000);
-} // namespace facebook::velox::exec::test
+}
 
 TEST_F(RowNumberTest, basic) {
   auto data = makeRowVector({

--- a/velox/exec/tests/TopNRowNumberTest.cpp
+++ b/velox/exec/tests/TopNRowNumberTest.cpp
@@ -83,41 +83,50 @@ TEST_F(TopNRowNumberTest, basic) {
 }
 
 TEST_F(TopNRowNumberTest, largeOutput) {
+  // Make 10 vectors. Use different types for partitioning key, sorting key and
+  // data. Use order of columns different from partitioning keys, followed by
+  // sorting keys, followed by data.
   const vector_size_t size = 10'000;
-  auto data = makeRowVector({
-      // Partitioning key.
-      makeFlatVector<int64_t>(size, [](auto row) { return row % 7; }),
-      // Sorting key.
-      makeFlatVector<int64_t>(size, [](auto row) { return (size - row) * 10; }),
-      // Data.
-      makeFlatVector<int64_t>(size, [](auto row) { return row; }),
-  });
+  auto data = split(
+      makeRowVector(
+          {"d", "p", "s"},
+          {
+              // Data.
+              makeFlatVector<float>(size, [](auto row) { return row; }),
+              // Partitioning key.
+              makeFlatVector<int16_t>(size, [](auto row) { return row % 7; }),
+              // Sorting key.
+              makeFlatVector<int32_t>(
+                  size, [](auto row) { return (size - row) * 10; }),
+          }),
+      10);
 
-  createDuckDbTable({data});
+  createDuckDbTable(data);
 
   auto testLimit = [&](auto limit) {
+    SCOPED_TRACE(fmt::format("Limit: {}", limit));
     auto plan = PlanBuilder()
-                    .values({data})
-                    .topNRowNumber({"c0"}, {"c1"}, limit, true)
+                    .values(data)
+                    .topNRowNumber({"p"}, {"s"}, limit, true)
                     .planNode();
 
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
         .assertResults(fmt::format(
-            "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as rn FROM tmp) "
+            "SELECT * FROM (SELECT *, row_number() over (partition by p order by s) as rn FROM tmp) "
             " WHERE rn <= {}",
             limit));
 
     // No partitioning keys.
     plan = PlanBuilder()
-               .values({data})
-               .topNRowNumber({}, {"c1"}, limit, true)
+               .values(data)
+               .topNRowNumber({}, {"s"}, limit, true)
                .planNode();
 
     AssertQueryBuilder(plan, duckDbQueryRunner_)
         .config(core::QueryConfig::kPreferredOutputBatchBytes, "1024")
         .assertResults(fmt::format(
-            "SELECT * FROM (SELECT *, row_number() over (order by c1) as rn FROM tmp) "
+            "SELECT * FROM (SELECT *, row_number() over (order by s) as rn FROM tmp) "
             " WHERE rn <= {}",
             limit));
   };
@@ -131,32 +140,37 @@ TEST_F(TopNRowNumberTest, largeOutput) {
 
 TEST_F(TopNRowNumberTest, manyPartitions) {
   const vector_size_t size = 10'000;
-  auto data = makeRowVector({
-      // Partitioning key.
-      makeFlatVector<int64_t>(
-          size, [](auto row) { return row / 2; }, nullEvery(7)),
-      // Sorting key.
-      makeFlatVector<int64_t>(
-          size,
-          [](auto row) { return (size - row) * 10; },
-          [](auto row) { return row == 123; }),
-      // Data.
-      makeFlatVector<int64_t>(
-          size, [](auto row) { return row; }, nullEvery(11)),
-  });
+  auto data = split(
+      makeRowVector(
+          {"d", "s", "p"},
+          {
+              // Data.
+              makeFlatVector<int64_t>(
+                  size, [](auto row) { return row; }, nullEvery(11)),
+              // Sorting key.
+              makeFlatVector<int64_t>(
+                  size,
+                  [](auto row) { return (size - row) * 10; },
+                  [](auto row) { return row == 123; }),
+              // Partitioning key.
+              makeFlatVector<int64_t>(
+                  size, [](auto row) { return row / 2; }, nullEvery(7)),
+          }),
+      10);
 
-  createDuckDbTable({data});
+  createDuckDbTable(data);
 
   auto testLimit = [&](auto limit) {
+    SCOPED_TRACE(fmt::format("Limit: {}", limit));
     auto plan = PlanBuilder()
-                    .values({data})
-                    .topNRowNumber({"c0"}, {"c1"}, limit, true)
+                    .values(data)
+                    .topNRowNumber({"p"}, {"s"}, limit, true)
                     .planNode();
 
     assertQuery(
         plan,
         fmt::format(
-            "SELECT * FROM (SELECT *, row_number() over (partition by c0 order by c1) as rn FROM tmp) "
+            "SELECT * FROM (SELECT *, row_number() over (partition by p order by s) as rn FROM tmp) "
             " WHERE rn <= {}",
             limit));
   };


### PR DESCRIPTION
TopNRowNumber operator maintains a hash table of partitions and a RowContainer
of input rows (up to N rows per partition).

To add spilling support, it is convenient to store columns in the order of
partition keys, followed by sorting keys, followed by the rest of the input
columns.

This column order allows to sort and spill accumulated inputs, then merge-sort the 
data back and produce the output.