### PR TITLE
Make the initial thrift serialize buffer size configuable in arrow parquet writer

### DIFF
--- a/velox/dwio/parquet/writer/arrow/ThriftInternal.h
+++ b/velox/dwio/parquet/writer/arrow/ThriftInternal.h
@@ -27,6 +27,8 @@
 #include <utility>
 #include <vector>
 
+#include <gflags/gflags.h>
+
 // TCompactProtocol requires some #defines to work right.
 #define SIGNED_RIGHT_SHIFT_IS 1
 #define ARITHMETIC_RIGHT_SHIFT 1
@@ -45,6 +47,8 @@
 #include "velox/dwio/parquet/writer/arrow/Properties.h"
 #include "velox/dwio/parquet/writer/arrow/Types.h"
 #include "velox/dwio/parquet/writer/arrow/generated/parquet_types.h"
+
+DECLARE_int32(velox_arrow_parquet_writer_thrift_serialized_buffer_size);
 
 namespace facebook::velox::parquet::arrow {
 
@@ -506,7 +510,9 @@ class ThriftDeserializer {
 /// to treat it as a string.
 class ThriftSerializer {
  public:
-  explicit ThriftSerializer(int initial_buffer_size = 1024)
+  explicit ThriftSerializer(
+      int initial_buffer_size =
+          FLAGS_velox_arrow_parquet_writer_thrift_serialized_buffer_size)
       : mem_buffer_(new ThriftBuffer(initial_buffer_size)) {
     apache::thrift::protocol::TCompactProtocolFactoryT<ThriftBuffer> factory;
     protocol_ = factory.getProtocol(mem_buffer_);

--- a/velox/flag_definitions/flags.cpp
+++ b/velox/flag_definitions/flags.cpp
@@ -105,3 +105,10 @@ DEFINE_bool(
     "exception. This is only used by test to control the test error output size");
 
 DEFINE_bool(velox_memory_use_hugepages, true, "Use explicit huge pages");
+
+// Used in velox/dwio/parquet/writer/arrow/ThriftInternal.h
+
+DEFINE_int32(
+    velox_arrow_parquet_writer_thrift_serialized_buffer_size,
+    1024,
+    "Size of the serialized buffer for Arrow Parquet writer in MB");


### PR DESCRIPTION
We encountered an internal buffer size overflow exception while using Gluten to write Parquet data at a scale of 1GB. This exception occurred due to the default buffer size being hardcoded to 1024 [here](https://github.com/facebookincubator/velox/blob/88eb6436a51407e66ad6e6a415213bf6563c3eb3/velox/dwio/parquet/writer/arrow/ThriftInternal.h#L509), which is too small when dealing with high data scales. To address this issue, this pr introduces configurability for the initial buffer size.