### PR TITLE
Skip casting if there is no change in type

### DIFF
--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -2040,5 +2040,14 @@ TEST_F(CastExprTest, lazyInput) {
 
   evaluate("cast(switch(gt(c0, c1), c1, c0) as double)", data);
 }
+
+TEST_F(CastExprTest, identicalTypes) {
+  auto data = makeRowVector({
+      makeFlatVector<int64_t>(10, folly::identity),
+  });
+  auto result = evaluate("cast(c0 as bigint)", data);
+  ASSERT_EQ(result.get(), data->childAt(0).get());
+}
+
 } // namespace
 } // namespace facebook::velox::test

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -16,6 +16,7 @@
 #include "gtest/gtest.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/expression/Expr.h"
+#include "velox/expression/FieldReference.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
 #include "velox/functions/prestosql/types/JsonType.h"
 #include "velox/parse/Expressions.h"
@@ -300,6 +301,13 @@ TEST_F(ExprCompilerTest, rewrites) {
           makeTypedExpr("c1 + 5", rowType),
       },
       execCtx_.get()));
+}
+
+TEST_F(ExprCompilerTest, eliminateUnnecessaryCast) {
+  auto exprSet =
+      compile(makeTypedExpr("cast(c0 as BIGINT)", ROW({{"c0", BIGINT()}})));
+  ASSERT_EQ(exprSet->size(), 1);
+  ASSERT_TRUE(dynamic_cast<const FieldReference*>(exprSet->expr(0).get()));
 }
 
 } // namespace facebook::velox::exec::test

--- a/velox/functions/prestosql/tests/JsonCastTest.cpp
+++ b/velox/functions/prestosql/tests/JsonCastTest.cpp
@@ -704,15 +704,6 @@ TEST_F(JsonCastTest, unsupportedTypes) {
       evaluateCast(
           MAP(JSON(), BIGINT()), JSON(), makeRowVector({invalidJsonKeyMap})),
       "Cannot cast map with null keys to JSON");
-
-  // Not allowing to cast from json to itself.
-  VELOX_ASSERT_THROW(
-      evaluateCast(
-          JSON(),
-          JSON(),
-          makeRowVector({makeNullableFlatVector<JsonNativeType>(
-              {"123"_sv, R"("abc")"_sv, ""_sv, std::nullopt}, JSON())})),
-      "(JSON vs. JSON) Attempting to cast from JSON to itself");
 }
 
 TEST_F(JsonCastTest, toVarchar) {


### PR DESCRIPTION
Summary:
In some expression with row type reordering, the planner generates a
cast expression that have the same type for input and output.  For large structs
it will still recurse into children and spend e.g. 27% of the CPU time doing
nothing.  Skip this step if we can detect the types are identical.

Also stop holding onto the input vector in `LocalPartition` to allow reusing of vectors.

Differential Revision: D50457183


