### PR TITLE
Defer copying of non-key columns at TopN::addInput().

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "velox/core/PlanNode.h"
+#include <folly/container/F14Set.h>
+
 #include "velox/common/encode/Base64.h"
+#include "velox/core/PlanNode.h"
 #include "velox/vector/VectorSaver.h"
 
 namespace facebook::velox::core {
@@ -1920,13 +1922,13 @@ TopNNode::TopNNode(
       "Number of sorting keys and sorting orders in TopN must be the same");
   VELOX_USER_CHECK_GT(
       count, 0, "TopN must specify greater than zero number of rows to keep");
-  folly::F14FastSet<std::string> sortingKeyNameSet;
+  folly::F14FastSet<std::string> sortingKeyNames;
   for (const auto& sortingKey : sortingKeys_) {
-    auto res = sortingKeyNameSet.insert(sortingKey->name());
+    auto result = sortingKeyNames.insert(sortingKey->name());
     VELOX_USER_CHECK(
-        res.second,
-        "TopNNode doesn't allow duplicate sorting key: {}",
-        *res.first);
+        result.second,
+        "TopN must specify unique sorting keys. Found duplicate key: {}",
+        *result.first);
   }
 }
 

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <folly/container/F14Set.h>
+
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
@@ -1751,6 +1753,14 @@ class TopNNode : public PlanNode {
         "Number of sorting keys and sorting orders in TopN must be the same");
     VELOX_USER_CHECK_GT(
         count, 0, "TopN must specify greater than zero number of rows to keep");
+    folly::F14FastSet<std::string> sortingKeyNameSet;
+    for (const auto& sortingKey : sortingKeys_) {
+      const auto& keyName = sortingKey->name();
+      if (sortingKeyNameSet.contains(keyName)) {
+        VELOX_USER_FAIL("Duplicated sorting key {}", keyName);
+      }
+      sortingKeyNameSet.insert(keyName);
+    }
   }
 
   const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -15,8 +15,6 @@
  */
 #pragma once
 
-#include <folly/container/F14Set.h>
-
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -1739,29 +1739,7 @@ class TopNNode : public PlanNode {
       const std::vector<SortOrder>& sortingOrders,
       int32_t count,
       bool isPartial,
-      const PlanNodePtr& source)
-      : PlanNode(id),
-        sortingKeys_(sortingKeys),
-        sortingOrders_(sortingOrders),
-        count_(count),
-        isPartial_(isPartial),
-        sources_{source} {
-    VELOX_USER_CHECK(!sortingKeys.empty(), "TopN must specify sorting keys");
-    VELOX_USER_CHECK_EQ(
-        sortingKeys.size(),
-        sortingOrders.size(),
-        "Number of sorting keys and sorting orders in TopN must be the same");
-    VELOX_USER_CHECK_GT(
-        count, 0, "TopN must specify greater than zero number of rows to keep");
-    folly::F14FastSet<std::string> sortingKeyNameSet;
-    for (const auto& sortingKey : sortingKeys_) {
-      const auto& keyName = sortingKey->name();
-      if (sortingKeyNameSet.contains(keyName)) {
-        VELOX_USER_FAIL("Duplicated sorting key {}", keyName);
-      }
-      sortingKeyNameSet.insert(keyName);
-    }
-  }
+      const PlanNodePtr& source);
 
   const std::vector<FieldAccessTypedExprPtr>& sortingKeys() const {
     return sortingKeys_;

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -483,7 +483,7 @@ operations.
    * - Property
      - Description
    * - sortingKeys
-     - List of one of more input columns to sort by. Cannot be empty and cannot duplicate.
+     - List of one of more input columns to sort by. Must not be empty and must not contain duplicates.
    * - sortingOrders
      - Sorting order for each of the soring keys. See OrderBy for the list of supported orders.
    * - count
@@ -831,7 +831,7 @@ FilterNode(row_number <= limit), but it uses less memory and CPU.
   * - partitionKeys
     - Partition by columns for the window functions. May be empty.
   * - sortingKeys
-    - Order by columns for the window functions. Cannot be empty and cannot overlap with 'partitionKeys'.
+    - Order by columns for the window functions. Must not be empty and must not overlap with 'partitionKeys'.
   * - sortingOrders
     - Sorting order for each sorting key above. The supported sort orders are asc nulls first, asc nulls last, desc nulls first and desc nulls last.
   * - rowNumberColumnName

--- a/velox/docs/develop/operators.rst
+++ b/velox/docs/develop/operators.rst
@@ -483,7 +483,7 @@ operations.
    * - Property
      - Description
    * - sortingKeys
-     - List of one of more input columns to sort by.
+     - List of one of more input columns to sort by. Cannot be empty and cannot duplicate.
    * - sortingOrders
      - Sorting order for each of the soring keys. See OrderBy for the list of supported orders.
    * - count

--- a/velox/exec/TopN.cpp
+++ b/velox/exec/TopN.cpp
@@ -62,10 +62,10 @@ void TopN::addInput(RowVectorPtr input) {
     decodedVectors_[col].decode(*input->childAt(col));
   }
 
+  const bool hasNonKeyColumn{!nonKeyColumns_.empty()};
   // Maps passed rows of 'data_' to the corresponding input row number. These
   // input rows of non-key columns are later stored into data_.
-  const bool hasNonKeyColumn{!nonKeyColumns_.empty()};
-  folly::F14FastMap<void*, size_t> passedRows;
+  folly::F14FastMap<void*, vector_size_t> passedRows;
   for (auto row = 0; row < input->size(); ++row) {
     char* newRow = nullptr;
     if (topRows_.size() < count_) {

--- a/velox/exec/TopN.h
+++ b/velox/exec/TopN.h
@@ -49,6 +49,9 @@ class TopN : public Operator {
   bool finished_ = false;
   uint32_t numRowsReturned_ = 0;
 
+  std::vector<column_index_t> sortingKeyColumns_;
+  std::vector<column_index_t> nonKeyColumns_;
+
   // As the inputs are added to TopN operator, we use topRows_ (a priority
   // queue) to keep track of the pointers to rows stored in the
   // RowContainer (data_). We only update the RowContainer if a row is a

--- a/velox/exec/tests/TopNTest.cpp
+++ b/velox/exec/tests/TopNTest.cpp
@@ -302,5 +302,6 @@ TEST_F(TopNTest, planNodeValidation) {
       plan({"a"}, 0),
       "TopN must specify greater than zero number of rows to keep");
   VELOX_ASSERT_THROW(
-      plan({"a", "b", "a"}), "TopNNode doesn't allow duplicate sorting key: a");
+      plan({"a", "b", "a"}),
+      "TopN must specify unique sorting keys. Found duplicate key: a");
 }


### PR DESCRIPTION
Current implementation copies all the columns for the row that's added to the
priority queue to RowContainer. If a row is added to priority queue and then is
replaced by another row from the same batch of input, copying non-key columns
to RowContainer is wasteful.

This commit adds the following optimization. First, loop over the input rows,
identify rows that need to be added to the priority queue, copy key columns for
these to RowContainer and add these to the priority queue. For the input rows
that remain in the priority queue, copy non-key columns to the RowContainer.
This logic avoids copying non-key columns for rows that do not stay in the
priority queue.

Also, add a check for duplicate sorting keys to TopNNode's constructor.