### PR TITLE
Fix: Read orc with rowsPerRowGroup=0 in orc metadata

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.cpp
+++ b/velox/dwio/common/SelectiveColumnReader.cpp
@@ -374,6 +374,7 @@ void SelectiveColumnReader::addSkippedParentNulls(
     int32_t numNulls) {
   auto rowsPerRowGroup = formatData_->rowsPerRowGroup();
   if (rowsPerRowGroup.has_value() &&
+      rowsPerRowGroup.value() > 0 &&
       from / rowsPerRowGroup.value() >
           parentNullsRecordedTo_ / rowsPerRowGroup.value()) {
     // the new nulls are in a different row group than the last.

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -63,7 +63,7 @@ class SelectiveStructColumnReaderBase
   /// calling seekToRowGroup.
   void advanceFieldReader(SelectiveColumnReader* reader, vector_size_t offset)
       override {
-    if (!reader->isTopLevel()) {
+    if (!reader->isTopLevel() || rowsPerRowGroup_ <= 0) {
       return;
     }
     auto rowGroup = reader->readOffset() / rowsPerRowGroup_;


### PR DESCRIPTION
The `rowindexstride` in Orc footer may be 0, we should check `rowindexstride` or `rowsPerRowGroup` > 0 before dividing by `rowindexstride`.
The [related code ](https://github.com/apache/orc/blob/main/c%2B%2B/src/Reader.cc#L398) can be found in orc project.