### PR TITLE
Abandon partial TopNRowNumber early if not reducing cardinality

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -140,6 +140,12 @@ class QueryConfig {
   static constexpr const char* kAbandonPartialAggregationMinPct =
       "abandon_partial_aggregation_min_pct";
 
+  static constexpr const char* kAbandonPartialTopNRowNumberMinRows =
+      "abandon_partial_topn_row_number_min_rows";
+
+  static constexpr const char* kAbandonPartialTopNRowNumberMinPct =
+      "abandon_partial_topn_row_number_min_pct";
+
   static constexpr const char* kMaxPartitionedOutputBufferSize =
       "max_page_partitioning_buffer_size";
 
@@ -347,6 +353,14 @@ class QueryConfig {
 
   int32_t abandonPartialAggregationMinPct() const {
     return get<int32_t>(kAbandonPartialAggregationMinPct, 80);
+  }
+
+  int32_t abandonPartialTopNRowNumberMinRows() const {
+    return get<int32_t>(kAbandonPartialTopNRowNumberMinRows, 100'000);
+  }
+
+  int32_t abandonPartialTopNRowNumberMinPct() const {
+    return get<int32_t>(kAbandonPartialTopNRowNumberMinPct, 80);
   }
 
   uint64_t aggregationSpillMemoryThreshold() const {

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -34,13 +34,19 @@ Generic Configuration
    * - abandon_partial_aggregation_min_rows
      - integer
      - 100,000
-     - Min number of rows when we check if a partial aggregation is not reducing the cardinality well and might be
-       a subject to being abandoned.
+     - Number of input rows to receive before starting to check whether to abandon partial aggregation.
    * - abandon_partial_aggregation_min_pct
      - integer
      - 80
-     - If a partial aggregation's number of output rows constitues this or highler percentage of the number of input rows,
-       then this partial aggregation will be a subject to being abandoned.
+     - Abandons partial aggregation if number of groups equals or exceeds this percentage of the number of input rows.
+   * - abandon_partial_topn_row_number_min_rows
+     - integer
+     - 100,000
+     - Number of input rows to receive before starting to check whether to abandon partial TopNRowNumber.
+   * - abandon_partial_topn_row_number_min_pct
+     - integer
+     - 80
+     - Abandons partial TopNRowNumber if number of output rows equals or exceeds this percentage of the number of input rows.
    * - session_timezone
      - string
      -


### PR DESCRIPTION
Similar to partial aggregation, abandon partial TopNRowNumber if cardinality
reduction is not sufficient. By default, abandon after seeing 100K+ rows if
number of output rows is more than 80% of number of input rows.