### PR TITLE
Properly update TableWriter operator IO statistics after close

### DIFF
--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -161,9 +161,9 @@ RowVectorPtr TableWriter::getOutput() {
   }
 
   finished_ = true;
+  const std::vector<std::string> fragments = closeDataSink();
   updateWrittenBytes();
   updateNumWrittenFiles();
-  const std::vector<std::string> fragments = closeDataSink();
 
   if (outputType_->size() == 1) {
     // NOTE: this is for non-prestissimo use cases.

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2760,11 +2760,16 @@ TEST_P(AllTableWriterTest, tableWriterStats) {
   // bucketNum, bucket number is 4
   const int numWrittenFiles =
       bucketProperty_ == nullptr ? numBatches : numBatches * 4;
+  // The size of bytes (ORC_MAGIC_LEN) written when the DWRF writer
+  // initializes a file.
+  const int32_t ORC_HEADER_LEN{3};
+  const auto fixedWrittenBytes =
+      numWrittenFiles * (fileFormat_ == FileFormat::DWRF ? ORC_HEADER_LEN : 0);
   for (int i = 0; i < task->taskStats().pipelineStats.size(); ++i) {
     auto operatorStats = task->taskStats().pipelineStats.at(i).operatorStats;
     for (int j = 0; j < operatorStats.size(); ++j) {
       if (operatorStats.at(j).operatorType == "TableWrite") {
-        ASSERT_GT(operatorStats.at(j).physicalWrittenBytes, 0);
+        ASSERT_GT(operatorStats.at(j).physicalWrittenBytes, fixedWrittenBytes);
         ASSERT_EQ(
             operatorStats.at(j).runtimeStats.at("numWrittenFiles").sum,
             numWrittenFiles);


### PR DESCRIPTION
Previously, the TableWriter did not account for file statistics if the close operation caused outstanding data to be flushed.

The statistics are now updated after the close is complete and all data has been written.

Resolves https://github.com/facebookincubator/velox/issues/7169