### PR TITLE
Split the memory manager creation and get

### DIFF
--- a/pyvelox/context.h
+++ b/pyvelox/context.h
@@ -56,7 +56,7 @@ struct PyVeloxContext {
   PyVeloxContext& operator=(const PyVeloxContext&&) = delete;
 
   std::shared_ptr<facebook::velox::memory::MemoryPool> pool_ =
-      facebook::velox::memory::addDefaultLeafMemoryPool();
+      facebook::velox::memory::deprecatedAddDefaultLeafMemoryPool();
   std::shared_ptr<facebook::velox::core::QueryCtx> queryCtx_ =
       std::make_shared<facebook::velox::core::QueryCtx>();
   std::unique_ptr<facebook::velox::core::ExecCtx> execCtx_ =

--- a/velox/benchmarks/basic/LikeTpchBenchmark.cpp
+++ b/velox/benchmarks/basic/LikeTpchBenchmark.cpp
@@ -173,7 +173,8 @@ class LikeFunctionsBenchmark : public FunctionBaseTest,
  private:
   static constexpr const char* kWildcardCharacterSet = "%_";
   static constexpr const char* kAnyWildcardCharacter = "%";
-  std::shared_ptr<MemoryPool> pool_{addDefaultLeafMemoryPool()};
+  std::shared_ptr<MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorPtr inputFuzzer_;
 };
 
@@ -234,6 +235,7 @@ BENCHMARK(tpchQuery20) {
 
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv, true);
+  memory::MemoryManager::initialize({});
   benchmark = std::make_unique<LikeFunctionsBenchmark>();
   folly::runBenchmarks();
   benchmark.reset();

--- a/velox/benchmarks/basic/VectorFuzzer.cpp
+++ b/velox/benchmarks/basic/VectorFuzzer.cpp
@@ -28,7 +28,8 @@ namespace {
 
 using namespace facebook::velox;
 
-std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+std::shared_ptr<memory::MemoryPool> pool{
+    memory::MemoryManager::getInstance()->addLeafPool()};
 
 VectorFuzzer::Options getOpts(size_t n, double nullRatio = 0) {
   VectorFuzzer::Options opts;
@@ -130,6 +131,7 @@ BENCHMARK_RELATIVE_MULTI(flatMapArrayNested, n) {
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/benchmarks/basic/VectorSlice.cpp
+++ b/velox/benchmarks/basic/VectorSlice.cpp
@@ -37,7 +37,7 @@ constexpr int kVectorSize = 16 << 10;
 
 struct BenchmarkData {
   BenchmarkData()
-      : pool_(memory::addDefaultLeafMemoryPool(
+      : pool_(memory::MemoryManager::getInstance()->addLeafPool(
             "BenchmarkData",
             FLAGS_use_thread_safe_memory_usage_track)) {
     VectorFuzzer::Options opts;
@@ -114,6 +114,7 @@ int main(int argc, char* argv[]) {
   using namespace facebook::velox;
   gflags::ParseCommandLineFlags(&argc, &argv, true);
   VELOX_CHECK_LE(FLAGS_slice_size, kVectorSize);
+  memory::MemoryManager::initialize({});
   data = std::make_unique<BenchmarkData>();
   folly::runBenchmarks();
   data.reset();

--- a/velox/benchmarks/tpch/TpchBenchmark.cpp
+++ b/velox/benchmarks/tpch/TpchBenchmark.cpp
@@ -582,6 +582,7 @@ BENCHMARK(q22) {
 }
 
 int tpchBenchmarkMain() {
+  facebook::velox::memory::MemoryManager::initialize({});
   benchmark.initialize();
   queryBuilder =
       std::make_shared<TpchQueryBuilder>(toFileFormat(FLAGS_data_format));

--- a/velox/buffer/tests/StringViewBufferHolderTest.cpp
+++ b/velox/buffer/tests/StringViewBufferHolderTest.cpp
@@ -35,11 +35,16 @@ std::string inlinedString() {
 
 class StringViewBufferHolderTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::initialize({});
+  }
+
   StringViewBufferHolder makeHolder() {
     return StringViewBufferHolder(pool_.get());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(StringViewBufferHolderTest, inlinedStringViewDoesNotCopyToBuffer) {

--- a/velox/common/base/tests/IdMapTest.cpp
+++ b/velox/common/base/tests/IdMapTest.cpp
@@ -76,8 +76,12 @@ class IdMapTest : public testing::Test {
     int64_t n4;
   };
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    root_ = memory::MemoryManager::getInstance().addRootPool("IdMapRoot");
+    root_ = memory::MemoryManager::getInstance()->addRootPool("IdMapRoot");
     pool_ = root_->addLeafChild("IdMapLeakLeaf");
   }
 

--- a/velox/common/hyperloglog/tests/DenseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/DenseHllTest.cpp
@@ -36,6 +36,10 @@ uint64_t hashOne(T value) {
 
 class DenseHllTest : public ::testing::TestWithParam<int8_t> {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   DenseHll roundTrip(DenseHll& hll) {
     auto size = hll.serializedSize();
     std::string serialized;
@@ -100,7 +104,8 @@ class DenseHllTest : public ::testing::TestWithParam<int8_t> {
         expected.cardinality());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/hyperloglog/tests/SparseHllTest.cpp
+++ b/velox/common/hyperloglog/tests/SparseHllTest.cpp
@@ -30,6 +30,10 @@ uint64_t hashOne(T value) {
 
 class SparseHllTest : public ::testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   template <typename T>
   void testMergeWith(const std::vector<T>& left, const std::vector<T>& right) {
     testMergeWith(left, right, false);
@@ -98,7 +102,8 @@ class SparseHllTest : public ::testing::Test {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 
@@ -170,6 +175,10 @@ TEST_F(SparseHllTest, mergeWith) {
 
 class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::string serialize(DenseHll& denseHll) {
     auto size = denseHll.serializedSize();
     std::string serialized;
@@ -178,7 +187,8 @@ class SparseHllToDenseTest : public ::testing::TestWithParam<int8_t> {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/common/memory/tests/HashStringAllocatorTest.cpp
+++ b/velox/common/memory/tests/HashStringAllocatorTest.cpp
@@ -36,8 +36,12 @@ struct Multipart {
 
 class HashStringAllocatorTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::initialize({});
+  }
+
   void SetUp() override {
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
     allocator_ = std::make_unique<HashStringAllocator>(pool_.get());
     rng_.seed(1);
   }
@@ -483,7 +487,7 @@ TEST_F(HashStringAllocatorTest, stlAllocatorOverflow) {
 TEST_F(HashStringAllocatorTest, externalLeak) {
   constexpr int32_t kSize = HashStringAllocator ::kMaxAlloc * 10;
   auto root =
-      memory::MemoryManager::getInstance().addRootPool("HSALeakTestRoot");
+      memory::MemoryManager::getInstance()->addRootPool("HSALeakTestRoot");
   auto pool = root->addLeafChild("HSALeakLeaf");
   auto initialBytes = pool->currentBytes();
   auto allocator = std::make_unique<HashStringAllocator>(pool.get());

--- a/velox/common/memory/tests/MemoryCapExceededTest.cpp
+++ b/velox/common/memory/tests/MemoryCapExceededTest.cpp
@@ -97,7 +97,7 @@ TEST_P(MemoryCapExceededTest, singleDriver) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes));
   CursorParameters params;
   params.planNode = plan;
@@ -156,7 +156,7 @@ TEST_P(MemoryCapExceededTest, multipleDrivers) {
                   .planNode();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes));
 
   const int32_t numDrivers = 10;

--- a/velox/common/memory/tests/MemoryPoolTest.cpp
+++ b/velox/common/memory/tests/MemoryPoolTest.cpp
@@ -2253,7 +2253,7 @@ TEST_P(MemoryPoolTest, concurrentUpdateToSharedPools) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1234);
 
-  const int32_t kNumOpsPerThread = 1'000;
+  const int32_t kNumOpsPerThread = 200;
   std::vector<std::thread> threads;
   threads.reserve(kNumThreads);
   for (size_t i = 0; i < kNumThreads; ++i) {

--- a/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
+++ b/velox/connectors/hive/storage_adapters/s3fs/tests/S3FileSystemTest.cpp
@@ -27,6 +27,7 @@ static constexpr std::string_view kMinioConnectionString = "127.0.0.1:9000";
 class S3FileSystemTest : public S3Test {
  protected:
   static void SetUpTestSuite() {
+    memory::MemoryManager::testingSetInstance({});
     if (minioServer_ == nullptr) {
       minioServer_ = std::make_shared<MinioServer>(kMinioConnectionString);
       minioServer_->start();
@@ -187,7 +188,8 @@ TEST_F(S3FileSystemTest, writeFileAndRead) {
 
   auto hiveConfig = minioServer_->hiveConfig();
   filesystems::S3FileSystem s3fs(hiveConfig);
-  auto pool = memory::defaultMemoryManager().addLeafPool("S3FileSystemTest");
+  auto pool =
+      memory::MemoryManager::getInstance()->addLeafPool("S3FileSystemTest");
   auto writeFile = s3fs.openFileForWrite(s3File, {{}, pool.get()});
   auto s3WriteFile = dynamic_cast<filesystems::S3WriteFile*>(writeFile.get());
   std::string dataContent =

--- a/velox/connectors/hive/tests/HiveConnectorTest.cpp
+++ b/velox/connectors/hive/tests/HiveConnectorTest.cpp
@@ -32,7 +32,7 @@ using namespace facebook::velox::exec::test;
 class HiveConnectorTest : public exec::test::HiveConnectorTestBase {
  protected:
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
 };
 
 void validateNullConstant(const ScanSpec& spec, const Type& type) {

--- a/velox/connectors/hive/tests/HiveDataSinkTest.cpp
+++ b/velox/connectors/hive/tests/HiveDataSinkTest.cpp
@@ -61,6 +61,14 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
         std::thread::hardware_concurrency());
   }
 
+  void TearDown() override {
+    connectorQueryCtx_.reset();
+    connectorPool_.reset();
+    opPool_.reset();
+    root_.reset();
+    HiveConnectorTestBase::TearDown();
+  }
+
   std::vector<RowVectorPtr> createVectors(int vectorSize, int numVectors) {
     VectorFuzzer::Options options;
     options.vectorSize = vectorSize;
@@ -98,7 +106,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
     opPool_.reset();
     root_.reset();
 
-    root_ = memory::defaultMemoryManager().addRootPool(
+    root_ = memory::MemoryManager::getInstance()->addRootPool(
         "HiveDataSinkTest", 1L << 30, exec::MemoryReclaimer::create());
     opPool_ = root_->addLeafChild("operator");
     connectorPool_ =
@@ -183,7 +191,7 @@ class HiveDataSinkTest : public exec::test::HiveConnectorTestBase {
   }
 
   const std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
 
   std::shared_ptr<memory::MemoryPool> root_;
   std::shared_ptr<memory::MemoryPool> opPool_;

--- a/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
+++ b/velox/connectors/hive/tests/HivePartitionFunctionTest.cpp
@@ -25,6 +25,10 @@ using namespace facebook::velox;
 class HivePartitionFunctionTest : public ::testing::Test,
                                   public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void assertPartitions(
       const VectorPtr& vector,
       int bucketCount,

--- a/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
+++ b/velox/connectors/hive/tests/PartitionIdGeneratorTest.cpp
@@ -23,7 +23,12 @@
 namespace facebook::velox::connector::hive {
 
 class PartitionIdGeneratorTest : public ::testing::Test,
-                                 public test::VectorTestBase {};
+                                 public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(PartitionIdGeneratorTest, consecutiveIdsSingleKey) {
   auto numPartitions = 100;

--- a/velox/core/QueryCtx.h
+++ b/velox/core/QueryCtx.h
@@ -134,7 +134,7 @@ class QueryCtx {
 
   void initPool(const std::string& queryId) {
     if (pool_ == nullptr) {
-      pool_ = memory::defaultMemoryManager().addRootPool(
+      pool_ = memory::deprecatedDefaultMemoryManager().addRootPool(
           QueryCtx::generatePoolName(queryId));
     }
   }

--- a/velox/core/tests/PlanFragmentTest.cpp
+++ b/velox/core/tests/PlanFragmentTest.cpp
@@ -27,6 +27,10 @@ using facebook::velox::exec::test::PlanBuilder;
 namespace {
 class PlanFragmentTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     rowType_ = ROW({"c0", "c1", "c2"}, {BIGINT(), BIGINT(), BIGINT()});
     rowTypeWithProjection_ = ROW(
@@ -74,7 +78,8 @@ class PlanFragmentTest : public testing::Test {
   RowTypePtr probeTypeWithProjection_;
   std::vector<RowVectorPtr> emptyProbeVectors_;
   std::shared_ptr<PlanNode> probeValueNode_;
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 }; // namespace
 

--- a/velox/core/tests/QueryConfigTest.cpp
+++ b/velox/core/tests/QueryConfigTest.cpp
@@ -21,7 +21,14 @@
 
 namespace facebook::velox::core::test {
 
-TEST(TestQueryConfig, emptyConfig) {
+class QueryConfigTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(QueryConfigTest, emptyConfig) {
   std::unordered_map<std::string, std::string> configData;
   auto queryCtx = std::make_shared<QueryCtx>(nullptr, std::move(configData));
   const QueryConfig& config = queryCtx->queryConfig();
@@ -32,7 +39,7 @@ TEST(TestQueryConfig, emptyConfig) {
   ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 
-TEST(TestQueryConfig, setConfig) {
+TEST_F(QueryConfigTest, setConfig) {
   std::string path = "/tmp/CodeGenConfig";
   std::unordered_map<std::string, std::string> configData(
       {{QueryConfig::kCodegenEnabled, "true"},
@@ -47,7 +54,7 @@ TEST(TestQueryConfig, setConfig) {
   ASSERT_FALSE(config.isCastToIntByTruncate());
 }
 
-TEST(TestQueryConfig, memConfig) {
+TEST_F(QueryConfigTest, memConfig) {
   const std::string tz = "timezone1";
   const std::unordered_map<std::string, std::string> configData(
       {{QueryConfig::kCodegenEnabled, "true"},
@@ -91,7 +98,7 @@ TEST(TestQueryConfig, memConfig) {
   }
 }
 
-TEST(TestQueryConfig, taskWriterCountConfig) {
+TEST_F(QueryConfigTest, taskWriterCountConfig) {
   struct {
     std::optional<int> numWriterCounter;
     std::optional<int> numPartitionedWriterCounter;
@@ -138,10 +145,10 @@ TEST(TestQueryConfig, taskWriterCountConfig) {
   }
 }
 
-TEST(TestQueryConfig, enableExpressionEvaluationCacheConfig) {
-  std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::defaultMemoryManager().addRootPool()};
-  std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
+TEST_F(QueryConfigTest, enableExpressionEvaluationCacheConfig) {
+  std::shared_ptr<memory::MemoryPool> rootPool{
+      memory::MemoryManager::getInstance()->addRootPool()};
+  std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
 
   auto testConfig = [&](bool enableExpressionEvaluationCache) {
     std::unordered_map<std::string, std::string> configData(
@@ -154,7 +161,7 @@ TEST(TestQueryConfig, enableExpressionEvaluationCacheConfig) {
         config.isExpressionEvaluationCacheEnabled(),
         enableExpressionEvaluationCache);
 
-    auto execCtx = std::make_shared<core::ExecCtx>(pool_.get(), queryCtx.get());
+    auto execCtx = std::make_shared<core::ExecCtx>(pool.get(), queryCtx.get());
     ASSERT_EQ(execCtx->exprEvalCacheEnabled(), enableExpressionEvaluationCache);
     ASSERT_EQ(
         execCtx->vectorPool() != nullptr, enableExpressionEvaluationCache);
@@ -181,7 +188,7 @@ TEST(TestQueryConfig, enableExpressionEvaluationCacheConfig) {
   testConfig(false);
 }
 
-TEST(TestQueryConfig, capacityConversion) {
+TEST_F(QueryConfigTest, capacityConversion) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1);
 
@@ -218,7 +225,7 @@ TEST(TestQueryConfig, capacityConversion) {
   }
 }
 
-TEST(TestQueryConfig, durationConversion) {
+TEST_F(QueryConfigTest, durationConversion) {
   folly::Random::DefaultGenerator rng;
   rng.seed(1);
 

--- a/velox/core/tests/TypedExprSerdeTest.cpp
+++ b/velox/core/tests/TypedExprSerdeTest.cpp
@@ -23,6 +23,10 @@ namespace facebook::velox::core::test {
 class TypedExprSerDeTest : public testing::Test,
                            public velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   TypedExprSerDeTest() {
     Type::registerSerDe();
 

--- a/velox/docs/programming-guide/chapter01.rst
+++ b/velox/docs/programming-guide/chapter01.rst
@@ -15,7 +15,7 @@ Let’s start by getting access to a MemoryPool:
 
     #include "velox/common/memory/Memory.h"
 
-    auto pool = memory::addDefaultLeafMemoryPool();
+    auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
 `pool` is a std::shared_ptr<velox::memory::MemoryPool>. We can use it to
 allocate buffers.

--- a/velox/dwio/common/tests/BitConcatenationTest.cpp
+++ b/velox/dwio/common/tests/BitConcatenationTest.cpp
@@ -22,7 +22,9 @@ using namespace facebook::velox;
 using namespace facebook::velox::dwio::common;
 
 TEST(BitConcatenationTests, basic) {
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::testingSetInstance({});
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
   BitConcatenation bits(*pool);
   BufferPtr result;
 

--- a/velox/dwio/common/tests/DataBufferBenchmark.cpp
+++ b/velox/dwio/common/tests/DataBufferBenchmark.cpp
@@ -24,7 +24,8 @@ using namespace facebook::velox::dwio;
 using namespace facebook::velox::dwio::common;
 
 BENCHMARK(DataBufferOps, iters) {
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     DataBuffer<int32_t> buf{*pool};
@@ -39,7 +40,8 @@ BENCHMARK(DataBufferOps, iters) {
 }
 
 BENCHMARK(ChainedBufferOps, iters) {
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
   constexpr size_t size = 1024 * 1024 * 16;
   for (size_t i = 0; i < iters; ++i) {
     ChainedBuffer<int32_t> buf{*pool, size, size * 4};
@@ -55,5 +57,6 @@ BENCHMARK(ChainedBufferOps, iters) {
 int main(int argc, char* argv[]) {
   folly::init(&argc, &argv);
   folly::runBenchmarks();
+  facebook::velox::memory::MemoryManager::initialize({});
   return 0;
 }

--- a/velox/dwio/common/tests/E2EFilterTestBase.h
+++ b/velox/dwio/common/tests/E2EFilterTestBase.h
@@ -78,8 +78,13 @@ class E2EFilterTestBase : public testing::Test {
  protected:
   static constexpr int32_t kRowsInGroup = 10'000;
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    rootPool_ = memory::defaultMemoryManager().addRootPool("E2EFilterTestBase");
+    rootPool_ =
+        memory::MemoryManager::getInstance()->addRootPool("E2EFilterTestBase");
     leafPool_ = rootPool_->addLeafChild("E2EFilterTestBase");
   }
 

--- a/velox/dwio/common/tests/ReaderTest.cpp
+++ b/velox/dwio/common/tests/ReaderTest.cpp
@@ -24,7 +24,12 @@ namespace {
 
 using namespace facebook::velox::common;
 
-class ReaderTest : public testing::Test, public test::VectorTestBase {};
+class ReaderTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(ReaderTest, projectColumnsFilterStruct) {
   constexpr int kSize = 10;

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -342,6 +342,10 @@ class DwrfReader : public dwio::common::Reader {
       std::unique_ptr<dwio::common::BufferedInput> input,
       const dwio::common::ReaderOptions& options);
 
+  ReaderBase* testingReaderBase() const {
+    return readerBase_.get();
+  }
+
  private:
   // Ensures that files column names match the ones from the table schema using
   // column indices.
@@ -350,8 +354,6 @@ class DwrfReader : public dwio::common::Reader {
  private:
   std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::ReaderOptions options_;
-
-  friend class E2EEncryptionTest;
 };
 
 class DwrfReaderFactory : public dwio::common::ReaderFactory {

--- a/velox/dwio/dwrf/reader/StripeDictionaryCache.h
+++ b/velox/dwio/dwrf/reader/StripeDictionaryCache.h
@@ -60,7 +60,7 @@ class StripeDictionaryCache {
       EncodingKeyHash>
       intDictionaryFactories_;
 
-  VELOX_FRIEND_TEST(TestStripeDictionaryCache, RegisterDictionary);
+  VELOX_FRIEND_TEST(StripeDictionaryCacheTest, RegisterDictionary);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/CacheInputTest.cpp
+++ b/velox/dwio/dwrf/test/CacheInputTest.cpp
@@ -50,6 +50,10 @@ class CacheTest : public testing::Test {
     std::vector<Region> regions;
   };
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
     rng_.seed(1);
@@ -376,7 +380,8 @@ class CacheTest : public testing::Test {
   std::shared_ptr<AsyncDataCache> cache_;
   std::shared_ptr<IoStatistics> ioStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 
   // Id of simulated streams. Corresponds 1:1 to 'streamStarts_'.
   std::vector<std::unique_ptr<dwrf::DwrfStreamIdentifier>> streamIds_;

--- a/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterIndexTest.cpp
@@ -273,7 +273,8 @@ class WriterEncodingIndexTest2 {
  public:
   WriterEncodingIndexTest2()
       : config_{std::make_shared<Config>()},
-        pool_{facebook::velox::memory::addDefaultLeafMemoryPool()} {}
+        pool_{facebook::velox::memory::MemoryManager::getInstance()
+                  ->addLeafPool()} {}
 
   virtual ~WriterEncodingIndexTest2() = default;
 
@@ -302,7 +303,7 @@ class WriterEncodingIndexTest2 {
     ASSERT_EQ(recordPositionCount.size(), backfillPositionCount.size());
     WriterContext context{
         config_,
-        velox::memory::defaultMemoryManager().addRootPool(
+        velox::memory::MemoryManager::getInstance()->addRootPool(
             "WriterEncodingIndexTest2")};
     context.initBuffer();
     std::vector<StrictMock<MockIndexBuilder>*> mocks;
@@ -416,6 +417,10 @@ class TimestampWriterIndexTest : public testing::Test,
   TimestampWriterIndexTest() : WriterEncodingIndexTest2<Timestamp>() {}
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatchImpl<Timestamp>(
         size,
@@ -449,6 +454,10 @@ class IntegerColumnWriterDictionaryEncodingIndexTest
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatchImpl<Integer>(
         size, pool, generateSomewhatRandomData<Integer>, someNulls);
@@ -505,6 +514,10 @@ class BoolColumnWriterEncodingIndexTest
       : WriterEncodingIndexTest2<bool>() {}
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatchImpl<bool>(
         size,
@@ -537,6 +550,10 @@ class ByteColumnWriterEncodingIndexTest
       : WriterEncodingIndexTest2<int8_t>() {}
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     int8_t value = 0;
     return prepBatchImpl<int8_t>(
@@ -572,6 +589,10 @@ class BinaryColumnWriterEncodingIndexTest
   BinaryColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     BufferPtr nulls = allocateNulls(size, pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -631,6 +652,10 @@ class FloatColumnWriterEncodingIndexTest
   FloatColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatchImpl<FLOAT>(
         size,
@@ -664,7 +689,7 @@ TYPED_TEST(FloatColumnWriterEncodingIndexTest, TestIndex) {
 class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit IntegerColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : pool_{memory::addDefaultLeafMemoryPool()},
+      : pool_{memory::MemoryManager::getInstance()->addLeafPool()},
         config_{std::make_shared<Config>()},
         abandonDict_{abandonDict} {
     config_->set(
@@ -673,6 +698,10 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void testForAllTypes(
       size_t pageCount,
       size_t positionCount,
@@ -705,7 +734,7 @@ class IntegerColumnWriterDirectEncodingIndexTest : public testing::Test {
       std::function<bool(size_t, size_t)> callAbandonDict) {
     WriterContext context{
         config_,
-        velox::memory::defaultMemoryManager().addRootPool(
+        velox::memory::MemoryManager::getInstance()->addRootPool(
             "IntegerColumnWriterDirectEncodingIndexTest")};
     context.initBuffer();
     auto mockIndexBuilder = std::make_unique<StrictMock<MockIndexBuilder>>();
@@ -871,7 +900,7 @@ TEST_F(IntegerColumnWriterAbandonDictionaryIndexTest, AbandonDictionary) {
 class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDictionaryEncodingIndexTest()
-      : rootPool_{memory::defaultMemoryManager().addRootPool(
+      : rootPool_{memory::MemoryManager::getInstance()->addRootPool(
             "StringColumnWriterDictionaryEncodingIndexTest")},
         leafPool_{rootPool_->addLeafChild(
             "StringColumnWriterDictionaryEncodingIndexTest")},
@@ -883,6 +912,10 @@ class StringColumnWriterDictionaryEncodingIndexTest : public testing::Test {
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(
       size_t size,
       MemoryPool* pool,
@@ -976,7 +1009,7 @@ TEST_F(StringColumnWriterDictionaryEncodingIndexTest, OmitInDictStream) {
 class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
  public:
   explicit StringColumnWriterDirectEncodingIndexTest(bool abandonDict = false)
-      : rootPool_{memory::defaultMemoryManager().addRootPool(
+      : rootPool_{memory::MemoryManager::getInstance()->addRootPool(
             "StringColumnWriterDirectEncodingIndexTest")},
         leafPool_{rootPool_->addLeafChild(
             "StringColumnWriterDirectEncodingIndexTest")},
@@ -989,6 +1022,10 @@ class StringColumnWriterDirectEncodingIndexTest : public testing::Test {
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(
       size_t size,
       std::function<std::string(size_t, size_t)> genData,
@@ -1175,6 +1212,10 @@ class ListColumnWriterEncodingIndexTest
   ListColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     auto nulls = allocateNulls(size, pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -1241,6 +1282,10 @@ class MapColumnWriterEncodingIndexTest
   MapColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     auto nulls = allocateNulls(size, pool);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
@@ -1312,6 +1357,10 @@ class FlatMapColumnWriterEncodingIndexTest
   FlatMapColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     auto offsets = allocateOffsets(size, pool);
     auto* offsetsPtr = offsets->asMutable<vector_size_t>();
@@ -1402,6 +1451,10 @@ class StructColumnWriterEncodingIndexTest
   StructColumnWriterEncodingIndexTest() = default;
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPtr prepBatch(size_t size, MemoryPool* pool) override {
     return prepBatch(size, pool, false);
   }

--- a/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterStatsTests.cpp
@@ -141,8 +141,13 @@ using PopulateBatch =
 
 class ColumnWriterStatsTest : public ::testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    rootPool_ = defaultMemoryManager().addRootPool("ColumnWriterStatsTest");
+    rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
+        "ColumnWriterStatsTest");
     leafPool_ = rootPool_->addLeafChild("ColumnWriterStatsTest");
   }
 

--- a/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
+++ b/velox/dwio/dwrf/test/DirectBufferedInputTest.cpp
@@ -45,6 +45,10 @@ class DirectBufferedInputTest : public testing::Test {
  protected:
   static constexpr int32_t kLoadQuantum = 8 << 20;
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     executor_ = std::make_unique<folly::IOThreadPoolExecutor>(10, 10);
     ioStats_ = std::make_shared<IoStatistics>();
@@ -125,7 +129,8 @@ class DirectBufferedInputTest : public testing::Test {
   std::shared_ptr<IoStatistics> ioStats_;
   std::shared_ptr<IoStatistics> fileIoStats_;
   std::unique_ptr<folly::IOThreadPoolExecutor> executor_;
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(DirectBufferedInputTest, basic) {

--- a/velox/dwio/dwrf/test/E2EReaderTest.cpp
+++ b/velox/dwio/dwrf/test/E2EReaderTest.cpp
@@ -98,13 +98,18 @@ class ValueTypes {
   bool asStruct_;
 };
 
-class E2EReaderTest : public testing::TestWithParam<ValueTypes> {};
+class E2EReaderTest : public testing::TestWithParam<ValueTypes> {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 } // namespace
 
 TEST_P(E2EReaderTest, SharedDictionaryFlatmapReadAsStruct) {
   const size_t batchCount = 10;
   size_t size = 1;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   std::vector<uint32_t> flatMapCols(GetParam().size());
   std::iota(flatMapCols.begin(), flatMapCols.end(), 0);

--- a/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
+++ b/velox/dwio/dwrf/test/FloatColumnWriterBenchmark.cpp
@@ -42,7 +42,7 @@ void runBenchmark(int nullEvery) {
 
   auto type = CppToType<float>::create();
   auto typeWithId = TypeWithId::create(type, 1);
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorPtr vector;
   // Prepare input
   BufferPtr values = AlignedBuffer::allocate<float>(kVectorSize, pool.get());
@@ -78,7 +78,7 @@ void runBenchmark(int nullEvery) {
     auto config = std::make_shared<dwrf::Config>();
     WriterContext context{
         config,
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             "FloatColumnWriterBenchmark")};
     auto writer = BaseColumnWriter::create(context, *typeWithId, 0);
     writer->write(vector, common::Ranges::of(0, kVectorSize));
@@ -131,6 +131,7 @@ BENCHMARK(FloatColumnWriterBenchmark10000) {
 
 int32_t main(int32_t argc, char* argv[]) {
   folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/dwrf/test/FlushPolicyTest.cpp
+++ b/velox/dwio/dwrf/test/FlushPolicyTest.cpp
@@ -25,7 +25,14 @@ using namespace facebook::velox::memory;
 
 namespace facebook::velox::dwrf {
 
-TEST(DefaultFlushPolicyTest, StripeProgressTest) {
+class DefaultFlushPolicyTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(DefaultFlushPolicyTest, StripeProgressTest) {
   struct TestCase {
     const uint64_t stripeSizeThreshold;
     const int64_t stripeSize;
@@ -49,7 +56,7 @@ TEST(DefaultFlushPolicyTest, StripeProgressTest) {
   }
 }
 
-TEST(DefaultFlushPolicyTest, AdditionalCriteriaTest) {
+TEST_F(DefaultFlushPolicyTest, AdditionalCriteriaTest) {
   struct TestCase {
     const bool stripeProgressDecision;
     const bool overMemoryBudget;
@@ -119,7 +126,7 @@ TEST(DefaultFlushPolicyTest, AdditionalCriteriaTest) {
   }
 }
 
-TEST(RowsPerStripeFlushPolicyTest, EmptyFile) {
+TEST_F(DefaultFlushPolicyTest, EmptyFile) {
   // Empty vector creation succeeds.
   RowsPerStripeFlushPolicy policy({});
 
@@ -128,7 +135,7 @@ TEST(RowsPerStripeFlushPolicyTest, EmptyFile) {
       exception::LoggedException);
 }
 
-TEST(RowsPerStripeFlushPolicyTest, InvalidCases) {
+TEST_F(DefaultFlushPolicyTest, InvalidCases) {
   // Vector with 0 rows, throws
   ASSERT_THROW(
       RowsPerStripeFlushPolicy policy({5, 7, 0, 10}),
@@ -136,10 +143,12 @@ TEST(RowsPerStripeFlushPolicyTest, InvalidCases) {
 }
 
 // RowsPerStripeFlushPolicy has no dictionary flush criteria.
-TEST(RowsPerSTripeFlushPolicyTest, DictionaryCriteriaTest) {
+TEST_F(DefaultFlushPolicyTest, DictionaryCriteriaTest) {
   auto config = std::make_shared<Config>();
   WriterContext context{
-      config, defaultMemoryManager().addRootPool("DictionaryCriteriaTest")};
+      config,
+      memory::MemoryManager::getInstance()->addRootPool(
+          "DictionaryCriteriaTest")};
 
   RowsPerStripeFlushPolicy policy({42});
   EXPECT_EQ(
@@ -152,7 +161,7 @@ TEST(RowsPerSTripeFlushPolicyTest, DictionaryCriteriaTest) {
       FlushDecision::SKIP, policy.shouldFlushDictionary(true, true, context));
 }
 
-TEST(RowsPerStripeFlushPolicyTest, FlushTest) {
+TEST_F(DefaultFlushPolicyTest, FlushTest) {
   RowsPerStripeFlushPolicy policy({5, 7, 12});
 
   ASSERT_FALSE(policy.shouldFlush(

--- a/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
+++ b/velox/dwio/dwrf/test/IntEncoderBenchmark.cpp
@@ -30,7 +30,7 @@ using namespace facebook::velox::memory;
 
 static size_t generateAutoId(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
@@ -44,7 +44,7 @@ static size_t generateAutoId(int64_t startId, int64_t count) {
 
 static size_t generateAutoId2(int64_t startId, int64_t count) {
   size_t capacity = count * folly::kMaxVarintLength64;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   DataBufferHolder holder{*pool, capacity};
   auto output = std::make_unique<BufferedOutputStream>(holder);
   auto encoder =
@@ -205,6 +205,7 @@ BENCHMARK_RELATIVE(GenerateAutoIdNew_64) {
 
 int32_t main(int32_t argc, char* argv[]) {
   folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
+++ b/velox/dwio/dwrf/test/LayoutPlannerTests.cpp
@@ -35,9 +35,16 @@ void testCreateNodeToColumnIdMapping(
   auto typeWithId = dwio::common::TypeWithId::create(type);
   EXPECT_EQ(expected, TestLayoutPlanner{*typeWithId}.getNodeToColumnMap());
 }
+
+class LayoutPlannerTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 } // namespace
 
-TEST(LayoutPlannerTests, CreateNodeToColumnIdMapping) {
+TEST_F(LayoutPlannerTest, CreateNodeToColumnIdMapping) {
   testCreateNodeToColumnIdMapping(ROW({BOOLEAN()}), {{0, 0}, {1, 0}});
   testCreateNodeToColumnIdMapping(
       ROW(
@@ -89,13 +96,13 @@ TEST(LayoutPlannerTests, CreateNodeToColumnIdMapping) {
        {17, 5}});
 }
 
-TEST(LayoutPlannerTests, Basic) {
+TEST_F(LayoutPlannerTest, Basic) {
   auto config = std::make_shared<Config>();
   config->set(
       Config::COMPRESSION, common::CompressionKind::CompressionKind_NONE);
   WriterContext context{
       config,
-      facebook::velox::memory::defaultMemoryManager().addRootPool(
+      facebook::velox::memory::MemoryManager::getInstance()->addRootPool(
           "LayoutPlannerTests")};
   // fake streams
   std::vector<DwrfStreamIdentifier> streams;

--- a/velox/dwio/dwrf/test/OrcTest.h
+++ b/velox/dwio/dwrf/test/OrcTest.h
@@ -39,7 +39,8 @@ inline std::string getExampleFilePath(const std::string& fileName) {
 
 class MockStripeStreams : public StripeStreams {
  public:
-  MockStripeStreams() : pool_{memory::addDefaultLeafMemoryPool()} {};
+  MockStripeStreams()
+      : pool_{memory::MemoryManager::getInstance()->addLeafPool()} {};
   ~MockStripeStreams() = default;
 
   std::unique_ptr<dwio::common::SeekableInputStream> getStream(

--- a/velox/dwio/dwrf/test/ReaderTest.cpp
+++ b/velox/dwio/dwrf/test/ReaderTest.cpp
@@ -80,6 +80,10 @@ class TestReaderP
     : public testing::TestWithParam</* parallel decoding = */ bool>,
       public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   folly::Executor* executor() {
     if (GetParam() && !executor_) {
       std::make_shared<folly::CPUThreadPoolExecutor>(
@@ -98,6 +102,10 @@ class TestReaderP
 
 class TestReader : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::vector<VectorPtr> createBatches(
       const std::vector<std::vector<int32_t>>& values) {
     std::vector<VectorPtr> batches;
@@ -110,9 +118,19 @@ class TestReader : public testing::Test, public VectorTestBase {
   }
 };
 
-class TestRowReaderPrefetch : public testing::Test, public VectorTestBase {};
+class TestRowReaderPrefetch : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
-class TestRowReaderPfetch : public testing::Test, public VectorTestBase {};
+class TestRowReaderPfetch : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 } // namespace
 
@@ -392,7 +410,12 @@ void verifyCachedIndexStreamReads(
   }
 }
 
-class TestFlatMapReader : public TestWithParam<bool>, public VectorTestBase {};
+class TestFlatMapReader : public TestWithParam<bool>, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_P(TestFlatMapReader, testReadFlatMapEmptyMap) {
   const std::string emptyFile(getExampleFilePath("empty_flatmap.orc"));
@@ -780,7 +803,12 @@ struct ByStripeInfo {
 };
 
 class TestRowReaderPrefetchByStripe : public TestWithParam<ByStripeInfo>,
-                                      public VectorTestBase {};
+                                      public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 // This test ensures that we only return the prefetch units for the stripes that
 // we'll actually use, according to the range passed to the row reader. We
@@ -910,7 +938,12 @@ TEST_F(TestRowReaderPrefetch, testEmptyRowRange) {
 
 class TestFlatMapReaderFlatLayout
     : public TestWithParam<std::tuple<bool, size_t>>,
-      public VectorTestBase {};
+      public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_P(TestFlatMapReaderFlatLayout, testCompare) {
   dwio::common::ReaderOptions readerOptions{pool()};

--- a/velox/dwio/dwrf/test/StreamLabelsTests.cpp
+++ b/velox/dwio/dwrf/test/StreamLabelsTests.cpp
@@ -22,8 +22,16 @@ using namespace ::testing;
 using facebook::velox::memory::AllocationPool;
 using namespace facebook::velox::dwrf;
 
-TEST(StreamLabelsTest, E2E) {
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+class StreamLabelsTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    facebook::velox::memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(StreamLabelsTest, E2E) {
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
   AllocationPool allocationPool(pool.get());
   StreamLabels root(allocationPool);
   auto c0 = root.append("c0");

--- a/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
+++ b/velox/dwio/dwrf/test/StripeReaderBaseTests.cpp
@@ -33,6 +33,10 @@ namespace facebook::velox::dwrf {
 
 class StripeLoadKeysTest : public Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     HiveTypeParser parser;
     auto type = parser.parse("struct<a:int>");
@@ -63,7 +67,7 @@ class StripeLoadKeysTest : public Test {
 
     TestDecrypterFactory factory;
     auto handler = DecryptionHandler::create(FooterWrapper(footer), &factory);
-    pool_ = addDefaultLeafMemoryPool();
+    pool_ = MemoryManager::getInstance()->addLeafPool();
 
     reader_ = std::make_unique<ReaderBase>(
         *pool_,

--- a/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestByteRLEEncoder.cpp
@@ -110,8 +110,15 @@ void decodeAndVerifyBoolean(
   delete[] decodedData;
 }
 
-TEST(ByteRleEncoder, random_chars) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+class ByteRleEncoderTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(ByteRleEncoderTest, random_chars) {
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -130,8 +137,8 @@ TEST(ByteRleEncoder, random_chars) {
   delete[] data;
 }
 
-TEST(ByteRleEncoder, random_chars_with_null) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+TEST_F(ByteRleEncoderTest, random_chars_with_null) {
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -152,8 +159,15 @@ TEST(ByteRleEncoder, random_chars_with_null) {
   delete[] nulls;
 }
 
-TEST(BooleanRleEncoder, random_bits_not_aligned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+class BooleanRleEncoderTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(BooleanRleEncoderTest, random_bits_not_aligned) {
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -172,8 +186,8 @@ TEST(BooleanRleEncoder, random_bits_not_aligned) {
   delete[] data;
 }
 
-TEST(BooleanRleEncoder, random_bits_aligned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+TEST_F(BooleanRleEncoderTest, random_bits_aligned) {
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;
@@ -192,8 +206,8 @@ TEST(BooleanRleEncoder, random_bits_aligned) {
   delete[] data;
 }
 
-TEST(BooleanRleEncoder, random_bits_aligned_with_null) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+TEST_F(BooleanRleEncoderTest, random_bits_aligned_with_null) {
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
 
   uint64_t block = 1024;

--- a/velox/dwio/dwrf/test/TestColumnReader.cpp
+++ b/velox/dwio/dwrf/test/TestColumnReader.cpp
@@ -252,6 +252,10 @@ class StringReaderTests
     : public ::testing::TestWithParam<StringReaderTestParams>,
       public ColumnReaderTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   StringReaderTests()
       : useSelectiveReader_{GetParam().useSelectiveReader},
         returnFlatVector_{GetParam().returnFlatVector},
@@ -307,6 +311,10 @@ struct ReaderTestParams {
 class TestColumnReader : public testing::TestWithParam<ReaderTestParams>,
                          public ColumnReaderTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   TestColumnReader()
       : useSelectiveReader_{GetParam().useSelectiveReader},
         expectMemoryReuse_{GetParam().expectMemoryReuse},
@@ -364,6 +372,10 @@ class TestNonSelectiveColumnReader
     : public testing::TestWithParam<NonSelectiveReaderTestParams>,
       public ColumnReaderTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   TestNonSelectiveColumnReader()
       : expectMemoryReuse_{GetParam().expectMemoryReuse},
         parallelDecoding_{GetParam().parallelDecoding} {}
@@ -411,6 +423,10 @@ struct SchemaMismatchTestParam {
 class SchemaMismatchTest : public TestWithParam<SchemaMismatchTestParam>,
                            public ColumnReaderTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   SchemaMismatchTest()
       : useSelectiveReader_{GetParam().useSelectiveReader},
         parallelDecoding_{GetParam().parallelDecoding} {}

--- a/velox/dwio/dwrf/test/TestDecompression.cpp
+++ b/velox/dwio/dwrf/test/TestDecompression.cpp
@@ -36,15 +36,38 @@ using namespace folly::io;
 
 const std::string simpleFile(getExampleFilePath("simple-file.binary"));
 
-std::shared_ptr<MemoryPool> pool = addDefaultLeafMemoryPool();
+class DecompressionTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
 
-TEST(TestDecompression, testPrintBufferEmpty) {
+  std::unique_ptr<SeekableInputStream> createTestDecompressor(
+      CompressionKind kind,
+      std::unique_ptr<SeekableInputStream> input,
+      uint64_t bufferSize) {
+    return createDecompressor(
+        kind, std::move(input), bufferSize, *pool_, "Test Decompression");
+  }
+
+  SeekableFileInputStream createSeekableFileInputStream() {
+    auto readFile = std::make_shared<LocalReadFile>(simpleFile);
+    auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
+    return SeekableFileInputStream(
+        std::move(file), 0, 200, *pool_, LogType::TEST, 20);
+  }
+
+  std::shared_ptr<MemoryPool> pool_ =
+      memory::MemoryManager::getInstance()->addLeafPool();
+};
+
+TEST_F(DecompressionTest, testPrintBufferEmpty) {
   std::ostringstream str;
   printBuffer(str, nullptr, 0);
   EXPECT_EQ("", str.str());
 }
 
-TEST(TestDecompression, testPrintBufferSmall) {
+TEST_F(DecompressionTest, testPrintBufferSmall) {
   std::vector<char> buffer(10);
   std::ostringstream str;
   for (size_t i = 0; i < 10; ++i) {
@@ -54,7 +77,7 @@ TEST(TestDecompression, testPrintBufferSmall) {
   EXPECT_EQ("0000000 00 01 02 03 04 05 06 07 08 09\n", str.str());
 }
 
-TEST(TestDecompression, testPrintBufferLong) {
+TEST_F(DecompressionTest, testPrintBufferLong) {
   std::vector<char> buffer(300);
   std::ostringstream str;
   for (size_t i = 0; i < 300; ++i) {
@@ -90,7 +113,7 @@ TEST(TestDecompression, testPrintBufferLong) {
   EXPECT_EQ(expected.str(), str.str());
 }
 
-TEST(TestDecompression, testArrayBackup) {
+TEST_F(DecompressionTest, testArrayBackup) {
   std::vector<char> bytes(200);
   for (size_t i = 0; i < bytes.size(); ++i) {
     bytes[i] = static_cast<char>(i);
@@ -123,7 +146,7 @@ TEST(TestDecompression, testArrayBackup) {
   EXPECT_EQ(200, stream.ByteCount());
 }
 
-TEST(TestDecompression, testArraySkip) {
+TEST_F(DecompressionTest, testArraySkip) {
   std::vector<char> bytes(200);
   for (size_t i = 0; i < bytes.size(); ++i) {
     bytes[i] = static_cast<char>(i);
@@ -145,7 +168,7 @@ TEST(TestDecompression, testArraySkip) {
   EXPECT_EQ("SeekableArrayInputStream 200 of 200", stream.getName());
 }
 
-TEST(TestDecompression, testArrayCombo) {
+TEST_F(DecompressionTest, testArrayCombo) {
   std::vector<char> bytes(200);
   for (size_t i = 0; i < bytes.size(); ++i) {
     bytes[i] = static_cast<char>(i);
@@ -175,14 +198,7 @@ void checkBytes(const char* data, int32_t length, uint32_t startValue) {
   }
 }
 
-SeekableFileInputStream createSeekableFileInputStream() {
-  auto readFile = std::make_shared<LocalReadFile>(simpleFile);
-  auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
-  return SeekableFileInputStream(
-      std::move(file), 0, 200, *pool, LogType::TEST, 20);
-}
-
-TEST(TestDecompression, testFileBackup) {
+TEST_F(DecompressionTest, testFileBackup) {
   auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
@@ -211,7 +227,7 @@ TEST(TestDecompression, testFileBackup) {
   EXPECT_EQ(200, stream.ByteCount());
 }
 
-TEST(TestDecompression, testFileSkip) {
+TEST_F(DecompressionTest, testFileSkip) {
   auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
@@ -229,7 +245,7 @@ TEST(TestDecompression, testFileSkip) {
   EXPECT_EQ(std::string(simpleFile) + " from 0 for 200", stream.getName());
 }
 
-TEST(TestDecompression, testFileCombo) {
+TEST_F(DecompressionTest, testFileCombo) {
   auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
@@ -247,7 +263,7 @@ TEST(TestDecompression, testFileCombo) {
   EXPECT_EQ(true, !stream.Next(&ptr, &len));
 }
 
-TEST(TestDecompression, testFileSeek) {
+TEST_F(DecompressionTest, testFileSeek) {
   auto stream = createSeekableFileInputStream();
   const void* ptr;
   int32_t len;
@@ -278,18 +294,7 @@ TEST(TestDecompression, testFileSeek) {
   }
 }
 
-namespace {
-std::unique_ptr<SeekableInputStream> createTestDecompressor(
-    CompressionKind kind,
-    std::unique_ptr<SeekableInputStream> input,
-    uint64_t bufferSize) {
-  return createDecompressor(
-      kind, std::move(input), bufferSize, *pool, "Test Decompression");
-}
-
-} // namespace
-
-TEST(TestDecompression, testCreateNone) {
+TEST_F(DecompressionTest, testCreateNone) {
   std::vector<char> bytes(10);
   for (uint32_t i = 0; i < bytes.size(); ++i) {
     bytes[i] = static_cast<char>(i);
@@ -307,7 +312,7 @@ TEST(TestDecompression, testCreateNone) {
   }
 }
 
-TEST(TestDecompression, testLzoEmpty) {
+TEST_F(DecompressionTest, testLzoEmpty) {
   const unsigned char buffer[] = {0};
   std::unique_ptr<SeekableInputStream> result = createTestDecompressor(
       CompressionKind_LZO,
@@ -322,7 +327,7 @@ TEST(TestDecompression, testLzoEmpty) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testLzoSmall) {
+TEST_F(DecompressionTest, testLzoSmall) {
   const unsigned char buffer[] = {
       70,  0,   0,   48,  88,  88,  88, 88, 97, 98, 99, 100, 97,
       98,  99,  100, 65,  66,  67,  68, 65, 66, 67, 68, 119, 120,
@@ -344,7 +349,7 @@ TEST(TestDecompression, testLzoSmall) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testLzoLong) {
+TEST_F(DecompressionTest, testLzoLong) {
   // set up a framed lzo buffer with 100,000 'a'
   unsigned char buffer[482];
   bzero(buffer, VELOX_ARRAY_SIZE(buffer));
@@ -384,7 +389,7 @@ TEST(TestDecompression, testLzoLong) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testLz4Empty) {
+TEST_F(DecompressionTest, testLz4Empty) {
   const unsigned char buffer[] = {0};
   std::unique_ptr<SeekableInputStream> result = createTestDecompressor(
       CompressionKind_LZ4,
@@ -399,7 +404,7 @@ TEST(TestDecompression, testLz4Empty) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testLz4Small) {
+TEST_F(DecompressionTest, testLz4Small) {
   const unsigned char buffer[] = {60,  0,   0,   128, 88,  88,  88,  88,  97,
                                   98,  99,  100, 4,   0,   64,  65,  66,  67,
                                   68,  4,   0,   176, 119, 120, 121, 122, 119,
@@ -421,7 +426,7 @@ TEST(TestDecompression, testLz4Small) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testLz4Long) {
+TEST_F(DecompressionTest, testLz4Long) {
   // set up a framed lzo buffer with 100,000 'a'
   unsigned char buffer[406];
   memset(buffer, 255, VELOX_ARRAY_SIZE(buffer));
@@ -454,7 +459,7 @@ TEST(TestDecompression, testLz4Long) {
   ASSERT_TRUE(!result->Next(&ptr, &length));
 }
 
-TEST(TestDecompression, testCreateZlib) {
+TEST_F(DecompressionTest, testCreateZlib) {
   const unsigned char buffer[] = {0x0b, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4};
   std::unique_ptr<SeekableInputStream> result = createTestDecompressor(
       CompressionKind_ZLIB,
@@ -484,7 +489,7 @@ TEST(TestDecompression, testCreateZlib) {
   }
 }
 
-TEST(TestDecompression, testLiteralBlocks) {
+TEST_F(DecompressionTest, testLiteralBlocks) {
   const unsigned char buffer[] = {0x19, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4,
                                   0x5,  0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xb,
                                   0x0,  0x0, 0xc, 0xd, 0xe, 0xf, 0x10};
@@ -527,7 +532,7 @@ TEST(TestDecompression, testLiteralBlocks) {
   EXPECT_EQ(16, static_cast<const char*>(ptr)[2]);
 }
 
-TEST(TestDecompression, testInflate) {
+TEST_F(DecompressionTest, testInflate) {
   const unsigned char buffer[] = {
       0xe, 0x0, 0x0, 0x63, 0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0};
   std::unique_ptr<SeekableInputStream> result = createTestDecompressor(
@@ -546,7 +551,7 @@ TEST(TestDecompression, testInflate) {
   }
 }
 
-TEST(TestDecompression, testInflateSequence) {
+TEST_F(DecompressionTest, testInflateSequence) {
   const unsigned char buffer[] = {0xe,  0x0,  0x0,  0x63, 0x60, 0x64, 0x62,
                                   0xc0, 0x8d, 0x0,  0xe,  0x0,  0x0,  0x63,
                                   0x60, 0x64, 0x62, 0xc0, 0x8d, 0x0};
@@ -581,7 +586,7 @@ TEST(TestDecompression, testInflateSequence) {
   }
 }
 
-TEST(TestDecompression, testSkipZlib) {
+TEST_F(DecompressionTest, testSkipZlib) {
   const unsigned char buffer[] = {0x19, 0x0, 0x0, 0x0, 0x1, 0x2, 0x3, 0x4,
                                   0x5,  0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xb,
                                   0x0,  0x0, 0xc, 0xd, 0xe, 0xf, 0x10};
@@ -659,7 +664,7 @@ class CompressBuffer {
   }
 };
 
-TEST(TestDecompression, testBasic) {
+TEST_F(DecompressionTest, testBasic) {
   const int32_t N = 1024;
   std::vector<char> buf(N * sizeof(int));
   for (int32_t i = 0; i < N; ++i) {
@@ -692,7 +697,7 @@ TEST(TestDecompression, testBasic) {
   }
 }
 
-TEST(TestDecompression, testMultiBuffer) {
+TEST_F(DecompressionTest, testMultiBuffer) {
   const int32_t N = 1024;
   std::vector<char> buf(N * sizeof(int));
   for (int32_t i = 0; i < N; ++i) {
@@ -740,7 +745,7 @@ TEST(TestDecompression, testMultiBuffer) {
   }
 }
 
-TEST(TestDecompression, testSkipSnappy) {
+TEST_F(DecompressionTest, testSkipSnappy) {
   const int32_t N = 1024;
   std::vector<char> buf(N * sizeof(int));
   for (int32_t i = 0; i < N; ++i) {
@@ -776,7 +781,7 @@ TEST(TestDecompression, testSkipSnappy) {
   }
 }
 
-TEST(TestDecompression, testDelayedSkip) {
+TEST_F(DecompressionTest, testDelayedSkip) {
   constexpr int32_t N = 1024;
   std::vector<int> buf(N);
   for (int32_t i = 0; i < N; ++i) {
@@ -852,8 +857,21 @@ compress(char* buf, size_t size, char* output, size_t offset, Codec& codec) {
 
 class TestSeek : public ::testing::Test {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   ~TestSeek() override {}
-  static void runTest(Codec& codec, CompressionKind kind) {
+
+  std::unique_ptr<SeekableInputStream> createTestDecompressor(
+      CompressionKind kind,
+      std::unique_ptr<SeekableInputStream> input,
+      uint64_t bufferSize) {
+    return createDecompressor(
+        kind, std::move(input), bufferSize, *pool_, "Test Decompression");
+  }
+
+  void runTest(Codec& codec, CompressionKind kind) {
     constexpr size_t inputSize = 1024;
     constexpr size_t outputSize = 4096;
     char output[outputSize];
@@ -862,14 +880,13 @@ class TestSeek : public ::testing::Test {
     size_t offset1;
     size_t offset2;
     prepareTestData(codec, input1, input2, inputSize, output, offset1, offset2);
-    auto pool = addDefaultLeafMemoryPool();
 
     std::unique_ptr<SeekableInputStream> stream = createDecompressor(
         kind,
         std::unique_ptr<SeekableInputStream>(
             new SeekableArrayInputStream(output, offset2, outputSize / 10)),
         outputSize,
-        *pool,
+        *pool_,
         "TestSeek Decompressor",
         nullptr);
 
@@ -907,6 +924,9 @@ class TestSeek : public ::testing::Test {
     offset1 = compress(input1, inputSize, output, 0, codec);
     offset2 = compress(input2, inputSize, output, offset1, codec);
   }
+
+  std::shared_ptr<MemoryPool> pool_ =
+      memory::MemoryManager::getInstance()->addLeafPool();
 };
 
 TEST_F(TestSeek, Zlib) {

--- a/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
+++ b/velox/dwio/dwrf/test/TestDictionaryEncodingUtils.cpp
@@ -23,7 +23,14 @@ using namespace testing;
 using namespace facebook::velox::memory;
 
 namespace facebook::velox::dwrf {
-TEST(TestDictionaryEncodingUtils, StringGetSortedIndexLookupTable) {
+class DictionaryEncodingUtilsTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(DictionaryEncodingUtilsTest, StringGetSortedIndexLookupTable) {
   struct TestCase {
     explicit TestCase(
         bool sort,
@@ -91,7 +98,7 @@ TEST(TestDictionaryEncodingUtils, StringGetSortedIndexLookupTable) {
           {0, 1, 2, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -137,7 +144,7 @@ TEST(TestDictionaryEncodingUtils, StringGetSortedIndexLookupTable) {
   }
 }
 
-TEST(TestDictionaryEncodingUtils, StringStrideDictOptimization) {
+TEST_F(DictionaryEncodingUtilsTest, StringStrideDictOptimization) {
   constexpr size_t kStrideSize{10};
   struct TestCase {
     explicit TestCase(
@@ -296,7 +303,7 @@ TEST(TestDictionaryEncodingUtils, StringStrideDictOptimization) {
   };
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     size_t rowCount = 0;
     for (const auto& key : testCase.addKeySequence) {

--- a/velox/dwio/dwrf/test/TestEncodingSelector.cpp
+++ b/velox/dwio/dwrf/test/TestEncodingSelector.cpp
@@ -21,9 +21,15 @@
 using namespace facebook::velox::memory;
 
 namespace facebook::velox::dwrf {
+class EntropyEncodingSelectorTests : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
-TEST(TestEntropyEncodingSelector, Ctor) {
-  auto pool = addDefaultLeafMemoryPool();
+TEST_F(EntropyEncodingSelectorTests, Ctor) {
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   float slightlyOver = 1.0f + std::numeric_limits<float>::epsilon() * 2;
   float slightlyUnder = -std::numeric_limits<float>::epsilon();
   EXPECT_ANY_THROW(
@@ -70,7 +76,7 @@ class EntropyEncodingSelectorTest {
         decision_{decision} {}
 
   void runTest() const {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     dwio::common::DataBuffer<uint32_t> rows{*pool};
     rows.reserve(size_);
@@ -88,7 +94,7 @@ class EntropyEncodingSelectorTest {
   }
 };
 
-TEST(TestEntropyEncodingSelector, NoHeuristic) {
+TEST_F(EntropyEncodingSelectorTests, NoHeuristic) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(
@@ -131,7 +137,7 @@ TEST(TestEntropyEncodingSelector, NoHeuristic) {
   }
 }
 
-TEST(TestEntropyEncodingSelector, NoSampling) {
+TEST_F(EntropyEncodingSelectorTests, NoSampling) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(
@@ -181,7 +187,7 @@ std::string alphabeticRoundRobin(size_t index, size_t size) {
   return std::string(size % (index + 1), element);
 }
 
-TEST(TestEntropyEncodingSelector, Sampling) {
+TEST_F(EntropyEncodingSelectorTests, Sampling) {
   class TestCase : public EntropyEncodingSelectorTest {
    public:
     explicit TestCase(

--- a/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestIntegerDictionaryEncoder.cpp
@@ -29,6 +29,7 @@ class TestIntegerDictionaryEncoder : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+    memory::MemoryManager::testingSetInstance({});
   }
 };
 
@@ -50,7 +51,7 @@ TEST_F(TestIntegerDictionaryEncoder, AddKey) {
       TestCase{{-2, 2, 2, -2, 2}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -83,7 +84,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -115,7 +116,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
       TestCase{{-2, 1, 2, 0, -1, 1, 0, 2, 0, -2, -1, -2, 1}, 13}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -126,7 +127,7 @@ TEST_F(TestIntegerDictionaryEncoder, GetTotalCount) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, Clear) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   {
     IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
     EXPECT_EQ(1, intDictEncoder.refCount_);
@@ -207,7 +208,7 @@ TEST_F(TestIntegerDictionaryEncoder, Clear) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   IntegerDictionaryEncoder<int64_t> intDictEncoder{*pool, *pool};
   std::vector<int> keys{0, 1, 4, 9, 16, 25, 9, 1};
   for (const auto& key : keys) {
@@ -233,7 +234,7 @@ TEST_F(TestIntegerDictionaryEncoder, RepeatedFlush) {
 }
 
 TEST_F(TestIntegerDictionaryEncoder, Limit) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   for (size_t iter = 0; iter < 2; ++iter) {
     int16_t val = std::numeric_limits<int16_t>::min();
@@ -270,7 +271,7 @@ void testGetSortedIndexLookupTable() {
       TestCase{{-1, 0, -2, 2, 1}, false, {0, 1, 2, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);
@@ -337,7 +338,7 @@ TEST_F(TestIntegerDictionaryEncoder, ShortIntegerDictionary) {
     values.emplace_back(static_cast<int16_t>(i));
   }
 
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   IntegerDictionaryEncoder<int16_t> intDictEncoder{*pool, *pool};
   dwio::common::DataBuffer<bool> inDict{*pool};
   dwio::common::DataBuffer<int16_t> lookupTable{*pool};
@@ -450,7 +451,7 @@ void testInfrequentKeyOptimization() {
           24}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     IntegerDictionaryEncoder<T> intDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       intDictEncoder.addKey(key);

--- a/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
+++ b/velox/dwio/dwrf/test/TestRLEv1Encoder.cpp
@@ -86,14 +86,21 @@ void decodeAndVerify(
   delete[] decodedData;
 }
 
-class RleEncoderV1Test : public testing::Test {};
+class RleEncoderV1Test : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
 
-TEST(RleEncoderV1Test, encodeMinAndMax) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
+};
+
+TEST_F(RleEncoderV1Test, encodeMinAndMax) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -109,12 +116,11 @@ TEST(RleEncoderV1Test, encodeMinAndMax) {
   decodeAndVerify<false>(memSink, data.data(), 2, nullptr);
 }
 
-TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, encodeMinAndMaxint32) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -131,12 +137,11 @@ TEST(RleEncoderV1Test, encodeMinAndMaxint32) {
   decodeAndVerify<true>(memSink, data.data(), 2, nullptr);
 }
 
-TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -150,12 +155,11 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsigned) {
   delete[] data;
 }
 
-TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -171,12 +175,11 @@ TEST(RleEncoderV1Test, deltaIncreasingSequanceUnsignedNull) {
   delete[] nulls;
 }
 
-TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<false> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -190,12 +193,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceUnsigned) {
   delete[] data;
 }
 
-TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -209,12 +211,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSigned) {
   delete[] data;
 }
 
-TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -230,12 +231,11 @@ TEST(RleEncoderV1Test, deltaDecreasingSequanceSignedNull) {
   delete[] nulls;
 }
 
-TEST(RleEncoderV1Test, randomSequanceSigned) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, randomSequanceSigned) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -249,12 +249,11 @@ TEST(RleEncoderV1Test, randomSequanceSigned) {
   delete[] data;
 }
 
-TEST(RleEncoderV1Test, allNull) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, allNull) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -270,12 +269,11 @@ TEST(RleEncoderV1Test, allNull) {
   delete[] nulls;
 }
 
-TEST(RleEncoderV1Test, recordPosition) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, recordPosition) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);
@@ -292,12 +290,11 @@ TEST(RleEncoderV1Test, recordPosition) {
   EXPECT_EQ(pos.at(1), size - 130);
 }
 
-TEST(RleEncoderV1Test, backfillPosition) {
-  auto pool = memory::addDefaultLeafMemoryPool();
-  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool.get()});
+TEST_F(RleEncoderV1Test, backfillPosition) {
+  MemorySink memSink(DEFAULT_MEM_STREAM_SIZE, {.pool = pool_.get()});
 
   uint64_t block = 1024;
-  DataBufferHolder holder{*pool, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
+  DataBufferHolder holder{*pool_, block, 0, DEFAULT_PAGE_GROW_RATIO, &memSink};
 
   RleEncoderV1<true> encoder(
       std::make_unique<BufferedOutputStream>(holder), true, 8);

--- a/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
+++ b/velox/dwio/dwrf/test/TestStringDictionaryEncoder.cpp
@@ -28,6 +28,7 @@ class TestStringDictionaryEncoder : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
     FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
+    memory::MemoryManager::testingSetInstance({});
   }
 };
 
@@ -49,7 +50,7 @@ TEST_F(TestStringDictionaryEncoder, AddKey) {
       TestCase{{"doe", "sow", "sow", "doe", "sow"}, {0, 1, 1, 0, 1}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     std::vector<size_t> actualEncodedSequence{};
     for (const auto& key : testCase.addKeySequence) {
@@ -93,7 +94,7 @@ TEST_F(TestStringDictionaryEncoder, GetIndex) {
           {0, 3, 4, 2, 1, 3, 2, 4, 2, 0, 1, 0, 3}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -142,7 +143,7 @@ TEST_F(TestStringDictionaryEncoder, GetCount) {
           {3, 2, 3, 3, 2}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& key : testCase.addKeySequence) {
       stringDictEncoder.addKey(key, 0);
@@ -196,7 +197,7 @@ TEST_F(TestStringDictionaryEncoder, GetStride) {
           {1, 1, 6, 3, 4}}};
 
   for (const auto& testCase : testCases) {
-    auto pool = addDefaultLeafMemoryPool();
+    auto pool = MemoryManager::getInstance()->addLeafPool();
     StringDictionaryEncoder stringDictEncoder{*pool, *pool};
     for (const auto& kv : testCase.addKeySequence) {
       stringDictEncoder.addKey(kv.first, kv.second);
@@ -219,7 +220,7 @@ std::string genPaddedIntegerString(size_t integer, size_t length) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Clear) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 2500; ++i) {
@@ -241,7 +242,7 @@ TEST_F(TestStringDictionaryEncoder, Clear) {
 }
 
 TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   StringDictionaryEncoder stringDictEncoder{*pool, *pool};
   std::string baseString{"jjkkll"};
   for (size_t i = 0; i != 10000; ++i) {
@@ -252,7 +253,7 @@ TEST_F(TestStringDictionaryEncoder, MemBenchmark) {
 }
 
 TEST_F(TestStringDictionaryEncoder, Limit) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   StringDictionaryEncoder encoder{*pool, *pool};
   encoder.addKey(folly::StringPiece{"abc"}, 0);
   dwio::common::DataBuffer<char> buf{*pool};

--- a/velox/dwio/dwrf/test/TestStripeStream.cpp
+++ b/velox/dwio/dwrf/test/TestStripeStream.cpp
@@ -103,10 +103,19 @@ StripeStreamsImpl createAndLoadStripeStreams(
   streams.loadReadPlan();
   return streams;
 }
+
+class StripeStreamTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    MemoryManager::testingSetInstance({});
+  }
+
+  std::shared_ptr<MemoryPool> pool_{
+      MemoryManager::getInstance()->addLeafPool()};
+};
 } // namespace
 
-TEST(StripeStream, planReads) {
-  auto pool = addDefaultLeafMemoryPool();
+TEST_F(StripeStreamTest, planReads) {
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -115,10 +124,10 @@ TEST(StripeStream, planReads) {
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool,
+      *pool_,
       std::make_unique<BufferedInput>(
           std::move(is),
-          *pool,
+          *pool_,
           MetricsLog::voidLog(),
           nullptr,
           BufferedInput::kMaxMergeDistance,
@@ -156,8 +165,7 @@ TEST(StripeStream, planReads) {
       1000300);
 }
 
-TEST(StripeStream, filterSequences) {
-  auto pool = addDefaultLeafMemoryPool();
+TEST_F(StripeStreamTest, filterSequences) {
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -166,8 +174,8 @@ TEST(StripeStream, filterSequences) {
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool,
-      std::make_unique<BufferedInput>(std::move(is), *pool),
+      *pool_,
+      std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(proto::PostScript{}),
       footer,
       nullptr);
@@ -212,8 +220,7 @@ TEST(StripeStream, filterSequences) {
   }
 }
 
-TEST(StripeStream, zeroLength) {
-  auto pool = addDefaultLeafMemoryPool();
+TEST_F(StripeStreamTest, zeroLength) {
   google::protobuf::Arena arena;
   auto footer = google::protobuf::Arena::CreateMessage<proto::Footer>(&arena);
   footer->set_rowindexstride(100);
@@ -225,8 +232,8 @@ TEST(StripeStream, zeroLength) {
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool,
-      std::make_unique<BufferedInput>(std::move(is), *pool),
+      *pool_,
+      std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
       nullptr);
@@ -271,8 +278,7 @@ TEST(StripeStream, zeroLength) {
   }
 }
 
-TEST(StripeStream, planReadsIndex) {
-  auto pool = addDefaultLeafMemoryPool();
+TEST_F(StripeStreamTest, planReadsIndex) {
   google::protobuf::Arena arena;
 
   // build ps
@@ -298,7 +304,7 @@ TEST(StripeStream, planReadsIndex) {
 
   // build cache
   std::string str(buffer.str());
-  auto cacheBuffer = std::make_shared<DataBuffer<char>>(*pool, str.size());
+  auto cacheBuffer = std::make_shared<DataBuffer<char>>(*pool_, str.size());
   memcpy(cacheBuffer->data(), str.data(), str.size());
   auto cache = std::make_unique<StripeMetadataCache>(
       StripeCacheMode::INDEX, FooterWrapper(footer), std::move(cacheBuffer));
@@ -306,8 +312,8 @@ TEST(StripeStream, planReadsIndex) {
   auto is = std::make_unique<RecordingInputStream>();
   auto isPtr = is.get();
   auto readerBase = std::make_shared<ReaderBase>(
-      *pool,
-      std::make_unique<BufferedInput>(std::move(is), *pool),
+      *pool_,
+      std::make_unique<BufferedInput>(std::move(is), *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
       std::move(cache));
@@ -381,8 +387,8 @@ void addNode(T& t, uint32_t node, uint32_t offset = 0) {
   }
 }
 
-TEST(StripeStream, readEncryptedStreams) {
-  auto pool = defaultMemoryManager().addRootPool("readEncryptedStreams");
+TEST_F(StripeStreamTest, readEncryptedStreams) {
+  auto pool = MemoryManager::getInstance()->addRootPool("readEncryptedStreams");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
@@ -467,8 +473,8 @@ TEST(StripeStream, readEncryptedStreams) {
   }
 }
 
-TEST(StripeStream, schemaMismatch) {
-  auto pool = defaultMemoryManager().addRootPool("schemaMismatch");
+TEST_F(StripeStreamTest, schemaMismatch) {
+  auto pool = MemoryManager::getInstance()->addRootPool("schemaMismatch");
   google::protobuf::Arena arena;
   proto::PostScript ps;
   ps.set_compression(proto::CompressionKind::ZSTD);
@@ -507,7 +513,7 @@ TEST(StripeStream, schemaMismatch) {
       *readerPool,
       std::make_unique<BufferedInput>(
           std::make_shared<facebook::velox::InMemoryReadFile>(std::string()),
-          *pool),
+          *pool_),
       std::make_unique<PostScript>(std::move(ps)),
       footer,
       nullptr,
@@ -618,10 +624,8 @@ proto::ColumnEncoding genColumnEncoding(
 }
 } // namespace
 
-TEST(StripeStream, shareDictionary) {
-  std::shared_ptr<MemoryPool> pool =
-      addDefaultLeafMemoryPool("shareDictionary");
-  TestStripeStreams ss(pool.get());
+TEST_F(StripeStreamTest, shareDictionary) {
+  TestStripeStreams ss(pool_.get());
 
   auto nonSharedDictionaryEncoding =
       genColumnEncoding(1, 0, proto::ColumnEncoding_Kind_DICTIONARY, 100);
@@ -669,7 +673,7 @@ TEST(StripeStream, shareDictionary) {
       ss, getStreamProxy(2, Not(0), proto::Stream_Kind_DICTIONARY_DATA, _))
       .WillRepeatedly(Return(nullptr));
 
-  facebook::velox::memory::AllocationPool allocPool(pool.get());
+  facebook::velox::memory::AllocationPool allocPool(pool_.get());
   StreamLabels labels(allocPool);
   std::vector<std::function<facebook::velox::BufferPtr()>> dictInits{};
   dictInits.push_back(

--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -24,11 +24,19 @@
 using namespace ::testing;
 
 namespace facebook::velox::dwrf {
-TEST(TestWriterContext, GetIntDictionaryEncoder) {
+class WriterContextTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(WriterContextTest, GetIntDictionaryEncoder) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
-      memory::defaultMemoryManager().addRootPool("GetIntDictionaryEncoder")};
+      memory::MemoryManager::getInstance()->addRootPool(
+          "GetIntDictionaryEncoder")};
 
   EXPECT_EQ(0, context.dictEncoders_.size());
   auto& intEncoder_1_0 = context.getIntDictionaryEncoder<int32_t>(
@@ -58,12 +66,12 @@ TEST(TestWriterContext, GetIntDictionaryEncoder) {
   EXPECT_EQ(2, context.dictEncoders_.size());
 }
 
-TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode) {
+TEST_F(WriterContextTest, RemoveIntDictionaryEncoderForNode) {
   auto config = std::make_shared<Config>();
   config->set(Config::MAP_FLAT_DICT_SHARE, false);
   WriterContext context{
       config,
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           "RemoveIntDictionaryEncoderForNode")};
 
   context.getIntDictionaryEncoder<int32_t>(
@@ -111,11 +119,11 @@ TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode) {
   EXPECT_EQ(0, context.dictEncoders_.size());
 }
 
-TEST(TestWriterContext, BuildPhysicalSizeAggregators) {
+TEST_F(WriterContextTest, BuildPhysicalSizeAggregators) {
   auto config = std::make_shared<Config>();
   WriterContext context{
       config,
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           "BuildPhysicalSizeAggregators")};
   auto type = ROW({
       {"array", ARRAY(REAL())},
@@ -143,8 +151,8 @@ TEST(TestWriterContext, BuildPhysicalSizeAggregators) {
   }
 }
 
-TEST(TestWriterContext, memory) {
-  auto writerRoot = memory::defaultMemoryManager().addRootPool(
+TEST_F(WriterContextTest, memory) {
+  auto writerRoot = memory::MemoryManager::getInstance()->addRootPool(
       "memory", 1L << 30, exec::MemoryReclaimer::create());
   WriterContext context{std::make_shared<Config>(), writerRoot};
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);
@@ -213,8 +221,8 @@ TEST(TestWriterContext, memory) {
   ASSERT_EQ(context.availableMemoryReservation(), 786368);
 }
 
-TEST(TestWriterContext, abort) {
-  auto writerRoot = memory::defaultMemoryManager().addRootPool(
+TEST_F(WriterContextTest, abort) {
+  auto writerRoot = memory::MemoryManager::getInstance()->addRootPool(
       "abort", 1L << 30, exec::MemoryReclaimer::create());
   WriterContext context{std::make_shared<Config>(), writerRoot};
   ASSERT_EQ(context.getTotalMemoryUsage(), 0);

--- a/velox/dwio/dwrf/test/WriterExtendedTests.cpp
+++ b/velox/dwio/dwrf/test/WriterExtendedTests.cpp
@@ -114,10 +114,18 @@ void testWriterDefaultFlushPolicy(
       false);
 }
 
-TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
+class E2EWriterTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(E2EWriterTest, FlushPolicySimpleEncoding) {
   const size_t batchCount = 200;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -168,10 +176,11 @@ TEST(E2EWriterTests, FlushPolicySimpleEncoding) {
 
 // Many streams are not yet allocated prior to the first flush, hence first
 // flush is delayed if we rely on stream usage to estimate stripe size.
-TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
+TEST_F(E2EWriterTest, FlushPolicyDictionaryEncoding) {
   const size_t batchCount = 500;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -310,10 +319,11 @@ TEST(E2EWriterTests, FlushPolicyDictionaryEncoding) {
 }
 
 // stream usage seems to have a delta that is close to compression block size?
-TEST(E2EWriterTests, FlushPolicyNestedTypes) {
+TEST_F(E2EWriterTest, FlushPolicyNestedTypes) {
   const size_t batchCount = 10;
   const size_t size = 1000;
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
 
   HiveTypeParser parser;
   auto type = parser.parse(
@@ -371,10 +381,11 @@ TEST(E2EWriterTests, FlushPolicyNestedTypes) {
 }
 
 // Flat map has 1.5 orders of magnitude inflated stream memory usage.
-TEST(E2EWriterTests, FlushPolicyFlatMap) {
+TEST_F(E2EWriterTest, FlushPolicyFlatMap) {
   const size_t batchCount = 10;
   const size_t size = 500;
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
 
   HiveTypeParser parser;
   // A mixture of columns where dictionary sharing is not necessarily

--- a/velox/dwio/dwrf/test/WriterSinkTest.cpp
+++ b/velox/dwio/dwrf/test/WriterSinkTest.cpp
@@ -27,6 +27,10 @@ using namespace facebook::velox::memory;
 
 class WriterSinkTest : public Test {
  protected:
+  static void SetUpTestCase() {
+    MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     for (size_t i = 0; i < data.size(); ++i) {
       data.data()[i] = static_cast<char>(i % 0xff);
@@ -47,7 +51,7 @@ class WriterSinkTest : public Test {
 };
 
 TEST_F(WriterSinkTest, Checksum) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);
@@ -90,7 +94,7 @@ TEST_F(WriterSinkTest, Checksum) {
 }
 
 TEST_F(WriterSinkTest, NoChecksum) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -107,7 +111,7 @@ TEST_F(WriterSinkTest, NoChecksum) {
 }
 
 TEST_F(WriterSinkTest, NoCache) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -132,7 +136,7 @@ TEST_F(WriterSinkTest, NoCache) {
 }
 
 TEST_F(WriterSinkTest, CacheIndex) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -175,7 +179,7 @@ TEST_F(WriterSinkTest, CacheIndex) {
 }
 
 TEST_F(WriterSinkTest, CacheFooter) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -218,7 +222,7 @@ TEST_F(WriterSinkTest, CacheFooter) {
 }
 
 TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -247,7 +251,7 @@ TEST_F(WriterSinkTest, CacheBothEmptyIndex) {
 }
 
 TEST_F(WriterSinkTest, CacheBoth) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -296,7 +300,7 @@ TEST_F(WriterSinkTest, CacheBoth) {
 }
 
 TEST_F(WriterSinkTest, CacheExceedsLimit) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -424,7 +428,7 @@ TEST_F(WriterSinkTest, CacheExceedsLimit) {
 }
 
 TEST_F(WriterSinkTest, CacheLarge) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{10 * 1024 * 1024 + 3, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::NULL_);
@@ -451,7 +455,7 @@ TEST_F(WriterSinkTest, CacheLarge) {
 }
 
 TEST_F(WriterSinkTest, SetModeOutOfOrder) {
-  auto pool = addDefaultLeafMemoryPool();
+  auto pool = MemoryManager::getInstance()->addLeafPool();
   MemorySink out{1024, {.pool = pool.get()}};
   Config config;
   config.set(Config::CHECKSUM_ALGORITHM, proto::ChecksumAlgorithm::CRC32);

--- a/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
+++ b/velox/dwio/dwrf/test/utils/E2EWriterTestUtil.cpp
@@ -48,7 +48,7 @@ namespace facebook::velox::dwrf {
   return std::make_unique<dwrf::Writer>(
       std::move(sink),
       options,
-      velox::memory::defaultMemoryManager().addRootPool());
+      velox::memory::MemoryManager::getInstance()->addRootPool());
 }
 
 /* static */ std::unique_ptr<Writer> E2EWriterTestUtil::writeData(

--- a/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
+++ b/velox/dwio/dwrf/utils/test/BufferedWriterTest.cpp
@@ -30,10 +30,14 @@ class BufferedWriterTest : public testing::TestWithParam<bool> {
  protected:
   BufferedWriterTest()
       : usePool_(GetParam()),
-        pool_(memory::addDefaultLeafMemoryPool("BufferedWriterTest")) {}
+        pool_(memory::MemoryManager::getInstance()->addLeafPool(
+            "BufferedWriterTest")) {}
 
   void SetUp() override {}
-  static void SetUpTestCase() {}
+
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
 
   // Indicates test with buffered writer interface which takes memory pool or
   // not.

--- a/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
+++ b/velox/dwio/dwrf/writer/IntegerDictionaryEncoder.h
@@ -277,7 +277,7 @@ class IntegerDictionaryEncoder : public AbstractIntegerDictionaryEncoder {
  private:
   VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, Clear);
   VELOX_FRIEND_TEST(TestIntegerDictionaryEncoder, GetCount);
-  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(WriterContextTest, GetIntDictionaryEncoder);
 
   // TODO: partially specialize for integers only.
   template <typename T>

--- a/velox/dwio/dwrf/writer/WriterContext.h
+++ b/velox/dwio/dwrf/writer/WriterContext.h
@@ -659,8 +659,8 @@ class WriterContext : public CompressionBufferPool {
   template <typename TestType>
   friend class WriterEncodingIndexTest2;
 
-  VELOX_FRIEND_TEST(TestWriterContext, GetIntDictionaryEncoder);
-  VELOX_FRIEND_TEST(TestWriterContext, RemoveIntDictionaryEncoderForNode);
+  VELOX_FRIEND_TEST(WriterContextTest, GetIntDictionaryEncoder);
+  VELOX_FRIEND_TEST(WriterContextTest, RemoveIntDictionaryEncoderForNode);
 };
 
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/parquet/tests/ParquetTestBase.h
+++ b/velox/dwio/parquet/tests/ParquetTestBase.h
@@ -33,9 +33,14 @@ namespace facebook::velox::parquet {
 
 class ParquetTestBase : public testing::Test, public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     dwio::common::LocalFileSink::registerFactory();
-    rootPool_ = memory::defaultMemoryManager().addRootPool("ParquetTests");
+    rootPool_ =
+        memory::MemoryManager::getInstance()->addRootPool("ParquetTests");
     leafPool_ = rootPool_->addLeafChild("ParquetTests");
     tempPath_ = exec::test::TempDirectoryPath::create();
   }

--- a/velox/dwio/parquet/tests/ParquetTpchTest.cpp
+++ b/velox/dwio/parquet/tests/ParquetTpchTest.cpp
@@ -37,6 +37,10 @@ using namespace facebook::velox::exec::test;
 
 class ParquetTpchTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     duckDb_ = std::make_shared<DuckDbQueryRunner>();
     tempDirectory_ = TempDirectoryPath::create();
@@ -77,7 +81,7 @@ class ParquetTpchTest : public testing::Test {
 
   void saveTpchTablesAsParquet() {
     std::shared_ptr<memory::MemoryPool> rootPool{
-        memory::defaultMemoryManager().addRootPool()};
+        memory::MemoryManager::getInstance()->addRootPool()};
     std::shared_ptr<memory::MemoryPool> pool{rootPool->addLeafChild("leaf")};
 
     for (const auto& table : tpch::tables) {

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderBenchmark.cpp
@@ -30,7 +30,7 @@ class NestedStructureDecoderBenchmark {
       : numValues_(numValues),
         definitionLevels_(new unsigned char[numValues]()),
         repetitionLevels_(new unsigned char[numValues]()),
-        pool_(memory::addDefaultLeafMemoryPool()) {}
+        pool_(memory::MemoryManager::getInstance()->addLeafPool()) {}
 
   void setUp(uint16_t maxDefinition, uint16_t maxRepetition) {
     dwio::common::ensureCapacity<uint64_t>(
@@ -91,6 +91,7 @@ BENCHMARK(randomDefs) {
 }
 
 int main(int /*argc*/, char** /*argv*/) {
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/NestedStructureDecoderTest.cpp
@@ -28,9 +28,12 @@ class NestedStructureDecoderTest : public testing::Test {
  protected:
   static constexpr int32_t kMaxNumValues = 10'000;
 
- protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
 
     dwio::common::ensureCapacity<bool>(
         nullsBuffer_, kMaxNumValues, pool_.get());

--- a/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetPageReaderTest.cpp
@@ -24,20 +24,16 @@ using namespace facebook::velox::parquet;
 
 class ParquetPageReaderTest : public ParquetTestBase {};
 
-namespace {
-auto defaultPool = memory::addDefaultLeafMemoryPool();
-}
-
 TEST_F(ParquetPageReaderTest, smallPage) {
   auto readFile =
       std::make_shared<LocalReadFile>(getExampleFilePath("small_page_header"));
   auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
   auto headerSize = file->getLength();
   auto inputStream = std::make_unique<SeekableFileInputStream>(
-      std::move(file), 0, headerSize, *defaultPool, LogType::TEST);
+      std::move(file), 0, headerSize, *leafPool_, LogType::TEST);
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
-      *defaultPool,
+      *leafPool_,
       thrift::CompressionCodec::type::GZIP,
       headerSize);
   auto header = pageReader->readPageHeader();
@@ -62,10 +58,10 @@ TEST_F(ParquetPageReaderTest, largePage) {
   auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
   auto headerSize = file->getLength();
   auto inputStream = std::make_unique<SeekableFileInputStream>(
-      std::move(file), 0, headerSize, *defaultPool, LogType::TEST);
+      std::move(file), 0, headerSize, *leafPool_, LogType::TEST);
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
-      *defaultPool,
+      *leafPool_,
       thrift::CompressionCodec::type::GZIP,
       headerSize);
   auto header = pageReader->readPageHeader();
@@ -91,14 +87,14 @@ TEST_F(ParquetPageReaderTest, corruptedPageHeader) {
   auto file = std::make_shared<ReadFileInputStream>(std::move(readFile));
   auto headerSize = file->getLength();
   auto inputStream = std::make_unique<SeekableFileInputStream>(
-      std::move(file), 0, headerSize, *defaultPool, LogType::TEST);
+      std::move(file), 0, headerSize, *leafPool_, LogType::TEST);
 
   // In the corrupted_page_header, the min_value length is set incorrectly on
   // purpose. This is to simulate the situation where the Parquet Page Header is
   // corrupted. And an error is expected to be thrown.
   auto pageReader = std::make_unique<PageReader>(
       std::move(inputStream),
-      *defaultPool,
+      *leafPool_,
       thrift::CompressionCodec::type::GZIP,
       headerSize);
 

--- a/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderBenchmark.cpp
@@ -41,8 +41,8 @@ class ParquetReaderBenchmark {
  public:
   explicit ParquetReaderBenchmark(bool disableDictionary)
       : disableDictionary_(disableDictionary) {
-    rootPool_ =
-        memory::defaultMemoryManager().addRootPool("ParquetReaderBenchmark");
+    rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
+        "ParquetReaderBenchmark");
     leafPool_ = rootPool_->addLeafChild("ParquetReaderBenchmark");
     dataSetBuilder_ = std::make_unique<DataSetBuilder>(*leafPool_, 0);
     auto path = fileFolder_->path + "/" + fileName_;
@@ -403,6 +403,7 @@ PARQUET_BENCHMARKS_NO_FILTER(ARRAY(BIGINT()), List);
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetReaderTest.cpp
@@ -22,10 +22,6 @@ using namespace facebook::velox::common;
 using namespace facebook::velox::dwio::common;
 using namespace facebook::velox::parquet;
 
-namespace {
-auto defaultPool = memory::addDefaultLeafMemoryPool();
-}
-
 class ParquetReaderTest : public ParquetTestBase {
  public:
   std::unique_ptr<dwio::common::RowReader> createRowReader(
@@ -33,8 +29,7 @@ class ParquetReaderTest : public ParquetTestBase {
       const RowTypePtr& rowType) {
     const std::string sample(getExampleFilePath(fileName));
 
-    facebook::velox::dwio::common::ReaderOptions readerOptions{
-        defaultPool.get()};
+    facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
     auto reader = createReader(sample, readerOptions);
 
     RowReaderOptions rowReaderOpts;
@@ -60,7 +55,7 @@ class ParquetReaderTest : public ParquetTestBase {
       FilterMap filters,
       const RowVectorPtr& expected) {
     const auto filePath(getExampleFilePath(fileName));
-    facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+    facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
     auto reader = createReader(filePath, readerOpts);
     assertReadWithReaderAndFilters(
         std::move(reader), fileName, fileSchema, std::move(filters), expected);
@@ -75,7 +70,7 @@ TEST_F(ParquetReaderTest, parseSample) {
   //   b: [1.0..20.0]
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 20ULL);
 
@@ -104,7 +99,7 @@ TEST_F(ParquetReaderTest, parseSample) {
 TEST_F(ParquetReaderTest, parseSampleRange1) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -123,7 +118,7 @@ TEST_F(ParquetReaderTest, parseSampleRange1) {
 TEST_F(ParquetReaderTest, parseSampleRange2) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -142,7 +137,7 @@ TEST_F(ParquetReaderTest, parseSampleRange2) {
 TEST_F(ParquetReaderTest, parseSampleEmptyRange) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto reader = createReader(sample, readerOpts);
 
   auto rowReaderOpts = getReaderOpts(sampleSchema());
@@ -160,7 +155,7 @@ TEST_F(ParquetReaderTest, parseReadAsLowerCase) {
   // 2 rows.
   const std::string upper(getExampleFilePath("upper.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 2ULL);
@@ -194,7 +189,7 @@ TEST_F(ParquetReaderTest, parseRowMapArrayReadAsLowerCase) {
   // +-----------------------+
   const std::string upper(getExampleFilePath("upper_complex.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   readerOptions.setFileColumnNamesReadAsLowerCase(true);
   auto reader = createReader(upper, readerOptions);
 
@@ -237,7 +232,7 @@ TEST_F(ParquetReaderTest, parseEmpty) {
   // 0 rows.
   const std::string empty(getExampleFilePath("empty.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(empty, readerOptions);
   EXPECT_EQ(reader->numberOfRows(), 0ULL);
 
@@ -259,7 +254,7 @@ TEST_F(ParquetReaderTest, parseInt) {
   //   bigint: [1000 .. 1009]
   const std::string sample(getExampleFilePath("int.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto reader = createReader(sample, readerOpts);
 
   EXPECT_EQ(reader->numberOfRows(), 10ULL);
@@ -294,7 +289,7 @@ TEST_F(ParquetReaderTest, parseUnsignedInt1) {
   //   uint64: [18446744073709551615, 2000000000000000000, 3000000000000000000]
   const std::string sample(getExampleFilePath("uint.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 3ULL);
@@ -398,7 +393,7 @@ TEST_F(ParquetReaderTest, parseDate) {
   //   date: [1969-12-27 .. 1970-01-20]
   const std::string sample(getExampleFilePath("date.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 25ULL);
@@ -425,7 +420,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
   // ARRAY(INTEGER)) c1) c)
   const std::string sample(getExampleFilePath("row_map_array.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 1ULL);
@@ -458,7 +453,7 @@ TEST_F(ParquetReaderTest, parseRowMapArray) {
 TEST_F(ParquetReaderTest, projectNoColumns) {
   // This is the case for count(*).
   auto rowType = ROW({}, {});
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   auto reader = createReader(getExampleFilePath("sample.parquet"), readerOpts);
   RowReaderOptions rowReaderOpts;
   rowReaderOpts.setScanSpec(makeScanSpec(rowType));
@@ -482,7 +477,7 @@ TEST_F(ParquetReaderTest, parseIntDecimal) {
   //   a: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   //   b: [11.11, 11.11, 22.22, 22.22, 33.33, 33.33]
   auto rowType = ROW({"a", "b"}, {DECIMAL(7, 2), DECIMAL(14, 2)});
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   const std::string decimal_dict(getExampleFilePath("decimal_dict.parquet"));
 
   auto reader = createReader(decimal_dict, readerOpts);
@@ -723,7 +718,7 @@ TEST_F(ParquetReaderTest, filterRowGroups) {
   // decimal_no_ColumnMetadata.parquet has one columns a: DECIMAL(9,1). It
   // doesn't have ColumnMetaData, and rowGroups_[0].columns[0].file_offset is 0.
   auto rowType = ROW({"_c0"}, {DECIMAL(9, 1)});
-  facebook::velox::dwio::common::ReaderOptions readerOpts{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOpts{leafPool_.get()};
   const std::string decimal_dict(
       getExampleFilePath("decimal_no_ColumnMetadata.parquet"));
 
@@ -739,7 +734,7 @@ TEST_F(ParquetReaderTest, parseLongTagged) {
   // This is a case for long with annonation read
   const std::string sample(getExampleFilePath("tagged_long.parquet"));
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader = createReader(sample, readerOptions);
 
   EXPECT_EQ(reader->numberOfRows(), 4ULL);
@@ -755,9 +750,9 @@ TEST_F(ParquetReaderTest, preloadSmallFile) {
   const std::string sample(getExampleFilePath("sample.parquet"));
 
   auto file = std::make_shared<LocalReadFile>(sample);
-  auto input = std::make_unique<BufferedInput>(file, *defaultPool);
+  auto input = std::make_unique<BufferedInput>(file, *leafPool_);
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   auto reader =
       std::make_unique<ParquetReader>(std::move(input), readerOptions);
 
@@ -793,7 +788,7 @@ TEST_F(ParquetReaderTest, prefetchRowGroups) {
   const std::string sample(getExampleFilePath("multiple_row_groups.parquet"));
   const int numRowGroups = 4;
 
-  facebook::velox::dwio::common::ReaderOptions readerOptions{defaultPool.get()};
+  facebook::velox::dwio::common::ReaderOptions readerOptions{leafPool_.get()};
   // Disable preload of file.
   readerOptions.setFilePreloadThreshold(0);
 

--- a/velox/examples/ExpressionEval.cpp
+++ b/velox/examples/ExpressionEval.cpp
@@ -50,6 +50,8 @@ int main(int argc, char** argv) {
   // registered.
   registerFunction<TimesTwoFunction, int64_t, int64_t>({"times_two"});
 
+  memory::MemoryManager::initialize({});
+
   // First of all, executing an expression in Velox will require us to create a
   // query context, a memory pool, and an execution context.
   //
@@ -64,8 +66,8 @@ int main(int argc, char** argv) {
   // pointer to this pool can be obtained using execCtx.pool().
   //
   // Optionally, one can control the per-thread memory cap by passing it as an
-  // argument to addDefaultLeafMemoryPool() - no limit by default.
-  auto pool = memory::addDefaultLeafMemoryPool();
+  // argument to add() - no limit by default.
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, let's create an expression tree to be executed in this example. On a

--- a/velox/examples/OpaqueType.cpp
+++ b/velox/examples/OpaqueType.cpp
@@ -187,9 +187,10 @@ int main(int argc, char** argv) {
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_map_resolver_vector, "map_resolver_vector");
 
+  memory::MemoryManager::initialize({});
   // Create memory pool and other query-related structures.
   auto queryCtx = std::make_shared<core::QueryCtx>();
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   // Next, we need to generate an input batch of data (rowVector). We create a

--- a/velox/examples/OperatorExtensibility.cpp
+++ b/velox/examples/OperatorExtensibility.cpp
@@ -170,7 +170,8 @@ int main(int argc, char** argv) {
   // assert that the output results contain the dataset properly duplicated.
 
   // Create a new memory pool to in this example.
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   // VectorMaker is a test utility that helps you build vectors. Shouldn't be
   // used in production.

--- a/velox/examples/ScanAndSort.cpp
+++ b/velox/examples/ScanAndSort.cpp
@@ -45,7 +45,8 @@ int main(int argc, char** argv) {
   folly::init(&argc, &argv);
 
   // Default memory allocator used throughout this example.
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   // For this example, the input dataset will be comprised of a single BIGINT
   // column ("my_col"), containing 10 rows.

--- a/velox/examples/ScanOrc.cpp
+++ b/velox/examples/ScanOrc.cpp
@@ -41,7 +41,9 @@ int main(int argc, char** argv) {
   // filesystem. We also need to register the dwrf reader factory:
   filesystems::registerLocalFileSystem();
   dwrf::registerDwrfReaderFactory();
-  auto pool = facebook::velox::memory::addDefaultLeafMemoryPool();
+  facebook::velox::memory::MemoryManager::initialize({});
+  auto pool =
+      facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
 
   std::string filePath{argv[1]};
   dwio::common::ReaderOptions readerOpts{pool.get()};

--- a/velox/examples/VectorReaderWriter.cpp
+++ b/velox/examples/VectorReaderWriter.cpp
@@ -38,6 +38,7 @@ auto serial() {
 
 int main() {
   const int num_rows = 8;
+  memory::MemoryManager::initialize({});
 
   /****************** Vector Writer **********************/
 
@@ -46,7 +47,7 @@ int main() {
   // Array<Map<int,int>>
   auto type = TypeFactory<TypeKind::ARRAY>::create(
       TypeFactory<TypeKind::MAP>::create(BIGINT(), BIGINT()));
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   // result vector
   VectorPtr result;

--- a/velox/exec/benchmarks/ExchangeBenchmark.cpp
+++ b/velox/exec/benchmarks/ExchangeBenchmark.cpp
@@ -292,7 +292,7 @@ class ExchangeBenchmark : public VectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
     return Task::create(
@@ -386,6 +386,7 @@ BENCHMARK(localFlat10k) {
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();
   parse::registerTypeResolver();

--- a/velox/exec/benchmarks/HashTableBenchmark.cpp
+++ b/velox/exec/benchmarks/HashTableBenchmark.cpp
@@ -560,7 +560,8 @@ class HashTableBenchmark : public VectorTestBase {
         << std::endl;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   std::unique_ptr<VectorMaker> vectorMaker_{
       std::make_unique<VectorMaker>(pool_.get())};
   // Bitmap of positions in batches_ that end up in the table.
@@ -619,7 +620,7 @@ int main(int argc, char** argv) {
 
   auto allocator = std::make_shared<memory::MmapAllocator>(options);
   memory::MemoryAllocator::setDefaultInstance(allocator.get());
-  memory::MemoryManager::getInstance(memory::MemoryManagerOptions{
+  memory::MemoryManager::initialize(memory::MemoryManagerOptions{
       .capacity = static_cast<int64_t>(options.capacity),
       .allocator = allocator.get()});
 

--- a/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
+++ b/velox/exec/benchmarks/RowContainerSortBenchmark.cpp
@@ -63,7 +63,7 @@ facebook::velox::parquet::ParquetReader createReader(
 std::vector<std::optional<StringView>> getDataFromFile() {
   const std::string sample(getExampleFilePath("str_sort.parquet"));
   auto rowType = ROW({"query_sig", "result_sig"}, {VARCHAR(), VARCHAR()});
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   facebook::velox::dwio::common::ReaderOptions readerOptions{pool.get()};
   facebook::velox::parquet::ParquetReader reader =
       createReader(sample, readerOptions);
@@ -101,7 +101,7 @@ std::vector<char*> store(
 template <typename T>
 void rowContainerStdSortBenchmark(uint32_t iterations, size_t cardinality) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {
@@ -131,7 +131,7 @@ void rowContainerStdSortBenchmark(uint32_t iterations, size_t cardinality) {
 template <typename T>
 void rowContainerTimSortBenchmark(uint32_t iterations, size_t cardinality) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {
@@ -166,7 +166,7 @@ void BM_Int64_timSort(uint32_t iterations, size_t cardinality) {
 
 void BM_STR_stdSort(uint32_t iterations) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
   auto data = getDataFromFile();
   auto vector =
@@ -191,7 +191,7 @@ void BM_STR_stdSort(uint32_t iterations) {
 
 void BM_STR_timSort(uint32_t iterations) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
   auto data = getDataFromFile();
   auto vector =
@@ -234,6 +234,7 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/exec/benchmarks/VectorHasherBenchmark.cpp
+++ b/velox/exec/benchmarks/VectorHasherBenchmark.cpp
@@ -57,7 +57,8 @@ class BenchmarkBase {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 
@@ -240,6 +241,7 @@ BENCHMARK(computeValueIdsLowCardinalityNotAllUsed) {
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/exec/fuzzer/AggregationFuzzerBase.h
+++ b/velox/exec/fuzzer/AggregationFuzzerBase.h
@@ -232,7 +232,7 @@ class AggregationFuzzerBase {
   size_t currentSeed_{0};
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::defaultMemoryManager().addRootPool()};
+      memory::MemoryManager::getInstance()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   VectorFuzzer vectorFuzzer_;
 };

--- a/velox/exec/fuzzer/PrestoQueryRunner.h
+++ b/velox/exec/fuzzer/PrestoQueryRunner.h
@@ -88,7 +88,7 @@ class PrestoQueryRunner : public velox::exec::test::ReferenceQueryRunner {
   const std::chrono::milliseconds timeout_;
   folly::EventBaseThread eventBaseThread_{false};
   std::shared_ptr<velox::memory::MemoryPool> rootPool_{
-      velox::memory::defaultMemoryManager().addRootPool()};
+      velox::memory::MemoryManager::getInstance()->addRootPool()};
   std::shared_ptr<velox::memory::MemoryPool> pool_{
       rootPool_->addLeafChild("leaf")};
 };

--- a/velox/exec/prefixsort/benchmarks/PrefixSortAlgorithmBenchmark.cpp
+++ b/velox/exec/prefixsort/benchmarks/PrefixSortAlgorithmBenchmark.cpp
@@ -53,7 +53,8 @@ class PrefixSortAlgorithmBenchmark {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   folly::Random::DefaultGenerator rng_;
 };
 
@@ -84,6 +85,7 @@ BENCHMARK(PrefixSort_algorithm_10000k) {
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
+  memory::MemoryManager::initialize({});
   bm.seed(FLAGS_sort_data_seed);
   data10k = bm.generateTestVector(10'000);
   data100k = bm.generateTestVector(100'000);

--- a/velox/exec/prefixsort/tests/PrefixSortAlgorithmTest.cpp
+++ b/velox/exec/prefixsort/tests/PrefixSortAlgorithmTest.cpp
@@ -53,6 +53,11 @@ class PrefixSortAlgorithmTest : public testing::Test,
     testingDecodeInPlace(data1);
     ASSERT_EQ(data1, data2);
   }
+
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
 };
 
 TEST_F(PrefixSortAlgorithmTest, quickSort) {

--- a/velox/exec/tests/AddressableNonNullValueListTest.cpp
+++ b/velox/exec/tests/AddressableNonNullValueListTest.cpp
@@ -24,6 +24,10 @@ namespace {
 class AddressableNonNullValueListTest : public testing::Test,
                                         public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void test(const VectorPtr& data, const VectorPtr& uniqueData) {
     using T = HashStringAllocator::Position;
     using Set = folly::F14FastSet<

--- a/velox/exec/tests/AggregationFuzzerTest.cpp
+++ b/velox/exec/tests/AggregationFuzzerTest.cpp
@@ -71,6 +71,7 @@ int main(int argc, char** argv) {
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
   facebook::velox::window::prestosql::registerAllWindowFunctions();
   facebook::velox::functions::prestosql::registerInternalFunctions();
+  facebook::velox::memory::MemoryManager::initialize({});
 
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/velox/exec/tests/AggregationRunnerTest.cpp
+++ b/velox/exec/tests/AggregationRunnerTest.cpp
@@ -74,6 +74,7 @@ int main(int argc, char** argv) {
 
   facebook::velox::aggregate::prestosql::registerAllAggregateFunctions();
   facebook::velox::functions::prestosql::registerAllScalarFunctions();
+  facebook::velox::memory::MemoryManager::initialize({});
 
   auto duckQueryRunner =
       std::make_unique<facebook::velox::exec::test::DuckQueryRunner>();

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -2028,7 +2028,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringInputProcessing) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2171,7 +2171,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringReserve) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(PlanBuilder()
@@ -2281,7 +2281,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringAllocation) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2407,7 +2407,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringOutputProcessing) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2551,7 +2551,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimDuringNonReclaimableSection) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2704,7 +2704,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimWithEmptyAggregationTable) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2839,7 +2839,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringOutputProcessing) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -2928,7 +2928,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, abortDuringInputgProcessing) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -3114,7 +3114,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyInput) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
   auto task =
@@ -3185,7 +3185,7 @@ DEBUG_ONLY_TEST_F(AggregationTest, reclaimEmptyOutput) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   core::PlanNodeId aggNodeId;
   auto task =

--- a/velox/exec/tests/ContainerRowSerdeTest.cpp
+++ b/velox/exec/tests/ContainerRowSerdeTest.cpp
@@ -26,6 +26,10 @@ namespace {
 class ContainerRowSerdeTest : public testing::Test,
                               public velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   // Writes all rows together and returns a position at the start of this
   // combined write.
   HashStringAllocator::Position serialize(const VectorPtr& data) {

--- a/velox/exec/tests/ExchangeClientTest.cpp
+++ b/velox/exec/tests/ExchangeClientTest.cpp
@@ -30,6 +30,10 @@ namespace {
 class ExchangeClientTest : public testing::Test,
                            public velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     exec::ExchangeSource::factories().clear();
     exec::ExchangeSource::registerFactory(test::createLocalExchangeSource);
@@ -57,7 +61,7 @@ class ExchangeClientTest : public testing::Test,
       const core::PlanNodePtr& planNode) {
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(queryCtx->queryId()));
+        memory::MemoryManager::getInstance()->addRootPool(queryCtx->queryId()));
     return Task::create(
         taskId, core::PlanFragment{planNode}, 0, std::move(queryCtx));
   }

--- a/velox/exec/tests/ExchangeFuzzer.cpp
+++ b/velox/exec/tests/ExchangeFuzzer.cpp
@@ -260,7 +260,7 @@ class ExchangeFuzzer : public VectorTestBase {
       LOG(INFO) << "Memory after run="
                 << succinctBytes(memory::AllocationTraits::pageBytes(
                        memory::MemoryManager::getInstance()
-                           .allocator()
+                           ->allocator()
                            .numAllocated()));
 
       if (FLAGS_duration_sec == 0 && FLAGS_steps &&
@@ -371,7 +371,7 @@ class ExchangeFuzzer : public VectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), maxMemory));
     core::PlanFragment planFragment{planNode};
     return Task::create(
@@ -414,7 +414,7 @@ int main(int argc, char** argv) {
 
   auto allocator = std::make_shared<memory::MmapAllocator>(options);
   memory::MemoryAllocator::setDefaultInstance(allocator.get());
-  memory::MemoryManager::getInstance(memory::MemoryManagerOptions{
+  memory::MemoryManager::initialize(memory::MemoryManagerOptions{
       .capacity = static_cast<int64_t>(options.capacity),
       .allocator = allocator.get()});
 

--- a/velox/exec/tests/HashBitRangeTest.cpp
+++ b/velox/exec/tests/HashBitRangeTest.cpp
@@ -20,7 +20,12 @@
 using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
-class HashRangeBitTest : public test::VectorTestBase, public testing::Test {};
+class HashRangeBitTest : public test::VectorTestBase, public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(HashRangeBitTest, hashBitRange) {
   HashBitRange bitRange(29, 31);

--- a/velox/exec/tests/HashJoinBridgeTest.cpp
+++ b/velox/exec/tests/HashJoinBridgeTest.cpp
@@ -39,6 +39,7 @@ class HashJoinBridgeTest : public testing::Test,
 
  protected:
   static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
     filesystems::registerLocalFileSystem();
   }
 
@@ -132,7 +133,8 @@ class HashJoinBridgeTest : public testing::Test,
   const uint32_t maxNumPartitions_{8};
   const uint32_t numSpillFilesPerPartition_{20};
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   memory::MemoryAllocator* allocator_{memory::MemoryAllocator::getInstance()};
   std::shared_ptr<TempDirectoryPath> tempDir_;
 
@@ -481,9 +483,9 @@ TEST_P(HashJoinBridgeTest, multiThreading) {
   }
 }
 
-TEST(HashJoinBridgeTest, isHashBuildMemoryPool) {
-  auto root =
-      memory::defaultMemoryManager().addRootPool("isHashBuildMemoryPool");
+TEST_P(HashJoinBridgeTest, isHashBuildMemoryPool) {
+  auto root = memory::MemoryManager::getInstance()->addRootPool(
+      "isHashBuildMemoryPool");
   struct {
     std::string poolName;
     bool expectedHashBuildPool;

--- a/velox/exec/tests/HashJoinTest.cpp
+++ b/velox/exec/tests/HashJoinTest.cpp
@@ -4947,7 +4947,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringInputProcessing) {
     SCOPED_TRACE(testData.debugString());
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::defaultMemoryManager().addRootPool(
+    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5094,7 +5094,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringReserve) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::defaultMemoryManager().addRootPool(
+  auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
       "", kMaxBytes, memory::MemoryReclaimer::create());
 
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5224,7 +5224,8 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringAllocation) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
 
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::defaultMemoryManager().addRootPool("", kMaxBytes);
+    auto queryPool =
+        memory::MemoryManager::getInstance()->addRootPool("", kMaxBytes);
 
     core::PlanNodeId probeScanId;
     auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -5355,7 +5356,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringOutputProcessing) {
   for (const auto enableSpilling : enableSpillings) {
     SCOPED_TRACE(fmt::format("enableSpilling {}", enableSpilling));
     auto tempDirectory = exec::test::TempDirectoryPath::create();
-    auto queryPool = memory::defaultMemoryManager().addRootPool(
+    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5481,7 +5482,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, reclaimDuringWaitForProbe) {
   createDuckDbTable("u", buildVectors);
 
   auto tempDirectory = exec::test::TempDirectoryPath::create();
-  auto queryPool = memory::defaultMemoryManager().addRootPool(
+  auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
       "", kMaxBytes, memory::MemoryReclaimer::create());
 
   core::PlanNodeId probeScanId;
@@ -5630,7 +5631,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringOutputProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::defaultMemoryManager().addRootPool(
+    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5735,7 +5736,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashBuildAbortDuringInputgProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::defaultMemoryManager().addRootPool(
+    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;
@@ -5841,7 +5842,7 @@ DEBUG_ONLY_TEST_F(HashJoinTest, hashProbeAbortDuringInputProcessing) {
 
   for (const auto& testData : testSettings) {
     SCOPED_TRACE(testData.debugString());
-    auto queryPool = memory::defaultMemoryManager().addRootPool(
+    auto queryPool = memory::MemoryManager::getInstance()->addRootPool(
         "", kMaxBytes, memory::MemoryReclaimer::create());
 
     core::PlanNodeId probeScanId;

--- a/velox/exec/tests/HashPartitionFunctionTest.cpp
+++ b/velox/exec/tests/HashPartitionFunctionTest.cpp
@@ -21,7 +21,12 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
 class HashPartitionFunctionTest : public test::VectorTestBase,
-                                  public testing::Test {};
+                                  public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(HashPartitionFunctionTest, function) {
   const int numRows = 10'000;

--- a/velox/exec/tests/HashTableTest.cpp
+++ b/velox/exec/tests/HashTableTest.cpp
@@ -89,6 +89,10 @@ class HashTableTestHelper {
 class HashTableTest : public testing::TestWithParam<bool>,
                       public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     common::testutil::TestValue::enable();
     if (GetParam()) {

--- a/velox/exec/tests/JoinFuzzer.cpp
+++ b/velox/exec/tests/JoinFuzzer.cpp
@@ -132,7 +132,7 @@ class JoinFuzzer {
   size_t currentSeed_{0};
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::defaultMemoryManager().addRootPool()};
+      memory::MemoryManager::getInstance()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   VectorFuzzer vectorFuzzer_;
 };

--- a/velox/exec/tests/JoinFuzzerRunner.h
+++ b/velox/exec/tests/JoinFuzzerRunner.h
@@ -56,6 +56,7 @@
 class JoinFuzzerRunner {
  public:
   static int run(size_t seed) {
+    facebook::velox::memory::MemoryManager::initialize({});
     facebook::velox::serializer::presto::PrestoVectorSerde::
         registerVectorSerde();
     facebook::velox::filesystems::registerLocalFileSystem();

--- a/velox/exec/tests/MemoryReclaimerTest.cpp
+++ b/velox/exec/tests/MemoryReclaimerTest.cpp
@@ -26,7 +26,8 @@ using namespace facebook::velox::memory;
 
 class MemoryReclaimerTest : public OperatorTestBase {
  protected:
-  MemoryReclaimerTest() : pool_(memory::addDefaultLeafMemoryPool()) {
+  MemoryReclaimerTest()
+      : pool_(memory::MemoryManager::getInstance()->addLeafPool()) {
     const auto seed =
         std::chrono::system_clock::now().time_since_epoch().count();
     rng_.seed(seed);
@@ -86,7 +87,7 @@ TEST_F(MemoryReclaimerTest, abortTest) {
   for (const auto& leafPool : {false, true}) {
     const std::string testName = fmt::format("leafPool: {}", leafPool);
     SCOPED_TRACE(testName);
-    auto rootPool = defaultMemoryManager().addRootPool(
+    auto rootPool = memory::MemoryManager::getInstance()->addRootPool(
         testName, kMaxMemory, exec::MemoryReclaimer::create());
     ASSERT_FALSE(rootPool->aborted());
     if (leafPool) {

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -69,7 +69,7 @@ class MultiFragmentTest : public HiveConnectorTestBase {
     auto queryCtx = std::make_shared<core::QueryCtx>(
         executor_.get(), core::QueryConfig(std::move(configCopy)));
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), maxMemory, MemoryReclaimer::create()));
     core::PlanFragment planFragment{planNode};
     return Task::create(

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -124,7 +124,8 @@ class OperatorUtilsTest
     }
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   std::shared_ptr<Task> task_;
   std::shared_ptr<Driver> driver_;
   std::unique_ptr<DriverCtx> driverCtx_;

--- a/velox/exec/tests/OrderByTest.cpp
+++ b/velox/exec/tests/OrderByTest.cpp
@@ -551,7 +551,7 @@ TEST_F(OrderByTest, spillWithMemoryLimit) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes));
     auto results =
         AssertQueryBuilder(
@@ -616,7 +616,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringInputProcessing) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -756,7 +756,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringReserve) {
   auto tempDirectory = exec::test::TempDirectoryPath::create();
   auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
   queryCtx->testingOverrideMemoryPool(
-      memory::defaultMemoryManager().addRootPool(
+      memory::MemoryManager::getInstance()->addRootPool(
           queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
   auto expectedResult =
       AssertQueryBuilder(
@@ -870,7 +870,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringAllocation) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes));
     auto expectedResult =
         AssertQueryBuilder(
@@ -1001,7 +1001,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, reclaimDuringOutputProcessing) {
     auto tempDirectory = exec::test::TempDirectoryPath::create();
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -1132,7 +1132,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringOutputProcessing) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(
@@ -1226,7 +1226,7 @@ DEBUG_ONLY_TEST_F(OrderByTest, abortDuringInputgProcessing) {
     SCOPED_TRACE(testData.debugString());
     auto queryCtx = std::make_shared<core::QueryCtx>(executor_.get());
     queryCtx->testingOverrideMemoryPool(
-        memory::defaultMemoryManager().addRootPool(
+        memory::MemoryManager::getInstance()->addRootPool(
             queryCtx->queryId(), kMaxBytes, memory::MemoryReclaimer::create()));
     auto expectedResult =
         AssertQueryBuilder(

--- a/velox/exec/tests/OutputBufferManagerTest.cpp
+++ b/velox/exec/tests/OutputBufferManagerTest.cpp
@@ -36,8 +36,13 @@ class OutputBufferManagerTest : public testing::Test {
     rowType_ = ROW(std::move(names), std::move(types));
   }
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = facebook::velox::memory::addDefaultLeafMemoryPool();
+    pool_ =
+        facebook::velox::memory::MemoryManager::getInstance()->addLeafPool();
     bufferManager_ = OutputBufferManager::getInstance().lock();
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::

--- a/velox/exec/tests/PlanBuilderTest.cpp
+++ b/velox/exec/tests/PlanBuilderTest.cpp
@@ -26,6 +26,10 @@ namespace facebook::velox::exec::test {
 class PlanBuilderTest : public testing::Test,
                         public velox::test::VectorTestBase {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   PlanBuilderTest() {
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();

--- a/velox/exec/tests/PlanNodeSerdeTest.cpp
+++ b/velox/exec/tests/PlanNodeSerdeTest.cpp
@@ -28,6 +28,10 @@ namespace facebook::velox::exec::test {
 class PlanNodeSerdeTest : public testing::Test,
                           public velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   PlanNodeSerdeTest() {
     functions::prestosql::registerAllScalarFunctions();
     aggregate::prestosql::registerAllAggregateFunctions();

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -49,6 +49,11 @@ class PlanNodeToStringTest : public testing::Test, public test::VectorTestBase {
                 .planNode();
   }
 
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   RowVectorPtr data_;
   core::PlanNodePtr plan_;
 };

--- a/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
+++ b/velox/exec/tests/RoundRobinPartitionFunctionTest.cpp
@@ -22,12 +22,17 @@ using namespace facebook::velox;
 using namespace facebook::velox::exec;
 
 class RoundRobinPartitionFunctionTest : public test::VectorTestBase,
-                                        public testing::Test {};
+                                        public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(RoundRobinPartitionFunctionTest, basic) {
   exec::RoundRobinPartitionFunction partitionFunction(10);
 
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   test::VectorMaker vm(pool.get());
 
   auto data = vm.rowVector(ROW({}, {}), 1024);

--- a/velox/exec/tests/RowContainerTest.cpp
+++ b/velox/exec/tests/RowContainerTest.cpp
@@ -26,6 +26,10 @@ using namespace facebook::velox::test;
 
 class RowContainerTest : public exec::test::RowContainerTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void testExtractColumn(
       RowContainer& container,
       const std::vector<char*>& rows,

--- a/velox/exec/tests/SortBufferTest.cpp
+++ b/velox/exec/tests/SortBufferTest.cpp
@@ -75,7 +75,9 @@ class SortBufferTest : public OperatorTestBase {
 
   const int64_t maxBytes_ = 20LL << 20; // 20 MB
   const std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::defaultMemoryManager().addRootPool("SortBufferTest", maxBytes_)};
+      memory::MemoryManager::getInstance()->addRootPool(
+          "SortBufferTest",
+          maxBytes_)};
   const std::shared_ptr<memory::MemoryPool> pool_{
       rootPool_->addLeafChild("SortBufferTest", maxBytes_)};
   const std::shared_ptr<folly::Executor> executor_{
@@ -236,7 +238,7 @@ TEST_F(SortBufferTest, DISABLED_randomData) {
         &nonReclaimableSection_);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::addDefaultLeafMemoryPool("VectorFuzzer");
+        memory::MemoryManager::getInstance()->addLeafPool("VectorFuzzer");
 
     std::vector<RowVectorPtr> inputVectors;
     inputVectors.reserve(3);
@@ -309,7 +311,7 @@ TEST_F(SortBufferTest, batchOutput) {
     ASSERT_EQ(sortBuffer->canSpill(), testData.triggerSpill);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::addDefaultLeafMemoryPool("VectorFuzzer");
+        memory::MemoryManager::getInstance()->addLeafPool("VectorFuzzer");
 
     std::vector<RowVectorPtr> inputVectors;
     inputVectors.reserve(testData.numInputRows.size());
@@ -404,7 +406,7 @@ TEST_F(SortBufferTest, spill) {
         testData.spillMemoryThreshold);
 
     const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-        memory::addDefaultLeafMemoryPool("spillSource");
+        memory::MemoryManager::getInstance()->addLeafPool("spillSource");
     VectorFuzzer fuzzer({.vectorSize = 1024}, fuzzerPool.get());
     uint64_t totalNumInput = 0;
 
@@ -447,7 +449,7 @@ TEST_F(SortBufferTest, spill) {
 
 TEST_F(SortBufferTest, emptySpill) {
   const std::shared_ptr<memory::MemoryPool> fuzzerPool =
-      memory::addDefaultLeafMemoryPool("emptySpillSource");
+      memory::MemoryManager::getInstance()->addLeafPool("emptySpillSource");
 
   for (bool hasPostSpillData : {false, true}) {
     SCOPED_TRACE(fmt::format("hasPostSpillData {}", hasPostSpillData));

--- a/velox/exec/tests/SpillOperatorGroupTest.cpp
+++ b/velox/exec/tests/SpillOperatorGroupTest.cpp
@@ -30,7 +30,8 @@ using namespace facebook::velox::exec;
 class SpillOperatorGroupTest : public testing::Test {
  protected:
   SpillOperatorGroupTest(int32_t numOperators = 1)
-      : numOperators_(numOperators), pool_(memory::addDefaultLeafMemoryPool()) {
+      : numOperators_(numOperators),
+        pool_(memory::MemoryManager::getInstance()->addLeafPool()) {
     // All this is to prepare valid driver context for our mock operators.
     VectorMaker vectorMaker{pool_.get()};
     std::vector<RowVectorPtr> values = {vectorMaker.rowVector(
@@ -47,6 +48,10 @@ class SpillOperatorGroupTest : public testing::Test {
     driver_ = Driver::testingCreate();
     driverCtx_ = std::make_unique<DriverCtx>(task_, 0, 0, 0, 0);
     driverCtx_->driver = driver_.get();
+  }
+
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
   }
 
   void SetUp() override {

--- a/velox/exec/tests/SpillTest.cpp
+++ b/velox/exec/tests/SpillTest.cpp
@@ -66,6 +66,10 @@ class SpillTest : public ::testing::TestWithParam<common::CompressionKind>,
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     allocator_ = memory::MemoryAllocator::getInstance();
     tempDir_ = exec::test::TempDirectoryPath::create();

--- a/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerAggregateBenchmarkTest.cpp
@@ -24,6 +24,7 @@ using namespace facebook::velox::exec;
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  memory::MemoryManager::initialize({});
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   filesystems::registerLocalFileSystem();
 

--- a/velox/exec/tests/SpillerBenchmarkBase.cpp
+++ b/velox/exec/tests/SpillerBenchmarkBase.cpp
@@ -80,7 +80,8 @@ using namespace facebook::velox::memory;
 namespace facebook::velox::exec::test {
 
 void SpillerBenchmarkBase::setUp() {
-  rootPool_ = defaultMemoryManager().addRootPool(FLAGS_spiller_benchmark_name);
+  rootPool_ = memory::MemoryManager::getInstance()->addRootPool(
+      FLAGS_spiller_benchmark_name);
   pool_ = rootPool_->addLeafChild(FLAGS_spiller_benchmark_name);
 
   rowType_ =

--- a/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
+++ b/velox/exec/tests/SpillerJoinInputBenchmarkTest.cpp
@@ -23,6 +23,7 @@ using namespace facebook::velox;
 
 int main(int argc, char* argv[]) {
   gflags::ParseCommandLineFlags(&argc, &argv, true);
+  memory::MemoryManager::initialize({});
   serializer::presto::PrestoVectorSerde::registerVectorSerde();
   filesystems::registerLocalFileSystem();
   auto test = std::make_unique<exec::test::JoinSpillInputBenchmarkBase>();

--- a/velox/exec/tests/SpillerTest.cpp
+++ b/velox/exec/tests/SpillerTest.cpp
@@ -111,6 +111,7 @@ class SpillerTest : public exec::test::RowContainerTestBase {
  public:
   static void SetUpTestCase() {
     TestValue::enable();
+    memory::MemoryManager::testingSetInstance({});
   }
 
   explicit SpillerTest(const TestParam& param)

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -25,6 +25,10 @@ using namespace facebook::velox::test;
 
 class VectorHasherTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     allRows_ = SelectivityVector(100);
 

--- a/velox/exec/tests/utils/Cursor.h
+++ b/velox/exec/tests/utils/Cursor.h
@@ -76,7 +76,8 @@ class TaskQueue {
   };
 
   explicit TaskQueue(uint64_t maxBytes)
-      : pool_(memory::addDefaultLeafMemoryPool()), maxBytes_(maxBytes) {}
+      : pool_(memory::MemoryManager::getInstance()->addLeafPool()),
+        maxBytes_(maxBytes) {}
 
   void setNumProducers(int32_t n) {
     numProducers_ = n;

--- a/velox/exec/tests/utils/OperatorTestBase.cpp
+++ b/velox/exec/tests/utils/OperatorTestBase.cpp
@@ -56,6 +56,7 @@ OperatorTestBase::~OperatorTestBase() {
 void OperatorTestBase::SetUpTestCase() {
   FLAGS_velox_enable_memory_usage_track_in_default_memory_pool = true;
   FLAGS_velox_memory_leak_check_enabled = true;
+  memory::MemoryManager::testingSetInstance({});
   exec::SharedArbitrator::registerFactory();
   functions::prestosql::registerAllScalarFunctions();
   aggregate::prestosql::registerAllAggregateFunctions();

--- a/velox/exec/tests/utils/TpchQueryBuilder.h
+++ b/velox/exec/tests/utils/TpchQueryBuilder.h
@@ -143,7 +143,7 @@ class TpchQueryBuilder {
   static constexpr const char* kSupplier = "supplier";
   static constexpr const char* kPartsupp = "partsupp";
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
 };
 
 } // namespace facebook::velox::exec::test

--- a/velox/experimental/codegen/benchmark/CodegenBenchmark.h
+++ b/velox/experimental/codegen/benchmark/CodegenBenchmark.h
@@ -126,7 +126,7 @@ class CodegenBenchmark : public CodegenTestCore {
   CodegenBenchmark() {
     CodegenTestCore::init();
     queryCtx = std::make_shared<core::QueryCtx>();
-    pool = memory::addDefaultLeafMemoryPool();
+    pool = memory::deprecatedAddDefaultLeafMemoryPool();
     execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx_.get());
   }
 

--- a/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
+++ b/velox/experimental/codegen/code_generator/tests/CodegenExpressionsTestBase.h
@@ -326,6 +326,10 @@ struct RowTypeTrait {
 // A class with utilities for testing expression codegen
 class ExpressionCodegenTestBase : public testing::Test {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   // Given an expression, assert that the nullability of the elements of the
   // output row matches the expected nullability
   template <typename InputRowTypeTrait>
@@ -581,7 +585,8 @@ class ExpressionCodegenTestBase : public testing::Test {
   }
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   std::unique_ptr<core::ExecCtx> execCtx_{
       std::make_unique<facebook::velox::core::ExecCtx>(
           pool_.get(),

--- a/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
+++ b/velox/experimental/codegen/tests/CodegenASTAnalysisTest.cpp
@@ -57,7 +57,7 @@ class GenerateAstTest : public CodegenTestBase {
     registerVeloxArithmeticUDFs(udfManager_);
     useBuiltInForArithmetic_ = false;
 
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
 
     rowType_ = ROW({"c0", "c1", "c2"}, {DOUBLE(), DOUBLE(), DOUBLE()});
 

--- a/velox/experimental/codegen/tests/CodegenTestBase.h
+++ b/velox/experimental/codegen/tests/CodegenTestBase.h
@@ -104,7 +104,7 @@ class CodegenTestCore {
             udfManager_,
             useSymbolForArithmetic_,
             eventSequence_);
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = MemoryManager::getInstance()->addLeafPool();
     queryCtx_ = std::make_shared<core::QueryCtx>(executor_.get());
     execCtx_ = std::make_unique<core::ExecCtx>(pool_.get(), queryCtx_.get());
 
@@ -296,6 +296,10 @@ class CodegenTestCore {
 
 class CodegenTestBase : public CodegenTestCore, public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   /// Run the  same expressions with and without the codegen and
   /// compare the results
   /// \tparam SQLType

--- a/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/CodegenVectorFunctionTest.cpp
@@ -68,6 +68,13 @@ struct GeneratedVectorFunctionConfigDouble {
   static constexpr bool isDefaultNullStrict = false;
 };
 
+class TestConcatTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
 TEST(TestConcat, BasicConcatRow) {
   GeneratedVectorFunctionConfigDouble::GeneratedCodeClass concat;
   auto args =
@@ -89,7 +96,7 @@ TEST(TestConcat, EvalConcatFunction) {
   auto outRowType =
       ROW({"pl", "mi"},
           {std::make_shared<DoubleType>(), std::make_shared<DoubleType>()});
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   auto inRowVector = BaseVector::create(inRowType, rowLength, pool.get());
   auto outRowVector = BaseVector::create(outRowType, rowLength, pool.get());
 
@@ -191,7 +198,7 @@ struct GeneratedVectorFunctionConfigBool {
 
 TEST(TestBooEvalVectorFunction, EvalBoolExpression) {
   // TODO: Move those to test class
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   const size_t vectorSize = 1000;
   auto queryCtx = std::make_shared<core::QueryCtx>();
   auto execCtx = std::make_unique<core::ExecCtx>(pool.get(), queryCtx.get());

--- a/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
+++ b/velox/experimental/codegen/vector_function/tests/VectorReaderTest.cpp
@@ -21,12 +21,19 @@
 #include "velox/experimental/codegen/vector_function/StringTypes.h"
 
 namespace facebook::velox::codegen {
-TEST(VectorReader, ReadDoublesVectors) {
+class VectorReaderTest : public testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
+
+TEST_F(VectorReaderTest, ReadDoublesVectors) {
   const size_t vectorSize = 1000;
   auto inRowType = ROW({"columnA", "columnB"}, {DOUBLE(), DOUBLE()});
   auto outRowType = ROW({"expr1", "expr2"}, {DOUBLE(), DOUBLE()});
 
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   auto inRowVector = BaseVector::create(inRowType, vectorSize, pool.get());
   auto outRowVector = BaseVector::create(outRowType, vectorSize, pool.get());
 
@@ -52,9 +59,9 @@ TEST(VectorReader, ReadDoublesVectors) {
   }
 }
 
-TEST(VectorReader, ReadBoolVectors) {
+TEST_F(VectorReaderTest, ReadBoolVectors) {
   // TODO: Move those to test class
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   const size_t vectorSize = 1000;
 
   auto inRowType = ROW({"columnA", "columnB"}, {BOOLEAN(), BOOLEAN()});

--- a/velox/experimental/wave/common/tests/CudaTest.cpp
+++ b/velox/experimental/wave/common/tests/CudaTest.cpp
@@ -456,7 +456,8 @@ class CudaTest : public testing::Test {
     memory::MemoryAllocator::setDefaultInstance(mmapAllocator_.get());
 
     options.allocator = mmapAllocator_.get();
-    manager_ = &memory::MemoryManager::getInstance(options);
+    memory::MemoryManager::initialize(options);
+    manager_ = memory::MemoryManager::getInstance();
   }
 
   void waitFinish() {
@@ -611,7 +612,7 @@ class CudaTest : public testing::Test {
   void createData(int32_t numBatches, int32_t numColumns, int32_t numRows) {
     batches_.clear();
     if (!batchPool_) {
-      batchPool_ = memory::addDefaultLeafMemoryPool();
+      batchPool_ = memory::MemoryManager::getInstance()->addLeafPool();
     }
     int32_t sequence = 1;
     for (auto i = 0; i < numBatches; ++i) {

--- a/velox/expression/tests/EvalCtxTest.cpp
+++ b/velox/expression/tests/EvalCtxTest.cpp
@@ -27,6 +27,10 @@ using namespace facebook::velox::test;
 
 class EvalCtxTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   core::ExecCtx execCtx_{pool_.get(), nullptr};
 };
 

--- a/velox/expression/tests/ExprCompilerTest.cpp
+++ b/velox/expression/tests/ExprCompilerTest.cpp
@@ -29,12 +29,13 @@ namespace facebook::velox::exec::test {
 class ExprCompilerTest : public testing::Test,
                          public velox::test::VectorTestBase {
  protected:
-  void SetUp() override {
-    functions::prestosql::registerAllScalarFunctions();
-  }
-
   static void SetUpTestCase() {
     parse::registerTypeResolver();
+    functions::prestosql::registerAllScalarFunctions();
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();
   }
 

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -127,6 +127,10 @@ class ExprEncodingsTest
     : public testing::TestWithParam<std::tuple<int, int, bool>>,
       public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     // This test throws a lot of exceptions, so turn off stack trace capturing.
     FLAGS_velox_exception_user_stacktrace_enabled = false;

--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -45,6 +45,10 @@ namespace facebook::velox::test {
 namespace {
 class ExprTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();

--- a/velox/expression/tests/ExprToSubfieldFilterTest.cpp
+++ b/velox/expression/tests/ExprToSubfieldFilterTest.cpp
@@ -42,6 +42,7 @@ class ExprToSubfieldFilterTest : public testing::Test {
   static void SetUpTestSuite() {
     functions::prestosql::registerAllScalarFunctions();
     parse::registerTypeResolver();
+    memory::MemoryManager::testingSetInstance({});
   }
 
   core::TypedExprPtr parseExpr(
@@ -66,7 +67,7 @@ class ExprToSubfieldFilterTest : public testing::Test {
 
  private:
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
   core::QueryCtx queryCtx_;
   SimpleExpressionEvaluator evaluator_{&queryCtx_, pool_.get()};
 };

--- a/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionFuzzerUnitTest.cpp
@@ -22,6 +22,10 @@
 namespace facebook::velox::test {
 class ExpressionFuzzerUnitTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   uint32_t countLevelOfNesting(core::TypedExprPtr expression) {
     if (expression->inputs().empty()) {
       return 0;
@@ -50,7 +54,8 @@ class ExpressionFuzzerUnitTest : public testing::Test {
     auto index = folly::Random::rand32(kSupportedTypes.size(), seed);
     return kSupportedTypes[index];
   }
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 
   std::shared_ptr<VectorFuzzer> vectorfuzzer{
       std::make_shared<VectorFuzzer>(VectorFuzzer::Options{}, pool.get())};

--- a/velox/expression/tests/ExpressionFuzzerVerifier.h
+++ b/velox/expression/tests/ExpressionFuzzerVerifier.h
@@ -193,7 +193,8 @@ class ExpressionFuzzerVerifier {
 
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::deprecatedAddDefaultLeafMemoryPool()};
 
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
 

--- a/velox/expression/tests/ExpressionRunner.cpp
+++ b/velox/expression/tests/ExpressionRunner.cpp
@@ -119,7 +119,8 @@ void ExpressionRunner::run(
   VELOX_CHECK(!sql.empty());
 
   std::shared_ptr<core::QueryCtx> queryCtx{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::deprecatedAddDefaultLeafMemoryPool()};
   core::ExecCtx execCtx{pool.get(), queryCtx.get()};
 
   RowVectorPtr inputVector;

--- a/velox/expression/tests/ExpressionRunnerUnitTest.cpp
+++ b/velox/expression/tests/ExpressionRunnerUnitTest.cpp
@@ -35,7 +35,12 @@ class ExpressionRunnerUnitTest : public testing::Test, public VectorTestBase {
   }
 
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/expression/tests/ExpressionVerifierUnitTest.cpp
+++ b/velox/expression/tests/ExpressionVerifierUnitTest.cpp
@@ -67,6 +67,10 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
   }
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   core::TypedExprPtr parseExpression(
       const std::string& text,
       const RowTypePtr& rowType) {
@@ -75,7 +79,8 @@ class ExpressionVerifierUnitTest : public testing::Test, public VectorTestBase {
     return core::Expressions::inferTypes(untyped, rowType, pool_.get());
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   core::QueryCtx queryCtx_{};
   core::ExecCtx execCtx_{pool_.get(), &queryCtx_};
 };

--- a/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
+++ b/velox/expression/tests/FunctionCallToSpecialFormTest.cpp
@@ -36,6 +36,7 @@ class FunctionCallToSpecialFormTest : public testing::Test,
  protected:
   static void SetUpTestCase() {
     registerFunctionCallToSpecialForms();
+    memory::MemoryManager::testingSetInstance({});
   }
   const core::QueryConfig config_{{}};
 };

--- a/velox/expression/tests/PeeledEncodingTest.cpp
+++ b/velox/expression/tests/PeeledEncodingTest.cpp
@@ -34,6 +34,10 @@ class PeeledEncodingTest : public testing::Test, public VectorTestBase {
   };
 
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   static DictionaryWrap generateDictionaryWrap(
       VectorFuzzer& fuzzer,
       vector_size_t size) {

--- a/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
+++ b/velox/functions/lib/benchmarks/FunctionBenchmarkBase.h
@@ -95,7 +95,8 @@ class FunctionBenchmarkBase {
 
  protected:
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
   parse::ParseOptions options_;

--- a/velox/functions/lib/benchmarks/Re2FunctionsBenchmarks.cpp
+++ b/velox/functions/lib/benchmarks/Re2FunctionsBenchmarks.cpp
@@ -105,6 +105,7 @@ void registerRe2Functions() {
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
   facebook::velox::functions::test::registerRe2Functions();
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/functions/lib/tests/CheckNestedNullsTest.cpp
+++ b/velox/functions/lib/tests/CheckNestedNullsTest.cpp
@@ -22,7 +22,12 @@
 
 namespace facebook::velox::functions::test {
 class CheckNestedNullsTest : public testing::Test,
-                             public facebook::velox::test::VectorTestBase {};
+                             public facebook::velox::test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(CheckNestedNullsTest, array) {
   auto baseVector = makeArrayVectorFromJson<int32_t>({

--- a/velox/functions/lib/tests/IsNotNullTest.cpp
+++ b/velox/functions/lib/tests/IsNotNullTest.cpp
@@ -35,6 +35,7 @@ class IsNotNullTest : public functions::test::FunctionBaseTest {
  public:
   static void SetUpTestCase() {
     functions::registerIsNotNull();
+    memory::MemoryManager::testingSetInstance({});
   }
 
   template <typename T>

--- a/velox/functions/prestosql/aggregates/tests/MapAccumulatorTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MapAccumulatorTest.cpp
@@ -23,6 +23,11 @@ namespace {
 
 class MapAccumulatorTest : public testing::Test, public test::VectorTestBase {
  protected:
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   // Takes a vector of unique keys and a matching vector of non-null values.
   template <typename K>
   void test(const VectorPtr& uniqueKeys, const VectorPtr& values) {

--- a/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/PrestoHasherTest.cpp
@@ -28,6 +28,10 @@ using limits = std::numeric_limits<T>;
 class PrestoHasherTest : public testing::Test,
                          public facebook::velox::test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   template <typename T>
   void assertHash(
       const std::vector<std::optional<T>>& data,

--- a/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/ValueListTest.cpp
@@ -79,7 +79,8 @@ class ValueListTest : public functions::test::FunctionBaseTest {
     return allocator_.get();
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   std::unique_ptr<HashStringAllocator> allocator_{
       std::make_unique<HashStringAllocator>(pool_.get())};
 };

--- a/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/ArrayConstructorBenchmark.cpp
@@ -28,7 +28,8 @@ int main(int argc, char** argv) {
   folly::Init init(&argc, &argv);
 
   functions::prestosql::registerArrayFunctions();
-  auto anotherPool = memory::addDefaultLeafMemoryPool("bm");
+  memory::MemoryManager::initialize({});
+  auto anotherPool = memory::MemoryManager::getInstance()->addLeafPool("bm");
 
   ExpressionBenchmarkBuilder benchmarkBuilder;
 

--- a/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
+++ b/velox/functions/prestosql/tests/HyperLogLogFunctionsTest.cpp
@@ -48,7 +48,8 @@ class HyperLogLogFunctionsTest : public functions::test::FunctionBaseTest {
     return serialized;
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   HashStringAllocator allocator_{pool_.get()};
 };
 

--- a/velox/functions/prestosql/tests/InPredicateTest.cpp
+++ b/velox/functions/prestosql/tests/InPredicateTest.cpp
@@ -55,7 +55,7 @@ class InPredicateTest : public FunctionBaseTest {
       this->options_.parseDecimalAsDouble = false;
     }
     std::shared_ptr<memory::MemoryPool> pool{
-        memory::addDefaultLeafMemoryPool()};
+        memory::MemoryManager::getInstance()->addLeafPool()};
 
     const vector_size_t size = 1'000;
     auto inList = getInList<T>({1, 3, 5}, type);

--- a/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
+++ b/velox/functions/prestosql/tests/SimpleComparisonMatcherTest.cpp
@@ -29,6 +29,10 @@ namespace {
 class SimpleComparisonMatcherTest : public testing::Test,
                                     public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     functions::prestosql::registerAllScalarFunctions(prefix_);
     parse::registerTypeResolver();

--- a/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
+++ b/velox/functions/prestosql/tests/utils/FunctionBaseTest.cpp
@@ -23,6 +23,7 @@ namespace facebook::velox::functions::test {
 void FunctionBaseTest::SetUpTestCase() {
   parse::registerTypeResolver();
   functions::prestosql::registerAllScalarFunctions();
+  memory::MemoryManager::testingSetInstance({});
 }
 
 // static

--- a/velox/functions/remote/server/RemoteFunctionService.h
+++ b/velox/functions/remote/server/RemoteFunctionService.h
@@ -35,7 +35,8 @@ class RemoteFunctionServiceHandler
       std::unique_ptr<remote::RemoteFunctionRequest> request) override;
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   const std::string functionPrefix_;
 };
 

--- a/velox/functions/sparksql/tests/SparkFunctionBaseTest.h
+++ b/velox/functions/sparksql/tests/SparkFunctionBaseTest.h
@@ -30,6 +30,7 @@ class SparkFunctionBaseTest : public FunctionBaseTest {
   static void SetUpTestCase() {
     parse::registerTypeResolver();
     sparksql::registerFunctions("");
+    memory::MemoryManager::testingSetInstance({});
   }
 };
 

--- a/velox/parse/tests/QueryPlannerTest.cpp
+++ b/velox/parse/tests/QueryPlannerTest.cpp
@@ -20,6 +20,10 @@ namespace facebook::velox::core::test {
 
 class QueryPlannerTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void assertPlan(
       const std::string& sql,
       const std::unordered_map<std::string, std::vector<RowVectorPtr>>&
@@ -54,7 +58,8 @@ class QueryPlannerTest : public testing::Test {
         std::vector<VectorPtr>{});
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(QueryPlannerTest, values) {

--- a/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
+++ b/velox/row/benchmark/DynamicRowVectorDeserializeBenchmark.cpp
@@ -49,8 +49,8 @@ class UnsaferowBatchDeserializer : public Deserializer {
   }
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 class BenchmarkHelper {
@@ -115,8 +115,8 @@ class BenchmarkHelper {
       MAP(VARCHAR(), ARRAY(INTEGER())),
       ROW({INTEGER()})};
 
-  std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 int deserialize(
@@ -174,6 +174,7 @@ BENCHMARK_NAMED_PARAM_MULTI(
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
+++ b/velox/row/benchmark/UnsafeRowSerializeBenchmark.cpp
@@ -200,7 +200,8 @@ class SerializeBenchmark {
     return pool_.get();
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 #define SERDE_BENCHMARKS(name, rowType)      \
@@ -299,6 +300,7 @@ SERDE_BENCHMARKS(
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/row/tests/CompactRowTest.cpp
+++ b/velox/row/tests/CompactRowTest.cpp
@@ -27,6 +27,10 @@ namespace {
 
 class CompactRowTest : public ::testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   /// TODO Replace with VectorFuzzer::fuzzInputRow once
   /// https://github.com/facebookincubator/velox/issues/6195 is fixed.
   RowVectorPtr fuzzInputRow(VectorFuzzer& fuzzer, const RowTypePtr& rowType) {

--- a/velox/row/tests/UnsafeRowFuzzTest.cpp
+++ b/velox/row/tests/UnsafeRowFuzzTest.cpp
@@ -31,6 +31,10 @@ using namespace facebook::velox::test;
 
 class UnsafeRowFuzzTests : public ::testing::Test {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   UnsafeRowFuzzTests() {
     clearBuffers();
   }
@@ -90,7 +94,7 @@ class UnsafeRowFuzzTests : public ::testing::Test {
   std::array<char[kBufferSize], kNumBuffers> buffers_{};
 
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
 };
 
 TEST_F(UnsafeRowFuzzTests, fast) {

--- a/velox/serializers/tests/CompactRowSerializerTest.cpp
+++ b/velox/serializers/tests/CompactRowSerializerTest.cpp
@@ -24,8 +24,12 @@ namespace {
 class CompactRowSerializerTest : public ::testing::Test,
                                  public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
     serde_ = std::make_unique<serializer::CompactRowVectorSerde>();
   }
 

--- a/velox/serializers/tests/PrestoSerializerTest.cpp
+++ b/velox/serializers/tests/PrestoSerializerTest.cpp
@@ -33,6 +33,7 @@ class PrestoSerializerTest
  protected:
   static void SetUpTestCase() {
     serializer::presto::PrestoVectorSerde::registerVectorSerde();
+    memory::MemoryManager::testingSetInstance({});
   }
 
   void SetUp() override {

--- a/velox/serializers/tests/UnsafeRowSerializerTest.cpp
+++ b/velox/serializers/tests/UnsafeRowSerializerTest.cpp
@@ -24,8 +24,12 @@ using namespace facebook::velox;
 class UnsafeRowSerializerTest : public ::testing::Test,
                                 public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::addDefaultLeafMemoryPool();
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool();
     serde_ = std::make_unique<serializer::spark::UnsafeRowVectorSerde>();
   }
 

--- a/velox/substrait/tests/FunctionTest.cpp
+++ b/velox/substrait/tests/FunctionTest.cpp
@@ -31,11 +31,15 @@ namespace vestrait = facebook::velox::substrait;
 
 class FunctionTest : public ::testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::shared_ptr<core::QueryCtx> queryCtx_ =
       std::make_shared<core::QueryCtx>();
 
   std::shared_ptr<memory::MemoryPool> pool_ =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
 
   std::shared_ptr<vestrait::SubstraitParser> substraitParser_ =
       std::make_shared<vestrait::SubstraitParser>();

--- a/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
+++ b/velox/substrait/tests/Substrait2VeloxPlanConversionTest.cpp
@@ -33,6 +33,10 @@ using namespace facebook::velox::exec;
 class Substrait2VeloxPlanConversionTest
     : public exec::test::HiveConnectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::vector<std::shared_ptr<facebook::velox::connector::ConnectorSplit>>
   makeSplits(
       const facebook::velox::substrait::SubstraitVeloxPlanConverter& converter,
@@ -117,7 +121,8 @@ TEST_F(Substrait2VeloxPlanConversionTest, DISABLED_q6) {
            VARCHAR(),
            VARCHAR(),
            VARCHAR()});
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   std::vector<VectorPtr> vectors;
   // TPC-H lineitem table has 16 columns.
   int colNum = 16;

--- a/velox/tpch/gen/tests/TpchGenTest.cpp
+++ b/velox/tpch/gen/tests/TpchGenTest.cpp
@@ -29,8 +29,13 @@ using namespace facebook::velox::tpch;
 
 class TpchGenTestNationTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestNationTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestNationTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -132,8 +137,13 @@ TEST_F(TpchGenTestNationTest, reproducible) {
 // Region.
 class TpchGenTestRegionTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestRegionTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestRegionTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -194,8 +204,13 @@ TEST_F(TpchGenTestRegionTest, reproducible) {
 // Orders tests.
 class TpchGenTestOrdersTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestOrdersTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestOrdersTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -300,9 +315,13 @@ TEST_F(TpchGenTestOrdersTest, reproducible) {
 // Lineitem.
 class TpchGenTestLineItemTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ =
-        memory::defaultMemoryManager().addLeafPool("TpchGenTestLineItemTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestLineItemTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -412,9 +431,13 @@ TEST_F(TpchGenTestLineItemTest, reproducible) {
 // Supplier.
 class TpchGenTestSupplierTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ =
-        memory::defaultMemoryManager().addLeafPool("TpchGenTestSupplierTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestSupplierTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -505,8 +528,13 @@ TEST_F(TpchGenTestSupplierTest, reproducible) {
 // Part.
 class TpchGenTestPartTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ = memory::defaultMemoryManager().addLeafPool("TpchGenTestPartTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestPartTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;
@@ -590,9 +618,13 @@ TEST_F(TpchGenTestPartTest, reproducible) {
 // PartSupp.
 class TpchGenTestPartSuppTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ =
-        memory::defaultMemoryManager().addLeafPool("TpchGenTestPartSuppTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestPartSuppTest");
   }
 
   bool partSuppCheck(
@@ -735,9 +767,13 @@ TEST_F(TpchGenTestPartSuppTest, reproducible) {
 // Customer.
 class TpchGenTestCustomerTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
-    pool_ =
-        memory::defaultMemoryManager().addLeafPool("TpchGenTestCustomerTest");
+    pool_ = memory::MemoryManager::getInstance()->addLeafPool(
+        "TpchGenTestCustomerTest");
   }
 
   std::shared_ptr<memory::MemoryPool> pool_;

--- a/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeArrayTest.cpp
@@ -44,6 +44,10 @@ struct VeloxToArrowType<Timestamp> {
 
 class ArrowBridgeArrayExportTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   template <typename T>
   void testFlatVector(
       const std::vector<std::optional<T>>& inputData,
@@ -354,7 +358,8 @@ class ArrowBridgeArrayExportTest : public testing::Test {
 
   // Boiler plate structures required by vectorMaker.
   std::shared_ptr<core::QueryCtx> queryCtx_{std::make_shared<core::QueryCtx>()};
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   core::ExecCtx execCtx_{pool_.get(), queryCtx_.get()};
   facebook::velox::test::VectorMaker vectorMaker_{execCtx_.pool()};
 };
@@ -1426,7 +1431,8 @@ class ArrowBridgeArrayImportTest : public ArrowBridgeArrayExportTest {
     EXPECT_NO_THROW(importFromArrow(arrowSchema, arrowArray, pool_.get()));
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 class ArrowBridgeArrayImportAsViewerTest : public ArrowBridgeArrayImportTest {

--- a/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
+++ b/velox/vector/arrow/tests/ArrowBridgeSchemaTest.cpp
@@ -29,6 +29,10 @@ static void mockRelease(ArrowSchema*) {}
 
 class ArrowBridgeSchemaExportTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void testScalarType(const TypePtr& type, const char* arrowFormat) {
     ArrowSchema arrowSchema;
     exportToArrow(type, arrowSchema);
@@ -168,7 +172,8 @@ class ArrowBridgeSchemaExportTest : public testing::Test {
     };
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(ArrowBridgeSchemaExportTest, scalar) {
@@ -415,6 +420,10 @@ TEST_F(ArrowBridgeSchemaImportTest, unsupported) {
 
 class ArrowBridgeSchemaTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void roundtripTest(const TypePtr& inputType) {
     ArrowSchema arrowSchema;
     exportToArrow(inputType, arrowSchema);
@@ -427,7 +436,8 @@ class ArrowBridgeSchemaTest : public testing::Test {
     velox::exportToArrow(BaseVector::create(type, 0, pool_.get()), out);
   }
 
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(ArrowBridgeSchemaTest, roundtrip) {

--- a/velox/vector/benchmarks/CopyBenchmark.cpp
+++ b/velox/vector/benchmarks/CopyBenchmark.cpp
@@ -68,7 +68,8 @@ size_t runBenchmark(
 
 BENCHMARK_MULTI(copyArray) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -84,7 +85,8 @@ BENCHMARK_MULTI(copyArray) {
 
 BENCHMARK_MULTI(copyArrayWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -101,7 +103,8 @@ BENCHMARK_MULTI(copyArrayWithNulls) {
 
 BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -131,7 +134,8 @@ BENCHMARK_MULTI(copyArrayDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyArrayOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -147,7 +151,8 @@ BENCHMARK_MULTI(copyArrayOneAtATime) {
 
 BENCHMARK_MULTI(copyArrayTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -163,7 +168,8 @@ BENCHMARK_MULTI(copyArrayTwoAtATime) {
 
 BENCHMARK_MULTI(copyArrayOfVarchar) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 50'000;
@@ -192,7 +198,8 @@ BENCHMARK_MULTI(copyArrayOfVarchar) {
 
 BENCHMARK_MULTI(copyArrayOfArray) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -220,7 +227,8 @@ BENCHMARK_MULTI(copyArrayOfArray) {
 
 BENCHMARK_MULTI(copyMap) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -238,7 +246,8 @@ BENCHMARK_MULTI(copyMap) {
 
 BENCHMARK_MULTI(copyMapWithNulls) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -257,7 +266,8 @@ BENCHMARK_MULTI(copyMapWithNulls) {
 
 BENCHMARK_MULTI(copyMapDictionaryEncoded) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -290,7 +300,8 @@ BENCHMARK_MULTI(copyMapDictionaryEncoded) {
 
 BENCHMARK_MULTI(copyMapOneAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -308,7 +319,8 @@ BENCHMARK_MULTI(copyMapOneAtATime) {
 
 BENCHMARK_MULTI(copyMapTwoAtATime) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
 
   const vector_size_t size = 1'000;
@@ -326,7 +338,8 @@ BENCHMARK_MULTI(copyMapTwoAtATime) {
 
 BENCHMARK_MULTI(copyStructNonContiguous) {
   folly::BenchmarkSuspender suspender;
-  std::shared_ptr<memory::MemoryPool> pool{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   test::VectorMaker vectorMaker{pool.get()};
   constexpr vector_size_t kSize = 2'000;
   std::vector<VectorPtr> children = {
@@ -352,7 +365,7 @@ BENCHMARK_MULTI(copyStructNonContiguous) {
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
-
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
+++ b/velox/vector/benchmarks/SimpleVectorHashAllBenchmark.cpp
@@ -89,7 +89,7 @@ void vectorBenchmark(
     bool sequences,
     VectorEncoding::Simple encoding) {
   folly::BenchmarkSuspender suspender;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker vectorMaker(pool.get());
 
   for (size_t k = 0; k < iterations; ++k) {
@@ -468,6 +468,7 @@ BENCHMARK_DRAW_LINE();
 
 int main(int argc, char** argv) {
   folly::init(&argc, &argv);
+  facebook::velox::memory::MemoryManager::initialize({});
   folly::runBenchmarks();
   return 0;
 }

--- a/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ArrayGeneratorExample.cpp
@@ -38,7 +38,8 @@ int main() {
   auto uniform = std::uniform_int_distribution<int32_t>(lo, hi);
 
   FuzzerGenerator rng;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   GeneratorSpecPtr randomArray =
       RANDOM_ARRAY(RANDOM_DOUBLE(normal, nullProbability), uniform);

--- a/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/EncodingGeneratorExample.cpp
@@ -47,7 +47,8 @@ int main() {
   };
 
   FuzzerGenerator rng;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   GeneratorSpecPtr encodedNormalDoubleGenerator =
       ENCODE(RANDOM_DOUBLE(normal, nullProbability), encoding, 1, 5, 0.3);
 

--- a/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/MapGeneratorExample.cpp
@@ -39,7 +39,8 @@ int main() {
   auto normal = std::normal_distribution<double>(mu, sigma);
 
   FuzzerGenerator rng;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   GeneratorSpecPtr randomMap =
       RANDOM_MAP(RANDOM_INTEGER(uniform), RANDOM_DOUBLE(normal), lengthDist);

--- a/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/RowGeneratorExample.cpp
@@ -39,7 +39,8 @@ int main() {
   auto bernoulli = std::bernoulli_distribution(p);
 
   FuzzerGenerator rng;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   GeneratorSpecPtr randomRow = RANDOM_ROW(
       {RANDOM_INTEGER(uniform),

--- a/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
+++ b/velox/vector/fuzzer/examples/ScalarGeneratorExample.cpp
@@ -49,7 +49,8 @@ int main() {
   };
 
   FuzzerGenerator rng;
-  auto pool = memory::addDefaultLeafMemoryPool();
+  memory::MemoryManager::initialize({});
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
 
   GeneratorSpecPtr uniformIntGenerator =
       RANDOM_INTEGER(uniform, nullProbability);

--- a/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
+++ b/velox/vector/fuzzer/tests/VectorFuzzerTest.cpp
@@ -27,6 +27,10 @@ namespace {
 
 class VectorFuzzerTest : public testing::Test {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   memory::MemoryPool* pool() const {
     return pool_.get();
   }
@@ -78,7 +82,8 @@ class VectorFuzzerTest : public testing::Test {
   void validateMaxSizes(VectorPtr vector, size_t maxSize);
 
  private:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 };
 
 TEST_F(VectorFuzzerTest, flatPrimitive) {

--- a/velox/vector/tests/BiasVectorTest.cpp
+++ b/velox/vector/tests/BiasVectorTest.cpp
@@ -24,8 +24,12 @@ namespace facebook::velox::test {
 
 class BiasVectorTestBase : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::addDefaultLeafMemoryPool()};
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 };
 

--- a/velox/vector/tests/DecodedVectorTest.cpp
+++ b/velox/vector/tests/DecodedVectorTest.cpp
@@ -32,6 +32,10 @@ namespace facebook::velox::test {
 
 class DecodedVectorTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   DecodedVectorTest() : allSelected_(10010), halfSelected_(10010) {
     allSelected_.setAll();
     halfSelected_.setAll();

--- a/velox/vector/tests/EnsureWritableVectorTest.cpp
+++ b/velox/vector/tests/EnsureWritableVectorTest.cpp
@@ -21,7 +21,12 @@
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class EnsureWritableVectorTest : public testing::Test, public VectorTestBase {};
+class EnsureWritableVectorTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(EnsureWritableVectorTest, flat) {
   SelectivityVector rows(1'000);

--- a/velox/vector/tests/IsWritableVectorTest.cpp
+++ b/velox/vector/tests/IsWritableVectorTest.cpp
@@ -24,6 +24,10 @@ using namespace facebook::velox::test;
 
 class IsWritableVectorTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   // We use templates here to avoid the compiler automatically creating new
   // shared_ptrs which it would do if we used VectorPtr.
   template <typename T, typename V>

--- a/velox/vector/tests/LazyVectorTest.cpp
+++ b/velox/vector/tests/LazyVectorTest.cpp
@@ -22,7 +22,12 @@
 using namespace facebook::velox;
 using namespace facebook::velox::test;
 
-class LazyVectorTest : public testing::Test, public VectorTestBase {};
+class LazyVectorTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(LazyVectorTest, lazyInDictionary) {
   // We have a dictionary over LazyVector. We load for some indices in

--- a/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
+++ b/velox/vector/tests/MayHaveNullsRecursiveTest.cpp
@@ -22,8 +22,12 @@ namespace facebook::velox::test {
 
 class MayHaveNullsRecursiveTest : public testing::Test {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   std::shared_ptr<velox::memory::MemoryPool> pool_{
-      memory::addDefaultLeafMemoryPool()};
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorMaker vectorMaker_{pool_.get()};
 
   enum class TestOptions {

--- a/velox/vector/tests/SimpleVectorTestHelper.h
+++ b/velox/vector/tests/SimpleVectorTestHelper.h
@@ -102,7 +102,12 @@ class SimpleVectorTest : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VariantToVectorTest.cpp
+++ b/velox/vector/tests/VariantToVectorTest.cpp
@@ -25,9 +25,14 @@
 using namespace facebook::velox;
 
 class VariantToVectorTest : public testing::Test {
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
 
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   template <TypeKind KIND>
   void testCreateVector(
       const TypePtr& type,

--- a/velox/vector/tests/VectorCompareTest.cpp
+++ b/velox/vector/tests/VectorCompareTest.cpp
@@ -25,6 +25,10 @@ namespace facebook::velox {
 class VectorCompareTest : public testing::Test,
                           public velox::test::VectorTestBase {
  public:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   bool static constexpr kExpectNull = true;
   bool static constexpr kExpectNotNull = false;
   bool static constexpr kEqualsOnly = true;
@@ -221,7 +225,7 @@ TEST_F(VectorCompareTest, compareStopAtNullRow) {
 }
 
 TEST_F(VectorCompareTest, CompareWithNullChildVector) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   test::VectorMaker maker{pool.get()};
   auto rowType = ROW({"a", "b", "c"}, {INTEGER(), INTEGER(), INTEGER()});
   const auto& rowVector1 = std::make_shared<RowVector>(

--- a/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
+++ b/velox/vector/tests/VectorEstimateFlatSizeTest.cpp
@@ -23,6 +23,10 @@ class VectorEstimateFlatSizeTest : public testing::Test,
  protected:
   using test::VectorTestBase::makeArrayVector;
 
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   ArrayVectorPtr makeArrayVector(
       const TypePtr& type,
       vector_size_t size,

--- a/velox/vector/tests/VectorMakerTest.cpp
+++ b/velox/vector/tests/VectorMakerTest.cpp
@@ -26,7 +26,12 @@ using facebook::velox::test::VectorMaker;
 
 class VectorMakerTest : public ::testing::Test {
  protected:
-  std::shared_ptr<memory::MemoryPool> pool_{memory::addDefaultLeafMemoryPool()};
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
+  std::shared_ptr<memory::MemoryPool> pool_{
+      memory::MemoryManager::getInstance()->addLeafPool()};
   VectorMaker maker_{pool_.get()};
 };
 

--- a/velox/vector/tests/VectorPoolTest.cpp
+++ b/velox/vector/tests/VectorPoolTest.cpp
@@ -20,7 +20,12 @@
 
 namespace facebook::velox::test {
 
-class VectorPoolTest : public testing::Test, public test::VectorTestBase {};
+class VectorPoolTest : public testing::Test, public test::VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(VectorPoolTest, basic) {
   VectorPool vectorPool(pool());

--- a/velox/vector/tests/VectorPrepareForReuseTest.cpp
+++ b/velox/vector/tests/VectorPrepareForReuseTest.cpp
@@ -22,6 +22,10 @@ using namespace facebook::velox;
 class VectorPrepareForReuseTest : public testing::Test,
                                   public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorPrepareForReuseTest() = default;
 };
 

--- a/velox/vector/tests/VectorPrinterTest.cpp
+++ b/velox/vector/tests/VectorPrinterTest.cpp
@@ -19,7 +19,12 @@
 
 namespace facebook::velox::test {
 
-class VectorPrinterTest : public testing::Test, public VectorTestBase {};
+class VectorPrinterTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 // Sanity check that printVector doesn't fail or crash.
 TEST_F(VectorPrinterTest, basic) {

--- a/velox/vector/tests/VectorSaverTest.cpp
+++ b/velox/vector/tests/VectorSaverTest.cpp
@@ -29,6 +29,10 @@ namespace facebook::velox::test {
 
 class VectorSaverTest : public testing::Test, public VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   VectorSaverTest() {
     registerJsonType();
     registerHyperLogLogType();

--- a/velox/vector/tests/VectorTest.cpp
+++ b/velox/vector/tests/VectorTest.cpp
@@ -104,6 +104,10 @@ int NonPOD::alive = 0;
 
 class VectorTest : public testing::Test, public test::VectorTestBase {
  protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+
   void SetUp() override {
     if (!isRegisteredVectorSerde()) {
       facebook::velox::serializer::presto::PrestoVectorSerde::
@@ -2576,7 +2580,7 @@ TEST_F(VectorTest, mapSliceMutability) {
 TEST_F(VectorTest, lifetime) {
   ASSERT_DEATH(
       {
-        auto childPool = memory::addDefaultLeafMemoryPool();
+        auto childPool = memory::MemoryManager::getInstance()->addLeafPool();
         auto v = BaseVector::create(INTEGER(), 10, childPool.get());
 
         // BUG: Memory pool needs to stay alive until all memory allocated from

--- a/velox/vector/tests/VectorTestUtils.h
+++ b/velox/vector/tests/VectorTestUtils.h
@@ -83,7 +83,7 @@ class VectorGeneratedData {
 
   // In case T is StringView, the buffer below holds their actual data.
   std::shared_ptr<memory::MemoryPool> scopedPool =
-      memory::addDefaultLeafMemoryPool();
+      memory::MemoryManager::getInstance()->addLeafPool();
   StringViewBufferHolder stringViewBufferHolder_ =
       StringViewBufferHolder(scopedPool.get());
 };
@@ -271,7 +271,7 @@ template <typename T>
 SimpleVectorPtr<T> createAndAssert(
     const ExpectedData<T>& expected,
     VectorEncoding::Simple encoding) {
-  auto pool = memory::addDefaultLeafMemoryPool();
+  auto pool = memory::MemoryManager::getInstance()->addLeafPool();
   VectorMaker maker(pool.get());
 
   auto vector = maker.encodedVector(encoding, expected);

--- a/velox/vector/tests/VectorToStringTest.cpp
+++ b/velox/vector/tests/VectorToStringTest.cpp
@@ -17,7 +17,12 @@
 
 namespace facebook::velox::test {
 
-class VectorToStringTest : public testing::Test, public VectorTestBase {};
+class VectorToStringTest : public testing::Test, public VectorTestBase {
+ protected:
+  static void SetUpTestCase() {
+    memory::MemoryManager::testingSetInstance({});
+  }
+};
 
 TEST_F(VectorToStringTest, flatIntegers) {
   // No nulls.

--- a/velox/vector/tests/utils/VectorTestBase.h
+++ b/velox/vector/tests/utils/VectorTestBase.h
@@ -765,7 +765,7 @@ class VectorTestBase {
   }
 
   std::shared_ptr<memory::MemoryPool> rootPool_{
-      memory::defaultMemoryManager().addRootPool()};
+      memory::MemoryManager::getInstance()->addRootPool()};
   std::shared_ptr<memory::MemoryPool> pool_{rootPool_->addLeafChild("leaf")};
   velox::test::VectorMaker vectorMaker_{pool_.get()};
   std::shared_ptr<folly::Executor> executor_{


### PR DESCRIPTION
Split the process wide memory manager creation and get.
Deprecate the default memory manager and memory pool APIs.