### PR TITLE
Prepare flat map struct encoding column reader for parallel decoding

### DIFF
--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.cpp
@@ -665,9 +665,20 @@ void FlatMapStructEncodingColumnReader<T>::next(
     // children vectors.
     childrenPtr = &rowVector->children();
     children.clear();
+    result->setNullCount(nullCount);
   } else {
     children.resize(keyNodes_.size());
-    childrenPtr = &children;
+    auto rowResult = std::make_shared<RowVector>(
+        &memoryPool_,
+        ROW(std::vector<std::string>(keyNodes_.size()),
+            std::vector<std::shared_ptr<const Type>>(
+                keyNodes_.size(), requestedType_->type()->asMap().valueType())),
+        nulls,
+        numValues,
+        std::move(children),
+        nullCount);
+    childrenPtr = &rowResult->children();
+    result = std::move(rowResult);
   }
 
   for (size_t i = 0; i < keyNodes_.size(); ++i) {
@@ -679,20 +690,6 @@ void FlatMapStructEncodingColumnReader<T>::next(
     } else {
       nullColumnReader_->next(numValues, child, nullsPtr);
     }
-  }
-
-  if (result) {
-    result->setNullCount(nullCount);
-  } else {
-    result = std::make_shared<RowVector>(
-        &memoryPool_,
-        ROW(std::vector<std::string>(keyNodes_.size()),
-            std::vector<std::shared_ptr<const Type>>(
-                keyNodes_.size(), requestedType_->type()->asMap().valueType())),
-        nulls,
-        numValues,
-        std::move(children),
-        nullCount);
   }
 }
 


### PR DESCRIPTION
Summary: We'll parallelize this loop with an executor in a future diff, so we're moving it to the end of the method to make it easier to reason that this method can return while the tasks initiated (in the future) in the loop are still running. The caller of the entire tree will have to wait though.

Differential Revision: D50472518


