### PR TITLE
Rewrite and optimize EvalCtx::addNulls method

### DIFF
--- a/velox/expression/tests/ExprTest.cpp
+++ b/velox/expression/tests/ExprTest.cpp
@@ -3351,12 +3351,16 @@ TEST_P(ParameterizedExprTest, addNulls) {
     // We do not set null to row three.
     localRows.setValid(4, true);
     localRows.updateBounds();
+    auto nulls = allocateNulls(5, pool());
+    auto* rawNulls = nulls->asMutable<uint64_t>();
+    bits::setNull(rawNulls, 4, true);
     exec::EvalCtx::addNulls(
-        localRows, nullptr, context, rowVector->type(), rowVector);
+        localRows, rawNulls, context, rowVector->type(), rowVector);
     ASSERT_EQ(rowVector->size(), 5);
 
     rowVector->validate();
-    ASSERT_TRUE(rowVector->isNullAt(3));
+    // Unselected row does not need to be marked null, just has to be valid.
+    ASSERT_FALSE(rowVector->isNullAt(3));
   };
 
   {

--- a/velox/functions/prestosql/tests/ArrayNormalizeTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayNormalizeTest.cpp
@@ -30,8 +30,7 @@ class ArrayNormalizeTest : public FunctionBaseTest {
   void testExpr(
       const VectorPtr& expected,
       const std::vector<VectorPtr>& input) {
-    auto result =
-        evaluate<ArrayVector>("array_normalize(C0, C1)", makeRowVector(input));
+    auto result = evaluate("array_normalize(C0, C1)", makeRowVector(input));
     assertEqualVectors(expected, result);
   }
 

--- a/velox/functions/prestosql/tests/ArrayShuffleTest.cpp
+++ b/velox/functions/prestosql/tests/ArrayShuffleTest.cpp
@@ -81,8 +81,7 @@ class ArrayShuffleTest : public FunctionBaseTest {
     DecodedVector decodedExpected(*input.get());
     exec::VectorReader<Array<T>> readerExpected(&decodedExpected);
 
-    auto actualVector =
-        evaluate<ArrayVector>("shuffle(C0)", makeRowVector({input}));
+    auto actualVector = evaluate("shuffle(C0)", makeRowVector({input}));
     // Validate each row from the actual decoded ArrayVector is a permutation
     // of the corresponding row from the expected decoded ArrayVector.
     DecodedVector decodedActual(*actualVector.get());
@@ -172,8 +171,7 @@ class ArrayShuffleTest : public FunctionBaseTest {
         typename exec::ArrayView<false, int32_t>::materialize_t;
     folly::F14FastSet<materialize_t> distinctValueSet;
 
-    auto actualVector =
-        evaluate<ArrayVector>("shuffle(C0)", makeRowVector({inputVector}));
+    auto actualVector = evaluate("shuffle(C0)", makeRowVector({inputVector}));
 
     DecodedVector decodedActual(*actualVector.get());
     exec::VectorReader<Array<int32_t>> readerActual(&decodedActual);
@@ -248,8 +246,8 @@ TEST_F(ArrayShuffleTest, sortAndShuffle) {
         2,
         std::nullopt}});
   auto inputVector = makeRowVector({input});
-  auto result1 = evaluate<ArrayVector>("array_sort(C0)", inputVector);
-  auto result2 = evaluate<ArrayVector>("array_sort(shuffle(C0))", inputVector);
+  auto result1 = evaluate("array_sort(C0)", inputVector);
+  auto result2 = evaluate("array_sort(shuffle(C0))", inputVector);
 
   assertEqualVectors(result1, result2);
 }

--- a/velox/functions/prestosql/tests/ArraySortTest.cpp
+++ b/velox/functions/prestosql/tests/ArraySortTest.cpp
@@ -178,12 +178,10 @@ class ArraySortTest : public FunctionBaseTest,
     };
     for (const auto& testData : testSettings) {
       SCOPED_TRACE(testData.debugString());
-      auto actualResult =
-          evaluate<ArrayVector>("array_sort(c0)", testData.inputVector);
+      auto actualResult = evaluate("array_sort(c0)", testData.inputVector);
       assertEqualVectors(testData.expectedResult, actualResult);
 
-      auto descResult =
-          evaluate<ArrayVector>("array_sort_desc(c0)", testData.inputVector);
+      auto descResult = evaluate("array_sort_desc(c0)", testData.inputVector);
       assertEqualVectors(testData.expectedDescResult, descResult);
     }
   }

--- a/velox/functions/prestosql/tests/ReverseTest.cpp
+++ b/velox/functions/prestosql/tests/ReverseTest.cpp
@@ -23,9 +23,8 @@ using namespace facebook::velox::functions::test;
 namespace {
 class ReverseTest : public FunctionBaseTest {
  protected:
-  template <typename T>
   void testExpr(const VectorPtr& expected, const VectorPtr& input) {
-    auto result = evaluate<T>("reverse(C0)", makeRowVector({input}));
+    auto result = evaluate("reverse(C0)", makeRowVector({input}));
     assertEqualVectors(expected, result);
   }
 };
@@ -44,7 +43,7 @@ TEST_F(ReverseTest, intsArrays) {
        {std::nullopt, 8, 3},
        {8, 1},
        {}});
-  testExpr<ArrayVector>(expected, array1);
+  testExpr(expected, array1);
 }
 
 TEST_F(ReverseTest, doublesArrays) {
@@ -59,7 +58,7 @@ TEST_F(ReverseTest, doublesArrays) {
       {std::nullopt, 8, 3},
       {8, 1},
   });
-  testExpr<ArrayVector>(expected, input);
+  testExpr(expected, input);
 }
 
 TEST_F(ReverseTest, stringsArrays) {
@@ -74,7 +73,7 @@ TEST_F(ReverseTest, stringsArrays) {
        {std::nullopt, S("xyz"), S("mnoasda asasd aqqerewqe")},
        {}});
 
-  testExpr<ArrayVector>(expected, input);
+  testExpr(expected, input);
 }
 
 TEST_F(ReverseTest, constant) {
@@ -86,7 +85,7 @@ TEST_F(ReverseTest, constant) {
 
   auto expected = makeNullableArrayVector<int32_t>({{3, 2, 1}, {3, 2, 1}});
 
-  testExpr<SimpleVector<ComplexType>>(expected, constant);
+  testExpr(expected, constant);
 }
 
 TEST_F(ReverseTest, nestedArray) {
@@ -140,18 +139,18 @@ TEST_F(ReverseTest, nestedArray) {
        O({4, 3}),
        O({1, 2})});
 
-  testExpr<ArrayVector>(expected, arrayOfArrays);
+  testExpr(expected, arrayOfArrays);
 
   arrayOfArrays =
       createArrayOfArrays({O({1, 2, 3, 4}), O({4, 5, std::nullopt})});
   expected = createArrayOfArrays({O({4, 5, std::nullopt}), O({1, 2, 3, 4})});
 
-  testExpr<ArrayVector>(expected, arrayOfArrays);
+  testExpr(expected, arrayOfArrays);
 
   arrayOfArrays = createArrayOfArrays({std::nullopt, O({4, 5, std::nullopt})});
   expected = createArrayOfArrays({O({4, 5, std::nullopt}), std::nullopt});
 
-  testExpr<ArrayVector>(expected, arrayOfArrays);
+  testExpr(expected, arrayOfArrays);
 }
 
 TEST_F(ReverseTest, nullArray) {
@@ -164,6 +163,6 @@ TEST_F(ReverseTest, nullArray) {
   auto reverseNullArray =
       makeNullableArrayVector<int32_t>({reverseNullVec, std::nullopt});
 
-  testExpr<ArrayVector>(reverseNullArray, nullArray);
+  testExpr(reverseNullArray, nullArray);
 }
 } // namespace

--- a/velox/functions/prestosql/tests/ZipTest.cpp
+++ b/velox/functions/prestosql/tests/ZipTest.cpp
@@ -101,7 +101,7 @@ TEST_F(ZipTest, nullEmptyArray) {
       {5, 5},
   });
 
-  auto result = evaluate<ArrayVector>(
+  auto result = evaluate(
       "zip(c0, c1)",
       makeRowVector({
           firstVector,
@@ -138,7 +138,7 @@ TEST_F(ZipTest, arity) {
        {S("b"), S("b"), S("b")},
        {S("c"), S("c")}});
 
-  auto result = evaluate<ArrayVector>(
+  auto result = evaluate(
       "zip(c0, c1, c2, c3)",
       makeRowVector({firstVector, secondVector, thirdVector, fourthVector}));
 

--- a/velox/functions/sparksql/tests/ArraySortTest.cpp
+++ b/velox/functions/sparksql/tests/ArraySortTest.cpp
@@ -31,8 +31,7 @@ using facebook::velox::functions::test::FunctionBaseTest;
 class ArraySortTest : public SparkFunctionBaseTest {
  protected:
   void testArraySort(const VectorPtr& input, const VectorPtr& expected) {
-    auto result =
-        evaluate<ArrayVector>("array_sort(c0)", makeRowVector({input}));
+    auto result = evaluate("array_sort(c0)", makeRowVector({input}));
     assertEqualVectors(expected, result);
   }
 

--- a/velox/functions/sparksql/tests/SortArrayTest.cpp
+++ b/velox/functions/sparksql/tests/SortArrayTest.cpp
@@ -50,7 +50,7 @@ class SortArrayTest : public SparkFunctionBaseTest {
       const VectorPtr& input,
       const VectorPtr& expected) {
     SCOPED_TRACE(expr);
-    auto result = evaluate<ArrayVector>(expr, makeRowVector({input}));
+    auto result = evaluate(expr, makeRowVector({input}));
     assertEqualVectors(expected, result);
   }
 


### PR DESCRIPTION
This change rewrites the EvalCtx::addNulls() implementation to ensure
all cases are covered for generating a valid output vector.
Additionally adds an optimization where it wraps complex vectors
in a dictionary instead of copying them for cases where they are
not mutable or need to be resize.

Additionaly, modified tests that relied on the output to be a
non-encoded (dictionary or constant) complex vector.

Test Plan:
Verified that all tests pass