### PR TITLE
Add memory reservation protection for stripe flush

### DIFF
--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -417,6 +417,8 @@ class HiveDataSink : public DataSink {
 
   std::vector<std::string> close(bool success) override;
 
+  bool canReclaim() const;
+
  private:
   class WriterReclaimer : public exec::MemoryReclaimer {
    public:
@@ -445,13 +447,6 @@ class HiveDataSink : public DataSink {
 
   FOLLY_ALWAYS_INLINE bool sortWrite() const {
     return !sortColumnIndices_.empty();
-  }
-
-  FOLLY_ALWAYS_INLINE bool canReclaim() const {
-    // Currently, we only support memory reclaim on dwrf file writer.
-    return (spillConfig_ != nullptr) && !sortWrite() &&
-        (insertTableHandle_->tableStorageFormat() ==
-         dwio::common::FileFormat::DWRF);
   }
 
   // Returns true if the table is partitioned.

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -21,6 +21,7 @@
 
 #include <folly/Executor.h>
 #include "velox/common/compression/Compression.h"
+#include "velox/common/config/SpillConfig.h"
 #include "velox/common/io/Options.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
@@ -536,17 +537,10 @@ class ReaderOptions : public io::ReaderOptions {
   }
 };
 
-struct WriterMemoryReclaimConfig {
-  /// The pct of the minimum free available memory reserved in a file write.
-  int32_t minReservationPct;
-  /// The pct of the memory reservation growth in a file write.
-  int32_t reservationGrowthPct;
-};
-
 struct WriterOptions {
   TypePtr schema;
   velox::memory::MemoryPool* memoryPool;
-  std::optional<WriterMemoryReclaimConfig> memoryReclaimConfig;
+  const velox::common::SpillConfig* spillConfig{nullptr};
   std::optional<velox::common::CompressionKind> compressionKind;
   std::optional<uint64_t> maxStripeSize{std::nullopt};
   std::optional<uint64_t> maxDictionaryMemory{std::nullopt};

--- a/velox/dwio/dwrf/test/CMakeLists.txt
+++ b/velox/dwio/dwrf/test/CMakeLists.txt
@@ -412,7 +412,7 @@ target_link_libraries(
   ZLIB::ZLIB
   ${TEST_LINK_LIBS})
 
-add_executable(velox_dwrf_e2e_writer_test E2EWriterTests.cpp)
+add_executable(velox_dwrf_e2e_writer_test E2EWriterTest.cpp)
 add_test(velox_dwrf_e2e_writer_test velox_dwrf_e2e_writer_test)
 
 target_link_libraries(


### PR DESCRIPTION
- Add memory reservation protection for stripe flush which needs to allocate
   memory which might trigger memory arbitration. Given that, we add a step
   to reserve memory for stripe flush and skip the reservation if the stripe flush
   itself is triggered by memory arbitration.
- Add closed flag in dwrf writer to indicate if it has been aborted or closed to
   prevent memory reclaim.
- This PR also replace WriterMemoryReclaimConfig with SpillConfig in writer
   interface to indicate if memory reclaim is enabled or not. Also a bug fix in
   memory reservation on the write path.

The followup is to clear the dwrf writer buffer caching if the stripe flush is for
memory arbitration.