### PR TITLE
Fix crash in RowNumber::spillInput

### DIFF
--- a/velox/exec/RowNumber.cpp
+++ b/velox/exec/RowNumber.cpp
@@ -473,8 +473,8 @@ void RowNumber::spillInput(
 
   const auto numPartitions = spillHashFunction_->numPartitions();
 
-  std::vector<BufferPtr> partitionIndices(numInput);
-  std::vector<vector_size_t*> rawPartitionIndices(numInput);
+  std::vector<BufferPtr> partitionIndices(numPartitions);
+  std::vector<vector_size_t*> rawPartitionIndices(numPartitions);
 
   for (auto i = 0; i < numPartitions; ++i) {
     partitionIndices[i] = allocateIndices(numInput, pool);


### PR DESCRIPTION
RowNumber::spillInput used to allocate numInput(number of input rows) instead of
numPartitions (number of spill partitions)  buffers causing a crash when
processing tiny vectors: numInput < numPartitions.