### PR TITLE
Fix table writer crash because of unused memory reservation leak

### DIFF
--- a/velox/common/memory/MemoryPool.h
+++ b/velox/common/memory/MemoryPool.h
@@ -678,6 +678,10 @@ class MemoryPoolImpl : public MemoryPool {
     return allocator_;
   }
 
+  uint64_t testingMinReservationBytes() const {
+    return minReservationBytes_;
+  }
+
   /// Structure to store allocation details in debug mode.
   struct AllocationRecord {
     uint64_t size;

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -163,7 +163,7 @@ target_link_libraries(
   ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwio_dwrf_writer_context_test TestWriterContext.cpp)
+add_executable(velox_dwio_dwrf_writer_context_test WriterContextTest.cpp)
 add_test(velox_dwio_dwrf_writer_context_test
          velox_dwio_dwrf_writer_context_test)
 

--- a/velox/dwio/dwrf/test/WriterContextTest.cpp
+++ b/velox/dwio/dwrf/test/WriterContextTest.cpp
@@ -222,4 +222,76 @@ TEST(TestWriterContext, memory) {
     ASSERT_EQ(context.availableMemoryReservation(), 786368);
   }
 }
+
+TEST(TestWriterContext, abort) {
+  auto config = std::make_shared<Config>();
+  for (bool hasReclaimer : {false, true}) {
+    SCOPED_TRACE(fmt::format("hasReclaimer {}", hasReclaimer));
+    auto writerRoot = memory::defaultMemoryManager().addRootPool(
+        "abort",
+        1L << 30,
+        hasReclaimer ? exec::MemoryReclaimer::create() : nullptr);
+    WriterContext context{config, writerRoot};
+    // The writer context has some initial memory allocation on construction.
+    ASSERT_EQ(context.getTotalMemoryUsage(), 262208);
+    ASSERT_EQ(context.availableMemoryReservation(), 786368);
+
+    auto& generalPool = context.getMemoryPool(MemoryUsageCategory::GENERAL);
+    auto& dictPool = context.getMemoryPool(MemoryUsageCategory::DICTIONARY);
+    auto& outputPool =
+        context.getMemoryPool(MemoryUsageCategory::OUTPUT_STREAM);
+
+    const int bufferSize{1024};
+    void* generalBuf = generalPool.allocate(bufferSize);
+    void* dictBuf = dictPool.allocate(bufferSize);
+    void* outputBuf = outputPool.allocate(bufferSize);
+    ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
+    ASSERT_EQ(context.availableMemoryReservation(), 2880448);
+
+    ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+    ASSERT_EQ(generalPool.reservedBytes(), 1048576);
+    ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+    ASSERT_EQ(dictPool.reservedBytes(), 1048576);
+    ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+    ASSERT_EQ(outputPool.reservedBytes(), 1048576);
+    ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
+    ASSERT_EQ(context.availableMemoryReservation(), 2880448);
+
+    ASSERT_TRUE(generalPool.maybeReserve(4L << 20));
+    ASSERT_TRUE(dictPool.maybeReserve(4L << 20));
+    ASSERT_TRUE(outputPool.maybeReserve(4L << 20));
+    ASSERT_EQ(generalPool.currentBytes(), 262208 + bufferSize);
+    ASSERT_EQ(generalPool.reservedBytes(), 9437184);
+    ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+    ASSERT_EQ(dictPool.reservedBytes(), 9437184);
+    ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+    ASSERT_EQ(outputPool.reservedBytes(), 9437184);
+    ASSERT_EQ(context.getTotalMemoryUsage(), 262208 + bufferSize * 3);
+    ASSERT_EQ(context.availableMemoryReservation(), 28046272);
+
+    context.abort();
+
+    ASSERT_EQ(context.getTotalMemoryUsage(), bufferSize * 3);
+    ASSERT_EQ(generalPool.currentBytes(), bufferSize);
+    ASSERT_EQ(generalPool.reservedBytes(), 1048576);
+    ASSERT_EQ(dictPool.currentBytes(), bufferSize);
+    ASSERT_EQ(dictPool.reservedBytes(), 1048576);
+    ASSERT_EQ(outputPool.currentBytes(), bufferSize);
+    ASSERT_EQ(outputPool.reservedBytes(), 1048576);
+    ASSERT_EQ(context.availableMemoryReservation(), 3142656);
+
+    generalPool.free(generalBuf, bufferSize);
+    dictPool.free(dictBuf, bufferSize);
+    outputPool.free(outputBuf, bufferSize);
+    ASSERT_EQ(context.getTotalMemoryUsage(), 0);
+    ASSERT_EQ(generalPool.currentBytes(), 0);
+    ASSERT_EQ(generalPool.reservedBytes(), 0);
+    ASSERT_EQ(dictPool.currentBytes(), 0);
+    ASSERT_EQ(dictPool.reservedBytes(), 0);
+    ASSERT_EQ(outputPool.currentBytes(), 0);
+    ASSERT_EQ(outputPool.reservedBytes(), 0);
+    ASSERT_EQ(context.getTotalMemoryUsage(), 0);
+    ASSERT_EQ(context.availableMemoryReservation(), 0);
+  }
+}
 } // namespace facebook::velox::dwrf

--- a/velox/dwio/dwrf/test/WriterFlushTest.cpp
+++ b/velox/dwio/dwrf/test/WriterFlushTest.cpp
@@ -65,9 +65,7 @@ class MockMemoryPool : public velox::memory::MemoryPool {
     VELOX_NYI("{} unsupported", __FUNCTION__);
   }
 
-  void release() override {
-    VELOX_NYI("{} unsupported", __FUNCTION__);
-  }
+  void release() override {}
 
   Stats stats() const override {
     VELOX_NYI("{} unsupported", __FUNCTION__);

--- a/velox/dwio/dwrf/writer/WriterBase.h
+++ b/velox/dwio/dwrf/writer/WriterBase.h
@@ -40,7 +40,9 @@ class WriterBase {
 
   virtual void abort() {
     writerSink_ = nullptr;
-    context_ = nullptr;
+    if (context_ != nullptr) {
+      context_->abort();
+    }
     if (sink_) {
       sink_->close();
       sink_ = nullptr;

--- a/velox/dwio/dwrf/writer/WriterContext.cpp
+++ b/velox/dwio/dwrf/writer/WriterContext.cpp
@@ -69,6 +69,10 @@ WriterContext::WriterContext(
   }
 }
 
+WriterContext::~WriterContext() {
+  releaseMemoryReservation();
+}
+
 void WriterContext::validateConfigs() const {
   // the writer is implemented with strong assumption that index is enabled.
   // Things like dictionary encoding will fail if not. Before we clean that up,
@@ -140,5 +144,16 @@ void WriterContext::releaseMemoryReservation() {
   dictionaryPool_->release();
   outputStreamPool_->release();
   generalPool_->release();
+}
+
+void WriterContext::abort() {
+  compressionBuffer_.reset();
+  physicalSizeAggregators_.clear();
+  streams_.clear();
+  dictEncoders_.clear();
+  decodedVectorPool_.clear();
+  decodedVectorPool_.shrink_to_fit();
+  selectivityVector_.reset();
+  releaseMemoryReservation();
 }
 } // namespace facebook::velox::dwrf

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -246,16 +246,6 @@ void TableWriter::updateNumWrittenFiles() {
       "numWrittenFiles", RuntimeCounter(dataSink_->numWrittenFiles()));
 }
 
-void TableWriter::abort() {
-  // NOTE: it is not safe to abort table writer which is under memory
-  // arbitration processing. The latter is most likely triggered by memory
-  // allocation from the file writer, and the abort will simply reset the file
-  // writer which might cause unexpected behavior.
-  if (!nonReclaimableSection_) {
-    close();
-  }
-}
-
 void TableWriter::close() {
   if (!closed_) {
     // Abort the data sink if the query has already failed and no need for

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -135,8 +135,6 @@ class TableWriter : public Operator {
     return false;
   }
 
-  void abort() override;
-
  private:
   // The memory reclaimer customized for connector which interface with the
   // memory arbitrator to reclaim memory from the file writers created within


### PR DESCRIPTION
When dwrf file writer fail, the current writer failure code path doesn't release
the unused memory on exit. The writer memory arbitration adds to reserve
memory in dwrf writer to prevent writer oom.
Unit test added to reproduce the crash found in Meta cluster test and verify the
fix.