### PR TITLE
Add sanity checks to TopNRowNumberNode

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -1473,6 +1473,23 @@ TopNRowNumberNode::TopNRowNumberNode(
       sortingKeys_.size(),
       0,
       "Number of sorting keys must be greater than zero");
+
+  VELOX_USER_CHECK_GT(limit, 0, "Limit must be greater than zero");
+
+  std::unordered_set<std::string> keyNames;
+  for (const auto& key : partitionKeys_) {
+    VELOX_USER_CHECK(
+        keyNames.insert(key->name()).second,
+        "Partitioning keys must be unique. Found duplicate key: {}",
+        key->name());
+  }
+
+  for (const auto& key : sortingKeys_) {
+    VELOX_USER_CHECK(
+        keyNames.insert(key->name()).second,
+        "Sorting keys must be unique and not overlap with partitioning keys. Found duplicate key: {}",
+        key->name());
+  }
 }
 
 void TopNRowNumberNode::addDetails(std::stringstream& stream) const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -2237,6 +2237,9 @@ class MarkDistinctNode : public PlanNode {
 class TopNRowNumberNode : public PlanNode {
  public:
   /// @param partitionKeys Partitioning keys. May be empty.
+  /// @param sortingKeys Sorting keys. May not be empty and may not intersect
+  /// with 'partitionKeys'.
+  /// @param sortingOrders Sorting orders, one per sorting key.
   /// @param rowNumberColumnName Optional name of the column containing row
   /// numbers. If not specified, the output doesn't include 'row number' column.
   /// This is used when computing partial results.

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -752,9 +752,9 @@ FilterNode(row_number <= limit), but it uses less memory and CPU.
   * - Property
     - Description
   * - partitionKeys
-    - Partition by columns for the window functions.
+    - Partition by columns for the window functions. May be empty.
   * - sortingKeys
-    - Order by columns for the window functions.
+    - Order by columns for the window functions. Cannot be empty and cannot overlap with 'partitionKeys'.
   * - sortingOrders
     - Sorting order for each sorting key above. The supported sort orders are asc nulls first, asc nulls last, desc nulls first and desc nulls last.
   * - rowNumberColumnName


### PR DESCRIPTION
Limit must be greater than zero.

Partition and sorting keys should not overlap.