### PR TITLE
Optimize mapSubcript by caching input keys in a hash map.

### DIFF
--- a/velox/functions/lib/SubscriptUtil.cpp
+++ b/velox/functions/lib/SubscriptUtil.cpp
@@ -14,9 +14,257 @@
  * limitations under the License.
  */
 
+#include <cstdint>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "velox/common/memory/MemoryPool.h"
 #include "velox/functions/lib/SubscriptUtil.h"
+#include "velox/type/Type.h"
+#include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::functions {
+
+namespace {
+
+template <TypeKind Kind>
+struct SimpleType {
+  using type = typename TypeTraits<Kind>::NativeType;
+};
+
+template <>
+struct SimpleType<TypeKind::VARBINARY> {
+  using type = Varbinary;
+};
+
+template <>
+struct SimpleType<TypeKind::VARCHAR> {
+  using type = Varchar;
+};
+
+/// Decode arguments and transform result into a dictionaryVector where the
+/// dictionary maintains a mapping from a given row to the index of the input
+/// map value vector. This allows us to ensure that element_at is zero-copy.
+template <TypeKind kind>
+VectorPtr applyMapTyped(
+    bool triggerCashing,
+    std::shared_ptr<LookupTableBase>& cachedLookupTablePtr,
+    const SelectivityVector& rows,
+    const VectorPtr& mapArg,
+    const VectorPtr& indexArg,
+    exec::EvalCtx& context) {
+  static constexpr vector_size_t kMinCachedMapSize = 100;
+  using TKey = typename TypeTraits<kind>::NativeType;
+
+  if (triggerCashing) {
+    if (!cachedLookupTablePtr) {
+      cachedLookupTablePtr =
+          std::make_shared<LookupTable<kind>>(*context.pool());
+    }
+  }
+
+  auto& typedLookupTable = cachedLookupTablePtr->typedTable<kind>();
+
+  auto* pool = context.pool();
+  BufferPtr indices = allocateIndices(rows.end(), pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  // Create nulls for lazy initialization.
+  NullsBuilder nullsBuilder(rows.end(), pool);
+
+  // Get base MapVector.
+  // TODO: Optimize the case when indices are identity.
+  exec::LocalDecodedVector mapHolder(context, *mapArg, rows);
+  auto decodedMap = mapHolder.get();
+  auto baseMap = decodedMap->base()->as<MapVector>();
+  auto mapIndices = decodedMap->indices();
+
+  // Get map keys.
+  auto mapKeys = baseMap->mapKeys();
+  exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
+  allElementRows->setAll();
+  exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
+  auto decodedMapKeys = mapKeysHolder.get();
+
+  // Get index vector (second argument).
+  exec::LocalDecodedVector indexHolder(context, *indexArg, rows);
+  auto decodedIndices = indexHolder.get();
+
+  auto rawSizes = baseMap->rawSizes();
+  auto rawOffsets = baseMap->rawOffsets();
+
+  // Lambda that does the search for a key, for each row.
+  auto processRow = [&](vector_size_t row, TKey searchKey) {
+    size_t mapIndex = mapIndices[row];
+    auto size = rawSizes[mapIndex];
+    size_t offsetStart = rawOffsets[mapIndex];
+    size_t offsetEnd = offsetStart + size;
+    bool found = false;
+
+    if (triggerCashing && size >= kMinCachedMapSize) {
+      // Create map for mapIndex if not created.
+      if (!typedLookupTable.containsMapAtIndex(mapIndex)) {
+        typedLookupTable.ensureMapAtIndex(mapIndex);
+        // Materialize the map at index row.
+        auto& map = typedLookupTable.getMapAtIndex(mapIndex);
+        for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
+          map.emplace(decodedMapKeys->valueAt<TKey>(offset), offset);
+        }
+      }
+
+      // Fast lookup.
+      auto& map = typedLookupTable.getMapAtIndex(mapIndex);
+
+      // VELOX_DCHECK(containsMapAtIndex(rowIndex));
+
+      auto value = map.find(searchKey);
+      if (value != map.end()) {
+        rawIndices[row] = value->second;
+        found = true;
+      }
+
+    } else {
+      // Search map without caching.
+      for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
+        if (decodedMapKeys->valueAt<TKey>(offset) == searchKey) {
+          rawIndices[row] = offset;
+          found = true;
+          break;
+        }
+      }
+    }
+
+    // Handle NULLs.
+    if (!found) {
+      nullsBuilder.setNull(row);
+    }
+  };
+
+  // When second argument ("at") is a constant.
+  if (decodedIndices->isConstantMapping()) {
+    auto searchKey = decodedIndices->valueAt<TKey>(0);
+    rows.applyToSelected(
+        [&](vector_size_t row) { processRow(row, searchKey); });
+  }
+
+  // When the second argument ("at") is also a variable vector.
+  else {
+    rows.applyToSelected([&](vector_size_t row) {
+      auto searchKey = decodedIndices->valueAt<TKey>(row);
+      processRow(row, searchKey);
+    });
+  }
+
+  // Subscript into empty maps always returns NULLs. Check added at the end to
+  // ensure user error checks for indices are not skipped.
+  if (baseMap->mapValues()->size() == 0) {
+    return BaseVector::createNullConstant(
+        baseMap->mapValues()->type(), rows.end(), context.pool());
+  }
+
+  return BaseVector::wrapInDictionary(
+      nullsBuilder.build(), indices, rows.end(), baseMap->mapValues());
+}
+
+VectorPtr applyMapComplexType(
+    const SelectivityVector& rows,
+    const VectorPtr& mapArg,
+    const VectorPtr& indexArg,
+    exec::EvalCtx& context) {
+  auto* pool = context.pool();
+
+  // Use indices with the mapValues wrapped in a dictionary vector.
+  BufferPtr indices = allocateIndices(rows.end(), pool);
+  auto rawIndices = indices->asMutable<vector_size_t>();
+
+  // Create nulls for lazy initialization.
+  NullsBuilder nullsBuilder(rows.end(), pool);
+
+  // Get base MapVector.
+  exec::LocalDecodedVector mapHolder(context, *mapArg, rows);
+  auto decodedMap = mapHolder.get();
+  auto baseMap = decodedMap->base()->as<MapVector>();
+  auto mapIndices = decodedMap->indices();
+
+  // Get map keys.
+  auto mapKeys = baseMap->mapKeys();
+  exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
+  allElementRows->setAll();
+  exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
+  auto mapKeysDecoded = mapKeysHolder.get();
+  auto mapKeysBase = mapKeysDecoded->base();
+  auto mapKeysIndices = mapKeysDecoded->indices();
+
+  // Get index vector (second argument).
+  exec::LocalDecodedVector indexHolder(context, *indexArg, rows);
+  auto decodedIndices = indexHolder.get();
+  auto searchBase = decodedIndices->base();
+  auto searchIndices = decodedIndices->indices();
+
+  auto rawSizes = baseMap->rawSizes();
+  auto rawOffsets = baseMap->rawOffsets();
+
+  // Search the key in each row.
+  rows.applyToSelected([&](vector_size_t row) {
+    size_t mapIndex = mapIndices[row];
+    size_t size = rawSizes[mapIndex];
+    size_t offset = rawOffsets[mapIndex];
+
+    bool found = false;
+    auto searchIndex = searchIndices[row];
+    for (auto i = 0; i < size; i++) {
+      if (mapKeysBase->equalValueAt(
+              searchBase, mapKeysIndices[offset + i], searchIndex)) {
+        rawIndices[row] = offset + i;
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      nullsBuilder.setNull(row);
+    };
+  });
+
+  // Subscript into empty maps always returns NULLs.
+  if (baseMap->mapValues()->size() == 0) {
+    return BaseVector::createNullConstant(
+        baseMap->mapValues()->type(), rows.end(), context.pool());
+  }
+
+  return BaseVector::wrapInDictionary(
+      nullsBuilder.build(), indices, rows.end(), baseMap->mapValues());
+}
+
+} // namespace
+
+VectorPtr MapSubscript::applyMap(
+    const SelectivityVector& rows,
+    std::vector<VectorPtr>& args,
+    exec::EvalCtx& context) const {
+  auto& mapArg = args[0];
+  auto& indexArg = args[1];
+
+  // Ensure map key type and second argument are the same.
+  VELOX_CHECK(mapArg->type()->childAt(0)->equivalent(*indexArg->type()));
+
+  if (indexArg->type()->isPrimitiveType()) {
+    bool triggerCaching = shouldTriggerCaching(mapArg);
+
+    return VELOX_DYNAMIC_SCALAR_TYPE_DISPATCH(
+        applyMapTyped,
+        indexArg->typeKind(),
+        triggerCaching,
+        const_cast<std::shared_ptr<LookupTableBase>&>(lookupTable_),
+        rows,
+        mapArg,
+        indexArg,
+        context);
+  } else {
+    return applyMapComplexType(rows, mapArg, indexArg, context);
+  }
+}
 
 namespace {
 std::exception_ptr makeZeroSubscriptError() {

--- a/velox/functions/lib/SubscriptUtil.h
+++ b/velox/functions/lib/SubscriptUtil.h
@@ -16,10 +16,16 @@
 
 #pragma once
 
+#include <memory>
+#include "velox/expression/ComplexViewTypes.h"
 #include "velox/expression/Expr.h"
 #include "velox/expression/VectorFunction.h"
+#include "velox/expression/VectorReaders.h"
 #include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
 #include "velox/vector/NullsBuilder.h"
+#include "velox/vector/TypeAliases.h"
 
 namespace facebook::velox::functions {
 
@@ -29,11 +35,139 @@ const std::exception_ptr& zeroSubscriptError();
 const std::exception_ptr& badSubscriptError();
 const std::exception_ptr& negativeSubscriptError();
 
+template <TypeKind kind>
+class LookupTable;
+
+class LookupTableBase {
+ public:
+  template <TypeKind kind>
+  LookupTable<kind>& typedTable() {
+    return *static_cast<LookupTable<kind>*>(this);
+  }
+  virtual ~LookupTableBase() {}
+};
+
+template <TypeKind kind>
+class LookupTable : public LookupTableBase {
+  using key_t = typename TypeTraits<kind>::NativeType;
+
+ public:
+  LookupTable(memory::MemoryPool& pool)
+      : pool_(pool),
+        map_(std::make_unique<outer_map_t>(outer_allocator_t(pool))) {}
+
+  auto& map() {
+    return map_;
+  }
+
+  bool containsMapAtIndex(vector_size_t rowIndex) const {
+    return map_->count(rowIndex) != 0;
+  }
+
+  void ensureMapAtIndex(vector_size_t rowIndex) const {
+    map_->emplace(rowIndex, pool_);
+  }
+
+  auto& getMapAtIndex(vector_size_t rowIndex) {
+    VELOX_DCHECK(containsMapAtIndex(rowIndex));
+    return map_->find(rowIndex)->second;
+  }
+
+ private:
+  using inner_allocator_t =
+      memory::StlAllocator<std::pair<key_t const, vector_size_t>>;
+
+  using inner_map_t = folly::F14FastMap<
+      key_t,
+      vector_size_t,
+      folly::f14::DefaultHasher<key_t>,
+      folly::f14::DefaultKeyEqual<key_t>,
+      inner_allocator_t>;
+
+  using outer_allocator_t =
+      memory::StlAllocator<std::pair<vector_size_t const, inner_map_t>>;
+
+  // [rowindex][key] -> offset of value.
+  using outer_map_t = folly::F14FastMap<
+      vector_size_t,
+      inner_map_t,
+      folly::f14::DefaultHasher<vector_size_t>,
+      folly::f14::DefaultKeyEqual<vector_size_t>,
+      outer_allocator_t>;
+
+  memory::MemoryPool& pool_;
+  std::unique_ptr<outer_map_t> map_;
+};
+
+class MapSubscript {
+ public:
+  explicit MapSubscript(bool allowCaching) : allowCashing_(allowCaching) {}
+
+  VectorPtr applyMap(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      exec::EvalCtx& context) const;
+
+  bool cachingEnabled() const {
+    return allowCashing_;
+  }
+
+  auto& lookupTable() const {
+    return lookupTable_;
+  }
+
+  auto& firstSeenMap() const {
+    return firstSeenMap_;
+  }
+
+ private:
+  bool shouldTriggerCaching(const VectorPtr& mapArg) const {
+    if (!allowCashing_) {
+      return false;
+    }
+
+    if (!mapArg->type()->childAt(0)->isPrimitiveType() &&
+        !!mapArg->type()->childAt(0)->isBoolean()) {
+      // Disable caching if the key type is not primitive or is boolean.
+      allowCashing_ = false;
+      return false;
+    }
+
+    if (!firstSeenMap_) {
+      firstSeenMap_ = mapArg;
+      return false;
+    }
+
+    if (firstSeenMap_->wrappedVector() == mapArg->wrappedVector()) {
+      return true;
+    }
+
+    // Disable cashing forever.
+    allowCashing_ = false;
+    lookupTable_.reset();
+    firstSeenMap_.reset();
+    return false;
+  }
+
+  // When true the function is allowed to cache a materialized version of the
+  // processed map.
+  mutable bool allowCashing_;
+
+  // This is used to check if the same base map is being passed over and over
+  // in the function. A shared_ptr is used to guarantee that if the map is
+  // seen again then it was not modified.
+  mutable VectorPtr firstSeenMap_;
+
+  // Materialized cached version of firstSeenMap_ used to optimize the lookup.
+  mutable std::shared_ptr<LookupTableBase> lookupTable_;
+};
+
 /// Generic subscript/element_at implementation for both array and map data
 /// types.
 ///
 /// Provides four template parameters to configure the behavior:
-/// - allowNegativeIndices: if allowed, negative indices accesses elements from
+/// - allowNegativeIndices: if allowed, negative indices accesses elements
+/// from
 ///   last to the first; otherwise, throws.
 /// - nullOnNegativeIndices: returns NULL for negative indices instead of the
 ///   behavior described above.
@@ -47,6 +181,9 @@ template <
     bool indexStartsAtOne>
 class SubscriptImpl : public exec::Subscript {
  public:
+  explicit SubscriptImpl(bool allowCashing)
+      : mapSubscript_(MapSubscript(allowCashing)) {}
+
   void apply(
       const SelectivityVector& rows,
       std::vector<VectorPtr>& args,
@@ -62,13 +199,36 @@ class SubscriptImpl : public exec::Subscript {
         break;
 
       case TypeKind::MAP:
-        localResult = applyMap(rows, args, context);
+        localResult = mapSubscript_.applyMap(rows, args, context);
         break;
 
       default:
         VELOX_UNREACHABLE();
     }
     context.moveOrCopyResult(localResult, rows, result);
+  }
+
+  VectorPtr applyArray(
+      const SelectivityVector& rows,
+      std::vector<VectorPtr>& args,
+      exec::EvalCtx& context) const {
+    VELOX_CHECK_EQ(args[0]->typeKind(), TypeKind::ARRAY);
+
+    auto arrayArg = args[0];
+    auto indexArg = args[1];
+
+    switch (indexArg->typeKind()) {
+      case TypeKind::INTEGER:
+        return applyArrayTyped<int32_t>(rows, arrayArg, indexArg, context);
+
+      case TypeKind::BIGINT:
+        return applyArrayTyped<int64_t>(rows, arrayArg, indexArg, context);
+
+      default:
+        VELOX_UNSUPPORTED(
+            "Unsupported type for element_at index {}",
+            mapTypeKindToName(indexArg->typeKind()));
+    }
   }
 
   static std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {
@@ -96,78 +256,6 @@ class SubscriptImpl : public exec::Subscript {
     return signatures;
   }
 
- private:
-  VectorPtr applyArray(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      exec::EvalCtx& context) const {
-    VELOX_CHECK_EQ(args[0]->typeKind(), TypeKind::ARRAY);
-
-    auto arrayArg = args[0];
-    auto indexArg = args[1];
-
-    switch (indexArg->typeKind()) {
-      case TypeKind::INTEGER:
-        return applyArrayTyped<int32_t>(rows, arrayArg, indexArg, context);
-
-      case TypeKind::BIGINT:
-        return applyArrayTyped<int64_t>(rows, arrayArg, indexArg, context);
-
-      default:
-        VELOX_UNSUPPORTED(
-            "Unsupported type for element_at index {}",
-            mapTypeKindToName(indexArg->typeKind()));
-    }
-  }
-
-  VectorPtr applyMap(
-      const SelectivityVector& rows,
-      std::vector<VectorPtr>& args,
-      exec::EvalCtx& context) const {
-    VELOX_CHECK_EQ(args[0]->typeKind(), TypeKind::MAP);
-
-    auto mapArg = args[0];
-    auto indexArg = args[1];
-
-    // Ensure map key type and second argument are the same.
-    VELOX_CHECK(mapArg->type()->childAt(0)->equivalent(*indexArg->type()));
-
-    switch (indexArg->typeKind()) {
-      case TypeKind::HUGEINT:
-        return applyMapTyped<int128_t>(rows, mapArg, indexArg, context);
-      case TypeKind::BIGINT:
-        return applyMapTyped<int64_t>(rows, mapArg, indexArg, context);
-      case TypeKind::INTEGER:
-        return applyMapTyped<int32_t>(rows, mapArg, indexArg, context);
-      case TypeKind::SMALLINT:
-        return applyMapTyped<int16_t>(rows, mapArg, indexArg, context);
-      case TypeKind::TINYINT:
-        return applyMapTyped<int8_t>(rows, mapArg, indexArg, context);
-      case TypeKind::REAL:
-        return applyMapTyped<float>(rows, mapArg, indexArg, context);
-      case TypeKind::DOUBLE:
-        return applyMapTyped<double>(rows, mapArg, indexArg, context);
-      case TypeKind::BOOLEAN:
-        return applyMapTyped<bool>(rows, mapArg, indexArg, context);
-      case TypeKind::TIMESTAMP:
-        return applyMapTyped<Timestamp>(rows, mapArg, indexArg, context);
-      case TypeKind::VARCHAR:
-      case TypeKind::VARBINARY:
-        return applyMapTyped<StringView>(rows, mapArg, indexArg, context);
-      case TypeKind::ARRAY:
-      case TypeKind::MAP:
-      case TypeKind::ROW:
-        return applyMapComplexType(rows, mapArg, indexArg, context);
-      default:
-        VELOX_UNSUPPORTED(
-            "Unsupported map key type for element_at: {}",
-            mapTypeKindToName(indexArg->typeKind()));
-    }
-  }
-
-  /// Decode arguments and transform result into a dictionaryVector where the
-  /// dictionary maintains a mapping from a given row to the index of the input
-  /// elements vector. This allows us to ensure that element_at is zero-copy.
   template <typename I>
   VectorPtr applyArrayTyped(
       const SelectivityVector& rows,
@@ -266,7 +354,8 @@ class SubscriptImpl : public exec::Subscript {
 
   // Returns the actual Vector index given an array index. Checks and adjusts
   // negative indices, in addition to bound checks.
-  // `index` is always a 0-based array index (see `adjustIndex` function above).
+  // `index` is always a 0-based array index (see `adjustIndex` function
+  // above).
   template <typename I>
   vector_size_t getIndex(
       I index,
@@ -307,168 +396,8 @@ class SubscriptImpl : public exec::Subscript {
     return rawOffsets[indices[row]] + index;
   }
 
-  /// Decode arguments and transform result into a dictionaryVector where the
-  /// dictionary maintains a mapping from a given row to the index of the input
-  /// map value vector. This allows us to ensure that element_at is zero-copy.
-  template <typename TKey>
-  VectorPtr applyMapTyped(
-      const SelectivityVector& rows,
-      const VectorPtr& mapArg,
-      const VectorPtr& indexArg,
-      exec::EvalCtx& context) const {
-    auto* pool = context.pool();
-
-    BufferPtr indices = allocateIndices(rows.end(), pool);
-    auto rawIndices = indices->asMutable<vector_size_t>();
-
-    // Create nulls for lazy initialization.
-    NullsBuilder nullsBuilder(rows.end(), pool);
-
-    // Get base MapVector.
-    // TODO: Optimize the case when indices are identity.
-    exec::LocalDecodedVector mapHolder(context, *mapArg, rows);
-    auto decodedMap = mapHolder.get();
-    auto baseMap = decodedMap->base()->as<MapVector>();
-    auto mapIndices = decodedMap->indices();
-
-    // Get map keys.
-    auto mapKeys = baseMap->mapKeys();
-    exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
-    allElementRows->setAll();
-    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
-    auto decodedMapKeys = mapKeysHolder.get();
-
-    // Get index vector (second argument).
-    exec::LocalDecodedVector indexHolder(context, *indexArg, rows);
-    auto decodedIndices = indexHolder.get();
-
-    auto rawSizes = baseMap->rawSizes();
-    auto rawOffsets = baseMap->rawOffsets();
-
-    // Lambda that does the search for a key, for each row.
-    auto processRow = [&](vector_size_t row, TKey searchKey) {
-      size_t mapIndex = mapIndices[row];
-      size_t offsetStart = rawOffsets[mapIndex];
-      size_t offsetEnd = offsetStart + rawSizes[mapIndex];
-      bool found = false;
-
-      // Sequentially check each key on this map for a match. We use a
-      // sequential scan over the keys because it's easier to express (and
-      // likely has good memory locality), but if we find that this is slow
-      // for large maps we could try to canonicalize the whole vector and binary
-      // search `searchKey`.
-      for (size_t offset = offsetStart; offset < offsetEnd; ++offset) {
-        if (decodedMapKeys->valueAt<TKey>(offset) == searchKey) {
-          rawIndices[row] = offset;
-          found = true;
-          break;
-        }
-      }
-
-      // NB: We still allow non-existent map keys, even if out of bounds is
-      // disabled for arrays.
-
-      // Handle NULLs.
-      if (!found) {
-        nullsBuilder.setNull(row);
-      }
-    };
-
-    // When second argument ("at") is a constant.
-    if (decodedIndices->isConstantMapping()) {
-      auto searchKey = decodedIndices->valueAt<TKey>(0);
-      rows.applyToSelected(
-          [&](vector_size_t row) { processRow(row, searchKey); });
-    }
-    // When the second argument ("at") is also a variable vector.
-    else {
-      rows.applyToSelected([&](vector_size_t row) {
-        auto searchKey = decodedIndices->valueAt<TKey>(row);
-        processRow(row, searchKey);
-      });
-    }
-
-    // Subscript into empty maps always returns NULLs. Check added at the end to
-    // ensure user error checks for indices are not skipped.
-    if (baseMap->mapValues()->size() == 0) {
-      return BaseVector::createNullConstant(
-          baseMap->mapValues()->type(), rows.end(), context.pool());
-    }
-
-    return BaseVector::wrapInDictionary(
-        nullsBuilder.build(), indices, rows.end(), baseMap->mapValues());
-  }
-
-  VectorPtr applyMapComplexType(
-      const SelectivityVector& rows,
-      const VectorPtr& mapArg,
-      const VectorPtr& indexArg,
-      exec::EvalCtx& context) const {
-    auto* pool = context.pool();
-
-    // Use indices with the mapValues wrapped in a dictionary vector.
-    BufferPtr indices = allocateIndices(rows.end(), pool);
-    auto rawIndices = indices->asMutable<vector_size_t>();
-
-    // Create nulls for lazy initialization.
-    NullsBuilder nullsBuilder(rows.end(), pool);
-
-    // Get base MapVector.
-    exec::LocalDecodedVector mapHolder(context, *mapArg, rows);
-    auto decodedMap = mapHolder.get();
-    auto baseMap = decodedMap->base()->as<MapVector>();
-    auto mapIndices = decodedMap->indices();
-
-    // Get map keys.
-    auto mapKeys = baseMap->mapKeys();
-    exec::LocalSelectivityVector allElementRows(context, mapKeys->size());
-    allElementRows->setAll();
-    exec::LocalDecodedVector mapKeysHolder(context, *mapKeys, *allElementRows);
-    auto mapKeysDecoded = mapKeysHolder.get();
-    auto mapKeysBase = mapKeysDecoded->base();
-    auto mapKeysIndices = mapKeysDecoded->indices();
-
-    // Get index vector (second argument).
-    exec::LocalDecodedVector indexHolder(context, *indexArg, rows);
-    auto decodedIndices = indexHolder.get();
-    auto searchBase = decodedIndices->base();
-    auto searchIndices = decodedIndices->indices();
-
-    auto rawSizes = baseMap->rawSizes();
-    auto rawOffsets = baseMap->rawOffsets();
-
-    // Search the key in each row.
-    rows.applyToSelected([&](vector_size_t row) {
-      size_t mapIndex = mapIndices[row];
-      size_t size = rawSizes[mapIndex];
-      size_t offset = rawOffsets[mapIndex];
-
-      bool found = false;
-      auto searchIndex = searchIndices[row];
-      for (auto i = 0; i < size; i++) {
-        if (mapKeysBase->equalValueAt(
-                searchBase, mapKeysIndices[offset + i], searchIndex)) {
-          rawIndices[row] = offset + i;
-          found = true;
-          break;
-        }
-      }
-
-      if (!found) {
-        nullsBuilder.setNull(row);
-      };
-    });
-
-    // Subscript into empty maps always returns NULLs. Check added at the end to
-    // ensure user error checks for indices are not skipped.
-    if (baseMap->mapValues()->size() == 0) {
-      return BaseVector::createNullConstant(
-          baseMap->mapValues()->type(), rows.end(), context.pool());
-    }
-
-    return BaseVector::wrapInDictionary(
-        nullsBuilder.build(), indices, rows.end(), baseMap->mapValues());
-  }
+ private:
+  MapSubscript mapSubscript_;
 };
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/ElementAt.cpp
+++ b/velox/functions/prestosql/ElementAt.cpp
@@ -29,16 +29,35 @@ namespace {
 /// - allows out of bounds accesses for arrays and maps (returns NULL if out of
 ///    bounds).
 /// - index starts at 1 for arrays.
-using ElementAtFunction = SubscriptImpl<
-    /* allowNegativeIndices */ true,
-    /* nullOnNegativeIndices */ false,
-    /* allowOutOfBound */ true,
-    /* indexStartsAtOne */ true>;
+class ElementAtFunction : public SubscriptImpl<
+                              /* allowNegativeIndices */ true,
+                              /* nullOnNegativeIndices */ false,
+                              /* allowOutOfBound */ true,
+                              /* indexStartsAtOne */ true> {
+ public:
+  explicit ElementAtFunction(bool allowCashing) : SubscriptImpl(allowCashing) {}
+};
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_element_at,
-    ElementAtFunction::signatures(),
-    std::make_unique<ElementAtFunction>());
+void registerElementAtFunction(
+    const std::string& name,
+    bool enableCaching = true) {
+  exec::registerStatefulVectorFunction(
+      name,
+      ElementAtFunction::signatures(),
+      [enableCaching](
+          const std::string&,
+          const std::vector<exec::VectorFunctionArg>& inputArgs,
+          const velox::core::QueryConfig& config) {
+        static const auto kSubscriptStateLess =
+            std::make_shared<ElementAtFunction>(false);
+        if (inputArgs[0].type->isArray()) {
+          return kSubscriptStateLess;
+        } else {
+          return std::make_shared<ElementAtFunction>(
+              enableCaching && config.isExpressionEvaluationCacheEnabled());
+        }
+      });
+}
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/Subscript.cpp
+++ b/velox/functions/prestosql/Subscript.cpp
@@ -31,6 +31,8 @@ class SubscriptFunction : public SubscriptImpl<
                               /* allowOutOfBound */ false,
                               /* indexStartsAtOne */ true> {
  public:
+  explicit SubscriptFunction(bool allowCashing) : SubscriptImpl(allowCashing) {}
+
   bool canPushdown() const override {
     return true;
   }
@@ -38,9 +40,25 @@ class SubscriptFunction : public SubscriptImpl<
 
 } // namespace
 
-VELOX_DECLARE_VECTOR_FUNCTION(
-    udf_subscript,
-    SubscriptFunction::signatures(),
-    std::make_unique<SubscriptFunction>());
+void registerSubscriptFunction(
+    const std::string& name,
+    bool enableCaching = true) {
+  exec::registerStatefulVectorFunction(
+      name,
+      SubscriptFunction::signatures(),
+      [enableCaching](
+          const std::string&,
+          const std::vector<exec::VectorFunctionArg>& inputArgs,
+          const velox::core::QueryConfig& config) {
+        static const auto kSubscriptStateLess =
+            std::make_shared<SubscriptFunction>(false);
+        if (inputArgs[0].type->isArray()) {
+          return kSubscriptStateLess;
+        } else {
+          return std::make_shared<SubscriptFunction>(
+              enableCaching && config.isExpressionEvaluationCacheEnabled());
+        }
+      });
+}
 
 } // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -171,3 +171,8 @@ add_executable(velox_functions_benchmarks_simdjson_function_with_expr
                JsonExprBenchmark.cpp)
 target_link_libraries(velox_functions_benchmarks_simdjson_function_with_expr
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_prestosql_benchmarks_map_subscript
+               MapSubscriptCachingBenchmark.cpp)
+target_link_libraries(velox_functions_prestosql_benchmarks_map_subscript
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/MapSubscriptCachingBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/MapSubscriptCachingBenchmark.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+
+#include "velox/benchmarks/ExpressionBenchmarkBuilder.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+#include "velox/type/Type.h"
+#include "velox/vector/BaseVector.h"
+#include "velox/vector/ComplexVector.h"
+#include "velox/vector/DecodedVector.h"
+
+using namespace facebook::velox;
+using namespace facebook::velox::exec;
+using namespace facebook::velox::functions;
+
+namespace facebook::velox::functions {
+extern void registerSubscriptFunction(
+    const std::string& name,
+    bool enableCaching);
+}
+
+// This benchmark evaluates the effectiveness of the caching optimization of map
+// subscript and ensure that it does not degrade performance.
+int main(int argc, char** argv) {
+  folly::Init init(&argc, &argv);
+
+  ExpressionBenchmarkBuilder benchmarkBuilder;
+  facebook::velox::functions::prestosql::registerAllScalarFunctions();
+  facebook::velox::functions::registerSubscriptFunction(
+      "subscriptNoCashing", false);
+
+  auto* pool = benchmarkBuilder.pool();
+  auto& vm = benchmarkBuilder.vectorMaker();
+
+  auto createSet = [&](const TypePtr& mapType,
+                       size_t mapLength,
+                       size_t baseVectorSize,
+                       size_t numberOfBatches = 1000) {
+    VectorFuzzer::Options options;
+    options.vectorSize = 1000;
+    options.containerLength = mapLength;
+    options.complexElementsMaxSize = 10000000000;
+    options.containerVariableLength = false;
+
+    VectorFuzzer fuzzer(options, pool);
+    std::vector<VectorPtr> columns;
+
+    // Fuzz input map vector.
+    auto flatBase = fuzzer.fuzzFlat(mapType, baseVectorSize);
+    auto dictionary = fuzzer.fuzzDictionary(flatBase, options.vectorSize);
+
+    columns.push_back(dictionary);
+
+    // Fuzz indices vector.
+    DecodedVector decoded(*dictionary);
+    auto* map = flatBase->as<MapVector>();
+    auto indices = allocateIndices(options.vectorSize, pool);
+    auto* mutableIndices = indices->asMutable<vector_size_t>();
+
+    for (int i = 0; i < options.vectorSize; i++) {
+      auto mapIndex = decoded.index(i);
+      // Select a random exisiting key except when map is empty.
+      if (map->sizeAt(mapIndex) == 0) {
+        mutableIndices[i] = 0;
+      }
+      mutableIndices[i] = folly::Random::rand32() % map->sizeAt(mapIndex) +
+          map->offsetAt(mapIndex);
+    }
+
+    auto indicesVector = BaseVector::wrapInDictionary(
+        nullptr, indices, options.vectorSize, map->mapKeys());
+
+    columns.push_back(indicesVector);
+
+    auto name = fmt::format(
+        "{}_{}_{}", mapType->childAt(0)->toString(), mapLength, baseVectorSize);
+
+    benchmarkBuilder.addBenchmarkSet(name, vm.rowVector(columns))
+        .addExpression("subscript", "element_at(c0, c1)")
+        .addExpression("subscriptNoCashing", "subscriptNoCashing(c0, c1)")
+        .withIterations(numberOfBatches);
+  };
+
+  auto createSetsForType = [&](const auto& keyType) {
+    createSet(MAP(keyType, INTEGER()), 10, 1);
+    createSet(MAP(keyType, INTEGER()), 10, 1000);
+
+    createSet(MAP(keyType, INTEGER()), 100, 1);
+    createSet(MAP(keyType, INTEGER()), 100, 1000);
+
+    createSet(MAP(keyType, INTEGER()), 1000, 1);
+    createSet(MAP(keyType, INTEGER()), 1000, 1000);
+
+    createSet(MAP(keyType, INTEGER()), 10000, 1);
+    createSet(MAP(keyType, INTEGER()), 10000, 1000);
+  };
+
+  createSetsForType(INTEGER());
+  createSetsForType(VARCHAR());
+
+  benchmarkBuilder.registerBenchmarks();
+  benchmarkBuilder.testBenchmarks();
+
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -19,6 +19,12 @@
 #include "velox/functions/prestosql/Cardinality.h"
 
 namespace facebook::velox::functions {
+extern void registerSubscriptFunction(
+    const std::string& name,
+    bool enableCaching);
+extern void registerElementAtFunction(
+    const std::string& name,
+    bool enableCaching);
 
 // Special form functions don't have any prefix.
 void registerAllSpecialFormGeneralFunctions() {
@@ -29,8 +35,9 @@ void registerAllSpecialFormGeneralFunctions() {
 }
 
 void registerGeneralFunctions(const std::string& prefix) {
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, prefix + "element_at");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_subscript, prefix + "subscript");
+  registerSubscriptFunction(prefix + "subscript", true);
+  registerElementAtFunction(prefix + "element_at", true);
+
   VELOX_REGISTER_VECTOR_FUNCTION(udf_transform, prefix + "transform");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_reduce, prefix + "reduce");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_array_filter, prefix + "filter");

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -37,6 +37,9 @@
 #include "velox/functions/sparksql/String.h"
 
 namespace facebook::velox::functions {
+extern void registerElementAtFunction(
+    const std::string& name,
+    bool enableCaching);
 
 static void workAroundRegistrationMacro(const std::string& prefix) {
   // VELOX_REGISTER_VECTOR_FUNCTION must be invoked in the same namespace as the
@@ -54,7 +57,8 @@ static void workAroundRegistrationMacro(const std::string& prefix) {
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_array_intersect, prefix + "array_intersect");
   // This is the semantics of spark.sql.ansi.enabled = false.
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_element_at, prefix + "element_at");
+  registerElementAtFunction(prefix + "element_at", true);
+
   VELOX_REGISTER_VECTOR_FUNCTION(
       udf_map_allow_duplicates, prefix + "map_from_arrays");
   // String functions.


### PR DESCRIPTION
Summary:
There are cases where the mapSubscript function can receive the same (base) map over and over.
In that case searching the same map over and over is redundant.

This optimization makes mapSubscript a stateful function, if it sees that the same
base map is being provided for it, it will cache a materialized version of the input.

The shadowed query e2e runtime goes from 1.50 hours reduce to 16.48 min.
a local benchmark is added, the optimization is only enabled for non-bool pritmive types.

A benchmark is added. The function it self become so much faster speedups depends on the
number of batches, and the size of the base vector. The production case we have 1 map of size 80k
entry! so speedups for the function is extremely high.
```
============================================================================
[...]hmarks/ExpressionBenchmarkBuilder.cpp     relative  time/iter   iters/s
============================================================================
INTEGER_10000_1##subscript                                 29.09ms     34.37
INTEGER_10000_1##subscriptNoCashing                          3.08s   324.47m
INTEGER_10000_1000##subscript                              81.38ms     12.29
INTEGER_10000_1000##subscriptNoCashing                       3.19s   313.51m
INTEGER_1000_1##subscript                                  26.94ms     37.12
INTEGER_1000_1##subscriptNoCashing                        325.23ms      3.07
INTEGER_1000_1000##subscript                               40.22ms     24.86
INTEGER_1000_1000##subscriptNoCashing                     356.80ms      2.80
INTEGER_100_1##subscript                                   29.65ms     33.72
INTEGER_100_1##subscriptNoCashing                          51.72ms     19.34
INTEGER_100_1000##subscript                                32.03ms     31.22
INTEGER_100_1000##subscriptNoCashing                       56.16ms     17.81
INTEGER_10_1##subscript                                    23.61ms     42.35
INTEGER_10_1##subscriptNoCashing                           23.89ms     41.86
INTEGER_10_1000##subscript                                 24.46ms     40.88
INTEGER_10_1000##subscriptNoCashing                        24.65ms     40.58
VARCHAR_10000_1##subscript                                 77.48ms     12.91
VARCHAR_10000_1##subscriptNoCashing                          4.60s   217.57m
VARCHAR_10000_1000##subscript                             175.11ms      5.71
VARCHAR_10000_1000##subscriptNoCashing                       8.34s   119.88m
VARCHAR_1000_1##subscript                                  69.91ms     14.30
VARCHAR_1000_1##subscriptNoCashing                        592.40ms      1.69
VARCHAR_1000_1000##subscript                              133.53ms      7.49
VARCHAR_1000_1000##subscriptNoCashing                     617.93ms      1.62
VARCHAR_100_1##subscript                                   63.33ms     15.79
VARCHAR_100_1##subscriptNoCashing                          73.29ms     13.64
VARCHAR_100_1000##subscript                                84.33ms     11.86
VARCHAR_100_1000##subscriptNoCashing                       87.19ms     11.47
VARCHAR_10_1##subscript                                    31.01ms     32.25
VARCHAR_10_1##subscriptNoCashing                           31.62ms     31.62
VARCHAR_10_1000##subscript                                 33.86ms     29.54
VARCHAR_10_1000##subscriptNoCashing                        33.84ms     29.55
```

Differential Revision: D50544250


