### PR TITLE
Back out "Back out "[velox][PR] Fix 1ms-off issue for from_unixtime(double)""

### DIFF
--- a/velox/functions/prestosql/DateTimeImpl.h
+++ b/velox/functions/prestosql/DateTimeImpl.h
@@ -59,8 +59,8 @@ FOLLY_ALWAYS_INLINE std::optional<Timestamp> fromUnixtime(double unixtime) {
   }
 
   auto seconds = std::floor(unixtime);
-  auto nanos = unixtime - seconds;
-  return Timestamp(seconds, nanos * kNanosecondsInSecond);
+  auto milliseconds = std::llround((unixtime - seconds) * kMillisInSecond);
+  return Timestamp(seconds, milliseconds * kNanosecondsInMillisecond);
 }
 
 namespace {


### PR DESCRIPTION
Summary: Adding back #7047

Differential Revision: D50508903


