### PR TITLE
Fix memory reporting for table writer operator

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -769,7 +769,6 @@ void Driver::closeOperators() {
   // Add operator stats to the task.
   for (auto& op : operators_) {
     auto stats = op->stats(true);
-    stats.memoryStats.update(op->pool());
     stats.numDrivers = 1;
     task()->addOperatorStats(stats);
   }

--- a/velox/exec/Operator.cpp
+++ b/velox/exec/Operator.cpp
@@ -234,14 +234,17 @@ RowVectorPtr Operator::fillOutput(
 }
 
 OperatorStats Operator::stats(bool clear) {
+  OperatorStats stats;
   if (!clear) {
-    return *stats_.rlock();
+    stats = *stats_.rlock();
+  } else {
+    auto lockedStats = stats_.wlock();
+    stats = *lockedStats;
+    lockedStats->clear();
   }
 
-  auto lockedStats = stats_.wlock();
-  OperatorStats ret{*lockedStats};
-  lockedStats->clear();
-  return ret;
+  stats.memoryStats = MemoryStats::memStatsFromPool(pool());
+  return stats;
 }
 
 uint32_t Operator::outputBatchRows(

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "OperatorUtils.h"
 #include "velox/core/PlanNode.h"
 #include "velox/exec/MemoryReclaimer.h"
 #include "velox/exec/Operator.h"
@@ -133,6 +134,15 @@ class TableWriter : public Operator {
   /// created inside the connector.
   bool canReclaim() const override {
     return false;
+  }
+
+  OperatorStats stats(bool clear) override {
+    auto stats = Operator::stats(clear);
+    // NOTE: file writers allocates memory through 'connectorPool_', not from
+    // the table writer operator pool. So we report the memory usage from
+    // 'connectorPool_'.
+    stats.memoryStats = MemoryStats::memStatsFromPool(connectorPool_);
+    return stats;
   }
 
  private:

--- a/velox/exec/tests/OperatorUtilsTest.cpp
+++ b/velox/exec/tests/OperatorUtilsTest.cpp
@@ -442,3 +442,16 @@ TEST_F(OperatorUtilsTest, reclaimableSectionGuard) {
   }
   ASSERT_FALSE(mockOp.testingNonReclaimable());
 }
+
+TEST_F(OperatorUtilsTest, memStatsFromPool) {
+  auto leafPool = rootPool_->addLeafChild("leaf-1.0");
+  void* buffer;
+  buffer = leafPool->allocate(2L << 20);
+  leafPool->free(buffer, 1L << 20);
+  auto stats = MemoryStats::memStatsFromPool(leafPool.get());
+  ASSERT_EQ(stats.userMemoryReservation, 1L << 20);
+  ASSERT_EQ(stats.systemMemoryReservation, 0);
+  ASSERT_EQ(stats.peakUserMemoryReservation, 2L << 20);
+  ASSERT_EQ(stats.peakSystemMemoryReservation, 0);
+  ASSERT_EQ(stats.numMemoryAllocations, 1);
+}

--- a/velox/exec/tests/TableWriteTest.cpp
+++ b/velox/exec/tests/TableWriteTest.cpp
@@ -2091,6 +2091,11 @@ TEST_P(UnpartitionedTableWriterTest, runtimeStatsCheck) {
                 testData.maxStripeSize)
             .assertResults("SELECT count(*) FROM tmp");
     auto stats = task->taskStats().pipelineStats.front().operatorStats;
+    if (testData.maxStripeSize == "1GB") {
+      ASSERT_GT(
+          stats[1].memoryStats.peakTotalMemoryReservation,
+          testData.numInputVectors * options.stringLength);
+    }
     ASSERT_EQ(
         stats[1].runtimeStats["stripeSize"].count, testData.expectedNumStripes);
     ASSERT_EQ(stats[1].runtimeStats["numWrittenFiles"].sum, 1);
@@ -2275,7 +2280,7 @@ DEBUG_ONLY_TEST_P(BucketedTableOnlyWriteTest, spillingCheck) {
         std::function<void(memory::MemoryPool*)>(
             [&](memory::MemoryPool* pool) { memoryReserved = true; }));
     assertQueryWithWriterConfigs(plan, "SELECT count(*) FROM tmp");
-    // We don't expect memory reservation has been triggered.
+    // We don't expect memory reservation to be triggered.
     ASSERT_FALSE(memoryReserved);
   }
 }


### PR DESCRIPTION
Normally we use the operator pool for operator memory statistics reporting.
For special operator that uses additional memory pool, return customized result.

Table writer operator is a special case where it uses connecorPool to manage
its memory usage. Thus it should use memory stats from connecorPool instead.