### PR TITLE
Parallel decoding for FlatMapStruct and Struct (no selective readers yet)

### DIFF
--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1763,6 +1763,7 @@ class StructColumnReader : public ColumnReader {
  private:
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<ColumnReader>> children_;
+  folly::Executor* FOLLY_NULLABLE executor_;
 
  public:
   StructColumnReader(
@@ -1770,6 +1771,7 @@ class StructColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
       FlatMapContext flatMapContext);
   ~StructColumnReader() override = default;
 
@@ -1796,9 +1798,11 @@ StructColumnReader::StructColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
+    folly::Executor* executor,
     FlatMapContext flatMapContext)
     : ColumnReader(fileType, stripe, streamLabels, std::move(flatMapContext)),
-      requestedType_{requestedType} {
+      requestedType_{requestedType},
+      executor_{executor} {
   DWIO_ENSURE_EQ(
       fileType_->id(),
       fileType->id(),
@@ -1825,6 +1829,7 @@ StructColumnReader::StructColumnReader(
             fileType_->childAt(i),
             stripe,
             streamLabels.append(folly::to<std::string>(i)),
+            executor,
             makeCopyWithNullDecoder(flatMapContext_)));
       } else {
         children_.push_back(
@@ -1904,7 +1909,15 @@ void StructColumnReader::next(
   for (uint64_t i = 0; i < children_.size(); ++i) {
     auto& reader = children_[i];
     if (reader) {
-      reader->next(numValues, (*childrenVectorsPtr)[i], nullsPtr);
+      if (executor_) {
+        executor_->add(
+            [&reader,
+             numValues,
+             child = &(*childrenVectorsPtr)[i],
+             nullsPtr]() { reader->next(numValues, *child, nullsPtr); });
+      } else {
+        reader->next(numValues, (*childrenVectorsPtr)[i], nullsPtr);
+      }
     }
   }
 }
@@ -1921,7 +1934,8 @@ class ListColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
-      FlatMapContext flatMapContext);
+      FlatMapContext flatMapContext,
+      folly::Executor* FOLLY_NULLABLE executor);
   ~ListColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -1935,7 +1949,8 @@ ListColumnReader::ListColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
-    FlatMapContext flatMapContext)
+    FlatMapContext flatMapContext,
+    folly::Executor* executor)
     : ColumnReader(fileType, stripe, streamLabels, std::move(flatMapContext)),
       requestedType_{requestedType} {
   DWIO_ENSURE_EQ(fileType_->id(), fileType->id(), "working on the same node");
@@ -1960,6 +1975,7 @@ ListColumnReader::ListColumnReader(
         fileType_->childAt(0),
         stripe,
         streamLabels,
+        executor,
         makeCopyWithNullDecoder(flatMapContext_));
   }
 }
@@ -2086,7 +2102,8 @@ class MapColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
-      FlatMapContext flatMapContext);
+      FlatMapContext flatMapContext,
+      folly::Executor* FOLLY_NULLABLE executor);
   ~MapColumnReader() override = default;
 
   uint64_t skip(uint64_t numValues) override;
@@ -2100,7 +2117,8 @@ MapColumnReader::MapColumnReader(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
-    FlatMapContext flatMapContext)
+    FlatMapContext flatMapContext,
+    folly::Executor* executor)
     : ColumnReader(fileType, stripe, streamLabels, std::move(flatMapContext)),
       requestedType_{requestedType} {
   DWIO_ENSURE_EQ(fileType_->id(), fileType->id(), "working on the same node");
@@ -2125,6 +2143,7 @@ MapColumnReader::MapColumnReader(
         fileType_->childAt(0),
         stripe,
         streamLabels,
+        executor,
         makeCopyWithNullDecoder(flatMapContext_));
   }
 
@@ -2135,6 +2154,7 @@ MapColumnReader::MapColumnReader(
         fileType_->childAt(1),
         stripe,
         streamLabels,
+        executor,
         makeCopyWithNullDecoder(flatMapContext_));
   }
 
@@ -2405,6 +2425,7 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     StripeStreams& stripe,
     const StreamLabels& streamLabels,
+    folly::Executor* executor,
     FlatMapContext flatMapContext) {
   dwio::common::typeutils::checkTypeCompatibility(
       *fileType->type(), *requestedType->type());
@@ -2487,7 +2508,8 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
           fileType,
           stripe,
           streamLabels,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          executor);
     case TypeKind::MAP:
       if (stripe.getEncoding(ek).kind() ==
           proto::ColumnEncoding_Kind_MAP_FLAT) {
@@ -2496,6 +2518,7 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
             fileType,
             stripe,
             streamLabels,
+            executor,
             std::move(flatMapContext));
       }
       return std::make_unique<MapColumnReader>(
@@ -2503,13 +2526,15 @@ std::unique_ptr<ColumnReader> ColumnReader::build(
           fileType,
           stripe,
           streamLabels,
-          std::move(flatMapContext));
+          std::move(flatMapContext),
+          executor);
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(
           requestedType,
           fileType,
           stripe,
           streamLabels,
+          executor,
           std::move(flatMapContext));
     case TypeKind::REAL:
       if (requestedType->type()->kind() == TypeKind::REAL) {

--- a/velox/dwio/dwrf/reader/ColumnReader.h
+++ b/velox/dwio/dwrf/reader/ColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "folly/Executor.h"
 #include "velox/common/memory/Memory.h"
 #include "velox/dwio/common/ColumnSelector.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -114,6 +115,7 @@ class ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
       FlatMapContext flatMapContext = {});
 };
 
@@ -125,12 +127,14 @@ class ColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
       FlatMapContext flatMapContext = {}) {
     return ColumnReader::build(
         requestedType,
         fileType,
         stripe,
         streamLabels,
+        executor,
         std::move(flatMapContext));
   }
 

--- a/velox/dwio/dwrf/reader/DwrfReader.h
+++ b/velox/dwio/dwrf/reader/DwrfReader.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "folly/synchronization/Baton.h"
+#include "velox/dwio/common/ExecutorBarrier.h"
 #include "velox/dwio/common/ReaderFactory.h"
 #include "velox/dwio/dwrf/reader/SelectiveDwrfReader.h"
 
@@ -145,6 +146,7 @@ class DwrfRowReader : public StrideIndexProvider,
   uint64_t strideIndex_;
   std::shared_ptr<StripeDictionaryCache> stripeDictionaryCache_;
   dwio::common::RowReaderOptions options_;
+  std::unique_ptr<dwio::common::ExecutorBarrier> executorBarrier_;
 
   struct PrefetchedStripeState {
     bool preloaded;

--- a/velox/dwio/dwrf/reader/FlatMapColumnReader.h
+++ b/velox/dwio/dwrf/reader/FlatMapColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <folly/Executor.h>
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/FlatMapHelper.h"
@@ -176,6 +177,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
       FlatMapContext flatMapContext);
   ~FlatMapStructEncodingColumnReader() override = default;
 
@@ -190,6 +192,7 @@ class FlatMapStructEncodingColumnReader : public ColumnReader {
   const std::shared_ptr<const dwio::common::TypeWithId> requestedType_;
   std::vector<std::unique_ptr<KeyNode<T>>> keyNodes_;
   std::unique_ptr<NullColumnReader> nullColumnReader_;
+  folly::Executor* FOLLY_NULLABLE executor_;
   BufferPtr mergedNulls_;
 };
 
@@ -200,6 +203,7 @@ class FlatMapColumnReaderFactory {
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       StripeStreams& stripe,
       const StreamLabels& streamLabels,
+      folly::Executor* FOLLY_NULLABLE executor,
       FlatMapContext flatMapContext);
 };
 

--- a/velox/dwio/dwrf/test/ColumnWriterTest.cpp
+++ b/velox/dwio/dwrf/test/ColumnWriterTest.cpp
@@ -350,6 +350,7 @@ void testDataTypeWriter(
         reqType,
         streams,
         labels,
+        nullptr,
         FlatMapContext{
             .sequence = sequence,
             .inMapDecoder = nullptr,
@@ -934,8 +935,8 @@ void testMapWriter(
       auto pool = addDefaultLeafMemoryPool();
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
-      const auto reader =
-          ColumnReader::build(dataTypeWithId, dataTypeWithId, streams, labels);
+      const auto reader = ColumnReader::build(
+          dataTypeWithId, dataTypeWithId, streams, labels, nullptr);
       VectorPtr out;
 
       // Read map/row
@@ -1070,8 +1071,8 @@ void testMapWriterRow(
       auto pool = addDefaultLeafMemoryPool();
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
-      const auto reader =
-          ColumnReader::build(dataTypeWithId, dataTypeWithId, streams, labels);
+      const auto reader = ColumnReader::build(
+          dataTypeWithId, dataTypeWithId, streams, labels, nullptr);
       VectorPtr out;
 
       // Read map/row
@@ -2080,7 +2081,7 @@ struct IntegerColumnWriterTypedTestCase {
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
-          ColumnReader::build(reqType, reqType, streams, labels);
+          ColumnReader::build(reqType, reqType, streams, labels, nullptr);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         // TODO Make reuse work
@@ -3317,7 +3318,7 @@ struct StringColumnWriterTestCase {
       memory::AllocationPool allocPool(pool.get());
       StreamLabels labels(allocPool);
       auto columnReader =
-          ColumnReader::build(reqType, reqType, streams, labels);
+          ColumnReader::build(reqType, reqType, streams, labels, nullptr);
 
       for (size_t j = 0; j != repetitionCount; ++j) {
         if (!writeDirect) {
@@ -4393,7 +4394,8 @@ struct DictColumnWriterTestCase {
     auto reqType = rowTypeWithId->childAt(0);
     memory::AllocationPool allocPool(pool.get());
     StreamLabels labels(allocPool);
-    auto reader = ColumnReader::build(reqType, reqType, streams, labels);
+    auto reader =
+        ColumnReader::build(reqType, reqType, streams, labels, nullptr);
     VectorPtr out;
     reader->next(batch->size(), out);
     compareResults(batch, out);


### PR DESCRIPTION
Summary: Support parallel decoding for FlatMap Struct encoding and for Struct types for regular decoders (not for selective readers yet, which will be implemented in a future diff).

Differential Revision: D50481013


