### PR TITLE
Support order-able and comparable variables in the simple function interface.

### DIFF
--- a/velox/core/SimpleFunctionMetadata.h
+++ b/velox/core/SimpleFunctionMetadata.h
@@ -17,6 +17,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <folly/Likely.h>
+#include <optional>
 
 #include "velox/common/base/Exceptions.h"
 #include "velox/core/CoreTypeSystem.h"
@@ -153,11 +154,22 @@ struct TypeAnalysisResults {
     }
   } stats;
 
+  void addVariable(const exec::SignatureVariable& variable) {
+    if (!variablesInformation.count(variable.name())) {
+      variablesInformation.emplace(variable.name(), variable);
+    } else {
+      VELOX_CHECK(
+          variable == variablesInformation.at(variable.name()),
+          "Cant assign different properties to the same variable {}",
+          variable.name());
+    }
+  }
+
   // String representaion of the type in the FunctionSignatureBuilder.
   std::ostringstream out;
 
   // Set of generic variables used in the type.
-  std::set<std::string> variables;
+  folly::F14FastMap<std::string, exec::SignatureVariable> variablesInformation;
 
   std::string typeAsString() {
     return out.str();
@@ -196,15 +208,21 @@ struct TypeAnalysis {
   }
 };
 
-template <typename T>
-struct TypeAnalysis<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct TypeAnalysis<Generic<T, comparable, orderable>> {
   void run(TypeAnalysisResults& results) {
     if constexpr (std::is_same_v<T, AnyType>) {
       results.out << "any";
     } else {
-      auto variableType = fmt::format("__user_T{}", T::getId());
-      results.out << variableType;
-      results.variables.insert(variableType);
+      auto typeVariableName = fmt::format("__user_T{}", T::getId());
+      results.out << typeVariableName;
+      results.addVariable(exec::SignatureVariable(
+          typeVariableName,
+          std::nullopt,
+          exec::ParameterType::kTypeParameter,
+          false,
+          orderable,
+          comparable));
     }
     results.stats.hasGeneric = true;
   }
@@ -237,7 +255,9 @@ struct TypeAnalysis<Variadic<V>> {
         tmp.stats.hasGeneric || results.stats.hasVariadicOfGeneric;
 
     results.stats.concreteCount += tmp.stats.concreteCount;
-    results.variables.insert(tmp.variables.begin(), tmp.variables.end());
+    for (auto& [_, variable] : tmp.variablesInformation) {
+      results.addVariable(variable);
+    }
     results.out << tmp.typeAsString();
   }
 };
@@ -401,7 +421,7 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
   struct SignatureTypesAnalysisResults {
     std::vector<std::string> argsTypes;
     std::string outputType;
-    std::set<std::string> variables;
+    folly::F14FastMap<std::string, exec::SignatureVariable> variables;
     TypeAnalysisResults::Stats stats;
   };
 
@@ -425,7 +445,7 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
     return SignatureTypesAnalysisResults{
         std::move(argsTypes),
         std::move(outputType),
-        std::move(results.variables),
+        std::move(results.variablesInformation),
         std::move(results.stats)};
   }
 
@@ -438,8 +458,8 @@ class SimpleFunctionMetadata : public ISimpleFunctionMetadata {
       builder.argumentType(arg);
     }
 
-    for (const auto& variable : analysis.variables) {
-      builder.typeVariable(variable);
+    for (const auto& [_, variable] : analysis.variables) {
+      builder.variable(variable);
     }
 
     if (isVariadic()) {

--- a/velox/core/tests/TypeAnalysisTest.cpp
+++ b/velox/core/tests/TypeAnalysisTest.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "velox/core/SimpleFunctionMetadata.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/type/Type.h"
 
 // Test for simple function type analysis.
@@ -70,10 +71,11 @@ class TypeAnalysisTest : public testing::Test {
   }
 
   template <typename... Args>
-  void testVariables(const std::set<std::string>& expected) {
+  void testVariables(
+      const folly::F14FastMap<std::string, exec::SignatureVariable>& expected) {
     TypeAnalysisResults results;
     (TypeAnalysis<Args>().run(results), ...);
-    ASSERT_EQ(expected, results.variables);
+    ASSERT_EQ(expected, results.variablesInformation);
   }
 
   template <typename... Args>
@@ -99,6 +101,11 @@ TEST_F(TypeAnalysisTest, hasGeneric) {
 
   testHasGeneric<Map<Array<Any>, Array<int32_t>>>(true);
   testHasGeneric<Map<Array<Generic<T1>>, Array<int32_t>>>(true);
+  testHasGeneric<Map<Array<Generic<T1, true, true>>, Array<int32_t>>>(true);
+  testHasGeneric<Map<Array<Generic<T1, true, false>>, Array<int32_t>>>(true);
+  testHasGeneric<Map<Array<Comparable<T1>>, Array<int32_t>>>(true);
+  testHasGeneric<Map<Array<Orderable<T1>>, Array<int32_t>>>(true);
+
   testHasGeneric<Map<Array<int32_t>, Any>>(true);
   testHasGeneric<Variadic<Any>>(true);
   testHasGeneric<Any>(true);
@@ -130,6 +137,9 @@ TEST_F(TypeAnalysisTest, hasVariadicOfGeneric) {
   testHasVariadicOfGeneric<Any, Variadic<int32_t>>(false);
 
   testHasVariadicOfGeneric<Variadic<Any>>(true);
+  testHasVariadicOfGeneric<Variadic<Comparable<T2>>>(true);
+  testHasVariadicOfGeneric<Variadic<Generic<T2, true, false>>>(true);
+
   testHasVariadicOfGeneric<Variadic<Any>, int32_t>(true);
   testHasVariadicOfGeneric<int32_t, Variadic<Array<Any>>>(true);
   testHasVariadicOfGeneric<int32_t, Variadic<Map<int64_t, Array<Generic<T1>>>>>(
@@ -143,6 +153,9 @@ TEST_F(TypeAnalysisTest, countConcrete) {
   testCountConcrete<int32_t, int32_t, double>(3);
   testCountConcrete<Any>(0);
   testCountConcrete<Generic<T1>>(0);
+  testCountConcrete<Generic<T1, true, false>>(0);
+  testCountConcrete<Orderable<T1>>(0);
+
   testCountConcrete<Variadic<Any>>(0);
   testCountConcrete<Variadic<int32_t>>(1);
   testCountConcrete<Variadic<Array<Any>>>(1);
@@ -179,8 +192,21 @@ TEST_F(TypeAnalysisTest, testStringType) {
       "integer",
       "bigint",
       "map(array(integer), __user_T2)",
+
   });
 
+  testStringType<int32_t, int64_t, Map<Array<int32_t>, Orderable<T2>>>({
+      "integer",
+      "bigint",
+      "map(array(integer), __user_T2)",
+
+  });
+  testStringType<int32_t, int64_t, Map<Array<int32_t>, Comparable<T2>>>({
+      "integer",
+      "bigint",
+      "map(array(integer), __user_T2)",
+
+  });
   testStringType<Array<int32_t>>({"array(integer)"});
   testStringType<Map<int64_t, double>>({"map(bigint, double)"});
   testStringType<Row<Any, double, Generic<T1>>>(
@@ -191,11 +217,66 @@ TEST_F(TypeAnalysisTest, testVariables) {
   testVariables<int32_t>({});
   testVariables<Array<int32_t>>({});
   testVariables<Any>({});
-  testVariables<Generic<T1>>({"__user_T1"});
+
+  testVariables<Generic<T1>>(
+      {{"__user_T1",
+        exec::SignatureVariable(
+            "__user_T1",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            false,
+            false)}});
+
+  testVariables<Orderable<T1>>(
+      {{"__user_T1",
+        exec::SignatureVariable(
+            "__user_T1",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            true /*orderableTypesOnly*/,
+            true)}});
+
+  testVariables<Generic<T1, true, true>>(
+      {{"__user_T1",
+        exec::SignatureVariable(
+            "__user_T1",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            true /*orderableTypesOnly*/,
+            true /*comparableTypesOnly*/)}});
+
+  testVariables<Comparable<T1>>(
+      {{"__user_T1",
+        exec::SignatureVariable(
+            "__user_T1",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            false /*orderableTypesOnly*/,
+            true /*comparableTypesOnly*/)}});
+
   testVariables<Map<Any, int32_t>>({});
   testVariables<Variadic<int32_t>>({});
-  testVariables<int32_t, Generic<T5>, Map<Array<int32_t>, Generic<T2>>>(
-      {"__user_T2", "__user_T5"});
+  testVariables<int32_t, Generic<T5>, Map<Array<int32_t>, Orderable<T2>>>(
+      {{"__user_T5",
+        exec::SignatureVariable(
+            "__user_T5",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            false /*orderableTypesOnly*/,
+            false /*comparableTypesOnly*/)},
+       {"__user_T2",
+        exec::SignatureVariable(
+            "__user_T2",
+            std::nullopt,
+            exec::ParameterType::kTypeParameter,
+            false,
+            true /*orderableTypesOnly*/,
+            true /*comparableTypesOnly*/)}});
 }
 
 TEST_F(TypeAnalysisTest, testRank) {
@@ -210,12 +291,15 @@ TEST_F(TypeAnalysisTest, testRank) {
   testRank<Any>(3);
   testRank<Array<int32_t>, Any, Variadic<int32_t>>(3);
   testRank<Array<int32_t>, Generic<T2>>(3);
+  testRank<Array<int32_t>, Comparable<T2>>(3);
+
   testRank<Array<Any>, Generic<T2>>(3);
   testRank<Array<Any>, int32_t>(3);
   testRank<Array<int32_t>, Any, Any>(3);
 
   testRank<Variadic<Any>>(4);
   testRank<Array<int32_t>, Any, Variadic<Array<Any>>>(4);
+  testRank<Array<int32_t>, Any, Variadic<Array<Generic<T2, true, true>>>>(4);
 }
 
 TEST_F(TypeAnalysisTest, testPriority) {

--- a/velox/expression/ComplexViewTypes.h
+++ b/velox/expression/ComplexViewTypes.h
@@ -1004,8 +1004,8 @@ struct HasGeneric {
   }
 };
 
-template <typename T>
-struct HasGeneric<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct HasGeneric<Generic<T, comparable, orderable>> {
   static constexpr bool value() {
     return true;
   }

--- a/velox/expression/FunctionSignature.h
+++ b/velox/expression/FunctionSignature.h
@@ -274,6 +274,11 @@ class FunctionSignatureBuilder {
     return *this;
   }
 
+  FunctionSignatureBuilder& variable(const SignatureVariable& variable) {
+    addVariable(variables_, variable);
+    return *this;
+  }
+
   FunctionSignatureBuilder& knownTypeVariable(const std::string& name);
 
   /// Orderable implies comparable, this method would enable

--- a/velox/expression/UdfTypeResolver.h
+++ b/velox/expression/UdfTypeResolver.h
@@ -143,8 +143,8 @@ struct resolver<Variadic<T>> {
   // Variadic cannot be used as an out_type
 };
 
-template <typename T>
-struct resolver<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct resolver<Generic<T, comparable, orderable>> {
   using in_type = GenericView;
   using null_free_in_type = in_type;
   using out_type = GenericWriter;

--- a/velox/expression/VectorReaders.h
+++ b/velox/expression/VectorReaders.h
@@ -632,16 +632,18 @@ struct VectorReader<Variadic<T>> {
   std::vector<std::unique_ptr<VectorReader<T>>> childReaders_;
 };
 
-template <typename T>
-struct VectorReader<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct VectorReader<Generic<T, comparable, orderable>> {
   using exec_in_t = GenericView;
   using exec_null_free_in_t = exec_in_t;
 
   explicit VectorReader(const DecodedVector* decoded) : decoded_(*decoded) {}
 
-  explicit VectorReader(const VectorReader<Generic<T>>&) = delete;
+  explicit VectorReader(
+      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
 
-  VectorReader<Generic<T>>& operator=(const VectorReader<Generic<T>>&) = delete;
+  VectorReader<Generic<T, comparable, orderable>>& operator=(
+      const VectorReader<Generic<T, comparable, orderable>>&) = delete;
 
   bool isSet(vector_size_t offset) const {
     return !decoded_.isNullAt(offset);

--- a/velox/expression/VectorWriters.h
+++ b/velox/expression/VectorWriters.h
@@ -487,12 +487,14 @@ struct VectorWriter<std::shared_ptr<T>> : public VectorWriterBase {
   vector_t* vector_;
 };
 
-template <typename T>
-struct VectorWriter<Generic<T>> : public VectorWriterBase {
+template <typename T, bool comparable, bool orderable>
+struct VectorWriter<Generic<T, comparable, orderable>>
+    : public VectorWriterBase {
   using exec_out_t = GenericWriter;
   using vector_t = BaseVector;
 
-  VectorWriter<Generic<T>>() : writer_{castWriter_, castType_, offset_} {}
+  VectorWriter<Generic<T, comparable, orderable>>()
+      : writer_{castWriter_, castType_, offset_} {}
 
   void setOffset(vector_size_t offset) override {
     offset_ = offset;

--- a/velox/type/Type.h
+++ b/velox/type/Type.h
@@ -1743,12 +1743,20 @@ using T8 = TypeVariable<8>;
 
 struct AnyType {};
 
-template <typename T = AnyType>
+template <typename T = AnyType, bool comparable = false, bool orderable = false>
 struct Generic {
   Generic() = delete;
+  static_assert(!(orderable && !comparable), "Orderable implies comparable.");
 };
 
 using Any = Generic<>;
+
+template <typename T>
+using Comparable = Generic<T, true, false>;
+
+// Orderable implies comparable.
+template <typename T>
+using Orderable = Generic<T, true, true>;
 
 template <typename>
 struct isVariadicType : public std::false_type {};
@@ -1759,8 +1767,9 @@ struct isVariadicType<Variadic<T>> : public std::true_type {};
 template <typename>
 struct isGenericType : public std::false_type {};
 
-template <typename T>
-struct isGenericType<Generic<T>> : public std::true_type {};
+template <typename T, bool comparable, bool orderable>
+struct isGenericType<Generic<T, comparable, orderable>>
+    : public std::true_type {};
 
 template <typename>
 struct isOpaqueType : public std::false_type {};
@@ -1913,8 +1922,8 @@ struct SimpleTypeTrait<IntervalYearMonth> : public SimpleTypeTrait<int32_t> {
   static constexpr const char* name = "INTERVAL YEAR TO MONTH";
 };
 
-template <typename T>
-struct SimpleTypeTrait<Generic<T>> {
+template <typename T, bool comparable, bool orderable>
+struct SimpleTypeTrait<Generic<T, comparable, orderable>> {
   static constexpr TypeKind typeKind = TypeKind::UNKNOWN;
   static constexpr bool isPrimitiveType = false;
   static constexpr bool isFixedWidth = false;


### PR DESCRIPTION
Summary:
Before this diff, Generic<X> used to be translated to variables with the properties
only comparable and only order-able always being false.
this limitation is problematic for some functions like ArrayMax and Eq.

this diff allow expressions Orderable<Tx> and Comprable<Tx> in the simple function interface.

Differential Revision: D50568822


