### PR TITLE
Fix signature check script

### DIFF
--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -34,9 +34,11 @@ class bcolors:
 def export(args):
     """Exports Velox function signatures."""
     if args.spark:
+        pv.clear_signatures()
         pv.register_spark_signatures()
 
     if args.presto:
+        pv.clear_signatures()
         pv.register_presto_signatures()
 
     signatures = pv.get_function_signatures()

--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -169,7 +169,7 @@ def parse_args(args):
     command = parser.add_subparsers(dest="command")
     export_command_parser = command.add_parser("export")
     export_command_parser.add_argument("--spark", action="store_true")
-    export_command_parser.add_argument("--presto", action="store_false")
+    export_command_parser.add_argument("--presto", action="store_true")
     export_command_parser.add_argument("output_file", type=argparse.FileType("w"))
 
     diff_command_parser = command.add_parser("diff")

--- a/scripts/signature.py
+++ b/scripts/signature.py
@@ -33,12 +33,12 @@ class bcolors:
 
 def export(args):
     """Exports Velox function signatures."""
+    pv.clear_signatures()
+
     if args.spark:
-        pv.clear_signatures()
         pv.register_spark_signatures()
 
     if args.presto:
-        pv.clear_signatures()
         pv.register_presto_signatures()
 
     signatures = pv.get_function_signatures()


### PR DESCRIPTION
When args contains `--spark`, `pv.register_presto_signatures()` is called incorrectly.

It is necessary to execute `pv.clear_signatures()` before `pv.register_spark_signatures()`, because [the presto functions are registered when `import pyvelox.pyvelox as pv` is executed](https://github.com/facebookincubator/velox/blob/fe5feccb3b6ed01e1c9d1bfd56e020f00a2b09e8/pyvelox/pyvelox.cpp#L238).

