### PR TITLE
Add row vector unsafe row api.

### DIFF
--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -65,9 +65,9 @@ void SelectiveStructColumnReaderBase::next(
     // This can be either count(*) query or a query that select only
     // constant columns (partition keys or columns missing from an old file
     // due to schema evolution)
-    result->resize(numValues);
-
     auto resultRowVector = std::dynamic_pointer_cast<RowVector>(result);
+    resultRowVector->unsafeResize(numValues);
+
     auto& childSpecs = scanSpec_->children();
     for (auto& childSpec : childSpecs) {
       VELOX_CHECK(childSpec->isConstant());
@@ -325,7 +325,7 @@ void SelectiveStructColumnReaderBase::getValues(
         std::move(children));
   }
   auto* resultRow = static_cast<RowVector*>(result->get());
-  resultRow->resize(rows.size());
+  resultRow->unsafeResize(rows.size());
   if (!rows.size()) {
     return;
   }

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1862,10 +1862,9 @@ void StructColumnReader::next(
     // the parent vector.
     childrenVectors = rowVector->children();
     DWIO_ENSURE_GE(childrenVectors.size(), children_.size());
-  }
 
-  if (result) {
-    result->resize(numValues, false);
+    // Resize rowVector
+    rowVector->unsafeResize(numValues);
   }
 
   BufferPtr nulls = readNulls(numValues, result, incomingNulls);

--- a/velox/vector/ComplexVector.cpp
+++ b/velox/vector/ComplexVector.cpp
@@ -634,6 +634,10 @@ void RowVector::validate(const VectorValidateOptions& options) const {
   }
 }
 
+void RowVector::unsafeResize(vector_size_t newSize, bool setNotNull) {
+  BaseVector::resize(newSize, setNotNull);
+}
+
 void ArrayVectorBase::checkRanges() const {
   std::unordered_map<vector_size_t, vector_size_t> seenElements;
   seenElements.reserve(size());

--- a/velox/vector/ComplexVector.h
+++ b/velox/vector/ComplexVector.h
@@ -204,6 +204,11 @@ class RowVector : public BaseVector {
 
   void validate(const VectorValidateOptions& options) const override;
 
+  /// Only calls BaseVector::resize and doesnt resize the children.
+  /// This function is present for backwards compatibility,
+  /// until the few places that require it are migrated over.
+  void unsafeResize(vector_size_t newSize, bool setNotNull = true);
+
  private:
   vector_size_t childSize() const {
     bool allConstant = false;


### PR DESCRIPTION
This PR adds the row vector unsafe resize api. This Api is only intended for backwards compatibility in certain sensitive places (for e.g I/O Reader/Writers). The next PR will add recursive resize to all children of a RowVector. 
As a part of this change we also make changes to certain sections of the code which rely on the old behavior and cannot be immediately migrated away.