### PR TITLE
Move NestedLoopJoinProbe's initializeFilter from ctor to initialize.

### DIFF
--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -55,7 +55,7 @@ NestedLoopJoinProbe::NestedLoopJoinProbe(
           joinNode->id(),
           "NestedLoopJoinProbe"),
       outputBatchSize_{outputBatchRows()},
-      joinNode_(std::move(joinNode)),
+      joinNode_(joinNode),
       joinType_(joinNode_->joinType()) {
   auto probeType = joinNode_->sources()[0]->outputType();
   auto buildType = joinNode_->sources()[1]->outputType();

--- a/velox/exec/NestedLoopJoinProbe.cpp
+++ b/velox/exec/NestedLoopJoinProbe.cpp
@@ -55,18 +55,26 @@ NestedLoopJoinProbe::NestedLoopJoinProbe(
           joinNode->id(),
           "NestedLoopJoinProbe"),
       outputBatchSize_{outputBatchRows()},
-      joinType_(joinNode->joinType()) {
-  auto probeType = joinNode->sources()[0]->outputType();
-  auto buildType = joinNode->sources()[1]->outputType();
+      joinNode_(std::move(joinNode)),
+      joinType_(joinNode_->joinType()) {
+  auto probeType = joinNode_->sources()[0]->outputType();
+  auto buildType = joinNode_->sources()[1]->outputType();
   identityProjections_ = extractProjections(probeType, outputType_);
   buildProjections_ = extractProjections(buildType, outputType_);
+}
 
-  if (joinNode->joinCondition() != nullptr) {
+void NestedLoopJoinProbe::initialize() {
+  Operator::initialize();
+
+  VELOX_CHECK(joinNode_ != nullptr);
+  if (joinNode_->joinCondition() != nullptr) {
     initializeFilter(
-        joinNode->joinCondition(),
-        joinNode->sources()[0]->outputType(),
-        joinNode->sources()[1]->outputType());
+        joinNode_->joinCondition(),
+        joinNode_->sources()[0]->outputType(),
+        joinNode_->sources()[1]->outputType());
   }
+
+  joinNode_.reset();
 }
 
 BlockingReason NestedLoopJoinProbe::isBlocked(ContinueFuture* future) {

--- a/velox/exec/NestedLoopJoinProbe.h
+++ b/velox/exec/NestedLoopJoinProbe.h
@@ -27,6 +27,8 @@ class NestedLoopJoinProbe : public Operator {
       DriverCtx* driverCtx,
       const std::shared_ptr<const core::NestedLoopJoinNode>& joinNode);
 
+  void initialize() override;
+
   void addInput(RowVectorPtr input) override;
 
   RowVectorPtr getOutput() override;
@@ -121,6 +123,7 @@ class NestedLoopJoinProbe : public Operator {
  private:
   // Maximum number of rows in the output batch.
   const uint32_t outputBatchSize_;
+  std::shared_ptr<const core::NestedLoopJoinNode> joinNode_;
   const core::JoinType joinType_;
 
   ProbeOperatorState state_{ProbeOperatorState::kWaitForBuild};


### PR DESCRIPTION
Avoids memory allocation at ctor. Fixes #7208.