### PR TITLE
Fix flaky UnpartitionedTableWriterTest.runtimeStatsCheck for non dwrf…

### DIFF
--- a/velox/dwio/parquet/writer/arrow/ColumnPage.h
+++ b/velox/dwio/parquet/writer/arrow/ColumnPage.h
@@ -136,9 +136,7 @@ class DataPageV1 : public DataPage {
             statistics,
             std::move(first_row_index)),
         definition_level_encoding_(definition_level_encoding),
-        repetition_level_encoding_(repetition_level_encoding) {
-    LOG(ERROR) << "CREATING PAGE: " << encoding;
-  }
+        repetition_level_encoding_(repetition_level_encoding) {}
 
   Encoding::type repetition_level_encoding() const {
     return repetition_level_encoding_;

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2030,6 +2030,10 @@ TEST_P(UnpartitionedTableWriterTest, differentCompression) {
 }
 
 TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
+  // The runtime stats test only applies for dwrf file format.
+  if (fileFormat_ != dwio::common::FileFormat::DWRF) {
+    return;
+  }
   struct {
     int numInputVectors;
     std::string maxStripeSize;


### PR DESCRIPTION
Parquet file format doesn't handle constant encoding and the test
check for runtime stats not implemented in file format other than dwrf.
Only run this test for dwrf.