### PR TITLE
Add corr Spark function

### DIFF
--- a/velox/functions/lib/aggregates/CovarianceAggregatesBase.h
+++ b/velox/functions/lib/aggregates/CovarianceAggregatesBase.h
@@ -1,0 +1,615 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "velox/exec/Aggregate.h"
+#include "velox/vector/DecodedVector.h"
+#include "velox/vector/FlatVector.h"
+
+namespace facebook::velox::functions::aggregate {
+
+namespace {
+template <typename T>
+SimpleVector<T>* asSimpleVector(
+    const RowVector* rowVector,
+    int32_t childIndex) {
+  return rowVector->childAt(childIndex)->as<SimpleVector<T>>();
+}
+
+template <typename T>
+T* mutableRawValues(const RowVector* rowVector, int32_t childIndex) {
+  return rowVector->childAt(childIndex)
+      ->as<FlatVector<T>>()
+      ->mutableRawValues();
+}
+
+// Indices into RowType representing intermediate results of covar_samp and
+// covar_pop. Columns appear in alphabetical order.
+struct CovarIndices {
+  int32_t count;
+  int32_t meanX;
+  int32_t meanY;
+  int32_t c2;
+};
+constexpr CovarIndices kCovarIndices{1, 2, 3, 0};
+
+// Indices into RowType representing intermediate results of corr. Columns
+// appear in alphabetical order.
+struct CorrIndices : public CovarIndices {
+  int32_t m2X;
+  int32_t m2Y;
+};
+constexpr CorrIndices kCorrIndices{{1, 4, 5, 0}, 2, 3};
+
+// Indices into RowType representing intermediate results of regr_slope and
+// regr_intercept.
+struct RegrIndices : public CovarIndices {
+  int32_t m2X;
+};
+constexpr RegrIndices kRegrIndices{{1, 3, 4, 0}, 2};
+} // namespace
+
+struct CovarAccumulator {
+  double count() const {
+    return count_;
+  }
+
+  double meanX() const {
+    return meanX_;
+  }
+
+  double meanY() const {
+    return meanY_;
+  }
+
+  double c2() const {
+    return c2_;
+  }
+
+  void update(double x, double y) {
+    count_ += 1;
+    double deltaX = x - meanX();
+    meanX_ += deltaX / count();
+    double deltaY = y - meanY();
+    meanY_ += deltaY / count();
+    c2_ += deltaX * (y - meanY());
+  }
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other) {
+    if (countOther == 0) {
+      return;
+    }
+
+    int64_t newCount = countOther + count();
+    double deltaMeanX = meanXOther - meanX();
+    double deltaMeanY = meanYOther - meanY();
+    c2_ += c2Other +
+        deltaMeanX * deltaMeanY * count() * countOther / (double)newCount;
+    meanX_ += deltaMeanX * countOther / (double)newCount;
+    meanY_ += deltaMeanY * countOther / (double)newCount;
+    count_ = newCount;
+  }
+
+ private:
+  int64_t count_{0};
+  double meanX_{0};
+  double meanY_{0};
+  double c2_{0};
+};
+
+struct CovarSampResultAccessor {
+  static bool hasResult(const CovarAccumulator& accumulator) {
+    return accumulator.count() > 1;
+  }
+
+  static double result(const CovarAccumulator& accumulator) {
+    return accumulator.c2() / (accumulator.count() - 1);
+  }
+};
+
+struct CovarPopResultAccessor {
+  static bool hasResult(const CovarAccumulator& accumulator) {
+    return accumulator.count() > 0;
+  }
+
+  static double result(const CovarAccumulator& accumulator) {
+    return accumulator.c2() / accumulator.count();
+  }
+};
+
+class CovarIntermediateInput {
+ public:
+  explicit CovarIntermediateInput(
+      const RowVector* rowVector,
+      const CovarIndices& indices = kCovarIndices)
+      : count_{asSimpleVector<int64_t>(rowVector, indices.count)},
+        meanX_{asSimpleVector<double>(rowVector, indices.meanX)},
+        meanY_{asSimpleVector<double>(rowVector, indices.meanY)},
+        c2_{asSimpleVector<double>(rowVector, indices.c2)} {}
+
+  void mergeInto(CovarAccumulator& accumulator, vector_size_t row) {
+    accumulator.merge(
+        count_->valueAt(row),
+        meanX_->valueAt(row),
+        meanY_->valueAt(row),
+        c2_->valueAt(row));
+  }
+
+ protected:
+  SimpleVector<int64_t>* count_;
+  SimpleVector<double>* meanX_;
+  SimpleVector<double>* meanY_;
+  SimpleVector<double>* c2_;
+};
+
+class CovarIntermediateResult {
+ public:
+  explicit CovarIntermediateResult(
+      const RowVector* rowVector,
+      const CovarIndices& indices = kCovarIndices)
+      : count_{mutableRawValues<int64_t>(rowVector, indices.count)},
+        meanX_{mutableRawValues<double>(rowVector, indices.meanX)},
+        meanY_{mutableRawValues<double>(rowVector, indices.meanY)},
+        c2_{mutableRawValues<double>(rowVector, indices.c2)} {}
+
+  static std::string type() {
+    return "row(double,bigint,double,double)";
+  }
+
+  void set(vector_size_t row, const CovarAccumulator& accumulator) {
+    count_[row] = accumulator.count();
+    meanX_[row] = accumulator.meanX();
+    meanY_[row] = accumulator.meanY();
+    c2_[row] = accumulator.c2();
+  }
+
+ private:
+  int64_t* count_;
+  double* meanX_;
+  double* meanY_;
+  double* c2_;
+};
+
+struct CorrAccumulator : public CovarAccumulator {
+  double m2X() const {
+    return m2X_;
+  }
+
+  double m2Y() const {
+    return m2Y_;
+  }
+
+  void update(double x, double y) {
+    double oldMeanX = meanX();
+    double oldMeanY = meanY();
+    CovarAccumulator::update(x, y);
+
+    m2X_ += (x - oldMeanX) * (x - meanX());
+    m2Y_ += (y - oldMeanY) * (y - meanY());
+  }
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other,
+      double m2XOther,
+      double m2YOther) {
+    if (countOther == 0) {
+      return;
+    }
+
+    m2X_ += m2XOther +
+        count() * countOther * std::pow(meanX() - meanXOther, 2) /
+            (double)(count() + countOther);
+    m2Y_ += m2YOther +
+        count() * countOther * std::pow(meanY() - meanYOther, 2) /
+            (double)(count() + countOther);
+
+    CovarAccumulator::merge(countOther, meanXOther, meanYOther, c2Other);
+  }
+
+ private:
+  double m2X_{0};
+  double m2Y_{0};
+};
+
+struct CorrResultAccessor {
+  static bool hasResult(const CorrAccumulator& accumulator) {
+    return !std::isnan(result(accumulator));
+  }
+
+  static double result(const CorrAccumulator& accumulator) {
+    double stddevX = std::sqrt(accumulator.m2X());
+    double stddevY = std::sqrt(accumulator.m2Y());
+    return accumulator.c2() / stddevX / stddevY;
+  }
+};
+
+class CorrIntermediateInput : public CovarIntermediateInput {
+ public:
+  explicit CorrIntermediateInput(const RowVector* rowVector)
+      : CovarIntermediateInput(rowVector, kCorrIndices),
+        m2X_{asSimpleVector<double>(rowVector, kCorrIndices.m2X)},
+        m2Y_{asSimpleVector<double>(rowVector, kCorrIndices.m2Y)} {}
+
+  void mergeInto(CorrAccumulator& accumulator, vector_size_t row) {
+    accumulator.merge(
+        count_->valueAt(row),
+        meanX_->valueAt(row),
+        meanY_->valueAt(row),
+        c2_->valueAt(row),
+        m2X_->valueAt(row),
+        m2Y_->valueAt(row));
+  }
+
+ private:
+  SimpleVector<double>* m2X_;
+  SimpleVector<double>* m2Y_;
+};
+
+class CorrIntermediateResult : public CovarIntermediateResult {
+ public:
+  explicit CorrIntermediateResult(const RowVector* rowVector)
+      : CovarIntermediateResult(rowVector, kCorrIndices),
+        m2X_{mutableRawValues<double>(rowVector, kCorrIndices.m2X)},
+        m2Y_{mutableRawValues<double>(rowVector, kCorrIndices.m2Y)} {}
+
+  static std::string type() {
+    return "row(double,bigint,double,double,double,double)";
+  }
+
+  void set(vector_size_t row, const CorrAccumulator& accumulator) {
+    CovarIntermediateResult::set(row, accumulator);
+    m2X_[row] = accumulator.m2X();
+    m2Y_[row] = accumulator.m2Y();
+  }
+
+ private:
+  double* m2X_;
+  double* m2Y_;
+};
+
+struct RegrAccumulator : public CovarAccumulator {
+  double m2X() const {
+    return m2X_;
+  }
+
+  void update(double x, double y) {
+    double oldMeanX = meanX();
+    CovarAccumulator::update(x, y);
+
+    m2X_ += (x - oldMeanX) * (x - meanX());
+  }
+
+  void merge(
+      int64_t countOther,
+      double meanXOther,
+      double meanYOther,
+      double c2Other,
+      double m2XOther) {
+    if (countOther == 0) {
+      return;
+    }
+
+    m2X_ += m2XOther +
+        count() / (count() + countOther) * countOther *
+            std::pow(meanX() - meanXOther, 2);
+    CovarAccumulator::merge(countOther, meanXOther, meanYOther, c2Other);
+  }
+
+ private:
+  double m2X_{0};
+};
+
+struct RegrSlopeResultAccessor {
+  static bool hasResult(const RegrAccumulator& accumulator) {
+    return !std::isnan(result(accumulator));
+  }
+
+  static double result(const RegrAccumulator& accumulator) {
+    return accumulator.c2() / accumulator.m2X();
+  }
+};
+
+struct RegrInterceptResultAccessor {
+  static bool hasResult(const RegrAccumulator& accumulator) {
+    return !std::isnan(result(accumulator));
+  }
+
+  static double result(const RegrAccumulator& accumulator) {
+    double slope = RegrSlopeResultAccessor::result(accumulator);
+    return accumulator.meanY() - slope * accumulator.meanX();
+  }
+};
+
+class RegrIntermediateInput : public CovarIntermediateInput {
+ public:
+  explicit RegrIntermediateInput(const RowVector* rowVector)
+      : CovarIntermediateInput(rowVector, kRegrIndices),
+        m2X_{asSimpleVector<double>(rowVector, kRegrIndices.m2X)} {}
+
+  void mergeInto(RegrAccumulator& accumulator, vector_size_t row) {
+    accumulator.merge(
+        count_->valueAt(row),
+        meanX_->valueAt(row),
+        meanY_->valueAt(row),
+        c2_->valueAt(row),
+        m2X_->valueAt(row));
+  }
+
+ private:
+  SimpleVector<double>* m2X_;
+};
+
+class RegrIntermediateResult : public CovarIntermediateResult {
+ public:
+  explicit RegrIntermediateResult(const RowVector* rowVector)
+      : CovarIntermediateResult(rowVector, kRegrIndices),
+        m2X_{mutableRawValues<double>(rowVector, kRegrIndices.m2X)} {}
+
+  static std::string type() {
+    return "row(double,bigint,double,double,double)";
+  }
+
+  void set(vector_size_t row, const RegrAccumulator& accumulator) {
+    CovarIntermediateResult::set(row, accumulator);
+    m2X_[row] = accumulator.m2X();
+  }
+
+ private:
+  double* m2X_;
+};
+
+// @tparam T Type of the raw input and final result. Can be double or float.
+template <
+    typename T,
+    typename TAccumulator,
+    typename TIntermediateInput,
+    typename TIntermediateResult,
+    typename TResultAccessor>
+class CovarianceAggregate : public exec::Aggregate {
+ public:
+  explicit CovarianceAggregate(TypePtr resultType)
+      : exec::Aggregate(resultType) {}
+
+  int32_t accumulatorFixedWidthSize() const override {
+    return sizeof(TAccumulator);
+  }
+
+  void initializeNewGroups(
+      char** groups,
+      folly::Range<const vector_size_t*> indices) override {
+    setAllNulls(groups, indices);
+    for (auto i : indices) {
+      new (groups[i] + offset_) TAccumulator();
+    }
+  }
+
+  void addRawInput(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    if constexpr (std::is_same_v<TAccumulator, RegrAccumulator>) {
+      // The args order of linear regression function is (y, x), so we need to
+      // swap the order
+      decodedX_.decode(*args[1], rows);
+      decodedY_.decode(*args[0], rows);
+    } else {
+      decodedX_.decode(*args[0], rows);
+      decodedY_.decode(*args[1], rows);
+    }
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedX_.isNullAt(row) || decodedY_.isNullAt(row)) {
+        return;
+      }
+      auto* group = groups[row];
+      exec::Aggregate::clearNull(group);
+      accumulator(group)->update(
+          decodedX_.valueAt<T>(row), decodedY_.valueAt<T>(row));
+    });
+  }
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+
+    auto baseRowVector = static_cast<const RowVector*>(decodedPartial_.base());
+    TIntermediateInput input{baseRowVector};
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedPartial_.isNullAt(row)) {
+        return;
+      }
+      auto decodedIndex = decodedPartial_.index(row);
+      auto* group = groups[row];
+      exec::Aggregate::clearNull(group);
+      input.mergeInto(*accumulator(group), decodedIndex);
+    });
+  }
+
+  void addSingleGroupRawInput(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    if constexpr (std::is_same_v<TAccumulator, RegrAccumulator>) {
+      // The args order of linear regression function is (y, x), so we need to
+      // swap the order
+      decodedX_.decode(*args[1], rows);
+      decodedY_.decode(*args[0], rows);
+    } else {
+      decodedX_.decode(*args[0], rows);
+      decodedY_.decode(*args[1], rows);
+    }
+
+    exec::Aggregate::clearNull(group);
+    auto* accumulator = this->accumulator(group);
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedX_.isNullAt(row) || decodedY_.isNullAt(row)) {
+        return;
+      }
+      accumulator->update(decodedX_.valueAt<T>(row), decodedY_.valueAt<T>(row));
+    });
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+
+    exec::Aggregate::clearNull(group);
+    auto* accumulator = this->accumulator(group);
+
+    auto baseRowVector = static_cast<const RowVector*>(decodedPartial_.base());
+    TIntermediateInput input{baseRowVector};
+
+    rows.applyToSelected([&](auto row) {
+      if (decodedPartial_.isNullAt(row)) {
+        return;
+      }
+      auto decodedIndex = decodedPartial_.index(row);
+      input.mergeInto(*accumulator, decodedIndex);
+    });
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto vector = (*result)->as<FlatVector<T>>();
+    VELOX_CHECK(vector);
+    vector->resize(numGroups);
+    uint64_t* rawNulls = getRawNulls(vector);
+
+    T* rawValues = vector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        vector->setNull(i, true);
+      } else {
+        auto* accumulator = this->accumulator(group);
+        if (TResultAccessor::hasResult(*accumulator)) {
+          clearNull(rawNulls, i);
+          rawValues[i] = (T)TResultAccessor::result(*accumulator);
+        } else {
+          vector->setNull(i, true);
+        }
+      }
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    rowVector->resize(numGroups);
+    for (auto& child : rowVector->children()) {
+      child->resize(numGroups);
+    }
+
+    uint64_t* rawNulls = getRawNulls(rowVector);
+
+    TIntermediateResult covarResult{rowVector};
+
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      if (isNull(group)) {
+        rowVector->setNull(i, true);
+      } else {
+        clearNull(rawNulls, i);
+        covarResult.set(i, *accumulator(group));
+      }
+    }
+  }
+
+ private:
+  inline TAccumulator* accumulator(char* group) {
+    return exec::Aggregate::value<TAccumulator>(group);
+  }
+
+  DecodedVector decodedX_;
+  DecodedVector decodedY_;
+  DecodedVector decodedPartial_;
+};
+
+template <
+    typename TAccumulator,
+    typename TIntermediateInput,
+    typename TIntermediateResult,
+    typename TResultAccessor>
+exec::AggregateRegistrationResult registerCovariance(const std::string& name) {
+  std::vector<std::shared_ptr<exec::AggregateFunctionSignature>> signatures = {
+      // (double, double) -> double
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("double")
+          .intermediateType(TIntermediateResult::type())
+          .argumentType("double")
+          .argumentType("double")
+          .build(),
+      // (real, real) -> real
+      exec::AggregateFunctionSignatureBuilder()
+          .returnType("real")
+          .intermediateType(TIntermediateResult::type())
+          .argumentType("real")
+          .argumentType("real")
+          .build(),
+  };
+
+  return exec::registerAggregateFunction(
+      name,
+      std::move(signatures),
+      [](core::AggregationNode::Step step,
+         const std::vector<TypePtr>& argTypes,
+         const TypePtr& resultType,
+         const core::QueryConfig& /*config*/)
+          -> std::unique_ptr<exec::Aggregate> {
+        auto rawInputType = exec::isRawInput(step)
+            ? argTypes[0]
+            : (exec::isPartialOutput(step) ? DOUBLE() : resultType);
+        switch (rawInputType->kind()) {
+          case TypeKind::DOUBLE:
+            return std::make_unique<CovarianceAggregate<
+                double,
+                TAccumulator,
+                TIntermediateInput,
+                TIntermediateResult,
+                TResultAccessor>>(resultType);
+          case TypeKind::REAL:
+            return std::make_unique<CovarianceAggregate<
+                float,
+                TAccumulator,
+                TIntermediateInput,
+                TIntermediateResult,
+                TResultAccessor>>(resultType);
+          default:
+            VELOX_UNSUPPORTED(
+                "Unsupported raw input type: {}. Expected DOUBLE or REAL.",
+                rawInputType->toString())
+        }
+      });
+}
+
+} // namespace facebook::velox::functions::aggregate

--- a/velox/functions/sparksql/aggregates/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(
   AverageAggregate.cpp
   BitwiseXorAggregate.cpp
   BloomFilterAggAggregate.cpp
+  CorrelationAggregate.cpp
   FirstLastAggregate.cpp
   MinMaxByAggregate.cpp
   Register.cpp

--- a/velox/functions/sparksql/aggregates/CorrelationAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/CorrelationAggregate.cpp
@@ -19,34 +19,21 @@
 
 using namespace facebook::velox::functions::aggregate;
 
-namespace facebook::velox::aggregate::prestosql {
+namespace facebook::velox::functions::aggregate::sparksql {
+namespace {
+struct SparkCorrResultAccessor : public CorrResultAccessor {
+  static double result(const CorrAccumulator& accumulator) {
+    // Modify the calculation order to maintain the same accuracy with spark.
+    return accumulator.c2() / std::sqrt(accumulator.m2X() * accumulator.m2Y());
+  }
+};
+} // namespace
 
-void registerCovarianceAggregates(const std::string& prefix) {
-  registerCovariance<
-      CovarAccumulator,
-      CovarIntermediateInput,
-      CovarIntermediateResult,
-      CovarPopResultAccessor>(prefix + kCovarPop);
-  registerCovariance<
-      CovarAccumulator,
-      CovarIntermediateInput,
-      CovarIntermediateResult,
-      CovarSampResultAccessor>(prefix + kCovarSamp);
+void registerCorrelationAggregate(const std::string& prefix) {
   registerCovariance<
       CorrAccumulator,
       CorrIntermediateInput,
       CorrIntermediateResult,
-      CorrResultAccessor>(prefix + kCorr);
-  registerCovariance<
-      RegrAccumulator,
-      RegrIntermediateInput,
-      RegrIntermediateResult,
-      RegrInterceptResultAccessor>(prefix + kRegrIntercept);
-  registerCovariance<
-      RegrAccumulator,
-      RegrIntermediateInput,
-      RegrIntermediateResult,
-      RegrSlopeResultAccessor>(prefix + kRegrSlop);
+      SparkCorrResultAccessor>(prefix + facebook::velox::aggregate::kCorr);
 }
-
-} // namespace facebook::velox::aggregate::prestosql
+} // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/Register.cpp
+++ b/velox/functions/sparksql/aggregates/Register.cpp
@@ -19,12 +19,14 @@
 #include "velox/functions/sparksql/aggregates/AverageAggregate.h"
 #include "velox/functions/sparksql/aggregates/BitwiseXorAggregate.h"
 #include "velox/functions/sparksql/aggregates/BloomFilterAggAggregate.h"
+#include "velox/functions/sparksql/aggregates/CorrelationAggregate.cpp"
 #include "velox/functions/sparksql/aggregates/SumAggregate.h"
 
 namespace facebook::velox::functions::aggregate::sparksql {
 
 extern void registerFirstLastAggregates(const std::string& prefix);
 extern void registerMinMaxByAggregates(const std::string& prefix);
+extern void registerCorrelationAggregate(const std::string& prefix);
 
 void registerAggregateFunctions(const std::string& prefix) {
   registerFirstLastAggregates(prefix);
@@ -33,5 +35,6 @@ void registerAggregateFunctions(const std::string& prefix) {
   registerBloomFilterAggAggregate(prefix + "bloom_filter_agg");
   registerAverage(prefix + "avg");
   registerSum(prefix + "sum");
+  registerCorrelationAggregate(prefix);
 }
 } // namespace facebook::velox::functions::aggregate::sparksql

--- a/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
+++ b/velox/functions/sparksql/aggregates/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   velox_functions_spark_aggregates_test
   BitwiseXorAggregationTest.cpp
   BloomFilterAggAggregateTest.cpp
+  CorrelationAggregationTest.cpp
   FirstAggregateTest.cpp
   LastAggregateTest.cpp
   AverageAggregationTest.cpp

--- a/velox/functions/sparksql/aggregates/tests/CorrelationAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/CorrelationAggregationTest.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/exec/tests/utils/PlanBuilder.h"
+#include "velox/functions/lib/aggregates/tests/AggregationTestBase.h"
+#include "velox/functions/sparksql/aggregates/Register.h"
+
+using namespace facebook::velox::exec::test;
+using namespace facebook::velox::functions::aggregate::test;
+
+namespace facebook::velox::functions::aggregate::sparksql::test {
+
+namespace {
+
+class CorrelationAggregationTest : public AggregationTestBase {
+ protected:
+  void SetUp() override {
+    AggregationTestBase::SetUp();
+    allowInputShuffle();
+    registerAggregateFunctions("spark_");
+  }
+};
+
+TEST_F(CorrelationAggregationTest, precision) {
+  // Construct data to make covar = 0.5, both stddev = 0.5.
+  auto data = makeRowVector({
+      makeFlatVector<double>({0, 1}),
+      makeFlatVector<double>({0, 1}),
+  });
+  auto expected =
+      makeRowVector({makeFlatVector<int64_t>(std::vector<int64_t>({1}))});
+
+  // Add an extra cast to test the result is not 0.999...
+  testAggregations(
+      {data},
+      {},
+      {"spark_corr(c0, c1)"},
+      {"cast(a0 as BIGINT)"},
+      {expected},
+      std::unordered_map<std::string, std::string>(
+          {{facebook::velox::core::QueryConfig::kCastToIntByTruncate,
+            "true"}}));
+}
+
+} // namespace
+} // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
The 'corr' function is implemented differently in Spark and Presto. Specifically, when computing the final result, Presto uses the formula M/(sqrt(A)*sqrt(B)), while Spark uses M/sqrt(A*B). Even though the difference in precision between the two formulas might seem insignificant, it can result in more noticeable biases with further computations. For instance, when casting to an integer, as demonstrated in the unit test.

This PR extract shared calculations into `velox/functions/lib/aggregates/CovarianceAggregatesBase.h`, and provide a distinct implementation for spark "corr".

Spark's implementation reference:
https://github.com/apache/spark/blob/43852733307a229944bd254f38bcc1f84bca97fd/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/expressions/aggregate/Corr.scala#L124-L127

issue #4917 