### PR TITLE
Prepare struct column reader for parallel decoding

### DIFF
--- a/velox/dwio/common/CMakeLists.txt
+++ b/velox/dwio/common/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(
   DecoderUtil.cpp
   DirectDecoder.cpp
   DwioMetricsLog.cpp
+  ExecutorBarrier.cpp
   FileSink.cpp
   FlatMapHelper.cpp
   InputStream.cpp

--- a/velox/dwio/common/ExecutorBarrier.cpp
+++ b/velox/dwio/common/ExecutorBarrier.cpp
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/common/ExecutorBarrier.h"
+
+namespace facebook::velox::dwio::common {
+
+namespace {
+
+class BarrierElement {
+ public:
+  BarrierElement(size_t& count, std::mutex& mutex, std::condition_variable& cv)
+      : count_{&count}, mutex_{&mutex}, cv_{&cv} {
+    std::lock_guard lock{*mutex_};
+    ++*count_;
+  }
+
+  BarrierElement(BarrierElement&& other) noexcept
+      : count_(other.count_), mutex_(other.mutex_), cv_(other.cv_) {
+    // Move away
+    other.mutex_ = nullptr;
+  }
+
+  BarrierElement(const BarrierElement& other) = delete;
+  BarrierElement& operator=(BarrierElement&& other) = delete;
+  BarrierElement& operator=(const BarrierElement& other) = delete;
+
+  ~BarrierElement() {
+    // If this object wasn't moved away
+    if (mutex_) {
+      std::lock_guard lock{*mutex_};
+      --*count_;
+      cv_->notify_all();
+    }
+  }
+
+ private:
+  size_t* count_;
+  std::mutex* mutex_;
+  std::condition_variable* cv_;
+};
+
+} // namespace
+
+auto ExecutorBarrier::wrapMethod(folly::Func f) {
+  return [f = std::move(f),
+          this,
+          barrierElement = BarrierElement(count_, mutex_, cv_)]() mutable {
+    try {
+      f();
+    } catch (const std::exception& e) {
+      std::lock_guard lock{mutex_};
+      if (!exception_.has_exception_ptr()) {
+        exception_ = folly::exception_wrapper(
+            ::folly::exception_wrapper::from_catch_ref_t{},
+            std::current_exception(),
+            e);
+      }
+    } catch (...) {
+      std::lock_guard lock{mutex_};
+      if (!exception_.has_exception_ptr()) {
+        exception_ = folly::exception_wrapper(std::current_exception());
+      }
+    }
+  };
+}
+
+void ExecutorBarrier::add(folly::Func f) {
+  executor_->add(wrapMethod(std::move(f)));
+}
+
+void ExecutorBarrier::addWithPriority(folly::Func f, int8_t priority) {
+  executor_->addWithPriority(wrapMethod(std::move(f)), priority);
+}
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/ExecutorBarrier.h
+++ b/velox/dwio/common/ExecutorBarrier.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+#include "folly/ExceptionWrapper.h"
+#include "folly/Executor.h"
+
+namespace facebook::velox::dwio::common {
+
+class ExecutorBarrier : public folly::Executor {
+ public:
+  explicit ExecutorBarrier(folly::Executor* executor)
+      : executor_{std::move(executor)}, count_{0} {}
+
+  ~ExecutorBarrier() override {
+    // If this object gets destroyed while there are still tasks pending, those
+    // tasks will try to access invalid memory addresses in the current object.
+    std::unique_lock lock{mutex_};
+    cv_.wait(lock, [&]() { return count_ == 0; });
+    // We won't throw from the destructor so we don't check for exceptions
+  }
+
+  /// Enqueue a function to be executed by this executor. This and all
+  /// variants must be threadsafe.
+  void add(folly::Func) override;
+
+  /// Enqueue a function with a given priority, where 0 is the medium priority
+  /// This is up to the implementation to enforce
+  void addWithPriority(folly::Func, int8_t priority) override;
+
+  uint8_t getNumPriorities() const override {
+    return executor_->getNumPriorities();
+  }
+
+  void await() {
+    std::unique_lock lock{mutex_};
+    cv_.wait(lock, [&]() { return count_ == 0; });
+    if (exception_.has_exception_ptr()) {
+      folly::exception_wrapper ew;
+      // Clear the exception for the next time
+      std::swap(ew, exception_);
+      ew.throw_exception();
+    }
+  }
+
+  folly::Executor* executor() {
+    return executor_;
+  }
+
+ private:
+  auto wrapMethod(folly::Func f);
+
+  folly::Executor* executor_;
+  size_t count_;
+  std::mutex mutex_;
+  std::condition_variable cv_;
+  folly::exception_wrapper exception_;
+};
+
+} // namespace facebook::velox::dwio::common

--- a/velox/dwio/common/tests/CMakeLists.txt
+++ b/velox/dwio/common/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(
   ColumnSelectorTests.cpp
   DataBufferTests.cpp
   DecoderUtilTest.cpp
+  ExecutorBarrierTest.cpp
   LocalFileSinkTest.cpp
   LoggedExceptionTest.cpp
   RangeTests.cpp

--- a/velox/dwio/common/tests/ExecutorBarrierTest.cpp
+++ b/velox/dwio/common/tests/ExecutorBarrierTest.cpp
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "folly/executors/CPUThreadPoolExecutor.h"
+#include "velox/dwio/common/ExecutorBarrier.h"
+
+using namespace ::testing;
+using namespace ::facebook::velox::dwio::common;
+
+TEST(ExecutorBarrierTest, GetNumPriorities) {
+  const uint8_t kNumPriorities = 5;
+  auto executor =
+      std::make_shared<folly::CPUThreadPoolExecutor>(10, kNumPriorities);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+  EXPECT_EQ(barrier->getNumPriorities(), kNumPriorities);
+}
+
+TEST(ExecutorBarrierTest, CanAwaitMultipleTimes) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+  for (int time = 0, multipleTimes = 10; time < multipleTimes; ++time) {
+    barrier->await();
+  }
+}
+
+TEST(ExecutorBarrierTest, AddCanBeReused) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&]() { ++count; });
+  }
+  barrier->await();
+  EXPECT_EQ(count, kCalls);
+
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&]() { ++count; });
+  }
+  barrier->await();
+  EXPECT_EQ(count, (2 * kCalls));
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityCanBeReused) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority([&]() { ++count; }, kPriority);
+  }
+  barrier->await();
+  EXPECT_EQ(count, kCalls);
+
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority([&]() { ++count; }, kPriority);
+  }
+  barrier->await();
+  EXPECT_EQ(count, (2 * kCalls));
+}
+
+TEST(ExecutorBarrierTest, AddCanBeReusedAfterException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&count]() {
+      ++count;
+      throw std::runtime_error("");
+    });
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&]() { ++count; });
+  }
+  barrier->await();
+  EXPECT_EQ(count, (2 * kCalls));
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityCanBeReusedAfterException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority(
+        [&count]() {
+          ++count;
+          throw std::runtime_error("");
+        },
+        kPriority);
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority([&]() { ++count; }, kPriority);
+  }
+  barrier->await();
+  EXPECT_EQ(count, (2 * kCalls));
+}
+
+TEST(ExecutorBarrierTest, Add) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&]() { ++count; });
+  }
+  barrier->await();
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddWithPriority) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority([&]() { ++count; }, kPriority);
+  }
+  barrier->await();
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddCanIgnore) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([]() {});
+  }
+  // Discard: barrier->await();
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityCanIgnore) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority([]() {}, i);
+  }
+  // Discard: barrier->await();
+}
+
+TEST(ExecutorBarrierTest, DestructorDoesntThrow) {
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  {
+    auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+    auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+    for (int i = 0; i < kCalls; ++i) {
+      barrier->add([shouldThrow = (i == 0), &count]() {
+        ++count;
+        if (shouldThrow) {
+          throw std::runtime_error("");
+        }
+      });
+    }
+  } // executor awaits but doesn't throw
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([shouldThrow = (i == 0), &count]() {
+      ++count;
+      if (shouldThrow) {
+        throw std::runtime_error("");
+      }
+    });
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority(
+        [shouldThrow = (i == 0), &count]() {
+          ++count;
+          if (shouldThrow) {
+            throw std::runtime_error("");
+          }
+        },
+        kPriority);
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddNonStdException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([shouldThrow = (i == 0), &count]() {
+      ++count;
+      if (shouldThrow) {
+        throw 1;
+      }
+    });
+  }
+  EXPECT_THROW(barrier->await(), int);
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityNonStdException) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority(
+        [shouldThrow = (i == 0), &count]() {
+          ++count;
+          if (shouldThrow) {
+            throw 1;
+          }
+        },
+        kPriority);
+  }
+  EXPECT_THROW(barrier->await(), int);
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddExceptions) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->add([&]() {
+      ++count;
+      throw std::runtime_error("");
+    });
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+}
+
+TEST(ExecutorBarrierTest, AddWithPriorityExceptions) {
+  auto executor = std::make_shared<folly::CPUThreadPoolExecutor>(10);
+  auto barrier = std::make_shared<ExecutorBarrier>(executor.get());
+
+  const int kCalls = 30;
+  const int8_t kPriority = 4;
+  std::atomic<int> count{0};
+  for (int i = 0; i < kCalls; ++i) {
+    barrier->addWithPriority(
+        [&]() {
+          ++count;
+          throw std::runtime_error("");
+        },
+        kPriority);
+  }
+  EXPECT_THROW(barrier->await(), std::runtime_error);
+  EXPECT_EQ(count, kCalls);
+}

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1874,28 +1874,16 @@ void StructColumnReader::next(
     // children vectors.
     childrenVectorsPtr = &rowVector->children();
     childrenVectors.clear();
-  } else {
-    childrenVectors.resize(children_.size());
-    childrenVectorsPtr = &childrenVectors;
-  }
-
-  for (uint64_t i = 0; i < children_.size(); ++i) {
-    auto& reader = children_[i];
-    if (reader) {
-      reader->next(numValues, (*childrenVectorsPtr)[i], nullsPtr);
-    }
-  }
-
-  if (result) {
     result->setNullCount(nullCount);
   } else {
     // When read-string-as-row flag is on, string readers produce ROW(BIGINT,
     // BIGINT) type instead of VARCHAR or VARBINARY. In these cases,
     // requestedType_->type is not the right type of the final struct.
+    childrenVectors.resize(children_.size());
     std::vector<TypePtr> types;
-    types.reserve(childrenVectorsPtr->size());
-    for (auto i = 0; i < childrenVectorsPtr->size(); i++) {
-      const auto& child = (*childrenVectorsPtr)[i];
+    types.reserve(childrenVectors.size());
+    for (auto i = 0; i < childrenVectors.size(); i++) {
+      const auto& child = childrenVectors[i];
       if (child) {
         types.emplace_back(child->type());
       } else {
@@ -1903,13 +1891,22 @@ void StructColumnReader::next(
       }
     }
 
-    result = std::make_shared<RowVector>(
+    auto rowResult = std::make_shared<RowVector>(
         &memoryPool_,
         ROW(std::move(types)),
         nulls,
         numValues,
         std::move(childrenVectors),
         nullCount);
+    childrenVectorsPtr = &rowResult->children();
+    result = std::move(rowResult);
+  }
+
+  for (uint64_t i = 0; i < children_.size(); ++i) {
+    auto& reader = children_[i];
+    if (reader) {
+      reader->next(numValues, (*childrenVectorsPtr)[i], nullsPtr);
+    }
   }
 }
 


### PR DESCRIPTION
Summary: We'll parallelize this loop with an executor in a future diff, so we're moving it to the end of the method to make it easier to reason that this method can return while the tasks initiated (in the future) in the loop are still running. The caller of the entire tree will have to wait though.

Differential Revision: D50459051


