### PR TITLE
Make casting of string to integral throw if input contains space

### DIFF
--- a/velox/benchmarks/basic/CastBenchmark.cpp
+++ b/velox/benchmarks/basic/CastBenchmark.cpp
@@ -32,6 +32,11 @@ int main(int argc, char** argv) {
   auto invalidInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
   auto validInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
   auto nanInput = vectorMaker.flatVector<facebook::velox::StringView>({""});
+  auto whitespaceInput = vectorMaker.flatVector<facebook::velox::StringView>(
+      vectorSize, [&](auto j) {
+        return StringView::makeInline(
+            j % 2 == 0 ? fmt::format(" {}", j) : fmt::format("{} ", j));
+      });
   auto decimalInput = vectorMaker.flatVector<int64_t>(
       vectorSize, [&](auto j) { return 12345 * j; }, nullptr, DECIMAL(9, 2));
   auto shortDecimalInput = vectorMaker.flatVector<int64_t>(
@@ -68,6 +73,7 @@ int main(int argc, char** argv) {
               {"valid",
                "empty",
                "nan",
+               "whitespace",
                "decimal",
                "short_decimal",
                "long_decimal",
@@ -75,6 +81,7 @@ int main(int argc, char** argv) {
               {validInput,
                invalidInput,
                nanInput,
+               whitespaceInput,
                decimalInput,
                shortDecimalInput,
                longDecimalInput,
@@ -84,6 +91,10 @@ int main(int argc, char** argv) {
           "tryexpr_cast_invalid_empty_input", "try (cast (empty as int))")
       .addExpression("try_cast_invalid_nan", "try_cast (nan as int)")
       .addExpression("tryexpr_cast_invalid_nan", "try (cast (nan as int))")
+      .addExpression(
+          "try_cast_invalid_whitespace", "try_cast (whitespace as int)")
+      .addExpression(
+          "tryexpr_cast_invalid_whitespace", "try (cast (whitespace as int))")
       .addExpression("try_cast_valid", "try_cast (valid as int)")
       .addExpression("tryexpr_cast_valid", "try (cast (valid as int))")
       .addExpression("cast_valid", "cast(valid as int)")

--- a/velox/docs/functions/presto/conversion.rst
+++ b/velox/docs/functions/presto/conversion.rst
@@ -268,7 +268,9 @@ From strings
 
 Casting a string to an integral type is allowed if the string represents an
 integral number within the range of the result type. By default, casting from
-strings that represent floating-point numbers is not allowed.
+strings that represent floating-point numbers is not allowed. Casting from
+strings that contain non-numerical and non-sign characters, whitespaces for example
+is not valid either, by default.
 
 If cast_to_int_by_truncate is set to true, and the string represents a floating-point number,
 the decimal part will be truncated for casting to an integer.
@@ -314,12 +316,19 @@ Invalid examples if cast_to_int_by_truncate=false
 
   SELECT cast('12345.67' as tinyint); -- Invalid argument
   SELECT cast('1.2' as tinyint); -- Invalid argument
+  SELECT cast('1.0' as tinyint); -- Invalid argument
   SELECT cast('-1.8' as tinyint); -- Invalid argument
   SELECT cast('1.' as tinyint); -- Invalid argument
   SELECT cast('-1.' as tinyint); -- Invalid argument
   SELECT cast('0.' as tinyint); -- Invalid argument
+  SELECT cast('1E4' as bigint); -- Invalid argument
+  SELECT cast('1e4' as bigint); -- Invalid argument
   SELECT cast('.' as tinyint); -- Invalid argument
   SELECT cast('-.' as tinyint); -- Invalid argument
+  SELECT cast(' ' as smallint); -- Invalid argument
+  SELECT cast('1 ' as smallint); -- Invalid argument
+  SELECT cast('infinity' as bigint); -- Invalid argument
+  SELECT cast('nan' as bigint); -- Invalid argument
 
 From decimal
 ^^^^^^^^^^^^
@@ -391,6 +400,8 @@ Invalid examples
   SELECT cast('-1' as boolean); -- Invalid argument
   SELECT cast('tr' as boolean); -- Invalid argument
   SELECT cast('tru' as boolean); -- Invalid argument
+  SELECT cast('true ' as boolean); -- Invalid argument
+  SELECT cast(' f' as boolean); -- Invalid argument
 
 Cast to Floating-Point Types
 ----------------------------
@@ -428,7 +439,9 @@ Valid examples
 
   SELECT cast('1.' as real); -- 1.0
   SELECT cast('1' as real); -- 1.0
+  SELECT cast('1.0 ' as real); -- 1.0
   SELECT cast('1.7E308' as real); -- Infinity
+  SELECT cast(' 1.7E308' as real); -- Infinity
   SELECT cast('infinity' as real); -- Infinity (case insensitive)
   SELECT cast('-infinity' as real); -- -Infinity (case insensitive)
   SELECT cast('nan' as real); -- NaN (case insensitive)
@@ -437,7 +450,6 @@ Invalid examples
 
 ::
 
-  SELECT cast('1.7E308' as real); -- Out of range
   SELECT cast('1.2a' as real); -- Invalid argument
   SELECT cast('1.2.3' as real); -- Invalid argument
 

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -806,14 +806,22 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
     // Invalid strings.
     testCast<std::string, int8_t>("tinyint", {"1234567"}, {0}, true);
     testCast<std::string, int8_t>("tinyint", {"1.2"}, {0}, true);
+    testCast<std::string, int16_t>("smallint", {"1.0"}, {0}, true);
     testCast<std::string, int8_t>("tinyint", {"1.23444"}, {0}, true);
     testCast<std::string, int8_t>("tinyint", {".2355"}, {0}, true);
     testCast<std::string, int8_t>("tinyint", {"1a"}, {0}, true);
     testCast<std::string, int8_t>("tinyint", {""}, {0}, true);
+    testCast<std::string, int8_t>("tinyint", {" "}, {0}, true);
+    testCast<std::string, int16_t>("smallint", {"1 "}, {0}, true);
+    testCast<std::string, int16_t>("smallint", {" 1"}, {0}, true);
     testCast<std::string, int32_t>("integer", {"1'234'567"}, {0}, true);
     testCast<std::string, int32_t>("integer", {"1,234,567"}, {0}, true);
+    testCast<std::string, int64_t>("bigint", {"1E4"}, {0}, true);
+    testCast<std::string, int64_t>("bigint", {"1e4"}, {0}, true);
     testCast<std::string, int64_t>("bigint", {"infinity"}, {0}, true);
+    testCast<std::string, int64_t>("bigint", {"infinity "}, {0}, true);
     testCast<std::string, int64_t>("bigint", {"nan"}, {0}, true);
+    testCast<std::string, int64_t>("bigint", {"nan "}, {0}, true);
   }
 
   // To floating-point.
@@ -833,8 +841,12 @@ TEST_F(CastExprTest, primitiveInvalidCornerCases) {
     testCast<std::string, bool>("boolean", {"infinity"}, {0}, true);
     testCast<std::string, bool>("boolean", {"12"}, {0}, true);
     testCast<std::string, bool>("boolean", {"-1"}, {0}, true);
+    testCast<std::string, bool>("boolean", {"1.0"}, {0}, true);
+    testCast<std::string, bool>("boolean", {"0.0"}, {0}, true);
     testCast<std::string, bool>("boolean", {"tr"}, {0}, true);
     testCast<std::string, bool>("boolean", {"tru"}, {0}, true);
+    testCast<std::string, bool>("boolean", {"true "}, {0}, true);
+    testCast<std::string, bool>("boolean", {" f"}, {0}, true);
   }
 
   setCastIntByTruncate(true);
@@ -878,6 +890,8 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<double, int64_t>("bigint", {12345.12}, {12345}, false);
     testCast<double, int64_t>("bigint", {12345.67}, {12346}, false);
     testCast<std::string, int8_t>("tinyint", {"+1"}, {1}, false);
+    testCast<std::string, int32_t>("integer", {"-1"}, {-1}, false);
+    testCast<std::string, int64_t>("bigint", {"12345"}, {12345}, false);
   }
 
   // To floating-point.
@@ -885,6 +899,9 @@ TEST_F(CastExprTest, primitiveValidCornerCases) {
     testCast<std::string, float>("real", {"1.7E308"}, {kInf}, false);
     testCast<std::string, float>("real", {"1."}, {1.0}, false);
     testCast<std::string, float>("real", {"1"}, {1}, false);
+    testCast<std::string, float>("real", {" 1.7E308"}, {kInf}, false);
+    testCast<std::string, float>("real", {"1. "}, {1.0}, false);
+    testCast<std::string, float>("real", {"1 "}, {1}, false);
     // When casting from "Infinity" and "NaN", Presto is case sensitive. But we
     // let them be case insensitive to be consistent with other conversions.
     testCast<std::string, float>("real", {"infinity"}, {kInf}, false);

--- a/velox/expression/tests/ExprStatsTest.cpp
+++ b/velox/expression/tests/ExprStatsTest.cpp
@@ -384,9 +384,9 @@ TEST_F(ExprStatsTest, errorLog) {
 
   evaluate(*exprSet, data);
 
-  // Expect errors at rows 2 and 4.
-  ASSERT_EQ(2, listener->exceptionCount());
-  ASSERT_EQ(2, exceptions.size());
+  // Expect errors at rows 2, 4 and 6.
+  ASSERT_EQ(3, listener->exceptionCount());
+  ASSERT_EQ(3, exceptions.size());
   for (const auto& exception : exceptions) {
     ASSERT_TRUE(
         exception.find("Context: cast((c0) as INTEGER)") != std::string::npos);
@@ -422,7 +422,7 @@ TEST_F(ExprStatsTest, errorLog) {
   ASSERT_TRUE(
       exceptions[1].find("Error Code: INVALID_ARGUMENT") != std::string::npos);
   ASSERT_TRUE(
-      exceptions[2].find("Error Code: ARITHMETIC_ERROR") != std::string::npos);
+      exceptions[2].find("Error Code: INVALID_ARGUMENT") != std::string::npos);
   ASSERT_TRUE(
       exceptions[3].find("Error Code: ARITHMETIC_ERROR") != std::string::npos);
 


### PR DESCRIPTION
This change makes it throw exception to cast string to integral
types (bigint, integer, boolean, etc), when cast_to_int_by_truncate=false,
to have the same behavior as Presto. For the CAST expression, previous
behavior is to accept leading and trailing whitespaces in input strings
and can cast successfully when cast_to_int_by_truncate=false. 

For Presto, casting string to real & double accepts leading and trailing
whitespaces. So should keep the behavior as it is.

CAST expression accepts whitespace in input because it utilizes folly to do
conversion. folly explicitly accepts and processes leading and trailing
whitespaces of input strings. So we just need to override this part of behavior
and continue to utilize the rest.
https://github.com/facebook/folly/blob/00b7e630bdbd09e7f1cd173c80c2f52b1e631df6/folly/Conv.h#L1501-L1510
https://github.com/facebook/folly/blob/00b7e630bdbd09e7f1cd173c80c2f52b1e631df6/folly/Conv.h#L1458-L1466

Also add benchmark for the invalid cases of try_cast() and try(cast)) on strings
with whitespace.